### PR TITLE
Fields added to manifest export and import record

### DIFF
--- a/proxy/code/setup/cpsetup
+++ b/proxy/code/setup/cpsetup
@@ -148,10 +148,11 @@ class CertSetup(object):
         run_command('sudo chmod a+r %s' % self.keystore)
 
 
-def write_candlepin_conf(username, database):
+def write_candlepin_conf(options):
     """
-    Write database configuration to candlepin.conf.
+    Write configuration to candlepin.conf.
     """
+
     # If the file exists and it's size is not 0 (it will be empty after
     # fresh rpm install), write out a default with database configuration:
     if os.path.exists(CANDLEPIN_CONF) and os.stat(CANDLEPIN_CONF).st_size > 0:
@@ -162,10 +163,12 @@ def write_candlepin_conf(username, database):
     f = open(CANDLEPIN_CONF, 'w')
     f.write('jpa.config.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect\n')
     f.write('jpa.config.hibernate.connection.driver_class=org.postgresql.Driver\n')
-    f.write('jpa.config.hibernate.connection.url=jdbc:postgresql:%s\n' % database)
+    f.write('jpa.config.hibernate.connection.url=jdbc:postgresql:%s\n' % options.db)
     f.write('jpa.config.hibernate.hbm2ddl.auto=validate\n')
-    f.write('jpa.config.hibernate.connection.username=%s\n' % username)
+    f.write('jpa.config.hibernate.connection.username=%s\n' % options.dbuser)
     f.write('jpa.config.hibernate.connection.password=candlepin\n')
+    if options.webapp_prefix:
+        f.write('\ncandlepin.export.webapp.prefix=%s\n' % options.webapp_prefix)
     f.close()
 
 
@@ -181,6 +184,9 @@ def main(argv):
     parser.add_option("-d", "--database",
                   dest="db", default="candlepin",
                   help="the database to use")
+    parser.add_option("-w", "--webapp-prefix",
+                  dest="webapp_prefix",
+                  help="the web application prefix to use for export origin [host:port/prefix]")
     parser.add_option("-k", "--keystorepwd",
                   dest="keystorepwd", default="password",
                   help="the keystore password to use for the tomcat configuration")
@@ -201,7 +207,7 @@ def main(argv):
         options.dbuser, options.db))
 
     if not options.skipdbcfg:
-        write_candlepin_conf(options.dbuser, options.db)
+        write_candlepin_conf(options)
     else:
         print "** Skipping configuration file setup"
 

--- a/proxy/spec/import_spec.rb
+++ b/proxy/spec/import_spec.rb
@@ -48,6 +48,8 @@ describe 'Candlepin Import' do
       import['generatedDate'].should_not be_nil
       import['upstreamName'].should == consumer['name']
       import['upstreamId'].should == consumer['uuid']
+      import['upstreamType'].should == consumer['type']['label']
+      import.include?('webAppPrefix').should be_true
     end
   end
 

--- a/proxy/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/proxy/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -92,6 +92,8 @@ public class ConfigProperties {
     public static final String CONSUMER_PERSON_NAME_PATTERN =
          "candlepin.consumer_person_name_pattern";
 
+    public static final String WEBAPP_PREFIX = "candlepin.export.webapp.prefix";
+
     public static final Map<String, String> DEFAULT_PROPERTIES =
         new HashMap<String, String>() {
 
@@ -155,6 +157,8 @@ public class ConfigProperties {
                     "[\\#\\?\\'\\`\\!@{}()\\[\\]\\?&\\w-\\.]+");
                 this.put(CONSUMER_PERSON_NAME_PATTERN,
                     "[\\#\\?\\'\\`\\!@{}()\\[\\]\\?&\\w-\\.]+");
+
+                this.put(WEBAPP_PREFIX, "localhost:8443/candlepin");
 
             }
         };

--- a/proxy/src/main/java/org/candlepin/model/ImportRecord.java
+++ b/proxy/src/main/java/org/candlepin/model/ImportRecord.java
@@ -68,6 +68,10 @@ public class ImportRecord extends AbstractHibernateObject {
     private String upstreamName;
     @Column(name = "upstream_id", nullable = true)
     private String upstreamId;
+    @Column(name = "upstream_type", nullable = true)
+    private String upstreamType;
+    @Column(name = "webapp_prefix", nullable = true)
+    private String webAppPrefix;
 
     @SuppressWarnings("unused")
     private ImportRecord() {
@@ -136,12 +140,28 @@ public class ImportRecord extends AbstractHibernateObject {
         this.upstreamName = upstreamName;
     }
 
+    public String getUpstreamType() {
+        return upstreamType;
+    }
+
+    public void setUpstreamType(String upstreamType) {
+        this.upstreamType = upstreamType;
+    }
+
     public String getUpstreamId() {
         return upstreamId;
     }
 
     public void setUpstreamId(String upstreamId) {
         this.upstreamId = upstreamId;
+    }
+
+    public String getWebAppPrefix() {
+        return webAppPrefix;
+    }
+
+    public void setWebAppPrefix(String webAppPrefix) {
+        this.webAppPrefix = webAppPrefix;
     }
 
 

--- a/proxy/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/proxy/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -1105,10 +1105,14 @@ public class OwnerResource {
         if (meta != null) {
             record.setGeneratedBy(meta.getPrincipalName());
             record.setGeneratedDate(meta.getCreated());
+            record.setWebAppPrefix(meta.getWebAppPrefix());
         }
         if (consumer != null) {
             record.setUpstreamName(consumer.getName());
             record.setUpstreamId(consumer.getUuid());
+            if (consumer.getType() != null) {
+                record.setUpstreamType(consumer.getType().getLabel());
+            }
         }
 
         String msg = i18n.tr("{0} file imported successfully.", owner.getKey());
@@ -1128,10 +1132,12 @@ public class OwnerResource {
         if (meta != null) {
             record.setGeneratedBy(meta.getPrincipalName());
             record.setGeneratedDate(meta.getCreated());
+            record.setWebAppPrefix(meta.getWebAppPrefix());
         }
         if (consumer != null) {
             record.setUpstreamName(consumer.getName());
             record.setUpstreamId(consumer.getUuid());
+            record.setUpstreamType(consumer.getType().getLabel());
         }
 
         record.recordStatus(ImportRecord.Status.FAILURE, error.getMessage());

--- a/proxy/src/main/java/org/candlepin/sync/ConsumerDto.java
+++ b/proxy/src/main/java/org/candlepin/sync/ConsumerDto.java
@@ -15,6 +15,7 @@
 package org.candlepin.sync;
 
 import org.candlepin.model.Consumer;
+import org.candlepin.model.ConsumerType;
 
 /**
  * ConsumerDTO
@@ -22,13 +23,15 @@ import org.candlepin.model.Consumer;
 public class ConsumerDto {
     private String uuid;
     private String name;
+    private ConsumerType type;
 
     public ConsumerDto() {
     }
 
-    ConsumerDto(String uuid, String name) {
+    ConsumerDto(String uuid, String name, ConsumerType type) {
         this.uuid = uuid;
         this.name = name;
+        this.type = type;
     }
 
     public String getUuid() {
@@ -47,10 +50,19 @@ public class ConsumerDto {
         this.name = name;
     }
 
+    public ConsumerType getType() {
+        return type;
+    }
+
+    public void setType(ConsumerType type) {
+        this.type = type;
+    }
+
     public Consumer consumer() {
         Consumer toReturn = new Consumer();
         toReturn.setUuid(uuid);
         toReturn.setName(name);
+        toReturn.setType(type);
         return toReturn;
     }
 }

--- a/proxy/src/main/java/org/candlepin/sync/ConsumerExporter.java
+++ b/proxy/src/main/java/org/candlepin/sync/ConsumerExporter.java
@@ -33,7 +33,8 @@ public class ConsumerExporter {
 
     void export(ObjectMapper mapper, Writer writer, Consumer consumer)
         throws IOException {
-        ConsumerDto dto = new ConsumerDto(consumer.getUuid(), consumer.getName());
+        ConsumerDto dto = new ConsumerDto(consumer.getUuid(), consumer.getName(),
+            consumer.getType());
 
         mapper.writeValue(writer, dto);
     }

--- a/proxy/src/main/java/org/candlepin/sync/Exporter.java
+++ b/proxy/src/main/java/org/candlepin/sync/Exporter.java
@@ -276,9 +276,18 @@ public class Exporter {
         File file = new File(baseDir.getCanonicalPath(), "meta.json");
         FileWriter writer = new FileWriter(file);
         Meta m = new Meta(getVersion(), new Date(),
-            principalProvider.get().getPrincipalName());
+            principalProvider.get().getPrincipalName(),
+            getWebAppPrefix());
         meta.export(mapper, writer, m);
         writer.close();
+    }
+
+    private String getWebAppPrefix() {
+        String webAppPrefix = config.getString("candlepin.export.webapp.prefix");
+        if (webAppPrefix != null && webAppPrefix.trim().equals("")) {
+            webAppPrefix = null;
+        }
+        return webAppPrefix;
     }
 
     private String getVersion() throws IOException {

--- a/proxy/src/main/java/org/candlepin/sync/Meta.java
+++ b/proxy/src/main/java/org/candlepin/sync/Meta.java
@@ -23,13 +23,14 @@ public class Meta {
     private String version;
     private Date created;
     private String principalName;
+    private String webAppPrefix;
 
     public Meta() {
-        this("0.0.0", new Date(), "");
+        this("0.0.0", new Date(), "", null);
     }
 
     public Meta(String version, Date creation,
-                String userName) {
+                String userName, String webAppPrefix) {
         this.version = version;
         this.created = creation;
 
@@ -42,6 +43,7 @@ public class Meta {
         }
 
         this.principalName = userName;
+        this.webAppPrefix = webAppPrefix;
     }
 
     public String getVersion() {
@@ -56,6 +58,10 @@ public class Meta {
         return principalName;
     }
 
+    public String getWebAppPrefix() {
+        return webAppPrefix;
+    }
+
     public void setVersion(String version) {
         this.version = version;
     }
@@ -67,4 +73,9 @@ public class Meta {
     public void setPrincipalName(String name) {
         this.principalName = name;
     }
+
+    public void setWebAppPrefix(String prefix) {
+        this.webAppPrefix = prefix;
+    }
+
 }

--- a/proxy/src/main/resources/db/changelog/20120608114047-expand-import-record-webapp-prefix.xml
+++ b/proxy/src/main/resources/db/changelog/20120608114047-expand-import-record-webapp-prefix.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+
+    <changeSet id="20120608114047" author="wpoteat">
+        <comment>More information from impored manifest</comment>
+        <addColumn tableName="cp_import_record">
+            <column name="webapp_prefix" type="varchar(255)"/>
+            <column name="upstream_type" type="varchar(255)"/>
+        </addColumn>
+        <!-- See http://www.liquibase.org/manual/refactoring_commands -->
+    </changeSet>
+
+</databaseChangeLog>

--- a/proxy/src/main/resources/db/changelog/changelog-create.xml
+++ b/proxy/src/main/resources/db/changelog/changelog-create.xml
@@ -1098,4 +1098,5 @@
     <include file="db/changelog/20120523102544-add-owner-default-sla.xml" />
     <include file="db/changelog/20120522140529-expand-import-record.xml" />
     <include file="db/changelog/20120426124534-quartz-2-migration.xml" />
+    <include file="db/changelog/20120608114047-expand-import-record-webapp-prefix.xml" />
 </databaseChangeLog>

--- a/proxy/src/main/resources/db/changelog/changelog-update.xml
+++ b/proxy/src/main/resources/db/changelog/changelog-update.xml
@@ -5,4 +5,5 @@
     <include file="db/changelog/20120523102544-add-owner-default-sla.xml" />
     <include file="db/changelog/20120522140529-expand-import-record.xml" />
     <include file="db/changelog/20120426124534-quartz-2-migration.xml" />
+    <include file="db/changelog/20120608114047-expand-import-record-webapp-prefix.xml" />
 </databaseChangeLog>

--- a/proxy/src/test/java/org/candlepin/sync/ConsumerExporterTest.java
+++ b/proxy/src/test/java/org/candlepin/sync/ConsumerExporterTest.java
@@ -16,14 +16,15 @@ package org.candlepin.sync;
 
 import static org.junit.Assert.assertEquals;
 
+import org.candlepin.config.Config;
+import org.candlepin.model.Consumer;
+import org.candlepin.model.ConsumerType;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.junit.Test;
+
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.HashMap;
-
-import org.codehaus.jackson.map.ObjectMapper;
-import org.candlepin.config.Config;
-import org.candlepin.model.Consumer;
-import org.junit.Test;
 
 /**
  * ConsumerExporterTest
@@ -35,16 +36,25 @@ public class ConsumerExporterTest {
             new Config(new HashMap<String, String>()));
 
         ConsumerExporter exporter = new ConsumerExporter();
+        ConsumerType ctype = new ConsumerType("candlepin");
+        ctype.setId("8888");
+        ctype.setManifest(true);
 
         StringWriter writer = new StringWriter();
 
         Consumer consumer = new Consumer();
         consumer.setUuid("test-uuid");
         consumer.setName("testy consumer");
+        consumer.setType(ctype);
 
         exporter.export(mapper, writer, consumer);
 
-        assertEquals("{\"uuid\":\"test-uuid\",\"name\":\"testy consumer\"}",
+        assertEquals("{\"uuid\":\"" + consumer.getUuid() + "\"," +
+                     "\"name\":\"" + consumer.getName() + "\"," +
+                     "\"type\":" +
+                     "{\"id\":\"" + ctype.getId() + "\"," +
+                     "\"label\":\"" + ctype.getLabel() + "\"," +
+                     "\"manifest\":" + ctype.isManifest() + "}}",
             writer.toString());
     }
 }

--- a/proxy/src/test/java/org/candlepin/sync/ImporterTest.java
+++ b/proxy/src/test/java/org/candlepin/sync/ImporterTest.java
@@ -80,9 +80,9 @@ public class ImporterTest {
          */
         Date now = new Date();
         File file = createFile("/tmp/meta", "0.0.3", now,
-            "test_user");
+            "test_user", "prefix");
         File actual = createFile("/tmp/meta.json", "0.0.3", now,
-            "test_user");
+            "test_user", "prefix");
         ExporterMetadataCurator emc = mock(ExporterMetadataCurator.class);
         ExporterMetadata em = new ExporterMetadata();
         Date daybefore = getDateBeforeDays(1);
@@ -98,6 +98,7 @@ public class ImporterTest {
         Meta actualMeta = mapper.readValue(actual, Meta.class);
         assertEquals(fileMeta.getPrincipalName(), actualMeta.getPrincipalName());
         assertEquals(fileMeta.getCreated().getTime(), actualMeta.getCreated().getTime());
+        assertEquals(fileMeta.getWebAppPrefix(), actualMeta.getWebAppPrefix());
 
         assertTrue(file.delete());
         assertTrue(actual.delete());
@@ -107,9 +108,9 @@ public class ImporterTest {
     @Test
     public void firstRun() throws Exception {
         File f = createFile("/tmp/meta", "0.0.3", new Date(),
-            "test_user");
+            "test_user", "prefix");
         File actualmeta = createFile("/tmp/meta.json", "0.0.3", new Date(),
-            "test_user");
+            "test_user", "prefix");
         ExporterMetadataCurator emc = mock(ExporterMetadataCurator.class);
         when(emc.lookupByType(ExporterMetadata.TYPE_SYSTEM)).thenReturn(null);
         Importer i = new Importer(null, null, null, null, null, null, null,
@@ -124,7 +125,7 @@ public class ImporterTest {
     public void oldImport() throws Exception {
         // actualmeta is the mock for the import itself
         File actualmeta = createFile("/tmp/meta.json", "0.0.3", getDateBeforeDays(10),
-            "test_user");
+            "test_user", "prefix");
         ExporterMetadataCurator emc = mock(ExporterMetadataCurator.class);
         // emc is the mock for lastrun (i.e., the most recent import in CP)
         ExporterMetadata em = new ExporterMetadata();
@@ -142,7 +143,7 @@ public class ImporterTest {
         Date importDate = getDateBeforeDays(10);
         // actualmeta is the mock for the import itself
         File actualmeta = createFile("/tmp/meta.json", "0.0.3", importDate,
-            "test_user");
+            "test_user", "prefix");
         ExporterMetadataCurator emc = mock(ExporterMetadataCurator.class);
         // em is the mock for lastrun (i.e., the most recent import in CP)
         ExporterMetadata em = new ExporterMetadata();
@@ -162,7 +163,7 @@ public class ImporterTest {
         // import the rules.
 
         File actualmeta = createFile("/tmp/meta.json", "0.0.10", new Date(),
-            "test_user");
+            "test_user", "prefix");
         File[] jsArray = createMockJsFile(MOCK_JS_PATH);
         ExporterMetadataCurator emc = mock(ExporterMetadataCurator.class);
         RulesImporter ri = mock(RulesImporter.class);
@@ -180,7 +181,7 @@ public class ImporterTest {
         // if we are importing candlepin 0.0.1 data into
         // candlepin 0.0.3, do not import the rules
         File actualmeta = createFile("/tmp/meta.json", "0.0.1", new Date(),
-            "test_user");
+            "test_user", "prefix");
         ExporterMetadataCurator emc = mock(ExporterMetadataCurator.class);
         RulesImporter ri = mock(RulesImporter.class);
 
@@ -195,7 +196,7 @@ public class ImporterTest {
     @Test(expected = ImporterException.class)
     public void nullType() throws ImporterException, IOException {
         File actualmeta = createFile("/tmp/meta.json", "0.0.3", new Date(),
-            "test_user");
+            "test_user", "prefix");
         try {
             Importer i = new Importer(null, null, null, null, null, null, null,
                 null, null, null, null, null, i18n);
@@ -211,7 +212,7 @@ public class ImporterTest {
     @Test(expected = ImporterException.class)
     public void expectOwner() throws ImporterException, IOException {
         File actualmeta = createFile("/tmp/meta.json", "0.0.3", new Date(),
-            "test_user");
+            "test_user", "prefix");
         ExporterMetadataCurator emc = mock(ExporterMetadataCurator.class);
         when(emc.lookupByTypeAndOwner(ExporterMetadata.TYPE_PER_USER, null))
             .thenReturn(null);
@@ -236,11 +237,11 @@ public class ImporterTest {
     }
 
     private File createFile(String filename, String version, Date date,
-                 String username)
+                 String username, String prefix)
         throws JsonGenerationException, JsonMappingException, IOException {
 
         File f = new File(filename);
-        Meta meta = new Meta(version, date, username);
+        Meta meta = new Meta(version, date, username, prefix);
         mapper.writeValue(f, meta);
         return f;
     }

--- a/proxy/src/test/java/org/candlepin/sync/MetaExporterTest.java
+++ b/proxy/src/test/java/org/candlepin/sync/MetaExporterTest.java
@@ -43,11 +43,12 @@ public class MetaExporterTest {
         meta.setVersion("0.1.0");
         meta.setCreated(now);
         meta.setPrincipalName("myUsername");
+        meta.setWebAppPrefix("webapp_prefix");
 
         metaEx.export(mapper, writer, meta);
 
         assertEquals("{\"version\":\"0.1.0\",\"created\":\"" + nowString +
-            "\",\"principalName\":\"myUsername\"}",
+            "\",\"principalName\":\"myUsername\",\"webAppPrefix\":\"webapp_prefix\"}",
             writer.toString());
     }
 


### PR DESCRIPTION
Configuration entry on host candlepin system will need to be set in Katello installation
The entry in the config file is candlepin.export.webapp.prefix
The consumer type of the distribitor will be included as the upstreamType
