### PR TITLE
834591: 0 or no sockets count as infinite on products

### DIFF
--- a/src/test/java/org/candlepin/policy/js/compliance/ComplianceRulesTest.java
+++ b/src/test/java/org/candlepin/policy/js/compliance/ComplianceRulesTest.java
@@ -302,6 +302,49 @@ public class ComplianceRulesTest {
         assertTrue(status.getPartialStacks().keySet().contains(STACK_ID_1));
     }
 
+    @Test
+    public void testComplianceCountsZeroPoolSocketsAsInfinite() {
+        // Consumer with 8 sockets:
+        Consumer c = mockConsumer(new String [] {PRODUCT_1});
+        List<Entitlement> ents = new LinkedList<Entitlement>();
+
+        ents.add(mockEntitlement(c, "Awesome Product", PRODUCT_1));
+        ents.get(0).getPool().addProductAttribute(new ProductPoolAttribute("sockets",
+            "0", PRODUCT_1));
+
+        when(entCurator.listByConsumerAndDate(eq(c), any(Date.class))).thenReturn(ents);
+
+        ComplianceStatus status = compliance.getStatus(c, TestUtil.createDate(2011, 8, 30));
+
+        assertEquals(0, status.getNonCompliantProducts().size());
+        assertEquals(0, status.getPartiallyCompliantProducts().size());
+        assertEquals(1, status.getCompliantProducts().size());
+        assertEquals(0, status.getPartialStacks().size());
+
+        assertTrue(status.getCompliantProducts().keySet().contains(PRODUCT_1));
+    }
+
+    @Test
+    public void testComplianceCountsUndefinedPoolSocketsAsInfinite() {
+        // Consumer with 8 sockets:
+        Consumer c = mockConsumer(new String [] {PRODUCT_1});
+        List<Entitlement> ents = new LinkedList<Entitlement>();
+
+        // One entitlement that only provides four sockets:
+        ents.add(mockEntitlement(c, "Awesome Product", PRODUCT_1));
+
+        when(entCurator.listByConsumerAndDate(eq(c), any(Date.class))).thenReturn(ents);
+
+        ComplianceStatus status = compliance.getStatus(c, TestUtil.createDate(2011, 8, 30));
+
+        assertEquals(0, status.getNonCompliantProducts().size());
+        assertEquals(0, status.getPartiallyCompliantProducts().size());
+        assertEquals(1, status.getCompliantProducts().size());
+        assertEquals(0, status.getPartialStacks().size());
+
+        assertTrue(status.getCompliantProducts().keySet().contains(PRODUCT_1));
+    }
+
     // Test a fully stacked scenario:
     @Test
     public void compliantStack() {


### PR DESCRIPTION
Ensure candlepin, like subscription-manager, treats a product attribute
value of 0 for sockets as infinite sockets, or no value for sockets as
infinite. Do this both for select best pools and compliance.

In other words, if a pool has sockets=0 or no sockets, it will fully
entitle a consumer's product, regardless of how many sockets the
consumer has.
