### PR TITLE
835161: regenerate on-disk CRL on requests to crl resource

### DIFF
--- a/src/main/java/org/candlepin/util/CrlFileUtil.java
+++ b/src/main/java/org/candlepin/util/CrlFileUtil.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.util;
+
+import org.candlepin.controller.CrlGenerator;
+import org.candlepin.pki.PKIUtility;
+
+import com.google.inject.Inject;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.log4j.Logger;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.security.cert.CRLException;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509CRL;
+
+/**
+ * CrlFileUtil
+ */
+public class CrlFileUtil {
+    private static Logger log = Logger.getLogger(CrlFileUtil.class);
+    private CrlGenerator crlGenerator;
+    private PKIUtility pkiUtility;
+
+    @Inject
+    public CrlFileUtil(CrlGenerator crlGenerator, PKIUtility pkiUtility) {
+        this.crlGenerator = crlGenerator;
+        this.pkiUtility = pkiUtility;
+    }
+
+    public void updateCRLFile(File file, String principal)
+        throws CRLException, CertificateException, IOException {
+
+        FileInputStream in = null;
+        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        try {
+            if (file.exists() && file.length() > 0) {
+                log.info("CRL File: " + file + " exists. Loading the old CRL");
+                in = new FileInputStream(file);
+            }
+            else {
+                log.info("CRL File: " + file + " either does not exist or is empty.");
+            }
+            X509CRL x509crl = null;
+            if (in != null) {
+                x509crl = (X509CRL) CertificateFactory.getInstance("X.509")
+                    .generateCRL(in);
+            }
+            x509crl = this.crlGenerator.updateCRL(x509crl);
+            stream.write(pkiUtility.getPemEncoded(x509crl));
+            log.info("Completed generating CRL. Writing it to disk");
+            FileUtils.writeByteArrayToFile(file, stream.toByteArray());
+        }
+        finally {
+            if (in != null) {
+                try {
+                    in.close();
+                }
+                catch (IOException e) {
+                    log.error(
+                        "exception when closing a CRL file: " + file.getAbsolutePath());
+                    // we tried, we failed. better luck next time!
+                }
+            }
+        }
+
+    }
+
+}

--- a/src/test/java/org/candlepin/pinsetter/tasks/CertificateRevocationListTaskTest.java
+++ b/src/test/java/org/candlepin/pinsetter/tasks/CertificateRevocationListTaskTest.java
@@ -14,31 +14,18 @@
  */
 package org.candlepin.pinsetter.tasks;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.io.FileUtils;
 import org.candlepin.config.Config;
 import org.candlepin.config.ConfigProperties;
-import org.candlepin.controller.CrlGenerator;
-import org.candlepin.pki.PKIUtility;
+import org.candlepin.util.CrlFileUtil;
+
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
-
-import java.io.File;
-import java.io.IOException;
-import java.security.cert.CRLException;
-import java.security.cert.X509CRL;
 
 /**
  * CertificateRevocationListTaskTest
@@ -47,13 +34,12 @@ import java.security.cert.X509CRL;
 public class CertificateRevocationListTaskTest {
     private CertificateRevocationListTask task;
 
-    @Mock private CrlGenerator generator;
     @Mock private Config config;
-    @Mock private PKIUtility pkiUtility;
+    @Mock private CrlFileUtil crlFileUtil;
 
     @Before
     public void init() {
-        this.task = new CertificateRevocationListTask(generator, config, pkiUtility);
+        this.task = new CertificateRevocationListTask(config, crlFileUtil);
     }
 
     @Test(expected = JobExecutionException.class)
@@ -62,97 +48,4 @@ public class CertificateRevocationListTaskTest {
         task.execute(null);
     }
 
-    @Test(expected = JobExecutionException.class)
-    public void executeGivenDirectory() throws JobExecutionException {
-        when(config.getString(ConfigProperties.CRL_FILE_PATH)).thenReturn("/tmp");
-        JobExecutionContext ctx = mock(JobExecutionContext.class);
-        task.execute(ctx);
-    }
-
-    @Test
-    public void executeGivenNonExistentFile() throws Exception {
-        when(config.getString(ConfigProperties.CRL_FILE_PATH)).thenReturn(
-            "/tmp/biteme.crl");
-        X509CRL crl = mock(X509CRL.class);
-        when(crl.getEncoded()).thenReturn(Base64.encodeBase64("encoded".getBytes()));
-        when(generator.updateCRL(any(X509CRL.class))).thenReturn(crl);
-        when(pkiUtility.getPemEncoded(any(X509CRL.class))).thenReturn(new byte [2]);
-        task.execute(null);
-        File f = new File("/tmp/biteme.crl");
-        assertTrue(f.exists());
-        assertTrue(f.length() > 0);
-        f.delete();
-    }
-
-    @Test
-    public void emptyFile() throws IOException, JobExecutionException, CRLException {
-        File f = null;
-        try {
-            f = File.createTempFile("test", ".crl");
-            assertEquals(0, f.length());
-            when(config.getString(ConfigProperties.CRL_FILE_PATH)).thenReturn(
-                f.getAbsolutePath());
-            X509CRL crl = mock(X509CRL.class);
-            when(crl.getEncoded()).thenReturn(Base64.encodeBase64("encoded".getBytes()));
-            when(generator.updateCRL(any(X509CRL.class))).thenReturn(crl);
-            when(pkiUtility.getPemEncoded(any(X509CRL.class))).thenReturn(new byte [2]);
-
-            task.execute(null);
-            assertTrue(f.length() > 0);
-        }
-        finally {
-            if (f != null) {
-                f.delete();
-            }
-        }
-    }
-
-    @Test(expected = JobExecutionException.class)
-    public void handleCRLException() throws Exception {
-        File f = null;
-        try {
-            f = File.createTempFile("test", ".crl");
-            assertEquals(0, f.length());
-            // put some garbage in the file to cause the CRLException
-            FileUtils.writeByteArrayToFile(f, "gobbledygook".getBytes());
-            when(config.getString(ConfigProperties.CRL_FILE_PATH)).thenReturn(
-                f.getAbsolutePath());
-
-            task.execute(null);
-        }
-        finally {
-            if (f != null) {
-                f.delete();
-            }
-        }
-    }
-
-    @Test
-    @Ignore("need to write a VALID CRL to the file first in order to verify")
-    public void existingFile() throws Exception {
-        File f = null;
-        try {
-            X509CRL crl = mock(X509CRL.class);
-            f = File.createTempFile("test", ".crl");
-            assertEquals(0, f.length());
-            when(config.getString(ConfigProperties.CRL_FILE_PATH)).thenReturn(
-                f.getAbsolutePath());
-
-            when(crl.getEncoded()).thenReturn(Base64.encodeBase64("encoded".getBytes()))
-                .thenReturn(Base64.encodeBase64("added".getBytes()));
-            when(generator.updateCRL(any(X509CRL.class))).thenReturn(crl);
-
-            task.execute(null);
-            long len = f.length();
-            assertTrue(len > 0);
-            task.execute(null);
-            // make sure we added to the file
-            assertTrue(f.length() > len);
-        }
-        finally {
-            if (f != null) {
-                f.delete();
-            }
-        }
-    }
 }

--- a/src/test/java/org/candlepin/util/CrlFileUtilTest.java
+++ b/src/test/java/org/candlepin/util/CrlFileUtilTest.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.candlepin.controller.CrlGenerator;
+import org.candlepin.pki.PKIUtility;
+
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.io.FileUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.File;
+import java.io.IOException;
+import java.security.cert.CRLException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509CRL;
+import java.util.UUID;
+
+/**
+ * CrlFileUtilTest
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class CrlFileUtilTest {
+
+    private CrlFileUtil cfu;
+
+    @Mock private CrlGenerator crlGenerator;
+    @Mock private PKIUtility pkiUtility;
+
+    @Before
+    public void init() {
+        this.cfu = new CrlFileUtil(crlGenerator, pkiUtility);
+    }
+
+    @Test(expected = IOException.class)
+    public void executeGivenDirectory() throws IOException,
+                   CRLException, CertificateException {
+        File crlFile = new File("/tmp");
+        cfu.updateCRLFile(crlFile, "CN=test, UID=" + UUID.randomUUID());
+    }
+
+    @Test
+    public void executeGivenNonExistentFile() throws Exception {
+        File crlFile = new File("/tmp/biteme.crl");
+
+        X509CRL crl = mock(X509CRL.class);
+        when(crl.getEncoded()).thenReturn(Base64.encodeBase64("encoded".getBytes()));
+        when(crlGenerator.updateCRL(any(X509CRL.class))).thenReturn(crl);
+        when(pkiUtility.getPemEncoded(any(X509CRL.class))).thenReturn(new byte [2]);
+        cfu.updateCRLFile(crlFile, "CN=test, UID=" + UUID.randomUUID());
+        File f = new File("/tmp/biteme.crl");
+        assertTrue(f.exists());
+        assertTrue(f.length() > 0);
+        f.delete();
+    }
+
+    @Test
+    public void emptyFile() throws IOException, CRLException, CertificateException {
+        File f = null;
+        try {
+            f = File.createTempFile("test", ".crl");
+            assertEquals(0, f.length());
+            X509CRL crl = mock(X509CRL.class);
+            when(crl.getEncoded()).thenReturn(Base64.encodeBase64("encoded".getBytes()));
+            when(crlGenerator.updateCRL(any(X509CRL.class))).thenReturn(crl);
+            when(pkiUtility.getPemEncoded(any(X509CRL.class))).thenReturn(new byte [2]);
+            cfu.updateCRLFile(f, "CN=test, UID=" + UUID.randomUUID());
+            assertTrue(f.length() > 0);
+        }
+        finally {
+            if (f != null) {
+                f.delete();
+            }
+        }
+    }
+
+    @Test(expected = CRLException.class)
+    public void handleCRLException() throws IOException,
+            CRLException, CertificateException {
+        File f = null;
+        try {
+            f = File.createTempFile("test", ".crl");
+            assertEquals(0, f.length());
+            // put some garbage in the file to cause the CRLException
+            FileUtils.writeByteArrayToFile(f, "gobbledygook".getBytes());
+            cfu.updateCRLFile(f, "CN=test, UID=" + UUID.randomUUID());
+
+        }
+        finally {
+            if (f != null) {
+                f.delete();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Previously, if someone called /candlepin/crl, it would return a new CRL, but
the on-disk CRL would not get updated. Instad, it would only be updated by a
pinsetter job.

Instead, write the new CRL to disk whenever /crl is called, in addition to
returning it via the API.
