### PR TITLE
Fix 'class variable access from toplevel' spec warning

### DIFF
--- a/spec/oauth_spec.rb
+++ b/spec/oauth_spec.rb
@@ -8,18 +8,20 @@ describe 'OAuth' do
   include CandlepinMethods
   include CandlepinScenarios
 
-  @@site = "https://localhost:8443"
-  @@oauth_params = {
-   :site => @@site,
-   :http_method => :post,
-   :request_token_path => "",
-   :authorize_path => "",
-   :access_token_path => "",
-  }
-
   # XXX you must set these in your candlepin.conf
   oauth_consumer = "rspec"
   oauth_secret = "rspec-oauth-secret"
+
+  before(:all) do
+    @site = "https://localhost:8443"
+    @oauth_params = {
+     :site => @site,
+     :http_method => :post,
+     :request_token_path => "",
+     :authorize_path => "",
+     :access_token_path => "",
+    }
+  end
 
   before(:each) do
     @owner = create_owner "oauth-owner"
@@ -29,11 +31,11 @@ describe 'OAuth' do
   end
 
   def make_request(oauth_consumer, oauth_secret, uri, headers = {})
-    consumer = OAuth::Consumer.new(oauth_consumer, oauth_secret, @@oauth_params)
+    consumer = OAuth::Consumer.new(oauth_consumer, oauth_secret, @oauth_params)
 
-    request = Net::HTTP::Get.new("#{@@site}#{uri}")
+    request = Net::HTTP::Get.new("#{@site}#{uri}")
     consumer.sign!(request)
-    url = URI.parse("#{@@site}#{uri}")
+    url = URI.parse("#{@site}#{uri}")
 
     headers.each_pair do |k, v|
       request[k] = v

--- a/spec/product_cert_spec.rb
+++ b/spec/product_cert_spec.rb
@@ -4,13 +4,15 @@ describe 'Product Certificate' do
   include CandlepinMethods
   include CandlepinScenarios
 
-  # Static map of extension labels to OID values
-  @@oid_map = {
-    'name' => '1',
-    'variant' => '2',
-    'arch' => '3',
-    'version' => '4'
-  }
+  before(:all) do
+    # Static map of extension labels to OID values
+    @oid_map = {
+      'name' => '1',
+      'variant' => '2',
+      'arch' => '3',
+      'version' => '4'
+    }
+  end
 
   before(:each) do
     @product = create_product(nil, random_string('test-product'))
@@ -40,7 +42,7 @@ describe 'Product Certificate' do
   private
 
   def get_oid(product, label)
-    oid = @@oid_map[label]
+    oid = @oid_map[label]
 
     "1.3.6.1.4.1.2312.9.1.#{product.id}.#{oid}"
   end


### PR DESCRIPTION
only tested on ruby 1.9. I assume it works on old ruby too.
