### PR TITLE
Reduce amount of data in GET /consumers.

### DIFF
--- a/spec/consumer_resource_spec.rb
+++ b/spec/consumer_resource_spec.rb
@@ -54,10 +54,10 @@ describe 'Consumer Resource' do
 
     uuids = []
     @cp.list_consumers.each do |c|
-      # These are HATEOAS serialized consumers, the ID is the numeric DB
-      # ID, so pull the UUID off the URL.
-      # TODO: Find a better way once client is more HATEOASy.
-      uuids << c['href'].split('/')[-1]
+      uuids << c['uuid']
+      # Consumer lists should not have idCert or facts:
+      c['facts'].should be_nil
+      c['idCert'].should be_nil
     end
     uuids.include?(@consumer1.uuid).should be_true
     uuids.include?(@consumer2.uuid).should be_true

--- a/spec/hypervisor_check_in_spec.rb
+++ b/spec/hypervisor_check_in_spec.rb
@@ -17,7 +17,7 @@ describe 'Hypervisor Resource' do
     results = @user.hypervisor_check_in(@owner['key'],  host_guest_mapping)
     results.created.size.should == 1
 
-    consumer = results.created[0]
+    consumer = @cp.get_consumer(results.created[0]['uuid'])
     check_hypervisor_consumer(consumer, @expected_host, @expected_guest_ids)
 
     @cp.get_consumer_guests(@expected_host).length.should == 2

--- a/src/main/java/org/candlepin/guice/CandlepinModule.java
+++ b/src/main/java/org/candlepin/guice/CandlepinModule.java
@@ -183,7 +183,7 @@ public class CandlepinModule extends AbstractModule {
         bind(AuthInterceptor.class);
         bind(PinsetterAsyncInterceptor.class);
         bind(VersionPostInterceptor.class);
-        bind(JsonProvider.class).asEagerSingleton();
+        bind(JsonProvider.class);
         bind(EventSink.class).to(EventSinkImpl.class);
         bind(JobFactory.class).to(GuiceJobFactory.class);
         bind(JobListener.class).to(PinsetterJobListener.class);

--- a/src/main/java/org/candlepin/jackson/HateoasArrayExclude.java
+++ b/src/main/java/org/candlepin/jackson/HateoasArrayExclude.java
@@ -20,11 +20,11 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * HateoasField: Annotation used with JsonFilter and our HateoasBeanPropertyFilter.
- * Apply to the getter's of properties that are to be included when we trigger
- * the reduced "HATEOAS" style of serialization for certain nested objects.
+ * HateoasArrayIgnoreField: Annotation used with our HateoasBeanPropertyFilter.
+ * Applied to object fields that we want to skip serialization for if we're withing the
+ * context of an array.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD})
-public @interface HateoasField {
+public @interface HateoasArrayExclude {
 }

--- a/src/main/java/org/candlepin/jackson/HateoasBeanPropertyFilter.java
+++ b/src/main/java/org/candlepin/jackson/HateoasBeanPropertyFilter.java
@@ -33,16 +33,22 @@ public class HateoasBeanPropertyFilter extends JsonBeanPropertyFilter {
         SerializerProvider serializerProvider, BeanPropertyWriter writer) throws Exception {
         JsonStreamContext context = jsonGenerator.getOutputContext();
 
-        if ((context.getParent() == null) || (!context.getParent().inObject())) {
-            // Not serializing a nested object, so we'll write normally:
-            writer.serializeAsField(obj, jsonGenerator, serializerProvider);
-        }
-        else {
-            // We are doing HATEOAS serialization at this point, check if the getter
-            // for this property has the annotation, serialize if so, skip it if not:
-            if (annotationPresent(obj, writer.getName(), HateoasField.class)) {
+        if ((context.getParent() != null) && (context.getParent().inArray())) {
+            // skip annotated fields if within array:
+            if (!annotationPresent(obj, writer.getName(), HateoasArrayExclude.class)) {
                 writer.serializeAsField(obj, jsonGenerator, serializerProvider);
             }
+        }
+        // Check if we should trigger reduced HATEOAS serialization for a nested object by
+        // looking for the annotation on the fields getter:
+        else if ((context.getParent() != null) && (context.getParent().inObject())) {
+            if (annotationPresent(obj, writer.getName(), HateoasInclude.class)) {
+                writer.serializeAsField(obj, jsonGenerator, serializerProvider);
+            }
+        }
+        else {
+            // Normal serialization:
+            writer.serializeAsField(obj, jsonGenerator, serializerProvider);
         }
     }
 }

--- a/src/main/java/org/candlepin/jackson/HateoasInclude.java
+++ b/src/main/java/org/candlepin/jackson/HateoasInclude.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.jackson;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * HateoasInclude: Annotation used with JsonFilter and our HateoasBeanPropertyFilter.
+ * Apply to the getter's of properties that are to be included when we trigger
+ * the reduced "HATEOAS" style of serialization for certain nested objects.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD})
+public @interface HateoasInclude {
+}

--- a/src/main/java/org/candlepin/model/Consumer.java
+++ b/src/main/java/org/candlepin/model/Consumer.java
@@ -40,7 +40,8 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
 
-import org.candlepin.jackson.HateoasField;
+import org.candlepin.jackson.HateoasArrayExclude;
+import org.candlepin.jackson.HateoasInclude;
 import org.candlepin.util.Util;
 import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 import org.codehaus.jackson.map.annotate.JsonFilter;
@@ -186,7 +187,7 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
     /**
      * @return the Consumer's uuid
      */
-    @HateoasField
+    @HateoasInclude
     public String getUuid() {
         return uuid;
     }
@@ -208,7 +209,7 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
      * {@inheritDoc}
      */
     @Override
-    @HateoasField
+    @HateoasInclude
     public String getId() {
         return id;
     }
@@ -220,6 +221,7 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
         this.id = id;
     }
 
+    @HateoasArrayExclude
     public IdentityCertificate getIdCert() {
         return idCert;
     }
@@ -231,7 +233,7 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
     /**
      * @return the name of this consumer.
      */
-    @HateoasField
+    @HateoasInclude
     public String getName() {
         return name;
     }
@@ -297,6 +299,7 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
     /**
      * @return all facts about this consumer.
      */
+    @HateoasArrayExclude
     public Map<String, String> getFacts() {
         return facts;
     }
@@ -441,7 +444,7 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
     }
 
     @Override
-    @HateoasField
+    @HateoasInclude
     public String getHref() {
         return "/consumers/" + getUuid();
     }

--- a/src/main/java/org/candlepin/model/Entitlement.java
+++ b/src/main/java/org/candlepin/model/Entitlement.java
@@ -32,7 +32,7 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
 
-import org.candlepin.jackson.HateoasField;
+import org.candlepin.jackson.HateoasInclude;
 import org.candlepin.jackson.SkipExport;
 import org.codehaus.jackson.map.annotate.JsonFilter;
 import org.hibernate.annotations.ForeignKey;
@@ -116,7 +116,7 @@ public class Entitlement extends AbstractHibernateObject implements Linkable, Ow
      * @return the id
      */
     @Override
-    @HateoasField
+    @HateoasInclude
     public String getId() {
         return id;
     }
@@ -255,7 +255,7 @@ public class Entitlement extends AbstractHibernateObject implements Linkable, Ow
             ", consumer= " + (consumer == null ? "null" : consumer.getUuid()) + "]";
     }
 
-    @HateoasField
+    @HateoasInclude
     public String getHref() {
         return "/entitlements/" + getId();
     }

--- a/src/main/java/org/candlepin/model/Owner.java
+++ b/src/main/java/org/candlepin/model/Owner.java
@@ -31,7 +31,7 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
 
-import org.candlepin.jackson.HateoasField;
+import org.candlepin.jackson.HateoasInclude;
 import org.candlepin.resteasy.InfoProperty;
 import org.codehaus.jackson.map.annotate.JsonFilter;
 import org.hibernate.annotations.GenericGenerator;
@@ -128,7 +128,7 @@ public class Owner extends AbstractHibernateObject implements Serializable,
      * @return the id
      */
     @Override
-    @HateoasField
+    @HateoasInclude
     public String getId() {
         return id;
     }
@@ -141,7 +141,7 @@ public class Owner extends AbstractHibernateObject implements Serializable,
     }
 
     @InfoProperty("key")
-    @HateoasField
+    @HateoasInclude
     public String getKey() {
         return key;
     }
@@ -154,7 +154,7 @@ public class Owner extends AbstractHibernateObject implements Serializable,
      * @return the name
      */
     @InfoProperty("displayName")
-    @HateoasField
+    @HateoasInclude
     public String getDisplayName() {
         return this.displayName;
     }
@@ -299,7 +299,7 @@ public class Owner extends AbstractHibernateObject implements Serializable,
         return upstreamUuid;
     }
 
-    @HateoasField
+    @HateoasInclude
     public String getHref() {
         return "/owners/" + getKey();
     }

--- a/src/main/java/org/candlepin/model/Pool.java
+++ b/src/main/java/org/candlepin/model/Pool.java
@@ -14,7 +14,7 @@
  */
 package org.candlepin.model;
 
-import org.candlepin.jackson.HateoasField;
+import org.candlepin.jackson.HateoasInclude;
 import org.candlepin.util.DateSource;
 import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 import org.codehaus.jackson.map.annotate.JsonFilter;
@@ -173,7 +173,7 @@ public class Pool extends AbstractHibernateObject implements Persisted, Owned {
 
     /** {@inheritDoc} */
     @Override
-    @HateoasField
+    @HateoasInclude
     public String getId() {
         return id;
     }
@@ -280,7 +280,7 @@ public class Pool extends AbstractHibernateObject implements Persisted, Owned {
      *
      * @return the productName
      */
-    @HateoasField
+    @HateoasInclude
     public String getProductName() {
         return productName;
     }
@@ -503,7 +503,7 @@ public class Pool extends AbstractHibernateObject implements Persisted, Owned {
      * See getProvidedProductIds().
      * @return Top level product ID.
      */
-    @HateoasField
+    @HateoasInclude
     public String getProductId() {
         return productId;
     }
@@ -549,7 +549,7 @@ public class Pool extends AbstractHibernateObject implements Persisted, Owned {
         return getConsumed() > this.quantity;
     }
 
-    @HateoasField
+    @HateoasInclude
     public String getHref() {
         return "/pools/" + getId();
     }


### PR DESCRIPTION
When serializing lists of consumers, we can save ourselves a lot of
serialization time by skipping the identity cert and facts, which are
not likely to be used when listing.

Introduced a @HateoasArrayIgnore annotation to apply to fields that
should be skipped whenever being serialized in the context of an array.
