### PR TITLE
Remove total sub count and total subs consumed from owner info.

### DIFF
--- a/spec/owner_resource_spec.rb
+++ b/spec/owner_resource_spec.rb
@@ -195,40 +195,6 @@ describe 'Owner Resource' do
 
   end
 
-  it "updates consumed entitlement count" do
-    #TODO put this into candlepin_api.rb if others want to use it
-    def stats_helper(owner, expected_available, expected_consumed)
-        @cp.refresh_pools owner['key']
-        @cp.generate_statistics
-
-        info = @cp.get_owner_info(owner['key'])
-        info.totalSubscriptionCount.first.value.should == expected_available
-
-        stat = info.totalSubscriptionsConsumed.select {|stat| stat.valueType == 'RAW' && stat.entryType == 'TOTALSUBSCRIPTIONCONSUMED' }
-        total_consumed = 0
-        stat.each{ |s| total_consumed += s.value}
-        total_consumed == expected_consumed
-    end
-
-    #TODO maybe move to a before(:each)
-    owner = create_owner random_string('test_owner')
-    user = user_client(owner, random_string('guy'))
-    product = create_product(nil, random_string('consume-me'))
-
-    @cp.create_subscription(owner['key'], product.id, 4)
-    @cp.create_subscription(owner['key'], product.id, 4)
-    @cp.refresh_pools owner['key']
-
-    consumer = consumer_client(user, random_string('consumer'))
-    pool = consumer.list_pools(
-      :product => product.id,
-      :consumer => consumer.uuid).first
-    self.stats_helper(owner, 8, 0)
-    consumer.consume_pool(pool.id).first
-    self.stats_helper(owner, 8, 1)
-
-  end
-
   it "finds nearest entitlement to expiration" do
     #TODO maybe move to a before(:each)
     owner = create_owner random_string('test_owner')

--- a/src/main/java/org/candlepin/model/OwnerInfo.java
+++ b/src/main/java/org/candlepin/model/OwnerInfo.java
@@ -33,8 +33,6 @@ public class OwnerInfo {
     private Map<String, Integer> consumerCountsByComplianceStatus;
     private Map<String, ConsumptionTypeCounts> entitlementsConsumedByFamily;
     private Pool poolNearestToExpiry;
-    private List<Statistic> totalSubscriptionCount;
-    private List<Statistic> totalSubscriptionsConsumed;
 
     public static final String GUEST = "guest";
     public static final String PHYSICAL = "physical";
@@ -191,32 +189,4 @@ public class OwnerInfo {
         this.poolNearestToExpiry = poolNearestToExpiry;
     }
 
-    /**
-     * @param totalSubscriptionCount the totalSubscriptionCount to set
-     */
-    public void setTotalSubscriptionCount(List<Statistic> totalSubscriptionCount) {
-        this.totalSubscriptionCount = totalSubscriptionCount;
-    }
-
-    /**
-     * @return the totalSubscriptionCount
-     */
-    public List<Statistic> getTotalSubscriptionCount() {
-        return totalSubscriptionCount;
-    }
-
-    /**
-     * @param totalSubscriptionsConsumed the totalSubscriptionsConsumed to set
-     */
-    public void setTotalSubscriptionsConsumed(
-        List<Statistic> totalSubscriptionsConsumed) {
-        this.totalSubscriptionsConsumed = totalSubscriptionsConsumed;
-    }
-
-    /**
-     * @return the totalSubscriptionsConsumed
-     */
-    public List<Statistic> getTotalSubscriptionsConsumed() {
-        return totalSubscriptionsConsumed;
-    }
 }

--- a/src/main/java/org/candlepin/model/OwnerInfoCurator.java
+++ b/src/main/java/org/candlepin/model/OwnerInfoCurator.java
@@ -41,16 +41,13 @@ public class OwnerInfoCurator {
     private ConsumerTypeCurator consumerTypeCurator;
     private ProductServiceAdapter productAdapter;
     private static final String DEFAULT_CONSUMER_TYPE = "system";
-    private StatisticCuratorQueries statisticCuratorQueries;
 
     @Inject
     public OwnerInfoCurator(Provider<EntityManager> entityManager,
-        ConsumerTypeCurator consumerTypeCurator, ProductServiceAdapter psa,
-        StatisticCuratorQueries statisticCuratorQueries) {
+        ConsumerTypeCurator consumerTypeCurator, ProductServiceAdapter psa) {
         this.entityManager = entityManager;
         this.consumerTypeCurator = consumerTypeCurator;
         this.productAdapter = psa;
-        this.statisticCuratorQueries = statisticCuratorQueries;
     }
 
     public OwnerInfo lookupByOwner(Owner owner) {
@@ -87,12 +84,7 @@ public class OwnerInfoCurator {
 
         Date now = new Date();
         info.setConsumerTypesByPool(types);
-        List<Statistic> totalCount = statisticCuratorQueries.getStatisticsByOwner(owner,
-            "TOTALSUBSCRIPTIONCOUNT", null, null, null, null);
-        info.setTotalSubscriptionCount(totalCount);
-        info.setTotalSubscriptionsConsumed(statisticCuratorQueries
-            .getStatisticsByOwner(owner, "TOTALSUBSCRIPTIONSCONSUMED",
-                   null, null, null, null));
+
         for (Pool pool : owner.getPools()) {
             // clients using the ownerinfo details are only concerned with pools
             // active *right now*


### PR DESCRIPTION
This was catastrophically broken, we were returning every single
statistic in every owner info response. Each statistic is about 285
bytes, so the response was growing daily by 285 bytes \* # of pools \* 3.

The data was completely unused as far as we can tell.

Conflicts:
    src/main/java/org/candlepin/model/OwnerInfoCurator.java
