### PR TITLE
732538: Fix error message adding pools to activation keys.

### DIFF
--- a/src/main/java/org/candlepin/resource/ActivationKeyResource.java
+++ b/src/main/java/org/candlepin/resource/ActivationKeyResource.java
@@ -142,10 +142,8 @@ public class ActivationKeyResource {
             pool.getProductAttribute("requires_consumer_type") != null &&
             pool.getProductAttribute("requires_consumer_type").getValue()
                   .equals("person")) {
-            throw new BadRequestException(i18n.tr("Pools requiring a 'person' " +
-                "consumer should not be added to an activation key since a " +
-                "consumer type of 'person' cannot be used with activation " +
-                "keys"));
+            throw new BadRequestException(i18n.tr("Cannot add pools restricted to " +
+                "consumer type 'person' to activation keys."));
         }
         if (quantity > 1) {
             ProductPoolAttribute ppa = pool.getProductAttribute("multi-entitlement");


### PR DESCRIPTION
Previous version was reported as confusing.
