### PR TITLE
Change apidiff to format with python json.tool

### DIFF
--- a/buildconf/scripts/apidiff
+++ b/buildconf/scripts/apidiff
@@ -10,7 +10,7 @@
 function gen_api() {
     local out_file=$1
     buildr -s clean compile candlepin:apicrawl
-    cat target/candlepin_methods.json | json_reformat > $out_file
+    cat target/candlepin_methods.json | python -mjson.tool  > $out_file
 }
 
 function diff_apis() {


### PR DESCRIPTION
json_reformat that was being used before doesn't
seem to sort entries in a particular stable way,
so the diffs were kind of bogus and confusing.
