### PR TITLE
Add null check for Entitlement.getProductId

### DIFF
--- a/src/main/java/org/candlepin/model/Entitlement.java
+++ b/src/main/java/org/candlepin/model/Entitlement.java
@@ -168,7 +168,10 @@ public class Entitlement extends AbstractHibernateObject implements Linkable, Ow
      */
     @XmlTransient
     public String getProductId() {
-        return this.pool.getProductId();
+        if (this.pool != null) {
+            return this.pool.getProductId();
+        }
+        return null;
     }
 
     /**


### PR DESCRIPTION
Running unit tests with debugging on could trigger
a NPE when stringifying empty Entitlement

(or, we could change the unit tests to not use an
empty Entitlement constructor)
