### PR TITLE
Don't use the real /etc/candlepin/candlepin.conf during testing

### DIFF
--- a/src/test/java/org/candlepin/config/CandlepinCommonTestConfig.java
+++ b/src/test/java/org/candlepin/config/CandlepinCommonTestConfig.java
@@ -16,11 +16,18 @@ package org.candlepin.config;
 
 import java.net.URISyntaxException;
 import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * CandlepinCommonTestConfig
  */
 public class CandlepinCommonTestConfig extends Config {
+
+    public CandlepinCommonTestConfig() {
+        // explicitly _not_ using the /etc/candlepin/candlepin.conf file in testing.
+        this.configuration = new TreeMap<String, String>(
+            ConfigProperties.DEFAULT_PROPERTIES);
+    }
 
     @Override
     protected Map<String, String> loadProperties() {


### PR DESCRIPTION
fixes running buildr test for me.

might not solve all the current unit test issues, but is probably a good idea regardless
