### PR TITLE
Limit number of products allowed in the product cache.

### DIFF
--- a/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -96,6 +96,8 @@ public class ConfigProperties {
     public static final String PASSPHRASE_SECRET_FILE =
         "candlepin.passphrase.path";
 
+    public static final String PRODUCT_CACHE_MAX = "candlepin.cache.product_cache_max";
+
     public static final Map<String, String> DEFAULT_PROPERTIES =
         new HashMap<String, String>() {
 
@@ -165,6 +167,13 @@ public class ConfigProperties {
                 this.put(PASSPHRASE_SECRET_FILE,
                     "/etc/katello/secure/passphrase");
 
+                /**
+                 *  Defines the maximum number of products allowed in the product cache.
+                 *  On deployments with a large number of products, it might be better
+                 *  to set this to a large number, keeping in mind that it will yield
+                 *  a larger memory footprint as the cache fills up.
+                 */
+                this.put(PRODUCT_CACHE_MAX, "100");
             }
         };
     public static final String CRL_FILE_PATH = "candlepin.crl.file";

--- a/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -36,6 +36,7 @@ import org.candlepin.audit.EventFactory;
 import org.candlepin.audit.EventSink;
 import org.candlepin.auth.UserPrincipal;
 import org.candlepin.config.Config;
+import org.candlepin.config.ConfigProperties;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerCurator;
 import org.candlepin.model.Entitlement;
@@ -127,7 +128,9 @@ public class PoolManagerTest {
         o = new Owner("key", "displayname");
         pool = TestUtil.createPool(o, product);
 
-        this.productCache = new ProductCache(mockProductAdapter);
+        when(mockConfig.getInt(eq(ConfigProperties.PRODUCT_CACHE_MAX))).thenReturn(100);
+        this.productCache = new ProductCache(mockConfig, mockProductAdapter);
+
         this.principal = TestUtil.createOwnerPrincipal();
         this.manager = spy(new CandlepinPoolManager(mockPoolCurator, mockSubAdapter,
             productCache, entCertAdapterMock, mockEventSink, eventFactory,

--- a/src/test/java/org/candlepin/policy/test/DefaultRulesTest.java
+++ b/src/test/java/org/candlepin/policy/test/DefaultRulesTest.java
@@ -26,7 +26,21 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
 import org.candlepin.config.Config;
+import org.candlepin.config.ConfigProperties;
 import org.candlepin.controller.PoolManager;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerCurator;
@@ -67,19 +81,6 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.xnap.commons.i18n.I18nFactory;
 
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
-
 /**
  * DefaultRulesTest
  */
@@ -105,7 +106,8 @@ public class DefaultRulesTest {
     public void createEnforcer() throws Exception {
         MockitoAnnotations.initMocks(this);
 
-        this.productCache = new ProductCache(this.prodAdapter);
+        when(config.getInt(eq(ConfigProperties.PRODUCT_CACHE_MAX))).thenReturn(100);
+        this.productCache = new ProductCache(config, this.prodAdapter);
 
         URL url = this.getClass().getClassLoader()
             .getResource("rules/default-rules.js");

--- a/src/test/java/org/candlepin/policy/test/EnforcerTest.java
+++ b/src/test/java/org/candlepin/policy/test/EnforcerTest.java
@@ -17,6 +17,7 @@ package org.candlepin.policy.test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -32,6 +33,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.candlepin.config.Config;
+import org.candlepin.config.ConfigProperties;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.Entitlement;
 import org.candlepin.model.Owner;
@@ -79,7 +81,8 @@ public class EnforcerTest extends DatabaseTestFixture {
     public void createEnforcer() throws Exception {
         MockitoAnnotations.initMocks(this);
 
-        productCache = new ProductCache(productAdapter);
+        when(config.getInt(eq(ConfigProperties.PRODUCT_CACHE_MAX))).thenReturn(100);
+        productCache = new ProductCache(config, productAdapter);
 
         owner = createOwner();
         ownerCurator.create(owner);

--- a/src/test/java/org/candlepin/policy/test/JsPoolRulesTest.java
+++ b/src/test/java/org/candlepin/policy/test/JsPoolRulesTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -28,6 +29,7 @@ import java.util.List;
 
 import org.candlepin.auth.UserPrincipal;
 import org.candlepin.config.Config;
+import org.candlepin.config.ConfigProperties;
 import org.candlepin.controller.PoolManager;
 import org.candlepin.model.Entitlement;
 import org.candlepin.model.Owner;
@@ -84,7 +86,9 @@ public class JsPoolRulesTest {
         when(rulesCuratorMock.getUpdated()).thenReturn(new Date());
         when(rulesCuratorMock.getRules()).thenReturn(rules);
 
-        productCache = new ProductCache(productAdapterMock);
+        when(configMock.getInt(eq(ConfigProperties.PRODUCT_CACHE_MAX))).thenReturn(100);
+        productCache = new ProductCache(configMock, productAdapterMock);
+
         JsRulesProvider provider = new JsRulesProvider(rulesCuratorMock);
         poolRules = new JsPoolRules(provider.get(), poolManagerMock,
                                     productCache, configMock);

--- a/src/test/java/org/candlepin/policy/test/ManifestEntitlementRulesTest.java
+++ b/src/test/java/org/candlepin/policy/test/ManifestEntitlementRulesTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.candlepin.config.Config;
+import org.candlepin.config.ConfigProperties;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerType;
 import org.candlepin.model.Entitlement;
@@ -107,7 +108,9 @@ public class ManifestEntitlementRulesTest extends DatabaseTestFixture {
 
         jsRules = new JsRulesProvider(rulesCurator).get();
 
-        productCache = new ProductCache(productAdapter);
+        when(config.getInt(eq(ConfigProperties.PRODUCT_CACHE_MAX))).thenReturn(100);
+        productCache = new ProductCache(config, productAdapter);
+
         enforcer = new ManifestEntitlementRules(new DateSourceForTesting(2010, 1, 1),
             jsRules, productCache, i18n, config, consumerCurator);
 

--- a/src/test/java/org/candlepin/policy/test/PoolHelperTest.java
+++ b/src/test/java/org/candlepin/policy/test/PoolHelperTest.java
@@ -17,6 +17,7 @@ package org.candlepin.policy.test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -24,6 +25,8 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.candlepin.config.Config;
+import org.candlepin.config.ConfigProperties;
 import org.candlepin.controller.PoolManager;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.Entitlement;
@@ -60,7 +63,10 @@ public class PoolHelperTest {
         pm = mock(PoolManager.class);
         psa = mock(ProductServiceAdapter.class);
         ent = mock(Entitlement.class);
-        productCache = new ProductCache(psa);
+
+        Config config = mock(Config.class);
+        when(config.getInt(eq(ConfigProperties.PRODUCT_CACHE_MAX))).thenReturn(100);
+        productCache = new ProductCache(config, psa);
 
         // default to an empty list, override in the test
         when(pool.getProvidedProducts()).thenReturn(Collections.EMPTY_SET);


### PR DESCRIPTION
The cache can contain a maximum of 100 products at a time
and is implemented using SoftReferences
so that when memory becomes an issue, the GC can claim
any products it requires that have no hard references.
