### PR TITLE
certv3: sort path names alphabetically

### DIFF
--- a/src/main/java/org/candlepin/util/X509V3ExtensionUtil.java
+++ b/src/main/java/org/candlepin/util/X509V3ExtensionUtil.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -1095,6 +1096,7 @@ public class X509V3ExtensionUtil extends X509Util{
         }
 
         public List<NodePair> getChildren() {
+            Collections.sort(this.children);
             return this.children;
         }
 
@@ -1147,7 +1149,7 @@ public class X509V3ExtensionUtil extends X509Util{
      * NodePair
      */
 
-    public class NodePair {
+    public class NodePair implements Comparable{
         private String name;
         private PathNode connection;
 
@@ -1170,6 +1172,14 @@ public class X509V3ExtensionUtil extends X509Util{
 
         public String toString() {
             return "Name: " + name + ", Connection: " + connection.getId();
+        }
+
+        /* (non-Javadoc)
+         * @see java.lang.Comparable#compareTo(java.lang.Object)
+         */
+        @Override
+        public int compareTo(Object other) {
+            return this.name.compareTo(((NodePair) other).name);
         }
     }
 }

--- a/src/test/java/org/candlepin/service/impl/test/DefaultEntitlementCertServiceAdapterTest.java
+++ b/src/test/java/org/candlepin/service/impl/test/DefaultEntitlementCertServiceAdapterTest.java
@@ -954,6 +954,31 @@ public class DefaultEntitlementCertServiceAdapterTest {
     }
 
     @Test
+    public void testPathTreeSortsChildNodesAlphabetically() {
+        List<org.candlepin.json.model.Content> contentList =
+            new ArrayList<org.candlepin.json.model.Content>();
+
+        org.candlepin.json.model.Content contentA = new org.candlepin.json.model.Content();
+        contentA.setPath("/AAA");
+        org.candlepin.json.model.Content contentB = new org.candlepin.json.model.Content();
+        contentB.setPath("/BBB");
+        org.candlepin.json.model.Content contentC = new org.candlepin.json.model.Content();
+        contentC.setPath("/CCC");
+
+        contentList.add(contentB);
+        contentList.add(contentC);
+        contentList.add(contentA);
+
+        PathNode location = v3extensionUtil.makePathTree(contentList,
+            v3extensionUtil.new PathNode());
+
+        assertEquals(3, location.getChildren().size(), 3);
+        assertEquals("AAA", location.getChildren().get(0).getName());
+        assertEquals("BBB", location.getChildren().get(1).getName());
+        assertEquals("CCC", location.getChildren().get(2).getName());
+    }
+
+    @Test
     public void testPathDictionary() throws IOException {
         List<org.candlepin.json.model.Content> contentList =
             new ArrayList<org.candlepin.json.model.Content>();


### PR DESCRIPTION
By sorting the child paths of a node alphabetically, clients can do a
binary search for the node they want, rather than having to iterate over
all children.
