### PR TITLE
fixed 'Release' object serialization issue

### DIFF
--- a/src/main/java/org/candlepin/model/Release.java
+++ b/src/main/java/org/candlepin/model/Release.java
@@ -16,6 +16,8 @@ package org.candlepin.model;
 
 import java.io.Serializable;
 
+import javax.xml.bind.annotation.XmlTransient;
+
 /**
  * Release
  */
@@ -42,6 +44,7 @@ public class Release extends AbstractHibernateObject {
      * @see org.candlepin.model.Persisted#getId()
      */
     @Override
+    @XmlTransient
     public Serializable getId() {
         // TODO Auto-generated method stub
         return null;


### PR DESCRIPTION
'id' method shouldn't be invoked during serialization, as there's no 'id' field/setter. 
