### PR TITLE
800145: Update pools across all owners on product import

### DIFF
--- a/spec/product_resource_spec.rb
+++ b/spec/product_resource_spec.rb
@@ -61,6 +61,21 @@ describe 'Product Resource' do
     pool[0]['owner']['key'].should == owner['key']
   end
 
+  it 'does not refresh pools without a given product' do
+    owner = create_owner(random_string('owner'))
+    owner_client = user_client(owner, random_string('testuser'))
+    product = create_product(random_string("test_id"),
+      random_string("test_name"))
+    product2 = create_product()
+    provided_product = create_product()
+    @cp.create_subscription(owner['key'], product.id, 10, [provided_product.id])
+    pool = owner_client.list_pools(:owner => owner.id)
+    pool.should have(0).things
+    @cp.refresh_pools_for_product(product2.id)
+    pool = owner_client.list_pools(:owner => owner.id)
+    pool.should have(0).things
+  end
+
   it 'refreshes pools for specific provided products' do
     owner = create_owner(random_string('owner'))
     owner_client = user_client(owner, random_string('testuser'))

--- a/src/main/java/org/candlepin/controller/PoolManager.java
+++ b/src/main/java/org/candlepin/controller/PoolManager.java
@@ -93,24 +93,10 @@ public interface PoolManager {
 
     Pool find(String poolId);
 
-    Iterable<Pool> getListOfEntitlementPoolsForProduct(String productId);
-
     List<Pool> lookupBySubscriptionId(String id);
 
-    /**
-     * Check our underlying subscription service and update the pool data. Note
-     * that refreshing the pools doesn't actually take any action, should a subscription
-     * be reduced, expired, or revoked. Pre-existing entitlements will need to be dealt
-     * with separately from this event.
-     *
-     * @param owner Owner to be refreshed.
-     * @param lazy Should certificates be generated lazily. (normally yes)
-     */
-    void refreshPools(Owner owner, boolean lazy);
-
-    Set<Entitlement> refreshPoolsWithoutRegeneration(Owner owner);
-
-    void regenerateCertificatesOf(Iterable<Entitlement> iterable, boolean lazy);
+    Refresher getRefresher();
+    Refresher getRefresher(boolean lazy);
 
     /**
      * @param e

--- a/src/main/java/org/candlepin/controller/Refresher.java
+++ b/src/main/java/org/candlepin/controller/Refresher.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.controller;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.candlepin.model.Entitlement;
+import org.candlepin.model.Owner;
+import org.candlepin.model.Pool;
+import org.candlepin.model.PoolCurator;
+import org.candlepin.model.Product;
+import org.candlepin.model.Subscription;
+import org.candlepin.service.SubscriptionServiceAdapter;
+import org.candlepin.util.Util;
+
+/**
+ * Refresher
+ */
+public class Refresher {
+
+    private CandlepinPoolManager poolManager;
+    private SubscriptionServiceAdapter subAdapter;
+    private PoolCurator poolCurator;
+    private boolean lazy;
+
+    private Set<Owner> owners = Util.newSet();
+    private Set<Product> products = Util.newSet();
+
+    Refresher(CandlepinPoolManager poolManager, SubscriptionServiceAdapter subAdapter,
+        PoolCurator poolCurator, boolean lazy) {
+        this.poolManager = poolManager;
+        this.subAdapter = subAdapter;
+        this.poolCurator = poolCurator;
+        this.lazy = lazy;
+    }
+
+    public Refresher add(Owner owner) {
+        owners.add(owner);
+        return this;
+    }
+
+    public Refresher add(Product product) {
+        products.add(product);
+        return this;
+    }
+
+    public void run() {
+        Set<Subscription> subscriptions = Util.newSet();
+        for (Product product : products) {
+            List<Subscription> candidates = subAdapter.getSubscriptions(product);
+
+            // drop any subs for owners in our owners list. we'll get them with the full
+            // refreshPools call.
+            for (Subscription subscription : candidates) {
+                if (!owners.contains(subscription.getOwner())) {
+                    subscriptions.add(subscription);
+                }
+            }
+        }
+
+        Set<Entitlement> toRegen = new HashSet<Entitlement>();
+
+        for (Subscription subscription : subscriptions) {
+            /*
+             * on the off chance that this is actually a new subscription, make the required
+             * pools. this shouldn't happen; we should really get a refreshpools by owner
+             * call for it, but why not handle it, just in case!
+             */
+            List<Pool> pools = poolCurator.lookupBySubscriptionId(subscription.getId());
+            if (pools.isEmpty()) {
+                poolManager.createPoolsForSubscription(subscription);
+            }
+            else {
+                toRegen.addAll(poolManager.updatePoolsForSubscription(pools, subscription));
+            }
+        }
+
+        for (Owner owner : owners) {
+            toRegen.addAll(poolManager.refreshPoolsWithoutRegeneration(owner));
+        }
+
+        // now regenerate all pending entitlements
+        poolManager.regenerateCertificatesOf(toRegen, lazy);
+    }
+}

--- a/src/main/java/org/candlepin/model/PoolCurator.java
+++ b/src/main/java/org/candlepin/model/PoolCurator.java
@@ -103,7 +103,7 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
     @Transactional
     @EnforceAccessControl
     public List<Pool> listByOwner(Owner o, Date activeOn) {
-        return listAvailableEntitlementPools(null, o, (String) null, activeOn, true, false);
+        return listAvailableEntitlementPools(null, o, null, activeOn, true, false);
     }
 
     /**

--- a/src/main/java/org/candlepin/pinsetter/tasks/RefreshPoolsJob.java
+++ b/src/main/java/org/candlepin/pinsetter/tasks/RefreshPoolsJob.java
@@ -68,7 +68,7 @@ public class RefreshPoolsJob implements Job {
         }
 
         // Assume that we verified the request in the resource layer:
-        poolManager.refreshPools(owner, lazy);
+        poolManager.getRefresher(lazy).add(owner).run();
 
         context.setResult("Pools refreshed for owner " + owner.getDisplayName());
     }

--- a/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -615,7 +615,7 @@ public class ConsumerResource {
                 log.info("Principal carries permission for owner that does not exist.");
                 log.info("Creating new owner: " + owner.getKey());
                 existingOwner = ownerCurator.create(owner);
-                poolManager.refreshPools(existingOwner, true);
+                poolManager.getRefresher().add(existingOwner).run();
             }
         }
     }

--- a/src/main/java/org/candlepin/service/SubscriptionServiceAdapter.java
+++ b/src/main/java/org/candlepin/service/SubscriptionServiceAdapter.java
@@ -16,10 +16,10 @@ package org.candlepin.service;
 
 import java.util.Date;
 import java.util.List;
-import java.util.Set;
 
 import org.candlepin.model.Consumer;
 import org.candlepin.model.Owner;
+import org.candlepin.model.Product;
 import org.candlepin.model.Subscription;
 
 /**
@@ -148,10 +148,10 @@ public interface SubscriptionServiceAdapter {
     void deleteSubscription(Subscription s);
 
     /**
-     * Look up all the owners with subscriptions to a given list of products IDs.
+     * Search for all subscriptions that provide a given product.
      *
-     * @param productIds a list of product IDs to look up owners for.
-     * @return a set of owners subscribed to the given products.
+     * @param product the main or provided product to look for.
+     * @return a list of subscriptions that provide this product.
      */
-    Set<Owner> lookupOwnersByProduct(List<String> productIds);
+    List<Subscription> getSubscriptions(Product product);
 }

--- a/src/main/java/org/candlepin/service/impl/DefaultSubscriptionServiceAdapter.java
+++ b/src/main/java/org/candlepin/service/impl/DefaultSubscriptionServiceAdapter.java
@@ -164,8 +164,7 @@ public class DefaultSubscriptionServiceAdapter implements
     }
 
     @Override
-    public Set<Owner> lookupOwnersByProduct(List<String> productIds) {
-        return subCurator.lookupOwnersByProduct(productIds);
+    public List<Subscription> getSubscriptions(Product product) {
+        return subCurator.listByProduct(product);
     }
-
 }

--- a/src/test/java/org/candlepin/controller/PoolManagerFunctionalTest.java
+++ b/src/test/java/org/candlepin/controller/PoolManagerFunctionalTest.java
@@ -118,7 +118,7 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
         subCurator.create(new Subscription(o, provisioning, new HashSet<Product>(),
             5L, new Date(), TestUtil.createDate(3020, 12, 12), new Date()));
 
-        poolManager.refreshPools(o, true);
+        poolManager.getRefresher().add(o).run();
 
         this.systemType = new ConsumerType(ConsumerTypeEnum.SYSTEM);
         consumerTypeCurator.create(systemType);
@@ -235,7 +235,7 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
         subCurator.create(new Subscription(o, modifier, new HashSet<Product>(),
             5L, new Date(), TestUtil.createDate(3020, 12, 12), new Date()));
 
-        poolManager.refreshPools(o, true);
+        poolManager.getRefresher().add(o).run();
 
 
         // This test simulates https://bugzilla.redhat.com/show_bug.cgi?id=676870
@@ -272,7 +272,7 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
         subCurator.create(subscription);
 
         // set up initial pool
-        poolManager.refreshPools(o, true);
+        poolManager.getRefresher().add(o).run();
 
         List<Pool> pools = poolCurator.listByOwnerAndProduct(o, product1.getId());
         assertEquals(1, pools.size());
@@ -282,7 +282,7 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
         subCurator.merge(subscription);
 
         // set up initial pool
-        poolManager.refreshPools(o, true);
+        poolManager.getRefresher().add(o).run();
 
         pools = poolCurator.listByOwnerAndProduct(o, product2.getId());
         assertEquals(1, pools.size());

--- a/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -161,7 +161,7 @@ public class PoolManagerTest {
             mockPoolCurator.listAvailableEntitlementPools(any(Consumer.class),
                 any(Owner.class), anyString(), any(Date.class),
                 anyBoolean(), anyBoolean())).thenReturn(pools);
-        this.manager.refreshPools(getOwner(), true);
+        this.manager.getRefresher().add(getOwner()).run();
         verify(this.manager).deletePool(same(p));
     }
 
@@ -185,7 +185,7 @@ public class PoolManagerTest {
         newPools.add(p);
         when(poolRulesMock.createPools(s)).thenReturn(newPools);
 
-        this.manager.refreshPools(getOwner(), true);
+        this.manager.getRefresher().add(getOwner()).run();
         verify(this.mockPoolCurator, times(1)).create(any(Pool.class));
     }
 
@@ -394,7 +394,7 @@ public class PoolManagerTest {
         ValidationResult result = new ValidationResult();
         when(preHelper.getResult()).thenReturn(result);
 
-        manager.refreshPools(sub.getOwner(), true);
+        this.manager.getRefresher().add(sub.getOwner()).run();
 
         verify(mockSubAdapter).deleteSubscription(eq(sub));
         verify(mockPoolCurator).delete(eq(p));

--- a/src/test/java/org/candlepin/controller/RefresherTest.java
+++ b/src/test/java/org/candlepin/controller/RefresherTest.java
@@ -1,0 +1,146 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.controller;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.candlepin.model.Owner;
+import org.candlepin.model.Pool;
+import org.candlepin.model.PoolCurator;
+import org.candlepin.model.Product;
+import org.candlepin.model.Subscription;
+import org.candlepin.service.SubscriptionServiceAdapter;
+import org.candlepin.util.Util;
+import org.junit.Test;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+/**
+ * RefresherTest
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class RefresherTest {
+
+    private CandlepinPoolManager poolManager;
+    private SubscriptionServiceAdapter subAdapter;
+    private PoolCurator poolCurator;
+
+    private Refresher refresher;
+
+    @Before
+    public void setUp() {
+        poolManager = mock(CandlepinPoolManager.class);
+        subAdapter = mock(SubscriptionServiceAdapter.class);
+        poolCurator = mock(PoolCurator.class);
+
+        refresher = new Refresher(poolManager, subAdapter, poolCurator, false);
+    }
+
+    @Test
+    public void testOwnerOnlyExaminedOnce() {
+        Owner owner = mock(Owner.class);
+
+        refresher.add(owner);
+        refresher.add(owner);
+        refresher.run();
+
+        verify(poolManager, times(1)).refreshPoolsWithoutRegeneration(owner);
+    }
+
+    @Test
+    public void testProductOnlyExaminedOnce() {
+        Product product = mock(Product.class);
+
+        refresher.add(product);
+        refresher.add(product);
+        refresher.run();
+
+        verify(subAdapter, times(1)).getSubscriptions(product);
+    }
+
+    @Test
+    public void testPoolOnlyExaminedOnceProductAndOwner() {
+        Owner owner = mock(Owner.class);
+        Product product = mock(Product.class);
+
+        when(product.getId()).thenReturn("product id");
+
+        Pool pool = new Pool();
+        pool.setSubscriptionId("subId");
+        pool.setOwner(owner);
+        Subscription subscription = new Subscription();
+        subscription.setId("subId");
+        subscription.setOwner(owner);
+
+        List<Pool> pools = Util.newList();
+        pools.add(pool);
+        List<Subscription> subscriptions = Util.newList();
+        subscriptions.add(subscription);
+
+        when(subAdapter.getSubscriptions(product)).thenReturn(subscriptions);
+        when(subAdapter.getSubscriptions(owner)).thenReturn(subscriptions);
+        when(subAdapter.getSubscription("subId")).thenReturn(subscription);
+
+        when(poolCurator.listAvailableEntitlementPools(null, owner, null, null, false,
+            false)).thenReturn(pools);
+        when(poolCurator.lookupBySubscriptionId("subId")).thenReturn(pools);
+
+        refresher.add(owner);
+        refresher.add(product);
+        refresher.run();
+
+        verify(poolManager, times(1)).refreshPoolsWithoutRegeneration(owner);
+        verify(poolManager, times(0)).updatePoolsForSubscription(any(List.class),
+            any(Subscription.class));
+    }
+
+    @Test
+    public void testPoolOnlyExaminedOnceTwoProducts() {
+        Owner owner = mock(Owner.class);
+        Product product = mock(Product.class);
+        Product product2 = mock(Product.class);
+
+        when(product.getId()).thenReturn("product id");
+        when(product2.getId()).thenReturn("product id 2");
+
+        Pool pool = new Pool();
+        pool.setSubscriptionId("subId");
+        Subscription subscription = new Subscription();
+        subscription.setId("subId");
+
+        List<Pool> pools = Util.newList();
+        pools.add(pool);
+        List<Subscription> subscriptions = Util.newList();
+        subscriptions.add(subscription);
+
+        when(subAdapter.getSubscriptions(product)).thenReturn(subscriptions);
+        when(subAdapter.getSubscriptions(product2)).thenReturn(subscriptions);
+        when(subAdapter.getSubscription("subId")).thenReturn(subscription);
+        when(poolCurator.lookupBySubscriptionId("subId")).thenReturn(pools);
+        refresher.add(product);
+        refresher.add(product2);
+        refresher.run();
+
+        verify(poolManager, times(1)).updatePoolsForSubscription(any(List.class),
+            any(Subscription.class));
+    }
+}

--- a/src/test/java/org/candlepin/resource/test/ConsumerResourceVirtEntitlementTest.java
+++ b/src/test/java/org/candlepin/resource/test/ConsumerResourceVirtEntitlementTest.java
@@ -115,8 +115,6 @@ public class ConsumerResourceVirtEntitlementTest extends DatabaseTestFixture {
         subCurator.create(unlimitSub);
 
         unlimitPools = poolManager.createPoolsForSubscription(unlimitSub);
-
-        poolManager.refreshPools(owner, false);
     }
 
     /**
@@ -143,10 +141,6 @@ public class ConsumerResourceVirtEntitlementTest extends DatabaseTestFixture {
                 // ensure the correct # consumed from the bonus pool
                 assertTrue(p.getConsumed() == 20);
                 assertTrue(p.getQuantity() == 100);
-                poolManager.refreshPools(owner, true);
-                // double check after pools refresh
-                assertTrue(p.getConsumed() == 20);
-                assertTrue(p.getQuantity() == 100);
                 // keep this list so we don't need to search again
                 subscribedTo.add(p);
             }
@@ -160,10 +154,6 @@ public class ConsumerResourceVirtEntitlementTest extends DatabaseTestFixture {
         for (Pool p : subscribedTo) {
             assertTrue(p.getConsumed() == 20);
             assertTrue(p.getQuantity() == 30);
-            poolManager.refreshPools(owner, true);
-            // double check after pools refresh
-            assertTrue(p.getConsumed() == 20);
-            assertTrue(p.getQuantity() == 30);
         }
         // manifest consume from the physical pool and then check bonus pool quantities.
         //   Should result in a revocation of one of the 10 count entitlements.
@@ -172,20 +162,12 @@ public class ConsumerResourceVirtEntitlementTest extends DatabaseTestFixture {
         for (Pool p : subscribedTo) {
             assertTrue(p.getConsumed() == 10);
             assertTrue(p.getQuantity() == 10);
-            poolManager.refreshPools(owner, true);
-            // double check after pools refresh
-            assertTrue(p.getConsumed() == 10);
-            assertTrue(p.getQuantity() == 10);
         }
         // system consume from the physical pool and then check bonus pool quantities.
         //   Should result in no change in the entitlements for the guest.
         consumerResource.bind(systemConsumer.getUuid(), parentPool.getId(), null, 1, null,
             null, false, null);
         for (Pool p : subscribedTo) {
-            assertTrue(p.getConsumed() == 10);
-            assertTrue(p.getQuantity() == 10);
-            poolManager.refreshPools(owner, true);
-            // double check after pools refresh
             assertTrue(p.getConsumed() == 10);
             assertTrue(p.getQuantity() == 10);
         }
@@ -211,7 +193,7 @@ public class ConsumerResourceVirtEntitlementTest extends DatabaseTestFixture {
                     10, null, null, false, null);
                 assertTrue(p.getConsumed() == 20);
                 assertTrue(p.getQuantity() == -1);
-                poolManager.refreshPools(owner, true);
+                poolManager.getRefresher().add(owner).run();
                 // double check after pools refresh
                 assertTrue(p.getConsumed() == 20);
                 assertTrue(p.getQuantity() == -1);
@@ -227,20 +209,12 @@ public class ConsumerResourceVirtEntitlementTest extends DatabaseTestFixture {
         for (Pool p : subscribedTo) {
             assertTrue(p.getConsumed() == 20);
             assertTrue(p.getQuantity() == -1);
-            poolManager.refreshPools(owner, true);
-            // double check after pools refresh
-            assertTrue(p.getConsumed() == 20);
-            assertTrue(p.getQuantity() == -1);
         }
         // Full consumption of physical pool causes revocation of bonus pool entitlements
         //   and quantity change to 0
         consumerResource.bind(manifestConsumer.getUuid(), parentPool.getId(), null, 3, null,
             null, false, null);
         for (Pool p : subscribedTo) {
-            assertTrue(p.getConsumed() == 0);
-            assertTrue(p.getQuantity() == 0);
-            poolManager.refreshPools(owner, true);
-            // double check after pools refresh
             assertTrue(p.getConsumed() == 0);
             assertTrue(p.getQuantity() == 0);
         }

--- a/src/test/java/org/candlepin/resource/test/OwnerResourceTest.java
+++ b/src/test/java/org/candlepin/resource/test/OwnerResourceTest.java
@@ -111,7 +111,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         subCurator.create(sub);
 
         // Trigger the refresh:
-        poolManager.refreshPools(owner, true);
+        poolManager.getRefresher().add(owner).run();
         List<Pool> pools = poolCurator.listByOwnerAndProduct(owner,
             prod.getId());
         assertEquals(1, pools.size());
@@ -143,7 +143,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         pool.setSubscriptionId(sub.getId());
         poolCurator.merge(pool);
 
-        poolManager.refreshPools(owner, true);
+        poolManager.getRefresher().add(owner).run();
 
         pool = poolCurator.find(pool.getId());
         assertEquals(sub.getId(), pool.getSubscriptionId());
@@ -163,7 +163,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         subCurator.create(sub);
 
         // Trigger the refresh:
-        poolManager.refreshPools(owner, true);
+        poolManager.getRefresher().add(owner).run();
 
         List<Pool> pools = poolCurator.listByOwnerAndProduct(owner,
             prod.getId());
@@ -174,7 +174,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         subCurator.delete(sub);
 
         // Trigger the refresh:
-        poolManager.refreshPools(owner, true);
+        poolManager.getRefresher().add(owner).run();
         assertNull("Pool not having subscription should have been deleted",
             poolCurator.find(poolId));
     }
@@ -197,7 +197,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         subCurator.create(sub2);
 
         // Trigger the refresh:
-        poolManager.refreshPools(owner, true);
+        poolManager.getRefresher().add(owner).run();
 
         List<Pool> pools = poolCurator.listByOwner(owner);
         assertEquals(2, pools.size());
@@ -510,7 +510,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         this.config.setProperty(
             ConfigProperties.REVOKE_ENTITLEMENT_IN_FIFO_ORDER, fifo ? "true" :
                 "false");
-        poolManager.refreshPools(owner, true);
+        poolManager.getRefresher().add(owner).run();
         pool = poolCurator.find(pool.getId());
         return pool;
     }
@@ -626,7 +626,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         subCurator.create(sub2);
 
         // Trigger the refresh:
-        poolManager.refreshPools(owner, true);
+        poolManager.getRefresher().add(owner).run();
 
         owner.setDefaultServiceLevel("premium");
         Owner parentOwner1 = new Owner("Paren Owner 1", "parentTest1");


### PR DESCRIPTION
Previously, upon importing an export file, if a product was modified,
we would regenerate the certificates of all entitlements that referenced
that product. We would then run a refreshPools on the owner that
imported the export. the refreshPools would adjust that owner's pools to
reflect the new product attributes, but not any other owners.

That was the intention, anyways. In reality, the code to look for
changed products compared the new forms of the products to the products
from the db, but only after it had already updated the db. Thus, the
products were never found to have changed, and no certs were
regenerated.

This patch fixes that up by comparing the new forms of the products with
the form as it is in the db, before storing the new form. Further, it
corrects the code to check for changes, catching more instances when the
products are different.

To refresh the pools referencing the affected products, but also ensure
that a pool that references two products, or a pool that is owned by the
importing owner is not refreshed multiple times, introduce a new
Refresher object that takes care of gathering up the objects we want to
trigger a refresh on (products, owners), then executes the pool
refreshes and entitlement regens without repeating anything.

The existing code to trigger a refresh by product was being overly broad
on what pools it would refresh (triggering for all pools for an owner
that had a single pool that referenced the product, rather than just the
referencing pools). This patch also narrows the focus down to just the
affected pools, and introduces a spec test to verify that.
