### PR TITLE
Add new mechanism for detecting/overriding import conflicts.

### DIFF
--- a/client/ruby/candlepin_api.rb
+++ b/client/ruby/candlepin_api.rb
@@ -770,9 +770,18 @@ class Candlepin
   end
 
   def import(owner_key, filename, params = {})
-    force = params[:force] || false
-    path = "/owners/#{owner_key}/imports"
-    path += "?force=#{force}"
+    path = "/owners/#{owner_key}/imports?"
+    if params.has_key? :force
+      if params[:force].kind_of? Array
+        # New style, array of conflict keys to force:
+        params[:force].each do |f|
+          path += "force=#{f}&"
+        end
+      else
+        # Old style, force=true/false:
+        path += "force=#{force}"
+      end
+    end
     post_file path, File.new(filename)
   end
 

--- a/src/main/java/org/candlepin/exceptions/CandlepinException.java
+++ b/src/main/java/org/candlepin/exceptions/CandlepinException.java
@@ -27,7 +27,7 @@ public class CandlepinException extends RuntimeException {
     private static final long serialVersionUID = -3430329252623764984L;
     private final Status returnCode;
 
-    private final ExceptionMessage message;
+    protected final ExceptionMessage message;
 
     public CandlepinException(Status returnCode, String message) {
        this(returnCode, message, null);

--- a/src/main/java/org/candlepin/pki/PKIUtility.java
+++ b/src/main/java/org/candlepin/pki/PKIUtility.java
@@ -42,6 +42,7 @@ import java.util.Set;
 
 
 import org.apache.log4j.Logger;
+import org.candlepin.config.ConfigProperties;
 
 /**
  * PKIUtility
@@ -146,6 +147,16 @@ public abstract class PKIUtility {
 
             updateSignature(input, signature);
             return signature.verify(signedHash);
+        }
+        catch (SignatureException se) {
+            /*
+             * Can happen if your candlepin upstream cert is not the same length as the one
+             * which signed the manifest. Treat it like a bad signature check failure.
+             */
+            log.error(se);
+            log.warn(ConfigProperties.CA_CERT_UPSTREAM + " may not match the server" +
+                " that signed manifest.");
+            return false;
         }
         catch (Exception e) {
             throw new RuntimeException(e);

--- a/src/main/java/org/candlepin/sync/ConflictExceptionMessage.java
+++ b/src/main/java/org/candlepin/sync/ConflictExceptionMessage.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.sync;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import org.candlepin.exceptions.ExceptionMessage;
+
+/**
+ * ConflictExceptionMessage: Used to serialize exception message plus a list of
+ * import conflict keys.
+ */
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.FIELD)
+public class ConflictExceptionMessage extends ExceptionMessage {
+
+    private Set<Importer.Conflict> conflicts;
+
+    public ConflictExceptionMessage(String displayMessage,
+        Set<Importer.Conflict> conflicts) {
+        super(displayMessage);
+        this.conflicts = conflicts;
+    }
+
+    public ConflictExceptionMessage(String displayMessage,
+        Importer.Conflict conflict) {
+        super(displayMessage);
+        this.conflicts = new HashSet<Importer.Conflict>();
+        this.conflicts.add(conflict);
+    }
+
+    public ConflictExceptionMessage() {
+        super("");
+        this.conflicts = new HashSet<Importer.Conflict>();
+    }
+
+    public Set<Importer.Conflict> getConflicts() {
+        return this.conflicts;
+    }
+}

--- a/src/main/java/org/candlepin/sync/ConflictOverrides.java
+++ b/src/main/java/org/candlepin/sync/ConflictOverrides.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.sync;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * ConflictOverrides: Manifest conflicts the caller requested we override and continue
+ * importing.
+ */
+public class ConflictOverrides {
+
+    private Set<Importer.Conflict> conflictsToForce =
+        new HashSet<Importer.Conflict>();
+
+    public ConflictOverrides(String [] conflictStrings) {
+        for (String c : conflictStrings) {
+            conflictsToForce.add(Importer.Conflict.valueOf(c));
+        }
+    }
+
+    public ConflictOverrides(Importer.Conflict ... conflicts) {
+        for (Importer.Conflict c : conflicts) {
+            conflictsToForce.add(c);
+        }
+    }
+
+    public boolean isForced(Importer.Conflict c) {
+        return conflictsToForce.contains(c);
+    }
+
+    public boolean isEmpty() {
+        return conflictsToForce.size() == 0;
+    }
+}

--- a/src/main/java/org/candlepin/sync/ImportConflictException.java
+++ b/src/main/java/org/candlepin/sync/ImportConflictException.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.sync;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.ws.rs.core.Response.Status;
+
+import org.candlepin.exceptions.CandlepinException;
+
+/**
+ * ImportConflictException: An exception thrown when we encounter import conflicts
+ * which can be explicitly overridden. (but weren't)
+ *
+ * We generally try to return all conflicts that occurred so the caller can re-try and
+ * override them all if desired.
+ */
+public class ImportConflictException extends CandlepinException {
+
+    public ImportConflictException(String message, Importer.Conflict type) {
+        super(Status.CONFLICT, new ConflictExceptionMessage(
+            message, type));
+    }
+
+    /**
+     * Constructor for merging multiple import conflict exceptions into one. (so we can report
+     * them all)
+     *
+     * @param conflictExceptions All conflict exceptions that have occurred.
+     */
+    public ImportConflictException(List<ImportConflictException> conflictExceptions) {
+        super(Status.CONFLICT, buildExceptionMessage(conflictExceptions));
+
+    }
+
+    /**
+     * Merge another ImportConflictException's data into this one so we can notify the
+     * caller of everything that conflicted at once.
+     *
+     * @param e ImportConflictException thrown by a nested call.
+     */
+    private static ConflictExceptionMessage buildExceptionMessage(
+        List<ImportConflictException> conflictExceptions) {
+
+        StringBuffer newMessage = new StringBuffer();
+        Set<Importer.Conflict> conflicts = new HashSet<Importer.Conflict>();
+        for (ImportConflictException e : conflictExceptions) {
+            if (newMessage.length() > 0) {
+                newMessage.append("\n");
+            }
+            newMessage.append(e.message().getDisplayMessage());
+
+            conflicts.addAll(e.message().getConflicts());
+        }
+        return new ConflictExceptionMessage(newMessage.toString(), conflicts);
+    }
+
+    @Override // just casting to return the correct sub-class
+    public ConflictExceptionMessage message() {
+        return (ConflictExceptionMessage) message;
+    }
+
+}

--- a/src/test/java/org/candlepin/resource/test/OwnerResourceTest.java
+++ b/src/test/java/org/candlepin/resource/test/OwnerResourceTest.java
@@ -60,6 +60,7 @@ import org.candlepin.model.Product;
 import org.candlepin.model.Role;
 import org.candlepin.model.Subscription;
 import org.candlepin.resource.OwnerResource;
+import org.candlepin.sync.ConflictOverrides;
 import org.candlepin.sync.Importer;
 import org.candlepin.sync.ImporterException;
 import org.candlepin.test.DatabaseTestFixture;
@@ -709,10 +710,10 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         when(input.getParts()).thenReturn(parts);
         when(part.getHeaders()).thenReturn(mm);
         when(part.getBody(any(GenericType.class))).thenReturn(archive);
-        when(importer.loadExport(eq(owner), any(File.class), eq(false)))
+        when(importer.loadExport(eq(owner), any(File.class), any(ConflictOverrides.class)))
             .thenReturn(new HashMap<String, Object>());
 
-        thisOwnerResource.importData(owner.getKey(), false, input);
+        thisOwnerResource.importManifest(owner.getKey(), new String [] {}, input);
         List<ImportRecord> records = importRecordCurator.findRecords(owner);
         ImportRecord ir = records.get(0);
         assertEquals("test_file.zip", ir.getFileName());
@@ -743,11 +744,11 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         when(input.getParts()).thenReturn(parts);
         when(part.getHeaders()).thenReturn(mm);
         when(part.getBody(any(GenericType.class))).thenReturn(archive);
-        when(importer.loadExport(eq(owner), any(File.class), eq(false)))
+        when(importer.loadExport(eq(owner), any(File.class), any(ConflictOverrides.class)))
             .thenThrow(new ImporterException("Bad import"));
 
         try {
-            thisOwnerResource.importData(owner.getKey(), false, input);
+            thisOwnerResource.importManifest(owner.getKey(), new String [] {}, input);
         }
         catch (IseException ise) {
             // expected, so we catch and go on.


### PR DESCRIPTION
Added several new types of manifest import conflicts which can be
overridden by the caller. On import 409 responses will also include
programatic keys which other projects can use to distinguish why the
import failed. The request can be retried with a multi-valued force
parameter to override.

force=true will behave as it did before, ignoring an older manifest
creation date and importing anyhow.

Added distributor conflicts which allow the caller to link their org to
a new upstream distributor. (should they have deleted it accidentally,
etc) This may cause drastic changes to their subscriptions, but not if
used for a new distributor in the same upstream org and using the same
pools.

Signature checking code is brought back but disabled until other
projects are ready for it.

We also now distinguish between an older manifest, and the same manifest
currently imported.
