### PR TITLE
changing the internal name so it doesn't start with yum.

### DIFF
--- a/rel-eng/releasers.conf
+++ b/rel-eng/releasers.conf
@@ -22,7 +22,7 @@ rsync = fedorapeople.org:/srv/repos/candlepin/candlepin/epel-6Server/x86_64/ fed
 
 # Internal RHEL repos: (NOTE: only zeus has perms to do this)
 # We use the EL6 packages on EL5
-[yum-internal-rhel-ZEUSONLY]
+[internal-yum-rhel-ZEUSONLY]
 releaser = tito.release.YumRepoReleaser
 builder = tito.builder.BrewDownloadBuilder
 builder.disttag = el6_2


### PR DESCRIPTION
Not starting with yum makes building community builds easier. Since now you can
simply type: tito release --all-starting-with=yum

Today you have to do --all-starting-with=yum-f then again with
--all-starting-with=yum-r etc.  It's rather annoying. So removing the one item
that shouldn't be run externally makes more sense.
