### PR TITLE
Ignore old rules in database after a Candlepin upgrade.

### DIFF
--- a/src/main/java/org/candlepin/model/Rules.java
+++ b/src/main/java/org/candlepin/model/Rules.java
@@ -34,7 +34,7 @@ import org.hibernate.annotations.GenericGenerator;
 @Entity
 @Table(name = "cp_rules")
 @Embeddable
-public class Rules extends AbstractHibernateObject{
+public class Rules extends AbstractHibernateObject {
 
     @Id
     @GeneratedValue(generator = "system-uuid")
@@ -47,12 +47,17 @@ public class Rules extends AbstractHibernateObject{
     @Column(name = "rules_blob")
     private String rules;
 
+    @Column(name = "candlepin_version", nullable = false, length = 255)
+    private String candlepinVersion;
+
     /**
      * ctor
      * @param rulesBlob Rules script
+     * @param candlepinVersion Version of Candlepin these rules are from.
      */
-    public Rules(String rulesBlob) {
+    public Rules(String rulesBlob, String candlepinVersion) {
         this.rules = rulesBlob;
+        this.candlepinVersion = candlepinVersion;
     }
 
     /**
@@ -71,8 +76,20 @@ public class Rules extends AbstractHibernateObject{
 
     @Override
     public Serializable getId() {
-        // TODO Auto-generated method stub
         return this.id;
+    }
+
+    /**
+     * @return Version of Candlepin which exported these rules. If the rules were
+     * manually uploaded by an admin, the version will be set to the current version
+     * of that Candlepin server.
+     */
+    public String getCandlepinVersion() {
+        return candlepinVersion;
+    }
+
+    public void setCandlepinVersion(String candlepinVersion) {
+        this.candlepinVersion = candlepinVersion;
     }
 
 }

--- a/src/main/java/org/candlepin/resource/RulesResource.java
+++ b/src/main/java/org/candlepin/resource/RulesResource.java
@@ -31,6 +31,7 @@ import org.candlepin.exceptions.ServiceUnavailableException;
 import org.candlepin.model.CuratorException;
 import org.candlepin.model.Rules;
 import org.candlepin.model.RulesCurator;
+import org.candlepin.util.VersionUtil;
 import org.xnap.commons.i18n.I18n;
 
 import com.google.inject.Inject;
@@ -73,7 +74,7 @@ public class RulesResource {
         Rules rules = null;
         try {
             String decoded = new String(Base64.decodeBase64(rulesBuffer));
-            rules = new Rules(decoded);
+            rules = new Rules(decoded, VersionUtil.getVersionString());
         }
         catch (Throwable t) {
             log.error("Exception in rules upload", t);

--- a/src/main/java/org/candlepin/sync/Importer.java
+++ b/src/main/java/org/candlepin/sync/Importer.java
@@ -387,7 +387,7 @@ public class Importer {
             Reader reader = null;
             try {
                 reader = new FileReader(rulesFiles[0]);
-                rulesImporter.importObject(reader);
+                rulesImporter.importObject(reader, m.getVersion());
             }
             finally {
                 if (reader != null) {

--- a/src/main/java/org/candlepin/sync/RulesImporter.java
+++ b/src/main/java/org/candlepin/sync/RulesImporter.java
@@ -37,10 +37,11 @@ public class RulesImporter {
         this.curator = curator;
     }
 
-    public Rules importObject(Reader reader) throws IOException {
+    public Rules importObject(Reader reader, String candlepinVersion) throws IOException {
         log.debug("Importing rules file");
         new BufferedReader(reader);
 
-        return curator.update(new Rules(StringFromReader.asString(reader)));
+        return curator.update(new Rules(StringFromReader.asString(reader),
+            candlepinVersion));
     }
 }

--- a/src/main/java/org/candlepin/util/VersionUtil.java
+++ b/src/main/java/org/candlepin/util/VersionUtil.java
@@ -76,10 +76,11 @@ public class VersionUtil {
     }
 
     public static boolean getRulesVersionCompatibility(String importVersion) {
+
         // if the import version is older than our version, the
         // rules are not compatible
         RpmVersionComparator rpmcmp = new RpmVersionComparator();
-        String myVersion = getVersionMap().get("version");
+        String myVersion = getVersionString();
 
         if (rpmcmp.compare(myVersion, importVersion) == 1) {
             return false;

--- a/src/main/resources/db/changelog/20121015121627-add-rules-cp-version-column.xml
+++ b/src/main/resources/db/changelog/20121015121627-add-rules-cp-version-column.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+
+    <changeSet id="20121015121627" author="dgoodwin">
+        <comment>Add a column in rules table for the version of candlepin they came from.</comment>
+        <addColumn tableName="cp_rules">
+            <column name="candlepin_version" type="varchar(255)"/>
+        </addColumn>
+        <!-- this statement lets us update existing values without setting a column default -->
+        <addNotNullConstraint tableName="cp_rules"
+                columnName="candlepin_version"
+                defaultNullValue="0.0.0" />
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-create.xml
+++ b/src/main/resources/db/changelog/changelog-create.xml
@@ -1102,4 +1102,5 @@
     <include file="db/changelog/20120607124900-add-entitlement-dirty-column.xml" />
     <include file="db/changelog/20120720091214-add-foreign-key-indexes.xml" />
     <include file="db/changelog/20121004150608-add-file-name-to-import-record.xml" />
+    <include file="db/changelog/20121015121627-add-rules-cp-version-column.xml" />
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-update.xml
+++ b/src/main/resources/db/changelog/changelog-update.xml
@@ -9,4 +9,5 @@
     <include file="db/changelog/20120607124900-add-entitlement-dirty-column.xml" />
     <include file="db/changelog/20120720091214-add-foreign-key-indexes.xml" />
     <include file="db/changelog/20121004150608-add-file-name-to-import-record.xml" />
+    <include file="db/changelog/20121015121627-add-rules-cp-version-column.xml" />
 </databaseChangeLog>

--- a/src/test/java/org/candlepin/policy/js/compliance/ComplianceRulesTest.java
+++ b/src/test/java/org/candlepin/policy/js/compliance/ComplianceRulesTest.java
@@ -46,6 +46,7 @@ import org.candlepin.model.Rules;
 import org.candlepin.model.RulesCurator;
 import org.candlepin.test.TestUtil;
 import org.candlepin.util.Util;
+import org.candlepin.util.VersionUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -78,7 +79,7 @@ public class ComplianceRulesTest {
 
         // Load the default production rules:
         InputStream is = this.getClass().getResourceAsStream(RULES_FILE);
-        Rules rules = new Rules(Util.readFile(is));
+        Rules rules = new Rules(Util.readFile(is), VersionUtil.getVersionString());
         when(rulesCuratorMock.getUpdated()).thenReturn(new Date());
         when(rulesCuratorMock.getRules()).thenReturn(rules);
         provider = new JsRulesProvider(rulesCuratorMock);

--- a/src/test/java/org/candlepin/policy/test/JsExportRulesTest.java
+++ b/src/test/java/org/candlepin/policy/test/JsExportRulesTest.java
@@ -32,6 +32,7 @@ import org.candlepin.policy.js.JsRulesProvider;
 import org.candlepin.policy.js.export.JsExportRules;
 import org.candlepin.service.ProductServiceAdapter;
 import org.candlepin.util.Util;
+import org.candlepin.util.VersionUtil;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -65,7 +66,7 @@ public class JsExportRulesTest {
 
         // Load the default production rules:
         InputStream is = this.getClass().getResourceAsStream(RULES_FILE);
-        Rules rules = new Rules(Util.readFile(is));
+        Rules rules = new Rules(Util.readFile(is), VersionUtil.getVersionString());
 
         when(rulesCuratorMock.getUpdated()).thenReturn(new Date());
         when(rulesCuratorMock.getRules()).thenReturn(rules);

--- a/src/test/java/org/candlepin/policy/test/JsPoolRulesTest.java
+++ b/src/test/java/org/candlepin/policy/test/JsPoolRulesTest.java
@@ -50,6 +50,7 @@ import org.candlepin.policy.js.pool.PoolUpdate;
 import org.candlepin.service.ProductServiceAdapter;
 import org.candlepin.test.TestUtil;
 import org.candlepin.util.Util;
+import org.candlepin.util.VersionUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -81,7 +82,7 @@ public class JsPoolRulesTest {
 
         // Load the default production rules:
         InputStream is = this.getClass().getResourceAsStream(RULES_FILE);
-        Rules rules = new Rules(Util.readFile(is));
+        Rules rules = new Rules(Util.readFile(is), VersionUtil.getVersionString());
 
         when(rulesCuratorMock.getUpdated()).thenReturn(new Date());
         when(rulesCuratorMock.getRules()).thenReturn(rules);

--- a/src/test/java/org/candlepin/resource/test/RulesResourceTest.java
+++ b/src/test/java/org/candlepin/resource/test/RulesResourceTest.java
@@ -16,8 +16,10 @@ package org.candlepin.resource.test;
 
 import static org.junit.Assert.assertEquals;
 
+import org.candlepin.model.Rules;
 import org.candlepin.resource.RulesResource;
 import org.candlepin.test.DatabaseTestFixture;
+import org.candlepin.util.VersionUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.apache.commons.codec.binary.Base64;
@@ -31,7 +33,6 @@ public class RulesResourceTest extends DatabaseTestFixture {
 
     @Before
     public void setUp() {
-
         rulesResource = injector.getInstance(RulesResource.class);
     }
 
@@ -40,6 +41,8 @@ public class RulesResourceTest extends DatabaseTestFixture {
         String rulesBuffer = new String(Base64.encodeBase64String(("//foobar"
             .getBytes())));
         rulesResource.upload(rulesBuffer);
+        Rules rules = rulesCurator.getRules();
+        assertEquals(VersionUtil.getVersionString(), rules.getCandlepinVersion());
     }
 
     @Test

--- a/src/test/java/org/candlepin/resource/util/InstalledProductStatusCalculatorTest.java
+++ b/src/test/java/org/candlepin/resource/util/InstalledProductStatusCalculatorTest.java
@@ -44,6 +44,7 @@ import org.candlepin.policy.js.JsRulesProvider;
 import org.candlepin.policy.js.compliance.ComplianceRules;
 import org.candlepin.policy.js.compliance.ComplianceStatus;
 import org.candlepin.util.Util;
+import org.candlepin.util.VersionUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -74,7 +75,7 @@ public class InstalledProductStatusCalculatorTest {
 
         // Load the default production rules:
         InputStream is = this.getClass().getResourceAsStream(RULES_FILE);
-        Rules rules = new Rules(Util.readFile(is));
+        Rules rules = new Rules(Util.readFile(is), VersionUtil.getVersionString());
         when(rulesCuratorMock.getUpdated()).thenReturn(new Date());
         when(rulesCuratorMock.getRules()).thenReturn(rules);
         provider = new JsRulesProvider(rulesCuratorMock);

--- a/src/test/java/org/candlepin/sync/ImporterTest.java
+++ b/src/test/java/org/candlepin/sync/ImporterTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -226,7 +227,8 @@ public class ImporterTest {
         // if we do are importing candlepin 0.0.10 data into candlepin 0.0.3,
         // import the rules.
 
-        File actualmeta = createFile("/tmp/meta.json", "0.0.10", new Date(),
+        String version = "0.0.10";
+        File actualmeta = createFile("/tmp/meta.json", version, new Date(),
             "test_user", "prefix");
         File[] jsArray = createMockJsFile(MOCK_JS_PATH);
         ExporterMetadataCurator emc = mock(ExporterMetadataCurator.class);
@@ -237,7 +239,7 @@ public class ImporterTest {
         i.importRules(jsArray, actualmeta);
 
         //verify that rules were imported
-        verify(ri).importObject(any(Reader.class));
+        verify(ri).importObject(any(Reader.class), eq(version));
     }
 
     @Test
@@ -255,7 +257,7 @@ public class ImporterTest {
         i.validateMetadata(ExporterMetadata.TYPE_SYSTEM, null, actualmeta,
             new ConflictOverrides());
         //verify that rules were not imported
-        verify(ri, never()).importObject(any(Reader.class));
+        verify(ri, never()).importObject(any(Reader.class), any(String.class));
     }
 
     @Test(expected = ImporterException.class)

--- a/src/test/java/org/candlepin/sync/RulesExporterTest.java
+++ b/src/test/java/org/candlepin/sync/RulesExporterTest.java
@@ -23,6 +23,7 @@ import java.io.StringWriter;
 
 import org.candlepin.model.Rules;
 import org.candlepin.model.RulesCurator;
+import org.candlepin.util.VersionUtil;
 import org.junit.Test;
 
 /**
@@ -35,7 +36,8 @@ public class RulesExporterTest {
     @Test
     public void testMetaExporter() throws IOException {
         RulesCurator rulesCurator = mock(RulesCurator.class);
-        when(rulesCurator.getRules()).thenReturn(new Rules(FAKE_RULES));
+        when(rulesCurator.getRules()).thenReturn(new Rules(FAKE_RULES,
+            VersionUtil.getVersionString()));
         RulesExporter exporter = new RulesExporter(rulesCurator);
         StringWriter writer = new StringWriter();
         exporter.export(writer);

--- a/src/test/java/org/candlepin/sync/RulesImporterTest.java
+++ b/src/test/java/org/candlepin/sync/RulesImporterTest.java
@@ -22,6 +22,7 @@ import java.io.StringReader;
 
 import org.candlepin.model.Rules;
 import org.candlepin.model.RulesCurator;
+import org.candlepin.util.VersionUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -46,7 +47,7 @@ public class RulesImporterTest {
 
     @Test
     public void importRules() throws IOException {
-        importer.importObject(new StringReader(RULE));
+        importer.importObject(new StringReader(RULE), VersionUtil.getVersionString());
         verify(curator).update(any(Rules.class)); // TODO: can't get custom matcher to work?
     }
 

--- a/src/test/java/org/candlepin/util/VersionUtilTest.java
+++ b/src/test/java/org/candlepin/util/VersionUtilTest.java
@@ -17,6 +17,7 @@ package org.candlepin.util;
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertTrue;
 
+import org.candlepin.model.Rules;
 import org.junit.After;
 import org.junit.Test;
 
@@ -28,6 +29,7 @@ import java.util.Map;
  * VersionUtilTest
  */
 public class VersionUtilTest {
+
     @Test
     public void normalVersion() throws Exception {
         writeoutVersion("1.3.0", "1");
@@ -74,8 +76,14 @@ public class VersionUtilTest {
         assertTrue(VersionUtil.getRulesVersionCompatibility("0.5.20"));
     }
 
-    private void writeoutVersion(String version, String release) throws Exception {
-        PrintStream ps = new PrintStream(new File(this.getClass()
+    @Test
+    public void rulesCompatibilityVsNull() throws Exception {
+        writeoutVersion("0.5.15", "1");
+        assertFalse(VersionUtil.getRulesVersionCompatibility(null));
+    }
+
+    public static void writeoutVersion(String version, String release) throws Exception {
+        PrintStream ps = new PrintStream(new File(new Rules().getClass()
             .getClassLoader().getResource("candlepin_info.properties").toURI()));
         ps.println("version=" + version);
         ps.println("release=" + release);


### PR DESCRIPTION
We were correctly catching incoming old rules during manifest imports
and ignoring them in favor of those included in our rpm. We were not
handling old rules in the database after a candlepin upgrade however,
leading to major failures as we tried to use old rules that didn't work
on the new Candlepin.

Added a column in the rules table for the candlepin version the rules
originated from. This is set on import, as well as during a manual
upload (to the current version of candlepin).

When requesting the rules we check if the version in the database is
older than our current version and ignore it if so. If we see a null
candlepin version in the db, we know these must be older than the code
we're running.

Constructor updated to try to make sure we don't mistakenly store rules
without specifying that Candlepin version.
