### PR TITLE
allow to build in katello koji

### DIFF
--- a/rel-eng/releasers.conf
+++ b/rel-eng/releasers.conf
@@ -32,6 +32,10 @@ rsync = dept.rhndev.redhat.com:/var/www/dept/yum/candlepin/0.5/RHEL/6/ dept.rhnd
 releaser = tito.release.DistGitReleaser
 branches = sam-1.2-rhel-6
 
-[katello-koji]
+[koji]
 releaser = tito.release.KojiReleaser
 autobuild_tags = candlepin-nightly-rhel6 candlepin-nightly-fedora16
+
+[katello-koji]
+releaser = tito.release.KojiReleaser
+autobuild_tags = katello-thirdparty-candlepin-rhel6 katello-thirdparty-candlepin-fedora16 katello-thirdparty-candlepin-fedora17

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -14,3 +14,14 @@ blacklist =
 disttag = .fc17
 blacklist =
 
+[katello-thirdparty-candlepin-rhel6]
+disttag = .el6
+blacklist =
+
+[katello-thirdparty-candlepin-fedora16]
+disttag = .fc16
+blacklist =
+
+[katello-thirdparty-candlepin-fedora17]
+disttag = .fc17
+blacklist =


### PR DESCRIPTION
I suggest to use koji releaser for candlepin nightly and katello-koji releaser for candlepin for katello.
Which may not be always nightly.
