### PR TITLE
Fix a bug with distributor manifest conflicts.

### DIFF
--- a/src/main/java/org/candlepin/sync/Importer.java
+++ b/src/main/java/org/candlepin/sync/Importer.java
@@ -292,9 +292,10 @@ public class Importer {
         }
     }
 
-    @Transactional(rollbackOn = {IOException.class,
-            ImporterException.class, RuntimeException.class})
-    private ConsumerDto importObjects(Owner owner, Map<String, File> importFiles,
+    @Transactional(rollbackOn = {IOException.class, ImporterException.class,
+            RuntimeException.class, ImportConflictException.class})
+    // WARNING: Keep this method public, otherwise @Transactional is ignored:
+    ConsumerDto importObjects(Owner owner, Map<String, File> importFiles,
         ConflictOverrides overrides)
         throws IOException, ImporterException {
 


### PR DESCRIPTION
If you attempted to import and got a distributor conflict, the next
attempt would cause a MANIFEST_SAME conflict. Candlepin was not
correctly rolling back a change where we record the last import date and
the system mistakenly would think it had already imported this manifest.

Caused by @Transactional on a private method, which does not do
anything, so rollbacks were not kicking in correctly.
