### PR TITLE
variables should point to correct paths

### DIFF
--- a/code/setup/cpdb
+++ b/code/setup/cpdb
@@ -23,8 +23,8 @@ import os
 
 from optparse import OptionParser
 
-TOMCAT_CLASSPATH = "/var/lib/jbossas/server/production/deploy/candlepin.war/WEB-INF/classes/"
-JBOSS_CLASSPATH = "/var/lib/tomcat6/webapps/candlepin/WEB-INF/classes/"
+JBOSS_CLASSPATH = "/var/lib/jbossas/server/production/deploy/candlepin.war/WEB-INF/classes/"
+TOMCAT_CLASSPATH = "/var/lib/tomcat6/webapps/candlepin/WEB-INF/classes/"
 
 def run_command(command):
     (status, output) = commands.getstatusoutput(command)


### PR DESCRIPTION
The script variable names pointed to the wrong paths. This is really cosmetic because the code didn't care what they were called just looked to see if it was set and added it to the classpath. But as a maintainer the variable names are misleading.
