### PR TITLE
Allow retrieval of upstream subscription certificate via entitlement id

### DIFF
--- a/client/ruby/candlepin_api.rb
+++ b/client/ruby/candlepin_api.rb
@@ -598,6 +598,10 @@ class Candlepin
     return get_text("/subscriptions/#{sub_id}/cert", 'text/plain')
   end
 
+  def get_subscription_cert_by_ent_id(ent_id)
+    return get_text("/entitlements/#{ent_id}/upstream_cert", 'text/plain')
+  end
+
   def create_subscription(owner_key, product_id, quantity=1,
                           provided_products=[], contract_number='',
                           account_number='',start_date=nil,

--- a/spec/import_spec.rb
+++ b/spec/import_spec.rb
@@ -202,10 +202,18 @@ describe 'Candlepin Import' do
     end
   end
 
-  it "should store the subscription's upstream entitlement cert" do
+  it "should store the subscription upstream entitlement cert" do
     sublist = @cp.list_subscriptions(@import_owner['key'])
     cert = @cp.get_subscription_cert sublist.first.id
     cert[0..26].should == "-----BEGIN CERTIFICATE-----"
     cert.include?("-----BEGIN RSA PRIVATE KEY-----").should == true
+
+    # while were here, lets access the upstream cert via entitlement id
+    pools =  @import_owner_client.list_pools({:owner => @import_owner['id']})
+    pool = pools.find_all {|p| p.subscriptionId == sublist.first.id}[0]
+    consumer = consumer_client(@import_owner_client, 'system6')
+    entitlement = consumer.consume_pool(pool.id)[0]
+    ent =  @cp.get_subscription_cert_by_ent_id entitlement.id
+    cert.should == ent
   end
 end

--- a/src/main/java/org/candlepin/resource/EntitlementResource.java
+++ b/src/main/java/org/candlepin/resource/EntitlementResource.java
@@ -16,27 +16,10 @@ package org.candlepin.resource;
 
 import static org.quartz.JobBuilder.newJob;
 
-import org.candlepin.auth.interceptor.Verify;
-import org.candlepin.controller.PoolManager;
-import org.candlepin.exceptions.BadRequestException;
-import org.candlepin.exceptions.NotFoundException;
-import org.candlepin.model.Consumer;
-import org.candlepin.model.ConsumerCurator;
-import org.candlepin.model.Entitlement;
-import org.candlepin.model.EntitlementCurator;
-import org.candlepin.pinsetter.tasks.RegenProductEntitlementCertsJob;
-import org.candlepin.service.ProductServiceAdapter;
-import org.candlepin.util.Util;
-
-import com.google.inject.Inject;
-
-import org.quartz.JobDataMap;
-import org.quartz.JobDetail;
-import org.xnap.commons.i18n.I18n;
-
 import java.util.Arrays;
 import java.util.List;
 
+import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
@@ -47,6 +30,25 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
+import org.candlepin.auth.interceptor.Verify;
+import org.candlepin.controller.PoolManager;
+import org.candlepin.exceptions.BadRequestException;
+import org.candlepin.exceptions.NotFoundException;
+import org.candlepin.model.Consumer;
+import org.candlepin.model.ConsumerCurator;
+import org.candlepin.model.Entitlement;
+import org.candlepin.model.EntitlementCurator;
+import org.candlepin.model.SubscriptionCurator;
+import org.candlepin.pinsetter.tasks.RegenProductEntitlementCertsJob;
+import org.candlepin.service.ProductServiceAdapter;
+import org.candlepin.service.SubscriptionServiceAdapter;
+import org.candlepin.util.Util;
+import org.quartz.JobDataMap;
+import org.quartz.JobDetail;
+import org.xnap.commons.i18n.I18n;
+
+import com.google.inject.Inject;
+
 /**
  * REST api gateway for the User object.
  */
@@ -55,17 +57,23 @@ public class EntitlementResource {
     private final ConsumerCurator consumerCurator;
     private PoolManager poolManager;
     private final EntitlementCurator entitlementCurator;
+    private final SubscriptionCurator subscriptionCurator;
+    private SubscriptionServiceAdapter subService;
     private I18n i18n;
     private ProductServiceAdapter prodAdapter;
 
     @Inject
     public EntitlementResource(ProductServiceAdapter prodAdapter,
             EntitlementCurator entitlementCurator,
+            SubscriptionCurator subscriptionCurator,
             ConsumerCurator consumerCurator,
+            SubscriptionServiceAdapter subService,
             PoolManager poolManager,
             I18n i18n) {
 
         this.entitlementCurator = entitlementCurator;
+        this.subscriptionCurator = subscriptionCurator;
+        this.subService = subService;
         this.consumerCurator = consumerCurator;
         this.i18n = i18n;
         this.prodAdapter = prodAdapter;
@@ -150,6 +158,36 @@ public class EntitlementResource {
         }
         throw new NotFoundException(
             i18n.tr("Entitlement with ID ''{0}'' could not be found.", dbid));
+    }
+
+    /**
+     * Return the subscription cert for the given id.
+     * @param dbid entitlement id.
+     * @return the subscription cert for the given id.
+     * @httpcode 404
+     * @httpcode 200
+     */
+    @GET
+    @Consumes({MediaType.TEXT_PLAIN, MediaType.APPLICATION_JSON})
+    @Produces({ MediaType.TEXT_PLAIN })
+    @Path("{dbid}/upstream_cert")
+    public String getEntitlementUpstreamCert(
+        @PathParam("dbid") String dbid) {
+        Entitlement ent = entitlementCurator.find(dbid);
+        List<Entitlement> tempList = Arrays.asList(ent);
+        poolManager.regenerateDirtyEntitlements(tempList);
+
+        String subscriptionId = ent.getPool().getSubscriptionId();
+        SubscriptionResource subResource = new SubscriptionResource(subService,
+            consumerCurator, i18n);
+        String sc = subResource.getSubCertAsPem(subscriptionId);
+
+        if (sc != null) {
+            return sc;
+        }
+        throw new NotFoundException(
+            i18n.tr("SubscriptionsCertificate for Entitlement ID ''{0}'' " +
+                "could not be found.", dbid));
     }
 
     /**


### PR DESCRIPTION
Added to allow Thumbslug to get the subscription certificate from Candlepin without needing
 to parse the entitlement certificate
