### PR TITLE
Add a build target to build candlepin as a jar, so it can be used by other apps

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -53,8 +53,8 @@
               value="${target.dir}/candlepin-${version}.war" />
     <property name="api.jar"
               value="${target.dir}/candlepin-api-${version}.jar" />
-    <property name="candlepin.jar"
-              value="${target.dir}/candlepin-${version}.jar" />
+    <property name="candlepin-certgen.jar"
+              value="${target.dir}/candlepin-certgen-${version}.jar" />
   </target>
 
   <target name="da_popo">
@@ -160,9 +160,16 @@
         <attribute name="Build-Jdk" value="" />
       </manifest>
     </jar>
-    <jar destfile="${candlepin.jar}">
+    <jar destfile="${candlepin-certgen.jar}">
       <fileset dir="${target.dir}/classes">
-        <include name="**"/>
+        <include name="**/config/**"/>
+        <include name="**/util/**"/>
+        <include name="**/service/**"/>
+        <include name="**/model/**"/>
+        <include name="**/pki/**"/>
+        <include name="**/jackson/**"/>
+        <!-- only used to retrieve class names in Config-->
+        <include name="**/pinsetter/**"/>
       </fileset>
       <manifest>
         <attribute name="Implementation-Vendor" value="" />

--- a/buildfile
+++ b/buildfile
@@ -186,7 +186,7 @@ define "candlepin" do
   doc.using :tag => 'httpcode:m:HTTP Code:'
 
   package(:jar, :id=>'candlepin-api').clean.include 'target/classes/org/candlepin/auth','target/classes/org/candlepin/config','target/classes/org/candlepin/service','target/classes/org/candlepin/model','target/classes/org/candlepin/pki', 'target/classes/org/candlepin/exceptions', 'target/classes/org/candlepin/util', :path=>"org/candlepin/"
-  package(:jar, :id=>"candlepin").include 'target/classes/org/candlepin'
+  package(:jar, :id=>"candlepin-certgen").clean.include 'target/classes/org/candlepin/config', 'target/classes/org/candlepin/jackson', 'target/classes/org/candlepin/model', 'target/classes/org/candlepin/pki', 'target/classes/org/candlepin/util', 'target/classes/org/candlepin/service','target/classes/org/candlepin/pinsetter', :path=>'org/candlepin'
   package(:war, :id=>"candlepin").libs += artifacts(HSQLDB)
   package(:war, :id=>"candlepin").classes << generate
 

--- a/candlepin.spec
+++ b/candlepin.spec
@@ -141,11 +141,11 @@ Group: Development/Libraries
 %description devel
 Development libraries for candlepin integration
 
-%package jar
-Summary: candlepin library for use by other apps
+%package certgen-lib
+Summary: candlepin certgen library for use by other apps
 Group: Internet/Applications
 
-%description jar
+%description certgen-lib
 candlepin library for use by other apps
 
 
@@ -219,8 +219,8 @@ install -m 644 target/%{name}-api-%{version}.jar $RPM_BUILD_ROOT/%{_datadir}/%{n
 
 # jar
 install -d -m 755 $RPM_BUILD_ROOT/usr/share/java
-install -m 644 target/%{name}-%{version}.jar $RPM_BUILD_ROOT/usr/share/java/
-ln -s /usr/share/java/candlepin-%{version}.jar $RPM_BUILD_ROOT/usr/share/java/candlepin.jar
+install -m 644 target/%{name}-certgen-%{version}.jar $RPM_BUILD_ROOT/usr/share/java/
+ln -s /usr/share/java/candlepin-certgen-%{version}.jar $RPM_BUILD_ROOT/usr/share/java/candlepin-certgen.jar
 
 # /var/lib dir for hornetq state
 install -d -m 755 $RPM_BUILD_ROOT/%{_localstatedir}/lib/%{name}
@@ -292,10 +292,10 @@ fi
 %defattr(644,root,root,775)
 %{_datadir}/%{name}/lib/%{name}-api-%{version}.jar
 
-%files jar
+%files certgen-lib
 %defattr(644,root,root,775)
-/usr/share/java/%{name}-%{version}.jar
-/usr/share/java/%{name}.jar
+/usr/share/java/%{name}-certgen-%{version}.jar
+/usr/share/java/%{name}-certgen.jar
 
 %files selinux
 %defattr(-,root,root,0755)


### PR DESCRIPTION
Add a build target to build candlepin as a jar, so its code can be used by other apps.

Also, create a new rpm for the jar.
