### PR TITLE
Remove unneeded code from getEntitlementUpstreamCert

### DIFF
--- a/src/main/java/org/candlepin/resource/EntitlementResource.java
+++ b/src/main/java/org/candlepin/resource/EntitlementResource.java
@@ -174,20 +174,18 @@ public class EntitlementResource {
     public String getEntitlementUpstreamCert(
         @PathParam("dbid") String dbid) {
         Entitlement ent = entitlementCurator.find(dbid);
-        List<Entitlement> tempList = Arrays.asList(ent);
-        poolManager.regenerateDirtyEntitlements(tempList);
+        // optimization: don't do entitlement regen here, as we don't read
+        // the entitlement certificate in this call.
+
+        if (ent == null) {
+            throw new NotFoundException(i18n.tr(
+                "Entitlement with ID ''{0}'' could not be found.", dbid));
+        }
 
         String subscriptionId = ent.getPool().getSubscriptionId();
         SubscriptionResource subResource = new SubscriptionResource(subService,
             consumerCurator, i18n);
-        String sc = subResource.getSubCertAsPem(subscriptionId);
-
-        if (sc != null) {
-            return sc;
-        }
-        throw new NotFoundException(
-            i18n.tr("SubscriptionsCertificate for Entitlement ID ''{0}'' " +
-                "could not be found.", dbid));
+        return subResource.getSubCertAsPem(subscriptionId);
     }
 
     /**


### PR DESCRIPTION
There's no need to regenerate the entitlement certificate and doing so
could actually be harmful, as the call does not return the cert.

The code in SubscriptionResource will handle any exceptions for a
missing subscription or no upstream cert.
