### PR TITLE
Performance improvements around anonymous entry points.

### DIFF
--- a/src/main/java/org/candlepin/auth/interceptor/SecurityHole.java
+++ b/src/main/java/org/candlepin/auth/interceptor/SecurityHole.java
@@ -20,10 +20,23 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- *
+ * Annotation to control access into a method. If noAuth is set to true, then the
+ * system will attempt to authenticate the user, but will still let the call through
+ * if authentication can not be done. If anon is set to true, then no
+ * authentication will be done.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD})
 public @interface SecurityHole {
+    /**
+     * Set to true if the method does not require an identity (e.g.
+     * a ConsumerPrincipal) but the engine should try and create it first.
+     */
     boolean noAuth() default false;
+
+    /**
+     * Set to true if the method does not require an identity (e.g.
+     * a ConsumerPrincipal) and the engine should not try and create it.
+     */
+    boolean anon() default false;
 }

--- a/src/main/java/org/candlepin/resource/StatusResource.java
+++ b/src/main/java/org/candlepin/resource/StatusResource.java
@@ -71,7 +71,7 @@ public class StatusResource {
      */
     @GET
     @Produces({ MediaType.APPLICATION_JSON})
-    @SecurityHole(noAuth = true)
+    @SecurityHole(noAuth = true, anon = true)
     public Status status() {
         boolean good = true;
         try {


### PR DESCRIPTION
This should not be a huge benefit, but it allows for methods to mark themselves as anonymous. When
this is done, no principal is created. This is done primarily for the status and root controllers.

Other changes include:

1) Adding an authrnficationRequied method to the principal This method allwos
the security interceptor code to not use reflection to look for annotations unless it is necessary.

2) Only generate the links in the root controller once. This is really not related ot this patch, but it pissed me
off.
