### PR TITLE
Improve performance of subscribe action in standalone mode.

### DIFF
--- a/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -322,6 +322,10 @@ public class CandlepinPoolManager implements PoolManager {
         return this.poolCurator.lookupBySubscriptionId(id);
     }
 
+    public List<Pool> lookupOversubscribedBySubscriptionId(String id) {
+        return this.poolCurator.lookupOversubscribedBySubscriptionId(id);
+    }
+
     /**
      * Request an entitlement by product. If the entitlement cannot be granted,
      * null will be returned. TODO: Throw exception if entitlement not granted.
@@ -527,7 +531,8 @@ public class CandlepinPoolManager implements PoolManager {
      * @param pool
      */
     private void checkBonusPoolQuantities(Consumer consumer, Pool pool) {
-        for (Pool derivedPool : lookupBySubscriptionId(pool.getSubscriptionId())) {
+        for (Pool derivedPool :
+                lookupOversubscribedBySubscriptionId(pool.getSubscriptionId())) {
             if (!derivedPool.getId().equals(pool.getId()) &&
                 derivedPool.getQuantity() != -1) {
                 deleteExcessEntitlements(derivedPool);

--- a/src/main/java/org/candlepin/model/PoolCurator.java
+++ b/src/main/java/org/candlepin/model/PoolCurator.java
@@ -334,6 +334,16 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
         .add(Restrictions.eq("subscriptionId", subId)).list();
     }
 
+    public List<Pool> lookupOversubscribedBySubscriptionId(String subId) {
+        String queryString = "from Pool as pool " +
+            "where pool.subscriptionId = :subId AND " +
+            "pool.quantity >= 0 AND " +
+            "pool.consumed > pool.quantity ";
+        Query query = currentSession().createQuery(queryString);
+        query.setString("subId", subId);
+        return query.list();
+    }
+
     @Transactional
     public Pool replicate(Pool pool) {
         for (ProvidedProduct pp : pool.getProvidedProducts()) {

--- a/src/test/java/org/candlepin/model/test/PoolCuratorTest.java
+++ b/src/test/java/org/candlepin/model/test/PoolCuratorTest.java
@@ -229,6 +229,52 @@ public class PoolCuratorTest extends DatabaseTestFixture {
     }
 
     @Test
+    public void testLoookupOverconsumedBySubscriptionId() {
+
+        Pool pool = createPoolAndSub(owner, product, 1L,
+            TestUtil.createDate(2050, 3, 2), TestUtil.createDate(2055, 3, 2));
+        poolCurator.create(pool);
+        String subid = pool.getSubscriptionId();
+        assertEquals(1, poolCurator.lookupBySubscriptionId(subid).size());
+        assertEquals(0, poolCurator.lookupOversubscribedBySubscriptionId(subid).size());
+
+
+        Entitlement e = new Entitlement(pool, consumer, pool.getStartDate(),
+            pool.getEndDate(), 1);
+        entitlementCurator.create(e);
+
+        assertEquals(0, poolCurator.lookupOversubscribedBySubscriptionId(subid).size());
+
+        e = new Entitlement(pool, consumer, pool.getStartDate(),
+            pool.getEndDate(), 1);
+        entitlementCurator.create(e);
+        assertEquals(1, poolCurator.lookupOversubscribedBySubscriptionId(subid).size());
+    }
+
+    @Test
+    public void testLoookupOverconsumedBySubscriptionIdIgnoresUnlimited() {
+
+        Pool pool = createPoolAndSub(owner, product, -1L,
+            TestUtil.createDate(2050, 3, 2), TestUtil.createDate(2055, 3, 2));
+        poolCurator.create(pool);
+        String subid = pool.getSubscriptionId();
+        assertEquals(1, poolCurator.lookupBySubscriptionId(subid).size());
+        assertEquals(0, poolCurator.lookupOversubscribedBySubscriptionId(subid).size());
+
+
+        Entitlement e = new Entitlement(pool, consumer, pool.getStartDate(),
+            pool.getEndDate(), 1);
+        entitlementCurator.create(e);
+
+        assertEquals(0, poolCurator.lookupOversubscribedBySubscriptionId(subid).size());
+
+        e = new Entitlement(pool, consumer, pool.getStartDate(),
+            pool.getEndDate(), 1);
+        entitlementCurator.create(e);
+        assertEquals(0, poolCurator.lookupOversubscribedBySubscriptionId(subid).size());
+    }
+
+    @Test
     public void testListByActiveOnIncludesSameStartDay() {
         Date activeOn = TestUtil.createDate(2011, 2, 2);
 


### PR DESCRIPTION
For large subscriptions which provided bonus pools, there is a linear performance
degredation as the number of subscriptions increases. This is due to iterating over
all bonus pools in memory to find those which are overconsumed. This patch pushes the
calculation of what pools are over consumed ot the database, so that we are only iterating
over those which need to change in memory.
