### PR TITLE
874785: null pointer while migrating owner

### DIFF
--- a/src/main/java/org/candlepin/pinsetter/tasks/MigrateOwnerJob.java
+++ b/src/main/java/org/candlepin/pinsetter/tasks/MigrateOwnerJob.java
@@ -297,8 +297,11 @@ public class MigrateOwnerJob implements Job {
 
             log.info("consumer.id: " + consumer.getId());
             log.info("consumer.entitlements:  " +
-                consumer.getEntitlements().toString());
-            log.info("consumer.facts: " + consumer.getFacts().toString());
+                ((consumer.getEntitlements() != null) ?
+                    consumer.getEntitlements().toString() : "null"));
+            log.info("consumer.facts: " +
+                ((consumer.getFacts() != null) ?
+                    consumer.getFacts().toString() : "null"));
             log.info("consumer.keyPair: " + consumer.getKeyPair());
             log.info("consumer.idcert: " + consumer.getIdCert());
 


### PR DESCRIPTION
The MigrateOwnerJob contains a series of log statements that were
not checking for null before calling toString(). This patch adds
null checking to the parts that need it (i.e. won't cause catastrophic
failure later on).

For example, I don't check the consumer for being null, that's just
going to fail miserably anyway so no point in the log statements.
