### PR TITLE
873655: Don't bundle the jar deps

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -219,10 +219,10 @@
     <attribute name="dir" />
 
     <sequential>
-      <echo message="Symlinking @{jars}" />
+      <echo message="Copying @{jars}" />
       <exec executable="build-jar-repository" failonerror="true" >
-        <arg value="--preserve-naming" />
-        <arg value="-c @{dir}" />
+        <arg value="-p" />
+        <arg value="-s @{dir}" />
         <arg line="@{jars}" />
       </exec>
     </sequential>

--- a/candlepin.spec
+++ b/candlepin.spec
@@ -171,7 +171,6 @@ SELinux policy module supporting candlepin
 
 %prep
 %setup -q
-#rm -rf %{distlibdir}
 mkdir -p %{distlibdir}
 
 %build
@@ -202,16 +201,25 @@ install -d -m 755 $RPM_BUILD_ROOT/%{_localstatedir}/lib/tomcat6/webapps/
 install -d -m 755 $RPM_BUILD_ROOT/%{_localstatedir}/lib/tomcat6/webapps/%{name}/
 install -d -m 755 $RPM_BUILD_ROOT/%{_sysconfdir}/tomcat6/
 unzip target/%{name}-%{version}.war -d $RPM_BUILD_ROOT/%{_localstatedir}/lib/tomcat6/webapps/%{name}/
+
+
+%if !0%{?reqcpdeps}
+#remove the copied jars and resymlink
+rm $RPM_BUILD_ROOT/%{_localstatedir}/lib/tomcat6/webapps/%{name}/WEB-INF/lib/*.jar
+ant -Ddistlibdir=$RPM_BUILD_ROOT/%{_localstatedir}/lib/tomcat6/webapps/%{name}/WEB-INF/lib/ initjars
+%endif
 ln -s /etc/candlepin/certs/keystore $RPM_BUILD_ROOT/%{_sysconfdir}/tomcat6/keystore
-#rm -f $RPM_BUILD_ROOT/%{_localstatedir}/lib/tomcat6/webapps/%{name}/WEB-INF/lib/bc*jdk16*.jar
-#ln -s %{_datadir}/java/bcprov.jar $RPM_BUILD_ROOT/%{_localstatedir}/lib/tomcat6/webapps/%{name}/WEB-INF/lib/bcprov.jar
 
 # jbossas
 install -d -m 755 $RPM_BUILD_ROOT/%{_localstatedir}/lib/jbossas/server/production/deploy/
 install -d -m 755 $RPM_BUILD_ROOT/%{_localstatedir}/lib/jbossas/server/production/deploy/%{name}.war
 unzip target/%{name}-%{version}.war -d $RPM_BUILD_ROOT/%{_localstatedir}/lib/jbossas/server/production/deploy/%{name}.war/
-#rm -f $RPM_BUILD_ROOT/%{_localstatedir}/lib/jbossas/server/production/deploy/%{name}.war/WEB-INF/lib/bc*jdk16*.jar
-#ln -s %{_datadir}/java/bcprov.jar $RPM_BUILD_ROOT/%{_localstatedir}/lib/jbossas/server/production/deploy/%{name}.war/WEB-INF/lib/bcprov.jar
+
+%if !0%{?reqcpdeps}
+#remove the copied jars and resymlink
+rm $RPM_BUILD_ROOT/%{_localstatedir}/lib/jbossas/server/production/deploy/%{name}.war/WEB-INF/lib/*.jar
+ant -Ddistlibdir=$RPM_BUILD_ROOT/%{_localstatedir}/lib/jbossas/server/production/deploy/%{name}.war/WEB-INF/lib/ initjars 
+%endif
 
 # devel
 install -d -m 755 $RPM_BUILD_ROOT/%{_datadir}/%{name}/lib/


### PR DESCRIPTION
Reuse the ant target that creates symlinks to the system jar copies
after exploding the war, so they're recognized by rpmbuild as symlinks.
