### PR TITLE
add LICENSE file to candlepin rpm

### DIFF
--- a/candlepin.spec
+++ b/candlepin.spec
@@ -276,6 +276,7 @@ fi
 %{_datadir}/%{name}/cpdb
 %{_sysconfdir}/%{name}/certs/
 %ghost %attr(644, root, root) %{_sysconfdir}/%{name}/certs/candlepin-ca.crt
+%doc LICENSE
 
 %files jboss
 %defattr(-,jboss,jboss,-)


### PR DESCRIPTION
## TEST PLAN

Build a test rpm:

_tito build --builder mock --builder-arg 'mock=fedora-17-x86_64-candlepin -D "reqcpdeps 1"' --test --rpm_

Then verify it has the LICENSE file in it (NOTE: your rpm might have a different version):

_rpm -qlp /tmp/tito/candlepin-0.7.19-1.git.46.89216b0.fc17.noarch.rpm_

Output should look something like this:

/etc/candlepin/certs
/etc/candlepin/certs/candlepin-ca.crt
/usr/share/candlepin
/usr/share/candlepin/cpdb
/usr/share/candlepin/cpsetup
**/usr/share/doc/candlepin-0.7.19/LICENSE**
