### PR TITLE
879022: Add message for too many content sets when V3 is disabled.

### DIFF
--- a/src/main/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapter.java
+++ b/src/main/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapter.java
@@ -293,9 +293,21 @@ public class DefaultEntitlementCertServiceAdapter extends
         // likely going to generate a certificate too large for the CDN, and return an
         // informative error message to the user.
         if (contentCounter > X509ExtensionUtil.V1_CONTENT_LIMIT) {
-            throw new CertificateSizeException(i18n.tr("Too many content sets for " +
-                "certificate. Please upgrade to a newer client to use subscription: {0}",
-                ent.getPool().getProductName()));
+            String cause;
+            if (config.certV3IsEnabled()) {
+                cause = i18n.tr("Too many content sets for certificate. Please upgrade " +
+                                "to a newer client to use subscription: {0}",
+                                ent.getPool().getProductName());
+            }
+            // TODO This can be removed once the candlepin.enable_cert_v3 config
+            //      option is removed.
+            else {
+                cause = i18n.tr("The support of V3 certificates is not enabled on the " +
+                                "server and is required for large content set " +
+                                "subscription: {0}", ent.getPool().getProductName());
+            }
+
+            throw new CertificateSizeException(cause);
         }
 
         if (sub != null) {


### PR DESCRIPTION
When cert V3 is disabled on the server and a client who supports
V3 certs attempts to consume an entitlement with too many content
sets, the error message would say that the client should be updated.

This is not the case if the client supports V3.0 certs... It is
because of the server, not the client.
