### PR TITLE
Add a setter for ID on ProductContent, and a buildfile fix

### DIFF
--- a/buildfile
+++ b/buildfile
@@ -194,7 +194,7 @@ define "candlepin" do
   doc.using :tag => 'httpcode:m:HTTP Code:'
 
   package(:jar, :id=>'candlepin-api').clean.include 'target/classes/org/candlepin/auth','target/classes/org/candlepin/config','target/classes/org/candlepin/service','target/classes/org/candlepin/model','target/classes/org/candlepin/pki', 'target/classes/org/candlepin/exceptions', 'target/classes/org/candlepin/util', :path=>"org/candlepin/"
-  package(:jar, :id=>"candlepin-certgen").clean.include 'target/classes/org/candlepin/config', 'target/classes/org/candlepin/jackson', 'target/classes/org/candlepin/model', 'target/classes/org/candlepin/pki', 'target/classes/org/candlepin/util', 'target/classes/org/candlepin/service','target/classes/org/candlepin/pinsetter', :path=>'org/candlepin'
+  package(:jar, :id=>"candlepin-certgen").clean.include 'target/classes/org/candlepin/config', 'target/classes/org/candlepin/jackson', 'target/classes/org/candlepin/model', 'target/classes/org/candlepin/pki', 'target/classes/org/candlepin/util', 'target/classes/org/candlepin/service','target/classes/org/candlepin/pinsetter','target/classes/org/candlepin/exceptions', :path=>'org/candlepin'
   package(:war, :id=>"candlepin").libs += artifacts(HSQLDB)
   package(:war, :id=>"candlepin").classes << generate
 

--- a/src/main/java/org/candlepin/model/ProductContent.java
+++ b/src/main/java/org/candlepin/model/ProductContent.java
@@ -58,6 +58,11 @@ public class ProductContent extends AbstractHibernateObject {
         return null;
     }
 
+    public void setId(String s) {
+        // TODO: just here to appease jackson
+        return;
+    }
+
     /**
      * @param content the content to set
      */


### PR DESCRIPTION
ProductContent did not contain a setter for ID, which made it impossible to
serialize the object and then deserialize again. A dummy setter has been added,
to allow for deserialization from json.

Additionally, the custom candlepin exception classes were missing from the
certgen jar. I am not sure how this was missed, but it needs to be in there,
since we need to handle IseExceptions from library calls to candlepin.
