### PR TITLE
Overconsumption check performance fix.

### DIFF
--- a/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -324,8 +324,8 @@ public class CandlepinPoolManager implements PoolManager {
         return this.poolCurator.lookupBySubscriptionId(id);
     }
 
-    public List<Pool> lookupOversubscribedBySubscriptionId(String id) {
-        return this.poolCurator.lookupOversubscribedBySubscriptionId(id);
+    public List<Pool> lookupOversubscribedBySubscriptionId(String subId, Entitlement ent) {
+        return this.poolCurator.lookupOversubscribedBySubscriptionId(subId, ent);
     }
 
     /**
@@ -567,9 +567,9 @@ public class CandlepinPoolManager implements PoolManager {
      * @param consumer
      * @param pool
      */
-    private void checkBonusPoolQuantities(Consumer consumer, Pool pool) {
+    private void checkBonusPoolQuantities(Consumer consumer, Pool pool, Entitlement e) {
         for (Pool derivedPool :
-                lookupOversubscribedBySubscriptionId(pool.getSubscriptionId())) {
+                lookupOversubscribedBySubscriptionId(pool.getSubscriptionId(), e)) {
             if (!derivedPool.getId().equals(pool.getId()) &&
                 derivedPool.getQuantity() != -1) {
                 deleteExcessEntitlements(derivedPool);
@@ -994,7 +994,7 @@ public class CandlepinPoolManager implements PoolManager {
         @Override
         public void handleBonusPools(Consumer consumer, Pool pool,
             Entitlement entitlement) {
-            checkBonusPoolQuantities(consumer, pool);
+            checkBonusPoolQuantities(consumer, pool, entitlement);
         }
     }
 
@@ -1026,7 +1026,7 @@ public class CandlepinPoolManager implements PoolManager {
             Entitlement entitlement) {
             updatePoolsForSubscription(poolCurator.listBySourceEntitlement(entitlement),
                 subAdapter.getSubscription(pool.getSubscriptionId()));
-            checkBonusPoolQuantities(consumer, pool);
+            checkBonusPoolQuantities(consumer, pool, entitlement);
         }
     }
 }


### PR DESCRIPTION
Following a bind we check all pools that potentially may have been
modified during the bind to see if any are now oversubscribed. Currently
this is just to accomodate hosted binds to virt_limit pools when the
consumer is a manifest consumer. In this future this is probably going
to be used in other cases as well.

On-site, with virt bonus pools, we were looking at ~10k entitlements
from a virt_limit pool, plus one pool per entitlement for the host
restricted guest pools. This resulted in gradual performance
degredation, at the 10k mark a bind was taking about 20s.

Using some knowledge of what pools could actually be changed as the
result of a bind (or a modify entitlement quantity), we know that we
only need to check pools where the source entitlement is null (i.e. virt
bonus pools in hosted, at most 2), or the source entitlement is the
entitlement being granted/modified (at most 1). This cuts a massive
amount of data churn down to just a max of around 2 pools and eliminates
90% of the time spent in the bind operation.

After this bind should not experience any degredation as the number of
entitlements to the pool grows.

Conflicts:
    src/main/java/org/candlepin/controller/CandlepinPoolManager.java
