### PR TITLE
884694: Fix import of manifests into older candlepin.

### DIFF
--- a/src/main/java/org/candlepin/policy/js/pool/JsPoolRules.java
+++ b/src/main/java/org/candlepin/policy/js/pool/JsPoolRules.java
@@ -64,7 +64,6 @@ public class JsPoolRules implements PoolRules {
         args.put("helper", new PoolHelper(this.poolManager,
             this.productCache, null));
         args.put("standalone", config.standalone());
-        args.put("log", rulesLogger);
         List<Pool> poolsCreated = null;
         try {
             poolsCreated = jsRules.invokeMethod("createPools", args);

--- a/src/main/resources/rules/default-rules.js
+++ b/src/main/resources/rules/default-rules.js
@@ -185,7 +185,7 @@ function get_attribute_from_pool(pool, attributeName) {
     return value
 }
 
-// get the number of sockets that each entitlement from a pool covers. 
+// get the number of sockets that each entitlement from a pool covers.
 // if sockets is set to 0 or is not set, it is considered to be unlimited.
 function get_pool_sockets(pool) {
     if (pool.getProductAttribute("sockets")) {
@@ -236,7 +236,7 @@ function findStackingPools(pool_class, consumer, compliance) {
     for each (stack_id in compliance.getPartialStacks().keySet().toArray()) {
         var covered_sockets = 0;
         for each (entitlement in partialStacks.get(stack_id).toArray()) {
-            covered_sockets += entitlement.getQuantity() * get_pool_sockets(entitlement.getPool()); 
+            covered_sockets += entitlement.getQuantity() * get_pool_sockets(entitlement.getPool());
             productIdToStackId[entitlement.getPool().getProductId()] = stack_id;
             for each (product in entitlement.getPool().getProvidedProducts().toArray()) {
                 productIdToStackId[product.getProductId()] = stack_id;
@@ -867,7 +867,6 @@ var Pool = {
      * Creates all appropriate pools for a subscription.
      */
     createPools: function () {
-        log.info("creating pool: " + sub.getId());
         var pools = new java.util.LinkedList();
         var quantity = sub.getQuantity() * sub.getProduct().getMultiplier();
         var providedProducts = new java.util.HashSet();
@@ -919,7 +918,6 @@ var Pool = {
                 if (virt_limit_quantity > 0) {
                     var virt_quantity = quantity * virt_limit_quantity;
 
-                    log.debug("creating virt only pool");
                     var derivedPool = helper.createPool(sub, sub.getProduct().getId(),
                                                         virt_quantity.toString(),
                                                         virt_attributes);
@@ -1094,12 +1092,12 @@ function ent_is_compliant(consumer, ent, log) {
         log.debug("  Entitlement does not cover system sockets.");
         return false;
     }
-    
+
     // Verify RAM coverage if required.
     // Default consumer RAM to 1 GB if not defined
     var consumerRam = get_consumer_ram(consumer);
     log.debug("  Consumer RAM found: " + consumerRam);
-    
+
     if (ent.getPool().getProductAttribute("ram")) {
         var poolRamAttr = get_attribute_from_pool(ent.getPool(), "ram");
         if (poolRamAttr != null && !poolRamAttr.isEmpty()) {
@@ -1113,7 +1111,7 @@ function ent_is_compliant(consumer, ent, log) {
     else {
         log.debug("  No RAM attribute on pool. Skipping RAM check.");
     }
-    
+
     return true
 }
 


### PR DESCRIPTION
This logger argument was introduced in 0.7.9, but we cannot make this
kind of change without breaking import into all previous candlepin's
with the framework we have today. (they do not make the log argument
available to the javascript, so any attempt to run it will fail)

This issue is a little hard to hit in that it only occurs after the bad
rules are imported, and another import is attempted which contains new
subscriptions. (the original import succeeds because it uses the old
rules for the duration of the request)

Have to remove the logger for now.

Changes originated in commit: 9c9e3d62
