### PR TITLE
858759: Do not remove guest virt ents when no host required

### DIFF
--- a/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -949,6 +949,12 @@ public class ConsumerResource {
         Set<Entitlement> deletableGuestEntitlements = new HashSet<Entitlement>();
         for (Entitlement entitlement : guest.getEntitlements()) {
             Pool pool = entitlement.getPool();
+
+            // If there is no host required, do not revoke the entitlement.
+            if (!pool.hasAttribute("requires_host")) {
+                continue;
+            }
+
             String requiredHost = getRequiredHost(pool);
             if (isVirtOnly(pool) && !requiredHost.equals(host.getUuid())) {
                 log.warn("Removing entitlement " + entitlement.getProductId() +

--- a/src/test/java/org/candlepin/resource/test/ConsumerResourceUpdateTest.java
+++ b/src/test/java/org/candlepin/resource/test/ConsumerResourceUpdateTest.java
@@ -545,7 +545,7 @@ public class ConsumerResourceUpdateTest {
 
         when(this.consumerCurator.findByUuid(uuid)).thenReturn(host);
 
-        Consumer updatedHost = createConsumerWithGuests("Guest 2");
+        Consumer updatedHost = createConsumerWithGuests("Guest 1");
         updatedHost.setUuid(uuid);
 
         Entitlement entitlement = TestUtil.createEntitlement();


### PR DESCRIPTION
When guest IDs are updated in hosted mode, do not remove
the guest's virt entitlements if requires_host is _not_ set
on the pool. This generally means that candlepin is running
in hosted mode and uses a 'flex guest' model. Regardless of
the guest's host, the guest can rightfully have the
entitlement.

Found a test covering this scenario that was falsly passing,
hence the bug. It is now fixed up and properly tests this
BZ fix.
