### PR TITLE
884973: Make guest/host UUID comparisons case insensitive.

### DIFF
--- a/src/main/java/org/candlepin/model/GuestId.java
+++ b/src/main/java/org/candlepin/model/GuestId.java
@@ -102,7 +102,7 @@ public class GuestId extends AbstractHibernateObject {
             return false;
         }
         GuestId that = (GuestId) other;
-        if (this.getGuestId().equals(that.getGuestId())) {
+        if (this.getGuestId().equalsIgnoreCase(that.getGuestId())) {
             return true;
         }
         return false;

--- a/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -921,6 +921,16 @@ public class ConsumerResource {
             sink.sendEvent(eventFactory.guestIdDeleted(existing, guestId));
 
         }
+
+        // If nothing shows as being added, and nothing shows as being removed, we should
+        // return false here and stop. This is done after the above logic however, as we
+        // still need to watch out for multiple hosts reporting the same guest, even if
+        // the list they are reporting has not changed.
+        if (removedGuests.size() == 0 && addedGuests.size() == 0) {
+            return false;
+        }
+
+        // Otherwise something must have changed:
         return true;
     }
 

--- a/src/test/java/org/candlepin/model/test/ConsumerTest.java
+++ b/src/test/java/org/candlepin/model/test/ConsumerTest.java
@@ -146,12 +146,17 @@ public class ConsumerTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void ensureUpdatedDateChangesOnUpdate() {
+    public void ensureUpdatedDateChangesOnUpdate() throws Exception {
         Date beforeUpdateDate = consumer.getUpdated();
 
         ConsumerResource consumerResource = injector.getInstance(ConsumerResource.class);
-        consumer.setFact("FACT", "FACT_VALUE");
-        consumerResource.updateConsumer(consumer.getUuid(), consumer);
+
+        // Create a new consumer, can't re-use reference to the old:
+        Consumer newConsumer = new Consumer();
+        newConsumer.setUuid(consumer.getUuid());
+        newConsumer.setFact("FACT", "FACT_VALUE");
+
+        consumerResource.updateConsumer(consumer.getUuid(), newConsumer);
 
         Consumer lookedUp = consumerCurator.find(consumer.getId());
         Date lookedUpDate = lookedUp.getUpdated();


### PR DESCRIPTION
Virt-who running against hyper-v can report guest UUIDs as uppercase,
while the guest itself will report it lowercase, breaking our guest/host
mapping mechanism.
- Updated queries to use case insensitive comparisons.
- Make sure getHost is case insensitive when looking for multiple hosts
  who have reported same guest ID but with different case. (just in
  case)
- Fixed an issue where events trigger when guest ID list being updated
  has not changed.
- Modified guest ID list reporting to be case insensitive when checking
  if anything has changed.
- Fix test incorrectly passing due to guest ID comparison event bug.
