### PR TITLE
886211: Fix a deadlock in mysql.

### DIFF
--- a/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -763,9 +763,18 @@ public class CandlepinPoolManager implements PoolManager {
         }
     }
 
-    @Override
+    /**
+     * Remove the given entitlement and clean up.
+     *
+     * @param entitlement entitlement to remove
+     * @param regenModified should we look for modified entitlements that are affected
+     * and regenerated. False if we're mass deleting all the entitlements for a consumer
+     * anyhow, true otherwise. Prevents a deadlock issue on mysql (at least).
+     */
     @Transactional
-    public void removeEntitlement(Entitlement entitlement) {
+    void removeEntitlement(Entitlement entitlement,
+        boolean regenModified) {
+
         Consumer consumer = entitlement.getConsumer();
         Pool pool = entitlement.getPool();
 
@@ -824,11 +833,13 @@ public class CandlepinPoolManager implements PoolManager {
         PoolHelper poolHelper = new PoolHelper(this, productCache, entitlement);
         enforcer.postUnbind(consumer, poolHelper, entitlement);
 
-        // Find all of the entitlements that modified the original entitlement,
-        // and regenerate those to remove the content sets.
-        // Lazy regeneration is ok here.
-        this.regenerateCertificatesOf(entitlementCurator
-            .listModifying(entitlement), true);
+        if (regenModified) {
+            // Find all of the entitlements that modified the original entitlement,
+            // and regenerate those to remove the content sets.
+            // Lazy regeneration is ok here.
+            this.regenerateCertificatesOf(entitlementCurator
+                .listModifying(entitlement), true);
+        }
 
         // Check consumer's new compliance status and save:
         ComplianceStatus compliance = complianceRules.getStatus(consumer, new Date());
@@ -842,7 +853,7 @@ public class CandlepinPoolManager implements PoolManager {
     @Transactional
     public void revokeEntitlement(Entitlement entitlement) {
         entCertAdapter.revokeEntitlementCertificates(entitlement);
-        removeEntitlement(entitlement);
+        removeEntitlement(entitlement, true);
     }
 
     @Override
@@ -850,7 +861,8 @@ public class CandlepinPoolManager implements PoolManager {
     public int revokeAllEntitlements(Consumer consumer) {
         int count = 0;
         for (Entitlement e : entitlementCurator.listByConsumer(consumer)) {
-            revokeEntitlement(e);
+            entCertAdapter.revokeEntitlementCertificates(e);
+            removeEntitlement(e, false);
             count++;
         }
         return count;
@@ -861,7 +873,7 @@ public class CandlepinPoolManager implements PoolManager {
     public int removeAllEntitlements(Consumer consumer) {
         int count = 0;
         for (Entitlement e : entitlementCurator.listByConsumer(consumer)) {
-            removeEntitlement(e);
+            removeEntitlement(e, false);
             count++;
         }
         return count;

--- a/src/main/java/org/candlepin/controller/PoolManager.java
+++ b/src/main/java/org/candlepin/controller/PoolManager.java
@@ -118,8 +118,6 @@ public interface PoolManager {
 
     void revokeEntitlement(Entitlement entitlement);
 
-    void removeEntitlement(Entitlement entitlement);
-
     Pool updatePoolQuantity(Pool pool, long adjust);
 
     Pool setPoolQuantity(Pool pool, long set);

--- a/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Matchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
@@ -286,6 +287,7 @@ public class PoolManagerTest {
         int total = manager.revokeAllEntitlements(c);
 
         assertEquals(2, total);
+        verify(entitlementCurator, never()).listModifying(any(Entitlement.class));
     }
 
     @Test


### PR DESCRIPTION
Appears to be an issue with deadlocks when deleting a consumer
originating in the listModifying routine. Verified that the bug in
question was not _actually_ using modifier entitlements, just the simple
act of looking for them across entitlements which were already deleted
caused a deadlock on mysql.

We don't need to do this when mass deleting entitlements because a
consumer was deleted, so disable this functionality when the
entitlements are getting revoked anyhow.

Made method in question package protected so @Transactional continues to
work, as it was only used by other methods in the class.

Used the one line from revokeEntitlement inside revokeAllEntitlements,
this prevents the regenModified parameter from leaking up into the
interface and around the code, when really it should be transparently
handled just by using the revoke/removeAll methods.
