### PR TITLE
887287: Detect when virt_limit is removed from subscriptions.

### DIFF
--- a/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -246,6 +246,15 @@ public class CandlepinPoolManager implements PoolManager {
 
             Pool existingPool = updatedPool.getPool();
 
+            // Delete pools the rules signal needed to be cleaned up:
+            if (existingPool.hasAttribute(PoolManager.DELETE_FLAG) &&
+                existingPool.getAttributeValue(PoolManager.DELETE_FLAG).equals("true")) {
+                log.warn("Deleting pool as requested by rules: " +
+                    existingPool.getId());
+                deletePool(existingPool);
+                continue;
+            }
+
             // quantity has changed. delete any excess entitlements from pool
             if (updatedPool.getQuantityChanged()) {
                 this.deleteExcessEntitlements(existingPool);

--- a/src/main/java/org/candlepin/controller/PoolManager.java
+++ b/src/main/java/org/candlepin/controller/PoolManager.java
@@ -32,6 +32,9 @@ import java.util.Set;
  */
 public interface PoolManager {
 
+    // WARNING: Changing these will impact rules files in the wild.
+    String DELETE_FLAG = "candlepin.delete_pool";
+
     Pool createPool(Pool p);
 
     /**

--- a/src/main/resources/rules/default-rules.js
+++ b/src/main/resources/rules/default-rules.js
@@ -953,37 +953,50 @@ var Pool = {
                 existingPool.attributeEquals("virt_only", "true") &&
                 existingPool.hasProductAttribute("virt_limit")) {
 
-                // Assuming there mere be a virt limit attribute set on the sub product,
-                // this is true for all pools with pool_derived. (for now...)
-                var virt_limit = attributes.get("virt_limit");
-
-                if ('unlimited'.equals(virt_limit)) {
-                    if (existingPool.getQuantity() == 0) {
-                        // this will only happen if the rules set it to be 0.
-                        //   don't modify
-                        expectedQuantity = 0;
-                    }
-                    else {
-                        // pretty much all the rest.
-                        expectedQuantity = -1;
-                    }
+                if (!attributes.containsKey("virt_limit")) {
+                    log.warn("virt_limit attribute has been removed from subscription, flagging pool for deletion if supported: " + existingPool.getId());
+                    // virt_limit has been removed! We need to clean up this pool. Set
+                    // attribute to notify the server of this:
+                    existingPool.setAttribute("candlepin.delete_pool", "true");
+                    // Older candlepin's won't look at the delete attribute, so we will
+                    // set the expected quantity to 0 to effectively disable the pool
+                    // on those servers as well.
+                    expectedQuantity = 0;
                 }
                 else {
-                    if (standalone) {
-                        // this is how we determined the quantity
-                        expectedQuantity = existingPool.getSourceEntitlement().getQuantity() * parseInt(virt_limit);
+                    var virt_limit = attributes.get("virt_limit");
+
+                    if ('unlimited'.equals(virt_limit)) {
+                        if (existingPool.getQuantity() == 0) {
+                            // this will only happen if the rules set it to be 0.
+                            //   don't modify
+                            expectedQuantity = 0;
+                        }
+                        else {
+                            // pretty much all the rest.
+                            expectedQuantity = -1;
+                        }
                     }
                     else {
-                        // we need to see if a parent pool exists and has been exported. Adjust is number exported
-                        //   from a parent pool. If no parent pool, adjust = 0 [a scenario of virtual pool only]
-                        var adjust = 0;
-                        for (var idex = 0 ; idex < pools.size(); idex++ ) {
-                            var derivedPool = pools.get(idex);
-                            if (!derivedPool.getAttributeValue("pool_derived")) {
-                                adjust = derivedPool.getExported();
-                            }
+                        if (standalone) {
+                            // this is how we determined the quantity
+                            expectedQuantity = existingPool.getSourceEntitlement().getQuantity() * parseInt(virt_limit);
                         }
-                        expectedQuantity = (expectedQuantity-adjust) * parseInt(virt_limit);
+                        else {
+                            // we need to see if a parent pool exists and has been exported. Adjust is number exported
+                            //   from a parent pool. If no parent pool, adjust = 0 [a scenario of virtual pool only]
+                            // WARNING: we're assuming there is only one base (non-derived) pool. This may change in the
+                            // future requiring a more complex adjustment for exported quantities if there are multiple
+                            // pools in play.
+                            var adjust = 0;
+                            for (var idex = 0 ; idex < pools.size(); idex++ ) {
+                                var derivedPool = pools.get(idex);
+                                if (!derivedPool.getAttributeValue("pool_derived")) {
+                                    adjust = derivedPool.getExported();
+                                }
+                            }
+                            expectedQuantity = (expectedQuantity-adjust) * parseInt(virt_limit);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
We now detect this scenario by comparing the incoming latest attributes
for a product, against the cached attributes on the pool being
refreshed. If we see virt_limit has disappeared, we signal to candlepin
that the pool should be cleaned up. Because old candlepin's will not
have this functionality, we also set the expected quantity to 0 to
effectively disable it on those servers as well.

This mechanism for the js rules to signal to candlepin that something
should be done is a new idea, but one that might help us get around the
issues we have where we cannot add new functionality/variables to the
rules as it would break on old candlepins. At least with this scenario,
the behavior is not implemented, but no errors will occur when used on
an old server.

This does not include support for detecting when virt_limit has been
_added_ to a product and creating the necessary bonus pool. This will be
handled as a separate bug due to time contraints.
