### PR TITLE
Fix improper logging of exceptions.

### DIFF
--- a/src/main/java/org/candlepin/audit/HornetqContextListener.java
+++ b/src/main/java/org/candlepin/audit/HornetqContextListener.java
@@ -107,7 +107,7 @@ public class HornetqContextListener {
             hornetqServer.start();
         }
         catch (Exception e) {
-            log.error("Failed to start hornetq message server - " + e);
+            log.error("Failed to start hornetq message server:", e);
             throw new RuntimeException(e);
         }
 
@@ -163,11 +163,11 @@ public class HornetqContextListener {
             session.close();
         }
         catch (HornetQException e) {
-            log.error("Problem cleaning old message queues - " + e);
+            log.error("Problem cleaning old message queues:", e);
             throw new RuntimeException(e);
         }
         catch (Exception e) {
-            log.error("Problem cleaning old message queues - " + e);
+            log.error("Problem cleaning old message queues:", e);
             throw new RuntimeException(e);
         }
     }

--- a/src/main/java/org/candlepin/pinsetter/tasks/CertificateRevocationListTask.java
+++ b/src/main/java/org/candlepin/pinsetter/tasks/CertificateRevocationListTask.java
@@ -74,15 +74,15 @@ public class CertificateRevocationListTask implements Job {
             crlFileUtil.writeCRLFile(crlFile, crl);
         }
         catch (CRLException e) {
-            log.error(e);
+            log.error("CRLException:", e);
             throw new JobExecutionException(e, false);
         }
         catch (CertificateException e) {
-            log.error(e);
+            log.error("CertificateException:", e);
             throw new JobExecutionException(e, false);
         }
         catch (IOException e) {
-            log.error(e);
+            log.error("IOException:", e);
             throw new JobExecutionException(e, false);
         }
     }

--- a/src/main/java/org/candlepin/pki/PKIUtility.java
+++ b/src/main/java/org/candlepin/pki/PKIUtility.java
@@ -153,7 +153,7 @@ public abstract class PKIUtility {
              * Can happen if your candlepin upstream cert is not the same length as the one
              * which signed the manifest. Treat it like a bad signature check failure.
              */
-            log.error(se);
+            log.error("SignatureException:", se);
             log.warn(ConfigProperties.CA_CERT_UPSTREAM + " may not match the server" +
                 " that signed manifest.");
             return false;

--- a/src/main/java/org/candlepin/policy/criteria/RulesCriteria.java
+++ b/src/main/java/org/candlepin/policy/criteria/RulesCriteria.java
@@ -83,8 +83,7 @@ public class RulesCriteria  {
             poolsCriteria = jsRules.invokeMethod("poolCriteria", args);
         }
         catch (NoSuchMethodException e) {
-            log.error("Unable to find javascript method: poolCriteria");
-            log.error(e);
+            log.error("Unable to find javascript method: poolCriteria", e);
             throw new IseException("Unable to create pool criteria.");
         }
         return poolsCriteria;

--- a/src/main/java/org/candlepin/policy/js/pool/JsPoolRules.java
+++ b/src/main/java/org/candlepin/policy/js/pool/JsPoolRules.java
@@ -69,8 +69,7 @@ public class JsPoolRules implements PoolRules {
             poolsCreated = jsRules.invokeMethod("createPools", args);
         }
         catch (NoSuchMethodException e) {
-            log.error("Unable to find javascript method: createPools");
-            log.error(e);
+            log.error("Unable to find javascript method: createPools", e);
             throw new IseException("Unable to create pools.");
         }
         return poolsCreated;
@@ -90,8 +89,7 @@ public class JsPoolRules implements PoolRules {
             poolsUpdated = jsRules.invokeMethod("updatePools", args);
         }
         catch (NoSuchMethodException e) {
-            log.error("Unable to find javascript method: updatePools");
-            log.error(e);
+            log.error("Unable to find javascript method: updatePools", e);
             throw new IseException("Unable to update pools.");
         }
         return poolsUpdated;

--- a/src/main/java/org/candlepin/sync/Importer.java
+++ b/src/main/java/org/candlepin/sync/Importer.java
@@ -294,8 +294,7 @@ public class Importer {
                     FileUtils.deleteDirectory(tmpDir);
                 }
                 catch (IOException e) {
-                    log.error("Failed to delete extracted export");
-                    log.error(e);
+                    log.error("Failed to delete extracted export", e);
                 }
             }
             if (exportStream != null) {


### PR DESCRIPTION
Using log.error(throwable) will just toString() the object and give you
a single line summary, hiding the stack trace entirely.
