### PR TITLE
886211: Add transactional annotations for CrlGenerator task.

### DIFF
--- a/src/main/java/org/candlepin/controller/CrlGenerator.java
+++ b/src/main/java/org/candlepin/controller/CrlGenerator.java
@@ -34,6 +34,7 @@ import org.candlepin.util.OIDUtil;
 import org.candlepin.util.Util;
 
 import com.google.inject.Inject;
+import com.google.inject.persist.Transactional;
 
 // TODO:  Clean up these protected methods - most are protected only for unit testing!
 /**
@@ -67,6 +68,7 @@ public class CrlGenerator {
      * @param x509crl the crl to sync (can be null).
      * @return the updated crl
      */
+    @Transactional
     public X509CRL syncCRLWithDB(X509CRL x509crl) {
         List<X509CRLEntryWrapper> crlEntries = null;
         BigInteger no = getCRLNumber(x509crl);
@@ -158,6 +160,7 @@ public class CrlGenerator {
      * @param serials certificate serials to be removed.
      * @return updated CRL with the given entries removed.
      */
+    @Transactional
     public X509CRL removeEntries(X509CRL x509crl, List<CertificateSerial> serials) {
         List<X509CRLEntryWrapper> crlEntries = null;
         BigInteger no = getCRLNumber(x509crl);


### PR DESCRIPTION
Looks like no transactions being explicitly opened during a CrlGenerate,
which does change things in the database. (deleting expired cert serials
for example)

This is another attempts fix for deadlocks on MySQL, current theory
being that an error in CrlGenerate may be deadlocking the db and
preventing consumer deletion.
