### PR TITLE
888035: Update messages for invalid certificates.

### DIFF
--- a/spec/ram_spec.rb
+++ b/spec/ram_spec.rb
@@ -59,7 +59,8 @@ describe 'RAM Limiting' do
     pool = find_pool(@owner.id, @ram_sub.id)
     pool.should_not == nil
 
-    expected_error = "Please upgrade to a newer client to use subscription: %s" % [@ram_product.name]
+    expected_error = ("The client must support at least v3.1 certificates in order to use subscription: %s." +
+                     " A newer client may be available to address this problem.") % [@ram_product.name]
     begin
       entitlement = system.consume_pool(pool.id)
       entitlement.should_not == nil

--- a/src/main/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapter.java
+++ b/src/main/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapter.java
@@ -198,8 +198,11 @@ public class DefaultEntitlementCertServiceAdapter extends
         // versions for all attributes.
         if (!ProductVersionValidator.verifyClientSupport(ent.getConsumer(),
             sub.getProduct().getAttributes())) {
-            throw new CertVersionConflictException(i18n.tr("Please upgrade to a newer " +
-                "client to use subscription: {0}", sub.getProduct().getName()));
+            throw new CertVersionConflictException(i18n.tr("The client must support " +
+                "at least v{0} certificates in order to use subscription: {1}. " +
+                "A newer client may be available to address this " +
+                "problem.", ProductVersionValidator.getMinimumCertificateVersion(sub),
+                sub.getProduct().getName()));
         }
     }
 
@@ -295,9 +298,10 @@ public class DefaultEntitlementCertServiceAdapter extends
         if (contentCounter > X509ExtensionUtil.V1_CONTENT_LIMIT) {
             String cause;
             if (config.certV3IsEnabled()) {
-                cause = i18n.tr("Too many content sets for certificate. Please upgrade " +
-                                "to a newer client to use subscription: {0}",
-                                ent.getPool().getProductName());
+                cause = i18n.tr("Too many content sets for certificate {0}. A newer " +
+                    "client may be available to address this problem. " +
+                    "See kbase https://access.redhat.com/knowledge/node/129003 for more " +
+                    "information.", ent.getPool().getProductName());
             }
             // TODO This can be removed once the candlepin.enable_cert_v3 config
             //      option is removed.

--- a/src/main/java/org/candlepin/version/ProductVersionValidator.java
+++ b/src/main/java/org/candlepin/version/ProductVersionValidator.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import org.candlepin.config.Config;
 import org.candlepin.model.Attribute;
 import org.candlepin.model.Consumer;
+import org.candlepin.model.Subscription;
 import org.candlepin.util.RpmVersionComparator;
 
 /**
@@ -82,6 +83,10 @@ public class ProductVersionValidator {
         Set<? extends Attribute> productAttributes) {
         String consumerVersion = consumer.getFact("system.certificate_version");
         return ProductVersionValidator.validate(productAttributes, consumerVersion);
+    }
+
+    public static String getMinimumCertificateVersion(Subscription sub) {
+        return ProductVersionValidator.getMin(sub.getProduct().getAttributes());
     }
 
     /**

--- a/src/test/java/org/candlepin/service/impl/test/DefaultEntitlementCertServiceAdapterTest.java
+++ b/src/test/java/org/candlepin/service/impl/test/DefaultEntitlementCertServiceAdapterTest.java
@@ -637,8 +637,10 @@ public class DefaultEntitlementCertServiceAdapterTest {
             fail("Expected CertException here.");
         }
         catch (CertVersionConflictException e) {
-            assertEquals("Please upgrade to a newer client to use subscription: " +
-                         subscription.getProduct().getName(), e.getMessage());
+            String expected = "The client must support at least v3.1 certificates in " +
+                "order to use subscription: " + subscription.getProduct().getName() +
+                ". A newer client may be available to address this problem.";
+            assertEquals(expected, e.getMessage());
         }
     }
 
@@ -669,8 +671,10 @@ public class DefaultEntitlementCertServiceAdapterTest {
             fail("Expected CertException here.");
         }
         catch (CertVersionConflictException e) {
-            assertEquals("Please upgrade to a newer client to use subscription: " +
-                         subscription.getProduct().getName(), e.getMessage());
+            String expected = "The client must support at least v3.1 certificates in " +
+                "order to use subscription: " + subscription.getProduct().getName() +
+                ". A newer client may be available to address this problem.";
+            assertEquals(expected, e.getMessage());
         }
     }
 


### PR DESCRIPTION
Requested message changes for when invalid certs are encountered:
- too many content sets
- client does not support vX.X certificates.
