### PR TITLE
888849: Fixed stalled jobs on async bind

### DIFF
--- a/src/main/java/org/candlepin/pinsetter/tasks/EntitlerJob.java
+++ b/src/main/java/org/candlepin/pinsetter/tasks/EntitlerJob.java
@@ -68,8 +68,10 @@ public class EntitlerJob implements Job {
 
             ctx.setResult("Entitlements created for owner");
         }
-        catch (CandlepinException ce) {
-            throw new JobExecutionException(ce.getMessage(), ce, false);
+        // Catch any exception that is fired and re-throw as a JobExecutionException
+        // so that the job will be properly cleaned up on failure.
+        catch (Exception e) {
+            throw new JobExecutionException(e.getMessage(), e, false);
         }
     }
 


### PR DESCRIPTION
Async bind jobs were only catching exceptions
at a CandlepinException level, however different
areas of the bind code path were throwing
RuntimeExceptions. When an uncaught exception was
thrown, the job would stall.

This became evident when an exception was thrown
because of too many content sets.
