### PR TITLE
803757: Users should not be able to enter anything other than positive i...

### DIFF
--- a/src/main/java/org/candlepin/config/Config.java
+++ b/src/main/java/org/candlepin/config/Config.java
@@ -16,7 +16,9 @@ package org.candlepin.config;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
@@ -258,6 +260,28 @@ public class Config {
         }
 
         return value.split(",");
+    }
+
+    /**
+     * get the config entry for string s
+     *
+     * @param s string to get the value of
+     * @return the value as an List
+     */
+    public List<String> getStringList(String s) {
+        if (s == null) {
+            return null;
+        }
+        String value = getString(s);
+
+        if (value == null) {
+            return null;
+        }
+        List<String> list = new ArrayList<String>();
+        for (String entry : value.split(",")) {
+            list.add(entry.trim());
+        }
+        return list;
     }
 
     public boolean getBoolean(String s) {

--- a/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -100,6 +100,51 @@ public class ConfigProperties {
 
     public static final String ENABLE_CERT_V3 = "candlepin.enable_cert_v3";
 
+    public static final String INTEGER_FACTS =
+        "candlepin.integer_facts";
+    private static final String INTEGER_FACT_LIST =
+        "";
+
+    public static final String POSITIVE_INTEGER_FACTS =
+        "candlepin.positive_integer_facts";
+    private static final String POSITIVE_INTEGER_FACT_LIST =
+        "cpu.core(s)_per_socket," +
+        "cpu.cpu(s)," +
+        "cpu.cpu_socket(s)," +
+        "lscpu.core(s)_per_socket," +
+        "lscpu.cpu(s)," +
+        "lscpu.numa_node(s)," +
+        "lscpu.numa_node0_cpu(s)," +
+        "lscpu.on-line_cpu(s)_list," +
+        "lscpu.socket(s)," +
+        "lscpu.thread(s)_per_core";
+
+    public static final String INTEGER_ATTRIBUTES =
+        "candlepin.integer_attriubtes";
+    private static final String INTEGER_ATTRIBUTE_LIST = "";
+
+    public static final String POSITIVE_INTEGER_ATTRIBUTES =
+        "candlepin.positive_integer_attributes";
+    private static final String POSITIVE_INTEGER_ATTRIBUTE_LIST =
+        "sockets," +
+        "warning_period," +
+        "ram";
+
+    public static final String LONG_ATTRIBUTES =
+        "candlepin.long_attributes";
+    private static final String LONG_ATTRIBUTE_LIST =
+        "";
+
+    public static final String POSITIVE_LONG_ATTRIBUTES =
+        "candlepin.positive_long_attributes";
+    private static final String POSITIVE_LONG_ATTRIBUTE_LIST =
+        "metadata_expire";
+
+    public static final String BOOLEAN_ATTRIBUTES = "candlepin.boolean_attributes";
+    private static final String BOOLEAN_ATTRIBUTE_LIST =
+        "management_enabled," +
+        "virt_only";
+
     public static final Map<String, String> DEFAULT_PROPERTIES =
         new HashMap<String, String>() {
 
@@ -181,6 +226,17 @@ public class ConfigProperties {
                  * By default, disable cert v3.
                  */
                 this.put(ENABLE_CERT_V3, "false");
+                /**
+                 * As we do math on some facts and attributes, we need to constrain
+                 * some values
+                 */
+                this.put(INTEGER_FACTS, INTEGER_FACT_LIST);
+                this.put(POSITIVE_INTEGER_FACTS, POSITIVE_INTEGER_FACT_LIST);
+                this.put(INTEGER_ATTRIBUTES, INTEGER_ATTRIBUTE_LIST);
+                this.put(POSITIVE_INTEGER_ATTRIBUTES, POSITIVE_INTEGER_ATTRIBUTE_LIST);
+                this.put(LONG_ATTRIBUTES, LONG_ATTRIBUTE_LIST);
+                this.put(POSITIVE_LONG_ATTRIBUTES, POSITIVE_LONG_ATTRIBUTE_LIST);
+                this.put(BOOLEAN_ATTRIBUTES, BOOLEAN_ATTRIBUTE_LIST);
             }
         };
     public static final String CRL_FILE_PATH = "candlepin.crl.file";

--- a/src/main/java/org/candlepin/model/ConsumerCurator.java
+++ b/src/main/java/org/candlepin/model/ConsumerCurator.java
@@ -60,7 +60,7 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
     public Consumer create(Consumer entity) {
         entity.ensureUUID();
         if (entity.getFacts() != null) {
-            entity.setFacts(filterFacts(entity.getFacts()));
+            entity.setFacts(filterAndVerifyFacts(entity.getFacts()));
         }
         validate(entity);
         return super.create(entity);
@@ -248,7 +248,7 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
         // TODO: Are any of these read-only?
         existingConsumer.setEntitlements(entitlementCurator
             .bulkUpdate(updatedConsumer.getEntitlements()));
-        Map<String, String> newFacts = filterFacts(updatedConsumer.getFacts());
+        Map<String, String> newFacts = filterAndVerifyFacts(updatedConsumer.getFacts());
         if (factsChanged(newFacts, existingConsumer.getFacts())) {
             existingConsumer.setFacts(newFacts);
         }
@@ -284,12 +284,35 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
      * @param facts
      * @return the list of facts filtered by the fact filter regex config
      */
-    private Map<String, String> filterFacts(Map<String, String> factsIn) {
+    private Map<String, String> filterAndVerifyFacts(Map<String, String> factsIn) {
         Map<String, String> facts = new HashMap<String, String>();
-        for (Entry<String, String> entry : factsIn.entrySet()) {
-            if (entry.getKey().matches(
-                config.getString(ConfigProperties.CONSUMER_FACTS_MATCHER))) {
+        String factMatch = config.getString(ConfigProperties.CONSUMER_FACTS_MATCHER);
+        List<String> intFacts = config.getStringList(
+            ConfigProperties.INTEGER_FACTS);
+        List<String> posFacts = config.getStringList(
+            ConfigProperties.POSITIVE_INTEGER_FACTS);
 
+        for (Entry<String, String> entry : factsIn.entrySet()) {
+            if (entry.getKey().matches(factMatch)) {
+                if (intFacts != null && intFacts.contains(entry.getKey()) ||
+                    posFacts != null && posFacts.contains(entry.getKey())) {
+                    int value = -1;
+                    try {
+                        value = Integer.parseInt(entry.getValue());
+                    }
+                    catch (NumberFormatException nfe) {
+                        throw new BadRequestException(i18n.tr(
+                            "The fact ''{0}'' must be an integer.",
+                            entry.getKey()));
+                    }
+                    if (posFacts != null && posFacts.contains(
+                        entry.getKey()) &&
+                        value <= 0) {
+                        throw new BadRequestException(i18n.tr(
+                            "The fact ''{0}'' must have a positive value.",
+                            entry.getKey()));
+                    }
+                }
                 facts.put(entry.getKey(), entry.getValue());
             }
         }

--- a/src/main/java/org/candlepin/model/ProductCurator.java
+++ b/src/main/java/org/candlepin/model/ProductCurator.java
@@ -14,17 +14,26 @@
  */
 package org.candlepin.model;
 
+import java.util.List;
+
 import org.candlepin.auth.interceptor.EnforceAccessControl;
-
-import com.google.inject.persist.Transactional;
-
+import org.candlepin.config.Config;
+import org.candlepin.config.ConfigProperties;
+import org.candlepin.exceptions.BadRequestException;
 import org.hibernate.Query;
 import org.hibernate.criterion.Restrictions;
+import org.xnap.commons.i18n.I18n;
+
+import com.google.inject.Inject;
+import com.google.inject.persist.Transactional;
 
 /**
  * interact with Products.
  */
 public class ProductCurator extends AbstractHibernateCurator<Product> {
+
+    @Inject private Config config;
+    @Inject private I18n i18n;
 
     /**
      * default ctor
@@ -68,6 +77,7 @@ public class ProductCurator extends AbstractHibernateCurator<Product> {
 
         for (ProductAttribute attr : p.getAttributes()) {
             attr.setProduct(p);
+            validateAttributeValue(attr);
         }
 
         merge(p);
@@ -84,9 +94,72 @@ public class ProductCurator extends AbstractHibernateCurator<Product> {
          */
         for (ProductAttribute attr : entity.getAttributes()) {
             attr.setProduct(entity);
+            validateAttributeValue(attr);
         }
 
         return super.create(entity);
+    }
+
+    private void validateAttributeValue(ProductAttribute attr) {
+        List<String> intAttrs = config.getStringList(ConfigProperties.INTEGER_ATTRIBUTES);
+        List<String> posIntAttrs = config.getStringList(
+            ConfigProperties.POSITIVE_INTEGER_ATTRIBUTES);
+        List<String> longAttrs = config.getStringList(ConfigProperties.LONG_ATTRIBUTES);
+        List<String> posLongAttrs = config.getStringList(
+            ConfigProperties.POSITIVE_LONG_ATTRIBUTES);
+        List<String> boolAttrs = config.getStringList(ConfigProperties.BOOLEAN_ATTRIBUTES);
+
+        if (attr.getValue() == null || attr.getValue().trim().equals("")) { return; }
+
+        if (intAttrs != null && intAttrs.contains(attr.getName()) ||
+            posIntAttrs != null && posIntAttrs.contains(attr.getName())) {
+            int value = -1;
+            try {
+                value = Integer.parseInt(attr.getValue());
+            }
+            catch (NumberFormatException nfe) {
+                throw new BadRequestException(i18n.tr(
+                    "The attribute ''{0}'' must be an integer value.",
+                    attr.getName()));
+            }
+            if (posIntAttrs != null && posIntAttrs.contains(
+                attr.getName()) &&
+                value <= 0) {
+                throw new BadRequestException(i18n.tr(
+                    "The attribute ''{0}'' must have a positive value.",
+                    attr.getName()));
+            }
+        }
+        else if (longAttrs != null && longAttrs.contains(attr.getName()) ||
+            posLongAttrs != null && posLongAttrs.contains(attr.getName())) {
+            long value = -1;
+            try {
+                value = Long.parseLong(attr.getValue());
+            }
+            catch (NumberFormatException nfe) {
+                throw new BadRequestException(i18n.tr(
+                    "The attribute ''{0}'' must be a long value.",
+                    attr.getName()));
+            }
+            if (posLongAttrs != null && posLongAttrs.contains(
+                attr.getName()) &&
+                value <= 0) {
+                throw new BadRequestException(i18n.tr(
+                    "The attribute ''{0}'' must have a positive value.",
+                    attr.getName()));
+            }
+        }
+        else if (boolAttrs != null && boolAttrs.contains(attr.getName())) {
+            if (attr.getValue() != null &&
+                !"true".equalsIgnoreCase(attr.getValue().trim()) &&
+                !"false".equalsIgnoreCase(attr.getValue()) &&
+                !"1".equalsIgnoreCase(attr.getValue()) &&
+                !"0".equalsIgnoreCase(attr.getValue())) {
+                throw new BadRequestException(i18n.tr(
+                    "The attribute ''{0}'' must be a boolean value.",
+                    attr.getName()));
+            }
+        }
     }
 
     @Transactional

--- a/src/test/java/org/candlepin/model/test/ConsumerTest.java
+++ b/src/test/java/org/candlepin/model/test/ConsumerTest.java
@@ -20,6 +20,12 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.persistence.PersistenceException;
+
 import org.candlepin.auth.ConsumerPrincipal;
 import org.candlepin.config.CandlepinCommonTestConfig;
 import org.candlepin.config.Config;
@@ -39,15 +45,8 @@ import org.candlepin.model.User;
 import org.candlepin.resource.ConsumerResource;
 import org.candlepin.test.DatabaseTestFixture;
 import org.candlepin.test.TestUtil;
-
 import org.junit.Before;
 import org.junit.Test;
-
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
-
-import javax.persistence.PersistenceException;
 
 public class ConsumerTest extends DatabaseTestFixture {
 

--- a/src/test/java/org/candlepin/model/test/ProductCuratorTest.java
+++ b/src/test/java/org/candlepin/model/test/ProductCuratorTest.java
@@ -31,15 +31,37 @@ import java.util.Set;
 
 import javax.persistence.PersistenceException;
 
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.type.TypeReference;
+import org.candlepin.config.CandlepinCommonTestConfig;
+import org.candlepin.config.Config;
+import org.candlepin.config.ConfigProperties;
+import org.candlepin.exceptions.BadRequestException;
 import org.candlepin.model.Content;
 import org.candlepin.model.Product;
 import org.candlepin.model.ProductAttribute;
 import org.candlepin.test.DatabaseTestFixture;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.type.TypeReference;
+import org.junit.Before;
 import org.junit.Test;
 
 public class ProductCuratorTest extends DatabaseTestFixture {
+
+    private CandlepinCommonTestConfig config = null;
+
+    @Before
+    public void setUp() {
+        config = (CandlepinCommonTestConfig) injector.getInstance(Config.class);
+        config.setProperty(ConfigProperties.INTEGER_ATTRIBUTES,
+            "product.count, product.multiplier");
+        config.setProperty(ConfigProperties.POSITIVE_INTEGER_ATTRIBUTES,
+            "product.pos_count");
+        config.setProperty(ConfigProperties.LONG_ATTRIBUTES,
+            "product.long_count, product.long_multiplier");
+        config.setProperty(ConfigProperties.POSITIVE_LONG_ATTRIBUTES,
+            "product.long_pos_count");
+        config.setProperty(ConfigProperties.BOOLEAN_ATTRIBUTES,
+            "product.bool_val_str, product.bool_val_num");
+    }
 
     @Test
     @SuppressWarnings("unchecked")
@@ -301,6 +323,142 @@ public class ProductCuratorTest extends DatabaseTestFixture {
         }
         // Old attributes should get cleaned up:
         assertEquals(3, all.size());
+    }
+
+    @Test
+    public void testProductAttributeValidationSuccessCreate() {
+        Product original = createTestProduct();
+        original.addAttribute(new ProductAttribute("product.count", "1"));
+        original.addAttribute(new ProductAttribute("product.pos_count", "5"));
+        original.addAttribute(new ProductAttribute("product.long_multiplier",
+            (new Long(Integer.MAX_VALUE * 1000)).toString()));
+        original.addAttribute(new ProductAttribute("product.long_pos_count", "23"));
+        original.addAttribute(new ProductAttribute("product.bool_val_str", "true"));
+        original.addAttribute(new ProductAttribute("product.bool_val_num", "0"));
+        productCurator.create(original);
+        assertTrue(original.getId() != null);
+    }
+
+    @Test
+    public void testProductAttributeValidationSuccessUpdate() {
+        Product original = createTestProduct();
+        productCurator.create(original);
+        assertTrue(original.getId() != null);
+        original.setAttribute("product.count", "134");
+        original.setAttribute("product.pos_count", "333");
+        original.setAttribute("product.long_multiplier",
+            (new Long(Integer.MAX_VALUE * 100)).toString());
+        original.setAttribute("product.long_pos_count", "10");
+        original.setAttribute("product.bool_val_str", "false");
+        original.setAttribute("product.bool_val_num", "1");
+        productCurator.createOrUpdate(original);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void testProductAttributeCreationFailBadInt() {
+        Product original = createTestProduct();
+        original.addAttribute(new ProductAttribute("product.count", "1.0"));
+        productCurator.create(original);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void testProductAttributeCreationFailBadPosInt() {
+        Product original = createTestProduct();
+        original.addAttribute(new ProductAttribute("product.pos_count", "-5"));
+        productCurator.create(original);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void testProductAttributeCreationFailBadLong() {
+        Product original = createTestProduct();
+        original.addAttribute(new ProductAttribute("product.long_multiplier",
+            "ZZ"));
+        productCurator.create(original);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void testProductAttributeCreationFailBadPosLong() {
+        Product original = createTestProduct();
+        original.addAttribute(new ProductAttribute("product.long_pos_count",
+            "-1"));
+        productCurator.create(original);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void testProductAttributeCreationFailBadStringBool() {
+        Product original = createTestProduct();
+        original.addAttribute(new ProductAttribute("product.bool_val_str", "yes"));
+        productCurator.create(original);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void testProductAttributeCreationFailNumberBool() {
+        Product original = createTestProduct();
+        original.addAttribute(new ProductAttribute("product.bool_val_num", "2"));
+        productCurator.create(original);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void testProductAttributeUpdateFailInt() {
+        Product original = createTestProduct();
+        productCurator.create(original);
+        assertTrue(original.getId() != null);
+        original.addAttribute(new ProductAttribute("product.count", "one"));
+        productCurator.createOrUpdate(original);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void testProductAttributeUpdateFailPosInt() {
+        Product original = createTestProduct();
+        productCurator.create(original);
+        assertTrue(original.getId() != null);
+        original.addAttribute(new ProductAttribute("product.pos_count", "-44"));
+        productCurator.createOrUpdate(original);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void testProductAttributeUpdateFailLong() {
+        Product original = createTestProduct();
+        productCurator.create(original);
+        assertTrue(original.getId() != null);
+        original.addAttribute(new ProductAttribute("product.long_multiplier",
+            "10^23"));
+        productCurator.createOrUpdate(original);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void testProductAttributeUpdateFailPosLong() {
+        Product original = createTestProduct();
+        productCurator.create(original);
+        assertTrue(original.getId() != null);
+        original.addAttribute(new ProductAttribute("product.long_pos_count",
+            "-23"));
+        productCurator.createOrUpdate(original);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void testProductAttributeUpdateFailStringBool() {
+        Product original = createTestProduct();
+        productCurator.create(original);
+        assertTrue(original.getId() != null);
+        original.addAttribute(new ProductAttribute("product.bool_val_str", "flase"));
+        productCurator.createOrUpdate(original);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void testProductAttributeUpdateFailNumberBool() {
+        Product original = createTestProduct();
+        productCurator.create(original);
+        assertTrue(original.getId() != null);
+        original.addAttribute(new ProductAttribute("product.bool_val_num", "6"));
+        productCurator.createOrUpdate(original);
+    }
+
+    @Test
+    public void testSubstringConfigList() {
+        Product original = createTestProduct();
+        original.addAttribute(new ProductAttribute("product.pos", "-5"));
+        productCurator.create(original);
     }
 
     public void testRemoveProductContent() {


### PR DESCRIPTION
...ntegers for sockets

858286: Type checking for product attributes

Both facts and product attributes are checked for typing where needed.
Configurable list added for each of fact names and product attributes.
Facts can be specifically typed as integer or positive integer.
Product attributes can be specifically typed as integer, positive integer, long, positive long, or boolean.
Unlisted facts or attributes allow strings as always.
