### PR TITLE
Fix attempts to delete null cron triggers.

### DIFF
--- a/src/main/java/org/candlepin/pinsetter/core/PinsetterKernel.java
+++ b/src/main/java/org/candlepin/pinsetter/core/PinsetterKernel.java
@@ -178,7 +178,12 @@ public class PinsetterKernel {
                             jd.getJobClass().getName().equals(jobImpl)) {
                             CronTrigger trigger = (CronTrigger) scheduler.getTrigger(
                                 triggerKey(key.getName(), CRON_GROUP));
-                            existingCronTriggers.add(trigger);
+                            if (trigger != null) {
+                                existingCronTriggers.add(trigger);
+                            }
+                            else {
+                                log.warn("JobKey " + key + " returned null cron trigger.");
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
We do not fully understand why this can be but it looks like the old
code accommodated it, and we've run into problems with it being removed
already. Re-adding this check and skipping attempts to delete.

We will investigate what exactly it means for a cron job detail to exist
but the trigger doesn't.
