### PR TITLE
893590: "lscpu.on-line_cpu(s)_list" is a string

### DIFF
--- a/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -115,7 +115,6 @@ public class ConfigProperties {
         "lscpu.cpu(s)," +
         "lscpu.numa_node(s)," +
         "lscpu.numa_node0_cpu(s)," +
-        "lscpu.on-line_cpu(s)_list," +
         "lscpu.socket(s)," +
         "lscpu.thread(s)_per_core";
 


### PR DESCRIPTION
Default config was set to require "lscpu.on-line_cpu(s)_list"
to be a POSITIVE_INTEGER_FACTS, but it should just be a
string.
