### PR TITLE
Removed DoubleCheckedLocking checkstyle module.

### DIFF
--- a/buildconf/checkstyle.xml
+++ b/buildconf/checkstyle.xml
@@ -149,7 +149,6 @@
     <!-- <module name="ArrayTrailingComma" /> -->
     <!-- <module name="AvoidInlineConditionals"/> -->
     <!-- <module name="CovariantEquals"/> -->
-    <module name="DoubleCheckedLocking"/>
     <module name="EmptyStatement"/>
     <module name="EqualsHashCode"/>
     <!-- module name="FinalLocalVariable"/> -->
@@ -202,7 +201,7 @@
        #######################################################################
      -->
     <module name="AvoidStarImport">
-        <property name="allowStaticMemberImports" value="true"/> 
+        <property name="allowStaticMemberImports" value="true"/>
     </module>
     <!-- <module name="AvoidStaticImport"/> -->
     <module name="IllegalImport"/>

--- a/conf/eclipse/checkstyle_eclipse.xml
+++ b/conf/eclipse/checkstyle_eclipse.xml
@@ -96,8 +96,6 @@ test
 </module>
 <module name="NeedBraces">
 </module>
-<module name="DoubleCheckedLocking">
-</module>
 <module name="EmptyStatement">
 </module>
 <module name="EqualsHashCode">


### PR DESCRIPTION
Has been removed in checkstyle 5.6 as it's obsolete since Java 5.

http://checkstyle.sourceforge.net/releasenotes.html
