### PR TITLE
Fix some non-performant logging in refresh pools.

### DIFF
--- a/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -124,26 +124,12 @@ public class CandlepinPoolManager implements PoolManager {
     }
 
     Set<Entitlement> refreshPoolsWithoutRegeneration(Owner owner) {
-        log.debug("Refreshing pools");
-
+        log.info("Refreshing pools for owner: " + owner.getKey());
         List<Subscription> subs = subAdapter.getSubscriptions(owner);
-
-        if (log.isDebugEnabled()) {
-            log.debug("Found subscriptions: ");
-            for (Subscription sub : subs) {
-                log.debug("   " + sub);
-            }
-        }
+        log.debug("Found " + subs.size() + " subscriptions.");
 
         List<Pool> pools = this.poolCurator.listAvailableEntitlementPools(null,
             owner, null, null, false, false);
-
-        if (log.isDebugEnabled()) {
-            log.debug("Found pools: ");
-            for (Pool p : pools) {
-                log.debug("   " + p);
-            }
-        }
 
         // Map all pools for this owner/product that have a
         // subscription ID associated with them.
@@ -163,7 +149,7 @@ public class CandlepinPoolManager implements PoolManager {
             // Delete any expired subscriptions. Leave it in the map
             // so that the pools will get deleted as well.
             if (isExpired(sub)) {
-                log.debug("Deleting expired subscription " + sub);
+                log.info("Deleting expired subscription: " + sub);
                 subAdapter.deleteSubscription(sub);
                 continue;
             }

--- a/src/main/java/org/candlepin/model/PoolCurator.java
+++ b/src/main/java/org/candlepin/model/PoolCurator.java
@@ -228,7 +228,6 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
         }
 
         if (log.isDebugEnabled()) {
-            log.debug("results(postfilter): " + results);
             log.debug("active pools for owner: " + results.size());
         }
 

--- a/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
+++ b/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
@@ -56,6 +56,7 @@ public class PoolRules {
     }
 
     public List<Pool> createPools(Subscription sub) {
+        log.info("Creating pools for new subscription: " + sub);
         Map<String, Object> args = new HashMap<String, Object>();
         args.put("sub", sub);
         args.put("attributes", jsRules.getFlattenedAttributes(sub.getProduct()));
@@ -74,6 +75,8 @@ public class PoolRules {
     }
 
     public List<PoolUpdate> updatePools(Subscription sub, List<Pool> existingPools) {
+        log.info("Refreshing pools for existing subscription: " + sub);
+        log.info("  existing pools: " + existingPools.size());
         Map<String, Object> args = new HashMap<String, Object>();
         args.put("sub", sub);
         args.put("pools", existingPools);

--- a/src/main/resources/rules/default-rules.js
+++ b/src/main/resources/rules/default-rules.js
@@ -935,7 +935,6 @@ var Pool = {
     updatePools: function () {
         var poolsUpdated = new java.util.LinkedList();
         for each (var existingPool in pools.toArray()) {
-            log.info("Updating pool: " + existingPool.getId());
             var datesChanged = (!sub.getStartDate().equals(
                 existingPool.getStartDate())) ||
                 (!sub.getEndDate().equals(existingPool.getEndDate()));
@@ -1013,7 +1012,6 @@ var Pool = {
             if (!(quantityChanged || datesChanged || productsChanged ||
                   productAttributesChanged)) {
                 //TODO: Should we check whether pool is overflowing here?
-                log.info("   No updates required.");
                 continue;
             }
 


### PR DESCRIPTION
Attempts to log every pool we lookup for subscriptions (about three
times) was causing refresh pools to take minutes when it should take
seconds for large (10k) numbers of pools if you had debug logging
enabled.
