### PR TITLE
Changes to HypervisorResource that addresses BZ 902804

### DIFF
--- a/spec/hypervisor_check_in_spec.rb
+++ b/spec/hypervisor_check_in_spec.rb
@@ -25,6 +25,73 @@ describe 'Hypervisor Resource' do
     @host_client.consume_pool(@virt_limit_pool['id'])
   end
 
+  it 'should add consumer to created when new host id and no guests reported' do
+    consumer_uuid = random_string('host')
+    mapping = get_host_guest_mapping(consumer_uuid, [])
+    result = @user.hypervisor_check_in(@owner['key'], mapping)
+    # Should only  have a result entry for created.
+    result.created.size.should == 1
+    result.updated.size.should == 0
+    result.unchanged.size.should == 0
+    result.failedUpdate.size.should == 0
+    # verify our created consumer is correct.
+    result.created[0].uuid.should == consumer_uuid
+  end
+
+  it 'should add consumer to created when new host id and guests were reported' do
+    consumer_uuid = random_string('host')
+    mapping = get_host_guest_mapping(consumer_uuid, ['g1'])
+    result = @user.hypervisor_check_in(@owner['key'], mapping)
+    # Should only  have a result entry for created.
+    result.created.size.should == 1
+    result.updated.size.should == 0
+    result.unchanged.size.should == 0
+    result.failedUpdate.size.should == 0
+    # verify our created consumer is correct.
+    result.created[0].uuid.should == consumer_uuid
+  end
+
+  it 'should add consumer to updated when guest ids are updated' do
+    mapping = get_host_guest_mapping(@expected_host, ['g1', 'g2'])
+    result = @user.hypervisor_check_in(@owner['key'], mapping)
+    # Should only  have a result entry for updated.
+    result.created.size.should ==0 
+    result.updated.size.should == 1
+    result.unchanged.size.should == 0
+    result.failedUpdate.size.should == 0
+    # verify our created consumer is correct.
+    result.updated[0].uuid.should == @expected_host
+  end
+
+  it 'should add consumer to unchanged when same guest ids are sent' do
+    mapping = get_host_guest_mapping(@expected_host, @expected_guest_ids)
+    result = @user.hypervisor_check_in(@owner['key'], mapping)
+    # Should only  have a result entry for unchanged.
+    result.created.size.should ==0 
+    result.updated.size.should == 0
+    result.unchanged.size.should == 1
+    result.failedUpdate.size.should == 0
+    # verify our created consumer is correct.
+    result.unchanged[0].uuid.should == @expected_host
+  end
+
+  it 'should add consumer to unchanged when comparing empty guest id lists' do
+    consumer_uuid = random_string('host')
+    mapping = get_host_guest_mapping(consumer_uuid, [])
+    result = @user.hypervisor_check_in(@owner['key'], mapping)
+    result.created.size.should == 1
+    result.created[0].uuid.should == consumer_uuid
+
+    # Do the same update with [] and it should be considered unchanged.
+    result = @user.hypervisor_check_in(@owner['key'], mapping)
+    result.created.size.should == 0
+    result.updated.size.should == 0
+    result.unchanged.size.should == 1 
+    result.failedUpdate.size.should == 0
+    # verify our unchanged consumer is correct.
+    result.unchanged[0].uuid.should == consumer_uuid
+  end
+
   it 'should add host and associate guests' do
     consumer = @cp.get_consumer(@expected_host)
     check_hypervisor_consumer(consumer, @expected_host, @expected_guest_ids)
@@ -38,8 +105,6 @@ describe 'Hypervisor Resource' do
     results = @user.hypervisor_check_in(@owner['key'], updated_host_guest_mapping)
     # Host consumer already existed, no creation occurred.
     results.created.size.should == 0
-    # Check updates.
-    results.updated.size.should == 1
     # Ensure that we are returning the updated consumer correctly.
     check_hypervisor_consumer(results.updated[0], @expected_host, updated_guest_ids)
     # Check that all updates were persisted correctly.
@@ -128,14 +193,9 @@ describe 'Hypervisor Resource' do
   it 'should initialize guest ids to empty when creating new host' do
     host_guest_mapping = get_host_guest_mapping(random_string('new_host'), [])
     results = @user.hypervisor_check_in(@owner['key'], host_guest_mapping)
-
     # Host consumer should have been created.
     results.created.size.should == 1
-    # Check updates.
-    results.updated.size.should == 1
-
     results.created[0]['guestIds'].should_not == nil
-    results.updated[0]['guestIds'].should_not == nil
   end
 
   def get_host_guest_mapping(host_uuid, guest_id_list)

--- a/src/main/java/org/candlepin/resource/HypervisorResource.java
+++ b/src/main/java/org/candlepin/resource/HypervisorResource.java
@@ -105,6 +105,8 @@ public class HypervisorResource {
                         i18n.tr("Hypervisor {0} has been deleted previously",
                             hostEntry.getKey(), hostEntry.getKey()));
                 }
+
+                boolean hostConsumerCreated = false;
                 Consumer consumer = consumerCurator.findByUuid(hostEntry.getKey());
                 if (consumer == null) {
                     // Create new consumer
@@ -116,7 +118,7 @@ public class HypervisorResource {
                     consumer.setGuestIds(new ArrayList<GuestId>());
                     consumer = consumerResource.create(consumer, principal, null, ownerKey,
                         null);
-                    result.created(consumer);
+                    hostConsumerCreated = true;
                 }
                 /* commented out per 768872
                 // Revoke all entitlements from the host if no guests were reported.
@@ -127,10 +129,22 @@ public class HypervisorResource {
 
                 Consumer withIds = new Consumer();
                 withIds.setGuestIds(guestIds);
-                if (consumerResource.performConsumerUpdates(withIds, consumer)) {
+                boolean guestIdsUpdated =
+                    consumerResource.performConsumerUpdates(withIds, consumer);
+                if (guestIdsUpdated) {
                     consumerCurator.update(consumer);
                 }
-                result.updated(consumer);
+
+                // Populate the result with the processed consumer.
+                if (hostConsumerCreated) {
+                    result.created(consumer);
+                }
+                else if (guestIdsUpdated && !hostConsumerCreated) {
+                    result.updated(consumer);
+                }
+                else {
+                    result.unchanged(consumer);
+                }
             }
             catch (Exception e) {
                 result.failed(hostEntry.getKey(), e.getMessage());

--- a/src/main/java/org/candlepin/resource/dto/HypervisorCheckInResult.java
+++ b/src/main/java/org/candlepin/resource/dto/HypervisorCheckInResult.java
@@ -25,7 +25,8 @@ import org.candlepin.model.Consumer;
  *
  * <pre>
  *     created: the consumers that have been created from the host ids.
- *     updated: the host's virt ids of host consumers that have been updated.
+ *     updated: the host consumers that have had their guest IDs updated.
+ *     unchanged: the host consumers that have not been changed.
  *     failed: a list of strings formated as '{host_virt_id}: Error message'.
  * </pre>
  */
@@ -33,11 +34,13 @@ public class HypervisorCheckInResult {
 
     private Set<Consumer> created;
     private Set<Consumer> updated;
+    private Set<Consumer> unchanged;
     private Set<String> failed;
 
     public HypervisorCheckInResult() {
         this.created = new HashSet<Consumer>();
         this.updated = new HashSet<Consumer>();
+        this.unchanged = new HashSet<Consumer>();
         this.failed = new HashSet<String>();
     }
 
@@ -47,6 +50,10 @@ public class HypervisorCheckInResult {
 
     public void updated(Consumer c) {
         this.updated.add(c);
+    }
+
+    public void unchanged(Consumer c) {
+        this.unchanged.add(c);
     }
 
     public void failed(String hostVirtId, String errorMessage) {
@@ -62,7 +69,12 @@ public class HypervisorCheckInResult {
         return updated;
     }
 
+    public Set<Consumer> getUnchanged() {
+        return unchanged;
+    }
+
     public Set<String> getFailedUpdate() {
         return failed;
     }
+
 }


### PR DESCRIPTION
1. Properly init consumer guest id list to empty when creating a new host consumer.
   - can not do this on the Consumer object itself since updateConsumer requires null to signify no changes.
2. Do not add created consumer to the update list in the result
   - revamped this a little to align along: created, updated, unchanged, failed.
