### PR TITLE
908483: Add consumer types for katello.

### DIFF
--- a/buildconf/scripts/deploy
+++ b/buildconf/scripts/deploy
@@ -25,7 +25,7 @@ function gendb ()
     if [ -n "$DBPASSWORD" ] ; then
         LQCOMMAND="$LQCOMMAND --password=$DBPASSWORD "
     fi
-    LQCOMMAND="$LQCOMMAND update"
+    LQCOMMAND="$LQCOMMAND update -Dcommunity=True"
     $LQCOMMAND
     evalrc $? "schema creation failed"
 }
@@ -38,7 +38,7 @@ function updatedb ()
     if [ -n "$DBPASSWORD" ] ; then
         LQCOMMAND="$LQCOMMAND --password=$DBPASSWORD "
     fi
-    LQCOMMAND="$LQCOMMAND update"
+    LQCOMMAND="$LQCOMMAND update -Dcommunity=True"
     $LQCOMMAND
     evalrc $? "schema update failed"
 }

--- a/code/setup/cpdb
+++ b/code/setup/cpdb
@@ -42,10 +42,11 @@ def error_out(command, status, output):
 
 class DbSetup(object):
 
-    def __init__(self, username, password, db):
+    def __init__(self, username, password, db, community):
         self.username = username
         self.db = db
         self.password = password
+        self.community = community
         if password:
             os.environ["PGPASSWORD"] = password
 
@@ -91,13 +92,15 @@ class DbSetup(object):
             classpath,
             changelog_path,
             self.db,
-            self.username,
+            self.username
         )
 
         if self.password:
             liquibase_options += " --password=%s" % self.password
 
-        output = run_command("liquibase %s migrate" % liquibase_options)
+        output = run_command("liquibase %s migrate -Dcommunity=%s" % (
+            liquibase_options,
+            self.community))
         print output
 
 
@@ -122,6 +125,10 @@ if __name__ == "__main__":
     parser.add_option("-p", "--password",
             dest="dbpassword",
             help="database password to use")
+    parser.add_option("--community",
+            action="store_true", default=False,
+            dest="community",
+            help="true if used in a community fashion")
 
     (options, args) = parser.parse_args()
 
@@ -130,7 +137,7 @@ if __name__ == "__main__":
         print("ERROR: Please specify --create or --update.")
         sys.exit(1)
 
-    dbsetup = DbSetup(options.dbuser, options.dbpassword, options.db)
+    dbsetup = DbSetup(options.dbuser, options.dbpassword, options.db, options.community)
     if options.create:
         if options.drop:
             dbsetup.drop()

--- a/src/main/resources/db/changelog/20130212124537-insert-katello-consumer-types.xml
+++ b/src/main/resources/db/changelog/20130212124537-insert-katello-consumer-types.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+
+    <changeSet id="20130212124537-community" author="bkearney">
+        <preConditions onFail="MARK_RAN">
+            <changeLogPropertyDefined property="community" value="True"/>
+        </preConditions>
+        <comment>Add community friendly names for Headpin and Katello</comment>
+        <insert tableName="cp_consumer_type">
+            <column name="id" value="1006"/>
+            <column name="label" value="headpin"/>
+            <column name="manifest" value="Y"/>
+        </insert>
+        <insert tableName="cp_consumer_type">
+            <column name="id" value="1007"/>
+            <column name="label" value="katello"/>
+            <column name="manifest" value="Y"/>
+        </insert>
+    </changeSet>
+
+    <changeSet id="20130212124537-product" author="bkearney">
+        <preConditions onFail="MARK_RAN">
+            <changeLogPropertyDefined property="community" value="False"/>
+        </preConditions>
+        <comment>Add product friendly names for Headpin and Katello</comment>
+        <insert tableName="cp_consumer_type">
+            <column name="id" value="1006"/>
+            <column name="label" value="sam"/>
+            <column name="manifest" value="Y"/>
+        </insert>
+        <insert tableName="cp_consumer_type">
+            <column name="id" value="1007"/>
+            <column name="label" value="system engine"/>
+            <column name="manifest" value="Y"/>
+        </insert>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-create.xml
+++ b/src/main/resources/db/changelog/changelog-create.xml
@@ -1105,4 +1105,5 @@
     <include file="db/changelog/20121015121627-add-rules-cp-version-column.xml" />
     <include file="db/changelog/20130114143642-add-order-number-to-subscription.xml" />
     <include file="db/changelog/20130124112705-add-reliant-product.xml" />
+    <include file="db/changelog/20130212124537-insert-katello-consumer-types.xml" />
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-update.xml
+++ b/src/main/resources/db/changelog/changelog-update.xml
@@ -12,4 +12,5 @@
     <include file="db/changelog/20121015121627-add-rules-cp-version-column.xml" />
     <include file="db/changelog/20130114143642-add-order-number-to-subscription.xml" />
     <include file="db/changelog/20130124112705-add-reliant-product.xml" />
+    <include file="db/changelog/20130212124537-insert-katello-consumer-types.xml" />
 </databaseChangeLog>


### PR DESCRIPTION
The liquidbase scripts take in a community property. If this is set to True, then the types
Headpin and Katello are loaded. If this is set to False, then the types SAM and Katello are loaded.
The types share the same id, so the changelogs are mutually exclusive.

The cpdb and deploy tools are updated to pass in the new property. For Katello to take advantage of this, the katello configure tools will need to be updated.
