### PR TITLE
Improve the performance is checking for guests for a given host.

### DIFF
--- a/src/main/java/org/candlepin/model/ConsumerCurator.java
+++ b/src/main/java/org/candlepin/model/ConsumerCurator.java
@@ -29,9 +29,8 @@ import org.candlepin.config.Config;
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.exceptions.BadRequestException;
 import org.hibernate.Criteria;
-import org.hibernate.Hibernate;
+import org.hibernate.Query;
 import org.hibernate.ReplicationMode;
-import org.hibernate.criterion.Order;
 import org.hibernate.criterion.Restrictions;
 import org.xnap.commons.i18n.I18n;
 
@@ -145,17 +144,26 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
      */
     @Transactional
     @EnforceAccessControl
-    public Consumer findByVirtUuid(String uuid) {
+    public Consumer findByVirtUuid(String uuid, String ownerId) {
         Consumer result = null;
-        List<Consumer> options = currentSession()
-            .createCriteria(Consumer.class)
-            .addOrder(Order.desc("updated"))
-            .add(Restrictions.sqlRestriction("{alias}.id in (select cp_consumer_id " +
-                "from cp_consumer_facts where mapkey = 'virt.uuid' and lower(element) = ?)",
-                uuid.toLowerCase(), Hibernate.STRING)).list();
+
+        String sql = "select cp_consumer.id from cp_consumer " +
+            "inner join cp_consumer_facts " +
+            "on cp_consumer.id = cp_consumer_facts.cp_consumer_id " +
+            "where cp_consumer_facts.mapkey = 'virt.uuid' and " +
+            "lower(cp_consumer_facts.element) = :uuid and " +
+            "cp_consumer.owner_id = :ownerid " +
+            "order by cp_consumer.updated desc";
+
+        Query q = currentSession().createSQLQuery(sql);
+        q.setParameter("uuid", uuid.toLowerCase());
+        q.setParameter("ownerid", ownerId);
+        List<String> options = (List<String>) q.list();
+
         if (options != null && options.size() != 0) {
-            result = options.get(0);
+            result = this.find(options.get(0));
         }
+
         return result;
     }
 
@@ -395,7 +403,8 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
                 // Check if this is the most recent host to report the guest by asking
                 // for the consumer's current host and comparing it to ourselves.
                 if (consumer.equals(getHost(cg.getGuestId()))) {
-                    Consumer guest = findByVirtUuid(cg.getGuestId());
+                    Consumer guest = findByVirtUuid(cg.getGuestId(),
+                        consumer.getOwner().getId());
                     if (guest != null) {
                         guests.add(guest);
                     }

--- a/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -854,7 +854,8 @@ public class ConsumerResource {
         // Check guests that are existing/added.
         for (GuestId guestId : incoming.getGuestIds()) {
             Consumer host = consumerCurator.getHost(guestId.getGuestId());
-            Consumer guest = consumerCurator.findByVirtUuid(guestId.getGuestId());
+            Consumer guest = consumerCurator.findByVirtUuid(guestId.getGuestId(),
+                existing.getOwner().getId());
 
             // Add back the guestId.
             existing.addGuestId(guestId);

--- a/src/test/java/org/candlepin/model/test/ConsumerCuratorTest.java
+++ b/src/test/java/org/candlepin/model/test/ConsumerCuratorTest.java
@@ -108,6 +108,25 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
     }
 
     @Test
+    public void caseInsensitiveVirtUuidMatchingDifferentOwners() {
+        Consumer host = new Consumer("hostConsumer", "testUser", owner, ct);
+        consumerCurator.create(host);
+
+        owner = new Owner("test-owner2", "Test Owner2");
+        owner = ownerCurator.create(owner);
+
+        Consumer gConsumer1 = new Consumer("guestConsumer1", "testUser", owner, ct);
+        gConsumer1.getFacts().put("virt.uuid", "daf0fe10-956b-7b4e-b7dc-b383ce681ba8");
+        consumerCurator.create(gConsumer1);
+
+        host.addGuestId(new GuestId("DAF0FE10-956B-7B4E-B7DC-B383CE681BA8"));
+        consumerCurator.update(host);
+
+        List<Consumer> guests = consumerCurator.getGuests(host);
+        assertTrue(guests.size() == 0);
+    }
+
+    @Test
     public void addGuestsNotConsumers() {
         Consumer consumer = new Consumer("hostConsumer", "testUser", owner, ct);
         consumerCurator.create(consumer);

--- a/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
+++ b/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
@@ -173,8 +173,11 @@ public class HypervisorResourceTest {
         Map<String, List<GuestId>> hostGuestMap = new HashMap<String, List<GuestId>>();
         hostGuestMap.put("test-host", Arrays.asList(new GuestId("GUEST_B")));
 
+        Owner o = new Owner();
+        o.setId("owner-id");
         Consumer existing = new Consumer();
         existing.setUuid("test-host");
+        existing.setOwner(o);
         existing.addGuestId(new GuestId("GUEST_A"));
 
         when(consumerCurator.findByUuid(eq("test-host"))).thenReturn(existing);

--- a/src/test/java/org/candlepin/resource/test/ConsumerResourceUpdateTest.java
+++ b/src/test/java/org/candlepin/resource/test/ConsumerResourceUpdateTest.java
@@ -43,6 +43,7 @@ import org.candlepin.model.Environment;
 import org.candlepin.model.EnvironmentCurator;
 import org.candlepin.model.GuestId;
 import org.candlepin.model.IdentityCertificate;
+import org.candlepin.model.Owner;
 import org.candlepin.model.Release;
 import org.candlepin.policy.js.compliance.ComplianceRules;
 import org.candlepin.policy.js.compliance.ComplianceStatus;
@@ -109,8 +110,11 @@ public class ConsumerResourceUpdateTest {
 
     private Consumer getFakeConsumer() {
         Consumer consumer = new Consumer();
+        Owner owner = new Owner();
+        owner.setId("FAKEOWNERID");
         String uuid = "FAKEUUID";
         consumer.setUuid(uuid);
+        consumer.setOwner(owner);
         // go ahead and patch the curator to match it
         when(this.consumerCurator.findByUuid(uuid)).thenReturn(consumer);
         return consumer;
@@ -400,7 +404,8 @@ public class ConsumerResourceUpdateTest {
         ConsumerInstalledProduct installed = mock(ConsumerInstalledProduct.class);
         guest1.addInstalledProduct(installed);
 
-        when(consumerCurator.findByVirtUuid("Guest 1")).thenReturn(guest1);
+        when(consumerCurator.findByVirtUuid("Guest 1",
+            existingHost.getOwner().getId())).thenReturn(guest1);
         // Ensure that the guests host is the existing.
         when(consumerCurator.getHost("Guest 1")).thenReturn(existingHost);
         when(consumerCurator.findByUuid("Guest 1")).thenReturn(guest1);
@@ -433,7 +438,8 @@ public class ConsumerResourceUpdateTest {
         guest1.setUuid("Guest 1");
         guest1.addEntitlement(entitlement);
 
-        when(consumerCurator.findByVirtUuid("Guest 1")).thenReturn(guest1);
+        when(consumerCurator.findByVirtUuid("Guest 1",
+            existingHost.getOwner().getId())).thenReturn(guest1);
         // Ensure that the guests host is the existing.
         when(consumerCurator.getHost("Guest 1")).thenReturn(existingHost);
 
@@ -467,7 +473,8 @@ public class ConsumerResourceUpdateTest {
         guest1.setUuid("Guest 1");
         guest1.addEntitlement(entitlement);
 
-        when(consumerCurator.findByVirtUuid("Guest 1")).thenReturn(guest1);
+        when(consumerCurator.findByVirtUuid("Guest 1",
+            host.getOwner().getId())).thenReturn(guest1);
 
         // Ensure that the guest was not reported by another host.
         when(consumerCurator.getHost("Guest 1")).thenReturn(null);
@@ -495,7 +502,8 @@ public class ConsumerResourceUpdateTest {
         guest1.setUuid("Guest 1");
         guest1.addEntitlement(entitlement);
 
-        when(consumerCurator.findByVirtUuid("Guest 1")).thenReturn(guest1);
+        when(consumerCurator.findByVirtUuid("Guest 1",
+            host.getOwner().getId())).thenReturn(guest1);
 
         // Ensure that the guest was already reported by same host.
         when(consumerCurator.getHost("Guest 1")).thenReturn(host);
@@ -523,7 +531,8 @@ public class ConsumerResourceUpdateTest {
         guest1.setUuid("Guest 1");
         guest1.addEntitlement(entitlement);
 
-        when(consumerCurator.findByVirtUuid("Guest 1")).thenReturn(guest1);
+        when(consumerCurator.findByVirtUuid("Guest 1",
+            host.getOwner().getId())).thenReturn(guest1);
 
         this.resource.updateConsumer(host.getUuid(), updatedHost);
         //verify(consumerCurator).findByVirtUuid(eq("Guest 1"));
@@ -550,7 +559,8 @@ public class ConsumerResourceUpdateTest {
         guest1.setUuid("Guest 1");
         guest1.addEntitlement(entitlement);
 
-        when(consumerCurator.findByVirtUuid("Guest 1")).thenReturn(guest1);
+        when(consumerCurator.findByVirtUuid("Guest 1",
+            host.getOwner().getId())).thenReturn(guest1);
         when(consumerCurator.getHost("Guest 1")).thenReturn(host);
 
         this.resource.updateConsumer(host.getUuid(), updatedHost);
@@ -576,7 +586,8 @@ public class ConsumerResourceUpdateTest {
         guest1.setUuid("Guest 1");
         guest1.addEntitlement(entitlement);
 
-        when(consumerCurator.findByVirtUuid("Guest 1")).thenReturn(guest1);
+        when(consumerCurator.findByVirtUuid("Guest 1",
+            host.getOwner().getId())).thenReturn(guest1);
 
         this.resource.updateConsumer(host.getUuid(), updatedHost);
 
@@ -709,6 +720,9 @@ public class ConsumerResourceUpdateTest {
 
     private Consumer createConsumerWithGuests(String ... guestIds) {
         Consumer a = new Consumer();
+        Owner owner = new Owner();
+        owner.setId("FAKEOWNERID");
+        a.setOwner(owner);
         for (String guestId : guestIds) {
             a.addGuestId(new GuestId(guestId));
         }


### PR DESCRIPTION
This patch removes a sub-select from the query in lieu of using joins. Joins tend to be much more performant. This does hardcode the table names which is bad, but the table names existed in the old subselect. This should not be any more fragile.

During the research, it was pointed out that this query should facter in the owner to handle the cases where two owners have guests witht he same UUID. This patch resolves that issue as well by taking in the owner id as part of the query.
