### PR TITLE
Refactor 'for each ...' into 'Array.forEach'

### DIFF
--- a/src/main/resources/rules/rules.js
+++ b/src/main/resources/rules/rules.js
@@ -36,14 +36,18 @@ function createPool(pool) {
     origProdAttrs = pool.productAttributes;
     if (Array.isArray(origProdAttrs)) {
         pool.productAttributes = {};
-        for each (var attr in origProdAttrs) {
+        for (var k = 0; k < origProdAttrs.length; k++) {
+            var attr = origProdAttrs[k];
+
             pool.productAttributes[attr.name] = attr.value;
         }
     }
     */
 
     pool.getProductAttribute = function (attrName) {
-        for each (var attr in this.productAttributes) {
+        for (var k = 0; k < this.productAttributes.length; k++) {
+            var attr = this.productAttributes[k];
+
             if (attr.name == attrName) {
                 return attr.value;
             }
@@ -56,7 +60,9 @@ function createPool(pool) {
         if (this.productId == productId) {
             return true;
         }
-        for each (var provided in this.providedProducts) {
+        for (var k = 0; k < this.providedProducts.length; k++) {
+            var provided = this.providedProducts[k];
+
             if (provided.productId == productId) {
                 return true;
             }
@@ -108,7 +114,9 @@ function providesSameProducts(products1, products2) {
 
 function arrayToString(a) {
     msg = "[";
-    for each (q in a) {
+    for (var j = 0; j < a.length; j++) {
+        var q = a[j];
+
         msg += q.getId() + " ";
     }
     msg += "]";
@@ -122,7 +130,9 @@ function powerSet(a, n) {
     }
 
     var res = [];
-    for each (x in powerSet(a.slice(1), n)) {
+    for (var j = 0; j < powerSet(a.slice(1), n).length; j++) {
+        var x = powerSet(a.slice(1), n)[j];
+
         if (x.length <= n) {
             res.push(x);
         }
@@ -142,7 +152,9 @@ function powerSet(a, n) {
 // as you can use as many of those as you want.
 function hasNoProductOverlap(combination) {
     var seen_product_ids = [];
-    for each (pool_class in combination) {
+    for (var j = 0; j < combination.length; j++) {
+        var pool_class = combination[j];
+
         var pool = pool_class[0];
         var products = pool.products;
         for (var i = 0 ; i < products.length ; i++) {
@@ -239,7 +251,9 @@ function get_pool_sockets(pool) {
 }
 
 function new_get_pool_sockets(pool) {
-    for each (prodAttr in pool.productAttributes) {
+    for (var j = 0; j < pool.productAttributes.length; j++) {
+        var prodAttr = pool.productAttributes[j];
+
         if (prodAttr.name == "sockets") {
             var sockets = prodAttr.value;
             // TODO: is this 0 right? We would have a string here...
@@ -286,12 +300,18 @@ function findStackingPools(pool_class, consumer, compliance) {
     var partialStacks = compliance.getPartialStacks();
 
     // going to assume one stack per product on the system
-    for each (stack_id in compliance.getPartialStacks().keySet().toArray()) {
+    for (var j = 0; j < compliance.getPartialStacks().keySet().toArray().length; j++) {
+        var stack_id = compliance.getPartialStacks().keySet().toArray()[j];
+
         var covered_sockets = 0;
-        for each (entitlement in partialStacks.get(stack_id).toArray()) {
+        for (var k = 0; k < partialStacks.get(stack_id).toArray().length; k++) {
+            var entitlement = partialStacks.get(stack_id).toArray()[k];
+
             covered_sockets += entitlement.getQuantity() * get_pool_sockets(entitlement.getPool());
             productIdToStackId[entitlement.getPool().getProductId()] = stack_id;
-            for each (product in entitlement.getPool().getProvidedProducts().toArray()) {
+            for (var m = 0; m < entitlement.getPool().getProvidedProducts().toArray().length; m++) {
+                var product = entitlement.getPool().getProvidedProducts().toArray()[m];
+
                 productIdToStackId[product.getProductId()] = stack_id;
             }
         }
@@ -299,7 +319,9 @@ function findStackingPools(pool_class, consumer, compliance) {
         stackToEntitledSockets[stack_id] = covered_sockets;
     }
 
-    for each (pool in pool_class) {
+    for (var j = 0; j < pool_class.length; j++) {
+        var pool = pool_class[j];
+
         var quantity = 0;
         // ignore any pools that clash with installed compliant products
         if (!hasNoInstalledOverlap(pool, compliance)) {
@@ -313,7 +335,9 @@ function findStackingPools(pool_class, consumer, compliance) {
             var installed_stack_id;
             var seen_stack_id = false;
             var conflicting_stacks = false;
-            for each (product in pool.getProducts()) {
+            for (var m = 0; m < pool.getProducts().length; m++) {
+                var product = pool.getProducts()[m];
+
                 if (productIdToStackId.hasOwnProperty(product.id)) {
                     var new_installed_stack_id = productIdToStackId[product.id];
                     if (new_installed_stack_id != installed_stack_id) {
@@ -384,7 +408,9 @@ function findStackingPools(pool_class, consumer, compliance) {
     var not_stacked_pool_map = new java.util.HashMap();
     // We have a not stackable pool.
     if (notStackable.length > 0) {
-        for each (pool in notStackable) {
+        for (var k = 0; k < notStackable.length; k++) {
+            var pool = notStackable[k];
+
             var covered_sockets = get_pool_sockets(pool);
             if (covered_sockets > not_stacked_sockets) {
                 found_pool = true;
@@ -467,7 +493,9 @@ function comparePools(pool1, pool2) {
 }
 
 function isLevelExempt (level, exemptList) {
-    for each (var exemptLevel in exemptList.toArray()) {
+    for (var j = 0; j < exemptList.toArray().length; j++) {
+        var exemptLevel = exemptList.toArray()[j];
+
         if (exemptLevel.equalsIgnoreCase(level)) {
             return true;
         }
@@ -615,7 +643,9 @@ var Autobind = {
         // "pools" is a list of all the owner's pools which are compatible for the system:
         if (log.isDebugEnabled()) {
             log.debug("Selecting best pools from: " + pools.length);
-            for each (pool in pools) {
+            for (var m = 0; m < pools.length; m++) {
+                var pool = pools[m];
+
                 log.debug("   " + pool.getId());
             }
         }
@@ -650,7 +680,9 @@ var Autobind = {
             if (architectureMatches(pool.getTopLevelProduct(), consumer)) {
                 var provided_products = getRelevantProvidedProducts(pool, products);
                 log.debug("  relevant provided products: ");
-                for each (pp in provided_products) {
+                for (var n = 0; n < provided_products.length; n++) {
+                    var pp = provided_products[n];
+
                     log.debug("    " + pp.getId());
                 }
                 // XXX wasteful, should be a hash or something.
@@ -658,7 +690,9 @@ var Autobind = {
                 var duplicate_found = false;
 
                 // Check current pool against previous best to see if it's better:
-                for each (pool_class in pools_by_class) {
+                for (var n = 0; n < pools_by_class.length; n++) {
+                    var pool_class = pools_by_class[n];
+
                     var best_pool = pool_class[0];
                     var best_provided_products = getRelevantProvidedProducts(best_pool, products);
 
@@ -705,13 +739,19 @@ var Autobind = {
         var best_provided_count = 0;
         var best_entitlements_count = 0;
 
-        for each (pool_combo in candidate_combos) {
+        for (var k = 0; k < candidate_combos.length; k++) {
+            var pool_combo = candidate_combos[k];
+
             var provided_count = 0;
             var unique_provided = [];
-            for each (pool_class in pool_combo) {
+            for (var m = 0; m < pool_combo.length; m++) {
+                var pool_class = pool_combo[m];
+
                 var pool = pool_class[0];
                 var provided_products = getRelevantProvidedProducts(pool, products);
-                for each (provided_product in provided_products) {
+                for (var n = 0; n < provided_products.length; n++) {
+                    var provided_product = provided_products[n];
+
                     log.debug("\t\tprovided_product " + provided_product.getId());
                     if (!contains(unique_provided, provided_product)) {
                         unique_provided.push(provided_product);
@@ -719,7 +759,9 @@ var Autobind = {
                 }
             }
 
-            for each (product in unique_provided){
+            for (var m = 0; m < unique_provided.length; m++) {
+                var product = unique_provided[m];
+
                 log.debug("unique_provided " + product.getId() + " " + product.getName());
             }
 
@@ -737,7 +779,9 @@ var Autobind = {
                 if (hasNoProductOverlap(pool_combo)) {
                     var new_selection = new java.util.HashMap();
                     var total_entitlements = 0;
-                    for each (pool_class in pool_combo) {
+                    for (var p = 0; p < pool_combo.length; p++) {
+                        var pool_class = pool_combo[p];
+
                         var poolMap = findStackingPools(pool_class, consumer, compliance);
                         new_selection.putAll(poolMap);
 
@@ -766,7 +810,9 @@ var Autobind = {
 }
 
 function is_stacked(ent) {
-    for each (var attr in ent.pool.productAttributes) {
+    for (var j = 0; j < ent.pool.productAttributes.length; j++) {
+        var attr = ent.pool.productAttributes[j];
+
         if (attr.name == "stacking_id") {
             return true;
         }
@@ -803,7 +849,9 @@ function find_relevant_pids(entitlement, consumer) {
     if (consumer.installedProducts == null) {
         return provided_pids;
     }
-    for each (var installed_prod in consumer.installedProducts) {
+    for (var j = 0; j < consumer.installedProducts.length; j++) {
+        var installed_prod = consumer.installedProducts[j];
+
         var installed_pid = installed_prod.productId;
         if (entitlement.pool.provides(installed_pid)) {
             log.debug("pool provides: " + installed_pid);
@@ -826,7 +874,9 @@ var Compliance = {
         context.ondate = new Date(context.ondate);
 
         // Add some methods to the various Pool objects:
-        for each (var e in context.entitlements) {
+        for (var k = 0; k < ((context.entitlements) ? context.entitlements.length : 0); k++) {
+            var e = context.entitlements[k];
+
             e.pool = createPool(e.pool);
         }
         if ("entitlement" in context) {
@@ -870,7 +920,9 @@ var Compliance = {
 
     filterEntitlementsByDate: function (entitlements, date) {
         var filtered_ents = [];
-        for each (var ent in entitlements) {
+        for (var k = 0; k < entitlements.length; k++) {
+            var ent = entitlements[k];
+
             var startDate = new Date(ent.startDate);
             var endDate = new Date(ent.endDate);
             if (Utils.date_compare(startDate, date) <= 0 && Utils.date_compare(endDate, date) >= 0) {
@@ -888,7 +940,9 @@ var Compliance = {
         };
 
         var dates = [];
-        for each (var ent in entitlements) {
+        for (var k = 0; k < entitlements.length; k++) {
+            var ent = entitlements[k];
+
             dates.push(new Date(ent.endDate));
         }
         dates.sort(function(d1, d2) { Utils.date_compare(d1, d2) });
@@ -959,7 +1013,9 @@ var Compliance = {
 
         log.debug("Checking compliance status for consumer: " + consumer.uuid + " on date: " + ondate);
         var entitlementsOnDate = Compliance.filterEntitlementsByDate(entitlements, ondate);
-        for each (var e in entitlementsOnDate) {
+        for (var k = 0; k < entitlementsOnDate.length; k++) {
+            var e = entitlementsOnDate[k];
+
             log.debug("  checking entitlement: " + e.id);
             relevant_pids = find_relevant_pids(e, consumer);
             log.debug("    relevant products: " + relevant_pids);
@@ -993,7 +1049,9 @@ var Compliance = {
                 }
             }
 
-            for each (relevant_pid in relevant_pids) {
+            for (var m = 0; m < relevant_pids.length; m++) {
+                var relevant_pid = relevant_pids[m];
+
                 if (partially_stacked) {
                     log.debug("   partially compliant: " + relevant_pid);
                     compStatus.add_partial_product(relevant_pid, e);
@@ -1022,7 +1080,9 @@ var Compliance = {
 
         // Run through the consumer's installed products and see if there are any we
         // didn't find an entitlement for along the way:
-        for each (var installed_prod in consumer.installedProducts) {
+        for (var k = 0; k < ((consumer.installedProducts) ? consumer.installedProducts.length : 0); k++) {
+            var installed_prod = consumer.installedProducts[k];
+
             var installed_pid = installed_prod.productId;
             // Not compliant if we didn't find any entitlements for this product:
             if (typeof compStatus.compliantProducts[installed_pid] === "undefined" &&
@@ -1043,7 +1103,9 @@ var Compliance = {
         // Get all end dates from current entitlements sorted ascending.
         var dates = Compliance.getSortedEndDates(initialEntitlements);
 
-        for each (var dateToCheck in dates) {
+        for (var k = 0; k < dates.length; k++) {
+            var dateToCheck = dates[k];
+
 
             // Ignore past dates.
             if (dateToCheck < startDate) {
@@ -1076,7 +1138,9 @@ var Compliance = {
         log.debug("Consumer sockets: " + consumer_sockets);
 
         var covered_sockets = 0;
-        for each (var ent in ents) {
+        for (var k = 0; k < ents.length; k++) {
+            var ent = ents[k];
+
             if (is_stacked(ent)) {
                 var currentStackId = ent.pool.getProductAttribute("stacking_id");
                 if (currentStackId == stack_id) {


### PR DESCRIPTION
The 'for each' statement is not part of the ECMAScript standard, as such it's
not supported by all major javascript engines (such as Google's V8).  It's also
been deprecated to discourage it's use.  See
https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Statements/for_each...in
for more information.

This patch refactors its usage into 'Array.forEach'.

I believe this should create equivalent functionality each time.  If you see any issues, let me know and I could look into updating those occurrences to something different.
