### PR TITLE
Fix autobind performance problem.

### DIFF
--- a/src/main/resources/rules/rules.js
+++ b/src/main/resources/rules/rules.js
@@ -139,8 +139,9 @@ function powerSet(a, n) {
     }
 
     var res = [];
-    for (var j = 0; j < powerSet(a.slice(1), n).length; j++) {
-        var x = powerSet(a.slice(1), n)[j];
+    var tempSet = powerSet(a.slice(1), n);
+    for (var j = 0; j < tempSet.length; j++) {
+        var x = tempSet[j];
 
         if (x.length <= n) {
             res.push(x);


### PR DESCRIPTION
Caused by a search replace of array functionality where we started
recalculating a powerSet multiple times when we only previously did it
once per execution.

Was surfacing only on slower hardware with a moderately high number of
installed products (26) and pools available. (28)
