### PR TITLE
fix random test failure

### DIFF
--- a/src/test/java/org/candlepin/model/test/ConsumerCuratorTest.java
+++ b/src/test/java/org/candlepin/model/test/ConsumerCuratorTest.java
@@ -200,6 +200,7 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
         Date date = new Date();
         Consumer consumer = new Consumer("hostConsumer", "testUser", owner, ct);
         consumer.setLastCheckin(date);
+        Thread.sleep(5); // sleep for at 5ms to allow enough time to pass
         consumer = consumerCurator.create(consumer);
         consumerCurator.updateLastCheckin(consumer);
         assertTrue(consumer.getLastCheckin().after(date));


### PR DESCRIPTION
At times the test will fail because the date used to set the lastcheckin
is precisely the same as the date generated by the updateLastcheckin
method. This only affects the test because we're creating an arbitrary
situation to see if the method is actually changing the value. In
a production setting the setting and updating would not be this close.

I've added a 5ms sleep to give it just enough of a window to consistently
pass.
## TEST

buildr test:ConsumerCuratorTest

you can even put it in a for loop, but ultimately only time will tell
