### PR TITLE
Return a 400 if owner creation request has the same key as an existing owner

### DIFF
--- a/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -256,6 +256,11 @@ public class OwnerResource {
                 "Could not create the Owner: {0}. Parent {1} does not exist.",
                 owner, parent));
         }
+
+        if (ownerCurator.lookupByKey(owner.getKey()) != null) {
+            throw new BadRequestException(i18n.tr("Owner {0} already exists",
+                                                    owner.getKey()));
+        }
         Owner toReturn = ownerCurator.create(owner);
 
         sink.emitOwnerCreated(owner);

--- a/src/test/java/org/candlepin/resource/test/OwnerResourceTest.java
+++ b/src/test/java/org/candlepin/resource/test/OwnerResourceTest.java
@@ -582,6 +582,12 @@ public class OwnerResourceTest extends DatabaseTestFixture {
     }
 
     @Test(expected = BadRequestException.class)
+    public void ownerWithDuplicateKeyCannotBeCreated() {
+        this.ownerResource.createOwner(owner);
+        this.ownerResource.createOwner(owner);
+    }
+
+    @Test(expected = BadRequestException.class)
     public void ownerWithInvalidParentWhoseIdIsNullCannotBeCreated() {
         Owner child = new Owner("name", "name1");
         Owner owner1 = new Owner("name2", "name3");
@@ -657,7 +663,6 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         Owner parentOwner2 = new Owner("Paren Owner 2", "parentTest2");
         ownerResource.createOwner(parentOwner2);
         owner.setParentOwner(parentOwner1);
-        ownerResource.createOwner(owner);
 
         // Update with Display Name Only
         Owner upOwner1 = mock(Owner.class);


### PR DESCRIPTION
Previously, creating the same owner twice would result in a SQL error. Instead,
print a nicer message to the log and return a 400.
