### PR TITLE
A developer script used to attach idcert to upstream consumer

### DIFF
--- a/fixes/updateidcert
+++ b/fixes/updateidcert
@@ -14,7 +14,7 @@
 # in this software or its documentation.
 #
 
-""" A CLI utility for managing the Candlepin database. """
+""" A CLI utility for associating an idcert with an upstream consumer. """
 
 
 import simplejson as json


### PR DESCRIPTION
When uploading an older manifest without an idcert embedded,
the identity cert will not be attached to the upstream consumer.
This script allows you to pass in a consumer.json to extract
the idcert from it and attach it to the upstream consumer that
matches the given uuid parameter value.
