### PR TITLE
Proper comparison between 2 strings of json data

### DIFF
--- a/src/test/java/org/candlepin/sync/ConsumerExporterTest.java
+++ b/src/test/java/org/candlepin/sync/ConsumerExporterTest.java
@@ -14,17 +14,18 @@
  */
 package org.candlepin.sync;
 
-import static org.junit.Assert.assertEquals;
-
-import org.candlepin.config.Config;
-import org.candlepin.model.Consumer;
-import org.candlepin.model.ConsumerType;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.junit.Test;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.HashMap;
+
+import org.candlepin.config.Config;
+import org.candlepin.model.Consumer;
+import org.candlepin.model.ConsumerType;
+import org.candlepin.test.TestUtil;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.junit.Test;
 
 /**
  * ConsumerExporterTest
@@ -49,15 +50,16 @@ public class ConsumerExporterTest {
 
         exporter.export(mapper, writer, consumer, "/subscriptions", "/candlepin");
 
-        assertEquals("{\"uuid\":\"" + consumer.getUuid() + "\"," +
-                     "\"name\":\"" + consumer.getName() + "\"," +
-                     "\"type\":" +
-                     "{\"id\":\"" + ctype.getId() + "\"," +
-                     "\"label\":\"" + ctype.getLabel() + "\"," +
-                     "\"manifest\":" + ctype.isManifest() + "}," +
-                     "\"owner\":null," +
-                     "\"urlWeb\":\"/subscriptions\"," +
-                     "\"urlApi\":\"/candlepin\"}",
-            writer.toString());
+        StringBuffer json = new StringBuffer();
+        json.append("{\"uuid\":\"").append(consumer.getUuid()).append("\",");
+        json.append("\"name\":\"").append(consumer.getName()).append("\",");
+        json.append("\"type\":");
+        json.append("{\"id\":\"").append(ctype.getId()).append("\",");
+        json.append("\"label\":\"").append(ctype.getLabel()).append("\",");
+        json.append("\"manifest\":").append(ctype.isManifest()).append("},");
+        json.append("\"owner\":null,");
+        json.append("\"urlWeb\":\"/subscriptions\",");
+        json.append("\"urlApi\":\"/candlepin\"}");
+        assertTrue(TestUtil.isJsonEqual(json.toString(), writer.toString()));
     }
 }

--- a/src/test/java/org/candlepin/sync/ConsumerTypeExporterTest.java
+++ b/src/test/java/org/candlepin/sync/ConsumerTypeExporterTest.java
@@ -14,10 +14,11 @@
  */
 package org.candlepin.sync;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import org.candlepin.config.Config;
 import org.candlepin.model.ConsumerType;
+import org.candlepin.test.TestUtil;
 
 import org.codehaus.jackson.map.ObjectMapper;
 import org.junit.Test;
@@ -44,8 +45,10 @@ public class ConsumerTypeExporterTest {
 
         consumerType.export(mapper, writer, type);
 
-        assertEquals("{\"id\":null,\"label\":\"TESTTYPE\",\"manifest\":false}",
-                     writer.toString());
+        StringBuffer json = new StringBuffer();
+        json.append("{\"id\":null,\"label\":\"TESTTYPE\",");
+        json.append("\"manifest\":false}");
+        assertTrue(TestUtil.isJsonEqual(json.toString(), writer.toString()));
     }
 
 }

--- a/src/test/java/org/candlepin/sync/MetaExporterTest.java
+++ b/src/test/java/org/candlepin/sync/MetaExporterTest.java
@@ -14,9 +14,10 @@
  */
 package org.candlepin.sync;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import org.candlepin.config.Config;
+import org.candlepin.test.TestUtil;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.junit.Test;
 
@@ -47,9 +48,11 @@ public class MetaExporterTest {
 
         metaEx.export(mapper, writer, meta);
 
-        assertEquals("{\"version\":\"0.1.0\",\"created\":\"" + nowString +
-            "\",\"principalName\":\"myUsername\",\"webAppPrefix\":\"webapp_prefix\"}",
-            writer.toString());
+        StringBuffer json = new StringBuffer();
+        json.append("{\"version\":\"0.1.0\",\"created\":\"").append(nowString);
+        json.append("\",\"principalName\":\"myUsername\",");
+        json.append("\"webAppPrefix\":\"webapp_prefix\"}");
+        assertTrue(TestUtil.isJsonEqual(json.toString(), writer.toString()));
     }
 
 }

--- a/src/test/java/org/candlepin/test/TestUtil.java
+++ b/src/test/java/org/candlepin/test/TestUtil.java
@@ -14,6 +14,16 @@
  */
 package org.candlepin.test;
 
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+
+import org.apache.commons.codec.binary.Base64;
 import org.candlepin.auth.Access;
 import org.candlepin.auth.UserPrincipal;
 import org.candlepin.auth.permissions.Permission;
@@ -34,16 +44,9 @@ import org.candlepin.model.ProvidedProduct;
 import org.candlepin.model.RulesCurator;
 import org.candlepin.model.Subscription;
 import org.candlepin.model.User;
-
-import org.apache.commons.codec.binary.Base64;
-
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Random;
-import java.util.Set;
+import org.codehaus.jackson.JsonNode;
+import org.codehaus.jackson.JsonProcessingException;
+import org.codehaus.jackson.map.ObjectMapper;
 
 /**
  * TestUtil for creating various testing objects. Objects backed by the database
@@ -296,4 +299,11 @@ public class TestUtil {
             "\n//somerules";
     }
 
+    public static boolean isJsonEqual(String one, String two)
+        throws JsonProcessingException, IOException {
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode tree1 = mapper.readTree(one);
+        JsonNode tree2 = mapper.readTree(two);
+        return tree1.equals(tree2);
+    }
 }


### PR DESCRIPTION
Found an issue where the strings to be compared contained the right nodes and values, but not the same order.
This method should be used to compare any json test strings in place of String.equals().
