### PR TITLE
Removing the Cert V3 Enable flag from configuration

### DIFF
--- a/spec/entitlement_certificate_v3_spec.rb
+++ b/spec/entitlement_certificate_v3_spec.rb
@@ -31,9 +31,20 @@ describe 'Entitlement Certificate V3' do
 				 :arch => 'i386, x86_64',
                                  :sockets => 4,
                                  :cores => 8,
+                                 :ram => 16,
                                  :warning_period => 15,
                                  :management_enabled => true,
                                  :stacking_id => '8888',
+                                 :virt_only => 'false',
+                                 :support_level => 'standard',
+                                 :support_type => 'excellent',})
+
+    @product_30 = create_product(nil, nil, :attributes =>
+				{:version => '6.4',
+				 :arch => 'i386, x86_64',
+                                 :sockets => 4,
+                                 :warning_period => 15,
+                                 :management_enabled => true,
                                  :virt_only => 'false',
                                  :support_level => 'standard',
                                  :support_type => 'excellent',})
@@ -46,13 +57,13 @@ describe 'Entitlement Certificate V3' do
     @cp.add_content_to_product(@product.id, @content.id, false)
 
     @subscription = @cp.create_subscription(@owner['key'], @product.id, 10, [], '12345', '6789', 'order1')
+    @subscription_30 = @cp.create_subscription(@owner['key'], @product_30.id, 10, [], '123456', '67890', 'order2')
     @cp.refresh_pools(@owner['key'])
 
     @user = user_client(@owner, random_string('billy'))
 
     @system = consumer_client(@user, random_string('system1'), :candlepin, nil,
-				{'system.certificate_version' => '3.1',
-				 'system.testing' => 'true'})
+				{'system.certificate_version' => '3.1'})
     @entitlement = @system.consume_product(@product.id)[0]
   end
 
@@ -61,9 +72,8 @@ describe 'Entitlement Certificate V3' do
     # the server is creating 3.2 certs, and the product contains attributes
     # supported by 3.0.
     v3_system = consumer_client(@user, random_string('v3system'), :candlepin, nil,
-                                  {'system.certificate_version' => '3.0',
-                                   'system.testing' => 'true'})
-    v3_system.consume_product(@product.id)
+                                  {'system.certificate_version' => '3.0'})
+    v3_system.consume_product(@product_30.id)
     value = extension_from_cert(v3_system.list_certificates[0]['cert'], "1.3.6.1.4.1.2312.9.6")
     value.should == "3.2"
   end
@@ -84,6 +94,7 @@ describe 'Entitlement Certificate V3' do
     json_body['subscription']['warning'].should == 15
     json_body['subscription']['sockets'].should == 4
     json_body['subscription']['cores'].should == 8
+    json_body['subscription']['ram'].should == 16
     json_body['subscription']['management'].should == true
     json_body['subscription']['stacking_id'].should == '8888'
     json_body['subscription']['virt_only'].should be_nil

--- a/spec/environment_cert_v3_spec.rb
+++ b/spec/environment_cert_v3_spec.rb
@@ -14,7 +14,7 @@ describe 'Environments Certificate V3' do
 
   it 'filters content not promoted to environment' do
     consumer = @org_admin.register(random_string('testsystem'), :system, nil, 
-        {'system.certificate_version' => '3.1', 'system.testing' => 'true'},
+        {'system.certificate_version' => '3.1'},
         nil, nil, [], [], @env['id'])
     consumer['environment'].should_not be_nil
     consumer_cp = Candlepin.new(nil, nil, consumer['idCert']['cert'],
@@ -51,7 +51,7 @@ describe 'Environments Certificate V3' do
 
   it 'regenerates certificates after promoting/demoting content' do
     consumer = @org_admin.register(random_string('testsystem'), :system, nil, 
-        {'system.certificate_version' => '3.1', 'system.testing' => 'true'},
+        {'system.certificate_version' => '3.1'},
         nil, nil, [], [], @env['id'])
     consumer['environment'].should_not be_nil
     consumer_cp = Candlepin.new(nil, nil, consumer['idCert']['cert'],

--- a/spec/ram_spec.rb
+++ b/spec/ram_spec.rb
@@ -37,18 +37,14 @@ describe 'RAM Limiting' do
 
   it 'can consume ram entitlement if requesting v3.1 certificate' do
     system = consumer_client(@user, random_string('system1'), :system, nil,
-                {'system.certificate_version' => '3.1',
-                 # Since cert v3 is disabled by default, configure consumer bypass.
-                 'system.testing' => 'true'})
+                {'system.certificate_version' => '3.1'})
     entitlement = system.consume_product(@ram_product.id)[0]
     entitlement.should_not == nil
   end
 
   it 'can not consume ram entitlement when requesting less than v3.1 certificate' do
     system = consumer_client(@user, random_string('system1'), :system, nil,
-                {'system.certificate_version' => '3.0',
-                 # Since cert v3 is disabled by default, configure consumer bypass.
-                 'system.testing' => 'true'})
+                {'system.certificate_version' => '3.0'})
 
     installed = [
         {'productId' => @ram_sub.id,
@@ -71,38 +67,11 @@ describe 'RAM Limiting' do
     end
   end
 
-  it 'can not consume ram entitlement when server does not support cert V3' do
-    system = consumer_client(@user, random_string('system1'), :system, nil,
-                # cert v3 is currently disabled by default.
-                {'system.certificate_version' => '3.1'})
-
-    installed = [
-        {'productId' => @ram_sub.id,
-        'productName' => @ram_sub.name}
-    ]
-    system.update_consumer({:installedProducts => installed})
-
-    pool = find_pool(@owner.id, @ram_sub.id)
-    pool.should_not == nil
-
-    expected_error = "The server does not support subscriptions requiring V3 certificates."
-    begin
-      response = system.consume_pool(pool.id)
-      #end.should raise_exception(RestClient::Conflict)
-      fail("Conflict error should have been raised since system's certificate version is incorrect.")
-    rescue RestClient::Conflict => e
-      message = JSON.parse(e.http_body)['displayMessage']
-      message.should == expected_error
-    end
-  end
-
   it 'consumer status should be valid when consumer RAM is covered' do
     system = consumer_client(@user, random_string('system1'), :system, nil,
                 {'system.certificate_version' => '3.1',
                  # Simulate 8 GB of RAM as would be returned from system fact (kb)
-                 'memory.memtotal' => '8000000',
-                 # Since cert v3 is disabled by default, configure consumer bypass.
-                 'system.testing' => 'true'})
+                 'memory.memtotal' => '8000000'})
     installed = [
         {'productId' => @ram_product.id, 'productName' => @ram_product.name}
     ]
@@ -122,9 +91,7 @@ describe 'RAM Limiting' do
     system = consumer_client(@user, random_string('system1'), :system, nil,
                 {'system.certificate_version' => '3.1',
                  # Simulate 16 GB of RAM as would be returned from system fact (kb)
-                 'memory.memtotal' => '16000000',
-                 # Since cert v3 is disabled by default, configure consumer bypass.
-                 'system.testing' => 'true'})
+                 'memory.memtotal' => '16000000'})
     installed = [
         {'productId' => @ram_product.id, 'productName' => @ram_product.name}
     ]
@@ -151,9 +118,7 @@ describe 'RAM Limiting' do
                  'memory.memtotal' => '8000000',
                  # Simulate system having 12 sockets which won't be covered after consuming
                  # the entitlement
-                 'cpu.cpu_socket(s)' => '12',
-                 # Since cert v3 is disabled by default, configure consumer bypass.
-                 'system.testing' => 'true'})
+                 'cpu.cpu_socket(s)' => '12'})
     installed = [
         {'productId' => @ram_and_socket_product.id,
         'productName' => @ram_and_socket_product.name}
@@ -181,9 +146,7 @@ describe 'RAM Limiting' do
                  'memory.memtotal' => '16000000',
                  # Simulate system having 4 sockets which will be covered after consuming
                  # the entitlement
-                 'cpu.cpu_socket(s)' => '4',
-                 # Since cert v3 is disabled by default, configure consumer bypass.
-                 'system.testing' => 'true'})
+                 'cpu.cpu_socket(s)' => '4'})
     installed = [
         {'productId' => @ram_and_socket_product.id,
         'productName' => @ram_and_socket_product.name}
@@ -211,9 +174,7 @@ describe 'RAM Limiting' do
                  'memory.memtotal' => '8000000',
                  # Simulate system having 4 sockets which will be covered after consuming
                  # the entitlement
-                 'cpu.cpu_socket(s)' => '4',
-                 # Since cert v3 is disabled by default, configure consumer bypass.
-                 'system.testing' => 'true'})
+                 'cpu.cpu_socket(s)' => '4'})
     installed = [
         {'productId' => @ram_and_socket_product.id,
         'productName' => @ram_and_socket_product.name}
@@ -233,9 +194,7 @@ describe 'RAM Limiting' do
     system = consumer_client(@user, random_string('system1'), :system, nil,
                 {'system.certificate_version' => '3.1',
                  # Simulate 8 GB of RAM as would be returned from system fact (kb)
-                 'memory.memtotal' => '8000000',
-                 # Since cert v3 is disabled by default, configure consumer bypass.
-                 'system.testing' => 'true'})
+                 'memory.memtotal' => '8000000'})
     installed = [
         {'productId' => @ram_product.id, 'productName' => @ram_product.name}
     ]
@@ -250,9 +209,7 @@ describe 'RAM Limiting' do
     system = consumer_client(@user, random_string('system1'), :system, nil,
                 {'system.certificate_version' => '3.1',
                  # Simulate 12 GB of RAM as would be returned from system fact (kb)
-                 'memory.memtotal' => '12000000',
-                 # Since cert v3 is disabled by default, configure consumer bypass.
-                 'system.testing' => 'true'})
+                 'memory.memtotal' => '12000000'})
     installed = [
         {'productId' => @ram_product.id, 'productName' => @ram_product.name}
     ]
@@ -271,9 +228,7 @@ describe 'RAM Limiting' do
                  'memory.memtotal' => '8000000',
                  # Simulate system having 4 sockets which will be covered after consuming
                  # the entitlement
-                 'cpu.cpu_socket(s)' => '4',
-                 # Since cert v3 is disabled by default, configure consumer bypass.
-                 'system.testing' => 'true'})
+                 'cpu.cpu_socket(s)' => '4'})
     installed = [
         {'productId' => @ram_and_socket_product.id,
         'productName' => @ram_and_socket_product.name}

--- a/src/main/java/org/candlepin/config/Config.java
+++ b/src/main/java/org/candlepin/config/Config.java
@@ -194,9 +194,6 @@ public class Config {
         return getBoolean(ConfigProperties.ENV_CONTENT_FILTERING);
     }
 
-    public boolean certV3IsEnabled() {
-        return getBoolean(ConfigProperties.ENABLE_CERT_V3);
-    }
 
     protected Map<String, String> loadProperties() {
         try {

--- a/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -99,8 +99,6 @@ public class ConfigProperties {
 
     public static final String PRODUCT_CACHE_MAX = "candlepin.cache.product_cache_max";
 
-    public static final String ENABLE_CERT_V3 = "candlepin.enable_cert_v3";
-
     public static final String INTEGER_FACTS =
         "candlepin.integer_facts";
     private static final String INTEGER_FACT_LIST =
@@ -224,10 +222,6 @@ public class ConfigProperties {
                  */
                 this.put(PRODUCT_CACHE_MAX, "100");
 
-                /**
-                 * By default, disable cert v3.
-                 */
-                this.put(ENABLE_CERT_V3, "false");
                 /**
                  * As we do math on some facts and attributes, we need to constrain
                  * some values

--- a/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -424,18 +424,9 @@ public class CandlepinPoolManager implements PoolManager {
                     }
                 }
                 else {
-
-                    // If cert V3 is disabled, do not create a certificate with anything
-                    // considered V3+ as it is not supported in V1.
-                    if (!ProductVersionValidator.verifyServerSupport(config, consumer,
-                        pool.getProductAttributes())) {
-                        log.debug("Pool filtered from candidates because the server " +
-                                  "does not support subscriptions requiring V3 " +
-                                  "certificates.");
-                    }
                     // Check to make sure that the consumer supports the required cert
                     // versions for all attributes.
-                    else if (!ProductVersionValidator.verifyClientSupport(consumer,
+                    if (!ProductVersionValidator.verifyClientSupport(consumer,
                         pool.getProductAttributes())) {
                         log.debug("Pool filtered from candidates because it is " +
                                   "unsupported by the consumer. Upgrade client to use.");

--- a/src/main/java/org/candlepin/version/ProductVersionValidator.java
+++ b/src/main/java/org/candlepin/version/ProductVersionValidator.java
@@ -48,6 +48,7 @@ public class ProductVersionValidator {
     // Add any product atttribute version requirements here.
     static {
         PRODUCT_ATTR_VERSION_REQUIREMENTS.put("ram", "3.1");
+        PRODUCT_ATTR_VERSION_REQUIREMENTS.put("cores", "3.1");
     }
 
     private ProductVersionValidator() {
@@ -72,8 +73,7 @@ public class ProductVersionValidator {
     public static boolean verifyServerSupport(Config config, Consumer consumer,
         Set<? extends Attribute> productAttributes) {
         String min = ProductVersionValidator.getMin(productAttributes);
-        if ((!config.certV3IsEnabled() && !consumer.hasFact("system.testing")) &&
-            ProductVersionValidator.compareVersion(min, "1.0") > 0) {
+        if (ProductVersionValidator.compareVersion(min, "1.0") > 0) {
             return false;
         }
         return true;

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -10,3 +10,4 @@ log4j.logger.org.candlepin.util.filters.DumpFilter=INFO
 # used for debugging with the jdbc logdriver
 #log4j.logger.net.rkbloom.logdriver.LogConnection=DEBUG
 #log4j.logger.net.rkbloom.logdriver.LogPreparedStatement=DEBUG
+log4j.logger.org.candlepin.policy.js.compliance=DEBUG

--- a/src/test/java/org/candlepin/model/test/ContentTest.java
+++ b/src/test/java/org/candlepin/model/test/ContentTest.java
@@ -20,7 +20,6 @@ import org.candlepin.test.DatabaseTestFixture;
 import org.junit.Test;
 import static org.junit.Assert.*;
 import static org.hamcrest.collection.IsCollectionContaining.hasItem;
-import static org.junit.Assert.assertThat;
 
 
 /**

--- a/src/test/java/org/candlepin/service/impl/test/DefaultEntitlementCertServiceAdapterTest.java
+++ b/src/test/java/org/candlepin/service/impl/test/DefaultEntitlementCertServiceAdapterTest.java
@@ -627,7 +627,6 @@ public class DefaultEntitlementCertServiceAdapterTest {
         throws Exception {
 
         Config mockConfig = mock(Config.class);
-        when(mockConfig.certV3IsEnabled()).thenReturn(true);
 
         // RAM requires 3.1, so an exception should be thrown for cert V1 clients.
         when(consumer.getFact(eq("system.certificate_version"))).thenReturn("1.0");
@@ -661,7 +660,6 @@ public class DefaultEntitlementCertServiceAdapterTest {
     public void ensureV3CertificateCreationFailsWithUnsupportedConsumerCertVersion()
         throws Exception {
         Config mockConfig = mock(Config.class);
-        when(mockConfig.certV3IsEnabled()).thenReturn(true);
 
         // RAM requires 3.1, so an exception should be thrown.
         when(consumer.getFact(eq("system.certificate_version"))).thenReturn("3.0");
@@ -695,7 +693,6 @@ public class DefaultEntitlementCertServiceAdapterTest {
     public void ensureV3CertificateCreationOkWhenConsumerSupportsV3Dot1Certs()
         throws Exception {
         Config mockConfig = mock(Config.class);
-        when(mockConfig.certV3IsEnabled()).thenReturn(true);
 
         when(consumer.getFact(eq("system.certificate_version"))).thenReturn("3.2");
         ProductAttribute attr = new ProductAttribute("ram", "4");
@@ -713,37 +710,6 @@ public class DefaultEntitlementCertServiceAdapterTest {
 
         entAdapter.createX509Certificate(entitlement, subscription, product,
             new BigInteger("1234"), keyPair(), true);
-    }
-
-    @Test
-    public void ensureV3ProductCreationNotOkWhenV3SupportIsDisabledOnServer()
-        throws Exception {
-        Config mockConfig = mock(Config.class);
-        when(mockConfig.certV3IsEnabled()).thenReturn(false);
-
-        when(consumer.getFact(eq("system.certificate_version"))).thenReturn("3.0");
-
-        X509V3ExtensionUtil mockV3extensionUtil = mock(X509V3ExtensionUtil.class);
-        X509ExtensionUtil mockExtensionUtil = mock(X509ExtensionUtil.class);
-
-        ProductAttribute attr = new ProductAttribute("ram", "4");
-        subscription.getProduct().addAttribute(attr);
-
-        DefaultEntitlementCertServiceAdapter entAdapter =
-            new DefaultEntitlementCertServiceAdapter(mockedPKI, mockExtensionUtil,
-                mockV3extensionUtil, mock(EntitlementCertificateCurator.class),
-                keyPairCurator, serialCurator, productAdapter, entCurator,
-                I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK),
-                mockConfig);
-        try {
-            entAdapter.createX509Certificate(entitlement, subscription, product,
-                new BigInteger("1234"), keyPair(), true);
-            fail("Expected CertVersionConflictException to be thrown.");
-        }
-        catch (CertVersionConflictException e) {
-            assertEquals("The server does not support subscriptions requiring " +
-                         "V3 certificates.", e.getMessage());
-        }
     }
 
     @Test
@@ -766,7 +732,6 @@ public class DefaultEntitlementCertServiceAdapterTest {
     @Test
     public void ensureV3CertIsCreatedWhenEnableCertV3ConfigIsTrue() throws Exception {
         Config mockConfig = mock(Config.class);
-        when(mockConfig.certV3IsEnabled()).thenReturn(true);
 
         when(consumer.getFact(eq("system.certificate_version"))).thenReturn("3.0");
 
@@ -787,35 +752,6 @@ public class DefaultEntitlementCertServiceAdapterTest {
         verify(mockV3extensionUtil).getByteExtensions(any(Set.class),
             eq(entitlement), any(String.class), any(Map.class), eq(subscription));
         verifyZeroInteractions(mockExtensionUtil);
-    }
-
-    @Test
-    public void ensureV1CertIsCreatedWhenEnableCertV3ConfigIsFalse() throws Exception {
-        Config mockConfig = mock(Config.class);
-        when(mockConfig.certV3IsEnabled()).thenReturn(false);
-        // Ensure that the consumer is still at V3.
-        when(consumer.getFact(eq("system.certificate_version"))).thenReturn("3.0");
-
-        X509V3ExtensionUtil mockV3extensionUtil = mock(X509V3ExtensionUtil.class);
-        X509ExtensionUtil mockExtensionUtil = mock(X509ExtensionUtil.class);
-
-        DefaultEntitlementCertServiceAdapter entAdapter =
-            new DefaultEntitlementCertServiceAdapter(mockedPKI, mockExtensionUtil,
-                mockV3extensionUtil, mock(EntitlementCertificateCurator.class),
-                keyPairCurator, serialCurator, productAdapter, entCurator,
-                I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK),
-                mockConfig);
-
-        entAdapter.createX509Certificate(entitlement, subscription,
-            product, new BigInteger("1234"), keyPair(), true);
-        verify(mockExtensionUtil).productExtensions(eq(product));
-        verify(mockExtensionUtil).contentExtensions(any(Set.class), any(String.class),
-            any(Map.class), eq(consumer));
-        verify(mockExtensionUtil).subscriptionExtensions(eq(subscription),
-            eq(entitlement));
-        verify(mockExtensionUtil).entitlementExtensions(eq(entitlement));
-        verify(mockExtensionUtil).consumerExtensions(eq(consumer));
-        verifyZeroInteractions(mockV3extensionUtil);
     }
 
     @Test

--- a/src/test/java/org/candlepin/version/ProductVersionValidatorTests.java
+++ b/src/test/java/org/candlepin/version/ProductVersionValidatorTests.java
@@ -16,14 +16,11 @@ package org.candlepin.version;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.candlepin.config.Config;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ProductAttribute;
 import org.junit.Before;
@@ -34,13 +31,11 @@ import org.junit.Test;
  */
 public class ProductVersionValidatorTests {
 
-    private Config config;
     private Consumer consumer;
     private Set<ProductAttribute> attrs;
 
     @Before
     public void setUp() {
-        config = mock(Config.class);
         consumer = new Consumer();
         consumer.setFacts(new HashMap<String, String>());
         attrs = new HashSet<ProductAttribute>();
@@ -95,44 +90,4 @@ public class ProductVersionValidatorTests {
         consumer.setFacts(new HashMap<String, String>());
         assertFalse(ProductVersionValidator.verifyClientSupport(consumer, attrs));
     }
-
-
-    // verifyServerVersion tests
-    //
-    // Since RAM requires cert v3.1, we want to make sure that we
-    // check that the server is supporting the correct min version
-    // of 3.1
-
-    @Test
-    public void verifyServerVersionWhenCertV3Enabled() {
-        // RAM requires 3.1 version certs so if V3 is enabled we are Ok.
-        when(config.certV3IsEnabled()).thenReturn(true);
-        assertTrue(ProductVersionValidator.verifyServerSupport(config, consumer, attrs));
-    }
-
-    @Test
-    public void verifyServerVersionWhenCertV3Disabled() {
-        // RAM requires 3.1 version certs so if V3 is disabled we are NOT Ok.
-        when(config.certV3IsEnabled()).thenReturn(false);
-        assertFalse(ProductVersionValidator.verifyServerSupport(config, consumer, attrs));
-    }
-
-    @Test
-    public void verifyServerVersionWhenV3DisabledButProductRequires1Point0Minimum() {
-        Set<ProductAttribute> supportedWhenDisabled = new HashSet<ProductAttribute>();
-        supportedWhenDisabled.add(new ProductAttribute("sockets", "4"));
-
-        when(config.certV3IsEnabled()).thenReturn(false);
-        assertTrue(ProductVersionValidator.verifyServerSupport(config, consumer,
-            supportedWhenDisabled));
-    }
-
-    @Test
-    public void verifyServerVersionWhenCertV3DisabledButTestingConsumerSpecified() {
-        when(config.certV3IsEnabled()).thenReturn(false);
-        // Force the served back into v3 mode.
-        consumer.setFact("system.testing", "");
-        assertTrue(ProductVersionValidator.verifyServerSupport(config, consumer, attrs));
-    }
-
 }


### PR DESCRIPTION
From this time forward, all candlepins will be enabled.
Use of the old config entry will be ignored.
Removed tests that considered the V3 disablement.
Removed spec test system-test flag.
