### PR TITLE
look at upstream_name *NOT* upstream_id

### DIFF
--- a/src/main/resources/db/changelog/20130315171104-migrate-upstream-uuid.xml
+++ b/src/main/resources/db/changelog/20130315171104-migrate-upstream-uuid.xml
@@ -8,7 +8,7 @@
 
     <changeSet id="20130315171104-1" author="jesusr">
         <preConditions onFail="MARK_RAN">
-            <columnExists tableName="cp_import_record" columnName="upstream_id" />
+            <columnExists tableName="cp_import_record" columnName="upstream_name" />
         </preConditions>
         <comment>Create Upstream Consumer records</comment>
         <!-- See http://www.liquibase.org/manual/refactoring_commands -->
@@ -31,7 +31,7 @@
 
     <changeSet id="20130315171104-2" author="jesusr">
         <preConditions onFail="MARK_RAN">
-            <columnExists tableName="cp_import_record" columnName="upstream_id" />
+            <columnExists tableName="cp_import_record" columnName="upstream_name" />
         </preConditions>
         <comment>Link UpstreamConsumers to Owners</comment>
         <sql>


### PR DESCRIPTION
I re-added upstream_id to the cp_import_record table rendering the
precondition invalid. The precondition needs to check a column that
has been removed like: upstream_name.
## TEST
- Deploy with GENDB=1
- Redeploy with GENDB=0

The redeploy should work, to see the error use master and run the above 2 deploy scenarios. The second one will fail with an exception.
