### PR TITLE
only get latest import record

### DIFF
--- a/src/main/resources/db/changelog/20130315171104-migrate-upstream-uuid.xml
+++ b/src/main/resources/db/changelog/20130315171104-migrate-upstream-uuid.xml
@@ -15,13 +15,15 @@
         <!-- Copy only the successful records with consumer types -->
         <sql>
         INSERT INTO cp_upstream_consumer (id, uuid, name, owner_id,
-               type_id, prefix_url_web)
+               type_id, prefix_url_web, created, updated)
         SELECT ir.id,
                ir.upstream_id,
                ir.upstream_name,
                ir.owner_id,
                ct.id,
-               ir.webapp_prefix
+               ir.webapp_prefix,
+               ir.created,
+               ir.updated
         FROM cp_import_record ir,
              cp_consumer_type ct
         WHERE ct.label = ir.upstream_type


### PR DESCRIPTION
We need the latest import record with a status of 0. Previously we got
_ALL_ records with status of 0 even if the latest one was a delete
(status of 2).
## TEST
- deploy candlepin-0.8.0-1 tag 
  - `git checkout candlepin-0.8.0-1`
  - `git checkout -b testbranch`
- '''NOW INSERT''' (by hand) 5 new records into cp_import_record table such that the status will be 0 and 2 and the 2 being the latest. We want to ensure that this record does NOT get inserted into cp_upstream_consumer (see the comment for a bash script that will do this for you).
- now checkout this branch (the one containing this patch) and run the liquibase update scripts:
  - `git checkout onlygetlatest`
    *

``````
liquibase  --driver=org.postgresql.Driver --classpath=src/main/resources/:target/classes/:/usr/share/java/postgresql-jdbc.jar --changeLogFile=db/changelog/changelog-update.xml --url=jdbc:postgresql:candlepin --username=candlepin --logLevel=debug update -Dcommunity=True```

* Verify there is a record in cp_upstream_consumer, it should match record 30 from cp_import_record:
  * ```psql -U candlepin -c "select * from cp_upstream_consumer;"```
``````
