### PR TITLE
web and api url transposed.

### DIFF
--- a/src/main/java/org/candlepin/sync/Exporter.java
+++ b/src/main/java/org/candlepin/sync/Exporter.java
@@ -313,8 +313,8 @@ public class Exporter {
     private void exportConsumer(File baseDir, Consumer consumer) throws IOException {
         File file = new File(baseDir.getCanonicalPath(), "consumer.json");
         FileWriter writer = new FileWriter(file);
-        this.consumerExporter.export(mapper, writer, consumer, getPrefixApiUrl(),
-            getPrefixWebUrl());
+        this.consumerExporter.export(mapper, writer, consumer, getPrefixWebUrl(),
+            getPrefixApiUrl());
         writer.close();
     }
 


### PR DESCRIPTION
Added unit test to catch this in the future, as well as very the
other items on consumer.json
## TEST
- register a candlepin consumer, then get `href` from following command
  `./cpc register mymachine candlepin ""   '{"key" => "fact"}' admin admin`
- then export said consumer
  `curl -k -u admin:admin https://localhost:8443/candlepin/consumers/UUID/export > export.zip`
- verify the consumer.json contains the correct values for urlApi and urlWeb.
  - mkdir verify
  - cd verify
  - unzip ../export.zip
  - unzip consumer_export.zip
  - vi export/consumer.json
