### PR TITLE
956873: Fix broken rules on older Candlepin servers.

### DIFF
--- a/src/main/java/org/candlepin/model/Consumer.java
+++ b/src/main/java/org/candlepin/model/Consumer.java
@@ -560,8 +560,4 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
         return new Release(releaseVer);
     }
 
-    @Transient
-    public boolean isManifest() {
-        return getType() == null ? false : getType().isManifest();
-    }
 }

--- a/src/main/java/org/candlepin/policy/criteria/CriteriaRules.java
+++ b/src/main/java/org/candlepin/policy/criteria/CriteriaRules.java
@@ -74,7 +74,7 @@ public class CriteriaRules  {
 
         // Don't load virt_only pools if this consumer isn't a guest
         // or a manifest consumer
-        if (consumer.isManifest()) {
+        if (consumer.getType().isManifest()) {
             DetachedCriteria noRequiresHost = DetachedCriteria.forClass(
                     PoolAttribute.class, "attr")
                 .add(Restrictions.eq("name", "requires_host"))

--- a/src/main/java/org/candlepin/policy/js/entitlement/AbstractEntitlementRules.java
+++ b/src/main/java/org/candlepin/policy/js/entitlement/AbstractEntitlementRules.java
@@ -366,7 +366,7 @@ public abstract class AbstractEntitlementRules implements Enforcer {
         Entitlement entitlement, Pool pool, Consumer c,
         Map<String, String> attributes) {
         log.debug("Running virt_limit post unbind.");
-        if (!config.standalone() && c.isManifest()) {
+        if (!config.standalone() && c.getType().isManifest()) {
             String virtLimit = attributes.get("virt_limit");
             if (!"unlimited".equals(virtLimit)) {
                 // As we have unbound an entitlement from a physical pool that
@@ -409,7 +409,7 @@ public abstract class AbstractEntitlementRules implements Enforcer {
     private void postBindUserLicense(PoolHelper postHelper, Pool pool,
         Consumer c, Map<String, String> attributes) {
         log.debug("Running user_license post-bind.");
-        if (!c.isManifest()) {
+        if (!c.getType().isManifest()) {
             // Default to using the same product from the pool.
             String productId = pool.getProductId();
 
@@ -428,7 +428,7 @@ public abstract class AbstractEntitlementRules implements Enforcer {
         Entitlement entitlement, Pool pool, Consumer c,
         Map<String, String> attributes) {
         log.debug("Running virt_limit post-bind.");
-        if (!c.isManifest() &&
+        if (!c.getType().isManifest() &&
             (config.standalone() || attributes.containsKey("host_limited"))) {
             String productId = pool.getProductId();
             String virtLimit = attributes.get("virt_limit");
@@ -446,7 +446,7 @@ public abstract class AbstractEntitlementRules implements Enforcer {
             }
         }
         else {
-            if (!config.standalone() && c.isManifest()) {
+            if (!config.standalone() && c.getType().isManifest()) {
                 String virtLimit = attributes.get("virt_limit");
                 if (!"unlimited".equals(virtLimit)) {
                     // if the bonus pool is not unlimited, then the bonus pool

--- a/src/main/resources/rules/default-rules.js
+++ b/src/main/resources/rules/default-rules.js
@@ -812,7 +812,7 @@ var PoolCriteria = {
         // Don't load virt_only pools if this consumer isn't a guest:
         // or it isn't a manifest consumer
 
-        if (consumer.isManifest()) {
+        if (consumer.getType().isManifest()) {
             var noRequiresHost = org.hibernate.criterion.DetachedCriteria.forClass(
                     org.candlepin.model.PoolAttribute, "attr")
                     .add(org.hibernate.criterion.Restrictions.eq("name", "requires_host"))

--- a/src/test/java/org/candlepin/model/test/ConsumerTest.java
+++ b/src/test/java/org/candlepin/model/test/ConsumerTest.java
@@ -493,20 +493,4 @@ public class ConsumerTest extends DatabaseTestFixture {
         assertEquals(1, lookedUp.getGuestIds().size());
     }
 
-    @Test
-    public void nullType() {
-        Consumer c = new Consumer();
-        c.setType(null);
-        assertFalse(c.isManifest());
-    }
-
-    @Test
-    public void isManifest() {
-        Consumer c = new Consumer();
-        ConsumerType type = new ConsumerType(
-            ConsumerType.ConsumerTypeEnum.CANDLEPIN);
-        c.setType(type);
-        assertTrue(c.isManifest());
-    }
-
 }


### PR DESCRIPTION
Cherry pick from the hostfix branch.

Adding a new java method and then attempting to use it broke all old
servers. Manifest will import but then fail to list pools.

Changed consumer.isManifest() to consumer.getType().isManifest().
