### PR TITLE
make the next int more random

### DIFF
--- a/src/test/java/org/candlepin/test/TestUtil.java
+++ b/src/test/java/org/candlepin/test/TestUtil.java
@@ -93,7 +93,7 @@ public class TestUtil {
     private static final Random RANDOM = new Random(System.currentTimeMillis());
 
     public static int randomInt() {
-        return RANDOM.nextInt(10000);
+        return Math.abs(RANDOM.nextInt());
     }
 
     public static Product createProduct(String id, String name) {


### PR DESCRIPTION
A unit test failed on jenkins with this exception:

```
javax.persistence.PersistenceException: org.hibernate.NonUniqueObjectException: a different object with the same identifier value was already associated with the session: [org.candlepin.model.Product#371]
```

I tracked it down to the randomInt method causing duplicate ids, to the point that running 1000 consecutive calls would result in 30-50 duplicate ids. By simply calling nextInt without a bound, and taking the absolute value of the result, I got it down to 2 duplicates for 100000 consecutive runs.

Here's the test I used to verify it, I didn't include it in the commit because it really isn't something I could consistently verify. It could be 0, could be 1, sometimes it would hit 5, but most of the time it was 2.

```
    @Test
    public void test() {
        Map<Integer, Integer> dupes = new HashMap<Integer, Integer>();
        List<Integer> dupelist = new ArrayList<Integer>();
        int[] ints = new int[100000];
        for (int i = 0; i < 100000; i++) {
            ints[i] = TestUtil.randomInt();
            //System.out.println("num: " + TestUtil.randomInt());
        }

        for (int i : ints) {
            if (!dupes.containsKey(i)) {
                dupes.put(i, i);
            }
            else {
                dupelist.add(i);
            }
        }

        System.out.println("There are " + dupelist.size() + " duplicate ids");
    }
```

http://hudson.rhq.lab.eng.bos.redhat.com:8080/hudson/view/chainsaw/job/candlepin-unittest/69/testReport/junit/org.candlepin.model.test/OwnerInfoCuratorTest/testOwnerPoolEnabledZeroCount/
