### PR TITLE
957218: Require 3.2 certs for cores enabled subscriptions

### DIFF
--- a/spec/core_and_ram_spec.rb
+++ b/spec/core_and_ram_spec.rb
@@ -44,7 +44,7 @@ describe 'Core and RAM Limiting' do
 
   it 'consumer status should be valid when cores, ram and sockets are covered' do
     system = consumer_client(@user, random_string('system1'), :system, nil,
-                {'system.certificate_version' => '3.1',
+                {'system.certificate_version' => '3.2',
                  'cpu.core(s)_per_socket' => '4',
                  'memory.memtotal' => '8000000',
                  'cpu.cpu_socket(s)' => '4'})
@@ -69,7 +69,7 @@ describe 'Core and RAM Limiting' do
   # entitle by getting single entitlement and checking status
   it 'consumer status should be partial when consumer core only not covered' do
     system = consumer_client(@user, random_string('system1'), :system, nil,
-                {'system.certificate_version' => '3.1',
+                {'system.certificate_version' => '3.2',
                  'cpu.core(s)_per_socket' => '8',
                  'memory.memtotal' => '8000000',
                  'cpu.cpu_socket(s)' => '4'})
@@ -93,7 +93,7 @@ describe 'Core and RAM Limiting' do
 
   it 'consumer status should be partial when consumer ram only not covered' do
     system = consumer_client(@user, random_string('system1'), :system, nil,
-                {'system.certificate_version' => '3.1',
+                {'system.certificate_version' => '3.2',
                  'cpu.core(s)_per_socket' => '4',
                  'memory.memtotal' => '16000000',
                  'cpu.cpu_socket(s)' => '4'})
@@ -117,7 +117,7 @@ describe 'Core and RAM Limiting' do
 
   it 'consumer status should be partial when consumer sockets only not covered' do
     system = consumer_client(@user, random_string('system1'), :system, nil,
-                {'system.certificate_version' => '3.1',
+                {'system.certificate_version' => '3.2',
                  'cpu.core(s)_per_socket' => '2',
                  'memory.memtotal' => '8000000',
                  'cpu.cpu_socket(s)' => '8'})
@@ -142,7 +142,7 @@ describe 'Core and RAM Limiting' do
   # autobind tests. can we get a full bind to cover the limiting reagent?
   it 'consumer status should be valid when consumer core requires extra entitlement' do
     system = consumer_client(@user, random_string('system1'), :system, nil,
-                {'system.certificate_version' => '3.1',
+                {'system.certificate_version' => '3.2',
                  'cpu.core(s)_per_socket' => '8',
                  'memory.memtotal' => '8000000',
                  'cpu.cpu_socket(s)' => '4'})
@@ -164,7 +164,7 @@ describe 'Core and RAM Limiting' do
 
   it 'consumer status should be invalid when consumer ram exceeds entitlement' do
     system = consumer_client(@user, random_string('system1'), :system, nil,
-                {'system.certificate_version' => '3.1',
+                {'system.certificate_version' => '3.2',
                  'cpu.core(s)_per_socket' => '4',
                  'memory.memtotal' => '16000000',
                  'cpu.cpu_socket(s)' => '4'})
@@ -190,7 +190,7 @@ describe 'Core and RAM Limiting' do
 
   it 'consumer status should be valid when consumer socket requires extra entitlement' do
     system = consumer_client(@user, random_string('system1'), :system, nil,
-                {'system.certificate_version' => '3.1',
+                {'system.certificate_version' => '3.2',
                  'cpu.core(s)_per_socket' => '2',
                  'memory.memtotal' => '8000000',
                  'cpu.cpu_socket(s)' => '8'})
@@ -214,7 +214,7 @@ describe 'Core and RAM Limiting' do
     owner = create_owner random_string('test_owner')
     user = user_client(owner, random_string('test-user'))
     system = consumer_client(user, random_string('system'), :system, nil,
-                {'system.certificate_version' => '3.1',
+                {'system.certificate_version' => '3.2',
                  'cpu.cpu_socket(s)' => '4',
                  'cpu.core(s)_per_socket' => '8'})
     prod1 = create_product(random_string('product'), random_string('product'), :attributes =>

--- a/spec/core_spec.rb
+++ b/spec/core_spec.rb
@@ -35,16 +35,16 @@ describe 'Core Limiting' do
     @user = user_client(@owner, random_string('test-user'))
   end
 
-  it 'can consume core entitlement if requesting v3.1 certificate' do
+  it 'can consume core entitlement if requesting v3.2 certificate' do
     system = consumer_client(@user, random_string('system1'), :system, nil,
-                {'system.certificate_version' => '3.1'})
+                {'system.certificate_version' => '3.2'})
     entitlement = system.consume_product(@core_product.id)[0]
     entitlement.should_not == nil
   end
 
-  it 'can not consume core entitlement when requesting less than v3.1 certificate' do
+  it 'can not consume core entitlement when requesting less than v3.2 certificate' do
     system = consumer_client(@user, random_string('system1'), :system, nil,
-                {'system.certificate_version' => '3.0'})
+                {'system.certificate_version' => '3.1'})
 
     installed = [
         {'productId' => @core_sub.id,
@@ -55,7 +55,7 @@ describe 'Core Limiting' do
     pool = find_pool(@owner.id, @core_sub.id)
     pool.should_not == nil
 
-    expected_error = ("The client must support at least v3.1 certificates in order to use subscription: %s." +
+    expected_error = ("The client must support at least v3.2 certificates in order to use subscription: %s." +
                      " A newer client may be available to address this problem.") % [@core_product.name]
     begin
       entitlement = system.consume_pool(pool.id)
@@ -69,7 +69,7 @@ describe 'Core Limiting' do
 
   it 'consumer status should be valid when consumer core is covered' do
     system = consumer_client(@user, random_string('system1'), :system, nil,
-                {'system.certificate_version' => '3.1',
+                {'system.certificate_version' => '3.2',
                  # Simulate 8 cores as would be returned from system fact
                  'cpu.core(s)_per_socket' => '8'})
     installed = [
@@ -89,7 +89,7 @@ describe 'Core Limiting' do
 
   it 'consumer status should be partial when consumer core not covered' do
     system = consumer_client(@user, random_string('system1'), :system, nil,
-                {'system.certificate_version' => '3.1',
+                {'system.certificate_version' => '3.2',
                  # Simulate 16 cores as would be returned from system fact
                  'cpu.core(s)_per_socket' => '16'})
     installed = [
@@ -112,7 +112,7 @@ describe 'Core Limiting' do
 
   it 'consumer status should be partial when consumer core covered but not sockets' do
     system = consumer_client(@user, random_string('system1'), :system, nil,
-                {'system.certificate_version' => '3.1',
+                {'system.certificate_version' => '3.2',
                  # Simulate 2 cores as would be returned from system fact
                  # which should be covered by the enitlement when consumed.
                  'cpu.core(s)_per_socket' => '2',
@@ -140,7 +140,7 @@ describe 'Core Limiting' do
 
   it 'consumer status should be partial when consumer sockets covered but not core' do
     system = consumer_client(@user, random_string('system1'), :system, nil,
-                {'system.certificate_version' => '3.1',
+                {'system.certificate_version' => '3.2',
                  # Simulate 16 cores as would be returned from system fact
                  # which will not be covered by the enitlement when consumed.
                  'cpu.core(s)_per_socket' => '8',
@@ -168,7 +168,7 @@ describe 'Core Limiting' do
 
   it 'consumer status is valid when both core and sockets are covered' do
     system = consumer_client(@user, random_string('system1'), :system, nil,
-                {'system.certificate_version' => '3.1',
+                {'system.certificate_version' => '3.2',
                  # Simulate 8 cores as would be returned from system fact
                  # which will be covered by the enitlement when consumed.
                  'cpu.core(s)_per_socket' => '4',
@@ -192,7 +192,7 @@ describe 'Core Limiting' do
 
   it 'can heal when core limited' do
     system = consumer_client(@user, random_string('system1'), :system, nil,
-                {'system.certificate_version' => '3.1',
+                {'system.certificate_version' => '3.2',
                  # Simulate 8 cores as would be returned from system fact
                  'cpu.core(s)_per_socket' => '8'})
     installed = [
@@ -207,7 +207,7 @@ describe 'Core Limiting' do
 
   it 'will not heal when system core is not covered by any entitlements' do
     system = consumer_client(@user, random_string('system1'), :system, nil,
-                {'system.certificate_version' => '3.1',
+                {'system.certificate_version' => '3.2',
                  # Simulate 12 corse as would be returned from system fact
                  'cpu.core(s)_per_socket' => '12'})
     installed = [
@@ -222,7 +222,7 @@ describe 'Core Limiting' do
 
   it 'can heal when both core and socket limited' do
     system = consumer_client(@user, random_string('system1'), :system, nil,
-                {'system.certificate_version' => '3.1',
+                {'system.certificate_version' => '3.2',
                  # Simulate 8 cores as would be returned from system fact
                  # which will be covered by the enitlement when consumed.
                  'cpu.core(s)_per_socket' => '4',

--- a/spec/entitlement_certificate_v3_spec.rb
+++ b/spec/entitlement_certificate_v3_spec.rb
@@ -63,7 +63,7 @@ describe 'Entitlement Certificate V3' do
     @user = user_client(@owner, random_string('billy'))
 
     @system = consumer_client(@user, random_string('system1'), :candlepin, nil,
-				{'system.certificate_version' => '3.1'})
+				{'system.certificate_version' => '3.2'})
     @entitlement = @system.consume_product(@product.id)[0]
   end
 
@@ -78,7 +78,7 @@ describe 'Entitlement Certificate V3' do
     value.should == "3.2"
   end
 
-  it 'generated a version 3.1 certificate' do
+  it 'generated a version 3.2 certificate' do
     value = extension_from_cert(@system.list_certificates[0]['cert'], "1.3.6.1.4.1.2312.9.6")
     value.should == "3.2"
   end

--- a/src/main/java/org/candlepin/version/ProductVersionValidator.java
+++ b/src/main/java/org/candlepin/version/ProductVersionValidator.java
@@ -29,7 +29,7 @@ import org.candlepin.util.RpmVersionComparator;
  *
  * Since the introduction of cert V3, we now have the concept of a certificate
  * version. When certificates are changed (i.e, new attributes), we will bump
- * the certificate's version.
+ * the certificate's version. See X509V3ExtenstionUtil
  *
  * This class defines what certificate version is required for a Product
  * based on its attributes. It has the ability to determine if a given
@@ -48,7 +48,7 @@ public class ProductVersionValidator {
     // Add any product atttribute version requirements here.
     static {
         PRODUCT_ATTR_VERSION_REQUIREMENTS.put("ram", "3.1");
-        PRODUCT_ATTR_VERSION_REQUIREMENTS.put("cores", "3.1");
+        PRODUCT_ATTR_VERSION_REQUIREMENTS.put("cores", "3.2");
     }
 
     private ProductVersionValidator() {


### PR DESCRIPTION
If testing with a newer client, set a custom fact to simulate a lower certificate version:

ie. system.certificate_version: 3.1
