### PR TITLE
892696: Turn down the logging so that missing rules are infos instead of...

### DIFF
--- a/src/main/java/org/candlepin/policy/js/JsRunner.java
+++ b/src/main/java/org/candlepin/policy/js/JsRunner.java
@@ -115,7 +115,7 @@ public class JsRunner {
             returner = this.invokeMethod(ruleName);
         }
         catch (NoSuchMethodException ex) {
-            log.warn("No rule found: " + ruleName + " in namespace: " + namespace);
+            log.info("No rule found: " + ruleName + " in namespace: " + namespace);
         }
         catch (RhinoException ex) {
             throw new RuleExecutionException(ex);

--- a/src/main/java/org/candlepin/policy/js/entitlement/AbstractEntitlementRules.java
+++ b/src/main/java/org/candlepin/policy/js/entitlement/AbstractEntitlementRules.java
@@ -185,7 +185,7 @@ public abstract class AbstractEntitlementRules implements Enforcer {
         }
         catch (NoSuchMethodException ex) {
             // This is fine, I hope...
-            log.warn("No default rule found: " + GLOBAL_POST_FUNCTION);
+            log.info("No default rule found: " + GLOBAL_POST_FUNCTION);
         }
         catch (RhinoException ex) {
             throw new RuleExecutionException(ex);
@@ -202,7 +202,7 @@ public abstract class AbstractEntitlementRules implements Enforcer {
         }
         catch (NoSuchMethodException ex) {
             // This is fine, I hope...
-            log.warn("No default rule found: " + GLOBAL_PRE_FUNCTION);
+            log.info("No default rule found: " + GLOBAL_PRE_FUNCTION);
         }
         catch (Exception ex) {
             throw new RuleExecutionException(ex);
@@ -225,7 +225,7 @@ public abstract class AbstractEntitlementRules implements Enforcer {
         }
         catch (NoSuchMethodException ex) {
             // This is fine, I hope...
-            log.warn("No default rule found: " + GLOBAL_POST_FUNCTION);
+            log.info("No default rule found: " + GLOBAL_POST_FUNCTION);
         }
         catch (RhinoException ex) {
             throw new RuleExecutionException(ex);


### PR DESCRIPTION
... warns.

In normal cases, the missing rules are fine. So, show tuem for deubgging, but not for normal operations which would use WARN for a log level.
