### PR TITLE
Add buildfile target to generate a .syntastic_class_path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ lib
 *.log.*
 buildconf/builder/config/local
 .classpath
+.syntastic_class_path
 .project
 .pydevproject
 .externalToolBuilders

--- a/buildfile
+++ b/buildfile
@@ -226,6 +226,22 @@ define "candlepin" do
     end
   end
 
+  desc "generate a .syntastic_class_path for vim/syntastic"
+  task :list_classpath do
+    # see https://github.com/scrooloose/syntastic/blob/master/syntax_checkers/java/javac.vim
+    # this generates a .syntastic_class_path so the syntastic javac checker will
+    # work properly
+    syntastic_class_path = File.new(".syntastic_class_path", "w")
+    syn_class_path_buf = ""
+    compile.dependencies.inject("") { |a,c| syn_class_path_buf << "#{c}\n"}
+    syn_class_path_buf << "#{Java.tools_jar}\n"
+    # I'm sure there is a better way to figure out local target
+    syn_class_path_buf << "target/classes\n"
+
+    syntastic_class_path.write(syn_class_path_buf)
+    syntastic_class_path.close()
+  end
+
   desc 'Crawl the REST API and print a summary.'
   task :apicrawl  do
     options.test = 'no'


### PR DESCRIPTION
Used by the vim/syntastic javac syntax checker
