### PR TITLE
Better method of detecting when to apply instance multiplier.

### DIFF
--- a/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
+++ b/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
@@ -58,7 +58,9 @@ public class PoolRules {
         // In hosted, we increase the quantity on the subscription. However in standalone,
         // we assume this already has happened in hosted and the accurate quantity was
         // exported:
-        if (sub.getProduct().hasAttribute("instance_multiplier") && !config.standalone()) {
+        if (sub.getProduct().hasAttribute("instance_multiplier") &&
+            sub.getUpstreamPoolId() == null) {
+
             int instanceMultiplier = Integer.parseInt(
                 sub.getProduct().getAttribute("instance_multiplier").getValue());
             log.info("Increasing pool quantity for instance multiplier: " +

--- a/src/test/java/org/candlepin/policy/test/PoolRulesInstanceTest.java
+++ b/src/test/java/org/candlepin/policy/test/PoolRulesInstanceTest.java
@@ -78,8 +78,7 @@ public class PoolRulesInstanceTest {
 
     @Test
     public void hostedCreateInstanceBasedPool() {
-        when(configMock.standalone()).thenReturn(false);
-        Subscription s = createInstanceBasedSub("INSTANCEPROD", 100, 2);
+        Subscription s = createInstanceBasedSub("INSTANCEPROD", 100, 2, false);
         List<Pool> pools = poolRules.createPools(s);
         assertEquals(1, pools.size());
 
@@ -91,8 +90,7 @@ public class PoolRulesInstanceTest {
 
     @Test
     public void standaloneCreateInstanceBasedPool() {
-        when(configMock.standalone()).thenReturn(true);
-        Subscription s = createInstanceBasedSub("INSTANCEPROD", 100, 2);
+        Subscription s = createInstanceBasedSub("INSTANCEPROD", 100, 2, true);
         List<Pool> pools = poolRules.createPools(s);
         assertEquals(1, pools.size());
 
@@ -106,8 +104,7 @@ public class PoolRulesInstanceTest {
 
     @Test
     public void hostedInstanceBasedUpdatePool() {
-        when(configMock.standalone()).thenReturn(false);
-        Subscription s = createInstanceBasedSub("INSTANCEPROD", 100, 2);
+        Subscription s = createInstanceBasedSub("INSTANCEPROD", 100, 2, false);
         List<Pool> pools = poolRules.createPools(s);
         assertEquals(1, pools.size());
         Pool pool = pools.get(0);
@@ -129,8 +126,7 @@ public class PoolRulesInstanceTest {
 
     @Test
     public void hostedInstanceBasedRemoved() {
-        when(configMock.standalone()).thenReturn(false);
-        Subscription s = createInstanceBasedSub("INSTANCEPROD", 100, 2);
+        Subscription s = createInstanceBasedSub("INSTANCEPROD", 100, 2, false);
         List<Pool> pools = poolRules.createPools(s);
         assertEquals(1, pools.size());
         Pool pool = pools.get(0);
@@ -154,8 +150,7 @@ public class PoolRulesInstanceTest {
 
     @Test
     public void standaloneInstanceBasedUpdatePool() {
-        when(configMock.standalone()).thenReturn(true);
-        Subscription s = createInstanceBasedSub("INSTANCEPROD", 100, 2);
+        Subscription s = createInstanceBasedSub("INSTANCEPROD", 100, 2, true);
         List<Pool> pools = poolRules.createPools(s);
         assertEquals(1, pools.size());
         Pool pool = pools.get(0);
@@ -179,12 +174,15 @@ public class PoolRulesInstanceTest {
     }
 
     private Subscription createInstanceBasedSub(String productId, int quantity,
-        int instanceMultiplier) {
+        int instanceMultiplier, boolean exported) {
         Product product = new Product(productId, productId);
         product.setAttribute("instance_multiplier",
             new Integer(instanceMultiplier).toString());
         when(productAdapterMock.getProductById(productId)).thenReturn(product);
         Subscription s = TestUtil.createSubscription(product);
+        if (exported) {
+            s.setUpstreamPoolId("SOMETHING");
+        }
         s.setQuantity(new Long(quantity));
         return s;
     }


### PR DESCRIPTION
Previously we were using config for hosted/standalone, which means no
multiplier would be applied in standalone even if the subscription was
being created there. (custom products, dev testing, etc)

Instead we want to know if the subscription has been exported, if so we
know we do not need to re-apply multipliers.
