### PR TITLE
put target/resources at the front of the classpath.

### DIFF
--- a/buildfile
+++ b/buildfile
@@ -201,7 +201,7 @@ define "candlepin" do
   test.setup do |task|
     filter('src/main/resources/META-INF').into('target/classes/META-INF').run
   end
-  test.with COMMONS, DB, RESTEASY, JUNIT, LOG4J, HIBERNATE, BOUNCYCASTLE, HSQLDB, GUICE, QUARTZ, GETTEXT_COMMONS, MIME4J, RHINO, COLLECTIONS, generate
+  test.with 'target/resources', COMMONS, DB, RESTEASY, JUNIT, LOG4J, HIBERNATE, BOUNCYCASTLE, HSQLDB, GUICE, QUARTZ, GETTEXT_COMMONS, MIME4J, RHINO, COLLECTIONS, generate
   test.with LOGDRIVER if use_logdriver
   test.using :java_args => [ '-Xmx2g', '-XX:+HeapDumpOnOutOfMemoryError' ]
 


### PR DESCRIPTION
We've had a series of folks wanting to log from the rules.js file.
Making changes to log4j.properties has proved to be useless. I added
-Dlog4j.debug to the jvm_args for testing to see what was going on
and it turns out log4j was picking up the log4j.properties from:
<drum roll>GUICE-PERSIST!!!!</drum roll>

There's a bug for that already:

  https://code.google.com/p/google-guice/issues/detail?id=623

No matter what we do buildr test will never pick up our log4j.properties
unless we put target/resources at the beginning of the classpath. By
default buildr adds it to the end.

This does not affect the application because we forcibly configure
log4j in LoggingConfig.java.

In order to see debug logging from javascript rules add this
to your log4j.properties:

   log4j.logger.org.candlepin.policy.js=DEBUG
