### PR TITLE
Fix values for host_limited attribute.

### DIFF
--- a/buildconf/scripts/test_data.json
+++ b/buildconf/scripts/test_data.json
@@ -661,7 +661,7 @@
                 "instance_multiplier": 2,
                 "sockets": 2,
                 "virt_limit": 1,
-                "host_limited": 1,
+                "host_limited": "true",
                 "stacking_id": 15,
                 "multi-entitlement": "yes",
                 "support_level" : "Standard",

--- a/src/main/java/org/candlepin/policy/js/entitlement/AbstractEntitlementRules.java
+++ b/src/main/java/org/candlepin/policy/js/entitlement/AbstractEntitlementRules.java
@@ -370,7 +370,9 @@ public abstract class AbstractEntitlementRules implements Enforcer {
         Entitlement entitlement, Pool pool, Consumer c,
         Map<String, String> attributes) {
         log.debug("Running virt_limit post unbind.");
-        if (!config.standalone() && !attributes.containsKey("host_limited") &&
+        boolean hostLimited = attributes.containsKey("host_limited") &&
+            attributes.get("host_limited").equals("true");
+        if (!config.standalone() && !hostLimited &&
                 c.getType().isManifest()) {
             String virtLimit = attributes.get("virt_limit");
             if (!"unlimited".equals(virtLimit)) {
@@ -433,8 +435,10 @@ public abstract class AbstractEntitlementRules implements Enforcer {
         Entitlement entitlement, Pool pool, Consumer c,
         Map<String, String> attributes) {
         log.debug("Running virt_limit post-bind.");
+        boolean hostLimited = attributes.containsKey("host_limited") &&
+            attributes.get("host_limited").equals("true");
         if (!c.getType().isManifest() &&
-            (config.standalone() || attributes.containsKey("host_limited"))) {
+            (config.standalone() || hostLimited)) {
             String productId = pool.getProductId();
             String virtLimit = attributes.get("virt_limit");
             if ("unlimited".equals(virtLimit)) {
@@ -462,8 +466,10 @@ public abstract class AbstractEntitlementRules implements Enforcer {
     private void decrementHostedBonusPoolQuantity(PoolHelper postHelper,
         Entitlement entitlement, Pool pool, Consumer c,
         Map<String, String> attributes) {
+        boolean hostLimited = attributes.containsKey("host_limited") &&
+            attributes.get("host_limited").equals("true");
         if (c.getType().isManifest() && !config.standalone() &&
-                !attributes.containsKey("host_limited")) {
+                !hostLimited) {
             String virtLimit = attributes.get("virt_limit");
             if (!"unlimited".equals(virtLimit)) {
                 // if the bonus pool is not unlimited, then the bonus pool

--- a/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
+++ b/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
@@ -109,9 +109,11 @@ public class PoolRules {
 
         pools.add(newPool);
 
+        boolean hostLimited = attributes.containsKey("host_limited") &&
+            attributes.get("host_limited").equals("true");
         // Check if we need to create a virt-only pool for this subscription:
         if (attributes.containsKey("virt_limit") && !config.standalone() &&
-            !attributes.containsKey("host_limited")) {
+            !hostLimited) {
             HashMap<String, String> virtAttributes = new HashMap<String, String>();
             virtAttributes.put("virt_only", "true");
             virtAttributes.put("pool_derived", "true");

--- a/src/test/java/org/candlepin/policy/js/entitlement/test/HostedVirtLimitEntitlementRulesTest.java
+++ b/src/test/java/org/candlepin/policy/js/entitlement/test/HostedVirtLimitEntitlementRulesTest.java
@@ -100,7 +100,7 @@ public class HostedVirtLimitEntitlementRulesTest extends EntitlementRulesTestFix
     public void hostedVirtLimitWithHostLimitedCreatesBonusPoolsOnBind() {
         when(config.standalone()).thenReturn(false);
         Subscription s = createVirtLimitSub("virtLimitProduct", 10, "unlimited");
-        s.getProduct().setAttribute("host_limited", "yes");
+        s.getProduct().setAttribute("host_limited", "true");
         List<Pool> pools = poolRules.createPools(s);
         assertEquals(1, pools.size());
 

--- a/src/test/java/org/candlepin/policy/test/PoolRulesTest.java
+++ b/src/test/java/org/candlepin/policy/test/PoolRulesTest.java
@@ -361,9 +361,19 @@ public class PoolRulesTest {
     public void hostedVirtLimitWithHostLimitedSkipsBonusPools() {
         when(configMock.standalone()).thenReturn(false);
         Subscription s = createVirtLimitSub("virtLimitProduct", 10, 10);
-        s.getProduct().setAttribute("host_limited", "yes");
+        s.getProduct().setAttribute("host_limited", "true");
         List<Pool> pools = poolRules.createPools(s);
         assertEquals(1, pools.size());
+    }
+
+    // Make sure host_limited false is working:
+    @Test
+    public void hostedVirtLimitWithHostLimitedFalseCreatesBonusPools() {
+        when(configMock.standalone()).thenReturn(false);
+        Subscription s = createVirtLimitSub("virtLimitProduct", 10, 10);
+        s.getProduct().setAttribute("host_limited", "false");
+        List<Pool> pools = poolRules.createPools(s);
+        assertEquals(2, pools.size());
     }
 
     @Test


### PR DESCRIPTION
We were already using true, yes, and 1, and any value would have
triggered the behaviour, including "false".

Standardize on "true", which allows us a way to override/disable in pool
attribute should we ever need to do so.
