### PR TITLE
ensure no test uses /etc/candlepin/candlepin.conf

### DIFF
--- a/src/main/java/org/candlepin/audit/EventSinkImpl.java
+++ b/src/main/java/org/candlepin/audit/EventSinkImpl.java
@@ -51,11 +51,11 @@ public class EventSinkImpl implements EventSink {
     private ObjectMapper mapper;
 
     @Inject
-    public EventSinkImpl(EventFactory eventFactory, ObjectMapper mapper) {
+    public EventSinkImpl(EventFactory eventFactory, ObjectMapper mapper, Config config) {
         this.eventFactory = eventFactory;
         this.mapper = mapper;
         try {
-            largeMsgSize = new Config().getInt(ConfigProperties.HORNETQ_LARGE_MSG_SIZE);
+            largeMsgSize = config.getInt(ConfigProperties.HORNETQ_LARGE_MSG_SIZE);
 
             factory =  createClientSessionFactory();
             clientSession = factory.createSession();

--- a/src/test/java/org/candlepin/audit/EventSinkImplTest.java
+++ b/src/test/java/org/candlepin/audit/EventSinkImplTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.when;
 import org.mockito.ArgumentCaptor;
 
 import org.candlepin.auth.Principal;
+import org.candlepin.config.CandlepinCommonTestConfig;
 import org.candlepin.guice.PrincipalProvider;
 import org.candlepin.model.ActivationKey;
 import org.candlepin.model.Consumer;
@@ -90,7 +91,7 @@ public class EventSinkImplTest {
      * @return
      */
     private EventSinkImpl createEventSink(final ClientSessionFactory sessionFactory) {
-        return new EventSinkImpl(factory, mapper) {
+        return new EventSinkImpl(factory, mapper, new CandlepinCommonTestConfig()) {
             @Override
             protected ClientSessionFactory createClientSessionFactory() {
                 return sessionFactory;

--- a/src/test/java/org/candlepin/client/CandlepinConnectionTest.java
+++ b/src/test/java/org/candlepin/client/CandlepinConnectionTest.java
@@ -17,7 +17,7 @@ package org.candlepin.client;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-import org.candlepin.config.Config;
+import org.candlepin.config.CandlepinCommonTestConfig;
 import org.candlepin.model.Owner;
 
 import org.apache.commons.httpclient.Credentials;
@@ -35,7 +35,8 @@ public class CandlepinConnectionTest {
     @Ignore("needs mock connection to test with")
     @Test
     public void connect() {
-        CandlepinConnection conn = new CandlepinConnection(new Config());
+        CandlepinConnection conn = new CandlepinConnection(
+            new CandlepinCommonTestConfig());
         Credentials creds = new UsernamePasswordCredentials("admin", "admin");
         OwnerClient client = conn.connect(OwnerClient.class, creds,
             "http://localhost:8080/candlepin/");
@@ -51,7 +52,8 @@ public class CandlepinConnectionTest {
     @Ignore("needs mock connection to test with")
     @Test
     public void doesnotexist() {
-        CandlepinConnection conn = new CandlepinConnection(new Config());
+        CandlepinConnection conn = new CandlepinConnection(
+            new CandlepinCommonTestConfig());
         Credentials creds = new UsernamePasswordCredentials("admin", "admin");
         OwnerClient client = conn.connect(OwnerClient.class, creds,
             "http://localhost:8080/candlepin/");

--- a/src/test/java/org/candlepin/config/CandlepinCommonTestConfig.java
+++ b/src/test/java/org/candlepin/config/CandlepinCommonTestConfig.java
@@ -24,10 +24,10 @@ import java.util.TreeMap;
 public class CandlepinCommonTestConfig extends Config {
 
     public CandlepinCommonTestConfig() {
-        // explicitly _not_ using the /etc/candlepin/candlepin.conf file in testing.
-        this.configuration = new TreeMap<String, String>(
-            ConfigProperties.DEFAULT_PROPERTIES);
-        this.configuration.putAll(loadProperties());
+        super(new TreeMap<String, String>());
+        // be very careful not to invoke the default Config ctor here
+        // because it will read in your /etc/candlepin/candlepin.conf
+        // which we do not want in our testing framework.
     }
 
     @Override

--- a/src/test/java/org/candlepin/config/ConfigTest.java
+++ b/src/test/java/org/candlepin/config/ConfigTest.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import org.junit.Before;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -33,15 +32,10 @@ import java.util.TreeMap;
  * ConfigTest
  */
 public class ConfigTest {
-    private Config config;
-
-    @Before
-    public void init() {
-        config = new Config();
-    }
 
     @Test
     public void testTrimSpaces() {
+        Config config = new Config(new TreeMap<String, String>());
         TreeMap<String, String> testData = new TreeMap<String, String>();
         testData.put("good", "good");
         testData.put("bad", "    bad    ");
@@ -52,6 +46,13 @@ public class ConfigTest {
 
     @Test
     public void basicauth() {
+        Config config = new Config(
+            new HashMap<String, String>() {
+
+                {
+                    put(ConfigProperties.BASIC_AUTHENTICATION, "true");
+                }
+            });
         boolean auth = config.getBoolean(ConfigProperties.BASIC_AUTHENTICATION);
         assertEquals(auth, config.basicAuthEnabled());
     }
@@ -75,6 +76,7 @@ public class ConfigTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void getBooleanWithNonExistentEntryThrowsError() {
+        Config config = new Config(new TreeMap<String, String>());
         config.getBoolean("notthere");
     }
 

--- a/src/test/java/org/candlepin/config/DbBasicAuthConfigTest.java
+++ b/src/test/java/org/candlepin/config/DbBasicAuthConfigTest.java
@@ -34,7 +34,7 @@ public class DbBasicAuthConfigTest {
 
     @Before
     public void init() {
-        config = new Config();
+        config = new CandlepinCommonTestConfig();
     }
 
     @Test

--- a/src/test/java/org/candlepin/config/JPAConfigParserTest.java
+++ b/src/test/java/org/candlepin/config/JPAConfigParserTest.java
@@ -40,7 +40,7 @@ public class JPAConfigParserTest {
 
     @Before
     public void init() {
-        config = new Config();
+        config = new CandlepinCommonTestConfig();
     }
 
     @SuppressWarnings("serial")

--- a/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
+++ b/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
@@ -23,7 +23,7 @@ import org.candlepin.audit.EventFactory;
 import org.candlepin.audit.EventSink;
 import org.candlepin.auth.Access;
 import org.candlepin.auth.UserPrincipal;
-import org.candlepin.config.Config;
+import org.candlepin.config.CandlepinCommonTestConfig;
 import org.candlepin.controller.PoolManager;
 import org.candlepin.model.ActivationKeyCurator;
 import org.candlepin.model.Consumer;
@@ -121,7 +121,7 @@ public class HypervisorResourceTest {
             this.userService, null, null, null, null, this.ownerCurator,
             this.activationKeyCurator,
             null, this.complianceRules, this.deletedConsumerCurator,
-            null, new Config());
+            null, new CandlepinCommonTestConfig());
         hypervisorResource = new HypervisorResource(consumerResource, poolManager,
             consumerCurator, this.deletedConsumerCurator, i18n);
 

--- a/src/test/java/org/candlepin/resource/test/ConsumerResourceIntegrationTest.java
+++ b/src/test/java/org/candlepin/resource/test/ConsumerResourceIntegrationTest.java
@@ -35,7 +35,7 @@ import org.candlepin.auth.ConsumerPrincipal;
 import org.candlepin.auth.Principal;
 import org.candlepin.auth.UserPrincipal;
 import org.candlepin.auth.permissions.Permission;
-import org.candlepin.config.Config;
+import org.candlepin.config.CandlepinCommonTestConfig;
 import org.candlepin.exceptions.BadRequestException;
 import org.candlepin.exceptions.ForbiddenException;
 import org.candlepin.model.Consumer;
@@ -540,7 +540,7 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
         ConsumerResource cr = new ConsumerResource(this.consumerCurator, null,
             null, null, this.entitlementCurator, null, null, null, null, null,
             null, null, null, null, this.poolManager, null, null, null, null,
-            null, null, null, null, new Config());
+            null, null, null, null, new CandlepinCommonTestConfig());
 
         Response rsp = consumerResource.bind(
             consumer.getUuid(), pool.getId().toString(), null, 1, null,

--- a/src/test/java/org/candlepin/resource/test/ConsumerResourceTest.java
+++ b/src/test/java/org/candlepin/resource/test/ConsumerResourceTest.java
@@ -31,7 +31,7 @@ import org.candlepin.audit.EventSink;
 import org.candlepin.auth.Access;
 import org.candlepin.auth.NoAuthPrincipal;
 import org.candlepin.auth.UserPrincipal;
-import org.candlepin.config.Config;
+import org.candlepin.config.CandlepinCommonTestConfig;
 import org.candlepin.controller.CandlepinPoolManager;
 import org.candlepin.controller.Entitler;
 import org.candlepin.controller.PoolManager;
@@ -127,7 +127,7 @@ public class ConsumerResourceTest {
             mockedConsumerCurator, null, null, null, mockedEntitlementCurator, null,
             mockedEntitlementCertServiceAdapter, null, null, null, null, null,
             null, null, mockedPoolManager, null, null, null, null, null, null,
-            null, null, new Config());
+            null, null, new CandlepinCommonTestConfig());
 
         List<CertificateSerialDto> serials = consumerResource
             .getEntitlementCertificateSerials(consumer.getUuid());
@@ -155,14 +155,15 @@ public class ConsumerResourceTest {
 
         CandlepinPoolManager poolManager = new CandlepinPoolManager(null,
             mockedSubscriptionServiceAdapter, null,
-            mockedEntitlementCertServiceAdapter, null, null, new Config(), null,
-            null, mockedEntitlementCurator, mockedConsumerCurator, null, null, null, null);
+            mockedEntitlementCertServiceAdapter, null, null,
+            new CandlepinCommonTestConfig(), null, null,
+            mockedEntitlementCurator, mockedConsumerCurator, null, null, null, null);
 
         ConsumerResource consumerResource = new ConsumerResource(
             mockedConsumerCurator, null, null, null, mockedEntitlementCurator, null,
             mockedEntitlementCertServiceAdapter, null, null, null, null, null,
             null, null, poolManager, null, null, null, null, null, null,
-            null, null, new Config());
+            null, null, new CandlepinCommonTestConfig());
 
         consumerResource.regenerateEntitlementCertificates(consumer.getUuid(), "9999",
             false);
@@ -196,7 +197,8 @@ public class ConsumerResourceTest {
         CandlepinPoolManager mgr = mock(CandlepinPoolManager.class);
         ConsumerResource cr = new ConsumerResource(mockedConsumerCurator, null,
             null, null, null, null, null, null, null, null, null, null, null,
-            null, mgr, null, null, null, null, null, null, null, null, new Config());
+            null, mgr, null, null, null, null, null, null, null, null,
+            new CandlepinCommonTestConfig());
         cr.regenerateEntitlementCertificates(consumer.getUuid(), null, true);
         Mockito.verify(mgr, Mockito.times(1))
             .regenerateEntitlementCertificates(eq(consumer), eq(true));
@@ -227,7 +229,7 @@ public class ConsumerResourceTest {
         ConsumerResource cr = new ConsumerResource(mockedConsumerCurator, null,
             null, null, null, mockedIdSvc, null, null, sink, factory, null, null,
             null, null, null, null, null, mockedOwnerCurator, null, null, null, null,
-            null, new Config());
+            null, new CandlepinCommonTestConfig());
 
         Consumer fooc = cr.regenerateIdentityCertificates(consumer.getUuid());
 
@@ -263,7 +265,7 @@ public class ConsumerResourceTest {
         ConsumerResource cr = new ConsumerResource(mockedConsumerCurator, null,
             null, ssa, null, mockedIdSvc, null, null, sink, factory, null, null,
             null, null, null, null, null, mockedOwnerCurator, null, null, rules,
-            null, null, new Config());
+            null, null, new CandlepinCommonTestConfig());
 
         Consumer c = cr.getConsumer(consumer.getUuid());
 
@@ -285,7 +287,7 @@ public class ConsumerResourceTest {
         ConsumerResource cr = new ConsumerResource(mockedConsumerCurator, null,
             null, ssa, null, null, null, null, null, null, null, null,
             null, null, null, null, null, mockedOwnerCurator, null, null, rules,
-            null, null, new Config());
+            null, null, new CandlepinCommonTestConfig());
 
         Consumer c = cr.getConsumer(consumer.getUuid());
 
@@ -313,7 +315,8 @@ public class ConsumerResourceTest {
 
         ConsumerResource cr = new ConsumerResource(null, ctc,
             null, null, null, null, null, i18n, null, null, null, null,
-            null, null, null, null, null, oc, akc, null, null, null, null, new Config());
+            null, null, null, null, null, oc, akc, null, null, null, null,
+            new CandlepinCommonTestConfig());
         cr.create(c, nap, null, "testOwner", "testKey");
     }
 
@@ -336,7 +339,7 @@ public class ConsumerResourceTest {
             ConsumerResource cr = new ConsumerResource(cc, null,
                 null, sa, null, null, null, i18n, null, null, null, null,
                 null, null, null, null, null, null, null, e, null, null, null,
-                new Config());
+                new CandlepinCommonTestConfig());
             cr.bind("fakeConsumer", null, prodIds, 1, null, null, false, null);
         }
         catch (Throwable t) {
@@ -362,7 +365,8 @@ public class ConsumerResourceTest {
 
         ConsumerResource cr = new ConsumerResource(cc, null,
             null, sa, null, null, null, null, null, null, null, null,
-            null, null, null, null, null, null, null, e, null, null, null, new Config());
+            null, null, null, null, null, null, null, e, null, null, null,
+            new CandlepinCommonTestConfig());
         String dtStr = "2011-09-26T18:10:50.184081+00:00";
         Date dt = ResourceDateParser.parseDateString(dtStr);
         cr.bind("fakeConsumer", null, null, 1, null, null, false, dtStr);
@@ -381,7 +385,7 @@ public class ConsumerResourceTest {
         ConsumerResource consumerResource = new ConsumerResource(consumerCurator, null,
             null, null, entitlementCurator, null, null, i18n, null, null, null,
             null, null, null, null, null, null, null, null, null, null, null, null,
-            new Config());
+            new CandlepinCommonTestConfig());
 
         consumerResource.unbindBySerial("fake uuid",
             Long.valueOf(1234L));
@@ -394,7 +398,8 @@ public class ConsumerResourceTest {
 
         ConsumerResource consumerResource = new ConsumerResource(consumerCurator, null,
             null, null, null, null, null, i18n, null, null, null, null,
-            null, null, null, null, null, null, null, null, null, null, null, new Config());
+            null, null, null, null, null, null, null, null, null, null, null,
+            new CandlepinCommonTestConfig());
 
         consumerResource.unbindBySerial("fake uuid",
             Long.valueOf(1234L));
@@ -405,7 +410,8 @@ public class ConsumerResourceTest {
         ConsumerCurator consumerCurator = mock(ConsumerCurator.class);
         ConsumerResource consumerResource = new ConsumerResource(consumerCurator, null,
             null, null, null, null, null, i18n, null, null, null, null,
-            null, null, null, null, null, null, null, null, null, null, null, new Config());
+            null, null, null, null, null, null, null, null, null, null, null,
+            new CandlepinCommonTestConfig());
 
         consumerResource.bind("fake uuid", "fake pool uuid",
             new String[]{"12232"}, 1, null, null, false, null);
@@ -417,7 +423,8 @@ public class ConsumerResourceTest {
         ConsumerCurator consumerCurator = mock(ConsumerCurator.class);
         ConsumerResource consumerResource = new ConsumerResource(consumerCurator, null,
             null, null, null, null, null, i18n, null, null, null, null,
-            null, null, null, null, null, null, null, null, null, null, null, new Config());
+            null, null, null, null, null, null, null, null, null, null, null,
+            new CandlepinCommonTestConfig());
 
         consumerResource.bind("notarealuuid", "fake pool uuid", null, null, null,
             null, false, null);
@@ -430,7 +437,7 @@ public class ConsumerResourceTest {
         ConsumerResource consumerResource = new ConsumerResource(consumerCurator, null,
             null, null, null, null, null, i18n, null, null, null, null,
             null, null, null, null, null, null, null, null, null, null, null,
-            new Config());
+            new CandlepinCommonTestConfig());
         Consumer c = mock(Consumer.class);
         String dtStr = "2011-09-26T18:10:50.184081+00:00";
         Date dt = ResourceDateParser.parseDateString(dtStr);
@@ -446,7 +453,7 @@ public class ConsumerResourceTest {
         ConsumerResource consumerResource = new ConsumerResource(consumerCurator, null,
             null, null, null, null, null, i18n, null, null, null, null,
             null, null, null, null, null, null, null, null, null, null, null,
-            new Config());
+            new CandlepinCommonTestConfig());
         String dtStr = "2011-09-26T18:10:50.184081+00:00";
         Date dt = ResourceDateParser.parseDateString(dtStr);
         consumerResource.updateLastCheckin("not-a-valid-uuid", dtStr);
@@ -461,7 +468,8 @@ public class ConsumerResourceTest {
         ConsumerCurator consumerCurator = mock(ConsumerCurator.class);
         ConsumerResource consumerResource = new ConsumerResource(consumerCurator, null,
             null, null, null, null, null, i18n, null, null, null, null,
-            null, null, null, null, null, null, null, null, null, null, null, new Config());
+            null, null, null, null, null, null, null, null, null, null, null,
+            new CandlepinCommonTestConfig());
 
         consumerResource.regenerateEntitlementCertificates("xyz", null, true);
     }
@@ -501,7 +509,8 @@ public class ConsumerResourceTest {
 
         ConsumerResource cr = new ConsumerResource(null, ctc,
             null, null, null, null, null, i18n, null, null, null, null,
-            usa, null, null, null, null, oc, null, null, null, null, null, new Config());
+            usa, null, null, null, null, oc, null, null, null, null, null,
+            new CandlepinCommonTestConfig());
         cr.create(c, up, null, "testOwner", null);
     }
 }

--- a/src/test/java/org/candlepin/resource/test/ConsumerResourceUpdateTest.java
+++ b/src/test/java/org/candlepin/resource/test/ConsumerResourceUpdateTest.java
@@ -27,7 +27,7 @@ import java.util.Locale;
 import org.candlepin.audit.Event;
 import org.candlepin.audit.EventFactory;
 import org.candlepin.audit.EventSink;
-import org.candlepin.config.Config;
+import org.candlepin.config.CandlepinCommonTestConfig;
 import org.candlepin.controller.Entitler;
 import org.candlepin.controller.PoolManager;
 import org.candlepin.exceptions.BadRequestException;
@@ -92,7 +92,7 @@ public class ConsumerResourceUpdateTest {
             this.userService, null, poolManager, null, null, null,
             this.activationKeyCurator,
             this.entitler, this.complianceRules, this.deletedConsumerCurator,
-            this.environmentCurator, new Config());
+            this.environmentCurator, new CandlepinCommonTestConfig());
 
         when(complianceRules.getStatus(any(Consumer.class), any(Date.class)))
             .thenReturn(new ComplianceStatus(new Date()));

--- a/src/test/java/org/candlepin/resource/test/RootResourceTest.java
+++ b/src/test/java/org/candlepin/resource/test/RootResourceTest.java
@@ -17,7 +17,7 @@ package org.candlepin.resource.test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-import org.candlepin.config.Config;
+import org.candlepin.config.CandlepinCommonTestConfig;
 import org.candlepin.resource.Link;
 import org.candlepin.resource.RootResource;
 
@@ -33,7 +33,7 @@ public class RootResourceTest {
 
     @Test
     public void getRootResources() {
-        RootResource rr = new RootResource(new Config());
+        RootResource rr = new RootResource(new CandlepinCommonTestConfig());
         List<Link> links = rr.getRootResources();
         assertNotNull(links);
         for (Link link : links) {

--- a/src/test/java/org/candlepin/resteasy/interceptor/AuthInterceptorTest.java
+++ b/src/test/java/org/candlepin/resteasy/interceptor/AuthInterceptorTest.java
@@ -31,6 +31,7 @@ import org.candlepin.auth.NoAuthPrincipal;
 import org.candlepin.auth.Principal;
 import org.candlepin.auth.UserPrincipal;
 import org.candlepin.auth.interceptor.SecurityHole;
+import org.candlepin.config.CandlepinCommonTestConfig;
 import org.candlepin.config.Config;
 import org.candlepin.exceptions.UnauthorizedException;
 import org.candlepin.guice.I18nProvider;
@@ -67,7 +68,7 @@ public class AuthInterceptorTest {
 
     @Before
     public void init() {
-        config = new Config();
+        config = new CandlepinCommonTestConfig();
         usa = mock(UserServiceAdapter.class);
         oc = mock(OwnerCurator.class);
         cc = mock(ConsumerCurator.class);

--- a/src/test/java/org/candlepin/service/impl/test/DefaultEntitlementCertServiceAdapterTest.java
+++ b/src/test/java/org/candlepin/service/impl/test/DefaultEntitlementCertServiceAdapterTest.java
@@ -51,6 +51,7 @@ import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.zip.InflaterOutputStream;
 
+import org.candlepin.config.CandlepinCommonTestConfig;
 import org.candlepin.config.Config;
 import org.candlepin.model.CertificateSerial;
 import org.candlepin.model.CertificateSerialCurator;
@@ -150,7 +151,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
 
     @Before
     public void setUp() {
-        Config config = new Config();
+        Config config = new CandlepinCommonTestConfig();
         extensionUtil = new X509ExtensionUtil(config);
         v3extensionUtil = new X509V3ExtensionUtil(config, entCurator);
 


### PR DESCRIPTION
In a previous commit 45b2aaec0 we changed CandlepinCommonTestConfig not
to use candlepin.conf. But we didn't do enough, there were many tests
that simply called the default constructor of Config.

I changed the tests to either use CandlepinCommonTestConfig() or
to create a custom Config passing in their own Map with data used
by the specific tests where they didn't need a full on Config.

I also changed the EventSinkImpl to let guice pass in its Config
instead of it constructing one (causing it to reload the config)
simply to get a value. It is better for it to use the existing
system's Config object.
