### PR TITLE
965310: Fix broken import of identity cert.

### DIFF
--- a/spec/candlepin_scenarios.rb
+++ b/spec/candlepin_scenarios.rb
@@ -232,6 +232,8 @@ module ExportMethods
 
     @candlepin_client = consumer_client(owner_client, random_string('test_client'),
         "candlepin", @user['username'])
+    @candlepin_consumer = @candlepin_client.get_consumer()
+
     @entitlement1 = @candlepin_client.consume_pool(pool1.id)[0]
     @entitlement2 = @candlepin_client.consume_pool(pool2.id)[0]
     @candlepin_client.consume_pool(pool3.id)

--- a/spec/import_spec.rb
+++ b/spec/import_spec.rb
@@ -10,6 +10,9 @@ describe 'Candlepin Import' do
   before(:all) do
     @users = []
     create_candlepin_export()
+
+    @cp.unregister @candlepin_consumer['uuid']
+
     @import_owner = @cp.create_owner(random_string("test_owner"))
     @import_owner_client = user_client(@import_owner, random_string('testuser'))
     @cp.import(@import_owner['key'], @export_filename)
@@ -43,7 +46,7 @@ describe 'Candlepin Import' do
 
   it "originating information should be populated in the import" do
     @import_owner_client.list_imports(@import_owner['key']).find_all do |import|
-      consumer = @candlepin_client.get_consumer()
+      consumer = @candlepin_consumer
       import['generatedBy'].should == consumer['name']
       import['generatedDate'].should_not be_nil
       import['upstreamId'].should == consumer['uuid']
@@ -186,9 +189,9 @@ describe 'Candlepin Import' do
 
   it 'should return 400 when importing manifest in use by another owner' do
     # Because the previous tests put the original import into a different state
-    # than if you just run this single one, we need to clear first and then 
+    # than if you just run this single one, we need to clear first and then
     # re-import the original.
-    # Also added the confirmation that the exception occurs when importing to 
+    # Also added the confirmation that the exception occurs when importing to
     # another owner.
     @import_owner_client.undo_import(@import_owner['key'])
     @cp.import(@import_owner['key'], @export_filename)
@@ -223,7 +226,7 @@ describe 'Candlepin Import' do
 
   it 'contains upstream consumer' do
     # this information used to be on /imports but now exists on Owner
-    consumer = @candlepin_client.get_consumer()
+    consumer = @candlepin_consumer
     upstream = @cp.get_owner(@import_owner['key'])['upstreamConsumer']
     upstream.uuid.should == consumer['uuid']
     upstream.include?('apiUrl').should be_true

--- a/src/main/java/org/candlepin/sync/ConsumerImporter.java
+++ b/src/main/java/org/candlepin/sync/ConsumerImporter.java
@@ -15,7 +15,10 @@
 package org.candlepin.sync;
 
 import org.apache.log4j.Logger;
+import org.candlepin.model.CertificateSerial;
+import org.candlepin.model.CertificateSerialCurator;
 import org.candlepin.model.IdentityCertificate;
+import org.candlepin.model.IdentityCertificateCurator;
 import org.candlepin.model.Owner;
 import org.candlepin.model.OwnerCurator;
 import org.candlepin.model.UpstreamConsumer;
@@ -32,11 +35,16 @@ public class ConsumerImporter {
     private static Logger log = Logger.getLogger(ConsumerImporter.class);
 
     private OwnerCurator curator;
+    private IdentityCertificateCurator idCertCurator;
     private I18n i18n;
+    private CertificateSerialCurator serialCurator;
 
-    public ConsumerImporter(OwnerCurator curator, I18n i18n) {
+    public ConsumerImporter(OwnerCurator curator, IdentityCertificateCurator idCertCurator,
+        I18n i18n, CertificateSerialCurator serialCurator) {
         this.curator = curator;
+        this.idCertCurator = idCertCurator;
         this.i18n = i18n;
+        this.serialCurator = serialCurator;
     }
 
     public ConsumerDto createObject(ObjectMapper mapper, Reader reader) throws IOException {
@@ -82,6 +90,24 @@ public class ConsumerImporter {
                 log.warn("New distributor UUID: " + consumer.getUuid());
             }
         }
+
+        /*
+         * WARNING: Strange quirk here, we create a certificate serial object here which
+         * does not match the actual serial of the identity certificate. Presumably this is
+         * to prevent potential conflicts with a serial that came from somewhere else.
+         * This is consistent with importing entitlement certs (as subscription certs).
+         */
+        CertificateSerial cs = new CertificateSerial();
+        cs.setCollected(idcert.getSerial().isCollected());
+        cs.setExpiration(idcert.getSerial().getExpiration());
+        cs.setRevoked(idcert.getSerial().isRevoked());
+        cs.setUpdated(idcert.getSerial().getUpdated());
+        cs.setCreated(idcert.getSerial().getCreated());
+        serialCurator.create(cs);
+
+        idcert.setId(null);
+        idcert.setSerial(cs);
+        idCertCurator.create(idcert);
 
         // create an UpstreamConsumer from the imported ConsumerDto
         UpstreamConsumer uc = new UpstreamConsumer(consumer.getName(),

--- a/src/main/java/org/candlepin/sync/Importer.java
+++ b/src/main/java/org/candlepin/sync/Importer.java
@@ -31,6 +31,7 @@ import org.candlepin.model.ContentCurator;
 import org.candlepin.model.ExporterMetadata;
 import org.candlepin.model.ExporterMetadataCurator;
 import org.candlepin.model.IdentityCertificate;
+import org.candlepin.model.IdentityCertificateCurator;
 import org.candlepin.model.Owner;
 import org.candlepin.model.OwnerCurator;
 import org.candlepin.model.Product;
@@ -112,6 +113,7 @@ public class Importer {
     private OwnerCurator ownerCurator;
     private ContentCurator contentCurator;
     private SubscriptionCurator subCurator;
+    private IdentityCertificateCurator idCertCurator;
     private PoolManager poolManager;
     private PKIUtility pki;
     private Config config;
@@ -123,6 +125,7 @@ public class Importer {
     @Inject
     public Importer(ConsumerTypeCurator consumerTypeCurator, ProductCurator productCurator,
         RulesImporter rulesImporter, OwnerCurator ownerCurator,
+        IdentityCertificateCurator idCertCurator,
         ContentCurator contentCurator, SubscriptionCurator subCurator, PoolManager pm,
         PKIUtility pki, Config config, ExporterMetadataCurator emc,
         CertificateSerialCurator csc, EventSink sink, I18n i18n) {
@@ -132,6 +135,7 @@ public class Importer {
         this.productCurator = productCurator;
         this.rulesImporter = rulesImporter;
         this.ownerCurator = ownerCurator;
+        this.idCertCurator = idCertCurator;
         this.contentCurator = contentCurator;
         this.subCurator = subCurator;
         this.poolManager = pm;
@@ -489,7 +493,8 @@ public class Importer {
             }
         }
 
-        ConsumerImporter importer = new ConsumerImporter(ownerCurator, i18n);
+        ConsumerImporter importer = new ConsumerImporter(ownerCurator, idCertCurator,
+            i18n, csCurator);
         Reader reader = null;
         ConsumerDto consumer = null;
         try {

--- a/src/test/java/org/candlepin/sync/ConsumerImporterTest.java
+++ b/src/test/java/org/candlepin/sync/ConsumerImporterTest.java
@@ -24,6 +24,10 @@ import static org.mockito.Mockito.when;
 
 import org.candlepin.config.Config;
 import org.candlepin.config.ConfigProperties;
+import org.candlepin.model.CertificateSerial;
+import org.candlepin.model.CertificateSerialCurator;
+import org.candlepin.model.IdentityCertificate;
+import org.candlepin.model.IdentityCertificateCurator;
 import org.candlepin.model.Owner;
 import org.candlepin.model.OwnerCurator;
 import org.candlepin.model.UpstreamConsumer;
@@ -49,13 +53,17 @@ public class ConsumerImporterTest {
     private ConsumerImporter importer;
     private ObjectMapper mapper;
     private OwnerCurator curator;
+    private CertificateSerialCurator serialCurator;
+    private IdentityCertificateCurator idCertCurator;
     private I18n i18n;
 
     @Before
     public void setUp() {
         curator = mock(OwnerCurator.class);
+        serialCurator = mock(CertificateSerialCurator.class);
+        idCertCurator = mock(IdentityCertificateCurator.class);
         i18n = I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK);
-        importer = new ConsumerImporter(curator, i18n);
+        importer = new ConsumerImporter(curator, idCertCurator, i18n, serialCurator);
         mapper = SyncUtils.getObjectMapper(new Config(new HashMap<String, String>()));
     }
 
@@ -102,7 +110,10 @@ public class ConsumerImporterTest {
         when(consumer.getUuid()).thenReturn("test-uuid");
         when(consumer.getOwner()).thenReturn(owner);
 
-        importer.store(owner, consumer, new ConflictOverrides(), null);
+        IdentityCertificate idCert = new IdentityCertificate();
+        idCert.setSerial(new CertificateSerial());
+
+        importer.store(owner, consumer, new ConflictOverrides(), idCert);
 
         // now verify that the owner has the upstream consumer set
         ArgumentCaptor<UpstreamConsumer> arg =
@@ -121,7 +132,10 @@ public class ConsumerImporterTest {
         when(consumer.getUuid()).thenReturn("test-uuid");
         when(consumer.getOwner()).thenReturn(owner);
 
-        importer.store(owner, consumer, new ConflictOverrides(), null);
+        IdentityCertificate idCert = new IdentityCertificate();
+        idCert.setSerial(new CertificateSerial());
+
+        importer.store(owner, consumer, new ConflictOverrides(), idCert);
 
         // now verify that the owner didn't change
         // arg.getValue() returns the Owner being stored
@@ -175,8 +189,11 @@ public class ConsumerImporterTest {
         when(consumer.getUuid()).thenReturn("test-uuid");
         when(consumer.getOwner()).thenReturn(owner);
 
+        IdentityCertificate idCert = new IdentityCertificate();
+        idCert.setSerial(new CertificateSerial());
+
         importer.store(owner, consumer,
-            new ConflictOverrides(Importer.Conflict.DISTRIBUTOR_CONFLICT), null);
+            new ConflictOverrides(Importer.Conflict.DISTRIBUTOR_CONFLICT), idCert);
 
         // now verify that the owner has the upstream consumer set
         ArgumentCaptor<UpstreamConsumer> arg =

--- a/src/test/java/org/candlepin/sync/ImporterTest.java
+++ b/src/test/java/org/candlepin/sync/ImporterTest.java
@@ -32,9 +32,11 @@ import org.candlepin.config.Config;
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.model.ConsumerType;
 import org.candlepin.model.ConsumerType.ConsumerTypeEnum;
+import org.candlepin.model.CertificateSerialCurator;
 import org.candlepin.model.ConsumerTypeCurator;
 import org.candlepin.model.ExporterMetadata;
 import org.candlepin.model.ExporterMetadataCurator;
+import org.candlepin.model.IdentityCertificateCurator;
 import org.candlepin.model.Owner;
 import org.candlepin.model.OwnerCurator;
 import org.candlepin.pki.PKIUtility;
@@ -123,7 +125,7 @@ public class ImporterTest {
         em.setId("42");
         em.setType(ExporterMetadata.TYPE_SYSTEM);
         when(emc.lookupByType(ExporterMetadata.TYPE_SYSTEM)).thenReturn(em);
-        Importer i = new Importer(null, null, null, null, null, null, null,
+        Importer i = new Importer(null, null, null, null, null, null, null, null,
             null, null, emc, null, null, i18n);
         i.validateMetadata(ExporterMetadata.TYPE_SYSTEM, null, actual,
             new ConflictOverrides());
@@ -147,7 +149,7 @@ public class ImporterTest {
             "test_user", "prefix");
         ExporterMetadataCurator emc = mock(ExporterMetadataCurator.class);
         when(emc.lookupByType(ExporterMetadata.TYPE_SYSTEM)).thenReturn(null);
-        Importer i = new Importer(null, null, null, null, null, null, null,
+        Importer i = new Importer(null, null, null, null, null, null, null, null,
             null, null, emc, null, null, i18n);
         i.validateMetadata(ExporterMetadata.TYPE_SYSTEM, null, actualmeta,
             new ConflictOverrides());
@@ -168,7 +170,7 @@ public class ImporterTest {
         em.setId("42");
         em.setType(ExporterMetadata.TYPE_SYSTEM);
         when(emc.lookupByType(ExporterMetadata.TYPE_SYSTEM)).thenReturn(em);
-        Importer i = new Importer(null, null, null, null, null, null, null,
+        Importer i = new Importer(null, null, null, null, null, null, null, null,
             null, null, emc, null, null, i18n);
         try {
             i.validateMetadata(ExporterMetadata.TYPE_SYSTEM, null, actualmeta,
@@ -196,7 +198,7 @@ public class ImporterTest {
         em.setId("42");
         em.setType(ExporterMetadata.TYPE_SYSTEM);
         when(emc.lookupByType(ExporterMetadata.TYPE_SYSTEM)).thenReturn(em);
-        Importer i = new Importer(null, null, null, null, null, null, null,
+        Importer i = new Importer(null, null, null, null, null, null, null, null,
             null, null, emc, null, null, i18n);
         try {
             i.validateMetadata(ExporterMetadata.TYPE_SYSTEM, null, actualmeta,
@@ -244,7 +246,7 @@ public class ImporterTest {
         em.setId("42");
         em.setType(ExporterMetadata.TYPE_SYSTEM);
         when(emc.lookupByType(ExporterMetadata.TYPE_SYSTEM)).thenReturn(em);
-        Importer i = new Importer(null, null, null, null, null, null, null,
+        Importer i = new Importer(null, null, null, null, null, null, null, null,
             null, null, emc, null, null, i18n);
         i.validateMetadata(ExporterMetadata.TYPE_SYSTEM, null, actualmeta,
             new ConflictOverrides());
@@ -256,7 +258,7 @@ public class ImporterTest {
         File actualmeta = createFile("meta.json", "0.0.3", new Date(),
             "test_user", "prefix");
         try {
-            Importer i = new Importer(null, null, null, null, null, null, null,
+            Importer i = new Importer(null, null, null, null, null, null, null, null,
                 null, null, null, null, null, i18n);
 
             // null Type should cause exception
@@ -275,7 +277,7 @@ public class ImporterTest {
         when(emc.lookupByTypeAndOwner(ExporterMetadata.TYPE_PER_USER, null))
             .thenReturn(null);
 
-        Importer i = new Importer(null, null, null, null, null, null, null,
+        Importer i = new Importer(null, null, null, null, null, null, null, null,
             null, null, emc, null, null, i18n);
 
         // null Type should cause exception
@@ -287,7 +289,7 @@ public class ImporterTest {
     @Test
     public void testImportWithNonZipArchive()
         throws IOException, ImporterException {
-        Importer i = new Importer(null, null, null, null, null, null, null,
+        Importer i = new Importer(null, null, null, null, null, null, null, null,
             null, config, null, null, null, i18n);
 
         Owner owner = mock(Owner.class);
@@ -311,7 +313,7 @@ public class ImporterTest {
     @Test
     public void testImportZipArchiveNoContent()
         throws IOException, ImporterException {
-        Importer i = new Importer(null, null, null, null, null, null, null,
+        Importer i = new Importer(null, null, null, null, null, null, null, null,
             null, config, null, null, null, i18n);
 
         Owner owner = mock(Owner.class);
@@ -337,7 +339,7 @@ public class ImporterTest {
     public void testImportBadSignature()
         throws IOException, ImporterException {
         PKIUtility pki = mock(PKIUtility.class);
-        Importer i = new Importer(null, null, null, null, null, null, null,
+        Importer i = new Importer(null, null, null, null, null, null, null, null,
             pki, config, null, null, null, i18n);
 
         Owner owner = mock(Owner.class);
@@ -360,7 +362,7 @@ public class ImporterTest {
     @Test
     public void testImportBadConsumerZip() throws Exception {
         PKIUtility pki = mock(PKIUtility.class);
-        Importer i = new Importer(null, null, null, null, null, null, null,
+        Importer i = new Importer(null, null, null, null, null, null, null, null,
             pki, config, null, null, null, i18n);
 
         Owner owner = mock(Owner.class);
@@ -397,7 +399,7 @@ public class ImporterTest {
     public void testImportZipSigAndEmptyConsumerZip()
         throws Exception {
         PKIUtility pki = mock(PKIUtility.class);
-        Importer i = new Importer(null, null, null, null, null, null, null,
+        Importer i = new Importer(null, null, null, null, null, null, null, null,
             pki, config, null, null, null, i18n);
 
         Owner owner = mock(Owner.class);
@@ -441,7 +443,7 @@ public class ImporterTest {
 
     @Test
     public void testImportNoMeta() throws IOException {
-        Importer i = new Importer(null, null, null, null, null, null, null,
+        Importer i = new Importer(null, null, null, null, null, null, null, null,
             null, config, null, null, null, i18n);
         Owner owner = mock(Owner.class);
         ConflictOverrides co = mock(ConflictOverrides.class);
@@ -462,7 +464,7 @@ public class ImporterTest {
 
     @Test
     public void testImportNoConsumerTypesDir() throws IOException {
-        Importer i = new Importer(null, null, null, null, null, null, null,
+        Importer i = new Importer(null, null, null, null, null, null, null, null,
             null, config, null, null, null, i18n);
         Owner owner = mock(Owner.class);
         ConflictOverrides co = mock(ConflictOverrides.class);
@@ -483,7 +485,7 @@ public class ImporterTest {
 
     @Test
     public void testImportNoConsumer() throws IOException {
-        Importer i = new Importer(null, null, null, null, null, null, null,
+        Importer i = new Importer(null, null, null, null, null, null, null, null,
             null, config, null, null, null, i18n);
         Owner owner = mock(Owner.class);
         ConflictOverrides co = mock(ConflictOverrides.class);
@@ -506,7 +508,7 @@ public class ImporterTest {
     public void testImportNoProductDir()
         throws IOException, ImporterException {
         RulesImporter ri = mock(RulesImporter.class);
-        Importer i = new Importer(null, null, ri, null, null, null, null,
+        Importer i = new Importer(null, null, ri, null, null, null, null, null,
             null, config, null, null, null, i18n);
         Owner owner = mock(Owner.class);
         ConflictOverrides co = mock(ConflictOverrides.class);
@@ -541,7 +543,7 @@ public class ImporterTest {
 
     @Test
     public void testImportProductNoEntitlementDir() throws IOException {
-        Importer i = new Importer(null, null, null, null, null, null, null,
+        Importer i = new Importer(null, null, null, null, null, null, null, null,
             null, config, null, null, null, i18n);
         Owner owner = mock(Owner.class);
         ConflictOverrides co = mock(ConflictOverrides.class);
@@ -626,8 +628,9 @@ public class ImporterTest {
         ConsumerType type = new ConsumerType(ConsumerTypeEnum.CANDLEPIN);
         when(ctc.lookupByLabel(eq("candlepin"))).thenReturn(type);
 
-        Importer i = new Importer(ctc, null, null, oc, null, null, null,
-            pki, null, null, null, null, i18n);
+        Importer i = new Importer(ctc, null, null, oc,
+            mock(IdentityCertificateCurator.class), null, null, null,
+            pki, null, null, mock(CertificateSerialCurator.class), null, i18n);
         File[] upstream = new File[2];
         File idcertfile = new File("target/test/resources/upstream/testidcert.json");
         File kpfile = new File("target/test/resources/upstream/keypair.pem");


### PR DESCRIPTION
Import was incorrectly trying to re-use a link to the original identity
certificate and it's serial. This worked fine if that existed in the
same db, as is often the case in our spec tests.

It doesn't work at all if you try the manifest on another server, or
wipe the db and then try to import the manifest.

Instead we will stay consistent with how EntitlementImporter gets around
this problem by creating a fake cert serial and making sure to create a
fresh copy of the identity certificate.

Spec tests modified to expose this by deleting the consumer we exported
from. These will fail on master, and pass with this fix.
