### PR TITLE
959967: calculate installed prods correctly

### DIFF
--- a/src/test/java/org/candlepin/resource/util/InstalledProductStatusCalculatorTest.java
+++ b/src/test/java/org/candlepin/resource/util/InstalledProductStatusCalculatorTest.java
@@ -220,6 +220,62 @@ public class InstalledProductStatusCalculatorTest {
     }
 
     @Test
+    public void validRangeIgnoresFutureWithOverlap() {
+        Consumer c = mockConsumer(PRODUCT_1);
+
+        Calendar cal = Calendar.getInstance();
+        Date now = cal.getTime();
+        DateRange future = rangeRelativeToDate(now, 12, 24);
+        DateRange current = rangeRelativeToDate(now, 0, 13);
+
+        // Add current entitlement
+        c.addEntitlement(mockEntitlement(c, PRODUCT_1, current, PRODUCT_1));
+        // Add future entitlement
+        c.addEntitlement(mockEntitlement(c, PRODUCT_1, future, PRODUCT_1));
+        // Add future entitlement
+        c.addEntitlement(mockEntitlement(c, PRODUCT_1, future, PRODUCT_1));
+
+        List<Entitlement> ents = new LinkedList<Entitlement>(c.getEntitlements());
+        when(entCurator.listByConsumer(eq(c))).thenReturn(ents);
+
+        ComplianceStatus status = compliance.getStatus(c, now);
+        ConsumerInstalledProductEnricher calculator =
+            new ConsumerInstalledProductEnricher(c, status, compliance);
+        Product p = new Product(PRODUCT_1, "Awesome Product");
+        DateRange validRange = calculator.getValidDateRange(p);
+        assertEquals(current.getStartDate(), validRange.getStartDate());
+        assertEquals(future.getEndDate(), validRange.getEndDate());
+    }
+
+    @Test
+    public void validRangeIgnoresFutureBackToBack() {
+        Consumer c = mockConsumer(PRODUCT_1);
+
+        Calendar cal = Calendar.getInstance();
+        Date now = cal.getTime();
+        DateRange future = rangeRelativeToDate(now, 12, 24);
+        DateRange current = rangeRelativeToDate(now, 0, 12);
+
+        // Add current entitlement
+        c.addEntitlement(mockEntitlement(c, PRODUCT_1, current, PRODUCT_1));
+        // Add future entitlement
+        c.addEntitlement(mockEntitlement(c, PRODUCT_1, future, PRODUCT_1));
+        // Add future entitlement
+        c.addEntitlement(mockEntitlement(c, PRODUCT_1, future, PRODUCT_1));
+
+        List<Entitlement> ents = new LinkedList<Entitlement>(c.getEntitlements());
+        when(entCurator.listByConsumer(eq(c))).thenReturn(ents);
+
+        ComplianceStatus status = compliance.getStatus(c, now);
+        ConsumerInstalledProductEnricher calculator =
+            new ConsumerInstalledProductEnricher(c, status, compliance);
+        Product p = new Product(PRODUCT_1, "Awesome Product");
+        DateRange validRange = calculator.getValidDateRange(p);
+        assertEquals(current.getStartDate(), validRange.getStartDate());
+        assertEquals(future.getEndDate(), validRange.getEndDate());
+    }
+
+    @Test
     public void validRangeWithMultipleEntsWithOverlap() {
         Consumer c = mockConsumer(PRODUCT_1);
 


### PR DESCRIPTION
There was a slight issue where we passed in the lastProcessed entitlement
instead of the current one when comparing validity. This caused us to mark
the previous entitlement invalid, and reset the start date in our
calculations.

I've added two new unit tests to test for the bug as well as comment the
complicated method for future devs.
## TEST

See the original bugzilla for testing procedures: https://bugzilla.redhat.com/show_bug.cgi?id=959967

Here is an example of the output I got before and after:

BEFORE

```
[root@dhcp231-74 ~]# subscription-manager list --installed
+-------------------------------------------+
    Installed Product Status
+-------------------------------------------+
Product Name:   Red Hat Enterprise Linux Server
Product ID:     69
Version:        6.3
Arch:           x86_64
Status:         Not Subscribed
Status Details: Not covered by a valid subscription.
Starts:         
Ends:           

Product Name:   Multi-Attribute Limited Product
Product ID:     900
Version:        1.0
Arch:           x86_64
Status:         Subscribed
Status Details: 
Starts:         05/09/2014
Ends:           05/09/2015
```

AFTER

```
[root@dhcp231-74 ~]# subscription-manager list --installed
+-------------------------------------------+
    Installed Product Status
+-------------------------------------------+
Product Name:   Red Hat Enterprise Linux Server
Product ID:     69
Version:        6.3
Arch:           x86_64
Status:         Not Subscribed
Status Details: Not covered by a valid subscription.
Starts:         
Ends:           

Product Name:   Multi-Attribute Limited Product
Product ID:     900
Version:        1.0
Arch:           x86_64
Status:         Subscribed
Status Details: 
Starts:         05/19/2013
Ends:           05/09/2015
```
