### PR TITLE
966860: handle older manifests with no id cert

### DIFF
--- a/src/main/java/org/candlepin/sync/ConsumerImporter.java
+++ b/src/main/java/org/candlepin/sync/ConsumerImporter.java
@@ -92,22 +92,25 @@ public class ConsumerImporter {
         }
 
         /*
-         * WARNING: Strange quirk here, we create a certificate serial object here which
-         * does not match the actual serial of the identity certificate. Presumably this is
-         * to prevent potential conflicts with a serial that came from somewhere else.
-         * This is consistent with importing entitlement certs (as subscription certs).
+         * WARNING: Strange quirk here, we create a certificate serial object
+         * here which does not match the actual serial of the identity
+         * certificate. Presumably this is to prevent potential conflicts with
+         * a serial that came from somewhere else. This is consistent with
+         * importing entitlement certs (as subscription certs).
          */
-        CertificateSerial cs = new CertificateSerial();
-        cs.setCollected(idcert.getSerial().isCollected());
-        cs.setExpiration(idcert.getSerial().getExpiration());
-        cs.setRevoked(idcert.getSerial().isRevoked());
-        cs.setUpdated(idcert.getSerial().getUpdated());
-        cs.setCreated(idcert.getSerial().getCreated());
-        serialCurator.create(cs);
+        if (idcert != null) {
+            CertificateSerial cs = new CertificateSerial();
+            cs.setCollected(idcert.getSerial().isCollected());
+            cs.setExpiration(idcert.getSerial().getExpiration());
+            cs.setRevoked(idcert.getSerial().isRevoked());
+            cs.setUpdated(idcert.getSerial().getUpdated());
+            cs.setCreated(idcert.getSerial().getCreated());
+            serialCurator.create(cs);
 
-        idcert.setId(null);
-        idcert.setSerial(cs);
-        idCertCurator.create(idcert);
+            idcert.setId(null);
+            idcert.setSerial(cs);
+            idCertCurator.create(idcert);
+        }
 
         // create an UpstreamConsumer from the imported ConsumerDto
         UpstreamConsumer uc = new UpstreamConsumer(consumer.getName(),

--- a/src/test/java/org/candlepin/sync/ConsumerImporterTest.java
+++ b/src/test/java/org/candlepin/sync/ConsumerImporterTest.java
@@ -212,4 +212,26 @@ public class ConsumerImporterTest {
 
         importer.store(owner, consumer, new ConflictOverrides(), null);
     }
+
+    /*
+     * BZ#966860
+     */
+    @Test
+    public void importConsumerWithNullIdCertShouldNotFail() throws ImporterException {
+        Owner owner = mock(Owner.class);
+        ConsumerDto consumer = mock(ConsumerDto.class);
+        when(owner.getUpstreamUuid()).thenReturn("test-uuid");
+        when(consumer.getUuid()).thenReturn("test-uuid");
+        when(consumer.getOwner()).thenReturn(owner);
+
+        importer.store(owner, consumer, new ConflictOverrides(), null);
+
+        // now verify that the owner has the upstream consumer set
+        ArgumentCaptor<UpstreamConsumer> arg =
+            ArgumentCaptor.forClass(UpstreamConsumer.class);
+
+        verify(owner).setUpstreamConsumer(arg.capture());
+        assertEquals("test-uuid", arg.getValue().getUuid());
+        verify(curator).merge(owner);
+    }
 }


### PR DESCRIPTION
Older manifests will not have the identity certificate for import. This results
in a null pointer exception when importing older manifests. We now check the
idcert for null and ignore it if it is not there.

Added a unit test to verify the bug as well.
