### PR TITLE
Update the last checkin date in the consumer update json only

### DIFF
--- a/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -721,29 +721,6 @@ public class ConsumerResource {
             consumerCurator.update(toUpdate);
         }
     }
-    @PUT
-    @Produces(MediaType.APPLICATION_JSON)
-    @Path("{consumer_uuid}/checkin")
-    @Transactional
-    public void updateLastCheckin(
-        @PathParam("consumer_uuid") String uuid,
-        @QueryParam("checkin_date") String checkinDateStr) {
-        Date checkinDate = null;
-        if (checkinDateStr != null) {
-            checkinDate = ResourceDateParser.parseDateString(checkinDateStr);
-        }
-        log.debug("parsed " + checkinDateStr + " to " + checkinDate);
-
-        Consumer c = verifyAndLookupConsumer(uuid);
-
-        if (checkinDate != null) {
-            consumerCurator.updateLastCheckin(c, checkinDate);
-        }
-        else {
-            consumerCurator.updateLastCheckin(c);
-        }
-    }
-
 
     // Requires security hole since security interceptor will intercept when the method is
     // called. This is because it is protected. This method is called from other resources,
@@ -823,6 +800,11 @@ public class ConsumerResource {
             // get the new name into the id cert
             IdentityCertificate ic = generateIdCert(toUpdate, true);
             toUpdate.setIdCert(ic);
+        }
+
+        if (updated.getLastCheckin() != null) {
+            toUpdate.setLastCheckin(updated.getLastCheckin());
+            changesMade = true;
         }
 
         if (changesMade) {

--- a/src/test/java/org/candlepin/resource/test/ConsumerResourceTest.java
+++ b/src/test/java/org/candlepin/resource/test/ConsumerResourceTest.java
@@ -430,34 +430,6 @@ public class ConsumerResourceTest {
             null, false, null);
     }
 
-    @Test
-    public void testUpdateLastCheckinTime() {
-        // this test is to make sure ConsumerResource is calling the curator correctly
-        ConsumerCurator consumerCurator = mock(ConsumerCurator.class);
-        ConsumerResource consumerResource = new ConsumerResource(consumerCurator, null,
-            null, null, null, null, null, i18n, null, null, null, null,
-            null, null, null, null, null, null, null, null, null, null, null,
-            null, new CandlepinCommonTestConfig());
-        Consumer c = mock(Consumer.class);
-        String dtStr = "2011-09-26T18:10:50.184081+00:00";
-        Date dt = ResourceDateParser.parseDateString(dtStr);
-        when(consumerCurator.findByUuid("123123")).thenReturn(c);
-        when(consumerCurator.updateLastCheckin(c, dt)).thenReturn(c);
-        consumerResource.updateLastCheckin("123123", dtStr);
-        verify(consumerCurator).updateLastCheckin(eq(c), eq(dt));
-    }
-
-    @Test(expected = NotFoundException.class)
-    public void testUpdateLastCheckinTimeBadUUID() {
-        ConsumerCurator consumerCurator = mock(ConsumerCurator.class);
-        ConsumerResource consumerResource = new ConsumerResource(consumerCurator, null,
-            null, null, null, null, null, i18n, null, null, null, null,
-            null, null, null, null, null, null, null, null, null, null, null,
-            null, new CandlepinCommonTestConfig());
-        String dtStr = "2011-09-26T18:10:50.184081+00:00";
-        consumerResource.updateLastCheckin("not-a-valid-uuid", dtStr);
-    }
-
     /**
      * Basic test. If invalid id is given, should throw
      * {@link NotFoundException}

--- a/src/test/java/org/candlepin/resource/test/ConsumerResourceUpdateTest.java
+++ b/src/test/java/org/candlepin/resource/test/ConsumerResourceUpdateTest.java
@@ -760,6 +760,22 @@ public class ConsumerResourceUpdateTest {
         assertEquals(0, c.getCapabilities().size());
     }
 
+    @Test
+    public void consumerLastCheckin() {
+        Consumer c = getFakeConsumer();
+        Date now = new Date();
+        c.setLastCheckin(now);
+        ConsumerType ct = new ConsumerType();
+        ct.setManifest(true);
+        c.setType(ct);
+
+        Consumer updated = new Consumer();
+        Date then = new Date(now.getTime() + 10000L);
+        updated.setLastCheckin(then);
+        resource.updateConsumer(c.getUuid(), updated);
+        assertEquals(then, c.getLastCheckin());
+    }
+
     private Consumer createConsumerWithGuests(String ... guestIds) {
         Consumer a = new Consumer();
         Owner owner = new Owner();


### PR DESCRIPTION
Removed the API call for lastCheckin only
Update now recoginizes the last checkin set on the updating consumer object
