### PR TITLE
963535: Fix instance quantity increment of 2 on virt guests.

### DIFF
--- a/src/main/java/org/candlepin/model/RulesCurator.java
+++ b/src/main/java/org/candlepin/model/RulesCurator.java
@@ -39,7 +39,7 @@ public class RulesCurator extends AbstractHibernateCurator<Rules> {
      * Current rules API major version number. (the x in x.y) If a rules file does not
      * match this major version number exactly, we do not import the rules.
      */
-    public static final int RULES_API_VERSION = 3;
+    public static final int RULES_API_VERSION = 4;
 
     protected RulesCurator() {
         super(Rules.class);

--- a/src/main/java/org/candlepin/policy/js/quantity/QuantityRules.java
+++ b/src/main/java/org/candlepin/policy/js/quantity/QuantityRules.java
@@ -46,7 +46,7 @@ public class QuantityRules {
         jsRules.init("quantity_name_space");
     }
 
-    public long getSuggestedQuantity(Pool p, Consumer c) {
+    public SuggestedQuantity getSuggestedQuantity(Pool p, Consumer c) {
         JsonJsContext args = new JsonJsContext(mapper);
 
         Set<Entitlement> validEntitlements = new HashSet<Entitlement>();
@@ -61,14 +61,9 @@ public class QuantityRules {
         args.put("validEntitlements", validEntitlements);
         args.put("log", log, false);
 
-        // Fun fact: All numbers in javascript (ECMAScript) are double-precision.
-        // See http://www.ecma-international.org/ecma-262/5.1/#sec-8.5
-
-        // For some reason Rhino will return an integer sometimes and a double
-        // other times.  So let's just deal with Strings to make everything
-        // consistent.
-        String q = jsRules.runJsFunction(String.class, "get_suggested_quantity", args);
-        return Long.valueOf(q);
+        String json = jsRules.runJsFunction(String.class, "get_suggested_quantity", args);
+        SuggestedQuantity dto = mapper.toObject(json, SuggestedQuantity.class);
+        return dto;
     }
 
     private boolean isValid(Entitlement e) {

--- a/src/main/java/org/candlepin/policy/js/quantity/SuggestedQuantity.java
+++ b/src/main/java/org/candlepin/policy/js/quantity/SuggestedQuantity.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.policy.js.quantity;
+
+/**
+ * SuggestedQuantity: Just used to transfer a couple values back from the quantity rules
+ * namespace in just one invocation.
+ */
+public class SuggestedQuantity {
+
+    private Long suggested;
+    private Long increment;
+
+    public Long getSuggested() {
+        return suggested;
+    }
+
+    public void setSuggested(Long suggested) {
+        this.suggested = suggested;
+    }
+
+    public Long getIncrement() {
+        return increment;
+    }
+
+    public void setIncrement(Long increment) {
+        this.increment = increment;
+    }
+
+}

--- a/src/main/java/org/candlepin/resource/util/CalculatedAttributesUtil.java
+++ b/src/main/java/org/candlepin/resource/util/CalculatedAttributesUtil.java
@@ -17,6 +17,7 @@ package org.candlepin.resource.util;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.Pool;
 import org.candlepin.policy.js.quantity.QuantityRules;
+import org.candlepin.policy.js.quantity.SuggestedQuantity;
 
 import com.google.inject.Inject;
 
@@ -41,13 +42,12 @@ public class CalculatedAttributesUtil {
             return attrMap;
         }
 
-        attrMap.put("suggested_quantity",
-            String.valueOf(quantityRules.getSuggestedQuantity(p, c)));
+        SuggestedQuantity suggested = quantityRules.getSuggestedQuantity(p, c);
 
-        if (p.hasProductAttribute("instance_multiplier")) {
-            attrMap.put("quantity_increment",
-                p.getProductAttribute("instance_multiplier").getValue());
-        }
+        attrMap.put("suggested_quantity",
+            String.valueOf(suggested.getSuggested()));
+        attrMap.put("quantity_increment",
+            String.valueOf(suggested.getIncrement()));
 
         return attrMap;
     }

--- a/src/test/java/org/candlepin/model/test/RulesCuratorTest.java
+++ b/src/test/java/org/candlepin/model/test/RulesCuratorTest.java
@@ -78,7 +78,7 @@ public class RulesCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void uploadRules() {
-        Rules rules = new Rules("// Version: 3.1000\n//these are the new rules");
+        Rules rules = new Rules("// Version: 4.1000\n//these are the new rules");
         rulesCurator.update(rules);
         Rules updateRules = rulesCurator.getRules();
         assertEquals(rules.getRules(), updateRules.getRules());
@@ -86,9 +86,9 @@ public class RulesCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void uploadMultipleRules() {
-        Rules rules = new Rules("// Version: 3.1000\n// rules1 ");
+        Rules rules = new Rules("// Version: 4.1000\n// rules1 ");
         rulesCurator.update(rules);
-        Rules rules2 = new Rules("// Version: 3.1001\n// rules2 ");
+        Rules rules2 = new Rules("// Version: 4.1001\n// rules2 ");
         rulesCurator.update(rules2);
         Rules updateRules = rulesCurator.getRules();
         assertEquals(rules2.getRules(), updateRules.getRules());

--- a/src/test/java/org/candlepin/policy/js/quantity/QuantityRulesTest.java
+++ b/src/test/java/org/candlepin/policy/js/quantity/QuantityRulesTest.java
@@ -46,6 +46,7 @@ import java.util.Set;
 public class QuantityRulesTest {
 
     private static final String SOCKET_ATTRIBUTE = "sockets";
+    private static final String INSTANCE_ATTRIBUTE = "instance_multiplier";
     private static final String SOCKET_FACT = "cpu.cpu_socket(s)";
     private static final String CORES_ATTRIBUTE = "cores";
     private static final String CORES_FACT = "cpu.core(s)_per_socket";
@@ -109,22 +110,25 @@ public class QuantityRulesTest {
     @Test
     public void testNonMultiEntitlementPool() {
         pool.setProductAttribute("multi-entitlement", "no", product.getId());
-        assertEquals(1L, quantityRules.getSuggestedQuantity(pool, new Consumer()));
+        SuggestedQuantity suggested = quantityRules.getSuggestedQuantity(pool,
+            new Consumer());
+        assertEquals(new Long(1), suggested.getSuggested());
     }
 
     @Test
     public void testPhysicalDefaultToNumSocketsBySocketCount() {
         consumer.setFact(SOCKET_FACT, "4");
         pool.setProductAttribute(SOCKET_ATTRIBUTE, "2", product.getId());
-
-        assertEquals(2L, quantityRules.getSuggestedQuantity(pool, consumer));
+        SuggestedQuantity suggested = quantityRules.getSuggestedQuantity(pool, consumer);
+        assertEquals(new Long(2), suggested.getSuggested());
     }
 
     @Test
     public void testPhysicalRoundsUp() {
         consumer.setFact(SOCKET_FACT, "4");
         pool.setProductAttribute(SOCKET_ATTRIBUTE, "3", product.getId());
-        assertEquals(2L, quantityRules.getSuggestedQuantity(pool, consumer));
+        SuggestedQuantity suggested = quantityRules.getSuggestedQuantity(pool, consumer);
+        assertEquals(new Long(2), suggested.getSuggested());
     }
 
     @Test
@@ -140,7 +144,8 @@ public class QuantityRulesTest {
 
         consumer.setEntitlements(ents);
 
-        assertEquals(2L, quantityRules.getSuggestedQuantity(pool, consumer));
+        SuggestedQuantity suggested = quantityRules.getSuggestedQuantity(pool, consumer);
+        assertEquals(new Long(2), suggested.getSuggested());
     }
 
     @Test
@@ -148,7 +153,8 @@ public class QuantityRulesTest {
         consumer.setFact(IS_VIRT, "true");
         consumer.setFact(CORES_FACT, "8");
         pool.setProductAttribute(CORES_ATTRIBUTE, "4", product.getId());
-        assertEquals(2L, quantityRules.getSuggestedQuantity(pool, consumer));
+        SuggestedQuantity suggested = quantityRules.getSuggestedQuantity(pool, consumer);
+        assertEquals(new Long(2), suggested.getSuggested());
     }
 
     @Test
@@ -156,7 +162,8 @@ public class QuantityRulesTest {
         consumer.setFact(IS_VIRT, "true");
         consumer.setFact(SOCKET_FACT, "4");
         pool.setProductAttribute(SOCKET_ATTRIBUTE, "2", product.getId());
-        assertEquals(2L, quantityRules.getSuggestedQuantity(pool, consumer));
+        SuggestedQuantity suggested = quantityRules.getSuggestedQuantity(pool, consumer);
+        assertEquals(new Long(2), suggested.getSuggested());
     }
 
     @Test
@@ -164,7 +171,8 @@ public class QuantityRulesTest {
         consumer.setFact(IS_VIRT, "true");
         consumer.setFact(SOCKET_FACT, "4");
         consumer.setFact(CORES_FACT, "8");
-        assertEquals(1L, quantityRules.getSuggestedQuantity(pool, consumer));
+        SuggestedQuantity suggested = quantityRules.getSuggestedQuantity(pool, consumer);
+        assertEquals(new Long(1), suggested.getSuggested());
     }
 
     @Test
@@ -172,7 +180,8 @@ public class QuantityRulesTest {
         consumer.setFact(IS_VIRT, "true");
         consumer.setFact(CORES_FACT, "8");
         pool.setProductAttribute(CORES_ATTRIBUTE, "6", product.getId());
-        assertEquals(2L, quantityRules.getSuggestedQuantity(pool, consumer));
+        SuggestedQuantity suggested = quantityRules.getSuggestedQuantity(pool, consumer);
+        assertEquals(new Long(2), suggested.getSuggested());
     }
 
     @Test
@@ -189,7 +198,8 @@ public class QuantityRulesTest {
 
         consumer.setEntitlements(ents);
 
-        assertEquals(2L, quantityRules.getSuggestedQuantity(pool, consumer));
+        SuggestedQuantity suggested = quantityRules.getSuggestedQuantity(pool, consumer);
+        assertEquals(new Long(2), suggested.getSuggested());
     }
 
     @Test
@@ -198,7 +208,33 @@ public class QuantityRulesTest {
         consumer.setFact(SOCKET_FACT, "4");
         pool.setProductAttribute(SOCKET_ATTRIBUTE, "2", product.getId());
 
-        assertEquals(2L, quantityRules.getSuggestedQuantity(pool, consumer));
+        SuggestedQuantity suggested = quantityRules.getSuggestedQuantity(pool, consumer);
+        assertEquals(new Long(2), suggested.getSuggested());
+        assertEquals(new Long(1), suggested.getIncrement());
+    }
+
+    @Test
+    public void testInstanceBasedOnPhysical() {
+        consumer.setFact(IS_VIRT, "false");
+        consumer.setFact(SOCKET_FACT, "4");
+        pool.setProductAttribute(SOCKET_ATTRIBUTE, "2", product.getId());
+        pool.setProductAttribute(INSTANCE_ATTRIBUTE, "2", product.getId());
+
+        SuggestedQuantity suggested = quantityRules.getSuggestedQuantity(pool, consumer);
+        assertEquals(new Long(4), suggested.getSuggested());
+        assertEquals(new Long(2), suggested.getIncrement());
+    }
+
+    @Test
+    public void testInstanceBasedOnGuest() {
+        consumer.setFact(IS_VIRT, "true");
+        consumer.setFact(SOCKET_FACT, "4");
+        pool.setProductAttribute(SOCKET_ATTRIBUTE, "2", product.getId());
+        pool.setProductAttribute(INSTANCE_ATTRIBUTE, "2", product.getId());
+
+        SuggestedQuantity suggested = quantityRules.getSuggestedQuantity(pool, consumer);
+        assertEquals(new Long(1), suggested.getSuggested());
+        assertEquals(new Long(1), suggested.getIncrement());
     }
 
     @Test
@@ -207,7 +243,8 @@ public class QuantityRulesTest {
         consumer.setFact(SOCKET_FACT, "4");
         pool.setProductAttribute(SOCKET_ATTRIBUTE, "2", product.getId());
 
-        assertEquals(2L, quantityRules.getSuggestedQuantity(pool, consumer));
+        SuggestedQuantity suggested = quantityRules.getSuggestedQuantity(pool, consumer);
+        assertEquals(new Long(2), suggested.getSuggested());
     }
 
     @Test
@@ -227,7 +264,8 @@ public class QuantityRulesTest {
 
         consumer.setEntitlements(ents);
 
-        assertEquals(2L, quantityRules.getSuggestedQuantity(pool, consumer));
+        SuggestedQuantity suggested = quantityRules.getSuggestedQuantity(pool, consumer);
+        assertEquals(new Long(2), suggested.getSuggested());
     }
 
     @Test
@@ -244,7 +282,8 @@ public class QuantityRulesTest {
 
         consumer.setEntitlements(ents);
 
-        assertEquals(0L, quantityRules.getSuggestedQuantity(pool, consumer));
+        SuggestedQuantity suggested = quantityRules.getSuggestedQuantity(pool, consumer);
+        assertEquals(new Long(0), suggested.getSuggested());
     }
 
     @Test
@@ -263,7 +302,8 @@ public class QuantityRulesTest {
 
         consumer.setEntitlements(ents);
 
-        assertEquals(2L, quantityRules.getSuggestedQuantity(pool, consumer));
+        SuggestedQuantity suggested = quantityRules.getSuggestedQuantity(pool, consumer);
+        assertEquals(new Long(2), suggested.getSuggested());
     }
 
 }

--- a/src/test/java/org/candlepin/resource/util/CalculatedAttributesUtilTest.java
+++ b/src/test/java/org/candlepin/resource/util/CalculatedAttributesUtilTest.java
@@ -26,6 +26,7 @@ import org.candlepin.model.Pool;
 import org.candlepin.model.Product;
 import org.candlepin.model.ProductAttribute;
 import org.candlepin.policy.js.quantity.QuantityRules;
+import org.candlepin.policy.js.quantity.SuggestedQuantity;
 import org.candlepin.test.DatabaseTestFixture;
 import org.candlepin.test.TestUtil;
 
@@ -69,8 +70,11 @@ public class CalculatedAttributesUtilTest extends DatabaseTestFixture {
 
     @Test
     public void testCalculatedAttributesPresent() {
+        SuggestedQuantity suggested = new SuggestedQuantity();
+        suggested.setSuggested(1L);
+        suggested.setIncrement(1L);
         when(quantityRules.getSuggestedQuantity(any(Pool.class), any(Consumer.class))).
-            thenReturn(1L);
+            thenReturn(suggested);
 
         Map<String, String> attrs = attrUtil.buildCalculatedAttributes(pool1, consumer);
         assertTrue(attrs.containsKey("suggested_quantity"));
@@ -86,8 +90,11 @@ public class CalculatedAttributesUtilTest extends DatabaseTestFixture {
         Pool pool2 = createPoolAndSub(owner1, product2, 500L,
             TestUtil.createDate(2000, 1, 1), TestUtil.createDate(3000, 1, 1));
 
+        SuggestedQuantity suggested = new SuggestedQuantity();
+        suggested.setSuggested(1L);
+        suggested.setIncrement(12L);
         when(quantityRules.getSuggestedQuantity(any(Pool.class), any(Consumer.class))).
-            thenReturn(1L);
+            thenReturn(suggested);
 
         Map<String, String> attrs = attrUtil.buildCalculatedAttributes(pool2, consumer);
         assertEquals("12", attrs.get("quantity_increment"));


### PR DESCRIPTION
We were returning the instance multiplier as the increment all the time,
which is incorrect for guests.

Further this is a rules style decision, so should be handled there.
Refactored QuantityRules to return both values we need with just the one
call. This unfortunately means a major rules API bump as there's no way
to do it without breaking compatability, or making a separate JS
invocation. However the previous major rules version is not yet released
so no major harm done.
