### PR TITLE
971121: Candlepin Lists Derived Pools For Distributors

### DIFF
--- a/src/main/resources/rules/rules.js
+++ b/src/main/resources/rules/rules.js
@@ -1342,13 +1342,7 @@ var Entitlement = {
         if (virt_pool) {
             if (consumer.type.manifest) {
                 if (pool_derived) {
-                    if (BEST_POOLS_CALLER == caller ||
-                        BIND_CALLER == caller) {
-                    	result.addError("pool.not.available.to.manifest.consumers");
-                    }
-                    else {
-                        result.addWarning("pool.not.available.to.manifest.consumers");
-                    }
+                    result.addError("pool.not.available.to.manifest.consumers");
                 }
         	}
         	else if (!guest) {
@@ -1368,9 +1362,9 @@ var Entitlement = {
         var result = Entitlement.ValidationResult();
         context = Entitlement.get_attribute_context();
 
-        // It shouldn't be possible to get a host restricted pool in hosted, but just in
-        // case, make sure it won't be enforced if we do.
-        if (!context.standalone) {
+        // requires_host derived pools not available to manifest
+        if (context.consumer.type.manifest) {
+            result.addError("pool.not.available.to.manifest.consumers");
             return JSON.stringify(result);
         }
 

--- a/src/test/java/org/candlepin/policy/js/entitlement/test/ManifestEntitlementRulesTest.java
+++ b/src/test/java/org/candlepin/policy/js/entitlement/test/ManifestEntitlementRulesTest.java
@@ -282,6 +282,58 @@ public class ManifestEntitlementRulesTest extends EntitlementRulesTestFixture {
     }
 
     @Test
+    public void preEntitlementShouldNotAllowListOfDerivedPools() {
+        Consumer c = TestUtil.createConsumer();
+        c.getType().setManifest(true);
+
+        Product prod = TestUtil.createProduct();
+        Pool p = TestUtil.createPool(prod);
+        p.setAttribute("virt_only", "true");
+        p.setAttribute("pool_derived", "true");
+
+        ValidationResult results = enforcer.preEntitlement(c, p, 1, CallerType.LIST_POOLS);
+        assertNotNull(results);
+        assertEquals(1, results.getErrors().size());
+        ValidationError error = results.getErrors().get(0);
+        assertEquals("pool.not.available.to.manifest.consumers", error.getResourceKey());
+    }
+
+    @Test
+    public void preEntitlementShouldNotAllowConsumptionFromRequiresHostPools() {
+        Consumer c = TestUtil.createConsumer();
+        c.getType().setManifest(true);
+
+        Product prod = TestUtil.createProduct();
+        Pool p = TestUtil.createPool(prod);
+        p.setAttribute("virt_only", "true");
+        p.setAttribute("requires_host", "true");
+
+        ValidationResult results = enforcer.preEntitlement(c, p, 1, CallerType.BIND);
+        assertNotNull(results);
+        assertEquals(1, results.getErrors().size());
+        ValidationError error = results.getErrors().get(0);
+        assertEquals("pool.not.available.to.manifest.consumers", error.getResourceKey());
+    }
+
+    @Test
+    public void preEntitlementShouldNotAllowListOfRequiresHostPools() {
+        Consumer c = TestUtil.createConsumer();
+        c.getType().setManifest(true);
+
+        Product prod = TestUtil.createProduct();
+        Pool p = TestUtil.createPool(prod);
+        p.setAttribute("virt_only", "true");
+        p.setAttribute("requires_host", "true");
+
+        ValidationResult results = enforcer.preEntitlement(c, p, 1, CallerType.LIST_POOLS);
+        assertNotNull(results);
+        assertEquals(1, results.getErrors().size());
+        ValidationError error = results.getErrors().get(0);
+        assertEquals("pool.not.available.to.manifest.consumers", error.getResourceKey());
+    }
+
+
+    @Test
     public void preEntitlementShouldNotAllowOverConsumptionOfEntitlements() {
         Consumer c = TestUtil.createConsumer();
         c.getType().setManifest(true);

--- a/src/test/java/org/candlepin/policy/js/entitlement/test/PreEntitlementRulesTest.java
+++ b/src/test/java/org/candlepin/policy/js/entitlement/test/PreEntitlementRulesTest.java
@@ -452,28 +452,6 @@ public class PreEntitlementRulesTest extends EntitlementRulesTestFixture {
         assertFalse(result.hasWarnings());
     }
 
-    // There shouldn't be any way to get a host restricted pool in hosted, but make sure
-    // if it were to happen, it wouldn't be enforced.
-    @Test
-    public void hostedVirtOnlyPoolGuestHostDoesNotMatch() {
-        Consumer parent = new Consumer("test parent consumer", "test user", owner,
-            new ConsumerType(ConsumerTypeEnum.SYSTEM));
-        Pool pool = setupHostRestrictedPool(parent);
-        Consumer otherParent = new Consumer("test parent consumer", "test user", owner,
-            new ConsumerType(ConsumerTypeEnum.SYSTEM));
-
-        when(config.standalone()).thenReturn(false);
-        String guestId = "virtguestuuid";
-        consumer.setFact("virt.is_guest", "true");
-        consumer.setFact("virt.uuid", guestId);
-
-        when(consumerCurator.getHost(guestId)).thenReturn(otherParent);
-
-        ValidationResult result = enforcer.preEntitlement(consumer, pool, 1);
-        assertFalse(result.hasErrors());
-        assertFalse(result.hasWarnings());
-    }
-
     @Test
     public void virtOnlyPoolGuestHostDoesNotMatch() {
         when(config.standalone()).thenReturn(true);


### PR DESCRIPTION
also stopped the showing of requires_host pools when listing
