### PR TITLE
972752: Correct stacked marketing names

### DIFF
--- a/src/main/java/org/candlepin/model/Entitlement.java
+++ b/src/main/java/org/candlepin/model/Entitlement.java
@@ -296,4 +296,13 @@ public class Entitlement extends AbstractHibernateObject implements Linkable, Ow
         this.dirty = dirty;
     }
 
+    @XmlTransient
+    public boolean isValidOnDate(Date d) {
+        return d.after(this.getStartDate()) && d.before(this.getEndDate());
+    }
+
+    @XmlTransient
+    public boolean isValid() {
+        return this.isValidOnDate(new Date());
+    }
 }

--- a/src/main/java/org/candlepin/policy/js/compliance/StatusReasonMessageGenerator.java
+++ b/src/main/java/org/candlepin/policy/js/compliance/StatusReasonMessageGenerator.java
@@ -14,6 +14,10 @@
  */
 package org.candlepin.policy.js.compliance;
 
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.commons.lang.StringUtils;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerInstalledProduct;
 import org.candlepin.model.Entitlement;
@@ -79,18 +83,20 @@ public class StatusReasonMessageGenerator {
         }
     }
 
+    //Only works for the current time, which is currently the only time reasons are supplied
     private String getStackedMarketingName(String stackId, Consumer consumer) {
-        String result = "";
+        Set<String> results = new HashSet<String>();
         for (Entitlement e : consumer.getEntitlements()) {
-            if (e.getPool().getProductAttribute("stacking_id") != null) {
+            if (e.getPool().getProductAttribute("stacking_id") != null &&
+                    e.isValid()) {
                 if (e.getPool().getProductAttribute("stacking_id")
                     .getValue().equals(stackId)) {
-                    result += e.getPool().getProductName() + "/";
+                    results.add(e.getPool().getProductName());
                 }
             }
         }
-        if (result.length() > 0) {
-            return result.substring(0, result.length() - 1);
+        if (results.size() > 0) {
+            return StringUtils.join(results, "/");
         }
         else {
             return "UNABLE_TO_GET_NAME";

--- a/src/test/java/org/candlepin/policy/js/compliance/StatusReasonMessageGeneratorTest.java
+++ b/src/test/java/org/candlepin/policy/js/compliance/StatusReasonMessageGeneratorTest.java
@@ -15,6 +15,8 @@
 package org.candlepin.policy.js.compliance;
 
 import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -78,6 +80,10 @@ public class StatusReasonMessageGeneratorTest {
         generator.setMessage(consumer, reason);
         String message = reason.getMessage();
         assertEquals("Only covers 4 of 8 sockets.", message);
+        String[] names = reason.getAttributes().get("name").split("/");
+        Arrays.sort(names);
+        assertEquals("Stack Subscription One", names[0]);
+        assertEquals("Stack Subscription Two", names[1]);
     }
 
     @Test


### PR DESCRIPTION
Fixes multiple occurences of the same sub name in a stack name.
ex: "Awesome os for x86_64/Awesome os for x86_64"

Added a check for time range validity when building a stack name, so names of future subs aren't used.
