### PR TITLE
966430: Don't suggest quantities we can't actually have.

### DIFF
--- a/src/main/resources/rules/rules.js
+++ b/src/main/resources/rules/rules.js
@@ -797,6 +797,19 @@ var CoverageCalculator = {
             if (maxQuantity < amountRequiredFromPool) {
                 maxQuantity = amountRequiredFromPool;
             }
+
+            // Don't try to take more than the pool has available:
+            if (maxQuantity > pool.quantity - pool.consumed) {
+                maxQuantity = pool.quantity - pool.consumed;
+            }
+
+            // Adjust the suggested quantity if necessary:
+            if (pool.hasProductAttribute("instance_multiplier") && !Utils.isGuest(consumer)) {
+                // Make sure we never recommend something that isn't a multiple of
+                // instance multiplier:
+                maxQuantity = maxQuantity - (maxQuantity % stackTracker.instanceMultiplier);
+            }
+
         }
         log.debug("Quantity required to cover consumer: " + maxQuantity);
         return maxQuantity;
@@ -927,9 +940,6 @@ function findStackingPools(pool_class, consumer, compliance) {
             // don't take more entitlements than are available!
             var quantity = CoverageCalculator.getQuantityToCoverStack(stackTrackerToProcess,
                 pool, consumer);
-            if (quantity > pool.quantity - pool.consumed) {
-                quantity = pool.quantity - pool.consumed;
-            }
             log.debug("Incrementing pool quantity for stack to: " + quantity);
 
             // Update the stack accumulated values to simulate attaching X

--- a/src/test/java/org/candlepin/policy/js/quantity/QuantityRulesTest.java
+++ b/src/test/java/org/candlepin/policy/js/quantity/QuantityRulesTest.java
@@ -226,6 +226,32 @@ public class QuantityRulesTest {
     }
 
     @Test
+    public void testInstanceBasedOnPhysicalNotEnoughAvailable() {
+        consumer.setFact(IS_VIRT, "false");
+        consumer.setFact(SOCKET_FACT, "40"); // lots of ents required
+        pool.setProductAttribute(SOCKET_ATTRIBUTE, "2", product.getId());
+        pool.setProductAttribute(INSTANCE_ATTRIBUTE, "2", product.getId());
+
+        pool.setQuantity(4L);
+        SuggestedQuantity suggested = quantityRules.getSuggestedQuantity(pool, consumer);
+        assertEquals(new Long(4), suggested.getSuggested());
+        assertEquals(new Long(2), suggested.getIncrement());
+    }
+
+    @Test
+    public void testInstanceBasedOnPhysicalNotEnoughAvailableUneven() {
+        consumer.setFact(IS_VIRT, "false");
+        consumer.setFact(SOCKET_FACT, "40"); // lots of ents required
+        pool.setProductAttribute(SOCKET_ATTRIBUTE, "2", product.getId());
+        pool.setProductAttribute(INSTANCE_ATTRIBUTE, "2", product.getId());
+
+        pool.setQuantity(3L);
+        SuggestedQuantity suggested = quantityRules.getSuggestedQuantity(pool, consumer);
+        assertEquals(new Long(2), suggested.getSuggested());
+        assertEquals(new Long(2), suggested.getIncrement());
+    }
+
+    @Test
     public void testInstanceBasedOnGuest() {
         consumer.setFact(IS_VIRT, "true");
         consumer.setFact(SOCKET_FACT, "4");

--- a/src/test/java/org/candlepin/policy/test/AutobindRulesTest.java
+++ b/src/test/java/org/candlepin/policy/test/AutobindRulesTest.java
@@ -457,6 +457,34 @@ public class AutobindRulesTest {
     }
 
     @Test
+    public void instanceAutobindForPhysical8SocketNotEnoughUneven() {
+        List<Pool> pools = createInstanceBasedPool();
+        pools.get(0).setQuantity(7L); // Only 7 available
+        setupConsumer("8", false);
+
+        List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
+            new String[]{ productId }, pools, compliance, null, new HashSet<String>());
+
+        assertEquals(1, bestPools.size());
+        PoolQuantity q = bestPools.get(0);
+        assertEquals(new Integer(6), q.getQuantity());
+    }
+
+    @Test
+    public void instanceAutobindForPhysical8SocketNotEnoughEven() {
+        List<Pool> pools = createInstanceBasedPool();
+        pools.get(0).setQuantity(4L); // Only 4 available
+        setupConsumer("8", false);
+
+        List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
+            new String[]{ productId }, pools, compliance, null, new HashSet<String>());
+
+        assertEquals(1, bestPools.size());
+        PoolQuantity q = bestPools.get(0);
+        assertEquals(new Integer(4), q.getQuantity());
+    }
+
+    @Test
     public void instanceAutobindForPhysical8SocketCompletePartialStack() {
         List<Pool> pools = createInstanceBasedPool();
         setupConsumer("8", false);


### PR DESCRIPTION
Quantity rules were not respecting the amount currently available in the
pool.

Also check to make sure that we don't suggest a physical system use a
quantity that is not a multiple of the instance multiplier.
