### PR TITLE
group if statements and log.debug instead of warn.

### DIFF
--- a/src/main/java/org/candlepin/hibernate/EmptyStringInterceptor.java
+++ b/src/main/java/org/candlepin/hibernate/EmptyStringInterceptor.java
@@ -46,18 +46,14 @@ public class EmptyStringInterceptor extends EmptyInterceptor {
         String[] propertyNames, Type[] types) {
         boolean modified = false;
         for (int i = 0; i < types.length; i++) {
-            if (types[i] instanceof StringType) {
-                if ("".equals(state[i])) {
-                    log.warn("Attempting to write an empty string to the database " +
-                            "for " + propertyNames[i] + ".  Substituting null instead.");
-                    state[i] = null;
-                    modified = true;
-                }
+            if (types[i] instanceof StringType && "".equals(state[i])) {
+                log.debug("Attempting to write an empty string to the database" +
+                    " for " + propertyNames[i] + ".  Substituting null instead.");
+                state[i] = null;
+                modified = true;
             }
         }
 
         return modified;
     }
-
-
 }


### PR DESCRIPTION
EmptyStringInterceptor was logging a warning every time it ran which just clouds the logs with noise. Just today there are 1610 occurrences.

While I was in there I combined the if statements which fixes a pmd static analysis complaint of if statements that could be collapsed.
