### PR TITLE
Added empty hash for the new opts param for JSON parsing.

### DIFF
--- a/buildconf/scripts/import_products.rb
+++ b/buildconf/scripts/import_products.rb
@@ -23,7 +23,7 @@ data = {}
 filenames.each do |filename|
   puts filename
   product_data_buf = File.read(filename)
-  product_data = JSON product_data_buf
+  product_data = JSON(product_data_buf, {})
   data['products'] = data.fetch('products',[]) + product_data['products']
   data['content'] = data.fetch('content',[]) + product_data['content']
   data['owners'] = data.fetch('owners', []) + product_data['owners']


### PR DESCRIPTION
Added compatibility to conform with latest JSON pure, which adds an opts hash parameter for security purposes to the JSON parse method. Because of this, candlepin would crash with the new version of JSON pure. Added empty hash param fixes that.
