### PR TITLE
Default hypervisor types to be certificate version 3.2.

### DIFF
--- a/src/main/java/org/candlepin/resource/HypervisorResource.java
+++ b/src/main/java/org/candlepin/resource/HypervisorResource.java
@@ -111,7 +111,10 @@ public class HypervisorResource {
                     consumer.setName(hostEntry.getKey());
                     consumer.setUuid(hostEntry.getKey());
                     consumer.setType(new ConsumerType(ConsumerTypeEnum.HYPERVISOR));
+                    // Default hypervisors to be x86_64 machines with the latest
+                    // cert version
                     consumer.setFact("uname.machine", "x86_64");
+                    consumer.setFact("system.certificate_version", "3.2");
                     consumer.setGuestIds(new ArrayList<GuestId>());
                     consumer = consumerResource.create(consumer, principal, null, ownerKey,
                         null);

--- a/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
+++ b/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
@@ -161,6 +161,7 @@ public class HypervisorResourceTest {
         assertEquals("GUEST_A", c1.getGuestIds().get(0).getGuestId());
         assertEquals("GUEST_B", c1.getGuestIds().get(1).getGuestId());
         assertEquals("x86_64", c1.getFact("uname.machine"));
+        assertEquals("3.2", c1.getFact("system.certificate_version"));
         assertEquals("hypervisor", c1.getType().getLabel());
     }
 


### PR DESCRIPTION
This will ensure that hypervisors can consume subscriptions
which have the larger content sets. The drawback is that we may
need to improve the defaulting logic over time.

Note, this only effects consumers which are created by virt-who against hypervisor managers such as HyperV and VMWare.
