### PR TITLE
976089: Expose new api to get entitlements for a pool

### DIFF
--- a/src/main/java/org/candlepin/resource/PoolResource.java
+++ b/src/main/java/org/candlepin/resource/PoolResource.java
@@ -290,17 +290,16 @@ public class PoolResource {
             throw new NotFoundException(i18n.tr(
                 "Subscription Pool with ID ''{0}'' could not be found.", id));
         }
+
+        Owner o = pool.getOwner();
+        if (principal.canAccess(o, Access.READ_POOLS)) {
+            List<Entitlement> entitlements = new ArrayList<Entitlement>();
+            entitlements.addAll(pool.getEntitlements());
+            return entitlements;
+        }
         else {
-            Owner o = pool.getOwner();
-            if (principal.canAccess(o, Access.READ_POOLS)) {
-                List<Entitlement> entitlements = new ArrayList<Entitlement>();
-                entitlements.addAll(pool.getEntitlements());
-                return entitlements;
-            }
-            else {
-                throw new ForbiddenException(i18n.tr("User {0} cannot access owner {1}",
-                    principal.getPrincipalName(), o.getKey()));
-            }
+            throw new ForbiddenException(i18n.tr("User {0} cannot access owner {1}",
+                principal.getPrincipalName(), o.getKey()));
         }
     }
 

--- a/src/test/java/org/candlepin/resource/test/PoolResourceTest.java
+++ b/src/test/java/org/candlepin/resource/test/PoolResourceTest.java
@@ -300,6 +300,11 @@ public class PoolResourceTest extends DatabaseTestFixture {
         assertEquals(0, ents.size());
     }
 
+    @Test(expected = NotFoundException.class)
+    public void testUnknownConsumerRequestingEntitlements() {
+        poolResource.getPoolEntitlements("xyzzy", adminPrincipal);
+    }
+
     @Test(expected = ForbiddenException.class)
     public void testUnauthorizedUserRequestingPoolEntitlements() {
         Owner owner2 = createOwner();


### PR DESCRIPTION
This new API is at /pools/{pool_id}/entitlements. This API should be
more performant then iterating over all the entitlements.
