### PR TITLE
pmd: remove useless override.

### DIFF
--- a/src/main/java/org/candlepin/model/RulesCurator.java
+++ b/src/main/java/org/candlepin/model/RulesCurator.java
@@ -142,10 +142,6 @@ public class RulesCurator extends AbstractHibernateCurator<Rules> {
 
     }
 
-    public Rules merge(Rules entity) {
-        return super.merge(entity);
-    }
-
     private Rules rulesFromFile(String path) {
         InputStream is = this.getClass().getResourceAsStream(path);
         return new Rules(Util.readFile(is));


### PR DESCRIPTION
This override is not necessary since we just end up calling the
parent version. None of the other curators do this.
