### PR TITLE
Test data update

### DIFF
--- a/buildconf/scripts/test_data.json
+++ b/buildconf/scripts/test_data.json
@@ -668,7 +668,8 @@
                 "support_level" : "None",
                 "support_type" : "Self-Support",
                 "multi-entitlement" : "no",
-                "virt_limit" : "unlimited"
+                "virt_limit" : "unlimited",
+                "host_limited": "true"
             },
             "derived_product_id" : "awesomeos-server-basic-vdc",
             "derived_provided_products" : [


### PR DESCRIPTION
Set host_limited on data center test product so that
the derived product functionality kicks in when running
candlepin in hosted mode. Aligns better with production
deployment
