### PR TITLE
make deleted consumers call more predictable

### DIFF
--- a/spec/deleted_consumer_spec.rb
+++ b/spec/deleted_consumer_spec.rb
@@ -22,10 +22,9 @@ describe 'Deleted Consumer Resource' do
     uuid = consumer1.uuid
     @cp.unregister(consumer1.uuid)
 
-    @cp.get_deleted_consumers().length.should_not == 0
     deleted_consumers = @cp.get_deleted_consumers(date=date)
+    deleted_consumers.length.should_not == 0
     deleted_consumers.first.consumerUuid.should == uuid
-    deleted_consumers.length.should == 1
   end
 
 end

--- a/src/main/java/org/candlepin/model/DeletedConsumerCurator.java
+++ b/src/main/java/org/candlepin/model/DeletedConsumerCurator.java
@@ -14,6 +14,7 @@
  */
 package org.candlepin.model;
 
+import org.hibernate.criterion.Order;
 import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
 
@@ -48,6 +49,7 @@ public class DeletedConsumerCurator extends
     public List<DeletedConsumer> findByOwnerId(String oid) {
         return currentSession().createCriteria(DeletedConsumer.class)
             .add(Restrictions.eq("ownerId", oid))
+            .addOrder(Order.desc("created"))
             .list();
     }
 
@@ -65,6 +67,8 @@ public class DeletedConsumerCurator extends
     @SuppressWarnings("unchecked")
     public List<DeletedConsumer> findByDate(Date date) {
         return currentSession().createCriteria(DeletedConsumer.class)
-            .add(Restrictions.ge("created", date)).list();
+            .add(Restrictions.ge("created", date))
+            .addOrder(Order.desc("created"))
+            .list();
     }
 }

--- a/src/test/java/org/candlepin/model/test/DeletedConsumerCuratorTest.java
+++ b/src/test/java/org/candlepin/model/test/DeletedConsumerCuratorTest.java
@@ -67,6 +67,7 @@ public class DeletedConsumerCuratorTest extends DatabaseTestFixture {
             // TODO Auto-generated catch block
             e.printStackTrace();
         }
+
         oneResultDate = new Date();
         dc = new DeletedConsumer("klmno", "20");
         dcc.create(dc);
@@ -123,5 +124,17 @@ public class DeletedConsumerCuratorTest extends DatabaseTestFixture {
         assertEquals(2, dcc.findByDate(twoResultsDate).size());
         assertEquals(1, dcc.findByDate(oneResultDate).size());
         assertEquals(0, dcc.findByDate(new Date()).size());
+    }
+
+    @Test
+    public void descOrderByDate() {
+        DeletedConsumer newest = dcc.findByDate(twoResultsDate).get(0);
+        assertEquals("klmno", newest.getConsumerUuid());
+    }
+
+    @Test
+    public void descOrderByOwnerId() {
+        DeletedConsumer newest = dcc.findByOwnerId("10").get(0);
+        assertEquals("fghij", newest.getConsumerUuid());
     }
 }


### PR DESCRIPTION
the deleted_consumer spec test would fail on occasion. Best guess is that the
first item in the returned list doesn't necessarily have to be the latest
because the query doesn't sort the list at all. I added a descending
sort order on created date which is the date the deleted consumer record was
created. By doing a descending sort we ensure that the first record is
always the latest deleted consumer. Made a minor tweak to the spec test to
look at the length of the list on the variable instead of making a second
call to the API. And we were erroneously checking that we only got one
record back which isn't always the case.
