### PR TITLE
914827: Do not insert new consumer types if they are already present.

### DIFF
--- a/src/main/resources/db/changelog/20130212124537-insert-katello-consumer-types.xml
+++ b/src/main/resources/db/changelog/20130212124537-insert-katello-consumer-types.xml
@@ -10,6 +10,9 @@
     <changeSet id="20130212124537-community" author="bkearney" dbms="postgresql">
         <preConditions onFail="MARK_RAN">
             <changeLogPropertyDefined property="community" value="True"/>
+            <sqlCheck expectedResult="0">
+                select count(*) from cp_consumer_type where label = 'headpin'
+            </sqlCheck>
         </preConditions>
         <comment>Add community friendly names for Headpin and Katello</comment>
         <insert tableName="cp_consumer_type">
@@ -27,6 +30,9 @@
     <changeSet id="20130212124537-product" author="bkearney" dbms="postgresql">
         <preConditions onFail="MARK_RAN">
             <changeLogPropertyDefined property="community" value="False"/>
+            <sqlCheck expectedResult="0">
+                select count(*) from cp_consumer_type where label = 'sam'
+            </sqlCheck>
         </preConditions>
         <comment>Add product friendly names for Headpin and Katello</comment>
         <insert tableName="cp_consumer_type">


### PR DESCRIPTION
The manifest files pull down the latest consumer types. Therefore, the
scripts which work on the install fail on an upgrade. This patch causes
the inserts to be marked as having run if the content is already there.

Since the two types were added at the same time, there is no need to
test for both values
