### PR TITLE
return null instead of throwing exception during autobind

### DIFF
--- a/src/main/java/org/candlepin/policy/js/autobind/AutobindRules.java
+++ b/src/main/java/org/candlepin/policy/js/autobind/AutobindRules.java
@@ -70,7 +70,7 @@ public class AutobindRules {
         int poolsBeforeContentFilter = pools.size();
         pools = filterPoolsForV1Certificates(consumer, pools);
 
-        // TODO: Not the best behavior:
+        // per dgoodwin, this needs to throw an exception for legacy clients
         if (pools.size() == 0) {
             throw new RuntimeException("No entitlements for products: " +
                 Arrays.toString(productIds));


### PR DESCRIPTION
Previously, autobind attempts for consumers with no products would result in a
stack trace in catalina.out. This causes some alarm to users like myself when
the "autobind the org" job runs, since it appears that something is broken. :scream_cat: 

Instead, print a message at INFO level.
