### PR TITLE
Bug 990113 - '500 Internal Server Error' importing manifest from stage

### DIFF
--- a/src/main/java/org/candlepin/model/Content.java
+++ b/src/main/java/org/candlepin/model/Content.java
@@ -26,6 +26,7 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.candlepin.service.UniqueIdGenerator;
@@ -147,6 +148,9 @@ public class Content extends AbstractHibernateObject {
     }
 
     public void setVendor(String vendor) {
+        if (StringUtils.isBlank(vendor)) {
+            vendor = "unknown";
+        }
         this.vendor = vendor;
     }
 


### PR DESCRIPTION
Was passing a value of empty string in the manifest for the field
Content.vendor. This got translated to null in the database column
and the field in non-null. Will use string 'unknown'. The data originates
too far away for us to control.
