### PR TITLE
990728: Refresh Manifest fails when the upstream distributor has all th...

### DIFF
--- a/spec/candlepin_scenarios.rb
+++ b/spec/candlepin_scenarios.rb
@@ -358,6 +358,28 @@ module ExportMethods
     unzip_export_file(File.join(@tmp_dir_update, "consumer_export.zip"), @tmp_dir_update)
   end
 
+  def create_candlepin_export_update_no_ent
+    ## We need to test the behavoir of the manifest update when no entitlements
+    ## are included
+    ## You must execute the create_candlepin_export method in the same test before
+    ## this one.
+    ents = @candlepin_client.list_entitlements()
+    # remove all entitlements
+    ents.each do |ent|
+      @cp.unbind_entitlement(ent.id, {:uuid => @candlepin_client.uuid})
+    end
+
+    # Make a temporary directory where we can safely extract our archive:
+    @tmp_dir_update = File.join(Dir.tmpdir, random_string('candlepin-rspec'))
+    @export_dir_update = File.join(@tmp_dir_update, "export")
+    Dir.mkdir(@tmp_dir_update)
+
+    @export_filename_update = @candlepin_client.export_consumer(@tmp_dir_update)
+    File.exist?(@export_filename_update).should == true
+    unzip_export_file(@export_filename_update, @tmp_dir_update)
+    unzip_export_file(File.join(@tmp_dir_update, "consumer_export.zip"), @tmp_dir_update)
+  end
+
   def cleanup_candlepin_export
     Dir.chdir(@orig_working_dir)
     FileUtils.rm_rf(@tmp_dir)

--- a/spec/import_update_spec.rb
+++ b/spec/import_update_spec.rb
@@ -12,8 +12,6 @@ describe 'Candlepin Import Update' do
     @import_owner_client = user_client(@import_owner, random_string('testuser'))
     @cp.import(@import_owner['key'], @export_filename)
     @sublist = @cp.list_subscriptions(@import_owner['key'])
-    create_candlepin_export_update()
-    @cp.import(@import_owner['key'], @export_filename_update)
   end
 
   after(:all) do
@@ -21,6 +19,9 @@ describe 'Candlepin Import Update' do
   end
 
   it 'should successfully update the import' do
+    create_candlepin_export_update()
+    @cp.import(@import_owner['key'], @export_filename_update)
+
     @sublist.size().should == 5
     new_sublist = @cp.list_subscriptions(@import_owner['key'])
     new_sublist.size().should == 6
@@ -39,4 +40,13 @@ describe 'Candlepin Import Update' do
     hasChanged.should == true
   end
 
+
+  it 'should remove all imported subscriptions if import has no entitlements' do
+    create_candlepin_export_update_no_ent()
+    @cp.import(@import_owner['key'], @export_filename_update)
+    # manifest consumer
+    @candlepin_client.list_entitlements().size.should == 0
+    # import owner 
+    @cp.list_subscriptions(@import_owner['key']).size.should == 0
+  end
 end

--- a/src/main/java/org/candlepin/sync/Importer.java
+++ b/src/main/java/org/candlepin/sync/Importer.java
@@ -412,8 +412,8 @@ public class Importer {
 
         // If the consumer has no entitlements, this products directory will end up empty.
         // This also implies there will be no entitlements to import.
+        Refresher refresher = poolManager.getRefresher();
         if (importFiles.get(ImportFile.PRODUCTS.fileName()) != null) {
-            Refresher refresher = poolManager.getRefresher();
             ProductImporter importer = new ProductImporter(productCurator, contentCurator);
 
             Set<Product> productsToImport = importProducts(
@@ -434,10 +434,12 @@ public class Importer {
             refresher.run();
         }
         else {
-            log.warn("No products found to import, skipping product and entitlement import.");
+            log.warn("No products found to import, skipping product import.");
+            log.warn("No entitlements in manifest, removing all subscriptions for owner.");
+            importEntitlements(owner, new HashSet<Product>(), new File[]{}, consumer);
+            refresher.add(owner);
+            refresher.run();
         }
-
-
         return consumer;
     }
 


### PR DESCRIPTION
...e subscriptions removed

As the manifest is the entirety of the definition of the distributor, if the
manifest update contains no entitlements, then the distributor must lose
all of its subscriptions.
