### PR TITLE
990113: '500 Internal Server Error' importing manifest from stag

### DIFF
--- a/src/main/java/org/candlepin/sync/ProductImporter.java
+++ b/src/main/java/org/candlepin/sync/ProductImporter.java
@@ -18,13 +18,15 @@ import java.io.IOException;
 import java.io.Reader;
 import java.util.Set;
 
-import org.codehaus.jackson.map.ObjectMapper;
+import org.apache.commons.lang.StringUtils;
+import org.candlepin.model.Content;
 import org.candlepin.model.ContentCurator;
 import org.candlepin.model.Product;
 import org.candlepin.model.ProductAttribute;
 import org.candlepin.model.ProductContent;
 import org.candlepin.model.ProductCurator;
 import org.candlepin.util.Util;
+import org.codehaus.jackson.map.ObjectMapper;
 
 import com.google.common.collect.Sets;
 
@@ -69,7 +71,13 @@ public class ProductImporter {
             // will be
             // updated multiple times during the import.
             for (ProductContent content : importedProduct.getProductContent()) {
-                contentCurator.createOrUpdate(content.getContent());
+                // BZ 990113 error occurs because incoming content data has
+                //  no value for Vendor. Will place one to avoid DB issues.
+                Content c = content.getContent();
+                if (StringUtils.isBlank(c.getVendor())) {
+                    c.setVendor("unknown");
+                }
+                contentCurator.createOrUpdate(c);
             }
 
             curator.createOrUpdate(importedProduct);

--- a/src/test/java/org/candlepin/sync/ProductImporterTest.java
+++ b/src/test/java/org/candlepin/sync/ProductImporterTest.java
@@ -389,10 +389,36 @@ public class ProductImporterTest {
         assertEquals(1, changed.size());
     }
 
+    @Test
+    public void testVendorSetToUnknown() throws Exception {
+        Product product = TestUtil.createProduct();
+        addNoVendorContentTo(product);
+
+        String json = getJsonForProduct(product);
+        Reader reader = new StringReader(json);
+        Product created = importer.createObject(mapper, reader);
+        Content c = created.getProductContent().iterator().next().getContent();
+        Set<Product> storeThese = new HashSet<Product>();
+        storeThese.add(created);
+        importer.store(storeThese);
+
+        verify(contentCuratorMock).createOrUpdate(c);
+
+        assertEquals("unknown", c.getVendor());
+    }
+
     // Returns the Content object added
     private void addContentTo(Product p) {
         Content c = new Content("name", "100130", "label", "type",
             "vendor", "url", "gpgurl", "arch");
+        c.setMetadataExpire(1000L);
+        p.getProductContent().add(new ProductContent(p, c, true));
+    }
+
+    // Returns the Content object added without vendor
+    private void addNoVendorContentTo(Product p) {
+        Content c = new Content("name", "100130", "label", "type",
+            "", "url", "gpgurl", "arch");
         c.setMetadataExpire(1000L);
         p.getProductContent().add(new ProductContent(p, c, true));
     }


### PR DESCRIPTION
Was passing a value of empty string in the manifest for the field
Content.vendor. This got translated to null in the database column
and the field i non-null. Will use string 'unknown'. The data originates
too far away for us to control.
