### PR TITLE
989698: Attempted fix for hornetq journal errors.

### DIFF
--- a/src/main/java/org/candlepin/audit/HornetqContextListener.java
+++ b/src/main/java/org/candlepin/audit/HornetqContextListener.java
@@ -85,10 +85,6 @@ public class HornetqContextListener {
             // in vm, who needs security?
             config.setSecurityEnabled(false);
 
-            int largeMsgSize =
-                candlepinConfig.getInt(ConfigProperties.HORNETQ_LARGE_MSG_SIZE);
-            //config.setJournalBufferSize_AIO(largeMsgSize);
-            config.setJournalBufferSize_NIO(largeMsgSize);
             // XXX: should use AIO when we get the native bindings working
             config.setJournalType(JournalType.NIO);
 

--- a/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -157,7 +157,7 @@ public class ConfigProperties {
                 this.put(ACTIVATION_DEBUG_PREFIX, "");
 
                 this.put(HORNETQ_BASE_DIR, "/var/lib/candlepin/hornetq");
-                this.put(HORNETQ_LARGE_MSG_SIZE, Integer.toString(10 * 1024));
+                this.put(HORNETQ_LARGE_MSG_SIZE, Integer.toString(100 * 1024));
                 this.put(AUDIT_LISTENERS,
                     "org.candlepin.audit.DatabaseListener," +
                         "org.candlepin.audit.LoggingListener," +


### PR DESCRIPTION
Unable to reproduce original bug with current config, however was able
to reproduce by removing explicit setting for journal size, and then
bumping the min-large message size up beyond the default value and
sending a huge message.

I believe it was incorrect to use the same value both for journal size,
and the min large message size, but I am not sure why the problem won't
happen locally. The large message size should always be smaller than the
journal buffer size. (equal is probably not correct either)

Attempted fix is to remove explicit setting of the journal size
and using the default ~500kb (which is much larger than we were setting)
Then bumping the min-large msg size to 100kb.
