### PR TITLE
don't list expired

### DIFF
--- a/src/main/java/org/candlepin/model/EntitlementCurator.java
+++ b/src/main/java/org/candlepin/model/EntitlementCurator.java
@@ -80,7 +80,14 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
 
     public List<Entitlement> listByConsumer(Consumer consumer) {
         Page<List<Entitlement>> p = listByConsumer(consumer, null);
-        return p.getPageData();
+        List<Entitlement> ents = p.getPageData();
+        //Don't show entitlements that are expired
+        for (int i = ents.size() - 1; i >= 0; i--) {
+            if (ents.get(i).getEndDate().before(new Date())) {
+                ents.remove(i);
+            }
+        }
+        return ents;
     }
 
     public List<Entitlement> listByEnvironment(Environment environment) {


### PR DESCRIPTION
I'm not sure if this is the best solution, or if we should even consider it a problem.

Server re-serializes expired certs after they expire, but before they are cleaned up.  This keeps an expired cert on the clients disk.  Subscription-manager ignores the certificate, so it's not a problem, and the client will get rid of the certificate on its next check-in after the server deletes it.

This patch just filters the list of reported entitlements, perhaps we should force the removal at this point, if that is possible.
