### PR TITLE
994711: protect against consuming other org ents

### DIFF
--- a/spec/consumer_resource_spec.rb
+++ b/spec/consumer_resource_spec.rb
@@ -19,7 +19,17 @@ describe 'Consumer Resource' do
     @consumer2 = consumer_client(@user2, random_string("consumer2"))
   end
 
-   it 'should receive paged data back when requested' do
+  it "should block consumers from using other org's pools" do
+    product1 = create_product
+    sub = @cp.create_subscription(@owner1['key'], product1.id)
+    @cp.refresh_pools(@owner1['key'])
+    pool = @consumer1.list_pools({:owner => @owner1['id']}).first
+    lambda {
+      @consumer2.consume_pool(pool.id).size.should == 1
+    }.should raise_exception(RestClient::Forbidden)
+  end
+
+  it 'should receive paged data back when requested' do
     (1..4).each do |i|
       consumer_client(@user1, random_string('system'))
     end

--- a/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -1308,7 +1308,7 @@ public class ConsumerResource {
     @Path("/{consumer_uuid}/entitlements")
     public Response bind(
         @PathParam("consumer_uuid") @Verify(Consumer.class) String consumerUuid,
-        @QueryParam("pool") String poolIdString,
+        @QueryParam("pool") @Verify(Pool.class) String poolIdString,
         @QueryParam("product") String[] productIds,
         @QueryParam("quantity") @DefaultValue("1") Integer quantity,
         @QueryParam("email") String email,


### PR DESCRIPTION
# TEST

Deploy Candlepin, then use a system running subscription-manager to test against:

``` #!/bin/bash
# register to grumpy to snowshites org
sudo subscription-manager register --username grumpy --password password --org snowwhite --force

# get a list of available pools, and pick the last one
POOL=$(sudo subscription-manager list --available | grep ^Pool | tail -1 | cut -f2 -d':')

# strip whitespace
POOL="${POOL//[[:space:]]/}"

# register to user huey in donaldducks org
sudo subscription-manager register --username huey --password password --org donaldduck --force

# verify it's not in the list available
sudo subscription-manager list --available | grep "${POOL}"

# subscribe to it anyway
sudo subscription-manager subscribe --pool "${POOL}"

sudo subscription-manager list --consumed
```

You should get an Insufficient permissions error. Here is sample output of the expected behavior.

```
The system has been registered with ID: 60d1d38d-6487-4ead-87a8-f3b6215189d2 
The system with UUID 60d1d38d-6487-4ead-87a8-f3b6215189d2 has been unregistered
The system has been registered with ID: 089d8735-7a91-4d6e-afab-d84ec701965a 
Insufficient permissions
No consumed subscription pools to list
```
