### PR TITLE
996925: Exception while deleting manifest

### DIFF
--- a/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -178,7 +178,9 @@ public class CandlepinPoolManager implements PoolManager {
         // delete pools whose subscription disappeared:
         for (Entry<String, List<Pool>> entry : subToPoolMap.entrySet()) {
             for (Pool p : entry.getValue()) {
-                deletePool(p);
+                if (!p.hasAttribute("pool_derived")) {
+                    deletePool(p);
+                }
             }
         }
 

--- a/src/main/java/org/candlepin/model/ActivationKey.java
+++ b/src/main/java/org/candlepin/model/ActivationKey.java
@@ -14,14 +14,9 @@
  */
 package org.candlepin.model;
 
-import org.hibernate.annotations.ForeignKey;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Index;
-
 import java.util.HashSet;
 import java.util.Set;
 
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -34,6 +29,11 @@ import javax.persistence.UniqueConstraint;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
+
+import org.hibernate.annotations.Cascade;
+import org.hibernate.annotations.ForeignKey;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Index;
 
 /**
  * ActivationKey
@@ -61,8 +61,10 @@ public class ActivationKey extends AbstractHibernateObject implements Owned {
     @Index(name = "cp_activation_key_owner_fk_idx")
     private Owner owner;
 
-    @OneToMany(cascade = CascadeType.ALL, mappedBy = "key")
-    @org.hibernate.annotations.Cascade(org.hibernate.annotations.CascadeType.DELETE_ORPHAN)
+    @OneToMany(mappedBy = "key")
+    @Cascade({org.hibernate.annotations.CascadeType.ALL,
+        org.hibernate.annotations.CascadeType.DELETE_ORPHAN})
+
     private Set<ActivationKeyPool> pools = new HashSet<ActivationKeyPool>();
 
     public ActivationKey() {

--- a/src/main/java/org/candlepin/model/Consumer.java
+++ b/src/main/java/org/candlepin/model/Consumer.java
@@ -146,7 +146,6 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
 
     @OneToMany(mappedBy = "consumer", targetEntity = ConsumerInstalledProduct.class)
     @Cascade({org.hibernate.annotations.CascadeType.ALL,
-        org.hibernate.annotations.CascadeType.MERGE,
         org.hibernate.annotations.CascadeType.DELETE_ORPHAN})
     private Set<ConsumerInstalledProduct> installedProducts;
 
@@ -155,13 +154,11 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
 
     @OneToMany(mappedBy = "consumer", targetEntity = GuestId.class)
     @Cascade({org.hibernate.annotations.CascadeType.ALL,
-        org.hibernate.annotations.CascadeType.MERGE,
         org.hibernate.annotations.CascadeType.DELETE_ORPHAN})
     private List<GuestId> guestIds;
 
     @OneToMany(mappedBy = "consumer", targetEntity = ConsumerCapability.class)
     @Cascade({org.hibernate.annotations.CascadeType.ALL,
-        org.hibernate.annotations.CascadeType.MERGE,
         org.hibernate.annotations.CascadeType.DELETE_ORPHAN})
     private Set<ConsumerCapability> capabilities;
 

--- a/src/main/java/org/candlepin/model/DistributorVersion.java
+++ b/src/main/java/org/candlepin/model/DistributorVersion.java
@@ -61,7 +61,6 @@ public class DistributorVersion extends AbstractHibernateObject {
     @OneToMany(mappedBy = "distributorVersion", targetEntity =
         DistributorVersionCapability.class)
     @Cascade({org.hibernate.annotations.CascadeType.ALL,
-        org.hibernate.annotations.CascadeType.MERGE,
         org.hibernate.annotations.CascadeType.DELETE_ORPHAN})
     private Set<DistributorVersionCapability> capabilities;
 

--- a/src/main/java/org/candlepin/model/Pool.java
+++ b/src/main/java/org/candlepin/model/Pool.java
@@ -136,7 +136,6 @@ public class Pool extends AbstractHibernateObject implements Persisted, Owned {
 
     @OneToMany(targetEntity = ProvidedProduct.class)
     @Cascade({org.hibernate.annotations.CascadeType.ALL,
-        org.hibernate.annotations.CascadeType.MERGE,
         org.hibernate.annotations.CascadeType.DELETE_ORPHAN})
     @JoinColumn(name = "pool_id", insertable = false, updatable = false)
     @Where(clause = "dtype='provided'")
@@ -144,31 +143,27 @@ public class Pool extends AbstractHibernateObject implements Persisted, Owned {
 
     @OneToMany(targetEntity = DerivedProvidedProduct.class)
     @Cascade({org.hibernate.annotations.CascadeType.ALL,
-        org.hibernate.annotations.CascadeType.MERGE,
         org.hibernate.annotations.CascadeType.DELETE_ORPHAN})
     @JoinColumn(name = "pool_id", insertable = false, updatable = false)
     @Where(clause = "dtype='derived'")
     private Set<DerivedProvidedProduct> derivedProvidedProducts =
         new HashSet<DerivedProvidedProduct>();
 
-    @OneToMany(cascade = CascadeType.ALL, mappedBy = "pool")
+    @OneToMany(mappedBy = "pool")
     @Cascade({org.hibernate.annotations.CascadeType.ALL,
-        org.hibernate.annotations.CascadeType.MERGE,
         org.hibernate.annotations.CascadeType.DELETE_ORPHAN})
     private Set<PoolAttribute> attributes = new HashSet<PoolAttribute>();
 
-    @OneToMany(cascade = CascadeType.ALL)
+    @OneToMany
     @Cascade({org.hibernate.annotations.CascadeType.ALL,
-        org.hibernate.annotations.CascadeType.MERGE,
         org.hibernate.annotations.CascadeType.DELETE_ORPHAN})
     @JoinColumn(name = "pool_id", insertable = false, updatable = false)
     @Where(clause = "dtype='product'")
     private Set<ProductPoolAttribute> productAttributes =
         new HashSet<ProductPoolAttribute>();
 
-    @OneToMany(cascade = CascadeType.ALL)
+    @OneToMany
     @Cascade({org.hibernate.annotations.CascadeType.ALL,
-        org.hibernate.annotations.CascadeType.MERGE,
         org.hibernate.annotations.CascadeType.DELETE_ORPHAN})
     @JoinColumn(name = "pool_id", insertable = false, updatable = false)
     @Where(clause = "dtype='derived'")

--- a/src/main/java/org/candlepin/model/Product.java
+++ b/src/main/java/org/candlepin/model/Product.java
@@ -17,7 +17,6 @@ package org.candlepin.model;
 import java.util.HashSet;
 import java.util.Set;
 
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
@@ -68,9 +67,8 @@ public class Product extends AbstractHibernateObject implements Linkable {
     // NOTE: we need a product "type" so we can tell what class of
     // product we are...
 
-    @OneToMany(cascade = CascadeType.ALL, mappedBy = "product")
+    @OneToMany(mappedBy = "product")
     @Cascade({ org.hibernate.annotations.CascadeType.ALL,
-        org.hibernate.annotations.CascadeType.MERGE,
         org.hibernate.annotations.CascadeType.DELETE_ORPHAN })
     private Set<ProductAttribute> attributes;
 

--- a/src/test/java/org/candlepin/model/test/PoolCuratorTest.java
+++ b/src/test/java/org/candlepin/model/test/PoolCuratorTest.java
@@ -634,4 +634,26 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         Pool pool = poolCurator.getSubPoolForStackId(consumer, expectedStackId);
         assertNotNull(pool);
     }
+
+    @Test (expected = IllegalArgumentException.class)
+    public void confirmExceptionOnBonusPoolDelete() {
+        Subscription sub = new Subscription(owner, product, new HashSet<Product>(), 16L,
+            TestUtil.createDate(2006, 10, 21), TestUtil.createDate(2020, 1, 1), new Date());
+        subCurator.create(sub);
+
+        Pool sourcePool = poolManager.createPoolsForSubscription(sub).get(0);
+        poolCurator.create(sourcePool);
+        Entitlement e = new Entitlement(sourcePool, consumer, sourcePool.getStartDate(),
+            sourcePool.getEndDate(), 1);
+        entitlementCurator.create(e);
+
+        Pool pool2 = TestUtil.createPool(owner, product);
+        pool2.setSourceEntitlement(e);
+        pool2.setSubscriptionId(sourcePool.getSubscriptionId());
+        poolCurator.create(pool2);
+
+        assertTrue(poolCurator.lookupBySubscriptionId(sub.getId()).size() == 2);
+        poolManager.deletePool(sourcePool);
+        poolManager.deletePool(pool2);
+    }
 }


### PR DESCRIPTION
The error is caused by the refresh pools. If a source pool is deleted before
the bonus pool, the deletion of the bonus pool causes the error in the trace.
In this scenario, the bonus pools will now not be deleted explicitly.

Also cleaned up the annotations as both javax.persistence.CascadeType.ALL and
hibernate.CascadeType.ALL were used on the same relationship. This has been shown
to cause conflicts. Removed the hibernate.CascadeType.MERGE because it is redundant.
