### PR TITLE
750872: complete partial stacks with no installed products

### DIFF
--- a/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -463,10 +463,19 @@ public class CandlepinPoolManager implements PoolManager {
 
         for (Pool pool : allOwnerPools) {
             boolean providesProduct = false;
-            for (String productId : productIds) {
-                if (pool.provides(productId)) {
-                    providesProduct = true;
-                    break;
+            // If We want to complete partial stacks if possible,
+            // even if they do not provide any products
+            if (pool.hasProductAttribute("stacking_id") &&
+                    compliance.getPartialStacks().containsKey(
+                        pool.getProductAttribute("stacking_id").getValue())) {
+                providesProduct = true;
+            }
+            else {
+                for (String productId : productIds) {
+                    if (pool.provides(productId)) {
+                        providesProduct = true;
+                        break;
+                    }
                 }
             }
             if (providesProduct) {


### PR DESCRIPTION
Filtering pools here can still cause problems with stacks where different entitlements provide different products, only some of which are installed.  I don't think that is a real case out in the wild though.

Why don't we just let the rules do filtering?
