### PR TITLE
1000444: Fixed find by stack id query

### DIFF
--- a/src/main/java/org/candlepin/model/EntitlementCurator.java
+++ b/src/main/java/org/candlepin/model/EntitlementCurator.java
@@ -351,14 +351,14 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
     public List<Entitlement> findByStackId(Consumer consumer, String stackId) {
         DetachedCriteria stackCriteria = DetachedCriteria.forClass(
             ProductPoolAttribute.class, "attr")
-                .add(Restrictions.and(Restrictions.eq("name", "stacking_id"),
-                    Restrictions.eq("value", stackId)))
-                .add(Property.forName("pool.id").eqProperty("attr.pool.id"))
+                .add(Restrictions.eq("name", "stacking_id"))
+                .add(Restrictions.eq("value", stackId))
+                .add(Property.forName("ent_pool.id").eqProperty("attr.pool.id"))
                 .setProjection(Projections.property("attr.id"));
 
         Criteria activeNowQuery = currentSession().createCriteria(Entitlement.class)
             .add(Restrictions.eq("consumer", consumer))
-            .createCriteria("pool")
+            .createCriteria("pool", "ent_pool")
                 .add(Restrictions.isNull("sourceEntitlement"))
                 .add(Restrictions.isNull("sourceStackId"))
                 .add(Subqueries.exists(stackCriteria));


### PR DESCRIPTION
The pool id comparison in the detached criteria was actually comparing
that the attributes pool id was the same as itself, which would yeild a
match for any entitlement after an entitlement was added with the correct
stack id.

The fix was to alias the pool criteria in the main query, and reference it
in the detached criteria. Detached criteria was comparing the attributes
pool.id to iteself, but the main criteria also had pool. Using alias
avoids the common name.
