### PR TITLE
998317: check delete for null

### DIFF
--- a/src/main/java/org/candlepin/model/PoolCurator.java
+++ b/src/main/java/org/candlepin/model/PoolCurator.java
@@ -550,7 +550,12 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
         }
         entity.getAttributes().clear();
 
-        currentSession().delete(toDelete);
+        if (toDelete != null) {
+            currentSession().delete(toDelete);
+        }
+        else {
+            log.info("Pool " + entity.getId() + " not found. Skipping deletion. noop");
+        }
     }
 
     /**

--- a/src/test/java/org/candlepin/model/test/PoolCuratorTest.java
+++ b/src/test/java/org/candlepin/model/test/PoolCuratorTest.java
@@ -635,8 +635,8 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         assertNotNull(pool);
     }
 
-    @Test (expected = IllegalArgumentException.class)
-    public void confirmExceptionOnBonusPoolDelete() {
+    @Test
+    public void confirmBonusPoolDeleted() {
         Subscription sub = new Subscription(owner, product, new HashSet<Product>(), 16L,
             TestUtil.createDate(2006, 10, 21), TestUtil.createDate(2020, 1, 1), new Date());
         subCurator.create(sub);
@@ -654,6 +654,21 @@ public class PoolCuratorTest extends DatabaseTestFixture {
 
         assertTrue(poolCurator.lookupBySubscriptionId(sub.getId()).size() == 2);
         poolManager.deletePool(sourcePool);
-        poolManager.deletePool(pool2);
+
+        // because we check for null now, we want to verify the
+        // subpool gets deleted when the original pool is deleted.
+        Pool gone = poolCurator.find(pool2.getId());
+        assertEquals(gone, null);
+    }
+
+    @Test
+    public void handleNull() {
+        Pool noexist = new Pool(owner, product.getId(), product.getName(),
+            new HashSet<ProvidedProduct>(), 1L, TestUtil.createDate(2011, 3, 2),
+            TestUtil.createDate(2055, 3, 2),
+            "", "", "");
+        noexist.setId("betternotexist");
+
+        poolCurator.delete(noexist);
     }
 }


### PR DESCRIPTION
If the pool we are deleting is not found, check it for null and log
if we're skipping it.
