### PR TITLE
Fix unlimited stackable pool autobinding, fix unlimited pool quantity

### DIFF
--- a/src/test/java/org/candlepin/policy/js/quantity/QuantityRulesTest.java
+++ b/src/test/java/org/candlepin/policy/js/quantity/QuantityRulesTest.java
@@ -203,6 +203,15 @@ public class QuantityRulesTest {
     }
 
     @Test
+    public void testUnlimitedQuantity() {
+        consumer.setFact(SOCKET_FACT, "8");
+        pool.setProductAttribute(SOCKET_ATTRIBUTE, "2", product.getId());
+        pool.setQuantity(new Long(-1));
+        SuggestedQuantity suggested = quantityRules.getSuggestedQuantity(pool, consumer);
+        assertEquals(new Long(4), suggested.getSuggested());
+    }
+
+    @Test
     public void testIsNotVirtWhenFactIsFalse() {
         consumer.setFact(IS_VIRT, "false");
         consumer.setFact(SOCKET_FACT, "4");

--- a/src/test/java/org/candlepin/policy/test/AutobindRulesTest.java
+++ b/src/test/java/org/candlepin/policy/test/AutobindRulesTest.java
@@ -701,6 +701,27 @@ public class AutobindRulesTest {
             new String[]{ product.getId() }, pools, compliance, null,
             new HashSet<String>());
         assertEquals(1, bestPools.size());
+        assertEquals(new Integer(1), bestPools.get(0).getQuantity());
+        assertEquals("POOL-ID", bestPools.get(0).getPool().getId());
     }
 
+    @Test
+    public void unlimitedStackedPoolIsPickedUp() {
+        consumer.setFact("cpu.cpu_socket(s)", "8");
+        Product product = mockStackingProduct(productId, "my-prod", "stackid", "2");
+        Pool pool = TestUtil.createPool(owner, product, -1);
+        pool.setId("POOL-ID");
+
+        when(this.prodAdapter.getProductById(product.getId())).thenReturn(product);
+
+        List<Pool> pools = new LinkedList<Pool>();
+        pools.add(pool);
+
+        List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
+            new String[]{ product.getId() }, pools, compliance, null,
+            new HashSet<String>());
+        assertEquals(1, bestPools.size());
+        assertEquals(new Integer(4), bestPools.get(0).getQuantity());
+        assertEquals("POOL-ID", bestPools.get(0).getPool().getId());
+    }
 }


### PR DESCRIPTION
Support quantities > 1 from unlimited multi-entitlement/stackable pools.

Fixed CoverageCalculator.getQuantityToCoverStack to work with unlimited pools, use it to get an upper bound for the quantity required of unlimited pools.

Use currently_available pool variable rather than modifying pool.quantity and pool.consumed.  This variable is created in the creation of autobind context (only available/used in autobind).

Removed date checking in autobind, the exact same check is done in pre-entitlement, and it was a pain to support in tests.
