### PR TITLE
1002946: Fix entitlement dates not being updated when pool dates change.

### DIFF
--- a/spec/one_sub_pool_per_stack_spec.rb
+++ b/spec/one_sub_pool_per_stack_spec.rb
@@ -21,7 +21,7 @@ describe 'One Sub Pool Per Stack Feature' do
             'multi-entitlement' => 'yes'
         }
     })
-    
+
     @virt_limit_product2 = create_product(nil, nil, {
         :attributes => {
             'virt_limit' => 6,
@@ -29,7 +29,7 @@ describe 'One Sub Pool Per Stack Feature' do
             'multi-entitlement' => 'yes'
         }
     })
-    
+
     @virt_limit_provided_product = create_product()
 
     @regular_stacked_product = create_product(nil, nil, {
@@ -58,7 +58,7 @@ describe 'One Sub Pool Per Stack Feature' do
         'multi-entitlement' => "yes"
       }
     })
-    
+
     @derived_product = create_product(nil, nil, {
       :attributes => {
           :cores => '6',
@@ -99,19 +99,19 @@ describe 'One Sub Pool Per Stack Feature' do
     @stacked_non_virt_sub_diff_stack_id = @cp.create_subscription(@owner['key'],
       @stacked_product_diff_id.id, 2, [], "888")
     @cp.refresh_pools(@owner['key'])
-    
+
     # Determine our pools by matching on contract number.
     pools = @user.list_pools :owner => @owner.id
-    
+
     @initial_pool_count = pools.size
     @initial_pool_count.should == 7
-    
+
     @stacked_virt_pool1 = pools.detect { |p| p['contractNumber'] == "123" }
     @stacked_virt_pool1.should_not be_nil
 
     @stacked_virt_pool2 = pools.detect { |p| p['contractNumber'] == "456" }
     @stacked_virt_pool2.should_not be_nil
-    
+
     @stacked_virt_pool3 = pools.detect { |p| p['contractNumber'] == "444" }
     @stacked_virt_pool3.should_not be_nil
 
@@ -120,13 +120,13 @@ describe 'One Sub Pool Per Stack Feature' do
 
     @non_stacked_pool = pools.detect { |p| p['contractNumber'] == "234" }
     @non_stacked_pool.should_not be_nil
-    
+
     @datacenter_pool = pools.detect { |p| p['contractNumber'] == '222' }
     @datacenter_pool.should_not be_nil
-    
+
     @regular_stacked_with_diff_stackid = pools.detect { |p| p['contractNumber'] == '888' }
     @regular_stacked_with_diff_stackid.should_not be_nil
-    
+
     # Setup two a guest consumer:
     @guest_uuid = random_string('system.uuid')
     @guest = @user.register(random_string('guest'), :system, nil,
@@ -174,11 +174,11 @@ describe 'One Sub Pool Per Stack Feature' do
   it 'should not include host entitlements from another stack' do
     ent1 = @host_client.consume_pool(@regular_stacked_with_diff_stackid['id'])[0]
     ent2 = @host_client.consume_pool(@stacked_virt_pool1['id'])[0]
-   
+
     sub_pool = find_sub_pool(@guest_client, @guest['uuid'], @stack_id)
     sub_pool.should_not be_nil
     find_product_attribute(sub_pool, "sockets").should be_nil
-    
+
     sub_pool['startDate'].should == ent1['startDate']
     sub_pool['endDate'].should == ent1['endDate']
   end
@@ -188,22 +188,22 @@ describe 'One Sub Pool Per Stack Feature' do
     ent2 = @host_client.consume_pool(@stacked_virt_pool2['id'])[0]
     ent3 = @host_client.consume_pool(@stacked_non_virt_pool['id'])[0]
     @host_client.list_entitlements.length.should == 3
-    
+
     sub_pool = find_sub_pool(@guest_client, @guest['uuid'], @stack_id)
     sub_pool.should_not be_nil
-    
+
     @host_client.unbind_entitlement(ent1['id'])
     @host_client.unbind_entitlement(ent2['id'])
     @host_client.unbind_entitlement(ent3['id'])
     @host_client.list_entitlements.length.should == 0
-    
+
     find_sub_pool(@guest_client, @guest['uuid'], @stack_id).should be_nil
   end
 
   it 'should update sub pool date range when another stacked entitlement is added' do
     ent1 = @host_client.consume_pool(@stacked_virt_pool1['id'])[0]
     ent2 = @host_client.consume_pool(@stacked_virt_pool2['id'])[0]
-   
+
     sub_pool = find_sub_pool(@guest_client, @guest['uuid'], @stack_id)
     sub_pool.should_not be_nil
 
@@ -217,14 +217,14 @@ describe 'One Sub Pool Per Stack Feature' do
 
     sub_pool = find_sub_pool(@guest_client, @guest['uuid'], @stack_id)
     sub_pool.should_not be_nil
-    
+
     # Check that the product data was copied.
     check_product_attr_value(sub_pool, "virt_limit", '3')
     check_product_attr_value(sub_pool, "multi-entitlement", 'yes')
     check_product_attr_value(sub_pool, "sockets", "6")
     check_product_attr_value(sub_pool, "stacking_id", @stack_id)
   end
-  
+
   it 'should update provided products when stacked entitlements change' do
     ent1 = @host_client.consume_pool(@stacked_virt_pool1['id'])[0]
 
@@ -238,15 +238,15 @@ describe 'One Sub Pool Per Stack Feature' do
     sub_pool = find_sub_pool(@guest_client, @guest['uuid'], @stack_id)
     sub_pool.should_not be_nil
     sub_pool['providedProducts'].length.should == 2
-    
+
     @host_client.unbind_entitlement(ent1['id'])
-    
+
     sub_pool = find_sub_pool(@guest_client, @guest['uuid'], @stack_id)
     sub_pool.should_not be_nil
     sub_pool['providedProducts'].length.should == 1
     sub_pool['providedProducts'][0]['productId'].should == @regular_stacked_provided_product.id
   end
-  
+
   it 'should incude derived provided products if supporting entitlements are in stack' do
     ent1 = @host_client.consume_pool(@datacenter_pool['id'])[0]
     ent1.should_not be_nil
@@ -263,23 +263,23 @@ describe 'One Sub Pool Per Stack Feature' do
     sub_pool = find_sub_pool(@guest_client, @guest['uuid'], @stack_id)
     sub_pool.should_not be_nil
     sub_pool['providedProducts'].length.should == 2
-    
+
     @host_client.unbind_entitlement(ent1['id'])
-    
+
     sub_pool = find_sub_pool(@guest_client, @guest['uuid'], @stack_id)
     sub_pool.should_not be_nil
     sub_pool['providedProducts'].length.should == 1
     sub_pool['providedProducts'][0]['productId'].should == @regular_stacked_provided_product.id
   end
-  
+
   it 'should update product data on removing entitlement of same stack' do
     ent1 = @host_client.consume_pool(@stacked_virt_pool1['id'])[0]
     ent2 = @host_client.consume_pool(@stacked_non_virt_pool['id'])[0]
     @host_client.unbind_entitlement(ent1['id'])
-    
+
     sub_pool = find_sub_pool(@guest_client, @guest['uuid'], @stack_id)
     sub_pool.should_not be_nil
-    
+
     find_product_attribute(sub_pool, "virt_limit").should be_nil
     check_product_attr_value(sub_pool, "multi-entitlement", 'yes')
     check_product_attr_value(sub_pool, "sockets", "6")
@@ -288,92 +288,92 @@ describe 'One Sub Pool Per Stack Feature' do
 
   it 'should not update product data from products not in the stack' do
     ent1 = @host_client.consume_pool(@stacked_virt_pool1['id'])[0]
-    ent2 = @host_client.consume_pool(@non_stacked_pool['id'])[0]	
+    ent2 = @host_client.consume_pool(@non_stacked_pool['id'])[0]
     ent2.should_not be_nil
-    
+
     sub_pool = find_sub_pool(@guest_client, @guest['uuid'], @stack_id)
     sub_pool.should_not be_nil
-    
+
     # Check that cores was not added from the non stacked ent.
     find_product_attribute(sub_pool, "cores").should be_nil
   end
-  
+
   it 'should revoke guest entitlement from sub pool when last host ent in stack is removed' do
     ent1 = @host_client.consume_pool(@stacked_virt_pool1['id'])[0]
     ent2 = @host_client.consume_pool(@stacked_virt_pool2['id'])[0]
     ent3 = @host_client.consume_pool(@stacked_non_virt_pool['id'])[0]
     @host_client.list_entitlements.length.should == 3
-    
+
     sub_pool = find_sub_pool(@guest_client, @guest['uuid'], @stack_id)
     sub_pool.should_not be_nil
-    
+
     @guest_client.consume_pool(sub_pool['id'])
     @guest_client.list_entitlements.length.should == 1
-    
+
     @host_client.unbind_entitlement(ent1['id'])
     @host_client.unbind_entitlement(ent2['id'])
     @host_client.unbind_entitlement(ent3['id'])
     @host_client.list_entitlements.length.should == 0
-    
+
     # Guest entitlement should now be revoked.
     @guest_client.list_entitlements.length.should == 0
   end
-  
+
   it 'should remove guest entitlement when host unregisters' do
     ent1 = @host_client.consume_pool(@stacked_virt_pool1['id'])[0]
     ent2 = @host_client.consume_pool(@stacked_virt_pool2['id'])[0]
     ent3 = @host_client.consume_pool(@stacked_non_virt_pool['id'])[0]
     @host_client.list_entitlements.length.should == 3
-    
+
     sub_pool = find_sub_pool(@guest_client, @guest['uuid'], @stack_id)
     sub_pool.should_not be_nil
-    
+
     @guest_client.consume_pool(sub_pool['id'])
     @guest_client.list_entitlements.length.should == 1
-    
+
     @host_client.unregister
-    
+
     # Guest entitlement should now be revoked.
     @guest_client.list_entitlements.length.should == 0
   end
-  
+
   it 'should remove guest entitlement when guest is migrated' do
     ent1 = @host_client.consume_pool(@stacked_virt_pool1['id'])[0]
     sub_pool = find_sub_pool(@guest_client, @guest['uuid'], @stack_id)
     sub_pool.should_not be_nil
-    
+
     @guest_client.consume_pool(sub_pool['id'])
     @guest_client.list_entitlements.length.should == 1
-    
+
     # Simulate migration
     @host2_client.update_consumer({:guestIds => [{'guestId' => @guest_uuid}]})
-    
+
     # Guest entitlement should now be revoked.
     @guest_client.list_entitlements.length.should == 0
   end
-  
+
   it 'should update guest sub pool ent when product is updated' do
     # Attach sub to host and ensure sub pool is created.
     host_ent = @host_client.consume_pool(@stacked_virt_pool1['id'])[0]
     sub_pool = find_sub_pool(@guest_client, @guest['uuid'], @stack_id)
     sub_pool.should_not be_nil
-    
+
     # Consumer ent for guest
     initial_guest_ent = @guest_client.consume_pool(sub_pool['id'])[0]
     initial_guest_ent.should_not be_nil
     find_product_attribute(initial_guest_ent.pool, "sockets").should be_nil
-    
+
     attrs = @virt_limit_product['attributes']
     attrs << {"name" => "sockets", "value" => "4"}
     @cp.update_product(@virt_limit_product.id, :attributes => attrs)
     updated_product = @cp.get_product(@virt_limit_product.id)
-    
+
     @cp.refresh_pools(@owner['key'])
-    
+
     updated_ent = @guest_client.list_entitlements[0]
     check_product_attr_value(updated_ent.pool, "sockets", "4")
   end
-  
+
   it 'should update guest sub pool ent as host stack is updated' do
     @host_client.consume_pool(@stacked_virt_pool1['id'])
     ent = @host_client.consume_pool(@stacked_non_virt_pool['id'])[0]
@@ -381,10 +381,10 @@ describe 'One Sub Pool Per Stack Feature' do
     sub_pool = find_sub_pool(@guest_client, @guest['uuid'], @stack_id)
     sub_pool.should_not be_nil
     initial_guest_ent = @guest_client.consume_pool(sub_pool['id'])[0]
-    
+
     # Remove an ent from the host so that the guest ent will be updated.
     @host_client.unbind_entitlement(ent['id'])
-    
+
     # Check that the product data was copied.
     updated_ent = @guest_client.list_entitlements[0]
     check_product_attr_value(updated_ent.pool, "virt_limit", '3')
@@ -392,7 +392,7 @@ describe 'One Sub Pool Per Stack Feature' do
     check_product_attr_value(updated_ent.pool, "stacking_id", @stack_id)
     find_product_attribute(updated_ent.pool, "sockets").should be_nil
   end
-  
+
   it 'should update quantity of sub pool when stack changes' do
     ent1 = @host_client.consume_pool(@stacked_virt_pool1['id'])[0]
     ent2 = @host_client.consume_pool(@stacked_non_virt_pool['id'])[0]
@@ -413,7 +413,7 @@ describe 'One Sub Pool Per Stack Feature' do
     # specifying virt_limit -- use the last instead.
     sub_pool['quantity'].should == 6
   end
-  
+
   it 'should regenerate ent certs when sub pool is update and client checks in' do
     @host_client.consume_pool(@stacked_virt_pool1['id'])
 
@@ -423,10 +423,10 @@ describe 'One Sub Pool Per Stack Feature' do
     initial_guest_ent.should_not be_nil
     initial_guest_ent["certificates"].length.should == 1
     initial_guest_cert = initial_guest_ent['certificates'][0]
-    
+
     # Grab another ent for the host to force a change in the guest's cert.
     @host_client.consume_pool(@stacked_virt_pool2['id'])[0]
-    
+
     # Listing the certs will cause a regeneration of dirty ents before
     # returning them (simulate client checkin).
     guest_certs = @guest_client.list_certificates()
@@ -434,6 +434,12 @@ describe 'One Sub Pool Per Stack Feature' do
     regenerated_cert = guest_certs[0]
     # Make sure that it was regenerated.
     regenerated_cert['id'].should_not == initial_guest_cert['id']
+
+    # Make sure the entitlement picked up the pool's date change:
+    initial_guest_ent = @guest_client.get_entitlement(initial_guest_ent['id'])
+    sub_pool = @guest_client.get_pool(sub_pool['id'])
+    initial_guest_ent['startDate'].should == sub_pool['startDate']
+    initial_guest_ent['endDate'].should == sub_pool['endDate']
   end
 
   it 'should not regenerate certs on refresh pools when sub pool has not been changed' do
@@ -445,10 +451,10 @@ describe 'One Sub Pool Per Stack Feature' do
     initial_guest_ent.should_not be_nil
     initial_guest_ent["certificates"].length.should == 1
     initial_guest_cert = initial_guest_ent['certificates'][0]
-    
+
     # Perform refresh pools -- an old bug marked sub pool as dirty
     @cp.refresh_pools(@owner['key'])
-    
+
     # Listing the certs will cause a regeneration of dirty ents before
     # returning them (simulate client checkin).
     guest_certs = @guest_client.list_certificates()
@@ -461,16 +467,16 @@ describe 'One Sub Pool Per Stack Feature' do
   def find_product_attribute(pool, attribute_name)
     return pool['productAttributes'].detect { |a| a['name'] == attribute_name }
   end
-  
+
   def check_product_attr_value(pool, attribute_name, expected_value)
     attribute = find_product_attribute(pool, attribute_name)
     attribute.should_not be_nil
     attribute['value'].should == expected_value
   end
-  
+
   def find_sub_pool(guest_client, guest_uuid, stack_id)
     guest_pools = guest_client.list_pools(:consumer => guest_uuid)
     return guest_pools.detect { |i| i['sourceStackId'] == stack_id }
   end
-  
+
 end

--- a/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -289,15 +289,6 @@ public class CandlepinPoolManager implements PoolManager {
                 updatedPool.getProductsChanged()) {
                 List<Entitlement> entitlements = poolCurator
                     .retrieveFreeEntitlementsOfPool(existingPool, true);
-
-                // when subscription dates change, entitlement dates should
-                // change as well
-                for (Entitlement entitlement : entitlements) {
-                    entitlement.setStartDate(updatedPool.getPool().getStartDate());
-                    entitlement.setEndDate(updatedPool.getPool().getEndDate());
-                    // TODO: perhaps optimize it to use hibernate query?
-                    this.entitlementCurator.merge(entitlement);
-                }
                 entitlementsToRegen.addAll(entitlements);
             }
             // save changes for the pool
@@ -1031,7 +1022,7 @@ public class CandlepinPoolManager implements PoolManager {
         public Entitlement handleEntitlement(Consumer consumer, Pool pool,
             Entitlement entitlement, int quantity) {
             Entitlement newEntitlement = new Entitlement(pool, consumer,
-                pool.getStartDate(), pool.getEndDate(), quantity);
+                quantity);
             consumer.addEntitlement(newEntitlement);
             pool.getEntitlements().add(newEntitlement);
             return newEntitlement;

--- a/src/main/java/org/candlepin/model/Entitlement.java
+++ b/src/main/java/org/candlepin/model/Entitlement.java
@@ -89,9 +89,6 @@ public class Entitlement extends AbstractHibernateObject implements Linkable, Ow
     @Index(name = "cp_entitlement_pool_fk_idx")
     private Pool pool;
 
-    private Date startDate;
-    private Date endDate;
-
     // Not positive this should be mapped here, not all entitlements will have
     // certificates.
     @OneToMany(mappedBy = "entitlement", cascade = CascadeType.ALL)
@@ -128,15 +125,11 @@ public class Entitlement extends AbstractHibernateObject implements Linkable, Ow
      * ctor
      * @param poolIn pool associated with the entitlement
      * @param consumerIn consumer associated with the entitlement
-     * @param startDateIn when the entitlement starts.
      */
-    public Entitlement(Pool poolIn, Consumer consumerIn, Date startDateIn,
-            Date endDateIn, Integer quantityIn) {
+    public Entitlement(Pool poolIn, Consumer consumerIn, Integer quantityIn) {
         pool = poolIn;
         owner = consumerIn.getOwner();
         consumer = consumerIn;
-        startDate = startDateIn;
-        endDate = endDateIn;
         quantity = quantityIn == null || quantityIn.intValue() < 1 ?
             1 : quantityIn;
     }
@@ -185,28 +178,28 @@ public class Entitlement extends AbstractHibernateObject implements Linkable, Ow
      * @return Returns the startDate.
      */
     public Date getStartDate() {
-        return startDate;
+        if (pool == null) {
+            return null;
+        }
+        return pool.getStartDate();
     }
 
-    /**
-     * @param startDateIn The startDate to set.
-     */
-    public void setStartDate(Date startDateIn) {
-        startDate = startDateIn;
+    public void setStartDate(Date date) {
+        // Only for serialization, start date lives on pool now.
     }
 
     /**
      * @return Returns the endDate.
      */
     public Date getEndDate() {
-        return endDate;
+        if (pool == null) {
+            return null;
+        }
+        return pool.getEndDate();
     }
 
-    /**
-     * @param endDateIn The endDate to set.
-     */
-    public void setEndDate(Date endDateIn) {
-        endDate = endDateIn;
+    public void setEndDate(Date date) {
+        // Only for serialization, end date lives on pool now.
     }
 
     /**

--- a/src/main/java/org/candlepin/model/OwnerCurator.java
+++ b/src/main/java/org/candlepin/model/OwnerCurator.java
@@ -86,14 +86,15 @@ public class OwnerCurator extends AbstractHibernateCurator<Owner> {
 
         DetachedCriteria ownerIdQuery = DetachedCriteria.forClass(Entitlement.class, "e")
             .add(Subqueries.propertyIn("e.pool.id", poolIdQuery))
-            .add(Restrictions.gt("e.endDate", new Date()))
+            .createCriteria("pool")
+                .add(Restrictions.gt("endDate", new Date()))
             .setProjection(Property.forName("e.owner.id"));
 
         DetachedCriteria distinctQuery = DetachedCriteria.forClass(Owner.class, "o2")
             .add(Subqueries.propertyIn("o2.id", ownerIdQuery))
             .setProjection(Projections.distinct(Projections.property("o2.key")));
 
-        return (List<Owner>) currentSession().createCriteria(Owner.class, "o")
+        return currentSession().createCriteria(Owner.class, "o")
             .add(Subqueries.propertyIn("o.key", distinctQuery))
             .list();
     }

--- a/src/main/resources/db/changelog/20130904120007-remove-ent-date-copies.xml
+++ b/src/main/resources/db/changelog/20130904120007-remove-ent-date-copies.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+
+    <changeSet id="20130904120007" author="dgoodwin">
+        <comment>Drop duplicated start/end dates on entitlement, use the pool.</comment>
+        <dropColumn tableName="cp_entitlement" columnName="startdate"/>
+        <dropColumn tableName="cp_entitlement" columnName="enddate"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-create.xml
+++ b/src/main/resources/db/changelog/changelog-create.xml
@@ -1131,4 +1131,5 @@
     <include file="db/changelog/20130723134939-add-linked-stack-id-to-pool.xml" />
     <include file="db/changelog/20130725093910-add-source-consumer-to-pool.xml" />
     <include file="db/changelog/20130829085043-add-sat-5.6-dist-version.xml" />
+    <include file="db/changelog/20130904120007-remove-ent-date-copies.xml" />
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-update.xml
+++ b/src/main/resources/db/changelog/changelog-update.xml
@@ -39,4 +39,5 @@
     <include file="db/changelog/20130723134939-add-linked-stack-id-to-pool.xml" />
     <include file="db/changelog/20130725093910-add-source-consumer-to-pool.xml" />
     <include file="db/changelog/20130829085043-add-sat-5.6-dist-version.xml" />
+    <include file="db/changelog/20130904120007-remove-ent-date-copies.xml" />
 </databaseChangeLog>

--- a/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -293,7 +293,7 @@ public class PoolManagerTest {
         s.setId("testSubId");
         pool.setSubscriptionId(s.getId());
         Entitlement e = new Entitlement(pool, TestUtil.createConsumer(o),
-            pool.getStartDate(), pool.getEndDate(), 1);
+            1);
         e.setDirty(true);
 
         when(mockSubAdapter.getSubscription(pool.getSubscriptionId())).thenReturn(s);
@@ -335,9 +335,9 @@ public class PoolManagerTest {
         Consumer c = TestUtil.createConsumer(o);
 
         Entitlement e1 = new Entitlement(pool, c,
-            pool.getStartDate(), pool.getEndDate(), 1);
+            1);
         Entitlement e2 = new Entitlement(pool, c,
-            pool.getStartDate(), pool.getEndDate(), 1);
+            1);
         List<Entitlement> entitlementList = new ArrayList<Entitlement>();
         entitlementList.add(e1);
         entitlementList.add(e2);
@@ -358,7 +358,7 @@ public class PoolManagerTest {
     @Test
     public void testRevokeCleansUpPoolsWithSourceEnt() throws Exception {
         Entitlement e = new Entitlement(pool, TestUtil.createConsumer(o),
-            pool.getStartDate(), pool.getEndDate(), 1);
+            1);
         List<Pool> poolsWithSource = createPoolsWithSourceEntitlement(e, product);
         when(mockPoolCurator.listBySourceEntitlement(e)).thenReturn(poolsWithSource);
         PreUnbindHelper preHelper =  mock(PreUnbindHelper.class);
@@ -504,11 +504,11 @@ public class PoolManagerTest {
     private Pool createPoolWithEntitlements() {
         Pool newPool = TestUtil.createPool(o, product);
         Entitlement e1 = new Entitlement(newPool, TestUtil.createConsumer(o),
-            newPool.getStartDate(), newPool.getEndDate(), 1);
+            1);
         e1.setId("1");
 
         Entitlement e2 = new Entitlement(newPool, TestUtil.createConsumer(o),
-            newPool.getStartDate(), newPool.getEndDate(), 1);
+            1);
         e2.setId("2");
 
         newPool.getEntitlements().add(e1);

--- a/src/test/java/org/candlepin/model/test/ConsumerTest.java
+++ b/src/test/java/org/candlepin/model/test/ConsumerTest.java
@@ -241,7 +241,7 @@ public class ConsumerTest extends DatabaseTestFixture {
     }
 
     private Entitlement createEntitlement(Pool pool, Consumer c) {
-        Entitlement e = new Entitlement(pool, c, pool.getStartDate(), pool.getEndDate(), 1);
+        Entitlement e = new Entitlement(pool, c, 1);
         return e;
     }
 

--- a/src/test/java/org/candlepin/model/test/PoolCuratorTest.java
+++ b/src/test/java/org/candlepin/model/test/PoolCuratorTest.java
@@ -215,8 +215,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
 
         Pool sourcePool = TestUtil.createPool(owner, product);
         poolCurator.create(sourcePool);
-        Entitlement e = new Entitlement(sourcePool, consumer, sourcePool.getStartDate(),
-            sourcePool.getEndDate(), 1);
+        Entitlement e = new Entitlement(sourcePool, consumer, 1);
         entitlementCurator.create(e);
 
         Pool pool2 = TestUtil.createPool(owner, product);
@@ -240,15 +239,13 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         String subid = pool.getSubscriptionId();
         assertEquals(1, poolCurator.lookupBySubscriptionId(subid).size());
 
-        Entitlement e = new Entitlement(pool, consumer, pool.getStartDate(),
-            pool.getEndDate(), 1);
+        Entitlement e = new Entitlement(pool, consumer, 1);
         entitlementCurator.create(e);
 
         assertEquals(0, poolCurator.lookupOversubscribedBySubscriptionId(
             subid, e).size());
 
-        e = new Entitlement(pool, consumer, pool.getStartDate(),
-            pool.getEndDate(), 1);
+        e = new Entitlement(pool, consumer, 1);
         entitlementCurator.create(e);
         assertEquals(1, poolCurator.lookupOversubscribedBySubscriptionId(
             subid, e).size());
@@ -263,8 +260,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
 
         String subid = pool.getSubscriptionId();
 
-        Entitlement sourceEnt = new Entitlement(pool, consumer, pool.getStartDate(),
-            pool.getEndDate(), 1);
+        Entitlement sourceEnt = new Entitlement(pool, consumer, 1);
         entitlementCurator.create(sourceEnt);
 
         // Create derived pool referencing the entitlement just made:
@@ -281,7 +277,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
 
         // Oversubscribe to the derived pool:
         Entitlement derivedEnt = new Entitlement(derivedPool, consumer,
-            derivedPool.getStartDate(), derivedPool.getEndDate(), 2);
+            2);
         entitlementCurator.create(derivedEnt);
 
         // Passing the source entitlement should find the oversubscribed derived pool:
@@ -303,15 +299,13 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         assertEquals(1, poolCurator.lookupBySubscriptionId(subid).size());
 
 
-        Entitlement e = new Entitlement(pool, consumer, pool.getStartDate(),
-            pool.getEndDate(), 1);
+        Entitlement e = new Entitlement(pool, consumer, 1);
         entitlementCurator.create(e);
 
         assertEquals(0, poolCurator.lookupOversubscribedBySubscriptionId(
             subid, e).size());
 
-        e = new Entitlement(pool, consumer, pool.getStartDate(),
-            pool.getEndDate(), 1);
+        e = new Entitlement(pool, consumer, 1);
         entitlementCurator.create(e);
         assertEquals(0, poolCurator.lookupOversubscribedBySubscriptionId(
             subid, e).size());
@@ -643,8 +637,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
 
         Pool sourcePool = poolManager.createPoolsForSubscription(sub).get(0);
         poolCurator.create(sourcePool);
-        Entitlement e = new Entitlement(sourcePool, consumer, sourcePool.getStartDate(),
-            sourcePool.getEndDate(), 1);
+        Entitlement e = new Entitlement(sourcePool, consumer, 1);
         entitlementCurator.create(e);
 
         Pool pool2 = TestUtil.createPool(owner, product);

--- a/src/test/java/org/candlepin/policy/js/compliance/ComplianceRulesTest.java
+++ b/src/test/java/org/candlepin/policy/js/compliance/ComplianceRulesTest.java
@@ -137,7 +137,7 @@ public class ComplianceRulesTest {
         }
         Pool p = new Pool(owner, productId, productId, provided,
             new Long(1000), start, end, "1000", "1000", "1000");
-        Entitlement e = new Entitlement(p, consumer, p.getStartDate(), p.getEndDate(), 1);
+        Entitlement e = new Entitlement(p, consumer, 1);
         return e;
     }
 

--- a/src/test/java/org/candlepin/policy/js/compliance/StatusReasonMessageGeneratorTest.java
+++ b/src/test/java/org/candlepin/policy/js/compliance/StatusReasonMessageGeneratorTest.java
@@ -178,7 +178,7 @@ public class StatusReasonMessageGeneratorTest {
         Pool p = new Pool(owner, productId, name, null,
             new Long(1000), TestUtil.createDate(2000, 1, 1),
             TestUtil.createDate(2050, 1, 1), "1000", "1000", "1000");
-        Entitlement e = new Entitlement(p, consumer, p.getStartDate(), p.getEndDate(), 1);
+        Entitlement e = new Entitlement(p, consumer, 1);
         return e;
     }
 }

--- a/src/test/java/org/candlepin/policy/js/entitlement/test/HostedVirtLimitEntitlementRulesTest.java
+++ b/src/test/java/org/candlepin/policy/js/entitlement/test/HostedVirtLimitEntitlementRulesTest.java
@@ -25,7 +25,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 
 import org.candlepin.model.ConsumerType;
@@ -45,8 +44,7 @@ public class HostedVirtLimitEntitlementRulesTest extends EntitlementRulesTestFix
     @Test
     public void hostedParentConsumerPostCreatesNoPool() {
         Pool pool = setupVirtLimitPool();
-        Entitlement e = new Entitlement(pool, consumer, new Date(), new Date(),
-            1);
+        Entitlement e = new Entitlement(pool, consumer, 1);
 
         PoolHelper postHelper = mock(PoolHelper.class);
         when(config.standalone()).thenReturn(false);
@@ -77,8 +75,7 @@ public class HostedVirtLimitEntitlementRulesTest extends EntitlementRulesTestFix
         assertEquals("true", virtBonusPool.getAttributeValue("virt_only"));
         assertEquals("10", virtBonusPool.getProductAttribute("virt_limit").getValue());
 
-        Entitlement e = new Entitlement(physicalPool, consumer, new Date(), new Date(),
-            1);
+        Entitlement e = new Entitlement(physicalPool, consumer, 1);
         PoolHelper postHelper = new PoolHelper(poolManagerMock, productCache, e);
         List<Pool> poolList = new ArrayList<Pool>();
         poolList.add(virtBonusPool);
@@ -110,8 +107,7 @@ public class HostedVirtLimitEntitlementRulesTest extends EntitlementRulesTestFix
         assertEquals(new Long(10), physicalPool.getQuantity());
         assertEquals(0, physicalPool.getAttributes().size());
 
-        Entitlement e = new Entitlement(physicalPool, consumer, new Date(), new Date(),
-            1);
+        Entitlement e = new Entitlement(physicalPool, consumer, 1);
         PoolHelper postHelper = new PoolHelper(poolManagerMock, productCache, e);
 
         enforcer.postEntitlement(consumer, postHelper, e);
@@ -139,8 +135,7 @@ public class HostedVirtLimitEntitlementRulesTest extends EntitlementRulesTestFix
         assertEquals("unlimited", virtBonusPool.getProductAttribute("virt_limit")
             .getValue());
 
-        Entitlement e = new Entitlement(physicalPool, consumer, new Date(), new Date(),
-            1);
+        Entitlement e = new Entitlement(physicalPool, consumer, 1);
         PoolHelper postHelper = new PoolHelper(poolManagerMock, productCache, e);
         List<Pool> poolList = new ArrayList<Pool>();
         poolList.add(virtBonusPool);
@@ -179,8 +174,7 @@ public class HostedVirtLimitEntitlementRulesTest extends EntitlementRulesTestFix
         assertEquals("unlimited", virtBonusPool.getProductAttribute("virt_limit")
             .getValue());
 
-        Entitlement e = new Entitlement(physicalPool, consumer, new Date(), new Date(),
-            1);
+        Entitlement e = new Entitlement(physicalPool, consumer, 1);
         PoolHelper postHelper = new PoolHelper(poolManagerMock, productCache, e);
 
         enforcer.postEntitlement(consumer, postHelper, e);
@@ -214,8 +208,7 @@ public class HostedVirtLimitEntitlementRulesTest extends EntitlementRulesTestFix
         assertEquals("unlimited", virtBonusPool.getProductAttribute("virt_limit")
             .getValue());
 
-        Entitlement e = new Entitlement(physicalPool, consumer, new Date(), new Date(),
-            10);
+        Entitlement e = new Entitlement(physicalPool, consumer, 10);
         physicalPool.setConsumed(10L);
         physicalPool.setExported(10L);
         PoolHelper postHelper = new PoolHelper(poolManagerMock, productCache, e);
@@ -244,8 +237,7 @@ public class HostedVirtLimitEntitlementRulesTest extends EntitlementRulesTestFix
         virtBonusPool.setAttribute("virt_limit", "10");
         virtBonusPool.setAttribute("pool_derived", "true");
 
-        Entitlement e = new Entitlement(virtBonusPool, consumer, new Date(), new Date(),
-            1);
+        Entitlement e = new Entitlement(virtBonusPool, consumer, 1);
         PoolHelper postHelper = new PoolHelper(poolManagerMock, productCache, e);
         List<Pool> poolList = new ArrayList<Pool>();
         poolList.add(virtBonusPool);

--- a/src/test/java/org/candlepin/policy/js/entitlement/test/PostEntitlementRulesTest.java
+++ b/src/test/java/org/candlepin/policy/js/entitlement/test/PostEntitlementRulesTest.java
@@ -23,8 +23,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.Date;
-
 import org.candlepin.model.ConsumerType;
 import org.candlepin.model.ConsumerType.ConsumerTypeEnum;
 import org.candlepin.model.Entitlement;
@@ -44,8 +42,7 @@ public class PostEntitlementRulesTest extends EntitlementRulesTestFixture {
     @Test
     public void virtLimitSubPool() {
         Pool pool = setupVirtLimitPool();
-        Entitlement e = new Entitlement(pool, consumer, new Date(), new Date(),
-            5);
+        Entitlement e = new Entitlement(pool, consumer, 5);
 
         PoolHelper postHelper = mock(PoolHelper.class);
         when(postHelper.getFlattenedAttributes(eq(pool))).thenReturn(
@@ -62,8 +59,7 @@ public class PostEntitlementRulesTest extends EntitlementRulesTestFixture {
     public void unlimitedVirtLimitSubPool() {
         Pool pool = setupVirtLimitPool();
         pool.setAttribute("virt_limit", "unlimited");
-        Entitlement e = new Entitlement(pool, consumer, new Date(), new Date(),
-            5);
+        Entitlement e = new Entitlement(pool, consumer, 5);
 
         PoolHelper postHelper = mock(PoolHelper.class);
         when(postHelper.getFlattenedAttributes(eq(pool))).thenReturn(
@@ -82,8 +78,7 @@ public class PostEntitlementRulesTest extends EntitlementRulesTestFixture {
         when(config.standalone()).thenReturn(true);
         consumer.setType(new ConsumerType(ConsumerTypeEnum.CANDLEPIN));
         Pool pool = setupVirtLimitPool();
-        Entitlement e = new Entitlement(pool, consumer, new Date(), new Date(),
-            1);
+        Entitlement e = new Entitlement(pool, consumer, 1);
 
         PoolHelper postHelper = new PoolHelper(poolManagerMock, productCache, e);
 
@@ -102,8 +97,7 @@ public class PostEntitlementRulesTest extends EntitlementRulesTestFixture {
         when(config.standalone()).thenReturn(true);
         Pool pool = setupVirtLimitPool();
         consumer.setFact("virt.is_guest", "true");
-        Entitlement e = new Entitlement(pool, consumer, new Date(), new Date(),
-            1);
+        Entitlement e = new Entitlement(pool, consumer, 1);
 
         PoolHelper postHelper = new PoolHelper(poolManagerMock, productCache, e);
 

--- a/src/test/java/org/candlepin/policy/js/entitlement/test/PreEntitlementRulesTest.java
+++ b/src/test/java/org/candlepin/policy/js/entitlement/test/PreEntitlementRulesTest.java
@@ -19,7 +19,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
-import java.util.Date;
 import java.util.HashMap;
 
 import org.candlepin.model.Consumer;
@@ -41,8 +40,7 @@ public class PreEntitlementRulesTest extends EntitlementRulesTestFixture {
         Product product = new Product(productId, "A product for testing");
         Pool pool = createPool(owner, product);
 
-        Entitlement e = new Entitlement(pool, consumer, new Date(), new Date(),
-            1);
+        Entitlement e = new Entitlement(pool, consumer, 1);
         consumer.addEntitlement(e);
 
         when(this.prodAdapter.getProductById(productId)).thenReturn(product);
@@ -75,8 +73,7 @@ public class PreEntitlementRulesTest extends EntitlementRulesTestFixture {
         product.addAttribute(new ProductAttribute("multi-entitlement", "yes"));
         Pool pool = createPool(owner, product);
 
-        Entitlement e = new Entitlement(pool, consumer, new Date(), new Date(),
-            1);
+        Entitlement e = new Entitlement(pool, consumer, 1);
         consumer.addEntitlement(e);
 
         when(this.prodAdapter.getProductById(productId)).thenReturn(product);
@@ -93,8 +90,7 @@ public class PreEntitlementRulesTest extends EntitlementRulesTestFixture {
         Pool pool = TestUtil.createPool(owner, product, 0);
         pool.setId("fakeid" + TestUtil.randomInt());
 
-        Entitlement e = new Entitlement(pool, consumer, new Date(), new Date(),
-            1);
+        Entitlement e = new Entitlement(pool, consumer, 1);
         consumer.addEntitlement(e);
 
         when(this.prodAdapter.getProductById(productId)).thenReturn(product);

--- a/src/test/java/org/candlepin/policy/js/quantity/QuantityRulesTest.java
+++ b/src/test/java/org/candlepin/policy/js/quantity/QuantityRulesTest.java
@@ -103,7 +103,7 @@ public class QuantityRulesTest {
         Date dayAgo = cal.getTime();
 
         e.setCreated(dayAgo);
-        e.setEndDate(dayFromNow);
+        p.setEndDate(dayFromNow);
         return e;
     }
 
@@ -329,7 +329,7 @@ public class QuantityRulesTest {
 
         Entitlement e = TestUtil.createEntitlement(owner, consumer, pool, null);
         e.setCreated(TestUtil.createDate(9000, 1, 1));
-        e.setEndDate(TestUtil.createDate(9001, 1, 1));
+        pool.setEndDate(TestUtil.createDate(9001, 1, 1));
         e.setQuantity(2);
 
         Set<Entitlement> ents = new HashSet<Entitlement>();

--- a/src/test/java/org/candlepin/policy/test/PoolRulesStackDerivedTest.java
+++ b/src/test/java/org/candlepin/policy/test/PoolRulesStackDerivedTest.java
@@ -178,8 +178,7 @@ public class PoolRulesStackDerivedTest {
     }
 
     private Entitlement createEntFromPool(Pool pool) {
-        Entitlement e = new Entitlement(pool, consumer, pool.getStartDate(),
-            pool.getEndDate(), 2);
+        Entitlement e = new Entitlement(pool, consumer, 2);
         e.setCreated(new Date());
         try {
             Thread.sleep(1);

--- a/src/test/java/org/candlepin/resource/util/InstalledProductStatusCalculatorTest.java
+++ b/src/test/java/org/candlepin/resource/util/InstalledProductStatusCalculatorTest.java
@@ -722,7 +722,7 @@ public class InstalledProductStatusCalculatorTest {
         Pool p = new Pool(owner, productId, productId, provided,
             new Long(1000), range.getStartDate(), range.getEndDate(), "1000", "1000",
             "1000");
-        Entitlement e = new Entitlement(p, consumer, p.getStartDate(), p.getEndDate(), 1);
+        Entitlement e = new Entitlement(p, consumer, 1);
 
         Random gen = new Random();
         int id = gen.nextInt(Integer.MAX_VALUE);

--- a/src/test/java/org/candlepin/service/impl/test/DefaultEntitlementCertServiceAdapterTest.java
+++ b/src/test/java/org/candlepin/service/impl/test/DefaultEntitlementCertServiceAdapterTest.java
@@ -244,15 +244,11 @@ public class DefaultEntitlementCertServiceAdapterTest {
         entitlement = new Entitlement();
         entitlement.setQuantity(new Integer(ENTITLEMENT_QUANTITY));
         entitlement.setConsumer(consumer);
-        entitlement.setStartDate(subscription.getStartDate());
-        entitlement.setEndDate(subscription.getEndDate());
         entitlement.setPool(pool);
         entitlement.setOwner(owner);
         largeContentEntitlement = new Entitlement();
         largeContentEntitlement.setQuantity(new Integer(ENTITLEMENT_QUANTITY));
         largeContentEntitlement.setConsumer(consumer);
-        largeContentEntitlement.setStartDate(largeContentSubscription.getStartDate());
-        largeContentEntitlement.setEndDate(largeContentSubscription.getEndDate());
         largeContentEntitlement.setPool(largeContentPool);
         largeContentEntitlement.setOwner(owner);
 

--- a/src/test/java/org/candlepin/test/TestUtil.java
+++ b/src/test/java/org/candlepin/test/TestUtil.java
@@ -273,8 +273,6 @@ public class TestUtil {
         toReturn.setPool(pool);
         toReturn.setOwner(owner);
         toReturn.setConsumer(consumer);
-        toReturn.setStartDate(pool.getStartDate());
-        toReturn.setEndDate(pool.getEndDate());
         if (cert != null) {
             cert.setEntitlement(toReturn);
             toReturn.getCertificates().add(cert);


### PR DESCRIPTION
Caused issues where sub-pool dates looked correct, but consumer status
was inaccurate because calculation was done using entitlement dates
rather than the pool.

No need for duplication of this data, so drop the entitlement date
columns and use the pool instead.

Entitlement will still report a start/end date to maintain API
compatability, it just comes from the pool now.
