### PR TITLE
1004780: truncate result string to fit in db

### DIFF
--- a/src/main/java/org/candlepin/pinsetter/core/model/JobStatus.java
+++ b/src/main/java/org/candlepin/pinsetter/core/model/JobStatus.java
@@ -107,20 +107,22 @@ public class JobStatus extends AbstractHibernateObject {
         long runTime = context.getJobRunTime();
 
         if (this.startTime != null) {
-            this.state = JobState.RUNNING;
+            setState(JobState.RUNNING);
 
             if (runTime > -1) {
                 this.finishTime = new Date(startTime.getTime() + runTime);
-                this.state = JobState.FINISHED;
+                setState(JobState.FINISHED);
             }
         }
         else {
-            this.state = JobState.PENDING;
+            setState(JobState.PENDING);
         }
 
         Object jobResult = context.getResult();
         if (jobResult != null) {
-            this.result = jobResult.toString();
+            // BZ1004780: setResult truncates long strings
+            // setting result directly causes database issues.
+            setResult(jobResult.toString());
         }
     }
 

--- a/src/test/java/org/candlepin/model/JobCuratorTest.java
+++ b/src/test/java/org/candlepin/model/JobCuratorTest.java
@@ -28,6 +28,7 @@ import org.candlepin.pinsetter.core.model.JobStatus.JobState;
 import org.candlepin.test.DatabaseTestFixture;
 import org.candlepin.util.Util;
 
+import org.apache.commons.lang.RandomStringUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.quartz.JobDataMap;
@@ -39,7 +40,7 @@ import java.util.List;
 /**
  * JobCuratorTest
  */
-public class JobCuratorTest extends DatabaseTestFixture{
+public class JobCuratorTest extends DatabaseTestFixture {
 
     private JobCurator curator;
 
@@ -126,6 +127,19 @@ public class JobCuratorTest extends DatabaseTestFixture{
         assertNotNull(job);
         assertEquals(jobid, job.getId());
         assertEquals(JobStatus.JobState.CANCELED, job.getState());
+    }
+
+    @Test
+    public void updateWithLargeResult() {
+        String longstr = RandomStringUtils.randomAlphanumeric(300);
+        JobExecutionContext ctx = mock(JobExecutionContext.class);
+        when(ctx.getFireTime()).thenReturn(new Date());
+        when(ctx.getJobRunTime()).thenReturn(1000L);
+        when(ctx.getResult()).thenReturn(longstr);
+
+        JobStatus status = newJobStatus().owner("terps").create();
+        status.update(ctx);
+        curator.merge(status);
     }
 
     private JobStatusBuilder newJobStatus() {


### PR DESCRIPTION
The JobStatus.update() method was not calling the setResult method, which
means the result would be set to whatever string the JobExecutionContext
had, even one longer than 255 characters. This issue was fixed some time
ago in the setResult() method, where we truncate the text.

The JobStatus.update() method was changed to call setResult() to avoid
this data issue. While there, update() now calls setState() as well.
The other members do not have setters or data transformations, so no
setters were called for those.

Added a test in the JobCuratorTest because this error only surfaced when
using an actual database.
