### PR TITLE
996672: Make quantity suggestions date aware.

### DIFF
--- a/src/main/java/org/candlepin/policy/js/quantity/QuantityRules.java
+++ b/src/main/java/org/candlepin/policy/js/quantity/QuantityRules.java
@@ -47,11 +47,15 @@ public class QuantityRules {
     }
 
     public SuggestedQuantity getSuggestedQuantity(Pool p, Consumer c) {
+        return getSuggestedQuantity(p, c, new Date());
+    }
+
+    public SuggestedQuantity getSuggestedQuantity(Pool p, Consumer c, Date onDate) {
         JsonJsContext args = new JsonJsContext(mapper);
 
         Set<Entitlement> validEntitlements = new HashSet<Entitlement>();
         for (Entitlement e : c.getEntitlements()) {
-            if (e.getProductId().equals(p.getProductId()) && isValid(e)) {
+            if (e.getProductId().equals(p.getProductId()) && isValid(e, onDate)) {
                 validEntitlements.add(e);
             }
         }
@@ -66,8 +70,7 @@ public class QuantityRules {
         return dto;
     }
 
-    private boolean isValid(Entitlement e) {
-        Date now = new Date();
-        return now.after(e.getCreated()) && now.before(e.getEndDate());
+    private boolean isValid(Entitlement e, Date onDate) {
+        return onDate.after(e.getStartDate()) && onDate.before(e.getEndDate());
     }
 }

--- a/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -670,7 +670,7 @@ public class OwnerResource {
         if (c != null) {
             for (Pool p : poolList) {
                 p.setCalculatedAttributes(
-                    calculatedAttributesUtil.buildCalculatedAttributes(p, c));
+                    calculatedAttributesUtil.buildCalculatedAttributes(p, c, activeOnDate));
             }
         }
 

--- a/src/main/java/org/candlepin/resource/PoolResource.java
+++ b/src/main/java/org/candlepin/resource/PoolResource.java
@@ -178,7 +178,7 @@ public class PoolResource {
         if (c != null) {
             for (Pool p : poolList) {
                 p.setCalculatedAttributes(
-                    calculatedAttributesUtil.buildCalculatedAttributes(p, c));
+                    calculatedAttributesUtil.buildCalculatedAttributes(p, c, activeOnDate));
             }
         }
 
@@ -220,7 +220,8 @@ public class PoolResource {
 
         if (toReturn != null) {
             toReturn.setCalculatedAttributes(
-                calculatedAttributesUtil.buildCalculatedAttributes(toReturn, c));
+                calculatedAttributesUtil.buildCalculatedAttributes(toReturn, c,
+                    new Date()));
             return toReturn;
         }
 

--- a/src/main/java/org/candlepin/resource/util/CalculatedAttributesUtil.java
+++ b/src/main/java/org/candlepin/resource/util/CalculatedAttributesUtil.java
@@ -21,6 +21,7 @@ import org.candlepin.policy.js.quantity.SuggestedQuantity;
 
 import com.google.inject.Inject;
 
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -35,14 +36,14 @@ public class CalculatedAttributesUtil {
         this.quantityRules = quantityRules;
     }
 
-    public Map<String, String> buildCalculatedAttributes(Pool p, Consumer c) {
+    public Map<String, String> buildCalculatedAttributes(Pool p, Consumer c, Date onDate) {
         Map<String, String> attrMap = new HashMap<String, String>();
 
         if (c == null) {
             return attrMap;
         }
 
-        SuggestedQuantity suggested = quantityRules.getSuggestedQuantity(p, c);
+        SuggestedQuantity suggested = quantityRules.getSuggestedQuantity(p, c, onDate);
 
         attrMap.put("suggested_quantity",
             String.valueOf(suggested.getSuggested()));

--- a/src/test/java/org/candlepin/resource/test/PoolResourceTest.java
+++ b/src/test/java/org/candlepin/resource/test/PoolResourceTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import java.util.Date;
 import java.util.List;
 
 import org.candlepin.auth.Access;
@@ -173,7 +174,7 @@ public class PoolResourceTest extends DatabaseTestFixture {
         assertEquals(1, pools.size());
 
         verify(attrUtil).buildCalculatedAttributes(any(Pool.class),
-            eq(passConsumer));
+            eq(passConsumer), any(Date.class));
     }
 
     @Test(expected = ForbiddenException.class)
@@ -199,7 +200,7 @@ public class PoolResourceTest extends DatabaseTestFixture {
         assertEquals(2, pools.size());
 
         verify(attrUtil, times(2)).buildCalculatedAttributes(any(Pool.class),
-            eq(passConsumer));
+            eq(passConsumer), any(Date.class));
     }
 
     @Test(expected = NotFoundException.class)

--- a/src/test/java/org/candlepin/resource/util/CalculatedAttributesUtilTest.java
+++ b/src/test/java/org/candlepin/resource/util/CalculatedAttributesUtilTest.java
@@ -17,6 +17,7 @@ package org.candlepin.resource.util;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -29,12 +30,12 @@ import org.candlepin.policy.js.quantity.QuantityRules;
 import org.candlepin.policy.js.quantity.SuggestedQuantity;
 import org.candlepin.test.DatabaseTestFixture;
 import org.candlepin.test.TestUtil;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import java.util.Date;
 import java.util.Map;
 
 /**
@@ -73,12 +74,15 @@ public class CalculatedAttributesUtilTest extends DatabaseTestFixture {
         SuggestedQuantity suggested = new SuggestedQuantity();
         suggested.setSuggested(1L);
         suggested.setIncrement(1L);
-        when(quantityRules.getSuggestedQuantity(any(Pool.class), any(Consumer.class))).
+        when(quantityRules.getSuggestedQuantity(any(Pool.class), any(Consumer.class),
+            any(Date.class))).
             thenReturn(suggested);
 
-        Map<String, String> attrs = attrUtil.buildCalculatedAttributes(pool1, consumer);
+        Map<String, String> attrs = attrUtil.buildCalculatedAttributes(pool1, consumer,
+            new Date());
         assertTrue(attrs.containsKey("suggested_quantity"));
-        verify(quantityRules).getSuggestedQuantity(pool1, consumer);
+        verify(quantityRules).getSuggestedQuantity(eq(pool1), eq(consumer),
+            any(Date.class));
     }
 
     @Test
@@ -93,11 +97,14 @@ public class CalculatedAttributesUtilTest extends DatabaseTestFixture {
         SuggestedQuantity suggested = new SuggestedQuantity();
         suggested.setSuggested(1L);
         suggested.setIncrement(12L);
-        when(quantityRules.getSuggestedQuantity(any(Pool.class), any(Consumer.class))).
+        when(quantityRules.getSuggestedQuantity(any(Pool.class), any(Consumer.class),
+            any(Date.class))).
             thenReturn(suggested);
 
-        Map<String, String> attrs = attrUtil.buildCalculatedAttributes(pool2, consumer);
+        Map<String, String> attrs = attrUtil.buildCalculatedAttributes(pool2, consumer,
+            new Date());
         assertEquals("12", attrs.get("quantity_increment"));
-        verify(quantityRules).getSuggestedQuantity(pool2, consumer);
+        verify(quantityRules).getSuggestedQuantity(eq(pool2), eq(consumer),
+            any(Date.class));
     }
 }


### PR DESCRIPTION
All entitlements were being considered for quantity calculations,
meaning that being green in the future would result in a suggested
quantity of 0 for today. (or vice versa)

Fixed by passing the date specified in the resource list methods all the
way through to the quantity suggestion code.
