### PR TITLE
Stop using Exporter as a singleton.

### DIFF
--- a/src/main/java/org/candlepin/guice/CandlepinModule.java
+++ b/src/main/java/org/candlepin/guice/CandlepinModule.java
@@ -205,7 +205,7 @@ public class CandlepinModule extends AbstractModule {
         bind(CertificateRevocationListTask.class);
         bind(JobCleaner.class);
 
-        bind(Exporter.class).asEagerSingleton();
+        bind(Exporter.class);
         bind(MetaExporter.class);
         bind(ConsumerTypeExporter.class);
         bind(ConsumerExporter.class);


### PR DESCRIPTION
Strange things are afoot in some environments where we export and get
data we didn't ask the product adapter for. Just in case, stop using
exporter as a singleton.
