### PR TITLE
Make v1 certs populate 'brand_type' too.

### DIFF
--- a/src/main/java/org/candlepin/util/X509ExtensionUtil.java
+++ b/src/main/java/org/candlepin/util/X509ExtensionUtil.java
@@ -194,10 +194,10 @@ public class X509ExtensionUtil  extends X509Util{
         toReturn.add(new X509ExtensionWrapper(productOid + "." +
             OIDUtil.ORDER_PRODUCT_OIDS.get(OIDUtil.OP_VERSION_KEY), false, version));
 
-        String osName = product.hasAttribute("os") ?
-            product.getAttributeValue("os") : "";
+        String brandType = product.hasAttribute("brand_type") ?
+            product.getAttributeValue("brand_type") : "";
         toReturn.add(new X509ExtensionWrapper(productOid + "." +
-            OIDUtil.ORDER_PRODUCT_OIDS.get(OIDUtil.OP_BRAND_TYPE_KEY), false, osName));
+            OIDUtil.ORDER_PRODUCT_OIDS.get(OIDUtil.OP_BRAND_TYPE_KEY), false, brandType));
 
         // XXX include provides here (after defined in attributes)
 

--- a/src/test/java/org/candlepin/service/impl/test/DefaultEntitlementCertServiceAdapterTest.java
+++ b/src/test/java/org/candlepin/service/impl/test/DefaultEntitlementCertServiceAdapterTest.java
@@ -775,6 +775,20 @@ public class DefaultEntitlementCertServiceAdapterTest {
             cont.getId() + "." + contentType + ".1");
     }
 
+    private Boolean extMapHasProductBrandType(Product product, Map<String, String> extMap) {
+        return extMap.containsKey("1.3.6.1.4.1.2312.9.1." +
+            product.getId() + "." + "5");
+    }
+
+    private Boolean extMapProductBrandTypeMatches(Product product, Map<String,
+        String> extMap, String brandType) {
+        String brandTypeOid = "1.3.6.1.4.1.2312.9.1." +
+            product.getId() + "." + "5";
+        String extBrandType = extMap.get(brandTypeOid);
+
+        return extBrandType.equals(brandType);
+    }
+
     @Test
     public void testPrepareV1Extensions() throws IOException,
         GeneralSecurityException {
@@ -795,6 +809,28 @@ public class DefaultEntitlementCertServiceAdapterTest {
         // do we have a yum content type oid
         assertTrue(extMapHasContentType(content, extMap, "1"));
         assertFalse(extMapHasContentType(content, extMap, "2"));
+    }
+
+    @Test
+    public void testPrepareV1ExtensionsBrandedProduct() throws IOException,
+        GeneralSecurityException {
+        Set<Product> products = new HashSet<Product>();
+
+        ProductAttribute brandAttr = new ProductAttribute("brand_type", "os");
+        product.addAttribute(brandAttr);
+        products.add(product);
+        setupEntitlements(ARCH_LABEL, "1.0");
+
+        Set<X509ExtensionWrapper> extensions =
+            certServiceAdapter.prepareV1Extensions(products, entitlement, "",
+                null);
+        Map<String, X509ExtensionWrapper> map = getEncodedContent(extensions);
+        Map<String, String> extMap = getEncodedContentMap(extensions);
+
+        assertTrue(isEncodedContentValid(map));
+        assertTrue(extMapHasProductBrandType(product, extMap));
+        assertTrue(extMapProductBrandTypeMatches(product, extMap, "os"));
+
     }
 
     @Test


### PR DESCRIPTION
The product attribute v1 certs looks for was still
'os', instead of 'brand_type'.
