### PR TITLE
Fix NPE from base64

### DIFF
--- a/src/main/java/org/candlepin/util/Util.java
+++ b/src/main/java/org/candlepin/util/Util.java
@@ -55,8 +55,6 @@ public class Util {
     public static final String UTC_STR = "UTC";
     private static Logger log = Logger.getLogger(Util.class);
     private static ObjectMapper mapper = new ObjectMapper();
-    // If we don't specify the line separator, it will use CRLF
-    private static Base64 base64 = new Base64(64, "\n".getBytes());
 
     private Util() {
         // default ctor
@@ -245,7 +243,9 @@ public class Util {
 
     public static String toBase64(byte [] data) {
         try {
-            return new String(base64.encode(data), "ASCII");
+            // to be thread-safe, we should create it from the static method
+            // If we don't specify the line separator, it will use CRLF
+            return new String(new Base64(64, "\n".getBytes()).encode(data), "ASCII");
         }
         catch (UnsupportedEncodingException e) {
             log.warn("Unable to convert binary data to string", e);


### PR DESCRIPTION
java.lang.NullPointerException
    at org.apache.commons.codec.binary.Base64.encode(Base64.java:500)
    at org.apache.commons.codec.binary.Base64.encode(Base64.java:936)
    at org.candlepin.util.Util.toBase64(Util.java:250)
    at org.candlepin.servlet.filter.logging.LoggingRequestWrapper.getBody(LoggingRequestWrapper.java:65)
    at org.candlepin.servlet.filter.logging.LoggingFilter.logBody(LoggingFilter.java:114)
    at org.candlepin.servlet.filter.logging.LoggingFilter.logRequest(LoggingFilter.java:69)
    at org.candlepin.servlet.filter.logging.LoggingFilter.doFilter(LoggingFilter.java:54)
    at com.google.inject.servlet.FilterDefinition.doFilter(FilterDefinition.java:163)
    at com.google.inject.servlet.FilterChainInvocation.doFilter(FilterChainInvocation.java:58)
    at org.candlepin.servlet.filter.CandlepinPersistFilter.doFilter(CandlepinPersistFilter.java:48)
    at com.google.inject.servlet.FilterDefinition.doFilter(FilterDefinition.java:163)
    at com.google.inject.servlet.FilterChainInvocation.doFilter(FilterChainInvocation.java:58)
    at org.candlepin.servlet.filter.CandlepinScopeFilter.doFilter(CandlepinScopeFilter.java:57)
    at com.google.inject.servlet.FilterDefinition.doFilter(FilterDefinition.java:163)
    at com.google.inject.servlet.FilterChainInvocation.doFilter(FilterChainInvocation.java:58)
    at com.google.inject.servlet.ManagedFilterPipeline.dispatch(ManagedFilterPipeline.java:118)
    at com.google.inject.servlet.GuiceFilter.doFilter(GuiceFilter.java:113)
    ...

The above would only happen if you have debug logging enabled AND using
the parallel product import. The hypothesis here is that Util.java is static,
and had an instance of Base64. The Base64 class has a buffer member variable
that isn't thread safe, so if multiple threads are calling Util.toBase64() at
the same time we run the risk of causing problems.
