### PR TITLE
Fix use of skip_subs in test data importer.

### DIFF
--- a/buildconf/scripts/test_data.json
+++ b/buildconf/scripts/test_data.json
@@ -641,13 +641,13 @@
             "type": "MKT",
             "version": "0.1",
             "arch": "x86_64,x86,s390x,ppc64,ia64,arm",
+            "skip_subs" : "true",
             "attributes": {
                 "sockets": 2,
                 "cores": 4,
                 "ram": 2,
                 "support_level": "Full-Service",
-                "support_type": "Drive-Through",
-                "skip_subs" : "true"
+                "support_type": "Drive-Through"
             }
         },
         {


### PR DESCRIPTION
Moved the attribute out of attributes and into
the product definition. A code change to the test
data importer was looking for it on the product
JSON. Moved it in the test data.
