### PR TITLE
Add a type indicator to Pool.

### DIFF
--- a/spec/pool_resource_spec.rb
+++ b/spec/pool_resource_spec.rb
@@ -18,6 +18,7 @@ describe 'Pool Resource' do
     consumer_client = consumer_client(owner1_client, random_string('testsystem'))
     p = consumer_client.get_pool(pool.id)
     p.id.should == pool.id
+    p['type'].should == 'NORMAL'
   end
 
   it 'does not let consumers view another owners pool' do

--- a/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -48,6 +48,7 @@ import org.candlepin.model.PoolQuantity;
 import org.candlepin.model.Product;
 import org.candlepin.model.ProvidedProduct;
 import org.candlepin.model.Subscription;
+import org.candlepin.model.Pool.PoolType;
 import org.candlepin.paging.Page;
 import org.candlepin.paging.PageRequest;
 import org.candlepin.policy.EntitlementRefusedException;
@@ -184,11 +185,7 @@ public class CandlepinPoolManager implements PoolManager {
                 //
                 // However if this is an older bonus pool (hosted) not tied to any
                 // entitlements, we need to proceed:
-                if (p.hasAttribute("pool_derived") && (
-                    p.getSourceStackId() != null || p.getSourceEntitlement() != null)) {
-                    continue;
-                }
-                else {
+                if (p.getType() == PoolType.NORMAL || p.getType() == PoolType.BONUS) {
                     deletePool(p);
                 }
             }
@@ -649,7 +646,7 @@ public class CandlepinPoolManager implements PoolManager {
         if (sub != null) {
             // Need to make sure that we check for a defined sub product
             // if it is a derived pool.
-            boolean derived = pool.hasAttribute("pool_derived");
+            boolean derived = pool.getType() != PoolType.NORMAL;
             product = derived && sub.getDerivedProduct() != null ? sub.getDerivedProduct() :
                 sub.getProduct();
         }

--- a/src/test/java/org/candlepin/model/test/PoolTest.java
+++ b/src/test/java/org/candlepin/model/test/PoolTest.java
@@ -35,6 +35,7 @@ import org.candlepin.model.Product;
 import org.candlepin.model.ProductPoolAttribute;
 import org.candlepin.model.ProvidedProduct;
 import org.candlepin.model.Subscription;
+import org.candlepin.model.Pool.PoolType;
 import org.candlepin.policy.EntitlementRefusedException;
 import org.candlepin.test.DatabaseTestFixture;
 import org.candlepin.test.TestUtil;
@@ -307,5 +308,20 @@ public class PoolTest extends DatabaseTestFixture {
         Pool pool2 = poolCurator.find(pool.getId());
         assertTrue(pool2.getConsumed() == 5);
         assertTrue(pool2.getEntitlements().size() == 1);
+    }
+
+    @Test
+    public void testPoolType() {
+        assertEquals(PoolType.NORMAL, pool.getType());
+
+        pool.setAttribute("pool_derived", "true");
+        assertEquals(PoolType.BONUS, pool.getType());
+
+        pool.setSourceEntitlement(new Entitlement());
+        assertEquals(PoolType.ENTITLEMENT_DERIVED, pool.getType());
+
+        pool.setSourceEntitlement(null);
+        pool.setSourceStackId("something");
+        assertEquals(PoolType.STACK_DERIVED, pool.getType());
     }
 }


### PR DESCRIPTION
When debugging we're currently having to figure out what type of pool
we're looking at based on implied attribute rules. Add a db transient
field to the Pool which will help us clarify what type of pool we're
looking at. Third party callers can use this to adjust behaviour in
displaying pools as necessary.

Also added a wrapper to see if a pool is stacked, and get it's stack ID,
as this is a fairly common check as well.

Ultimately it would be nice to have this saved in the db, but this
requires a more complicated rollout as there is a progrematic upgrade
involved. For now, it will just be transient.
