### PR TITLE
support default quantity for future pools

### DIFF
--- a/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -1362,8 +1362,13 @@ public class ConsumerResource {
         if (poolIdString != null && quantity == null) {
             Pool pool = poolManager.find(poolIdString);
             if (pool != null) {
+                Date now = new Date();
+                // If the pool is being attached in the future, calculate
+                // suggested quantity on the start date
+                Date onDate = now.before(pool.getStartDate()) ?
+                    pool.getStartDate() : now;
                 quantity = Math.max(1, quantityRules.getSuggestedQuantity(pool,
-                    consumer, new Date()).getSuggested().intValue());
+                    consumer, onDate).getSuggested().intValue());
             }
             else {
                 quantity = 1;


### PR DESCRIPTION
Low priority.  Right now we calculate default quantity based upon what is attached right now, for future subscriptions we should probably check the start date.

The other option is to use quantity 1 as the default for future subscriptions, but I think this works better in every case.
