### PR TITLE
1011257: Throw Conflict exception on StaleStateException

### DIFF
--- a/src/main/java/org/candlepin/exceptions/ConcurrentModificationException.java
+++ b/src/main/java/org/candlepin/exceptions/ConcurrentModificationException.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.exceptions;
+
+/**
+ * ConcurrentModificationException
+ *
+ * Thrown when a request attempts to modify an Entity that has already been
+ * modified by another request.
+ *
+ * This exception produces a 409 error.
+ */
+public class ConcurrentModificationException extends ConflictException {
+
+    public ConcurrentModificationException(String message, Exception e) {
+        super(message, e);
+    }
+
+}

--- a/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
+++ b/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
@@ -14,13 +14,17 @@
  */
 package org.candlepin.model;
 
-import org.candlepin.paging.PageRequest;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import javax.persistence.EntityManager;
+import javax.persistence.OptimisticLockException;
+
+import org.candlepin.exceptions.ConcurrentModificationException;
 import org.candlepin.paging.Page;
-
-import com.google.inject.Inject;
-import com.google.inject.Provider;
-import com.google.inject.persist.Transactional;
-
+import org.candlepin.paging.PageRequest;
 import org.hibernate.Criteria;
 import org.hibernate.Session;
 import org.hibernate.criterion.DetachedCriteria;
@@ -30,13 +34,11 @@ import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
 import org.hibernate.impl.CriteriaImpl;
 import org.hibernate.transform.ResultTransformer;
+import org.xnap.commons.i18n.I18n;
 
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
-import javax.persistence.EntityManager;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.google.inject.persist.Transactional;
 
 /**
  * AbstractHibernateCurator base class for all Candlepin curators. Curators are
@@ -47,6 +49,7 @@ import javax.persistence.EntityManager;
  */
 public abstract class AbstractHibernateCurator<E extends Persisted> {
     @Inject protected Provider<EntityManager> entityManager;
+    @Inject protected I18n i18n;
     private final Class<E> entityType;
     private int batchSize = 30;
 
@@ -283,7 +286,13 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
     }
 
     protected final void flush() {
-        getEntityManager().flush();
+        try {
+            getEntityManager().flush();
+        }
+        catch (OptimisticLockException e) {
+            throw new ConcurrentModificationException(getConcurrentModificationMessage(),
+                e);
+        }
     }
 
     protected Session currentSession() {
@@ -296,13 +305,19 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
     }
 
     public void saveOrUpdateAll(List<E> entries) {
-        Session session = currentSession();
-        for (int i = 0; i < entries.size(); i++) {
-            session.saveOrUpdate(entries.get(i));
-            if (i % batchSize == 0) {
-                session.flush();
-                session.clear();
+        try {
+            Session session = currentSession();
+            for (int i = 0; i < entries.size(); i++) {
+                session.saveOrUpdate(entries.get(i));
+                if (i % batchSize == 0) {
+                    session.flush();
+                    session.clear();
+                }
             }
+        }
+        catch (OptimisticLockException e) {
+            throw new ConcurrentModificationException(getConcurrentModificationMessage(),
+                e);
         }
 
     }
@@ -324,5 +339,9 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
         // sublist returns a portion of the list between the specified fromIndex,
         // inclusive, and toIndex, exclusive.
         return results.subList(fromIndex, toIndex);
+    }
+
+    private String getConcurrentModificationMessage() {
+        return i18n.tr("Request failed due to concurrent modification, please re-try.");
     }
 }

--- a/src/main/java/org/candlepin/model/ConsumerCurator.java
+++ b/src/main/java/org/candlepin/model/ConsumerCurator.java
@@ -28,7 +28,6 @@ import org.hibernate.Query;
 import org.hibernate.ReplicationMode;
 import org.hibernate.criterion.DetachedCriteria;
 import org.hibernate.criterion.Restrictions;
-import org.xnap.commons.i18n.I18n;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -49,7 +48,6 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
     @Inject private ConsumerTypeCurator consumerTypeCurator;
     @Inject private DeletedConsumerCurator deletedConsumerCurator;
     @Inject private Config config;
-    @Inject private I18n i18n;
     private static final int NAME_LENGTH = 250;
     private static Logger log = Logger.getLogger(ConsumerCurator.class);
 

--- a/src/main/java/org/candlepin/model/EntitlementCurator.java
+++ b/src/main/java/org/candlepin/model/EntitlementCurator.java
@@ -29,7 +29,6 @@ import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Property;
 import org.hibernate.criterion.Restrictions;
 import org.hibernate.criterion.Subqueries;
-import org.xnap.commons.i18n.I18n;
 
 import java.util.Date;
 import java.util.HashSet;
@@ -43,16 +42,14 @@ import java.util.Set;
 public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
     private static Logger log = Logger.getLogger(EntitlementCurator.class);
     private ProductServiceAdapter productAdapter;
-    private I18n i18n;
 
     /**
      * default ctor
      */
     @Inject
-    public EntitlementCurator(ProductServiceAdapter productAdapter, I18n i18n) {
+    public EntitlementCurator(ProductServiceAdapter productAdapter) {
         super(Entitlement.class);
         this.productAdapter = productAdapter;
-        this.i18n = i18n;
     }
 
     // TODO: handles addition of new entitlements only atm!

--- a/src/test/java/org/candlepin/pinsetter/core/PinsetterJobListenerDatabaseTest.java
+++ b/src/test/java/org/candlepin/pinsetter/core/PinsetterJobListenerDatabaseTest.java
@@ -28,6 +28,7 @@ import com.google.inject.persist.jpa.JpaPersistModule;
 import org.apache.commons.lang.RandomStringUtils;
 import org.candlepin.CandlepinNonServletEnvironmentTestingModule;
 import org.candlepin.auth.Principal;
+import org.candlepin.guice.I18nProvider;
 import org.candlepin.guice.JPAInitializer;
 import org.candlepin.guice.PrincipalProvider;
 import org.candlepin.guice.TestPrincipalProvider;
@@ -41,6 +42,7 @@ import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 import org.quartz.JobListener;
 import org.quartz.spi.JobFactory;
+import org.xnap.commons.i18n.I18n;
 
 /**
  * PinsetterJobListenerDatabaseTest is a unit test that uses a real database to
@@ -101,6 +103,7 @@ public class PinsetterJobListenerDatabaseTest {
         @Override
         protected void configure() {
             install(new JpaPersistModule("default"));
+            bind(I18n.class).toProvider(I18nProvider.class);
             bind(JPAInitializer.class).asEagerSingleton();
             bind(JobFactory.class).to(GuiceJobFactory.class);
             bind(JobListener.class).to(PinsetterJobListener.class);


### PR DESCRIPTION
Wrap stale edits in a custom ConcurrentModificationException so that a
clients recieve a 409 with a more descriptive message.

NOTE: I was unable to get an automated test to reproduce this scenario.

When testing, check out the referenced bug for details on how to reproduce.

Ping me if you need help.
