### PR TITLE
Correct Pythonism that slipped into spec tests.

### DIFF
--- a/spec/import_spec.rb
+++ b/spec/import_spec.rb
@@ -285,7 +285,7 @@ describe 'Candlepin Import', :serial => true do
     # while were here, lets access the upstream cert via entitlement id
     pools =  @import_owner_client.list_pools({:owner => @import_owner['id']})
     pool = pools.find_all {
-      |p| p.subscriptionId == sublist.first.id and p.subscriptionSubKey == "master"
+      |p| p.subscriptionId == sublist.first.id && p.subscriptionSubKey == "master"
     }[0]
     consumer = consumer_client(@import_owner_client, 'system6')
     entitlement = consumer.consume_pool(pool.id, {:quantity => 1})[0]


### PR DESCRIPTION
In Ruby, the "and" operator has extremely low precedence
and is not generally what you want to use.
See http://devblog.avdi.org/2010/08/02/using-and-and-or-in-ruby/
