### PR TITLE
1023187: Events for Rules addition and delete were missing event string.

### DIFF
--- a/src/main/java/org/candlepin/audit/EventAdapterImpl.java
+++ b/src/main/java/org/candlepin/audit/EventAdapterImpl.java
@@ -158,8 +158,10 @@ public class EventAdapterImpl implements EventAdapter {
             I18n.marktr("{0} deleted the activation key {1}"));
         MESSAGES.put("GUESTIDCREATED", I18n.marktr("{0} created the guest id {1}"));
         MESSAGES.put("GUESTIDDELETED", I18n.marktr("{0} deleted the guest id {1}"));
-        MESSAGES.put("RULESMODIFIED", I18n.marktr("{0} updated the rules in the databse to version {1}"));
-        MESSAGES.put("RULESDELETED", I18n.marktr("{0} removed the rules from the database"));
+        MESSAGES.put("RULESMODIFIED",
+            I18n.marktr("{0} updated the rules in the databse to version {1}"));
+        MESSAGES.put("RULESDELETED",
+            I18n.marktr("{0} removed the rules from the database"));
     }
 
 }


### PR DESCRIPTION
This resulted in messages in the atom feed such as

<messageText>Unknown event for user admin and target 4.4</messageText>

New strings were addded, and the correct text is shown.
