### PR TITLE
Moved the foreign key constraint from new table on creation

### DIFF
--- a/candlepin.spec
+++ b/candlepin.spec
@@ -31,7 +31,7 @@ Name: candlepin
 Summary: Candlepin is an open source entitlement management system
 Group: System Environment/Daemons
 License: GPLv2
-Version: 0.8.29
+Version: 0.8.29.1
 Release: 1%{?dist}
 URL: http://fedorahosted.org/candlepin
 # Source0: https://fedorahosted.org/releases/c/a/candlepin/%{name}-%{version}.tar.gz

--- a/src/main/resources/db/changelog/20130912153356-create-import-upstream-consumer.xml
+++ b/src/main/resources/db/changelog/20130912153356-create-import-upstream-consumer.xml
@@ -6,7 +6,6 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
 
-
     <changeSet id="20130912153356" author="wpoteat">
         <createTable tableName="cp_import_upstream_consumer">
             <column name="id" type="VARCHAR(32)">
@@ -29,9 +28,6 @@
             <column name="prefix_url_web" type="VARCHAR(255)"/>
             <column name="prefix_url_api" type="VARCHAR(255)"/>
         </createTable>
-    </changeSet>
-    <changeSet id="20130912153356-1" author="wpoteat">
-        <addForeignKeyConstraint constraintName="fk_imp_upstream_cnsmr_id" baseColumnNames="upstream_id" baseTableName="cp_import_record" referencedTableName="cp_import_upstream_consumer" referencedColumnNames="id"/>
     </changeSet>
     <changeSet id="20130912153356-2" author="wpoteat">
         <addForeignKeyConstraint baseColumnNames="type_id" baseTableName="cp_import_upstream_consumer" constraintName="fk_import_upstream_cnsmr_type" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" referencedColumnNames="id" referencedTableName="cp_consumer_type" referencesUniqueColumn="false"/>

--- a/src/main/resources/db/changelog/20131025111347-migrate-import-upstream-consumer.xml
+++ b/src/main/resources/db/changelog/20131025111347-migrate-import-upstream-consumer.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+    <changeSet id="20131025111347" author="wpoteat">
+        <addDefaultValue
+            tableName="cp_import_upstream_consumer"
+            columnName="uuid"
+            defaultValue="unknown"
+        />
+        <addDefaultValue
+            tableName="cp_import_upstream_consumer"
+            columnName="name"
+            defaultValue="unknown"
+        />
+    </changeSet> 
+    <changeSet id="20131025111347-1" author="wpoteat">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <foreignKeyConstraintExists foreignKeyName="fk_imp_upstream_cnsmr_id" />
+            </not>
+        </preConditions>
+        <comment>Need to move some data from import record for exisitng entries</comment>
+        <sql>
+            INSERT INTO cp_import_upstream_consumer (id, owner_id,
+                   type_id, created, updated)
+            SELECT ir.id,
+                   ir.owner_id,
+                   ct.id,
+                   ir.created,
+                   ir.updated
+            FROM cp_import_record ir,
+                   cp_consumer_type ct
+            WHERE ct.label = 'candlepin'
+       </sql>
+       <sql>
+           UPDATE cp_import_upstream_consumer
+           SET uuid = cp_import_record.upstream_id
+           FROM cp_import_record
+           WHERE cp_import_upstream_consumer.id = cp_import_record.id
+           AND cp_import_record.upstream_id IS NOT NULL
+       </sql>
+       <sql>
+            UPDATE cp_import_record set upstream_id = id 
+       </sql>
+    </changeSet>
+    <changeSet id="20131025111347-2" author="wpoteat">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <foreignKeyConstraintExists foreignKeyName="fk_imp_upstream_cnsmr_id" />
+            </not>
+        </preConditions>
+        <addForeignKeyConstraint constraintName="fk_imp_upstream_cnsmr_id" baseColumnNames="upstream_id" baseTableName="cp_import_record" referencedTableName="cp_import_upstream_consumer" referencedColumnNames="id"/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-create.xml
+++ b/src/main/resources/db/changelog/changelog-create.xml
@@ -1135,4 +1135,5 @@
     <include file="db/changelog/20130916125243-create-mysql-schema.xml" />
     <include file="db/changelog/20130912153356-create-import-upstream-consumer.xml" />
     <include file="db/changelog/20130920132949-add-delete-cascade-pool-products.xml" />
+    <include file="db/changelog/20131025111347-migrate-import-upstream-consumer.xml" />
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-update.xml
+++ b/src/main/resources/db/changelog/changelog-update.xml
@@ -43,4 +43,5 @@
     <include file="db/changelog/20130916125243-create-mysql-schema.xml" />
     <include file="db/changelog/20130912153356-create-import-upstream-consumer.xml" />
     <include file="db/changelog/20130920132949-add-delete-cascade-pool-products.xml" />
+    <include file="db/changelog/20131025111347-migrate-import-upstream-consumer.xml" />
 </databaseChangeLog>


### PR DESCRIPTION
Added data population to the new table prior to the foreign key addition.
   This covers systems with existing import data that have not had the import upstream consumer table created.
Foreign key application is conditional to cover systems that had original create script executed.
