### PR TITLE
add order number to imported subscriptions.

### DIFF
--- a/src/main/java/org/candlepin/sync/EntitlementImporter.java
+++ b/src/main/java/org/candlepin/sync/EntitlementImporter.java
@@ -80,6 +80,7 @@ public class EntitlementImporter {
 
         subscription.setAccountNumber(entitlement.getPool().getAccountNumber());
         subscription.setContractNumber(entitlement.getPool().getContractNumber());
+        subscription.setOrderNumber(entitlement.getPool().getOrderNumber());
 
         subscription.setQuantity(entitlement.getQuantity().longValue());
 

--- a/src/test/java/org/candlepin/sync/EntitlementImporterTest.java
+++ b/src/test/java/org/candlepin/sync/EntitlementImporterTest.java
@@ -62,6 +62,7 @@ import java.util.Set;
  * EntitlementImporterTest
  */
 @RunWith(MockitoJUnitRunner.class)
+@SuppressWarnings("synthetic-access")
 public class EntitlementImporterTest {
 
     @Mock private EventSink sink;
@@ -618,6 +619,7 @@ public class EntitlementImporterTest {
 
         assertEquals(pool.getAccountNumber(), sub.getAccountNumber());
         assertEquals(pool.getContractNumber(), sub.getContractNumber());
+        assertEquals(pool.getOrderNumber(), sub.getOrderNumber());
 
         assertEquals(ent.getQuantity().intValue(), sub.getQuantity().intValue());
 
@@ -640,7 +642,7 @@ public class EntitlementImporterTest {
         assertEquals(cert.getSerial().getUpdated(), serial.getUpdated());
     }
 
-    private Subscription createSubscription(Owner owner, String productId,
+    private Subscription createSubscription(Owner daOwner, String productId,
             String poolId, String entId, String conId, long quantity) {
         Subscription sub = new Subscription();
         sub.setProduct(new Product(productId, productId));
@@ -648,7 +650,7 @@ public class EntitlementImporterTest {
         sub.setUpstreamEntitlementId(entId);
         sub.setUpstreamConsumerId(conId);
         sub.setQuantity(quantity);
-        sub.setOwner(owner);
+        sub.setOwner(daOwner);
         sub.setId("" + index++);
         return sub;
     }


### PR DESCRIPTION
## TEST

First let's verify the problem.
- get a manifest from stage
- deploy candlepin master `buildconf/scripts/deploy`
- import manifest
  ```cd /client/ruby/
  ./cpc create_owner orgA
  ./cpc import orgA /path/to/manifest.zip

``````
* subscribe a client to your candlepin
```subscription-manager register
Username: admin
Password: admin
Owner: orgA
``````
- auto attach
  `subscription-manager attach --auto`
## VERIFY
- verify in database that the ordernumber is indeed EMPTY
  `select o.account, s.ordernumber, s.contractnumber from cp_subscription s, cp_owner o where s.owner_id = o.id and o.account = 'orgA';`
- verify the entitlement certificate has no order number:
  `rct cat-cert /etc/pki/entitlements/XXXXX.pem > /tmp/noorder.txt`
  - open the file and look for the Order: section, see that the Number is empty.
## RE-TEST
- checkout this branch
- redeploy
- import manifest
  ```cd /client/ruby/
  ./cpc create_owner orgA
  ./cpc import orgA /path/to/manifest.zip

``````
* subscribe a client to your candlepin
```subscription-manager register
Username: admin
Password: admin
Owner: orgA
``````
- auto attach
  `subscription-manager attach --auto`
## RE-VERIFY
- verify in database that the ordernumber is indeed filled in
  `select o.account, s.ordernumber, s.contractnumber from cp_subscription s, cp_owner o where s.owner_id = o.id and o.account = 'orgA';`
- verify the entitlement certificate has an order number:
  `rct cat-cert /etc/pki/entitlements/XXXXX.pem > /tmp/noorder.txt`
  - open the file and look for the Order: section, see that the Number is NOT empty.
