### PR TITLE
Upgrade to SLF4J 1.7.5.

### DIFF
--- a/buildfile
+++ b/buildfile
@@ -53,7 +53,7 @@ HIBERNATE = ['org.hibernate:hibernate-core:jar:3.3.2.GA',
              'cglib:cglib:jar:2.2',
              'javassist:javassist:jar:3.9.0.GA',
              'javax.transaction:jta:jar:1.1',
-             'org.slf4j:slf4j-api:jar:1.6.1',
+             'org.slf4j:slf4j-api:jar:1.7.5',
              'org.freemarker:freemarker:jar:2.3.15',
              'c3p0:c3p0:jar:0.9.0',
              'dom4j:dom4j:jar:1.6.1']

--- a/candlepin.spec
+++ b/candlepin.spec
@@ -89,7 +89,7 @@ BuildRequires: netty
 BuildRequires: glassfish-jaxb
 BuildRequires: jms >= 0:1.1
 BuildRequires: oauth
-BuildRequires: slf4j >= 0:1.6.1
+BuildRequires: slf4j >= 0:1.7.5
 
 # needed to setup runtime deps, not for compilation
 BuildRequires: c3p0
@@ -133,7 +133,7 @@ Requires: oauth
 Requires: logback-classic
 Requires: glassfish-jaxb
 Requires: scannotation
-Requires: slf4j >= 0:1.6.1
+Requires: slf4j >= 0:1.7.5
 Requires: jakarta-commons-lang
 Requires: jakarta-commons-io
 Requires: apache-commons-codec


### PR DESCRIPTION
We are going to need to upgrade to SLF4J 1.7.5 because that's what the new logback in brew is built against.  As a bonus, 1.7.5 gives us the ability to use varargs with parameterized logging and faster logger retrieval times.
