### PR TITLE
Fix apidoc generation

### DIFF
--- a/apidoc/apidoc.rb
+++ b/apidoc/apidoc.rb
@@ -29,6 +29,9 @@ apistruct = JSON.load(api_file)
 resources = {}
 apistruct.each do |method|
   url = method['url']
+  if url.nil?
+      next
+  end
   resource = '/' + (url.split('/')[1] || '')
   
   resources[resource] ||= {:page => resource, :methods => []}


### PR DESCRIPTION
Removed methods show up as deprecated/removed, but have
no url attribute, so skip them for apidocs generation.
