### PR TITLE
Modify buildfile to allow msgfmt to run for specific locales.

### DIFF
--- a/buildfile
+++ b/buildfile
@@ -172,7 +172,8 @@ define "candlepin" do
     mkdir_p dir.to_s
     sources.each do |source|
       locale = source.match("\/([^/]*)?\.po$")[1]
-      if nopo.nil? #we do this inside the loop, in order to still create a stub "generate" var
+      #we do this inside the loop, in order to create a stub "generate" var
+      if nopo.nil? || nopo.split(/,\s*/).include?(locale)
         sh "msgfmt --java -r org.candlepin.i18n.Messages -d #{dir} -l #{locale} #{source}"
       end
     end


### PR DESCRIPTION
Since some of our tests require translations (specifically German), this
change will allow you to build the minimum number of translations.
Simply set 'nopo' to a comma delimited list of locales or place the
following in your ~/.candlepinrc

```
nopo='de_DE'
export nopo
```
