### PR TITLE
support vcpu attribute

### DIFF
--- a/src/main/java/org/candlepin/policy/js/compliance/StatusReasonMessageGenerator.java
+++ b/src/main/java/org/candlepin/policy/js/compliance/StatusReasonMessageGenerator.java
@@ -82,7 +82,7 @@ public class StatusReasonMessageGenerator {
                 reason.getAttributes().get("covered"),
                 reason.getAttributes().get("has")));
         }
-        else if (reason.getKey().equals("VCPUS")) {
+        else if (reason.getKey().equals("VCPU")) {
             reason.setMessage(i18n.tr("Only supports {0} of {1} virtual cpus.",
                 reason.getAttributes().get("covered"),
                 reason.getAttributes().get("has")));

--- a/src/main/resources/rules/rules.js
+++ b/src/main/resources/rules/rules.js
@@ -49,7 +49,7 @@ var PROD_ARCHITECTURE_SEPARATOR = ",";
 
 // Product attribute names
 var SOCKETS_ATTRIBUTE = "sockets";
-var VCPUS_ATTRIBUTE = "vcpus";
+var VCPUS_ATTRIBUTE = "vcpu";
 var CORES_ATTRIBUTE = "cores";
 var ARCH_ATTRIBUTE = "arch";
 var RAM_ATTRIBUTE = "ram";

--- a/src/test/java/org/candlepin/policy/js/compliance/ComplianceRulesTest.java
+++ b/src/test/java/org/candlepin/policy/js/compliance/ComplianceRulesTest.java
@@ -1789,7 +1789,7 @@ public class ComplianceRulesTest {
         assertEquals(0, status.getNonCompliantProducts().size());
         assertEquals(1, status.getPartiallyCompliantProducts().size());
         assertEquals(1, status.getReasons().size());
-        assertEquals("VCPUS", status.getReasons().iterator().next().getKey());
+        assertEquals("VCPU", status.getReasons().iterator().next().getKey());
     }
 
     @Test
@@ -1799,7 +1799,7 @@ public class ComplianceRulesTest {
         c.setFact("cpu.cpu_socket(s)", "4");
         List<Entitlement> ents = new LinkedList<Entitlement>();
         Entitlement mockEntitlement = mockEntitlement(c, PRODUCT_1);
-        mockEntitlement.getPool().setProductAttribute("vcpus", "4", PRODUCT_1);
+        mockEntitlement.getPool().setProductAttribute("vcpu", "4", PRODUCT_1);
         ents.add(mockEntitlement);
         ents.get(0).setQuantity(1);
         mockEntCurator(c, ents);
@@ -1819,7 +1819,7 @@ public class ComplianceRulesTest {
         c.setFact("cpu.cpu_socket(s)", "4");
         List<Entitlement> ents = new LinkedList<Entitlement>();
         Entitlement mockEntitlement = mockEntitlement(c, "Awesome OS server", PRODUCT_1);
-        mockEntitlement.getPool().setProductAttribute("vcpus", "1", PRODUCT_1);
+        mockEntitlement.getPool().setProductAttribute("vcpu", "1", PRODUCT_1);
         ents.add(mockEntitlement);
         ents.get(0).setQuantity(1);
         mockEntCurator(c, ents);
@@ -1830,7 +1830,7 @@ public class ComplianceRulesTest {
         assertEquals(0, status.getNonCompliantProducts().size());
         assertEquals(1, status.getPartiallyCompliantProducts().size());
         assertEquals(1, status.getReasons().size());
-        assertEquals("VCPUS", status.getReasons().iterator().next().getKey());
+        assertEquals("VCPU", status.getReasons().iterator().next().getKey());
     }
 
     private void mockEntCurator(Consumer c, List<Entitlement> ents) {

--- a/src/test/java/org/candlepin/policy/js/compliance/StatusReasonMessageGeneratorTest.java
+++ b/src/test/java/org/candlepin/policy/js/compliance/StatusReasonMessageGeneratorTest.java
@@ -118,7 +118,7 @@ public class StatusReasonMessageGeneratorTest {
 
     @Test
     public void testVcpuMessage() {
-        ComplianceReason reason = buildReason("VCPUS",
+        ComplianceReason reason = buildReason("VCPU",
             buildGeneralAttributes("8", "4"));
         generator.setMessage(consumer, reason, new Date());
         assertEquals(

--- a/src/test/java/org/candlepin/policy/js/quantity/QuantityRulesTest.java
+++ b/src/test/java/org/candlepin/policy/js/quantity/QuantityRulesTest.java
@@ -54,7 +54,7 @@ public class QuantityRulesTest {
     private static final String CORES_FACT = "cpu.core(s)_per_socket";
     private static final String IS_VIRT = "virt.is_guest";
     private static final String GUEST_LIMIT_ATTRIBUTE = "guest_limit";
-    private static final String VCPU_ATTRIBUTE = "vcpus";
+    private static final String VCPU_ATTRIBUTE = "vcpu";
 
     private Consumer consumer;
     private Pool pool;


### PR DESCRIPTION
It doesn't fit very well with the design, but it works.

There are some bits that I wouldn't mid changing, but they'd take fairly major code overhauls.  For instance adding the product attribute to block multiplying attributes again seems silly, but if we calculate compliance completely internally lots of tests break.   Could be worth changing though.
