### PR TITLE
Only use entitlements that provide products for compliantUntil

### DIFF
--- a/src/main/java/org/candlepin/policy/js/compliance/ComplianceRules.java
+++ b/src/main/java/org/candlepin/policy/js/compliance/ComplianceRules.java
@@ -63,12 +63,6 @@ public class ComplianceRules {
      */
     public ComplianceStatus getStatus(Consumer c, Date date) {
 
-        if (c.getType().isManifest()) {
-            // We don't care about status for manifest consumer and they can have a LOT
-            // of entitlements. Skip it.
-            return new ComplianceStatus(date);
-        }
-
         List<Entitlement> ents = entCurator.listByConsumerAndDate(c, date);
 
         JsonJsContext args = new JsonJsContext(mapper);


### PR DESCRIPTION
Removed dead code, fixed comparator with no return.
Stopped checking duplicate dates.
