### PR TITLE
include log4j-bridge so logdriver works again

### DIFF
--- a/buildfile
+++ b/buildfile
@@ -104,6 +104,8 @@ SCHEMASPY = 'net.sourceforge:schemaSpy:jar:4.1.1'
 
 RHINO = 'org.mozilla:rhino:jar:1.7R3'
 
+# required by LOGDRIVER
+LOG4J_BRIDGE = 'org.slf4j:log4j-over-slf4j:jar:1.7.5'
 LOGDRIVER = 'logdriver:logdriver:jar:1.0'
 
 #############################################################################
@@ -136,6 +138,7 @@ if not use_pmd.nil?
 end
 
 use_logdriver = ENV['logdriver']
+puts use_logdriver
 
 #############################################################################
 # PROJECT BUILD
@@ -192,7 +195,7 @@ define "candlepin" do
   compile_classpath = [COMMONS, SLF4J_BRIDGES, RESTEASY, LOGBACK, HIBERNATE, BOUNCYCASTLE,
     GUICE, JACKSON, QUARTZ, GETTEXT_COMMONS, HORNETQ, SUN_JAXB, MIME4J, OAUTH, RHINO, COLLECTIONS]
   compile.with compile_classpath
-  compile.with LOGDRIVER if use_logdriver
+  compile.with LOGDRIVER, LOG4J_BRIDGE if use_logdriver
   if Buildr.environment == 'oracle'
     compile.with ORACLE
   else
@@ -210,7 +213,7 @@ define "candlepin" do
 
   # the other dependencies are gotten from compile.classpath automagically
   test.with HSQLDB, JUNIT, generate
-  test.with LOGDRIVER if use_logdriver
+  test.with LOGDRIVER, LOG4J_BRIDGE if use_logdriver
   test.using :java_args => [ '-Xmx2g', '-XX:+HeapDumpOnOutOfMemoryError' ]
 
   #


### PR DESCRIPTION
logdriver uses log4j to log its messages. With the move to
slf4j we no longer saw logdriver debug logging in any of the
log files. To avoid adding log4j and a log4j.properties just
to use logdriver in development, we decided the bridge for
log4j is a better solution.
## TEST

**master**
In _master_ branch, ensure the following lines are defined in your `/etc/candlepin/candlepin.conf`

```
log4j.logger.net.rkbloom.logdriver.LogPreparedStatement=DEBUG
log4j.logger.net.rkbloom.logdriver.LogStatement=DEBUG
log4j.logger.net.rkbloom.logdriver.LogCallableStatement=DEBUG
log4j.logger.net.rkbloom.logdriver.LogConnection=DEBUG
```

Deploy candlepin with the logdriver (`buildconf/scripts/deploy -l`) and observe the candlepin.log file will not have any log statements for the above classes.

**log4jbridge**
Now deploy the _log4jbridge_ branch using the same command: (`buildconf/scripts/deploy -l`). Now observe
that candlepin.log now has logdriver statements:

```
2013-12-18 15:36:20,824 [job=refresh_pools_4e76300b-ed37-4a6a-9958-b105e968a716, org=] DEBUG net.rkbloom.logdriver.LogPreparedStatement - executing PreparedStatement: 'insert into cp_pool (created, updated, accountNumber, activeSubscription, contractNumber, derivedProductId, derivedProductName, endDate, orderNumber, owner_id, productId, productName, quantity, restrictedToUsername, sourceConsumer_id, sourceEntitlement_id, sourceStackId, startDate, subscriptionId, subscriptionSubKey, version, id) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)' with bind parameters: {1=2013-12-18 15:36:20.806, 2=2013-12-18 15:36:20.806, 3=12331131231, 4=true, 5=2, 6=null, 7=null, 8=2014-12-17 19:00:00.0, 9=order-8675309, 10=8a8d089d43076be50143076bff160002, 11=awesomeos-server-basic, 12=Awesome OS Server Basic, 13=5, 14=null, 15=null, 16=null, 17=null, 18=2013-12-17 19:00:00.0, 19=8a8d089d43076be50143076c2dfb019d, 20=master, 21=0, 22=8a8d089d43076be50143076c64c615d0}
2013-12-18 15:36:20,839 [job=refresh_pools_42e43e54-f3f2-4b77-9aa7-37478007d6ce, org=] DEBUG net.rkbloom.logdriver.LogPreparedStatement - executing PreparedStatement: 'insert into cp_pool (created, updated, accountNumber, activeSubscription, contractNumber, derivedProductId, derivedProductName, endDate, orderNumber, owner_id, productId, productName, quantity, restrictedToUsername, sourceConsumer_id, sourceEntitlement_id, sourceStackId, startDate, subscriptionId, subscriptionSubKey, version, id) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)' with bind parameters: {1=2013-12-18 15:36:20.819, 2=2013-12-18 15:36:20.819, 3=12331131231, 4=true, 5=0, 6=null, 7=null, 8=2014-12-17 19:00:00.0, 9=order-8675309, 10=8a8d089d43076be50143076bff160003, 11=awesomeos-modifier, 12=Awesome OS Modifier, 13=5, 14=null, 15=null, 16=null, 17=null, 18=2013-12-17 19:00:00.0, 19=8a8d089d43076be50143076c2bf4018a, 20=master, 21=0, 22=8a8d089d43076be50143076c64d315de}
2013-12-18 15:36:20,854 [job=refresh_pools_4e76300b-ed37-4a6a-9958-b105e968a716, org=] DEBUG net.rkbloom.logdriver.LogPreparedStatement - executing PreparedStatement: 'insert into cp_pool (created, updated, accountNumber, activeSubscription, contractNumber, derivedProductId, derivedProductName, endDate, orderNumber, owner_id, productId, productName, quantity, restrictedToUsername, sourceConsumer_id, sourceEntitlement_id, sourceStackId, startDate, subscriptionId, subscriptionSubKey, version, id) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)' with bind parameters: {1=2013-12-18 15:36:20.837, 2=2013-12-18 15:36:20.837, 3=12331131231, 4=true, 5=2, 6=awesomeos-server-basic-vdc, 7=Awesome OS Server Basic (dc-virt), 8=2014-12-17 19:00:00.0, 9=order-8675309, 10=8a8d089d43076be50143076bff160002, 11=awesomeos-server-basic-dc, 12=Awesome OS Server Basic (data center), 13=5, 14=null, 15=null, 16=null, 17=null, 18=2013-12-17 19:00:00.0, 19=8a8d089d43076be50143076c2dc2019b, 20=master, 21=0, 22=8a8d089d43076be50143076c64e515e7}
2013-12-18 15:36:20,867 [job=refresh_pools_42e43e54-f3f2-4b77-9aa7-37478007d6ce, org=] DEBUG net.rkbloom.logdriver.LogPreparedStatement - executing PreparedStatement: 'insert into cp_pool (created, updated, accountNumber, activeSubscription, contractNumber, derivedProductId, derivedProductName, endDate, orderNumber, owner_id, productId, productName, quantity, restrictedToUsername, sourceConsumer_id, sourceEntitlement_id, sourceStackId, startDate, subscriptionId, subscriptionSubKey, version, id) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)' with bind parameters: {1=2013-12-18 15:36:20.847, 2=2013-12-18 15:36:20.847, 3=12331131231, 4=true, 5=0, 6=null, 7=null, 8=2014-12-17 19:00:00.0, 9=order-8675309, 10=8a8d089d43076be50143076bff160003, 11=awesomeos-server-basic, 12=Awesome OS Server Basic, 13=5, 14=null, 15=null, 16=null, 17=null, 18=2013-12-17 19:00:00.0, 19=8a8d089d43076be50143076c2bf5018b, 20=master, 21=0, 22=8a8d089d43076be50143076c64ef1601}
```
