### PR TITLE
1044574: Added --schema-only option to cpsetup/cpdb

### DIFF
--- a/code/setup/cpdb
+++ b/code/setup/cpdb
@@ -56,6 +56,10 @@ class DbSetup(object):
     def create(self):
         raise NotImplementedError("Implemented by subclasses")
 
+    def initialize_schema(self):
+        print("Loading candlepin schema")
+        self._run_liquibase("db/changelog/changelog-create.xml")
+
     def drop(self):
         raise NotImplementedError("Implemented by subclasses")
 
@@ -126,9 +130,6 @@ class OracleSetup(DbSetup):
         out = self._runSql('grant dba to %s;' % self.username)
         print out
 
-        print("Loading candlepin schema")
-        self._run_liquibase("db/changelog/changelog-create.xml")
-
     def drop(self):
         print("Dropping candlepin database")
         out = self._runSql('drop user %s cascade;' % self.username)
@@ -155,9 +156,6 @@ class PostgresqlSetup(DbSetup):
         elif status > 0:
             error_out(command, status, output)
 
-        print("Loading candlepin schema")
-        self._run_liquibase("db/changelog/changelog-create.xml")
-
     def drop(self):
         print("Dropping candlepin database")
         command = "dropdb -U %s %s" % (self.username, self.db)
@@ -173,6 +171,10 @@ if __name__ == "__main__":
     parser.add_option("--create",
             dest="create", action="store_true", default=False,
             help="create the Candlepin database")
+    parser.add_option("--schema-only",
+            dest="schema_only", action="store_true", default=False,
+            help="assumes database is already created by another tool and"
+                 "applies schema to database; used with --create")
     parser.add_option("--update",
             dest="update", action="store_true", default=False,
             help="update the Candlepin database")
@@ -219,6 +221,14 @@ if __name__ == "__main__":
         print("ERROR: Please specify --create or --update.")
         sys.exit(1)
 
+    if options.schema_only and not options.create:
+        print("ERROR: --schema-only must only be specified with --create.")
+        sys.exit(1)
+
+    if options.drop and options.schema_only:
+        print("ERROR: --drop can not be used with --schema-only")
+        sys.exit(1)
+
     if options.oracle:
         dbsetup = OracleSetup(options.dbuser, options.dbpassword, options.db,
                 options.community, options.oracle_user, options.oracle_password)
@@ -228,6 +238,8 @@ if __name__ == "__main__":
     if options.create:
         if options.drop:
             dbsetup.drop()
-        dbsetup.create()
+        if not options.schema_only:
+            dbsetup.create()
+        dbsetup.initialize_schema()
     if options.update:
         dbsetup.update()

--- a/code/setup/cpsetup
+++ b/code/setup/cpsetup
@@ -221,6 +221,9 @@ def main(argv):
     parser.add_option("-d", "--database",
                   dest="db", default="candlepin",
                   help="the database to use")
+    parser.add_option("--schema-only",
+                  action="store_true", dest="schema_only", default=False,
+                  help="database already exists, only load the schema.")
     parser.add_option("-w", "--webapp-prefix",
                   dest="webapp_prefix",
                   help="the web application prefix to use for export origin [host:port/prefix]")
@@ -251,17 +254,21 @@ def main(argv):
     tsetup.fix_perms()
     tsetup.stop()
 
-    # Call the cpdb script to create the candlepin database. This will fail
-    # if the database already exists, protecting us from accidentally wiping
-    # it out if cpsetup is re-run.
+    # Call the cpdb script to create the candlepin database. Database creation will be
+    # skipped if it already exists. The --schema-only option can be used if the database
+    # is expected to have been created by an external script, and only the schema is to
+    # be applied.
     script_dir = os.path.dirname(__file__)
     cpdb_script = os.path.join(script_dir, "cpdb")
     command = "%s --create -u %s --database %s --password %s" % (cpdb_script,
         options.dbuser, options.db, options.password)
+
+    if options.schema_only:
+        command = " ".join([command, "--schema-only"])
+
     if options.oracle:
         command = " ".join([command, "--oracle --oracle-user %s --oracle-password %s" %
             (options.oracle_user, options.oracle_password)])
-
     run_command(command)
 
     if not options.skipdbcfg:


### PR DESCRIPTION
On create, skip db creation step and only load the schema.
This is useful for situations where the database is created
by an external source, and only the schema should be applied.
