### PR TITLE
Run CRL spec tests in serial.

### DIFF
--- a/spec/cert_revocation_spec.rb
+++ b/spec/cert_revocation_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'candlepin_scenarios'
 require 'openssl'
 
-describe 'Certificate Revocation List' do
+describe 'Certificate Revocation List', :serial => true do
 
   include CandlepinMethods
 


### PR DESCRIPTION
Because there is now a ReadWriteLock on the CRL file, it is possible
for one thread to hold the file lock and delay the writing of a serial
to the CRL.  If the spec tests are running in parallel, the delayed
write may cause a failure for one of the tests that checks for a new serial
in the CRL.
