### PR TITLE
Modify compliance message strings

### DIFF
--- a/spec/compliance_reasons_spec.rb
+++ b/spec/compliance_reasons_spec.rb
@@ -57,7 +57,7 @@ describe 'Single Entitlement Compliance Reasons' do
     reasons = compliance_status['reasons']
     reasons.size.should == 1
     
-    expected_message = "Not covered by a valid subscription."
+    expected_message = "Not supported by a valid subscription."
     assert_reason(reasons[0], "NOTCOVERED", expected_message, {"product_id" => @product1.id,
                                                                 "name" => @product1.name})
   end
@@ -86,7 +86,7 @@ describe 'Single Entitlement Compliance Reasons' do
 
     expected_has = "16"
     expected_covered = "8"
-    expected_message = "Only covers %sGB of %sGB of RAM." % [expected_covered,
+    expected_message = "Only supports %sGB of %sGB of RAM." % [expected_covered,
                                                            expected_has]
 
     reasons = compliance_status['reasons']
@@ -123,7 +123,7 @@ describe 'Single Entitlement Compliance Reasons' do
 
     expected_has = "16"
     expected_covered = "8"
-    expected_message = "Only covers %sGB of %sGB of RAM." % [expected_covered,
+    expected_message = "Only supports %sGB of %sGB of RAM." % [expected_covered,
                                                            expected_has]
 
     reasons = compliance_status['reasons']
@@ -161,7 +161,7 @@ describe 'Single Entitlement Compliance Reasons' do
     compliance_status['compliant'].should == false
     compliance_status.should have_key('reasons')
 
-    expected_message = "Not covered by a valid subscription."
+    expected_message = "Not supported by a valid subscription."
 
     reasons = compliance_status['reasons']
     reasons.size.should == 1
@@ -198,7 +198,7 @@ describe 'Single Entitlement Compliance Reasons' do
 
     expected_has = "12"
     expected_covered = "2"
-    expected_message = "Only covers %s of %s sockets." % [expected_covered,
+    expected_message = "Only supports %s of %s sockets." % [expected_covered,
                                                            expected_has]
 
     reasons = compliance_status['reasons']
@@ -237,7 +237,7 @@ describe 'Single Entitlement Compliance Reasons' do
 
     expected_has = "24"
     expected_covered = "22"
-    expected_message = "Only covers %s of %s cores." % [expected_covered,
+    expected_message = "Only supports %s of %s cores." % [expected_covered,
                                                            expected_has]
 
     reasons = compliance_status['reasons']
@@ -274,7 +274,7 @@ describe 'Single Entitlement Compliance Reasons' do
 
     expected_has = "ppc64"
     expected_covered = "x86_64"
-    expected_message = "Covers architecture %s but the system is %s." % [expected_covered,
+    expected_message = "Supports architecture %s but the system is %s." % [expected_covered,
                                                                            expected_has]
 
     reasons = compliance_status['reasons']
@@ -321,7 +321,7 @@ describe 'Single Entitlement Compliance Reasons' do
 
     expected_has = "ppc64"
     expected_covered = "x86_64"
-    expected_message = "Covers architecture %s but the system is %s." % [expected_covered,
+    expected_message = "Supports architecture %s but the system is %s." % [expected_covered,
                                                                            expected_has]
     reason_expectations["ARCH"] = {
             "key" => "ARCH",
@@ -338,7 +338,7 @@ describe 'Single Entitlement Compliance Reasons' do
     
     expected_has = "16"
     expected_covered = "8"
-    expected_message = "Only covers %sGB of %sGB of RAM." % [expected_covered,
+    expected_message = "Only supports %sGB of %sGB of RAM." % [expected_covered,
                                                               expected_has]
     reason_expectations["RAM"] = {
             "key" => "RAM",
@@ -353,7 +353,7 @@ describe 'Single Entitlement Compliance Reasons' do
 
     expected_has = "20"
     expected_covered = "2"
-    expected_message = "Only covers %s of %s sockets." % [expected_covered,
+    expected_message = "Only supports %s of %s sockets." % [expected_covered,
                                                               expected_has]
     reason_expectations["SOCKETS"] = {
             "key" => "SOCKETS",
@@ -368,7 +368,7 @@ describe 'Single Entitlement Compliance Reasons' do
     
     expected_has = "240"
     expected_covered = "22"
-    expected_message = "Only covers %s of %s cores." % [expected_covered,
+    expected_message = "Only supports %s of %s cores." % [expected_covered,
                                                               expected_has]
     reason_expectations["CORES"] = {
             "key" => "CORES",
@@ -453,7 +453,7 @@ describe 'Stacking Compliance Reasons' do
     
     expected_has = "16"
     expected_covered = "8"
-    expected_message = "Only covers %sGB of %sGB of RAM." % [expected_covered,
+    expected_message = "Only supports %sGB of %sGB of RAM." % [expected_covered,
                                                                 expected_has]
 
     reasons = compliance_status['reasons']
@@ -489,7 +489,7 @@ describe 'Stacking Compliance Reasons' do
     
     expected_has = "16"
     expected_covered = "8"
-    expected_message = "Only covers %sGB of %sGB of RAM." % [expected_covered,
+    expected_message = "Only supports %sGB of %sGB of RAM." % [expected_covered,
                                                                 expected_has]
 
     reasons = compliance_status['reasons']
@@ -527,7 +527,7 @@ describe 'Stacking Compliance Reasons' do
     
     expected_has = "6"
     expected_covered = "4"
-    expected_message = "Only covers %s of %s sockets." % [expected_covered,
+    expected_message = "Only supports %s of %s sockets." % [expected_covered,
                                                              expected_has]
 
     reasons = compliance_status['reasons']
@@ -567,7 +567,7 @@ describe 'Stacking Compliance Reasons' do
     
     expected_has = "30"
     expected_covered = "20"
-    expected_message = "Only covers %s of %s cores." % [expected_covered,
+    expected_message = "Only supports %s of %s cores." % [expected_covered,
                                                            expected_has]
 
     reasons = compliance_status['reasons']
@@ -608,7 +608,7 @@ describe 'Stacking Compliance Reasons' do
     
     expected_has = "30"
     expected_covered = "16"
-    expected_message = "Only covers %s of %s vCPUs." % [expected_covered,
+    expected_message = "Only supports %s of %s vCPUs." % [expected_covered,
                                                            expected_has]
 
     reasons = compliance_status['reasons']
@@ -648,7 +648,7 @@ describe 'Stacking Compliance Reasons' do
     
     expected_has = "ppc64"
     expected_covered = "x86_64"
-    expected_message = "Covers architecture %s but the system is %s." % [expected_covered,
+    expected_message = "Supports architecture %s but the system is %s." % [expected_covered,
                                                                            expected_has]
 
     reasons = compliance_status['reasons']
@@ -685,7 +685,7 @@ describe 'Stacking Compliance Reasons' do
     compliance_status['compliant'].should == false
     compliance_status.should have_key('reasons')
     
-    expected_message = "Not covered by a valid subscription."
+    expected_message = "Not supported by a valid subscription."
 
     reasons = compliance_status['reasons']
     reasons.size.should == 1
@@ -726,7 +726,7 @@ describe 'Stacking Compliance Reasons' do
     
     expected_has = "ppc64"
     expected_covered = "x86_64"
-    expected_message = "Covers architecture %s but the system is %s." % [expected_covered,
+    expected_message = "Supports architecture %s but the system is %s." % [expected_covered,
                                                                             expected_has]
 
     reason_expectations["ARCH"] = {
@@ -742,7 +742,7 @@ describe 'Stacking Compliance Reasons' do
     
     expected_has = "16"
     expected_covered = "8"
-    expected_message = "Only covers %sGB of %sGB of RAM." % [expected_covered,
+    expected_message = "Only supports %sGB of %sGB of RAM." % [expected_covered,
                                                                 expected_has]
     reason_expectations["RAM"] = {
             "key" => "RAM",
@@ -757,7 +757,7 @@ describe 'Stacking Compliance Reasons' do
     
     expected_has = "20"
     expected_covered = "4"
-    expected_message = "Only covers %s of %s sockets." % [expected_covered,
+    expected_message = "Only supports %s of %s sockets." % [expected_covered,
                                                            expected_has]
     reason_expectations["SOCKETS"] = {
             "key" => "SOCKETS",
@@ -772,7 +772,7 @@ describe 'Stacking Compliance Reasons' do
     
     expected_has = "240"
     expected_covered = "20"
-    expected_message = "Only covers %s of %s cores." % [expected_covered,
+    expected_message = "Only supports %s of %s cores." % [expected_covered,
                                                            expected_has]
     reason_expectations["CORES"] = {
             "key" => "CORES",

--- a/src/main/java/org/candlepin/policy/js/compliance/StatusReasonMessageGenerator.java
+++ b/src/main/java/org/candlepin/policy/js/compliance/StatusReasonMessageGenerator.java
@@ -55,40 +55,40 @@ public class StatusReasonMessageGenerator {
             reason.getAttributes().put("name", marketingName);
         }
         if (reason.getKey().equals("NOTCOVERED")) {
-            reason.setMessage(i18n.tr("Not covered by a valid subscription."));
+            reason.setMessage(i18n.tr("Not supported by a valid subscription."));
         }
         else if (reason.getKey().equals("ARCH")) {
-            reason.setMessage(i18n.tr("Covers architecture {0} but the system is {1}.",
+            reason.setMessage(i18n.tr("Supports architecture {0} but the system is {1}.",
                 reason.getAttributes().get("covered"),
                 reason.getAttributes().get("has")));
         }
         else if (reason.getKey().equals("SOCKETS")) {
-            reason.setMessage(i18n.tr("Only covers {0} of {1} sockets.",
+            reason.setMessage(i18n.tr("Only supports {0} of {1} sockets.",
                 reason.getAttributes().get("covered"),
                 reason.getAttributes().get("has")));
         }
         else if (reason.getKey().equals("CORES")) {
-            reason.setMessage(i18n.tr("Only covers {0} of {1} cores.",
+            reason.setMessage(i18n.tr("Only supports {0} of {1} cores.",
                 reason.getAttributes().get("covered"),
                 reason.getAttributes().get("has")));
         }
         else if (reason.getKey().equals("RAM")) {
-            reason.setMessage(i18n.tr("Only covers {0}GB of {1}GB of RAM.",
+            reason.setMessage(i18n.tr("Only supports {0}GB of {1}GB of RAM.",
                 reason.getAttributes().get("covered"),
                 reason.getAttributes().get("has")));
         }
         else if (reason.getKey().equals("GUEST_LIMIT")) {
-            reason.setMessage(i18n.tr("Only covers {0} of {1} virtual guests.",
+            reason.setMessage(i18n.tr("Only supports {0} of {1} virtual guests.",
                 reason.getAttributes().get("covered"),
                 reason.getAttributes().get("has")));
         }
         else if (reason.getKey().equals("VCPU")) {
-            reason.setMessage(i18n.tr("Only covers {0} of {1} vCPUs.",
+            reason.setMessage(i18n.tr("Only supports {0} of {1} vCPUs.",
                 reason.getAttributes().get("covered"),
                 reason.getAttributes().get("has")));
         }
         else { //default fallback
-            reason.setMessage(i18n.tr("{2} COVERAGE PROBLEM.  Covers {0} of {1}",
+            reason.setMessage(i18n.tr("{2} COVERAGE PROBLEM.  Supports {0} of {1}",
                 reason.getAttributes().get("covered"),
                 reason.getAttributes().get("has"), reason.getKey()));
         }

--- a/src/test/java/org/candlepin/policy/js/compliance/StatusReasonMessageGeneratorTest.java
+++ b/src/test/java/org/candlepin/policy/js/compliance/StatusReasonMessageGeneratorTest.java
@@ -71,7 +71,7 @@ public class StatusReasonMessageGeneratorTest {
         ComplianceReason reason = buildReason("SOCKETS", buildGeneralAttributes("8", "4"));
         generator.setMessage(consumer, reason, new Date());
         assertEquals(
-            "Only covers 4 of 8 sockets.",
+            "Only supports 4 of 8 sockets.",
             reason.getMessage());
     }
 
@@ -80,7 +80,7 @@ public class StatusReasonMessageGeneratorTest {
         ComplianceReason reason = buildReason("SOCKETS", buildStackedAttributes("8", "4"));
         generator.setMessage(consumer, reason, new Date());
         String message = reason.getMessage();
-        assertEquals("Only covers 4 of 8 sockets.", message);
+        assertEquals("Only supports 4 of 8 sockets.", message);
         String[] names = reason.getAttributes().get("name").split("/");
         Arrays.sort(names);
         assertEquals("Stack Subscription One", names[0]);
@@ -93,7 +93,7 @@ public class StatusReasonMessageGeneratorTest {
             buildGeneralAttributes("x86_64", "ppc64"));
         generator.setMessage(consumer, reason, new Date());
         assertEquals(
-            "Covers architecture ppc64 but" +
+            "Supports architecture ppc64 but" +
             " the system is x86_64.", reason.getMessage());
     }
 
@@ -102,7 +102,7 @@ public class StatusReasonMessageGeneratorTest {
         ComplianceReason reason = buildReason("RAM", buildGeneralAttributes("8", "4"));
         generator.setMessage(consumer, reason, new Date());
         assertEquals(
-            "Only covers 4GB of 8GB of RAM.",
+            "Only supports 4GB of 8GB of RAM.",
             reason.getMessage());
     }
 
@@ -112,7 +112,7 @@ public class StatusReasonMessageGeneratorTest {
             buildGeneralAttributes("8", "4"));
         generator.setMessage(consumer, reason, new Date());
         assertEquals(
-            "Only covers 4 of 8 virtual guests.",
+            "Only supports 4 of 8 virtual guests.",
             reason.getMessage());
     }
 
@@ -121,7 +121,7 @@ public class StatusReasonMessageGeneratorTest {
         ComplianceReason reason = buildReason("CORES", buildGeneralAttributes("8", "4"));
         generator.setMessage(consumer, reason, new Date());
         assertEquals(
-            "Only covers 4 of 8 cores.",
+            "Only supports 4 of 8 cores.",
             reason.getMessage());
     }
 
@@ -130,7 +130,7 @@ public class StatusReasonMessageGeneratorTest {
         ComplianceReason reason = buildReason("VCPU", buildGeneralAttributes("8", "4"));
         generator.setMessage(consumer, reason, new Date());
         assertEquals(
-            "Only covers 4 of 8 vCPUs.",
+            "Only supports 4 of 8 vCPUs.",
             reason.getMessage());
     }
 
@@ -141,7 +141,7 @@ public class StatusReasonMessageGeneratorTest {
         generator.setMessage(consumer, reason, new Date());
         assertEquals(
             "NOT_A_KEY COVERAGE PROBLEM.  " +
-            "Covers 4 of 8", reason.getMessage());
+            "Supports 4 of 8", reason.getMessage());
     }
 
     @Test
@@ -154,7 +154,7 @@ public class StatusReasonMessageGeneratorTest {
         installed.setProductName("NonCovered Product");
         consumer.addInstalledProduct(installed);
         generator.setMessage(consumer, reason, new Date());
-        assertEquals("Not covered by a valid subscription.", reason.getMessage());
+        assertEquals("Not supported by a valid subscription.", reason.getMessage());
     }
 
     private ComplianceReason buildReason(String key, Map<String, String> attributes) {


### PR DESCRIPTION
Replace usage of the word "covers" with "supports"
