### PR TITLE
Truncate binary data when logging request/response bodies.

### DIFF
--- a/src/main/java/org/candlepin/servlet/filter/logging/ServletLogger.java
+++ b/src/main/java/org/candlepin/servlet/filter/logging/ServletLogger.java
@@ -14,11 +14,13 @@
  */
 package org.candlepin.servlet.filter.logging;
 
+import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.MediaType;
 
 /**
  * ServletLogger
@@ -66,14 +68,8 @@ public class ServletLogger {
 
     public static StringBuilder logBody(String type, BodyLogger bodyLogger) {
         StringBuilder builder = new StringBuilder();
-
-        // Don't log file download responses, they make a mess of the log:
-        if ((bodyLogger.getContentType() == null ||
-            (!bodyLogger.getContentType().equals("application/x-download") &&
-            !bodyLogger.getContentType().equals("application/zip")))) {
-            builder.append("====").append(type).append(" Body====\n");
-            builder.append(bodyLogger.getBody());
-        }
+        builder.append("====").append(type).append(" Body====\n");
+        builder.append(bodyLogger.getBody());
         return builder;
     }
 
@@ -95,5 +91,17 @@ public class ServletLogger {
                 .append(resp.getStatus())
                 .append(", content-type=\"").append(resp.getContentType())
                 .append("\", time=").append(duration).append("ms");
+    }
+
+    public static boolean showAsText(String contentType) {
+        String[] textTypes = {
+            MediaType.APPLICATION_JSON,
+            MediaType.APPLICATION_ATOM_XML,
+            MediaType.TEXT_PLAIN,
+            MediaType.TEXT_XML,
+            MediaType.TEXT_HTML,
+            MediaType.APPLICATION_FORM_URLENCODED
+        };
+        return Arrays.asList(textTypes).contains(contentType);
     }
 }

--- a/src/main/java/org/candlepin/servlet/filter/logging/TeeHttpServletRequest.java
+++ b/src/main/java/org/candlepin/servlet/filter/logging/TeeHttpServletRequest.java
@@ -17,6 +17,7 @@ package org.candlepin.servlet.filter.logging;
 import org.candlepin.util.Util;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
@@ -27,14 +28,13 @@ import java.io.InputStreamReader;
 import javax.servlet.ServletInputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
-import javax.ws.rs.core.MediaType;
 
 /**
  * This class gives us a new ServletInputStream every time we call getInputStream()
  * so we can read a request body more than once.
  */
 public class TeeHttpServletRequest extends HttpServletRequestWrapper implements BodyLogger {
-    private final byte [] body;
+    private final byte[] body;
 
     public TeeHttpServletRequest(HttpServletRequest request) throws IOException {
         super(request);
@@ -65,9 +65,9 @@ public class TeeHttpServletRequest extends HttpServletRequestWrapper implements 
 
     @Override
     public String getBody() {
-        if (MediaType.APPLICATION_JSON.equals(getContentType())) {
+        if (ServletLogger.showAsText(getContentType())) {
             return new String(body);
         }
-        return Util.toBase64(body);
+        return StringUtils.abbreviate(Util.toBase64(body), 100);
     }
 }

--- a/src/main/java/org/candlepin/servlet/filter/logging/TeeHttpServletResponse.java
+++ b/src/main/java/org/candlepin/servlet/filter/logging/TeeHttpServletResponse.java
@@ -14,6 +14,10 @@
  */
 package org.candlepin.servlet.filter.logging;
 
+import org.candlepin.util.Util;
+
+import org.apache.commons.lang.StringUtils;
+
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
@@ -89,7 +93,15 @@ public class TeeHttpServletResponse extends HttpServletResponseWrapper
     @Override
     public String getBody() {
         byte[] buff = getOutputBuffer();
-        return (buff == null) ? null : new String(getOutputBuffer());
+
+        if (buff != null) {
+            if (ServletLogger.showAsText(getContentType())) {
+                return new String(buff);
+            }
+            return StringUtils.abbreviate(Util.toBase64(buff), 100);
+        }
+
+        return "";
     }
 
     @Override

--- a/src/test/java/org/candlepin/servlet/filter/logging/TeeHttpServletRequestTest.java
+++ b/src/test/java/org/candlepin/servlet/filter/logging/TeeHttpServletRequestTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.when;
 
 import org.candlepin.util.Util;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -30,9 +31,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.servlet.ServletInputStream;
 import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.MediaType;
 
 
 /**
@@ -42,12 +46,8 @@ public class TeeHttpServletRequestTest {
     @Mock private HttpServletRequest request;
 
     @Before
-    public void setUp() {
+    public void setUp() throws IOException {
         MockitoAnnotations.initMocks(this);
-    }
-
-    @Test
-    public void testCtor() throws IOException {
         final ByteArrayInputStream bais =
             new ByteArrayInputStream("this is my body".getBytes());
         when(request.getInputStream()).thenReturn(new ServletInputStream() {
@@ -55,14 +55,43 @@ public class TeeHttpServletRequestTest {
                 return bais.read();
             }
         });
+    }
 
+    @Test
+    public void testCtor() throws IOException {
         TeeHttpServletRequest tee = new TeeHttpServletRequest(request);
         assertNotNull(tee);
-        assertEquals(Util.toBase64("this is my body".getBytes()), tee.getBody());
         assertNotNull(tee.getInputStream());
         assertEquals("this is my body", readData(tee.getInputStream()));
         assertEquals("this is my body", readData(tee.getReader()));
+    }
 
+    @Test
+    public void getBodyTest() throws IOException {
+        TeeHttpServletRequest tee = new TeeHttpServletRequest(request);
+
+        // Map content types to whether they should be logged as text or base64 encoded
+        Map<String, Boolean> types = new HashMap<String, Boolean>();
+        types.put(MediaType.APPLICATION_JSON, true);
+        types.put(MediaType.APPLICATION_ATOM_XML, true);
+        types.put(MediaType.TEXT_PLAIN, true);
+        types.put(MediaType.TEXT_HTML, true);
+        types.put(MediaType.TEXT_XML, true);
+        types.put(MediaType.APPLICATION_FORM_URLENCODED, true);
+        types.put(MediaType.APPLICATION_OCTET_STREAM, false);
+        types.put("multipart/form-data", false);
+        types.put("application/zip", false);
+
+        for (String type : types.keySet()) {
+            when(request.getContentType()).thenReturn(type);
+            if (types.get(type)) {
+                assertEquals(type + " failed!", "this is my body", tee.getBody());
+            }
+            else {
+                assertEquals(type + " failed!", Util.toBase64("this is my body".getBytes()),
+                    tee.getBody());
+            }
+        }
     }
 
     private String readData(InputStream is) throws IOException {


### PR DESCRIPTION
Bodies with content types that are not in a whitelist defined in ServletLogger will be printed base64 encoded and then truncated to 100 characters.
