### PR TITLE
Use Ruby's require_relative to load project specific libraries.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,4 @@ gem 'rest-client'
 gem 'oauth'
 gem 'iconv'
 gem 'parallel_tests'
+gem 'backports', :require => false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ GEM
   specs:
     atoulme-Antwrap (0.7.2)
       rjb (>= 1.0.3)
+    backports (3.4.0)
     builder (2.1.2)
     buildr (1.4.7)
       atoulme-Antwrap (~> 0.7.2)
@@ -60,6 +61,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  backports
   buildr (= 1.4.7)
   iconv
   oauth

--- a/buildconf/scripts/bind-performance.rb
+++ b/buildconf/scripts/bind-performance.rb
@@ -7,7 +7,13 @@
 #
 # Can be run and re-run against a typical dev deployment without any arguments.
 
-require  "../../client/ruby/candlepin_api"
+begin
+  require 'backports/1.9.1/kernel/require_relative'
+rescue LoadError
+  require 'rubygems'
+  require 'backports/1.9.1/kernel/require_relative'
+end
+require_relative "../../client/ruby/candlepin_api"
 require 'pp'
 
 require 'benchmark'

--- a/buildconf/scripts/bulk-crl-test.rb
+++ b/buildconf/scripts/bulk-crl-test.rb
@@ -1,6 +1,12 @@
 #!/usr/bin/env ruby
 
-require  "../../client/ruby/candlepin_api"
+begin
+  require 'backports/1.9.1/kernel/require_relative'
+rescue LoadError
+  require 'rubygems'
+  require 'backports/1.9.1/kernel/require_relative'
+end
+require_relative "../../client/ruby/candlepin_api"
 require 'pp'
 
 cp = Candlepin.new('admin', 'admin')

--- a/buildconf/scripts/concurrency-bonuspool-test.rb
+++ b/buildconf/scripts/concurrency-bonuspool-test.rb
@@ -8,7 +8,13 @@
 # watch the progress bar in terminal 2 (green dot for consumed ent, red N for not)
 # watch the details in terminal 1
 
-require "../../client/ruby/candlepin_api"
+begin
+  require 'backports/1.9.1/kernel/require_relative'
+rescue LoadError
+  require 'rubygems'
+  require 'backports/1.9.1/kernel/require_relative'
+end
+require_relative "../../client/ruby/candlepin_api"
 require 'pp'
 require 'optparse'
 

--- a/buildconf/scripts/concurrency-test.rb
+++ b/buildconf/scripts/concurrency-test.rb
@@ -8,9 +8,16 @@
 # watch the progress bar in terminal 2 (green dot for consumed ent, red N for not)
 # watch the details in terminal 1
 
-require "../../client/ruby/candlepin_api"
+begin
+  require 'backports/1.9.1/kernel/require_relative'
+rescue LoadError
+  require 'rubygems'
+  require 'backports/1.9.1/kernel/require_relative'
+end
+require_relative "../../client/ruby/candlepin_api"
 require 'pp'
 require 'optparse'
+require 'thread'
 
 CP_SERVER = "localhost"
 CP_PORT = 8443

--- a/buildconf/scripts/generate-all-export.rb
+++ b/buildconf/scripts/generate-all-export.rb
@@ -6,7 +6,13 @@
 #
 # None of the above will be cleaned up.
 
-require  "../../client/ruby/candlepin_api"
+begin
+  require 'backports/1.9.1/kernel/require_relative'
+rescue LoadError
+  require 'rubygems'
+  require 'backports/1.9.1/kernel/require_relative'
+end
+require_relative "../../client/ruby/candlepin_api"
 require 'pp'
 
 ADMIN_USERNAME = "admin"

--- a/buildconf/scripts/generate-export.rb
+++ b/buildconf/scripts/generate-export.rb
@@ -6,7 +6,13 @@
 #
 # None of the above will be cleaned up.
 
-require  "../../client/ruby/candlepin_api"
+begin
+  require 'backports/1.9.1/kernel/require_relative'
+rescue LoadError
+  require 'rubygems'
+  require 'backports/1.9.1/kernel/require_relative'
+end
+require_relative "../../client/ruby/candlepin_api"
 require 'pp'
 
 ADMIN_USERNAME = "admin"

--- a/buildconf/scripts/import_products.rb
+++ b/buildconf/scripts/import_products.rb
@@ -1,6 +1,12 @@
 #!/usr/bin/env ruby
 
-require  "./client/ruby/candlepin_api"
+begin
+  require 'backports/1.9.1/kernel/require_relative'
+rescue LoadError
+  require 'rubygems'
+  require 'backports/1.9.1/kernel/require_relative'
+end
+require_relative "../../client/ruby/candlepin_api"
 
 require 'rubygems'
 require 'date'

--- a/buildconf/scripts/performance-dataloader.rb
+++ b/buildconf/scripts/performance-dataloader.rb
@@ -11,7 +11,13 @@
 # A number of fake systems are then registered with installed
 # products, and then an autobind is performed for each.
 
-require  "../../client/ruby/candlepin_api"
+begin
+  require 'backports/1.9.1/kernel/require_relative'
+rescue LoadError
+  require 'rubygems'
+  require 'backports/1.9.1/kernel/require_relative'
+end
+require_relative "../../client/ruby/candlepin_api"
 require 'pp'
 require 'benchmark'
 require 'optparse'

--- a/client/ruby/candlepin_api.rb
+++ b/client/ruby/candlepin_api.rb
@@ -1,8 +1,12 @@
+begin
+  require 'rest_client'
+rescue LoadError
+  require 'rubygems'
+  require 'rest_client'
+end
 require 'base64'
 require 'openssl'
 require 'date'
-require 'rubygems'
-require 'rest_client'
 require 'json'
 require 'uri'
 require 'pp'

--- a/client/ruby/cpc
+++ b/client/ruby/cpc
@@ -1,8 +1,14 @@
 #!/usr/bin/env ruby
 $VERBOSE = nil
 
+begin
+  require 'backports/1.9.1/kernel/require_relative'
+rescue LoadError
+  require 'rubygems'
+  require 'backports/1.9.1/kernel/require_relative'
+end
 require 'pp'
-require './candlepin_api'
+require_relative 'candlepin_api'
 require 'optparse'
 
 # Wrapper class for the base Candlepin lib that

--- a/spec/candlepin_scenarios.rb
+++ b/spec/candlepin_scenarios.rb
@@ -1,4 +1,10 @@
-require 'candlepin_api'
+begin
+  require 'backports/1.9.1/kernel/require_relative'
+rescue LoadError
+  require 'rubygems'
+  require 'backports/1.9.1/kernel/require_relative'
+end
+require_relative '../client/ruby/candlepin_api'
 
 require 'pp'
 require 'zip/zip'

--- a/spec/rules_import_spec.rb
+++ b/spec/rules_import_spec.rb
@@ -1,6 +1,5 @@
 require 'spec_helper'
 require 'candlepin_scenarios'
-require 'candlepin_api'
 require 'pp'
 require 'base64'
 

--- a/tasks/parallel_rspec.rake
+++ b/tasks/parallel_rspec.rake
@@ -21,9 +21,8 @@ module ParallelRSpec
     end
 
     after_define do |project|
-      CANDLEPIN_API = File.join(project.base_dir, "client/ruby")
       RSpec::Core::RakeTask.new('serial_rspec') do |task|
-        task.rspec_opts = %W{-I #{CANDLEPIN_API} --tag serial --color -fd}
+        task.rspec_opts = %W{--tag serial --color -fd}
         # Running buildr parall_rspec all_tests=true will cause all the tests
         # to run even if a test fails during the run.
         if not ENV['all_tests'].nil?
@@ -32,14 +31,13 @@ module ParallelRSpec
       end
 
       project.task('parallel_rspec' => 'serial_rspec') do |task|
-        rspec_opts = { 
-          "I" => CANDLEPIN_API,
+        rspec_opts = {
           "tag" => "~serial",
           "format" => "documentation"
         }
 
         spec_dir = project.path_to(:spec)
-        ParallelTests::CLI.new.run(["--type", "rspec", "-o", ParallelRSpec.opts_to_string(rspec_opts), spec_dir])  
+        ParallelTests::CLI.new.run(["--type", "rspec", "-o", ParallelRSpec.opts_to_string(rspec_opts), spec_dir])
       end
     end
   end


### PR DESCRIPTION
By using require_relative, we can run cpc and spec tests without
having to be in a certain directory.  The require_relative method
was added in Ruby 1.9.2.

See https://practicingruby.com/articles/ways-to-load-code?u=dc2ab0f9bb
and http://extensions.rubyforge.org/rdoc/classes/Kernel.html
