### PR TITLE
Allow CPC to run from anywhere.

### DIFF
--- a/client/ruby/cpc
+++ b/client/ruby/cpc
@@ -2,7 +2,7 @@
 $VERBOSE = nil
 
 require 'pp'
-require './candlepin_api'
+require File.expand_path('candlepin_api', File.dirname(__FILE__))
 require 'optparse'
 
 # Wrapper class for the base Candlepin lib that


### PR DESCRIPTION
This construction allows CPC to reference the candlepin_api.rb file
without depending on the working directory.  It is compatible with Ruby
1.8.x, 1.9.x, and 2.0.  See http://stackoverflow.com/questions/4325759

In an ideal world, we'd forsake Ruby 1.8.x and just use require_relative which was introduced in 1.9.1; however, it is very nice to be able to run everything in RHEL 6.
