### PR TITLE
1037665:  /var/cache/candlepin seemingly not being cleaned up

### DIFF
--- a/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang.StringUtils;
 import org.candlepin.pinsetter.tasks.CancelJobJob;
 import org.candlepin.pinsetter.tasks.CertificateRevocationListTask;
 import org.candlepin.pinsetter.tasks.ExpiredPoolsJob;
+import org.candlepin.pinsetter.tasks.ExportCleaner;
 import org.candlepin.pinsetter.tasks.ImportRecordJob;
 import org.candlepin.pinsetter.tasks.JobCleaner;
 import org.candlepin.pinsetter.tasks.SweepBarJob;
@@ -77,7 +78,8 @@ public class ConfigProperties {
         JobCleaner.class.getName(), ImportRecordJob.class.getName(),
         StatisticHistoryTask.class.getName(),
         CancelJobJob.class.getName(), ExpiredPoolsJob.class.getName(),
-        UnpauseJob.class.getName(), SweepBarJob.class.getName()};
+        UnpauseJob.class.getName(), SweepBarJob.class.getName(),
+        ExportCleaner.class.getName()};
 
     public static final String SYNC_WORK_DIR = "candlepin.sync.work_dir";
     public static final String CONSUMER_FACTS_MATCHER =

--- a/src/main/java/org/candlepin/guice/CandlepinModule.java
+++ b/src/main/java/org/candlepin/guice/CandlepinModule.java
@@ -46,6 +46,7 @@ import org.candlepin.pinsetter.core.PinsetterKernel;
 import org.candlepin.pinsetter.tasks.CertificateRevocationListTask;
 import org.candlepin.pinsetter.tasks.EntitlerJob;
 import org.candlepin.pinsetter.tasks.JobCleaner;
+import org.candlepin.pinsetter.tasks.ExportCleaner;
 import org.candlepin.pinsetter.tasks.RefreshPoolsJob;
 import org.candlepin.pinsetter.tasks.SweepBarJob;
 import org.candlepin.pinsetter.tasks.UnpauseJob;
@@ -233,6 +234,7 @@ public class CandlepinModule extends AbstractModule {
         bind(PinsetterKernel.class);
         bind(CertificateRevocationListTask.class);
         bind(JobCleaner.class);
+        bind(ExportCleaner.class);
         bind(UnpauseJob.class);
         bind(SweepBarJob.class);
     }

--- a/src/main/java/org/candlepin/pinsetter/tasks/ExportCleaner.java
+++ b/src/main/java/org/candlepin/pinsetter/tasks/ExportCleaner.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.pinsetter.tasks;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Date;
+
+import org.apache.commons.io.FileUtils;
+import org.candlepin.config.Config;
+import org.candlepin.config.ConfigProperties;
+import org.candlepin.util.Util;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.inject.Inject;
+import com.google.inject.persist.UnitOfWork;
+
+/**
+ * ExportCleaner
+ *
+ * This pinsetter task examines the directory where the exporter compiles its
+ * information and resultant zip file. Data that is more that a day old will
+ * be expunged.
+ *
+ */
+public class ExportCleaner extends KingpinJob {
+
+    public static final String DEFAULT_SCHEDULE = "0 0 12 * * ?";
+    private Config config;
+    private static Logger log = LoggerFactory.getLogger(ExportCleaner.class);
+
+    @Inject
+    public ExportCleaner(Config config, UnitOfWork unitOfWork) {
+        super(unitOfWork);
+        this.config = config;
+    }
+
+    @Override
+    public void toExecute(JobExecutionContext arg0) throws JobExecutionException {
+        File baseDir = new File(config.getString(ConfigProperties.SYNC_WORK_DIR));
+        Date deadLineDt = Util.yesterday();
+
+        long dirCount = 0;
+        long delCount = 0;
+        long leftCount = 0;
+        if (baseDir.listFiles() != null) {
+            dirCount =  baseDir.listFiles().length;
+            for (File f : baseDir.listFiles()) {
+                if (f.lastModified() < deadLineDt.getTime()) {
+                    try {
+                        FileUtils.deleteDirectory(f);
+                        delCount++;
+                    }
+                    catch (IOException io) {
+                        log.error("Unable to delete export directory that is old enough " +
+                            "to delete", io);
+                    }
+                }
+                else {
+                    leftCount++;
+                }
+            }
+        }
+        log.info("Export Data Cleaner run:");
+        log.info("Begining directory count: " + dirCount);
+        log.info("Directories deleted: " + delCount);
+        log.info("Directories remaining: " + leftCount);
+    }
+}

--- a/src/test/java/org/candlepin/pinsetter/tasks/ExportCleanerTest.java
+++ b/src/test/java/org/candlepin/pinsetter/tasks/ExportCleanerTest.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.pinsetter.tasks;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+
+import org.apache.commons.io.FileUtils;
+import org.candlepin.config.Config;
+import org.candlepin.config.ConfigProperties;
+import org.candlepin.util.Util;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+
+/**
+ * ExportCleanerTest
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ExportCleanerTest {
+
+    @Mock private Config config;
+    private ExportCleaner cleaner;
+
+    @Before
+    public void init() {
+        cleaner = new ExportCleaner(config, null);
+    }
+
+    @Test
+    public void execute() throws Exception {
+        File baseDir = new File("/tmp/syncdirtest");
+        baseDir.mkdir();
+        try {
+            File tmp1 = new File(baseDir.getAbsolutePath(), "test-dir-1");
+            tmp1.mkdir();
+            tmp1.setLastModified(Util.yesterday().getTime() - 1000);
+            File tmp2 = new File(baseDir.getAbsolutePath(), "test-dir-2");
+            tmp2.mkdir();
+            tmp2.setLastModified(Util.yesterday().getTime() - 1000);
+            File tmp3 = new File(baseDir.getAbsolutePath(), "test-dir-3");
+            tmp3.mkdir();
+
+            when(config.getString(eq(ConfigProperties.SYNC_WORK_DIR)))
+                .thenReturn(baseDir.getPath());
+            cleaner.execute(null);
+
+            assert (!tmp1.exists());
+            assert (!tmp2.exists());
+            assert (tmp3.exists());
+        }
+        finally {
+            FileUtils.deleteDirectory(baseDir);
+        }
+    }
+}


### PR DESCRIPTION
Pinsetter task will remove temporary export directories more than a day old
