### PR TITLE
Fix mysql timestamps with liquibase >= 3.1.

### DIFF
--- a/src/main/resources/db/changelog/20130912153356-create-import-upstream-consumer.xml
+++ b/src/main/resources/db/changelog/20130912153356-create-import-upstream-consumer.xml
@@ -6,7 +6,12 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
 
+    <property name="timestamp.type" value="TIMESTAMP WITHOUT TIME ZONE" dbms="oracle"/>
+    <property name="timestamp.type" value="TIMESTAMP WITHOUT TIME ZONE" dbms="postgresql"/>
+    <property name="timestamp.type" value="DATETIME" dbms="mysql"/>
+
     <changeSet id="20130912153356" author="wpoteat">
+        <validCheckSum>7:69e9ff14c6d2da8962d4870401700340</validCheckSum>
         <createTable tableName="cp_import_upstream_consumer">
             <column name="id" type="VARCHAR(32)">
                 <constraints nullable="false" primaryKey="true" primaryKeyName="cp_imp_upstream_cnsmr_pkey"/>
@@ -17,8 +22,8 @@
             <column name="name" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="created" type="TIMESTAMP WITHOUT TIME ZONE"/>
-            <column name="updated" type="TIMESTAMP WITHOUT TIME ZONE"/>
+            <column name="created" type="${timestamp.type}"/>
+            <column name="updated" type="${timestamp.type}"/>
             <column name="owner_id" type="VARCHAR(32)">
                 <constraints nullable="false"/>
             </column>
@@ -32,6 +37,6 @@
     <changeSet id="20130912153356-2" author="wpoteat">
         <addForeignKeyConstraint baseColumnNames="type_id" baseTableName="cp_import_upstream_consumer" constraintName="fk_import_upstream_cnsmr_type" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" referencedColumnNames="id" referencedTableName="cp_consumer_type" referencesUniqueColumn="false"/>
     </changeSet>
-    
+
 
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/20131002150608-consumer-content-override.xml
+++ b/src/main/resources/db/changelog/20131002150608-consumer-content-override.xml
@@ -7,7 +7,12 @@
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
 
 
+    <property name="timestamp.type" value="TIMESTAMP WITHOUT TIME ZONE" dbms="oracle"/>
+    <property name="timestamp.type" value="TIMESTAMP WITHOUT TIME ZONE" dbms="postgresql"/>
+    <property name="timestamp.type" value="DATETIME" dbms="mysql"/>
+
     <changeSet id="20131002150608" author="wpoteat">
+        <validCheckSum>7:bef3100eb209f06cd08332a032e87c3f</validCheckSum>
         <comment>Consumer content overrides</comment>
         <createTable tableName="cp_consumer_content_override">
             <column name="id" type="VARCHAR(32)">
@@ -25,8 +30,8 @@
             <column name="value" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="created" type="TIMESTAMP WITHOUT TIME ZONE"/>
-            <column name="updated" type="TIMESTAMP WITHOUT TIME ZONE"/>
+            <column name="created" type="${timestamp.type}"/>
+            <column name="updated" type="${timestamp.type}"/>
         </createTable>
     </changeSet>
     <changeSet author="wpoteat" id="20131002150608-01">
@@ -35,6 +40,6 @@
     <changeSet author="wpoteat" id="20131002150608-02">
         <addUniqueConstraint columnNames="consumer_id, content_label, name" constraintName="cp_consumer_content_ukey" deferrable="false" disabled="false" initiallyDeferred="false" tableName="cp_consumer_content_override"/>
     </changeSet>
-    
+
 
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/20140205152431-fix-mysql-datetimes.xml
+++ b/src/main/resources/db/changelog/20140205152431-fix-mysql-datetimes.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+
+    <changeSet id="20140205152431" author="dgoodwin" dbms="mysql">
+        <comment>MySQL databases may have incorrect created/updated columns of type timestamp when they should have datetime. Original changeset is corrected for new databases, this changeset will attempt to correct it on all. The change is safe even if the database already has the correct type.</comment>
+        <modifyDataType tableName="cp_import_upstream_consumer" columnName="created" newDataType="DATETIME"/>
+        <modifyDataType tableName="cp_import_upstream_consumer" columnName="updated" newDataType="DATETIME"/>
+        <modifyDataType tableName="cp_consumer_content_override" columnName="created" newDataType="DATETIME"/>
+        <modifyDataType tableName="cp_consumer_content_override" columnName="updated" newDataType="DATETIME"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-create.xml
+++ b/src/main/resources/db/changelog/changelog-create.xml
@@ -1148,4 +1148,5 @@
     <include file="db/changelog/20131126095353-add-guest-attributes.xml" />
     <include file="db/changelog/20140114145843-add-jobquery-index.xml" />
     <include file="db/changelog/20140115110932-add-overrides-and-release-to-actkey.xml" />
+    <include file="db/changelog/20140205152431-fix-mysql-datetimes.xml" />
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-update.xml
+++ b/src/main/resources/db/changelog/changelog-update.xml
@@ -56,4 +56,5 @@
     <include file="db/changelog/20131126095353-add-guest-attributes.xml" />
     <include file="db/changelog/20140114145843-add-jobquery-index.xml" />
     <include file="db/changelog/20140115110932-add-overrides-and-release-to-actkey.xml" />
+    <include file="db/changelog/20140205152431-fix-mysql-datetimes.xml" />
 </databaseChangeLog>


### PR DESCRIPTION
These two tables were being created with an incorrect column type for
created/updated on mysql of timestamp without time zone. (should be datetime)
As of liquibase 3.1, the "without time zone" portion started being used and
failing due to incorrect syntax. All other mysql tables use timestamp for these
columns.

This leaves us in a bad situation where some mysql databases (stage) have been
created with incorrect column types and liquibase < 3.1.

This patch attempts to correct both problems, the original changesets are
modified to create the correct column type, and the checksum fix is
incorporated so existing mysql db's will not complain about the change.
Postgres and oracle db's do not see a changed checksum as their sql has not
actually changed.

If the changeset has already been applied incorrectly, a subsequent mysql-only
changeset will run that converts the column type to datetime. If it's already
datetime, this should have no effect.

Tested against master -> this branch for a variety of combinations of
postgres/mysql and liquibase versions, everything should be working correctly
now.
