### PR TITLE
symlink hibernate4-c3p0 jar

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -31,7 +31,7 @@
     dom4j gettext-commons google-collections guice
     guice-assistedinject guice-multibindings guice-persist guice-servlet
     guice-throwingproviders hibernate-commons-annotations
-    hibernate4-core hibernate4-entitymanager hornetq-commons hornetq-server
+    hibernate4-core hibernate4-c3p0 hibernate4-entitymanager hornetq-commons hornetq-server
     hornetq-core-client hornetq-journal javassist javax.inject jaxb-impl
     jboss-logging hibernate-jpa-2.0-api jta log4j netty oauth oauth-provider
     postgresql-jdbc resteasy/resteasy-atom-provider


### PR DESCRIPTION
We forgot to symlink hibernate4-c3p0.

This is the scratch build: http://brewweb.devel.redhat.com/brew/taskinfo?taskID=7013103

Here are the results for the scratch build:

```
$ rpm -qlpv candlepin-tomcat6-0.9.2-1.git.30.d46a1ac.el6_5.noarch.rpm  | grep c3p0
lrw-r--r--    1 tomcat  tomcat                     24 Feb  6 12:49 /var/lib/tomcat6/webapps/candlepin/WEB-INF/lib/c3p0.jar -> /usr/share/java/c3p0.jar
lrw-r--r--    1 tomcat  tomcat                     35 Feb  6 12:49 /var/lib/tomcat6/webapps/candlepin/WEB-INF/lib/hibernate4-c3p0.jar -> /usr/share/java/hibernate4-c3p0.jar
$ 
```

The original build did not have the jar:

```
$ rpm -qlpv candlepin-tomcat6-0.9.2-1.el6_5.noarch.rpm | grep c3p0
lrw-r--r--    1 tomcat  tomcat                     24 Jan 15 15:45 /var/lib/tomcat6/webapps/candlepin/WEB-INF/lib/c3p0.jar -> /usr/share/java/c3p0.jar
$
```
