### PR TITLE
Allow consumers to check in hypervisors

### DIFF
--- a/src/main/java/org/candlepin/auth/ConsumerPrincipal.java
+++ b/src/main/java/org/candlepin/auth/ConsumerPrincipal.java
@@ -16,6 +16,7 @@ package org.candlepin.auth;
 
 import org.candlepin.auth.permissions.AttachPermission;
 import org.candlepin.auth.permissions.ConsumerEntitlementPermission;
+import org.candlepin.auth.permissions.ConsumerOrgHypervisorPermission;
 import org.candlepin.auth.permissions.ConsumerPermission;
 import org.candlepin.auth.permissions.ConsumerServiceLevelsPermission;
 import org.candlepin.auth.permissions.OwnerPoolsPermission;
@@ -44,6 +45,9 @@ public class ConsumerPrincipal extends Principal {
 
         // Allow consumers to view their owner's service levels:
         addPermission(new ConsumerServiceLevelsPermission(consumer));
+
+        // Allow consumers to run virt-who hypervisor update
+        addPermission(new ConsumerOrgHypervisorPermission(consumer.getOwner()));
     }
 
     public Consumer getConsumer() {

--- a/src/main/java/org/candlepin/auth/SubResource.java
+++ b/src/main/java/org/candlepin/auth/SubResource.java
@@ -24,5 +24,6 @@ public enum SubResource {
     CONSUMERS, // org consumers
     POOLS, // org pools
     SUBSCRIPTIONS, // org subscriptions
-    SERVICE_LEVELS; // org service levels
+    SERVICE_LEVELS, // org service levels
+    HYPERVISOR;
 }

--- a/src/main/java/org/candlepin/auth/permissions/ConsumerOrgHypervisorPermission.java
+++ b/src/main/java/org/candlepin/auth/permissions/ConsumerOrgHypervisorPermission.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.auth.permissions;
+
+import org.candlepin.auth.Access;
+import org.candlepin.auth.SubResource;
+import org.candlepin.model.Owner;
+import org.hibernate.criterion.Criterion;
+import org.hibernate.criterion.Restrictions;
+
+/**
+ * ConsumerOrgHypervisorPermission
+ * Permission allowing consumers to check in hypervisors for their owner.
+ *
+ * NOTE: consumer principals do not get full read access to their owner,
+ * this should only provide permission for hypervisorCheckIn.
+ */
+public class ConsumerOrgHypervisorPermission extends TypedPermission<Owner> {
+
+    private Owner owner;
+
+    public ConsumerOrgHypervisorPermission(Owner owner) {
+        this.owner = owner;
+    }
+
+    @Override
+    public Class<Owner> getTargetType() {
+        return Owner.class;
+    }
+
+    @Override
+    public boolean canAccessTarget(Owner target, SubResource subResource,
+        Access required) {
+        return subResource.equals(SubResource.HYPERVISOR) &&
+            Access.READ_ONLY.provides(required) &&
+            this.owner.getKey().equals(target.getKey());
+    }
+
+    @Override
+    public Criterion getCriteriaRestrictions(Class entityClass) {
+        if (entityClass.equals(Owner.class)) {
+            return Restrictions.eq("key", owner.getKey());
+        }
+        return null;
+    }
+
+    @Override
+    public Owner getOwner() {
+        return owner;
+    }
+}

--- a/src/main/java/org/candlepin/model/ConsumerCurator.java
+++ b/src/main/java/org/candlepin/model/ConsumerCurator.java
@@ -389,6 +389,10 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
             .uniqueResult();
     }
 
+    public Consumer getConsumerInsecure(String uuid) {
+        return (Consumer) currentSession().createCriteria(Consumer.class)
+            .add(Restrictions.eq("uuid", uuid)).uniqueResult();
+    }
     /**
      * Get guest consumers for a host consumer.
      *


### PR DESCRIPTION
Permission changes blocked consumers from
looking up hypervisor consumers in order to
decide whether to create a new one, or update
guestIds.

Add error message when host is skipped
This will get passed to virt-who so that there is some
context as to why a host was not updated. Also added
a warning log message.

Drop SecurityHole on hypervisor resource.
Add some logging in hypervisor resource.
