### PR TITLE
Turn off oauth and trusted auth by default.

### DIFF
--- a/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -177,9 +177,9 @@ public class ConfigProperties {
 
                 this.put(SYNC_WORK_DIR, "/var/cache/candlepin/sync");
                 this.put(CONSUMER_FACTS_MATCHER, ".*");
-                this.put(TRUSTED_AUTHENTICATION, "true");
+                this.put(TRUSTED_AUTHENTICATION, "false");
                 this.put(SSL_AUTHENTICATION, "true");
-                this.put(OAUTH_AUTHENTICATION, "true");
+                this.put(OAUTH_AUTHENTICATION, "false");
                 this.put(BASIC_AUTHENTICATION, "true");
 
                 // By default, environments should be hidden so clients do not need to


### PR DESCRIPTION
These should not be enabled by default, as they defeat
the real auth mechanisms. They are designed for use
in tightly controlled enviroments, not default setups.
