### PR TITLE
Make createModifiesDateFilteringCriteria more readable

### DIFF
--- a/src/main/java/org/candlepin/model/EntitlementCurator.java
+++ b/src/main/java/org/candlepin/model/EntitlementCurator.java
@@ -136,19 +136,15 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
             .add(Restrictions.eq("consumer", consumer))
             .createCriteria("pool")
                 .add(Restrictions.or(
-                    // Checks start date overlap:
-                    Restrictions.and(
-                        Restrictions.le("startDate", startDate),
-                        Restrictions.ge("endDate", startDate)),
+                    // Dates overlap if the start or end date is in our range
                     Restrictions.or(
-                        // Checks end date overlap:
-                        Restrictions.and(
-                            Restrictions.le("startDate", endDate),
-                            Restrictions.ge("endDate", endDate)),
-                        // Checks total overlap:
-                        Restrictions.and(
-                            Restrictions.ge("startDate", startDate),
-                            Restrictions.le("endDate", endDate)))));
+                        Restrictions.between("startDate", startDate, endDate),
+                        Restrictions.between("endDate", startDate, endDate)),
+                    Restrictions.and(
+                        // The dates overlap if our range is completely encapsulated
+                        Restrictions.le("startDate", startDate),
+                        Restrictions.ge("endDate", endDate))
+                    ));
         return criteria;
     }
 


### PR DESCRIPTION
Use the "between" criteria restriction rather than implementing
our own.

Between can be inclusive or exclusive depending on the database
implementation.   We are safe in either case because the check
for complete overlap, where the entitlement is completely
encapsulated uses <= and >=.

The only logical change is that depending on database impl,
we will no longer check if an entitlement modifies another
entitlement that starts on the first ents end datetime.
