### PR TITLE
Fix autobind host during guest autobind for derived pools.

### DIFF
--- a/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -552,7 +552,9 @@ public class CandlepinPoolManager implements PoolManager {
             if (pool.hasProductAttribute("virt_limit") &&
                     !pool.getProductAttribute("virt_limit").getValue().equals("0")) {
                 for (String productId : productIds) {
-                    if (pool.provides(productId)) {
+                    // If this is a derived pool, we need to see if the derived product
+                    // provides anything for the guest, otherwise we use the parent.
+                    if (pool.providesDerived(productId)) {
                         providesProduct = true;
                         break;
                     }
@@ -585,7 +587,7 @@ public class CandlepinPoolManager implements PoolManager {
 
         List<PoolQuantity> enforced = autobindRules.selectBestPools(host,
             productIds, filteredPools, hostCompliance, serviceLevelOverride,
-            poolCurator.retrieveServiceLevelsForOwner(owner, true));
+            poolCurator.retrieveServiceLevelsForOwner(owner, true), true);
         return enforced;
     }
 
@@ -666,7 +668,7 @@ public class CandlepinPoolManager implements PoolManager {
 
         List<PoolQuantity> enforced = autobindRules.selectBestPools(consumer,
             productIds, filteredPools, compliance, serviceLevelOverride,
-            poolCurator.retrieveServiceLevelsForOwner(owner, true));
+            poolCurator.retrieveServiceLevelsForOwner(owner, true), false);
         return enforced;
     }
 

--- a/src/main/java/org/candlepin/controller/Entitler.java
+++ b/src/main/java/org/candlepin/controller/Entitler.java
@@ -249,6 +249,7 @@ public class Entitler {
                 try {
                     List<Entitlement> hostEntitlements =
                         poolManager.entitleByProductsForHost(consumer, host, entitleDate);
+                    log.debug("Granted host {} entitlements", hostEntitlements.size());
                     sendEvents(hostEntitlements);
                 }
                 catch (Exception e) {

--- a/src/main/java/org/candlepin/model/Pool.java
+++ b/src/main/java/org/candlepin/model/Pool.java
@@ -566,11 +566,11 @@ public class Pool extends AbstractHibernateObject implements Persisted, Owned {
 
     /**
      * Check if this pool provides the given product ID.
+     *
      * @param productId
      * @return true if pool provides this product
      */
     public Boolean provides(String productId) {
-        // Direct match?
         if (this.productId.equals(productId)) {
             return true;
         }
@@ -581,6 +581,36 @@ public class Pool extends AbstractHibernateObject implements Persisted, Owned {
                     return true;
                 }
             }
+        }
+        return false;
+    }
+
+    /**
+     * Check if this pool provides the given product ID as a derived provided product.
+     * Used when we're looking for pools we could give to a host that will create
+     * sub-pools for guest products.
+     *
+     * If derived product ID is not set, we just use the normal set of products.
+     *
+     * @param productId
+     * @return true if pool provides this product
+     */
+    public Boolean providesDerived(String productId) {
+        if (this.getDerivedProductId() != null) {
+            if (getDerivedProductId().equals(productId)) {
+                return true;
+            }
+
+            if (getDerivedProvidedProducts() != null) {
+                for (DerivedProvidedProduct p : getDerivedProvidedProducts()) {
+                    if (p.getProductId().equals(productId)) {
+                        return true;
+                    }
+                }
+            }
+        }
+        else {
+            return provides(productId);
         }
         return false;
     }

--- a/src/main/java/org/candlepin/policy/js/autobind/AutobindRules.java
+++ b/src/main/java/org/candlepin/policy/js/autobind/AutobindRules.java
@@ -67,7 +67,7 @@ public class AutobindRules {
 
     public List<PoolQuantity> selectBestPools(Consumer consumer, String[] productIds,
         List<Pool> pools, ComplianceStatus compliance, String serviceLevelOverride,
-        Set<String> exemptLevels) {
+        Set<String> exemptLevels, boolean considerDerived) {
 
         int poolsBeforeContentFilter = pools.size();
         pools = filterPoolsForV1Certificates(consumer, pools);
@@ -97,6 +97,7 @@ public class AutobindRules {
         args.put("log", log, false);
         args.put("compliance", compliance);
         args.put("exemptList", exemptLevels);
+        args.put("considerDerived", considerDerived);
 
         // Convert the JSON returned into a Map object:
         Map<String, Integer> result = null;

--- a/src/main/resources/rules/rules.js
+++ b/src/main/resources/rules/rules.js
@@ -1,4 +1,4 @@
-// Version: 5.5
+// Version: 5.6
 
 /*
  * Default Candlepin rule set.
@@ -141,7 +141,10 @@ function getComplianceAttributes(consumer) {
 
 function createPool(pool) {
 
+    // Lazily initialized arrays of provided product IDs. Includes the pool's
+    // main productId.
     pool.product_list = [];
+    pool.derived_product_list = [];
 
     // General function to look for an attribute in the specified
     // attribute collection.
@@ -201,6 +204,7 @@ function createPool(pool) {
         return false;
     };
 
+    // Lazily initialize the list of provided product IDs.
     pool.products = function () {
         if (this.product_list == 0) {
             this.product_list.push(this.productId);
@@ -209,6 +213,35 @@ function createPool(pool) {
             }
         }
         return this.product_list;
+    };
+
+    // Return true if this pool is carrying derived pool information. Watch out
+    // for older servers which didn't send any derived properties in, just in
+    // case. (this is probably impossible to hit due to changes in rule
+    // versioning)
+    pool.hasDerived = function () {
+        if (this.derivedProductId == null) {
+          return false;
+        }
+        return true;
+    }
+
+    // Lazily initialize the list of derived provided product IDs.
+    pool.derivedProducts = function () {
+
+        // Just being overly cautious here, but make sure that if this were requested
+        // on a server that didn't support derived pools, we just return empty results.
+        if (!this.hasDerived()) {
+          return this.derived_product_list;
+        }
+
+        if (this.derived_product_list == 0) {
+            this.derived_product_list.push(this.derivedProductId);
+            for (var k = 0; k < this.derivedProvidedProducts.length; k++) {
+                this.derived_product_list.push(this.derivedProvidedProducts[k].productId);
+            }
+        }
+        return this.derived_product_list;
     };
     return pool;
 }
@@ -1428,7 +1461,13 @@ var Entitlement = {
 
 var Autobind = {
 
-    create_entitlement_group: function(stackable, stack_id, installed_ids, consumer, attached_ents) {
+    /*
+     * An entitlement group is an abstraction that allows us to check
+     * and modify groups of available subscriptions uniformly.  That way we don't
+     * have to know if it's a stack, single entitlement, etc... It is either valid
+     * or not, and provides products.
+     */
+    create_entitlement_group: function(stackable, stack_id, installed_ids, consumer, attached_ents, consider_derived) {
         return {
             pools: [],
             stackable: stackable,
@@ -1437,9 +1476,16 @@ var Autobind = {
             consumer: consumer,
             attached_ents: attached_ents,
 
+            // Indicates we are trying to autobind a host to things that would unlock pools for it's guests.
+            // Implies we should look at derived product data if it exists on the pool, otherwise we look at
+            // the usual. (product ID, attributes, provided products)
+            consider_derived: consider_derived,
+
             /*
              * Method returns whether or not it is possible for the entitlement
-             * group to be valid.
+             * group to fully cover the consumer.  If this is stackable, some subset
+             * of entitlements must become fully compliant.  Pools that break compliance
+             * are removed.
              */
             validate: function(context) {
                 var all_ents = this.get_all_ents(this.pools).concat(this.attached_ents);
@@ -1453,6 +1499,7 @@ var Autobind = {
                     return true;
                 }
                 else if (!this.stackable) {
+                    log.debug("Not stackable...");
                     return false;
                 }
                 // At this point, we must be stackable
@@ -1520,7 +1567,13 @@ var Autobind = {
             },
 
             /*
-             * 2^n again, but this time n is the number of stackable attributes that aren't arch. (3)
+             * 2^n again, but this time n is the number of stackable attributes that aren't arch.
+             * This method generates combinations of compliance attributes so that we can attempt
+             * to become compliant without some pools.
+             *
+             * This avoids parallel stacks where removing
+             * any 1 sockets pool or any 1 cores pool will become incompliant, but removing all of
+             * either one will not.
              */
             get_sets: function(list, max_length) {
                 if (list.length == 0) {
@@ -1539,6 +1592,10 @@ var Autobind = {
 
             /*
              * Generates sets of attributes to attempt to remove
+             *
+             * This avoids parallel stacks where removing
+             * any 1 sockets pool or any 1 cores pool will become incompliant, but removing all of
+             * either one will not.
              */
             get_attribute_sets: function(pools) {
                 var stack_attributes = [];
@@ -1569,6 +1626,9 @@ var Autobind = {
             },
 
             /*
+             * Remove parallel stacks so we aren't essentially binding two stacks
+             * that would be fully compliant on their own
+             *
              * Attempts to remove all pools from a group that enforce each set of stackable attributes, then
              * checks compliance.  This prevents us from suggesting two fully compliant stacks that
              * enforce different attributes
@@ -1631,6 +1691,7 @@ var Autobind = {
 
             /*
              * Remove all pools that aren't necessary for compliance
+             * TODO: needs elaboration
              */
             prune_pools: function() {
                 // We know this group is required at this point,
@@ -1742,11 +1803,19 @@ var Autobind = {
                 return this.get_provided_products_pools(this.pools);
             },
 
-            // use custom pools
+            // Returns list of all provided product IDs from the given array of pools.
             get_provided_products_pools: function(in_pools) {
                 var provided = [];
                 for (var i = 0; i < in_pools.length; i++) {
                     var provided_by_pool = in_pools[i].products();
+
+                    // If we are considering derived provided products, check
+                    // to see if this pool has any and use them instead of the
+                    // regular set if so:
+                    if (this.consider_derived && in_pools[i].hasDerived()) {
+                      provided_by_pool = in_pools[i].derivedProducts();
+                    }
+
                     for (var j = 0; j < provided_by_pool.length; j++) {
                         var provided_id = provided_by_pool[j];
                         if (provided.indexOf(provided_id) == -1 && this.installed.indexOf(provided_id) >= 0) {
@@ -1761,6 +1830,15 @@ var Autobind = {
 
     create_autobind_context: function() {
         var context = JSON.parse(json_context);
+
+        // The considerDerived property indicates if we should look to derived
+        // provided products rather than the usual set. Used in situations where
+        // we're binding a host to things that will unlock pools for it's
+        // guests.
+        // Check for unset property for backward compatability with old servers.
+        if (!context.hasOwnProperty("considerDerived")) {
+            context.considerDerived = false;
+        }
 
         // Also need to convert all pools reported in compliance.
         var compliance = context.compliance;
@@ -1893,7 +1971,7 @@ var Autobind = {
     /*
      * Builds entitlement group objects that allow us to treat stacks and individual entitlements the same
      */
-    build_entitlement_groups: function(valid_pools, installed, consumer, attached_ents) {
+    build_entitlement_groups: function(valid_pools, installed, consumer, attached_ents, consider_derived) {
         var ent_groups = [];
         for (var i = 0; i < valid_pools.length; i++) {
             var pool = valid_pools[i];
@@ -1911,13 +1989,13 @@ var Autobind = {
                 }
                 // If the pool is stackable, and not part of an existing entitlement group, create a new group and add it
                 if (!found) {
-                    var new_ent_group = this.create_entitlement_group(true, stack_id, installed, consumer, attached_ents);
+                    var new_ent_group = this.create_entitlement_group(true, stack_id, installed, consumer, attached_ents, consider_derived);
                     new_ent_group.add_pool(pool);
                     ent_groups.push(new_ent_group);
                 }
             } else {
                 //if the entitlement is not stackable, create a new stack group for it
-                var new_ent_group = this.create_entitlement_group(false, "", installed, consumer, attached_ents);
+                var new_ent_group = this.create_entitlement_group(false, "", installed, consumer, attached_ents, consider_derived);
                 new_ent_group.add_pool(pool);
                 ent_groups.push(new_ent_group);
             }
@@ -1926,7 +2004,7 @@ var Autobind = {
     },
 
     /*
-     * returns the list of productIds that the stack will cover, which the consumer has installed
+     * Returns the list of productIds that the stack will cover, which the consumer requires.
      */
     get_common_products: function(installed, group) {
         var group_installed = group.get_provided_products();
@@ -2064,19 +2142,21 @@ var Autobind = {
 
     select_pools: function() {
         var context = this.create_autobind_context();
+        log.debug("considerDerived = " + context.considerDerived);
 
         var attached_ents = this.get_attached_ents(context.compliance);
 
         var valid_pools = this.get_valid_pools(context);
 
         var installed = context.products;
+        log.debug("Installed products: " + installed);
         //filter compliant products from this list
         for (var prod in context.compliance["compliantProducts"]) {
             if (installed.indexOf(prod) != -1) {
                 installed.splice(installed.indexOf(prod), 1);
             }
         }
-        var ent_groups = this.build_entitlement_groups(valid_pools, installed, context.consumer, attached_ents);
+        var ent_groups = this.build_entitlement_groups(valid_pools, installed, context.consumer, attached_ents, context.considerDerived);
         log.debug("Total ent groups: "+ent_groups.length);
 
         var valid_groups = [];
@@ -2088,9 +2168,11 @@ var Autobind = {
                 log.debug("Group "+ent_group.stack_id+" failed validation.");
             }
         }
+        log.debug("valid ent groups size: " + valid_groups.length);
 
         log.debug("finding best ent groups");
-        var best_groups = this.get_best_entitlement_groups(valid_groups, installed, context.compliance);
+        var best_groups = this.get_best_entitlement_groups(valid_groups, installed, context.compliance,
+                                                           context.considerDerived);
         log.debug("best_groups size: "+best_groups.length);
 
         for (var i = 0; i < best_groups.length; i++) {
@@ -2614,7 +2696,7 @@ var Override = {
     get_allow_override: function() {
         var blacklist = ['name','label','baseurl']
         var context = Override.get_override_context();
-        
+
         var check = context.name ? context.name.toLowerCase() : "";
         return Utils.inArray(blacklist, check);
     }

--- a/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -497,7 +497,7 @@ public class PoolManagerTest {
         bestPools.add(new PoolQuantity(pool1, 1));
         when(autobindRules.selectBestPools(any(Consumer.class), any(String[].class),
             any(List.class), any(ComplianceStatus.class), any(String.class),
-            any(Set.class)))
+            any(Set.class), eq(false)))
             .thenReturn(bestPools);
 
         List<Entitlement> e = manager.entitleByProducts(TestUtil.createConsumer(o),
@@ -649,7 +649,7 @@ public class PoolManagerTest {
         bestPools.add(new PoolQuantity(pool1, 1));
         when(autobindRules.selectBestPools(any(Consumer.class), any(String[].class),
             any(List.class), any(ComplianceStatus.class), any(String.class),
-            any(Set.class)))
+            any(Set.class), eq(false)))
             .thenReturn(bestPools);
 
         // Make the call but provide a null array of product IDs (simulates healing):
@@ -658,6 +658,6 @@ public class PoolManagerTest {
 
         verify(autobindRules).selectBestPools(any(Consumer.class), eq(installedPids),
             any(List.class), eq(mockCompliance), any(String.class),
-            any(Set.class));
+            any(Set.class), eq(false));
     }
 }


### PR DESCRIPTION
Derived provided products were not being considered at all during a guest
autobind where we attempt to autobind the host to things that will unlock
virt_only pools for the guest.

Fixed so autobind is now aware of this type of autobind and knows to consider
the derived product info instead of the top level in this case.

Includes some additional comments for autobind javascript from Carter.
