### PR TITLE
Use a version of oauth in line with upstream.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -33,7 +33,7 @@
     guice-throwingproviders hibernate-commons-annotations
     hibernate4-core hibernate4-c3p0 hibernate4-entitymanager hornetq-commons hornetq-server
     hornetq-core-client hornetq-journal javassist javax.inject jaxb-impl
-    jboss-logging hibernate-jpa-2.0-api jta log4j netty oauth oauth-provider
+    jboss-logging hibernate-jpa-2.0-api jta log4j netty oauth/oauth oauth/oauth-provider
     postgresql-jdbc resteasy/resteasy-atom-provider
     resteasy/resteasy-guice resteasy/resteasy-jaxb-provider
     resteasy/resteasy-jaxrs resteasy/jaxrs-api

--- a/candlepin.spec
+++ b/candlepin.spec
@@ -93,7 +93,7 @@ BuildRequires: hibernate-jpa-2.0-api >= 1.0.1
 BuildRequires: netty
 BuildRequires: jaxb-impl
 BuildRequires: jms >= 0:1.1
-BuildRequires: oauth
+BuildRequires: oauth >= 20100601-4
 BuildRequires: slf4j-api >= 0:1.7.5
 BuildRequires: jcl-over-slf4j >= 0:1.7.5
 
@@ -139,7 +139,7 @@ Requires: jackson-jaxrs-json-provider >= %{jackson_version}
 Requires: jackson-module-jaxb-annotations >= %{jackson_version}
 Requires: hornetq >= 0:2.3.5
 Requires: netty
-Requires: oauth
+Requires: oauth >= 20100601-4
 Requires: logback-classic
 Requires: jaxb-impl
 Requires: scannotation


### PR DESCRIPTION
The version of oauth in Fedora places the JARs under an oauth directory.  I have rebuilt our package to follow this convention and this patch updates the spec and build.xml files to use the new build.
