### PR TITLE
Fix localization spec failure.

### DIFF
--- a/spec/localization_spec.rb
+++ b/spec/localization_spec.rb
@@ -11,7 +11,7 @@ describe 'Localization' do
       lambda { Candlepin.new('admin', 'badpass', nil, nil, 'localhost', 8443,
                              'de-DE').list_consumer_types() }.should raise_error(
         RestClient::Unauthorized) { |error|
-        expected = "Ungültige Berechtigungnachweise"
+        expected = "Ungültige Berechtigungsnachweise"
         JSON.parse(error.http_body)["displayMessage"].should == expected
       }
   end


### PR DESCRIPTION
Update the expected value for the one string
we check since the translation updated.
