### PR TITLE
 Ckozak/rules stuff

### DIFF
--- a/src/main/java/org/candlepin/model/Rules.java
+++ b/src/main/java/org/candlepin/model/Rules.java
@@ -22,11 +22,12 @@ import javax.persistence.Basic;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Table;
-import javax.persistence.Transient;
 
 import org.candlepin.policy.js.RuleParseException;
 import org.hibernate.annotations.GenericGenerator;
@@ -57,7 +58,8 @@ public class Rules extends AbstractHibernateObject {
     @Column(name = "rules_blob", length = 4194304)
     private String rules;
 
-    @Transient
+    @Enumerated(EnumType.STRING)
+    @Column(name = "rulessource")
     private RulesSourceEnum rulesSource = RulesSourceEnum.UNDEFINED;
 
     @Column(name = "version", nullable = false, length = 20)

--- a/src/main/java/org/candlepin/policy/js/JsRunnerProvider.java
+++ b/src/main/java/org/candlepin/policy/js/JsRunnerProvider.java
@@ -75,8 +75,8 @@ public class JsRunnerProvider implements Provider<JsRunner> {
         this.rulesCurator = rulesCurator;
 
         log.debug("Compiling rules for initial load");
-        this.updated = new Date(0L);
-        compileRules(rulesCurator);
+        this.rulesCurator.updateDbRules();
+        this.compileRules(this.rulesCurator);
     }
 
     /**
@@ -127,8 +127,10 @@ public class JsRunnerProvider implements Provider<JsRunner> {
          * Create a new thread/request local javascript scope for the JsRules,
          * based on the preinitialized global one (which contains our js rules).
          */
-        // try and recompile (if needed) first
-        compileRules(this.rulesCurator);
+        // Avoid a write lock if we can
+        if (!rulesCurator.getUpdated().equals(this.updated)) {
+            compileRules(this.rulesCurator);
+        }
         Scriptable rulesScope;
         scriptLock.readLock().lock();
         try {

--- a/src/main/resources/db/changelog/20140311170628-add-rulessource.xml
+++ b/src/main/resources/db/changelog/20140311170628-add-rulessource.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+
+    <changeSet id="20140311170628" author="ckozak">
+        <comment>Add rules source to db</comment>
+        <addColumn tableName="cp_rules">
+            <column name="rulessource" type="varchar(255)"/>
+        </addColumn>
+
+	    <!-- Set the rulessource here -->
+	    <sql>
+	        UPDATE cp_rules
+	        SET rulessource='database'
+	    </sql>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-create.xml
+++ b/src/main/resources/db/changelog/changelog-create.xml
@@ -1156,4 +1156,5 @@
     <include file="db/changelog/20140226200158-add-hypervisorid-index.xml" />
     <include file="db/changelog/20140228095321-ids-to-uuid2.xml" />
     <include file="db/changelog/20140306150357-constrain-one-subpool-per-stack.xml" />
+    <include file="db/changelog/20140311170628-add-rulessource.xml" />
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-update.xml
+++ b/src/main/resources/db/changelog/changelog-update.xml
@@ -64,4 +64,5 @@
     <include file="db/changelog/20140226200158-add-hypervisorid-index.xml" />
     <include file="db/changelog/20140228095321-ids-to-uuid2.xml" />
     <include file="db/changelog/20140306150357-constrain-one-subpool-per-stack.xml" />
+    <include file="db/changelog/20140311170628-add-rulessource.xml" />
 </databaseChangeLog>


### PR DESCRIPTION
Solves a server lockup under heavy load.  When we get the rules,
we check the version of our cached rules against the latest in
the database.  We did not correctly release the lock when the
database throws exceptions on this query, so nothing else
could read the rules.

Added a broader try/finally block, I can no longer reproduce
the lockup.

In master this can be reproduced by concurrently running compliance ~100 times.

Removed some strange looking code around storing rules in the
database, particularly around storing up to one at a time.

Now we always put the rules in the database, and getRules
looks up the row with the most recent updated date. Also
avoid getting the write lock for rules unless it actually
might be necessary by making one check outside the lock,
and only getting the lock for a second check if the first
shows a change.
