### PR TITLE
Fix failing spec due to mysql cutting off milliseconds

### DIFF
--- a/spec/consumer_resource_content_spec.rb
+++ b/spec/consumer_resource_content_spec.rb
@@ -18,8 +18,17 @@ describe 'Consumer Resource Content' do
     overrides = create_content_override_set(2, @consumer1, false);
     returnOverrides = @consumer1.add_content_overrides(@consumer1.uuid, overrides)
     returnOverrides.size.should == 2
+    results = @consumer1.get_content_overrides(@consumer1.uuid)
+    # MySQL doesn't support milliseconds.  The first value returned has them serialized
+    # from the java Date object, the one from the database is zeroed.
+    [returnOverrides, results].each do |override_list|
+      override_list.each do |override|
+        override.delete('created')
+        override.delete('updated')
+      end
+    end
     # make sure the add content returns the same as the get
-    @consumer1.get_content_overrides(@consumer1.uuid).should =~ returnOverrides
+    results.should =~ returnOverrides
   end
 
   it "should allow content value overrides updates" do


### PR DESCRIPTION
Spec test was failing on MySQL db due to the way dates are handled.

```
Consumer Resource Content
  should allow content value overrides per consumer (FAILED - 1)

Failures:

  1) Consumer Resource Content should allow content value overrides per consumer
     Failure/Error: results.should =~ returnOverrides
       expected collection contained:  [{"contentLabel"=>"content1.label", "name"=>"field1", "value"=>"3218c5cb-0b08-4d5f-86a8-a5905e184963", "created"=>"2014-03-17T18:03:20.129+0000", "updated"=>"2014-03-17T18:03:20.129+0000"}, {"contentLabel"=>"content2.label", "name"=>"field2", "value"=>"3218c5cb-0b08-4d5f-86a8-a5905e184963", "created"=>"2014-03-17T18:03:20.131+0000", "updated"=>"2014-03-17T18:03:20.131+0000"}]
       actual collection contained:    [{"contentLabel"=>"content1.label", "name"=>"field1", "value"=>"3218c5cb-0b08-4d5f-86a8-a5905e184963", "created"=>"2014-03-17T18:03:20.000+0000", "updated"=>"2014-03-17T18:03:20.000+0000"}, {"contentLabel"=>"content2.label", "name"=>"field2", "value"=>"3218c5cb-0b08-4d5f-86a8-a5905e184963", "created"=>"2014-03-17T18:03:20.000+0000", "updated"=>"2014-03-17T18:03:20.000+0000"}]
       the missing elements were:      [{"contentLabel"=>"content1.label", "name"=>"field1", "value"=>"3218c5cb-0b08-4d5f-86a8-a5905e184963", "created"=>"2014-03-17T18:03:20.129+0000", "updated"=>"2014-03-17T18:03:20.129+0000"}, {"contentLabel"=>"content2.label", "name"=>"field2", "value"=>"3218c5cb-0b08-4d5f-86a8-a5905e184963", "created"=>"2014-03-17T18:03:20.131+0000", "updated"=>"2014-03-17T18:03:20.131+0000"}]
       the extra elements were:        [{"contentLabel"=>"content1.label", "name"=>"field1", "value"=>"3218c5cb-0b08-4d5f-86a8-a5905e184963", "created"=>"2014-03-17T18:03:20.000+0000", "updated"=>"2014-03-17T18:03:20.000+0000"}, {"contentLabel"=>"content2.label", "name"=>"field2", "value"=>"3218c5cb-0b08-4d5f-86a8-a5905e184963", "created"=>"2014-03-17T18:03:20.000+0000", "updated"=>"2014-03-17T18:03:20.000+0000"}]
     # ./spec/consumer_resource_content_spec.rb:28:in `block (2 levels) in <top (required)>'
```
