### PR TITLE
Add version to resource classes

### DIFF
--- a/src/main/java/org/candlepin/resource/ActivationKeyResource.java
+++ b/src/main/java/org/candlepin/resource/ActivationKeyResource.java
@@ -23,6 +23,7 @@ import org.candlepin.model.Release;
 import org.candlepin.model.activationkeys.ActivationKey;
 import org.candlepin.model.activationkeys.ActivationKeyCurator;
 import org.candlepin.model.activationkeys.ActivationKeyPool;
+import org.candlepin.resource.util.ResourceVersion;
 
 import com.google.inject.Inject;
 
@@ -49,6 +50,7 @@ import javax.ws.rs.core.MediaType;
  * SubscriptionTokenResource
  */
 @Path("/activation_keys")
+@ResourceVersion(1)
 public class ActivationKeyResource {
     private static Logger log = LoggerFactory.getLogger(ActivationKeyResource.class);
     private ActivationKeyCurator activationKeyCurator;

--- a/src/main/java/org/candlepin/resource/AdminResource.java
+++ b/src/main/java/org/candlepin/resource/AdminResource.java
@@ -19,6 +19,7 @@ import org.candlepin.auth.SystemPrincipal;
 import org.candlepin.auth.interceptor.SecurityHole;
 import org.candlepin.model.User;
 import org.candlepin.model.UserCurator;
+import org.candlepin.resource.util.ResourceVersion;
 import org.candlepin.service.UserServiceAdapter;
 import org.candlepin.service.impl.DefaultUserServiceAdapter;
 
@@ -37,6 +38,7 @@ import javax.ws.rs.core.MediaType;
  * Candlepin server administration REST calls.
  */
 @Path("/admin")
+@ResourceVersion(1)
 public class AdminResource {
 
     private static Logger log = LoggerFactory.getLogger(AdminResource.class);

--- a/src/main/java/org/candlepin/resource/AtomFeedResource.java
+++ b/src/main/java/org/candlepin/resource/AtomFeedResource.java
@@ -17,6 +17,7 @@ package org.candlepin.resource;
 import org.candlepin.audit.Event;
 import org.candlepin.audit.EventAdapter;
 import org.candlepin.model.EventCurator;
+import org.candlepin.resource.util.ResourceVersion;
 
 import com.google.inject.Inject;
 
@@ -33,6 +34,7 @@ import javax.ws.rs.core.MediaType;
  * Resource exposing an Atom feed of Candlepin events.
  */
 @Path("/atom")
+@ResourceVersion(1)
 public class AtomFeedResource {
 
     private static final int ATOM_FEED_LIMIT = 1000;

--- a/src/main/java/org/candlepin/resource/CdnResource.java
+++ b/src/main/java/org/candlepin/resource/CdnResource.java
@@ -33,6 +33,7 @@ import org.candlepin.exceptions.BadRequestException;
 import org.candlepin.exceptions.NotFoundException;
 import org.candlepin.model.Cdn;
 import org.candlepin.model.CdnCurator;
+import org.candlepin.resource.util.ResourceVersion;
 import org.xnap.commons.i18n.I18n;
 
 import com.google.inject.Inject;
@@ -41,6 +42,7 @@ import com.google.inject.Inject;
  * CdnResource
  */
 @Path("/cdn")
+@ResourceVersion(1)
 public class CdnResource {
 
     private I18n i18n;

--- a/src/main/java/org/candlepin/resource/CertificateSerialResource.java
+++ b/src/main/java/org/candlepin/resource/CertificateSerialResource.java
@@ -24,6 +24,7 @@ import javax.ws.rs.core.MediaType;
 
 import org.candlepin.model.CertificateSerial;
 import org.candlepin.model.CertificateSerialCurator;
+import org.candlepin.resource.util.ResourceVersion;
 
 import com.google.inject.Inject;
 
@@ -31,6 +32,7 @@ import com.google.inject.Inject;
  * CertificateSerialResource
  */
 @Path("/serials")
+@ResourceVersion(1)
 public class CertificateSerialResource {
 
     private CertificateSerialCurator certificateSerialCurator;

--- a/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -85,6 +85,7 @@ import org.candlepin.policy.js.quantity.SuggestedQuantity;
 import org.candlepin.resource.util.CalculatedAttributesUtil;
 import org.candlepin.resource.util.ConsumerInstalledProductEnricher;
 import org.candlepin.resource.util.ResourceDateParser;
+import org.candlepin.resource.util.ResourceVersion;
 import org.candlepin.resteasy.parameter.CandlepinParam;
 import org.candlepin.resteasy.parameter.KeyValueParameter;
 import org.candlepin.service.EntitlementCertServiceAdapter;
@@ -143,6 +144,7 @@ import javax.ws.rs.core.Response;
  * API Gateway for Consumers
  */
 @Path("/consumers")
+@ResourceVersion(1)
 public class ConsumerResource {
     private Pattern consumerSystemNamePattern;
     private Pattern consumerPersonNamePattern;

--- a/src/main/java/org/candlepin/resource/ConsumerTypeResource.java
+++ b/src/main/java/org/candlepin/resource/ConsumerTypeResource.java
@@ -18,6 +18,7 @@ import org.candlepin.exceptions.BadRequestException;
 import org.candlepin.exceptions.NotFoundException;
 import org.candlepin.model.ConsumerType;
 import org.candlepin.model.ConsumerTypeCurator;
+import org.candlepin.resource.util.ResourceVersion;
 
 import com.google.inject.Inject;
 
@@ -42,6 +43,7 @@ import javax.ws.rs.core.MediaType;
  * Access Path for consumer types
  */
 @Path("/consumertypes")
+@ResourceVersion(1)
 public class ConsumerTypeResource {
     private static Logger log = LoggerFactory.getLogger(ConsumerTypeResource.class);
     private ConsumerTypeCurator consumerTypeCurator;

--- a/src/main/java/org/candlepin/resource/ContentOverrideResource.java
+++ b/src/main/java/org/candlepin/resource/ContentOverrideResource.java
@@ -34,6 +34,7 @@ import org.candlepin.exceptions.ForbiddenException;
 import org.candlepin.model.AbstractHibernateObject;
 import org.candlepin.model.ContentOverride;
 import org.candlepin.model.ContentOverrideCurator;
+import org.candlepin.resource.util.ResourceVersion;
 import org.candlepin.util.ContentOverrideValidator;
 import org.xnap.commons.i18n.I18n;
 
@@ -46,6 +47,7 @@ import com.google.inject.persist.Transactional;
  * @param <Curator> curator class for the ContentOverride type
  * @param <Parent> parent of the content override, Consumer or ActivationKey for example
  */
+@ResourceVersion(1)
 public abstract class ContentOverrideResource<T extends ContentOverride,
         Curator extends ContentOverrideCurator<T, Parent>,
         Parent extends AbstractHibernateObject> {

--- a/src/main/java/org/candlepin/resource/ContentResource.java
+++ b/src/main/java/org/candlepin/resource/ContentResource.java
@@ -35,6 +35,7 @@ import org.candlepin.model.Content;
 import org.candlepin.model.ContentCurator;
 import org.candlepin.model.EnvironmentContent;
 import org.candlepin.model.EnvironmentContentCurator;
+import org.candlepin.resource.util.ResourceVersion;
 import org.candlepin.service.ProductServiceAdapter;
 import org.candlepin.service.UniqueIdGenerator;
 import org.xnap.commons.i18n.I18n;
@@ -45,6 +46,7 @@ import com.google.inject.Inject;
  */
 
 @Path("/content")
+@ResourceVersion(1)
 public class ContentResource {
 
     private ContentCurator contentCurator;

--- a/src/main/java/org/candlepin/resource/CrlResource.java
+++ b/src/main/java/org/candlepin/resource/CrlResource.java
@@ -23,6 +23,7 @@ import org.candlepin.controller.CrlGenerator;
 import org.candlepin.exceptions.IseException;
 import org.candlepin.model.CertificateSerial;
 import org.candlepin.model.CertificateSerialCurator;
+import org.candlepin.resource.util.ResourceVersion;
 import org.candlepin.util.CrlFileUtil;
 
 import java.io.File;
@@ -44,6 +45,7 @@ import javax.ws.rs.core.MediaType;
  * CrlResource
  */
 @Path("/crl")
+@ResourceVersion(1)
 public class CrlResource {
 
     private CrlGenerator crlGenerator;

--- a/src/main/java/org/candlepin/resource/DeletedConsumerResource.java
+++ b/src/main/java/org/candlepin/resource/DeletedConsumerResource.java
@@ -25,6 +25,7 @@ import javax.ws.rs.core.MediaType;
 import org.candlepin.model.DeletedConsumer;
 import org.candlepin.model.DeletedConsumerCurator;
 import org.candlepin.resource.util.ResourceDateParser;
+import org.candlepin.resource.util.ResourceVersion;
 
 import com.google.inject.Inject;
 
@@ -32,6 +33,7 @@ import com.google.inject.Inject;
  * DeletedConsumerResource
  */
 @Path("/deleted_consumers")
+@ResourceVersion(1)
 public class DeletedConsumerResource {
     private DeletedConsumerCurator deletedConsumerCurator;
 

--- a/src/main/java/org/candlepin/resource/DistributorVersionResource.java
+++ b/src/main/java/org/candlepin/resource/DistributorVersionResource.java
@@ -34,6 +34,7 @@ import org.candlepin.exceptions.BadRequestException;
 import org.candlepin.exceptions.NotFoundException;
 import org.candlepin.model.DistributorVersion;
 import org.candlepin.model.DistributorVersionCurator;
+import org.candlepin.resource.util.ResourceVersion;
 import org.xnap.commons.i18n.I18n;
 
 import com.google.inject.Inject;
@@ -42,6 +43,7 @@ import com.google.inject.Inject;
  * DistributorVersionResource
  */
 @Path("/distributor_versions")
+@ResourceVersion(1)
 public class DistributorVersionResource {
 
     private I18n i18n;

--- a/src/main/java/org/candlepin/resource/EntitlementResource.java
+++ b/src/main/java/org/candlepin/resource/EntitlementResource.java
@@ -46,6 +46,7 @@ import org.candlepin.paging.Page;
 import org.candlepin.paging.PageRequest;
 import org.candlepin.paging.Paginate;
 import org.candlepin.pinsetter.tasks.RegenProductEntitlementCertsJob;
+import org.candlepin.resource.util.ResourceVersion;
 import org.candlepin.service.ProductServiceAdapter;
 import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.util.Util;
@@ -60,6 +61,7 @@ import com.google.inject.Inject;
  * REST api gateway for the User object.
  */
 @Path("/entitlements")
+@ResourceVersion(1)
 public class EntitlementResource {
     private final ConsumerCurator consumerCurator;
     private PoolManager poolManager;

--- a/src/main/java/org/candlepin/resource/EnvironmentResource.java
+++ b/src/main/java/org/candlepin/resource/EnvironmentResource.java
@@ -29,6 +29,7 @@ import org.candlepin.model.EnvironmentContent;
 import org.candlepin.model.EnvironmentContentCurator;
 import org.candlepin.model.EnvironmentCurator;
 import org.candlepin.pinsetter.tasks.RegenEnvEntitlementCertsJob;
+import org.candlepin.resource.util.ResourceVersion;
 import org.candlepin.util.Util;
 
 import com.google.inject.Inject;
@@ -58,6 +59,7 @@ import javax.ws.rs.core.MediaType;
  * REST API for managing Environments.
  */
 @Path("/environments")
+@ResourceVersion(1)
 public class EnvironmentResource {
 
     private EnvironmentCurator envCurator;

--- a/src/main/java/org/candlepin/resource/EventResource.java
+++ b/src/main/java/org/candlepin/resource/EventResource.java
@@ -18,6 +18,7 @@ import org.candlepin.audit.Event;
 import org.candlepin.audit.EventAdapter;
 import org.candlepin.exceptions.NotFoundException;
 import org.candlepin.model.EventCurator;
+import org.candlepin.resource.util.ResourceVersion;
 
 import com.google.inject.Inject;
 
@@ -36,6 +37,7 @@ import javax.ws.rs.core.MediaType;
  * Candlepin Events Resource
  */
 @Path("/events")
+@ResourceVersion(1)
 public class EventResource {
 
     private EventCurator eventCurator;

--- a/src/main/java/org/candlepin/resource/GuestIdResource.java
+++ b/src/main/java/org/candlepin/resource/GuestIdResource.java
@@ -42,6 +42,7 @@ import org.candlepin.model.GuestId;
 import org.candlepin.model.GuestIdCurator;
 import org.candlepin.paging.Page;
 import org.candlepin.paging.PageRequest;
+import org.candlepin.resource.util.ResourceVersion;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,6 +54,7 @@ import com.google.inject.Inject;
  * API Gateway for registered consumers guests
  */
 @Path("/consumers/{consumer_uuid}/guestids")
+@ResourceVersion(1)
 public class GuestIdResource {
 
     private static Logger log = LoggerFactory.getLogger(GuestIdResource.class);

--- a/src/main/java/org/candlepin/resource/HypervisorResource.java
+++ b/src/main/java/org/candlepin/resource/HypervisorResource.java
@@ -30,6 +30,7 @@ import org.candlepin.model.HypervisorId;
 import org.candlepin.model.Owner;
 import org.candlepin.model.OwnerCurator;
 import org.candlepin.resource.dto.HypervisorCheckInResult;
+import org.candlepin.resource.util.ResourceVersion;
 
 import com.google.inject.Inject;
 import com.google.inject.persist.Transactional;
@@ -56,6 +57,7 @@ import javax.ws.rs.core.MediaType;
  * HypervisorResource
  */
 @Path("/hypervisors")
+@ResourceVersion(1)
 public class HypervisorResource {
     private static Logger log = LoggerFactory.getLogger(HypervisorResource.class);
     private ConsumerCurator consumerCurator;

--- a/src/main/java/org/candlepin/resource/JobResource.java
+++ b/src/main/java/org/candlepin/resource/JobResource.java
@@ -23,6 +23,7 @@ import org.candlepin.pinsetter.core.PinsetterException;
 import org.candlepin.pinsetter.core.PinsetterKernel;
 import org.candlepin.pinsetter.core.model.JobStatus;
 import org.candlepin.pinsetter.core.model.JobStatus.JobState;
+import org.candlepin.resource.util.ResourceVersion;
 
 import com.google.inject.Inject;
 
@@ -45,6 +46,7 @@ import javax.ws.rs.core.MediaType;
  * JobResource
  */
 @Path("/jobs")
+@ResourceVersion(1)
 public class JobResource {
 
     private JobCurator curator;

--- a/src/main/java/org/candlepin/resource/Link.java
+++ b/src/main/java/org/candlepin/resource/Link.java
@@ -27,10 +27,12 @@ public class Link {
 
     private String rel;
     private String href;
+    private int version;
 
-    public Link(String rel, String href) {
+    public Link(String rel, String href, int version) {
         this.rel = rel;
         this.href = href;
+        this.version = version;
     }
 
     public String getRel() {
@@ -47,6 +49,14 @@ public class Link {
 
     public void setHref(String href) {
         this.href = href;
+    }
+
+    public int getVersion() {
+        return version;
+    }
+
+    public void setVersion(int version) {
+        this.version = version;
     }
 
 }

--- a/src/main/java/org/candlepin/resource/MigrationResource.java
+++ b/src/main/java/org/candlepin/resource/MigrationResource.java
@@ -16,6 +16,7 @@ package org.candlepin.resource;
 
 import org.candlepin.exceptions.BadRequestException;
 import org.candlepin.pinsetter.tasks.MigrateOwnerJob;
+import org.candlepin.resource.util.ResourceVersion;
 
 import com.google.inject.Inject;
 
@@ -35,6 +36,7 @@ import javax.ws.rs.core.MediaType;
  * MigrationResource
  */
 @Path("/migrations")
+@ResourceVersion(1)
 public class MigrationResource {
     private static Logger log = LoggerFactory.getLogger(MigrationResource.class);
     public static final String OWNER = "owner";

--- a/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -92,6 +92,7 @@ import org.candlepin.pinsetter.tasks.HealEntireOrgJob;
 import org.candlepin.pinsetter.tasks.RefreshPoolsJob;
 import org.candlepin.resource.util.CalculatedAttributesUtil;
 import org.candlepin.resource.util.ResourceDateParser;
+import org.candlepin.resource.util.ResourceVersion;
 import org.candlepin.resteasy.parameter.KeyValueParameter;
 import org.candlepin.resteasy.parameter.CandlepinParam;
 import org.candlepin.service.SubscriptionServiceAdapter;
@@ -121,6 +122,7 @@ import com.google.inject.persist.Transactional;
  * Owner Resource
  */
 @Path("/owners")
+@ResourceVersion(1)
 public class OwnerResource {
 
     private OwnerCurator ownerCurator;

--- a/src/main/java/org/candlepin/resource/PoolResource.java
+++ b/src/main/java/org/candlepin/resource/PoolResource.java
@@ -51,6 +51,7 @@ import org.candlepin.paging.PageRequest;
 import org.candlepin.paging.Paginate;
 import org.candlepin.resource.util.CalculatedAttributesUtil;
 import org.candlepin.resource.util.ResourceDateParser;
+import org.candlepin.resource.util.ResourceVersion;
 import org.jboss.resteasy.annotations.providers.jaxb.Wrapped;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.xnap.commons.i18n.I18n;
@@ -62,6 +63,7 @@ import com.google.inject.Inject;
  */
 
 @Path("/pools")
+@ResourceVersion(1)
 public class PoolResource {
 
     private ConsumerCurator consumerCurator;

--- a/src/main/java/org/candlepin/resource/ProductResource.java
+++ b/src/main/java/org/candlepin/resource/ProductResource.java
@@ -29,6 +29,7 @@ import org.candlepin.model.Statistic;
 import org.candlepin.model.StatisticCurator;
 import org.candlepin.pinsetter.tasks.RefreshPoolsForProductJob;
 import org.candlepin.resource.util.ResourceDateParser;
+import org.candlepin.resource.util.ResourceVersion;
 import org.candlepin.service.ProductServiceAdapter;
 
 import com.google.inject.Inject;
@@ -61,6 +62,7 @@ import javax.ws.rs.core.MediaType;
  * @version $Rev$
  */
 @Path("/products")
+@ResourceVersion(1)
 public class ProductResource {
 
     private static Logger log = LoggerFactory.getLogger(ProductResource.class);

--- a/src/main/java/org/candlepin/resource/RoleResource.java
+++ b/src/main/java/org/candlepin/resource/RoleResource.java
@@ -22,6 +22,7 @@ import org.candlepin.model.PermissionBlueprint;
 import org.candlepin.model.PermissionBlueprintCurator;
 import org.candlepin.model.Role;
 import org.candlepin.model.User;
+import org.candlepin.resource.util.ResourceVersion;
 import org.candlepin.service.UserServiceAdapter;
 
 import com.google.inject.Inject;
@@ -48,6 +49,7 @@ import javax.ws.rs.core.MediaType;
  *
  */
 @Path("/roles")
+@ResourceVersion(1)
 public class RoleResource {
 
     private UserServiceAdapter userService;

--- a/src/main/java/org/candlepin/resource/RulesResource.java
+++ b/src/main/java/org/candlepin/resource/RulesResource.java
@@ -20,6 +20,7 @@ import org.candlepin.exceptions.ServiceUnavailableException;
 import org.candlepin.model.CuratorException;
 import org.candlepin.model.Rules;
 import org.candlepin.model.RulesCurator;
+import org.candlepin.resource.util.ResourceVersion;
 
 import com.google.inject.Inject;
 
@@ -42,6 +43,7 @@ import javax.ws.rs.core.Response;
  * Rules API entry path
  */
 @Path("/rules")
+@ResourceVersion(1)
 public class RulesResource {
     private static Logger log = LoggerFactory.getLogger(RulesResource.class);
     private RulesCurator rulesCurator;

--- a/src/main/java/org/candlepin/resource/StatisticResource.java
+++ b/src/main/java/org/candlepin/resource/StatisticResource.java
@@ -16,6 +16,7 @@ package org.candlepin.resource;
 
 import org.candlepin.exceptions.ServiceUnavailableException;
 import org.candlepin.model.StatisticCurator;
+import org.candlepin.resource.util.ResourceVersion;
 
 import com.google.inject.Inject;
 
@@ -31,6 +32,7 @@ import javax.ws.rs.Path;
  * Rules API entry path
  */
 @Path("/statistics/generate")
+@ResourceVersion(1)
 public class StatisticResource {
     private static Logger log = LoggerFactory.getLogger(StatisticResource.class);
     private StatisticCurator statisticCurator;

--- a/src/main/java/org/candlepin/resource/StatusResource.java
+++ b/src/main/java/org/candlepin/resource/StatusResource.java
@@ -18,6 +18,7 @@ import org.candlepin.auth.interceptor.SecurityHole;
 import org.candlepin.config.Config;
 import org.candlepin.model.RulesCurator;
 import org.candlepin.model.Status;
+import org.candlepin.resource.util.ResourceVersion;
 import org.candlepin.util.VersionUtil;
 
 import com.google.inject.Inject;
@@ -33,6 +34,7 @@ import javax.ws.rs.core.MediaType;
  * Status Resource
  */
 @Path("/status")
+@ResourceVersion(1)
 public class StatusResource {
 
     /**

--- a/src/main/java/org/candlepin/resource/SubscriptionResource.java
+++ b/src/main/java/org/candlepin/resource/SubscriptionResource.java
@@ -20,6 +20,7 @@ import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerCurator;
 import org.candlepin.model.Subscription;
 import org.candlepin.model.SubscriptionsCertificate;
+import org.candlepin.resource.util.ResourceVersion;
 import org.candlepin.service.SubscriptionServiceAdapter;
 
 import com.google.inject.Inject;
@@ -48,6 +49,7 @@ import javax.ws.rs.core.MediaType;
  */
 
 @Path("/subscriptions")
+@ResourceVersion(1)
 @Consumes(MediaType.APPLICATION_JSON)
 public class SubscriptionResource {
     private static Logger log = LoggerFactory.getLogger(SubscriptionResource.class);

--- a/src/main/java/org/candlepin/resource/UserResource.java
+++ b/src/main/java/org/candlepin/resource/UserResource.java
@@ -41,6 +41,7 @@ import org.candlepin.model.Owner;
 import org.candlepin.model.OwnerCurator;
 import org.candlepin.model.Role;
 import org.candlepin.model.User;
+import org.candlepin.resource.util.ResourceVersion;
 import org.candlepin.service.UserServiceAdapter;
 import org.xnap.commons.i18n.I18n;
 
@@ -50,6 +51,7 @@ import com.google.inject.Inject;
  * UserResource
  */
 @Path("/users")
+@ResourceVersion(1)
 public class UserResource {
 
     private UserServiceAdapter userService;

--- a/src/main/java/org/candlepin/resource/util/ResourceVersion.java
+++ b/src/main/java/org/candlepin/resource/util/ResourceVersion.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.resource.util;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * ResourceVersion
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+public @interface ResourceVersion {
+
+    int value() default 1;
+}


### PR DESCRIPTION
This gives us more flexibility to add new features without overloading RootResource with representative resources.  This can be tested with python-rhsm branch [ckozak/resource_version](https://github.com/candlepin/python-rhsm/tree/ckozak/resource_version)
