### PR TITLE
Create ActivationKeyRules

### DIFF
--- a/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -41,6 +41,7 @@ import org.candlepin.paging.PageRequest;
 import org.candlepin.policy.EntitlementRefusedException;
 import org.candlepin.policy.ValidationResult;
 import org.candlepin.policy.js.ProductCache;
+import org.candlepin.policy.js.activationkey.ActivationKeyRules;
 import org.candlepin.policy.js.autobind.AutobindRules;
 import org.candlepin.policy.js.compliance.ComplianceRules;
 import org.candlepin.policy.js.compliance.ComplianceStatus;
@@ -94,6 +95,7 @@ public class CandlepinPoolManager implements PoolManager {
     private ComplianceRules complianceRules;
     private ProductCache productCache;
     private AutobindRules autobindRules;
+    private ActivationKeyRules activationKeyRules;
 
     /**
      * @param poolCurator
@@ -110,7 +112,7 @@ public class CandlepinPoolManager implements PoolManager {
         EventFactory eventFactory, Config config, Enforcer enforcer,
         PoolRules poolRules, EntitlementCurator curator1, ConsumerCurator consumerCurator,
         EntitlementCertificateCurator ecC, ComplianceRules complianceRules,
-        AutobindRules autobindRules) {
+        AutobindRules autobindRules, ActivationKeyRules activationKeyRules) {
 
         this.poolCurator = poolCurator;
         this.subAdapter = subAdapter;
@@ -126,6 +128,7 @@ public class CandlepinPoolManager implements PoolManager {
         this.complianceRules = complianceRules;
         this.productCache = productCache;
         this.autobindRules = autobindRules;
+        this.activationKeyRules = activationKeyRules;
     }
 
     Set<Entitlement> refreshPoolsWithoutRegeneration(Owner owner) {
@@ -133,7 +136,7 @@ public class CandlepinPoolManager implements PoolManager {
         List<Subscription> subs = subAdapter.getSubscriptions(owner);
         log.debug("Found " + subs.size() + " existing subscriptions.");
 
-        List<Pool> pools = this.listAvailableEntitlementPools(null,
+        List<Pool> pools = this.listAvailableEntitlementPools(null, null,
             owner, null, null, false, false, new PoolFilterBuilder(), null).getPageData();
 
         // Pools with no subscription ID:
@@ -502,10 +505,11 @@ public class CandlepinPoolManager implements PoolManager {
         ValidationResult failedResult = null;
 
         List<Pool> allOwnerPools = this.listAvailableEntitlementPools(
-            host, owner, (String) null, entitleDate, true, false,
+            host, null, owner, (String) null, entitleDate, true, false,
             new PoolFilterBuilder(), null).getPageData();
         List<Pool> allOwnerPoolsForGuest = this.listAvailableEntitlementPools(
-            guest, owner, (String) null, entitleDate, true, false, new PoolFilterBuilder(),
+            guest, null, owner, (String) null, entitleDate,
+            true, false, new PoolFilterBuilder(),
             null).getPageData();
         for (Entitlement ent : host.getEntitlements()) {
             //filter out pools that are attached, there is no need to
@@ -598,7 +602,7 @@ public class CandlepinPoolManager implements PoolManager {
         ValidationResult failedResult = null;
 
         List<Pool> allOwnerPools = this.listAvailableEntitlementPools(
-            consumer, owner, (String) null, entitleDate, true, false,
+            consumer, null, owner, (String) null, entitleDate, true, false,
             new PoolFilterBuilder(), null).getPageData();
         List<Pool> filteredPools = new LinkedList<Pool>();
 
@@ -943,7 +947,7 @@ public class CandlepinPoolManager implements PoolManager {
     @Override
     @Transactional
     public void regenerateCertificatesOf(String productId, boolean lazy) {
-        List<Pool> poolsForProduct = this.listAvailableEntitlementPools(null, null,
+        List<Pool> poolsForProduct = this.listAvailableEntitlementPools(null, null, null,
             productId, new Date(), false, false, new PoolFilterBuilder(), null)
             .getPageData();
         for (Pool pool : poolsForProduct) {
@@ -1262,13 +1266,15 @@ public class CandlepinPoolManager implements PoolManager {
 
     @Override
     public Page<List<Pool>> listAvailableEntitlementPools(Consumer consumer,
-        Owner owner, String productId, Date activeOn, boolean activeOnly,
-        boolean includeWarnings, PoolFilterBuilder filters, PageRequest pageRequest) {
-        boolean postFilter = consumer != null; // Only postfilter if we have to
+        ActivationKey key, Owner owner, String productId, Date activeOn,
+        boolean activeOnly, boolean includeWarnings, PoolFilterBuilder filters,
+        PageRequest pageRequest) {
+        // Only postfilter if we have to
+        boolean postFilter = consumer != null || key != null;
         Page<List<Pool>> page = this.poolCurator.listAvailableEntitlementPools(consumer,
             owner, productId, activeOn, activeOnly, filters, pageRequest, postFilter);
 
-        if (consumer == null) {
+        if (consumer == null && key == null) {
             return page;
         }
 
@@ -1282,8 +1288,15 @@ public class CandlepinPoolManager implements PoolManager {
         List<Pool> preFilterResults = page.getPageData();
         List<Pool> newResults = new LinkedList<Pool>();
         for (Pool p : preFilterResults) {
-            ValidationResult result = enforcer.preEntitlement(
-                consumer, p, 1, CallerType.LIST_POOLS);
+            ValidationResult result = new ValidationResult();
+            if (consumer != null) {
+                result.add(enforcer.preEntitlement(
+                    consumer, p, 1, CallerType.LIST_POOLS));
+            }
+            if (key != null) {
+                result.add(activationKeyRules.runPreActKey(key, p, null));
+            }
+
             if (result.isSuccessful() && (!result.hasWarnings() || includeWarnings)) {
                 newResults.add(p);
             }

--- a/src/main/java/org/candlepin/controller/PoolManager.java
+++ b/src/main/java/org/candlepin/controller/PoolManager.java
@@ -22,6 +22,7 @@ import org.candlepin.model.Owner;
 import org.candlepin.model.Pool;
 import org.candlepin.model.PoolQuantity;
 import org.candlepin.model.Subscription;
+import org.candlepin.model.activationkeys.ActivationKey;
 import org.candlepin.paging.Page;
 import org.candlepin.paging.PageRequest;
 import org.candlepin.policy.EntitlementRefusedException;
@@ -157,9 +158,9 @@ public interface PoolManager {
      * @param pageRequest used to determine if results paging is required.
      * @return List of entitlement pools.
      */
-    Page<List<Pool>> listAvailableEntitlementPools(Consumer consumer, Owner owner,
-        String productId, Date activeOn, boolean activeOnly, boolean includeWarnings,
-        PoolFilterBuilder filterBuilder, PageRequest pageRequest);
+    Page<List<Pool>> listAvailableEntitlementPools(Consumer consumer, ActivationKey key,
+        Owner owner, String productId, Date activeOn, boolean activeOnly,
+        boolean includeWarnings, PoolFilterBuilder filterBuilder, PageRequest pageRequest);
 
     /**
      *  Get the available service levels for consumers for this owner. Exempt

--- a/src/main/java/org/candlepin/model/Pool.java
+++ b/src/main/java/org/candlepin/model/Pool.java
@@ -495,10 +495,7 @@ public class Pool extends AbstractHibernateObject implements Persisted, Owned {
      */
     @XmlTransient
     public boolean isUnlimited() {
-        if (this.getQuantity() < 0) {
-            return true;
-        }
-        return false;
+        return this.getQuantity() < 0;
     }
 
     /**
@@ -746,6 +743,21 @@ public class Pool extends AbstractHibernateObject implements Persisted, Owned {
 
     public String getProductAttributeValue(String name) {
         return findAttributeValue(this.productAttributes, name);
+    }
+
+    public boolean hasMergedAttribute(String name) {
+        return this.getMergedAttribute(name) != null;
+    }
+
+    /*
+     * Gets either pool or product attributes, not derived attributes
+     */
+    public AbstractPoolAttribute getMergedAttribute(String name) {
+        AbstractPoolAttribute result = findAttribute(this.attributes, name);
+        if (result == null) {
+            result = findAttribute(this.productAttributes, name);
+        }
+        return result;
     }
 
     public DerivedProductPoolAttribute getDerivedProductAttribute(String name) {

--- a/src/main/java/org/candlepin/policy/js/activationkey/ActivationKeyRules.java
+++ b/src/main/java/org/candlepin/policy/js/activationkey/ActivationKeyRules.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.policy.js.activationkey;
+
+import org.candlepin.exceptions.BadRequestException;
+import org.candlepin.model.Pool;
+import org.candlepin.model.activationkeys.ActivationKey;
+import org.candlepin.policy.ValidationResult;
+import org.candlepin.policy.js.JsRunner;
+import org.candlepin.policy.js.JsonJsContext;
+import org.candlepin.policy.js.RulesObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xnap.commons.i18n.I18n;
+
+import com.google.inject.Inject;
+
+/**
+ * ActivationKeyRules
+ *
+ * Enforces rules similar to EntitlementRules.java for
+ * attaching pools to activation keys
+ */
+public class ActivationKeyRules {
+
+    private static Logger log = LoggerFactory.getLogger(ActivationKeyRules.class);
+
+    private JsRunner jsRules;
+    private RulesObjectMapper mapper;
+    private I18n i18n;
+
+    @Inject
+    public ActivationKeyRules(JsRunner jsRules, I18n i18n) {
+        this.jsRules = jsRules;
+        this.i18n = i18n;
+
+        mapper = RulesObjectMapper.instance();
+        jsRules.init("activation_key_name_space");
+    }
+
+    public ValidationResult runPreActKey(ActivationKey key, Pool pool, Long quantity) {
+        JsonJsContext args = new JsonJsContext(mapper);
+        args.put("key", key);
+        args.put("pool", pool);
+        args.put("quantity", quantity);
+        args.put("log", log, false);
+
+        String json = jsRules.invokeRule("validate_pool", args);
+        ValidationResult result = mapper.toObject(json, ValidationResult.class);
+        return result;
+    }
+
+    public void validatePoolForActKey(ActivationKey key, Pool pool, Long quantity) {
+        ValidationResult validation = runPreActKey(key, pool, quantity);
+        if (!validation.getErrors().isEmpty()) {
+            // Use the first error
+            handleActkeyValidationError(
+                validation.getErrors().get(0).getResourceKey(), pool);
+        }
+    }
+
+    private void handleActkeyValidationError(String error, Pool pool) {
+        String msg;
+        if (error.equals("rulefailed.actkey.single.consumertype")) {
+            msg = i18n.tr("Activation keys can only use consumer type restricted " +
+                "pools for a single consumer type.");
+        }
+        else if (error.equals("rulefailed.actkey.cannot.use.person.pools")) {
+            msg = i18n.tr("Cannot add pools that are " +
+                "restricted to unit type 'person' to activation keys.");
+        }
+        else if (error.equals("rulefailed.host.restriction.physical.only")) {
+            msg = i18n.tr("Cannot use pools with host restriction with physical" +
+                " only pools on a single activation key");
+        }
+        else if (error.equals("rulefailed.multiple.host.restrictions")) {
+            msg = i18n.tr("Activation keys can only use host restricted pools from " +
+                "a single host.");
+        }
+        else if (error.equals("rulefailed.already.exists")) {
+            msg = i18n.tr("Multi-entitlement not supported for pool ''{0}''", pool.getId());
+        }
+        else if (error.equals("rulefailed.invalid.nonmultient.quantity")) {
+            msg = i18n.tr("Error: Only pools with multi-entitlement product" +
+                " subscriptions can be added to the activation key with" +
+                " a quantity greater than one.");
+        }
+        else if (error.equals("rulefailed.insufficient.quantity")) {
+            msg = i18n.tr("The quantity must not be greater than the total " +
+                "allowed for the pool");
+        }
+        else if (error.equals("rulefailed.invalid.quantity")) {
+            msg = i18n.tr("The quantity must be greater than 0");
+        }
+        else if (error.equals("rulefailed.invalid.quantity.instancebased.physical")) {
+            String multip = null;
+            if (pool.hasMergedAttribute("instance_multiplier")) {
+                multip = pool.getMergedAttribute("instance_multiplier").getValue();
+            }
+            msg = i18n.tr("Activation key with for physical systems can only use " +
+                "quantities of pool ''{0}'' evenly divisible by {1}", pool.getId(), multip);
+        }
+        else if (error.equals("rulefailed.virtonly.on.physical.key")) {
+            msg = i18n.tr("Cannot add virtual pool ''{0}'' to activation key" +
+                " for physical systems.", pool.getId());
+        }
+        else if (error.equals("rulefailed.physicalonly.on.virt.key")) {
+            msg = i18n.tr("Cannot add physical pool ''{0}'' to activation key" +
+                " for virtual systems.", pool.getId());
+        }
+        else {
+            msg = error;
+        }
+        throw new BadRequestException(msg);
+    }
+}

--- a/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -664,6 +664,7 @@ public class OwnerResource {
         @PathParam("owner_key")
             @Verify(value = Owner.class, subResource = SubResource.POOLS) String ownerKey,
         @QueryParam("consumer") String consumerUuid,
+        @QueryParam("activation_key") String activationKeyName,
         @QueryParam("product") String productId,
         @QueryParam("listall") @DefaultValue("false") boolean listAll,
         @QueryParam("activeon") String activeOn,
@@ -698,13 +699,23 @@ public class OwnerResource {
             }
         }
 
+        ActivationKey key = null;
+        if (activationKeyName != null) {
+            key = activationKeyCurator.lookupForOwner(activationKeyName, owner);
+            if (key == null) {
+                throw new BadRequestException(
+                    i18n.tr("ActivationKey with id {0} could not be found.",
+                        activationKeyName));
+            }
+        }
+
         // Process the filters passed for the attributes
         PoolFilterBuilder poolFilters = new PoolFilterBuilder();
         for (KeyValueParameter filterParam : attrFilters) {
             poolFilters.addAttributeFilter(filterParam.key(), filterParam.value());
         }
 
-        Page<List<Pool>> page = poolManager.listAvailableEntitlementPools(c, owner,
+        Page<List<Pool>> page = poolManager.listAvailableEntitlementPools(c, key, owner,
             productId, activeOnDate, true, listAll, poolFilters, pageRequest);
         List<Pool> poolList = page.getPageData();
 

--- a/src/main/java/org/candlepin/resource/PoolResource.java
+++ b/src/main/java/org/candlepin/resource/PoolResource.java
@@ -173,8 +173,8 @@ public class PoolResource {
                     principal.getPrincipalName()));
         }
 
-        Page<List<Pool>> page = poolManager.listAvailableEntitlementPools(c, o, productId,
-            activeOnDate, true, listAll, new PoolFilterBuilder(), pageRequest);
+        Page<List<Pool>> page = poolManager.listAvailableEntitlementPools(c, null, o,
+            productId, activeOnDate, true, listAll, new PoolFilterBuilder(), pageRequest);
         List<Pool> poolList = page.getPageData();
 
         if (c != null) {

--- a/src/main/resources/rules/rules.js
+++ b/src/main/resources/rules/rules.js
@@ -14,6 +14,10 @@ function entitlement_name_space() {
     return Entitlement;
 }
 
+function activation_key_name_space() {
+    return ActivationKey;
+}
+
 function compliance_name_space() {
     return Compliance;
 }
@@ -225,7 +229,15 @@ function createPool(pool) {
           return false;
         }
         return true;
-    }
+    };
+
+    pool.isUnlimited = function() {
+        return pool.quantity < 0;
+    };
+
+    pool.getAvailable = function() {
+        return pool.quantity - pool.consumed; 
+    };
 
     // Lazily initialize the list of derived provided product IDs.
     pool.derivedProducts = function () {
@@ -245,6 +257,39 @@ function createPool(pool) {
         return this.derived_product_list;
     };
     return pool;
+}
+
+function createActivationKey(key) {
+    key.virt_only = false;
+    key.physical_only = false;
+    key.requires_host = null;
+    key.consumer_type = null;
+
+    for (var i = 0; i < key.pools.length; i++) {
+        var pool = createPool(key.pools[i].pool);
+
+        // If any pools in the key are physical only, consider the key physical only
+        key.physical_only = key.physical_only ||
+            Utils.equalsIgnoreCase('true', pool.getAttribute(PHYSICAL_ONLY));
+
+        // If any pools in the key are virt only, consider the key virt only
+        key.virt_only = key.virt_only ||
+            Utils.equalsIgnoreCase('true', pool.getAttribute(VIRT_ONLY)) ||
+            (pool.hasAttribute(INSTANCE_ATTRIBUTE) &&
+             context.key.pools[i].quantity !== null &&
+             parseInt(pool.getAttribute(INSTANCE_ATTRIBUTE)) > context.key.pools[i].quantity);
+
+        var pool_host_requires = pool.getAttribute(REQUIRES_HOST_ATTRIBUTE);
+        if (pool_host_requires !== null && pool_host_requires != "") {
+            key.requires_host = pool_host_requires;
+            key.virt_only = true;
+        }
+        var pool_consumer_type = pool.getAttribute("requires_consumer_type");
+        if (pool_consumer_type !== null && pool_consumer_type != "") {
+            key.consumer_type = pool_consumer_type;
+        }
+    }
+    return key;
 }
 
 /*
@@ -1092,6 +1137,125 @@ function isLevelExempt (level, exemptList) {
         }
     }
     return false;
+}
+
+/*
+ * Code to validate pools before adding them to an activation key.
+ * This way we can't create activation keys that can never successfully
+ * register a consumer.
+ */
+var ActivationKey = {
+
+    get_attribute_context: function() {
+        context = JSON.parse(json_context);
+
+        // Pool to validate
+        context.pool = createPool(context.pool);
+        context.key = createActivationKey(context.key);
+
+        return context;
+    },
+
+    /*
+     * If the activation key is only for physical machines, the quantity of instance
+     * based pools must be either null or evenly divisible by the instance multiplier
+     */
+    validate_instance: function(key, pool, quantity, result) {
+        if (key.physical_only && quantity !== null && pool.hasAttribute(INSTANCE_ATTRIBUTE)) {
+            var instance_multi = parseInt(pool.getAttribute(INSTANCE_ATTRIBUTE));
+            if (quantity % instance_multi != 0) {
+                result.addError("rulefailed.invalid.quantity.instancebased.physical");
+            }
+        }
+    },
+
+    /*
+     * Quantity of the pool we're attaching must be null or positive.
+     * There must be sufficient quantity available if quantity is specified.
+     */
+    validate_quantity: function(key, pool, quantity, result) {
+        if (quantity !== null && quantity < 1) {
+            result.addError("rulefailed.invalid.quantity");
+        }
+        if (pool.getAvailable() == 0 || (quantity !== null && !pool.isUnlimited() && quantity > pool.getAvailable())) {
+            result.addError("rulefailed.insufficient.quantity");
+        }
+        if (!Utils.isMultiEnt(pool)) {
+            // If the pool isn't multi-entitlable, we can only accept null quantity and 1
+            if (quantity !== null && quantity > 1) {
+                result.addError("rulefailed.invalid.nonmultient.quantity");
+            }
+            // Don't allow non-multi-ent pools to be attached to an activation key more than once
+            for (var i = 0; i < key.pools.length; i++) {
+                if (pool.id == key.pools[i].pool.id) {
+                    result.addError("rulefailed.already.exists");
+                    break;
+                }
+            }
+        }
+    },
+
+    /*
+     * We can only allow one required host per activation key, otherwise the key becomes
+     * useless.
+     *
+     * If there are physical only pools, we cannot require hosts, because the attributes
+     * are mutually exclusive.
+     */
+    validate_requires_host: function(key, pool, result) {
+        pool_requires = pool.getAttribute(REQUIRES_HOST_ATTRIBUTE);
+        if (pool_requires !== null && pool_requires != "") {
+            if (key.requires_host !== null && pool_requires != key.requires_host) {
+                result.addError("rulefailed.multiple.host.restrictions");
+            }
+            if (key.physical_only) {
+                result.addError("rulefailed.host.restriction.physical.only");
+            }
+        }
+    },
+
+    /*
+     * Do not allow pools that require a "person" type consumer to be added to an activation key.
+     * Do not allow multiple different consumer types to be required on the same activation key.
+     */
+    validate_consumer_type: function(key, pool, result) {
+        pool_consumer_type = pool.getAttribute("requires_consumer_type");
+        if (pool_consumer_type == "person") {
+            result.addError("rulefailed.actkey.cannot.use.person.pools");
+        }
+        else if (key.consumer_type !== null && pool_consumer_type !== null &&
+                key.consumer_type != pool_consumer_type) {
+            result.addError("rulefailed.actkey.single.consumertype");
+        }
+    },
+
+    validate_physical_virtual: function(key, pool, result) {
+       var virt_pool = Utils.equalsIgnoreCase('true', pool.getAttribute(VIRT_ONLY));
+       var phys_pool = Utils.equalsIgnoreCase('true', pool.getAttribute(PHYSICAL_ONLY));
+       if (virt_pool && key.physical_only) {
+           result.addError("rulefailed.virtonly.on.physical.key");
+       }
+       if (phys_pool && key.virt_only) {
+           result.addError("rulefailed.physicalonly.on.virt.key");
+       }
+    },
+
+    validate_pool: function() {
+        // TODO: rewrite Entitlement rules in such a way that we can use overlapping code.
+        // pre-entitlement rules should probably be redesigned to take only one call.
+        var result = Entitlement.ValidationResult();
+        context = this.get_attribute_context();
+        key = context.key;
+        pool = context.pool;
+        quantity = context.quantity;
+
+        this.validate_quantity(key, pool, quantity, result);
+        this.validate_consumer_type(key, pool, result);
+        this.validate_requires_host(key, pool, result);
+        this.validate_physical_virtual(key, pool, result);
+        this.validate_instance(key, pool, quantity, result);
+        return JSON.stringify(result);
+    }
 }
 
 var Entitlement = {

--- a/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -63,6 +63,7 @@ import org.candlepin.paging.Page;
 import org.candlepin.paging.PageRequest;
 import org.candlepin.policy.ValidationResult;
 import org.candlepin.policy.js.ProductCache;
+import org.candlepin.policy.js.activationkey.ActivationKeyRules;
 import org.candlepin.policy.js.autobind.AutobindRules;
 import org.candlepin.policy.js.compliance.ComplianceRules;
 import org.candlepin.policy.js.compliance.ComplianceStatus;
@@ -122,6 +123,9 @@ public class PoolManagerTest {
     @Mock
     private ComplianceRules complianceRules;
 
+    @Mock
+    private ActivationKeyRules activationKeyRules;
+
     private CandlepinPoolManager manager;
     private UserPrincipal principal;
 
@@ -144,7 +148,8 @@ public class PoolManagerTest {
         this.manager = spy(new CandlepinPoolManager(mockPoolCurator, mockSubAdapter,
             productCache, entCertAdapterMock, mockEventSink, eventFactory,
             mockConfig, enforcerMock, poolRulesMock, entitlementCurator,
-            consumerCuratorMock, certCuratorMock, complianceRules, autobindRules));
+            consumerCuratorMock, certCuratorMock, complianceRules, autobindRules,
+            activationKeyRules));
 
         when(entCertAdapterMock.generateEntitlementCert(any(Entitlement.class),
             any(Subscription.class), any(Product.class))).thenReturn(

--- a/src/test/java/org/candlepin/policy/js/activationkey/ActivationKeyRulesTest.java
+++ b/src/test/java/org/candlepin/policy/js/activationkey/ActivationKeyRulesTest.java
@@ -1,0 +1,406 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.policy.js.activationkey;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.when;
+
+import java.io.InputStream;
+import java.util.Date;
+import java.util.Locale;
+
+import org.candlepin.exceptions.BadRequestException;
+import org.candlepin.model.Pool;
+import org.candlepin.model.Rules;
+import org.candlepin.model.RulesCurator;
+import org.candlepin.model.activationkeys.ActivationKey;
+import org.candlepin.policy.ValidationResult;
+import org.candlepin.policy.js.JsRunnerProvider;
+import org.candlepin.util.Util;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.xnap.commons.i18n.I18n;
+import org.xnap.commons.i18n.I18nFactory;
+
+/**
+ * ActivationKeyRulesTest
+ */
+public class ActivationKeyRulesTest {
+
+    private ActivationKeyRules actKeyRules;
+    private static int poolid = 0;
+
+    @Mock private RulesCurator rulesCuratorMock;
+    private I18n i18n;
+    private JsRunnerProvider provider;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        Locale locale = new Locale("en_US");
+        i18n = I18nFactory.getI18n(getClass(), "org.candlepin.i18n.Messages", locale,
+            I18nFactory.FALLBACK);
+        // Load the default production rules:
+        InputStream is = this.getClass().getResourceAsStream(
+            RulesCurator.DEFAULT_RULES_FILE);
+        Rules rules = new Rules(Util.readFile(is));
+        when(rulesCuratorMock.getUpdated()).thenReturn(new Date());
+        when(rulesCuratorMock.getRules()).thenReturn(rules);
+        provider = new JsRunnerProvider(rulesCuratorMock);
+        actKeyRules = new ActivationKeyRules(provider.get(), i18n);
+    }
+
+    @Test
+    public void testActivationKeyRules() {
+        ActivationKey key = new ActivationKey();
+        key.addPool(genPool(), new Long(1));
+        key.addPool(genPool(), new Long(1));
+
+        Pool pool = genPool();
+        ValidationResult result = actKeyRules.runPreActKey(key, pool, new Long(1));
+        assertTrue(result.getErrors().isEmpty());
+        assertTrue(result.getWarnings().isEmpty());
+    }
+
+    @Test
+    public void testActivationKeyRulesNoPools() {
+        ActivationKey key = new ActivationKey();
+        Pool pool = genPool();
+        ValidationResult result = actKeyRules.runPreActKey(key, pool, new Long(1));
+        assertTrue(result.getErrors().isEmpty());
+        assertTrue(result.getWarnings().isEmpty());
+    }
+
+    @Test
+    public void testVirtOnlyOnKeyWithPhysical() {
+        ActivationKey key = new ActivationKey();
+        key.addPool(genPhysOnlyPool(), new Long(1));
+
+        Pool pool = genVirtOnlyPool();
+        ValidationResult result = actKeyRules.runPreActKey(key, pool, new Long(1));
+        assertTrue(result.getWarnings().isEmpty());
+        assertEquals(1, result.getErrors().size());
+        String expected = "rulefailed.virtonly.on.physical.key";
+        assertEquals(expected, result.getErrors().get(0).getResourceKey());
+    }
+
+    @Test
+    public void testPhysicalOnlyOnKeyWithVirt() {
+        ActivationKey key = new ActivationKey();
+        key.addPool(genVirtOnlyPool(), new Long(1));
+
+        Pool pool = genPhysOnlyPool();
+        ValidationResult result = actKeyRules.runPreActKey(key, pool, new Long(1));
+        assertTrue(result.getWarnings().isEmpty());
+        assertEquals(1, result.getErrors().size());
+        String expected = "rulefailed.physicalonly.on.virt.key";
+        assertEquals(expected, result.getErrors().get(0).getResourceKey());
+        try {
+            actKeyRules.validatePoolForActKey(key, pool, new Long(1));
+            fail("Should have thrown an exception");
+        }
+        catch (BadRequestException bre) {
+            String expectedMsg = "Cannot add physical pool '" + pool.getId() +
+                "' to activation key for virtual systems.";
+            assertEquals(expectedMsg, bre.getMessage());
+        }
+    }
+
+    @Test
+    public void testNullQuantityEmptyPool() {
+        ActivationKey key = new ActivationKey();
+        Pool existing = genPool();
+        existing.setConsumed(existing.getQuantity());
+        key.addPool(genVirtOnlyPool(), null);
+
+        Pool pool = genPhysOnlyPool();
+        ValidationResult result = actKeyRules.runPreActKey(key, pool, new Long(1));
+        assertTrue(result.getWarnings().isEmpty());
+        assertEquals(1, result.getErrors().size());
+        String expected = "rulefailed.physicalonly.on.virt.key";
+        assertEquals(expected, result.getErrors().get(0).getResourceKey());
+    }
+
+    /*
+     * This should be identical to the previous test.  Instance based pool
+     * with quantity one can only be used on virtual systems, so the key
+     * should be treated as virt only.
+     */
+    @Test
+    public void testPhysicalOnlyOnKeyWithOneInstanceBased() {
+        ActivationKey key = new ActivationKey();
+        key.addPool(genInstanceBased(), new Long(1));
+
+        Pool pool = genPhysOnlyPool();
+        ValidationResult result = actKeyRules.runPreActKey(key, pool, new Long(1));
+        assertTrue(result.getWarnings().isEmpty());
+        assertEquals(1, result.getErrors().size());
+        String expected = "rulefailed.physicalonly.on.virt.key";
+        assertEquals(expected, result.getErrors().get(0).getResourceKey());
+    }
+
+    /*
+     * Similar to above, but because quantity of the instance based
+     * subscription is null, it will attempt to bind the correct
+     * amount for physical or virtual systems.
+     */
+    @Test
+    public void testPhysicalOnlyOnKeyWithNullInstanceBased() {
+        ActivationKey key = new ActivationKey();
+        key.addPool(genInstanceBased(), null);
+
+        Pool pool = genPhysOnlyPool();
+        // Should be a valid combination
+        ValidationResult result = actKeyRules.runPreActKey(key, pool, new Long(1));
+        assertTrue(result.getWarnings().isEmpty());
+        assertTrue(result.getErrors().isEmpty());
+    }
+
+    /*
+     * Activation key already has a physical only pool, adding an invalid quantity
+     * of an instance based subscription (for physical) should cause a failure.
+     */
+    @Test
+    public void testAlreadyHasPhysAddingVirtQuantityInstanceBased() {
+        ActivationKey key = new ActivationKey();
+        key.addPool(genPhysOnlyPool(), new Long(1));
+
+        Pool pool = genInstanceBased();
+        ValidationResult result = actKeyRules.runPreActKey(key, pool, new Long(1));
+        assertTrue(result.getWarnings().isEmpty());
+        assertEquals(1, result.getErrors().size());
+        String expected = "rulefailed.invalid.quantity.instancebased.physical";
+        assertEquals(expected, result.getErrors().get(0).getResourceKey());
+        try {
+            actKeyRules.validatePoolForActKey(key, pool, new Long(1));
+            fail("Should have thrown an exception");
+        }
+        catch (BadRequestException bre) {
+            String expectedMsg = "Activation key with for physical systems can only" +
+                " use quantities of pool '" + pool.getId() + "' evenly divisible by 2";
+            assertEquals(expectedMsg, bre.getMessage());
+        }
+    }
+
+    /*
+     * Adding an invalid (physical) quantity of an instance based subscription
+     * should not cause a failure if there are no physical pools.
+     */
+    @Test
+    public void testAllowsAddingVirtQuantityInstanceBased() {
+        ActivationKey key = new ActivationKey();
+        key.addPool(genPool(), new Long(1));
+
+        Pool pool = genInstanceBased();
+        ValidationResult result = actKeyRules.runPreActKey(key, pool, new Long(1));
+        assertTrue(result.getWarnings().isEmpty());
+        assertTrue(result.getErrors().isEmpty());
+    }
+
+    @Test
+    public void testActivationKeyRulesBadQuantity() {
+        ActivationKey key = new ActivationKey();
+        Pool pool = genPool();
+        ValidationResult result = actKeyRules.runPreActKey(key, pool, new Long(-1));
+        assertTrue(result.getWarnings().isEmpty());
+        assertEquals(1, result.getErrors().size());
+        String expected = "rulefailed.invalid.quantity";
+        assertEquals(expected, result.getErrors().get(0).getResourceKey());
+    }
+
+    @Test
+    public void testActivationKeyRulesInsufficientQuantity() {
+        ActivationKey key = new ActivationKey();
+        Pool pool = genPool();
+        pool.setQuantity(5L);
+        pool.setConsumed(4L);
+
+        // Attempting to overconsume the pool
+        ValidationResult result = actKeyRules.runPreActKey(key, pool, new Long(2));
+        assertTrue(result.getWarnings().isEmpty());
+        assertEquals(1, result.getErrors().size());
+        String expected = "rulefailed.insufficient.quantity";
+        assertEquals(expected, result.getErrors().get(0).getResourceKey());
+    }
+
+    @Test
+    public void testActivationKeyRulesUnlimitedQuantity() {
+        ActivationKey key = new ActivationKey();
+        Pool pool = genPool();
+        // Unlimited
+        pool.setQuantity(-1L);
+        pool.setConsumed(4L);
+
+        ValidationResult result = actKeyRules.runPreActKey(key, pool, new Long(2));
+        assertTrue(result.getWarnings().isEmpty());
+        assertTrue(result.getErrors().isEmpty());
+    }
+
+    @Test
+    public void testDoesntAllowPeoplePools() {
+        ActivationKey key = new ActivationKey();
+        Pool pool = genPoolForType("person");
+
+        ValidationResult result = actKeyRules.runPreActKey(key, pool, new Long(1));
+        assertTrue(result.getWarnings().isEmpty());
+        assertEquals(1, result.getErrors().size());
+        String expected = "rulefailed.actkey.cannot.use.person.pools";
+        assertEquals(expected, result.getErrors().get(0).getResourceKey());
+    }
+
+    @Test
+    public void testDoesntAllowMismatchedConsumerTypePools() {
+        ActivationKey key = new ActivationKey();
+        key.addPool(genPoolForType("system"), 1L);
+
+        Pool pool = genPoolForType("hypervisor");
+
+        ValidationResult result = actKeyRules.runPreActKey(key, pool, new Long(1));
+        assertTrue(result.getWarnings().isEmpty());
+        assertEquals(1, result.getErrors().size());
+        String expected = "rulefailed.actkey.single.consumertype";
+        assertEquals(expected, result.getErrors().get(0).getResourceKey());
+    }
+
+    @Test
+    public void testDoesAllowSameConsumerTypePools() {
+        ActivationKey key = new ActivationKey();
+        key.addPool(genPoolForType("system"), 1L);
+
+        Pool pool = genPoolForType("system");
+        ValidationResult result = actKeyRules.runPreActKey(key, pool, new Long(1));
+        assertTrue(result.getWarnings().isEmpty());
+        assertTrue(result.getErrors().isEmpty());
+    }
+
+    @Test
+    public void testDoesntAllowMismatchedHostRequires() {
+        ActivationKey key = new ActivationKey();
+        key.addPool(genHostRestricted("host1"), 1L);
+
+        Pool pool = genHostRestricted("host2");
+
+        ValidationResult result = actKeyRules.runPreActKey(key, pool, new Long(1));
+        assertTrue(result.getWarnings().isEmpty());
+        assertEquals(1, result.getErrors().size());
+        String expected = "rulefailed.multiple.host.restrictions";
+        assertEquals(expected, result.getErrors().get(0).getResourceKey());
+    }
+
+    @Test
+    public void testDoesAllowSameHostRequires() {
+        ActivationKey key = new ActivationKey();
+        key.addPool(genHostRestricted("host1"), 1L);
+
+        Pool pool = genHostRestricted("host1");
+        ValidationResult result = actKeyRules.runPreActKey(key, pool, new Long(1));
+        assertTrue(result.getWarnings().isEmpty());
+        assertTrue(result.getErrors().isEmpty());
+    }
+
+    @Test
+    public void testNonMultientOne() {
+        ActivationKey key = new ActivationKey();
+
+        Pool pool = genNonMultiEnt();
+        ValidationResult result = actKeyRules.runPreActKey(key, pool, new Long(1));
+        assertTrue(result.getWarnings().isEmpty());
+        assertTrue(result.getErrors().isEmpty());
+    }
+
+    @Test
+    public void testNonMultientMultipleQuantity() {
+        ActivationKey key = new ActivationKey();
+
+        Pool pool = genNonMultiEnt();
+        ValidationResult result = actKeyRules.runPreActKey(key, pool, new Long(2));
+        assertTrue(result.getWarnings().isEmpty());
+        assertEquals(1, result.getErrors().size());
+        String expected = "rulefailed.invalid.nonmultient.quantity";
+        assertEquals(expected, result.getErrors().get(0).getResourceKey());
+    }
+
+    @Test
+    public void testNonMultientOneTwice() {
+        ActivationKey key = new ActivationKey();
+        Pool pool = genNonMultiEnt();
+        key.addPool(pool, 1L);
+
+        ValidationResult result = actKeyRules.runPreActKey(key, pool, new Long(1));
+        assertTrue(result.getWarnings().isEmpty());
+        assertEquals(1, result.getErrors().size());
+        String expected = "rulefailed.already.exists";
+        assertEquals(expected, result.getErrors().get(0).getResourceKey());
+    }
+
+    @Test
+    public void testNullQuantityInstanceAndPhysicalOnly() {
+        ActivationKey key = new ActivationKey();
+        key.addPool(genInstanceBased(), null);
+
+        ValidationResult result = actKeyRules.runPreActKey(key, genPhysOnlyPool(), new Long(1));
+        assertTrue(result.getWarnings().isEmpty());
+        assertTrue(result.getErrors().isEmpty());
+    }
+
+    private Pool genPool() {
+        Pool pool = new Pool();
+        pool.setId("" + poolid++);
+        pool.setQuantity(10L);
+        pool.setConsumed(4L);
+        pool.setAttribute("multi-entitlement", "yes");
+        return pool;
+    }
+
+    private Pool genNonMultiEnt() {
+        Pool pool = genPool();
+        pool.setAttribute("multi-entitlement", "no");
+        return pool;
+    }
+
+    private Pool genVirtOnlyPool() {
+        Pool pool = genPool();
+        pool.setAttribute("virt_only", "true");
+        return pool;
+    }
+
+    private Pool genPhysOnlyPool() {
+        Pool pool = genPool();
+        pool.setAttribute("physical_only", "true");
+        return pool;
+    }
+
+    private Pool genInstanceBased() {
+        Pool pool = genPool();
+        pool.setAttribute("instance_multiplier", "2");
+        return pool;
+    }
+
+    private Pool genPoolForType(String type) {
+        Pool pool = genPool();
+        pool.setAttribute("requires_consumer_type", type);
+        return pool;
+    }
+
+    private Pool genHostRestricted(String host) {
+        Pool pool = genPool();
+        pool.setAttribute("requires_host", host);
+        return pool;
+    }
+}

--- a/src/test/java/org/candlepin/resource/test/ConsumerResourceTest.java
+++ b/src/test/java/org/candlepin/resource/test/ConsumerResourceTest.java
@@ -58,6 +58,7 @@ import org.candlepin.model.OwnerCurator;
 import org.candlepin.model.Pool;
 import org.candlepin.model.Product;
 import org.candlepin.model.Subscription;
+import org.candlepin.policy.js.activationkey.ActivationKeyRules;
 import org.candlepin.policy.js.compliance.ComplianceRules;
 import org.candlepin.policy.js.compliance.ComplianceStatus;
 import org.candlepin.resource.ConsumerResource;
@@ -114,6 +115,8 @@ public class ConsumerResourceTest {
     private ComplianceRules mockedComplianceRules;
     @Mock
     private ServiceLevelValidator mockedServiceLevelValidator;
+    @Mock
+    private ActivationKeyRules mockedActivationKeyRules;
 
     @Before
     public void setUp() {
@@ -167,7 +170,8 @@ public class ConsumerResourceTest {
             mockedSubscriptionServiceAdapter, null,
             mockedEntitlementCertServiceAdapter, null, null,
             new CandlepinCommonTestConfig(), null, null,
-            mockedEntitlementCurator, mockedConsumerCurator, null, null, null);
+            mockedEntitlementCurator, mockedConsumerCurator, null, null, null,
+            mockedActivationKeyRules);
 
         ConsumerResource consumerResource = new ConsumerResource(
             mockedConsumerCurator, null, null, null, mockedEntitlementCurator, null,

--- a/src/test/java/org/candlepin/resource/test/OwnerResourceTest.java
+++ b/src/test/java/org/candlepin/resource/test/OwnerResourceTest.java
@@ -292,7 +292,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
 
         securityInterceptor.enable();
 
-        ownerResource.listPools(owner.getKey(), null, null, false, null,
+        ownerResource.listPools(owner.getKey(), null, null, null, false, null,
             new ArrayList<KeyValueParameter>(), principal, null);
     }
 
@@ -308,7 +308,8 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         poolCurator.create(pool2);
 
         List<Pool> pools = ownerResource.listPools(owner.getKey(),
-            null, null, true, null, new ArrayList<KeyValueParameter>(), principal, null);
+            null, null, null, true, null, new ArrayList<KeyValueParameter>(),
+            principal, null);
         assertEquals(2, pools.size());
     }
 
@@ -330,16 +331,16 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         List<KeyValueParameter> params = new ArrayList<KeyValueParameter>();
         params.add(createKeyValueParam("cores", "12"));
 
-        List<Pool> pools = ownerResource.listPools(owner.getKey(), null, null, true,
-            null, params, principal, null);
+        List<Pool> pools = ownerResource.listPools(owner.getKey(), null,
+            null, null, true, null, params, principal, null);
         assertEquals(1, pools.size());
         assertEquals(pool2, pools.get(0));
 
         params.clear();
         params.add(createKeyValueParam("virt_only", "true"));
 
-        pools = ownerResource.listPools(owner.getKey(), null, null, true,
-            null, params, principal, null);
+        pools = ownerResource.listPools(owner.getKey(), null, null,
+            null, true, null, params, principal, null);
         assertEquals(1, pools.size());
         assertEquals(pool1, pools.get(0));
     }
@@ -360,7 +361,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         securityInterceptor.enable();
 
         // Filtering should just cause this to return no results:
-        ownerResource.listPools(owner.getKey(), null, null, true, null,
+        ownerResource.listPools(owner.getKey(), null, null, null, true, null,
             new ArrayList<KeyValueParameter>(), principal, null);
     }
 
@@ -554,7 +555,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         Principal principal = setupPrincipal(new ConsumerPrincipal(c));
         securityInterceptor.enable();
 
-        List<Pool> pools = ownerResource.listPools(owner.getKey(), c.getUuid(),
+        List<Pool> pools = ownerResource.listPools(owner.getKey(), c.getUuid(), null,
             p.getId(), true, null, new ArrayList<KeyValueParameter>(), principal, null);
         assertEquals(1, pools.size());
         Pool returnedPool = pools.get(0);
@@ -577,7 +578,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         Owner owner2 = createOwner();
         ownerCurator.create(owner2);
 
-        ownerResource.listPools(owner.getKey(), c.getUuid(),
+        ownerResource.listPools(owner.getKey(), c.getUuid(), null,
             p.getId(), true, null, new ArrayList<KeyValueParameter>(),
             setupPrincipal(owner2, Access.NONE), null);
     }


### PR DESCRIPTION
More extensive checking of pools before adding them to
activation keys.  Moved all checking logic to rules.js

When listing pools by owner we allow filtering based
on what can be added to a given activation key
