### PR TITLE
Clean up some recent activation key changes

### DIFF
--- a/client/ruby/candlepin_api.rb
+++ b/client/ruby/candlepin_api.rb
@@ -917,14 +917,6 @@ class Candlepin
       return get("/activation_keys/#{key_id}/content_overrides")
   end
 
-  def set_activation_key_release(key_id, release)
-      return post("/activation_keys/#{key_id}/release", release)
-  end
-
-  def get_activation_key_release(key_id)
-      return get("/activation_keys/#{key_id}/release")
-  end
-
   def list_certificates(serials = [])
     path = "/consumers/#{@uuid}/certificates"
     path += "?serials=" + serials.join(",") if serials.length > 0

--- a/spec/activation_key_spec.rb
+++ b/spec/activation_key_spec.rb
@@ -122,8 +122,8 @@ describe 'Activation Keys' do
   end
 
   it 'should allow release to be set on keys' do
-    @cp.set_activation_key_release(@activation_key['id'], "Some Release")
-    @cp.get_activation_key_release(@activation_key['id'])['releaseVer'].should == "Some Release"
+    @cp.update_activation_key({'id' => @activation_key['id'], 'releaseVer' => "Some Release"})
+    @cp.get_activation_key(@activation_key['id'])['releaseVer']['releaseVer'].should == "Some Release"
   end
 
   it 'should allow service level to be set on keys' do

--- a/spec/consumer_resource_spec.rb
+++ b/spec/consumer_resource_spec.rb
@@ -408,7 +408,7 @@ describe 'Consumer Resource' do
 
     key1 = @cp.create_activation_key(owner['key'], 'key1')
 
-    @cp.set_activation_key_release(key1['id'], "Registration Release")
+    @cp.update_activation_key({'id' => key1['id'], 'releaseVer' => "Registration Release"})
 
     consumer = client.register(random_string('machine1'), :system, nil, {}, nil,
       owner['key'], ["key1"])
@@ -432,7 +432,7 @@ describe 'Consumer Resource' do
     key1 = @cp.create_activation_key(owner['key'], 'key1', 'VIP')
     key2 = @cp.create_activation_key(owner['key'], 'key2')
 
-    @cp.set_activation_key_release(key1['id'], "Registration Release")
+    @cp.update_activation_key({'id' => key1['id'], 'releaseVer' => "Registration Release"})
 
     consumer = client.register(random_string('machine1'), :system, nil, {}, nil,
       owner['key'], ["key1", "key2"])
@@ -456,7 +456,7 @@ describe 'Consumer Resource' do
     key1 = @cp.create_activation_key(owner['key'], 'key1', 'VIP')
     key2 = @cp.create_activation_key(owner['key'], 'key2')
 
-    @cp.set_activation_key_release(key1['id'], "Registration Release")
+    @cp.update_activation_key({'id' => key1['id'], 'releaseVer' => "Registration Release"})
 
     @cp.delete_subscription(subs1.id)
     @cp.refresh_pools(owner['key'])

--- a/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -1307,7 +1307,7 @@ public class ConsumerResource {
 
     private Set<String> splitKeys(String activationKeyString) {
         Set<String> keys = new LinkedHashSet<String>();
-        if (!StringUtils.isBlank(activationKeyString)) {
+        if (activationKeyString != null) {
             for (String s : activationKeyString.split(",")) {
                 keys.add(s);
             }

--- a/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -39,6 +39,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 
+import org.apache.commons.lang.StringUtils;
 import org.candlepin.audit.Event;
 import org.candlepin.audit.EventAdapter;
 import org.candlepin.audit.EventFactory;
@@ -500,7 +501,7 @@ public class OwnerResource {
         Owner owner = findOwner(ownerKey);
         activationKey.setOwner(owner);
 
-        if (activationKey.getName() == null || activationKey.getName().trim().equals("")) {
+        if (StringUtils.isBlank(activationKey.getName())) {
             throw new BadRequestException(
                 i18n.tr("Must provide a name for activation key."));
         }

--- a/src/test/java/org/candlepin/resource/test/ConsumerResourceCreationTest.java
+++ b/src/test/java/org/candlepin/resource/test/ConsumerResourceCreationTest.java
@@ -289,7 +289,11 @@ public class ConsumerResourceCreationTest {
     }
 
     private String createKeysString(List<String> activationKeys) {
-        return StringUtils.join(activationKeys, ',');
+        // Allow empty string through because we accept it for ",foo" etc.
+        if (!activationKeys.isEmpty()) {
+            return StringUtils.join(activationKeys, ',');
+        }
+        return null;
     }
 
     @Test
@@ -297,7 +301,7 @@ public class ConsumerResourceCreationTest {
         // Should be able to register successfully with as a trusted user principal:
         Principal p = new TrustedUserPrincipal("anyuser");
         Consumer consumer = new Consumer("sys.example.com", null, null, system);
-        resource.create(consumer, p, null, owner.getKey(), "");
+        resource.create(consumer, p, null, owner.getKey(), null);
     }
 
     @Test
@@ -343,7 +347,7 @@ public class ConsumerResourceCreationTest {
         Consumer consumer = new Consumer();
         consumer.setType(system);
         consumer.setName("consumername");
-        resource.create(consumer, p, USER, owner.getKey(), "");
+        resource.create(consumer, p, USER, owner.getKey(), null);
     }
 
     @Test
@@ -353,7 +357,7 @@ public class ConsumerResourceCreationTest {
         consumer.setType(system);
         consumer.setName("consumername");
         consumer.setReleaseVer(null);
-        resource.create(consumer, p, USER, owner.getKey(), "");
+        resource.create(consumer, p, USER, owner.getKey(), null);
 
     }
 
@@ -364,7 +368,7 @@ public class ConsumerResourceCreationTest {
         consumer.setType(system);
         consumer.setName("consumername");
         consumer.setReleaseVer(new Release(""));
-        resource.create(consumer, p, USER, owner.getKey(), "");
+        resource.create(consumer, p, USER, owner.getKey(), null);
     }
 
     @Test
@@ -373,7 +377,7 @@ public class ConsumerResourceCreationTest {
         Consumer consumer = new Consumer();
         consumer.setType(system);
         consumer.setName("consumername");
-        resource.create(consumer, p, USER, owner.getKey(), "");
+        resource.create(consumer, p, USER, owner.getKey(), null);
     }
 
     @Test
@@ -382,7 +386,7 @@ public class ConsumerResourceCreationTest {
         Consumer consumer = new Consumer();
         consumer.setType(system);
         consumer.setName("consumername");
-        resource.create(consumer, p, USER, owner.getKey(), "");
+        resource.create(consumer, p, USER, owner.getKey(), null);
         verify(complianceRules).getStatus(eq(consumer), any(Date.class));
     }
 }


### PR DESCRIPTION
Removing get/set release version apis because we can
use get/update for the entire key.

Cleaned up consumer registration with activation keys.
We shouldn't allow empty string to go through if we don't allow
"," which also tries to look up an empty string.
