### PR TITLE
1075883: whitelist hypervisor consumers for certv3

### DIFF
--- a/src/main/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapter.java
+++ b/src/main/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapter.java
@@ -32,6 +32,7 @@ import org.candlepin.model.CertificateSerial;
 import org.candlepin.model.CertificateSerialCurator;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerCapability;
+import org.candlepin.model.ConsumerType.ConsumerTypeEnum;
 import org.candlepin.model.Entitlement;
 import org.candlepin.model.EntitlementCertificate;
 import org.candlepin.model.EntitlementCertificateCurator;
@@ -195,6 +196,11 @@ public class DefaultEntitlementCertServiceAdapter extends
                 }
             }
             return false;
+        }
+        else if (consumer.getType().getLabel().equals(
+            ConsumerTypeEnum.HYPERVISOR.getLabel())) {
+            // Hypervisors in this context don't use content, so allow v3
+            return true;
         }
         else {
             String entitlementVersion = consumer.getFact("system.certificate_version");

--- a/src/test/java/org/candlepin/service/impl/test/DefaultEntitlementCertServiceAdapterTest.java
+++ b/src/test/java/org/candlepin/service/impl/test/DefaultEntitlementCertServiceAdapterTest.java
@@ -757,6 +757,58 @@ public class DefaultEntitlementCertServiceAdapterTest {
 
 
     @Test
+    public void ensureV1CertIsCreatedWhenV3factNotPresent() throws Exception {
+        Config mockConfig = mock(Config.class);
+
+        when(consumer.getType()).thenReturn(
+            new ConsumerType(ConsumerType.ConsumerTypeEnum.SYSTEM));
+
+        X509V3ExtensionUtil mockV3extensionUtil = mock(X509V3ExtensionUtil.class);
+        X509ExtensionUtil mockExtensionUtil = mock(X509ExtensionUtil.class);
+
+        DefaultEntitlementCertServiceAdapter entAdapter =
+            new DefaultEntitlementCertServiceAdapter(
+                mockedPKI, mockExtensionUtil, mockV3extensionUtil,
+                mock(EntitlementCertificateCurator.class), keyPairCurator,
+                serialCurator, productAdapter, entCurator,
+                I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK),
+                mockConfig);
+
+        entAdapter.createX509Certificate(entitlement,
+            product, new HashSet<Product>(), new BigInteger("1234"), keyPair(), true);
+        // Verify v1
+        verify(mockExtensionUtil).consumerExtensions(eq(consumer));
+        verifyZeroInteractions(mockV3extensionUtil);
+    }
+
+    @Test
+    public void ensureV3CertIsCreatedWhenHypervisor() throws Exception {
+        Config mockConfig = mock(Config.class);
+
+        when(consumer.getType()).thenReturn(
+            new ConsumerType(ConsumerType.ConsumerTypeEnum.HYPERVISOR));
+
+        X509V3ExtensionUtil mockV3extensionUtil = mock(X509V3ExtensionUtil.class);
+        X509ExtensionUtil mockExtensionUtil = mock(X509ExtensionUtil.class);
+
+        DefaultEntitlementCertServiceAdapter entAdapter =
+            new DefaultEntitlementCertServiceAdapter(
+                mockedPKI, mockExtensionUtil, mockV3extensionUtil,
+                mock(EntitlementCertificateCurator.class), keyPairCurator,
+                serialCurator, productAdapter, entCurator,
+                I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK),
+                mockConfig);
+
+        entAdapter.createX509Certificate(entitlement,
+            product, new HashSet<Product>(), new BigInteger("1234"), keyPair(), true);
+        verify(mockV3extensionUtil).getExtensions(eq(entitlement), any(String.class),
+            any(Map.class));
+        verify(mockV3extensionUtil).getByteExtensions(any(Set.class),
+            eq(entitlement), any(String.class), any(Map.class));
+        verifyZeroInteractions(mockExtensionUtil);
+    }
+
+    @Test
     public void testCleanUpPrefixNoChange() throws Exception {
         String[] prefixes = {"/",
                              "/some_prefix/",


### PR DESCRIPTION
Hypervisors don't consume/use content or report facts, so theres no reason to block them from consuming pools with too much content.
