### PR TITLE
use unit of work while instanciating job objects

### DIFF
--- a/src/main/java/org/candlepin/pinsetter/core/PinsetterKernel.java
+++ b/src/main/java/org/candlepin/pinsetter/core/PinsetterKernel.java
@@ -409,7 +409,7 @@ public class PinsetterKernel {
 
     public void unpauseScheduler() throws PinsetterException {
         log.debug("looking for canceled jobs since scheduler was paused");
-        CancelJobJob cjj = new CancelJobJob(jobCurator, this, null);
+        CancelJobJob cjj = new CancelJobJob(jobCurator, this);
         try {
             //Not sure why we don't want to use a UnitOfWork here
             cjj.toExecute(null);

--- a/src/main/java/org/candlepin/pinsetter/tasks/CancelJobJob.java
+++ b/src/main/java/org/candlepin/pinsetter/tasks/CancelJobJob.java
@@ -20,7 +20,6 @@ import org.candlepin.pinsetter.core.PinsetterKernel;
 import org.candlepin.pinsetter.core.model.JobStatus;
 
 import com.google.inject.Inject;
-import com.google.inject.persist.UnitOfWork;
 
 import org.hibernate.HibernateException;
 import org.quartz.DisallowConcurrentExecution;
@@ -49,8 +48,7 @@ public class CancelJobJob extends KingpinJob {
 
     @Inject
     public CancelJobJob(JobCurator jobCurator,
-            PinsetterKernel pinsetterKernel, UnitOfWork unitOfWork) {
-        super(unitOfWork);
+            PinsetterKernel pinsetterKernel) {
         this.jobCurator = jobCurator;
         this.pinsetterKernel = pinsetterKernel;
     }

--- a/src/main/java/org/candlepin/pinsetter/tasks/CertificateRevocationListTask.java
+++ b/src/main/java/org/candlepin/pinsetter/tasks/CertificateRevocationListTask.java
@@ -20,7 +20,6 @@ import org.candlepin.controller.CrlGenerator;
 import org.candlepin.util.CrlFileUtil;
 
 import com.google.inject.Inject;
-import com.google.inject.persist.UnitOfWork;
 
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
@@ -57,9 +56,7 @@ public class CertificateRevocationListTask extends KingpinJob {
      */
     @Inject
     public CertificateRevocationListTask(Config conf,
-        CrlFileUtil crlFileUtil, CrlGenerator crlGenerator,
-        UnitOfWork unitOfWork) {
-        super(unitOfWork);
+        CrlFileUtil crlFileUtil, CrlGenerator crlGenerator) {
         this.config = conf;
         this.crlFileUtil = crlFileUtil;
         this.crlGenerator = crlGenerator;

--- a/src/main/java/org/candlepin/pinsetter/tasks/EntitleByProductsJob.java
+++ b/src/main/java/org/candlepin/pinsetter/tasks/EntitleByProductsJob.java
@@ -32,7 +32,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.inject.Inject;
-import com.google.inject.persist.UnitOfWork;
 
 /**
  * EntitleByProductsJob
@@ -44,8 +43,7 @@ public class EntitleByProductsJob extends KingpinJob {
     protected ConsumerCurator consumerCurator;
 
     @Inject
-    public EntitleByProductsJob(Entitler e, ConsumerCurator c, UnitOfWork unitOfWork) {
-        super(unitOfWork);
+    public EntitleByProductsJob(Entitler e, ConsumerCurator c) {
         entitler = e;
         consumerCurator = c;
     }

--- a/src/main/java/org/candlepin/pinsetter/tasks/EntitlerJob.java
+++ b/src/main/java/org/candlepin/pinsetter/tasks/EntitlerJob.java
@@ -23,7 +23,6 @@ import org.candlepin.pinsetter.core.model.JobStatus;
 import org.candlepin.util.Util;
 
 import com.google.inject.Inject;
-import com.google.inject.persist.UnitOfWork;
 
 import org.quartz.JobDataMap;
 import org.quartz.JobDetail;
@@ -44,8 +43,7 @@ public class EntitlerJob extends KingpinJob {
     protected ConsumerCurator consumerCurator;
 
     @Inject
-    public EntitlerJob(Entitler e, ConsumerCurator c, UnitOfWork unitOfWork) {
-        super(unitOfWork);
+    public EntitlerJob(Entitler e, ConsumerCurator c) {
         entitler = e;
         consumerCurator = c;
     }

--- a/src/main/java/org/candlepin/pinsetter/tasks/ExpiredPoolsJob.java
+++ b/src/main/java/org/candlepin/pinsetter/tasks/ExpiredPoolsJob.java
@@ -17,7 +17,6 @@ package org.candlepin.pinsetter.tasks;
 import org.candlepin.controller.PoolManager;
 
 import com.google.inject.Inject;
-import com.google.inject.persist.UnitOfWork;
 
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
@@ -42,8 +41,7 @@ public class ExpiredPoolsJob extends KingpinJob {
     private static Logger log = LoggerFactory.getLogger(ExpiredPoolsJob.class);
 
     @Inject
-    public ExpiredPoolsJob(PoolManager poolManager, UnitOfWork unitOfWork) {
-        super(unitOfWork);
+    public ExpiredPoolsJob(PoolManager poolManager) {
         this.poolManager = poolManager;
     }
 

--- a/src/main/java/org/candlepin/pinsetter/tasks/ExportCleaner.java
+++ b/src/main/java/org/candlepin/pinsetter/tasks/ExportCleaner.java
@@ -28,7 +28,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.inject.Inject;
-import com.google.inject.persist.UnitOfWork;
 
 /**
  * ExportCleaner
@@ -45,8 +44,7 @@ public class ExportCleaner extends KingpinJob {
     private static Logger log = LoggerFactory.getLogger(ExportCleaner.class);
 
     @Inject
-    public ExportCleaner(Config config, UnitOfWork unitOfWork) {
-        super(unitOfWork);
+    public ExportCleaner(Config config) {
         this.config = config;
     }
 

--- a/src/main/java/org/candlepin/pinsetter/tasks/HealEntireOrgJob.java
+++ b/src/main/java/org/candlepin/pinsetter/tasks/HealEntireOrgJob.java
@@ -34,7 +34,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.inject.Inject;
-import com.google.inject.persist.UnitOfWork;
 
 /**
  * HealEntireOrgJob
@@ -47,9 +46,8 @@ public class HealEntireOrgJob extends UniqueByOwnerJob {
     protected static String prefix = "heal_entire_org_";
 
     @Inject
-    public HealEntireOrgJob(Entitler e, UnitOfWork unitOfWork,
+    public HealEntireOrgJob(Entitler e,
             ConsumerCurator c, OwnerCurator o) {
-        super(unitOfWork);
         this.entitler = e;
         this.consumerCurator = c;
         this.ownerCurator = o;

--- a/src/main/java/org/candlepin/pinsetter/tasks/ImportRecordJob.java
+++ b/src/main/java/org/candlepin/pinsetter/tasks/ImportRecordJob.java
@@ -15,7 +15,6 @@
 package org.candlepin.pinsetter.tasks;
 
 import com.google.inject.Inject;
-import com.google.inject.persist.UnitOfWork;
 
 import java.util.List;
 
@@ -42,8 +41,7 @@ public class ImportRecordJob extends KingpinJob {
 
     @Inject
     public ImportRecordJob(ImportRecordCurator importRecordCurator,
-            OwnerCurator ownerCurator, UnitOfWork unitOfWork) {
-        super(unitOfWork);
+            OwnerCurator ownerCurator) {
         this.importRecordCurator = importRecordCurator;
         this.ownerCurator = ownerCurator;
     }

--- a/src/main/java/org/candlepin/pinsetter/tasks/JobCleaner.java
+++ b/src/main/java/org/candlepin/pinsetter/tasks/JobCleaner.java
@@ -22,7 +22,6 @@ import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 
 import com.google.inject.Inject;
-import com.google.inject.persist.UnitOfWork;
 
 /**
  * JobCleaner removes finished jobs older than yesterday, and failed
@@ -34,8 +33,7 @@ public class JobCleaner extends KingpinJob {
     public static final String DEFAULT_SCHEDULE = "0 0 12 * * ?";
 
     @Inject
-    public JobCleaner(JobCurator curator, UnitOfWork unitOfWork) {
-        super(unitOfWork);
+    public JobCleaner(JobCurator curator) {
         this.jobCurator = curator;
     }
 

--- a/src/main/java/org/candlepin/pinsetter/tasks/MigrateOwnerJob.java
+++ b/src/main/java/org/candlepin/pinsetter/tasks/MigrateOwnerJob.java
@@ -35,7 +35,6 @@ import org.candlepin.model.PoolCurator;
 import org.candlepin.util.Util;
 
 import com.google.inject.Inject;
-import com.google.inject.persist.UnitOfWork;
 
 import org.apache.commons.httpclient.Credentials;
 import org.apache.commons.httpclient.UsernamePasswordCredentials;
@@ -90,9 +89,7 @@ public class MigrateOwnerJob extends KingpinJob {
     @Inject
     public MigrateOwnerJob(CandlepinConnection connection, Config conf,
         OwnerCurator oc, PoolCurator pc, EntitlementCurator ec,
-        ConsumerCurator cc, EventSink es,
-        UnitOfWork unitOfWork) {
-        super(unitOfWork);
+        ConsumerCurator cc, EventSink es) {
         ownerCurator = oc;
         consumerCurator = cc;
         conn = connection;

--- a/src/main/java/org/candlepin/pinsetter/tasks/RefreshPoolsForProductJob.java
+++ b/src/main/java/org/candlepin/pinsetter/tasks/RefreshPoolsForProductJob.java
@@ -23,7 +23,6 @@ import org.candlepin.service.ProductServiceAdapter;
 import org.candlepin.util.Util;
 
 import com.google.inject.Inject;
-import com.google.inject.persist.UnitOfWork;
 
 import org.quartz.JobDataMap;
 import org.quartz.JobDetail;
@@ -42,8 +41,7 @@ public class RefreshPoolsForProductJob extends KingpinJob {
 
     @Inject
     public RefreshPoolsForProductJob(ProductServiceAdapter productAdapter,
-        PoolManager poolManager, UnitOfWork unitOfWork) {
-        super(unitOfWork);
+        PoolManager poolManager) {
         this.productAdapter = productAdapter;
         this.poolManager = poolManager;
     }

--- a/src/main/java/org/candlepin/pinsetter/tasks/RefreshPoolsJob.java
+++ b/src/main/java/org/candlepin/pinsetter/tasks/RefreshPoolsJob.java
@@ -24,7 +24,6 @@ import org.candlepin.util.Util;
 
 import com.google.inject.Inject;
 import com.google.inject.persist.Transactional;
-import com.google.inject.persist.UnitOfWork;
 
 import org.quartz.JobDataMap;
 import org.quartz.JobDetail;
@@ -47,9 +46,7 @@ public class RefreshPoolsJob extends UniqueByOwnerJob {
     protected static String prefix = "refresh_pools_";
 
     @Inject
-    public RefreshPoolsJob(OwnerCurator ownerCurator, PoolManager poolManager,
-        UnitOfWork unitOfWork) {
-        super(unitOfWork);
+    public RefreshPoolsJob(OwnerCurator ownerCurator, PoolManager poolManager) {
         this.ownerCurator = ownerCurator;
         this.poolManager = poolManager;
     }

--- a/src/main/java/org/candlepin/pinsetter/tasks/RegenEnvEntitlementCertsJob.java
+++ b/src/main/java/org/candlepin/pinsetter/tasks/RegenEnvEntitlementCertsJob.java
@@ -20,7 +20,6 @@ import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 
 import com.google.inject.Inject;
-import com.google.inject.persist.UnitOfWork;
 
 import org.candlepin.controller.PoolManager;
 import org.candlepin.model.Environment;
@@ -39,8 +38,7 @@ public class RegenEnvEntitlementCertsJob extends KingpinJob {
     public static final String LAZY_REGEN = "lazy_regen";
 
     @Inject
-    public RegenEnvEntitlementCertsJob(PoolManager poolManager, UnitOfWork unitOfWork) {
-        super(unitOfWork);
+    public RegenEnvEntitlementCertsJob(PoolManager poolManager) {
         this.poolManager = poolManager;
     }
 

--- a/src/main/java/org/candlepin/pinsetter/tasks/RegenProductEntitlementCertsJob.java
+++ b/src/main/java/org/candlepin/pinsetter/tasks/RegenProductEntitlementCertsJob.java
@@ -18,7 +18,6 @@ import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 
 import com.google.inject.Inject;
-import com.google.inject.persist.UnitOfWork;
 
 import org.candlepin.controller.PoolManager;
 
@@ -32,8 +31,7 @@ public class RegenProductEntitlementCertsJob extends KingpinJob {
     public static final String LAZY_REGEN = "lazy_regen";
 
     @Inject
-    public RegenProductEntitlementCertsJob(PoolManager poolManager, UnitOfWork unitOfWork) {
-        super(unitOfWork);
+    public RegenProductEntitlementCertsJob(PoolManager poolManager) {
         this.poolManager = poolManager;
     }
 

--- a/src/main/java/org/candlepin/pinsetter/tasks/StatisticHistoryTask.java
+++ b/src/main/java/org/candlepin/pinsetter/tasks/StatisticHistoryTask.java
@@ -17,7 +17,6 @@ package org.candlepin.pinsetter.tasks;
 import org.candlepin.model.StatisticCurator;
 
 import com.google.inject.Inject;
-import com.google.inject.persist.UnitOfWork;
 
 import org.hibernate.HibernateException;
 import org.quartz.JobExecutionContext;
@@ -43,9 +42,7 @@ public class StatisticHistoryTask extends KingpinJob {
      * @param statCurator the StatisticCurator
      */
     @Inject
-    public StatisticHistoryTask(StatisticCurator statCurator,
-        UnitOfWork unitOfWork) {
-        super(unitOfWork);
+    public StatisticHistoryTask(StatisticCurator statCurator) {
         this.statCurator = statCurator;
     }
 

--- a/src/main/java/org/candlepin/pinsetter/tasks/SweepBarJob.java
+++ b/src/main/java/org/candlepin/pinsetter/tasks/SweepBarJob.java
@@ -18,7 +18,6 @@ import org.candlepin.model.JobCurator;
 import org.candlepin.pinsetter.core.PinsetterKernel;
 
 import com.google.inject.Inject;
-import com.google.inject.persist.UnitOfWork;
 
 import org.quartz.DisallowConcurrentExecution;
 import org.quartz.JobExecutionContext;
@@ -60,8 +59,7 @@ public class SweepBarJob extends KingpinJob {
 
     @Inject
     public SweepBarJob(JobCurator jobCurator,
-        PinsetterKernel pinsetterKernel, UnitOfWork unitOfWork) {
-        super(unitOfWork);
+        PinsetterKernel pinsetterKernel) {
         this.jobCurator = jobCurator;
         this.pinsetterKernel = pinsetterKernel;
     }

--- a/src/main/java/org/candlepin/pinsetter/tasks/UniqueByOwnerJob.java
+++ b/src/main/java/org/candlepin/pinsetter/tasks/UniqueByOwnerJob.java
@@ -23,8 +23,6 @@ import org.quartz.Trigger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.inject.persist.UnitOfWork;
-
 /**
  * UniqueByOwnerJob can by extended by jobs that should not be
  * run concurrently per owner.  A job will wait for the running
@@ -33,10 +31,6 @@ import com.google.inject.persist.UnitOfWork;
  */
 public abstract class UniqueByOwnerJob extends KingpinJob {
     private static Logger log = LoggerFactory.getLogger(UniqueByOwnerJob.class);
-
-    public UniqueByOwnerJob(UnitOfWork unitOfWork) {
-        super(unitOfWork);
-    }
 
     @SuppressWarnings("unchecked")
     public static JobStatus scheduleJob(JobCurator jobCurator,

--- a/src/main/java/org/candlepin/pinsetter/tasks/UnpauseJob.java
+++ b/src/main/java/org/candlepin/pinsetter/tasks/UnpauseJob.java
@@ -20,7 +20,6 @@ import org.candlepin.pinsetter.core.model.JobStatus;
 import org.candlepin.pinsetter.core.model.JobStatus.JobState;
 
 import com.google.inject.Inject;
-import com.google.inject.persist.UnitOfWork;
 
 import org.hibernate.HibernateException;
 import org.quartz.DisallowConcurrentExecution;
@@ -47,8 +46,7 @@ public class UnpauseJob extends KingpinJob {
 
     @Inject
     public UnpauseJob(JobCurator jobCurator,
-            PinsetterKernel pinsetterKernel, UnitOfWork unitOfWork) {
-        super(unitOfWork);
+            PinsetterKernel pinsetterKernel) {
         this.jobCurator = jobCurator;
         this.pinsetterKernel = pinsetterKernel;
     }

--- a/src/test/java/org/candlepin/pinsetter/core/HighlanderFactoryTest.java
+++ b/src/test/java/org/candlepin/pinsetter/core/HighlanderFactoryTest.java
@@ -16,19 +16,18 @@ package org.candlepin.pinsetter.core;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.quartz.CronScheduleBuilder.cronSchedule;
 import static org.quartz.JobBuilder.newJob;
 import static org.quartz.TriggerBuilder.newTrigger;
 
-import org.candlepin.guice.CandlepinSingletonScope;
 import org.candlepin.test.DatabaseTestFixture;
 import org.junit.Test;
 import org.quartz.Job;
 import org.quartz.JobDetail;
 import org.quartz.SchedulerException;
 import org.quartz.Trigger;
+import org.quartz.spi.JobFactory;
 import org.quartz.spi.OperableTrigger;
 import org.quartz.spi.TriggerFiredBundle;
 
@@ -38,19 +37,18 @@ import java.text.ParseException;
  * HighlanderFactoryTest
  * @version $Rev$
  */
-public class HighlanderFactoryTest extends DatabaseTestFixture{
+public class HighlanderFactoryTest extends DatabaseTestFixture {
 
     @Test
     public void testNewJob() throws SchedulerException, ParseException {
-        GuiceJobFactory hf = new GuiceJobFactory(injector,
-            injector.getInstance(CandlepinSingletonScope.class));
+        JobFactory hf = injector.getInstance(JobFactory.class);
         assertNotNull(hf);
         try {
             hf.newJob(null, null);
             fail("should've died with npe");
         }
         catch (NullPointerException npe) {
-            assertTrue(true);
+            // Expected
         }
 
         String crontab = "0 0 12 * * ?";

--- a/src/test/java/org/candlepin/pinsetter/core/TestJob.java
+++ b/src/test/java/org/candlepin/pinsetter/core/TestJob.java
@@ -18,9 +18,6 @@ import org.candlepin.pinsetter.tasks.KingpinJob;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 
-import com.google.inject.Inject;
-import com.google.inject.persist.UnitOfWork;
-
 /**
  * TestJob
  * @version $Rev$
@@ -28,14 +25,6 @@ import com.google.inject.persist.UnitOfWork;
 public class TestJob extends KingpinJob {
 
     private boolean ran = false;
-
-    /**
-     * @param unitOfWork
-     */
-    @Inject
-    public TestJob(UnitOfWork unitOfWork) {
-        super(unitOfWork);
-    }
 
     @Override
     public void toExecute(JobExecutionContext arg0In)

--- a/src/test/java/org/candlepin/pinsetter/tasks/CancelJobJobTest.java
+++ b/src/test/java/org/candlepin/pinsetter/tasks/CancelJobJobTest.java
@@ -55,7 +55,7 @@ public class CancelJobJobTest {
     @Before
     public void init() {
         MockitoAnnotations.initMocks(this);
-        cancelJobJob = new CancelJobJob(j, pk, null);
+        cancelJobJob = new CancelJobJob(j, pk);
     }
 
     @Test

--- a/src/test/java/org/candlepin/pinsetter/tasks/CertificateRevocationListTaskTest.java
+++ b/src/test/java/org/candlepin/pinsetter/tasks/CertificateRevocationListTaskTest.java
@@ -48,7 +48,7 @@ public class CertificateRevocationListTaskTest {
 
     @Before
     public void init() {
-        this.task = new CertificateRevocationListTask(config, crlFileUtil, generator, null);
+        this.task = new CertificateRevocationListTask(config, crlFileUtil, generator);
     }
 
     @Test(expected = JobExecutionException.class)

--- a/src/test/java/org/candlepin/pinsetter/tasks/EntitleByProductsJobTest.java
+++ b/src/test/java/org/candlepin/pinsetter/tasks/EntitleByProductsJobTest.java
@@ -77,7 +77,7 @@ public class EntitleByProductsJobTest {
         when(e.bindByProducts(eq(pids), eq(consumerUuid),
             eq((Date) null))).thenReturn(ents);
 
-        EntitleByProductsJob job = new EntitleByProductsJob(e, null, null);
+        EntitleByProductsJob job = new EntitleByProductsJob(e, null);
         job.execute(ctx);
         verify(e).bindByProducts(eq(pids), eq(consumerUuid), eq((Date) null));
         verify(e).sendEvents(eq(ents));

--- a/src/test/java/org/candlepin/pinsetter/tasks/EntitlerJobTest.java
+++ b/src/test/java/org/candlepin/pinsetter/tasks/EntitlerJobTest.java
@@ -79,7 +79,7 @@ public class EntitlerJobTest {
         List<Entitlement> ents = new ArrayList<Entitlement>();
         when(e.bindByPool(eq(pool), eq(consumerUuid), eq(1))).thenReturn(ents);
 
-        EntitlerJob job = new EntitlerJob(e, null, null);
+        EntitlerJob job = new EntitlerJob(e, null);
         job.execute(ctx);
         verify(e).bindByPool(eq(pool), eq(consumerUuid), eq(1));
         verify(e).sendEvents(eq(ents));
@@ -121,7 +121,7 @@ public class EntitlerJobTest {
         when(e.bindByPool(eq(pool), eq(consumerUuid), eq(1))).thenThrow(
             new ForbiddenException("job should fail"));
 
-        EntitlerJob job = new EntitlerJob(e, null, null);
+        EntitlerJob job = new EntitlerJob(e, null);
         job.execute(ctx);
     }
 

--- a/src/test/java/org/candlepin/pinsetter/tasks/ExportCleanerTest.java
+++ b/src/test/java/org/candlepin/pinsetter/tasks/ExportCleanerTest.java
@@ -41,7 +41,7 @@ public class ExportCleanerTest {
 
     @Before
     public void init() {
-        cleaner = new ExportCleaner(config, null);
+        cleaner = new ExportCleaner(config);
     }
 
     @Test

--- a/src/test/java/org/candlepin/pinsetter/tasks/JobCleanerTest.java
+++ b/src/test/java/org/candlepin/pinsetter/tasks/JobCleanerTest.java
@@ -32,7 +32,7 @@ public class JobCleanerTest {
     @Test
     public void execute() throws Exception {
         JobCurator curator = mock(JobCurator.class);
-        JobCleaner cleaner = new JobCleaner(curator, null);
+        JobCleaner cleaner = new JobCleaner(curator);
         cleaner.execute(null);
         verify(curator).cleanUpOldCompletedJobs(any(Date.class));
         verify(curator).cleanupAllOldJobs(any(Date.class));

--- a/src/test/java/org/candlepin/pinsetter/tasks/MigrateOwnerJobTest.java
+++ b/src/test/java/org/candlepin/pinsetter/tasks/MigrateOwnerJobTest.java
@@ -86,7 +86,7 @@ public class MigrateOwnerJobTest {
         entCurator = mock(EntitlementCurator.class);
         sink = mock(EventSink.class);
         moj = new MigrateOwnerJob(conn, config, ownerCurator, poolCurator,
-            entCurator, consumerCurator, sink, null);
+            entCurator, consumerCurator, sink);
     }
 
     @Test

--- a/src/test/java/org/candlepin/pinsetter/tasks/RefreshPoolsJobTest.java
+++ b/src/test/java/org/candlepin/pinsetter/tasks/RefreshPoolsJobTest.java
@@ -57,7 +57,7 @@ public class RefreshPoolsJobTest {
         when(refresher.add(eq(owner))).thenReturn(refresher);
 
         // test
-        RefreshPoolsJob rpj = new RefreshPoolsJob(oc, pm, null);
+        RefreshPoolsJob rpj = new RefreshPoolsJob(oc, pm);
         rpj.execute(ctx);
 
         // verification
@@ -100,7 +100,7 @@ public class RefreshPoolsJobTest {
         doThrow(new NullPointerException()).when(refresher).run();
 
         // test
-        RefreshPoolsJob rpj = new RefreshPoolsJob(oc, pm, null);
+        RefreshPoolsJob rpj = new RefreshPoolsJob(oc, pm);
         rpj.execute(ctx);
     }
 }

--- a/src/test/java/org/candlepin/pinsetter/tasks/RegenEntitlementCertsJobTest.java
+++ b/src/test/java/org/candlepin/pinsetter/tasks/RegenEntitlementCertsJobTest.java
@@ -47,7 +47,7 @@ public class RegenEntitlementCertsJobTest {
 
         // test
         RegenProductEntitlementCertsJob recj =
-            new RegenProductEntitlementCertsJob(pm, null);
+            new RegenProductEntitlementCertsJob(pm);
         recj.execute(jec);
 
         // verification

--- a/src/test/java/org/candlepin/pinsetter/tasks/StatisticHistoryTaskTest.java
+++ b/src/test/java/org/candlepin/pinsetter/tasks/StatisticHistoryTaskTest.java
@@ -30,7 +30,7 @@ public class StatisticHistoryTaskTest extends DatabaseTestFixture {
     @Before
     public void init() {
         super.init();
-        this.task = new StatisticHistoryTask(statisticCurator, null);
+        this.task = new StatisticHistoryTask(statisticCurator);
     }
 
     @Test

--- a/src/test/java/org/candlepin/pinsetter/tasks/SweepBarJobTest.java
+++ b/src/test/java/org/candlepin/pinsetter/tasks/SweepBarJobTest.java
@@ -43,7 +43,7 @@ public class SweepBarJobTest {
     @Before
     public void init() throws SchedulerException {
         MockitoAnnotations.initMocks(this);
-        sweepBarJob = new SweepBarJob(j, pk, null);
+        sweepBarJob = new SweepBarJob(j, pk);
         when(pk.getSingleJobKeys()).thenReturn((new HashSet<JobKey>()));
     }
 

--- a/src/test/java/org/candlepin/pinsetter/tasks/UnpauseJobTest.java
+++ b/src/test/java/org/candlepin/pinsetter/tasks/UnpauseJobTest.java
@@ -51,7 +51,7 @@ public class UnpauseJobTest {
     @Before
     public void init() {
         MockitoAnnotations.initMocks(this);
-        unpauseJob = new UnpauseJob(j, pk, null);
+        unpauseJob = new UnpauseJob(j, pk);
     }
 
     @Test


### PR DESCRIPTION
## Use Unit of Work While Instantiating Job Objects

This fixes an issue where we create a job outside of a unit of
work, which uses an old (possibly closed) connection.

Also updated jobs to no longer require a unit of work to be
passed into the constructor, rather the superclass is injected.
Anywhere we manually instantiate (non-guice) jobs, we're
already inside of a unit of work, so the step is skipped.
## Reproducing the Issue from Stage

The issue from stage can be reproduced by setting short timeouts.  This doesn't change behavior, we just don't need to wait 8 hours (the default mysql timeout) to verify the issue.

/etc/my.cnf

```
[mysqld]
wait-timeout=10
interactive-timeout=10
```

And set shorter timeouts for c3p0
/etc/candlepin/candlepin.conf

```
jpa.config.hibernate.c3p0.timeout=8
jpa.config.hibernate.c3p0.idle_test_period=8
```
- with timeouts below 1 minute, you should use the in-memory quartz database.  It doesn't use c3p0 by default, and causes tracebacks when connections die quickly.

After restarting mysql and tomcat, running a refresh pools for an owner (more than **timeout** seconds after the first one is run) will cause a stack trace.
