### PR TITLE
Efficient entitlement pool validation

### DIFF
--- a/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -1336,42 +1336,24 @@ public class CandlepinPoolManager implements PoolManager {
         // Note that something could change between the time we list a pool as
         // available, and the consumer requests the actual entitlement, and the
         // request still could fail.
-        List<Pool> preFilterResults = page.getPageData();
-        List<Pool> newResults = new LinkedList<Pool>();
-        for (Pool p : preFilterResults) {
-            ValidationResult result = new ValidationResult();
-            if (consumer != null) {
-                result.add(enforcer.preEntitlement(
-                    consumer, p, 1, CallerType.LIST_POOLS));
-            }
-            if (key != null) {
-                result.add(activationKeyRules.runPreActKey(key, p, null));
-            }
-
-            if (result.isSuccessful() && (!result.hasWarnings() || includeWarnings)) {
-                newResults.add(p);
-            }
-            else {
-                if (log.isDebugEnabled()) {
-                    log.debug("Omitting pool due to failed rules: " + p.getId());
-                    if (result.hasErrors()) {
-                        log.debug("\tErrors: " + result.getErrors());
-                    }
-                    if (result.hasWarnings()) {
-                        log.debug("\tWarnings: " + result.getWarnings());
-                    }
-                }
-            }
+        List<Pool> resultingPools = page.getPageData();
+        if (consumer != null) {
+            resultingPools = enforcer.filterPools(
+                consumer, resultingPools, includeWarnings);
+        }
+        if (key != null) {
+            resultingPools = this.filterPoolsForActKey(
+                key, resultingPools, includeWarnings);
         }
 
         // Set maxRecords once we are done filtering
-        page.setMaxRecords(newResults.size());
+        page.setMaxRecords(resultingPools.size());
 
         if (pageRequest != null && pageRequest.isPaging()) {
-            newResults = poolCurator.takeSubList(pageRequest, newResults);
+            resultingPools = poolCurator.takeSubList(pageRequest, resultingPools);
         }
 
-        page.setPageData(newResults);
+        page.setPageData(resultingPools);
         return page;
     }
 
@@ -1406,5 +1388,26 @@ public class CandlepinPoolManager implements PoolManager {
 
     public List<Pool> getOwnerSubPoolsForStackId(Owner owner, String stackId) {
         return poolCurator.getOwnerSubPoolsForStackId(owner, stackId);
+    }
+
+    private List<Pool> filterPoolsForActKey(ActivationKey key,
+        List<Pool> pools, boolean includeWarnings) {
+        List<Pool> filteredPools = new LinkedList<Pool>();
+        for (Pool p : pools) {
+            ValidationResult result = activationKeyRules.runPreActKey(key, p, null);
+            if (result.isSuccessful() && (!result.hasWarnings() || includeWarnings)) {
+                filteredPools.add(p);
+            }
+            else if (log.isDebugEnabled()) {
+                log.debug("Omitting pool due to failed rules: " + p.getId());
+                if (result.hasErrors()) {
+                    log.debug("\tErrors: " + result.getErrors());
+                }
+                if (result.hasWarnings()) {
+                    log.debug("\tWarnings: " + result.getWarnings());
+                }
+            }
+        }
+        return filteredPools;
     }
 }

--- a/src/main/java/org/candlepin/policy/js/RulesObjectMapper.java
+++ b/src/main/java/org/candlepin/policy/js/RulesObjectMapper.java
@@ -16,6 +16,7 @@ package org.candlepin.policy.js;
 
 import org.candlepin.exceptions.IseException;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.AnnotationIntrospector;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -120,4 +121,14 @@ public class RulesObjectMapper {
         }
     }
 
+    public <T extends Object> T toObject(String json, TypeReference<T> typeref) {
+        try {
+            return mapper.readValue(json, typeref);
+        }
+        catch (Exception e) {
+            log.error("Error parsing JSON from rules");
+            log.error(json);
+            throw new IseException("Unable to build object from JSON.", e);
+        }
+    }
 }

--- a/src/main/java/org/candlepin/policy/js/entitlement/AbstractEntitlementRules.java
+++ b/src/main/java/org/candlepin/policy/js/entitlement/AbstractEntitlementRules.java
@@ -23,7 +23,6 @@ import org.candlepin.model.PoolCurator;
 import org.candlepin.policy.ValidationError;
 import org.candlepin.policy.ValidationResult;
 import org.candlepin.policy.ValidationWarning;
-import org.candlepin.policy.js.JsContext;
 import org.candlepin.policy.js.JsRunner;
 import org.candlepin.policy.js.ProductCache;
 import org.candlepin.policy.js.RulesObjectMapper;
@@ -62,7 +61,6 @@ public abstract class AbstractEntitlementRules implements Enforcer {
 
     protected RulesObjectMapper objectMapper = RulesObjectMapper.instance();
 
-    protected static final String PRE_PREFIX = "pre_";
     protected static final String POST_PREFIX = "post_";
 
     protected void rulesInit() {
@@ -148,28 +146,6 @@ public abstract class AbstractEntitlementRules implements Enforcer {
             throw new IllegalArgumentException(i18n.tr(
                 "second parameter should be the priority number.", e));
         }
-    }
-
-    protected ValidationResult callPreEntitlementRules(List<Rule> matchingRules,
-        JsContext context) {
-        ValidationResult result = new ValidationResult();
-        for (Rule rule : matchingRules) {
-            if (log.isDebugEnabled()) {
-                log.debug("invoking rule: " + PRE_PREFIX + rule.getRuleName());
-            }
-
-            String validationJson = jsRules.invokeRule(PRE_PREFIX + rule.getRuleName(),
-                context);
-
-            // If the resulting validation json is empty, either the method
-            // did not exist in the rules, or the method did not return
-            // anything. In this case we skip the result.
-            if (validationJson == null) {
-                continue;
-            }
-            result.add(objectMapper.toObject(validationJson, ValidationResult.class));
-        }
-        return result;
     }
 
     protected void callPostEntitlementRules(List<Rule> matchingRules) {

--- a/src/main/java/org/candlepin/policy/js/entitlement/Enforcer.java
+++ b/src/main/java/org/candlepin/policy/js/entitlement/Enforcer.java
@@ -14,6 +14,8 @@
  */
 package org.candlepin.policy.js.entitlement;
 
+import java.util.List;
+
 import org.candlepin.model.Consumer;
 import org.candlepin.model.Entitlement;
 import org.candlepin.model.Pool;
@@ -84,6 +86,15 @@ public interface Enforcer {
      */
     ValidationResult preEntitlement(Consumer consumer, Pool entitlementPool,
         Integer quantity, CallerType caller);
+
+    /**
+     * @param consumer Consumer who wishes to consume an entitlement.
+     * @param pools Entitlement pools to potentially consume from.
+     * @param showAll if true, allows pools with warnings
+     * @return list of valid pools for the given consumer
+     */
+    List<Pool> filterPools(Consumer consumer, List<Pool> pools, boolean showAll);
+
     /**
      * Run post-entitlement actions.
      *

--- a/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRules.java
+++ b/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRules.java
@@ -21,19 +21,21 @@ import org.candlepin.model.Pool;
 import org.candlepin.model.PoolCurator;
 import org.candlepin.policy.ValidationError;
 import org.candlepin.policy.ValidationResult;
-import org.candlepin.policy.js.AttributeHelper;
 import org.candlepin.policy.js.JsRunner;
 import org.candlepin.policy.js.JsonJsContext;
 import org.candlepin.policy.js.ProductCache;
+import org.candlepin.policy.js.RuleExecutionException;
 import org.candlepin.util.DateSource;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.inject.Inject;
 
 import org.slf4j.LoggerFactory;
 import org.xnap.commons.i18n.I18n;
 
+import java.util.LinkedList;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
 
 /**
  * Enforces entitlement rules for normal (non-manifest) consumers.
@@ -57,6 +59,7 @@ public class EntitlementRules extends AbstractEntitlementRules implements Enforc
         this.poolCurator = poolCurator;
 
         log = LoggerFactory.getLogger(EntitlementRules.class);
+        jsRules.init("entitlement_name_space");
     }
 
     @Override
@@ -70,58 +73,82 @@ public class EntitlementRules extends AbstractEntitlementRules implements Enforc
     public ValidationResult preEntitlement(Consumer consumer, Pool entitlementPool,
         Integer quantity, CallerType caller) {
 
-        jsRules.reinitTo("entitlement_name_space");
-        rulesInit();
+        JsonJsContext args = new JsonJsContext(objectMapper);
+        args.put("consumer", consumer);
+        args.put("hostConsumer", consumer.hasFact("virt.uuid") ?
+            this.consumerCurator.getHost(consumer.getFact("virt.uuid"),
+                consumer.getOwner()) : null);
+        args.put("consumerEntitlements", consumer.getEntitlements());
+        args.put("standalone", config.standalone());
+        args.put("pool", entitlementPool);
+        args.put("quantity", quantity);
+        args.put("caller", caller.getLabel());
+        args.put("log", log, false);
 
-        ValidationResult result = runPreEntitlement(consumer,
-            entitlementPool, quantity, caller);
-        validatePoolQuantity(result, entitlementPool, quantity);
+        String json = jsRules.runJsFunction(String.class, "validate_pool", args);
+        ValidationResult result;
+        try {
+            result = objectMapper.toObject(json, ValidationResult.class);
+            finishValidation(result, entitlementPool, quantity);
+        }
+        catch (Exception e) {
+            throw new RuleExecutionException(e);
+        }
 
-        if (entitlementPool.isExpired(dateSource)) {
+        return result;
+    }
+
+    @Override
+    public List<Pool> filterPools(Consumer consumer, List<Pool> pools, boolean showAll) {
+        JsonJsContext args = new JsonJsContext(objectMapper);
+        args.put("consumer", consumer);
+        args.put("hostConsumer", consumer.hasFact("virt.uuid") ?
+            this.consumerCurator.getHost(consumer.getFact("virt.uuid"),
+                consumer.getOwner()) : null);
+        args.put("consumerEntitlements", consumer.getEntitlements());
+        args.put("standalone", config.standalone());
+        args.put("pools", pools);
+        args.put("caller", CallerType.LIST_POOLS.getLabel());
+        args.put("log", log, false);
+
+        String json = jsRules.runJsFunction(String.class, "validate_pools_list", args);
+        Map<String, ValidationResult> resultMap;
+        TypeReference<Map<String, ValidationResult>> typeref =
+            new TypeReference<Map<String, ValidationResult>>() {};
+        try {
+            resultMap = objectMapper.toObject(json, typeref);
+        }
+        catch (Exception e) {
+            throw new RuleExecutionException(e);
+        }
+        List<Pool> filteredPools = new LinkedList<Pool>();
+        for (Pool pool : pools) {
+            ValidationResult result = resultMap.get(pool.getId());
+            finishValidation(result, pool, 1);
+
+            if (result.isSuccessful() && (!result.hasWarnings() || showAll)) {
+                filteredPools.add(pool);
+            }
+            else if (log.isDebugEnabled()) {
+                log.debug("Omitting pool due to failed rules: " + pool.getId());
+                if (result.hasErrors()) {
+                    log.debug("\tErrors: " + result.getErrors());
+                }
+                if (result.hasWarnings()) {
+                    log.debug("\tWarnings: " + result.getWarnings());
+                }
+            }
+        }
+        return filteredPools;
+    }
+
+    private void finishValidation(ValidationResult result, Pool pool, Integer quantity) {
+        validatePoolQuantity(result, pool, quantity);
+        if (pool.isExpired(dateSource)) {
             result.addError(
                 new ValidationError(i18n.tr("Subscriptions for {0} expired on: {1}",
-                    entitlementPool.getProductId(),
-                    entitlementPool.getEndDate())));
+                    pool.getProductId(),
+                    pool.getEndDate())));
         }
-
-        return result;
     }
-
-    private ValidationResult runPreEntitlement(Consumer consumer, Pool pool,
-        Integer quantity, CallerType caller) {
-        // Provide objects for the script:
-        JsonJsContext context = new JsonJsContext(this.objectMapper);
-        context.put("consumer", consumer);
-        // Entitlements are put into the context seperately because they do
-        // not get serialized along with the Consumer.
-        context.put("consumerEntitlements", consumer.getEntitlements());
-        context.put("pool", pool);
-        context.put("standalone", config.standalone());
-        context.put("quantity", quantity);
-        context.put("caller", caller.getLabel());
-
-        // If the consumer is a guest, the rules may require the host
-        // consumer.
-        if (consumer.hasFact("virt.uuid")) {
-            String guestUuid = consumer.getFact("virt.uuid");
-            context.put("hostConsumer",
-                consumerCurator.getHost(guestUuid, consumer.getOwner()));
-        }
-
-        // Add all non-serializable objects to the context.
-        context.put("log", log, false);
-
-        log.debug("Running pre-entitlement rules for: " + consumer.getUuid() +
-            " product: " + pool.getProductId());
-
-        // Determine all rules to run based on the pool's attributes.
-        AttributeHelper attributeHelper = new AttributeHelper();
-        Set<String> attributeNames = attributeHelper.getFlattenedAttributes(pool).keySet();
-        List<Rule> matchingRules = rulesForAttributes(attributeNames, attributesToRules);
-        ValidationResult result = callPreEntitlementRules(matchingRules, context);
-        logResult(result);
-
-        return result;
-    }
-
 }

--- a/src/test/java/org/candlepin/policy/test/EnforcerTest.java
+++ b/src/test/java/org/candlepin/policy/test/EnforcerTest.java
@@ -212,61 +212,6 @@ public class EnforcerTest extends DatabaseTestFixture {
         );
     }
 
-    // grrr. have to test two conditions atm: sufficient number of entitlements
-    // *when* pool has not expired
-    //
-    // shouldPassValidationWhenSufficientNumberOfEntitlementsIsAvailableAndNotExpired
-    @Test
-    public void passValidationEnoughNumberOfEntitlementsIsAvailableAndNotExpired() {
-        Product product = new Product("a-product", "A product for testing");
-        productCurator.create(product);
-
-        when(this.productAdapter.getProductById("a-product")).thenReturn(product);
-
-        ValidationResult result = enforcer.preEntitlement(
-            createConsumer(owner),
-            entitlementPoolWithMembersAndExpiration(owner, product, 1, 2,
-                expiryDate(2010, 10, 10)),
-            1);
-        assertTrue(result.isSuccessful());
-        assertFalse(result.hasErrors());
-        assertFalse(result.hasWarnings());
-    }
-
-    @Test
-    public void shouldFailValidationWhenNoEntitlementsAreAvailable() {
-        Product product = new Product("a-product", "A product for testing");
-        productCurator.create(product);
-
-        when(this.productAdapter.getProductById("a-product")).thenReturn(product);
-
-        ValidationResult result = enforcer.preEntitlement(
-            createConsumer(owner),
-            entitlementPoolWithMembersAndExpiration(owner, product, 1, 1,
-                expiryDate(2010, 10, 10)),
-            1);
-
-        assertFalse(result.isSuccessful());
-        assertTrue(result.hasErrors());
-        assertFalse(result.hasWarnings());
-    }
-
-    @Test
-    public void shouldFailWhenEntitlementsAreExpired() {
-        Product product = new Product("a-product", "A product for testing");
-        productCurator.create(product);
-
-        when(this.productAdapter.getProductById("a-product")).thenReturn(product);
-
-        ValidationResult result = enforcer.preEntitlement(
-            createConsumer(owner),
-            entitlementPoolWithMembersAndExpiration(owner, product, 1, 2,
-                expiryDate(2000, 1, 1)), 1);
-        assertFalse(result.isSuccessful());
-        assertTrue(result.hasErrors());
-        assertFalse(result.hasWarnings());
-    }
-
     // This exception should mention wrapping a MissingFactException
     @Test(expected = RuleExecutionException.class)
     public void testRuleFailsWhenConsumerDoesntHaveFact() {

--- a/src/test/java/org/candlepin/test/EnforcerForTesting.java
+++ b/src/test/java/org/candlepin/test/EnforcerForTesting.java
@@ -14,6 +14,8 @@
  */
 package org.candlepin.test;
 
+import java.util.List;
+
 import org.candlepin.model.Consumer;
 import org.candlepin.model.Entitlement;
 import org.candlepin.model.Pool;
@@ -53,5 +55,11 @@ public class EnforcerForTesting implements Enforcer {
     public PoolHelper postUnbind(Consumer consumer, PoolHelper postEntHelper,
             Entitlement ent) {
         return postEntHelper;
+    }
+
+    @Override
+    public List<Pool> filterPools(Consumer consumer, List<Pool> pools,
+        boolean showAll) {
+        return pools;
     }
 }


### PR DESCRIPTION
# Changes
- Validate entire pools at once
- No longer call the js rules validation for individual attributes
- Support filtering lists of pools (only for listing pools, no bulk binds etc)
## The Problem

Prior to this patch, running [EntitlementRules](https://github.com/candlepin/candlepin/blob/candlepin-0.9.10-1/src/main/java/org/candlepin/policy/js/entitlement/AbstractEntitlementRules.java#L84-L105) passes through the javascript rules for each attribute (selected from a list of white-listed strings).

For each pool, we try to [look up a host consumer](https://github.com/candlepin/candlepin/blob/candlepin-0.9.10-1/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRules.java#L105-L109).

When we're listing pools for a consumer, we only need to do that lookup once.  Furthermore, we might as well send the entire list into the rules at once.
## Compatibility

Unless we are willing to rev the major version in rules.js, we need to make sure we don't break old candlepin servers that consume our exports.

I've renamed all the validator methods, and they must be passed a context, and validation result.  I wrote a [wrapper function generator](https://github.com/candlepin/candlepin/blob/ae366725524e4c95e39fc740da6c8317d4db84b0/src/main/resources/rules/rules.js#L1342-L1353) that can be used to generate old-style validators:

```
    pre_FOO: function() {
        return this.build_func("do_pre_FOO")();
    },
```
## Performance

Performance on physical systems hasn't been affected very much, however on virtual systems the runtime is now in line with what we expect for physical systems.

Performance measured with:

```
time curl -k -u admin:admin "https://localhost:8443/candlepin/owners/admin/pools?consumer={UUID}"
```
### Virtual

| master | this branch |
| --- | --- |
| 11.314 | 6.911 |
| 10.487 | 5.495 |
| 10.714 | 5.379 |
### Physical

| master | this branch |
| --- | --- |
| 6.344 | 6.156 |
| 5.538 | 5.433 |
| 5.494 | 5.292 |
## Final Notes

![Am I doing this right?](http://i.imgur.com/ahFdEA7.jpg)
