### PR TITLE
let cascade delete actkey pools

### DIFF
--- a/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -1152,13 +1152,6 @@ public class CandlepinPoolManager implements PoolManager {
     public void deletePool(Pool pool) {
         Event event = eventFactory.poolDeleted(pool);
 
-        // remove the link between the key and the pool before deleting the pool
-        // TODO: is there a better way to do this with hibernate annotations?
-        List<ActivationKey> keys = poolCurator.getActivationKeysForPool(pool);
-        for (ActivationKey k : keys) {
-            k.removePool(pool);
-        }
-
         // Must do a full revoke for all entitlements:
         for (Entitlement e : poolCurator.entitlementsIn(pool)) {
             revokeEntitlement(e);


### PR DESCRIPTION
The cascade has been there for a while, just removing extra unnecessary work that we do.
