### PR TITLE
Remove bad validator from Consumer.java

### DIFF
--- a/src/main/java/org/candlepin/model/Consumer.java
+++ b/src/main/java/org/candlepin/model/Consumer.java
@@ -151,7 +151,6 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
     @MapKeyColumn(name = "mapkey")
     @Column(name = "element")
     @Cascade({org.hibernate.annotations.CascadeType.ALL})
-    @Size(max = 255)
     private Map<String, String> facts;
 
     @OneToOne(cascade = CascadeType.ALL)

--- a/src/test/java/org/candlepin/model/test/HibernateValidationAnnotationTest.java
+++ b/src/test/java/org/candlepin/model/test/HibernateValidationAnnotationTest.java
@@ -152,7 +152,6 @@ public class HibernateValidationAnnotationTest extends DatabaseTestFixture{
         fm.put(Consumer.class.getDeclaredField("entitlementStatus"), size);
         fm.put(Consumer.class.getDeclaredField("serviceLevel"), size);
         fm.put(Consumer.class.getDeclaredField("releaseVer"), size);
-        fm.put(Consumer.class.getDeclaredField("facts"), size);
         runMap(fm);
     }
 


### PR DESCRIPTION
The size annotation on Consumer.facts limited the number of
fact key/value combinations rather than the length of keys
and values.
