### PR TITLE
1092678: Handle failure to delete expired revoked serials.

### DIFF
--- a/src/test/java/org/candlepin/controller/CrlGeneratorTest.java
+++ b/src/test/java/org/candlepin/controller/CrlGeneratorTest.java
@@ -277,6 +277,24 @@ public class CrlGeneratorTest {
     }
 
     @Test
+    public void updateCRLWithErrorDeletingExpired() {
+        List<CertificateSerial> serials = getStubCSList();
+        when(this.curator.retrieveTobeCollectedSerials())
+            .thenReturn(serials);
+        when(this.curator.deleteExpiredSerials()).thenThrow(new RuntimeException());
+
+        X509CRL x509crl = this.generator.syncCRLWithDB((X509CRL) null);
+        Set<? extends X509CRLEntry> entries = x509crl.getRevokedCertificates();
+        Set<BigInteger> nos = Util.newSet();
+        for (X509CRLEntry entry : entries) {
+            nos.add(entry.getSerialNumber());
+        }
+        assertTrue(nos.contains(BigInteger.ONE));
+        assertTrue(nos.contains(new BigInteger("100")));
+        assertTrue(nos.contains(new BigInteger("1235465")));
+    }
+
+    @Test
     @SuppressWarnings({ "unchecked", "serial", "rawtypes" })
     public void testUpdateCRLWithMockedCRL() {
         X509CRL oldCert = mock(X509CRL.class);


### PR DESCRIPTION
We have not been able to identify how this is possible, but in meantime we will
gracefully handle the error. With this patch the error will be logged, but will
not block CRL regeneration entirely.

The bad serials remain in the db, but should not be present in the CRL itself.
