### PR TITLE
Ensure that a null Product will not cause Subscription#toString to throw a NullPointerException

### DIFF
--- a/src/main/java/org/candlepin/model/Subscription.java
+++ b/src/main/java/org/candlepin/model/Subscription.java
@@ -160,7 +160,8 @@ public class Subscription extends AbstractHibernateObject {
     }
 
     public String toString() {
-        return "Subscription [id = " + getId() + ", product = " + getProduct().getId() +
+        String productId = ((getProduct() == null) ? "null" : getProduct().getId());
+        return "Subscription [id = " + getId() + ", product = " + productId +
             ", quantity = " + getQuantity() + ", expires = " + getEndDate() + "]";
     }
 


### PR DESCRIPTION
During some of my testing I have a Subscription w/out a Product. Obviously this should not happen in a live system, but even if it did I would think that the error should come from elsewhere. This change simply prevents the toString method from blowing up.
