### PR TITLE
Update consumer.updated when modifying lastCheckIn

### DIFF
--- a/src/main/java/org/candlepin/model/ConsumerCurator.java
+++ b/src/main/java/org/candlepin/model/ConsumerCurator.java
@@ -288,7 +288,8 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
     @Transactional
     public void updateLastCheckin(Consumer consumer, Date checkinDate) {
         currentSession().createQuery("update Consumer c " +
-            "set c.lastCheckin = :date " +
+            "set c.lastCheckin = :date, " +
+            "c.updated = :date " +
             "where c.id = :consumerid")
             .setTimestamp("date", checkinDate)
             .setParameter("consumerid", consumer.getId())


### PR DESCRIPTION
This is already tested by:
consumer_resource_spec "updates consumer updated timestamp on bind"

Update the consumer.updated record when we update lastCheckin
