### PR TITLE
1094492: Consumer name in Alternate Subject needs to be different type

### DIFF
--- a/src/main/java/org/candlepin/pki/impl/BouncyCastlePKIUtility.java
+++ b/src/main/java/org/candlepin/pki/impl/BouncyCastlePKIUtility.java
@@ -139,7 +139,7 @@ public class BouncyCastlePKIUtility extends PKIUtility {
 
         // Add an alternate name if provided
         if (alternateName != null) {
-            GeneralName name = new GeneralName(GeneralName.directoryName,
+            GeneralName name = new GeneralName(GeneralName.uniformResourceIdentifier,
                 "CN=" + alternateName);
             certGen.addExtension(X509Extensions.SubjectAlternativeName, false,
                 new GeneralNames(name));


### PR DESCRIPTION
If the consumer name is 221-255 characters, it does not get included into
the appropriate field.
