### PR TITLE
1070388; Changes userpass string parsing to allow colons in passwords.

### DIFF
--- a/src/main/java/org/candlepin/resteasy/interceptor/BasicAuth.java
+++ b/src/main/java/org/candlepin/resteasy/interceptor/BasicAuth.java
@@ -50,8 +50,7 @@ class BasicAuth extends UserAuth {
             if (auth != null && auth.toUpperCase().startsWith("BASIC ")) {
                 String userpassEncoded = auth.substring(6);
                 String[] userpass = new String(Base64
-                    .decodeBase64(userpassEncoded)).split(":");
-
+                    .decodeBase64(userpassEncoded)).split(":", 2);
                 String username = userpass[0];
                 String password = null;
                 if (userpass.length > 1) {

--- a/src/test/java/org/candlepin/resteasy/interceptor/BasicAuthViaUserServiceTest.java
+++ b/src/test/java/org/candlepin/resteasy/interceptor/BasicAuthViaUserServiceTest.java
@@ -120,11 +120,57 @@ public class BasicAuthViaUserServiceTest {
         assertEquals(expected, this.auth.getPrincipal(request));
     }
 
+    @Test
+    public void correctPrincipalColonPassword() throws Exception {
+        Owner owner = new Owner("user", "user");
+
+        setUserAndPassword("user", "1:2");
+        when(userService.validateUser("user", "1:2")).thenReturn(true);
+
+
+        Set<OwnerPermission> permissions = new HashSet<OwnerPermission>();
+        permissions.add(new OwnerPermission(owner, Access.ALL));
+
+        when(userService.findByLogin("user")).thenReturn(new User());
+
+        UserPrincipal expected = new UserPrincipal("user",
+                new ArrayList<Permission>(permissions), false);
+        assertEquals(expected, this.auth.getPrincipal(request));
+    }
+    @Test
+    public void correctPrincipalNoPassword() throws Exception {
+        Owner owner = new Owner("user", "user");
+
+        setUserNoPassword("user");
+        when(userService.validateUser("user", null)).thenReturn(true);
+
+
+        Set<OwnerPermission> permissions = new HashSet<OwnerPermission>();
+        permissions.add(new OwnerPermission(owner, Access.ALL));
+
+        when(userService.findByLogin("user")).thenReturn(new User());
+
+        UserPrincipal expected = new UserPrincipal("user",
+                new ArrayList<Permission>(permissions), false);
+        assertEquals(expected, this.auth.getPrincipal(request));
+    }
+
     // TODO:  Add in owner creation/retrieval tests?
 
     private void setUserAndPassword(String username, String password) {
         headers.getRequestHeaders().add("Authorization",
             "BASIC " + encodeUserAndPassword(username, password));
+    }
+
+    private void setUserNoPassword(String username) {
+        headers.getRequestHeaders().add("Authorization",
+            "BASIC " + encodeUserNoPassword(username));
+    }
+
+    private String encodeUserNoPassword(String username) {
+        String decoded = username;
+        byte[] encoded = Base64.encodeBase64(decoded.getBytes());
+        return new String(encoded);
     }
 
     private String encodeUserAndPassword(String username, String password) {


### PR DESCRIPTION
This changes the way the userpass string is parsed to allow for colons in the password. This should fix: https://bugzilla.redhat.com/show_bug.cgi?id=1070388
