### PR TITLE
Spec test failure when running in parallel

### DIFF
--- a/spec/activation_key_spec.rb
+++ b/spec/activation_key_spec.rb
@@ -17,8 +17,7 @@ describe 'Activation Keys' do
     @sub = @cp.create_subscription(@owner['key'], @some_product['id'], 37)
     @cp.refresh_pools(@owner['key'])
 
-    pools = @cp.list_pools
-    @pool = pools.select { |p| p['owner']['key'] == @owner['key'] }.first
+    @pool = @cp.list_pools(:owner => @owner.id).first
 
     @activation_key = @cp.create_activation_key(@owner['key'], random_string('test_token'))
     @activation_key['id'].should_not be_nil

--- a/spec/oauth_spec.rb
+++ b/spec/oauth_spec.rb
@@ -21,7 +21,7 @@ describe 'OAuth' do
      :authorize_path => "",
      :access_token_path => "",
     }
-    @owner = create_owner "oauth-owner"
+    @owner = create_owner random_string("oauth-owner")
     @user = create_user(@owner, "oauth-user", 'password')
     @consumer = @cp.register("oauth-consumer", :system, nil, {},
                              @user.username, @owner['key'])

--- a/spec/pool_resource_spec.rb
+++ b/spec/pool_resource_spec.rb
@@ -170,8 +170,7 @@ describe 'Pool Resource' do
 
     @cp.create_subscription(owner['key'], product.id, 25)
     @cp.refresh_pools(owner['key'])
-    pools = @cp.list_pools
-    pool = pools.select { |p| p['owner']['key'] == owner['key'] }.first
+    pool = @cp.list_pools(:owner => owner.id).first
 
     user = user_client(owner, random_string('billy'))
     system = consumer_client(user, 'system')


### PR DESCRIPTION
Tests were using list_pools with no parameters which caused the query to go across
all owners. This set up a race condition where other owners not created by the test
would get deleted mid-stream. Test now retrieves needed pools by specific owner.

**This commit was lost due to a force push to master.  Resubmitting.**
