### PR TITLE
Fix async bind for "my" system admins.

### DIFF
--- a/spec/system_admin_spec.rb
+++ b/spec/system_admin_spec.rb
@@ -79,6 +79,15 @@ describe 'System Admins' do
     end.should raise_exception(RestClient::ResourceNotFound)
   end
 
+  it "can create entitlements asynchronously" do
+    pool = create_pool()
+    @user_cp.consume_pool(pool['id'],
+      {
+        :uuid => @consumer1['uuid'],
+        :async => true
+      })
+  end
+
   it "can view only their system's entitlements" do
     pool = create_pool()
     ent = @user_cp.consume_pool(pool['id'], {:uuid => @consumer1['uuid']})[0]

--- a/src/main/java/org/candlepin/auth/permissions/UsernameConsumersPermission.java
+++ b/src/main/java/org/candlepin/auth/permissions/UsernameConsumersPermission.java
@@ -14,6 +14,8 @@
  */
 package org.candlepin.auth.permissions;
 
+import java.io.Serializable;
+
 import org.candlepin.auth.Access;
 import org.candlepin.auth.SubResource;
 import org.candlepin.model.Consumer;
@@ -32,7 +34,7 @@ import org.hibernate.criterion.Restrictions;
  *
  * Allows the user to create and manage entitlements for the consumer as well.
  */
-public class UsernameConsumersPermission implements Permission {
+public class UsernameConsumersPermission implements Permission, Serializable {
 
     private final User user;
     private final Owner owner;


### PR DESCRIPTION
A use case that would only surface in hosted, if a principal carrying the my
systems permission runs a job, of which there is probably only one (async
bind), our code attempts to serialize the principal to the db. Unfortunately
the new permission did not implement serializable.

Attempted a unit test but this seems to occur pretty deep in the quartz code
where our unit tests typically mock everything out. Switched to a spec test
which made exposing the issue easy.
