### PR TITLE
Fix client registration for my system admins.

### DIFF
--- a/spec/system_admin_spec.rb
+++ b/spec/system_admin_spec.rb
@@ -166,6 +166,11 @@ describe 'System admins with read-only on org' do
     return pool
   end
 
+  it 'can list their owners' do
+    owners = @user_cp.list_users_owners(@username)
+    owners.size.should == 1
+  end
+
   it 'can see all systems in org' do
     # Admin should see both systems in the org:
     @cp.list_consumers({:owner => @owner['key']}).size.should == 2

--- a/src/main/java/org/candlepin/model/User.java
+++ b/src/main/java/org/candlepin/model/User.java
@@ -154,10 +154,13 @@ public class User extends AbstractHibernateObject {
      * @return associated owners
      */
     @XmlTransient
-    public Set<Owner> getOwners(Access accessLevel) {
+    public Set<Owner> getOwners(SubResource sub, Access accessLevel) {
         Set<Owner> owners = new HashSet<Owner>();
+        if (sub == null) {
+            sub = SubResource.NONE;
+        }
         for (Permission p : this.getPermissions()) {
-            if (p.canAccess(p.getOwner(), SubResource.NONE, accessLevel)) {
+            if (p.canAccess(p.getOwner(), sub, accessLevel)) {
                 owners.add(p.getOwner());
             }
         }

--- a/src/main/java/org/candlepin/resource/UserResource.java
+++ b/src/main/java/org/candlepin/resource/UserResource.java
@@ -33,6 +33,7 @@ import javax.ws.rs.core.MediaType;
 
 import org.candlepin.auth.Access;
 import org.candlepin.auth.Principal;
+import org.candlepin.auth.SubResource;
 import org.candlepin.auth.interceptor.Verify;
 import org.candlepin.exceptions.ConflictException;
 import org.candlepin.exceptions.GoneException;
@@ -185,14 +186,17 @@ public class UserResource {
     }
 
     /**
-     * Retrieve a list of Owners by User
+     * Retrieve a list of owners the user can register systems to.
      * <p>
-     * Owners for which this User has admin rights.
+     * Previously this represented owners the user was an admin for. Because the client uses
+     * this API call to list the owners a user can register to, when we introduced "my
+     * systems" administrator, we have to change its meaning to listing the owners that
+     * can be registered to by default to maintain compatability with released clients.
      *
      * @return a list of Owner objects
      * @httpcode 200
      */
-    // TODO: should probably accept an access level query param someday
+    // TODO: should probably accept access level and sub-resource query params someday
     @GET
     @Path("/{username}/owners")
     @Produces(MediaType.APPLICATION_JSON)
@@ -206,7 +210,7 @@ public class UserResource {
             owners.addAll(ownerCurator.listAll());
         }
         else {
-            for (Owner o : user.getOwners(Access.ALL)) {
+            for (Owner o : user.getOwners(SubResource.CONSUMERS, Access.CREATE)) {
                 owners.add(o);
             }
         }

--- a/src/test/java/org/candlepin/model/test/UserTest.java
+++ b/src/test/java/org/candlepin/model/test/UserTest.java
@@ -53,14 +53,33 @@ public class UserTest extends DatabaseTestFixture {
         Owner owner2 = new Owner("owner2", "owner two");
         User user = new User(username, password);
 
-        Set<Owner> owners = user.getOwners(Access.ALL);
+        Set<Owner> owners = user.getOwners(null, Access.ALL);
         assertEquals(0, owners.size());
         user.addPermissions(new TestPermission(owner1));
         user.addPermissions(new TestPermission(owner2));
 
         // Adding the new permissions should give us access
         // to both new owners
-        owners = user.getOwners(Access.ALL);
+        owners = user.getOwners(null, Access.ALL);
+        assertEquals(2, owners.size());
+    }
+
+    @Test
+    public void testGetOwnersCoversCreateConsumers() {
+        String username = "TESTUSER";
+        String password = "sekretpassword";
+        Owner owner1 = new Owner("owner1", "owner one");
+        Owner owner2 = new Owner("owner2", "owner two");
+        User user = new User(username, password);
+
+        Set<Owner> owners = user.getOwners(null, Access.ALL);
+        assertEquals(0, owners.size());
+        user.addPermissions(new TestPermission(owner1));
+        user.addPermissions(new TestPermission(owner2));
+
+        // This is the check we do in API call, make sure owner admins show up as
+        // having perms to create consumers as well:
+        owners = user.getOwners(SubResource.CONSUMERS, Access.CREATE);
         assertEquals(2, owners.size());
     }
 
@@ -72,14 +91,14 @@ public class UserTest extends DatabaseTestFixture {
         Owner owner2 = new Owner("owner2", "owner two");
         User user = new User(username, password);
 
-        Set<Owner> owners = user.getOwners(Access.ALL);
+        Set<Owner> owners = user.getOwners(null, Access.ALL);
         assertEquals(0, owners.size());
         user.addPermissions(new OtherPermission(owner1));
         user.addPermissions(new OtherPermission(owner2));
 
         // Adding the new permissions should not give us access
         // to either of the new owners
-        owners = user.getOwners(Access.ALL);
+        owners = user.getOwners(null, Access.ALL);
         assertEquals(0, owners.size());
     }
 


### PR DESCRIPTION
In an environment where my system admins are live, using such an account with
the subscription-manager client will need to first check how many owners the
account can register too. The old API call for this was asking for access level
ALL, i.e. org admins, which these accounts do not have. The result is failed
registrations for any my systems admin.

Because we must maintain compatability with old clients, we'll stick with
original meaning of this API call which is "what orgs can I register to", but
asking specifically for the ability to create a consumer. Tests included verify
this still returns correct owner for an org admin.
