### PR TITLE
Wait for async bind spec test to finish.

### DIFF
--- a/spec/job_status_spec.rb
+++ b/spec/job_status_spec.rb
@@ -12,27 +12,18 @@ describe 'Job Status' do
     @cp.create_subscription(@owner['key'], @monitoring.id, 4)
   end
 
-  def finish_job(status)
-    #let it finish
-    while status != nil && status['state'].downcase != 'finished'
-      sleep 1
-      # POSTing here will delete the job once it has finished
-      status = @owner.post(status['statusPath'])
-    end
-  end
-
   it 'should contain the owner key' do
     status = @cp.refresh_pools(@owner['key'], true)
     status['targetId'].should == @owner['key']
 
-    finish_job(status)
+    wait_for_job(status['id'], 15)
   end
 
   it 'should contain the target type' do
     status = @cp.refresh_pools(@owner['key'], true)
     status['targetType'].should == "owner"
 
-    finish_job(status)
+    wait_for_job(status['id'], 15)
   end
 
 
@@ -40,7 +31,7 @@ describe 'Job Status' do
     jobs = []
     3.times {
         jobs << @cp.refresh_pools(@owner['key'], true)
-        finish_job(jobs[-1])
+        wait_for_job(jobs[-1]['id'], 15)
     }
 
     @cp.list_jobs(@owner['key']).length.should == 3
@@ -55,12 +46,12 @@ describe 'Job Status' do
     4.times {
         jobs << @cp.refresh_pools(owner2['key'], true)
         jobs << @cp.refresh_pools(@owner['key'], true)
-        finish_job(jobs[-1])
-        finish_job(jobs[-2])
+        wait_for_job(jobs[-1]['id'], 15)
+        wait_for_job(jobs[-2]['id'], 15)
     }
     2.times {
         jobs << @cp.refresh_pools(owner2['key'], true)
-        finish_job(jobs[-1])
+        wait_for_job(jobs[-1]['id'], 15)
     }
 
     @cp.list_jobs(@owner['key']).length.should == 4
@@ -104,7 +95,7 @@ describe 'Job Status' do
     status['targetType'].should == "consumer"
     status['targetId'].should == system.uuid
 
-    finish_job(status)
+    wait_for_job(status['id'], 15)
   end
 
 

--- a/spec/system_admin_spec.rb
+++ b/spec/system_admin_spec.rb
@@ -81,11 +81,12 @@ describe 'System Admins' do
 
   it "can create entitlements asynchronously" do
     pool = create_pool()
-    @user_cp.consume_pool(pool['id'],
+    job = @user_cp.consume_pool(pool['id'],
       {
         :uuid => @consumer1['uuid'],
         :async => true
       })
+    wait_for_job(job['id'], 10)
   end
 
   it "can view only their system's entitlements" do


### PR DESCRIPTION
Looks like slower systems may fail on this trying to cleanup owner at end of
test, when the async bind is still underway. This causes an entitlement to be
committed that the delete owner job didn't get loaded in time, and a failed
cleanup due to foreign key constraint vilolations.

Noticed we have two "wait for job" implementations, switched to the better
looking one.
