### PR TITLE
Move repositories to top of buildfile.

### DIFF
--- a/buildfile
+++ b/buildfile
@@ -1,3 +1,5 @@
+# vi: set ft=ruby:
+
 ### Repositories
 repositories.remote << "http://jmrodri.fedorapeople.org/ivy/candlepin/"
 repositories.remote << "http://repository.jboss.org/nexus/content/groups/public/"


### PR DESCRIPTION
Prevents errors on clean checkouts that have not yet downloaded deps.
