### PR TITLE
Entitlements from derived product pool not able to get upstream

### DIFF
--- a/spec/derived_product_import_spec.rb
+++ b/spec/derived_product_import_spec.rb
@@ -1,0 +1,116 @@
+require 'spec_helper'
+require 'candlepin_scenarios'
+require 'json'
+
+describe 'Import', :serial => true do
+
+  include CandlepinMethods
+
+  before(:all) do
+    @cp = Candlepin.new('admin', 'admin')
+    @owners = []
+    @owner = @cp.create_owner(random_string('owner'))
+    @user = user_client(@owner, random_string('user'))
+    @dist_owner = create_owner(random_string('owner'))
+    @dist_user = user_client(@dist_owner, random_string('user'))
+    @owners = [@owner, @dist_owner]
+    @exporter = Export.new
+    @exporters = [@exporter]
+
+  end
+
+  after(:all) do
+    @owners.each do |o|
+      @cp.delete_owner(o['key'])
+    end
+    @exporters.each do |e|
+      e.cleanup()
+    end
+  end
+
+  it 'can retrieve subscripton certificate from derived pool entitlement' do
+    stacked_datacenter_product = create_product(nil, nil, {
+      :attributes => {
+        :virt_limit => "unlimited",
+        :stacking_id => 'mixed-stack',
+        :sockets => "2",
+        'multi-entitlement' => "yes"
+      }
+    })
+    derived_product = create_product(nil, nil, {
+      :attributes => {
+          :cores => '6',
+          :sockets=>'8'
+      }
+    })
+    datacenter_sub = @cp.create_subscription(@owner['key'], stacked_datacenter_product.id,
+      10, [], '222', '', '', nil, nil,
+      {
+        'derived_product_id' => derived_product.id
+      })
+    @cp.refresh_pools(@owner['key'])
+    pool = @cp.list_owner_pools(@owner['key'], {:product => stacked_datacenter_product.id})[0]
+
+    # create the distributor consumer
+    consumer = @user.register(random_string("consumer"), :candlepin, nil, {
+      'distributor_version' => 'sam-1.3'
+    })
+    consumer_client = Candlepin.new(username=nil, password=nil,
+        cert=consumer['idCert']['cert'],
+        key=consumer['idCert']['key'])
+    # entitlements from data center pool
+    ent = consumer_client.consume_pool(pool['id'], {:quantity => 5})[0]
+
+    # make manifest
+    @exporter.export_filename = consumer_client.export_consumer(@exporter.tmp_dir)
+    @exporter.extract()
+
+    # remove client at 'host'
+    consumer_client.unregister consumer_client.uuid
+    @cp.delete_subscription(datacenter_sub['id'])
+
+    # import to make org at 'distributor'
+    import_user_client = user_client(@dist_owner, random_string("user"))
+    import_user_client.import(@dist_owner['key'], @exporter.export_filename)
+    @cp.refresh_pools(@dist_owner['key'])
+    dist_pool = @cp.list_owner_pools(@dist_owner['key'], {:product => stacked_datacenter_product.id})[0]
+
+    # make host client to get entitlement from distributor
+    dist_consumer_1 = @dist_user.register(random_string("consumer"))
+    dist_consumer_client_1 = Candlepin.new(username=nil, password=nil,
+        cert=dist_consumer_1['idCert']['cert'],
+        key=dist_consumer_1['idCert']['key'])
+    virt_uuid = random_string('system.uuid')
+    guests = [{'guestId' => virt_uuid}]
+    dist_consumer_client_1.update_consumer({:guestIds => guests})
+
+    # spawn pool for derived product
+    dist_consumer_client_1.consume_pool(dist_pool['id'])[0]
+
+    # make guest client
+    dist_consumer_2 = @dist_user.register(random_string("consumer"), :system, nil,
+       {'virt.uuid' => virt_uuid, 'virt.is_guest' => 'true'})
+    dist_consumer_client_2 = Candlepin.new(username=nil, password=nil,
+        cert=dist_consumer_2['idCert']['cert'],
+        key=dist_consumer_2['idCert']['key'])
+
+    # entitle from derived pool
+    dist_ent = nil
+    @cp.list_owner_pools(@dist_owner['key']).each do |p|
+      p.attributes.each do |a|
+        if a.name == 'pool_derived' and a.value == 'true'
+            dist_ent = dist_consumer_client_2.consume_pool(p['id'])[0]
+        end
+      end
+    end
+
+    # use entitlement to get subsription cert back at master pool
+    upstream_cert = @cp.get_subscription_cert_by_ent_id(dist_ent.id)
+    upstream_cert[0..26].should == "-----BEGIN CERTIFICATE-----"
+
+    # remove created subs
+    @cp.list_subscriptions(@dist_owner['key']).each do |s|
+        @cp.delete_subscription(s.id)
+    end
+  end
+end

--- a/src/main/java/org/candlepin/resource/EntitlementResource.java
+++ b/src/main/java/org/candlepin/resource/EntitlementResource.java
@@ -32,26 +32,29 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 
+import org.apache.commons.lang.StringUtils;
 import org.candlepin.auth.interceptor.Verify;
 import org.candlepin.controller.Entitler;
 import org.candlepin.controller.PoolManager;
 import org.candlepin.exceptions.BadRequestException;
 import org.candlepin.exceptions.NotFoundException;
+import org.candlepin.model.Cdn;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerCurator;
-import org.candlepin.model.Cdn;
 import org.candlepin.model.Entitlement;
 import org.candlepin.model.EntitlementCurator;
+import org.candlepin.model.Pool;
 import org.candlepin.paging.Page;
 import org.candlepin.paging.PageRequest;
 import org.candlepin.paging.Paginate;
 import org.candlepin.pinsetter.tasks.RegenProductEntitlementCertsJob;
 import org.candlepin.service.ProductServiceAdapter;
-import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.util.Util;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.quartz.JobDataMap;
 import org.quartz.JobDetail;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xnap.commons.i18n.I18n;
 
 import com.google.inject.Inject;
@@ -61,29 +64,29 @@ import com.google.inject.Inject;
  */
 @Path("/entitlements")
 public class EntitlementResource {
+    private static Logger log = LoggerFactory.getLogger(EntitlementResource.class);
     private final ConsumerCurator consumerCurator;
     private PoolManager poolManager;
     private final EntitlementCurator entitlementCurator;
-    private SubscriptionServiceAdapter subService;
     private I18n i18n;
     private ProductServiceAdapter prodAdapter;
     private Entitler entitler;
+    private SubscriptionResource subResource;
 
     @Inject
     public EntitlementResource(ProductServiceAdapter prodAdapter,
             EntitlementCurator entitlementCurator,
             ConsumerCurator consumerCurator,
-            SubscriptionServiceAdapter subService,
             PoolManager poolManager,
-            I18n i18n, Entitler entitler) {
+            I18n i18n, Entitler entitler, SubscriptionResource subResource) {
 
         this.entitlementCurator = entitlementCurator;
-        this.subService = subService;
         this.consumerCurator = consumerCurator;
         this.i18n = i18n;
         this.prodAdapter = prodAdapter;
         this.poolManager = poolManager;
         this.entitler = entitler;
+        this.subResource = subResource;
     }
 
     private void verifyExistence(Object o, String id) {
@@ -243,7 +246,7 @@ public class EntitlementResource {
      * public CdnInfo getEntitlementUpstreamCert
      * will also @Produces(MediaType.APPLICATION_JSON)
      *
-     * @param dbid entitlement id.
+     * @param entitlementId entitlement id.
      * @return a String object
      * @httpcode 404
      * @httpcode 200
@@ -251,20 +254,42 @@ public class EntitlementResource {
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     @Path("{dbid}/upstream_cert")
-    public String getEntitlementUpstreamCert(
-        @PathParam("dbid") String dbid) {
-        Entitlement ent = entitlementCurator.find(dbid);
-        // optimization: don't do entitlement regen here, as we don't read
-        // the entitlement certificate in this call.
-
+    public String getUpstreamCert(
+        @PathParam("dbid") String entitlementId) {
+        Entitlement ent = entitlementCurator.find(entitlementId);
         if (ent == null) {
             throw new NotFoundException(i18n.tr(
-                "Entitlement with ID ''{0}'' could not be found.", dbid));
+                "Entitlement with ID ''{0}'' could not be found.", entitlementId));
         }
 
-        String subscriptionId = ent.getPool().getSubscriptionId();
-        SubscriptionResource subResource = new SubscriptionResource(subService,
-            consumerCurator, i18n);
+        String subscriptionId = null;
+        Pool entPool = ent.getPool();
+        if (StringUtils.isBlank(entPool.getSourceStackId())) {
+            subscriptionId = entPool.getSubscriptionId();
+        }
+        /*
+         * A derived pool originating from a stacked parent pool will have no subscription
+         * ID as the pool is technically from many subscriptions. (i.e. all the
+         * entitlements in the stack) In this case we must look up an active entitlement
+         * in the hosts stack, and use this as our upstream certificate.
+         */
+        else {
+            log.debug("Entitlement is from a stack derived pool, searching for oldest " +
+                "active entitlements in source stack.");
+            Entitlement e = entitlementCurator.findUpstreamEntitlementForStack(
+                entPool.getSourceConsumer(),
+                entPool.getSourceStackId());
+            if (e != null) {
+                subscriptionId = e.getPool().getSubscriptionId();
+            }
+        }
+
+        if (subscriptionId == null) {
+            throw new NotFoundException(
+                i18n.tr("Unable to find upstream certificate for entitlement: {0}",
+                    entitlementId));
+        }
+
         return subResource.getSubCertAsPem(subscriptionId);
         // Cdn cdn = subResource.getSubscription(subscriptionId).getCdn();
         // CdnInfo result = new CdnInfo(cdn, subResource.getSubCertAsPem(subscriptionId));


### PR DESCRIPTION
The subscritption id is not on the stacked pools that are created for derived products.
The entitlements for those pools do not allow Thumbslug use as the upstream
cert comes from the subscription.
