### PR TITLE
Fix consumer facts spec in mysql

### DIFF
--- a/spec/consumer_facts_spec.rb
+++ b/spec/consumer_facts_spec.rb
@@ -87,6 +87,9 @@ describe 'Consumer Facts' do
       'uname.system' => 'x86_64',
     }
     initial_date = @consumer.updated
+
+    # MySQL drops millis, we need to wait a bit longer
+    sleep 1
     @consumer_api.update_consumer({:facts => updated_facts})
 
     updated_consumer = @consumer_api.get_consumer


### PR DESCRIPTION
We were checking update times, we expected a greater update time,
however they were equal because mysql drops millis
