### PR TITLE
1110843: Lookup correct upstream cert from source stack.

### DIFF
--- a/spec/derived_product_import_spec.rb
+++ b/spec/derived_product_import_spec.rb
@@ -1,0 +1,116 @@
+require 'spec_helper'
+require 'candlepin_scenarios'
+require 'json'
+
+describe 'Import', :serial => true do
+
+  include CandlepinMethods
+
+  before(:all) do
+    @cp = Candlepin.new('admin', 'admin')
+    @owners = []
+    @owner = @cp.create_owner(random_string('owner'))
+    @user = user_client(@owner, random_string('user'))
+    @dist_owner = create_owner(random_string('owner'))
+    @dist_user = user_client(@dist_owner, random_string('user'))
+    @owners = [@owner, @dist_owner]
+    @exporter = Export.new
+    @exporters = [@exporter]
+
+  end
+
+  after(:all) do
+    @owners.each do |o|
+      @cp.delete_owner(o['key'])
+    end
+    @exporters.each do |e|
+      e.cleanup()
+    end
+  end
+
+  it 'can retrieve subscripton certificate from derived pool entitlement' do
+    stacked_datacenter_product = create_product(nil, nil, {
+      :attributes => {
+        :virt_limit => "unlimited",
+        :stacking_id => 'mixed-stack',
+        :sockets => "2",
+        'multi-entitlement' => "yes"
+      }
+    })
+    derived_product = create_product(nil, nil, {
+      :attributes => {
+          :cores => '6',
+          :sockets=>'8'
+      }
+    })
+    datacenter_sub = @cp.create_subscription(@owner['key'], stacked_datacenter_product.id,
+      10, [], '222', '', '', nil, nil,
+      {
+        'derived_product_id' => derived_product.id
+      })
+    @cp.refresh_pools(@owner['key'])
+    pool = @cp.list_owner_pools(@owner['key'], {:product => stacked_datacenter_product.id})[0]
+
+    # create the distributor consumer
+    consumer = @user.register(random_string("consumer"), :candlepin, nil, {
+      'distributor_version' => 'sam-1.3'
+    })
+    consumer_client = Candlepin.new(username=nil, password=nil,
+        cert=consumer['idCert']['cert'],
+        key=consumer['idCert']['key'])
+    # entitlements from data center pool
+    ent = consumer_client.consume_pool(pool['id'], {:quantity => 5})[0]
+
+    # make manifest
+    @exporter.export_filename = consumer_client.export_consumer(@exporter.tmp_dir)
+    @exporter.extract()
+
+    # remove client at 'host'
+    consumer_client.unregister consumer_client.uuid
+    @cp.delete_subscription(datacenter_sub['id'])
+
+    # import to make org at 'distributor'
+    import_user_client = user_client(@dist_owner, random_string("user"))
+    import_user_client.import(@dist_owner['key'], @exporter.export_filename)
+    @cp.refresh_pools(@dist_owner['key'])
+    dist_pool = @cp.list_owner_pools(@dist_owner['key'], {:product => stacked_datacenter_product.id})[0]
+
+    # make host client to get entitlement from distributor
+    dist_consumer_1 = @dist_user.register(random_string("consumer"))
+    dist_consumer_client_1 = Candlepin.new(username=nil, password=nil,
+        cert=dist_consumer_1['idCert']['cert'],
+        key=dist_consumer_1['idCert']['key'])
+    virt_uuid = random_string('system.uuid')
+    guests = [{'guestId' => virt_uuid}]
+    dist_consumer_client_1.update_consumer({:guestIds => guests})
+
+    # spawn pool for derived product
+    dist_consumer_client_1.consume_pool(dist_pool['id'])[0]
+
+    # make guest client
+    dist_consumer_2 = @dist_user.register(random_string("consumer"), :system, nil,
+       {'virt.uuid' => virt_uuid, 'virt.is_guest' => 'true'})
+    dist_consumer_client_2 = Candlepin.new(username=nil, password=nil,
+        cert=dist_consumer_2['idCert']['cert'],
+        key=dist_consumer_2['idCert']['key'])
+
+    # entitle from derived pool
+    dist_ent = nil
+    @cp.list_owner_pools(@dist_owner['key']).each do |p|
+      p.attributes.each do |a|
+        if a.name == 'pool_derived' and a.value == 'true'
+            dist_ent = dist_consumer_client_2.consume_pool(p['id'])[0]
+        end
+      end
+    end
+
+    # use entitlement to get subsription cert back at master pool
+    upstream_cert = @cp.get_subscription_cert_by_ent_id(dist_ent.id)
+    upstream_cert[0..26].should == "-----BEGIN CERTIFICATE-----"
+
+    # remove created subs
+    @cp.list_subscriptions(@dist_owner['key']).each do |s|
+        @cp.delete_subscription(s.id)
+    end
+  end
+end

--- a/src/test/java/org/candlepin/model/test/EntitlementCuratorTest.java
+++ b/src/test/java/org/candlepin/model/test/EntitlementCuratorTest.java
@@ -17,6 +17,7 @@ package org.candlepin.model.test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import org.candlepin.model.Consumer;
@@ -434,6 +435,66 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
         List<Entitlement> results = entitlementCurator.findByStackId(consumer, stackingId);
         assertEquals(1, results.size());
         assertEquals(createdEntitlements.get(4), results.get(0));
+    }
+
+    @Test
+    public void findUpstreamEntitlementForStack() {
+        String stackingId = "test_stack_id";
+        Product product = TestUtil.createProduct();
+        product.setAttribute("stacking_id", stackingId);
+        productCurator.create(product);
+
+        Pool futurePool = createPoolAndSub(owner, product, 1L,
+            createDate(2020, 1, 1), createDate(2021, 1, 1));
+        poolCurator.create(futurePool);
+        bind(consumer, futurePool);
+
+        Pool currentPool = createPoolAndSub(owner, product, 1L,
+            dateSource.currentDate(), createDate(2020, 1, 1));
+        poolCurator.create(currentPool);
+        bind(consumer, currentPool);
+
+        Pool anotherCurrentPool = createPoolAndSub(owner, product, 1L,
+            dateSource.currentDate(), createDate(2020, 1, 1));
+        poolCurator.create(anotherCurrentPool);
+        bind(consumer, anotherCurrentPool);
+
+        // The future entitlement should have been omitted, and the eldest active
+        // entitlement should have been selected:
+        Entitlement result = entitlementCurator.findUpstreamEntitlementForStack(
+            consumer, stackingId);
+        assertNotNull(result);
+        assertEquals(currentPool, result.getPool());
+    }
+
+    @Test
+    public void findUpstreamEntitlementForStackNothingActive() {
+        String stackingId = "test_stack_id";
+        Product product = TestUtil.createProduct();
+        product.setAttribute("stacking_id", stackingId);
+        productCurator.create(product);
+
+        Pool futurePool = createPoolAndSub(owner, product, 1L,
+            createDate(2020, 1, 1), createDate(2021, 1, 1));
+        poolCurator.create(futurePool);
+        bind(consumer, futurePool);
+
+        // The future entitlement should have been omitted:
+        Entitlement result = entitlementCurator.findUpstreamEntitlementForStack(
+            consumer, stackingId);
+        assertNull(result);
+    }
+
+    @Test
+    public void findUpstreamEntitlementForStackNoResults() {
+        String stackingId = "test_stack_id";
+        Product product = TestUtil.createProduct();
+        product.setAttribute("stacking_id", stackingId);
+        productCurator.create(product);
+
+        Entitlement result = entitlementCurator.findUpstreamEntitlementForStack(
+            consumer, stackingId);
+        assertNull(result);
     }
 
     private Entitlement bind(Consumer consumer, Pool pool) {

--- a/src/test/java/org/candlepin/resource/test/EntitlementResourceTest.java
+++ b/src/test/java/org/candlepin/resource/test/EntitlementResourceTest.java
@@ -15,108 +15,122 @@
 package org.candlepin.resource.test;
 
 import org.candlepin.model.Consumer;
-import org.candlepin.model.ConsumerType;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.util.Locale;
+
+import org.candlepin.controller.CandlepinPoolManager;
+import org.candlepin.controller.Entitler;
+import org.candlepin.exceptions.NotFoundException;
+import org.candlepin.model.ConsumerCurator;
+import org.candlepin.model.Entitlement;
+import org.candlepin.model.EntitlementCurator;
 import org.candlepin.model.Owner;
-import org.candlepin.model.Pool;
-import org.candlepin.model.Product;
-import org.candlepin.test.DatabaseTestFixture;
-import org.candlepin.test.TestDateUtil;
+import org.candlepin.model.SourceStack;
+import org.candlepin.resource.EntitlementResource;
+import org.candlepin.resource.SubscriptionResource;
+import org.candlepin.service.ProductServiceAdapter;
 import org.candlepin.test.TestUtil;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.xnap.commons.i18n.I18n;
+import org.xnap.commons.i18n.I18nFactory;
 
 /**
- * ConsumerResourceTest
+ * EntitlementResourceTest
  */
-public class EntitlementResourceTest extends DatabaseTestFixture {
+@RunWith(MockitoJUnitRunner.class)
+public class EntitlementResourceTest {
 
+    private I18n i18n;
     private Consumer consumer;
-    private Product product;
-    private Pool ep;
     private Owner owner;
+    @Mock private ProductServiceAdapter prodAdapter;
+    @Mock private EntitlementCurator entitlementCurator;
+    @Mock private ConsumerCurator consumerCurator;
+    @Mock private CandlepinPoolManager poolManager;
+    @Mock private Entitler entitler;
+    @Mock private SubscriptionResource subResource;
 
-    // private EntitlementResource eapi;
-    // private Entitler entitler;
+    private EntitlementResource entResource;
 
     @Before
-    public void createTestObjects() {
-        owner = createOwner();
-        ownerCurator.create(owner);
-
-        ConsumerType type = new ConsumerType("some-consumer-type");
-        consumerTypeCurator.create(type);
-
-        consumer = TestUtil.createConsumer(type, owner);
-        consumerCurator.create(consumer);
-
-        product = TestUtil.createProduct();
-        productCurator.create(product);
-
-        ep = createPoolAndSub(owner, product, 10L, TestDateUtil.date(
-            2010, 1, 1), TestDateUtil.date(2020, 12, 31));
-        poolCurator.create(ep);
-
-        // entitler = injector.getInstance(Entitler.class);
-
-        // eapi = new EntitlementResource(
-        // poolCurator, entitlementCurator,
-        // consumerCurator, productAdapter, subAdapter, entitler);
-
-        dateSource.currentDate(TestDateUtil.date(2010, 1, 13));
+    public void before() {
+        i18n = I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK);
+        entResource = new EntitlementResource(prodAdapter, entitlementCurator,
+            consumerCurator, poolManager, i18n, entitler, subResource);
+        owner = new Owner("admin");
+        consumer = new Consumer("myconsumer", "bill", owner,
+            TestUtil.createConsumerType());
     }
 
     @Test
-    public void testEntitleOwnerHasNoEntitlements() {
-        // TODO
+    public void getUpstreamCertSimple() {
+        Entitlement e = TestUtil.createEntitlement();
+        e.setId("entitlementID");
+        e.getPool().setSubscriptionId("subId");
+        System.out.println(e.getPool().getSubscriptionId());
+
+        when(entitlementCurator.find(eq(e.getId()))).thenReturn(e);
+
+        String expected = "HELLO";
+        // Mock out the PEM text so we can verify without actually generating a cert:
+        when(subResource.getSubCertAsPem(eq(e.getPool().getSubscriptionId())))
+            .thenReturn(expected);
+        String result = entResource.getUpstreamCert(e.getId());
+        assertEquals(expected, result);
+    }
+
+    @Test(expected = NotFoundException.class)
+    public void getUpstreamCertSimpleNothingFound() {
+        // Entitlement from stack sub-pool:
+        Entitlement e = TestUtil.createEntitlement();
+        e.setId("entitlementID");
+        e.getPool().setSubscriptionId(null);
+        when(entitlementCurator.find(eq(e.getId()))).thenReturn(e);
+        entResource.getUpstreamCert(e.getId());
     }
 
     @Test
-    public void testEntitleOwnerHasNoAviailableEntitlements() {
-        // TODO
+    public void getUpstreamCertStackSubPool() {
+        Entitlement parentEnt = TestUtil.createEntitlement();
+        parentEnt.setId("parentEnt");
+        parentEnt.getPool().setSubscriptionId("subId");
+        when(entitlementCurator.findUpstreamEntitlementForStack(consumer, "mystack"))
+            .thenReturn(parentEnt);
+
+        String expected = "HELLO";
+        // Mock out the PEM text so we can verify without actually generating a cert:
+        when(subResource.getSubCertAsPem(eq(parentEnt.getPool().getSubscriptionId())))
+            .thenReturn(expected);
+
+        // Entitlement from stack sub-pool:
+        Entitlement e = TestUtil.createEntitlement();
+        e.setId("entitlementID");
+        e.getPool().setSourceStack(new SourceStack(consumer, "mystack"));
+        when(entitlementCurator.find(eq(e.getId()))).thenReturn(e);
+
+        String result = entResource.getUpstreamCert(e.getId());
+        assertEquals(expected, result);
     }
 
-    @Test
-    public void testEntitleConsumerAlreadyEntitledForProduct() {
-        // TODO
-    }
+    @Test(expected = NotFoundException.class)
+    public void getUpstreamCertStackSubPoolNothingFound() {
+        when(entitlementCurator.findUpstreamEntitlementForStack(consumer, "mystack"))
+            .thenReturn(null);
 
-    // @Ignore
-    // public void testHasEntitlement() {
-    //
-    // eapi.entitleByProduct(consumer.getUuid(), product.getLabel());
-    //
-    // // TODO: Disabling this test, boils into ObjectFactory things that need
-    // // to be fixed before we can do this check! Sorry! :) - dgoodwin
-    // // assertTrue(eapi.hasEntitlement(consumer.getUuid(),
-    // product.getUuid()));
-    // }
+        // Entitlement from stack sub-pool:
+        Entitlement e = TestUtil.createEntitlement();
+        e.setId("entitlementID");
+        e.getPool().setSourceStack(new SourceStack(consumer, "mystack"));
+        when(entitlementCurator.find(eq(e.getId()))).thenReturn(e);
 
-    @Test
-    @Ignore
-    public void testJson() {
-//        ClientConfig cc = new DefaultClientConfig();
-//        Client c = Client.create(cc);
-//
-//
-//
-//        Object[] params = new Object[2];
-//        params[0] = consumer;
-//        params[1] = product;
-//        List<Object> aparams = new ArrayList<Object>();
-//        aparams.add(consumer);
-//        aparams.add(product);
-//
-//        WebResource postresource =
-//            c.resource("http://localhost:8080/candlepin/entitlement/foo/");
-//        postresource.accept("application/json").type("application/json").post(consumer);
-
-
-        // System.out.println(jto.getName());
-        // jto =
-        // getresource.accept("application/json").get(JsonTestObject.class);
-        // assertEquals("testname", jto.getName());
-        // assertEquals("AEF", jto.getUuid());
+        entResource.getUpstreamCert(e.getId());
     }
 
 }


### PR DESCRIPTION
Sub-pools originating from a stack have no subscription ID because they
technically could be from multiple subscriptions, causing Candlepin to return
no upstream certificate when thumbslug requested one to proxy a guests
entitlement.

When thumbslug fetches the upstream cert for an entitlement from a stack
derived sub-pool, we'll return the eldest entitlement in the host's stack that
is currently active.

Replace barren entitlement resource test with some actual tests for this
functionality.

Spec test author: William Poteat wpoteat@redhat.com

Conflicts:
    src/main/java/org/candlepin/resource/EntitlementResource.java
    src/test/java/org/candlepin/resource/test/EntitlementResourceTest.java
