### PR TITLE
1113598: Correct date ranges when global attrs are in play

### DIFF
--- a/src/main/java/org/candlepin/model/Entitlement.java
+++ b/src/main/java/org/candlepin/model/Entitlement.java
@@ -297,7 +297,8 @@ public class Entitlement extends AbstractHibernateObject implements Linkable, Ow
 
     @XmlTransient
     public boolean isValidOnDate(Date d) {
-        return d.after(this.getStartDate()) && d.before(this.getEndDate());
+        return (d.after(this.getStartDate()) || d.equals(this.getStartDate())) &&
+            (d.before(this.getEndDate()) || d.equals(this.getEndDate()));
     }
 
     @XmlTransient

--- a/src/main/java/org/candlepin/policy/js/compliance/ComplianceRules.java
+++ b/src/main/java/org/candlepin/policy/js/compliance/ComplianceRules.java
@@ -62,13 +62,24 @@ public class ComplianceRules {
      * @return Compliance status.
      */
     public ComplianceStatus getStatus(Consumer c, Date date) {
+        return getStatus(c, date, true);
+    }
 
-        List<Entitlement> ents = entCurator.listByConsumerAndDate(c, date);
+    /**
+     * Check compliance status for a consumer on a specific date.
+     *
+     * @param c Consumer to check.
+     * @param date Date to check compliance status for.
+     * @param calculateCompliantUntil calculate how long the system will remain compliant (expensive)
+     * @return Compliance status.
+     */
+    public ComplianceStatus getStatus(Consumer c, Date date, boolean calculateCompliantUntil) {
 
         JsonJsContext args = new JsonJsContext(mapper);
         args.put("consumer", c);
-        args.put("entitlements", ents);
+        args.put("entitlements", c.getEntitlements());
         args.put("ondate", date);
+        args.put("calculateCompliantUntil", calculateCompliantUntil);
         args.put("log", log, false);
 
         // Convert the JSON returned into a ComplianceStatus object:

--- a/src/main/java/org/candlepin/policy/js/compliance/StatusReasonMessageGenerator.java
+++ b/src/main/java/org/candlepin/policy/js/compliance/StatusReasonMessageGenerator.java
@@ -114,7 +114,7 @@ public class StatusReasonMessageGenerator {
 
     private String getMarketingName(String id, Consumer consumer, Date onDate) {
         for (Entitlement e : getEntitlementsOnDate(consumer, onDate)) {
-            if (e.getId().equals(id)) {
+            if (e.getId() != null && e.getId().equals(id)) {
                 return e.getPool().getProductName();
             }
         }

--- a/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -2069,7 +2069,7 @@ public class ConsumerResource {
     private void addDataToInstalledProducts(Consumer consumer) {
 
         ComplianceStatus complianceStatus = complianceRules.getStatus(
-                           consumer, Calendar.getInstance().getTime());
+                           consumer, Calendar.getInstance().getTime(), false);
         consumer.setEntitlementStatus(complianceStatus.getStatus());
 
         ConsumerInstalledProductEnricher enricher = new ConsumerInstalledProductEnricher(

--- a/src/test/java/org/candlepin/policy/js/compliance/ComplianceRulesTest.java
+++ b/src/test/java/org/candlepin/policy/js/compliance/ComplianceRulesTest.java
@@ -147,6 +147,7 @@ public class ComplianceRulesTest {
         Pool p = new Pool(owner, productId, productId, provided,
             new Long(1000), start, end, "1000", "1000", "1000");
         Entitlement e = new Entitlement(p, consumer, 1);
+        e.setId("ent_" + TestUtil.randomInt());
         return e;
     }
 
@@ -777,7 +778,7 @@ public class ComplianceRulesTest {
         Consumer consumer = mockConsumer("Only One Installed Prod");
         Date expectedOnDate = TestUtil.createDate(9999, 4, 12);
         ComplianceStatus status = compliance.getStatus(consumer, expectedOnDate);
-        assertEquals(expectedOnDate, status.getCompliantUntil());
+        assertNull(status.getCompliantUntil());
     }
 
     @Test
@@ -878,7 +879,7 @@ public class ComplianceRulesTest {
         Date expectedOnDate = TestUtil.createDate(2011, 8, 30);
         ComplianceStatus status = compliance.getStatus(c, expectedOnDate);
         assertEquals(1, status.getPartialStacks().size());
-        assertEquals(expectedOnDate, status.getCompliantUntil());
+        assertNull(status.getCompliantUntil());
     }
 
     // NOTE: This scenario should NEVER happen since listByConsumerAndDate should
@@ -1745,6 +1746,7 @@ public class ComplianceRulesTest {
         mockHypervisorEntitlement.getPool()
             .setProductAttribute("guest_limit", "-1", PRODUCT_1);
         ents.add(mockHypervisorEntitlement);
+        mockEntCurator(c, ents);
 
         // Now that we've added the hypervisor,
         // the base guest_limit of 4 should be overridden
@@ -1756,8 +1758,8 @@ public class ComplianceRulesTest {
         assertTrue(status.getCompliantProducts().keySet().contains(PRODUCT_1));
         assertTrue(status.getCompliantProducts().keySet().contains(PRODUCT_2));
 
-        assertEquals(1, status.getCompliantProducts().get(PRODUCT_1).size());
-        assertEquals(1, status.getCompliantProducts().get(PRODUCT_2).size());
+        assertEquals(2, status.getCompliantProducts().get(PRODUCT_1).size());
+        assertEquals(2, status.getCompliantProducts().get(PRODUCT_2).size());
     }
 
     @Test
@@ -1907,6 +1909,7 @@ public class ComplianceRulesTest {
     }
 
     private void mockEntCurator(Consumer c, List<Entitlement> ents) {
+        c.setEntitlements(new HashSet<Entitlement>(ents));
         when(entCurator.listByConsumer(eq(c))).thenReturn(ents);
         when(entCurator.listByConsumerAndDate(eq(c), any(Date.class))).thenReturn(ents);
     }

--- a/src/test/java/org/candlepin/resource/test/ConsumerResourceTest.java
+++ b/src/test/java/org/candlepin/resource/test/ConsumerResourceTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -271,7 +272,7 @@ public class ConsumerResourceTest {
 
         Consumer consumer = createConsumer();
         ComplianceStatus status = new ComplianceStatus();
-        when(rules.getStatus(any(Consumer.class), any(Date.class))).thenReturn(status);
+        when(rules.getStatus(any(Consumer.class), any(Date.class), anyBoolean())).thenReturn(status);
         // cert expires today which will trigger regen
         consumer.setIdCert(createIdCert());
         BigInteger origserial = consumer.getIdCert().getSerial().getSerial();
@@ -298,7 +299,7 @@ public class ConsumerResourceTest {
 
         Consumer consumer = createConsumer();
         ComplianceStatus status = new ComplianceStatus();
-        when(rules.getStatus(any(Consumer.class), any(Date.class))).thenReturn(status);
+        when(rules.getStatus(any(Consumer.class), any(Date.class), anyBoolean())).thenReturn(status);
         consumer.setIdCert(createIdCert(TestUtil.createDate(2025, 6, 9)));
         BigInteger origserial = consumer.getIdCert().getSerial().getSerial();
 


### PR DESCRIPTION
We were checking if single entitlements or stacks were valid, which doesn't take global attributes (like guest limit) from unrelated entitlements into account.

You can reproduce this by attaching  a guest limit subscription while you're over the limit of allowed guests, then attaching a hypervisor sub (anything with -1 guest limit, or more than you've got active).  We fail to properly compute valid date ranges.
