### PR TITLE
Commit after each system heal

### DIFF
--- a/src/main/java/org/candlepin/pinsetter/tasks/HealEntireOrgJob.java
+++ b/src/main/java/org/candlepin/pinsetter/tasks/HealEntireOrgJob.java
@@ -68,6 +68,8 @@ public class HealEntireOrgJob extends UniqueByOwnerJob {
                     List<Entitlement> ents = entitler.bindByProducts(null, consumer,
                         entitleDate, true);
                     entitler.sendEvents(ents);
+                    // commit after each bind so that we don't lock pools forever
+                    commitAndContinue();
                 }
                 // We want to catch everything and continue.
                 // Perhaps add something to surface errors later

--- a/src/main/java/org/candlepin/pinsetter/tasks/KingpinJob.java
+++ b/src/main/java/org/candlepin/pinsetter/tasks/KingpinJob.java
@@ -173,6 +173,11 @@ public abstract class KingpinJob implements Job {
         }
     }
 
+    protected void commitAndContinue() {
+        endUnitOfWork();
+        startUnitOfWork();
+    }
+
     private int getMaxRetries() {
         int maxRetries = ConfigProperties.PINSETTER_MAX_RETRIES_DEFAULT;
         try {


### PR DESCRIPTION
Healing an entire org can potentially take a very long time.
We do not want to lock pools for the duration of this process.
