### PR TITLE
Allow UsernameConsumersPermission to list owner info

### DIFF
--- a/spec/candlepin_scenarios.rb
+++ b/spec/candlepin_scenarios.rb
@@ -113,7 +113,7 @@ module CandlepinMethods
     @users << user
 
     role = @cp.create_role(random_string('testrole'), perms)
-    @cp.add_role_user(role['id'], @username)
+    @cp.add_role_user(role['id'], username)
 
     return Candlepin.new(username, password)
   end
@@ -429,8 +429,8 @@ class StandardExporter < Exporter
     @candlepin_client.consume_pool(@pool3.id, {:quantity => 1})
 
     @cdn = create_cdn(@cdn_label,
-	              "Test CDN",
-	              "https://cdn.test.com")
+                "Test CDN",
+                "https://cdn.test.com")
   end
 
   def create_candlepin_export_update

--- a/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -274,7 +274,7 @@ public class OwnerResource {
     @Path("/{owner_key}/info")
     @Produces(MediaType.APPLICATION_JSON)
     public OwnerInfo getOwnerInfo(@PathParam("owner_key")
-        @Verify(Owner.class) String ownerKey) {
+        @Verify(value = Owner.class, subResource = SubResource.CONSUMERS) String ownerKey) {
         Owner owner = findOwner(ownerKey);
         return ownerInfoCurator.lookupByOwner(owner);
     }


### PR DESCRIPTION
A SubResource.CONSUMERS subresource was added to the
verify annotation of OwnerInfo.getOwnerInfo to properly
allow filtering of OwnerInfo based on consumer permissions.

Without the subresource, the permission would not allow
getting owner info w/o an OwnerPermission (allowing access
to all consumers, not only consumers created by the user).
