### PR TITLE
Fix for ResponseFacade IllegalStateException

### DIFF
--- a/src/main/java/org/candlepin/servlet/filter/CandlepinScopeFilter.java
+++ b/src/main/java/org/candlepin/servlet/filter/CandlepinScopeFilter.java
@@ -24,6 +24,8 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 
 import org.candlepin.guice.CandlepinSingletonScope;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -42,7 +44,9 @@ import com.google.inject.Singleton;
 @Singleton
 public class CandlepinScopeFilter implements Filter {
 
-    private CandlepinSingletonScope singletonScope;
+    private static Logger log = LoggerFactory.getLogger(CandlepinScopeFilter.class);
+
+    private final CandlepinSingletonScope singletonScope;
 
     @Inject
     public CandlepinScopeFilter(CandlepinSingletonScope singletonScope) {
@@ -52,6 +56,12 @@ public class CandlepinScopeFilter implements Filter {
     @Override
     public void doFilter(ServletRequest request, ServletResponse response,
         FilterChain chain) throws IOException, ServletException {
+
+        if(response.isCommitted()){
+            log.warn("Response was already committed!");
+            return;
+        }
+
         singletonScope.enter();
         try {
             chain.doFilter(request, response);

--- a/src/test/java/org/candlepin/servlet/filter/CandlepinScopeFilterTest.java
+++ b/src/test/java/org/candlepin/servlet/filter/CandlepinScopeFilterTest.java
@@ -15,9 +15,10 @@
 package org.candlepin.servlet.filter;
 
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.doThrow;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
@@ -27,6 +28,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.candlepin.guice.CandlepinSingletonScope;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.internal.verification.VerificationModeFactory;
 
 /**
  * CandlepinScopeFilterTest
@@ -68,6 +70,14 @@ public class CandlepinScopeFilterTest {
         }
         verify(scope).enter();
         verify(scope).exit();
+    }
+
+    @Test
+    public void ensureAlreadyCommitedResponsesSafelyExit() throws Exception{
+        doReturn(true).when(response).isCommitted();
+
+        filter.doFilter(request, response, chain);
+        verify(scope, VerificationModeFactory.noMoreInteractions()).enter();
     }
 
 }


### PR DESCRIPTION
This is a purposed fix for the exception below which is frequently being thrown. This fix does not address how we are getting into this state, but should essentially silence the exception gracefully.

See Also:
- http://stackoverflow.com/questions/7881258/jsf-2-0-session-timeout-throws-illegalstateexception
- http://stackoverflow.com/questions/5092222/how-to-avoid-illegal-state-exception

Jul 10, 2014 10:16:14 AM org.apache.catalina.core.StandardWrapperValve invoke
SEVERE: Servlet.service() for servlet default threw exception
java.lang.IllegalStateException
    at org.apache.catalina.connector.ResponseFacade.reset(ResponseFacade.java:310)
    at javax.servlet.ServletResponseWrapper.reset(ServletResponseWrapper.java:183)
    at org.jboss.resteasy.plugins.server.servlet.HttpServletResponseWrapper.reset(HttpServletResponseWrapper.java:119)
    at org.jboss.resteasy.core.SynchronousDispatcher.writeFailure(SynchronousDispatcher.java:444)
    at org.jboss.resteasy.core.SynchronousDispatcher.executeExactExceptionMapper(SynchronousDispatcher.java:311)
    at org.jboss.resteasy.core.SynchronousDispatcher.handleException(SynchronousDispatcher.java:228)
    at org.jboss.resteasy.core.SynchronousDispatcher.handleWriteResponseException(SynchronousDispatcher.java:222)
    at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:532)
    at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:126)
    at org.jboss.resteasy.plugins.server.servlet.ServletContainerDispatcher.service(ServletContainerDispatcher.java:208)
    at org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher.service(HttpServletDispatcher.java:55)
    at org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher.service(HttpServletDispatcher.java:50)
    at javax.servlet.http.HttpServlet.service(HttpServlet.java:723)
    at com.google.inject.servlet.ServletDefinition.doService(ServletDefinition.java:263)
    at com.google.inject.servlet.ServletDefinition.service(ServletDefinition.java:178)
    at com.google.inject.servlet.ManagedServletPipeline.service(ManagedServletPipeline.java:91)
    at com.google.inject.servlet.FilterChainInvocation.doFilter(FilterChainInvocation.java:62)
    at org.candlepin.servlet.filter.ContentTypeHackFilter.doFilter(ContentTypeHackFilter.java:58)
    at com.google.inject.servlet.FilterDefinition.doFilter(FilterDefinition.java:163)
    at com.google.inject.servlet.FilterChainInvocation.doFilter(FilterChainInvocation.java:58)
    at org.candlepin.servlet.filter.logging.LoggingFilter.doFilter(LoggingFilter.java:77)
    at com.google.inject.servlet.FilterDefinition.doFilter(FilterDefinition.java:163)
    at com.google.inject.servlet.FilterChainInvocation.doFilter(FilterChainInvocation.java:58)
    at org.candlepin.servlet.filter.CandlepinPersistFilter.doFilter(CandlepinPersistFilter.java:48)
    at com.google.inject.servlet.FilterDefinition.doFilter(FilterDefinition.java:163)
    at com.google.inject.servlet.FilterChainInvocation.doFilter(FilterChainInvocation.java:58)
    at org.candlepin.servlet.filter.CandlepinScopeFilter.doFilter(CandlepinScopeFilter.java:57)
    at com.google.inject.servlet.FilterDefinition.doFilter(FilterDefinition.java:163)
    at com.google.inject.servlet.FilterChainInvocation.doFilter(FilterChainInvocation.java:58)
    at com.google.inject.servlet.ManagedFilterPipeline.dispatch(ManagedFilterPipeline.java:118)
    at com.google.inject.servlet.GuiceFilter.doFilter(GuiceFilter.java:113)
    at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:235)
    at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:206)
    at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:233)
    at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:191)
    at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:127)
    at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:103)
    at org.apache.catalina.valves.AccessLogValve.invoke(AccessLogValve.java:615)
    at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:109)
    at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:293)
    at org.apache.coyote.http11.Http11Processor.process(Http11Processor.java:861)
    at org.apache.coyote.http11.Http11Protocol$Http11ConnectionHandler.process(Http11Protocol.java:606)
    at org.apache.tomcat.util.net.JIoEndpoint$Worker.run(JIoEndpoint.java:489)
    at java.lang.Thread.run(Thread.java:744)
