### PR TITLE
Replace apache-commons-codec with apache-commons-codec-eap6

### DIFF
--- a/candlepin.spec
+++ b/candlepin.spec
@@ -98,7 +98,7 @@ BuildRequires: resteasy >= 0:2.3.7
 BuildRequires: hornetq >= 0:2.3.5
 BuildRequires: jakarta-commons-lang
 BuildRequires: jakarta-commons-io
-BuildRequires: apache-commons-codec
+BuildRequires: apache-commons-codec-eap6
 
 %global jackson_version 0:2.3.0
 BuildRequires: jackson-annotations >= %{jackson_version}
@@ -186,7 +186,7 @@ Requires: oauth >= 20100601-4
 Requires: scannotation
 Requires: jakarta-commons-lang
 Requires: jakarta-commons-io
-Requires: apache-commons-codec
+Requires: apache-commons-codec-eap6
 
 # RESTEasy breaks if you use a newer version because the location of some
 # of the packages changed between 0.6 and 0.7

--- a/deps/el6.txt
+++ b/deps/el6.txt
@@ -6,7 +6,7 @@ aopalliance
 apache-mime4j
 bcprov-jdk16
 c3p0
-commons-codec
+commons-codec-eap6/commons-codec
 commons-collections
 commons-io
 commons-lang

--- a/deps/el7.txt
+++ b/deps/el7.txt
@@ -9,7 +9,7 @@ bcprov-jdk16
 c3p0
 candlepin-guice // This will pull in all the jars under candlepin-guice
 cglib
-commons-codec
+commons-codec-eap6/commons-codec
 commons-collections
 commons-io
 commons-lang


### PR DESCRIPTION
the apache-commons-codec conflicts with jakarta-commons-codec,
which is an older version of itself.  The eap6 build is installed
into a separate directory, so conflicts shoudln't be a problem.
