### PR TITLE
Allow an env var to specify if supervisor is controlling tomcat service.

### DIFF
--- a/server/bin/deploy
+++ b/server/bin/deploy
@@ -250,6 +250,12 @@ else
         CONTAINER_CONF_DIR="/etc/$TC"
     fi
 
+    # Check if we're in a container using supervisord instead:
+    if [ "$SUPERVISOR" == "1" ]; then
+        START="supervisorctl start tomcat"
+        STOP="supervisorctl stop tomcat"
+    fi
+
     DEPLOY="$TC_HOME/webapps/candlepin.war"
     CLEAN="$TC_HOME/webapps/candlepin/"
 fi


### PR DESCRIPTION
Part of upcoming patches for running spec tests in a docker container.
