### PR TITLE
1121674: Persist new entitlements to the database before post-ent

### DIFF
--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -803,6 +803,9 @@ public class CandlepinPoolManager implements PoolManager {
         }
 
         entitlement = handler.handleEntitlement(consumer, pool, entitlement, quantity);
+        // Persist the entitlement after it has been created.  It requires an ID in order to
+        // create an entitlement-derived subpool
+        handler.handleEntitlementPersist(entitlement);
 
         // The quantity is calculated at fetch time. We update it here
         // To reflect what we just added to the db.
@@ -817,7 +820,6 @@ public class CandlepinPoolManager implements PoolManager {
         ComplianceStatus compliance = complianceRules.getStatus(consumer, new Date());
         consumer.setEntitlementStatus(compliance.getStatus());
 
-        handler.handleEntitlementPersist(entitlement);
         consumerCurator.update(consumer);
 
         handler.handleSelfCertificate(consumer, pool, entitlement, generateUeberCert);


### PR DESCRIPTION
The source entitlement was getting an ID set when it was flushed
at a random point (because it was added to pool and consumer).
This didn't always occur before we needed to read the entitlement
ID in order to create a SourceSubscription entry with ent.id as
subkey
