### PR TITLE
Fix consumer modified events

### DIFF
--- a/server/src/main/java/org/candlepin/audit/ConsumerEventBuilder.java
+++ b/server/src/main/java/org/candlepin/audit/ConsumerEventBuilder.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.audit;
+
+import org.candlepin.model.Consumer;
+
+/**
+ * ConsumerEventBuilder Allows us to easily build a consumer modified
+ * event one piece at a time.
+ *
+ * TODO: expand this to work for more types
+ */
+public class ConsumerEventBuilder {
+
+    private EventFactory eventFactory;
+
+    private String id;
+    private String ownerId;
+    private String name;
+
+    private String oldJson;
+    private String newJson;
+
+    public ConsumerEventBuilder(EventFactory eventFactory) {
+        this.eventFactory = eventFactory;
+    }
+
+    public ConsumerEventBuilder setOldConsumer(Consumer old) {
+        name = old.getName();
+        ownerId = old.getOwner().getId();
+        id = old.getId();
+        oldJson = eventFactory.entityToJson(old);
+        return this;
+    }
+
+    public ConsumerEventBuilder setNewConsumer(Consumer updated) {
+        name = updated.getName();
+        ownerId = updated.getOwner().getId();
+        id = updated.getId();
+        newJson = eventFactory.entityToJson(updated);
+        return this;
+    }
+
+    public Event buildEvent() {
+        return new Event(Event.Type.MODIFIED, Event.Target.CONSUMER,
+                name, eventFactory.principalProvider.get(),
+                ownerId, id, id, oldJson, newJson, null, null);
+    }
+}

--- a/server/src/main/java/org/candlepin/audit/EventFactory.java
+++ b/server/src/main/java/org/candlepin/audit/EventFactory.java
@@ -42,7 +42,7 @@ import org.slf4j.LoggerFactory;
  * EventFactory
  */
 public class EventFactory {
-    private final PrincipalProvider principalProvider;
+    protected final PrincipalProvider principalProvider;
     private final ObjectMapper mapper;
     private static Logger logger = LoggerFactory.getLogger(EventFactory.class);
 
@@ -120,25 +120,21 @@ public class EventFactory {
         return e;
     }
 
-    public Event consumerModified(Consumer newConsumer) {
-        String newEntityJson = entityToJson(newConsumer);
-        Principal principal = principalProvider.get();
+    public ConsumerEventBuilder getConsumerModifiedEventBuilder() {
+        return new ConsumerEventBuilder(this);
+    }
 
-        return new Event(Event.Type.MODIFIED, Event.Target.CONSUMER,
-            newConsumer.getName(), principal, newConsumer.getOwner().getId(),
-            newConsumer.getId(), newConsumer.getId(), null, newEntityJson,
-            null, null);
+    public Event consumerModified(Consumer newConsumer) {
+        return getConsumerModifiedEventBuilder()
+                .setNewConsumer(newConsumer)
+                .buildEvent();
     }
 
     public Event consumerModified(Consumer oldConsumer, Consumer newConsumer) {
-        String oldEntityJson = entityToJson(oldConsumer);
-        String newEntityJson = entityToJson(newConsumer);
-        Principal principal = principalProvider.get();
-
-        return new Event(Event.Type.MODIFIED, Event.Target.CONSUMER,
-            oldConsumer.getName(), principal, oldConsumer.getOwner().getId(),
-            oldConsumer.getId(), oldConsumer.getId(), oldEntityJson, newEntityJson,
-            null, null);
+        return getConsumerModifiedEventBuilder()
+                .setOldConsumer(oldConsumer)
+                .setNewConsumer(newConsumer)
+                .buildEvent();
     }
 
     public Event consumerDeleted(Consumer oldConsumer) {
@@ -306,7 +302,7 @@ public class EventFactory {
         return event;
     }
 
-    private String entityToJson(Object entity) {
+    protected String entityToJson(Object entity) {
         String newEntityJson = "";
         // TODO: Throw an auditing exception here
 

--- a/server/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.when;
 
+import org.candlepin.audit.ConsumerEventBuilder;
 import org.candlepin.audit.EventFactory;
 import org.candlepin.audit.EventSink;
 import org.candlepin.auth.Access;
@@ -44,6 +45,7 @@ import org.candlepin.service.IdentityCertServiceAdapter;
 import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.service.UserServiceAdapter;
 import org.candlepin.util.ServiceLevelValidator;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -104,6 +106,9 @@ public class HypervisorResourceTest {
     @Mock
     private ServiceLevelValidator mockedServiceLevelValidator;
 
+    @Mock
+    private ConsumerEventBuilder consumerEventBuilder;
+
     private ConsumerResource consumerResource;
 
     private I18n i18n;
@@ -138,6 +143,9 @@ public class HypervisorResourceTest {
             .thenReturn(new ComplianceStatus(new Date()));
 
         when(ownerCurator.lookupByKey(any(String.class))).thenReturn(new Owner());
+        when(eventFactory.getConsumerModifiedEventBuilder()).thenReturn(consumerEventBuilder);
+        when(consumerEventBuilder.setNewConsumer(any(Consumer.class))).thenReturn(consumerEventBuilder);
+        when(consumerEventBuilder.setOldConsumer(any(Consumer.class))).thenReturn(consumerEventBuilder);
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/resource/test/ConsumerResourceUpdateTest.java
+++ b/server/src/test/java/org/candlepin/resource/test/ConsumerResourceUpdateTest.java
@@ -34,6 +34,7 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
 
+import org.candlepin.audit.ConsumerEventBuilder;
 import org.candlepin.audit.Event;
 import org.candlepin.audit.EventFactory;
 import org.candlepin.audit.EventSink;
@@ -65,6 +66,7 @@ import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.service.UserServiceAdapter;
 import org.candlepin.test.TestUtil;
 import org.candlepin.util.ServiceLevelValidator;
+
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -91,6 +93,7 @@ public class ConsumerResourceUpdateTest {
     @Mock private DeletedConsumerCurator deletedConsumerCurator;
     @Mock private EnvironmentCurator environmentCurator;
     @Mock private ServiceLevelValidator serviceLevelValidator;
+    @Mock private ConsumerEventBuilder consumerEventBuilder;
 
     private I18n i18n;
 
@@ -114,6 +117,10 @@ public class ConsumerResourceUpdateTest {
 
         when(idCertService.regenerateIdentityCert(any(Consumer.class)))
             .thenReturn(new IdentityCertificate());
+
+        when(consumerEventBuilder.setNewConsumer(any(Consumer.class))).thenReturn(consumerEventBuilder);
+        when(consumerEventBuilder.setOldConsumer(any(Consumer.class))).thenReturn(consumerEventBuilder);
+        when(eventFactory.getConsumerModifiedEventBuilder()).thenReturn(consumerEventBuilder);
     }
 
     @Test


### PR DESCRIPTION
We were sending the wrong 'updated' consumer record.  We dont
want to send an event with just the consumer update (with null
values for every field that isn't being updated).  Now we send
the resulting consumer after the update is applied.

I also added a ConsumerEventBuilder helper that we could
eventually build out to support other types of events.
