### PR TITLE
Require candlepin-common

### DIFF
--- a/server/candlepin.spec
+++ b/server/candlepin.spec
@@ -48,6 +48,7 @@ BuildRequires: java-devel >= 0:1.6.0
 BuildRequires: ant >= 0:1.7.0
 BuildRequires: gettext
 BuildRequires: selinux-policy-doc
+BuildRequires: candlepin-common
 
 %if 0%{?reqcpdeps}
 %global distlibdir %{_datadir}/%{name}/lib/
@@ -135,6 +136,7 @@ Requires: java >= 0:1.6.0
 Requires: wget
 Requires: liquibase >= 0:2.0.5
 Requires: postgresql-jdbc
+Requires: candlepin-common
 
 # specific requires
 # if not using cpdeps, we'll need real requires

--- a/server/deps/el6.txt
+++ b/server/deps/el6.txt
@@ -6,6 +6,7 @@ aopalliance
 apache-mime4j
 bcprov-jdk16
 c3p0
+candlepin-common
 commons-codec-eap6/commons-codec
 commons-collections
 commons-io

--- a/server/deps/el7.txt
+++ b/server/deps/el7.txt
@@ -7,6 +7,7 @@ apache-mime4j
 atinject
 bcprov-jdk16
 c3p0
+candlepin-common
 candlepin-guice // This will pull in all the jars under candlepin-guice
 cglib
 commons-codec-eap6/commons-codec


### PR DESCRIPTION
This patch prepares candlepin to be built against the new candlepin-common rpm.
## TEST
- Build a SRPM
  `tito build --test --srpm`
- Do an el7 scratch build to verify it builds for you
  `brew build --nowait --scratch candlepin-1-rhel-7-candidate /path/to/candlepin.src.rpm`
- Do an el6 scratch build to verify it builds for you
  `brew build --nowait --scratch candlepin-1-rhel-6-candidate /path/to/candlepin.src.rpm`

What doesn't work yet is building candlepin against fedora for the community builds nor building in katello-koji as candlepin-common is not there yet.
