### PR TITLE
don't double poool ram usage when validating available pools

### DIFF
--- a/server/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRules.java
@@ -27,7 +27,6 @@ import org.candlepin.policy.js.ProductCache;
 import org.candlepin.policy.js.RuleExecutionException;
 import org.candlepin.util.DateSource;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.inject.Inject;
 
 import org.slf4j.LoggerFactory;
@@ -35,7 +34,6 @@ import org.xnap.commons.i18n.I18n;
 
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Enforces entitlement rules for normal (non-manifest) consumers.
@@ -65,19 +63,24 @@ public class EntitlementRules extends AbstractEntitlementRules implements Enforc
     @Override
     public ValidationResult preEntitlement(Consumer consumer, Pool entitlementPool,
         Integer quantity) {
-
         return preEntitlement(consumer, entitlementPool, quantity, CallerType.UNKNOWN);
     }
 
     @Override
     public ValidationResult preEntitlement(Consumer consumer, Pool entitlementPool,
         Integer quantity, CallerType caller) {
+        Consumer host = consumer.hasFact("virt.uuid") ?
+                consumerCurator.getHost(consumer.getFact("virt.uuid"),
+                        consumer.getOwner()) : null;
+        return preEntitlement(consumer, host, entitlementPool, quantity, caller);
+    }
+
+    public ValidationResult preEntitlement(Consumer consumer, Consumer host,
+        Pool entitlementPool, Integer quantity, CallerType caller) {
 
         JsonJsContext args = new JsonJsContext(objectMapper);
         args.put("consumer", consumer);
-        args.put("hostConsumer", consumer.hasFact("virt.uuid") ?
-            this.consumerCurator.getHost(consumer.getFact("virt.uuid"),
-                consumer.getOwner()) : null);
+        args.put("hostConsumer", host);
         args.put("consumerEntitlements", consumer.getEntitlements());
         args.put("standalone", config.standalone());
         args.put("pool", entitlementPool);
@@ -100,30 +103,13 @@ public class EntitlementRules extends AbstractEntitlementRules implements Enforc
 
     @Override
     public List<Pool> filterPools(Consumer consumer, List<Pool> pools, boolean showAll) {
-        JsonJsContext args = new JsonJsContext(objectMapper);
-        args.put("consumer", consumer);
-        args.put("hostConsumer", consumer.hasFact("virt.uuid") ?
-            this.consumerCurator.getHost(consumer.getFact("virt.uuid"),
-                consumer.getOwner()) : null);
-        args.put("consumerEntitlements", consumer.getEntitlements());
-        args.put("standalone", config.standalone());
-        args.put("pools", pools);
-        args.put("caller", CallerType.LIST_POOLS.getLabel());
-        args.put("log", log, false);
+        Consumer host = consumer.hasFact("virt.uuid") ?
+                consumerCurator.getHost(consumer.getFact("virt.uuid"),
+                        consumer.getOwner()) : null;
 
-        String json = jsRules.runJsFunction(String.class, "validate_pools_list", args);
-        Map<String, ValidationResult> resultMap;
-        TypeReference<Map<String, ValidationResult>> typeref =
-            new TypeReference<Map<String, ValidationResult>>() {};
-        try {
-            resultMap = objectMapper.toObject(json, typeref);
-        }
-        catch (Exception e) {
-            throw new RuleExecutionException(e);
-        }
         List<Pool> filteredPools = new LinkedList<Pool>();
         for (Pool pool : pools) {
-            ValidationResult result = resultMap.get(pool.getId());
+            ValidationResult result = preEntitlement(consumer, host, pool, 0, CallerType.LIST_POOLS);
             finishValidation(result, pool, 1);
 
             if (result.isSuccessful() && (!result.hasWarnings() || showAll)) {


### PR DESCRIPTION
If we send the entire pool list into pre-entitlement rules, we use twice the ram.   Sending them all in at once didn't save very much time, so we're better off sending one pool at a time.
