### PR TITLE
1129740: truncate long facts

### DIFF
--- a/server/src/main/java/org/candlepin/model/ConsumerCurator.java
+++ b/server/src/main/java/org/candlepin/model/ConsumerCurator.java
@@ -58,6 +58,7 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
     @Inject private DeletedConsumerCurator deletedConsumerCurator;
     @Inject private Config config;
 
+    private static final int MAX_FACT_STR_LENGTH = 255;
     private static final int NAME_LENGTH = 250;
     private static Logger log = LoggerFactory.getLogger(ConsumerCurator.class);
 
@@ -341,10 +342,17 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
                         continue;
                     }
                 }
-                facts.put(entry.getKey(), entry.getValue());
+                facts.put(sanitizeFact(entry.getKey()), sanitizeFact(entry.getValue()));
             }
         }
         return facts;
+    }
+
+    private String sanitizeFact(String value) {
+        if (value != null && value.length() > MAX_FACT_STR_LENGTH) {
+            return value.substring(0, MAX_FACT_STR_LENGTH - 3) + "...";
+        }
+        return value;
     }
 
     /**


### PR DESCRIPTION
Prod is getting some exceptions where subman is reporting a fact that's too long for the db column.  Subman should probably do some checking there, but rather than ship out a bunch of new submen, we can just truncate the value server-side, and continue with our update normally.

Keys and values with length > 255 are truncated to length 252, and end with "..." so we can tell that there may have been some data lost.  This way we lose 252 less characters than failing an update.
