### PR TITLE
regenerate entitlements when branding changes

### DIFF
--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -339,7 +339,8 @@ public class CandlepinPoolManager implements PoolManager {
 
             // dates changed. regenerate all entitlement certificates
             if (updatedPool.getDatesChanged() ||
-                updatedPool.getProductsChanged()) {
+                updatedPool.getProductsChanged() ||
+                updatedPool.getBrandingChanged()) {
                 List<String> entitlements = poolCurator
                     .retrieveFreeEntitlementIdsOfPool(existingPool, true);
                 entitlementsToRegen.addAll(entitlements);


### PR DESCRIPTION
This is tough to test, we can't update a subscription with different branding.. Might be useful to add that actually.
