### PR TITLE
Ensure proper object population in events

### DIFF
--- a/server/src/main/java/org/candlepin/audit/Event.java
+++ b/server/src/main/java/org/candlepin/audit/Event.java
@@ -108,11 +108,8 @@ public class Event implements Persisted {
     @NotNull
     private Date timestamp;
 
-    // Uniquely identifies the entity's ID when combined with the event type.
-    // The entity type can be determined from the type field.
-    @Column(nullable = false)
+    @Column(nullable = true)
     @Size(max = 255)
-    @NotNull
     private String entityId;
 
     @Column(nullable = true)

--- a/server/src/main/java/org/candlepin/audit/EventFactory.java
+++ b/server/src/main/java/org/candlepin/audit/EventFactory.java
@@ -79,6 +79,8 @@ public class EventFactory {
             SimpleBeanPropertyFilter.serializeAllExcept("created", "updated", "id"));
         filterProvider = filterProvider.addFilter("ProductPoolAttributeFilter",
             SimpleBeanPropertyFilter.serializeAllExcept("created", "updated", "productId", "id"));
+        filterProvider = filterProvider.addFilter("SubscriptionCertificateFilter",
+            SimpleBeanPropertyFilter.serializeAllExcept("cert", "key"));
         mapper.setFilters(filterProvider);
 
         Hibernate4Module hbm = new Hibernate4Module();

--- a/server/src/main/java/org/candlepin/model/SubscriptionsCertificate.java
+++ b/server/src/main/java/org/candlepin/model/SubscriptionsCertificate.java
@@ -16,6 +16,8 @@
 package org.candlepin.model;
 
 
+import com.fasterxml.jackson.annotation.JsonFilter;
+
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -39,6 +41,7 @@ import org.hibernate.annotations.GenericGenerator;
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @Entity
 @Table(name = "cp_certificate")
+@JsonFilter("SubscriptionCertificateFilter")
 public class SubscriptionsCertificate extends AbstractCertificate {
 
     @Id

--- a/server/src/main/resources/db/changelog/20140815131046-drop-event-entity-id-not-null.xml
+++ b/server/src/main/resources/db/changelog/20140815131046-drop-event-entity-id-not-null.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+
+    <changeSet id="20140815131046" author="wpoteat">
+        <dropNotNullConstraint tableName="cp_event" columnName="entityid"/>
+        <!-- See http://www.liquibase.org/manual/refactoring_commands -->
+    </changeSet>
+
+</databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-create.xml
+++ b/server/src/main/resources/db/changelog/changelog-create.xml
@@ -1162,4 +1162,5 @@
     <include file="db/changelog/20140408160212-add-pool-source-sub-table.xml" />
     <include file="db/changelog/20140506122111-remove-certserial-revoked.xml" />
     <include file="db/changelog/20140616140315-remove-reliant-product.xml" />
+    <include file="db/changelog/20140815131046-drop-event-entity-id-not-null.xml" />
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-update.xml
+++ b/server/src/main/resources/db/changelog/changelog-update.xml
@@ -70,4 +70,5 @@
     <include file="db/changelog/20140408160212-add-pool-source-sub-table.xml" />
     <include file="db/changelog/20140506122111-remove-certserial-revoked.xml" />
     <include file="db/changelog/20140616140315-remove-reliant-product.xml" />
+    <include file="db/changelog/20140815131046-drop-event-entity-id-not-null.xml" />
 </databaseChangeLog>


### PR DESCRIPTION
Removed subscription certificate from event
Added old/new object treatment to owner update events
Allow null value for Event entity id as some events are sent before object storage
