### PR TITLE
Move ConsumerProperty to model from json.model

### DIFF
--- a/server/src/main/java/org/candlepin/audit/EventBuilder.java
+++ b/server/src/main/java/org/candlepin/audit/EventBuilder.java
@@ -16,9 +16,9 @@ package org.candlepin.audit;
 
 import org.candlepin.audit.Event.Target;
 import org.candlepin.audit.Event.Type;
-import org.candlepin.json.model.ConsumerProperty;
 import org.candlepin.model.AbstractHibernateObject;
 import org.candlepin.model.Consumer;
+import org.candlepin.model.ConsumerProperty;
 import org.candlepin.model.Entitlement;
 import org.candlepin.model.Named;
 import org.candlepin.model.Owned;

--- a/server/src/main/java/org/candlepin/model/Consumer.java
+++ b/server/src/main/java/org/candlepin/model/Consumer.java
@@ -47,7 +47,6 @@ import javax.xml.bind.annotation.XmlTransient;
 
 import org.candlepin.jackson.HateoasArrayExclude;
 import org.candlepin.jackson.HateoasInclude;
-import org.candlepin.json.model.ConsumerProperty;
 import org.candlepin.util.Util;
 
 import org.hibernate.annotations.Cascade;

--- a/server/src/main/java/org/candlepin/model/ConsumerProperty.java
+++ b/server/src/main/java/org/candlepin/model/ConsumerProperty.java
@@ -12,9 +12,8 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.json.model;
+package org.candlepin.model;
 
-import org.candlepin.model.Consumer;
 
 /**
  * Interface for Objects with a consumer

--- a/server/src/main/java/org/candlepin/model/Entitlement.java
+++ b/server/src/main/java/org/candlepin/model/Entitlement.java
@@ -34,7 +34,6 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
 
 import org.candlepin.jackson.HateoasInclude;
-import org.candlepin.json.model.ConsumerProperty;
 
 import org.hibernate.annotations.ForeignKey;
 import org.hibernate.annotations.GenericGenerator;

--- a/server/src/main/java/org/candlepin/model/GuestId.java
+++ b/server/src/main/java/org/candlepin/model/GuestId.java
@@ -39,7 +39,6 @@ import org.apache.commons.lang.builder.HashCodeBuilder;
 
 import org.candlepin.jackson.HateoasArrayExclude;
 import org.candlepin.jackson.HateoasInclude;
-import org.candlepin.json.model.ConsumerProperty;
 
 import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.ForeignKey;


### PR DESCRIPTION
ConsumerProperty is only ever used by the model package. It also meant it was
not included in the candlepin-api.jar which only includes a subset of the
candlepin code.
