### PR TITLE
Mark JsRunnerProvider.updated volatile

### DIFF
--- a/server/src/main/java/org/candlepin/policy/js/JsRunnerProvider.java
+++ b/server/src/main/java/org/candlepin/policy/js/JsRunnerProvider.java
@@ -46,7 +46,7 @@ public class JsRunnerProvider implements Provider<JsRunner> {
 
     private Script script;
     private Scriptable scope;
-    private Date updated;
+    private volatile Date updated;
     // Use this lock to access script, scope and updated
     private ReadWriteLock scriptLock = new ReentrantReadWriteLock();
 


### PR DESCRIPTION
This should help us avoid wrongly-cached references in
some situations.  Probably won't make a difference, but should
be slightly safer.
