### PR TITLE
Remove duplicate hypervisor check outside of org

### DIFF
--- a/server/spec/hypervisor_check_in_spec.rb
+++ b/server/spec/hypervisor_check_in_spec.rb
@@ -197,7 +197,7 @@ describe 'Hypervisor Resource', :type => :virt do
     results.created[0]['guestIds'].should_not == nil
   end
 
-  it 'should not really support multiple orgs reporting the same cluster' do
+  it 'should support multiple orgs reporting the same cluster' do
     owner1 = create_owner(random_string('owner1'))
     owner2 = create_owner(random_string('owner2'))
     user1 = user_client(owner1, random_string('username1'))
@@ -210,12 +210,12 @@ describe 'Hypervisor Resource', :type => :virt do
     results1 = consumer1.hypervisor_check_in(owner1['key'], host_guest_mapping)
     results2 = consumer2.hypervisor_check_in(owner2['key'], host_guest_mapping)
     results1.created.size.should == 1
-    results2.created.size.should == 0
+    results2.created.size.should == 1
     results1.updated.size.should == 0
     results2.updated.size.should == 0
     results1.unchanged.size.should == 0
     results2.unchanged.size.should == 0
-    results2.failedUpdate.size == 1
+    results2.failedUpdate.size == 0
     # Now check in each org again
     results1 = consumer1.hypervisor_check_in(owner1['key'], host_guest_mapping)
     results2 = consumer2.hypervisor_check_in(owner2['key'], host_guest_mapping)
@@ -225,8 +225,8 @@ describe 'Hypervisor Resource', :type => :virt do
     results1.updated.size.should == 0
     results2.updated.size.should == 0
     results1.unchanged.size.should == 1
-    results2.unchanged.size.should == 0
-    results2.failedUpdate.size.should == 1
+    results2.unchanged.size.should == 1
+    results2.failedUpdate.size.should == 0
     # Send modified data for owner 1, but it shouldn't impact owner 2 at all
     new_host_guest_mapping = get_host_guest_mapping(hostname, ["guest1", "guest2", "guest3", "guest4"])
     results1 = consumer1.hypervisor_check_in(owner1['key'], new_host_guest_mapping)
@@ -237,8 +237,8 @@ describe 'Hypervisor Resource', :type => :virt do
     results1.updated.size.should == 1
     results2.updated.size.should == 0
     results1.unchanged.size.should == 0
-    results2.unchanged.size.should == 0
-    results2.failedUpdate.size.should == 1
+    results2.unchanged.size.should == 1
+    results2.failedUpdate.size.should == 0
   end
 
   def get_host_guest_mapping(host_uuid, guest_id_list)

--- a/server/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/server/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -164,9 +164,6 @@ public class ConfigProperties {
         "management_enabled," +
         "virt_only";
 
-    public static final String BLOCK_DUPLICATE_HYPERVISOR_IDS =
-        "candlepin.block_duplicate_hypervisor_ids";
-
     public static final Map<String, String> DEFAULT_PROPERTIES =
         new HashMap<String, String>() {
 
@@ -266,9 +263,6 @@ public class ConfigProperties {
                 this.put(LONG_ATTRIBUTES, LONG_ATTRIBUTE_LIST);
                 this.put(NON_NEG_LONG_ATTRIBUTES, NON_NEG_LONG_ATTRIBUTE_LIST);
                 this.put(BOOLEAN_ATTRIBUTES, BOOLEAN_ATTRIBUTE_LIST);
-
-                // Hopefully temporary configuration to block duplicate hypervisorIds
-                this.put(BLOCK_DUPLICATE_HYPERVISOR_IDS, "true");
 
                 // Default 20 minutes
                 this.put(PINSETTER_ASYNC_JOB_TIMEOUT, Integer.toString(1200));

--- a/server/src/main/java/org/candlepin/model/ConsumerCurator.java
+++ b/server/src/main/java/org/candlepin/model/ConsumerCurator.java
@@ -489,20 +489,6 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
             .list();
     }
 
-    /*
-     * setMaxResults(1) should be more efficient than Projections.rowCount
-     * because we don't care how many rows there are, only whether or not
-     * they exist.
-     */
-    public boolean isHypervisorIdUsed(String hypervisorId) {
-        return currentSession().createCriteria(Consumer.class)
-        .createAlias("hypervisorId", "hvsr")
-        .add(Restrictions.eq("hvsr.hypervisorId", hypervisorId).ignoreCase())
-        .setProjection(Projections.id())
-        .setMaxResults(1)
-        .uniqueResult() != null;
-    }
-
     public boolean doesConsumerExist(String uuid) {
         long result = (Long) createSecureCriteria()
             .add(Restrictions.eq("uuid", uuid))

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -864,6 +864,7 @@ public class ConsumerResource {
         }
     }
 
+    @Transactional
     protected boolean performConsumerUpdates(Consumer updated, Consumer toUpdate) {
         if (log.isDebugEnabled()) {
             log.debug("Updating consumer: " + toUpdate.getUuid());

--- a/server/src/main/java/org/candlepin/resource/HypervisorResource.java
+++ b/server/src/main/java/org/candlepin/resource/HypervisorResource.java
@@ -19,8 +19,6 @@ import org.candlepin.auth.Principal;
 import org.candlepin.auth.SubResource;
 import org.candlepin.auth.interceptor.Verify;
 import org.candlepin.common.exceptions.NotFoundException;
-import org.candlepin.config.Config;
-import org.candlepin.config.ConfigProperties;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerCurator;
 import org.candlepin.model.ConsumerType;
@@ -62,17 +60,14 @@ public class HypervisorResource {
     private ConsumerResource consumerResource;
     private I18n i18n;
     private OwnerCurator ownerCurator;
-    private Config config;
 
     @Inject
     public HypervisorResource(ConsumerResource consumerResource,
-        ConsumerCurator consumerCurator, I18n i18n, OwnerCurator ownerCurator,
-        Config config) {
+        ConsumerCurator consumerCurator, I18n i18n, OwnerCurator ownerCurator) {
         this.consumerResource = consumerResource;
         this.consumerCurator = consumerCurator;
         this.i18n = i18n;
         this.ownerCurator = ownerCurator;
-        this.config = config;
     }
 
     /**
@@ -128,15 +123,6 @@ public class HypervisorResource {
                             hostEntry.getKey() + " in org " + ownerKey);
                         result.failed(hostEntry.getKey(), i18n.tr(
                             "Unable to find hypervisor in org ''{0}''", ownerKey));
-                        continue;
-                    }
-                    if (this.blockDuplicateHypervisors() &&
-                        consumerCurator.isHypervisorIdUsed(hostEntry.getKey())) {
-                        // If the hypervisorID is being used, we know it is not in this org
-                        log.info("Hypervisor id " + hostEntry.getKey() +
-                            " is in use by another org");
-                        result.failed(hostEntry.getKey(), i18n.tr(
-                            "Hypervisor ''{0}'' is in use by another org", ownerKey));
                         continue;
                     }
                     log.info("Registering new host consumer");
@@ -211,9 +197,5 @@ public class HypervisorResource {
         // Create Consumer
         return consumerResource.create(consumer,
             principal, null, owner.getKey(), null);
-    }
-
-    private boolean blockDuplicateHypervisors() {
-        return config.getBoolean(ConfigProperties.BLOCK_DUPLICATE_HYPERVISOR_IDS);
     }
 }

--- a/server/src/test/java/org/candlepin/model/test/ConsumerCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/test/ConsumerCuratorTest.java
@@ -594,37 +594,6 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void testisHypervisorIdUsed() {
-        Consumer consumer = new Consumer("testConsumer", "testUser", owner, ct);
-        consumer.setHypervisorId(new HypervisorId("hypervisor"));
-        consumer = consumerCurator.create(consumer);
-        Owner otherOwner = ownerCurator.create(new Owner("other owner"));
-        Consumer consumer2 = new Consumer("testConsumer2", "testUser2", otherOwner, ct);
-        consumer2.setHypervisorId(new HypervisorId("hypervisor"));
-        consumer2 = consumerCurator.create(consumer2);
-
-        // Also test the lookup is case insensitive
-        boolean result = consumerCurator.isHypervisorIdUsed("hyperVIsor");
-        assertTrue(result);
-    }
-
-
-    @Test
-    public void testisHypervisorIdUsedNoMatches() {
-        Consumer consumer = new Consumer("testConsumer", "testUser", owner, ct);
-        consumer.setHypervisorId(new HypervisorId("hypervisor"));
-        consumer = consumerCurator.create(consumer);
-        Owner otherOwner = ownerCurator.create(new Owner("other owner"));
-        Consumer consumer2 = new Consumer("testConsumer2", "testUser2", otherOwner, ct);
-        consumer2.setHypervisorId(new HypervisorId("hypervisor"));
-        consumer2 = consumerCurator.create(consumer2);
-
-        // Should return zero
-        boolean result = consumerCurator.isHypervisorIdUsed("different id");
-        assertFalse(result);
-    }
-
-    @Test
     public void testGetConsumerIdsWithStartedEnts() {
         Consumer consumer = new Consumer("testConsumer", "testUser", owner, ct);
         consumerCurator.create(consumer);

--- a/server/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
@@ -130,7 +130,7 @@ public class HypervisorResourceTest {
             null, null, null, null, null, mockedServiceLevelValidator);
 
         hypervisorResource = new HypervisorResource(consumerResource,
-            consumerCurator, i18n, ownerCurator, new CandlepinCommonTestConfig());
+            consumerCurator, i18n, ownerCurator);
 
         // Ensure that we get the consumer that was passed in back from the create call.
         when(consumerCurator.create(any(Consumer.class))).thenAnswer(new Answer<Object>() {
@@ -182,37 +182,6 @@ public class HypervisorResourceTest {
         assertEquals("GUEST_B", c1.getGuestIds().get(1).getGuestId());
         assertEquals("x86_64", c1.getFact("uname.machine"));
         assertEquals("hypervisor", c1.getType().getLabel());
-    }
-
-    @Test
-    public void hypervisorCheckInFailsWhenHypervisorIdInUse() throws Exception {
-        Owner owner = new Owner("admin");
-
-        Map<String, List<GuestId>> hostGuestMap = new HashMap<String, List<GuestId>>();
-        hostGuestMap.put("test-host", Arrays.asList(new GuestId("GUEST_A"),
-            new GuestId("GUEST_B")));
-
-        when(ownerCurator.lookupByKey(eq(owner.getKey()))).thenReturn(owner);
-        when(consumerCurator.getHypervisor(eq("test-host"), eq(owner))).thenReturn(null);
-        when(ownerCurator.lookupByKey(eq(owner.getKey()))).thenReturn(owner);
-        when(principal.canAccess(eq(owner), eq(SubResource.CONSUMERS), eq(Access.CREATE))).
-            thenReturn(true);
-        when(consumerTypeCurator.lookupByLabel(
-            eq(ConsumerTypeEnum.HYPERVISOR.getLabel()))).thenReturn(hypervisorType);
-        when(idCertService.generateIdentityCert(any(Consumer.class)))
-            .thenReturn(new IdentityCertificate());
-        when(consumerCurator.isHypervisorIdUsed(eq("test-host"))).thenReturn(true);
-
-        HypervisorCheckInResult result = hypervisorResource.hypervisorCheckIn(hostGuestMap,
-            principal, owner.getKey(), true);
-
-        Set<Consumer> created = result.getCreated();
-        assertEquals(0, created.size());
-
-        int failCount = result.getFailedUpdate().size();
-        assertEquals(1, failCount);
-        String failed = result.getFailedUpdate().iterator().next();
-        assertTrue(failed.contains("test-host"));
     }
 
     @Test


### PR DESCRIPTION
No long block hypervisor creation when the id exists outside of the target organization.
