### PR TITLE
Add secondary sorting on events list.

### DIFF
--- a/server/src/main/java/org/candlepin/model/EventCurator.java
+++ b/server/src/main/java/org/candlepin/model/EventCurator.java
@@ -49,7 +49,10 @@ public class EventCurator extends AbstractHibernateCurator<Event> {
      */
     private Criteria createEventCriteria(int limit) {
         return currentSession().createCriteria(Event.class)
-            .setMaxResults(limit).addOrder(Order.desc("timestamp"));
+            .setMaxResults(limit).addOrder(Order.desc("timestamp"))
+            .addOrder(Order.asc("target"))
+            .addOrder(Order.asc("type"))
+            .addOrder(Order.asc("entityId"));
     }
 
     @SuppressWarnings("unchecked")

--- a/server/src/test/java/org/candlepin/model/test/EventCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/test/EventCuratorTest.java
@@ -18,20 +18,26 @@ import static org.junit.Assert.*;
 
 import org.candlepin.audit.Event;
 import org.candlepin.audit.Event.Type;
+import org.candlepin.audit.EventBuilder;
 import org.candlepin.audit.EventFactory;
 import org.candlepin.auth.Access;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerType;
 import org.candlepin.model.Owner;
+import org.candlepin.model.Rules;
 import org.candlepin.test.DatabaseTestFixture;
 
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Date;
+import java.util.List;
+
 
 public class EventCuratorTest extends DatabaseTestFixture {
 
     private Owner owner;
+
 
     @Before
     public void setUp() {
@@ -55,6 +61,49 @@ public class EventCuratorTest extends DatabaseTestFixture {
         assertNull(lookedUp.getOldEntity());
         assertEquals(Type.CREATED, lookedUp.getType());
         assertNotNull(lookedUp.getId());
+    }
+
+    @Test
+    public void testSecondarySorting() {
+
+        Consumer newConsumer = new Consumer("consumername", "user", owner,
+                new ConsumerType("system"));
+        consumerTypeCurator.create(newConsumer.getType());
+        consumerCurator.create(newConsumer);
+
+        setupPrincipal(owner, Access.ALL);
+        EventFactory eventFactory = injector.getInstance(EventFactory.class);
+
+        // Force all events to have exact same timestamp:
+        Date forcedDate = new Date();
+
+        EventBuilder builder = eventFactory.getEventBuilder(Event.Target.RULES,
+                Event.Type.DELETED);
+        Event rulesDeletedEvent = builder.setOldEntity(new Rules()).buildEvent();
+        rulesDeletedEvent.setTimestamp(forcedDate);
+
+        builder = eventFactory.getEventBuilder(Event.Target.CONSUMER,
+                Event.Type.CREATED);
+        Event consumerCreatedEvent = builder.setNewEntity(newConsumer).buildEvent();
+        consumerCreatedEvent.setTimestamp(forcedDate);
+
+        builder = eventFactory.getEventBuilder(Event.Target.CONSUMER,
+                Event.Type.MODIFIED);
+        Event consumerModifiedEvent = builder.setNewEntity(newConsumer).
+                setOldEntity(newConsumer).buildEvent();
+        consumerModifiedEvent.setTimestamp(forcedDate);
+
+        eventCurator.create(rulesDeletedEvent);
+        eventCurator.create(consumerCreatedEvent);
+        eventCurator.create(consumerModifiedEvent);
+
+        List<Event> mostRecent = eventCurator.listMostRecent(3);
+        assertEquals(3, mostRecent.size());
+
+        // We should see this sorted by timestamp (all the same), then entity, then type:
+        assertEquals(consumerCreatedEvent.getId(), mostRecent.get(0).getId());
+        assertEquals(consumerModifiedEvent.getId(), mostRecent.get(1).getId());
+        assertEquals(rulesDeletedEvent.getId(), mostRecent.get(2).getId());
     }
 
 }


### PR DESCRIPTION
Some events can show up with the exact same timestamp, causing their order to
sometimes change when queried over the API multiple times. Add some additional
sorting on target, type, and event ID. The problem could theoretically still
occur if somehow the same entity has the same type of event occuring at the
exact same millisecond, but this should be extremely unlikely.
