### PR TITLE
Use proper c3p0 class

### DIFF
--- a/server/src/main/resources/META-INF/persistence.xml
+++ b/server/src/main/resources/META-INF/persistence.xml
@@ -14,7 +14,7 @@
             <property name="hibernate.connection.password" value=""/>
             <property name="hibernate.show_sql" value="false" />
             <property name="hibernate.ejb.interceptor" value="org.candlepin.hibernate.EmptyStringInterceptor"/>
-            <property name="hibernate.connection.provider_class" value="org.hibernate.connection.C3P0ConnectionProvider" />
+            <property name="hibernate.connection.provider_class" value="org.hibernate.service.jdbc.connections.internal.C3P0ConnectionProvider" />
             <!-- c3p0 connection manager settings -->
             <property name="hibernate.c3p0.min_size" value="5" />
             <property name="hibernate.c3p0.max_size" value="20" />


### PR DESCRIPTION
We've been getting warnings with C3P0.

WARN
org.hibernate.service.jdbc.connections.internal.ConnectionProviderInitiator -
HHH000208: org.hibernate.connection.C3P0ConnectionProvider has been deprecated
in favor of
org.hibernate.service.jdbc.connections.internal.C3P0ConnectionProvider; that
provider will be used instead.
