### PR TITLE
Fix another spec test needing a sleep.

### DIFF
--- a/server/spec/refresh_pools_spec.rb
+++ b/server/spec/refresh_pools_spec.rb
@@ -53,6 +53,7 @@ describe 'Refresh Pools' do
     end
 
     @cp.refresh_pools(owner['key'])
+    sleep 1
 
     events = @cp.list_owner_events(owner['key'])
     pool_created_events = events.find_all { |event| event['target'] == 'POOL' && event['type'] == 'CREATED'}


### PR DESCRIPTION
As before, events are not received / stored in the same transaction as the
request. If we ask for them too soon, they won't be there.
