### PR TITLE
add error handling around the refreshing of an individual subscription

### DIFF
--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -164,7 +164,16 @@ public class CandlepinPoolManager implements PoolManager {
                 continue;
             }
 
-            refreshPoolsForSubscription(sub, lazy);
+            try {
+              refreshPoolsForSubscription(sub, lazy);
+            }
+            catch(RuntimeException e){
+              log.error("Unable to refresh subscription: " + subId, e);
+
+              //Not technically a deleted sub, but we don't want to delete a sub
+              // that was not refreshed.
+              deletedSubs.add(subId);
+            }
         }
 
         // We deleted some, need to take that into account so we


### PR DESCRIPTION
I am uncertain how to really functionally test this, but the idea is just because one pool fails to refresh it doesn't mean the entire process needs to stop.
