### PR TITLE
Remove unnecessary CA key entry.

### DIFF
--- a/server/bin/gen-certs
+++ b/server/bin/gen-certs
@@ -2,7 +2,7 @@
 
 CERTS_HOME=/etc/candlepin/certs
 UPSTREAM_CERTS_HOME=$CERTS_HOME/upstream
-CA_KEY_PASSWORD=$CERTS_HOME/candlepin-ca-password.txt
+KEYSTORE_PASSWORD=$CERTS_HOME/keystore-password.txt
 CA_KEY=$CERTS_HOME/candlepin-ca.key
 CA_REDHAT_CERT=conf/candlepin-redhat-ca.crt
 CA_UPSTREAM_CERT=$UPSTREAM_CERTS_HOME/candlepin-redhat-ca.crt
@@ -39,15 +39,14 @@ HOSTNAME=${HOSTNAME:-$(hostname)}
 if [ -f $CA_KEY ] && [ -f $CA_CERT ] && [ "$FORCECERT" != "1" ]; then
     echo "Certificates are already present."
 else
-    echo "Creating CA private key password"
-    sudo su -c "echo -n "password" > $CA_KEY_PASSWORD"
     echo "Creating CA private key"
-    sudo openssl genrsa -out $CA_KEY -passout file:$CA_KEY_PASSWORD 1024
+    sudo openssl genrsa -out $CA_KEY 1024
     echo "Creating CA public key"
     sudo openssl rsa -pubout -in $CA_KEY -out $CA_PUB_KEY
     echo "Creating CA certificate"
     sudo openssl req -new -x509 -days 365 -key $CA_KEY -out $CA_CERT -subj "/CN=$HOSTNAME/C=US/L=Raleigh/"
-    sudo openssl pkcs12 -export -in $CA_CERT -inkey $CA_KEY -out $KEYSTORE -name tomcat -CAfile $CA_CERT -caname root -chain -password file:$CA_KEY_PASSWORD
+    sudo su -c "echo -n "password" > $KEYSTORE_PASSWORD"
+    sudo openssl pkcs12 -export -in $CA_CERT -inkey $CA_KEY -out $KEYSTORE -name tomcat -CAfile $CA_CERT -caname root -chain -password file:$KEYSTORE_PASSWORD
     sudo cp $CA_REDHAT_CERT $CA_UPSTREAM_CERT
     sudo chmod a+r $KEYSTORE
 fi

--- a/server/erb/candlepin.conf.erb
+++ b/server/erb/candlepin.conf.erb
@@ -40,7 +40,6 @@ candlepin.hidden_resources=<%= hidden_resources %>
 #log4j.logger.org.candlepin=DEBUG
 
 candlepin.pinsetter.enable=<%= pinsetter_enabled || true %>
-candlepin.ca_key_password=password
 
 org.quartz.jobStore.misfireThreshold=60000
 org.quartz.jobStore.useProperties=false


### PR DESCRIPTION
Private keys only need a password if they are generated with the
'-des3' (or similar) option in openssl.  Under normal circumstances,
private key PEM files are not encrypted.  This patch removes the
candlepin.ca_key_password configuration entry and corrects the
gen-certs script to indicate more clearly that the CA keys are not being
encrypted.
