### PR TITLE
Rename contains text param to matches.

### DIFF
--- a/server/src/main/java/org/candlepin/model/PoolFilterBuilder.java
+++ b/server/src/main/java/org/candlepin/model/PoolFilterBuilder.java
@@ -21,8 +21,6 @@ import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Property;
 import org.hibernate.criterion.Restrictions;
 import org.hibernate.criterion.Subqueries;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -36,28 +34,26 @@ import java.util.List;
  */
 public class PoolFilterBuilder extends FilterBuilder {
 
-    private static Logger log = LoggerFactory.getLogger(PoolFilterBuilder.class);
-
     /**
-     * Add filters to search only for pools containing the given text. A number of
-     * fields on the pool are searched including it's SKU, SKU product name, and provided
-     * (engineering) product IDs and their names.
+     * Add filters to search only for pools matching the given text. A number of
+     * fields on the pool are searched including it's SKU, SKU product name,
+     * contract number, SLA, and provided (engineering) product IDs and their names.
      *
-     * @param containsText Text to search for in various fields on the pool. Basic
+     * @param matches Text to search for in various fields on the pool. Basic
      * wildcards are supported for everything or a single character. (* and ? respectively)
      */
-    public void addContainsTextFilter(String containsText) {
+    public void addMatchesFilter(String matches) {
 
         Disjunction textOr = Restrictions.disjunction();
-        textOr.add(new FilterLikeExpression("productName", containsText, true));
-        textOr.add(new FilterLikeExpression("productId", containsText, true));
-        textOr.add(new FilterLikeExpression("contractNumber", containsText, true));
-        textOr.add(new FilterLikeExpression("orderNumber", containsText, true));
+        textOr.add(new FilterLikeExpression("productName", matches, true));
+        textOr.add(new FilterLikeExpression("productId", matches, true));
+        textOr.add(new FilterLikeExpression("contractNumber", matches, true));
+        textOr.add(new FilterLikeExpression("orderNumber", matches, true));
         textOr.add(Subqueries.exists(
-                createProvidedProductCriteria(containsText)));
+                createProvidedProductCriteria(matches)));
         textOr.add(Subqueries.exists(
                 createAttributeCriteria(ProductPoolAttribute.class, "support_level",
-                Arrays.asList(containsText))));
+                Arrays.asList(matches))));
         this.otherCriteria.add(textOr);
     }
 

--- a/server/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -692,7 +692,8 @@ public class OwnerResource {
      * Retrieves a list of Pools for an Owner
      *
      * @param ownerKey id of the owner whose entitlement pools are sought.
-     * @param containsText TODO
+     * @param matches Find pools matching the given pattern in a variety of fields.
+     * * and ? wildcards are supported.
      * @return a list of Pool objects
      * @httpcode 400
      * @httpcode 404
@@ -710,7 +711,7 @@ public class OwnerResource {
         @QueryParam("product") String productId,
         @QueryParam("listall") @DefaultValue("false") boolean listAll,
         @QueryParam("activeon") String activeOn,
-        @QueryParam("containstext") String containsText,
+        @QueryParam("matches") String matches,
         @QueryParam("attribute") @CandlepinParam(type = KeyValueParameter.class)
             List<KeyValueParameter> attrFilters,
         @Context Principal principal,
@@ -757,8 +758,8 @@ public class OwnerResource {
         for (KeyValueParameter filterParam : attrFilters) {
             poolFilters.addAttributeFilter(filterParam.key(), filterParam.value());
         }
-        if (!StringUtils.isEmpty(containsText)) {
-            poolFilters.addContainsTextFilter(containsText);
+        if (!StringUtils.isEmpty(matches)) {
+            poolFilters.addMatchesFilter(matches);
         }
 
         Page<List<Pool>> page = poolManager.listAvailableEntitlementPools(c, key, owner,

--- a/server/src/test/java/org/candlepin/model/test/PoolCuratorFilterTest.java
+++ b/server/src/test/java/org/candlepin/model/test/PoolCuratorFilterTest.java
@@ -83,7 +83,7 @@ public class PoolCuratorFilterTest extends DatabaseTestFixture {
 
     private void searchTest(String searchFor, int expectedResults, String ... expectedIds) {
         PoolFilterBuilder filters = new PoolFilterBuilder();
-        filters.addContainsTextFilter(searchFor);
+        filters.addMatchesFilter(searchFor);
         Page<List<Pool>> page = poolCurator.listAvailableEntitlementPools(
                 null, owner, null, null, false, filters,
                 req, false);


### PR DESCRIPTION
We dropped the implicit leading/trailing wildcard, thus contains is not really
accurate. Switching to matches along with the client.
