### PR TITLE
Workaround EL6 build failures.

### DIFF
--- a/server/candlepin.spec
+++ b/server/candlepin.spec
@@ -44,7 +44,7 @@ BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
 Vendor: Red Hat, Inc.
 BuildArch: noarch
 
-BuildRequires: java-devel >= 0:1.6.0
+BuildRequires: java-devel >= 1:1.6.0
 BuildRequires: ant >= 0:1.7.0
 BuildRequires: gettext
 BuildRequires: selinux-policy-doc


### PR DESCRIPTION
Picking up openjdk 1.8 in brew, which should not be happening for a variety of
reasons/bugs.

For now we'll require epoch >= 1 which will not match 1.8.
