### PR TITLE
modify pom generation to include dependency version properties

### DIFF
--- a/tasks/pom.rake
+++ b/tasks/pom.rake
@@ -37,13 +37,25 @@ module PomTask
         xml.groupId(artifact_spec[:group])
         xml.artifactId(artifact_spec[:id])
         xml.version(artifact_spec[:version])
+        
+        dep_version_prop_hsh = {}
+        
+        xml.properties do
+          dependencies.each do |dep|
+            h = dep.to_hash
+            prop_name = h[:group] + "-" + h[:id] + ".version"
+            xml.__send__(prop_name, h[:version])
+            dep_version_prop_hsh[h] = '${' + prop_name + '}'
+          end
+        end
+        
         xml.dependencies do
           dependencies.each do |dep|
             h = dep.to_hash
             xml.dependency do
               xml.groupId(h[:group])
               xml.artifactId(h[:id])
-              xml.version(h[:version])
+              xml.version(dep_version_prop_hsh[h])
             end
           end
         end


### PR DESCRIPTION
In our adapters pom.xml we need to be able to get at the versions of dependencies used. This change would set all such versions as properties and then use substitution in the dependency definition. Then we could inherit this pom as a parent and gain access to all the version numbers.
