### PR TITLE
Make rspec buildr plugin only run on the relevant project.

### DIFF
--- a/tasks/rspec.rake
+++ b/tasks/rspec.rake
@@ -1,29 +1,180 @@
 require 'parallel_tests'
+require 'rspec/core/rake_task'
+
+require './tasks/util'
 
 module ModifiedRSpec
-  class << self
-    def default_rspec_opts(rspec)
+  class CleanFailuresTask < Rake::Task
+    attr_reader :project
+
+    def execute(*args)
+      super
+      trace("Killing #{project.rspec.failure_file}")
+      FileUtils.rm_f(project.rspec.failure_file)
+    end
+
+    protected
+
+    def associate_with(project)
+      @project = project
+    end
+  end
+
+  class ModifiedRSpecTask < Rake::Task
+    attr_reader :project
+
+    class << self
+      def run_local(name, *args)
+        Project.local_projects do |local_project|
+          local_project.task(name).invoke(*args)
+        end
+      end
+
+      def include(includes)
+        Project.local_projects do |local_project|
+          local_project.task('rspec').send(:include, includes)
+        end
+      end
+
+      def exclude(excludes)
+        Project.local_projects do |local_project|
+          local_project.task('rspec').send(:exclude, excludes)
+        end
+      end
+
+      def signifiers(signifiers)
+        Project.local_projects do |local_project|
+          local_project.task('rspec').send(:signifiers, signifiers)
+        end
+      end
+    end
+
+    def initialize(*args)
+      super
+      @include = []
+      @exclude = []
+      @signifiers = []
+      # The RSpec rake task doesn't inherit from Rake::Task but we need to, so we'll wrap it
+      @rspec_task = RSpec::Core::RakeTask.new
+      # Set fail_on_error to rspec default
+      @fail_on_error = @rspec_task.fail_on_error
+    end
+
+    attr_writer :additional_opts
+    def additional_opts
+      @additional_opts ||= []
+    end
+
+    attr_accessor :fail_on_error
+
+    def include(includes)
+      @include += includes
+    end
+
+    def exclude(excludes)
+      @exclude += excludes
+    end
+
+    def signifiers(signifiers)
+      @signifiers += signifiers
+    end
+
+    def build_rspec_opts(rspec)
       opts = %W{--color --format documentation}
       opts.concat(%W{--require #{File.join(Dir.pwd, 'tasks', 'failure_formatter')}})
       opts.concat(%W{--format ModifiedRSpec::Formatters::FailuresFormatter})
 
-      includes = rspec.includes.map { |dir| "-I #{dir}" }
-      opts.concat(includes)
+      ruby_includes = rspec.ruby_includes.map { |dir| "-I #{dir}" }
+      opts.concat(ruby_includes)
+
+      @signifiers.each do |signifier|
+        if signifier =~ /\d+/
+          opts.concat(%W{-l #{signifier}})
+        else
+          opts.concat(%W{-e "#{signifier}"})
+        end
+      end
+
+      opts.concat(additional_opts)
       opts << ENV['RSPEC_OPTS'] unless ENV['RSPEC_OPTS'].nil?
       opts
     end
 
-    def rspec_task(name, rspec, &block)
-      RSpec::Core::RakeTask.new(name) do |task|
-        task.verbose = false
-        task.rspec_opts = self.default_rspec_opts(rspec)
-        # Running buildr rspec:parallel all_tests=true will cause all the tests
-        # to run even if there is a failure in the serial portion of the run.
-        unless ENV['all_tests'].nil?
-          task.fail_on_error = false
-        end
-        yield task if block_given?
+    def execute(args)
+      super
+      rspec = project.rspec
+
+      unless rspec.enabled?
+        fail("Project #{project} does not have RSpec enabled")
       end
+
+      @rspec_task.rspec_opts = build_rspec_opts(rspec)
+      @rspec_task.verbose = false
+      @rspec_task.fail_on_error = fail_on_error
+
+      @rspec_task.rspec_opts.concat(files_to_run(rspec.pattern))
+
+      # spec_command is private for some reason
+      command = @rspec_task.send(:spec_command)
+      begin
+        info(command)
+        # If you just use system(command) and then interrupt the Buildr process, RSpec will
+        # keep running for a little while longer and print extra stuff to the console.  To prevent
+        # that, we spawn the command to get the pid.  Then we set a trap so that on a SIGINT, the
+        # SIGINT gets sent to rspec too.
+        pid = Process.spawn(command)
+        set_trap(pid)
+        _, status = Process.wait2(pid)
+      rescue
+        error(@rspec_task.failure_message) if @rspec_task.failure_message
+      end
+      fail("#{command} failed") if @rspec_task.fail_on_error unless status.success?
+    end
+
+    protected
+
+    def set_trap(pid)
+      Signal.trap('INT') do
+        Process.kill('INT', pid)
+      end
+    end
+
+    def files_to_run(pattern)
+      specs_to_run = Dir[pattern]
+      unless @include.empty?
+        specs_to_run.select! do |s|
+          File.basename(s).start_with?(*@include)
+        end
+      end
+
+      specs_to_run.reject! do |s|
+        File.basename(s).start_with?(*@exclude)
+      end
+
+      if specs_to_run.empty?
+        fail("No specs found matching #{tests}")
+      end
+      specs_to_run
+    end
+
+    def associate_with(project)
+      @project = project
+    end
+  end
+
+  class ParallelRspecTask < Rake::Task
+    attr_reader :project
+    attr_accessor :rspec_opts
+
+    def execute(args)
+      super
+      rspec = project.rspec
+      ParallelTests::CLI.new.run(["--type", "rspec", "-o", @rspec_opts.join(' '), rspec.spec_dir])
+    end
+
+    protected
+    def associate_with(project)
+      @project = project
     end
   end
 
@@ -42,8 +193,11 @@ module ModifiedRSpec
       File.exist?(spec_dir)
     end
 
-    def includes
-      [spec_dir] + requires
+    def ruby_includes
+      ruby_includes = [spec_dir] + requires
+      ruby_includes.select do |dir|
+        File.exist?(dir)
+      end
     end
 
     # This is not configurable because we have no way to
@@ -52,129 +206,100 @@ module ModifiedRSpec
       project.path_to(:target, 'rspec.failures')
     end
 
+    def pattern
+      File.join(spec_dir, '**', '*_spec.rb')
+    end
+
     protected
+
+    attr_reader :project
     def initialize(project)
       @project = project
     end
-
-    attr_reader :project
   end
 
   module ProjectExtension
     include Extension
+    include Candlepin::Util
+
+    TEST_SPECIFIC_REGEX = /^rspec:(.+)/
 
     def rspec
       @rspec ||= ModifiedRSpec::Config.new(project)
     end
 
     first_time do
-      desc "Run RSpec tests in parallel"
-      Project.local_task('rspec:parallel')
-
-      desc "*DEPRECATED* use rspec:parallel"
-      Project.local_task('parallel_rspec')
+      desc "Run RSpec tests in serial"
+      task('rspec') do |task|
+        ModifiedRSpecTask.run_local('rspec')
+      end
 
       desc "Run RSpec tests that failed last run"
       Project.local_task('rspec:failures')
 
-      desc "Run RSpec tests in serial"
-      Project.local_task('rspec')
+      desc "Run RSpec tests in parallel"
+      Project.local_task('rspec:parallel')
+
+      rule(TEST_SPECIFIC_REGEX) do |task|
+        tests, signifiers = TEST_SPECIFIC_REGEX.match(task.name)[1].split(/:/, 2)
+        tests = tests.split(/,/)
+        tests.map!(&:strip)
+
+        signifiers ||= ""
+        signifiers = signifiers.split(/,/)
+        signifiers.map!(&:strip)
+
+        excluded_tests, included_tests = tests.partition { |t| t =~ /^-/ }
+
+        # Remove leading '-' from test name
+        excluded_tests.map! { |t| t[1..-1] }
+
+        ModifiedRSpecTask.include(included_tests)
+        ModifiedRSpecTask.exclude(excluded_tests)
+        ModifiedRSpecTask.signifiers(signifiers)
+        task('rspec').invoke()
+      end
     end
 
-    TEST_SPECIFIC_REGEX = /^rspec:(.+)/
+    before_define do |project|
+      clean_failures = CleanFailuresTask.define_task('rspec_clean')
+      clean_failures.send(:associate_with, project)
 
-    after_define do |project|
-      rspec = project.rspec
+      rspec_task = ModifiedRSpecTask.define_task('rspec' => ['rspec_clean'])
+      rspec_task.send(:associate_with, project)
 
-      if rspec.enabled?
-        universal_pattern = File.join(rspec.spec_dir, '*_spec.rb')
-
-        task('rspec:clean_failures') do |task|
-          FileUtils.rm_f(rspec.failure_file)
+      rspec_failures = ModifiedRSpecTask.define_task('rspec_failures')
+      rspec_failures.send(:associate_with, project)
+      project.task('rspec:failures') do |task|
+        if File.exist?(project.rspec.failure_file)
+          failures = IO.readlines(project.rspec.failure_file)
+          failures.map!(&:strip)
+        else
+          failures = nil
         end
 
-        project.recursive_task('rspec' => 'rspec:clean_failures') do |task|
-          ModifiedRSpec.rspec_task('hidden_rspec', rspec) do |rspec_task|
-            rspec_task.pattern = universal_pattern
-          end
-          task('hidden_rspec').invoke
-        end
-
-        project.recursive_task('rspec:parallel' => 'rspec:clean_failures') do |task|
-          ModifiedRSpec.rspec_task('rspec_serial_only', rspec) do |rspec_task|
-            rspec_task.rspec_opts.concat(%w{--tag serial})
-            rspec_task.pattern = universal_pattern
-          end
-          task('rspec_serial_only').invoke
-
-          rspec_opts = ModifiedRSpec.default_rspec_opts(rspec)
-          rspec_opts.concat(%w{--tag ~serial})
-          ParallelTests::CLI.new.run(["--type", "rspec", "-o", rspec_opts.join(' '), rspec.spec_dir])
-        end
-
-        project.recursive_task('parallel_rspec') do |task|
-          warn("'parallel_rspec' is deprecated.  Use 'rspec:parallel'")
-          task('rspec:parallel').invoke
-        end
-
-        project.recursive_task('rspec:failures') do |task|
-          failures = IO.readlines(rspec.failure_file)
-          failures.map! do |f|
-            %Q{-e "#{f.strip}"}
-          end
-
-          FileUtils.rm_f(rspec.failure_file)
-
-          ModifiedRSpec.rspec_task('rspec_failures', rspec) do |rspec_task|
-            rspec_task.rspec_opts.concat(failures)
-            rspec_task.pattern = universal_pattern
-          end
-          task('rspec_failures').invoke
-        end
-
-        rule(TEST_SPECIFIC_REGEX) do |task|
-          tests, signifiers = TEST_SPECIFIC_REGEX.match(task.name)[1].split(/:/, 2)
-          tests = tests.split(/,/)
-          tests.map!(&:strip)
-
-          signifiers ||= ""
-          signifiers = signifiers.split(/,/)
-          signifiers.map!(&:strip)
-
-          excluded_tests, included_tests = tests.partition { |t| t =~ /^-/ }
-
-          # Remove leading '-' from test name
-          excluded_tests.map! { |t| t[1..-1] }
-
-          specs_to_run = Dir[universal_pattern]
-          unless included_tests.empty?
-            specs_to_run.select! do |s|
-              File.basename(s).start_with?(*included_tests)
-            end
-          end
-
-          specs_to_run.reject! do |s|
-            File.basename(s).start_with?(*excluded_tests)
-          end
-
-          if specs_to_run.empty?
-            fail("No specs found matching #{tests}")
-          end
-
-          ModifiedRSpec.rspec_task('filtered_rspec', rspec) do |rspec_task|
-            signifiers.each do |signifier|
-              if signifier =~ /\d+/
-                rspec_task.rspec_opts.concat(%W{-l #{signifier}})
-              else
-                rspec_task.rspec_opts.concat(%W{-e "#{signifier}"})
-              end
-            end
-            rspec_task.rspec_opts.concat(specs_to_run)
-            rspec_task.verbose = true
-          end
-          task('filtered_rspec').invoke
+        if failures.nil?
+          success("No failures found to test.")
+        else
+          rspec_failures.signifiers(failures)
+          rspec_failures.enhance(['rspec_clean'])
+          rspec_failures.invoke
         end
       end
+
+      rspec_serial = ModifiedRSpecTask.define_task('rspec_serial')
+      rspec_serial.send(:associate_with, project)
+      rspec_serial.enhance do |task|
+        task.additional_opts = %w{--tag serial}
+        task.fail_on_error = false if ENV.key?('all_tests')
+      end
+
+      rspec_parallel = ParallelRspecTask.define_task('rspec_parallel') do |task|
+        task.rspec_opts = rspec_serial.build_rspec_opts(project.rspec) + %w{--tag ~serial}
+      end
+      rspec_parallel.send(:associate_with, project)
+
+      project.task('rspec:parallel' => ['rspec_clean', 'rspec_serial', 'rspec_parallel'])
     end
   end
 end

--- a/tasks/util.rb
+++ b/tasks/util.rb
@@ -18,6 +18,10 @@ module Candlepin
         s.gsub(/^[ \t]{#{indent}}/, '')
       end
 
+      def success(message)
+        puts Buildr::Console.color(message.to_s, :green)
+      end
+
       def top_project(project)
         until project.parent.nil? do
           project = project.parent


### PR DESCRIPTION
The previous version of the plugin contained a bug where it would
actually run rspec tests in all projects on any invocation of `buildr
rspec`.
