### PR TITLE
Report "report" from report keys.

### DIFF
--- a/gutterball/src/main/java/org/candlepin/gutterball/report/ConsumerStatusReport.java
+++ b/gutterball/src/main/java/org/candlepin/gutterball/report/ConsumerStatusReport.java
@@ -40,7 +40,7 @@ public class ConsumerStatusReport extends Report<MultiRowResult<Compliance>> {
      */
     @Inject
     public ConsumerStatusReport(I18nProvider i18nProvider, ComplianceSnapshotCurator curator) {
-        super(i18nProvider, "consumer_status_report",
+        super(i18nProvider, "consumer_status",
                 i18nProvider.get().tr("List the status of all consumers"));
         this.complianceSnapshotCurator = curator;
     }

--- a/gutterball/src/main/java/org/candlepin/gutterball/report/ConsumerTrendReport.java
+++ b/gutterball/src/main/java/org/candlepin/gutterball/report/ConsumerTrendReport.java
@@ -41,7 +41,7 @@ public class ConsumerTrendReport extends Report<ConsumerTrendReportResult> {
      */
     @Inject
     public ConsumerTrendReport(I18nProvider i18nProvider, ComplianceSnapshotCurator snapshotCurator) {
-        super(i18nProvider, "consumer_trend_report",
+        super(i18nProvider, "consumer_trend",
                 i18nProvider.get().tr("Lists the status of each consumer over a date range"));
         this.snapshotCurator = snapshotCurator;
     }


### PR DESCRIPTION
Info is redundant with the /report/ in the URI, so may as well shorten it up
and establish a convention before this goes out into the wild.

Ex: /gutterball/reports/consumer_trend_report becomes:
/gutterball/reports/consumer_trend
