### PR TITLE
1150562: Fixed exception in CP when re-registering a pool/product to keys

### DIFF
--- a/server/src/main/java/org/candlepin/model/activationkeys/ActivationKey.java
+++ b/server/src/main/java/org/candlepin/model/activationkeys/ActivationKey.java
@@ -205,6 +205,32 @@ public class ActivationKey extends AbstractHibernateObject implements Owned, Nam
         this.getProductIds().remove(toRemove);
     }
 
+    /**
+     * Checks if the specified product has been added to this activation key.
+     *
+     * @param product
+     *  The product to check
+     *
+     * @throws IllegalArgumentException
+     *  if product is null
+     *
+     * @return
+     *  true if the product has been added to this activation key; false otherwise.
+     */
+    public boolean hasProduct(Product product) {
+        if (product == null) {
+            throw new IllegalArgumentException("product is null");
+        }
+
+        for (ActivationKeyProduct akp : this.getProductIds()) {
+            if (akp.getProductId().equals(product.getId())) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     public void addPool(Pool pool, Long quantity) {
         ActivationKeyPool akp = new ActivationKeyPool(this, pool, quantity);
         this.getPools().add(akp);
@@ -220,6 +246,32 @@ public class ActivationKey extends AbstractHibernateObject implements Owned, Nam
             }
         }
         this.getPools().remove(toRemove);
+    }
+
+    /**
+     * Checks if the specified pool has been added to this activation key.
+     *
+     * @param pool
+     *  The pool to check
+     *
+     * @throws IllegalArgumentException
+     *  if pool is null
+     *
+     * @return
+     *  true if the pool has been added to this activation key; false otherwise.
+     */
+    public boolean hasPool(Pool pool) {
+        if (pool == null) {
+            throw new IllegalArgumentException("pool is null");
+        }
+
+        for (ActivationKeyPool akp : this.getPools()) {
+            if (akp.getPool().getId().equals(pool.getId())) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/server/src/main/java/org/candlepin/resource/ActivationKeyResource.java
+++ b/server/src/main/java/org/candlepin/resource/ActivationKeyResource.java
@@ -183,6 +183,14 @@ public class ActivationKeyResource {
 
         // Throws a BadRequestException if adding pool to key is a bad idea
         activationKeyRules.validatePoolForActKey(key, pool, quantity);
+
+        // Make sure we don't try to register the pool twice.
+        if (key.hasPool(pool)) {
+            throw new BadRequestException(
+                i18n.tr("Pool ID \"{0}\" has already been registered with this activation key", poolId)
+            );
+        }
+
         key.addPool(pool, quantity);
         activationKeyCurator.update(key);
         return key;
@@ -225,6 +233,14 @@ public class ActivationKeyResource {
 
         ActivationKey key = activationKeyCurator.verifyAndLookupKey(activationKeyId);
         Product product = confirmProduct(productId);
+
+        // Make sure we don't try to register the product ID twice.
+        if (key.hasProduct(product)) {
+            throw new BadRequestException(
+                i18n.tr("Product ID \"{0}\" has already been registered with this activation key", productId)
+            );
+        }
+
         key.addProduct(product);
         activationKeyCurator.update(key);
         return key;

--- a/server/src/test/java/org/candlepin/model/ActivationKeyTest.java
+++ b/server/src/test/java/org/candlepin/model/ActivationKeyTest.java
@@ -98,4 +98,40 @@ public class ActivationKeyTest extends DatabaseTestFixture {
         assertTrue("The count of pools should be 1", key.getPools().size() == 1);
         assertEquals(null, key.getPools().iterator().next().getQuantity());
     }
+
+    @Test
+    public void testActivationKeyHasPool() {
+        ActivationKey key = this.createActivationKey(this.owner);
+        Product prod = TestUtil.createProduct();
+        productCurator.create(prod);
+        Pool pool = createPoolAndSub(
+            this.owner,
+            prod,
+            12L,
+            new Date(),
+            new Date(System.currentTimeMillis() + (365 * 24 * 60 * 60 * 1000))
+        );
+
+        assertTrue(!key.hasPool(pool));
+
+        key.addPool(pool, 1L);
+        assertTrue(key.hasPool(pool));
+
+        key.removePool(pool);
+        assertTrue(!key.hasPool(pool));
+    }
+
+    @Test
+    public void testActivationKeyHasProduct() {
+        ActivationKey key = this.createActivationKey(this.owner);
+        Product product = TestUtil.createProduct();
+
+        assertTrue(!key.hasProduct(product));
+
+        key.addProduct(product);
+        assertTrue(key.hasProduct(product));
+
+        key.removeProduct(product);
+        assertTrue(!key.hasProduct(product));
+    }
 }

--- a/server/src/test/java/org/candlepin/resource/ActivationKeyResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/ActivationKeyResourceTest.java
@@ -118,6 +118,27 @@ public class ActivationKeyResourceTest extends DatabaseTestFixture {
     }
 
     @Test(expected = BadRequestException.class)
+    public void testReaddingPools() {
+        ActivationKey key = new ActivationKey();
+        Owner owner = createOwner();
+        Product product = TestUtil.createProduct();
+        productCurator.create(product);
+        Pool pool = createPoolAndSub(owner, product, 10L, new Date(), new Date());
+
+        key.setOwner(owner);
+        key.setName("dd");
+        key = activationKeyCurator.create(key);
+
+        assertNotNull(key.getId());
+
+        activationKeyResource.addPoolToKey(key.getId(), pool.getId(), 1L);
+        assertTrue(key.getPools().size() == 1);
+
+        activationKeyResource.addPoolToKey(key.getId(), pool.getId(), 1L);
+        // ^ Kaboom.
+    }
+
+    @Test(expected = BadRequestException.class)
     public void testActivationKeyWithNonMultiPool() {
         ActivationKey ak = genActivationKey();
         ActivationKeyCurator akc = mock(ActivationKeyCurator.class);
@@ -316,6 +337,44 @@ public class ActivationKeyResourceTest extends DatabaseTestFixture {
         key2.setServiceLevel("level1");
         key2.setReleaseVer(new Release(TestUtil.getStringOfSize(256)));
         key = activationKeyResource.updateActivationKey(key.getId(), key2);
+    }
+
+    @Test
+    public void testAddingRemovingProductIDs() {
+        ActivationKey key = new ActivationKey();
+        Owner owner = createOwner();
+        Product product = TestUtil.createProduct();
+        productCurator.create(product);
+
+        key.setOwner(owner);
+        key.setName("dd");
+        key = activationKeyCurator.create(key);
+
+        assertNotNull(key.getId());
+        activationKeyResource.addProductIdToKey(key.getId(), product.getId());
+        assertTrue(key.getProductIds().size() == 1);
+        activationKeyResource.removeProductIdFromKey(key.getId(), product.getId());
+        assertTrue(key.getProductIds().size() == 0);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void testReaddingProductIDs() {
+        ActivationKey key = new ActivationKey();
+        Owner owner = createOwner();
+        Product product = TestUtil.createProduct();
+        productCurator.create(product);
+
+        key.setOwner(owner);
+        key.setName("dd");
+        key = activationKeyCurator.create(key);
+
+        assertNotNull(key.getId());
+
+        activationKeyResource.addProductIdToKey(key.getId(), product.getId());
+        assertTrue(key.getProductIds().size() == 1);
+
+        activationKeyResource.addProductIdToKey(key.getId(), product.getId());
+        // ^ Kaboom.
     }
 
     private Pool genPool() {


### PR DESCRIPTION
- CP will no longer throw an exception when a client attempts to add a pool
  or product to an activation key multiple times. Instead, a proper error
  message is returned to the client.
