### PR TITLE
1173139: Make responses include the req uuid again

### DIFF
--- a/server/src/main/java/org/candlepin/guice/CandlepinFilterModule.java
+++ b/server/src/main/java/org/candlepin/guice/CandlepinFilterModule.java
@@ -39,7 +39,7 @@ public class CandlepinFilterModule extends ServletModule {
 
         filter("/*").through(CandlepinScopeFilter.class);
         filter("/*").through(CandlepinPersistFilter.class);
-        filter("/*").through(LoggingFilter.class);
+        filter("/*").through(LoggingFilter.class, loggingFilterConfig);
         filter("/*").through(ContentTypeHackFilter.class);
         filter("/*").through(EventFilter.class);
 


### PR DESCRIPTION
LoggingFilter wasn't getting passed it's config when
created, so the 'header.name' config item was never
found so the 'x-candlepin-request-uuid' was not
populated in the http response.
