### PR TITLE
1156576: Fix NPE on hypervisor checkin

### DIFF
--- a/server/spec/hypervisor_check_in_spec.rb
+++ b/server/spec/hypervisor_check_in_spec.rb
@@ -281,6 +281,13 @@ describe 'Hypervisor Resource', :type => :virt do
     end.should raise_exception(RestClient::ResourceNotFound)
   end
 
+  it 'should raise bad request exception if mapping was not provided' do
+    virtwho = create_virtwho_client(@user)
+    lambda do
+      virtwho.hypervisor_check_in(@owner['key'], nil)
+    end.should raise_exception(RestClient::BadRequest)
+  end
+
   def create_virtwho_client(user)
     consumer = user.register(random_string("virt-who"), :system, nil, {},
         nil, nil, [], [{:productId => 'installedprod',

--- a/server/src/main/java/org/candlepin/resource/HypervisorResource.java
+++ b/server/src/main/java/org/candlepin/resource/HypervisorResource.java
@@ -18,6 +18,7 @@ import org.candlepin.auth.Access;
 import org.candlepin.auth.Principal;
 import org.candlepin.auth.SubResource;
 import org.candlepin.auth.interceptor.Verify;
+import org.candlepin.common.exceptions.BadRequestException;
 import org.candlepin.common.exceptions.NotFoundException;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerCurator;
@@ -105,6 +106,12 @@ public class HypervisorResource {
             subResource = SubResource.HYPERVISOR) String ownerKey,
         @QueryParam("create_missing") @DefaultValue("true") boolean createMissing) {
         log.info("Hypervisor check-in by principal: " + principal);
+
+        if (hostGuestMap == null) {
+            log.debug("Host/Guest mapping provided during hypervisor checkin was null.");
+            throw new BadRequestException(
+                i18n.tr("Host to guest mapping was not provided for hypervisor checkin."));
+        }
 
         Owner owner = this.getOwner(ownerKey);
 

--- a/server/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
@@ -27,6 +27,7 @@ import org.candlepin.audit.EventSink;
 import org.candlepin.auth.Access;
 import org.candlepin.auth.SubResource;
 import org.candlepin.auth.UserPrincipal;
+import org.candlepin.common.exceptions.BadRequestException;
 import org.candlepin.config.CandlepinCommonTestConfig;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerCurator;
@@ -305,5 +306,10 @@ public class HypervisorResourceTest {
         String failed = result.getFailedUpdate().iterator().next();
         String expected = "test-host: Unable to find hypervisor in org 'admin'";
         assertEquals(expected, failed);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void ensureBadRequestWhenNoMappingIsIncludedInRequest() {
+        hypervisorResource.hypervisorCheckIn(null, principal, "an-owner", false);
     }
 }


### PR DESCRIPTION
The NPE was occuring if a request was made with an empty body.

This was fixed by checking for a null host to guest mapping
and throwing a BadRequestException. I had considered
equating the null data as an empty mapping and allowing
the request to succeed, but IMO the request should be
made with at least an empty mapping.

**Testing Instructions**
Consider no mapping provided a bad request, but an empty set is Ok.

No mapping provided:

``` bash
$ curl -X POST -H "Content-Type: application/json" -k -u admin:admin -d "" https://localhost:8443/candlepin/hypervisors?owner=admin
{
  "displayMessage" : "Host to guest mapping was not provided for hypervisor checkin.",
  "requestUuid" : "c16dadca-ef0a-44b8-aefe-fe449962e645"
}
```

Empty mapping:

``` bash
$ curl -X POST -H "Content-Type: application/json" -k -u admin:admin -d "{}" https://localhost:8443/candlepin/hypervisors?owner=admin
{
  "created" : [ ],
  "updated" : [ ],
  "unchanged" : [ ],
  "failedUpdate" : [ ]
}
```
