### PR TITLE
1171781: Major performance improvements for list owner pools.

### DIFF
--- a/server/src/main/java/org/candlepin/policy/js/RulesObjectMapper.java
+++ b/server/src/main/java/org/candlepin/policy/js/RulesObjectMapper.java
@@ -133,7 +133,7 @@ public class RulesObjectMapper {
             return mapper.readValue(json, typeref);
         }
         catch (Exception e) {
-            log.error("Error parsing JSON from rules");
+            log.error("Error parsing JSON from rules", e);
             log.error(json);
             throw new IseException("Unable to build object from JSON.", e);
         }

--- a/server/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRules.java
@@ -27,6 +27,7 @@ import org.candlepin.policy.js.ProductCache;
 import org.candlepin.policy.js.RuleExecutionException;
 import org.candlepin.util.DateSource;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.inject.Inject;
 
 import org.slf4j.LoggerFactory;
@@ -34,6 +35,7 @@ import org.xnap.commons.i18n.I18n;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Enforces entitlement rules for normal (non-manifest) consumers.
@@ -103,13 +105,31 @@ public class EntitlementRules extends AbstractEntitlementRules implements Enforc
 
     @Override
     public List<Pool> filterPools(Consumer consumer, List<Pool> pools, boolean showAll) {
-        Consumer host = consumer.hasFact("virt.uuid") ?
-                consumerCurator.getHost(consumer.getFact("virt.uuid"),
-                        consumer.getOwner()) : null;
+        JsonJsContext args = new JsonJsContext(objectMapper);
+        args.put("consumer", consumer);
+        args.put("hostConsumer", consumer.hasFact("virt.uuid") ?
+            this.consumerCurator.getHost(consumer.getFact("virt.uuid"),
+                consumer.getOwner()) : null);
+        args.put("consumerEntitlements", consumer.getEntitlements());
+        args.put("standalone", config.standalone());
+        args.put("pools", pools);
+        args.put("caller", CallerType.LIST_POOLS.getLabel());
+        args.put("log", log, false);
+
+        String json = jsRules.runJsFunction(String.class, "validate_pools_list", args);
+        Map<String, ValidationResult> resultMap;
+        TypeReference<Map<String, ValidationResult>> typeref =
+            new TypeReference<Map<String, ValidationResult>>() {};
+        try {
+            resultMap = objectMapper.toObject(json, typeref);
+        }
+        catch (Exception e) {
+            throw new RuleExecutionException(e);
+        }
 
         List<Pool> filteredPools = new LinkedList<Pool>();
         for (Pool pool : pools) {
-            ValidationResult result = preEntitlement(consumer, host, pool, 0, CallerType.LIST_POOLS);
+            ValidationResult result = resultMap.get(pool.getId());
             finishValidation(result, pool, 1);
 
             if (result.isSuccessful() && (!result.hasWarnings() || showAll)) {

--- a/server/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -761,10 +761,7 @@ public class OwnerResource {
         List<Pool> poolList = page.getPageData();
 
         if (c != null) {
-            for (Pool p : poolList) {
-                p.setCalculatedAttributes(
-                    calculatedAttributesUtil.buildCalculatedAttributes(p, c, activeOnDate));
-            }
+            calculatedAttributesUtil.setCalculatedAttributes(poolList, c, activeOnDate);
         }
 
         // Store the page for the LinkHeaderPostInterceptor

--- a/server/src/main/java/org/candlepin/resource/util/CalculatedAttributesUtil.java
+++ b/server/src/main/java/org/candlepin/resource/util/CalculatedAttributesUtil.java
@@ -27,6 +27,7 @@ import org.xnap.commons.i18n.I18n;
 
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -65,5 +66,32 @@ public class CalculatedAttributesUtil {
             String.valueOf(suggested.getIncrement()));
 
         return attrMap;
+    }
+
+
+    public void setCalculatedAttributes(List<Pool> poolList, Consumer c, Date date) {
+        if (c == null) {
+            return;
+        }
+        Map<String, SuggestedQuantity> results = quantityRules.getSuggestedQuantities(
+                poolList, c, date);
+
+        for (Pool p : poolList) {
+            SuggestedQuantity suggested = results.get(p.getId());
+
+            Map<String, String> attrMap = new HashMap<String, String>();
+
+            PoolComplianceType type = poolTypeRules.getPoolType(p);
+            type.translatePoolType(i18n);
+            attrMap.put("compliance_type", type.getPoolType());
+
+
+            attrMap.put("suggested_quantity",
+                String.valueOf(suggested.getSuggested()));
+            attrMap.put("quantity_increment",
+                String.valueOf(suggested.getIncrement()));
+
+            p.setCalculatedAttributes(attrMap);
+        }
     }
 }

--- a/server/src/main/resources/rules/rules.js
+++ b/server/src/main/resources/rules/rules.js
@@ -1,4 +1,4 @@
-// Version: 5.11
+// Version: 5.12
 
 /*
  * Default Candlepin rule set.
@@ -236,7 +236,7 @@ function createPool(pool) {
     };
 
     pool.getAvailable = function() {
-        return pool.quantity - pool.consumed; 
+        return pool.quantity - pool.consumed;
     };
 
     pool.getInstanceMulti = function() {
@@ -2905,7 +2905,17 @@ var Compliance = {
 var Quantity = {
     get_quantity_context: function() {
         context = JSON.parse(json_context);
-        context.pool = createPool(context.pool);
+
+        if ("pool" in context) {
+            context.pool = createPool(context.pool);
+        }
+
+        if ("pools" in context) {
+            for (var i = 0; i < context.pools.length; i++) {
+                context.pools[i] = createPool(context.pools[i]);
+            }
+        }
+
         if ("validEntitlements" in context) {
             for (var i = 0; i < context.validEntitlements.length; i++) {
                 var e = context.validEntitlements[i];
@@ -2916,10 +2926,30 @@ var Quantity = {
     },
 
     get_suggested_quantity: function() {
-        var context = Quantity.get_quantity_context();
+        context = Quantity.get_quantity_context();
         var pool = context.pool;
         var consumer = context.consumer;
         var validEntitlements = context.validEntitlements;
+        return JSON.stringify(Quantity.get_suggested_quantity_worker(pool, consumer, validEntitlements));
+    },
+
+    /* Multi-pool version of the above for large list pools requests. */
+    get_suggested_quantities: function() {
+        context = Quantity.get_quantity_context();
+        var consumer = context.consumer;
+        var validEntitlements = context.validEntitlements;
+
+        var result_map = {};
+        for (var i = 0; i < context.pools.length; i++) {
+            pool = context.pools[i];
+            var result = Quantity.get_suggested_quantity_worker(pool, consumer, validEntitlements);
+            result_map[pool['id']] = result;
+        }
+        return JSON.stringify(result_map);
+    },
+
+    /* Consider this a "private" worker method, not called by java, used by the other methods we do call from Java. */
+    get_suggested_quantity_worker: function(pool, consumer, validEntitlements) {
 
         var result = {
             suggested: 1,
@@ -2928,7 +2958,7 @@ var Quantity = {
 
         // Distributors increment is always 1, suggested is irrelevant
         if (!Utils.isMultiEnt(pool) || consumer.type.manifest) {
-            return JSON.stringify(result);
+            return result;
         }
 
         if (pool.hasProductAttribute("stacking_id")) {
@@ -2952,7 +2982,7 @@ var Quantity = {
             result.increment = parseInt(pool.getProductAttribute("instance_multiplier"));
         }
 
-        return JSON.stringify(result);
+        return result;
     },
 
     get_suggested_pool_quantity: function(pool, consumer, entitlements) {

--- a/server/src/test/java/org/candlepin/policy/js/quantity/QuantityRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/quantity/QuantityRulesTest.java
@@ -15,7 +15,7 @@
 package org.candlepin.policy.js.quantity;
 
 import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.when;
 
 import org.candlepin.model.Consumer;
 import org.candlepin.model.Entitlement;
@@ -40,6 +40,8 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -82,6 +84,7 @@ public class QuantityRulesTest {
         owner = new Owner("Test Owner " + TestUtil.randomInt());
         product = TestUtil.createProduct();
         pool = TestUtil.createPool(owner, product);
+        pool.setId("fakepoolid");
 
         consumer = TestUtil.createConsumer(owner);
         Entitlement e = TestUtil.createEntitlement(owner, consumer, pool,
@@ -117,6 +120,19 @@ public class QuantityRulesTest {
         pool.setProductAttribute("multi-entitlement", "no", product.getId());
         SuggestedQuantity suggested = quantityRules.getSuggestedQuantity(pool,
             new Consumer(), new Date());
+        assertEquals(new Long(1), suggested.getSuggested());
+    }
+
+    @Test
+    public void testNonMultiEntitlementPoolMultiPool() {
+        pool.setProductAttribute("multi-entitlement", "no", product.getId());
+        List<Pool> pools = new LinkedList<Pool>();
+        pools.add(pool);
+        Map<String, SuggestedQuantity> results =
+                quantityRules.getSuggestedQuantities(pools,
+            new Consumer(), new Date());
+        assertTrue(results.containsKey(pool.getId()));
+        SuggestedQuantity suggested = results.get(pool.getId());
         assertEquals(new Long(1), suggested.getSuggested());
     }
 


### PR DESCRIPTION
With large numbers of pools (~1600) and a consumer with many entitlements
(~350), list owner pools was taking ~50s when filtering for pools applicable
for a specific consumer.

The problem resulted from the use of two rules classes, Entitlement and
Quantity. Each was called once per pool (1600 times), and serializing the
consumer's entitlements each time. (minus the actual entitlement certificate
blob thankfully)

Brought back an old approach for entitlement rules where we make one rules call
to filter all pools. This was backed out in
c7d65e7a6eb9f485959facaf8b19d4a3577a409b for memory usage reasons, but those
were not spawned by any particular bug or error only observation. In the above
scenario, the JSON context is about 3.5mb.

Pursued a similar approach for QuantityRules where we only make one call for
all pools.

End result is about 4s for the same list pools operation, virtually
indistinguishable from the API call without consumer filtering (no rules). The
time is spent serializing the JSON response, about 6.3mb.

This PR is against the 0.9.26-hotfix branch where we need to release this. I'll merge it to master manually after, and also bump the rules version in master again as this one is equal to what we have in master atm.
