### PR TITLE
Fixed GB event status DB upgrade

### DIFF
--- a/gutterball/src/main/resources/db/changelog/2014-12-03-15-39-add-event-status.xml
+++ b/gutterball/src/main/resources/db/changelog/2014-12-03-15-39-add-event-status.xml
@@ -9,10 +9,14 @@
     <changeSet id="20141203153942-1" author="dgoodwin">
         <comment>add event status</comment>
         <addColumn tableName="gb_event">
-            <column name="status" type="varchar(32)">
+            <column name="status" type="varchar(32)" defaultValue="SKIPPED">
                 <constraints nullable="false"/>
             </column>
         </addColumn>
+        <update tableName="gb_event">
+            <column name="status" type="varchar(32)" value="PROCESSED"/>
+            <where>(target='CONSUMER' and (type='DELETED' or type='CREATED')) or (target='COMPLIANCE' and type='CREATED')</where>
+        </update>
     </changeSet>
 
 </databaseChangeLog>


### PR DESCRIPTION
The status column is not null, and can not
be NULL for existing records. Initially default
this value to SKIPPED, and then perform an
update to set the appropriate events to
PROCESSED.
