### PR TITLE
Fixed broken consumer status report query

### DIFF
--- a/gutterball/src/main/java/org/candlepin/gutterball/curator/ConsumerStateCurator.java
+++ b/gutterball/src/main/java/org/candlepin/gutterball/curator/ConsumerStateCurator.java
@@ -59,23 +59,4 @@ public class ConsumerStateCurator extends BaseCurator<ConsumerState> {
         save(consumer);
     }
 
-    public List<String> getConsumerUuidsOnDate(Date targetDate, List<String> ownerKeys, List<String> uuids) {
-        Criteria find = currentSession().createCriteria(ConsumerState.class);
-        if (ownerKeys != null && !ownerKeys.isEmpty()) {
-            find.add(Restrictions.in("ownerKey", ownerKeys));
-        }
-        if (uuids != null && !uuids.isEmpty()) {
-            find.add(Restrictions.in("uuid", uuids));
-        }
-
-        Date toCheck = targetDate == null ? new Date() : targetDate;
-        find.add(Restrictions.or(
-            Restrictions.isNull("deleted"),
-            Restrictions.gt("deleted", toCheck)
-        ));
-        find.add(Restrictions.le("created", toCheck));
-        find.setProjection(Property.forName("uuid"));
-
-        return find.list();
-    }
 }

--- a/gutterball/src/test/java/org/candlepin/gutterball/curator/ConsumerStateCuratorTest.java
+++ b/gutterball/src/test/java/org/candlepin/gutterball/curator/ConsumerStateCuratorTest.java
@@ -15,9 +15,7 @@
 
 package org.candlepin.gutterball.curator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import org.candlepin.gutterball.DatabaseTestFixture;
 import org.candlepin.gutterball.TestUtils;
@@ -25,10 +23,7 @@ import org.candlepin.gutterball.model.ConsumerState;
 
 import org.junit.Test;
 
-import java.util.Arrays;
-import java.util.Calendar;
 import java.util.Date;
-import java.util.List;
 
 public class ConsumerStateCuratorTest extends DatabaseTestFixture {
 
@@ -53,125 +48,6 @@ public class ConsumerStateCuratorTest extends DatabaseTestFixture {
 
         ConsumerState found = consumerStateCurator.findByUuid(uuid);
         assertEquals(deletedOn, found.getDeleted());
-    }
-
-    @Test
-    public void testUuidIncludedWhenNotDeletedAndWasCreatedOnTargetDate() {
-        Calendar cal = getPrimedCalendar();
-        String uuid = TestUtils.randomString("test-consumer-uuid");
-        ConsumerState state = new ConsumerState(uuid, "test-owner", cal.getTime());
-        consumerStateCurator.create(state);
-
-        List<String> uuids = consumerStateCurator.getConsumerUuidsOnDate(cal.getTime(), null, null);
-        assertEquals(1, uuids.size());
-        assertTrue(uuids.contains(state.getUuid()));
-    }
-
-    @Test
-    public void testUuidIncludedWhenNotDeletedAndWasCreatedBeforeTargetDate() {
-        Calendar cal = getPrimedCalendar();
-        String uuid = TestUtils.randomString("test-consumer-uuid");
-        ConsumerState state = new ConsumerState(uuid, "test-owner", cal.getTime());
-        consumerStateCurator.create(state);
-
-        cal.add(Calendar.DAY_OF_MONTH, 1);
-        List<String> uuids = consumerStateCurator.getConsumerUuidsOnDate(cal.getTime(), null, null);
-        assertEquals(1, uuids.size());
-        assertTrue(uuids.contains(state.getUuid()));
-    }
-
-    @Test
-    public void testUuidNotIncludedWhenDeletedBeforeTargetDate() {
-        Calendar cal = getPrimedCalendar();
-        String uuid = TestUtils.randomString("test-consumer-uuid");
-        ConsumerState state = new ConsumerState(uuid, "test-owner", cal.getTime());
-        consumerStateCurator.create(state);
-
-        cal.add(Calendar.DAY_OF_MONTH, 1);
-        consumerStateCurator.setConsumerDeleted(uuid, cal.getTime());
-        assertTrue(consumerStateCurator.getConsumerUuidsOnDate(cal.getTime(), null, null).isEmpty());
-    }
-
-    @Test
-    public void testUuidIncludedWhenTargetDateIsBetweenConsumerCreateAndDeleteDates() {
-        Calendar cal = getPrimedCalendar();
-        String uuid = TestUtils.randomString("test-consumer-uuid");
-        ConsumerState state = new ConsumerState(uuid, "test-owner", cal.getTime());
-        consumerStateCurator.create(state);
-
-        cal.add(Calendar.MONTH, 1);
-        consumerStateCurator.setConsumerDeleted(uuid, cal.getTime());
-
-        cal.add(Calendar.DAY_OF_MONTH, -2);
-        List<String> uuids = consumerStateCurator.getConsumerUuidsOnDate(cal.getTime(), null, null);
-        assertEquals(1, uuids.size());
-        assertTrue(uuids.contains(uuid));
-    }
-
-    @Test
-    public void testConsumerUuidsFilteredByOwner() {
-        Calendar cal = Calendar.getInstance();
-        cal.set(Calendar.YEAR, 2012);
-        cal.set(Calendar.MONTH, Calendar.JANUARY);
-        cal.set(Calendar.DAY_OF_MONTH, 15);
-
-        Date creationDate = cal.getTime();
-
-        cal.add(Calendar.MONTH, 1);
-        Date deletionDate = cal.getTime();
-
-        cal.add(Calendar.MONTH, 1);
-        Date targetDate = cal.getTime();
-
-        // Should be filtered out due to different owner.
-        String filteredUuid = TestUtils.randomString("filtered-consumer-uuid");
-        consumerStateCurator.create(new ConsumerState(filteredUuid, "TO1", creationDate));
-
-        String targetOwnerKey = "TO2";
-        String includedUuid = TestUtils.randomString("included-consumer-uuid");
-        consumerStateCurator.create(new ConsumerState(includedUuid, targetOwnerKey, creationDate));
-
-        // Should not be returned as it is deleted
-        String deletedUuid = TestUtils.randomString("deleted-consumer-uuid");
-        consumerStateCurator.create(new ConsumerState(deletedUuid, targetOwnerKey, creationDate));
-        consumerStateCurator.setConsumerDeleted(deletedUuid, deletionDate);
-
-        List<String> uuids = consumerStateCurator.getConsumerUuidsOnDate(targetDate,
-                Arrays.asList(targetOwnerKey), null);
-        assertEquals(1, uuids.size());
-        assertTrue(uuids.contains(includedUuid));
-    }
-
-    @Test
-    public void testGetConsumerUuidsFilteredByUuids() {
-        Calendar cal = Calendar.getInstance();
-        cal.set(Calendar.YEAR, 2012);
-        cal.set(Calendar.MONTH, Calendar.JANUARY);
-        cal.set(Calendar.DAY_OF_MONTH, 15);
-
-        Date creationDate = cal.getTime();
-
-        cal.add(Calendar.MONTH, 1);
-        Date targetDate = cal.getTime();
-
-        String ownerKey = TestUtils.randomString("owner-key");
-        String expectedUuid = TestUtils.randomString("expected-consumer-uuid");
-
-        consumerStateCurator.create(new ConsumerState(expectedUuid, ownerKey, creationDate));
-        consumerStateCurator.create(new ConsumerState(TestUtils.randomString("not-inculded"), ownerKey,
-                creationDate));
-        List<String> uuids = consumerStateCurator.getConsumerUuidsOnDate(targetDate, null,
-                Arrays.asList(expectedUuid));
-        assertEquals(1, uuids.size());
-        assertTrue(uuids.contains(expectedUuid));
-    }
-
-    private Calendar getPrimedCalendar() {
-        Calendar cal = Calendar.getInstance();
-        cal.set(Calendar.YEAR, 2012);
-        cal.set(Calendar.MONTH, Calendar.JANUARY);
-        cal.set(Calendar.DAY_OF_MONTH, 15);
-        return cal;
     }
 
 }


### PR DESCRIPTION
Postgres has a hard query parameter limit of 32767. Since
the report query had been using an IN criteria of active
consumer uuids, once the active consumer uuid records
passed the 32767 limit, our query would break.

This produced a rather useless error of:
org.postgresql.util.PSQLException: This connection has been closed.

Switching from criteria.list() to criteria.scroll() temporarily,
produced a better error presented itself.

The fix was to remove the IN clause, and incorporate the
'active' check into the overall main query.
