### PR TITLE
Removed unused object reference

### DIFF
--- a/gutterball/src/main/java/org/candlepin/gutterball/curator/ComplianceSnapshotCurator.java
+++ b/gutterball/src/main/java/org/candlepin/gutterball/curator/ComplianceSnapshotCurator.java
@@ -26,7 +26,6 @@ import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
 import org.hibernate.criterion.Subqueries;
 
-import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
@@ -45,12 +44,10 @@ import java.util.TreeMap;
  *
  */
 public class ComplianceSnapshotCurator extends BaseCurator<Compliance> {
-    private ConsumerStateCurator consumerStateCurator;
 
     @Inject
-    public ComplianceSnapshotCurator(ConsumerStateCurator consumerStateCurator) {
+    public ComplianceSnapshotCurator() {
         super(Compliance.class);
-        this.consumerStateCurator = consumerStateCurator;
     }
 
     public List<Compliance> getSnapshotsOnDate(Date targetDate, List<String> consumerUuids,

--- a/gutterball/src/main/java/org/candlepin/gutterball/curator/ConsumerStateCurator.java
+++ b/gutterball/src/main/java/org/candlepin/gutterball/curator/ConsumerStateCurator.java
@@ -20,12 +20,9 @@ import org.candlepin.gutterball.model.ConsumerState;
 import com.google.inject.Inject;
 import com.google.inject.persist.Transactional;
 
-import org.hibernate.Criteria;
-import org.hibernate.criterion.Property;
 import org.hibernate.criterion.Restrictions;
 
 import java.util.Date;
-import java.util.List;
 
 /**
  * A curator responsible for managing {@link ConsumerState} model objects.


### PR DESCRIPTION
ConsumerStateCurator is no longer needed by the
ComplianceSnapshotCurator.

Also fixed some checkstyle issues.