### PR TITLE
Add option to skip dirty certificate regeneration on list entitlements.

### DIFF
--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -1531,6 +1531,7 @@ public class ConsumerResource {
     public List<Entitlement> listEntitlements(
         @PathParam("consumer_uuid") @Verify(Consumer.class) String consumerUuid,
         @QueryParam("product") String productId,
+        @QueryParam("regen") @DefaultValue("true") Boolean regen,
         @Context PageRequest pageRequest) {
 
         Consumer consumer = consumerCurator.verifyAndLookupConsumer(consumerUuid);
@@ -1555,7 +1556,13 @@ public class ConsumerResource {
         for (Entitlement ent : returnedEntitlements) {
             addCalculatedAttributes(ent);
         }
-        poolManager.regenerateDirtyEntitlements(returnedEntitlements);
+
+        if (regen) {
+            poolManager.regenerateDirtyEntitlements(returnedEntitlements);
+        }
+        else {
+            log.debug("Skipping certificate regeneration.");
+        }
 
         return returnedEntitlements;
     }

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -1443,8 +1443,7 @@ public class ConsumerResource {
                 throw cvce;
             }
             catch (RuntimeException re) {
-                log.warn("Unable to attach a subscription for a product that " +
-                    "has no pool: {}", re.getMessage());
+                log.error("Autobind error", re);
             }
         }
 

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
@@ -14,10 +14,7 @@
  */
 package org.candlepin.resource;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 
 import org.candlepin.auth.Access;
@@ -371,7 +368,7 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
         consumerResource.unbindBySerial(consumer.getUuid(), serials.get(0)
             .getSerial().getId());
         assertEquals(0,
-            consumerResource.listEntitlements(consumer.getUuid(), null, null).size());
+            consumerResource.listEntitlements(consumer.getUuid(), null, true, null).size());
     }
 
     @Test(expected = NotFoundException.class)
@@ -496,7 +493,7 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
         securityInterceptor.enable();
 
         assertEquals(3,
-            consumerResource.listEntitlements(consumer.getUuid(), null, null).size());
+            consumerResource.listEntitlements(consumer.getUuid(), null, true, null).size());
     }
 
     @Test(expected = NotFoundException.class)
@@ -515,7 +512,7 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
         setupPrincipal(new ConsumerPrincipal(evilConsumer));
         securityInterceptor.enable();
 
-        consumerResource.listEntitlements(consumer.getUuid(), null, null);
+        consumerResource.listEntitlements(consumer.getUuid(), null, true, null);
     }
 
     @Test(expected = NotFoundException.class)
@@ -533,7 +530,7 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
         securityInterceptor.enable();
         setupPrincipal(evilOwner, Access.ALL);
 
-        consumerResource.listEntitlements(consumer.getUuid(), null, null);
+        consumerResource.listEntitlements(consumer.getUuid(), null, true, null);
     }
 
     @Test
@@ -548,7 +545,7 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
         securityInterceptor.enable();
 
         assertEquals(3,
-            consumerResource.listEntitlements(consumer.getUuid(), null, null).size());
+            consumerResource.listEntitlements(consumer.getUuid(), null, true, null).size());
     }
 
     @Test


### PR DESCRIPTION
Deadlocks are occurring in certain situations where we do a mass bind involving modifier entitlements, followed by several simultaneous requests to list entitlements. Each list call attempts
to regenerate entitlement certs, which do not technically need to be
regenerated at this point.

Allow the caller to specify that they wish to skip regeneration of any dirty
entitlements.

This is a short term fix, we may with to pursue something better longterm, but
this is a quick gain for hosted scenarios.