### PR TITLE
Virt-Who Checkin Performance Improvements

### DIFF
--- a/common/src/main/java/org/candlepin/common/filter/ServletLogger.java
+++ b/common/src/main/java/org/candlepin/common/filter/ServletLogger.java
@@ -90,7 +90,7 @@ public class ServletLogger {
         return new StringBuilder().append("Response: status=")
                 .append(resp.getStatus())
                 .append(", content-type=\"").append(resp.getContentType())
-                .append("\", time=").append(duration).append("ms");
+                .append("\", time=").append(duration);
     }
 
     public static boolean showAsText(String contentType) {

--- a/server/src/main/java/org/candlepin/model/VirtConsumerMap.java
+++ b/server/src/main/java/org/candlepin/model/VirtConsumerMap.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.model;
+
+import org.candlepin.util.Util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Maintains a mapping of virt UUIDs to Candlepin Consumers.
+ *
+ * Virt UUID could be either a guest or hypervisor ID. Helps to perform lookups
+ * involving endianness discrepancies and account for differences in case of the UUID.
+ */
+public class VirtConsumerMap {
+
+    private static Logger log = LoggerFactory.getLogger(VirtConsumerMap.class);
+
+    private Map<String, Consumer> virtUuidToConsumerMap;
+
+    public VirtConsumerMap() {
+        virtUuidToConsumerMap = new HashMap<String, Consumer>();
+    }
+
+
+    public void add(String virtUuid, Consumer consumer) {
+        // Assumes caller has already sorted by updated date (desc), so if we already have
+        // this virt UUID, just skip the later one.
+        if (virtUuidToConsumerMap.containsKey(virtUuid)) {
+            return;
+        }
+        virtUuidToConsumerMap.put(virtUuid, consumer);
+    }
+
+    /**
+     * Return the consumer for the given virt UUID, should one exist.
+     *
+     * Will check both uuid as given, lower case, and lower case with endianness swapped.
+     *
+     * @param virtUuid
+     * @return Consumer mapping to the given virt UUID, or none if none exists.
+     */
+    public Consumer get(String virtUuid) {
+        if (virtUuidToConsumerMap.containsKey(virtUuid)) {
+            return virtUuidToConsumerMap.get(virtUuid);
+        }
+
+        String virtUuidLower = virtUuid.toLowerCase();
+        if (virtUuidToConsumerMap.containsKey(virtUuidLower)) {
+            return virtUuidToConsumerMap.get(virtUuidLower);
+        }
+
+        String virtUuidLowerEndian = Util.transformUuid(virtUuidLower);
+        if (virtUuidToConsumerMap.containsKey(virtUuidLowerEndian)) {
+            return virtUuidToConsumerMap.get(virtUuidLowerEndian);
+        }
+
+        return null;
+    }
+
+    public int size() {
+        return virtUuidToConsumerMap.keySet().size();
+    }
+
+}

--- a/server/src/main/java/org/candlepin/resource/GuestIdResource.java
+++ b/server/src/main/java/org/candlepin/resource/GuestIdResource.java
@@ -27,6 +27,7 @@ import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerCurator;
 import org.candlepin.model.GuestId;
 import org.candlepin.model.GuestIdCurator;
+import org.candlepin.model.VirtConsumerMap;
 import org.candlepin.paging.Page;
 import org.candlepin.paging.PageRequest;
 
@@ -37,6 +38,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xnap.commons.i18n.I18n;
 
+import java.util.LinkedList;
 import java.util.List;
 
 import javax.ws.rs.DELETE;
@@ -141,7 +143,18 @@ public class GuestIdResource {
         Consumer consumer = new Consumer();
         consumer.setGuestIds(guestIds);
 
-        if (consumerResource.performConsumerUpdates(consumer, toUpdate)) {
+        List<String> allGuestIds = new LinkedList<String>();
+        for (GuestId gid : consumer.getGuestIds()) {
+            allGuestIds.add(gid.getGuestId());
+        }
+        VirtConsumerMap guestConsumerMap = consumerCurator.getGuestConsumersMap(
+                toUpdate.getOwner(), allGuestIds);
+
+        VirtConsumerMap guestsHostConsumerMap = consumerCurator.getGuestsHostMap(
+                toUpdate.getOwner(), allGuestIds);
+
+        if (consumerResource.performConsumerUpdates(consumer, toUpdate,
+                guestConsumerMap, guestsHostConsumerMap)) {
             consumerCurator.update(toUpdate);
         }
     }

--- a/server/src/main/java/org/candlepin/resource/HypervisorResource.java
+++ b/server/src/main/java/org/candlepin/resource/HypervisorResource.java
@@ -28,6 +28,7 @@ import org.candlepin.model.GuestId;
 import org.candlepin.model.HypervisorId;
 import org.candlepin.model.Owner;
 import org.candlepin.model.OwnerCurator;
+import org.candlepin.model.VirtConsumerMap;
 import org.candlepin.resource.dto.HypervisorCheckInResult;
 
 import com.google.inject.Inject;
@@ -38,6 +39,7 @@ import org.slf4j.LoggerFactory;
 import org.xnap.commons.i18n.I18n;
 
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -115,32 +117,55 @@ public class HypervisorResource {
 
         Owner owner = this.getOwner(ownerKey);
 
+        // Maps virt hypervisor ID to registered consumer for that hypervisor, should one exist:
+        VirtConsumerMap hypervisorConsumersMap =
+                consumerCurator.getHostConsumersMap(owner, hostGuestMap.keySet());
+
+        List<String> allGuestIds = new LinkedList<String>();
+        for (Entry<String, List<GuestId>> hostEntry : hostGuestMap.entrySet()) {
+            for (GuestId gid : hostEntry.getValue()) {
+                allGuestIds.add(gid.getGuestId());
+            }
+        }
+        // Maps virt guest ID to registered consumer for guest, if one exists:
+        VirtConsumerMap guestConsumersMap = consumerCurator.getGuestConsumersMap(
+                owner, allGuestIds);
+
+        // Maps virt guest ID to registered consumer for hypervisor, if one exists:
+        VirtConsumerMap guestHypervisorConsumers = consumerCurator.
+                getGuestsHostMap(owner, allGuestIds);
+
         HypervisorCheckInResult result = new HypervisorCheckInResult();
         for (Entry<String, List<GuestId>> hostEntry : hostGuestMap.entrySet()) {
+            String hypervisorId = hostEntry.getKey();
             try {
-                log.info("Syncing virt host: " + hostEntry.getKey() +
+                log.info("Syncing virt host: " + hypervisorId +
                         " (" + hostEntry.getValue().size() + " guest IDs)");
 
                 boolean hostConsumerCreated = false;
                 // Attempt to find a consumer for the given hypervisorId
-                Consumer consumer =
-                    consumerCurator.getHypervisor(hostEntry.getKey(), owner);
-                if (consumer == null) {
+                Consumer consumer = null;
+                if (hypervisorConsumersMap.get(hypervisorId) == null) {
                     if (!createMissing) {
                         log.info("Unable to find hypervisor with id " +
-                            hostEntry.getKey() + " in org " + ownerKey);
-                        result.failed(hostEntry.getKey(), i18n.tr(
+                            hypervisorId + " in org " + ownerKey);
+                        result.failed(hypervisorId, i18n.tr(
                             "Unable to find hypervisor in org ''{0}''", ownerKey));
                         continue;
                     }
-                    log.info("Registering new host consumer");
+                    log.info("Registering new host consumer for hypervisor ID: {}",
+                            hypervisorId);
                     // Create new consumer
                     consumer = createConsumerForHypervisorId(
-                        hostEntry.getKey(), owner, principal);
+                        hypervisorId, owner, principal);
                     hostConsumerCreated = true;
                 }
+                else {
+                    consumer = hypervisorConsumersMap.get(hypervisorId);
+                }
 
-                boolean guestIdsUpdated = addGuestIds(consumer, hostEntry.getValue());
+                boolean guestIdsUpdated = addGuestIds(consumer, hostEntry.getValue(),
+                        guestConsumersMap, guestHypervisorConsumers);
 
                 // Populate the result with the processed consumer.
                 if (hostConsumerCreated) {
@@ -155,7 +180,7 @@ public class HypervisorResource {
             }
             catch (Exception e) {
                 log.error("Hypervisor checkin failed", e);
-                result.failed(hostEntry.getKey(), e.getMessage());
+                result.failed(hypervisorId, e.getMessage());
             }
         }
         return result;
@@ -177,11 +202,14 @@ public class HypervisorResource {
      * Add a list of guestIds to the given consumer,
      * return whether or not there was any change
      */
-    private boolean addGuestIds(Consumer consumer, List<GuestId> guestIds) {
+    private boolean addGuestIds(Consumer consumer, List<GuestId> guestIds,
+            VirtConsumerMap guestConsumerMap,
+            VirtConsumerMap guestHypervisorConsumers) {
         Consumer withIds = new Consumer();
         withIds.setGuestIds(guestIds);
         boolean guestIdsUpdated =
-            consumerResource.performConsumerUpdates(withIds, consumer);
+            consumerResource.performConsumerUpdates(withIds, consumer,
+                    guestConsumerMap, guestHypervisorConsumers);
         if (guestIdsUpdated) {
             consumerCurator.update(consumer);
         }

--- a/server/src/main/java/org/candlepin/resource/HypervisorResource.java
+++ b/server/src/main/java/org/candlepin/resource/HypervisorResource.java
@@ -118,7 +118,8 @@ public class HypervisorResource {
         HypervisorCheckInResult result = new HypervisorCheckInResult();
         for (Entry<String, List<GuestId>> hostEntry : hostGuestMap.entrySet()) {
             try {
-                log.info("Checking virt host: " + hostEntry.getKey());
+                log.info("Syncing virt host: " + hostEntry.getKey() +
+                        " (" + hostEntry.getValue().size() + " guest IDs)");
 
                 boolean hostConsumerCreated = false;
                 // Attempt to find a consumer for the given hypervisorId

--- a/server/src/main/java/org/candlepin/util/Util.java
+++ b/server/src/main/java/org/candlepin/util/Util.java
@@ -388,16 +388,18 @@ public class Util {
      * this should return a list of length 1, with the given value.  All values
      * returned should be lower case
      */
-    public static List<String> getPossibleUuids(String id) {
-        if (id != null) {
-            // We want to use lower case everywhere we can in order
-            // to do less work at query time.
-            id = id.toLowerCase();
-        }
+    public static List<String> getPossibleUuids(String... ids) {
         List<String> results = new LinkedList<String>();
-        results.add(id);
-        if (isUuid(id)) {
-            results.add(transformUuid(id));
+        for (String id : ids) {
+            if (id != null) {
+                // We want to use lower case everywhere we can in order
+                // to do less work at query time.
+                id = id.toLowerCase();
+            }
+            results.add(id);
+            if (isUuid(id)) {
+                results.add(transformUuid(id));
+            }
         }
         return results;
     }

--- a/server/src/test/java/org/candlepin/resource/GuestIdResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/GuestIdResourceTest.java
@@ -14,10 +14,8 @@
  */
 package org.candlepin.resource;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.when;
 
 import org.candlepin.audit.EventFactory;
@@ -32,6 +30,7 @@ import org.candlepin.model.ConsumerType.ConsumerTypeEnum;
 import org.candlepin.model.GuestId;
 import org.candlepin.model.GuestIdCurator;
 import org.candlepin.model.Owner;
+import org.candlepin.model.VirtConsumerMap;
 import org.candlepin.paging.Page;
 import org.candlepin.paging.PageRequest;
 import org.candlepin.util.ServiceLevelValidator;
@@ -135,11 +134,13 @@ public class GuestIdResourceTest {
         List<GuestId> guestIds = new LinkedList<GuestId>();
         guestIds.add(new GuestId("1"));
         when(consumerResource.performConsumerUpdates(any(Consumer.class),
-            eq(consumer))).thenReturn(true);
+            eq(consumer), any(VirtConsumerMap.class), any(VirtConsumerMap.class))).
+            thenReturn(true);
 
         guestIdResource.updateGuests(consumer.getUuid(), guestIds);
         Mockito.verify(consumerResource, Mockito.times(1))
-            .performConsumerUpdates(any(Consumer.class), eq(consumer));
+            .performConsumerUpdates(any(Consumer.class), eq(consumer),
+                    any(VirtConsumerMap.class), any(VirtConsumerMap.class));
         // consumerResource returned true, so the consumer should be updated
         Mockito.verify(consumerCurator, Mockito.times(1)).update(eq(consumer));
     }
@@ -151,11 +152,13 @@ public class GuestIdResourceTest {
 
         // consumerResource tells us nothing changed
         when(consumerResource.performConsumerUpdates(any(Consumer.class),
-            eq(consumer))).thenReturn(false);
+            eq(consumer), any(VirtConsumerMap.class), any(VirtConsumerMap.class))).
+            thenReturn(false);
 
         guestIdResource.updateGuests(consumer.getUuid(), guestIds);
         Mockito.verify(consumerResource, Mockito.times(1))
-            .performConsumerUpdates(any(Consumer.class), eq(consumer));
+            .performConsumerUpdates(any(Consumer.class), eq(consumer),
+                    any(VirtConsumerMap.class), any(VirtConsumerMap.class));
         Mockito.verify(consumerCurator, Mockito.never()).update(eq(consumer));
     }
 
@@ -273,10 +276,6 @@ public class GuestIdResourceTest {
             super(null, null, null, null, null, null, null, null, null,
                   null, null, null, null, null, null, null, null, null,
                   null, null, null, null, null, null, null, null, null, null);
-        }
-
-        public boolean performConsumerUpdates(Consumer updated, Consumer toUpdate) {
-            return true;
         }
 
         public void revokeGuestEntitlementsNotMatchingHost(Consumer host, Consumer guest) {


### PR DESCRIPTION
virt-who checkins are easily blowing past the 60 second timeout that will occur with both virt-who or subscription-manager. Approx 150 hypervisors each with 15 guests is about enough to do it, in my system this was taking around 50s. 

Problem boiled down to looking up the host consumer record for every hypervisor record, and then two more queries to lookup the guest consumer and it's latest host for each guest ID on each hypervisor.

Fixed by batching up the requests and passing them in memory, so we lookup hypervisor consumers for all hypervisors in the checkin, and similarly the guest and host consumers for all guest IDs. These three large queries vs ~4500 small queries results in a close to 10x performance improvement. (50 -> 7s on my system with the sample data mentioned above)

Added a DTO for managing the intricacies of virt UUID casing and endianness when mapping these to their consumer records.