### PR TITLE
GB: Return correct gutterball version info

### DIFF
--- a/gutterball/src/main/java/org/candlepin/gutterball/model/Status.java
+++ b/gutterball/src/main/java/org/candlepin/gutterball/model/Status.java
@@ -14,10 +14,7 @@
  */
 package org.candlepin.gutterball.model;
 
-import org.candlepin.common.config.Configuration;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.inject.Inject;
 
 import org.xnap.commons.i18n.I18n;
 
@@ -33,19 +30,22 @@ import javax.xml.bind.annotation.XmlRootElement;
 @XmlAccessorType(XmlAccessType.PROPERTY)
 public class Status {
 
-    // TODO can we inject version directly from the configuration?
     private String version;
+    private String release;
     private String requestLocale;
 
-    @Inject
-    public Status(Provider<I18n> i18nProvider, Configuration config) {
-        version = config.getString("gutterball.version", i18nProvider.get().tr("Unknown"));
+    public Status(Provider<I18n> i18nProvider, String ver, String rel) {
         requestLocale = i18nProvider.get().getLocale().toString();
+        version = ver;
+        release = rel;
     }
 
-    @JsonProperty("gutterball.version")
     public String getVersion() {
         return version;
+    }
+
+    public String getRelease() {
+        return release;
     }
 
     @JsonProperty("request_locale")

--- a/gutterball/src/main/java/org/candlepin/gutterball/resource/StatusResource.java
+++ b/gutterball/src/main/java/org/candlepin/gutterball/resource/StatusResource.java
@@ -15,9 +15,15 @@
 package org.candlepin.gutterball.resource;
 
 import org.candlepin.common.auth.SecurityHole;
+import org.candlepin.common.util.VersionUtil;
 import org.candlepin.gutterball.model.Status;
 
+import org.xnap.commons.i18n.I18n;
+
+import java.util.Map;
+
 import javax.inject.Inject;
+import javax.inject.Provider;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -29,17 +35,23 @@ import javax.ws.rs.core.MediaType;
 @Path("status")
 public class StatusResource {
 
-    private Status status;
+    private Provider<I18n> i18nProvider;
+    private String version;
+    private String release;
 
     @Inject
-    public StatusResource(Status status) {
-        this.status = status;
+    public StatusResource(Provider<I18n> provider) {
+        i18nProvider = provider;
+
+        Map<String, String> versionMap = VersionUtil.getVersionMap();
+        version = versionMap.get("version");
+        release = versionMap.get("release");
     }
 
     @GET
     @Produces({ MediaType.APPLICATION_JSON })
     @SecurityHole(anon = true)
     public Status getStatus() {
-        return status;
+        return new Status(i18nProvider, version, release);
     }
 }


### PR DESCRIPTION
Version/Release version was coming from the config file. We were all setup to pull from version.properties so this PR does that instead.