### PR TITLE
Update logging to debug issues with lock wait timeouts.

### DIFF
--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -783,9 +783,11 @@ public class CandlepinPoolManager implements PoolManager {
         // pool
         // when it was read. As such we're going to reload it with a lock
         // before starting this process.
+        log.info("Locking pool: " + pool.getId());
         pool = poolCurator.lockAndLoad(pool);
 
         if (quantity > 0) {
+            log.info("Running pre-entitlement rules.");
             // XXX preEntitlement is run twice for new entitlement creation
             ValidationResult result = enforcer.preEntitlement(
                 consumer, pool, quantity, caller);
@@ -804,9 +806,11 @@ public class CandlepinPoolManager implements PoolManager {
             handler = new UpdateHandler();
         }
 
+        log.info("Processing entitlement.");
         entitlement = handler.handleEntitlement(consumer, pool, entitlement, quantity);
         // Persist the entitlement after it has been created.  It requires an ID in order to
         // create an entitlement-derived subpool
+        log.info("Persisting entitlement.");
         handler.handleEntitlementPersist(entitlement);
 
         // The quantity is calculated at fetch time. We update it here
@@ -863,7 +867,9 @@ public class CandlepinPoolManager implements PoolManager {
         Pool pool, Entitlement e, boolean generateUeberCert) {
         Subscription sub = null;
         if (pool.getSubscriptionId() != null) {
+            log.info("Getting subscription: " + pool.getSubscriptionId());
             sub = subAdapter.getSubscription(pool.getSubscriptionId());
+            log.info("Got subscription");
         }
 
         Product product = null;

--- a/server/src/main/java/org/candlepin/controller/Entitler.java
+++ b/server/src/main/java/org/candlepin/controller/Entitler.java
@@ -75,6 +75,7 @@ public class Entitler {
 
     public List<Entitlement> bindByPool(String poolId, Consumer consumer,
         Integer quantity) {
+        log.info("Looking up pool to bind: " + poolId);
         Pool pool = poolManager.find(poolId);
         List<Entitlement> entitlementList = new LinkedList<Entitlement>();
 

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -578,6 +578,9 @@ public class ConsumerResource {
                 change = true;
             }
         }
+        if (change) {
+            log.info("Capabilities changed.");
+        }
         return change;
     }
 
@@ -820,7 +823,7 @@ public class ConsumerResource {
 
         if (updated.getContentTags() != null &&
             !updated.getContentTags().equals(toUpdate.getContentTags())) {
-            log.debug("   Updating consumer content tags.");
+            log.info("   Updating content tags.");
             toUpdate.setContentTags(updated.getContentTags());
             changesMade = true;
         }
@@ -828,7 +831,7 @@ public class ConsumerResource {
         // Allow optional setting of the autoheal attribute:
         if (updated.isAutoheal() != null &&
              !updated.isAutoheal().equals(toUpdate.isAutoheal())) {
-            log.debug("   Updating consumer autoheal setting.");
+            log.info("   Updating consumer autoheal setting.");
             toUpdate.setAutoheal(updated.isAutoheal());
             changesMade = true;
         }
@@ -836,7 +839,7 @@ public class ConsumerResource {
         if (updated.getReleaseVer() != null &&
             (updated.getReleaseVer().getReleaseVer() != null) &&
             !updated.getReleaseVer().equals(toUpdate.getReleaseVer())) {
-            log.debug("   Updating consumer releaseVer setting.");
+            log.info("   Updating consumer releaseVer setting.");
             toUpdate.setReleaseVer(updated.getReleaseVer());
             changesMade = true;
         }
@@ -845,7 +848,7 @@ public class ConsumerResource {
         String level = updated.getServiceLevel();
         if (level != null &&
             !level.equals(toUpdate.getServiceLevel())) {
-            log.debug("   Updating consumer service level setting.");
+            log.info("   Updating consumer service level setting.");
             consumerBindUtil.validateServiceLevel(toUpdate.getOwner(), level);
             toUpdate.setServiceLevel(level);
             changesMade = true;
@@ -860,6 +863,7 @@ public class ConsumerResource {
                 throw new NotFoundException(i18n.tr(
                     "Environment with ID ''{0}'' could not be found.", environmentId));
             }
+            log.info("Updating environment to: " + environmentId);
             toUpdate.setEnvironment(e);
 
             // lazily regenerate certs, so the client can still work
@@ -871,6 +875,9 @@ public class ConsumerResource {
         // it should remain the same
         if (updated.getName() != null && !toUpdate.getName().equals(updated.getName())) {
             checkConsumerName(updated);
+
+            log.info("Updating consumer name: {} -> {}",
+                    toUpdate.getName(), updated.getName());
             toUpdate.setName(updated.getName());
 
             // get the new name into the id cert
@@ -879,6 +886,8 @@ public class ConsumerResource {
         }
 
         if (updated.getLastCheckin() != null) {
+            log.info("Updating to specific last checkin time: {}",
+                    updated.getLastCheckin());
             toUpdate.setLastCheckin(updated.getLastCheckin());
             changesMade = true;
         }
@@ -938,7 +947,7 @@ public class ConsumerResource {
             return false;
         }
         else if (!existing.factsAreEqual(incoming)) {
-            log.debug("Updating consumer facts.");
+            log.info("Updating facts.");
             existing.setFacts(incoming.getFacts());
             return true;
         }
@@ -962,7 +971,7 @@ public class ConsumerResource {
             return false;
         }
         else if (!existing.getInstalledProducts().equals(incoming.getInstalledProducts())) {
-            log.debug("Updating installed products.");
+            log.info("Updating installed products.");
             existing.getInstalledProducts().clear();
             for (ConsumerInstalledProduct cip : incoming.getInstalledProducts()) {
                 existing.addInstalledProduct(cip);
@@ -994,7 +1003,7 @@ public class ConsumerResource {
             return false;
         }
 
-        log.debug("Updating consumer's guest IDs.");
+        log.info("Updating {} guest IDs.", incoming.getGuestIds().size());
         List<GuestId> removedGuests = getRemovedGuestIds(existing, incoming);
         List<GuestId> addedGuests = getAddedGuestIds(existing, incoming);
 
@@ -1002,10 +1011,9 @@ public class ConsumerResource {
         if (existing.getGuestIds() != null) {
             // Always clear existing id so that the timestamps are updated
             // on each ID.
+            log.info("Clearing previous IDs.");
             existing.getGuestIds().clear();
         }
-
-        log.debug("Updating guest entitlements.");
 
         // Check guests that are existing/added.
         for (GuestId guestId : incoming.getGuestIds()) {
@@ -1020,7 +1028,7 @@ public class ConsumerResource {
             // If adding a new GuestId send notification.
             if (addedGuests.contains(guestId)) {
                 if (log.isDebugEnabled()) {
-                    log.debug("New guest ID added: {}", guestId.getGuestId());
+                    log.info("New guest ID added: {}", guestId.getGuestId());
                 }
                 sink.queueEvent(eventFactory.guestIdCreated(guestId));
             }
@@ -1057,7 +1065,7 @@ public class ConsumerResource {
         for (GuestId guestId : removedGuests) {
             // Report that the guestId was removed.
             if (log.isDebugEnabled()) {
-                log.debug("Guest ID removed: {}", guestId.getGuestId());
+                log.info("Guest ID removed: {}", guestId.getGuestId());
             }
             sink.queueEvent(eventFactory.guestIdDeleted(guestId));
 

--- a/server/src/main/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapter.java
+++ b/server/src/main/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapter.java
@@ -343,9 +343,7 @@ public class DefaultEntitlementCertServiceAdapter extends
         Subscription sub, Product product, boolean thisIsUeberCert)
         throws GeneralSecurityException, IOException {
 
-        log.debug("Generating entitlement cert for:");
-        log.debug("   consumer: {}", entitlement.getConsumer().getUuid());
-        log.debug("   product: {}" , product.getId());
+        log.info("Generating entitlement cert.");
 
         KeyPair keyPair = keyPairCurator.getConsumerKeyPair(entitlement.getConsumer());
         CertificateSerial serial = new CertificateSerial(entitlement.getEndDate());
@@ -361,6 +359,7 @@ public class DefaultEntitlementCertServiceAdapter extends
         // is available in the upstream certificate.
         products.addAll(getDerivedProductsForDistributor(sub, entitlement));
 
+        log.info("Creating X509 cert.");
         X509Certificate x509Cert = createX509Certificate(entitlement,
             product, products, BigInteger.valueOf(serial.getId()), keyPair,
             !thisIsUeberCert);
@@ -373,6 +372,7 @@ public class DefaultEntitlementCertServiceAdapter extends
         Map<String, EnvironmentContent> promotedContent = getPromotedContent(entitlement);
         String contentPrefix = getContentPrefix(entitlement, !thisIsUeberCert);
 
+        log.info("Getting PEM encoded cert.");
         String pem = new String(this.pki.getPemEncoded(x509Cert));
 
         if (shouldGenerateV3(entitlement)) {
@@ -400,6 +400,7 @@ public class DefaultEntitlementCertServiceAdapter extends
             log.debug("Cert: " + cert.getCert());
         }
 
+        log.info("Persisting cert.");
         entitlement.getCertificates().add(cert);
         entCertCurator.create(cert);
         return cert;


### PR DESCRIPTION
Slight increase in logging for consumer updated and binds. These do not
necessarily have to be permanent but will hopefully help identify slow portions
of bind, and give some insight into what's happening in consumer updates where
we're lock wait timing out.