### PR TITLE
1153375: make dev deploys disable sslv3 by default

### DIFF
--- a/server/bin/update-server-xml.py
+++ b/server/bin/update-server-xml.py
@@ -138,7 +138,7 @@ class SslContextEditor(AbstractBaseEditor):
             # Note SSLv3 is not included, to avoid poodle
             # For the time being, TLSv1 needs to stay enabled to support
             # existing python-rhsm based clients.
-            ("sslEnabledProtocol", "TLSv1.2,TLSv1.1,TLSv1"),
+            ("sslEnabledProtocols", "TLSv1.2,TLSv1.1,TLSv1"),
             ("SSLProtocol", "TLS"),
             ("keystoreFile", "conf/keystore"),
             ("truststoreFile", "conf/keystore"),


### PR DESCRIPTION
There was a typo in the config stanza, 'sslEnabledProtocol'
vs 'sslEnabledProcotols', the former is ignored.