### PR TITLE
Provide bridge to adapt Log4J to SLF4J.

### DIFF
--- a/buildfile
+++ b/buildfile
@@ -73,7 +73,9 @@ LOGBACK = [group('logback-core', 'logback-classic',
 
 # Artifacts that bridge other logging frameworks to slf4j. Mime4j uses
 # JCL for example.
-SLF4J_BRIDGES = 'org.slf4j:jcl-over-slf4j:jar:1.7.5'
+SLF4J_BRIDGES = [group('jcl-over-slf4j', 'log4j-over-slf4j',
+                       :under => 'org.slf4j',
+                       :version => '1.7.5')]
 SLF4J = 'org.slf4j:slf4j-api:jar:1.7.5'
 
 LOGGING = [LOGBACK, SLF4J_BRIDGES, SLF4J]


### PR DESCRIPTION
Candlepin proper uses SLF4J, but some of the third-party libraries
(e.g. Hibernate) use Log4J instead.  Since Candlepin does not configure
Log4J, the Hibernate logging messages get lost.  By providing a bridge
between Log4J and SLF4J, we can record logging messages from Log4J.

To test:

1. Add "log4j.logger.org.hibernate.SQL=DEBUG" to /etc/candlepin/candlepin.conf.  If you are using autoconf, you can do this easily be editing custom.yaml to look something like

```yaml
candlepin.conf:
  custom_logging:
    "org.hibernate.SQL": "DEBUG"
```

2. Deploy the current master and import test data.  Note that Hibernate does not log any SQL.
3. Deploy this branch and import test data.  Hibernate will now display SQL.

