### PR TITLE
Use minimized DTO for report defaults

### DIFF
--- a/gutterball/src/main/java/org/candlepin/gutterball/report/ComplianceTransformerIterator.java
+++ b/gutterball/src/main/java/org/candlepin/gutterball/report/ComplianceTransformerIterator.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package org.candlepin.gutterball.report;
+
+import org.candlepin.gutterball.model.snapshot.Compliance;
+
+import java.util.Iterator;
+
+
+/**
+ * An iterator that transforms Compliance records into objects of type T as we iterate through them.
+ * This class wraps an iterator of Compliance objects that typically come from the DB.
+ *
+ * @param <T> the type of object this iterator converts a Compliance snapshot into.
+ */
+public abstract class ComplianceTransformerIterator<T> implements Iterator<T>, ReportResult {
+
+    protected Iterator<Compliance> dbIterator;
+
+    public ComplianceTransformerIterator(Iterator<Compliance> dbIterator) {
+        this.dbIterator = dbIterator;
+    }
+
+    @Override
+    public boolean hasNext() {
+        return dbIterator.hasNext();
+    }
+
+    @Override
+    public T next() {
+        return convertDbObject(dbIterator.next());
+    }
+
+    @Override
+    public void remove() {
+        throw new UnsupportedOperationException("The remove operation is not supported on " +
+                "IterableReportResult instances.");
+    }
+
+    abstract T convertDbObject(Compliance compliance);
+}

--- a/gutterball/src/main/java/org/candlepin/gutterball/report/ConsumerStatusReportDefaultResult.java
+++ b/gutterball/src/main/java/org/candlepin/gutterball/report/ConsumerStatusReportDefaultResult.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package org.candlepin.gutterball.report;
+
+import org.candlepin.gutterball.model.snapshot.Compliance;
+import org.candlepin.gutterball.report.dto.ConsumerStatusComplianceDto;
+
+import java.util.Iterator;
+
+/**
+ * Represents the default ConsumerStatusReport results. An instance of this class wraps an iterator of
+ * Compliance records that come from the database, so that each Compliance record can be transformed
+ * into a minimal DTO that gets sent back to the client.
+ */
+public class ConsumerStatusReportDefaultResult extends
+    ComplianceTransformerIterator<ConsumerStatusComplianceDto> {
+
+    public ConsumerStatusReportDefaultResult(Iterator<Compliance> dbIterator) {
+        super(dbIterator);
+    }
+
+    @Override
+    ConsumerStatusComplianceDto convertDbObject(Compliance compliance) {
+        return new ConsumerStatusComplianceDto(compliance);
+    }
+
+}

--- a/gutterball/src/main/java/org/candlepin/gutterball/report/ConsumerTrendReportDefaultResult.java
+++ b/gutterball/src/main/java/org/candlepin/gutterball/report/ConsumerTrendReportDefaultResult.java
@@ -15,24 +15,25 @@
 package org.candlepin.gutterball.report;
 
 import org.candlepin.gutterball.model.snapshot.Compliance;
+import org.candlepin.gutterball.report.dto.ConsumerTrendComplianceDto;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.Iterator;
 
 /**
- * ConsumerTrendReportResult map of consumer uuid -> collection of compliance data
+ * Represents the default ConsumerTrendReport results. An instance of this class wraps an iterator of
+ * Compliance records that come from the database, so that each Compliance record can be transformed
+ * into a minimal DTO that gets sent back to the client.
  */
-public class ConsumerTrendReportResult extends HashMap<String, Set<Compliance>>
-    implements ReportResult {
+public class ConsumerTrendReportDefaultResult extends
+    ComplianceTransformerIterator<ConsumerTrendComplianceDto> {
 
-    public void add(String consumerUuid, Compliance snapshotToAdd) {
-        Set<Compliance> appendTo = get(consumerUuid);
-        if (appendTo == null) {
-            appendTo = new HashSet<Compliance>();
-            put(consumerUuid, appendTo);
-        }
-        appendTo.add(snapshotToAdd);
+    public ConsumerTrendReportDefaultResult(Iterator<Compliance> dbIterator) {
+        super(dbIterator);
+    }
+
+    @Override
+    ConsumerTrendComplianceDto convertDbObject(Compliance compliance) {
+        return new ConsumerTrendComplianceDto(compliance);
     }
 
 }

--- a/gutterball/src/main/java/org/candlepin/gutterball/report/dto/ConsumerStatusComplianceDto.java
+++ b/gutterball/src/main/java/org/candlepin/gutterball/report/dto/ConsumerStatusComplianceDto.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package org.candlepin.gutterball.report.dto;
+
+import org.candlepin.gutterball.model.ConsumerState;
+import org.candlepin.gutterball.model.snapshot.Compliance;
+import org.candlepin.gutterball.model.snapshot.ComplianceStatus;
+import org.candlepin.gutterball.model.snapshot.Consumer;
+import org.candlepin.gutterball.model.snapshot.Owner;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * The default data that will be returned by the ConsumerStatusReport. This is purely a DTO that
+ * limits the amount of processing that Jackson has to do when serializing {@link Compliance} objects
+ * to include in the response.
+ */
+public class ConsumerStatusComplianceDto extends HashMap<String, Object> {
+
+    public ConsumerStatusComplianceDto(Compliance snap) {
+        // TODO: Using maps instead of individual fields seems to be a little faster to serialize
+        //       and allows us to keep the same result JSON structure as using the custom report.
+        //       Should this object just contain a field for each property that we want to return.
+        Map<String, Object> ownerData = new HashMap<String, Object>();
+        Consumer consumer = snap.getConsumer();
+
+        Owner owner = consumer.getOwner();
+        ownerData.put("key", owner.getKey());
+        ownerData.put("displayName", owner.getDisplayName());
+
+        Map<String, Object> consumerStateData = new HashMap<String, Object>();
+        ConsumerState consumerState = consumer.getConsumerState();
+        consumerStateData.put("created", consumerState.getCreated());
+        consumerStateData.put("deleted", consumerState.getDeleted());
+
+        Map<String, Object> consumerData = new HashMap<String, Object>();
+        consumerData.put("uuid", consumer.getUuid());
+        consumerData.put("name", consumer.getName());
+        consumerData.put("lastCheckin", consumer.getLastCheckin());
+        consumerData.put("owner", ownerData);
+        // wrap in a new map to dereference hibernate in any way.
+        consumerData.put("facts", new HashMap<String, String>(consumer.getFacts()));
+        consumerData.put("consumerState", consumerStateData);
+
+
+        Map<String, Object> statusData = new HashMap<String, Object>();
+        ComplianceStatus status = snap.getStatus();
+        statusData.put("status", status.getStatus());
+        statusData.put("date", status.getDate());
+
+        put("consumer", consumerData);
+        put("status", statusData);
+    }
+
+}

--- a/gutterball/src/main/java/org/candlepin/gutterball/report/dto/ConsumerTrendComplianceDto.java
+++ b/gutterball/src/main/java/org/candlepin/gutterball/report/dto/ConsumerTrendComplianceDto.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package org.candlepin.gutterball.report.dto;
+
+import org.candlepin.gutterball.model.snapshot.Compliance;
+import org.candlepin.gutterball.model.snapshot.ComplianceReason;
+import org.candlepin.gutterball.model.snapshot.ComplianceStatus;
+import org.candlepin.gutterball.model.snapshot.Consumer;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The default data that will be returned by the ConsumerTrendReport. This is purly a DTO that
+ * limits the amount of processing that Jackson has to do when serializing {@link Compliance} objects
+ * to include in the response.
+ */
+public class ConsumerTrendComplianceDto extends HashMap<String, Object> {
+
+    public ConsumerTrendComplianceDto(Compliance compliance) {
+        ComplianceStatus status = compliance.getStatus();
+        Consumer consumer = compliance.getConsumer();
+
+        // TODO: Using maps instead of individual fields seems to be a little faster to serialize
+        //       and allows us to keep the same result JSON structure as using the custom report.
+        //       Should this object just contain a field for each property that we want to return.
+        List<Map<String, Object>> reasonsData = new LinkedList<Map<String, Object>>();
+        for (ComplianceReason cr : status.getReasons()) {
+            HashMap<String, Object> reasonData = new HashMap<String, Object>();
+            reasonData.put("message", cr.getMessage());
+            reasonData.put("attributes", new HashMap<String, String>(cr.getAttributes()));
+            reasonsData.add(reasonData);
+        }
+
+        HashMap<String, Object> statusData = new HashMap<String, Object>();
+        statusData.put("status", status.getStatus());
+        statusData.put("date", status.getDate());
+        statusData.put("reasons", reasonsData);
+
+        Map<String, Object> consumerData = new HashMap<String, Object>();
+        consumerData.put("uuid", consumer.getUuid());
+        consumerData.put("lastCheckin", consumer.getLastCheckin());
+
+        put("status", statusData);
+        put("consumer", consumerData);
+    }
+
+}

--- a/gutterball/src/test/java/org/candlepin/gutterball/TestUtils.java
+++ b/gutterball/src/test/java/org/candlepin/gutterball/TestUtils.java
@@ -18,6 +18,7 @@ package org.candlepin.gutterball;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import org.candlepin.gutterball.model.ConsumerState;
 import org.candlepin.gutterball.model.snapshot.Compliance;
 import org.candlepin.gutterball.model.snapshot.ComplianceReason;
 import org.candlepin.gutterball.model.snapshot.ComplianceStatus;
@@ -56,7 +57,13 @@ public class TestUtils {
 
     public static Compliance createComplianceSnapshot(Date statusDate, String consumerUuid,
             String owner, String statusString) {
+        return createComplianceSnapshot(statusDate, consumerUuid, owner, statusString, null);
+    }
+
+    public static Compliance createComplianceSnapshot(Date statusDate, String consumerUuid,
+            String owner, String statusString, ConsumerState state) {
         Consumer consumerSnap = new Consumer(consumerUuid, null, createOwnerSnapshot(owner, owner));
+        consumerSnap.setConsumerState(state);
         ComplianceStatus statusSnap = new ComplianceStatus(statusDate, statusString);
 
         if (statusString.toLowerCase().equals("invalid")) {


### PR DESCRIPTION
By default, reports will return as little data as possible
to help with performance. This will allow