### PR TITLE
Eliminate Lock Contention on Consumer Last Check-In Time

### DIFF
--- a/server/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/server/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -20,6 +20,7 @@ import static org.candlepin.common.config.ConfigurationPrefixes.JPA_CONFIG_PREFI
 import org.candlepin.pinsetter.tasks.ActiveEntitlementJob;
 import org.candlepin.pinsetter.tasks.CancelJobJob;
 import org.candlepin.pinsetter.tasks.CertificateRevocationListTask;
+import org.candlepin.pinsetter.tasks.CleanupCheckInsJob;
 import org.candlepin.pinsetter.tasks.ExpiredPoolsJob;
 import org.candlepin.pinsetter.tasks.ExportCleaner;
 import org.candlepin.pinsetter.tasks.ImportRecordJob;
@@ -103,7 +104,8 @@ public class ConfigProperties {
         StatisticHistoryTask.class.getName(),
         CancelJobJob.class.getName(), ExpiredPoolsJob.class.getName(),
         UnpauseJob.class.getName(), SweepBarJob.class.getName(),
-        ExportCleaner.class.getName(), ActiveEntitlementJob.class.getName()};
+        ExportCleaner.class.getName(), ActiveEntitlementJob.class.getName(),
+        CleanupCheckInsJob.class.getName()};
 
     public static final String SYNC_WORK_DIR = "candlepin.sync.work_dir";
     public static final String CONSUMER_FACTS_MATCHER = "candlepin.consumer.facts.match_regex";

--- a/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
+++ b/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
@@ -400,6 +400,10 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
         getEntityManager().refresh(object);
     }
 
+    public void evict(E object) {
+        currentSession().evict(object);
+    }
+
     public List<E> takeSubList(PageRequest pageRequest, List<E> results) {
         int fromIndex = (pageRequest.getPage() - 1) * pageRequest.getPerPage();
         if (fromIndex >= results.size()) {

--- a/server/src/main/java/org/candlepin/model/CheckIn.java
+++ b/server/src/main/java/org/candlepin/model/CheckIn.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.model;
+
+import org.hibernate.annotations.ForeignKey;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Index;
+
+import java.util.Date;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.validation.constraints.NotNull;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * Represents a consumer checkin time, created whenever a consumer auths with an identity
+ * certificate. (as opposed to a password)
+ *
+ * Checkins are added to this table, with older entries cleaned out after some configurable
+ * period of time. We're really only interested in the latest, but trying to update a
+ * single column was a frequent cause of lock contention in heavily loaded environments.
+ */
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.PROPERTY)
+@Entity
+@Table(name = "cp_consumer_checkin")
+public class CheckIn extends AbstractHibernateObject {
+
+    @Id
+    @GeneratedValue(generator = "system-uuid")
+    @GenericGenerator(name = "system-uuid", strategy = "uuid")
+    @Column(length = 32)
+    @NotNull
+    private String id;
+
+    @ManyToOne
+    @ForeignKey(name = "fk_consumer_checkin_consumer")
+    @JoinColumn(nullable = false)
+    @Index(name = "idx_consumer_checkin_consumer")
+    @NotNull
+    private Consumer consumer;
+
+    public CheckIn() {
+    }
+
+    public CheckIn(Consumer consumer, Date d) {
+        this();
+        this.consumer = consumer;
+        setCreated(d);
+        setUpdated(d);
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public Consumer getConsumer() {
+        return consumer;
+    }
+
+    public void setConsumer(Consumer consumer) {
+        this.consumer = consumer;
+    }
+}

--- a/server/src/main/java/org/candlepin/model/CheckIn.java
+++ b/server/src/main/java/org/candlepin/model/CheckIn.java
@@ -60,14 +60,19 @@ public class CheckIn extends AbstractHibernateObject {
     @NotNull
     private Consumer consumer;
 
+    /*
+     * Leveraging created/updated is too risky here, parent class wants to set them itself,
+     * and keeping everything separate technically gives us more information to work with.
+     */
+    private Date checkInTime;
+
     public CheckIn() {
     }
 
     public CheckIn(Consumer consumer, Date d) {
         this();
         this.consumer = consumer;
-        setCreated(d);
-        setUpdated(d);
+        this.checkInTime = d;
     }
 
     public String getId() {
@@ -84,5 +89,13 @@ public class CheckIn extends AbstractHibernateObject {
 
     public void setConsumer(Consumer consumer) {
         this.consumer = consumer;
+    }
+
+    public Date getCheckInTime() {
+        return checkInTime;
+    }
+
+    public void setCheckInTime(Date checkInTime) {
+        this.checkInTime = checkInTime;
     }
 }

--- a/server/src/main/java/org/candlepin/model/CheckInCurator.java
+++ b/server/src/main/java/org/candlepin/model/CheckInCurator.java
@@ -59,10 +59,10 @@ public class CheckInCurator extends AbstractHibernateCurator<CheckIn> {
 
         int totalDeleted = 0;
         int totalQueries = 1;
+        String deleteHql = "DELETE from CheckIn where id in (:deleteIds)";
+        Query deleteQuery = currentSession().createQuery(deleteHql);
         while (checkInIds.size() > 0) {
             log.debug("Found {} check-in IDs to be deleted.", checkInIds.size());
-            String deleteHql = "DELETE from CheckIn where id in (:deleteIds)";
-            Query deleteQuery = currentSession().createQuery(deleteHql);
             deleteQuery.setParameterList("deleteIds", checkInIds);
             totalDeleted += deleteQuery.executeUpdate();
 

--- a/server/src/main/java/org/candlepin/model/CheckInCurator.java
+++ b/server/src/main/java/org/candlepin/model/CheckInCurator.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.model;
+
+import org.hibernate.Query;
+
+
+/**
+ * Curator for consumer check-ins.
+ */
+public class CheckInCurator extends AbstractHibernateCurator<CheckIn> {
+
+    public CheckInCurator() {
+        super(CheckIn.class);
+    }
+
+    /**
+     * Cleans up all but the most recent check-in times for every consumer.
+     *
+     * @return Number of checkins deleted.
+     */
+    public int cleanupOldCheckIns() {
+        String hql = "DELETE FROM CheckIn cc1 WHERE cc1.checkInTime != (" +
+                "SELECT MAX(cc2.checkInTime) " +
+                "FROM CheckIn cc2 " +
+                "WHERE cc2.consumer = cc1.consumer)";
+        Query q = currentSession().createQuery(hql);
+        int count = q.executeUpdate();
+        return count;
+    }
+
+}

--- a/server/src/main/java/org/candlepin/model/CheckInCurator.java
+++ b/server/src/main/java/org/candlepin/model/CheckInCurator.java
@@ -15,12 +15,20 @@
 package org.candlepin.model;
 
 import org.hibernate.Query;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
 
 
 /**
  * Curator for consumer check-ins.
  */
 public class CheckInCurator extends AbstractHibernateCurator<CheckIn> {
+
+    private static Logger log = LoggerFactory.getLogger(CheckInCurator.class);
+
+    public static final int DELETE_BATCH_SIZE = 30000;
 
     public CheckInCurator() {
         super(CheckIn.class);
@@ -29,16 +37,41 @@ public class CheckInCurator extends AbstractHibernateCurator<CheckIn> {
     /**
      * Cleans up all but the most recent check-in times for every consumer.
      *
+     * Very difficult to get a delete statement to do this that works across all databases.
+     * Instead we use a select that will work, and batch the resulting IDs into chunks
+     * that shouldn't exceed the maximum size for an IN subquery.
+     *
      * @return Number of checkins deleted.
      */
     public int cleanupOldCheckIns() {
-        String hql = "DELETE FROM CheckIn cc1 WHERE cc1.checkInTime != (" +
+
+        String hql = "SELECT cc1.id FROM CheckIn cc1 WHERE cc1.checkInTime != (" +
                 "SELECT MAX(cc2.checkInTime) " +
                 "FROM CheckIn cc2 " +
                 "WHERE cc2.consumer = cc1.consumer)";
         Query q = currentSession().createQuery(hql);
-        int count = q.executeUpdate();
-        return count;
+
+        // Due to size restrictions on an IN clause which we'll use in delete, and for
+        // memory concerns, we're just going to look up one batch at a time and delete
+        // them until we stop finding results.
+        q.setMaxResults(DELETE_BATCH_SIZE);
+        List<String> checkInIds = q.list();
+
+        int totalDeleted = 0;
+        int totalQueries = 1;
+        while (checkInIds.size() > 0) {
+            log.debug("Found {} check-in IDs to be deleted.", checkInIds.size());
+            String deleteHql = "DELETE from CheckIn where id in (:deleteIds)";
+            Query deleteQuery = currentSession().createQuery(deleteHql);
+            deleteQuery.setParameterList("deleteIds", checkInIds);
+            totalDeleted += deleteQuery.executeUpdate();
+
+            checkInIds = q.list();
+            totalQueries += 2; // one for the delete, one for the next query
+        }
+        log.info("Deleted a total of {} consumer check-in times with {} queries.",
+                totalDeleted, totalQueries);
+        return totalDeleted;
     }
 
 }

--- a/server/src/main/java/org/candlepin/model/Consumer.java
+++ b/server/src/main/java/org/candlepin/model/Consumer.java
@@ -16,6 +16,8 @@ package org.candlepin.model;
 
 import org.candlepin.common.jackson.HateoasArrayExclude;
 import org.candlepin.common.jackson.HateoasInclude;
+import org.candlepin.policy.js.compliance.ComplianceRules;
+import org.candlepin.policy.js.compliance.ComplianceStatus;
 import org.candlepin.util.Util;
 
 import com.fasterxml.jackson.annotation.JsonFilter;
@@ -155,6 +157,9 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
     @OneToMany(cascade = CascadeType.ALL, mappedBy = "consumer", fetch = FetchType.LAZY)
     private Set<Entitlement> entitlements;
 
+    @OneToMany(cascade = CascadeType.ALL, mappedBy = "consumer", fetch = FetchType.LAZY)
+    private Set<CheckIn> checkIns;
+
     @ElementCollection
     @CollectionTable(name = "cp_consumer_facts",
                      joinColumns = @JoinColumn(name = "cp_consumer_id"))
@@ -220,6 +225,7 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
         // generate a UUID at this point.
         this.ensureUUID();
         this.entitlements = new HashSet<Entitlement>();
+        this.checkIns = new HashSet<CheckIn>();
     }
 
     /**
@@ -423,6 +429,7 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
         }
         return entitlementCount.longValue();
     }
+
     /**
      * @return Returns the entitlements.
      */
@@ -431,12 +438,27 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
         return entitlements;
     }
 
-
     /**
      * @param entitlementsIn The entitlements to set.
      */
     public void setEntitlements(Set<Entitlement> entitlementsIn) {
         entitlements = entitlementsIn;
+    }
+
+    /**
+     * @return All CheckIns that have not been reaped.
+     */
+    @XmlTransient
+    public Set<CheckIn> getCheckIns() {
+        return checkIns;
+    }
+
+    public void setCheckIns(Set<CheckIn> checkIns) {
+        this.checkIns = checkIns;
+    }
+
+    public void addCheckIn(Date checkInDate) {
+        this.checkIns.add(new CheckIn(this, checkInDate));
     }
 
     /**

--- a/server/src/main/java/org/candlepin/model/Consumer.java
+++ b/server/src/main/java/org/candlepin/model/Consumer.java
@@ -173,7 +173,8 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
     @OneToOne(cascade = CascadeType.ALL)
     private KeyPair keyPair;
 
-    @Formula("(select max(c.created) from cp_consumer_checkin c where c.consumer_id = id)")
+    @Formula("(select max(c.checkInTime) from cp_consumer_checkin c " +
+            "where c.consumer_id = id)")
     private Date lastCheckin;
 
     @OneToMany(mappedBy = "consumer",
@@ -473,7 +474,17 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
     }
 
     public void addCheckIn(Date checkInDate) {
+        if (this.checkIns == null) {
+            this.checkIns = new HashSet<CheckIn>();
+        }
         this.checkIns.add(new CheckIn(this, checkInDate));
+    }
+
+    /*
+     * Only for internal use as a pojo for resource update.
+     */
+   public void setLastCheckin(Date lastCheckin) {
+        this.lastCheckin = lastCheckin;
     }
 
     @XmlTransient

--- a/server/src/main/java/org/candlepin/model/Consumer.java
+++ b/server/src/main/java/org/candlepin/model/Consumer.java
@@ -483,7 +483,7 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
     /*
      * Only for internal use as a pojo for resource update.
      */
-   public void setLastCheckin(Date lastCheckin) {
+    public void setLastCheckin(Date lastCheckin) {
         this.lastCheckin = lastCheckin;
     }
 

--- a/server/src/main/java/org/candlepin/model/Consumer.java
+++ b/server/src/main/java/org/candlepin/model/Consumer.java
@@ -173,6 +173,7 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
     @OneToOne(cascade = CascadeType.ALL)
     private KeyPair keyPair;
 
+    @Formula("(select max(c.created) from cp_consumer_checkin c where c.consumer_id = id)")
     private Date lastCheckin;
 
     @OneToMany(mappedBy = "consumer",
@@ -446,6 +447,20 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
     }
 
     /**
+     * Add an Entitlement to this Consumer
+     * @param entitlementIn to add to this consumer
+     *
+     */
+    public void addEntitlement(Entitlement entitlementIn) {
+        entitlementIn.setConsumer(this);
+        this.entitlements.add(entitlementIn);
+    }
+
+    public void removeEntitlement(Entitlement entitlement) {
+        this.entitlements.remove(entitlement);
+    }
+
+    /**
      * @return All CheckIns that have not been reaped.
      */
     @XmlTransient
@@ -459,20 +474,6 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
 
     public void addCheckIn(Date checkInDate) {
         this.checkIns.add(new CheckIn(this, checkInDate));
-    }
-
-    /**
-     * Add an Entitlement to this Consumer
-     * @param entitlementIn to add to this consumer
-     *
-     */
-    public void addEntitlement(Entitlement entitlementIn) {
-        entitlementIn.setConsumer(this);
-        this.entitlements.add(entitlementIn);
-    }
-
-    public void removeEntitlement(Entitlement entitlement) {
-        this.entitlements.remove(entitlement);
     }
 
     @XmlTransient
@@ -519,10 +520,6 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
 
     public Date getLastCheckin() {
         return lastCheckin;
-    }
-
-    public void setLastCheckin(Date lastCheckin) {
-        this.lastCheckin = lastCheckin;
     }
 
     public boolean isCanActivate() {

--- a/server/src/main/java/org/candlepin/model/Consumer.java
+++ b/server/src/main/java/org/candlepin/model/Consumer.java
@@ -157,9 +157,6 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
     @OneToMany(cascade = CascadeType.ALL, mappedBy = "consumer", fetch = FetchType.LAZY)
     private Set<Entitlement> entitlements;
 
-    @OneToMany(cascade = CascadeType.ALL, mappedBy = "consumer", fetch = FetchType.LAZY)
-    private Set<CheckIn> checkIns;
-
     @ElementCollection
     @CollectionTable(name = "cp_consumer_facts",
                      joinColumns = @JoinColumn(name = "cp_consumer_id"))
@@ -172,6 +169,9 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
 
     @OneToOne(cascade = CascadeType.ALL)
     private KeyPair keyPair;
+
+    @OneToMany(cascade = CascadeType.ALL, mappedBy = "consumer", fetch = FetchType.LAZY)
+    private Set<CheckIn> checkIns;
 
     @Formula("(select max(c.checkInTime) from cp_consumer_checkin c " +
             "where c.consumer_id = id)")

--- a/server/src/main/java/org/candlepin/model/ConsumerCurator.java
+++ b/server/src/main/java/org/candlepin/model/ConsumerCurator.java
@@ -353,13 +353,8 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
 
     @Transactional
     public void updateLastCheckin(Consumer consumer, Date checkinDate) {
-        currentSession().createQuery("update Consumer c " +
-            "set c.lastCheckin = :date, " +
-            "c.updated = :date " +
-            "where c.id = :consumerid")
-            .setTimestamp("date", checkinDate)
-            .setParameter("consumerid", consumer.getId())
-            .executeUpdate();
+        consumer.addCheckIn(checkinDate);
+        save(consumer);
     }
 
     private boolean factsChanged(Map<String, String> updatedFacts,

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/CleanupCheckInsJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/CleanupCheckInsJob.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.pinsetter.tasks;
+
+import org.candlepin.model.CheckInCurator;
+
+import com.google.inject.Inject;
+
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Cleans up all but the most recent checkins for all consumers.
+ */
+public class CleanupCheckInsJob extends KingpinJob {
+
+    // Every 8 hours:
+    public static final String DEFAULT_SCHEDULE = "0 0 0/8 * * ?";
+
+    private CheckInCurator checkInCurator;
+
+    private static Logger log = LoggerFactory.getLogger(CleanupCheckInsJob.class);
+
+    @Inject
+    public CleanupCheckInsJob(CheckInCurator checkInCurator) {
+        this.checkInCurator = checkInCurator;
+    }
+
+    public void toExecute(JobExecutionContext ctx) throws JobExecutionException {
+        log.info("Cleaning up old consumer check-ins.");
+        int deleted = checkInCurator.cleanupOldCheckIns();
+        log.info("Deleted {} check-ins.", deleted);
+    }
+}

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -907,7 +907,7 @@ public class ConsumerResource {
         if (updated.getLastCheckin() != null) {
             log.info("Updating to specific last checkin time: {}",
                     updated.getLastCheckin());
-            toUpdate.setLastCheckin(updated.getLastCheckin());
+            toUpdate.addCheckIn(updated.getLastCheckin());
             changesMade = true;
         }
 

--- a/server/src/main/resources/db/changelog/20150123105016-add-consumer-checkin-table.xml
+++ b/server/src/main/resources/db/changelog/20150123105016-add-consumer-checkin-table.xml
@@ -6,8 +6,7 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
 
-    <property name="timestamp.type" value="TIMESTAMP WITH TIME ZONE" dbms="oracle"/>
-    <property name="timestamp.type" value="TIMESTAMP WITH TIME ZONE" dbms="postgresql"/>
+    <property name="timestamp.type" value="TIMESTAMP WITH TIME ZONE" dbms="oracle,postgresql,hsqldb"/>
     <property name="timestamp.type" value="DATETIME" dbms="mysql"/>
 
     <changeSet id="20150123105016-1" author="dgoodwin">
@@ -24,6 +23,7 @@
 
             <column name="created" type="${timestamp.type}"/>
             <column name="updated" type="${timestamp.type}"/>
+            <column name="checkintime" type="${timestamp.type}"/>
 
         </createTable>
 

--- a/server/src/main/resources/db/changelog/20150123105016-add-consumer-checkin-table.xml
+++ b/server/src/main/resources/db/changelog/20150123105016-add-consumer-checkin-table.xml
@@ -11,7 +11,7 @@
     <property name="timestamp.type" value="DATETIME" dbms="mysql"/>
 
     <changeSet id="20150123105016-1" author="dgoodwin">
-        <comment>add consumer checkin table</comment>
+        <comment>Add consumer checkin table.</comment>
         <createTable tableName="cp_consumer_checkin">
 
             <column name="id" type="VARCHAR(32)">
@@ -38,11 +38,15 @@
     </changeSet>
 
     <changeSet id="20150123105016-2" author="dgoodwin">
-        <comment>populate consumer checkins table with current values</comment>
+        <comment>Populate consumer checkins table with current values.</comment>
         <!-- re-use the consumer ID as the first checkin ID to avoid generated ID problem, we know it will be unique -->
         <sql>INSERT INTO cp_consumer_checkin(id, consumer_id, created, updated) SELECT cp_consumer.id, cp_consumer.id, cp_consumer.lastcheckin, cp_consumer.lastcheckin FROM cp_consumer WHERE cp_consumer.lastcheckin IS NOT NULL</sql>
     </changeSet>
 
+    <changeSet id="20150123105016-3" author="dgoodwin">
+        <comment>Drop the old last checkin column.</comment>
+        <dropColumn tableName="cp_consumer" columnName="lastcheckin"/>
+    </changeSet>
 
 </databaseChangeLog>
 <!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/server/src/main/resources/db/changelog/20150123105016-add-consumer-checkin-table.xml
+++ b/server/src/main/resources/db/changelog/20150123105016-add-consumer-checkin-table.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+    <property name="timestamp.type" value="TIMESTAMP WITH TIME ZONE" dbms="oracle"/>
+    <property name="timestamp.type" value="TIMESTAMP WITH TIME ZONE" dbms="postgresql"/>
+    <property name="timestamp.type" value="DATETIME" dbms="mysql"/>
+
+    <changeSet id="20150123105016-1" author="dgoodwin">
+        <comment>add consumer checkin table</comment>
+        <createTable tableName="cp_consumer_checkin">
+
+            <column name="id" type="VARCHAR(32)">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="cp_consumer_checkin_pkey"/>
+            </column>
+
+            <column name="consumer_id" type="VARCHAR(32)">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="created" type="${timestamp.type}"/>
+            <column name="updated" type="${timestamp.type}"/>
+
+        </createTable>
+
+        <addForeignKeyConstraint baseColumnNames="consumer_id" baseTableName="cp_consumer_checkin" constraintName="fk_consumer_checkin_consumer" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" referencedColumnNames="id" referencedTableName="cp_consumer" referencesUniqueColumn="true"/>
+
+        <createIndex indexName="idx_consumer_checkin" tableName="cp_consumer_checkin" unique="true">
+            <column name="id"/>
+        </createIndex>
+        <createIndex indexName="idx_consumer_checkin_consumer" tableName="cp_consumer_checkin" unique="true">
+            <column name="consumer_id"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="20150123105016-2" author="dgoodwin">
+        <comment>populate consumer checkins table with current values</comment>
+        <!-- re-use the consumer ID as the first checkin ID to avoid generated ID problem, we know it will be unique -->
+        <sql>INSERT INTO cp_consumer_checkin(id, consumer_id, created, updated) SELECT cp_consumer.id, cp_consumer.id, cp_consumer.lastcheckin, cp_consumer.lastcheckin FROM cp_consumer WHERE cp_consumer.lastcheckin IS NOT NULL</sql>
+    </changeSet>
+
+
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/server/src/main/resources/db/changelog/20150123105016-add-consumer-checkin-table.xml
+++ b/server/src/main/resources/db/changelog/20150123105016-add-consumer-checkin-table.xml
@@ -32,7 +32,7 @@
         <createIndex indexName="idx_consumer_checkin" tableName="cp_consumer_checkin" unique="true">
             <column name="id"/>
         </createIndex>
-        <createIndex indexName="idx_consumer_checkin_consumer" tableName="cp_consumer_checkin" unique="true">
+        <createIndex indexName="idx_consumer_checkin_consumer" tableName="cp_consumer_checkin" unique="false">
             <column name="consumer_id"/>
         </createIndex>
     </changeSet>

--- a/server/src/main/resources/db/changelog/changelog-create.xml
+++ b/server/src/main/resources/db/changelog/changelog-create.xml
@@ -1168,4 +1168,5 @@
     <include file="db/changelog/20140916131808-activation-key-expansion.xml"/>
     <include file="db/changelog/20141203123727-add-compliance-status-hash-column.xml"/>
     <include file="db/changelog/20141126150611-create-content-tags-table.xml"/>
+    <include file="db/changelog/20150123105016-add-consumer-checkin-table.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-testing.xml
+++ b/server/src/main/resources/db/changelog/changelog-testing.xml
@@ -2027,7 +2027,7 @@
     </changeSet>
     <changeSet author="awood" id="1413225753032-290">
         <comment>
-            Add the default quartz lock columns.
+             Add the default quartz lock columns. 
         </comment>
         <insert tableName="QRTZ_LOCKS">
             <column name="LOCK_NAME" value="TRIGGER_ACCESS"/>
@@ -2258,4 +2258,5 @@
     </changeSet> -->
     <include file="db/changelog/20141203123727-add-compliance-status-hash-column.xml"/>
     <include file="db/changelog/20141126150611-create-content-tags-table.xml"/>
+    <include file="db/changelog/20150123105016-add-consumer-checkin-table.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-update.xml
+++ b/server/src/main/resources/db/changelog/changelog-update.xml
@@ -76,4 +76,5 @@
     <include file="db/changelog/20140916131808-activation-key-expansion.xml"/>
     <include file="db/changelog/20141203123727-add-compliance-status-hash-column.xml"/>
     <include file="db/changelog/20141126150611-create-content-tags-table.xml"/>
+    <include file="db/changelog/20150123105016-add-consumer-checkin-table.xml"/>
 </databaseChangeLog>

--- a/server/src/test/java/org/candlepin/model/CheckInCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/CheckInCuratorTest.java
@@ -54,12 +54,14 @@ public class CheckInCuratorTest extends DatabaseTestFixture {
         consumerCurator.merge(c1);
 
         c2.addCheckIn(fourHoursAgo);
-        c1.addCheckIn(getDateHoursBefore(12));
-        c1.addCheckIn(getDateHoursBefore(16));
+        c2.addCheckIn(getDateHoursBefore(12));
+        c2.addCheckIn(getDateHoursBefore(16));
+        c2.addCheckIn(getDateHoursBefore(18));
+        c2.addCheckIn(getDateHoursBefore(20));
         consumerCurator.merge(c1);
 
         int deleted = checkInCurator.cleanupOldCheckIns();
-        assertEquals(4, deleted);
+        assertEquals(6, deleted);
 
         consumerCurator.evict(c1);
         c1 = consumerCurator.find(c1.getId());

--- a/server/src/test/java/org/candlepin/model/CheckInCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/CheckInCuratorTest.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.model;
+
+import static org.junit.Assert.assertEquals;
+
+import org.candlepin.test.DatabaseTestFixture;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Calendar;
+import java.util.Date;
+
+import javax.inject.Inject;
+
+public class CheckInCuratorTest extends DatabaseTestFixture {
+
+    private Owner owner;
+    private Consumer c1;
+    private Consumer c2;
+    private Consumer c3;
+
+    @Inject private CheckInCurator checkInCurator;
+    @Inject private ConsumerCurator consumerCurator;
+
+    @Before
+    public void setUp() {
+        owner = createOwner();
+        c1 = createConsumer(owner);
+        c2 = createConsumer(owner);
+        c3 = createConsumer(owner);
+    }
+
+    @Test
+    public void cleanupOldCheckins() {
+        Date mostRecent = new Date();
+        Date fourHoursAgo = getDateHoursBefore(4);
+        c1.addCheckIn(mostRecent);
+        c1.addCheckIn(fourHoursAgo);
+        c1.addCheckIn(getDateHoursBefore(8));
+        consumerCurator.merge(c1);
+
+        c2.addCheckIn(fourHoursAgo);
+        c1.addCheckIn(getDateHoursBefore(12));
+        c1.addCheckIn(getDateHoursBefore(16));
+        consumerCurator.merge(c1);
+
+        int deleted = checkInCurator.cleanupOldCheckIns();
+        assertEquals(4, deleted);
+
+        consumerCurator.evict(c1);
+        c1 = consumerCurator.find(c1.getId());
+        assertEquals(1, c1.getCheckIns().size());
+        assertEquals(mostRecent, c1.getLastCheckin());
+
+        consumerCurator.evict(c2);
+        c2 = consumerCurator.find(c2.getId());
+        assertEquals(1, c2.getCheckIns().size());
+        assertEquals(fourHoursAgo, c2.getLastCheckin());
+
+        // This consumer had no check-in times to begin with:
+        consumerCurator.evict(c3);
+        c3 = consumerCurator.find(c3.getId());
+        assertEquals(0, c3.getCheckIns().size());
+    }
+
+    private Date getDateHoursBefore(int hours) {
+        Calendar cal = Calendar.getInstance();
+        cal.add(Calendar.HOUR, 0 - hours);
+        return cal.getTime();
+
+    }
+}

--- a/server/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
@@ -319,7 +319,7 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
     public void updatelastCheckin() throws Exception {
         Date date = new Date();
         Consumer consumer = new Consumer("hostConsumer", "testUser", owner, ct);
-        consumer.setLastCheckin(date);
+        consumer.addCheckIn(date);
         Thread.sleep(5); // sleep for at 5ms to allow enough time to pass
         consumer = consumerCurator.create(consumer);
         consumerCurator.updateLastCheckin(consumer);

--- a/server/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
@@ -312,6 +312,7 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
         Date dt = ResourceDateParser.parseDateString("2011-09-26T18:10:50.184081+00:00");
         consumerCurator.updateLastCheckin(consumer, dt);
         consumerCurator.refresh(consumer);
+        consumer = consumerCurator.find(consumer.getId());
 
         assertEquals(consumer.getLastCheckin().getTime(), dt.getTime());
     }

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
@@ -835,14 +835,14 @@ public class ConsumerResourceUpdateTest {
     public void consumerLastCheckin() {
         Consumer c = getFakeConsumer();
         Date now = new Date();
-        c.setLastCheckin(now);
+        c.addCheckIn(now);
         ConsumerType ct = new ConsumerType();
         ct.setManifest(true);
         c.setType(ct);
 
         Consumer updated = new Consumer();
         Date then = new Date(now.getTime() + 10000L);
-        updated.setLastCheckin(then);
+        updated.addCheckIn(then);
         resource.updateConsumer(c.getUuid(), updated);
         assertEquals(then, c.getLastCheckin());
     }

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
@@ -839,12 +839,13 @@ public class ConsumerResourceUpdateTest {
         ConsumerType ct = new ConsumerType();
         ct.setManifest(true);
         c.setType(ct);
+        assertEquals(1, c.getCheckIns().size());
 
         Consumer updated = new Consumer();
         Date then = new Date(now.getTime() + 10000L);
-        updated.addCheckIn(then);
+        updated.setLastCheckin(then);
         resource.updateConsumer(c.getUuid(), updated);
-        assertEquals(then, c.getLastCheckin());
+        assertEquals(2, c.getCheckIns().size());
     }
 
     private Consumer createConsumerWithGuests(String ... guestIds) {


### PR DESCRIPTION
Problems surface in deployments with extremely high load. Because we update the consumer's row every time they authenticate, any request running long can cause other requests to wait longer than mysql's 50 second limit trying to get the lock to update that row.

To work around this I introduced a new table for consumer check-in times. The Consumer's last checkin time is calculated as the max in the table for that consumer.

A job is included to run periodically (every 8 hours by default) and clean out all but the most recent row for each consumer. In a really big deployment, this could be well into the millions. Multiple attempts were made to delete all but the most recent row for each consumer, none would scale to that level and work on all dbs. Instead we query checkins to be deleted in batches and delete them one chunk (30k) at a time until there are none left.

End result should eliminate lock wait timeouts on cp_consumer.lastcheckin because we're now doing fresh inserts in each request, rather than everyone trying to update the same row.