### PR TITLE
Fix broken db upgrade on Oracle.

### DIFF
--- a/server/src/main/resources/db/changelog/20150123105016-add-consumer-checkin-table.xml
+++ b/server/src/main/resources/db/changelog/20150123105016-add-consumer-checkin-table.xml
@@ -29,9 +29,6 @@
 
         <addForeignKeyConstraint baseColumnNames="consumer_id" baseTableName="cp_consumer_checkin" constraintName="fk_consumer_checkin_consumer" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" referencedColumnNames="id" referencedTableName="cp_consumer" referencesUniqueColumn="true"/>
 
-        <createIndex indexName="idx_consumer_checkin" tableName="cp_consumer_checkin" unique="true">
-            <column name="id"/>
-        </createIndex>
         <createIndex indexName="idx_consumer_checkin_consumer" tableName="cp_consumer_checkin" unique="false">
             <column name="consumer_id"/>
         </createIndex>


### PR DESCRIPTION
All DBMSes appear to create an index on a primary key, Oracle actually errors
out if you try to create another. (Postgres and MySQL do not)