### PR TITLE
Some updates to the GB reports params

### DIFF
--- a/gutterball/src/main/java/org/candlepin/gutterball/report/ConsumerStatusReport.java
+++ b/gutterball/src/main/java/org/candlepin/gutterball/report/ConsumerStatusReport.java
@@ -38,6 +38,7 @@ import javax.ws.rs.core.MultivaluedMap;
  */
 public class ConsumerStatusReport extends Report<ReportResult> {
 
+    private static final String CUSTOM_RESULTS_PARAM = "custom_results";
     private ComplianceSnapshotCurator complianceSnapshotCurator;
     private StatusReasonMessageGenerator messageGenerator;
 
@@ -84,8 +85,20 @@ public class ConsumerStatusReport extends Report<ReportResult> {
         );
 
         addParameter(
-            builder.init("custom", i18n.tr("Allows building a custom result data set by tayloring " +
-                         "the data to include in the JSON (boolean)")).getParameter());
+            builder.init(CUSTOM_RESULTS_PARAM, i18n.tr("Enables/disables custom report result functionality " +
+                    "via attribute filtering (boolean).")).getParameter());
+
+        addParameter(builder.init("include", i18n.tr("Includes the specified attribute in the result JSON"))
+                .mustHave(CUSTOM_RESULTS_PARAM)
+                .mustNotHave("exclude")
+                .multiValued()
+                .getParameter());
+
+        addParameter(builder.init("exclude", i18n.tr("Excludes the specified attribute in the result JSON"))
+                .mustHave(CUSTOM_RESULTS_PARAM)
+                .mustNotHave("include")
+                .multiValued()
+                .getParameter());
 
     }
 
@@ -102,7 +115,8 @@ public class ConsumerStatusReport extends Report<ReportResult> {
             parseDateTime(queryParams.getFirst("on_date")) :
             new Date();
 
-        String custom = queryParams.containsKey("custom") ? queryParams.getFirst("custom") : "";
+        String custom = queryParams.containsKey(CUSTOM_RESULTS_PARAM) ?
+            queryParams.getFirst(CUSTOM_RESULTS_PARAM) : "";
         boolean useCustom = PropertyConverter.toBoolean(custom);
 
         Page<Iterator<Compliance>> page = this.complianceSnapshotCurator.getSnapshotIterator(

--- a/gutterball/src/main/java/org/candlepin/gutterball/report/ConsumerStatusReport.java
+++ b/gutterball/src/main/java/org/candlepin/gutterball/report/ConsumerStatusReport.java
@@ -71,7 +71,8 @@ public class ConsumerStatusReport extends Report<ReportResult> {
                 .getParameter());
 
         addParameter(
-            builder.init("status", i18n.tr("The subscription status to filter on."))
+            builder.init("status", i18n.tr("The subscription status to filter on [{0}, {1}, {2}].",
+                    "valid", "invalid", "partial"))
                 .multiValued()
                 .getParameter()
         );

--- a/gutterball/src/main/java/org/candlepin/gutterball/report/ConsumerTrendReport.java
+++ b/gutterball/src/main/java/org/candlepin/gutterball/report/ConsumerTrendReport.java
@@ -37,6 +37,8 @@ import javax.ws.rs.core.MultivaluedMap;
  */
 public class ConsumerTrendReport extends Report<ReportResult> {
 
+    private static final String CUSTOM_RESULTS_PARAM = "custom_results";
+
     private ComplianceSnapshotCurator snapshotCurator;
     private StatusReasonMessageGenerator messageGenerator;
 
@@ -86,8 +88,22 @@ public class ConsumerTrendReport extends Report<ReportResult> {
                 .getParameter());
 
         addParameter(
-            builder.init("custom", i18n.tr("Allows building a custom result data set by tayloring the " +
-                         "data to include in the JSON (boolean)")).getParameter());
+            builder.init(CUSTOM_RESULTS_PARAM, i18n.tr("Enables/disables custom report result functionality " +
+                        "via attribute filtering (boolean).")).getParameter());
+
+            addParameter(builder.init("include",
+                    i18n.tr("Includes the specified attribute in the result JSON"))
+                .multiValued()
+                .mustHave(CUSTOM_RESULTS_PARAM)
+                .mustNotHave("exclude")
+                .getParameter());
+
+            addParameter(builder.init("exclude",
+                    i18n.tr("Excludes the specified attribute in the result JSON"))
+                .multiValued()
+                .mustHave(CUSTOM_RESULTS_PARAM)
+                .mustNotHave("include")
+                .getParameter());
     }
 
     @Override
@@ -112,7 +128,8 @@ public class ConsumerTrendReport extends Report<ReportResult> {
             endDate = parseDateTime(queryParams.getFirst("end_date"));
         }
 
-        String custom = queryParams.containsKey("custom") ? queryParams.getFirst("custom") : "";
+        String custom = queryParams.containsKey(CUSTOM_RESULTS_PARAM) ?
+            queryParams.getFirst(CUSTOM_RESULTS_PARAM) : "";
         boolean useCustom = PropertyConverter.toBoolean(custom);
 
         Page<Iterator<Compliance>> page = this.snapshotCurator.getSnapshotIteratorForConsumer(

--- a/gutterball/src/test/java/org/candlepin/gutterball/report/ConsumerStatusReportTest.java
+++ b/gutterball/src/test/java/org/candlepin/gutterball/report/ConsumerStatusReportTest.java
@@ -178,9 +178,9 @@ public class ConsumerStatusReportTest {
     }
 
     @Test
-    public void testDefaultResultSetContainsCustomMap() {
+    public void testDefaultResultSetContainsCustomDto() {
         MultivaluedMap<String, String> params = mock(MultivaluedMap.class);
-        when(params.containsKey("custom")).thenReturn(false);
+        when(params.containsKey("custom_results")).thenReturn(false);
 
         List<Compliance> complianceList = new LinkedList<Compliance>();
         complianceList.add(TestUtils.createComplianceSnapshot(new Date(), "abcd", "an-owner", "valid",
@@ -202,8 +202,8 @@ public class ConsumerStatusReportTest {
     @Test
     public void testCustomResultSetContainsComplianceObjects() {
         MultivaluedMap<String, String> params = mock(MultivaluedMap.class);
-        when(params.containsKey("custom")).thenReturn(true);
-        when(params.getFirst("custom")).thenReturn("1");
+        when(params.containsKey("custom_results")).thenReturn(true);
+        when(params.getFirst("custom_results")).thenReturn("1");
 
         List<Compliance> complianceList = new LinkedList<Compliance>();
         complianceList.add(TestUtils.createComplianceSnapshot(new Date(), "abcd", "an-owner", "valid"));

--- a/gutterball/src/test/java/org/candlepin/gutterball/report/ConsumerTrendReportTest.java
+++ b/gutterball/src/test/java/org/candlepin/gutterball/report/ConsumerTrendReportTest.java
@@ -267,7 +267,7 @@ public class ConsumerTrendReportTest extends DatabaseTestFixture {
     @SuppressWarnings("unchecked")
     public void testDefaultResultSetContainsCustomMap() {
         MultivaluedMap<String, String> params = mock(MultivaluedMap.class);
-        when(params.containsKey("custom")).thenReturn(false);
+        when(params.containsKey("custom_results")).thenReturn(false);
 
         String uuid = "c3";
         when(params.containsKey("consumer_uuid")).thenReturn(true);
@@ -286,8 +286,8 @@ public class ConsumerTrendReportTest extends DatabaseTestFixture {
     @Test
     public void testCustomResultSetContainsComplianceObjects() {
         MultivaluedMap<String, String> params = mock(MultivaluedMap.class);
-        when(params.containsKey("custom")).thenReturn(true);
-        when(params.getFirst("custom")).thenReturn("1");
+        when(params.containsKey("custom_results")).thenReturn(true);
+        when(params.getFirst("custom_results")).thenReturn("1");
 
         String uuid = "c3";
         when(params.containsKey("consumer_uuid")).thenReturn(true);


### PR DESCRIPTION
- changed 'custom' to 'custom_results' to avoid confusion with custom products (asked about it a couple of times)
- added actual report parameters for include/exclude parameters.
- updated description for consumer status report 'status' parameter