### PR TITLE
1190040: Add tomcat dependency for gutterball.

### DIFF
--- a/gutterball/gutterball.spec
+++ b/gutterball/gutterball.spec
@@ -107,6 +107,7 @@ BuildRequires: mvn(ch.qos.logback:logback-classic)
 
 %if !0%{?reqcpdeps}
 # Universal requires
+Requires: %{tomcat}
 Requires: java >= 0:1.6.0
 Requires: servlet
 Requires: qpid-java-client >= 0:0.30


### PR DESCRIPTION
This was only working as candlepin was expected to be there already, but in
installers it was possible for gutterball to install before tomcat arrived
leading to warnings and permissions problems.

Verification, before, if I setup this repo:

[candlepin]
name=candlepin
baseurl=http://download.devel.redhat.com/brewroot/repos/candlepin-1-rhel-6-build/latest/x86_64

And yum install gutterball, tomcat is not in the list of packages to be installed, and you get a pile of errors:

warning: user tomcat does not exist - using root
warning: group tomcat does not exist - using root


With new build including this dep change everything functions correctly and tomcat ends up installed.