### PR TITLE
1194997: Don't use referencesUniqueColumn true.

### DIFF
--- a/server/src/main/resources/db/changelog/20150123105016-add-consumer-checkin-table.xml
+++ b/server/src/main/resources/db/changelog/20150123105016-add-consumer-checkin-table.xml
@@ -27,7 +27,7 @@
 
         </createTable>
 
-        <addForeignKeyConstraint baseColumnNames="consumer_id" baseTableName="cp_consumer_checkin" constraintName="fk_consumer_checkin_consumer" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" referencedColumnNames="id" referencedTableName="cp_consumer" referencesUniqueColumn="true"/>
+        <addForeignKeyConstraint baseColumnNames="consumer_id" baseTableName="cp_consumer_checkin" constraintName="fk_consumer_checkin_consumer" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" referencedColumnNames="id" referencedTableName="cp_consumer" referencesUniqueColumn="false"/>
 
         <createIndex indexName="idx_consumer_checkin_consumer" tableName="cp_consumer_checkin" unique="false">
             <column name="consumer_id"/>


### PR DESCRIPTION
This option (when set to true) is unsupported on postgres and will cause an
error, *if* you're using liquibase 2.x. The issue does not surface if you are
running liquibase 3.x.

Set to false to match all existing use of addForeignKeyConstraint element.

WARNING: This will not apply clean on an existing db with the old changeset due to checksum change. I believe this is ok only developers have this deployed, who will need to regen db clean or do a little hacking if they hit the issue.