### PR TITLE
Fix unmapped guest pools with derived product data.

### DIFF
--- a/server/src/main/java/org/candlepin/policy/js/pool/PoolHelper.java
+++ b/server/src/main/java/org/candlepin/policy/js/pool/PoolHelper.java
@@ -16,6 +16,7 @@ package org.candlepin.policy.js.pool;
 
 import org.candlepin.controller.PoolManager;
 import org.candlepin.model.Attribute;
+import org.candlepin.model.Branding;
 import org.candlepin.model.DerivedProductPoolAttribute;
 import org.candlepin.model.DerivedProvidedProduct;
 import org.candlepin.model.Entitlement;
@@ -153,13 +154,19 @@ public class PoolHelper extends AttributeHelper {
     }
 
     /**
-     * Copies the provided products from a subscription to a pool.
+     * Copies the provided products from a subscription to a derived pool.
      *
      * @param source subscription
      * @param destination pool
      */
-    public void copyProvidedProducts(Subscription source, Pool destination) {
-        for (Product providedProduct : source.getProvidedProducts()) {
+    private void copyProvidedProducts(Subscription source, Pool destination) {
+        Set<Product> products = source.getProvidedProducts();
+        // Use derived product data if it exists, as this is a derived bonus pool:
+        if (source.getDerivedProvidedProducts() != null &&
+                source.getDerivedProvidedProducts().size() > 0) {
+            products = source.getDerivedProvidedProducts();
+        }
+        for (Product providedProduct : products) {
             destination.addProvidedProduct(new ProvidedProduct(providedProduct.getId(),
                 providedProduct.getName()));
         }
@@ -182,6 +189,11 @@ public class PoolHelper extends AttributeHelper {
         }
 
         copyProductAttributesOntoPool(productId, pool);
+
+        for (Branding b : sub.getBranding()) {
+            pool.getBranding().add(new Branding(b.getProductId(), b.getType(),
+                b.getName()));
+        }
 
         return pool;
     }

--- a/server/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
@@ -99,17 +99,45 @@ public class PoolRules {
             helper.getFlattenedAttributes(sub.getProduct());
         long quantity = calculateQuantity(sub);
         Set<ProvidedProduct> providedProducts = new HashSet<ProvidedProduct>();
-        Set<DerivedProvidedProduct> subProvidedProducts =
-            new HashSet<DerivedProvidedProduct>();
 
         if (!hasMasterPool(existingPools)) {
             Pool newPool = new Pool(sub.getOwner(), sub.getProduct().getId(),
                     sub.getProduct().getName(), providedProducts, quantity, sub.getStartDate(),
                     sub.getEndDate(), sub.getContractNumber(), sub.getAccountNumber(),
                     sub.getOrderNumber());
-            newPool.setDerivedProvidedProducts(subProvidedProducts);
 
-            updatePoolFromSubscription(sub, newPool, providedProducts, subProvidedProducts, helper);
+            if (sub.getProvidedProducts() != null) {
+                for (Product p : sub.getProvidedProducts()) {
+                    ProvidedProduct providedProduct = new ProvidedProduct(p.getId(),
+                        p.getName());
+                    providedProduct.setPool(newPool);
+                    providedProducts.add(providedProduct);
+                }
+            }
+
+            if (sub.getDerivedProvidedProducts() != null) {
+                for (Product p : sub.getDerivedProvidedProducts()) {
+                    DerivedProvidedProduct providedProduct =
+                        new DerivedProvidedProduct(p.getId(), p.getName());
+                    providedProduct.setPool(newPool);
+                    newPool.getDerivedProvidedProducts().add(providedProduct);
+                }
+            }
+
+            helper.copyProductAttributesOntoPool(sub.getProduct().getId(), newPool);
+
+            if (sub.getDerivedProduct() != null) {
+                newPool.setDerivedProductId(sub.getDerivedProduct().getId());
+                newPool.setDerivedProductName(sub.getDerivedProduct().getName());
+                helper.copySubProductAttributesOntoPool(sub.getDerivedProduct().getId(),
+                        newPool);
+            }
+
+            for (Branding b : sub.getBranding()) {
+                newPool.getBranding().add(new Branding(b.getProductId(), b.getType(),
+                    b.getName()));
+            }
+
 
             newPool.setSourceSubscription(new SourceSubscription(sub.getId(), "master"));
             ProductAttribute virtAtt = sub.getProduct().getAttribute("virt_only");
@@ -126,9 +154,11 @@ public class PoolRules {
             pools.add(newPool);
         }
 
+        // If this subscription carries a virt_limit, we need to either create a bonus
+        // pool for any guest (legacy behavior, only in hosted), or a pool for temporary
+        // use of unmapped guests. (current behavior for any pool with virt_limit)
         boolean hostLimited = attributes.containsKey("host_limited") &&
             attributes.get("host_limited").equals("true");
-        // Check if we need to create a virt-only pool for this subscription:
         if (attributes.containsKey("virt_limit") && !hasBonusPool(existingPools)) {
 
             HashMap<String, String> virtAttributes = new HashMap<String, String>();
@@ -153,8 +183,6 @@ public class PoolRules {
                 Pool derivedPool = helper.createPool(sub, poolProduct.getId(),
                     virtQuantity, virtAttributes);
 
-                updatePoolFromSubscription(sub, derivedPool, providedProducts, subProvidedProducts, helper);
-
                 // Using derived here because only one derived pool
                 // is created for this subscription
                 derivedPool.setSourceSubscription(new SourceSubscription(sub.getId(), "derived"));
@@ -162,44 +190,6 @@ public class PoolRules {
             }
         }
         return pools;
-    }
-
-    private void updatePoolFromSubscription(Subscription sub,
-                                            Pool pool,
-                                            Set<ProvidedProduct> providedProducts,
-                                            Set<DerivedProvidedProduct> subProvidedProducts,
-                                            PoolHelper helper) {
-        if (sub.getProvidedProducts() != null) {
-            for (Product p : sub.getProvidedProducts()) {
-                ProvidedProduct providedProduct = new ProvidedProduct(p.getId(),
-                    p.getName());
-                providedProduct.setPool(pool);
-                providedProducts.add(providedProduct);
-            }
-        }
-
-        if (sub.getDerivedProvidedProducts() != null) {
-            for (Product p : sub.getDerivedProvidedProducts()) {
-                DerivedProvidedProduct providedProduct =
-                    new DerivedProvidedProduct(p.getId(), p.getName());
-                providedProduct.setPool(pool);
-                subProvidedProducts.add(providedProduct);
-            }
-        }
-
-        helper.copyProductAttributesOntoPool(sub.getProduct().getId(), pool);
-        if (sub.getDerivedProduct() != null) {
-            pool.setDerivedProductId(sub.getDerivedProduct().getId());
-            pool.setDerivedProductName(sub.getDerivedProduct().getName());
-            helper.copySubProductAttributesOntoPool(sub.getDerivedProduct().getId(),
-                pool);
-        }
-
-        for (Branding b : sub.getBranding()) {
-            pool.getBranding().add(new Branding(b.getProductId(), b.getType(),
-                b.getName()));
-        }
-
     }
 
     private boolean hasMasterPool(List<Pool> pools) {


### PR DESCRIPTION
Attributes and provided products were not being properly copied to unmapped
guest pools on creation, resulting in breakage of the main VDC use-case.

Some cleanup will take place in the multi-org branch.