### PR TITLE
1200358: Wait for successful message bus connection on startup

### DIFF
--- a/gutterball/src/main/java/org/candlepin/gutterball/config/ConfigProperties.java
+++ b/gutterball/src/main/java/org/candlepin/gutterball/config/ConfigProperties.java
@@ -26,6 +26,8 @@ public class ConfigProperties {
 
     public static final String DEFAULT_CONFIG_FILE = "/etc/gutterball/gutterball.conf";
     public static final String AMQP_CONNECT_STRING = "gutterball.amqp.connect";
+    public static final String AMQP_CONNECTION_RETRY_ATTEMPTS = "gutterball.amqp.connection.retry_attempts";
+    public static final String AMQP_CONNECTION_RETRY_INTERVAL = "gutterball.amqp.connection.retry_interval";
     public static final String AMQP_KEYSTORE = "gutterball.amqp.keystore";
     public static final String AMQP_KEYSTORE_PASSWORD = "gutterball.amqp.keystore_password";
     public static final String AMQP_TRUSTSTORE = "gutterball.amqp.truststore";
@@ -52,8 +54,9 @@ public class ConfigProperties {
                 // AMQP (Qpid) defaults
                 this.put(AMQP_CONNECT_STRING, "amqp://guest:guest@localhost/test?brokerlist=" +
                         "'tcp://localhost:5671?ssl='true'&ssl_cert_alias='gutterball''");
-                this.put(AMQP_KEYSTORE,
-                        "/etc/gutterball/certs/amqp/gutterball.jks");
+                this.put(AMQP_CONNECTION_RETRY_INTERVAL, "10"); // Every 10 seconds
+                this.put(AMQP_CONNECTION_RETRY_ATTEMPTS, "12"); // Try for 2 minutes (10s * 12)
+                this.put(AMQP_KEYSTORE, "/etc/gutterball/certs/amqp/gutterball.jks");
                 this.put(AMQP_KEYSTORE_PASSWORD, "password");
                 this.put(AMQP_TRUSTSTORE,
                         "/etc/gutterball/certs/amqp/gutterball.truststore");

--- a/gutterball/src/test/java/org/candlepin/gutterball/receiver/EventRecieverTests.java
+++ b/gutterball/src/test/java/org/candlepin/gutterball/receiver/EventRecieverTests.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package org.candlepin.gutterball.receiver;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import org.candlepin.common.config.Configuration;
+import org.candlepin.gutterball.config.ConfigProperties;
+
+import org.apache.qpid.AMQException;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.URISyntaxException;
+
+import javax.jms.JMSException;
+
+public class EventRecieverTests {
+
+    private static int callCount = 0;
+
+    @Before
+    public void before() {
+        callCount = 0;
+    }
+
+    @Test
+    public void ensureConnectionRetryOnStartUp() {
+        Configuration config = mock(Configuration.class);
+        when(config.getString(any(String.class))).thenReturn("");
+        when(config.getInt(ConfigProperties.AMQP_CONNECTION_RETRY_ATTEMPTS)).thenReturn(2);
+        when(config.getInt(ConfigProperties.AMQP_CONNECTION_RETRY_INTERVAL)).thenReturn(1);
+
+        try {
+            new EventReceiver(config, null) {
+
+                @Override
+                protected void init(Configuration config) throws AMQException,
+                        JMSException, URISyntaxException {
+                    callCount++;
+                    throw new JMSException("Forced failure");
+                }
+
+            };
+            fail("Exception should have been thrown once max retries was hit.");
+        } catch (Exception e) {
+            assertEquals(2, callCount);
+        }
+    }
+
+}


### PR DESCRIPTION
If gutterball fails to connect to the event bus on startup,
pause and retry a configured amount of times before failing
completely.

Both the number of times to retry and the time between retries
are configurable.