### PR TITLE
Fix NPE deleting consumer without identity cert.

### DIFF
--- a/server/spec/ueber_cert_spec.rb
+++ b/server/spec/ueber_cert_spec.rb
@@ -17,5 +17,15 @@ describe 'Uebercert' do
     end.should raise_exception(RestClient::ResourceNotFound)
   end
 
+  it 'consumers can be deleted' do
+    owner = @cp.create_owner random_string("test_owner1")
+    @cp.generate_ueber_cert(owner['key'])
+    consumers = @cp.list_consumers({:owner => owner['key']})
+    consumers.size.should == 1
+    uber_consumer = consumers[0]
+    @cp.unregister(uber_consumer['uuid'])
+    @cp.list_consumers({:owner => owner['key']}).size.should == 0
+  end
+
 end
 

--- a/server/src/main/java/org/candlepin/service/impl/DefaultIdentityCertServiceAdapter.java
+++ b/server/src/main/java/org/candlepin/service/impl/DefaultIdentityCertServiceAdapter.java
@@ -66,6 +66,11 @@ public class DefaultIdentityCertServiceAdapter implements
 
     @Override
     public void deleteIdentityCert(Consumer consumer) {
+        if (consumer.getIdCert() == null) {
+            log.warn("Unable to delete null identity cert for consumer: " +
+                    consumer.getUuid());
+            return;
+        }
         IdentityCertificate certificate = idCertCurator
             .find(consumer.getIdCert().getId());
         if (certificate != null) {


### PR DESCRIPTION
This can happen for ubercert consumers in Satellite at the very least, it seems
to be happening very rarely for real systems, and the cause of this is
currently unknown. None the less we should allow them to be deleted.