### PR TITLE
1200142: Support overriding content metadata expiry to 0 in Satellite.

### DIFF
--- a/server/src/main/java/org/candlepin/model/ContentCurator.java
+++ b/server/src/main/java/org/candlepin/model/ContentCurator.java
@@ -35,4 +35,20 @@ public class ContentCurator extends AbstractHibernateCurator<Content> {
         // Copy the ID so Hibernate knows this is an existing entity to merge:
         return merge(c);
     }
+
+    /**
+     * Forces metadata expiry to the given value for all content in the system, globally.
+     *
+     * Part of the temporary API call for Satellite, this method should go away when
+     * PUT /content/metadataexpire does.
+     * @param metadataExpire
+     * @return Number of rows updated.
+     */
+    public int forceMetadataExpiry(Long metadataExpire) {
+        String hql = "update Content c set c.metadataExpire = :expiry "
+                + "where c.metadataExpire != :expiry";
+        int updated = currentSession().createQuery(hql).setLong("expiry",
+                metadataExpire).executeUpdate();
+        return updated;
+    }
 }

--- a/server/src/main/java/org/candlepin/resource/ContentResource.java
+++ b/server/src/main/java/org/candlepin/resource/ContentResource.java
@@ -26,6 +26,8 @@ import org.candlepin.service.UniqueIdGenerator;
 
 import com.google.inject.Inject;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xnap.commons.i18n.I18n;
 
 import java.util.ArrayList;
@@ -54,6 +56,7 @@ public class ContentResource {
     private EnvironmentContentCurator envContentCurator;
     private PoolManager poolManager;
     private ProductServiceAdapter productAdapter;
+    private static Logger log = LoggerFactory.getLogger(ContentResource.class);
 
     @Inject
     public ContentResource(ContentCurator contentCurator, I18n i18n,
@@ -194,6 +197,20 @@ public class ContentResource {
         }
 
         return updated;
+    }
+
+    /**
+     * Forces the metadata expire of all content to 0 in the database.
+     *
+     * This API is a temporary measure for Satellite and will be removed in future
+     * releases. Do not use it.
+     */
+    @PUT
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("/metadataexpire")
+    public void  forceMetadataExpire() {
+        int changes = contentCurator.forceMetadataExpiry(new Long(0));
+        log.warn("Forced metadata expire to 0 for {} content rows.", changes);
     }
 
     private <T> Set<T> setFrom(T anElement) {


### PR DESCRIPTION
This is a temporary solution to a problem in Satellite where clients
should always have metadata expire set to 0. In the absence of some
kind of global override for this value on all content, we'll expose
an API call which overrides all content to 0. Satellite will call
this API whenever a manifest is imported.

A big caveat here, this will have no effect on existing entitlements.
The client sees the local value as a manual edit and thus preserves
it. There is little that can be done about this, even re-binding would
require a client check-in in between the old and new entitlements.