### PR TITLE
1200142: Force content metadata expire to 0 in standalone.

### DIFF
--- a/server/src/main/java/org/candlepin/sync/ProductImporter.java
+++ b/server/src/main/java/org/candlepin/sync/ProductImporter.java
@@ -77,6 +77,13 @@ public class ProductImporter {
                 if (StringUtils.isBlank(c.getVendor())) {
                     c.setVendor("unknown");
                 }
+
+                // On standalone servers we need metadata expiry to be 0 so clients can
+                // immediately get changes to content when published on the server.
+                // We can assume this is a standalone server due to the fact that
+                // import is being used, so no need to guard this behavior:
+                c.setMetadataExpire(new Long(0));
+
                 contentCurator.createOrUpdate(c);
             }
 

--- a/server/src/main/resources/db/changelog/20150311151612-force-all-content-metadataexpire-to-0.xml
+++ b/server/src/main/resources/db/changelog/20150311151612-force-all-content-metadataexpire-to-0.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+    <changeSet id="20150311151612-1" author="dgoodwin">
+        <comment>Force all content metadataexpire to 0. Only takes effect in standalone servers as in upstream these tables are empty.</comment>
+        <sql>UPDATE cp_content SET metadataexpire = 0</sql>
+    </changeSet>
+
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/server/src/main/resources/db/changelog/changelog-create.xml
+++ b/server/src/main/resources/db/changelog/changelog-create.xml
@@ -1171,4 +1171,5 @@
     <include file="db/changelog/20150123105016-add-consumer-checkin-table.xml"/>
     <include file="db/changelog/20150211111319-add-last-guest-update-table.xml"/>
     <include file="db/changelog/20150316122833-add-entitlement-end-date-override.xml"/>
+    <include file="db/changelog/20150311151612-force-all-content-metadataexpire-to-0.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-testing.xml
+++ b/server/src/main/resources/db/changelog/changelog-testing.xml
@@ -2027,7 +2027,7 @@
     </changeSet>
     <changeSet author="awood" id="1413225753032-290">
         <comment>
-             Add the default quartz lock columns. 
+             Add the default quartz lock columns.
         </comment>
         <insert tableName="QRTZ_LOCKS">
             <column name="LOCK_NAME" value="TRIGGER_ACCESS"/>
@@ -2261,4 +2261,5 @@
     <include file="db/changelog/20150123105016-add-consumer-checkin-table.xml"/>
     <include file="db/changelog/20150211111319-add-last-guest-update-table.xml"/>
     <include file="db/changelog/20150316122833-add-entitlement-end-date-override.xml"/>
+    <include file="db/changelog/20150311151612-force-all-content-metadataexpire-to-0.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-update.xml
+++ b/server/src/main/resources/db/changelog/changelog-update.xml
@@ -79,4 +79,5 @@
     <include file="db/changelog/20150123105016-add-consumer-checkin-table.xml"/>
     <include file="db/changelog/20150211111319-add-last-guest-update-table.xml"/>
     <include file="db/changelog/20150316122833-add-entitlement-end-date-override.xml"/>
+    <include file="db/changelog/20150311151612-force-all-content-metadataexpire-to-0.xml"/>
 </databaseChangeLog>

--- a/server/src/test/java/org/candlepin/sync/ProductImporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/ProductImporterTest.java
@@ -14,12 +14,8 @@
  */
 package org.candlepin.sync;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 import org.candlepin.common.config.MapConfiguration;
 import org.candlepin.config.ConfigProperties;
@@ -52,6 +48,7 @@ public class ProductImporterTest {
     private ProductImporter importer;
     private ProductCurator productCuratorMock;
     private ContentCurator contentCuratorMock;
+
     @Before
     public void setUp() throws IOException {
         mapper = SyncUtils.getObjectMapper(new MapConfiguration(
@@ -130,7 +127,8 @@ public class ProductImporterTest {
 
         verify(contentCuratorMock).createOrUpdate(c);
 
-        assertEquals(new Long(1000), c.getMetadataExpire());
+        // Metadata expiry should be overridden to 0 on import:
+        assertEquals(new Long(0), c.getMetadataExpire());
     }
 
     @Test
@@ -418,11 +416,12 @@ public class ProductImporterTest {
     }
 
     // Returns the Content object added
-    private void addContentTo(Product p) {
+    private Content addContentTo(Product p) {
         Content c = new Content("name", "100130", "label", "type",
             "vendor", "url", "gpgurl", "arch");
         c.setMetadataExpire(1000L);
         p.getProductContent().add(new ProductContent(p, c, true));
+        return c;
     }
 
     // Returns the Content object added without vendor


### PR DESCRIPTION
Imports only run in standalone, thus it's safe to assume that on import
we can force metadata expire to 0, allowing clients to immediately see
changes to published content.

On upgrade we'll flip all content to 0. This should be safe as these
tables are currently empty in production, thus this should only affect
standalone servers.