### PR TITLE
Mstead/gb mgmt enabled filtering fixes

### DIFF
--- a/gutterball/src/main/java/org/candlepin/gutterball/curator/ComplianceSnapshotCurator.java
+++ b/gutterball/src/main/java/org/candlepin/gutterball/curator/ComplianceSnapshotCurator.java
@@ -15,19 +15,19 @@
 
 package org.candlepin.gutterball.curator;
 
+import org.candlepin.common.config.PropertyConverter;
 import org.candlepin.common.paging.Page;
 import org.candlepin.common.paging.PageRequest;
-
-import org.candlepin.gutterball.util.AutoEvictingColumnarResultsIterator;
 import org.candlepin.gutterball.model.snapshot.Compliance;
+import org.candlepin.gutterball.util.AutoEvictingColumnarResultsIterator;
 
 import com.google.inject.Inject;
 
-import org.hibernate.Criteria;
 import org.hibernate.CacheMode;
+import org.hibernate.Criteria;
 import org.hibernate.Query;
-import org.hibernate.ScrollableResults;
 import org.hibernate.ScrollMode;
+import org.hibernate.ScrollableResults;
 import org.hibernate.Session;
 import org.hibernate.criterion.DetachedCriteria;
 import org.hibernate.criterion.Order;
@@ -102,13 +102,14 @@ public class ComplianceSnapshotCurator extends BaseCurator<Compliance> {
      *  An iterator over the compliance snapshots for the target date.
      */
     public Iterator<Compliance> getSnapshotIterator(Date targetDate, List<String> consumerUuids,
-        List<String> ownerFilters, List<String> statusFilters) {
+        List<String> ownerFilters, List<String> statusFilters, Map<String, String> attributeFilters) {
 
         Page<Iterator<Compliance>> result = this.getSnapshotIterator(
             targetDate,
             consumerUuids,
             ownerFilters,
             statusFilters,
+            attributeFilters,
             null
         );
 
@@ -143,7 +144,8 @@ public class ComplianceSnapshotCurator extends BaseCurator<Compliance> {
      *  the paging information for the query.
      */
     public Page<Iterator<Compliance>> getSnapshotIterator(Date targetDate, List<String> consumerUuids,
-        List<String> ownerFilters, List<String> statusFilters, PageRequest pageRequest) {
+        List<String> ownerFilters, List<String> statusFilters, Map<String, String> attributeFilters,
+        PageRequest pageRequest) {
 
         Page<Iterator<Compliance>> page = new Page<Iterator<Compliance>>();
         page.setPageRequest(pageRequest);
@@ -185,9 +187,19 @@ public class ComplianceSnapshotCurator extends BaseCurator<Compliance> {
             .setCacheMode(CacheMode.IGNORE)
             .setReadOnly(true);
 
-        if (statusFilters != null && !statusFilters.isEmpty()) {
+
+        if ((statusFilters != null && !statusFilters.isEmpty()) ||
+                (attributeFilters != null && attributeFilters.containsKey("management_enabled"))) {
             query.createAlias("status", "stat");
-            query.add(Restrictions.in("stat.status", statusFilters));
+            if (statusFilters != null && !statusFilters.isEmpty()) {
+                query.add(Restrictions.in("stat.status", statusFilters));
+            }
+
+            if (attributeFilters != null && attributeFilters.containsKey("management_enabled")) {
+                boolean managementEnabledFilter =
+                        PropertyConverter.toBoolean(attributeFilters.get("management_enabled"));
+                query.add(Restrictions.eq("stat.managementEnabled", managementEnabledFilter));
+            }
         }
 
         if (pageRequest != null && pageRequest.isPaging()) {

--- a/gutterball/src/main/java/org/candlepin/gutterball/curator/ComplianceSnapshotCurator.java
+++ b/gutterball/src/main/java/org/candlepin/gutterball/curator/ComplianceSnapshotCurator.java
@@ -829,6 +829,18 @@ public class ComplianceSnapshotCurator extends BaseCurator<Compliance> {
             }
 
             if (attributes != null) {
+
+                if (attributes.containsKey("management_enabled")) {
+                    boolean managementEnabledFilter =
+                            PropertyConverter.toBoolean(attributes.get("management_enabled"));
+                    criteria.add("ComplianceStatusSnap.managementEnabled = ?" + ++counter);
+                    parameters.add(managementEnabledFilter);
+
+                    // Don't process this attribute as part of entitlement attributes,
+                    // as it has already been handled.
+                    attributes.remove("management_enabled");
+                }
+
                 for (Map.Entry<String, String> entry : attributes.entrySet()) {
                     criteria.add(String.format(
                         "(?%d, ?%d) IN (" +

--- a/gutterball/src/main/java/org/candlepin/gutterball/model/snapshot/ComplianceStatus.java
+++ b/gutterball/src/main/java/org/candlepin/gutterball/model/snapshot/ComplianceStatus.java
@@ -129,6 +129,7 @@ public class ComplianceStatus {
         this.compliantProducts = new HashSet<String>();
         this.partiallyCompliantProducts = new HashSet<String>();
         this.partialStacks = new HashSet<String>();
+        this.managementEnabled = Boolean.FALSE;
     }
 
     public ComplianceStatus(Date date, String status) {

--- a/gutterball/src/main/java/org/candlepin/gutterball/model/snapshot/ComplianceStatus.java
+++ b/gutterball/src/main/java/org/candlepin/gutterball/model/snapshot/ComplianceStatus.java
@@ -119,6 +119,9 @@ public class ComplianceStatus {
     @JsonDeserialize(converter = MapToKeysConverter.class)
     private Set<String> partialStacks;
 
+    @Column(name="management_enabled")
+    private Boolean managementEnabled;
+
     public ComplianceStatus() {
         // Required by hibernate.
         reasons = new HashSet<ComplianceReason>();
@@ -220,6 +223,14 @@ public class ComplianceStatus {
 
     public void setPartialStacks(Set<String> partialStacks) {
         this.partialStacks = partialStacks;
+    }
+
+    public Boolean getManagementEnabled() {
+        return managementEnabled;
+    }
+
+    public void setManagementEnabled(Boolean managementEnabled) {
+        this.managementEnabled = managementEnabled;
     }
 
 }

--- a/gutterball/src/main/java/org/candlepin/gutterball/model/snapshot/ComplianceStatus.java
+++ b/gutterball/src/main/java/org/candlepin/gutterball/model/snapshot/ComplianceStatus.java
@@ -119,7 +119,7 @@ public class ComplianceStatus {
     @JsonDeserialize(converter = MapToKeysConverter.class)
     private Set<String> partialStacks;
 
-    @Column(name="management_enabled")
+    @Column(name = "management_enabled")
     private Boolean managementEnabled;
 
     public ComplianceStatus() {

--- a/gutterball/src/main/java/org/candlepin/gutterball/report/ConsumerStatusReport.java
+++ b/gutterball/src/main/java/org/candlepin/gutterball/report/ConsumerStatusReport.java
@@ -89,14 +89,14 @@ public class ConsumerStatusReport extends Report<ReportResult> {
 
         addParameter(
             builder.init(
-               "management_enabled",
+                "management_enabled",
                 i18n.tr("Filter on subscriptions which have management enabled set to this value (boolean)"))
                 .getParameter()
         );
 
         addParameter(
-            builder.init(CUSTOM_RESULTS_PARAM, i18n.tr("Enables/disables custom report result functionality " +
-                    "via attribute filtering (boolean).")).getParameter());
+            builder.init(CUSTOM_RESULTS_PARAM, i18n.tr("Enables/disables custom report result " +
+                    "functionality via attribute filtering (boolean).")).getParameter());
 
         addParameter(builder.init("include_reasons", i18n.tr("Include status reasons in results"))
                 .mustNotHave(CUSTOM_RESULTS_PARAM)

--- a/gutterball/src/main/java/org/candlepin/gutterball/report/ConsumerStatusReport.java
+++ b/gutterball/src/main/java/org/candlepin/gutterball/report/ConsumerStatusReport.java
@@ -98,6 +98,10 @@ public class ConsumerStatusReport extends Report<ReportResult> {
             builder.init(CUSTOM_RESULTS_PARAM, i18n.tr("Enables/disables custom report result functionality " +
                     "via attribute filtering (boolean).")).getParameter());
 
+        addParameter(builder.init("include_reasons", i18n.tr("Include status reasons in results"))
+                .mustNotHave(CUSTOM_RESULTS_PARAM)
+                .getParameter());
+
         addParameter(builder.init("include", i18n.tr("Includes the specified attribute in the result JSON"))
                 .mustHave(CUSTOM_RESULTS_PARAM)
                 .mustNotHave("exclude")
@@ -138,6 +142,11 @@ public class ConsumerStatusReport extends Report<ReportResult> {
             }
         }
 
+        boolean includeReasons = true;
+        if (queryParams.containsKey("include_reasons")) {
+            includeReasons = PropertyConverter.toBoolean(queryParams.getFirst("include_reasons"));
+        }
+
         String custom = queryParams.containsKey(CUSTOM_RESULTS_PARAM) ?
             queryParams.getFirst(CUSTOM_RESULTS_PARAM) : "";
         boolean useCustom = PropertyConverter.toBoolean(custom);
@@ -155,6 +164,6 @@ public class ConsumerStatusReport extends Report<ReportResult> {
 
         return useCustom ?
             new ReasonGeneratingReportResult(page.getPageData(), this.messageGenerator) :
-            new ConsumerStatusReportDefaultResult(page.getPageData());
+            new ConsumerStatusReportDefaultResult(page.getPageData(), includeReasons);
     }
 }

--- a/gutterball/src/main/java/org/candlepin/gutterball/report/ConsumerStatusReport.java
+++ b/gutterball/src/main/java/org/candlepin/gutterball/report/ConsumerStatusReport.java
@@ -15,6 +15,7 @@
 
 package org.candlepin.gutterball.report;
 
+import org.candlepin.common.config.ConversionException;
 import org.candlepin.common.config.PropertyConverter;
 import org.candlepin.common.paging.Page;
 import org.candlepin.common.paging.PageRequest;
@@ -27,8 +28,10 @@ import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.xnap.commons.i18n.I18n;
 
 import java.util.Date;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 import javax.inject.Provider;
 import javax.ws.rs.core.MultivaluedMap;
@@ -85,8 +88,15 @@ public class ConsumerStatusReport extends Report<ReportResult> {
         );
 
         addParameter(
-            builder.init(CUSTOM_RESULTS_PARAM, i18n.tr("Enables/disables custom report result " +
-                    "functionality via attribute filtering (boolean).")).getParameter());
+            builder.init(
+               "management_enabled",
+                i18n.tr("Filter on subscriptions which have management enabled set to this value (boolean)"))
+                .getParameter()
+        );
+
+        addParameter(
+            builder.init(CUSTOM_RESULTS_PARAM, i18n.tr("Enables/disables custom report result functionality " +
+                    "via attribute filtering (boolean).")).getParameter());
 
         addParameter(builder.init("include", i18n.tr("Includes the specified attribute in the result JSON"))
                 .mustHave(CUSTOM_RESULTS_PARAM)
@@ -115,6 +125,19 @@ public class ConsumerStatusReport extends Report<ReportResult> {
             parseDateTime(queryParams.getFirst("on_date")) :
             new Date();
 
+        Map<String, String> attributeFilters = new HashMap<String, String>();
+        String managementEnabled = queryParams.getFirst("management_enabled");
+        if (managementEnabled != null) {
+            try {
+                attributeFilters.put(
+                    "management_enabled", (PropertyConverter.toBoolean(managementEnabled) ? "1" : "0")
+                );
+            }
+            catch (ConversionException e) {
+                // This shouldn't happen; but if it does, do nothing. Maybe assume false?
+            }
+        }
+
         String custom = queryParams.containsKey(CUSTOM_RESULTS_PARAM) ?
             queryParams.getFirst(CUSTOM_RESULTS_PARAM) : "";
         boolean useCustom = PropertyConverter.toBoolean(custom);
@@ -124,6 +147,7 @@ public class ConsumerStatusReport extends Report<ReportResult> {
             consumerIds,
             ownerFilters,
             statusFilters,
+            attributeFilters,
             pageRequest
         );
 

--- a/gutterball/src/main/java/org/candlepin/gutterball/report/ConsumerStatusReportDefaultResult.java
+++ b/gutterball/src/main/java/org/candlepin/gutterball/report/ConsumerStatusReportDefaultResult.java
@@ -28,13 +28,16 @@ import java.util.Iterator;
 public class ConsumerStatusReportDefaultResult extends
     ComplianceTransformerIterator<ConsumerStatusComplianceDto> {
 
-    public ConsumerStatusReportDefaultResult(Iterator<Compliance> dbIterator) {
+    private boolean includeReasons;
+
+    public ConsumerStatusReportDefaultResult(Iterator<Compliance> dbIterator, boolean includeReasons) {
         super(dbIterator);
+        this.includeReasons = includeReasons;
     }
 
     @Override
     ConsumerStatusComplianceDto convertDbObject(Compliance compliance) {
-        return new ConsumerStatusComplianceDto(compliance);
+        return new ConsumerStatusComplianceDto(compliance, includeReasons);
     }
 
 }

--- a/gutterball/src/main/java/org/candlepin/gutterball/report/ConsumerTrendReport.java
+++ b/gutterball/src/main/java/org/candlepin/gutterball/report/ConsumerTrendReport.java
@@ -91,19 +91,19 @@ public class ConsumerTrendReport extends Report<ReportResult> {
             builder.init(CUSTOM_RESULTS_PARAM, i18n.tr("Enables/disables custom report result " +
                         "functionality via attribute filtering (boolean).")).getParameter());
 
-        addParameter(
-            builder.init("include", i18n.tr("Includes the specified attribute in the result JSON"))
-                .multiValued()
-                .mustHave(CUSTOM_RESULTS_PARAM)
-                .mustNotHave("exclude")
-                .getParameter());
+        addParameter(builder.init("include",
+                i18n.tr("Includes the specified attribute in the result JSON"))
+            .multiValued()
+            .mustHave(CUSTOM_RESULTS_PARAM)
+            .mustNotHave("exclude")
+            .getParameter());
 
-        addParameter(
-            builder.init("exclude", i18n.tr("Excludes the specified attribute in the result JSON"))
-                .multiValued()
-                .mustHave(CUSTOM_RESULTS_PARAM)
-                .mustNotHave("include")
-                .getParameter());
+        addParameter(builder.init("exclude",
+                i18n.tr("Excludes the specified attribute in the result JSON"))
+            .multiValued()
+            .mustHave(CUSTOM_RESULTS_PARAM)
+            .mustNotHave("include")
+            .getParameter());
     }
 
     @Override

--- a/gutterball/src/main/java/org/candlepin/gutterball/report/StatusTrendReport.java
+++ b/gutterball/src/main/java/org/candlepin/gutterball/report/StatusTrendReport.java
@@ -113,7 +113,7 @@ public class StatusTrendReport extends Report<StatusTrendReportResult> {
         this.addParameter(
             builder.init(
                 "management_enabled",
-                i18n.tr("Whether or not to filter on subscriptions which have management enabled (boolean)")
+                i18n.tr("Filter on subscriptions which have management enabled set to this value (boolean)")
             )
                 .mustNotHave("sku", "subscription_name")
                 .getParameter()

--- a/gutterball/src/main/java/org/candlepin/gutterball/report/dto/ConsumerStatusComplianceDto.java
+++ b/gutterball/src/main/java/org/candlepin/gutterball/report/dto/ConsumerStatusComplianceDto.java
@@ -61,6 +61,7 @@ public class ConsumerStatusComplianceDto extends HashMap<String, Object> {
         ComplianceStatus status = snap.getStatus();
         statusData.put("status", status.getStatus());
         statusData.put("date", status.getDate());
+        statusData.put("managementEnabled", status.getManagementEnabled());
 
         put("consumer", consumerData);
         put("status", statusData);

--- a/gutterball/src/main/java/org/candlepin/gutterball/report/dto/ConsumerStatusComplianceDto.java
+++ b/gutterball/src/main/java/org/candlepin/gutterball/report/dto/ConsumerStatusComplianceDto.java
@@ -17,11 +17,14 @@ package org.candlepin.gutterball.report.dto;
 
 import org.candlepin.gutterball.model.ConsumerState;
 import org.candlepin.gutterball.model.snapshot.Compliance;
+import org.candlepin.gutterball.model.snapshot.ComplianceReason;
 import org.candlepin.gutterball.model.snapshot.ComplianceStatus;
 import org.candlepin.gutterball.model.snapshot.Consumer;
 import org.candlepin.gutterball.model.snapshot.Owner;
 
 import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -31,7 +34,7 @@ import java.util.Map;
  */
 public class ConsumerStatusComplianceDto extends HashMap<String, Object> {
 
-    public ConsumerStatusComplianceDto(Compliance snap) {
+    public ConsumerStatusComplianceDto(Compliance snap, boolean includeReasons) {
         // TODO: Using maps instead of individual fields seems to be a little faster to serialize
         //       and allows us to keep the same result JSON structure as using the custom report.
         //       Should this object just contain a field for each property that we want to return.
@@ -56,12 +59,22 @@ public class ConsumerStatusComplianceDto extends HashMap<String, Object> {
         consumerData.put("facts", new HashMap<String, String>(consumer.getFacts()));
         consumerData.put("consumerState", consumerStateData);
 
-
         Map<String, Object> statusData = new HashMap<String, Object>();
         ComplianceStatus status = snap.getStatus();
         statusData.put("status", status.getStatus());
         statusData.put("date", status.getDate());
         statusData.put("managementEnabled", status.getManagementEnabled());
+
+        if (includeReasons) {
+            List<Map<String, Object>> reasonsData = new LinkedList<Map<String, Object>>();
+            for (ComplianceReason cr : status.getReasons()) {
+                HashMap<String, Object> reasonData = new HashMap<String, Object>();
+                reasonData.put("message", cr.getMessage());
+                reasonData.put("attributes", new HashMap<String, String>(cr.getAttributes()));
+                reasonsData.add(reasonData);
+            }
+            statusData.put("reasons", reasonsData);
+        }
 
         put("consumer", consumerData);
         put("status", statusData);

--- a/gutterball/src/main/java/org/candlepin/gutterball/report/dto/ConsumerTrendComplianceDto.java
+++ b/gutterball/src/main/java/org/candlepin/gutterball/report/dto/ConsumerTrendComplianceDto.java
@@ -51,6 +51,7 @@ public class ConsumerTrendComplianceDto extends HashMap<String, Object> {
         statusData.put("status", status.getStatus());
         statusData.put("date", status.getDate());
         statusData.put("reasons", reasonsData);
+        statusData.put("managementEnabled", status.getManagementEnabled());
 
         Map<String, Object> consumerData = new HashMap<String, Object>();
         consumerData.put("uuid", consumer.getUuid());

--- a/gutterball/src/main/resources/db/changelog/2015-03-11-09-28-add-management-enabled-to-compliance.xml
+++ b/gutterball/src/main/resources/db/changelog/2015-03-11-09-28-add-management-enabled-to-compliance.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+    <changeSet id="20150311092807-1" author="mstead">
+        <comment>Add management_enabled column to gb_compliance_snap</comment>
+        <addColumn tableName="gb_compliance_status_snap">
+            <column name="management_enabled" type="boolean" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+    <changeSet id="20150311092807-2" author="mstead">
+        <comment>Migrate management_enabled column data from entitlements</comment>
+        <sql>
+      update gb_compliance_status_snap
+                  set management_enabled = true
+                  where compliance_snap_id in (
+                      select distinct comp.id
+                          from gb_compliance_snap comp
+                          inner join gb_entitlement_snap ent on ent.compliance_snap_id = comp.id
+                          inner join gb_ent_attr_snap attr on attr.ent_snap_id = ent.id
+                          where attr.gb_ent_attr_name = 'management_enabled'
+                          and (
+                  attr.gb_ent_attr_value = '1'
+                  or attr.gb_ent_attr_value = 'true'
+                  or attr.gb_ent_attr_value = 'True'
+                  or attr.gb_ent_attr_value = 'T'
+                  or attr.gb_ent_attr_value = 't'
+                  or attr.gb_ent_attr_value = 'Yes'
+                  or attr.gb_ent_attr_value = 'yes'
+                  or attr.gb_ent_attr_value = 'Y'
+                  or attr.gb_ent_attr_value = 'Y')
+      );
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/gutterball/src/main/resources/db/changelog/changelog.xml
+++ b/gutterball/src/main/resources/db/changelog/changelog.xml
@@ -5,4 +5,5 @@
     <include file="db/changelog/2014-11-03-07-57-additional-indexes.xml"/>
     <include file="db/changelog/2014-12-03-15-20-drop-unused-messagetext-event-column.xml"/>
     <include file="db/changelog/2014-12-03-15-39-add-event-status.xml"/>
+    <include file="db/changelog/2015-03-11-09-28-add-management-enabled-to-compliance.xml"/>
 </databaseChangeLog>

--- a/gutterball/src/test/java/org/candlepin/gutterball/report/ConsumerStatusReportTest.java
+++ b/gutterball/src/test/java/org/candlepin/gutterball/report/ConsumerStatusReportTest.java
@@ -21,7 +21,6 @@ import static org.mockito.Mockito.*;
 
 import org.candlepin.common.paging.Page;
 import org.candlepin.common.paging.PageRequest;
-
 import org.candlepin.gutterball.TestUtils;
 import org.candlepin.gutterball.curator.ComplianceSnapshotCurator;
 import org.candlepin.gutterball.guice.I18nProvider;
@@ -42,6 +41,7 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
@@ -77,7 +77,8 @@ public class ConsumerStatusReportTest {
 
         // Indentation note: This is what checkstyle actually wants. :/
         when(complianceSnapshotCurator.getSnapshotIterator(
-                any(Date.class), any(List.class), any(List.class), any(List.class), any(PageRequest.class)
+                any(Date.class), any(List.class), any(List.class), any(List.class), any(Map.class),
+                any(PageRequest.class)
         )).thenReturn(page);
 
         report = new ConsumerStatusReport(i18nProvider, complianceSnapshotCurator, messageGenerator);
@@ -115,7 +116,7 @@ public class ConsumerStatusReportTest {
         report.run(params, pageRequest);
 
         verify(complianceSnapshotCurator).getSnapshotIterator(eq(cal.getTime()),
-                eq(uuids), eq(owners), eq(status), eq(pageRequest));
+                eq(uuids), eq(owners), eq(status), any(Map.class), eq(pageRequest));
         verifyNoMoreInteractions(complianceSnapshotCurator);
     }
 
@@ -133,7 +134,7 @@ public class ConsumerStatusReportTest {
         report.run(params, pageRequest);
 
         verify(complianceSnapshotCurator).getSnapshotIterator(any(Date.class),
-                eq(uuids), eq(owners), eq(status), eq(pageRequest));
+                eq(uuids), eq(owners), eq(status), any(Map.class), eq(pageRequest));
         verifyNoMoreInteractions(complianceSnapshotCurator);
     }
 
@@ -151,6 +152,7 @@ public class ConsumerStatusReportTest {
         verify(complianceSnapshotCurator).getSnapshotIterator(any(Date.class),
                 eq(uuids), eq(owners),
                 eq(Arrays.asList("partial")),
+                any(Map.class),
                 eq(pageRequest));
         verifyNoMoreInteractions(complianceSnapshotCurator);
     }
@@ -172,6 +174,7 @@ public class ConsumerStatusReportTest {
                 eq(uuids),
                 eq(owners),
                 eq(statuses),
+                any(Map.class),
                 eq(pageRequest)
         );
         verifyNoMoreInteractions(complianceSnapshotCurator);
@@ -190,7 +193,8 @@ public class ConsumerStatusReportTest {
         page.setPageData(complianceList.iterator());
 
         when(complianceSnapshotCurator.getSnapshotIterator(
-                any(Date.class), any(List.class), any(List.class), any(List.class), any(PageRequest.class)
+                any(Date.class), any(List.class), any(List.class), any(List.class), any(Map.class),
+                any(PageRequest.class)
         )).thenReturn(page);
 
         ComplianceTransformerIterator result = (ComplianceTransformerIterator) report.run(params, null);
@@ -212,7 +216,8 @@ public class ConsumerStatusReportTest {
         page.setPageData(complianceList.iterator());
 
         when(complianceSnapshotCurator.getSnapshotIterator(
-                any(Date.class), any(List.class), any(List.class), any(List.class), any(PageRequest.class)
+                any(Date.class), any(List.class), any(List.class), any(List.class),
+                any(Map.class), any(PageRequest.class)
         )).thenReturn(page);
 
         ReasonGeneratingReportResult result = (ReasonGeneratingReportResult) report.run(params, null);


### PR DESCRIPTION
Added a new column to ComplianceStatus that tracks whether
the consumer has an entitlement that sets management_enabled.

This value is populated when a consumer event is processed.

This approach was a lot easier than having the query determine
it and avoids another subquery. The data does not change once
received and stored, so this is Ok.

Added ability to filter consumer_status by management_enabled.

Added reasons to consumer_status default output and a query parameter to allow disabling them if required.