### PR TITLE
1201727: Filter entitle_id from reason attributes

### DIFF
--- a/server/src/main/java/org/candlepin/policy/js/compliance/StatusReasonMessageGenerator.java
+++ b/server/src/main/java/org/candlepin/policy/js/compliance/StatusReasonMessageGenerator.java
@@ -90,6 +90,11 @@ public class StatusReasonMessageGenerator {
                 reason.getAttributes().get("has")));
         }
         else if (reason.getKey().equals("UNMAPPEDGUEST")) {
+            // clients don't like reasons to have entitlement_id attributes that
+            // may not be valid entitlements, but we need it returned from rules so
+            // we can set the name correctly. See
+            // https://bugzilla.redhat.com/show_bug.cgi?id=1201727
+            reason.getAttributes().remove("entitlement_id");
             reason.setMessage(i18n.tr("Guest has not been reported on any host" +
                 " and is using a temporary unmapped guest subscription."));
         }


### PR DESCRIPTION
For reasons related to unmapped guests, filter out
the attribute 'entitlement_id' so deployed clients
don't attempt to match it with local valid entitlement
certs, since it can reference expired entitlements.

Do this after returning from the rules so
StatusReasonMapGenerator can create a meaningful
name.