### PR TITLE
Fix entitlement validity code for temp entitlements.

### DIFF
--- a/server/src/main/java/org/candlepin/controller/Entitler.java
+++ b/server/src/main/java/org/candlepin/controller/Entitler.java
@@ -252,20 +252,13 @@ public class Entitler {
                 consumer, "unmapped_guests_only", "true");
         }
 
-        Date now = new Date();
         for (Entitlement e : unmappedGuestEntitlements) {
-            if (isLapsed(e, now)) {
+            if (!e.isValid()) {
                 poolManager.revokeEntitlement(e);
                 total++;
             }
         }
         return total;
-    }
-
-    protected boolean isLapsed(Entitlement e, Date now) {
-        Date consumerCreation = e.getConsumer().getCreated();
-        Date lapseDate = new Date(consumerCreation.getTime() + 24L * 60L * 60L * 1000L);
-        return lapseDate.before(now);
     }
 
     public int revokeUnmappedGuestEntitlements() {

--- a/server/src/main/java/org/candlepin/model/Entitlement.java
+++ b/server/src/main/java/org/candlepin/model/Entitlement.java
@@ -18,6 +18,7 @@ import org.candlepin.common.jackson.HateoasInclude;
 
 import com.fasterxml.jackson.annotation.JsonFilter;
 
+import org.apache.commons.lang.BooleanUtils;
 import org.hibernate.annotations.ForeignKey;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Index;
@@ -302,8 +303,13 @@ public class Entitlement extends AbstractHibernateObject
 
     @XmlTransient
     public boolean isValidOnDate(Date d) {
+        Date endDate = this.getEndDate();
+        boolean isUnmappedGuestPool = BooleanUtils.toBoolean(pool.getAttributeValue("unmapped_guests_only"));
+        if (isUnmappedGuestPool) {
+            endDate = new Date(consumer.getCreated().getTime() + 24L * 60L * 60L * 1000L);
+        }
         return (d.after(this.getStartDate()) || d.equals(this.getStartDate())) &&
-            (d.before(this.getEndDate()) || d.equals(this.getEndDate()));
+            (d.before(endDate) || d.equals(endDate));
     }
 
     @XmlTransient

--- a/server/src/main/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapter.java
+++ b/server/src/main/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapter.java
@@ -201,7 +201,7 @@ public class DefaultEntitlementCertServiceAdapter extends
             startDate = consumer.getCreated();
         }
 
-        Date oneDayFromRegistration = new Date(startDate.getTime() + (24 * 60 * 60 * 1000));
+        Date oneDayFromRegistration = new Date(startDate.getTime() + 24L * 60L * 60L * 1000L);
 
         boolean isUnmappedGuestPool = BooleanUtils.toBoolean(pool.getAttributeValue("unmapped_guests_only"));
 

--- a/server/src/test/java/org/candlepin/policy/js/compliance/ComplianceRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/compliance/ComplianceRulesTest.java
@@ -133,6 +133,7 @@ public class ComplianceRulesTest {
             c.addInstalledProduct(new ConsumerInstalledProduct(pid, pid));
         }
         c.setFact("cpu.cpu_socket(s)", "8"); // 8 socket machine
+        c.setCreated(new Date(new Date().getTime() - 60L * 60L * 1000L));
         return c;
     }
 


### PR DESCRIPTION
Note that the expired unmapped guest entitlement cleaner job is still necessary because expired items are removed at the pool level.