### PR TITLE
1199443: Add entitlement end date override.

### DIFF
--- a/server/src/main/java/org/candlepin/controller/Entitler.java
+++ b/server/src/main/java/org/candlepin/controller/Entitler.java
@@ -252,20 +252,13 @@ public class Entitler {
                 consumer, "unmapped_guests_only", "true");
         }
 
-        Date now = new Date();
         for (Entitlement e : unmappedGuestEntitlements) {
-            if (isLapsed(e, now)) {
+            if (!e.isValid()) {
                 poolManager.revokeEntitlement(e);
                 total++;
             }
         }
         return total;
-    }
-
-    protected boolean isLapsed(Entitlement e, Date now) {
-        Date consumerCreation = e.getConsumer().getCreated();
-        Date lapseDate = new Date(consumerCreation.getTime() + 24L * 60L * 60L * 1000L);
-        return lapseDate.before(now);
     }
 
     public int revokeUnmappedGuestEntitlements() {

--- a/server/src/main/java/org/candlepin/model/Entitlement.java
+++ b/server/src/main/java/org/candlepin/model/Entitlement.java
@@ -109,6 +109,8 @@ public class Entitlement extends AbstractHibernateObject
     // rerun compliance once we hit the active date range.
     private boolean updatedOnStart = false;
 
+    private Date endDateOverride;
+
     /**
      * default ctor
      */
@@ -200,17 +202,41 @@ public class Entitlement extends AbstractHibernateObject
     }
 
     /**
-     * @return Returns the endDate.
+     * @return Returns the endDate. If an override is specified for this entitlement,
+     * we return this value. If not we'll use the end date of the pool.
      */
     public Date getEndDate() {
+        if (endDateOverride != null) {
+            return endDateOverride;
+        }
+
         if (pool == null) {
             return null;
         }
+
         return pool.getEndDate();
     }
 
     public void setEndDate(Date date) {
         // Only for serialization, end date lives on pool now.
+    }
+
+
+    /**
+     * An optional end date override for this entitlement.
+     *
+     * Typically this is set to null, and the pool's end date is used. In some cases
+     * we need to control the expiry of an entitlement separate from the pool.
+     *
+     * @return optional end date override for this entitlement.
+     */
+    @XmlTransient
+    public Date getEndDateOverride() {
+        return endDateOverride;
+    }
+
+    public void setEndDateOverride(Date endDateOverride) {
+        this.endDateOverride = endDateOverride;
     }
 
     /**

--- a/server/src/main/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapter.java
+++ b/server/src/main/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapter.java
@@ -209,8 +209,7 @@ public class DefaultEntitlementCertServiceAdapter extends
                 pool.getAttributeValue("unmapped_guests_only"));
 
         if (isUnmappedGuestPool) {
-            Date oneDayFromRegistration = new Date(startDate.getTime() +
-                    (24 * 60 * 60 * 1000));
+            Date oneDayFromRegistration = new Date(startDate.getTime() + 24L * 60L * 60L * 1000L);
             log.info("Setting 24h expiration for unmapped guest pool entilement: " +
                     oneDayFromRegistration);
             ent.setEndDateOverride(oneDayFromRegistration);

--- a/server/src/main/resources/db/changelog/20150316122833-add-entitlement-end-date-override.xml
+++ b/server/src/main/resources/db/changelog/20150316122833-add-entitlement-end-date-override.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+    <property name="timestamp.type" value="TIMESTAMP WITH TIME ZONE" dbms="oracle,postgresql,hsqldb"/>
+    <property name="timestamp.type" value="DATETIME" dbms="mysql"/>
+
+    <changeSet id="20150316122833-1" author="dgoodwin">
+        <comment>add entitlement end date override</comment>
+        <!-- See http://www.liquibase.org/documentation/changes/index.html -->
+        <addColumn tableName="cp_entitlement">
+            <column name="enddateoverride" type="${timestamp.type}"/>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/server/src/main/resources/db/changelog/changelog-create.xml
+++ b/server/src/main/resources/db/changelog/changelog-create.xml
@@ -1170,4 +1170,5 @@
     <include file="db/changelog/20141126150611-create-content-tags-table.xml"/>
     <include file="db/changelog/20150123105016-add-consumer-checkin-table.xml"/>
     <include file="db/changelog/20150211111319-add-last-guest-update-table.xml"/>
+    <include file="db/changelog/20150316122833-add-entitlement-end-date-override.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-testing.xml
+++ b/server/src/main/resources/db/changelog/changelog-testing.xml
@@ -2260,4 +2260,5 @@
     <include file="db/changelog/20141126150611-create-content-tags-table.xml"/>
     <include file="db/changelog/20150123105016-add-consumer-checkin-table.xml"/>
     <include file="db/changelog/20150211111319-add-last-guest-update-table.xml"/>
+    <include file="db/changelog/20150316122833-add-entitlement-end-date-override.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-update.xml
+++ b/server/src/main/resources/db/changelog/changelog-update.xml
@@ -78,4 +78,5 @@
     <include file="db/changelog/20141126150611-create-content-tags-table.xml"/>
     <include file="db/changelog/20150123105016-add-consumer-checkin-table.xml"/>
     <include file="db/changelog/20150211111319-add-last-guest-update-table.xml"/>
+    <include file="db/changelog/20150316122833-add-entitlement-end-date-override.xml"/>
 </databaseChangeLog>

--- a/server/src/test/java/org/candlepin/controller/EntitlerTest.java
+++ b/server/src/test/java/org/candlepin/controller/EntitlerTest.java
@@ -330,6 +330,7 @@ public class EntitlerTest {
         p1.addAttribute(new PoolAttribute("unmapped_guests_only", "true"));
 
         Date thirtySixHoursAgo = new Date(new Date().getTime() - 36L * 60L * 60L * 1000L);
+        Date twelveHoursAgo = new Date(new Date().getTime() - 12L * 60L * 60L * 1000L);
 
         Consumer c;
 
@@ -338,6 +339,7 @@ public class EntitlerTest {
         c.setFact("virt.uuid", "1");
 
         Entitlement e1 = TestUtil.createEntitlement(owner1, c, p1, null);
+        e1.setEndDateOverride(twelveHoursAgo);
         Set<Entitlement> entitlementSet1 = new HashSet<Entitlement>();
         entitlementSet1.add(e1);
 
@@ -376,6 +378,7 @@ public class EntitlerTest {
         c.setCreated(thirtySixHoursAgo);
 
         Entitlement e1 = TestUtil.createEntitlement(owner1, c, p1, null);
+        e1.setEndDateOverride(new Date(twelveHoursAgo.getTime() + 12L * 60L * 60L * 1000L));
         Set<Entitlement> entitlementSet1 = new HashSet<Entitlement>();
         entitlementSet1.add(e1);
 
@@ -385,6 +388,7 @@ public class EntitlerTest {
         c.setCreated(twelveHoursAgo);
 
         Entitlement e2 = TestUtil.createEntitlement(owner2, c, p2, null);
+        e2.setEndDateOverride(new Date(thirtySixHoursAgo.getTime() + 12L * 60L * 60L * 1000L));
         Set<Entitlement> entitlementSet2 = new HashSet<Entitlement>();
         entitlementSet2.add(e2);
 


### PR DESCRIPTION
In the past both pools and entitlements had a start/end date. This was removed
as the data was redundant at the time, however the Entitlement getEndDate() and
setEndDate() methods remained for API compatability, and just returned the
pool's values.

With the addition of 24h unmapped guest entitlements, we actually want to have
entitlements with a different end date than the pool. This was implemented by
stamping the correct date in the cert, but not available anywhere else in the
code causing issues with things like installed product validity date ranges.

Fixed by adding an entitlement end date override. getEndDate() will return this
value if it's set, otherwise resort to the pools. Compliance code was already
properly set up to use the entitlement end date due to the original
implementation. (from getEndDate)