### PR TITLE
Consolidate request and response logging into one log statement.

### DIFF
--- a/common/src/main/java/org/candlepin/common/filter/LoggingFilter.java
+++ b/common/src/main/java/org/candlepin/common/filter/LoggingFilter.java
@@ -80,16 +80,20 @@ public class LoggingFilter implements Filter {
             // Not sure this is useful yet.
             resp.setHeader(customHeaderName, requestUUID);
 
-            log.info("{}", ServletLogger.logBasicRequestInfo(req));
             if (log.isDebugEnabled()) {
                 log.debug("{}", ServletLogger.logRequest(req));
+            }
+            else {
+                log.info("{}", ServletLogger.logBasicRequestInfo(req));
             }
 
             chain.doFilter(req, resp);
 
-            log.info("{}", ServletLogger.logBasicResponseInfo(resp, startTime));
             if (log.isDebugEnabled()) {
-                log.debug("{}", ServletLogger.logResponse(resp));
+                log.debug("{}", ServletLogger.logResponse(resp, startTime));
+            }
+            else {
+                log.info("{}", ServletLogger.logBasicResponseInfo(resp, startTime));
             }
 
             resp.finish();

--- a/common/src/main/java/org/candlepin/common/filter/ServletLogger.java
+++ b/common/src/main/java/org/candlepin/common/filter/ServletLogger.java
@@ -25,6 +25,7 @@ import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 
 /**
  * ServletLogger
@@ -40,50 +41,63 @@ public class ServletLogger {
     }
 
     protected ServletLogger() {
-
+        // Static methods only
     }
 
     public static StringBuilder logHeaders(HttpServletRequest req) {
         Enumeration<?> headerNames = req.getHeaderNames();
         StringBuilder builder = new StringBuilder();
 
-        builder.append("\n====Headers====");
         while (headerNames.hasMoreElements()) {
             String headerName = (String) headerNames.nextElement();
-            builder.append("\n  ").append(headerName).append(": ")
-                .append(req.getHeader(headerName));
+            builder.append(headerName).append(": ").append(req.getHeader(headerName)).append("\n");
         }
-        builder.append("\n====End Headers====\n");
+        builder.append("---\n");
         return builder;
     }
 
     public static StringBuilder logHeaders(TeeHttpServletResponse resp) {
         Map<String, List<String>> headers = resp.getHeaders();
         StringBuilder builder = new StringBuilder();
-        builder.append("\n====Headers====");
         for (Map.Entry<String, List<String>> header : headers.entrySet()) {
-            builder.append("\n");
-            builder.append(header.getKey()).append(": ").append(header.getValue());
+            builder.append(header.getKey()).append(": ").append(header.getValue()).append("\n");
         }
 
-        builder.append("\n====End Headers====\n");
+        builder.append("---\n");
         return builder;
     }
 
     public static StringBuilder logRequest(TeeHttpServletRequest req) {
-        return logHeaders(req).append(logBody("Request", req, true));
+        StringBuilder builder = new StringBuilder();
+        builder.append("\nRequest: ")
+            .append(req.getMethod()).append(" ").append(req.getRequestURI());
+        if (req.getQueryString() != null) {
+            builder.append("?").append(req.getQueryString());
+        }
+
+        return builder
+            .append(logHeaders(req))
+            .append(logBody("Request", req, true));
     }
 
-    public static StringBuilder logResponse(TeeHttpServletResponse resp) {
+    public static StringBuilder logResponse(TeeHttpServletResponse resp, long startTime) {
         // Impl note:
         // We're not formatting JSON output here as our JsonProvider already takes care of that.
-        return logHeaders(resp).append(logBody("Response", resp, false));
+        long duration = System.currentTimeMillis() - startTime;
+
+        StringBuilder builder = new StringBuilder();
+        int statusCode = resp.getStatus();
+        return builder.append("\nResponse: ")
+            .append(statusCode)
+            .append(" ")
+            .append(Response.Status.fromStatusCode(statusCode))
+            .append(" (").append(duration).append(" ms)\n")
+            .append(logHeaders(resp))
+            .append(logBody("Response", resp, false));
     }
 
     public static StringBuilder logBody(String type, BodyLogger bodyLogger, boolean formatJson) {
         StringBuilder builder = new StringBuilder();
-        builder.append("====").append(type).append(" Body====\n");
-
         String content = bodyLogger.getBody();
 
         if (formatJson && MediaType.APPLICATION_JSON.equals(bodyLogger.getContentType())) {

--- a/common/src/main/java/org/candlepin/common/filter/ServletLogger.java
+++ b/common/src/main/java/org/candlepin/common/filter/ServletLogger.java
@@ -69,7 +69,7 @@ public class ServletLogger {
 
     public static StringBuilder logRequest(TeeHttpServletRequest req) {
         StringBuilder builder = new StringBuilder();
-        builder.append("\nRequest: ")
+        builder.append("Request: ")
             .append(req.getMethod()).append(" ").append(req.getRequestURI());
         if (req.getQueryString() != null) {
             builder.append("?").append(req.getQueryString());
@@ -87,7 +87,7 @@ public class ServletLogger {
 
         StringBuilder builder = new StringBuilder();
         int statusCode = resp.getStatus();
-        return builder.append("\nResponse: ")
+        return builder.append("Response: ")
             .append(statusCode)
             .append(" ")
             .append(Response.Status.fromStatusCode(statusCode))


### PR DESCRIPTION
Previously the components of a request and/or response were spread
across multiple log statements.  One at INFO level would log the verb
and requested URL (or the response code) and one at DEBUG level would
log the headers and body.  Splitting what should logically be a single
unit across multiple statements made reading the logs harder than
necessary.

This patch consolidates an entire request and/or response into a single
statement.  If the logger is set to INFO, it writes a short statement
with the verb and URL combination (or response code).  If the logger is
set to DEBUG, it skips the aforementioned INFO statement and writes a
longer statement with the headers and body.

From this:

```
2015-02-04 11:50:09,849 [req=840fd586-b40b-4ef6-b3e6-0587c17d4e07, org=] INFO  org.candlepin.common.filter.LoggingFilter - Request: verb=GET, uri=/candlepin/pools?owner=8a8d01d34b556ac3014b557fab7f42e5&
2015-02-04 11:50:09,850 [req=840fd586-b40b-4ef6-b3e6-0587c17d4e07, org=] DEBUG org.candlepin.common.filter.LoggingFilter - 
====Headers====
  accept: application/json
  accept-encoding: gzip, deflate
  accept-language: 
  user-agent: Ruby
  authorization: Basic YWRtaW46YWRtaW4=
  host: localhost:8443
====End Headers====
====Request Body====
```

to this

```
2015-03-24 14:51:33,229 [req=3e2ddfba-ae3f-46ed-8d8a-82b60e007521, org=] DEBUG org.candlepin.common.filter.LoggingFilter - 
Request: POST /candlepin/jobs/refresh_pools_075a0025-0685-4105-bab2-cb59d85c60dcaccept: application/json
accept-encoding: gzip, deflate
accept-language: 
content-type: application/json
user-agent: Ruby
authorization: Basic YWRtaW46YWRtaW4=
host: localhost:8443
content-length: 0
---
```
