### PR TITLE
Awood/1204311

### DIFF
--- a/server/src/main/java/org/candlepin/model/ProvidedProduct.java
+++ b/server/src/main/java/org/candlepin/model/ProvidedProduct.java
@@ -154,6 +154,14 @@ public class ProvidedProduct extends AbstractHibernateObject {
     }
 
     @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(productName).append("(").append(productId).append(") ");
+        sb.append("Pool: [").append(pool).append("] ");
+        return sb.toString();
+    }
+
+    @Override
     public boolean equals(Object anObject) {
         if (this == anObject) {
             return true;

--- a/server/src/test/java/org/candlepin/controller/EntitlerTest.java
+++ b/server/src/test/java/org/candlepin/controller/EntitlerTest.java
@@ -378,6 +378,7 @@ public class EntitlerTest {
         c.setCreated(twelveHoursAgo);
 
         Entitlement e1 = TestUtil.createEntitlement(owner1, c, p1, null);
+        // expire an hour from now
         e1.setEndDateOverride(new Date(new Date().getTime() + 1L * 60L * 60L * 1000L));
         Set<Entitlement> entitlementSet1 = new HashSet<Entitlement>();
         entitlementSet1.add(e1);
@@ -388,7 +389,8 @@ public class EntitlerTest {
         c.setCreated(twelveHoursAgo);
 
         Entitlement e2 = TestUtil.createEntitlement(owner2, c, p2, null);
-        e2.setEndDateOverride(thirtySixHoursAgo);
+        // expire 24 hours ago
+        e2.setEndDateOverride(new Date(thirtySixHoursAgo.getTime() + 12L * 60L * 60L * 1000L));
         Set<Entitlement> entitlementSet2 = new HashSet<Entitlement>();
         entitlementSet2.add(e2);
 

--- a/server/src/test/java/org/candlepin/policy/PoolRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/PoolRulesTest.java
@@ -767,11 +767,12 @@ public class PoolRulesTest {
         assert ("true".equals(unmappedVirtPool.getAttributeValue("virt_only")));
         assert ("true".equals(unmappedVirtPool.getAttributeValue("unmapped_guests_only")));
 
-        assertProvidedProducts(s.getProvidedProducts(),
+        // The derived provided products of the sub should be promoted to provided products
+        // on the pool
+        assertProvidedProducts(s.getDerivedProvidedProducts(),
                 unmappedVirtPool.getProvidedProducts());
         assertDerivedProvidedProducts(new HashSet<Product>(),
                 unmappedVirtPool.getDerivedProvidedProducts());
-
     }
 
     @Test


### PR DESCRIPTION
If a subscription has derived products and/or derived provided products, those objects should be promoted on a temporary pool.  E.g. the subscription's derived provided products become the provided products of the temporary pool.