### PR TITLE
1200142: Force metadata expire to 1 in standalone.

### DIFF
--- a/server/src/main/java/org/candlepin/sync/ProductImporter.java
+++ b/server/src/main/java/org/candlepin/sync/ProductImporter.java
@@ -78,11 +78,17 @@ public class ProductImporter {
                     c.setVendor("unknown");
                 }
 
-                // On standalone servers we need metadata expiry to be 0 so clients can
-                // immediately get changes to content when published on the server.
-                // We can assume this is a standalone server due to the fact that
-                // import is being used, so no need to guard this behavior:
-                c.setMetadataExpire(new Long(0));
+                /*
+                 * On standalone servers we will set metadata expire to 1 second so
+                 * clients an immediately get changes to content when published on the
+                 * server. We would use 0, but the client plugin interprets this as unset
+                 * and ignores it completely resulting in the default yum values being
+                 * used.
+                 *
+                 * We know this is a standalone server due to the fact that import is
+                 * being used, so there is no need to guard this behavior.
+                 */
+                c.setMetadataExpire(new Long(1));
 
                 contentCurator.createOrUpdate(c);
             }

--- a/server/src/test/java/org/candlepin/sync/ProductImporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/ProductImporterTest.java
@@ -128,7 +128,7 @@ public class ProductImporterTest {
         verify(contentCuratorMock).createOrUpdate(c);
 
         // Metadata expiry should be overridden to 0 on import:
-        assertEquals(new Long(0), c.getMetadataExpire());
+        assertEquals(new Long(1), c.getMetadataExpire());
     }
 
     @Test


### PR DESCRIPTION
We just implemented this at 0 in commit
15653851a7bfcb14d9d86a7aec8ac974403be89c, however it has been discovered that
somehow the client plugin is interpreting 0 as unset and just ignoring the
setting entirely, which would result in the default timeout being used. (which
is not 0)

Instead we're setting for 1 second which should have the same effect.