### PR TITLE
1207822: EnvironmentResource fix for duplicate content IDs

### DIFF
--- a/server/src/main/java/org/candlepin/model/EnvironmentContentCurator.java
+++ b/server/src/main/java/org/candlepin/model/EnvironmentContentCurator.java
@@ -28,9 +28,7 @@ public class EnvironmentContentCurator extends
         super(EnvironmentContent.class);
     }
 
-    public EnvironmentContent lookupByEnvironmentAndContent(
-        Environment e, String contentId) {
-
+    public EnvironmentContent lookupByEnvironmentAndContent(Environment e, String contentId) {
         return (EnvironmentContent) this.currentSession().createCriteria(
             EnvironmentContent.class).add(Restrictions.eq("environment", e))
             .add(Restrictions.eq("contentId", contentId)).uniqueResult();

--- a/server/src/main/java/org/candlepin/resource/EnvironmentResource.java
+++ b/server/src/main/java/org/candlepin/resource/EnvironmentResource.java
@@ -20,6 +20,7 @@ import org.candlepin.auth.Principal;
 import org.candlepin.auth.interceptor.Verify;
 import org.candlepin.common.auth.SecurityHole;
 import org.candlepin.common.exceptions.BadRequestException;
+import org.candlepin.common.exceptions.ConflictException;
 import org.candlepin.common.exceptions.NotFoundException;
 import org.candlepin.controller.PoolManager;
 import org.candlepin.model.Consumer;
@@ -172,6 +173,19 @@ public class EnvironmentResource {
         Environment env = lookupEnvironment(envId);
 
         Set<String> contentIds = new HashSet<String>();
+        // Make sure this content has not already been promoted within this environment
+        // Impl note:
+        // We have to do this in a separate loop or we'll end up with an undefined state, should
+        // there be a problem with the request.
+        for (EnvironmentContent promoteMe : contentToPromote) {
+            if (this.envContentCurator.lookupByEnvironmentAndContent(env, promoteMe.getContentId()) != null) {
+                throw new ConflictException(i18n.tr(
+                    "The content with id {0} has already been promoted in this environment.",
+                    promoteMe.getContentId()
+                ));
+            }
+        }
+
         for (EnvironmentContent promoteMe : contentToPromote) {
             // Make sure the content exists:
             promoteMe.setContentId(promoteMe.getContentId());
@@ -240,7 +254,6 @@ public class EnvironmentResource {
             .build();
 
         return detail;
-
     }
 
     private Environment lookupEnvironment(String envId) {


### PR DESCRIPTION
- EnvironmentResource will now throw a ConflictException if an API
  user attempts to promote content that has already been promoted.
- Added spec tests to verify the above behavior