### PR TITLE
1207810: Add missing symlink for gutterball and c3p0.

### DIFF
--- a/gutterball/deps/el7.txt
+++ b/gutterball/deps/el7.txt
@@ -10,6 +10,7 @@ antlr
 aopalliance
 apache-mime4j
 atinject
+c3p0
 candlepin-common
 candlepin-guice // This will pull in all the jars under candlepin-guice
 cglib


### PR DESCRIPTION
Tested and found to contain the symlink, and allow gb to run on EL7 system experiencing the bug.