### PR TITLE
1204962: remove throw/catch/eat of runtime exception in bind

### DIFF
--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -474,7 +474,7 @@ public class CandlepinPoolManager implements PoolManager {
             for (ConsumerInstalledProduct cip : consumer.getInstalledProducts()) {
                 fullList.add(cip.getId());
             }
-            log.warn("No entitlements available for products: " + fullList);
+            log.info("No entitlements available for products: " + fullList);
             return null;
         }
 
@@ -525,7 +525,7 @@ public class CandlepinPoolManager implements PoolManager {
             entitleDate, owner, null, possiblePools);
 
         if (bestPools == null) {
-            log.warn("No entitlements for host: " + host.getUuid());
+            log.info("No entitlements for host: " + host.getUuid());
             return null;
         }
 

--- a/server/src/main/java/org/candlepin/policy/js/autobind/AutobindRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/autobind/AutobindRules.java
@@ -81,7 +81,7 @@ public class AutobindRules {
             for (ConsumerInstalledProduct cip : consumer.getInstalledProducts()) {
                 fullList.add(cip.getId());
             }
-            log.warn("No pools available to rules for products: " + fullList);
+            log.info("No pools available to rules for products: " + fullList);
             return null;
         }
 

--- a/server/src/main/java/org/candlepin/policy/js/autobind/AutobindRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/autobind/AutobindRules.java
@@ -15,6 +15,7 @@
 package org.candlepin.policy.js.autobind;
 
 import org.candlepin.model.Consumer;
+import org.candlepin.model.ConsumerInstalledProduct;
 import org.candlepin.model.Pool;
 import org.candlepin.model.PoolQuantity;
 import org.candlepin.model.Product;
@@ -74,10 +75,14 @@ public class AutobindRules {
         log.debug("pools.size() before V1 certificate filter: {}, after: {}",
                 poolsBeforeContentFilter, pools.size());
 
-        // per dgoodwin, this needs to throw an exception for legacy clients
         if (pools.size() == 0) {
-            throw new RuntimeException("No entitlements for products: " +
-                Arrays.toString(productIds));
+            List<String> fullList = new ArrayList<String>();
+            fullList.addAll(Arrays.asList(productIds));
+            for (ConsumerInstalledProduct cip : consumer.getInstalledProducts()) {
+                fullList.add(cip.getId());
+            }
+            log.warn("No pools available to rules for products: " + fullList);
+            return null;
         }
 
         if (log.isDebugEnabled()) {
@@ -120,8 +125,13 @@ public class AutobindRules {
         }
 
         if (pools.size() > 0 && (result == null || result.isEmpty())) {
-            throw new RuleExecutionException(
-                "Rule did not select a pool for products: " + Arrays.toString(productIds));
+            List<String> fullList = new ArrayList<String>();
+            fullList.addAll(Arrays.asList(productIds));
+            for (ConsumerInstalledProduct cip : consumer.getInstalledProducts()) {
+                fullList.add(cip.getId());
+            }
+            log.info("Rules did not select a pools for products: " + fullList);
+            return null;
         }
 
         List<PoolQuantity> bestPools = new ArrayList<PoolQuantity>();

--- a/server/src/test/java/org/candlepin/controller/PoolManagerFunctionalTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerFunctionalTest.java
@@ -182,15 +182,7 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
         }
 
         // The cert should specify 5 monitoring entitlements, taking a 6th should fail:
-        try {
-            poolManager.entitleByProducts(data);
-            fail();
-        }
-        // With criteria filtered pools we end up with a RuntimeException
-        // here.
-        catch (RuntimeException e) {
-            //expected
-        }
+        assertEquals(null, poolManager.entitleByProducts(data));
 
         assertEquals(Long.valueOf(5), monitoringPool.getConsumed());
     }

--- a/server/src/test/java/org/candlepin/policy/AutobindRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/AutobindRulesTest.java
@@ -15,8 +15,8 @@
 package org.candlepin.policy;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.when;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
 
 import org.candlepin.common.config.Configuration;
 import org.candlepin.config.ConfigProperties;
@@ -40,7 +40,6 @@ import org.candlepin.model.SourceSubscription;
 import org.candlepin.policy.js.JsRunner;
 import org.candlepin.policy.js.JsRunnerProvider;
 import org.candlepin.policy.js.ProductCache;
-import org.candlepin.policy.js.RuleExecutionException;
 import org.candlepin.policy.js.autobind.AutobindRules;
 import org.candlepin.policy.js.compliance.ComplianceStatus;
 import org.candlepin.service.ProductServiceAdapter;
@@ -134,27 +133,17 @@ public class AutobindRulesTest {
         List<Pool> pools = new LinkedList<Pool>();
         pools.add(pool);
 
-        try {
-            autobindRules.selectBestPools(consumer,
-                new String[]{ productId }, pools, compliance, null, new HashSet<String>(),
-                false);
-            fail();
-        }
-        catch (RuntimeException e) {
-            // expected
-        }
+        List<PoolQuantity> poolQs = autobindRules.selectBestPools(consumer,
+            new String[]{ productId }, pools, compliance, null, new HashSet<String>(),
+            false);
+        assertEquals(null, poolQs);
 
         // Try again with explicitly setting the consumer to cert v1:
         consumer.setFact("system.certificate_version", "1.0");
-        try {
-            autobindRules.selectBestPools(consumer,
-                new String[]{ productId }, pools, compliance, null, new HashSet<String>(),
-                false);
-            fail();
-        }
-        catch (RuntimeException e) {
-            // expected
-        }
+        poolQs = autobindRules.selectBestPools(consumer,
+            new String[]{ productId }, pools, compliance, null, new HashSet<String>(),
+            false);
+        assertEquals(null, poolQs);
     }
 
     @Test
@@ -487,15 +476,15 @@ public class AutobindRulesTest {
         return p;
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void testSelectBestPoolNoPools() {
         when(this.prodAdapter.getProductById(HIGHEST_QUANTITY_PRODUCT))
             .thenReturn(new Product(HIGHEST_QUANTITY_PRODUCT, HIGHEST_QUANTITY_PRODUCT));
 
         // There are no pools for the product in this case:
-        autobindRules.selectBestPools(consumer,
+        assertEquals(null, autobindRules.selectBestPools(consumer,
             new String[] {HIGHEST_QUANTITY_PRODUCT}, new LinkedList<Pool>(), compliance,
-            null, new HashSet<String>(), false);
+            null, new HashSet<String>(), false));
     }
 
     @Test
@@ -624,26 +613,26 @@ public class AutobindRulesTest {
         assertEquals(new Integer(8), q.getQuantity());
     }
 
-    @Test(expected = RuleExecutionException.class)
+    @Test
     public void instanceAutobindForPhysical8SocketNotEnoughUneven() {
         List<Pool> pools = createInstanceBasedPool();
         pools.get(0).setQuantity(7L); // Only 7 available
         setupConsumer("8", false);
 
-        List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
+        assertEquals(null, autobindRules.selectBestPools(consumer,
             new String[]{ productId }, pools, compliance, null, new HashSet<String>(),
-            false);
+            false));
     }
 
-    @Test(expected = RuleExecutionException.class)
+    @Test
     public void instanceAutobindForPhysical8SocketNotEnoughEven() {
         List<Pool> pools = createInstanceBasedPool();
         pools.get(0).setQuantity(4L); // Only 4 available
         setupConsumer("8", false);
 
-        List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
+        assertEquals(null, autobindRules.selectBestPools(consumer,
             new String[]{ productId }, pools, compliance, null, new HashSet<String>(),
-            false);
+            false));
     }
 
     @Test
@@ -826,7 +815,7 @@ public class AutobindRulesTest {
      * Expect nothing to happen. We cannot bind the hypervisor in order to make
      * the guests compliant, but that'd be a nice feature in the future.
      */
-    @Test(expected = RuleExecutionException.class)
+    @Test
     public void guestLimitAutobindNeitherAttached() {
         consumer.setFact("cpu.cpu_socket(s)", "8");
         for (int i = 0; i < 5; i++) {
@@ -849,9 +838,9 @@ public class AutobindRulesTest {
         pools.add(serverPool);
         pools.add(hyperPool);
 
-        autobindRules.selectBestPools(consumer,
+        assertEquals(null, autobindRules.selectBestPools(consumer,
             new String[]{ server.getId() }, pools, compliance, null,
-            new HashSet<String>(), false);
+            new HashSet<String>(), false));
     }
 
     /*

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
@@ -14,18 +14,10 @@
  */
 package org.candlepin.resource;
 
-import static org.candlepin.test.TestUtil.createIdCert;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyBoolean;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.candlepin.test.TestUtil.*;
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
 
 import org.candlepin.audit.Event.Target;
 import org.candlepin.audit.Event.Type;
@@ -97,6 +89,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+
+import javax.ws.rs.core.Response;
 
 /**
  * ConsumerResourceTest
@@ -357,29 +351,24 @@ public class ConsumerResourceTest {
 
     @Test
     public void testProductNoPool() {
-        try {
-            Consumer c = mock(Consumer.class);
-            Owner o = mock(Owner.class);
-            SubscriptionServiceAdapter sa = mock(SubscriptionServiceAdapter.class);
-            Entitler e = mock(Entitler.class);
-            ConsumerCurator cc = mock(ConsumerCurator.class);
-            String[] prodIds = {"notthere"};
+        Consumer c = mock(Consumer.class);
+        Owner o = mock(Owner.class);
+        SubscriptionServiceAdapter sa = mock(SubscriptionServiceAdapter.class);
+        Entitler e = mock(Entitler.class);
+        ConsumerCurator cc = mock(ConsumerCurator.class);
+        String[] prodIds = {"notthere"};
 
-            when(c.getOwner()).thenReturn(o);
-            when(sa.hasUnacceptedSubscriptionTerms(eq(o))).thenReturn(false);
-            when(cc.verifyAndLookupConsumer(eq("fakeConsumer"))).thenReturn(c);
-            when(e.bindByProducts(any(AutobindData.class)))
-                .thenThrow(new RuntimeException());
+        when(c.getOwner()).thenReturn(o);
+        when(sa.hasUnacceptedSubscriptionTerms(eq(o))).thenReturn(false);
+        when(cc.verifyAndLookupConsumer(eq("fakeConsumer"))).thenReturn(c);
+        when(e.bindByProducts(any(AutobindData.class))).thenReturn(null);
 
-            ConsumerResource cr = new ConsumerResource(cc, null,
-                null, sa, null, null, null, i18n, null, null, null, null, null,
-                null, null, null, null, null, e, null, null, null, null,
-                new CandlepinCommonTestConfig(), null, null, null, consumerBindUtil);
-            cr.bind("fakeConsumer", null, prodIds, null, null, null, false, null, null);
-        }
-        catch (Throwable t) {
-            fail("Runtime exception should be caught in ConsumerResource.bind");
-        }
+        ConsumerResource cr = new ConsumerResource(cc, null,
+            null, sa, null, null, null, i18n, null, null, null, null, null,
+            null, null, null, null, null, e, null, null, null, null,
+            new CandlepinCommonTestConfig(), null, null, null, consumerBindUtil);
+        Response r = cr.bind("fakeConsumer", null, prodIds, null, null, null, false, null, null);
+        assertEquals(null, r.getEntity());
     }
 
     @Test


### PR DESCRIPTION
Submitted as a pull request, but more like experimental theatre.

The criteria is to ensure identical REST output while removing stack-trace logging for non-fatal conditions. This required removing a few thrown exceptions and then adjusting the code stack back to the resource.

All suggestions are welcome.