### PR TITLE
Address several gutterball startup/shutdown issues

### DIFF
--- a/gutterball/src/main/java/org/candlepin/gutterball/config/ConfigProperties.java
+++ b/gutterball/src/main/java/org/candlepin/gutterball/config/ConfigProperties.java
@@ -55,7 +55,7 @@ public class ConfigProperties {
                 this.put(AMQP_CONNECT_STRING, "amqp://guest:guest@localhost/test?brokerlist=" +
                         "'tcp://localhost:5671?ssl='true'&ssl_cert_alias='gutterball''");
                 this.put(AMQP_CONNECTION_RETRY_INTERVAL, "10"); // Every 10 seconds
-                this.put(AMQP_CONNECTION_RETRY_ATTEMPTS, "360"); // Try for 1h (10s * 360)
+                this.put(AMQP_CONNECTION_RETRY_ATTEMPTS, "12"); // Try for 2 minutes (10s * 12)
                 this.put(AMQP_KEYSTORE, "/etc/gutterball/certs/amqp/gutterball.jks");
                 this.put(AMQP_KEYSTORE_PASSWORD, "password");
                 this.put(AMQP_TRUSTSTORE,

--- a/gutterball/src/main/java/org/candlepin/gutterball/receiver/EventReceiver.java
+++ b/gutterball/src/main/java/org/candlepin/gutterball/receiver/EventReceiver.java
@@ -122,13 +122,32 @@ public class EventReceiver {
         return connFactory;
     }
 
-    // FIXME [mstead] This is not being called and should probably be called
-    //       when the app is being shut down.
-    private void finish() throws JMSException {
-        consumer.close();
-        sess.close();
-        conn.close();
-        log.info("DONE");
+    public void finish() {
+        log.info("Closing QPID connection");
+        try {
+            consumer.close();
+        }
+        catch (JMSException e) {
+            // Ok - just log the exception
+            log.debug("Unable to close consumer connection", e);
+        }
+
+        try {
+            sess.close();
+        }
+        catch (JMSException e) {
+            // Ok - just log the exception
+            log.debug("Unable to close session", e);
+        }
+
+        try {
+            conn.close();
+        }
+        catch (JMSException e) {
+            // Ok - just log the exception
+            log.debug("Unable to close connection", e);
+        }
+        log.info("Finished closing QPID connection");
     }
 
     /**

--- a/gutterball/src/main/java/org/candlepin/gutterball/receiver/EventReceiver.java
+++ b/gutterball/src/main/java/org/candlepin/gutterball/receiver/EventReceiver.java
@@ -26,6 +26,7 @@ import org.apache.qpid.url.URLSyntaxException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.Thread.UncaughtExceptionHandler;
 import java.net.URISyntaxException;
 
 import javax.jms.Connection;
@@ -57,7 +58,23 @@ public class EventReceiver {
     public EventReceiver(Configuration config, EventMessageListener eventMessageListener)
         throws Exception {
         this.eventMessageListener = eventMessageListener;
-        init(config);
+
+        // Connect in a separate thread so that gutterball deployment isn't
+        // blocked on startup.
+        //
+        // NOTE: This is safe since Event processing does not occur until a
+        //       connection is made and there is only one instance of the
+        //       EventReceiver class.
+        QpidConnectionThread connThread = new QpidConnectionThread(config);
+        connThread.setUncaughtExceptionHandler(new UncaughtExceptionHandler() {
+
+            @Override
+            public void uncaughtException(Thread t, Throwable e) {
+                log.error("Unable to initialize connection to QPID.", e);
+            }
+
+        });
+        connThread.start();
     }
 
     protected void init(final Configuration config) throws JMSException, URISyntaxException {
@@ -112,5 +129,38 @@ public class EventReceiver {
         sess.close();
         conn.close();
         log.info("DONE");
+    }
+
+    /**
+     * Initializes the QPID connection outside of the server's main thread
+     * to allow gutterball's context to fully initialize even if there are
+     * connection problems to QPID.
+     *
+     */
+    private class QpidConnectionThread extends Thread {
+
+        private Configuration config;
+
+        public QpidConnectionThread(Configuration config) {
+            super("gutterball-qpid-connect");
+            this.config = config;
+        }
+
+        public void run() {
+            try {
+                // Make this thread sleep for 30 seconds to allow the gutterball
+                // context to fully load before connecting and processing events.
+                //
+                // NOTE: This is a hacky solution to wait for hibernate to fully
+                // load before events start flowing.
+                sleep(30000);
+                EventReceiver.this.init(config);
+            }
+            catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+
     }
 }

--- a/gutterball/src/main/java/org/candlepin/gutterball/servlet/GutterballContextListener.java
+++ b/gutterball/src/main/java/org/candlepin/gutterball/servlet/GutterballContextListener.java
@@ -22,6 +22,7 @@ import org.candlepin.common.logging.LoggingConfigurator;
 import org.candlepin.gutterball.config.ConfigProperties;
 import org.candlepin.gutterball.guice.GutterballModule;
 import org.candlepin.gutterball.guice.GutterballServletModule;
+import org.candlepin.gutterball.receiver.EventReceiver;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
@@ -173,4 +174,15 @@ public class GutterballContextListener extends
         injector = inj;
         super.processInjector(context, injector);
     }
+
+    @Override
+    public void contextDestroyed(ServletContextEvent event) {
+        log.info("Destroying gutterball context");
+        super.contextDestroyed(event);
+
+        EventReceiver reciever = injector.getInstance(EventReceiver.class);
+        reciever.finish();
+    }
+
+
 }

--- a/server/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/server/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -228,7 +228,7 @@ public class ConfigProperties {
                 this.put(AMQP_TRUSTSTORE_PASSWORD, "password");
 
                 this.put(AMQP_CONNECTION_RETRY_INTERVAL, "10"); // Every 10 seconds
-                this.put(AMQP_CONNECTION_RETRY_ATTEMPTS, "360"); // Try for 1h (10s * 360)
+                this.put(AMQP_CONNECTION_RETRY_ATTEMPTS, "12"); // Try for 2 mins (10s * 12)
 
                 this.put(IDENTITY_CERT_YEAR_ADDENDUM, "16");
                 this.put(IDENTITY_CERT_EXPIRY_THRESHOLD, "90");


### PR DESCRIPTION
1) Establish QPID connection in a separate thread to avoid delay in bringing up the gutterball report API and stalling deployment of candlepin.
2) Properly close the gutterball context: shut down qpid connection
3) Adjusted the default retry configuration values for connecting to qpid (1h was way too long)