### PR TITLE
Alikins/1193803 manifest import speed [DO NOT MERGE]

### DIFF
--- a/server/client/ruby/candlepin_api.rb
+++ b/server/client/ruby/candlepin_api.rb
@@ -1257,6 +1257,7 @@ class Candlepin
 
   def create_basic_client(username=nil, password=nil)
     @client = RestClient::Resource.new(@base_url,
+                                       :timeout => -1,
                                        :user => username, :password => password,
                                        :headers => {:accept_language => @lang})
   end
@@ -1267,6 +1268,7 @@ class Candlepin
     @uuid = @identity_certificate.subject.to_s.scan(/\/CN=([^\/=]+)/)[0][0]
 
     @client = RestClient::Resource.new(@base_url,
+                                       :timeout => -1,
                                        :ssl_client_cert => @identity_certificate,
                                        :ssl_client_key => @identity_key,
                                        :headers => {:accept_language => @lang})
@@ -1275,6 +1277,7 @@ class Candlepin
   def create_trusted_consumer_client(uuid)
     @uuid = uuid
     @client = RestClient::Resource.new(@base_url,
+                                       :timeout => -1,
                                        :headers => {"cp-consumer" => uuid,
                                                     :accept_language => @lang}
                                         )

--- a/server/src/main/java/org/candlepin/audit/EventBuilder.java
+++ b/server/src/main/java/org/candlepin/audit/EventBuilder.java
@@ -38,7 +38,7 @@ public class EventBuilder {
     private final EventFactory factory;
 
     private Event event;
-    
+
     private static Logger log = LoggerFactory.getLogger(EventBuilder.class);
 
     public EventBuilder(EventFactory factory, Target target, Type type) {

--- a/server/src/main/java/org/candlepin/audit/EventBuilder.java
+++ b/server/src/main/java/org/candlepin/audit/EventBuilder.java
@@ -25,6 +25,9 @@ import org.candlepin.model.Owned;
 import org.candlepin.model.Owner;
 import org.candlepin.model.Pool;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * ConsumerEventBuilder Allows us to easily build a consumer modified
  * event one piece at a time.
@@ -35,6 +38,8 @@ public class EventBuilder {
     private final EventFactory factory;
 
     private Event event;
+    
+    private static Logger log = LoggerFactory.getLogger(EventBuilder.class);
 
     public EventBuilder(EventFactory factory, Target target, Type type) {
         this.factory = factory;
@@ -86,6 +91,7 @@ public class EventBuilder {
     }
 
     public EventBuilder setNewEntity(AbstractHibernateObject updated) {
+        log.debug("entering setNewEntity");
         if (updated != null) {
             if (event.getType() == Type.DELETED) {
                 throw new IllegalArgumentException("You cannot set the new entity for a deletion event");
@@ -93,6 +99,7 @@ public class EventBuilder {
             setEventData(updated);
             event.setNewEntity(factory.entityToJson(updated));
         }
+        log.debug("leaving setNewEntity");
         return this;
     }
 

--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -414,6 +414,7 @@ public class CandlepinPoolManager implements PoolManager {
     @Override
     public Pool createPool(Pool p) {
         Pool created = poolCurator.create(p);
+        poolCurator.refresh(p);
         if (log.isDebugEnabled()) {
             log.debug("   new pool: " + p);
         }

--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -147,7 +147,9 @@ public class CandlepinPoolManager implements PoolManager {
 
         List<String> deletedSubs = new LinkedList<String>();
         for (String subId : subIds) {
+            log.debug("about to getSubscription for: " + subId);
             Subscription sub = subAdapter.getSubscription(subId);
+            log.debug("got subscriptiption for: " + subId);
 
             // If this sub has been removed since getSubscriptionIds was called,
             if (sub == null) {
@@ -164,12 +166,15 @@ public class CandlepinPoolManager implements PoolManager {
                 continue;
             }
 
+            log.debug("about to refreshPoolsForSubscription");
             refreshPoolsForSubscription(sub, lazy);
         }
 
+        log.debug("about to removeAll: " + deletedSubs.size());
         // We deleted some, need to take that into account so we
         // remove everything that isn't actually active
         subIds.removeAll(deletedSubs);
+        log.debug("removedAll");
         // delete pools whose subscription disappeared:
         for (Pool p : poolCurator.getPoolsFromBadSubs(owner, subIds)) {
             if (p.getType() == PoolType.NORMAL || p.getType() == PoolType.BONUS) {
@@ -187,19 +192,28 @@ public class CandlepinPoolManager implements PoolManager {
     void refreshPoolsForSubscription(Subscription sub, boolean lazy) {
 
         // These don't all necessarily belong to this owner
+        log.debug("about to poolCurator.getPoolsBySubscriptionId");
         List<Pool> subscriptionPools = poolCurator.getPoolsBySubscriptionId(sub.getId());
 
+        log.debug("about to removeAndDeletePoolsOnOtherOwners");
         // Cleans up pools on other owners who have migrated subs away
         removeAndDeletePoolsOnOtherOwners(subscriptionPools, sub);
 
+        log.debug("about to createPoolsForSubscription");
         // BUG 1012386 This will regenerate master/derived for bonus scenarios
         //  if only one of the pair still exists.
         createPoolsForSubscription(sub, subscriptionPools);
 
-        regenerateCertificatesByEntIds(
+        
+        
+        //regenerateCertificatesByEntIds
+        log.debug("about to updatePoolsForSubscription");
+        Set<String> poolSet = updatePoolsForSubscription(subscriptionPools, sub, false);
+        log.debug("about to regenerateCertificateByEntIds");
+        regenerateCertificatesByEntIds(poolSet, lazy);
             // don't update floating here, we'll do that later
             // so we don't update anything twice
-            updatePoolsForSubscription(subscriptionPools, sub, false), lazy);
+      //      updatePoolsForSubscription(subscriptionPools, sub, false), lazy);
     }
 
     public void cleanupExpiredPools() {
@@ -226,6 +240,7 @@ public class CandlepinPoolManager implements PoolManager {
     }
 
     private boolean isExpired(Subscription subscription) {
+        log.debug("isExpired: " + subscription.getId());
         Date now = new Date();
         return now.after(subscription.getEndDate());
     }
@@ -404,8 +419,14 @@ public class CandlepinPoolManager implements PoolManager {
         }
 
         List<Pool> pools = poolRules.createPools(sub, existingPools);
+        if (log.isDebugEnabled()) {
+            log.debug("Creating new pool post poolRules.createPools: " + pools.size());
+        }
         for (Pool pool : pools) {
             createPool(pool);
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("Creating new pool post createPool " );
         }
 
         return pools;
@@ -413,10 +434,13 @@ public class CandlepinPoolManager implements PoolManager {
 
     @Override
     public Pool createPool(Pool p) {
+        if (log.isDebugEnabled()) {
+            log.debug("  about to create new pool: " + p);
+        }
         Pool created = poolCurator.create(p);
         poolCurator.refresh(p);
         if (log.isDebugEnabled()) {
-            log.debug("   new pool: " + p);
+            log.debug("   created new pool: " + p);
         }
         if (created != null) {
             sink.emitPoolCreated(created);

--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -205,7 +205,6 @@ public class CandlepinPoolManager implements PoolManager {
         createPoolsForSubscription(sub, subscriptionPools);
 
         
-        
         //regenerateCertificatesByEntIds
         log.debug("about to updatePoolsForSubscription");
         Set<String> poolSet = updatePoolsForSubscription(subscriptionPools, sub, false);
@@ -355,7 +354,9 @@ public class CandlepinPoolManager implements PoolManager {
             // Explicitly call flush to avoid issues with how we sync up the attributes.
             // This prevents "instance does not yet exist as a row in the database" errors
             // when we later try to lock the pool if we need to revoke entitlements:
-            this.poolCurator.flush();
+            // FIXME: This slows things down a lot...
+            log.debug("NOT FLUSHING in processPoolUpdates");
+            //this.poolCurator.flush();
 
             // quantity has changed. delete any excess entitlements from pool
             if (updatedPool.getQuantityChanged()) {
@@ -438,7 +439,7 @@ public class CandlepinPoolManager implements PoolManager {
             log.debug("  about to create new pool: " + p);
         }
         Pool created = poolCurator.create(p);
-        poolCurator.refresh(p);
+        //poolCurator.refresh(p);
         if (log.isDebugEnabled()) {
             log.debug("   created new pool: " + p);
         }

--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -204,7 +204,6 @@ public class CandlepinPoolManager implements PoolManager {
         //  if only one of the pair still exists.
         createPoolsForSubscription(sub, subscriptionPools);
 
-        
         //regenerateCertificatesByEntIds
         log.debug("about to updatePoolsForSubscription");
         Set<String> poolSet = updatePoolsForSubscription(subscriptionPools, sub, false);
@@ -427,7 +426,7 @@ public class CandlepinPoolManager implements PoolManager {
             createPool(pool);
         }
         if (log.isDebugEnabled()) {
-            log.debug("Creating new pool post createPool " );
+            log.debug("Creating new pool post createPool ");
         }
 
         return pools;

--- a/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
+++ b/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
@@ -404,7 +404,7 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
     public void evict(E object) {
         currentSession().evict(object);
     }
-    
+
     public void setFlushMode(FlushModeType flushModeType) {
         log.debug("setFlushMode=" + flushModeType);
         log.debug("setFlushMode em " + getEntityManager().getTransaction().toString());

--- a/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
+++ b/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
@@ -17,9 +17,9 @@ package org.candlepin.model;
 import org.candlepin.auth.Principal;
 import org.candlepin.auth.permissions.Permission;
 import org.candlepin.common.exceptions.ConcurrentModificationException;
-import org.candlepin.guice.PrincipalProvider;
 import org.candlepin.common.paging.Page;
 import org.candlepin.common.paging.PageRequest;
+import org.candlepin.guice.PrincipalProvider;
 
 import com.google.inject.Inject;
 import com.google.inject.Provider;
@@ -44,6 +44,7 @@ import java.util.Collection;
 import java.util.List;
 
 import javax.persistence.EntityManager;
+import javax.persistence.FlushModeType;
 import javax.persistence.OptimisticLockException;
 
 /**
@@ -402,6 +403,10 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
 
     public void evict(E object) {
         currentSession().evict(object);
+    }
+    
+    public void setFlushMode(FlushModeType flushModeType) {
+        getEntityManager().setFlushMode(flushModeType);
     }
 
     public List<E> takeSubList(PageRequest pageRequest, List<E> results) {

--- a/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
+++ b/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
@@ -406,6 +406,8 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
     }
     
     public void setFlushMode(FlushModeType flushModeType) {
+        log.debug("setFlushMode=" + flushModeType);
+        log.debug("setFlushMode em " + getEntityManager().getTransaction().toString());
         getEntityManager().setFlushMode(flushModeType);
     }
 

--- a/server/src/main/java/org/candlepin/model/Product.java
+++ b/server/src/main/java/org/candlepin/model/Product.java
@@ -14,6 +14,7 @@
  */
 package org.candlepin.model;
 
+import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.LazyCollection;
 import org.hibernate.annotations.LazyCollectionOption;
@@ -292,9 +293,11 @@ public class Product extends AbstractHibernateObject implements Linkable {
 
     @Override
     public int hashCode() {
-        return id.hashCode() * 31;
+        return new HashCodeBuilder(37, 17).append(this.id).append(this.name)
+                .toHashCode();
     }
 
+    
     /**
      * @param content
      */

--- a/server/src/main/java/org/candlepin/model/Product.java
+++ b/server/src/main/java/org/candlepin/model/Product.java
@@ -297,7 +297,6 @@ public class Product extends AbstractHibernateObject implements Linkable {
                 .toHashCode();
     }
 
-    
     /**
      * @param content
      */

--- a/server/src/main/java/org/candlepin/sync/CdnImporter.java
+++ b/server/src/main/java/org/candlepin/sync/CdnImporter.java
@@ -55,14 +55,17 @@ public class CdnImporter {
             Cdn existing = curator.lookupByLabel(cdn.getLabel());
             if (existing == null) {
                 curator.create(cdn);
+                curator.refresh(cdn);
                 log.debug("Created CDN: " + cdn.getName());
             }
             else {
                 existing.setName(cdn.getName());
                 existing.setUrl(cdn.getUrl());
                 curator.merge(existing);
+                //curator.refresh(existing);
                 log.debug("Updating CDN: " + cdn.getName());
             }
+            
         }
     }
 }

--- a/server/src/main/java/org/candlepin/sync/CdnImporter.java
+++ b/server/src/main/java/org/candlepin/sync/CdnImporter.java
@@ -65,7 +65,6 @@ public class CdnImporter {
                 //curator.refresh(existing);
                 log.debug("Updating CDN: " + cdn.getName());
             }
-            
         }
     }
 }

--- a/server/src/main/java/org/candlepin/sync/ConsumerImporter.java
+++ b/server/src/main/java/org/candlepin/sync/ConsumerImporter.java
@@ -123,6 +123,7 @@ public class ConsumerImporter {
         owner.setUpstreamConsumer(uc);
 
         curator.merge(owner);
+        //curator.refresh(owner);
     }
 
 }

--- a/server/src/main/java/org/candlepin/sync/ConsumerTypeImporter.java
+++ b/server/src/main/java/org/candlepin/sync/ConsumerTypeImporter.java
@@ -57,6 +57,6 @@ public class ConsumerTypeImporter {
                 curator.refresh(consumerType);
             }
         }
-        
+
     }
 }

--- a/server/src/main/java/org/candlepin/sync/ConsumerTypeImporter.java
+++ b/server/src/main/java/org/candlepin/sync/ConsumerTypeImporter.java
@@ -54,7 +54,9 @@ public class ConsumerTypeImporter {
             if (curator.lookupByLabel(consumerType.getLabel()) == null) {
                 curator.create(consumerType);
                 log.debug("Created consumer type: " + consumerType.getLabel());
+                curator.refresh(consumerType);
             }
         }
+        
     }
 }

--- a/server/src/main/java/org/candlepin/sync/DistributorVersionImporter.java
+++ b/server/src/main/java/org/candlepin/sync/DistributorVersionImporter.java
@@ -61,17 +61,13 @@ public class DistributorVersionImporter {
                 log.debug("Created distributor version: " + distVer.getName());
                 curator.create(distVer);
                 curator.refresh(distVer);
-                
             }
             else {
                 log.debug("Updating distributor version: " + distVer.getName());
                 existing.setCapabilities(distVer.getCapabilities());
                 existing.setDisplayName(distVer.getDisplayName());
                 curator.merge(existing);
-                //curator.refresh(existing);
-                
             }
-            
         }
     }
 }

--- a/server/src/main/java/org/candlepin/sync/DistributorVersionImporter.java
+++ b/server/src/main/java/org/candlepin/sync/DistributorVersionImporter.java
@@ -58,15 +58,20 @@ public class DistributorVersionImporter {
         for (DistributorVersion distVer : distVers) {
             DistributorVersion existing = curator.findByName(distVer.getName());
             if (existing == null) {
-                curator.create(distVer);
                 log.debug("Created distributor version: " + distVer.getName());
+                curator.create(distVer);
+                curator.refresh(distVer);
+                
             }
             else {
+                log.debug("Updating distributor version: " + distVer.getName());
                 existing.setCapabilities(distVer.getCapabilities());
                 existing.setDisplayName(distVer.getDisplayName());
                 curator.merge(existing);
-                log.debug("Updating distributor version: " + distVer.getName());
+                //curator.refresh(existing);
+                
             }
+            
         }
     }
 }

--- a/server/src/main/java/org/candlepin/sync/EntitlementImporter.java
+++ b/server/src/main/java/org/candlepin/sync/EntitlementImporter.java
@@ -330,12 +330,15 @@ public class EntitlementImporter {
         subscription.setId(local.getId());
         map.remove(local.getUpstreamEntitlementId());
         subscriptionCurator.merge(subscription);
+        //subscriptionCurator.refresh(subscription);
+
         // send updated event
         sink.emitSubscriptionModified(local, subscription);
     }
 
     private void createSubscription(Subscription subscription) {
         subscriptionCurator.create(subscription);
+        subscriptionCurator.refresh(subscription);
         // send out created event
         log.debug("emitting subscription event");
         sink.emitSubscriptionCreated(subscription);

--- a/server/src/main/java/org/candlepin/sync/EntitlementImporter.java
+++ b/server/src/main/java/org/candlepin/sync/EntitlementImporter.java
@@ -340,8 +340,9 @@ public class EntitlementImporter {
         subscriptionCurator.create(subscription);
         subscriptionCurator.refresh(subscription);
         // send out created event
-        log.debug("emitting subscription event");
+        log.debug("about to emit subscription event");
         sink.emitSubscriptionCreated(subscription);
+        log.debug("finished emitting subscription event");
     }
 
     /**

--- a/server/src/main/java/org/candlepin/sync/Importer.java
+++ b/server/src/main/java/org/candlepin/sync/Importer.java
@@ -66,6 +66,7 @@ import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
+import javax.persistence.FlushModeType;
 import javax.persistence.PersistenceException;
 
 
@@ -370,6 +371,10 @@ public class Importer {
          */
 //        validateMetadata(ExporterMetadata.TYPE_SYSTEM, null, metadata, force);
 
+        
+        // Set The transactions flush mode to COMMIT
+        contentCurator.setFlushMode(FlushModeType.COMMIT);
+        
         // If any calls find conflicts we'll assemble them into one exception detailing all
         // the conflicts which occurred, so the caller can override them all at once
         // if desired:

--- a/server/src/main/java/org/candlepin/sync/Importer.java
+++ b/server/src/main/java/org/candlepin/sync/Importer.java
@@ -443,20 +443,29 @@ public class Importer {
         if (importFiles.get(ImportFile.PRODUCTS.fileName()) != null) {
             ProductImporter importer = new ProductImporter(productCurator, contentCurator);
 
+            log.debug("before importProducts");
             Set<Product> productsToImport = importProducts(
                 importFiles.get(ImportFile.PRODUCTS.fileName()).listFiles(),
                 importer);
 
+            log.debug("before getModifiedProducts");
             Set<Product> modifiedProducts = importer.getChangedProducts(productsToImport);
             for (Product product : modifiedProducts) {
                 refresher.add(product);
+                log.debug("modified product: " + product.getId());
             }
 
+            log.debug("before productsToImport.store");
             importer.store(productsToImport);
+            log.debug("after productsToImport.store");
+
 
             meta = mapper.readValue(metadata, Meta.class);
+            log.debug("before importEntitlements");
             importEntitlements(owner, productsToImport, entitlements.listFiles(),
                 consumer, meta);
+            log.debug("after importEntitlements");
+            
 
             refresher.add(owner);
             refresher.run();

--- a/server/src/main/java/org/candlepin/sync/Importer.java
+++ b/server/src/main/java/org/candlepin/sync/Importer.java
@@ -385,16 +385,19 @@ public class Importer {
         importRules(rules, metadata);
 
         importConsumerTypes(consumerTypes.listFiles());
+        consumerTypeCurator.flush();
 
         File distributorVersions = importFiles.get(ImportFile.DISTRIBUTOR_VERSIONS.fileName());
         if (distributorVersions != null) {
             importDistributorVersions(distributorVersions.listFiles());
         }
-
+        distVerCurator.flush();
+        
         File cdns = importFiles.get(ImportFile.CONTENT_DELIVERY_NETWORKS.fileName());
         if (cdns != null) {
             importContentDeliveryNetworks(cdns.listFiles());
         }
+        cdnCurator.flush();
 
         // per user elements
         try {
@@ -419,7 +422,9 @@ public class Importer {
         catch (ImportConflictException e) {
             conflictExceptions.add(e);
         }
+        ownerCurator.flush();
 
+        
         // At this point we're done checking for any potential conflicts:
         if (!conflictExceptions.isEmpty()) {
             log.error("Conflicts occurred during import that were not overridden:");
@@ -429,6 +434,8 @@ public class Importer {
             throw new ImportConflictException(conflictExceptions);
         }
 
+        subCurator.flush();
+        productCurator.flush();
         // If the consumer has no entitlements, this products directory will end up empty.
         // This also implies there will be no entitlements to import.
         Refresher refresher = poolManager.getRefresher();

--- a/server/src/main/java/org/candlepin/sync/Importer.java
+++ b/server/src/main/java/org/candlepin/sync/Importer.java
@@ -385,19 +385,19 @@ public class Importer {
         importRules(rules, metadata);
 
         importConsumerTypes(consumerTypes.listFiles());
-        consumerTypeCurator.flush();
+        //consumerTypeCurator.refresh();
 
         File distributorVersions = importFiles.get(ImportFile.DISTRIBUTOR_VERSIONS.fileName());
         if (distributorVersions != null) {
             importDistributorVersions(distributorVersions.listFiles());
         }
-        distVerCurator.flush();
+        //distVerCurator.flush();
         
         File cdns = importFiles.get(ImportFile.CONTENT_DELIVERY_NETWORKS.fileName());
         if (cdns != null) {
             importContentDeliveryNetworks(cdns.listFiles());
         }
-        cdnCurator.flush();
+        //cdnCurator.flush();
 
         // per user elements
         try {
@@ -422,7 +422,7 @@ public class Importer {
         catch (ImportConflictException e) {
             conflictExceptions.add(e);
         }
-        ownerCurator.flush();
+        //ownerCurator.flush();
 
         
         // At this point we're done checking for any potential conflicts:
@@ -434,8 +434,8 @@ public class Importer {
             throw new ImportConflictException(conflictExceptions);
         }
 
-        subCurator.flush();
-        productCurator.flush();
+        //subCurator.flush();
+        //productCurator.flush();
         // If the consumer has no entitlements, this products directory will end up empty.
         // This also implies there will be no entitlements to import.
         Refresher refresher = poolManager.getRefresher();

--- a/server/src/main/java/org/candlepin/sync/Importer.java
+++ b/server/src/main/java/org/candlepin/sync/Importer.java
@@ -362,21 +362,17 @@ public class Importer {
                                         "required entitlements directory"));
         }
 
-
         // system level elements
         /*
          * Checking a system wide last import date breaks multi-tenant deployments whenever
          * one org imports a manifest slightly older than another org who has already
          * imported. Disabled for now. See bz #769644.
          */
-//        validateMetadata(ExporterMetadata.TYPE_SYSTEM, null, metadata, force);
+        //        validateMetadata(ExporterMetadata.TYPE_SYSTEM, null, metadata, force);
 
-        
-        
         // Set The transactions flush mode to COMMIT
-        log.debug("Setting FlushModeType=Commit");
         contentCurator.setFlushMode(FlushModeType.COMMIT);
-        
+
         // If any calls find conflicts we'll assemble them into one exception detailing all
         // the conflicts which occurred, so the caller can override them all at once
         // if desired:
@@ -387,19 +383,15 @@ public class Importer {
         importRules(rules, metadata);
 
         importConsumerTypes(consumerTypes.listFiles());
-        //consumerTypeCurator.refresh();
 
         File distributorVersions = importFiles.get(ImportFile.DISTRIBUTOR_VERSIONS.fileName());
         if (distributorVersions != null) {
             importDistributorVersions(distributorVersions.listFiles());
         }
-        //distVerCurator.flush();
-        
         File cdns = importFiles.get(ImportFile.CONTENT_DELIVERY_NETWORKS.fileName());
         if (cdns != null) {
             importContentDeliveryNetworks(cdns.listFiles());
         }
-        //cdnCurator.flush();
 
         // per user elements
         try {
@@ -424,9 +416,7 @@ public class Importer {
         catch (ImportConflictException e) {
             conflictExceptions.add(e);
         }
-        //ownerCurator.flush();
 
-        
         // At this point we're done checking for any potential conflicts:
         if (!conflictExceptions.isEmpty()) {
             log.error("Conflicts occurred during import that were not overridden:");
@@ -436,8 +426,6 @@ public class Importer {
             throw new ImportConflictException(conflictExceptions);
         }
 
-        //subCurator.flush();
-        //productCurator.flush();
         // If the consumer has no entitlements, this products directory will end up empty.
         // This also implies there will be no entitlements to import.
         Refresher refresher = poolManager.getRefresher();
@@ -450,7 +438,6 @@ public class Importer {
                 importFiles.get(ImportFile.PRODUCTS.fileName()).listFiles(),
                 importer);
 
-            log.debug("before getModifiedProducts");
             Set<Product> modifiedProducts = importer.getChangedProducts(productsToImport);
             for (Product product : modifiedProducts) {
                 refresher.add(product);
@@ -461,13 +448,9 @@ public class Importer {
             importer.store(productsToImport);
             log.debug("after productsToImport.store");
 
-
             meta = mapper.readValue(metadata, Meta.class);
-            log.debug("before importEntitlements");
             importEntitlements(owner, productsToImport, entitlements.listFiles(),
                 consumer, meta);
-            log.debug("after importEntitlements");
-            
 
             refresher.add(owner);
             refresher.run();

--- a/server/src/main/java/org/candlepin/sync/Importer.java
+++ b/server/src/main/java/org/candlepin/sync/Importer.java
@@ -372,7 +372,9 @@ public class Importer {
 //        validateMetadata(ExporterMetadata.TYPE_SYSTEM, null, metadata, force);
 
         
+        
         // Set The transactions flush mode to COMMIT
+        log.debug("Setting FlushModeType=Commit");
         contentCurator.setFlushMode(FlushModeType.COMMIT);
         
         // If any calls find conflicts we'll assemble them into one exception detailing all

--- a/server/src/main/java/org/candlepin/sync/ProductImporter.java
+++ b/server/src/main/java/org/candlepin/sync/ProductImporter.java
@@ -26,17 +26,21 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Sets;
 
 import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 /**
  * ProductImporter
  */
 public class ProductImporter {
-
+    private static Logger log = LoggerFactory.getLogger(ProductImporter.class);
     private ProductCurator curator;
     private ContentCurator contentCurator;
 
@@ -63,6 +67,9 @@ public class ProductImporter {
     }
 
     public void store(Set<Product> products) {
+        Map <String, Product> prodToStore = new HashMap<String, Product>();
+        Map <String, Content> contToStore = new HashMap<String, Content>();
+        
         for (Product importedProduct : products) {
             // Handling the storing/updating of Content here. This is technically a
             // disjoint entity, but really only makes sense in the concept of
@@ -78,23 +85,29 @@ public class ProductImporter {
                     c.setVendor("unknown");
                 }
 
-                /*
-                 * On standalone servers we will set metadata expire to 1 second so
-                 * clients an immediately get changes to content when published on the
-                 * server. We would use 0, but the client plugin interprets this as unset
-                 * and ignores it completely resulting in the default yum values being
-                 * used.
-                 *
-                 * We know this is a standalone server due to the fact that import is
-                 * being used, so there is no need to guard this behavior.
-                 */
-                c.setMetadataExpire(new Long(1));
-
-                contentCurator.createOrUpdate(c);
+                // On standalone servers we need metadata expiry to be 0 so clients can
+                // immediately get changes to content when published on the server.
+                // We can assume this is a standalone server due to the fact that
+                // import is being used, so no need to guard this behavior:
+                //c.setMetadataExpire(new Long(0));
+                contToStore.put(c.getId(), c);
+                //contentCurator.createOrUpdate(c);
             }
+            prodToStore.put(importedProduct.getId(), importedProduct);
 
-            curator.createOrUpdate(importedProduct);
         }
+        for (Content c : contToStore.values()) {
+            log.debug("Store Content: " + c.getLabel());
+            contentCurator.createOrUpdate(c);
+        }
+        contentCurator.flush();
+        curator.flush();
+        for (Product p : prodToStore.values()) {
+            log.debug("Store Product: " + p.getName());
+            curator.createOrUpdate(p);
+        }
+        contentCurator.flush();
+        curator.flush();
     }
 
     /**

--- a/server/src/main/java/org/candlepin/sync/ProductImporter.java
+++ b/server/src/main/java/org/candlepin/sync/ProductImporter.java
@@ -67,9 +67,9 @@ public class ProductImporter {
     }
 
     public void store(Set<Product> products) {
-        Map <String, Product> prodToStore = new HashMap<String, Product>();
-        Map <String, Content> contToStore = new HashMap<String, Content>();
-        
+        Map<String, Product> prodToStore = new HashMap<String, Product>();
+        Map<String, Content> contToStore = new HashMap<String, Content>();
+
         for (Product importedProduct : products) {
             // Handling the storing/updating of Content here. This is technically a
             // disjoint entity, but really only makes sense in the concept of

--- a/server/src/main/java/org/candlepin/sync/ProductImporter.java
+++ b/server/src/main/java/org/candlepin/sync/ProductImporter.java
@@ -89,9 +89,11 @@ public class ProductImporter {
                 // immediately get changes to content when published on the server.
                 // We can assume this is a standalone server due to the fact that
                 // import is being used, so no need to guard this behavior:
+
                 //c.setMetadataExpire(new Long(0));
                 contToStore.put(c.getId(), c);
                 //contentCurator.createOrUpdate(c);
+
             }
             prodToStore.put(importedProduct.getId(), importedProduct);
 

--- a/server/src/main/java/org/candlepin/sync/ProductImporter.java
+++ b/server/src/main/java/org/candlepin/sync/ProductImporter.java
@@ -98,16 +98,17 @@ public class ProductImporter {
         }
         for (Content c : contToStore.values()) {
             log.debug("Store Content: " + c.getLabel());
-            contentCurator.createOrUpdate(c);
+            Content newContent = contentCurator.createOrUpdate(c);
+            contentCurator.refresh(newContent);
         }
-        contentCurator.flush();
-        curator.flush();
+        //contentCurator.flush();
+        //curator.flush();
         for (Product p : prodToStore.values()) {
             log.debug("Store Product: " + p.getName());
             curator.createOrUpdate(p);
+            curator.refresh(p);
         }
-        contentCurator.flush();
-        curator.flush();
+
     }
 
     /**


### PR DESCRIPTION
Wip/notes/etc on manifest import for reference.

https://bugzilla.redhat.com/show_bug.cgi?id=1193803

Before:

sat6 client timeout importing a manifest with 
employee skus.

The ruby client times out after about 2 minutes, but the
request itself continues for ~5 minutes. 

~2 minutes import Contents and Products (about a second each)
~2 minutes generating new pools and subs

The tomcat thread running this was using 100% of one cpu.
Most of the time spent was in hibernate, doing a huge amount
of object comparisons to determine if everything in the
large transaction is up to date. 
See
http://stackoverflow.com/questions/10143880/hibernate-queries-much-slower-with-flushmode-auto-until-clear-is-called
for one description of this hibernate issue.


Now:

Takes about 12-14 seconds to do the manifest import.


Changes:
- Build list of uniq contents and products to import, then import them.
  Elliminates some unneeded duplication, and skips a lot of create or
  update logic. Saves 10-20 seconds. (This may be obsoleted by the
  COMMIT change)

- After creating new objects, refresh the session so the latest version
  is included in the session cache. This eliminates a lot of the update
  checking from the auto flush, and improves content/product import
  import alot. The product/content import stage goes from ~120 seconds
  to about 1-2 seconds total.

- Grab a reference to the EntityManager for the session and call
  setFlushMode(FlushModeType.COMMIT) on it. This prevents hibernate
  needing to constantly check if every object is up to date, and waits
  until transaction commit to "flush". This cuts the pool/sub creation
  and refresh portion from 2-3 minutes to approximately 10 seconds total.


- Experiemental: Remove the poolCurator.flush() in
  CandlepinPoolManager.processPoolUpdates(). The flush here seems to
  defeat some of the gain of using COMMIT flush mode, and removing it
  seems to work and gains a few seconds on the above (~16 secs to ~12
  secs), but is likely needed for prod or more active systems.

- Experimental: The hashCode for Product was changed to not depend 
  entirely on the product id, as per
  http://docs.jboss.org/hibernate/orm/4.2/manual/en-US/html/ch13.html#transactions-basics-identity
  This seems to worth a little performance when apply over the above
  (maybe a seconds worth in clock time, but more noticable in profile
  data). But I'm unsure if this would break compatability.

- Unaddressed potential improvements:

  - With the import down to ~12 seconds, the time spent creating json
  objects for the event queue become significant. Mostly in
  EventFactory.entityToJson(). Since that is done before the object is
  sent to the message bus and not async, the manifest import process
  blocks on it. For the kind of large subscriptions a employee sku
  manifest creates, that accounts for ~4secs of the ~12 seconds of a
  manifest import.

  - Some of these changes maybe applicable to the general refresh pools
  case as well.

- Unaddressed potential issues

  - Most testing was done with fresh db, and one manifest import.
    Updating an import, or concurrent imports were untested.

- General oddities

  - manifest import, and pool refresh/manager do a lot of slightly
    unusual thins in efforts to fight various symptons. It's hard to
    tell if there are interactions. It may be worth attempt to remove
    all of those fixes, and seeing if there is a better fundamental fix.
    (thinking of things like the poolCurator.refresh() in
    CandlepinPoolManager, and poolCurator.lockAndLoad(), the various
    session refresh()'s I added, etc).


  - On manifest import [POST /owners/{owner_key}/import] the request
    itself is marked @NonTransaction, but the transaction that is used
    results from the call to OwnerResource.findOwners() [via
    auth/principal creation?] which seems odd. Importer.importObjects()
    is @Transactional, but the request has already created a trx by
    then. Not sure I understand which interceptor should be closing it.
    (It does seem to work fine, just seems odd).


  - Creating the Event objects seems to take ~100ms on average, and as
    long as ~500ms for some large objects (like the Subscription
    mentioned above). Thats all created before queueing the Event, so it
    is a blocking process, and adds to the total request time.
