### PR TITLE
 Updated the method used to determine pool types

### DIFF
--- a/server/src/main/resources/db/changelog/20150401140006-add-pool-type-to-db.xml
+++ b/server/src/main/resources/db/changelog/20150401140006-add-pool-type-to-db.xml
@@ -16,54 +16,57 @@
 
     <changeSet id="20150401140006-2" author="crog">
         <sql>
-            UPDATE cp_pool SET type = 'ENTITLEMENT_DERIVED' WHERE cp_pool.id IN (
+            UPDATE cp_pool SET type = 'UNMAPPED_GUEST' WHERE cp_pool.id IN (
               SELECT P.id
               FROM cp_pool P
-                INNER JOIN cp_pool_attribute PA ON (P.id = PA.pool_id AND PA.name = 'pool_derived')
-              WHERE
-                PA.value = 'true'
-                AND (P.sourceentitlement_id IS NOT NULL AND p.sourceentitlement_id != '')
+                INNER JOIN cp_pool_attribute PA1 ON (P.id = PA1.pool_id AND PA1.name = 'pool_derived')
+                INNER JOIN cp_pool_attribute PA2 ON (P.id = PA2.pool_id AND PA2.name = 'unmapped_guests_only')
+              WHERE PA1.value = 'true' AND PA2.value = 'true'
             )
         </sql>
     </changeSet>
 
     <changeSet id="20150401140006-3" author="crog">
         <sql>
-            UPDATE cp_pool SET type = 'STACK_DERIVED' WHERE cp_pool.id IN (
+            UPDATE cp_pool SET type = 'ENTITLEMENT_DERIVED' WHERE cp_pool.id IN (
               SELECT P.id
               FROM cp_pool P
-                INNER JOIN cp_pool_attribute PA ON (P.id = PA.pool_id AND PA.name = 'pool_derived')
-                INNER JOIN cp_pool_source_stack SS ON p.id = SS.derivedpool_id
+                INNER JOIN cp_pool_attribute PA1 ON (P.id = PA1.pool_id AND PA1.name = 'pool_derived')
+                LEFT JOIN cp_pool_attribute PA2 ON (P.id = PA2.pool_id AND PA2.name = 'unmapped_guests_only')
               WHERE
-                PA.value = 'true'
-                AND (P.sourceentitlement_id IS NULL OR p.sourceentitlement_id = '')
+                PA1.value = 'true' AND PA2.id IS NULL
+                AND (P.sourceentitlement_id IS NOT NULL AND p.sourceentitlement_id != '')
             )
         </sql>
     </changeSet>
 
     <changeSet id="20150401140006-4" author="crog">
         <sql>
-            UPDATE cp_pool SET type = 'BONUS' WHERE cp_pool.id IN (
+            UPDATE cp_pool SET type = 'STACK_DERIVED' WHERE cp_pool.id IN (
               SELECT P.id
               FROM cp_pool P
-                INNER JOIN cp_pool_attribute PA ON (P.id = PA.pool_id AND PA.name = 'pool_derived')
-                LEFT JOIN cp_pool_source_stack SS ON p.id = SS.derivedpool_id
+                INNER JOIN cp_pool_attribute PA1 ON (P.id = PA1.pool_id AND PA1.name = 'pool_derived')
+                INNER JOIN cp_pool_source_stack SS ON p.id = SS.derivedpool_id
+                LEFT JOIN cp_pool_attribute PA2 ON (P.id = PA2.pool_id AND PA2.name = 'unmapped_guests_only')
               WHERE
-                PA.value = 'true'
+                PA1.value = 'true' AND PA2.id IS NULL
                 AND (P.sourceentitlement_id IS NULL OR p.sourceentitlement_id = '')
-                AND SS.id IS NULL
             )
         </sql>
     </changeSet>
 
     <changeSet id="20150401140006-5" author="crog">
         <sql>
-            UPDATE cp_pool SET type = 'UNMAPPED_GUEST' WHERE cp_pool.id IN (
+            UPDATE cp_pool SET type = 'BONUS' WHERE cp_pool.id IN (
               SELECT P.id
               FROM cp_pool P
-                LEFT JOIN cp_pool_attribute PA1 ON (P.id = PA1.pool_id AND PA1.name = 'pool_derived')
-                INNER JOIN cp_pool_attribute PA2 ON (P.id = PA2.pool_id AND PA2.name = 'unmapped_guest')
-              WHERE PA1.id IS NULL AND PA2.value = 'true'
+                INNER JOIN cp_pool_attribute PA1 ON (P.id = PA1.pool_id AND PA1.name = 'pool_derived')
+                LEFT JOIN cp_pool_source_stack SS ON p.id = SS.derivedpool_id
+                LEFT JOIN cp_pool_attribute PA2 ON (P.id = PA2.pool_id AND PA2.name = 'unmapped_guests_only')
+              WHERE
+                PA1.value = 'true' AND PA2.id IS NULL
+                AND (P.sourceentitlement_id IS NULL OR p.sourceentitlement_id = '')
+                AND SS.id IS NULL
             )
         </sql>
     </changeSet>
@@ -74,8 +77,7 @@
               SELECT P.id
               FROM cp_pool P
                 LEFT JOIN cp_pool_attribute PA1 ON (P.id = PA1.pool_id AND PA1.name = 'pool_derived')
-                LEFT JOIN cp_pool_attribute PA2 ON (P.id = PA2.pool_id AND PA2.name = 'unmapped_guest')
-              WHERE PA1.id IS NULL AND PA2.id IS NULL
+              WHERE PA1.id IS NULL OR PA1.value != 'true'
             )
         </sql>
     </changeSet>

--- a/server/src/test/java/org/candlepin/model/PoolTest.java
+++ b/server/src/test/java/org/candlepin/model/PoolTest.java
@@ -326,9 +326,7 @@ public class PoolTest extends DatabaseTestFixture {
 
     @Test
     public void testPoolType() {
-        assertEquals(PoolType.NORMAL, pool.getType());
-
-        pool.setAttribute("pool_derived", "true");
+        pool.setAttribute(Pool.DERIVED_POOL_ATTRIBUTE, "true");
         assertEquals(PoolType.BONUS, pool.getType());
 
         pool.setSourceEntitlement(new Entitlement());
@@ -337,6 +335,22 @@ public class PoolTest extends DatabaseTestFixture {
         pool.setSourceEntitlement(null);
         pool.setSourceStack(new SourceStack(new Consumer(), "something"));
         assertEquals(PoolType.STACK_DERIVED, pool.getType());
+
+        pool.setAttribute(Pool.UNMAPPED_GUESTS_ATTRIBUTE, "true");
+        assertEquals(PoolType.UNMAPPED_GUEST, pool.getType());
+
+        pool.setSourceEntitlement(new Entitlement());
+        pool.setSourceStack(null);
+        assertEquals(PoolType.UNMAPPED_GUEST, pool.getType());
+
+        pool.removeAttribute(Pool.DERIVED_POOL_ATTRIBUTE);
+        assertEquals(PoolType.NORMAL, pool.getType());
+
+        pool.setSourceEntitlement(null);
+        assertEquals(PoolType.NORMAL, pool.getType());
+
+        pool.setSourceStack(new SourceStack(new Consumer(), "something"));
+        assertEquals(PoolType.NORMAL, pool.getType());
     }
 
     @Test


### PR DESCRIPTION
- Pool.getType now only reports UNMAPPED_GUEST iff the pool has both
  the "pool_derived" and "unmapped_guests_only" attribute.
- Pool type DB migration queries and pool tests have been updated to
  reflect the change to Pool.getType.