### PR TITLE
Add Candlepin sub-projects as dependencies in POM files.

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.candlepin</groupId>
   <artifactId>candlepin-common</artifactId>
-  <version>1.0.19</version>
+  <version>1.0.22</version>
   <properties>
     <commons-codec-commons-codec.version>1.4</commons-codec-commons-codec.version>
     <commons-collections-commons-collections.version>3.1</commons-collections-commons-collections.version>

--- a/gutterball/pom.xml
+++ b/gutterball/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.candlepin</groupId>
   <artifactId>gutterball</artifactId>
-  <version>1.0.9</version>
+  <version>1.0.15</version>
   <properties>
     <org.apache.qpid-qpid-common.version>0.30</org.apache.qpid-qpid-common.version>
     <org.apache.qpid-qpid-client.version>0.30</org.apache.qpid-qpid-client.version>
@@ -71,6 +71,7 @@
     <com.sun.xml.bind-jaxb-impl.version>2.1.12</com.sun.xml.bind-jaxb-impl.version>
     <net.oauth.core-oauth.version>20100527</net.oauth.core-oauth.version>
     <net.oauth.core-oauth-provider.version>20100527</net.oauth.core-oauth-provider.version>
+    <org.candlepin-candlepin-common.version>1.0.22</org.candlepin-candlepin-common.version>
   </properties>
   <dependencies>
     <dependency>
@@ -402,6 +403,11 @@
       <groupId>net.oauth.core</groupId>
       <artifactId>oauth-provider</artifactId>
       <version>${net.oauth.core-oauth-provider.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.candlepin</groupId>
+      <artifactId>candlepin-common</artifactId>
+      <version>${org.candlepin-candlepin-common.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.candlepin</groupId>
   <artifactId>candlepin</artifactId>
-  <version>0.9.39</version>
+  <version>0.9.49</version>
   <properties>
     <org.apache.qpid-qpid-common.version>0.30</org.apache.qpid-qpid-common.version>
     <org.apache.qpid-qpid-client.version>0.30</org.apache.qpid-qpid-client.version>
@@ -77,6 +77,7 @@
     <javax.mail-mail.version>1.4</javax.mail-mail.version>
     <org.mozilla-rhino.version>1.7R3</org.mozilla-rhino.version>
     <com.sun.xml.bind-jaxb-impl.version>2.1.12</com.sun.xml.bind-jaxb-impl.version>
+    <org.candlepin-candlepin-common.version>1.0.22</org.candlepin-candlepin-common.version>
     <postgresql-postgresql.version>9.0-801.jdbc4</postgresql-postgresql.version>
     <mysql-mysql-connector-java.version>5.1.26</mysql-mysql-connector-java.version>
   </properties>
@@ -440,6 +441,11 @@
       <groupId>com.sun.xml.bind</groupId>
       <artifactId>jaxb-impl</artifactId>
       <version>${com.sun.xml.bind-jaxb-impl.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.candlepin</groupId>
+      <artifactId>candlepin-common</artifactId>
+      <version>${org.candlepin-candlepin-common.version}</version>
     </dependency>
     <dependency>
       <groupId>postgresql</groupId>

--- a/tasks/pom.rake
+++ b/tasks/pom.rake
@@ -88,8 +88,10 @@ module PomTask
       pom = project.pom
       if pom.enabled?
         project.recursive_task('pom') do
-          # Filter out Rake::FileTask dependencies
-          deps = project.compile.dependencies.select { |dep| dep.is_a?(Buildr::Artifact) }
+          # Filter out Rake::FileTask dependencies (note the use of instance_of
+          # because we need to match exact instances of FileTask and not
+          # child classes since other Buildr tasks inherit from FileTask)
+          deps = project.compile.dependencies.reject { |dep| dep.instance_of?(Rake::FileTask) }
           pom.artifacts.each do |artifact|
             spec = artifact.to_hash
             destination = project.path_to("pom.xml")


### PR DESCRIPTION
Previously the code was only adding "Buildr::Artifact" instances to the
POM files, but sub-projects are of the type "JarTask".  What we
really needed to do was filter out instances of "Rake::FileTask".  Note
that Buildr::Artifact is descended from Rake::FileTask so we need to do
an exact match on the class type using instance_of.