### PR TITLE
1217058: Fixed broken changeset affecting upgrade

### DIFF
--- a/gutterball/src/main/resources/db/changelog/2014-12-03-15-39-add-event-status.xml
+++ b/gutterball/src/main/resources/db/changelog/2014-12-03-15-39-add-event-status.xml
@@ -7,6 +7,7 @@
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
 
     <changeSet id="20141203153942-1" author="dgoodwin">
+        <validCheckSum>7:5682e551dd6fb1c61326d03bc0dab472</validCheckSum>
         <comment>add event status</comment>
         <addColumn tableName="gb_event">
             <column name="status" type="varchar(32)" defaultValue="SKIPPED">


### PR DESCRIPTION
When upgrading from gutterball-1.0.7-1, a changeset was
breaking DB upgrades because it was modified after
gutterball-1.0.7-1 was released.

The changeset modification was not critical and could
be skipped, so this commit will allow liquibase to
accept the new md5 checksum produced due to the
changeset file modification.