### PR TITLE
Apply permissions while getting Job Status

### DIFF
--- a/server/spec/job_status_spec.rb
+++ b/server/spec/job_status_spec.rb
@@ -6,6 +6,7 @@ describe 'Job Status' do
 
   before(:each) do
     @owner = create_owner(random_string("test_owner"))
+    @owner2 = create_owner(random_string("test_owner_2"))
     @user = user_client(@owner, random_string("test_user"))
     @monitoring = create_product
 
@@ -98,6 +99,56 @@ describe 'Job Status' do
     wait_for_job(status['id'], 15)
   end
 
+  it 'should allow admin to view any job status' do
+    job = @cp.refresh_pools(@owner['key'], true)
+    wait_for_job(job['id'], 15)
+    status = @cp.get_job(job['id'])
+    status['id'].should == job['id']
+  end
+
+  it 'should allow user to view status of own job' do
+    job = @user.autoheal_org(@owner['key'])
+    wait_for_job(job['id'], 15)
+    status = @user.get_job(job['id'])
+    status['id'].should == job['id']
+  end
+
+  it 'should allow user to view job status of consumer in managed org' do
+    system = consumer_client(@user, 's1')
+    job = system.consume_product(@monitoring.id, { :async => true })
+    status = @user.get_job(job['id'])
+    status['id'].should == job['id']
+  end
+
+  it 'should not allow user to view job status outside of managed org' do
+    other_user = user_client(@owner2, random_string("other_user"))
+    system = consumer_client(other_user, random_string("another_system"))
+    job = system.consume_product(@monitoring.id, { :async => true })
+
+    lambda do
+      @user.get_job(job['id'])
+    end.should raise_exception(RestClient::Forbidden)
+
+  end
+
+  it 'should allow consumer to view status of own job' do
+    system = consumer_client(@user, 'system7')
+    job = system.consume_product(@monitoring.id, { :async => true })
+    status = system.get_job(job['id'])
+    status['id'].should == job['id']
+  end
+
+  it 'should not allow consumer to access another consumers job status' do
+    system1 = consumer_client(@user, 's1')
+    system2 = consumer_client(@user, 's2')
+
+    job = system1.consume_product(@monitoring.id, { :async => true })
+    status = system1.get_job(job['id'])
+
+    lambda do
+      system2.get_job(job['id'])
+    end.should raise_exception(RestClient::Forbidden)
+  end
 
 end
 

--- a/server/src/main/java/org/candlepin/auth/ConsumerPrincipal.java
+++ b/server/src/main/java/org/candlepin/auth/ConsumerPrincipal.java
@@ -15,12 +15,15 @@
 package org.candlepin.auth;
 
 import org.candlepin.auth.permissions.AttachPermission;
+import org.candlepin.auth.permissions.CheckJobStatusPermission;
 import org.candlepin.auth.permissions.ConsumerEntitlementPermission;
 import org.candlepin.auth.permissions.ConsumerOrgHypervisorPermission;
 import org.candlepin.auth.permissions.ConsumerPermission;
 import org.candlepin.auth.permissions.ConsumerServiceLevelsPermission;
 import org.candlepin.auth.permissions.OwnerPoolsPermission;
 import org.candlepin.model.Consumer;
+
+import java.util.Arrays;
 
 /**
  *
@@ -48,6 +51,9 @@ public class ConsumerPrincipal extends Principal {
 
         // Allow consumers to run virt-who hypervisor update
         addPermission(new ConsumerOrgHypervisorPermission(consumer.getOwner()));
+
+        // Allow consumers to check the status of their own jobs.
+        addPermission(new CheckJobStatusPermission(getData(), Arrays.asList(consumer.getOwner().getKey())));
     }
 
     public Consumer getConsumer() {

--- a/server/src/main/java/org/candlepin/auth/UserPrincipal.java
+++ b/server/src/main/java/org/candlepin/auth/UserPrincipal.java
@@ -14,6 +14,7 @@
  */
 package org.candlepin.auth;
 
+import org.candlepin.auth.permissions.CheckJobStatusPermission;
 import org.candlepin.auth.permissions.Permission;
 import org.candlepin.auth.permissions.UserUserPermission;
 import org.candlepin.model.Owner;
@@ -44,16 +45,11 @@ public class UserPrincipal extends Principal {
             this.permissions.addAll(permissions);
         }
 
-        addPermissionToManageSelf();
-    }
+        // User principals should have an implicit permission to view their own data.
+        addPermission(new UserUserPermission(username));
 
-
-    /*
-     * User principals should have an implicit permission to view their own
-     * data.
-     */
-    private void addPermissionToManageSelf() {
-        this.permissions.add(new UserUserPermission(username));
+        // Allow users to check the status of their own jobs.
+        addPermission(new CheckJobStatusPermission(getData(), getOwnerKeys()));
     }
 
     public String getUsername() {

--- a/server/src/main/java/org/candlepin/auth/permissions/CheckJobStatusPermission.java
+++ b/server/src/main/java/org/candlepin/auth/permissions/CheckJobStatusPermission.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package org.candlepin.auth.permissions;
+
+import org.candlepin.auth.Access;
+import org.candlepin.auth.PrincipalData;
+import org.candlepin.auth.SubResource;
+import org.candlepin.model.Owner;
+import org.candlepin.pinsetter.core.model.JobStatus;
+
+import org.hibernate.criterion.Conjunction;
+import org.hibernate.criterion.Criterion;
+import org.hibernate.criterion.Restrictions;
+
+import java.util.List;
+
+/**
+ * Allows users/consumers access to any JobStatus from jobs that they
+ * created/initiated.
+ *
+ */
+public class CheckJobStatusPermission extends TypedPermission<JobStatus> {
+
+    private String principalName;
+    private String principalType;
+    private List<String> allowedOrgKeys;
+
+    public CheckJobStatusPermission(PrincipalData principalData, List<String> allowedOrgKeys) {
+        this.principalName = principalData.getName();
+        this.principalType = principalData.getType();
+        this.allowedOrgKeys = allowedOrgKeys;
+    }
+
+    @Override
+    public Class<JobStatus> getTargetType() {
+        return JobStatus.class;
+    }
+
+    @Override
+    public Owner getOwner() {
+        // This permission is not specific to any owner.
+        return null;
+    }
+
+    @Override
+    public Criterion getCriteriaRestrictions(Class entityClass) {
+        if (!entityClass.equals(JobStatus.class)) {
+            return null;
+        }
+
+        Conjunction conjunction = Restrictions.conjunction();
+        // Org has to match.
+        conjunction.add(Restrictions.in("ownerId", allowedOrgKeys));
+
+        conjunction.add(Restrictions.or(
+            Restrictions.ne("targetType", JobStatus.TargetType.OWNER),
+            Restrictions.and(
+                Restrictions.eq("targetType", JobStatus.TargetType.OWNER),
+                Restrictions.eqProperty("ownerId", "targetId")
+            )
+        ));
+
+        // If the principal is not a user, make sure to enforce a principalName match.
+        if (!"user".equalsIgnoreCase(principalType)) {
+            conjunction.add(Restrictions.eq("principalName", principalName));
+        }
+        return conjunction;
+    }
+
+    @Override
+    public boolean canAccessTarget(JobStatus target, SubResource subResource, Access required) {
+        boolean requiredAccessMet = Access.READ_ONLY.provides(required);
+        boolean principalNameMatch = principalName != null && principalName.equals(target.getPrincipalName());
+
+        String ownerId = target.getOwnerId();
+        boolean ownerOk = ownerId != null && allowedOrgKeys.contains(ownerId);
+
+        if (!ownerOk) {
+            return false;
+        }
+
+        // Make sure that the owner matches that of the target.
+        if (JobStatus.TargetType.OWNER.name().equalsIgnoreCase(target.getTargetType()) &&
+            !ownerId.equals(target.getTargetId())) {
+            return false;
+        }
+
+        if ("user".equalsIgnoreCase(principalType)) {
+            // Org was OK, but only allow a user to view consumer's status.
+            return true;
+        }
+
+        return requiredAccessMet && principalNameMatch;
+    }
+
+}

--- a/server/src/main/java/org/candlepin/model/JobCurator.java
+++ b/server/src/main/java/org/candlepin/model/JobCurator.java
@@ -99,13 +99,12 @@ public class JobCurator extends AbstractHibernateCurator<JobStatus> {
 
     @SuppressWarnings("unchecked")
     public List<JobStatus> findByPrincipalName(String principalName) {
-        return this.currentSession().createCriteria(JobStatus.class)
-        .add(Restrictions.eq("principalName", principalName)).list();
+        return createSecureCriteria().add(Restrictions.eq("principalName", principalName)).list();
     }
 
     @SuppressWarnings("unchecked")
     private List<JobStatus> findByTarget(TargetType type, String tgtid) {
-        return currentSession().createCriteria(JobStatus.class)
+        return createSecureCriteria()
             .add(Restrictions.eq("targetId", tgtid))
             .add(Restrictions.eq("targetType", type)).list();
     }

--- a/server/src/main/java/org/candlepin/pinsetter/core/model/JobStatus.java
+++ b/server/src/main/java/org/candlepin/pinsetter/core/model/JobStatus.java
@@ -46,6 +46,7 @@ public class JobStatus extends AbstractHibernateObject {
 
     public static final String TARGET_TYPE = "target_type";
     public static final String TARGET_ID = "target_id";
+    public static final String OWNER_ID = "owner_id";
     public static final int RESULT_COL_LENGTH = 255;
 
     /**
@@ -95,6 +96,9 @@ public class JobStatus extends AbstractHibernateObject {
     @Size(max = 255)
     private String targetId;
 
+    @Size(max = 255)
+    private String ownerId;
+
     @Column(length = 255)
     private Class<? extends KingpinJob> jobClass;
 
@@ -108,6 +112,7 @@ public class JobStatus extends AbstractHibernateObject {
         this.id = jobDetail.getKey().getName();
         this.jobGroup = jobDetail.getKey().getGroup();
         this.state = waiting ? JobState.WAITING : JobState.CREATED;
+        this.ownerId = this.getOwnerId(jobDetail);
         this.targetType = getTargetType(jobDetail);
         this.targetId = getTargetId(jobDetail);
         this.principalName = getPrincipalName(jobDetail);
@@ -126,6 +131,10 @@ public class JobStatus extends AbstractHibernateObject {
 
     private String getTargetId(JobDetail jobDetail) {
         return (String) jobDetail.getJobDataMap().get(TARGET_ID);
+    }
+
+    private String getOwnerId(JobDetail jobDetail) {
+        return (String) jobDetail.getJobDataMap().get(OWNER_ID);
     }
 
     @SuppressWarnings("unchecked")
@@ -214,6 +223,10 @@ public class JobStatus extends AbstractHibernateObject {
 
     public String getPrincipalName() {
         return this.principalName;
+    }
+
+    public String getOwnerId() {
+        return this.ownerId;
     }
 
     @XmlTransient

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/EntitleByProductsJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/EntitleByProductsJob.java
@@ -17,6 +17,7 @@ package org.candlepin.pinsetter.tasks;
 import static org.quartz.JobBuilder.*;
 
 import org.candlepin.controller.Entitler;
+import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerCurator;
 import org.candlepin.model.Entitlement;
 import org.candlepin.pinsetter.core.model.JobStatus;
@@ -74,12 +75,13 @@ public class EntitleByProductsJob extends KingpinJob {
         }
     }
 
-    public static JobDetail bindByProducts(String[] prodIds, String uuid,
+    public static JobDetail bindByProducts(String[] prodIds, Consumer consumer,
         Date entitleDate, Collection<String> fromPools) {
         JobDataMap map = new JobDataMap();
+        map.put(JobStatus.OWNER_ID, consumer.getOwner().getKey());
         map.put("product_ids", prodIds);
         map.put(JobStatus.TARGET_TYPE, JobStatus.TargetType.CONSUMER);
-        map.put(JobStatus.TARGET_ID, uuid);
+        map.put(JobStatus.TARGET_ID, consumer.getUuid());
         map.put("entitle_date", entitleDate);
         map.put("from_pools", fromPools);
 

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/EntitlerJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/EntitlerJob.java
@@ -17,6 +17,7 @@ package org.candlepin.pinsetter.tasks;
 import static org.quartz.JobBuilder.*;
 
 import org.candlepin.controller.Entitler;
+import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerCurator;
 import org.candlepin.model.Entitlement;
 import org.candlepin.pinsetter.core.model.JobStatus;
@@ -70,11 +71,12 @@ public class EntitlerJob extends KingpinJob {
         }
     }
 
-    public static JobDetail bindByPool(String poolId, String uuid, Integer qty) {
+    public static JobDetail bindByPool(String poolId, Consumer consumer, Integer qty) {
         JobDataMap map = new JobDataMap();
+        map.put(JobStatus.OWNER_ID, consumer.getOwner().getKey());
         map.put("pool_id", poolId);
         map.put(JobStatus.TARGET_TYPE, JobStatus.TargetType.CONSUMER);
-        map.put(JobStatus.TARGET_ID, uuid);
+        map.put(JobStatus.TARGET_ID, consumer.getUuid());
         map.put("quantity", qty);
 
         JobDetail detail = newJob(EntitlerJob.class)

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/HealEntireOrgJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/HealEntireOrgJob.java
@@ -97,6 +97,7 @@ public class HealEntireOrgJob extends UniqueByOwnerJob {
     public static JobDetail healEntireOrg(String ownerId, Date entitleDate) {
         JobDataMap map = new JobDataMap();
         map.put("ownerId", ownerId);
+        map.put(JobStatus.OWNER_ID, ownerId);
         map.put(JobStatus.TARGET_TYPE, JobStatus.TargetType.OWNER);
         map.put(JobStatus.TARGET_ID, ownerId);
         map.put("entitle_date", entitleDate);

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/RefreshPoolsJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/RefreshPoolsJob.java
@@ -115,6 +115,7 @@ public class RefreshPoolsJob extends UniqueByOwnerJob {
      */
     public static JobDetail forOwner(Owner owner, Boolean lazy) {
         JobDataMap map = new JobDataMap();
+        map.put(JobStatus.OWNER_ID, owner.getKey());
         map.put(JobStatus.TARGET_TYPE, JobStatus.TargetType.OWNER);
         map.put(JobStatus.TARGET_ID, owner.getKey());
         map.put(LAZY_REGEN, lazy);

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -1456,11 +1456,11 @@ public class ConsumerResource {
             JobDetail detail = null;
 
             if (poolIdString != null) {
-                detail = EntitlerJob.bindByPool(poolIdString, consumerUuid, quantity);
+                detail = EntitlerJob.bindByPool(poolIdString, consumer, quantity);
             }
             else {
                 detail = EntitleByProductsJob.bindByProducts(productIds,
-                        consumerUuid, entitleDate, fromPools);
+                        consumer, entitleDate, fromPools);
             }
 
             // events will be triggered by the job

--- a/server/src/main/java/org/candlepin/resource/JobResource.java
+++ b/server/src/main/java/org/candlepin/resource/JobResource.java
@@ -14,6 +14,7 @@
  */
 package org.candlepin.resource;
 
+import org.candlepin.auth.interceptor.Verify;
 import org.candlepin.common.exceptions.BadRequestException;
 import org.candlepin.common.exceptions.IseException;
 import org.candlepin.common.exceptions.NotFoundException;
@@ -203,7 +204,7 @@ public class JobResource {
     @GET
     @Path("/{job_id}")
     @Produces(MediaType.APPLICATION_JSON)
-    public JobStatus getStatus(@PathParam("job_id") String jobId) {
+    public JobStatus getStatus(@PathParam("job_id") @Verify(JobStatus.class) String jobId) {
         return curator.find(jobId);
     }
 
@@ -218,7 +219,7 @@ public class JobResource {
     @DELETE
     @Path("/{job_id}")
     @Produces(MediaType.APPLICATION_JSON)
-    public JobStatus cancel(@PathParam("job_id") String jobId) {
+    public JobStatus cancel(@PathParam("job_id") @Verify(JobStatus.class) String jobId) {
         JobStatus j = curator.find(jobId);
         if (j.getState().equals(JobState.CANCELED)) {
             throw new BadRequestException(i18n.tr("job already canceled"));
@@ -239,7 +240,8 @@ public class JobResource {
     @POST
     @Path("/{job_id}")
     @Produces(MediaType.APPLICATION_JSON)
-    public JobStatus getStatusAndDeleteIfFinished(@PathParam("job_id") String jobId) {
+    public JobStatus getStatusAndDeleteIfFinished(
+        @PathParam("job_id") @Verify(JobStatus.class) String jobId) {
         JobStatus status = curator.find(jobId);
 
         if (status != null && status.getState() == JobState.FINISHED) {

--- a/server/src/main/java/org/candlepin/resteasy/interceptor/AuthInterceptor.java
+++ b/server/src/main/java/org/candlepin/resteasy/interceptor/AuthInterceptor.java
@@ -39,6 +39,7 @@ import org.candlepin.model.Entitlement;
 import org.candlepin.model.EntitlementCurator;
 import org.candlepin.model.Environment;
 import org.candlepin.model.EnvironmentCurator;
+import org.candlepin.model.JobCurator;
 import org.candlepin.model.Owner;
 import org.candlepin.model.OwnerCurator;
 import org.candlepin.model.Persisted;
@@ -49,6 +50,7 @@ import org.candlepin.model.ProductCurator;
 import org.candlepin.model.User;
 import org.candlepin.model.activationkeys.ActivationKey;
 import org.candlepin.model.activationkeys.ActivationKeyCurator;
+import org.candlepin.pinsetter.core.model.JobStatus;
 import org.candlepin.service.UserServiceAdapter;
 import org.candlepin.util.Util;
 
@@ -187,6 +189,7 @@ public class AuthInterceptor implements PreProcessInterceptor, AcceptedByMethod 
         storeMap.put(User.class, new UserStore());
         storeMap.put(ActivationKey.class, new ActivationKeyStore());
         storeMap.put(Product.class, new ProductStore());
+        storeMap.put(JobStatus.class, new JobStatusStore());
     }
 
     /**
@@ -674,6 +677,36 @@ public class AuthInterceptor implements PreProcessInterceptor, AcceptedByMethod 
             // Products do not belong to an org:
             return null;
         }
+    }
+
+    private class JobStatusStore implements EntityStore<JobStatus> {
+
+        private JobCurator jobCurator;
+
+        private void initialize() {
+            if (jobCurator == null) {
+                jobCurator = injector.getInstance(JobCurator.class);
+            }
+        }
+
+        @Override
+        public JobStatus lookup(String jobId) {
+            initialize();
+            return jobCurator.find(jobId);
+        }
+
+        @Override
+        public List<JobStatus> lookup(Collection<String> jobIds) {
+            initialize();
+            return jobCurator.listAllByIds(jobIds);
+        }
+
+        @Override
+        public Owner getOwner(JobStatus entity) {
+            // JobStatus does not necessarily belong to an owner.
+            return null;
+        }
+
     }
 
     private static class UserStore implements EntityStore<User> {

--- a/server/src/main/resources/db/changelog/20150424150412-add-owner-id-to-jobstatus.xml
+++ b/server/src/main/resources/db/changelog/20150424150412-add-owner-id-to-jobstatus.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+    <changeSet id="20150424150412-1" author="mstead">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists columnName="ownerid" tableName="cp_job"/>
+            </not>
+        </preConditions>
+        <comment>Add ownerid to cp_job</comment>
+        <addColumn tableName="cp_job">
+            <column name="ownerid" type="VARCHAR(255)"/>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/server/src/main/resources/db/changelog/changelog-create.xml
+++ b/server/src/main/resources/db/changelog/changelog-create.xml
@@ -1173,4 +1173,5 @@
     <include file="db/changelog/20150316122833-add-entitlement-end-date-override.xml"/>
     <include file="db/changelog/20150311151612-force-all-content-metadataexpire-to-0.xml"/>
     <include file="db/changelog/20150401140006-add-pool-type-to-db.xml"/>
+    <include file="db/changelog/20150424150412-add-owner-id-to-jobstatus.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-testing.xml
+++ b/server/src/main/resources/db/changelog/changelog-testing.xml
@@ -2027,7 +2027,7 @@
     </changeSet>
     <changeSet author="awood" id="1413225753032-290">
         <comment>
-             Add the default quartz lock columns.
+             Add the default quartz lock columns. 
         </comment>
         <insert tableName="QRTZ_LOCKS">
             <column name="LOCK_NAME" value="TRIGGER_ACCESS"/>
@@ -2263,4 +2263,5 @@
     <include file="db/changelog/20150316122833-add-entitlement-end-date-override.xml"/>
     <include file="db/changelog/20150311151612-force-all-content-metadataexpire-to-0.xml"/>
     <include file="db/changelog/20150401140006-add-pool-type-to-db.xml"/>
+    <include file="db/changelog/20150424150412-add-owner-id-to-jobstatus.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-update.xml
+++ b/server/src/main/resources/db/changelog/changelog-update.xml
@@ -81,4 +81,5 @@
     <include file="db/changelog/20150316122833-add-entitlement-end-date-override.xml"/>
     <include file="db/changelog/20150311151612-force-all-content-metadataexpire-to-0.xml"/>
     <include file="db/changelog/20150401140006-add-pool-type-to-db.xml"/>
+    <include file="db/changelog/20150424150412-add-owner-id-to-jobstatus.xml"/>
 </databaseChangeLog>

--- a/server/src/test/java/org/candlepin/auth/ConsumerPrincipalTest.java
+++ b/server/src/test/java/org/candlepin/auth/ConsumerPrincipalTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 import org.candlepin.model.Consumer;
+import org.candlepin.model.ConsumerType;
 import org.candlepin.model.Entitlement;
 import org.candlepin.model.Owner;
 import org.candlepin.model.Pool;
@@ -80,7 +81,8 @@ public class ConsumerPrincipalTest {
 
     @Test
     public void equalsDifferentConsumer() {
-        Consumer c = mock(Consumer.class);
+        Consumer c = new Consumer("Test Consumer", "test-consumer", new Owner("o1"),
+            new ConsumerType(ConsumerType.ConsumerTypeEnum.SYSTEM));
         ConsumerPrincipal cp = new ConsumerPrincipal(c);
         assertFalse(principal.equals(cp));
     }

--- a/server/src/test/java/org/candlepin/model/JobCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/JobCuratorTest.java
@@ -14,14 +14,12 @@
  */
 package org.candlepin.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 import static org.quartz.JobBuilder.newJob;
 
+import org.candlepin.auth.Access;
+import org.candlepin.auth.ConsumerPrincipal;
 import org.candlepin.auth.Principal;
 import org.candlepin.common.exceptions.NotFoundException;
 import org.candlepin.pinsetter.core.PinsetterJobListener;
@@ -31,6 +29,7 @@ import org.candlepin.pinsetter.core.model.JobStatus.JobState;
 import org.candlepin.pinsetter.tasks.HealEntireOrgJob;
 import org.candlepin.pinsetter.tasks.RefreshPoolsJob;
 import org.candlepin.test.DatabaseTestFixture;
+import org.candlepin.test.TestUtil;
 import org.candlepin.util.Util;
 
 import org.apache.commons.lang.RandomStringUtils;
@@ -247,6 +246,136 @@ public class JobCuratorTest extends DatabaseTestFixture {
         assertEquals(JobStatus.JobState.CANCELED, status5.getState());
     }
 
+    @Test
+    public void findByPrincipalNameRestrictsUserToAccessableOrgs() {
+        JobStatus job = newJobStatus().principalName("donald").owner("ducks").create();
+        newJobStatus().principalName("donald").owner("marley").create();
+
+        setupPrincipal("goofy", new Owner("ducks"), Access.READ_ONLY);
+
+        List<JobStatus> jobs = this.curator.findByPrincipalName("donald");
+        assertNotNull(jobs);
+        assertEquals(1, jobs.size());
+        assertEquals("donald", job.getPrincipalName());
+        assertEquals(job, jobs.get(0));
+    }
+
+    @Test
+    public void findByPrincipalNameRestrictsConsumerToOwnJobs() {
+        Owner owner = new Owner("ducks");
+        Consumer consumer = TestUtil.createConsumer(owner);
+
+        JobStatus job = newJobStatus().principalName(consumer.getUuid()).owner(owner.getKey()).create();
+        newJobStatus().principalName("donald").owner(owner.getKey()).create();
+
+        setupPrincipal(new ConsumerPrincipal(consumer));
+
+        assertTrue(this.curator.findByPrincipalName("donald").isEmpty());
+
+        List<JobStatus> jobs = this.curator.findByPrincipalName(consumer.getUuid());
+        assertNotNull(jobs);
+        assertEquals(1, jobs.size());
+        assertEquals(consumer.getUuid(), job.getPrincipalName());
+        assertEquals(job, jobs.get(0));
+    }
+
+    @Test
+    public void findByOwnerReturnsAllWhenRequestedBySuperAdmin() {
+        newJobStatus().principalName("p1").owner("owner1").create();
+        newJobStatus().principalName("p2").owner("owner1").create();
+        newJobStatus().principalName("p3").owner("owner2").create();
+        setupAdminPrincipal("bob");
+
+        List<JobStatus> jobs = this.curator.findByOwnerKey("owner1");
+        assertNotNull(jobs);
+        assertEquals(2, jobs.size());
+
+        for (JobStatus job : jobs) {
+            assertEquals("owner1", job.getOwnerId());
+        }
+
+        assertEquals(1, this.curator.findByOwnerKey("owner2").size());
+    }
+
+    @Test
+    public void findByUserFiltersByOwnerAccessWhenRequestedByBasicUser() {
+        newJobStatus().principalName("p1").owner("owner1").create();
+        newJobStatus().principalName("p2").owner("owner1").create();
+        newJobStatus().principalName("p3").owner("owner2").create();
+        setupPrincipal("goofy", new Owner("owner1"), Access.READ_ONLY);
+
+        List<JobStatus> jobs = this.curator.findByOwnerKey("owner1");
+        assertNotNull(jobs);
+        assertEquals(2, jobs.size());
+
+        for (JobStatus job : jobs) {
+            assertEquals("owner1", job.getOwnerId());
+        }
+
+        assertTrue(this.curator.findByOwnerKey("owner2").isEmpty());
+    }
+
+    @Test
+    public void findByUserFiltersByOwnerAccessAndUUIDWhenRequestedByConsumer() {
+        Owner owner = new Owner("testowner");
+        Consumer consumer = TestUtil.createConsumer(owner);
+
+        JobStatus job = newJobStatus().principalName(consumer.getUuid()).owner(owner.getKey()).create();
+        newJobStatus().principalName("p1").owner("owner1").create();
+        newJobStatus().principalName("p2").owner("owner1").create();
+        newJobStatus().principalName("p3").owner("owner2").create();
+
+        setupPrincipal(new ConsumerPrincipal(consumer));
+
+        assertTrue(this.curator.findByOwnerKey("owner1").isEmpty());
+        assertTrue(this.curator.findByOwnerKey("owner2").isEmpty());
+
+        List<JobStatus> found = this.curator.findByOwnerKey("testowner");
+        assertEquals(1, found.size());
+        assertEquals(job, found.get(0));
+    }
+
+    @Test
+    public void findByConsumerUuidRestrictsByOwnerWhenRequestedByBasicUser() {
+        newJobStatus().principalName("p1").consumer("c1", "owner1").create();
+        newJobStatus().principalName("p4").owner("owner2").create();
+
+        JobStatus job = newJobStatus().principalName("p3").consumer("c2", "owner1").create();
+        // Technically this case should not happen since a consumer
+        // can belong to one org, but adding just to make sure that
+        // it gets filtered.
+        newJobStatus().principalName("p2").consumer("c2", "owner2").create();
+
+        setupPrincipal("goofy", new Owner("owner1"), Access.READ_ONLY);
+
+        List<JobStatus> found = curator.findByConsumerUuid("c2");
+        assertEquals(1, found.size());
+        assertEquals(job, found.get(0));
+    }
+
+    @Test
+    public void findByConsuemrUuidRestrictsByConsumerUuidEnforcesOwnerMatchWhenRequestedByConsumer() {
+        Owner owner = new Owner("testowner");
+        Consumer consumer = TestUtil.createConsumer(owner);
+
+        JobStatus job = newJobStatus().principalName(consumer.getUuid())
+            .consumer(consumer.getUuid(), consumer.getOwner().getKey()).create();
+
+        // Technically this case should not happen since a consumer
+        // can belong to one org, but adding just to make sure that
+        // it gets filtered.
+        newJobStatus().principalName(consumer.getUuid()).consumer(consumer.getUuid(), "owner1").create();
+
+        newJobStatus().principalName("p2").consumer("c2", "owner1").create();
+        newJobStatus().principalName("p3").owner("owner2").create();
+
+        setupPrincipal(new ConsumerPrincipal(consumer));
+
+        List<JobStatus> jobs = curator.findByConsumerUuid(consumer.getUuid());
+        assertEquals(1, jobs.size());
+        assertEquals(job, jobs.get(0));
+    }
+
     private JobStatusBuilder newJobStatus() {
         return new JobStatusBuilder();
     }
@@ -257,14 +386,22 @@ public class JobCuratorTest extends DatabaseTestFixture {
         private Date endDt;
         private String result;
         private JobState state;
-        private String ownerkey;
+        private String targetValue;
         private String principalName;
+
+        private String contextOwner;
+        private JobStatus.TargetType targetType;
+
         private JobDataMap map;
         private Class<? extends Job> jobClass = Job.class;
 
         public JobStatusBuilder() {
             id("id" + Math.random());
             map = new JobDataMap();
+
+            contextOwner = "an-owner-key";
+            targetValue = contextOwner;
+            targetType = JobStatus.TargetType.OWNER;
         }
 
         public JobStatusBuilder id(String id) {
@@ -293,7 +430,16 @@ public class JobCuratorTest extends DatabaseTestFixture {
         }
 
         public JobStatusBuilder owner(String key) {
-            this.ownerkey = key;
+            this.contextOwner = key;
+            this.targetValue = key;
+            this.targetType = JobStatus.TargetType.OWNER;
+            return this;
+        }
+
+        public JobStatusBuilder consumer(String consumerUuid, String consumerOwnerKey) {
+            this.contextOwner = consumerOwnerKey;
+            this.targetValue = consumerUuid;
+            this.targetType = JobStatus.TargetType.CONSUMER;
             return this;
         }
 
@@ -315,8 +461,9 @@ public class JobCuratorTest extends DatabaseTestFixture {
             when(p.getPrincipalName()).thenReturn(principalName);
 
             map.put(PinsetterJobListener.PRINCIPAL_KEY, p);
-            map.put(JobStatus.TARGET_TYPE, JobStatus.TargetType.OWNER);
-            map.put(JobStatus.TARGET_ID, ownerkey);
+            map.put(JobStatus.TARGET_TYPE, targetType);
+            map.put(JobStatus.TARGET_ID, targetValue);
+            map.put(JobStatus.OWNER_ID, contextOwner);
             JobStatus status = new JobStatus(
                 newJob(jobClass).withIdentity(id, PinsetterKernel.SINGLE_JOB_GROUP)
                 .usingJobData(map).build());

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/EntitleByProductsJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/EntitleByProductsJobTest.java
@@ -15,11 +15,14 @@
 package org.candlepin.pinsetter.tasks;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 
 import org.candlepin.controller.Entitler;
+import org.candlepin.model.Consumer;
+import org.candlepin.model.ConsumerType;
 import org.candlepin.model.Entitlement;
+import org.candlepin.model.Owner;
 import org.candlepin.pinsetter.core.model.JobStatus;
 
 import org.junit.Before;
@@ -42,12 +45,16 @@ import java.util.List;
  */
 public class EntitleByProductsJobTest {
 
+    private Consumer consumer;
     private String consumerUuid;
     private Entitler e;
 
     @Before
     public void init() {
         consumerUuid = "49bd6a8f-e9f8-40cc-b8d7-86cafd687a0e";
+        consumer = new Consumer("Test Consumer", "test-consumer", new Owner("test-owner"),
+            new ConsumerType("system"));
+        consumer.setUuid(consumerUuid);
         e = mock(Entitler.class);
     }
 
@@ -55,7 +62,7 @@ public class EntitleByProductsJobTest {
     public void bindByProductsSetup() {
         String[] pids = {"pid1", "pid2", "pid3"};
 
-        JobDetail detail = EntitleByProductsJob.bindByProducts(pids, consumerUuid, null, null);
+        JobDetail detail = EntitleByProductsJob.bindByProducts(pids, consumer, null, null);
         assertNotNull(detail);
         String[] resultpids = (String[]) detail.getJobDataMap().get("product_ids");
         assertEquals("pid2", resultpids[1]);
@@ -67,7 +74,7 @@ public class EntitleByProductsJobTest {
     public void bindByProductsExec() throws JobExecutionException {
         String[] pids = {"pid1", "pid2", "pid3"};
 
-        JobDetail detail = EntitleByProductsJob.bindByProducts(pids, consumerUuid, null, null);
+        JobDetail detail = EntitleByProductsJob.bindByProducts(pids, consumer, null, null);
         JobExecutionContext ctx = mock(JobExecutionContext.class);
         when(ctx.getMergedJobDataMap()).thenReturn(detail.getJobDataMap());
 
@@ -93,7 +100,7 @@ public class EntitleByProductsJobTest {
     @Test
     public void serializeJobDataMapForProducts() throws IOException {
         String[] pids = {"pid1", "pid2", "pid3"};
-        JobDetail detail = EntitleByProductsJob.bindByProducts(pids, consumerUuid, null, null);
+        JobDetail detail = EntitleByProductsJob.bindByProducts(pids, consumer, null, null);
         serialize(detail.getJobDataMap());
     }
 


### PR DESCRIPTION
Allow JobStatus to be fetched by a regular user
or consumer if they have the appropriate permission
to do so.

Permissions will be applied such that:
  * a super admin can view any job status
  * a user can view a job status if they have some level of access
    to an org (no matter who started the job)
  * a consumer can only view the status of jobs they have started