### PR TITLE
HATEOAS/JSON filtering enhancements

### DIFF
--- a/common/src/main/java/org/candlepin/common/jackson/DynamicFilterData.java
+++ b/common/src/main/java/org/candlepin/common/jackson/DynamicFilterData.java
@@ -22,6 +22,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+
+
 /**
  * DynamicFilterData
  *
@@ -31,21 +33,62 @@ import java.util.Map;
 public class DynamicFilterData {
     private static Logger log = LoggerFactory.getLogger(DynamicFilterData.class);
 
-    private Map<String, List<String>> filters;
-    private boolean excluding = true;
+    private static class Match {
+        private final int level;
+        private final boolean exact;
 
-    public DynamicFilterData(boolean excluding) {
-        this.filters = new HashMap<String, List<String>>();
-        this.excluding = excluding;
+        public Match(int level, boolean exact) {
+            this.level = level;
+            this.exact = exact;
+        }
+
+        public int getLevel() {
+            return this.level;
+        }
+
+        public boolean isExact() {
+            return this.exact;
+        }
     }
 
-    public void addAttributeFilter(String path) {
+
+    private Map<String, List<String>> includeFilters;
+    private Map<String, List<String>> excludeFilters;
+    private boolean whitelist;
+
+    public DynamicFilterData() {
+        this(false);
+    }
+
+    public DynamicFilterData(boolean whitelist) {
+        this.includeFilters = new HashMap<String, List<String>>();
+        this.excludeFilters = new HashMap<String, List<String>>();
+        this.whitelist = whitelist;
+    }
+
+    public void setWhitelistMode(boolean whitelist) {
+        this.whitelist = whitelist;
+    }
+
+    public void includeAttribute(String path) {
         if (path == null) {
             throw new IllegalArgumentException("path is null");
         }
 
+        this.addAttributeFilter(this.includeFilters, path);
+    }
+
+    public void excludeAttribute(String path) {
+        if (path == null) {
+            throw new IllegalArgumentException("path is null");
+        }
+
+        this.addAttributeFilter(this.excludeFilters, path);
+    }
+
+    private void addAttributeFilter(Map<String, List<String>> filters, String path) {
         String[] chunklets = path.split("\\.");
-        this.filters.put(path.toLowerCase(), Arrays.asList(chunklets));
+        filters.put(path.toLowerCase(), Arrays.asList(chunklets));
     }
 
     public boolean isAttributeExcluded(String path) {
@@ -54,25 +97,46 @@ public class DynamicFilterData {
     }
 
     public boolean isAttributeExcluded(List<String> path) {
-        boolean match = false;
+        Match iLevel = this.getFilterLevel(this.includeFilters, path);
+        Match eLevel = this.getFilterLevel(this.excludeFilters, path);
 
-        for (List<String> apath : this.filters.values()) {
-            int i = 0;
-            do {
-                String achunk = apath.get(i);
-                String pchunk = path.get(i);
-
-                match = achunk != null && achunk.equalsIgnoreCase(pchunk);
-                ++i;
-            } while (match && i < path.size() && i < apath.size());
-
-            if (match && (!this.excluding || i >= apath.size())) {
-                break;
-            }
-
-            match = false;
+        if (iLevel.isExact() && iLevel.getLevel() > eLevel.getLevel()) {
+            return false;
         }
 
-        return this.excluding ? match : !match;
+        if (eLevel.isExact() && eLevel.getLevel() > iLevel.getLevel()) {
+            return true;
+        }
+
+        return this.whitelist && (iLevel.getLevel() < 1 || iLevel.getLevel() < eLevel.getLevel());
+    }
+
+    private Match getFilterLevel(Map<String, List<String>> filters, List<String> path) {
+        int level = 0;
+        boolean exact = false;
+
+        for (List<String> fpath : filters.values()) {
+            boolean match = false;
+            int i = 0;
+
+            do {
+                String fchunk = fpath.get(i);
+                String pchunk = path.get(i);
+
+                match = fchunk != null && fchunk.equalsIgnoreCase(pchunk);
+                ++i;
+            } while (match && i < path.size() && i < fpath.size());
+
+            if (match && i > level) {
+                level = i + 1;
+                exact = i >= fpath.size();
+
+                if (exact) {
+                    break;
+                }
+            }
+        }
+
+        return new Match(level, exact);
     }
 }

--- a/common/src/main/java/org/candlepin/common/resteasy/interceptor/DynamicFilterInterceptor.java
+++ b/common/src/main/java/org/candlepin/common/resteasy/interceptor/DynamicFilterInterceptor.java
@@ -53,9 +53,16 @@ public class DynamicFilterInterceptor implements PreProcessInterceptor {
         boolean containsExcludes = queryParams.containsKey("exclude");
         boolean containsIncludes = queryParams.containsKey("include");
 
-        // We want the list to be a blacklist by default when neither include nor exclude is
-        // provided, so we don't accidentally filter anything
-        DynamicFilterData filterData = new DynamicFilterData(containsIncludes && !containsExcludes);
+        DynamicFilterData filterData = new DynamicFilterData();
+
+        if (queryParams.containsKey("filtermode")) {
+            List<String> values = queryParams.get("filtermode");
+            filterData.setWhitelistMode("whitelist".equalsIgnoreCase(values.get(0)));
+        } else {
+            // We want the list to be a blacklist by default when neither include nor exclude is
+            // provided, so we don't accidentally filter anything
+            filterData.setWhitelistMode(containsIncludes && !containsExcludes);
+        }
 
         if (containsIncludes) {
             for (String path : queryParams.get("include")) {

--- a/common/src/main/java/org/candlepin/common/resteasy/interceptor/DynamicFilterInterceptor.java
+++ b/common/src/main/java/org/candlepin/common/resteasy/interceptor/DynamicFilterInterceptor.java
@@ -58,7 +58,8 @@ public class DynamicFilterInterceptor implements PreProcessInterceptor {
         if (queryParams.containsKey("filtermode")) {
             List<String> values = queryParams.get("filtermode");
             filterData.setWhitelistMode("whitelist".equalsIgnoreCase(values.get(0)));
-        } else {
+        }
+        else {
             // We want the list to be a blacklist by default when neither include nor exclude is
             // provided, so we don't accidentally filter anything
             filterData.setWhitelistMode(containsIncludes && !containsExcludes);

--- a/common/src/main/java/org/candlepin/common/resteasy/interceptor/DynamicFilterInterceptor.java
+++ b/common/src/main/java/org/candlepin/common/resteasy/interceptor/DynamicFilterInterceptor.java
@@ -48,30 +48,31 @@ public class DynamicFilterInterceptor implements PreProcessInterceptor {
     @Override
     public ServerResponse preProcess(HttpRequest request, ResourceMethod method)
         throws Failure, WebApplicationException {
-        Map<String, List<String>> queryParams = request.getUri().getQueryParameters();
-        boolean containsExcl = queryParams.containsKey("exclude");
-        boolean containsIncl = queryParams.containsKey("include");
-        // Cannot do both types of filtering together,
-        // no point in continuing if neither are present
-        if ((containsExcl && containsIncl) ||
-            !(containsExcl || containsIncl)) {
-            return null;
-        }
-        // We wait the list to be a blacklist by default when neither include
-        // nor exclude is provided, so we don't accidentally filter anything
-        DynamicFilterData filterData = new DynamicFilterData(!containsIncl);
 
-        if (containsExcl) {
-            for (String toExclude : queryParams.get("exclude")) {
-                filterData.addAttributeFilter(toExclude);
+        Map<String, List<String>> queryParams = request.getUri().getQueryParameters();
+        boolean containsExcludes = queryParams.containsKey("exclude");
+        boolean containsIncludes = queryParams.containsKey("include");
+
+        // We want the list to be a blacklist by default when neither include nor exclude is
+        // provided, so we don't accidentally filter anything
+        DynamicFilterData filterData = new DynamicFilterData(containsIncludes && !containsExcludes);
+
+        if (containsIncludes) {
+            for (String path : queryParams.get("include")) {
+                filterData.includeAttribute(path);
             }
         }
-        else if (containsIncl) {
-            for (String toInclude : queryParams.get("include")) {
-                filterData.addAttributeFilter(toInclude);
+
+        if (containsExcludes) {
+            for (String path : queryParams.get("exclude")) {
+                filterData.excludeAttribute(path);
             }
         }
-        ResteasyProviderFactory.pushContext(DynamicFilterData.class, filterData);
+
+        if (containsIncludes || containsExcludes) {
+            ResteasyProviderFactory.pushContext(DynamicFilterData.class, filterData);
+        }
+
         return null;
     }
 }

--- a/common/src/test/java/org/candlepin/common/jackson/DynamicFilterDataTest.java
+++ b/common/src/test/java/org/candlepin/common/jackson/DynamicFilterDataTest.java
@@ -33,8 +33,8 @@ public class DynamicFilterDataTest {
 
     @Test
     public void testSimpleWhitelistFiltering() {
-        DynamicFilterData filterData = new DynamicFilterData(false);
-        filterData.addAttributeFilter("bacon");
+        DynamicFilterData filterData = new DynamicFilterData(true);
+        filterData.includeAttribute("bacon");
 
         assertTrue(filterData.isAttributeExcluded("spinach"));
         assertTrue(filterData.isAttributeExcluded(Arrays.asList("spinach")));
@@ -44,8 +44,8 @@ public class DynamicFilterDataTest {
 
     @Test
     public void testMultiLevelWhitelistFiltering() {
-        DynamicFilterData filterData = new DynamicFilterData(false);
-        filterData.addAttributeFilter("bacon.egg");
+        DynamicFilterData filterData = new DynamicFilterData(true);
+        filterData.includeAttribute("bacon.egg");
 
         assertTrue(filterData.isAttributeExcluded("spinach"));
         assertTrue(filterData.isAttributeExcluded(Arrays.asList("spinach")));
@@ -67,8 +67,8 @@ public class DynamicFilterDataTest {
 
     @Test
     public void testSimpleBlacklistFiltering() {
-        DynamicFilterData filterData = new DynamicFilterData(true);
-        filterData.addAttributeFilter("bacon");
+        DynamicFilterData filterData = new DynamicFilterData(false);
+        filterData.excludeAttribute("bacon");
 
         assertFalse(filterData.isAttributeExcluded("spinach"));
         assertFalse(filterData.isAttributeExcluded(Arrays.asList("spinach")));
@@ -78,8 +78,8 @@ public class DynamicFilterDataTest {
 
     @Test
     public void testMultiLevelBlacklistFiltering() {
-        DynamicFilterData filterData = new DynamicFilterData(true);
-        filterData.addAttributeFilter("bacon.egg");
+        DynamicFilterData filterData = new DynamicFilterData(false);
+        filterData.excludeAttribute("bacon.egg");
 
         assertFalse(filterData.isAttributeExcluded("spinach"));
         assertFalse(filterData.isAttributeExcluded(Arrays.asList("spinach")));
@@ -98,4 +98,36 @@ public class DynamicFilterDataTest {
         assertTrue(filterData.isAttributeExcluded("bacon.egg.cheese"));
         assertTrue(filterData.isAttributeExcluded(Arrays.asList("bacon", "egg", "cheese")));
     }
+
+    @Test
+    public void testMultiLevelDualFiltering() {
+        DynamicFilterData filterData = new DynamicFilterData(false);
+        filterData.includeAttribute("a.b1");
+        filterData.includeAttribute("a.b2.d2");
+        filterData.excludeAttribute("a.b1.c2");
+        filterData.excludeAttribute("a.b2");
+
+        // a: { b1: { c1, c2, c3 }, b2: { d1, d2, d3 } }
+
+        assertFalse(filterData.isAttributeExcluded("a"));
+        assertFalse(filterData.isAttributeExcluded("a.b1"));
+        assertFalse(filterData.isAttributeExcluded("a.b1.c1"));
+        assertTrue(filterData.isAttributeExcluded("a.b1.c2"));
+        assertFalse(filterData.isAttributeExcluded("a.b1.c3"));
+        assertFalse(filterData.isAttributeExcluded("a.b2"));
+        assertTrue(filterData.isAttributeExcluded("a.b2.d1"));
+        assertFalse(filterData.isAttributeExcluded("a.b2.d2"));
+        assertTrue(filterData.isAttributeExcluded("a.b2.d3"));
+
+        assertFalse(filterData.isAttributeExcluded(Arrays.asList("a")));
+        assertFalse(filterData.isAttributeExcluded(Arrays.asList("a", "b1")));
+        assertFalse(filterData.isAttributeExcluded(Arrays.asList("a", "b1", "c1")));
+        assertTrue(filterData.isAttributeExcluded(Arrays.asList("a", "b1", "c2")));
+        assertFalse(filterData.isAttributeExcluded(Arrays.asList("a", "b1", "c3")));
+        assertFalse(filterData.isAttributeExcluded(Arrays.asList("a", "b2")));
+        assertTrue(filterData.isAttributeExcluded(Arrays.asList("a", "b2", "d1")));
+        assertFalse(filterData.isAttributeExcluded(Arrays.asList("a", "b2", "d2")));
+        assertTrue(filterData.isAttributeExcluded(Arrays.asList("a", "b2", "d3")));
+    }
+
 }

--- a/common/src/test/java/org/candlepin/common/resteasy/interceptor/DynamicFilterInterceptorTest.java
+++ b/common/src/test/java/org/candlepin/common/resteasy/interceptor/DynamicFilterInterceptorTest.java
@@ -284,4 +284,39 @@ public class DynamicFilterInterceptorTest {
         assertFalse(filterData.isAttributeExcluded(Arrays.asList("a", "b2", "d2")));
         assertTrue(filterData.isAttributeExcluded(Arrays.asList("a", "b2", "d3")));
     }
+
+    @Test
+    public void testIncludesWithExcludesUsingWhitelist() throws Exception {
+        MockHttpRequest req = MockHttpRequest.create(
+            "GET",
+            "http://localhost/candlepin/status?" +
+            "include=a.b1&exclude=a.b1.c2&include=a.b2.d2&filtermode=whitelist"
+        );
+        this.interceptor.preProcess(req, rmethod);
+
+        DynamicFilterData filterData = ResteasyProviderFactory.getContextData(DynamicFilterData.class);
+        assertNotNull(filterData);
+
+        // a: { b1: { c1, c2, c3 }, b2: { d1, d2, d3 } }
+
+        assertFalse(filterData.isAttributeExcluded("a"));
+        assertFalse(filterData.isAttributeExcluded("a.b1"));
+        assertFalse(filterData.isAttributeExcluded("a.b1.c1"));
+        assertTrue(filterData.isAttributeExcluded("a.b1.c2"));
+        assertFalse(filterData.isAttributeExcluded("a.b1.c3"));
+        assertFalse(filterData.isAttributeExcluded("a.b2"));
+        assertTrue(filterData.isAttributeExcluded("a.b2.d1"));
+        assertFalse(filterData.isAttributeExcluded("a.b2.d2"));
+        assertTrue(filterData.isAttributeExcluded("a.b2.d3"));
+
+        assertFalse(filterData.isAttributeExcluded(Arrays.asList("a")));
+        assertFalse(filterData.isAttributeExcluded(Arrays.asList("a", "b1")));
+        assertFalse(filterData.isAttributeExcluded(Arrays.asList("a", "b1", "c1")));
+        assertTrue(filterData.isAttributeExcluded(Arrays.asList("a", "b1", "c2")));
+        assertFalse(filterData.isAttributeExcluded(Arrays.asList("a", "b1", "c3")));
+        assertFalse(filterData.isAttributeExcluded(Arrays.asList("a", "b2")));
+        assertTrue(filterData.isAttributeExcluded(Arrays.asList("a", "b2", "d1")));
+        assertFalse(filterData.isAttributeExcluded(Arrays.asList("a", "b2", "d2")));
+        assertTrue(filterData.isAttributeExcluded(Arrays.asList("a", "b2", "d3")));
+    }
 }

--- a/common/src/test/java/org/candlepin/common/resteasy/interceptor/DynamicFilterInterceptorTest.java
+++ b/common/src/test/java/org/candlepin/common/resteasy/interceptor/DynamicFilterInterceptorTest.java
@@ -52,8 +52,7 @@ public class DynamicFilterInterceptorTest {
 
     @Test
     public void testNoFilters() throws Exception {
-        MockHttpRequest req = MockHttpRequest.create("GET",
-            "http://localhost/candlepin/status");
+        MockHttpRequest req = MockHttpRequest.create("GET", "http://localhost/candlepin/status");
         this.interceptor.preProcess(req, rmethod);
 
         DynamicFilterData filterData = ResteasyProviderFactory.getContextData(DynamicFilterData.class);
@@ -252,4 +251,37 @@ public class DynamicFilterInterceptorTest {
         assertTrue(filterData.isAttributeExcluded(Arrays.asList("a3", "c2")));
     }
 
+    @Test
+    public void testIncludesWithExcludes() throws Exception {
+        MockHttpRequest req = MockHttpRequest.create(
+            "GET",
+            "http://localhost/candlepin/status?include=a.b1&exclude=a.b1.c2&exclude=a.b2&include=a.b2.d2"
+        );
+        this.interceptor.preProcess(req, rmethod);
+
+        DynamicFilterData filterData = ResteasyProviderFactory.getContextData(DynamicFilterData.class);
+        assertNotNull(filterData);
+
+        // a: { b1: { c1, c2, c3 }, b2: { d1, d2, d3 } }
+
+        assertFalse(filterData.isAttributeExcluded("a"));
+        assertFalse(filterData.isAttributeExcluded("a.b1"));
+        assertFalse(filterData.isAttributeExcluded("a.b1.c1"));
+        assertTrue(filterData.isAttributeExcluded("a.b1.c2"));
+        assertFalse(filterData.isAttributeExcluded("a.b1.c3"));
+        assertFalse(filterData.isAttributeExcluded("a.b2"));
+        assertTrue(filterData.isAttributeExcluded("a.b2.d1"));
+        assertFalse(filterData.isAttributeExcluded("a.b2.d2"));
+        assertTrue(filterData.isAttributeExcluded("a.b2.d3"));
+
+        assertFalse(filterData.isAttributeExcluded(Arrays.asList("a")));
+        assertFalse(filterData.isAttributeExcluded(Arrays.asList("a", "b1")));
+        assertFalse(filterData.isAttributeExcluded(Arrays.asList("a", "b1", "c1")));
+        assertTrue(filterData.isAttributeExcluded(Arrays.asList("a", "b1", "c2")));
+        assertFalse(filterData.isAttributeExcluded(Arrays.asList("a", "b1", "c3")));
+        assertFalse(filterData.isAttributeExcluded(Arrays.asList("a", "b2")));
+        assertTrue(filterData.isAttributeExcluded(Arrays.asList("a", "b2", "d1")));
+        assertFalse(filterData.isAttributeExcluded(Arrays.asList("a", "b2", "d2")));
+        assertTrue(filterData.isAttributeExcluded(Arrays.asList("a", "b2", "d3")));
+    }
 }


### PR DESCRIPTION
- include and exclude may now be used together to create more precise
  filters; using both will default to blacklist mode

- API consumers can now control the filter mode explicitly by
  specifying filtermode=[whitelist|blacklist]