### PR TITLE
Added product name filtering to the status trend report

### DIFF
--- a/gutterball/src/main/java/org/candlepin/gutterball/report/StatusTrendReport.java
+++ b/gutterball/src/main/java/org/candlepin/gutterball/report/StatusTrendReport.java
@@ -106,14 +106,20 @@ public class StatusTrendReport extends Report<StatusTrendReportResult> {
         );
 
         this.addParameter(
+            builder.init("product_name", i18n.tr("The name of a product on which to filter"))
+                .mustNotHave("sku", "subscription_name", "management_enabled")
+                .getParameter()
+        );
+
+        this.addParameter(
             builder.init("sku", i18n.tr("The entitlement sku on which to filter"))
-                .mustNotHave("subscription_name", "management_enabled")
+                .mustNotHave("product_name", "subscription_name", "management_enabled")
                 .getParameter()
         );
 
         this.addParameter(
             builder.init("subscription_name", i18n.tr("The name of a subscription on which to filter"))
-                .mustNotHave("sku", "management_enabled")
+                .mustNotHave("product_name", "sku", "management_enabled")
                 .getParameter()
         );
 
@@ -122,7 +128,7 @@ public class StatusTrendReport extends Report<StatusTrendReportResult> {
                 "management_enabled",
                 i18n.tr("Filter on subscriptions which have management enabled set to this value (boolean)")
             )
-                .mustNotHave("sku", "subscription_name")
+                .mustNotHave("product_name", "sku", "subscription_name")
                 .getParameter()
         );
 
@@ -146,6 +152,7 @@ public class StatusTrendReport extends Report<StatusTrendReportResult> {
         Date startDate = this.parseDate(queryParams.getFirst("start_date"), timezone);
         Date endDate = this.parseDate(queryParams.getFirst("end_date"), timezone);
         String ownerKey = queryParams.getFirst("owner");
+        String productName = queryParams.getFirst("product_name");
         String sku = queryParams.getFirst("sku");
         String subscriptionName = queryParams.getFirst("subscription_name");
         List<String> consumerUuids = queryParams.get("consumer_uuid");
@@ -167,13 +174,27 @@ public class StatusTrendReport extends Report<StatusTrendReportResult> {
             }
         }
 
-        if (sku != null) {
+        if (productName != null) {
+            page = this.curator.getComplianceStatusCounts(
+                startDate,
+                endDate,
+                ownerKey,
+                consumerUuids,
+                null,
+                null,
+                productName,
+                null,
+                pageRequest
+            );
+        }
+        else if (sku != null) {
             page = this.curator.getComplianceStatusCounts(
                 startDate,
                 endDate,
                 ownerKey,
                 consumerUuids,
                 sku,
+                null,
                 null,
                 null,
                 pageRequest
@@ -188,6 +209,7 @@ public class StatusTrendReport extends Report<StatusTrendReportResult> {
                 null,
                 subscriptionName,
                 null,
+                null,
                 pageRequest
             );
         }
@@ -197,6 +219,7 @@ public class StatusTrendReport extends Report<StatusTrendReportResult> {
                 endDate,
                 ownerKey,
                 consumerUuids,
+                null,
                 null,
                 null,
                 attributes,
@@ -209,6 +232,7 @@ public class StatusTrendReport extends Report<StatusTrendReportResult> {
                 endDate,
                 ownerKey,
                 consumerUuids,
+                null,
                 null,
                 null,
                 null,

--- a/gutterball/src/test/java/org/candlepin/gutterball/TestUtils.java
+++ b/gutterball/src/test/java/org/candlepin/gutterball/TestUtils.java
@@ -23,6 +23,7 @@ import org.candlepin.gutterball.model.snapshot.Compliance;
 import org.candlepin.gutterball.model.snapshot.ComplianceReason;
 import org.candlepin.gutterball.model.snapshot.ComplianceStatus;
 import org.candlepin.gutterball.model.snapshot.Consumer;
+import org.candlepin.gutterball.model.snapshot.ConsumerInstalledProduct;
 import org.candlepin.gutterball.model.snapshot.Owner;
 import org.candlepin.gutterball.report.Report;
 
@@ -30,8 +31,10 @@ import org.apache.commons.lang.RandomStringUtils;
 
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
+import java.util.Set;
 
 public class TestUtils {
 
@@ -64,6 +67,34 @@ public class TestUtils {
             String owner, String statusString, ConsumerState state) {
         Consumer consumerSnap = new Consumer(consumerUuid, null, createOwnerSnapshot(owner, owner));
         consumerSnap.setConsumerState(state);
+        ComplianceStatus statusSnap = new ComplianceStatus(statusDate, statusString);
+
+        if (statusString.toLowerCase().equals("invalid")) {
+            ComplianceReason reason = new ComplianceReason("reason-key", "Test message");
+            reason.setComplianceStatus(statusSnap);
+            statusSnap.getReasons().add(reason);
+        }
+        return new Compliance(statusDate, consumerSnap, statusSnap);
+    }
+
+    public static Compliance createComplianceSnapshotWithProducts(Date statusDate, String consumerUuid,
+            String owner, String statusString, ConsumerState state, Set<String> products) {
+        Consumer consumerSnap = new Consumer(consumerUuid, null, createOwnerSnapshot(owner, owner));
+        consumerSnap.setConsumerState(state);
+
+        Set<ConsumerInstalledProduct> installedProducts = new HashSet<ConsumerInstalledProduct>();
+
+        for (String productName : products) {
+            ConsumerInstalledProduct installed = new ConsumerInstalledProduct();
+
+            installed.setProductId(productName);
+            installed.setProductName(productName);
+
+            installedProducts.add(installed);
+        }
+
+        consumerSnap.setInstalledProducts(installedProducts);
+
         ComplianceStatus statusSnap = new ComplianceStatus(statusDate, statusString);
 
         if (statusString.toLowerCase().equals("invalid")) {

--- a/gutterball/src/test/java/org/candlepin/gutterball/curator/ComplianceSnapshotCuratorTest.java
+++ b/gutterball/src/test/java/org/candlepin/gutterball/curator/ComplianceSnapshotCuratorTest.java
@@ -29,7 +29,6 @@ import org.candlepin.gutterball.model.Event;
 import org.candlepin.gutterball.model.snapshot.Compliance;
 import org.candlepin.gutterball.model.snapshot.ComplianceStatus;
 import org.candlepin.gutterball.model.snapshot.Consumer;
-import org.candlepin.gutterball.model.snapshot.ConsumerInstalledProduct;
 import org.candlepin.gutterball.model.snapshot.Entitlement;
 
 import org.junit.Before;
@@ -104,9 +103,10 @@ public class ComplianceSnapshotCuratorTest extends DatabaseTestFixture {
                 }
             }
         );
-        entitlement1.setProvidedProducts(new HashMap<String, String>() {{
-            this.put("p1", "p1");
-        }});
+        entitlement1.setProvidedProducts(new HashMap<String, String>() { {
+                this.put("p1", "p1");
+            }
+        });
 
         Entitlement entitlement2 = createEntitlement(
             "testsku2",
@@ -120,9 +120,10 @@ public class ComplianceSnapshotCuratorTest extends DatabaseTestFixture {
                 }
             }
         );
-        entitlement2.setProvidedProducts(new HashMap<String, String>() {{
-            this.put("p2", "p2");
-        }});
+        entitlement2.setProvidedProducts(new HashMap<String, String>() { {
+                this.put("p2", "p2");
+            }
+        });
 
         Entitlement entitlement3 = createEntitlement(
             "testsku3",
@@ -136,9 +137,10 @@ public class ComplianceSnapshotCuratorTest extends DatabaseTestFixture {
                 }
             }
         );
-        entitlement3.setProvidedProducts(new HashMap<String, String>() {{
-            this.put("p3", "p3");
-        }});
+        entitlement3.setProvidedProducts(new HashMap<String, String>() { {
+                this.put("p3", "p3");
+            }
+        });
 
         this.beginTransaction();
 

--- a/gutterball/src/test/java/org/candlepin/gutterball/curator/ComplianceSnapshotCuratorTest.java
+++ b/gutterball/src/test/java/org/candlepin/gutterball/curator/ComplianceSnapshotCuratorTest.java
@@ -29,11 +29,14 @@ import org.candlepin.gutterball.model.Event;
 import org.candlepin.gutterball.model.snapshot.Compliance;
 import org.candlepin.gutterball.model.snapshot.ComplianceStatus;
 import org.candlepin.gutterball.model.snapshot.Consumer;
+import org.candlepin.gutterball.model.snapshot.ConsumerInstalledProduct;
 import org.candlepin.gutterball.model.snapshot.Entitlement;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
@@ -45,6 +48,7 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -56,6 +60,7 @@ import java.util.TreeMap;
 
 @RunWith(JUnitParamsRunner.class)
 public class ComplianceSnapshotCuratorTest extends DatabaseTestFixture {
+    private static Logger log = LoggerFactory.getLogger(ComplianceSnapshotCuratorTest.class);
 
     private Date baseTestingDate;
 
@@ -99,6 +104,9 @@ public class ComplianceSnapshotCuratorTest extends DatabaseTestFixture {
                 }
             }
         );
+        entitlement1.setProvidedProducts(new HashMap<String, String>() {{
+            this.put("p1", "p1");
+        }});
 
         Entitlement entitlement2 = createEntitlement(
             "testsku2",
@@ -112,6 +120,9 @@ public class ComplianceSnapshotCuratorTest extends DatabaseTestFixture {
                 }
             }
         );
+        entitlement2.setProvidedProducts(new HashMap<String, String>() {{
+            this.put("p2", "p2");
+        }});
 
         Entitlement entitlement3 = createEntitlement(
             "testsku3",
@@ -125,16 +136,27 @@ public class ComplianceSnapshotCuratorTest extends DatabaseTestFixture {
                 }
             }
         );
+        entitlement3.setProvidedProducts(new HashMap<String, String>() {{
+            this.put("p3", "p3");
+        }});
 
         this.beginTransaction();
 
+        // Consumer products
+        Set<String> c1prods = new HashSet(Arrays.asList("p1"));
+        Set<String> c2prods = new HashSet(Arrays.asList("p1", "p2"));
+        Set<String> c3prods = new HashSet(Arrays.asList("p3", "p4"));
+        Set<String> c4prods = new HashSet(Arrays.asList("p1", "p4"));
+
         // Consumer created
         cal.set(Calendar.MONTH, Calendar.MARCH);
-        compliance = createInitialConsumer(cal.getTime(), "c1", "o1", "invalid");
+        compliance = createInitialConsumer(cal.getTime(), "c1", "o1", "invalid", c1prods);
+        setCompliantProducts(compliance, null, null, c1prods);
         attachEntitlement(compliance, entitlement1);
         // Simulate status change
         cal.set(Calendar.MONTH, Calendar.MAY);
-        compliance = createSnapshot(cal.getTime(), "c1", "o1", "valid");
+        compliance = createSnapshotWithProducts(cal.getTime(), "c1", "o1", "valid", c1prods);
+        setCompliantProducts(compliance, c1prods, null, null);
         attachEntitlement(compliance, entitlement1);
         // Consumer was deleted
         cal.set(Calendar.MONTH, Calendar.JUNE);
@@ -142,33 +164,62 @@ public class ComplianceSnapshotCuratorTest extends DatabaseTestFixture {
         attachEntitlement(compliance, entitlement1);
 
         cal.set(Calendar.MONTH, Calendar.APRIL);
-        compliance = createInitialConsumer(cal.getTime(), "c2", "o1", "invalid");
+        compliance = createInitialConsumer(cal.getTime(), "c2", "o1", "invalid", c2prods);
+        this.complianceSnapshotCurator.merge(compliance);
+        setCompliantProducts(compliance, null, null, c2prods);
         attachEntitlement(compliance, entitlement1);
         attachEntitlement(compliance, entitlement2);
 
         cal.set(Calendar.MONTH, Calendar.MAY);
-        compliance = createInitialConsumer(cal.getTime(), "c3", "o2", "invalid");
+        compliance = createInitialConsumer(cal.getTime(), "c3", "o2", "invalid", c3prods);
+        setCompliantProducts(compliance, null, null, c3prods);
         attachEntitlement(compliance, entitlement2);
         cal.set(Calendar.MONTH, Calendar.JUNE);
-        compliance = createSnapshot(cal.getTime(), "c3", "o2", "partial");
+        compliance = createSnapshotWithProducts(cal.getTime(), "c3", "o2", "partial", c3prods);
+        setCompliantProducts(compliance, new HashSet(Arrays.asList("p3")),
+            new HashSet(Arrays.asList("p4")), null);
         attachEntitlement(compliance, entitlement2);
 
         cal.set(Calendar.MONTH, Calendar.MAY);
-        compliance = createInitialConsumer(cal.getTime(), "c4", "o3", "invalid");
+        compliance = createInitialConsumer(cal.getTime(), "c4", "o3", "invalid", c4prods);
+        setCompliantProducts(compliance, null, null, c4prods);
         attachEntitlement(compliance, entitlement2);
         attachEntitlement(compliance, entitlement3);
         cal.set(Calendar.MONTH, Calendar.JUNE);
-        compliance = createSnapshot(cal.getTime(), "c4", "o3", "partial");
+        compliance = createSnapshotWithProducts(cal.getTime(), "c4", "o3", "partial", c4prods);
+        setCompliantProducts(compliance, null, c4prods, null);
         attachEntitlement(compliance, entitlement2);
         attachEntitlement(compliance, entitlement3);
         cal.set(Calendar.MONTH, Calendar.JULY);
-        compliance = createSnapshot(cal.getTime(), "c4", "o3", "valid");
+        compliance = createSnapshotWithProducts(cal.getTime(), "c4", "o3", "valid", c4prods);
+        setCompliantProducts(compliance, c4prods, null, null);
         attachEntitlement(compliance, entitlement2);
         attachEntitlement(compliance, entitlement3);
 
         this.commitTransaction();
 
         /*
+            Entitlements:
+                testsku1 - p1
+                testsku2 - p2
+                testsku3 - p3, p4
+
+            Installed Products:
+                c1:
+                    p1
+
+                c2:
+                    p1
+                    p2
+
+                c3:
+                    p3
+                    p4
+
+                c4:
+                    p1
+                    p4
+
             Entitlement distribution:
                 c1:
                     testsku1 (test product 1)
@@ -196,7 +247,6 @@ public class ComplianceSnapshotCuratorTest extends DatabaseTestFixture {
                         attrib3: val3
                     testsku3 (test product 3)
                         attrib2: val2
-
 
             Timeline of the above events:
                 March 10th:
@@ -597,7 +647,7 @@ public class ComplianceSnapshotCuratorTest extends DatabaseTestFixture {
     public void testGetComplianceStatusCounts() {
         Map<Date, Map<String, Integer>> expected = this.buildMapForAllStatusCounts();
         Map<Date, Map<String, Integer>> actual = this.complianceSnapshotCurator
-            .getComplianceStatusCounts(null, null, null, null, null, null, null);
+            .getComplianceStatusCounts(null, null, null, null, null, null, null, null);
 
         assertEquals(expected, actual);
     }
@@ -618,7 +668,7 @@ public class ComplianceSnapshotCuratorTest extends DatabaseTestFixture {
             pageRequest.setPage(p);
 
             Page<Map<Date, Map<String, Integer>>> page = this.complianceSnapshotCurator
-                .getComplianceStatusCounts(null, null, null, null, null, null, null, pageRequest);
+                .getComplianceStatusCounts(null, null, null, null, null, null, null, null, pageRequest);
 
             if (pages == 0) {
                 pages = page.getMaxRecords();
@@ -646,7 +696,7 @@ public class ComplianceSnapshotCuratorTest extends DatabaseTestFixture {
     @Parameters(method = "buildMapForStatusCountsAfterDate")
     public void testGetComplianceStatusCountsAfterDate(Date date, Map<Date, Map<String, Integer>> expected) {
         Map<Date, Map<String, Integer>> actual = this.complianceSnapshotCurator
-            .getComplianceStatusCounts(date, null, null, null, null, null, null);
+            .getComplianceStatusCounts(date, null, null, null, null, null, null, null);
 
         assertEquals(expected, actual);
     }
@@ -655,7 +705,7 @@ public class ComplianceSnapshotCuratorTest extends DatabaseTestFixture {
     @Parameters(method = "buildMapForStatusCountsBeforeDate")
     public void testGetComplianceStatusCountsBeforeDate(Date date, Map<Date, Map<String, Integer>> expected) {
         Map<Date, Map<String, Integer>> actual = this.complianceSnapshotCurator
-            .getComplianceStatusCounts(null, date, null, null, null, null, null);
+            .getComplianceStatusCounts(null, date, null, null, null, null, null, null);
 
         assertEquals(expected, actual);
     }
@@ -666,7 +716,7 @@ public class ComplianceSnapshotCuratorTest extends DatabaseTestFixture {
         Map<Date, Map<String, Integer>> expected) {
 
         Map<Date, Map<String, Integer>> actual = this.complianceSnapshotCurator
-            .getComplianceStatusCounts(startDate, endDate, null, null, null, null, null);
+            .getComplianceStatusCounts(startDate, endDate, null, null, null, null, null, null);
 
         assertEquals(expected, actual);
     }
@@ -678,7 +728,7 @@ public class ComplianceSnapshotCuratorTest extends DatabaseTestFixture {
         Map<Date, Map<String, Integer>> actual;
 
         actual = this.complianceSnapshotCurator
-            .getComplianceStatusCounts(startDate, endDate, null, null, sku, null, null);
+            .getComplianceStatusCounts(startDate, endDate, null, null, sku, null, null, null);
 
         assertEquals(expected, actual);
     }
@@ -690,7 +740,19 @@ public class ComplianceSnapshotCuratorTest extends DatabaseTestFixture {
         Map<Date, Map<String, Integer>> actual;
 
         actual = this.complianceSnapshotCurator
-            .getComplianceStatusCounts(startDate, endDate, null, null, null, subscriptionName, null);
+            .getComplianceStatusCounts(startDate, endDate, null, null, null, subscriptionName, null, null);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    @Parameters(method = "buildMapForStatusCountsWithProducts")
+    public void testGetComplianceStatusCountsWithProduct(Date startDate, Date endDate,
+        String productName, Map<Date, Map<String, Integer>> expected) {
+        Map<Date, Map<String, Integer>> actual;
+
+        actual = this.complianceSnapshotCurator
+            .getComplianceStatusCounts(startDate, endDate, null, null, null, null, productName, null);
 
         assertEquals(expected, actual);
     }
@@ -702,7 +764,7 @@ public class ComplianceSnapshotCuratorTest extends DatabaseTestFixture {
         Map<Date, Map<String, Integer>> actual;
 
         actual = this.complianceSnapshotCurator
-            .getComplianceStatusCounts(startDate, endDate, null, null, null, null, attributes);
+            .getComplianceStatusCounts(startDate, endDate, null, null, null, null, null, attributes);
 
         assertEquals(expected, actual);
     }
@@ -713,7 +775,7 @@ public class ComplianceSnapshotCuratorTest extends DatabaseTestFixture {
         Map<Date, Map<String, Integer>> expected) {
 
         Map<Date, Map<String, Integer>> actual = this.complianceSnapshotCurator
-            .getComplianceStatusCounts(null, null, null, consumers, null, null, null);
+            .getComplianceStatusCounts(null, null, null, consumers, null, null, null, null);
 
         assertEquals(expected, actual);
     }
@@ -724,7 +786,7 @@ public class ComplianceSnapshotCuratorTest extends DatabaseTestFixture {
         List<String> consumers, Map<Date, Map<String, Integer>> expected) {
 
         Map<Date, Map<String, Integer>> actual = this.complianceSnapshotCurator
-            .getComplianceStatusCounts(startDate, endDate, null, consumers, null, null, null);
+            .getComplianceStatusCounts(startDate, endDate, null, consumers, null, null, null, null);
 
         assertEquals(expected, actual);
     }
@@ -958,6 +1020,37 @@ public class ComplianceSnapshotCuratorTest extends DatabaseTestFixture {
         return tests.toArray();
     }
 
+    public Object[] buildMapForStatusCountsWithProducts() {
+        LinkedList<Object[]> tests = new LinkedList<Object[]>();
+        Object[][] beforeSet = this.buildMapForStatusCountsBeforeDate();
+        Object[][] afterSet = this.buildMapForStatusCountsAfterDate();
+        Object[][] productSet = this.buildSubMapForStatusCountsWithProduct();
+
+        // Impl note:
+        // This intersection stuff to check date filtering does not work with dates beyond our data
+        // set. If our dates require extrapolating the data, the expected output will be missing
+        // all of the necessary extrapolated statuses.
+
+        for (Object[] before : beforeSet) {
+            for (Object[] after : afterSet) {
+                for (Object[] product : productSet) {
+                    tests.add(new Object[] {
+                        after[0],
+                        before[0],
+                        product[0],
+                        this.intersect(
+                            (Map<Date, Map<String, Integer>>) after[1],
+                            (Map<Date, Map<String, Integer>>) before[1],
+                            (Map<Date, Map<String, Integer>>) product[1]
+                        )
+                    });
+                }
+            }
+        }
+
+        return tests.toArray();
+    }
+
     public Object[] buildMapForStatusCountsWithAttributes() {
         LinkedList<Object[]> tests = new LinkedList<Object[]>();
         Object[][] beforeSet = this.buildMapForStatusCountsBeforeDate();
@@ -1043,6 +1136,112 @@ public class ComplianceSnapshotCuratorTest extends DatabaseTestFixture {
         expected.put(cal.getTime(), counts);
 
         return expected;
+    }
+
+    private Object[][] buildSubMapForStatusCountsWithProduct() {
+        Calendar cal = this.getCalendar();
+        cal.set(Calendar.YEAR, 2012);
+        cal.set(Calendar.DAY_OF_MONTH, 10);
+        cal.set(Calendar.HOUR_OF_DAY, 23);
+        cal.set(Calendar.MINUTE, 59);
+        cal.set(Calendar.SECOND, 59);
+        cal.set(Calendar.MILLISECOND, 999);
+
+        Map<Date, Map<String, Integer>> expected;
+        Map<Date, Map<String, Integer>> actual;
+        HashMap<String, Integer> counts;
+
+        Object[][] output = new Object[4][];
+
+        output[0] = $(null, this.buildMapForAllStatusCounts());
+
+
+        expected = new TreeMap<Date, Map<String, Integer>>();
+
+        cal.set(Calendar.MONTH, Calendar.MARCH);
+        counts = new HashMap<String, Integer>();
+        counts.put("invalid", 1);
+        for (int i = 0; i < 31; ++i) {
+            expected.put(cal.getTime(), counts);
+            cal.add(Calendar.DATE, 1);
+        }
+
+        cal.set(Calendar.MONTH, Calendar.APRIL);
+        counts = new HashMap<String, Integer>();
+        counts.put("invalid", 2);
+        for (int i = 0; i < 30; ++i) {
+            expected.put(cal.getTime(), counts);
+            cal.add(Calendar.DATE, 1);
+        }
+
+        cal.set(Calendar.MONTH, Calendar.MAY);
+        counts = new HashMap<String, Integer>();
+        counts.put("valid", 1);
+        counts.put("invalid", 2);
+        for (int i = 0; i < 31; ++i) {
+            expected.put(cal.getTime(), counts);
+            cal.add(Calendar.DATE, 1);
+        }
+
+        cal.set(Calendar.MONTH, Calendar.JUNE);
+        counts = new HashMap<String, Integer>();
+        counts.put("invalid", 1);
+        counts.put("partial", 1);
+        for (int i = 0; i < 30; ++i) {
+            expected.put(cal.getTime(), counts);
+            cal.add(Calendar.DATE, 1);
+        }
+
+        cal.set(Calendar.MONTH, Calendar.JULY);
+        counts = new HashMap<String, Integer>();
+        counts.put("valid", 1);
+        counts.put("invalid", 1);
+        expected.put(cal.getTime(), counts);
+
+        output[1] = $("p1", expected);
+
+
+        expected = new TreeMap<Date, Map<String, Integer>>();
+
+        cal.set(Calendar.MONTH, Calendar.APRIL);
+        counts = new HashMap<String, Integer>();
+        counts.put("invalid", 1);
+        for (int i = 0; i < 30; ++i) {
+            expected.put(cal.getTime(), counts);
+            cal.add(Calendar.DATE, 1);
+        }
+
+
+        expected = new TreeMap<Date, Map<String, Integer>>();
+
+        cal.set(Calendar.MONTH, Calendar.MAY);
+        counts = new HashMap<String, Integer>();
+        counts.put("invalid", 2);
+        for (int i = 0; i < 31; ++i) {
+            expected.put(cal.getTime(), counts);
+            cal.add(Calendar.DATE, 1);
+        }
+
+        cal.set(Calendar.MONTH, Calendar.JUNE);
+        counts = new HashMap<String, Integer>();
+        counts.put("partial", 2);
+        for (int i = 0; i < 30; ++i) {
+            expected.put(cal.getTime(), counts);
+            cal.add(Calendar.DATE, 1);
+        }
+
+        cal.set(Calendar.MONTH, Calendar.JULY);
+        counts = new HashMap<String, Integer>();
+        counts.put("valid", 1);
+        counts.put("partial", 1);
+        expected.put(cal.getTime(), counts);
+
+        output[2] = $("p4", expected);
+
+
+        output[3] = $("bad_product", new HashMap<Date, Map<String, Integer>>());
+
+        return output;
     }
 
     private Object[][] buildSubMapForStatusCountsWithSku() {
@@ -1595,9 +1794,21 @@ public class ComplianceSnapshotCuratorTest extends DatabaseTestFixture {
         return intersection;
     }
 
-    private Compliance createInitialConsumer(Date createdOn, String uuid, String owner, String status) {
-        Compliance snapshot = createSnapshot(createdOn, uuid, owner, status);
-        consumerStateCurator.create(new ConsumerState(uuid, owner, createdOn));
+    private Compliance createInitialConsumer(Date createdOn, String uuid, String owner,
+        String status, Set<String> products) {
+
+        Compliance snapshot = this.createSnapshotWithProducts(createdOn, uuid, owner, status, products);
+        this.consumerStateCurator.create(new ConsumerState(uuid, owner, createdOn));
+
+        return snapshot;
+    }
+
+    private Compliance createSnapshotWithProducts(Date date, String uuid, String owner,
+        String status, Set<String> products) {
+
+        Compliance snapshot = createComplianceSnapshotWithProducts(date, uuid, owner, status, null,
+            products);
+        complianceSnapshotCurator.create(snapshot);
 
         return snapshot;
     }
@@ -1614,6 +1825,28 @@ public class ComplianceSnapshotCuratorTest extends DatabaseTestFixture {
         consumerStateCurator.setConsumerDeleted(uuid, deletedOn);
 
         return snapshot;
+    }
+
+    private Compliance setCompliantProducts(Compliance compliance, Set<String> compliant,
+        Set<String> partiallyCompliant, Set<String> nonCompliant) {
+
+        ComplianceStatus status = compliance.getStatus();
+
+        status.setCompliantProducts(compliant);
+        status.setPartiallyCompliantProducts(partiallyCompliant);
+        status.setNonCompliantProducts(nonCompliant);
+
+        this.complianceSnapshotCurator.merge(compliance);
+
+
+        Compliance test = this.complianceSnapshotCurator.find(compliance.getId());
+        assertNotNull(test);
+
+        assertEquals(compliant, test.getStatus().getCompliantProducts());
+        assertEquals(partiallyCompliant, test.getStatus().getPartiallyCompliantProducts());
+        assertEquals(nonCompliant, test.getStatus().getNonCompliantProducts());
+
+        return compliance;
     }
 
     private Entitlement createEntitlement(String sku, String productName, int quantity,

--- a/gutterball/src/test/java/org/candlepin/gutterball/report/StatusTrendReportTest.java
+++ b/gutterball/src/test/java/org/candlepin/gutterball/report/StatusTrendReportTest.java
@@ -184,7 +184,7 @@ public class StatusTrendReportTest {
         MultivaluedMap<String, String> params = mock(MultivaluedMap.class);
 
         ComplianceSnapshotCurator mockCSCurator = mock(ComplianceSnapshotCurator.class);
-        when(mockCSCurator.getComplianceStatusCounts(null, null, null, null, null, null, null, null))
+        when(mockCSCurator.getComplianceStatusCounts(null, null, null, null, null, null, null, null, null))
             .thenReturn(testpage);
 
         StatusTrendReport report = new StatusTrendReport(this.i18nProvider, mockCSCurator);
@@ -195,7 +195,7 @@ public class StatusTrendReportTest {
 
         assertEquals(expected, actual);
 
-        verify(mockCSCurator).getComplianceStatusCounts(null, null, null, null, null, null, null, null);
+        verify(mockCSCurator).getComplianceStatusCounts(null, null, null, null, null, null, null, null, null);
         verifyNoMoreInteractions(mockCSCurator);
     }
 
@@ -221,7 +221,8 @@ public class StatusTrendReportTest {
         when(params.getFirst("end_date")).thenReturn("2014-11-08");
 
         ComplianceSnapshotCurator mockCSCurator = mock(ComplianceSnapshotCurator.class);
-        when(mockCSCurator.getComplianceStatusCounts(startDate, endDate, null, null, null, null, null, null))
+        when(mockCSCurator
+            .getComplianceStatusCounts(startDate, endDate, null, null, null, null, null, null, null))
             .thenReturn(testpage);
 
         StatusTrendReport report = new StatusTrendReport(this.i18nProvider, mockCSCurator);
@@ -233,7 +234,7 @@ public class StatusTrendReportTest {
         assertEquals(expected, actual);
 
         verify(mockCSCurator).getComplianceStatusCounts(
-            startDate, endDate, null, null, null, null, null, null
+            startDate, endDate, null, null, null, null, null, null, null
         );
         verifyNoMoreInteractions(mockCSCurator);
     }
@@ -264,7 +265,8 @@ public class StatusTrendReportTest {
         when(params.getFirst("owner")).thenReturn(owner);
 
         ComplianceSnapshotCurator mockCSCurator = mock(ComplianceSnapshotCurator.class);
-        when(mockCSCurator.getComplianceStatusCounts(startDate, endDate, owner, null, null, null, null, null))
+        when(mockCSCurator
+            .getComplianceStatusCounts(startDate, endDate, owner, null, null, null, null, null, null))
             .thenReturn(testpage);
 
         StatusTrendReport report = new StatusTrendReport(this.i18nProvider, mockCSCurator);
@@ -275,9 +277,8 @@ public class StatusTrendReportTest {
 
         assertEquals(expected, actual);
 
-        verify(mockCSCurator).getComplianceStatusCounts(
-            startDate, endDate, owner, null, null, null, null, null
-        );
+        verify(mockCSCurator)
+            .getComplianceStatusCounts(startDate, endDate, owner, null, null, null, null, null, null);
         verifyNoMoreInteractions(mockCSCurator);
     }
 
@@ -299,7 +300,7 @@ public class StatusTrendReportTest {
 
         ComplianceSnapshotCurator mockCSCurator = mock(ComplianceSnapshotCurator.class);
         when(mockCSCurator
-            .getComplianceStatusCounts(null, null, null, consumers, null, null, null, null))
+            .getComplianceStatusCounts(null, null, null, consumers, null, null, null, null, null))
             .thenReturn(testpage);
 
         StatusTrendReport report = new StatusTrendReport(this.i18nProvider, mockCSCurator);
@@ -311,7 +312,7 @@ public class StatusTrendReportTest {
         assertEquals(expected, actual);
 
         verify(mockCSCurator)
-            .getComplianceStatusCounts(null, null, null, consumers, null, null, null, null);
+            .getComplianceStatusCounts(null, null, null, consumers, null, null, null, null, null);
         verifyNoMoreInteractions(mockCSCurator);
     }
 
@@ -330,7 +331,8 @@ public class StatusTrendReportTest {
         when(params.get("sku")).thenReturn(Arrays.asList("testsku1"));
 
         ComplianceSnapshotCurator mockCSCurator = mock(ComplianceSnapshotCurator.class);
-        when(mockCSCurator.getComplianceStatusCounts(null, null, null, null, "testsku1", null, null, null))
+        when(mockCSCurator
+            .getComplianceStatusCounts(null, null, null, null, "testsku1", null, null, null, null))
             .thenReturn(testpage);
 
         StatusTrendReport report = new StatusTrendReport(this.i18nProvider, mockCSCurator);
@@ -341,7 +343,8 @@ public class StatusTrendReportTest {
 
         assertEquals(expected, actual);
 
-        verify(mockCSCurator).getComplianceStatusCounts(null, null, null, null, "testsku1", null, null, null);
+        verify(mockCSCurator)
+            .getComplianceStatusCounts(null, null, null, null, "testsku1", null, null, null, null);
         verifyNoMoreInteractions(mockCSCurator);
     }
 
@@ -366,7 +369,8 @@ public class StatusTrendReportTest {
         when(params.getFirst("owner")).thenReturn(owner);
 
         ComplianceSnapshotCurator mockCSCurator = mock(ComplianceSnapshotCurator.class);
-        when(mockCSCurator.getComplianceStatusCounts(null, null, owner, null, sku, null, null, null))
+        when(mockCSCurator
+            .getComplianceStatusCounts(null, null, owner, null, sku, null, null, null, null))
             .thenReturn(testpage);
 
         StatusTrendReport report = new StatusTrendReport(this.i18nProvider, mockCSCurator);
@@ -377,7 +381,8 @@ public class StatusTrendReportTest {
 
         assertEquals(expected, actual);
 
-        verify(mockCSCurator).getComplianceStatusCounts(null, null, owner, null, sku, null, null, null);
+        verify(mockCSCurator)
+            .getComplianceStatusCounts(null, null, owner, null, sku, null, null, null, null);
         verifyNoMoreInteractions(mockCSCurator);
     }
 
@@ -407,7 +412,8 @@ public class StatusTrendReportTest {
         when(params.get("sku")).thenReturn(Arrays.asList(sku));
 
         ComplianceSnapshotCurator mockCSCurator = mock(ComplianceSnapshotCurator.class);
-        when(mockCSCurator.getComplianceStatusCounts(startDate, endDate, null, null, sku, null, null, null))
+        when(mockCSCurator
+            .getComplianceStatusCounts(startDate, endDate, null, null, sku, null, null, null, null))
             .thenReturn(testpage);
 
         StatusTrendReport report = new StatusTrendReport(this.i18nProvider, mockCSCurator);
@@ -418,9 +424,8 @@ public class StatusTrendReportTest {
 
         assertEquals(expected, actual);
 
-        verify(mockCSCurator).getComplianceStatusCounts(
-            startDate, endDate, null, null, sku, null, null, null
-        );
+        verify(mockCSCurator)
+            .getComplianceStatusCounts(startDate, endDate, null, null, sku, null, null, null, null);
         verifyNoMoreInteractions(mockCSCurator);
     }
 
@@ -455,7 +460,8 @@ public class StatusTrendReportTest {
         when(params.getFirst("owner")).thenReturn(owner);
 
         ComplianceSnapshotCurator mockCSCurator = mock(ComplianceSnapshotCurator.class);
-        when(mockCSCurator.getComplianceStatusCounts(startDate, endDate, owner, null, sku, null, null, null))
+        when(mockCSCurator
+            .getComplianceStatusCounts(startDate, endDate, owner, null, sku, null, null, null, null))
             .thenReturn(testpage);
 
         StatusTrendReport report = new StatusTrendReport(this.i18nProvider, mockCSCurator);
@@ -466,9 +472,8 @@ public class StatusTrendReportTest {
 
         assertEquals(expected, actual);
 
-        verify(mockCSCurator).getComplianceStatusCounts(
-            startDate, endDate, owner, null, sku, null, null, null
-        );
+        verify(mockCSCurator)
+            .getComplianceStatusCounts(startDate, endDate, owner, null, sku, null, null, null, null);
         verifyNoMoreInteractions(mockCSCurator);
     }
 
@@ -494,7 +499,7 @@ public class StatusTrendReportTest {
 
         ComplianceSnapshotCurator mockCSCurator = mock(ComplianceSnapshotCurator.class);
         when(mockCSCurator
-            .getComplianceStatusCounts(null, null, null, consumers, "testsku1", null, null, null))
+            .getComplianceStatusCounts(null, null, null, consumers, "testsku1", null, null, null, null))
             .thenReturn(testpage);
 
         StatusTrendReport report = new StatusTrendReport(this.i18nProvider, mockCSCurator);
@@ -506,7 +511,7 @@ public class StatusTrendReportTest {
         assertEquals(expected, actual);
 
         verify(mockCSCurator)
-            .getComplianceStatusCounts(null, null, null, consumers, "testsku1", null, null, null);
+            .getComplianceStatusCounts(null, null, null, consumers, "testsku1", null, null, null, null);
         verifyNoMoreInteractions(mockCSCurator);
     }
 
@@ -527,7 +532,8 @@ public class StatusTrendReportTest {
         when(params.get("subscription_name")).thenReturn(Arrays.asList(subscription));
 
         ComplianceSnapshotCurator mockCSCurator = mock(ComplianceSnapshotCurator.class);
-        when(mockCSCurator.getComplianceStatusCounts(null, null, null, null, null, subscription, null, null))
+        when(mockCSCurator
+            .getComplianceStatusCounts(null, null, null, null, null, subscription, null, null, null))
             .thenReturn(testpage);
 
         StatusTrendReport report = new StatusTrendReport(this.i18nProvider, mockCSCurator);
@@ -539,7 +545,7 @@ public class StatusTrendReportTest {
         assertEquals(expected, actual);
 
         verify(mockCSCurator)
-            .getComplianceStatusCounts(null, null, null, null, null, subscription, null, null);
+            .getComplianceStatusCounts(null, null, null, null, null, subscription, null, null, null);
         verifyNoMoreInteractions(mockCSCurator);
     }
 
@@ -564,7 +570,8 @@ public class StatusTrendReportTest {
         when(params.getFirst("owner")).thenReturn(owner);
 
         ComplianceSnapshotCurator mockCSCurator = mock(ComplianceSnapshotCurator.class);
-        when(mockCSCurator.getComplianceStatusCounts(null, null, owner, null, null, subscription, null, null))
+        when(mockCSCurator
+            .getComplianceStatusCounts(null, null, owner, null, null, subscription, null, null, null))
             .thenReturn(testpage);
 
         StatusTrendReport report = new StatusTrendReport(this.i18nProvider, mockCSCurator);
@@ -575,9 +582,8 @@ public class StatusTrendReportTest {
 
         assertEquals(expected, actual);
 
-        verify(mockCSCurator).getComplianceStatusCounts(
-            null, null, owner, null, null, subscription, null, null
-        );
+        verify(mockCSCurator)
+            .getComplianceStatusCounts(null, null, owner, null, null, subscription, null, null, null);
         verifyNoMoreInteractions(mockCSCurator);
     }
 
@@ -608,7 +614,7 @@ public class StatusTrendReportTest {
 
         ComplianceSnapshotCurator mockCSCurator = mock(ComplianceSnapshotCurator.class);
         when(mockCSCurator
-            .getComplianceStatusCounts(startDate, endDate, null, null, null, subscription, null, null))
+            .getComplianceStatusCounts(startDate, endDate, null, null, null, subscription, null, null, null))
             .thenReturn(testpage);
 
         StatusTrendReport report = new StatusTrendReport(this.i18nProvider, mockCSCurator);
@@ -620,7 +626,7 @@ public class StatusTrendReportTest {
         assertEquals(expected, actual);
 
         verify(mockCSCurator)
-            .getComplianceStatusCounts(startDate, endDate, null, null, null, subscription, null, null);
+            .getComplianceStatusCounts(startDate, endDate, null, null, null, subscription, null, null, null);
         verifyNoMoreInteractions(mockCSCurator);
     }
 
@@ -654,8 +660,8 @@ public class StatusTrendReportTest {
         when(params.getFirst("owner")).thenReturn(owner);
 
         ComplianceSnapshotCurator mockCSCurator = mock(ComplianceSnapshotCurator.class);
-        when(mockCSCurator.getComplianceStatusCounts(
-            startDate, endDate, owner, null, null, subscription, null, null))
+        when(mockCSCurator
+            .getComplianceStatusCounts(startDate, endDate, owner, null, null, subscription, null, null, null))
             .thenReturn(testpage);
 
         StatusTrendReport report = new StatusTrendReport(this.i18nProvider, mockCSCurator);
@@ -667,7 +673,7 @@ public class StatusTrendReportTest {
         assertEquals(expected, actual);
 
         verify(mockCSCurator)
-            .getComplianceStatusCounts(startDate, endDate, owner, null, null, subscription, null, null);
+            .getComplianceStatusCounts(startDate, endDate, owner, null, null, subscription, null, null, null);
 
         verifyNoMoreInteractions(mockCSCurator);
     }
@@ -695,7 +701,7 @@ public class StatusTrendReportTest {
 
         ComplianceSnapshotCurator mockCSCurator = mock(ComplianceSnapshotCurator.class);
         when(mockCSCurator
-            .getComplianceStatusCounts(null, null, null, consumers, null, subscription, null, null))
+            .getComplianceStatusCounts(null, null, null, consumers, null, subscription, null, null, null))
             .thenReturn(testpage);
 
         StatusTrendReport report = new StatusTrendReport(this.i18nProvider, mockCSCurator);
@@ -707,7 +713,7 @@ public class StatusTrendReportTest {
         assertEquals(expected, actual);
 
         verify(mockCSCurator)
-            .getComplianceStatusCounts(null, null, null, consumers, null, subscription, null, null);
+            .getComplianceStatusCounts(null, null, null, consumers, null, subscription, null, null, null);
         verifyNoMoreInteractions(mockCSCurator);
     }
 
@@ -730,7 +736,8 @@ public class StatusTrendReportTest {
         attributes.put("management_enabled", "1");
 
         ComplianceSnapshotCurator mockCSCurator = mock(ComplianceSnapshotCurator.class);
-        when(mockCSCurator.getComplianceStatusCounts(null, null, null, null, null, null, attributes, null))
+        when(mockCSCurator
+            .getComplianceStatusCounts(null, null, null, null, null, null, null, attributes, null))
             .thenReturn(testpage);
 
         StatusTrendReport report = new StatusTrendReport(this.i18nProvider, mockCSCurator);
@@ -742,7 +749,7 @@ public class StatusTrendReportTest {
         assertEquals(expected, actual);
 
         verify(mockCSCurator)
-            .getComplianceStatusCounts(null, null, null, null, null, null, attributes, null);
+            .getComplianceStatusCounts(null, null, null, null, null, null, null, attributes, null);
 
         verifyNoMoreInteractions(mockCSCurator);
     }
@@ -771,7 +778,7 @@ public class StatusTrendReportTest {
 
         ComplianceSnapshotCurator mockCSCurator = mock(ComplianceSnapshotCurator.class);
         when(mockCSCurator
-            .getComplianceStatusCounts(null, null, owner, null, null, null, attributes, null))
+            .getComplianceStatusCounts(null, null, owner, null, null, null, null, attributes, null))
             .thenReturn(testpage);
 
         StatusTrendReport report = new StatusTrendReport(this.i18nProvider, mockCSCurator);
@@ -783,7 +790,7 @@ public class StatusTrendReportTest {
         assertEquals(expected, actual);
 
         verify(mockCSCurator)
-            .getComplianceStatusCounts(null, null, owner, null, null, null, attributes, null);
+            .getComplianceStatusCounts(null, null, owner, null, null, null, null, attributes, null);
         verifyNoMoreInteractions(mockCSCurator);
     }
 
@@ -816,7 +823,7 @@ public class StatusTrendReportTest {
 
         ComplianceSnapshotCurator mockCSCurator = mock(ComplianceSnapshotCurator.class);
         when(mockCSCurator
-            .getComplianceStatusCounts(startDate, endDate, null, null, null, null, attributes, null))
+            .getComplianceStatusCounts(startDate, endDate, null, null, null, null, null, attributes, null))
             .thenReturn(testpage);
 
         StatusTrendReport report = new StatusTrendReport(this.i18nProvider, mockCSCurator);
@@ -828,7 +835,7 @@ public class StatusTrendReportTest {
         assertEquals(expected, actual);
 
         verify(mockCSCurator)
-            .getComplianceStatusCounts(startDate, endDate, null, null, null, null, attributes, null);
+            .getComplianceStatusCounts(startDate, endDate, null, null, null, null, null, attributes, null);
         verifyNoMoreInteractions(mockCSCurator);
     }
 
@@ -865,7 +872,7 @@ public class StatusTrendReportTest {
 
         ComplianceSnapshotCurator mockCSCurator = mock(ComplianceSnapshotCurator.class);
         when(mockCSCurator
-            .getComplianceStatusCounts(startDate, endDate, owner, null, null, null, attributes, null))
+            .getComplianceStatusCounts(startDate, endDate, owner, null, null, null, null, attributes, null))
             .thenReturn(testpage);
 
         StatusTrendReport report = new StatusTrendReport(this.i18nProvider, mockCSCurator);
@@ -877,7 +884,7 @@ public class StatusTrendReportTest {
         assertEquals(expected, actual);
 
         verify(mockCSCurator)
-            .getComplianceStatusCounts(startDate, endDate, owner, null, null, null, attributes, null);
+            .getComplianceStatusCounts(startDate, endDate, owner, null, null, null, null, attributes, null);
         verifyNoMoreInteractions(mockCSCurator);
     }
 
@@ -906,7 +913,7 @@ public class StatusTrendReportTest {
 
         ComplianceSnapshotCurator mockCSCurator = mock(ComplianceSnapshotCurator.class);
         when(mockCSCurator
-            .getComplianceStatusCounts(null, null, null, consumers, null, null, attributes, null))
+            .getComplianceStatusCounts(null, null, null, consumers, null, null, null, attributes, null))
             .thenReturn(testpage);
 
         StatusTrendReport report = new StatusTrendReport(this.i18nProvider, mockCSCurator);
@@ -918,13 +925,13 @@ public class StatusTrendReportTest {
         assertEquals(expected, actual);
 
         verify(mockCSCurator)
-            .getComplianceStatusCounts(null, null, null, consumers, null, null, attributes, null);
+            .getComplianceStatusCounts(null, null, null, consumers, null, null, null, attributes, null);
 
         verifyNoMoreInteractions(mockCSCurator);
     }
 
     @Test
-    public void testReportingWithTimeZoneAdjustmnet() throws Exception {
+    public void testReportingWithTimeZoneAdjustment() throws Exception {
         HashMap<String, Integer> testcount = new HashMap<String, Integer>();
         Page<Map<Date, Map<String, Integer>>> testpage = new Page<Map<Date, Map<String, Integer>>>();
         HashMap<Date, Map<String, Integer>> testoutput = new HashMap<Date, Map<String, Integer>>();
@@ -945,7 +952,7 @@ public class StatusTrendReportTest {
         when(params.getFirst("timezone")).thenReturn(tzString);
 
         ComplianceSnapshotCurator mockCSCurator = mock(ComplianceSnapshotCurator.class);
-        when(mockCSCurator.getComplianceStatusCounts(null, null, null, null, null, null, null, null))
+        when(mockCSCurator.getComplianceStatusCounts(null, null, null, null, null, null, null, null, null))
             .thenReturn(testpage);
 
         StatusTrendReport report = new StatusTrendReport(this.i18nProvider, mockCSCurator);
@@ -957,7 +964,212 @@ public class StatusTrendReportTest {
 
         assertEquals(expected, actual);
 
-        verify(mockCSCurator).getComplianceStatusCounts(null, null, null, null, null, null, null, null);
+        verify(mockCSCurator).getComplianceStatusCounts(null, null, null, null, null, null, null, null, null);
         verifyNoMoreInteractions(mockCSCurator);
     }
+
+
+    @Test
+    public void testReportingByProduct() {
+        HashMap<String, Integer> testcount = new HashMap<String, Integer>();
+        Page<Map<Date, Map<String, Integer>>> testpage = new Page<Map<Date, Map<String, Integer>>>();
+        HashMap<Date, Map<String, Integer>> testoutput = new HashMap<Date, Map<String, Integer>>();
+        testcount.put("testcount1", 1);
+        testoutput.put(this.testDate, testcount);
+        testpage.setPageData(testoutput);
+
+        String product = "test_product";
+
+        MultivaluedMap<String, String> params = mock(MultivaluedMap.class);
+        when(params.containsKey("product_name")).thenReturn(true);
+        when(params.getFirst("product_name")).thenReturn(product);
+        when(params.get("product_name")).thenReturn(Arrays.asList(product));
+
+        ComplianceSnapshotCurator mockCSCurator = mock(ComplianceSnapshotCurator.class);
+        when(mockCSCurator
+            .getComplianceStatusCounts(null, null, null, null, null, null, product, null, null))
+            .thenReturn(testpage);
+
+        StatusTrendReport report = new StatusTrendReport(this.i18nProvider, mockCSCurator);
+
+        StatusTrendReportResult actual = report.run(params, null);
+        StatusTrendReportResult expected = new StatusTrendReportResult();
+        expected.put(this.testDateString, testcount);
+
+        assertEquals(expected, actual);
+
+        verify(mockCSCurator)
+            .getComplianceStatusCounts(null, null, null, null, null, null, product, null, null);
+
+        verifyNoMoreInteractions(mockCSCurator);
+    }
+
+    @Test
+    public void testReportingByOwnerAndProduct() {
+        HashMap<String, Integer> testcount = new HashMap<String, Integer>();
+        Page<Map<Date, Map<String, Integer>>> testpage = new Page<Map<Date, Map<String, Integer>>>();
+        HashMap<Date, Map<String, Integer>> testoutput = new HashMap<Date, Map<String, Integer>>();
+        testcount.put("testcount1", 1);
+        testoutput.put(this.testDate, testcount);
+        testpage.setPageData(testoutput);
+
+        String owner = "test_owner";
+        String product = "test_product";
+
+        MultivaluedMap<String, String> params = mock(MultivaluedMap.class);
+        when(params.containsKey("product_name")).thenReturn(true);
+        when(params.getFirst("product_name")).thenReturn(product);
+        when(params.get("product_name")).thenReturn(Arrays.asList(product));
+        when(params.containsKey("owner")).thenReturn(true);
+        when(params.get("owner")).thenReturn(Arrays.asList(owner));
+        when(params.getFirst("owner")).thenReturn(owner);
+
+        ComplianceSnapshotCurator mockCSCurator = mock(ComplianceSnapshotCurator.class);
+        when(mockCSCurator
+            .getComplianceStatusCounts(null, null, owner, null, null, null, product, null, null))
+            .thenReturn(testpage);
+
+        StatusTrendReport report = new StatusTrendReport(this.i18nProvider, mockCSCurator);
+
+        StatusTrendReportResult actual = report.run(params, null);
+        StatusTrendReportResult expected = new StatusTrendReportResult();
+        expected.put(this.testDateString, testcount);
+
+        assertEquals(expected, actual);
+
+        verify(mockCSCurator)
+            .getComplianceStatusCounts(null, null, owner, null, null, null, product, null, null);
+        verifyNoMoreInteractions(mockCSCurator);
+    }
+
+    @Test
+    public void testReportingByDateAndProduct() throws Exception {
+        HashMap<String, Integer> testcount = new HashMap<String, Integer>();
+        Page<Map<Date, Map<String, Integer>>> testpage = new Page<Map<Date, Map<String, Integer>>>();
+        HashMap<Date, Map<String, Integer>> testoutput = new HashMap<Date, Map<String, Integer>>();
+        testcount.put("testcount1", 1);
+        testoutput.put(this.testDate, testcount);
+        testpage.setPageData(testoutput);
+
+        SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
+        Date startDate = formatter.parse("2014-11-07");
+        Date endDate = formatter.parse("2014-11-08");
+        String product = "test_product";
+
+        MultivaluedMap<String, String> params = mock(MultivaluedMap.class);
+        when(params.containsKey("start_date")).thenReturn(true);
+        when(params.get("start_date")).thenReturn(Arrays.asList("2014-11-07"));
+        when(params.getFirst("start_date")).thenReturn("2014-11-07");
+        when(params.containsKey("end_date")).thenReturn(true);
+        when(params.get("end_date")).thenReturn(Arrays.asList("2014-11-08"));
+        when(params.getFirst("end_date")).thenReturn("2014-11-08");
+        when(params.containsKey("product_name")).thenReturn(true);
+        when(params.getFirst("product_name")).thenReturn(product);
+        when(params.get("product_name")).thenReturn(Arrays.asList(product));
+
+        ComplianceSnapshotCurator mockCSCurator = mock(ComplianceSnapshotCurator.class);
+        when(mockCSCurator
+            .getComplianceStatusCounts(startDate, endDate, null, null, null, null, product, null, null))
+            .thenReturn(testpage);
+
+        StatusTrendReport report = new StatusTrendReport(this.i18nProvider, mockCSCurator);
+
+        StatusTrendReportResult actual = report.run(params, null);
+        StatusTrendReportResult expected = new StatusTrendReportResult();
+        expected.put(this.testDateString, testcount);
+
+        assertEquals(expected, actual);
+
+        verify(mockCSCurator)
+            .getComplianceStatusCounts(startDate, endDate, null, null, null, null, product, null, null);
+        verifyNoMoreInteractions(mockCSCurator);
+    }
+
+    @Test
+    public void testReportingByDateOwnerAndProduct() throws Exception {
+        HashMap<String, Integer> testcount = new HashMap<String, Integer>();
+        Page<Map<Date, Map<String, Integer>>> testpage = new Page<Map<Date, Map<String, Integer>>>();
+        HashMap<Date, Map<String, Integer>> testoutput = new HashMap<Date, Map<String, Integer>>();
+        testcount.put("testcount1", 1);
+        testoutput.put(this.testDate, testcount);
+        testpage.setPageData(testoutput);
+
+        SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
+        Date startDate = formatter.parse("2014-11-07");
+        Date endDate = formatter.parse("2014-11-08");
+        String owner = "test_owner";
+        String product = "test_product";
+
+        MultivaluedMap<String, String> params = mock(MultivaluedMap.class);
+        when(params.containsKey("start_date")).thenReturn(true);
+        when(params.get("start_date")).thenReturn(Arrays.asList("2014-11-07"));
+        when(params.getFirst("start_date")).thenReturn("2014-11-07");
+        when(params.containsKey("end_date")).thenReturn(true);
+        when(params.get("end_date")).thenReturn(Arrays.asList("2014-11-08"));
+        when(params.getFirst("end_date")).thenReturn("2014-11-08");
+        when(params.containsKey("product_name")).thenReturn(true);
+        when(params.getFirst("product_name")).thenReturn(product);
+        when(params.get("product_name")).thenReturn(Arrays.asList(product));
+        when(params.containsKey("owner")).thenReturn(true);
+        when(params.get("owner")).thenReturn(Arrays.asList(owner));
+        when(params.getFirst("owner")).thenReturn(owner);
+
+        ComplianceSnapshotCurator mockCSCurator = mock(ComplianceSnapshotCurator.class);
+        when(mockCSCurator
+            .getComplianceStatusCounts(startDate, endDate, owner, null, null, null, product, null, null))
+            .thenReturn(testpage);
+
+        StatusTrendReport report = new StatusTrendReport(this.i18nProvider, mockCSCurator);
+
+        StatusTrendReportResult actual = report.run(params, null);
+        StatusTrendReportResult expected = new StatusTrendReportResult();
+        expected.put(this.testDateString, testcount);
+
+        assertEquals(expected, actual);
+
+        verify(mockCSCurator)
+            .getComplianceStatusCounts(startDate, endDate, owner, null, null, null, product, null, null);
+        verifyNoMoreInteractions(mockCSCurator);
+    }
+
+    @Test
+    public void testReportingByConsumerAndProduct() {
+        HashMap<String, Integer> testcount = new HashMap<String, Integer>();
+        Page<Map<Date, Map<String, Integer>>> testpage = new Page<Map<Date, Map<String, Integer>>>();
+        HashMap<Date, Map<String, Integer>> testoutput = new HashMap<Date, Map<String, Integer>>();
+        testcount.put("testcount1", 1);
+        testoutput.put(this.testDate, testcount);
+        testpage.setPageData(testoutput);
+
+        List<String> consumers = Arrays.asList("c1", "c2", "c3");
+        String product = "test_product";
+
+        MultivaluedMap<String, String> params = mock(MultivaluedMap.class);
+        when(params.containsKey("consumer_uuid")).thenReturn(true);
+        when(params.getFirst("consumer_uuid")).thenReturn(consumers.get(0));
+        when(params.get("consumer_uuid")).thenReturn(consumers);
+
+        when(params.containsKey("product_name")).thenReturn(true);
+        when(params.getFirst("product_name")).thenReturn(product);
+        when(params.get("product_name")).thenReturn(Arrays.asList(product));
+
+        ComplianceSnapshotCurator mockCSCurator = mock(ComplianceSnapshotCurator.class);
+        when(mockCSCurator
+            .getComplianceStatusCounts(null, null, null, consumers, null, null, product, null, null))
+            .thenReturn(testpage);
+
+        StatusTrendReport report = new StatusTrendReport(this.i18nProvider, mockCSCurator);
+
+        StatusTrendReportResult actual = report.run(params, null);
+        StatusTrendReportResult expected = new StatusTrendReportResult();
+        expected.put(this.testDateString, testcount);
+
+        assertEquals(expected, actual);
+
+        verify(mockCSCurator)
+            .getComplianceStatusCounts(null, null, null, consumers, null, null, product, null, null);
+
+        verifyNoMoreInteractions(mockCSCurator);
+    }
+
 }

--- a/gutterball/src/test/resources/logback-test.xml
+++ b/gutterball/src/test/resources/logback-test.xml
@@ -10,7 +10,7 @@
   <logger name="org.hibernate.id.UUIDHexGenerator" level="ERROR"/>
   <logger name="liquibase" level="ERROR"/>
 
-  <logger name="org.candlepin.gutterball" level="INFO"/>
+  <logger name="org.candlepin.gutterball" level="DEBUG"/>
   <root level="WARN">
     <appender-ref ref="RootAppender"/>
   </root>


### PR DESCRIPTION
- Adding "product_name=<value>" to the status trend report query will
  now allow filtering on consumers who have installed the specified
  product, so long as there's at least one compliance record indicating
  the product's status (compliant, partial or non)