### PR TITLE
1123560: Allow consumer with service level to autobind to pool without

### DIFF
--- a/server/src/main/resources/rules/rules.js
+++ b/server/src/main/resources/rules/rules.js
@@ -1,4 +1,4 @@
-// Version: 5.15
+// Version: 5.16
 
 /*
  * Default Candlepin rule set.
@@ -2210,8 +2210,9 @@ var Autobind = {
         var poolSLA = pool.getProductAttribute('support_level');
         var poolSLAExempt = isLevelExempt(pool.getProductAttribute('support_level'), context.exemptList);
 
-        if (!poolSLAExempt && consumerSLA &&
-            consumerSLA != "" && !Utils.equalsIgnoreCase(consumerSLA, poolSLA)) {
+        if (poolSLA && poolSLA != "" && !poolSLAExempt &&
+            consumerSLA && consumerSLA != "" &&
+            !Utils.equalsIgnoreCase(consumerSLA, poolSLA)) {
             log.debug("Skipping pool " + pool.id +
                     " since SLA does not match that of the consumer.");
             return false;

--- a/server/src/test/java/org/candlepin/policy/AutobindRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/AutobindRulesTest.java
@@ -357,8 +357,9 @@ public class AutobindRulesTest {
             new String[]{ productId, slaPremiumProdId, slaStandardProdId},
             pools, compliance, null, new HashSet<String>(), false);
 
-        assertEquals(1, bestPools.size());
+        assertEquals(2, bestPools.size());
         assertTrue(bestPools.contains(new PoolQuantity(slaPremiumPool, 1)));
+        assertTrue(bestPools.contains(new PoolQuantity(noSLAPool, 1)));
     }
 
     @Test
@@ -411,8 +412,9 @@ public class AutobindRulesTest {
             new String[]{ productId, slaPremiumProdId, slaStandardProdId},
             pools, compliance, null, new HashSet<String>(), false);
 
-        assertEquals(1, bestPools.size());
+        assertEquals(2, bestPools.size());
         assertTrue(bestPools.contains(new PoolQuantity(slaPremiumPool, 1)));
+        assertTrue(bestPools.contains(new PoolQuantity(noSLAPool, 1)));
     }
 
     @Test


### PR DESCRIPTION
Previously this scenario was blocked by rule. Seems that a product
without a support_level attribute should be usable by anyone, not
just those without a service level assignment.