### PR TITLE
1227930: Deleting invalid content Ids causes error 500

### DIFF
--- a/server/spec/environment_spec.rb
+++ b/server/spec/environment_spec.rb
@@ -150,6 +150,38 @@ describe 'Environments' do
     @env['environmentContent'].size.should == 0
   end
 
+  it 'gracefully aborts on invalid content during demotion' do
+    content = create_content
+    content2 = create_content
+    job = @org_admin.promote_content(@env['id'], [{:contentId => content['id']}])
+    wait_for_job(job['id'], 15)
+    job = @org_admin.promote_content(@env['id'], [{:contentId => content2['id']}])
+    wait_for_job(job['id'], 15)
+
+    lambda do
+      @org_admin.demote_content(@env['id'], ['bad_content_id'])
+    end.should raise_exception(RestClient::ResourceNotFound)
+    @env = @org_admin.get_environment(@env['id'])
+    @env['environmentContent'].size.should == 2
+
+    lambda do
+      @org_admin.demote_content(@env['id'], [content['id'], 'bad_content_id', content2['id']])
+    end.should raise_exception(RestClient::ResourceNotFound)
+    @env = @org_admin.get_environment(@env['id'])
+    @env['environmentContent'].size.should == 2
+
+    lambda do
+      @org_admin.demote_content(@env['id'], [content['id'], content2['id'], 'bad_content_id'])
+    end.should raise_exception(RestClient::ResourceNotFound)
+    @env = @org_admin.get_environment(@env['id'])
+    @env['environmentContent'].size.should == 2
+
+    job = @org_admin.demote_content(@env['id'], [content['id'], content2['id']])
+    wait_for_job(job['id'], 15)
+    @env = @org_admin.get_environment(@env['id'])
+    @env['environmentContent'].size.should == 0
+  end
+
   it 'filters content not promoted to environment' do
     consumer = @org_admin.register(random_string('testsystem'), :system, nil, {},
         nil, nil, [], [], @env['id'])

--- a/server/src/main/java/org/candlepin/resource/EnvironmentResource.java
+++ b/server/src/main/java/org/candlepin/resource/EnvironmentResource.java
@@ -42,6 +42,7 @@ import org.xnap.commons.i18n.I18n;
 import java.util.HashSet;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import javax.ws.rs.Consumes;
@@ -236,8 +237,7 @@ public class EnvironmentResource {
         @QueryParam("lazy_regen") @DefaultValue("true") Boolean lazyRegen) {
 
         Environment e = lookupEnvironment(envId);
-
-        HashMap<String, EnvironmentContent> demotedContent = new HashMap<String, EnvironmentContent>();
+        Map<String, EnvironmentContent> demotedContent = new HashMap<String, EnvironmentContent>();
 
         // Step through and validate all given content IDs before deleting
         for (String contentId : contentIds) {
@@ -257,7 +257,7 @@ public class EnvironmentResource {
 
         // Impl note: Unfortunately, we have to make an additional set here, as the keySet isn't
         // serializable. Attempting to use it causes exceptions.
-        HashSet<String> demotedContentIds = new HashSet<String>(demotedContent.keySet());
+        Set<String> demotedContentIds = new HashSet<String>(demotedContent.keySet());
         JobDataMap map = new JobDataMap();
         map.put(RegenEnvEntitlementCertsJob.ENV, e);
         map.put(RegenEnvEntitlementCertsJob.CONTENT, demotedContentIds);

--- a/server/src/main/java/org/candlepin/resource/EnvironmentResource.java
+++ b/server/src/main/java/org/candlepin/resource/EnvironmentResource.java
@@ -40,6 +40,7 @@ import org.quartz.JobDetail;
 import org.xnap.commons.i18n.I18n;
 
 import java.util.HashSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
 
@@ -235,14 +236,28 @@ public class EnvironmentResource {
         @QueryParam("lazy_regen") @DefaultValue("true") Boolean lazyRegen) {
 
         Environment e = lookupEnvironment(envId);
-        Set<String> demotedContentIds = new HashSet<String>();
+
+        HashMap<String, EnvironmentContent> demotedContent = new HashMap<String, EnvironmentContent>();
+
+        // Step through and validate all given content IDs before deleting
         for (String contentId : contentIds) {
-            EnvironmentContent envContent =
-                envContentCurator.lookupByEnvironmentAndContent(e, contentId);
-            envContentCurator.delete(envContent);
-            demotedContentIds.add(contentId);
+            EnvironmentContent envContent = envContentCurator.lookupByEnvironmentAndContent(e, contentId);
+
+            if (envContent == null) {
+                throw new NotFoundException(i18n.tr("Content does not exist in environment: {0}", contentId));
+            }
+
+            demotedContent.put(contentId, envContent);
         }
 
+        // We've validated everything here, so we're clear to start deleting...
+        for (EnvironmentContent envContent : demotedContent.values()) {
+            this.envContentCurator.delete(envContent);
+        }
+
+        // Impl note: Unfortunately, we have to make an additional set here, as the keySet isn't
+        // serializable. Attempting to use it causes exceptions.
+        HashSet<String> demotedContentIds = new HashSet<String>(demotedContent.keySet());
         JobDataMap map = new JobDataMap();
         map.put(RegenEnvEntitlementCertsJob.ENV, e);
         map.put(RegenEnvEntitlementCertsJob.CONTENT, demotedContentIds);


### PR DESCRIPTION
- Fixed a bug in EnvironmentResource that was causing a 500 error
  when an invalid content ID was provided
- The demotion logic has been slightly modified such that an invalid
  content ID will now cause a 404 to be thrown without performing
  any demotions