### PR TITLE
5x Bind Improvement for Large SKUs

### DIFF
--- a/server/src/main/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapter.java
+++ b/server/src/main/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapter.java
@@ -175,7 +175,7 @@ public class DefaultEntitlementCertServiceAdapter extends
 
         if (shouldGenerateV3(ent)) {
             extensions = prepareV3Extensions(ent, contentPrefix, promotedContent);
-            byteExtensions = prepareV3ByteExtensions(products, ent, contentPrefix,
+            byteExtensions = prepareV3ByteExtensions(product, products, ent, contentPrefix,
                 promotedContent);
         }
         else {
@@ -326,12 +326,12 @@ public class DefaultEntitlementCertServiceAdapter extends
         return result;
     }
 
-    public Set<X509ByteExtensionWrapper> prepareV3ByteExtensions(Set<Product> products,
-        Entitlement ent, String contentPrefix,
+    public Set<X509ByteExtensionWrapper> prepareV3ByteExtensions(Product sku,
+            Set<Product> products, Entitlement ent, String contentPrefix,
         Map<String, EnvironmentContent> promotedContent)
         throws IOException {
-        Set<X509ByteExtensionWrapper> result =  v3extensionUtil.getByteExtensions(products,
-            ent, contentPrefix, promotedContent);
+        Set<X509ByteExtensionWrapper> result =  v3extensionUtil.getByteExtensions(sku,
+                products, ent, contentPrefix, promotedContent);
         return result;
     }
 
@@ -388,8 +388,8 @@ public class DefaultEntitlementCertServiceAdapter extends
         String pem = new String(this.pki.getPemEncoded(x509Cert));
 
         if (shouldGenerateV3(entitlement)) {
-            byte[] payloadBytes = v3extensionUtil.createEntitlementDataPayload(products,
-                entitlement, contentPrefix, promotedContent);
+            byte[] payloadBytes = v3extensionUtil.createEntitlementDataPayload(product,
+                    products, entitlement, contentPrefix, promotedContent);
             String payload = "-----BEGIN ENTITLEMENT DATA-----\n";
             payload += Util.toBase64(payloadBytes);
             payload += "-----END ENTITLEMENT DATA-----\n";

--- a/server/src/main/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapter.java
+++ b/server/src/main/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapter.java
@@ -61,6 +61,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -158,8 +159,13 @@ public class DefaultEntitlementCertServiceAdapter extends
         return providedProducts;
     }
 
+    // TODO: productModels not used by V1 certificates. This whole v1/v3 split needs
+    // a re-org. Passing them here because it eliminates a substantial performance hit
+    // recalculating this for the entitlement body in v3 certs.
     public X509Certificate createX509Certificate(Entitlement ent,
-        Product product, Set<Product> products, BigInteger serialNumber,
+        Product product, Set<Product> products,
+        List<org.candlepin.json.model.Product> productModels,
+        BigInteger serialNumber,
         KeyPair keyPair, boolean useContentPrefix)
         throws GeneralSecurityException, IOException {
 
@@ -175,8 +181,8 @@ public class DefaultEntitlementCertServiceAdapter extends
 
         if (shouldGenerateV3(ent)) {
             extensions = prepareV3Extensions(ent, contentPrefix, promotedContent);
-            byteExtensions = prepareV3ByteExtensions(product, products, ent, contentPrefix,
-                promotedContent);
+            byteExtensions = prepareV3ByteExtensions(product, productModels,
+                    ent, contentPrefix, promotedContent);
         }
         else {
             extensions = prepareV1Extensions(products, ent, contentPrefix,
@@ -327,11 +333,12 @@ public class DefaultEntitlementCertServiceAdapter extends
     }
 
     public Set<X509ByteExtensionWrapper> prepareV3ByteExtensions(Product sku,
-            Set<Product> products, Entitlement ent, String contentPrefix,
-        Map<String, EnvironmentContent> promotedContent)
-        throws IOException {
+            List<org.candlepin.json.model.Product> productModels,
+            Entitlement ent, String contentPrefix,
+            Map<String, EnvironmentContent> promotedContent) throws IOException {
+
         Set<X509ByteExtensionWrapper> result =  v3extensionUtil.getByteExtensions(sku,
-                products, ent, contentPrefix, promotedContent);
+                productModels, ent, contentPrefix, promotedContent);
         return result;
     }
 
@@ -370,26 +377,31 @@ public class DefaultEntitlementCertServiceAdapter extends
         // to add any derived products as well so that their content
         // is available in the upstream certificate.
         products.addAll(getDerivedProductsForDistributor(sub, entitlement));
+        products.add(product);
+
+        Map<String, EnvironmentContent> promotedContent = getPromotedContent(entitlement);
+        String contentPrefix = getContentPrefix(entitlement, !thisIsUeberCert);
 
         log.info("Creating X509 cert.");
+        List<org.candlepin.json.model.Product> productModels =
+                v3extensionUtil.createProducts(product, products, contentPrefix,
+                        promotedContent,
+                        entitlement.getConsumer(), entitlement);
+
         X509Certificate x509Cert = createX509Certificate(entitlement,
-            product, products, BigInteger.valueOf(serial.getId()), keyPair,
+            product, products, productModels, BigInteger.valueOf(serial.getId()), keyPair,
             !thisIsUeberCert);
 
         EntitlementCertificate cert = new EntitlementCertificate();
         cert.setSerial(serial);
         cert.setKeyAsBytes(pki.getPemEncoded(keyPair.getPrivate()));
 
-        products.add(product);
-        Map<String, EnvironmentContent> promotedContent = getPromotedContent(entitlement);
-        String contentPrefix = getContentPrefix(entitlement, !thisIsUeberCert);
-
         log.info("Getting PEM encoded cert.");
         String pem = new String(this.pki.getPemEncoded(x509Cert));
 
         if (shouldGenerateV3(entitlement)) {
             byte[] payloadBytes = v3extensionUtil.createEntitlementDataPayload(product,
-                    products, entitlement, contentPrefix, promotedContent);
+                    productModels, entitlement, contentPrefix, promotedContent);
             String payload = "-----BEGIN ENTITLEMENT DATA-----\n";
             payload += Util.toBase64(payloadBytes);
             payload += "-----END ENTITLEMENT DATA-----\n";

--- a/server/src/main/java/org/candlepin/util/X509V3ExtensionUtil.java
+++ b/server/src/main/java/org/candlepin/util/X509V3ExtensionUtil.java
@@ -101,13 +101,13 @@ public class X509V3ExtensionUtil extends X509Util {
         return toReturn;
     }
 
-    public Set<X509ByteExtensionWrapper> getByteExtensions(Set<Product> products,
-        Entitlement ent, String contentPrefix,
+    public Set<X509ByteExtensionWrapper> getByteExtensions(Product sku,
+            Set<Product> products, Entitlement ent, String contentPrefix,
         Map<String, EnvironmentContent> promotedContent) throws IOException {
         Set<X509ByteExtensionWrapper> toReturn =
             new LinkedHashSet<X509ByteExtensionWrapper>();
 
-        EntitlementBody eb = createEntitlementBodyContent(products, ent,
+        EntitlementBody eb = createEntitlementBodyContent(sku, products, ent,
             contentPrefix, promotedContent);
 
         X509ByteExtensionWrapper bodyExtension =
@@ -119,12 +119,12 @@ public class X509V3ExtensionUtil extends X509Util {
         return toReturn;
     }
 
-    public byte[] createEntitlementDataPayload(Set<Product> products,
+    public byte[] createEntitlementDataPayload(Product skuProduct, Set<Product> products,
         Entitlement ent, String contentPrefix,
         Map<String, EnvironmentContent> promotedContent)
         throws UnsupportedEncodingException, IOException {
 
-        EntitlementBody map = createEntitlementBody(products, ent,
+        EntitlementBody map = createEntitlementBody(skuProduct, products, ent,
             contentPrefix, promotedContent);
 
         String json = toJson(map);
@@ -153,7 +153,7 @@ public class X509V3ExtensionUtil extends X509Util {
         return data.toByteArray();
     }
 
-    public EntitlementBody createEntitlementBody(Set<Product> products,
+    public EntitlementBody createEntitlementBody(Product skuProduct, Set<Product> products,
         Entitlement ent, String contentPrefix,
         Map<String, EnvironmentContent> promotedContent) {
 
@@ -162,19 +162,19 @@ public class X509V3ExtensionUtil extends X509Util {
         toReturn.setQuantity(ent.getQuantity());
         toReturn.setSubscription(createSubscription(ent));
         toReturn.setOrder(createOrder(ent.getPool()));
-        toReturn.setProducts(createProducts(products, contentPrefix, promotedContent,
-            ent.getConsumer(), ent));
+        toReturn.setProducts(createProducts(skuProduct, products, contentPrefix,
+                promotedContent, ent.getConsumer(), ent));
         toReturn.setPool(createPool(ent));
 
         return toReturn;
     }
 
-    public EntitlementBody createEntitlementBodyContent(Set<Product> products,
+    public EntitlementBody createEntitlementBodyContent(Product sku, Set<Product> products,
         Entitlement ent, String contentPrefix,
         Map<String, EnvironmentContent> promotedContent) {
 
         EntitlementBody toReturn = new EntitlementBody();
-        toReturn.setProducts(createProducts(products, contentPrefix, promotedContent,
+        toReturn.setProducts(createProducts(sku, products, contentPrefix, promotedContent,
             ent.getConsumer(), ent));
 
         return toReturn;
@@ -274,7 +274,8 @@ public class X509V3ExtensionUtil extends X509Util {
         return toReturn;
     }
 
-    public List<org.candlepin.json.model.Product> createProducts(Set<Product> products,
+    public List<org.candlepin.json.model.Product> createProducts(Product sku,
+            Set<Product> products,
         String contentPrefix, Map<String, EnvironmentContent> promotedContent,
         Consumer consumer, Entitlement ent) {
         List<org.candlepin.json.model.Product> toReturn =
@@ -284,7 +285,7 @@ public class X509V3ExtensionUtil extends X509Util {
                 ent.getStartDate(), ent.getEndDate());
         for (Product p : Collections2
             .filter(products, PROD_FILTER_PREDICATE)) {
-            toReturn.add(mapProduct(p, contentPrefix, promotedContent, consumer, ent,
+            toReturn.add(mapProduct(p, sku, contentPrefix, promotedContent, consumer, ent,
                     entitledProductIds));
         }
         return toReturn;
@@ -296,24 +297,24 @@ public class X509V3ExtensionUtil extends X509Util {
         return toReturn;
     }
 
-    private org.candlepin.json.model.Product mapProduct(Product product,
+    private org.candlepin.json.model.Product mapProduct(Product engProduct, Product sku,
         String contentPrefix, Map<String, EnvironmentContent> promotedContent,
         Consumer consumer, Entitlement ent, Set<String> entitledProductIds) {
 
         org.candlepin.json.model.Product toReturn = new org.candlepin.json.model.Product();
 
-        toReturn.setId(product.getId());
-        toReturn.setName(product.getName());
+        toReturn.setId(engProduct.getId());
+        toReturn.setName(engProduct.getName());
 
-        String version = product.hasAttribute("version") ?
-            product.getAttributeValue("version") : "";
+        String version = engProduct.hasAttribute("version") ?
+            engProduct.getAttributeValue("version") : "";
         toReturn.setVersion(version);
 
-        Branding brand = getBranding(ent.getPool(), product.getId());
+        Branding brand = getBranding(ent.getPool(), engProduct.getId());
         toReturn.setBrandType(brand.getType());
         toReturn.setBrandName(brand.getName());
 
-        String productArches = product.getAttributeValue("arch");
+        String productArches = engProduct.getAttributeValue("arch");
         Set<String> productArchSet = Arch.parseArches(productArches);
 
         // FIXME: getParsedArches might make more sense to just return a list
@@ -322,9 +323,9 @@ public class X509V3ExtensionUtil extends X509Util {
             archList.add(arch);
         }
         toReturn.setArchitectures(archList);
-        toReturn.setContent(createContent(filterProductContent(product, ent,
-                entitledProductIds),
-            contentPrefix, promotedContent, consumer, product, ent));
+        toReturn.setContent(createContent(filterProductContent(engProduct, ent,
+                entitledProductIds), sku,
+            contentPrefix, promotedContent, consumer, engProduct, ent));
 
         return toReturn;
     }
@@ -360,21 +361,21 @@ public class X509V3ExtensionUtil extends X509Util {
      *   product attributes.
      */
     public List<Content> createContent(
-        Set<ProductContent> productContent, String contentPrefix,
+        Set<ProductContent> productContent, Product sku, String contentPrefix,
         Map<String, EnvironmentContent> promotedContent,
         Consumer consumer, Product product, Entitlement ent) {
 
         List<Content> toReturn = new ArrayList<Content>();
 
-        boolean enableEnvironmentFiltering = config.getBoolean(ConfigProperties.ENV_CONTENT_FILTERING);
+        boolean enableEnvironmentFiltering = config.getBoolean(
+                ConfigProperties.ENV_CONTENT_FILTERING);
 
         // Return only the contents that are arch appropriate
         Set<ProductContent> archApproriateProductContent = filterContentByContentArch(
             productContent, consumer, product);
 
-        Product skuProd = prodAdapter.getProductById(ent.getPool().getProductId());
-        List<String> skuDisabled = skuProd.getSkuDisabledContentIds();
-        List<String> skuEnabled = skuProd.getSkuEnabledContentIds();
+        List<String> skuDisabled = sku.getSkuDisabledContentIds();
+        List<String> skuEnabled = sku.getSkuEnabledContentIds();
 
         for (ProductContent pc : archApproriateProductContent) {
             Content content = new Content();

--- a/server/src/main/java/org/candlepin/util/X509V3ExtensionUtil.java
+++ b/server/src/main/java/org/candlepin/util/X509V3ExtensionUtil.java
@@ -102,12 +102,13 @@ public class X509V3ExtensionUtil extends X509Util {
     }
 
     public Set<X509ByteExtensionWrapper> getByteExtensions(Product sku,
-            Set<Product> products, Entitlement ent, String contentPrefix,
+            List<org.candlepin.json.model.Product> productModels,
+            Entitlement ent, String contentPrefix,
         Map<String, EnvironmentContent> promotedContent) throws IOException {
         Set<X509ByteExtensionWrapper> toReturn =
             new LinkedHashSet<X509ByteExtensionWrapper>();
 
-        EntitlementBody eb = createEntitlementBodyContent(sku, products, ent,
+        EntitlementBody eb = createEntitlementBodyContent(sku, productModels, ent,
             contentPrefix, promotedContent);
 
         X509ByteExtensionWrapper bodyExtension =
@@ -119,18 +120,18 @@ public class X509V3ExtensionUtil extends X509Util {
         return toReturn;
     }
 
-    public byte[] createEntitlementDataPayload(Product skuProduct, Set<Product> products,
-        Entitlement ent, String contentPrefix,
-        Map<String, EnvironmentContent> promotedContent)
+    public byte[] createEntitlementDataPayload(Product skuProduct,
+            List<org.candlepin.json.model.Product> productModels,
+            Entitlement ent, String contentPrefix,
+            Map<String, EnvironmentContent> promotedContent)
         throws UnsupportedEncodingException, IOException {
 
-        EntitlementBody map = createEntitlementBody(skuProduct, products, ent,
-            contentPrefix, promotedContent);
+        EntitlementBody map = createEntitlementBody(skuProduct, productModels,
+                ent, contentPrefix, promotedContent);
 
         String json = toJson(map);
         return processPayload(json);
     }
-
 
     private byte[] retreiveContentValue(EntitlementBody eb) throws IOException {
         List<Content> contentList = getContentList(eb);
@@ -153,29 +154,29 @@ public class X509V3ExtensionUtil extends X509Util {
         return data.toByteArray();
     }
 
-    public EntitlementBody createEntitlementBody(Product skuProduct, Set<Product> products,
-        Entitlement ent, String contentPrefix,
-        Map<String, EnvironmentContent> promotedContent) {
+    public EntitlementBody createEntitlementBody(Product skuProduct,
+            List<org.candlepin.json.model.Product> productModels,
+            Entitlement ent, String contentPrefix,
+            Map<String, EnvironmentContent> promotedContent) {
 
         EntitlementBody toReturn = new EntitlementBody();
         toReturn.setConsumer(ent.getConsumer().getUuid());
         toReturn.setQuantity(ent.getQuantity());
         toReturn.setSubscription(createSubscription(ent));
         toReturn.setOrder(createOrder(ent.getPool()));
-        toReturn.setProducts(createProducts(skuProduct, products, contentPrefix,
-                promotedContent, ent.getConsumer(), ent));
+        toReturn.setProducts(productModels);
         toReturn.setPool(createPool(ent));
 
         return toReturn;
     }
 
-    public EntitlementBody createEntitlementBodyContent(Product sku, Set<Product> products,
+    public EntitlementBody createEntitlementBodyContent(Product sku,
+            List<org.candlepin.json.model.Product> productModels,
         Entitlement ent, String contentPrefix,
         Map<String, EnvironmentContent> promotedContent) {
 
         EntitlementBody toReturn = new EntitlementBody();
-        toReturn.setProducts(createProducts(sku, products, contentPrefix, promotedContent,
-            ent.getConsumer(), ent));
+        toReturn.setProducts(productModels);
 
         return toReturn;
     }

--- a/server/src/test/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapterTest.java
+++ b/server/src/test/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapterTest.java
@@ -313,7 +313,10 @@ public class DefaultEntitlementCertServiceAdapterTest {
             config);
 
         X509Certificate result = certServiceAdapter.createX509Certificate(entitlement,
-            product, new HashSet<Product>(), new BigInteger("1234"), keyPair, true);
+            product, new HashSet<Product>(),
+            getProductModels(product, new HashSet<Product>(), "prefix",
+                    entitlement),
+            new BigInteger("1234"), keyPair, true);
 
         Date twentyFiveHoursOut = new Date(now.getTime() + 25 * 60 * 60 * 1000);
         Date twentyThreeHoursOut = new Date(now.getTime() + 23 * 60 * 60 * 1000);
@@ -340,7 +343,9 @@ public class DefaultEntitlementCertServiceAdapterTest {
         subscription.setProvidedProducts(providedProducts);
 
         certServiceAdapter.createX509Certificate(entitlement,
-            product, providedProducts, new BigInteger("1234"), keyPair, true);
+            product, providedProducts,
+            getProductModels(product, providedProducts, "prefix", entitlement),
+            new BigInteger("1234"), keyPair, true);
     }
 
     private Set<Content> generateContent(int numberToGenerate, String prefix) {
@@ -365,7 +370,9 @@ public class DefaultEntitlementCertServiceAdapterTest {
 
         product.setContent(productContent);
         certServiceAdapter.createX509Certificate(entitlement,
-            product, new HashSet<Product>(), new BigInteger("1234"), keyPair, true);
+            product, new HashSet<Product>(),
+            getProductModels(product, new HashSet<Product>(), "prefix", entitlement),
+            new BigInteger("1234"), keyPair, true);
     }
 
     @Test
@@ -444,7 +451,9 @@ public class DefaultEntitlementCertServiceAdapterTest {
         owner.setContentPrefix("/somePrefix/");
 
         certServiceAdapter.createX509Certificate(entitlement,
-            product, new HashSet<Product>(), new BigInteger("1234"), keyPair, true);
+            product, new HashSet<Product>(),
+            getProductModels(product, new HashSet<Product>(), "prefix", entitlement),
+            new BigInteger("1234"), keyPair, true);
 
         verify(mockedPKI).createX509Certificate(
             any(String.class),
@@ -463,7 +472,9 @@ public class DefaultEntitlementCertServiceAdapterTest {
         consumer.setEnvironment(e);
 
         certServiceAdapter.createX509Certificate(entitlement,
-            product, new HashSet<Product>(), new BigInteger("1234"), keyPair, true);
+            product, new HashSet<Product>(),
+            getProductModels(product, new HashSet<Product>(), "prefix", entitlement),
+            new BigInteger("1234"), keyPair, true);
 
         verify(mockedPKI).createX509Certificate(
             any(String.class),
@@ -483,7 +494,9 @@ public class DefaultEntitlementCertServiceAdapterTest {
         consumer.setEnvironment(e);
 
         certServiceAdapter.createX509Certificate(entitlement,
-            product, new HashSet<Product>(), new BigInteger("1234"), keyPair, true);
+            product, new HashSet<Product>(),
+            getProductModels(product, new HashSet<Product>(), "prefix", entitlement),
+            new BigInteger("1234"), keyPair, true);
 
         verify(mockedPKI).createX509Certificate(
             any(String.class),
@@ -497,7 +510,9 @@ public class DefaultEntitlementCertServiceAdapterTest {
         owner.setContentPrefix("/someorg/$env/");
 
         certServiceAdapter.createX509Certificate(entitlement,
-            product, new HashSet<Product>(), new BigInteger("1234"), keyPair, true);
+            product, new HashSet<Product>(),
+            getProductModels(product, new HashSet<Product>(), "prefix", entitlement),
+            new BigInteger("1234"), keyPair, true);
 
         verify(mockedPKI).createX509Certificate(
             any(String.class),
@@ -511,7 +526,9 @@ public class DefaultEntitlementCertServiceAdapterTest {
         owner.setContentPrefix("/somePrefix/");
 
         certServiceAdapter.createX509Certificate(entitlement,
-            product, new HashSet<Product>(), new BigInteger("1234"), keyPair, false);
+            product, new HashSet<Product>(),
+            getProductModels(product, new HashSet<Product>(), "prefix", entitlement),
+            new BigInteger("1234"), keyPair, false);
 
         verify(mockedPKI).createX509Certificate(
             any(String.class),
@@ -525,7 +542,9 @@ public class DefaultEntitlementCertServiceAdapterTest {
         owner.setContentPrefix("");
 
         certServiceAdapter.createX509Certificate(entitlement,
-            product, new HashSet<Product>(), new BigInteger("1234"), keyPair, true);
+            product, new HashSet<Product>(),
+            getProductModels(product, new HashSet<Product>(), "prefix", entitlement),
+            new BigInteger("1234"), keyPair, true);
 
         verify(mockedPKI).createX509Certificate(any(String.class),
             argThat(new ListContainsContentUrl(CONTENT_URL, CONTENT_ID)),
@@ -538,7 +557,9 @@ public class DefaultEntitlementCertServiceAdapterTest {
         owner.setContentPrefix(null);
 
         certServiceAdapter.createX509Certificate(entitlement,
-            product, new HashSet<Product>(), new BigInteger("1234"), keyPair, true);
+            product, new HashSet<Product>(),
+            getProductModels(product, new HashSet<Product>(), "prefix", entitlement),
+            new BigInteger("1234"), keyPair, true);
 
         verify(mockedPKI).createX509Certificate(any(String.class),
             argThat(new ListContainsContentUrl(CONTENT_URL, CONTENT_ID)),
@@ -610,7 +631,9 @@ public class DefaultEntitlementCertServiceAdapterTest {
         throws Exception {
 
         certServiceAdapter.createX509Certificate(entitlement,
-            product, new HashSet<Product>(), new BigInteger("1234"), keyPair, true);
+            product, new HashSet<Product>(),
+            getProductModels(product, new HashSet<Product>(), "prefix", entitlement),
+            new BigInteger("1234"), keyPair, true);
 
         verify(mockedPKI).createX509Certificate(any(String.class),
             argThat(new ListContainsContentExtensions()), any(Set.class), any(Date.class),
@@ -623,7 +646,9 @@ public class DefaultEntitlementCertServiceAdapterTest {
         throws Exception {
 
         certServiceAdapter.createX509Certificate(entitlement,
-            product, new HashSet<Product>(), new BigInteger("1234"), keyPair, true);
+            product, new HashSet<Product>(),
+            getProductModels(product, new HashSet<Product>(), "prefix", entitlement),
+            new BigInteger("1234"), keyPair, true);
 
         verify(mockedPKI).createX509Certificate(any(String.class),
             argThat(new ListContainsEntitlementExtensions()), any(Set.class),
@@ -635,7 +660,9 @@ public class DefaultEntitlementCertServiceAdapterTest {
     public void managementDisabledByDefault() throws Exception {
 
         certServiceAdapter.createX509Certificate(entitlement,
-            product, new HashSet<Product>(), new BigInteger("1234"), keyPair, true);
+            product, new HashSet<Product>(),
+            getProductModels(product, new HashSet<Product>(), "prefix", entitlement),
+            new BigInteger("1234"), keyPair, true);
 
         verify(mockedPKI).createX509Certificate(any(String.class),
             argThat(new ListContainsProvidesManagement("0")), any(Set.class),
@@ -648,7 +675,9 @@ public class DefaultEntitlementCertServiceAdapterTest {
 
         pool.addProductAttribute(new ProductPoolAttribute("management_enabled", "1", "p"));
         certServiceAdapter.createX509Certificate(entitlement,
-            product, new HashSet<Product>(), new BigInteger("1234"), keyPair, true);
+            product, new HashSet<Product>(),
+            getProductModels(product, new HashSet<Product>(), "prefix", entitlement),
+            new BigInteger("1234"), keyPair, true);
 
         verify(mockedPKI).createX509Certificate(any(String.class),
             argThat(new ListContainsProvidesManagement("1")), any(Set.class),
@@ -661,7 +690,9 @@ public class DefaultEntitlementCertServiceAdapterTest {
 
         pool.addProductAttribute(new ProductPoolAttribute("stacking_id", "3456", "p"));
         certServiceAdapter.createX509Certificate(entitlement,
-            product, new HashSet<Product>(), new BigInteger("1234"), keyPair, true);
+            product, new HashSet<Product>(),
+            getProductModels(product, new HashSet<Product>(), "prefix", entitlement),
+            new BigInteger("1234"), keyPair, true);
 
         verify(mockedPKI).createX509Certificate(any(String.class),
             argThat(new ListContainsStackingId("3456")), any(Set.class), any(Date.class),
@@ -674,7 +705,9 @@ public class DefaultEntitlementCertServiceAdapterTest {
         PoolAttribute attr = new PoolAttribute("virt_only", "true");
         entitlement.getPool().addAttribute(attr);
         certServiceAdapter.createX509Certificate(entitlement,
-            product, new HashSet<Product>(), new BigInteger("1234"), keyPair, true);
+            product, new HashSet<Product>(),
+            getProductModels(product, new HashSet<Product>(), "prefix", entitlement),
+            new BigInteger("1234"), keyPair, true);
 
         verify(mockedPKI).createX509Certificate(any(String.class),
             argThat(new ListContainsVirtOnlyKey("1")), any(Set.class), any(Date.class),
@@ -687,7 +720,9 @@ public class DefaultEntitlementCertServiceAdapterTest {
         //note that "true" gets recoded to "1" to match other bools in the cert
         pool.setOrderNumber("this_order");
         certServiceAdapter.createX509Certificate(entitlement,
-            product, new HashSet<Product>(), new BigInteger("1234"), keyPair, true);
+            product, new HashSet<Product>(),
+            getProductModels(product, new HashSet<Product>(), "prefix", entitlement),
+            new BigInteger("1234"), keyPair, true);
 
         verify(mockedPKI).createX509Certificate(any(String.class),
             argThat(new ListContainsOrderNumberKey("this_order")), any(Set.class),
@@ -702,7 +737,9 @@ public class DefaultEntitlementCertServiceAdapterTest {
         pool.setProductAttribute("support_type", "Level 3", "p");
 
         certServiceAdapter.createX509Certificate(entitlement,
-            product, new HashSet<Product>(), new BigInteger("1234"), keyPair, true);
+            product, new HashSet<Product>(),
+            getProductModels(product, new HashSet<Product>(), "prefix", entitlement),
+            new BigInteger("1234"), keyPair, true);
 
         verify(mockedPKI).createX509Certificate(any(String.class),
             argThat(new ListContainsSupportLevel("Premium")), any(Set.class),
@@ -735,7 +772,9 @@ public class DefaultEntitlementCertServiceAdapterTest {
                 mockConfig);
 
         entAdapter.createX509Certificate(entitlement, product,
-            new HashSet<Product>(), new BigInteger("1234"), keyPair, true);
+            new HashSet<Product>(),
+            getProductModels(product, new HashSet<Product>(), "prefix", entitlement),
+            new BigInteger("1234"), keyPair, true);
     }
 
     @Test
@@ -743,7 +782,9 @@ public class DefaultEntitlementCertServiceAdapterTest {
         throws Exception {
 
         certServiceAdapter.createX509Certificate(entitlement,
-            product, new HashSet<Product>(), new BigInteger("1234"), keyPair, true);
+            product, new HashSet<Product>(),
+            getProductModels(product, new HashSet<Product>(), "prefix", entitlement),
+            new BigInteger("1234"), keyPair, true);
 
         verify(mockedPKI).createX509Certificate(any(String.class),
             argThat(new ListDoesNotContainSupportLevel()), any(Set.class), any(Date.class),
@@ -773,11 +814,13 @@ public class DefaultEntitlementCertServiceAdapterTest {
                 mockConfig);
 
         entAdapter.createX509Certificate(entitlement,
-            product, new HashSet<Product>(), new BigInteger("1234"), keyPair, true);
+            product, new HashSet<Product>(),
+            getProductModels(product, new HashSet<Product>(), "prefix", entitlement),
+            new BigInteger("1234"), keyPair, true);
         verify(mockV3extensionUtil).getExtensions(eq(entitlement), any(String.class),
             any(Map.class));
-        verify(mockV3extensionUtil).getByteExtensions(eq(product), any(Set.class),
-            eq(entitlement), any(String.class), any(Map.class));
+        verify(mockV3extensionUtil).getByteExtensions(eq(product),
+                any(List.class), eq(entitlement), any(String.class), any(Map.class));
         verifyZeroInteractions(mockExtensionUtil);
     }
 
@@ -803,10 +846,12 @@ public class DefaultEntitlementCertServiceAdapterTest {
                 mockConfig);
 
         entAdapter.createX509Certificate(entitlement,
-            product, new HashSet<Product>(), new BigInteger("1234"), keyPair, true);
+            product, new HashSet<Product>(),
+            getProductModels(product, new HashSet<Product>(), "prefix", entitlement),
+            new BigInteger("1234"), keyPair, true);
         verify(mockV3extensionUtil).getExtensions(eq(entitlement), any(String.class),
             any(Map.class));
-        verify(mockV3extensionUtil).getByteExtensions(eq(product), any(Set.class),
+        verify(mockV3extensionUtil).getByteExtensions(eq(product), any(List.class),
             eq(entitlement), any(String.class), any(Map.class));
         verifyZeroInteractions(mockExtensionUtil);
     }
@@ -830,7 +875,9 @@ public class DefaultEntitlementCertServiceAdapterTest {
                 mockConfig);
 
         entAdapter.createX509Certificate(entitlement,
-            product, new HashSet<Product>(), new BigInteger("1234"), keyPair, true);
+            product, new HashSet<Product>(),
+            getProductModels(product, new HashSet<Product>(), "prefix", entitlement),
+            new BigInteger("1234"), keyPair, true);
         // Verify v1
         verify(mockExtensionUtil).consumerExtensions(eq(consumer));
         verifyZeroInteractions(mockV3extensionUtil);
@@ -854,10 +901,12 @@ public class DefaultEntitlementCertServiceAdapterTest {
                 mockConfig);
 
         entAdapter.createX509Certificate(entitlement,
-            product, new HashSet<Product>(), new BigInteger("1234"), keyPair, true);
+            product, new HashSet<Product>(),
+            getProductModels(product, new HashSet<Product>(), "prefix", entitlement),
+            new BigInteger("1234"), keyPair, true);
         verify(mockV3extensionUtil).getExtensions(eq(entitlement), any(String.class),
             any(Map.class));
-        verify(mockV3extensionUtil).getByteExtensions(eq(product), any(Set.class),
+        verify(mockV3extensionUtil).getByteExtensions(eq(product), any(List.class),
             eq(entitlement), any(String.class), any(Map.class));
         verifyZeroInteractions(mockExtensionUtil);
     }
@@ -1117,6 +1166,15 @@ public class DefaultEntitlementCertServiceAdapterTest {
         assertFalse(extMapHasContentType(unknownTypeContent, extMap, "null"));
     }
 
+    private List<org.candlepin.json.model.Product> getProductModels(Product sku,
+            Set<Product> providedProducts, String prefix, Entitlement e) {
+        List<org.candlepin.json.model.Product> productModels =
+                v3extensionUtil.createProducts(sku, providedProducts, prefix,
+                        new HashMap<String, EnvironmentContent>(),
+                        e.getConsumer(), e);
+        return productModels;
+    }
+
     @Test
     public void testPrepareV3EntitlementData() throws IOException,
         GeneralSecurityException {
@@ -1152,7 +1210,8 @@ public class DefaultEntitlementCertServiceAdapterTest {
         assertEquals(map.get("1.3.6.1.4.1.2312.9.6").getValue(), ("3.2"));
 
         byte[] payload = v3extensionUtil.createEntitlementDataPayload(product,
-                products, entitlement, "prefix", null);
+                getProductModels(product, products, "prefix", entitlement),
+                entitlement, "prefix", null);
         String stringValue = "";
         try {
             stringValue = processPayload(payload);
@@ -1264,7 +1323,8 @@ public class DefaultEntitlementCertServiceAdapterTest {
             map.put(ext.getOid(), ext);
         }
 
-        byte[] payload = v3extensionUtil.createEntitlementDataPayload(product, products,
+        byte[] payload = v3extensionUtil.createEntitlementDataPayload(product,
+                getProductModels(product, products, "prefix", entitlement),
                 entitlement, "prefix", null);
         String stringValue = "";
         try {
@@ -1327,7 +1387,8 @@ public class DefaultEntitlementCertServiceAdapterTest {
         assertTrue(map.containsKey("1.3.6.1.4.1.2312.9.6"));
         assertEquals(map.get("1.3.6.1.4.1.2312.9.6").getValue(), ("3.2"));
 
-        byte[] payload = v3extensionUtil.createEntitlementDataPayload(product, products,
+        byte[] payload = v3extensionUtil.createEntitlementDataPayload(product,
+                getProductModels(product, products, "prefix", entitlement),
                 entitlement, "prefix", null);
         String stringValue = "";
         try {
@@ -1394,7 +1455,8 @@ public class DefaultEntitlementCertServiceAdapterTest {
         assertTrue(map.containsKey("1.3.6.1.4.1.2312.9.6"));
         assertEquals(map.get("1.3.6.1.4.1.2312.9.6").getValue(), ("3.2"));
 
-        byte[] payload = v3extensionUtil.createEntitlementDataPayload(product, products,
+        byte[] payload = v3extensionUtil.createEntitlementDataPayload(product,
+                getProductModels(product, products, "prefix", entitlement),
                 entitlement, "prefix", null);
         String stringValue = "";
         try {
@@ -1449,7 +1511,8 @@ public class DefaultEntitlementCertServiceAdapterTest {
         assertTrue(map.containsKey("1.3.6.1.4.1.2312.9.6"));
         assertEquals(map.get("1.3.6.1.4.1.2312.9.6").getValue(), ("3.2"));
 
-        byte[] payload = v3extensionUtil.createEntitlementDataPayload(product, products,
+        byte[] payload = v3extensionUtil.createEntitlementDataPayload(product,
+                getProductModels(product, products, "prefix", entitlement),
                 entitlement, "prefix", null);
         String stringValue = "";
         try {
@@ -1498,7 +1561,8 @@ public class DefaultEntitlementCertServiceAdapterTest {
         assertTrue(map.containsKey("1.3.6.1.4.1.2312.9.6"));
         assertEquals(map.get("1.3.6.1.4.1.2312.9.6").getValue(), ("3.2"));
 
-        byte[] payload = v3extensionUtil.createEntitlementDataPayload(product, products,
+        byte[] payload = v3extensionUtil.createEntitlementDataPayload(product,
+                getProductModels(product, products, "prefix", entitlement),
                 entitlement, "prefix", null);
         String stringValue = "";
         try {
@@ -1548,7 +1612,8 @@ public class DefaultEntitlementCertServiceAdapterTest {
         consumer.setFact("uname.machine", "x86_64");
 
         Set<X509ByteExtensionWrapper> byteExtensions =
-            certServiceAdapter.prepareV3ByteExtensions(product, products, entitlement,
+            certServiceAdapter.prepareV3ByteExtensions(product,
+                    getProductModels(product, products, "prefix", entitlement), entitlement,
                     "prefix", null);
         Map<String, X509ByteExtensionWrapper> byteMap =
             new HashMap<String, X509ByteExtensionWrapper>();
@@ -1590,7 +1655,9 @@ public class DefaultEntitlementCertServiceAdapterTest {
         consumer.setFact("system.certificate_version", "3.2");
 
         Set<X509ByteExtensionWrapper> byteExtensions =
-            certServiceAdapter.prepareV3ByteExtensions(product, products, entitlement,
+            certServiceAdapter.prepareV3ByteExtensions(product,
+                    getProductModels(product, products, "prefix", entitlement),
+                    entitlement,
                     "prefix", null);
         Map<String, X509ByteExtensionWrapper> byteMap =
             new HashMap<String, X509ByteExtensionWrapper>();
@@ -1625,7 +1692,8 @@ public class DefaultEntitlementCertServiceAdapterTest {
         consumer.setFact("system.certificate_version", "3.2");
 
         Set<X509ByteExtensionWrapper> byteExtensions =
-            certServiceAdapter.prepareV3ByteExtensions(product, products,
+            certServiceAdapter.prepareV3ByteExtensions(product,
+                    getProductModels(product, products, "prefix", largeContentEntitlement),
                     largeContentEntitlement, "prefix", null);
         Map<String, X509ByteExtensionWrapper> byteMap =
             new HashMap<String, X509ByteExtensionWrapper>();
@@ -1671,7 +1739,8 @@ public class DefaultEntitlementCertServiceAdapterTest {
 
         certServiceAdapter.prepareV3Extensions(entitlement, "prefix", null);
         Set<X509ByteExtensionWrapper> byteExtensions =
-            certServiceAdapter.prepareV3ByteExtensions(extremeProduct, products,
+            certServiceAdapter.prepareV3ByteExtensions(extremeProduct,
+                    getProductModels(extremeProduct, products, "prefix", entitlement),
                     entitlement, "prefix", null);
         Map<String, X509ByteExtensionWrapper> byteMap =
             new HashMap<String, X509ByteExtensionWrapper>();

--- a/server/src/test/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapterTest.java
+++ b/server/src/test/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapterTest.java
@@ -776,7 +776,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
             product, new HashSet<Product>(), new BigInteger("1234"), keyPair, true);
         verify(mockV3extensionUtil).getExtensions(eq(entitlement), any(String.class),
             any(Map.class));
-        verify(mockV3extensionUtil).getByteExtensions(any(Set.class),
+        verify(mockV3extensionUtil).getByteExtensions(eq(product), any(Set.class),
             eq(entitlement), any(String.class), any(Map.class));
         verifyZeroInteractions(mockExtensionUtil);
     }
@@ -806,7 +806,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
             product, new HashSet<Product>(), new BigInteger("1234"), keyPair, true);
         verify(mockV3extensionUtil).getExtensions(eq(entitlement), any(String.class),
             any(Map.class));
-        verify(mockV3extensionUtil).getByteExtensions(any(Set.class),
+        verify(mockV3extensionUtil).getByteExtensions(eq(product), any(Set.class),
             eq(entitlement), any(String.class), any(Map.class));
         verifyZeroInteractions(mockExtensionUtil);
     }
@@ -857,7 +857,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
             product, new HashSet<Product>(), new BigInteger("1234"), keyPair, true);
         verify(mockV3extensionUtil).getExtensions(eq(entitlement), any(String.class),
             any(Map.class));
-        verify(mockV3extensionUtil).getByteExtensions(any(Set.class),
+        verify(mockV3extensionUtil).getByteExtensions(eq(product), any(Set.class),
             eq(entitlement), any(String.class), any(Map.class));
         verifyZeroInteractions(mockExtensionUtil);
     }
@@ -1151,8 +1151,8 @@ public class DefaultEntitlementCertServiceAdapterTest {
         assertTrue(map.containsKey("1.3.6.1.4.1.2312.9.6"));
         assertEquals(map.get("1.3.6.1.4.1.2312.9.6").getValue(), ("3.2"));
 
-        byte[] payload = v3extensionUtil.createEntitlementDataPayload(products, entitlement,
-            "prefix", null);
+        byte[] payload = v3extensionUtil.createEntitlementDataPayload(product,
+                products, entitlement, "prefix", null);
         String stringValue = "";
         try {
             stringValue = processPayload(payload);
@@ -1264,8 +1264,8 @@ public class DefaultEntitlementCertServiceAdapterTest {
             map.put(ext.getOid(), ext);
         }
 
-        byte[] payload = v3extensionUtil.createEntitlementDataPayload(products, entitlement,
-            "prefix", null);
+        byte[] payload = v3extensionUtil.createEntitlementDataPayload(product, products,
+                entitlement, "prefix", null);
         String stringValue = "";
         try {
             stringValue = processPayload(payload);
@@ -1327,8 +1327,8 @@ public class DefaultEntitlementCertServiceAdapterTest {
         assertTrue(map.containsKey("1.3.6.1.4.1.2312.9.6"));
         assertEquals(map.get("1.3.6.1.4.1.2312.9.6").getValue(), ("3.2"));
 
-        byte[] payload = v3extensionUtil.createEntitlementDataPayload(products, entitlement,
-            "prefix", null);
+        byte[] payload = v3extensionUtil.createEntitlementDataPayload(product, products,
+                entitlement, "prefix", null);
         String stringValue = "";
         try {
             stringValue = processPayload(payload);
@@ -1394,8 +1394,8 @@ public class DefaultEntitlementCertServiceAdapterTest {
         assertTrue(map.containsKey("1.3.6.1.4.1.2312.9.6"));
         assertEquals(map.get("1.3.6.1.4.1.2312.9.6").getValue(), ("3.2"));
 
-        byte[] payload = v3extensionUtil.createEntitlementDataPayload(products, entitlement,
-            "prefix", null);
+        byte[] payload = v3extensionUtil.createEntitlementDataPayload(product, products,
+                entitlement, "prefix", null);
         String stringValue = "";
         try {
             stringValue = processPayload(payload);
@@ -1449,8 +1449,8 @@ public class DefaultEntitlementCertServiceAdapterTest {
         assertTrue(map.containsKey("1.3.6.1.4.1.2312.9.6"));
         assertEquals(map.get("1.3.6.1.4.1.2312.9.6").getValue(), ("3.2"));
 
-        byte[] payload = v3extensionUtil.createEntitlementDataPayload(products, entitlement,
-            "prefix", null);
+        byte[] payload = v3extensionUtil.createEntitlementDataPayload(product, products,
+                entitlement, "prefix", null);
         String stringValue = "";
         try {
             stringValue = processPayload(payload);
@@ -1498,8 +1498,8 @@ public class DefaultEntitlementCertServiceAdapterTest {
         assertTrue(map.containsKey("1.3.6.1.4.1.2312.9.6"));
         assertEquals(map.get("1.3.6.1.4.1.2312.9.6").getValue(), ("3.2"));
 
-        byte[] payload = v3extensionUtil.createEntitlementDataPayload(products, entitlement,
-            "prefix", null);
+        byte[] payload = v3extensionUtil.createEntitlementDataPayload(product, products,
+                entitlement, "prefix", null);
         String stringValue = "";
         try {
             stringValue = processPayload(payload);
@@ -1548,8 +1548,8 @@ public class DefaultEntitlementCertServiceAdapterTest {
         consumer.setFact("uname.machine", "x86_64");
 
         Set<X509ByteExtensionWrapper> byteExtensions =
-            certServiceAdapter.prepareV3ByteExtensions(products, entitlement, "prefix",
-                null);
+            certServiceAdapter.prepareV3ByteExtensions(product, products, entitlement,
+                    "prefix", null);
         Map<String, X509ByteExtensionWrapper> byteMap =
             new HashMap<String, X509ByteExtensionWrapper>();
         for (X509ByteExtensionWrapper ext : byteExtensions) {
@@ -1590,8 +1590,8 @@ public class DefaultEntitlementCertServiceAdapterTest {
         consumer.setFact("system.certificate_version", "3.2");
 
         Set<X509ByteExtensionWrapper> byteExtensions =
-            certServiceAdapter.prepareV3ByteExtensions(products, entitlement, "prefix",
-                null);
+            certServiceAdapter.prepareV3ByteExtensions(product, products, entitlement,
+                    "prefix", null);
         Map<String, X509ByteExtensionWrapper> byteMap =
             new HashMap<String, X509ByteExtensionWrapper>();
         for (X509ByteExtensionWrapper ext : byteExtensions) {
@@ -1625,8 +1625,8 @@ public class DefaultEntitlementCertServiceAdapterTest {
         consumer.setFact("system.certificate_version", "3.2");
 
         Set<X509ByteExtensionWrapper> byteExtensions =
-            certServiceAdapter.prepareV3ByteExtensions(products, largeContentEntitlement,
-                "prefix", null);
+            certServiceAdapter.prepareV3ByteExtensions(product, products,
+                    largeContentEntitlement, "prefix", null);
         Map<String, X509ByteExtensionWrapper> byteMap =
             new HashMap<String, X509ByteExtensionWrapper>();
         for (X509ByteExtensionWrapper ext : byteExtensions) {
@@ -1671,8 +1671,8 @@ public class DefaultEntitlementCertServiceAdapterTest {
 
         certServiceAdapter.prepareV3Extensions(entitlement, "prefix", null);
         Set<X509ByteExtensionWrapper> byteExtensions =
-            certServiceAdapter.prepareV3ByteExtensions(products, entitlement, "prefix",
-                null);
+            certServiceAdapter.prepareV3ByteExtensions(extremeProduct, products,
+                    entitlement, "prefix", null);
         Map<String, X509ByteExtensionWrapper> byteMap =
             new HashMap<String, X509ByteExtensionWrapper>();
         for (X509ByteExtensionWrapper ext : byteExtensions) {

--- a/server/src/test/java/org/candlepin/util/X509V3ExtensionUtilTest.java
+++ b/server/src/test/java/org/candlepin/util/X509V3ExtensionUtilTest.java
@@ -15,7 +15,7 @@
 package org.candlepin.util;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 
 import org.candlepin.common.config.Configuration;
@@ -146,8 +146,8 @@ public class X509V3ExtensionUtilTest {
         Entitlement e = new Entitlement(pool, consumer, 10);
         when(psa.getProductById(eq("mkt"))).thenReturn(mktProd);
 
-        List<org.candlepin.json.model.Product> certProds = util.createProducts(prods, "",
-            new HashMap<String, EnvironmentContent>(),  new Consumer(), e);
+        List<org.candlepin.json.model.Product> certProds = util.createProducts(mktProd,
+                prods, "", new HashMap<String, EnvironmentContent>(),  new Consumer(), e);
 
         assertEquals(1, certProds.size());
         assertEquals(brandedName, certProds.get(0).getBrandName());
@@ -174,8 +174,8 @@ public class X509V3ExtensionUtilTest {
         Entitlement e = new Entitlement(pool, consumer, 10);
         when(psa.getProductById(eq("mkt"))).thenReturn(mktProd);
 
-        List<org.candlepin.json.model.Product> certProds = util.createProducts(prods, "",
-            new HashMap<String, EnvironmentContent>(),  new Consumer(), e);
+        List<org.candlepin.json.model.Product> certProds = util.createProducts(mktProd,
+                prods, "", new HashMap<String, EnvironmentContent>(),  new Consumer(), e);
 
         assertEquals(1, certProds.size());
         // Should get the first name we encountered


### PR DESCRIPTION
Eliminate a db lookup for the exact same SKU product being run twice per content set when generating entitlement certificates, leading to substantial performance improvements.

Also includes a more minor fix to stop filtering the content twice. This only saves a second or so but it was the next highest hit and completely unnecessary.

Using test SKU with ~2600 content sets, bind time was 10.8 seconds. After these changes we're down to 2.2s.

The latter patch is getting a bit messy because the V1 / V3 code split is messy and really needs a refactor. Going to attempt to do this on 2.0 / per-org products branch and limit changes to this 0.9.x stream, so went with the messy but fast approach here.