### PR TITLE
Fixed cmv usage output omitting commands

### DIFF
--- a/server/bin/cmv
+++ b/server/bin/cmv
@@ -280,7 +280,7 @@ class VerifyCommand < CMVCommand
                 puts "\n#{message}\n"
             end
 
-            puts "\nDeployment failed validation against snapshot #{options[:file]} with #{messages.length} messages\n"
+            puts "\nDeployment failed validation against snapshot #{options[:file]} with #{messages.length} message(s)\n"
         end
     end
 
@@ -504,6 +504,8 @@ optparse.parse!
 
 if ARGV.empty?
     puts optparse
+    puts
+    print_commands(commands)
     exit
 else
     candlepin = Candlepin.new(


### PR DESCRIPTION
- The default usage message now displays the commands in addition
  to the options
- Fixed a grammar issue in the verify command's output