### PR TITLE
Added per-org/product pool refreshing and by-product owner lookups

### DIFF
--- a/server/client/ruby/candlepin_api.rb
+++ b/server/client/ruby/candlepin_api.rb
@@ -240,6 +240,16 @@ class Candlepin
     get(url)
   end
 
+  def get_owners_with_product(product_ids = [])
+    path = "/products/owners?"
+
+    product_ids.each do |pid|
+      path << "product=#{pid}&"
+    end
+
+    return get(path)
+  end
+
   def create_owner(key, params={})
     parent = params[:parent] || nil
     name = params['name'] || key
@@ -626,6 +636,16 @@ class Candlepin
       url << "product=#{pid}&"
     end
     get(url)
+  end
+
+  def refresh_pools_for_orgs_with_product(product_ids, immediate=false, lazy_regen=true)
+    url = "/products/subscriptions?"
+    product_ids.each do |pid|
+      url << "product=#{pid}&"
+    end
+    url << "lazy_regen=false&" if !lazy_regen
+
+    put(url)
   end
 
   def refresh_pools_for_product(owner_key, product_id, immediate=false, lazy_regen=true)

--- a/server/spec/product_resource_spec.rb
+++ b/server/spec/product_resource_spec.rb
@@ -40,9 +40,175 @@ describe 'Product Resource' do
     lambda do
       @cp.delete("/products/dummyid")
     end.should raise_exception(RestClient::BadRequest)
+  end
 
+  def setupOrgProductsAndPools()
+    owner1 = create_owner(random_string("owner"))
+    owner2 = create_owner(random_string("owner"))
+    owner3 = create_owner(random_string("owner"))
+
+    prod1o1 = create_product("p1", "p1", { :owner => owner1['key'] })
+    prod1o2 = create_product("p1", "p1", { :owner => owner2['key'] })
+    prod1o3 = create_product("p1", "p1", { :owner => owner3['key'] })
+
+    prod2o1 = create_product("p2", "p2", { :owner => owner1['key'] })
+    prod2o2 = create_product("p2", "p2", { :owner => owner2['key'] })
+
+    prod3o2 = create_product("p3", "p3", { :owner => owner2['key'] })
+    prod3o3 = create_product("p3", "p3", { :owner => owner3['key'] })
+
+    prod4 = create_product("p4", "p4", { :owner => owner1['key'] })
+    prod4d = create_product("p4d", "p4d", { :owner => owner1['key'] })
+    prod5 = create_product("p5", "p5", { :owner => owner2['key'] })
+    prod5d = create_product("p5d", "p5d", { :owner => owner2['key'] })
+    prod6 = create_product("p6", "p6", { :owner => owner3['key'] })
+    prod6d = create_product("p6d", "p6d", { :owner => owner3['key'] })
+
+    @cp.create_pool(owner1['key'], "p4", {
+      :derived_product_id         => "p4d",
+      :provided_products          => ["p1"],
+      :derived_provided_products  => ["p2"]
+    });
+
+    @cp.create_pool(owner2['key'], "p5", {
+      :derived_product_id         => "p5d",
+      :provided_products          => ["p1", "p2"],
+      :derived_provided_products  => ["p3"]
+    });
+
+    @cp.create_pool(owner3['key'], "p6", {
+      :derived_product_id         => "p6d",
+      :provided_products          => ["p1"],
+      :derived_provided_products  => ["p3"]
+    });
+
+    return [owner1, owner2, owner3]
+  end
+
+  it 'retrieves owners by product' do
+    owners = setupOrgProductsAndPools()
+    owner1 = owners[0]
+    owner2 = owners[1]
+    owner3 = owners[2]
+
+    result = @cp.get_owners_with_product(["p4"])
+    result.should_not be_nil
+    result.length.should == 1
+    result[0]['key'].should == owner1['key']
+
+    result = @cp.get_owners_with_product(["p5d"])
+    result.should_not be_nil
+    result.length.should == 1
+    result[0]['key'].should == owner2['key']
+
+    result = @cp.get_owners_with_product(["p1"])
+    result.should_not be_nil
+    result.length.should == 3
+
+    [owner1, owner2, owner3].each do |owner|
+      found = false
+      result.each do |recv|
+        if recv['key'] == owner['key'] then
+          found = true
+          break
+        end
+      end
+
+      found.should == true
+    end
+
+    result = @cp.get_owners_with_product(["p3"])
+    result.should_not be_nil
+    result.length.should == 2
+
+    [owner2, owner3].each do |owner|
+      found = false
+      result.each do |recv|
+        if recv['key'] == owner['key'] then
+          found = true
+          break
+        end
+      end
+
+      found.should == true
+    end
+
+    result = @cp.get_owners_with_product(["p4", "p6"])
+    result.should_not be_nil
+    result.length.should == 2
+
+    [owner1, owner3].each do |owner|
+      found = false
+      result.each do |recv|
+        if recv['key'] == owner['key'] then
+          found = true
+          break
+        end
+      end
+
+      found.should == true
+    end
+
+    result = @cp.get_owners_with_product(["nope"])
+    result.should_not be_nil
+    result.length.should == 0
+  end
+
+  it "refreshes pools for orgs owning products" do
+    owners = setupOrgProductsAndPools()
+    owner1 = owners[0]
+    owner2 = owners[1]
+    owner3 = owners[2]
+
+    # Override enabled to true:
+    jobs = @cp.refresh_pools_for_orgs_with_product(["p4"])
+    jobs.length.should == 1
+    jobs.each do |job|
+      job['id'].should include("refresh_pools")
+      wait_for_job(job['id'], 15)
+    end
+
+    jobs = @cp.refresh_pools_for_orgs_with_product(["p5d"])
+    jobs.length.should == 1
+    jobs.each do |job|
+      job['id'].should include("refresh_pools")
+      wait_for_job(job['id'], 15)
+    end
+
+    jobs = @cp.refresh_pools_for_orgs_with_product(["p1"])
+    jobs.length.should == 3
+    jobs.each do |job|
+      job['id'].should include("refresh_pools")
+      wait_for_job(job['id'], 15)
+    end
+
+    jobs = @cp.refresh_pools_for_orgs_with_product(["p3"])
+    jobs.length.should == 2
+    jobs.each do |job|
+      job['id'].should include("refresh_pools")
+      wait_for_job(job['id'], 15)
+    end
+
+    jobs = @cp.refresh_pools_for_orgs_with_product(["p4", "p6"])
+    jobs.length.should == 2
+    jobs.each do |job|
+      job['id'].should include("refresh_pools")
+      wait_for_job(job['id'], 15)
+    end
+
+    jobs = @cp.refresh_pools_for_orgs_with_product(["nope"])
+    jobs.length.should == 0
+  end
+
+  it 'throws exception on get_owners with no products' do
     lambda do
-      @cp.put("/products/dummyid/subscriptions", {})
+      @cp.put("/products/owners", {})
+    end.should raise_exception(RestClient::BadRequest)
+  end
+
+  it 'throws exception on refresh with no products' do
+    lambda do
+      @cp.put("/products/subscriptions", {})
     end.should raise_exception(RestClient::BadRequest)
   end
 

--- a/server/src/main/java/org/candlepin/resource/OwnerProductResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerProductResource.java
@@ -453,26 +453,6 @@ public class OwnerProductResource {
                                 ResourceDateParser.parseDateString(to));
     }
 
-    // TODO: Not sure what use this method has before OR after multiorg.
-    // /**
-    //  * Retrieves a list of Owners by Product
-    //  *
-    //  * @return a list of Owner objects
-    //  * @httpcode 200
-    //  * @httpcode 400
-    //  */
-    // @GET
-    // @Path("/owners")
-    // @Produces(MediaType.APPLICATION_JSON)
-    // public List<Owner> getActiveProductOwners(@QueryParam("product") String[] productId) {
-    //     List<String> ids = Arrays.asList(productId);
-    //     if (ids.isEmpty()) {
-    //         throw new BadRequestException(i18n.tr("Must specify product ID."));
-    //     }
-
-    //     return ownerCurator.lookupOwnersByActiveProduct(ids);
-    // }
-
     /**
      * Refreshes Pools by Product
      *


### PR DESCRIPTION
- Added a new/fixed an old API call to ProductResource to lookup owners
  for a given product or list thereof
- The refresh pools operation can now be triggered on a per-org basis by
  specifying changed products
- Added new methods to candlepin_api.rb: get_owners_with_products and
  refresh_pools_for_orgs_with_product
- Updated and added spec tests