### PR TITLE
Do not calculate compliance status if there are no installed products.

### DIFF
--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -2042,6 +2042,17 @@ public class ConsumerResource {
 
     private void addDataToInstalledProducts(Consumer consumer) {
 
+        if (consumer.getInstalledProducts().size() == 0) {
+            /*
+             * No installed products implies nothing to enrich.
+             *
+             * Distributors can have many entitlements, but no installed products.
+             * Calculating the status can be quite expensive but the data isn't
+             * actually used if there's nothing installed.
+             */
+            return;
+        }
+
         ComplianceStatus complianceStatus = complianceRules.getStatus(consumer, null, false);
 
         ConsumerInstalledProductEnricher enricher = new ConsumerInstalledProductEnricher(


### PR DESCRIPTION
Big performance optimization for distributors which can have many entitlements
but no installed products. Looking up the consumer would then result in a huge
chunk of serialization to the compliance rules to calculate data we then did
nothing with.

No installed products = skip adding data to installed products.