### PR TITLE
 Added filter options to Consumer/Entitlement resource ent lookups

### DIFF
--- a/server/client/ruby/candlepin_api.rb
+++ b/server/client/ruby/candlepin_api.rb
@@ -743,8 +743,30 @@ class Candlepin
     path << "per_page=#{params[:per_page]}&" if params[:per_page]
     path << "order=#{params[:order]}&" if params[:order]
     path << "sort_by=#{params[:sort_by]}&" if params[:sort_by]
+
+    attr_filters = params[:attr_filters] || []
+    attr_filters.each do | attr_name, attr_value |
+      path << "attribute=#{attr_name}:#{attr_value}&"
+    end
+    path << "matches=#{params[:matches]}" if params[:matches]
     results = get(path)
     return results
+  end
+
+  # NOTE: Purely for testing via the entitlement resource.
+  #       Very similar to list_entitlements above (consumer resource)
+  def list_ents_via_entitlements_resource(params={})
+    path = "/entitlements?"
+    path << "consumer=#{params[:consumer_uuid]}&" if params[:consumer_uuid]
+
+    attr_filters = params[:attr_filters] || []
+    attr_filters.each do | attr_name, attr_value |
+      path << "attribute=#{attr_name}:#{attr_value}&"
+    end
+
+    path << "matches=#{params[:matches]}" if params[:matches]
+    puts path
+    get(path)
   end
 
   def list_pool_entitlements(pool_id, params={})

--- a/server/spec/consumer_resource_spec.rb
+++ b/server/spec/consumer_resource_spec.rb
@@ -20,6 +20,38 @@ describe 'Consumer Resource' do
     @consumer2 = consumer_client(@user2, random_string("consumer2"))
   end
 
+  it 'should receive paged data back when requested' do
+    id_list = []
+    (1..4).each do |i|
+      prod = create_product(nil, nil, { :owner => @owner1['key'] })
+      @cp.create_subscription(@owner1['key'], prod.id, 6)
+      id_list.push(prod.id)
+    end
+    @cp.refresh_pools(@owner1['key'])
+
+    id_list.each do |id|
+      @consumer1.consume_product(id)
+    end
+
+    entitlements = @consumer1.list_entitlements({:page => 1, :per_page => 2, :sort_by => "id", :order => "asc"})
+    entitlements.length.should == 2
+    (entitlements[0].id <=> entitlements[1].id).should == -1
+  end
+
+  it 'does not allow a consumer to view entitlements from a different consumer' do
+    # Given
+    bad_owner = create_owner random_string 'baddie'
+    bad_user = user_client(bad_owner, 'bad_dude')
+    system = consumer_client(bad_user, 'wrong_system')
+
+    # When
+    lambda do
+      system.list_entitlements(:uuid => @consumer1.uuid)
+
+      # Then
+    end.should raise_exception(RestClient::ResourceNotFound)
+  end
+
   it "should block consumers from using other org's pools" do
     product_id = random_string('prod')
     product = create_product(product_id, product_id, {:owner => @owner1['key']})

--- a/server/spec/entitlement_resource_spec.rb
+++ b/server/spec/entitlement_resource_spec.rb
@@ -7,7 +7,8 @@ describe 'Entitlement Resource' do
 
   before do
     @owner = create_owner random_string 'test_owner'
-    @monitoring_prod = create_product(nil, 'monitoring')
+    @monitoring_prod = create_product(nil, 'monitoring',
+      :attributes => { 'variant' => "Satellite Starter Pack" })
     @virt_prod= create_product(nil, 'virtualization')
 
     #entitle owner for the virt and monitoring products.
@@ -24,22 +25,33 @@ describe 'Entitlement Resource' do
     @qowner = create_owner random_string 'test_owner'
   end
 
-  it 'should receive paged data back when requested' do
-    id_list = []
-    (1..4).each do |i|
-      prod = create_product()
-      @cp.create_subscription(@owner['key'], prod.id, 6)
-      id_list.push(prod.id)
-    end
-    @cp.refresh_pools(@owner['key'])
+  it 'can filter entitlements by product attribute' do
+    @system.consume_product(@monitoring_prod.id)
+    @system.consume_product(@virt_prod.id)
+    @cp.list_ents_via_entitlements_resource(:consumer_uuid => @system.uuid).should have(2).things
 
-    id_list.each do |id|
-      @system.consume_product(id)
-    end
+    ents = @cp.list_ents_via_entitlements_resource(:consumer_uuid => @system.uuid,
+      :attr_filters => { "variant" => "Satellite Starter Pack" })
+    ents.should have(1).things
 
-    entitlements = @system.list_entitlements({:page => 1, :per_page => 2, :sort_by => "id", :order => "asc"})
-    entitlements.length.should == 2
-    (entitlements[0].id <=> entitlements[1].id).should == -1
+    found_attr = false
+    ents[0].pool.productAttributes.each do |attr|
+      if attr["name"] == 'variant' && attr["value"] == "Satellite Starter Pack"
+        found_attr = true
+        break
+      end
+    end
+    found_attr.should == true
+  end
+
+  it 'can filter entitlements by using matches param' do
+    @system.consume_product(@monitoring_prod.id)
+    @system.consume_product(@virt_prod.id)
+    @cp.list_ents_via_entitlements_resource(:consumer_uuid => @system.uuid).should have(2).things
+
+    ents = @cp.list_ents_via_entitlements_resource(:consumer_uuid => @system.uuid,
+      :matches => "virtualization")
+    ents.should have(1).things
   end
 
   it 'should allow entitlement certificate regeneration based on product id' do
@@ -77,20 +89,6 @@ describe 'Entitlement Resource' do
   it 'allows listing certificates by serial numbers' do
     @system.consume_product(@monitoring_prod.id)
     @system.list_certificate_serials.length.should == 1
-  end
-
-  it 'does not allow a consumer to view entitlements from a different consumer' do
-    # Given
-    bad_owner = create_owner random_string 'baddie'
-    bad_user = user_client(bad_owner, 'bad_dude')
-    system2 = consumer_client(bad_user, 'wrong_system')
-
-    # When
-    lambda do
-      system2.list_entitlements(:uuid => @system.uuid)
-
-      # Then
-    end.should raise_exception(RestClient::ResourceNotFound)
   end
 
   it 'should allow consumer to change entitlement quantity' do

--- a/server/src/main/java/org/candlepin/model/EntitlementCurator.java
+++ b/server/src/main/java/org/candlepin/model/EntitlementCurator.java
@@ -73,12 +73,18 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
     }
 
     public Page<List<Entitlement>> listByConsumer(Consumer consumer,
-        PageRequest pageRequest) {
-        Criteria query = createSecureCriteria()
-            .createAlias("pool", "p")
-            .add(Restrictions.eq("consumer", consumer))
-            // Never show a consumer expired entitlements
-            .add(Restrictions.ge("p.endDate", new Date()));
+        EntitlementFilterBuilder filterBuilder, PageRequest pageRequest) {
+        Criteria query = createSecureCriteria().createAlias("pool", "p");
+        if (filterBuilder.hasMatchFilters()) {
+            query.createAlias("p.product", "product");
+            query.createAlias("p.providedProducts", "provProd", CriteriaSpecification.LEFT_JOIN);
+            query.createAlias("provProd.productContent", "ppcw", CriteriaSpecification.LEFT_JOIN);
+            query.createAlias("ppcw.content", "ppContent", CriteriaSpecification.LEFT_JOIN);
+        }
+        query.add(Restrictions.eq("consumer", consumer));
+        // Never show a consumer expired entitlements
+        query.add(Restrictions.ge("p.endDate", new Date()));
+        filterBuilder.applyTo(query);
         return listByCriteria(query, pageRequest);
     }
 
@@ -90,13 +96,27 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
      */
     @SuppressWarnings("unchecked")
     public List<Entitlement> listByConsumer(Consumer consumer) {
-        return createSecureCriteria()
-            .createAlias("pool", "p")
-            .add(Restrictions.eq("consumer", consumer))
-            // Never show a consumer expired entitlements
-            .add(Restrictions.ge("p.endDate", new Date()))
-            .addOrder(Order.asc("p.id"))
-            .list();
+        return listByConsumer(consumer, new EntitlementFilterBuilder());
+    }
+
+    @SuppressWarnings("unchecked")
+    public List<Entitlement> listByConsumer(Consumer consumer, EntitlementFilterBuilder filters) {
+        Criteria c = createSecureCriteria();
+        c.createAlias("pool", "p");
+
+        // Add the required aliases for the filter builder only if required.
+        if (filters.hasMatchFilters()) {
+            c.createAlias("p.product", "product");
+            c.createAlias("p.providedProducts", "provProd", CriteriaSpecification.LEFT_JOIN);
+            c.createAlias("provProd.productContent", "ppcw", CriteriaSpecification.LEFT_JOIN);
+            c.createAlias("ppcw.content", "ppContent", CriteriaSpecification.LEFT_JOIN);
+        }
+        c.add(Restrictions.eq("consumer", consumer));
+        // Never show a consumer expired entitlements
+        c.add(Restrictions.ge("p.endDate", new Date()));
+        filters.applyTo(c);
+        c.addOrder(Order.asc("p.id"));
+        return c.list();
     }
 
     public List<Entitlement> listByEnvironment(Environment environment) {
@@ -398,6 +418,12 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
             .addOrder(Order.asc("created")) // eldest entitlement
             .setMaxResults(1);
         return (Entitlement) activeNowQuery.uniqueResult();
+    }
+
+    public Page<List<Entitlement>> listAll(EntitlementFilterBuilder filters, PageRequest pageRequest) {
+        Criteria criteria = createSecureCriteria();
+        filters.applyTo(criteria);
+        return listByCriteria(criteria, pageRequest);
     }
 
 }

--- a/server/src/main/java/org/candlepin/model/EntitlementFilterBuilder.java
+++ b/server/src/main/java/org/candlepin/model/EntitlementFilterBuilder.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package org.candlepin.model;
+
+/**
+ * A filter builder that allows filtering Entitlements based on it's pools product
+ * attributes. When using this builder, a criteria is expected to have the Pool
+ * class aliased as 'p'.
+ */
+public class EntitlementFilterBuilder extends PoolFilterBuilder {
+
+    public EntitlementFilterBuilder() {
+        // Requires that the parent criteria has an alias set on the Pool class.
+        super("p");
+    }
+
+}

--- a/server/src/main/java/org/candlepin/model/PoolFilterBuilder.java
+++ b/server/src/main/java/org/candlepin/model/PoolFilterBuilder.java
@@ -17,6 +17,7 @@ package org.candlepin.model;
 import com.google.common.base.Function;
 import com.google.common.collect.Lists;
 
+import org.hibernate.Criteria;
 import org.hibernate.criterion.Conjunction;
 import org.hibernate.criterion.Criterion;
 import org.hibernate.criterion.DetachedCriteria;
@@ -39,21 +40,50 @@ import java.util.List;
  */
 public class PoolFilterBuilder extends FilterBuilder {
 
+    private String alias = "";
+    private List<String> matchFilters = new ArrayList<String>();
+
+    public PoolFilterBuilder() {
+        super();
+    }
+
+    public PoolFilterBuilder(String aliasName) {
+        this.alias = aliasName + ".";
+    }
+
+    @Override
+    public void applyTo(Criteria parentCriteria) {
+        for (String matches : matchFilters) {
+            applyMatchFilter(matches);
+        }
+        super.applyTo(parentCriteria);
+    }
+
     /**
      * Add filters to search only for pools matching the given text. A number of
      * fields on the pool are searched including it's SKU, SKU product name,
      * contract number, SLA, and provided (engineering) product IDs and their names.
      *
+     * NOTE: Parent criteria requires that an alias exists for pool.product,
+     * pool.providedProduct and pool.providedProductContent.
+     *
      * @param matches Text to search for in various fields on the pool. Basic
      * wildcards are supported for everything or a single character. (* and ? respectively)
      */
     public void addMatchesFilter(String matches) {
+        this.matchFilters.add(matches);
+    }
 
+    public boolean hasMatchFilters() {
+        return !matchFilters.isEmpty();
+    }
+
+    private void applyMatchFilter(String matches) {
         Disjunction textOr = Restrictions.disjunction();
         textOr.add(new FilterLikeExpression("product.name", matches, true));
         textOr.add(new FilterLikeExpression("product.id", matches, true));
-        textOr.add(new FilterLikeExpression("contractNumber", matches, true));
-        textOr.add(new FilterLikeExpression("orderNumber", matches, true));
+        textOr.add(new FilterLikeExpression(alias + "contractNumber", matches, true));
+        textOr.add(new FilterLikeExpression(alias + "orderNumber", matches, true));
 
         textOr.add(new FilterLikeExpression("provProd.id", matches, true));
         textOr.add(new FilterLikeExpression("provProd.name", matches, true));
@@ -136,7 +166,8 @@ public class PoolFilterBuilder extends FilterBuilder {
 
         subquery.add(disjunction);
 
-        subquery.add(Property.forName("this.id").eqProperty("attr.pool.id"));
+        String originalPoolAlias = this.alias.isEmpty() ? "this." : alias;
+        subquery.add(Property.forName(originalPoolAlias + "id").eqProperty("attr.pool.id"));
         subquery.setProjection(Projections.property("attr.id"));
 
         return subquery;
@@ -162,7 +193,8 @@ public class PoolFilterBuilder extends FilterBuilder {
 
         subquery.add(disjunction);
 
-        subquery.add(Property.forName("this.id").eqProperty("PoolI.id"));
+        String originalPoolAlias = this.alias.isEmpty() ? "this." : alias;
+        subquery.add(Property.forName(originalPoolAlias + "id").eqProperty("PoolI.id"));
         subquery.setProjection(Projections.property("PoolI.id"));
 
         // We don't want to match Product Attributes that have been overridden

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -59,6 +59,7 @@ import org.candlepin.model.DistributorVersionCurator;
 import org.candlepin.model.Entitlement;
 import org.candlepin.model.EntitlementCertificate;
 import org.candlepin.model.EntitlementCurator;
+import org.candlepin.model.EntitlementFilterBuilder;
 import org.candlepin.model.Environment;
 import org.candlepin.model.EnvironmentCurator;
 import org.candlepin.model.EventCurator;
@@ -1600,10 +1601,14 @@ public class ConsumerResource {
         @PathParam("consumer_uuid") @Verify(Consumer.class) String consumerUuid,
         @QueryParam("product") String productId,
         @QueryParam("regen") @DefaultValue("true") Boolean regen,
+        @QueryParam("matches") String matches,
+        @QueryParam("attribute") @CandlepinParam(type = KeyValueParameter.class)
+        List<KeyValueParameter> attrFilters,
         @Context PageRequest pageRequest) {
 
         Consumer consumer = consumerCurator.verifyAndLookupConsumer(consumerUuid);
         Page<List<Entitlement>> entitlementsPage;
+        // No need to add filters when matching by product.
         if (productId != null) {
             Product p = productCurator.lookupById(consumer.getOwner(), productId);
             if (p == null) {
@@ -1614,7 +1619,15 @@ public class ConsumerResource {
                 productId, pageRequest);
         }
         else {
-            entitlementsPage = entitlementCurator.listByConsumer(consumer, pageRequest);
+            // Build up any provided entitlement filters from query params.
+            EntitlementFilterBuilder filters = new EntitlementFilterBuilder();
+            for (KeyValueParameter filterParam : attrFilters) {
+                filters.addAttributeFilter(filterParam.key(), filterParam.value());
+            }
+            if (!StringUtils.isEmpty(matches)) {
+                filters.addMatchesFilter(matches);
+            }
+            entitlementsPage = entitlementCurator.listByConsumer(consumer, filters, pageRequest);
         }
 
         // Store the page for the LinkHeaderPostInterceptor

--- a/server/src/main/java/org/candlepin/resource/EntitlementResource.java
+++ b/server/src/main/java/org/candlepin/resource/EntitlementResource.java
@@ -29,6 +29,7 @@ import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerCurator;
 import org.candlepin.model.Entitlement;
 import org.candlepin.model.EntitlementCurator;
+import org.candlepin.model.EntitlementFilterBuilder;
 import org.candlepin.model.Pool;
 import org.candlepin.model.SubscriptionsCertificate;
 import org.candlepin.pinsetter.tasks.RegenProductEntitlementCertsJob;
@@ -36,6 +37,8 @@ import org.candlepin.policy.ValidationResult;
 import org.candlepin.policy.js.entitlement.Enforcer;
 import org.candlepin.policy.js.entitlement.Enforcer.CallerType;
 import org.candlepin.policy.js.entitlement.EntitlementRulesTranslator;
+import org.candlepin.resteasy.parameter.CandlepinParam;
+import org.candlepin.resteasy.parameter.KeyValueParameter;
 import org.candlepin.util.Util;
 
 import com.google.inject.Inject;
@@ -144,7 +147,18 @@ public class EntitlementResource {
     @Paginate
     public List<Entitlement> listAllForConsumer(
         @QueryParam("consumer") String consumerUuid,
+        @QueryParam("matches") String matches,
+        @QueryParam("attribute") @CandlepinParam(type = KeyValueParameter.class)
+        List<KeyValueParameter> attrFilters,
         @Context PageRequest pageRequest) {
+
+        EntitlementFilterBuilder filters = new EntitlementFilterBuilder();
+        for (KeyValueParameter filterParam : attrFilters) {
+            filters.addAttributeFilter(filterParam.key(), filterParam.value());
+        }
+        if (!StringUtils.isEmpty(matches)) {
+            filters.addMatchesFilter(matches);
+        }
 
         Page<List<Entitlement>> p;
         if (consumerUuid != null) {
@@ -154,11 +168,10 @@ public class EntitlementResource {
                 throw new BadRequestException(
                     i18n.tr("Unit with ID ''{0}'' could not be found.", consumerUuid));
             }
-
-            p = entitlementCurator.listByConsumer(consumer, pageRequest);
+            p = entitlementCurator.listByConsumer(consumer, filters, pageRequest);
         }
         else {
-            p = entitlementCurator.listAll(pageRequest);
+            p = entitlementCurator.listAll(filters, pageRequest);
         }
 
         // Store the page for the LinkHeaderPostInterceptor

--- a/server/src/main/resources/logback.xml
+++ b/server/src/main/resources/logback.xml
@@ -38,7 +38,7 @@
         </filter>
     </appender>
 
-    <logger name="org.candlepin" level="DEBUG"/>
+    <logger name="org.candlepin" level="INFO"/>
 
     <root level="WARN">
         <appender-ref ref="CandlepinAppender" />

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
@@ -56,6 +56,7 @@ import org.candlepin.model.UserCurator;
 import org.candlepin.pki.PKIReader;
 import org.candlepin.pki.impl.BouncyCastlePKIReader;
 import org.candlepin.resource.util.ConsumerBindUtil;
+import org.candlepin.resteasy.parameter.KeyValueParameter;
 import org.candlepin.service.IdentityCertServiceAdapter;
 import org.candlepin.test.DatabaseTestFixture;
 import org.candlepin.test.TestDateUtil;
@@ -368,7 +369,8 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
         consumerResource.unbindBySerial(consumer.getUuid(), serials.get(0)
             .getSerial().getId());
         assertEquals(0,
-            consumerResource.listEntitlements(consumer.getUuid(), null, true, null).size());
+            consumerResource.listEntitlements(consumer.getUuid(), null, true,
+                    "", new ArrayList<KeyValueParameter>(), null).size());
     }
 
     @Test(expected = NotFoundException.class)
@@ -493,7 +495,8 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
         securityInterceptor.enable();
 
         assertEquals(3,
-            consumerResource.listEntitlements(consumer.getUuid(), null, true, null).size());
+            consumerResource.listEntitlements(consumer.getUuid(), null, true,
+                    "", new ArrayList<KeyValueParameter>(), null).size());
     }
 
     @Test(expected = NotFoundException.class)
@@ -512,7 +515,8 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
         setupPrincipal(new ConsumerPrincipal(evilConsumer));
         securityInterceptor.enable();
 
-        consumerResource.listEntitlements(consumer.getUuid(), null, true, null);
+        consumerResource.listEntitlements(consumer.getUuid(), null, true,
+                "", new ArrayList<KeyValueParameter>(), null);
     }
 
     @Test(expected = NotFoundException.class)
@@ -530,7 +534,8 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
         securityInterceptor.enable();
         setupPrincipal(evilOwner, Access.ALL);
 
-        consumerResource.listEntitlements(consumer.getUuid(), null, true, null);
+        consumerResource.listEntitlements(consumer.getUuid(), null, true,
+                "", new ArrayList<KeyValueParameter>(), null);
     }
 
     @Test
@@ -545,7 +550,8 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
         securityInterceptor.enable();
 
         assertEquals(3,
-            consumerResource.listEntitlements(consumer.getUuid(), null, true, null).size());
+            consumerResource.listEntitlements(consumer.getUuid(), null, true,
+                    "", new ArrayList<KeyValueParameter>(), null).size());
     }
 
     @Test


### PR DESCRIPTION

Affected API calls:
  GET /consumers/:uuid/entitlements
  GET /entitlements

Caller can now specify an 'attribute' query parameter to filter
results by pool/product attributes.

Caller can now specify a 'matches' query parameter to filter
entitlements by an entitlement pool's:
- product name/id
- contract number
- order number
- provided product name/id