### PR TITLE
Added additional locking functionality to curators

### DIFF
--- a/server/bin/import_products.rb
+++ b/server/bin/import_products.rb
@@ -79,7 +79,7 @@ def create_owner(cp, new_owner)
   cp.create_activation_key(owner['key'], "awesome_os_pool")
 end
 
-thread_pool = Pool.new(4)
+thread_pool = Pool.new(5)
 data['owners'].each do |new_owner|
     thread_pool.schedule do
         create_owner(cp, new_owner)
@@ -101,7 +101,7 @@ def create_user(cp, new_user)
 end
 
 puts "Create some users"
-thread_pool = Pool.new(4)
+thread_pool = Pool.new(5)
 data['users'].each do |new_user|
     thread_pool.schedule do
         create_user(cp, new_user)
@@ -132,7 +132,7 @@ def create_role(cp, new_role)
 
 end
 
-thread_pool = Pool.new(4)
+thread_pool = Pool.new(5)
 data['roles'].each do |new_role|
     thread_pool.schedule do
         create_role(cp, new_role)
@@ -174,7 +174,7 @@ def create_content(cp, owner, content)
   )
 end
 
-thread_pool = Pool.new(4)
+thread_pool = Pool.new(5)
 data['owners'].each do |owner|
     if owner.has_key?('content')
         owner['content'].each do |content|
@@ -239,7 +239,7 @@ def create_eng_product(cp, thread_pool, owner, product)
   product_content = product['content'] || []
 
   # Generate a product id cert in generated_certs for each engineering product
-  product_cert = cp.get_product_cert(product_ret['id'])
+  product_cert = cp.get_product_cert(owner['name'], product_ret['id'])
   cert_file = File.new(CERT_DIR + '/' + product_ret['id'] + '.pem', 'w+')
   cert_file.puts(product_cert['cert'])
 
@@ -379,7 +379,7 @@ end
 thread_pool.shutdown
 
 # Refresh to create pools for all subscriptions just created:
-thread_pool = Pool.new(4)
+thread_pool = Pool.new(5)
 owner_keys.each do |owner_key|
     thread_pool.schedule do
         puts "refreshing pools for " + owner_key

--- a/server/client/ruby/candlepin_api.rb
+++ b/server/client/ruby/candlepin_api.rb
@@ -703,8 +703,8 @@ class Candlepin
     delete("/owners/#{owner_key}/products/#{product_id}")
   end
 
-  def get_product_cert(product_id)
-    get("/products/#{product_id}/certificate")
+  def get_product_cert(owner_key, product_id)
+    get("/owners/#{owner_key}/products/#{product_id}/certificate")
   end
 
   # TODO: Should we change these to bind to better match terminology?

--- a/server/spec/product_cert_spec.rb
+++ b/server/spec/product_cert_spec.rb
@@ -16,7 +16,7 @@ describe 'Product Certificate' do
     }
     @product = create_product(nil, random_string('test-product'))
 
-    cert_data = @cp.get_product_cert(@product.id)
+    cert_data = @cp.get_product_cert(@owner['key'], @product.id)
     @cert = OpenSSL::X509::Certificate.new(cert_data.cert)
   end
 

--- a/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
+++ b/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
@@ -44,6 +44,7 @@ import java.util.Collection;
 import java.util.List;
 
 import javax.persistence.EntityManager;
+import javax.persistence.LockModeType;
 import javax.persistence.OptimisticLockException;
 
 /**
@@ -418,6 +419,10 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
         getEntityManager().refresh(object);
     }
 
+    public void lock(E object, LockModeType lmt) {
+        this.getEntityManager().lock(object, lmt);
+    }
+
     public void evict(E object) {
         currentSession().evict(object);
     }
@@ -440,4 +445,5 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
     private String getConcurrentModificationMessage() {
         return i18n.tr("Request failed due to concurrent modification, please re-try.");
     }
+
 }

--- a/server/src/main/java/org/candlepin/model/ProductCertificateCurator.java
+++ b/server/src/main/java/org/candlepin/model/ProductCertificateCurator.java
@@ -56,6 +56,8 @@ public class ProductCertificateCurator extends AbstractHibernateCurator<ProductC
     }
 
     public ProductCertificate findForProduct(Product product) {
+        log.debug("Finding cert for product: {}", product);
+
         return (ProductCertificate) currentSession()
             .createCriteria(ProductCertificate.class)
             .add(Restrictions.eq("product", product))
@@ -69,6 +71,7 @@ public class ProductCertificateCurator extends AbstractHibernateCurator<ProductC
      * @return the stored or created {@link ProductCertificate}
      */
     public ProductCertificate getCertForProduct(Product product) {
+        log.debug("Retrieving cert for product: {}", product);
         ProductCertificate cert = this.findForProduct(product);
 
         if (cert == null) {
@@ -90,6 +93,7 @@ public class ProductCertificateCurator extends AbstractHibernateCurator<ProductC
 
     private ProductCertificate createCertForProduct(Product product)
         throws GeneralSecurityException, IOException {
+        log.debug("Generating cert for product: {}", product);
 
         KeyPair keyPair = this.pki.generateNewKeyPair();
         Set<X509ExtensionWrapper> extensions = this.extensionUtil.productExtensions(product);

--- a/server/src/main/java/org/candlepin/resource/OwnerProductResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerProductResource.java
@@ -43,6 +43,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import javax.persistence.LockModeType;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
@@ -358,10 +359,15 @@ public class OwnerProductResource {
         Product product = this.getProduct(ownerKey, productId);
         Content content = this.getContent(product.getOwner(), contentId);
 
+        this.productCurator.lock(product, LockModeType.PESSIMISTIC_WRITE);
+
         ProductContent productContent = new ProductContent(product, content, enabled);
         product.addProductContent(productContent);
 
-        return productCurator.find((product.getUuid()));
+        this.productCurator.merge(product);
+        this.productCurator.flush();
+
+        return product;
     }
 
     /**


### PR DESCRIPTION
- Added the lock method to AbstractHibernateCurator, which
  will set the locking mode on the provided entity for the
  remainder of the transaction
- Fixed an issue with adding content to products while
  looking up that product on MySQL
- Updated candlepin_api.rb to use the newer org-specific
  call to retrieve product certificates; import_products
  and various spec tests have also been updated accordingly