### PR TITLE
Reverted automatic permission elevation

### DIFF
--- a/docker/build_container.sh
+++ b/docker/build_container.sh
@@ -1,9 +1,5 @@
 #!/bin/sh
 
-if [ $(id -u) != 0 ]; then
-    exec sudo -- "$0" "$@"
-fi
-
 unset CDPATH
 SCRIPT_NAME=$( basename "$0" )
 SCRIPT_HOME=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )

--- a/docker/rebuild.sh
+++ b/docker/rebuild.sh
@@ -10,11 +10,6 @@
 # Add: INSECURE_REGISTRY='--insecure-registry docker.usersys.redhat.com'
 # To: /etc/sysconfig/docker
 
-if [ $(id -u) != 0 ]; then
-    exec sudo -- "$0" "$@"
-fi
-
-
 SCRIPT_NAME=$( basename "$0" )
 SCRIPT_HOME=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
@@ -62,6 +57,7 @@ if [ "$VERBOSE" == "1" ]; then
     PTARGS="$PTARGS -v"
 fi
 
+cd $SCRIPT_HOME
 ./candlepin-base/build.sh $PTARGS
 
 if [ "$?" != "0" ]; then


### PR DESCRIPTION
- Scripts no longer auto-elevate to root if not already run as root, as Docker has problems with the way this was done
- rebuild.sh no longer needs to be run from its containing directory