### PR TITLE
Fixed broken filters when listing all entitlements

### DIFF
--- a/server/client/ruby/candlepin_api.rb
+++ b/server/client/ruby/candlepin_api.rb
@@ -765,7 +765,6 @@ class Candlepin
     end
 
     path << "matches=#{params[:matches]}" if params[:matches]
-    puts path
     get(path)
   end
 

--- a/server/spec/entitlement_resource_spec.rb
+++ b/server/spec/entitlement_resource_spec.rb
@@ -25,7 +25,33 @@ describe 'Entitlement Resource' do
     @qowner = create_owner random_string 'test_owner'
   end
 
-  it 'can filter entitlements by product attribute' do
+  it 'can filter all entitlements by using matches param' do
+    @system.consume_product(@monitoring_prod.id)
+    @system.consume_product(@virt_prod.id)
+
+    ents = @cp.list_ents_via_entitlements_resource(:matches => "virtualization")
+    ents.should have(1).things
+  end
+
+  it 'can filter all entitlements by product attribute' do
+    @system.consume_product(@monitoring_prod.id)
+    @system.consume_product(@virt_prod.id)
+
+    ents = @cp.list_ents_via_entitlements_resource(
+      :attr_filters => { "variant" => "Satellite Starter Pack" })
+    ents.should have(1).things
+
+    found_attr = false
+    ents[0].pool.productAttributes.each do |attr|
+      if attr["name"] == 'variant' && attr["value"] == "Satellite Starter Pack"
+        found_attr = true
+        break
+      end
+    end
+    found_attr.should == true
+  end
+
+  it 'can filter consumer entitlements by product attribute' do
     @system.consume_product(@monitoring_prod.id)
     @system.consume_product(@virt_prod.id)
     @cp.list_ents_via_entitlements_resource(:consumer_uuid => @system.uuid).should have(2).things
@@ -44,7 +70,7 @@ describe 'Entitlement Resource' do
     found_attr.should == true
   end
 
-  it 'can filter entitlements by using matches param' do
+  it 'can filter consumer entitlements by using matches param' do
     @system.consume_product(@monitoring_prod.id)
     @system.consume_product(@virt_prod.id)
     @cp.list_ents_via_entitlements_resource(:consumer_uuid => @system.uuid).should have(2).things

--- a/server/src/main/java/org/candlepin/model/EntitlementCurator.java
+++ b/server/src/main/java/org/candlepin/model/EntitlementCurator.java
@@ -422,6 +422,13 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
 
     public Page<List<Entitlement>> listAll(EntitlementFilterBuilder filters, PageRequest pageRequest) {
         Criteria criteria = createSecureCriteria();
+        criteria.createAlias("pool", "p");
+        if (filters.hasMatchFilters()) {
+            criteria.createAlias("p.product", "product");
+            criteria.createAlias("p.providedProducts", "provProd", CriteriaSpecification.LEFT_JOIN);
+            criteria.createAlias("provProd.productContent", "ppcw", CriteriaSpecification.LEFT_JOIN);
+            criteria.createAlias("ppcw.content", "ppContent", CriteriaSpecification.LEFT_JOIN);
+        }
         filters.applyTo(criteria);
         return listByCriteria(criteria, pageRequest);
     }


### PR DESCRIPTION
Appropriate aliases were not in place for for the filter builder in EntitlementCurator.listAll(...)

Test the filters using the following as an example:

curl -k -u admin:admin 'https://localhost:8443/candlepin/entitlements?matches=awesomeos*' 
curl -k -u admin:admin 'https://localhost:8443/candlepin/entitlements?attribute=cores:2'