### PR TITLE
Added a delay to solve precision problem with tests on MySQL

### DIFF
--- a/server/spec/virt_spec.rb
+++ b/server/spec/virt_spec.rb
@@ -207,6 +207,8 @@ describe 'Standalone Virt-Limit Subscriptions', :type => :virt do
     @guest2_client.consume_pool(@guest_pool['id'], {:quantity => 1})
     @guest2_client.list_entitlements.length.should == 1
 
+    sleep 3
+
     # Host 2 reports the new guest before Host 1 reports it removed.
     # this is where the error would occur without the 786730 fix
     @host2_client.update_consumer({:guestIds => [{'guestId' => @uuid1}]})


### PR DESCRIPTION
- Added a delay to the virt guest auto-healing spec test to resolve
  an issue where checkins can be resolved out-of-order on MySQL when
  migrating a guest from one host to another within an interval too
  small for MySQL's timestamp field