### PR TITLE
Allow installing a single candlepin rpm in Docker base containers.

### DIFF
--- a/docker/README.mkd
+++ b/docker/README.mkd
@@ -27,6 +27,8 @@ docker run -P -e POSTGRES_PASSWORD=candlepin --name=postgres -d postgres
 
 These containers are prepped to install Candlepin RPMs, but no Candlepin packages have been installed yet. The startup script will look for the YUM_REPO URL environment variable defined in docker run command with -e. This will be used to configure a candlepin.repo, and then a ```yum install candlepin``` will be attempted. Note that this container takes a little while to startup as a result of this.
 
+It is also possible to instead specify a RPM_URL environment variable for a candlepin RPM to install, which should work for newer builds. (2.0+)
+
 ```
 $ docker run --name candlepin -d -P -e "YUM_REPO=http://download.devel.redhat.com/brewroot/repos/candlepin-mead-rhel-6-build/latest/x86_64" --link postgres:db candlepin/candlepin-rhel6-base
 $ docker attach candlepin

--- a/docker/candlepin-rhel6-base/startup.sh
+++ b/docker/candlepin-rhel6-base/startup.sh
@@ -2,16 +2,26 @@
 
 env
 
-# Create a candlepin.repo file with the URL we were given via env var:
-cat > /etc/yum.repos.d/candlepin.repo <<CANDLEPIN
+# Can specify either a YUM_REPO or a RPM_URL to install candlepin from:
+if [ -z "$YUM_REPO" ]
+then
+    # Not sure how long this will be required:
+    # https://bugzilla.redhat.com/show_bug.cgi?id=1205054
+    yum downgrade -y glibc glibc-common gdbm
+    yum install -y $RPM_URL
+else
+    # Create a candlepin.repo file with the URL we were given via env var:
+    cat > /etc/yum.repos.d/candlepin.repo <<CANDLEPIN
 [candlepin]
 name=candlepin
 baseurl=$YUM_REPO
 gpgcheck=0
 CANDLEPIN
 
-cat /etc/yum.repos.d/candlepin.repo
-yum install -y candlepin
+    cat /etc/yum.repos.d/candlepin.repo
+    yum install -y candlepin
+fi
+
 
 # TODO: use env variables to check which database we're linked to, for now
 # we'll just assume postgres.


### PR DESCRIPTION
Instead of YUM_REPO, you can specify a RPM_URL instead which points to a single
Candlepin rpm to install. Should work for newer 2.0 builds.