### PR TITLE
Setup scripts will now abort on any error

### DIFF
--- a/docker/candlepin-base/setup-devel-env.sh
+++ b/docker/candlepin-base/setup-devel-env.sh
@@ -3,6 +3,8 @@
 # Sets a system up for a candlepin development environment (minus a db,
 # handled separately), and an initial clone of candlepin.
 
+set -e
+
 export JAVA_HOME=/usr/lib/jvm/java-1.7.0/
 export HOME=/root
 

--- a/docker/candlepin-base/setup-supervisord.sh
+++ b/docker/candlepin-base/setup-supervisord.sh
@@ -1,5 +1,7 @@
 #! /bin/bash
 
+set -e
+
 setup_supervisor() {
     yum install -y supervisor
     mkdir -p /var/log/supervisor

--- a/docker/candlepin-mysql/setup-mysql.sh
+++ b/docker/candlepin-mysql/setup-mysql.sh
@@ -1,5 +1,7 @@
 #! /bin/bash
 
+set -e
+
 setup_mysql() {
     yum install -y mysql-server mysql-connector-java
 

--- a/docker/candlepin-oracle/launch-oracle.sh
+++ b/docker/candlepin-oracle/launch-oracle.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/sh
 
 # Oracle is annoying.  I could not find a way to run it in the foreground
 # so normal supervisor options are not appropriate.  Nor could I find a way
@@ -8,6 +8,8 @@
 # This script will start Oracle and then remain in the foreground as long
 # as Oracle is running.  When it receives SIGINT or SIGTERM it will stop
 # Oracle.
+
+set -e
 
 stop_oracle() {
     /etc/init.d/oracle-xe stop

--- a/docker/candlepin-oracle/setup-oracle.sh
+++ b/docker/candlepin-oracle/setup-oracle.sh
@@ -1,5 +1,7 @@
 #! /bin/bash
 
+set -e
+
 setup_oracle() {
 
     mkdir -p /var/lock/subsys

--- a/docker/candlepin-postgresql/setup-postgresql.sh
+++ b/docker/candlepin-postgresql/setup-postgresql.sh
@@ -1,5 +1,7 @@
 #! /bin/bash
 
+set -e
+
 setup_postgresql() {
     yum install -y postgresql postgresql-server postgresql-jdbc
     echo 'NETWORKING=yes' > /etc/sysconfig/network

--- a/docker/candlepin-rhel6-base/setup-supervisor.sh
+++ b/docker/candlepin-rhel6-base/setup-supervisor.sh
@@ -1,5 +1,7 @@
 #! /bin/bash
 
+set -e
+
 setup_supervisor() {
     pip install supervisor
     mkdir -p /var/log/supervisor

--- a/docker/candlepin-rhel6-base/startup.sh
+++ b/docker/candlepin-rhel6-base/startup.sh
@@ -1,5 +1,6 @@
 #! /bin/bash
 
+set -e
 env
 
 # Create a candlepin.repo file with the URL we were given via env var:

--- a/docker/candlepin-rhel6/startup.sh
+++ b/docker/candlepin-rhel6/startup.sh
@@ -1,5 +1,6 @@
 #! /bin/bash
 
+set -e
 env
 
 # TODO: use env variables to check which database we're linked to, for now

--- a/docker/candlepin-rhel7-base/setup-supervisor.sh
+++ b/docker/candlepin-rhel7-base/setup-supervisor.sh
@@ -1,5 +1,7 @@
 #! /bin/bash
 
+set -e
+
 setup_supervisor() {
     pip install supervisor
     mkdir -p /var/log/supervisor

--- a/docker/candlepin-rhel7-base/startup.sh
+++ b/docker/candlepin-rhel7-base/startup.sh
@@ -1,5 +1,6 @@
 #! /bin/bash
 
+set -e
 env
 
 # TODO: use env variables to check which database we're linked to, for now

--- a/docker/candlepin-rhel7/startup.sh
+++ b/docker/candlepin-rhel7/startup.sh
@@ -1,5 +1,6 @@
 #! /bin/bash
 
+set -e
 env
 
 # TODO: use env variables to check which database we're linked to, for now

--- a/docker/rebuild.sh
+++ b/docker/rebuild.sh
@@ -93,13 +93,13 @@ fi
 if build_image "candlepin-rhel6-base"; then
     build_image "candlepin-rhel6"
 else
-    echo "Unable to build candlepin-rhel6-base image; skipping rhel6 image..." >&2
+    echo "Unable to build candlepin-rhel6-base image; skipping rhel6 child images..." >&2
 fi
 
 if build_image "candlepin-rhel7-base"; then
     build_image "candlepin-rhel7"
 else
-    echo "Unable to build candlepin-rhel7-base image; skipping rhel7 image..." >&2
+    echo "Unable to build candlepin-rhel7-base image; skipping rhel7 child images..." >&2
 fi
 
 if [ "$MESSAGES" != "" ]; then


### PR DESCRIPTION
- Added "set -e" to scripts which don't explicitly track command/sub-script results
- Updated output in a few places
- The Jenkins smoke test will now output the server context on failure