### PR TITLE
Removed the log driver specification from the smoke test

### DIFF
--- a/docker/jenkins-scripts/smoke-test.sh
+++ b/docker/jenkins-scripts/smoke-test.sh
@@ -81,7 +81,7 @@ try:
             time.sleep(3)
 
             # Launch the candlepin container:
-            output = run_command("docker run --log-driver=\"json-file\" -P -d -e \"YUM_REPO=%s\" --link %s:db %s"
+            output = run_command("docker run -P -d -e \"YUM_REPO=%s\" --link %s:db %s"
                 % (cp_repo_url, db_container_name, image_name))
             server_container_id = output[-1]
             time.sleep(3)


### PR DESCRIPTION
- The Jenkins smoke test script no longer specifies the log driver
  when running the target container, as this requires Docker 1.6,
  which is not currently available on RHEL (and was specifying the
  default driver anyway)