### PR TITLE
Reduced required precision in check-in spec test

### DIFF
--- a/server/spec/consumer_resource_spec.rb
+++ b/server/spec/consumer_resource_spec.rb
@@ -311,8 +311,8 @@ describe 'Consumer Resource' do
     owner = create_owner(random_string('owner'))
     user_name = random_string('user')
     client = user_client(owner, user_name)
-    created_date = '2015-05-09T13:23:55.689+0000'
-    checkin_date = '2015-05-19T13:23:55.689+0000'
+    created_date = '2015-05-09T13:23:55.000+0000'
+    checkin_date = '2015-05-19T13:23:55.000+0000'
     consumer = client.register(random_string('system'), type=:system, nil, {}, user_name,
               owner['key'], [], [], nil, [], nil, [], created_date, checkin_date)
     consumer['lastCheckin'].should == checkin_date


### PR DESCRIPTION
- Reduced the precision required in the consumer_resource_spec tests
  to prevent the test from failing on MySQL where timestamp precision
  is lower

Not sure if the milliseconds were important or explicitly put there, so this "correction" may not be the best way to go about resolving the issue.