### PR TITLE
Fix cross-compile issue with ConcurrentHashMap.

### DIFF
--- a/buildfile
+++ b/buildfile
@@ -188,6 +188,7 @@ define "candlepin" do
 
   compile.options.target = '1.6'
   compile.options.source = '1.6'
+  compile.options.lint = 'all'
 
   # path_to() (and it's alias _()) simply provides the absolute path to
   # a directory relative to the project.

--- a/common/src/main/java/org/candlepin/common/config/MapConfiguration.java
+++ b/common/src/main/java/org/candlepin/common/config/MapConfiguration.java
@@ -29,7 +29,7 @@ import java.util.regex.Pattern;
 public class MapConfiguration extends AbstractConfiguration {
     private static Logger log = LoggerFactory.getLogger(MapConfiguration.class);
 
-    private ConcurrentHashMap<String, String> configMap;
+    private Map<String, String> configMap;
 
     public MapConfiguration() {
         configMap = new ConcurrentHashMap<String, String>();

--- a/server/src/main/java/org/candlepin/guice/I18nProvider.java
+++ b/server/src/main/java/org/candlepin/guice/I18nProvider.java
@@ -27,6 +27,7 @@ import org.xnap.commons.i18n.I18n;
 import org.xnap.commons.i18n.I18nFactory;
 
 import java.util.Locale;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import javax.servlet.http.HttpServletRequest;
@@ -39,7 +40,7 @@ public class I18nProvider extends CommonI18nProvider implements Provider<I18n> {
 
     private static Logger log = LoggerFactory.getLogger(I18nProvider.class);
 
-    private static ConcurrentHashMap<Locale, I18n>
+    private static Map<Locale, I18n>
     cache = new ConcurrentHashMap<Locale, I18n>();
 
     @Inject


### PR DESCRIPTION
The Java 1.7 ConcurrentHashMap#keySet() returns a Set<K> while the Java
1.8 version returns ConcurrentHashMap.KeySetView<K>.  Since Java allows an
overridden method to return a sub-type of the parent method's return
type, no compilation are raised.  When we run the code on Java 1.7,
however, it immediately fails since the ConcurrentHashMap.KeySetView
class is not available.

One solution is to compile against a 1.7 bootstrap classpath, but since
1.7 is not packaged for recent versions of Fedora, we will work around
the issue by upcasting ConcurrentHashMaps to just Maps.

See https://gist.github.com/AlainODea/1375759b8720a3f9f094 for a
detailed explanation.