### PR TITLE
Updated @Verify to use owner when checking products

### DIFF
--- a/server/spec/product_resource_spec.rb
+++ b/server/spec/product_resource_spec.rb
@@ -20,25 +20,31 @@ describe 'Product Resource' do
       })
   end
 
-  it 'throws exception on write operation' do
+  it 'throws exception on write operations' do
     lambda do
       @cp.post("/products", {})
     end.should raise_exception(RestClient::BadRequest)
 
     lambda do
-      @cp.put("/products/dummyid", {})
+      @cp.put("/products/#{@product.id}", {})
     end.should raise_exception(RestClient::BadRequest)
 
     lambda do
-      @cp.post("/products/dummyid/batch_content", {})
+      @cp.post("/products/#{@product.id}/batch_content", {})
     end.should raise_exception(RestClient::BadRequest)
 
     lambda do
-      @cp.post("/products/dummyid/content/contentid", {})
+      @cp.post("/products/#{@product.id}/content/contentid", {})
     end.should raise_exception(RestClient::BadRequest)
 
     lambda do
-      @cp.delete("/products/dummyid")
+      @cp.delete("/products/#{@product.id}")
+    end.should raise_exception(RestClient::BadRequest)
+
+    # This may look like a read operation, but it generates the certificate if it doesn't exist;
+    # making this a write operation at times.
+    lambda do
+      @cp.get("/products/#{@product.id}/certificate")
     end.should raise_exception(RestClient::BadRequest)
   end
 
@@ -202,7 +208,7 @@ describe 'Product Resource' do
 
   it 'throws exception on get_owners with no products' do
     lambda do
-      @cp.put("/products/owners", {})
+      @cp.get("/products/owners")
     end.should raise_exception(RestClient::BadRequest)
   end
 

--- a/server/src/main/java/org/candlepin/model/ProductCurator.java
+++ b/server/src/main/java/org/candlepin/model/ProductCurator.java
@@ -75,6 +75,24 @@ public class ProductCurator extends AbstractHibernateCurator<Product> {
     }
 
     /**
+     * Performs an owner-agnostic product lookup by product ID.
+     *
+     * @deprecated
+     *  This method is provided for legacy functionality only and may return the incorrect product
+     *  instance in situations where multiple owners exist with the same product.Use lookupById with
+     *  a specific owner to get accurate results.
+     *
+     * @param id Product ID to lookup. (note: not the database ID)
+     * @return the Product which matches the given id.
+     */
+    @Deprecated
+    @Transactional
+    public Product lookupById(String id) {
+        return (Product) this.createSecureCriteria()
+            .add(Restrictions.eq("id", id)).uniqueResult();
+    }
+
+    /**
      * @param owner owner to lookup product for
      * @param id Product ID to lookup. (note: not the database ID)
      * @return the Product which matches the given id.

--- a/server/src/main/java/org/candlepin/resource/OwnerProductResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerProductResource.java
@@ -14,6 +14,7 @@
  */
 package org.candlepin.resource;
 
+import org.candlepin.auth.interceptor.Verify;
 import org.candlepin.common.auth.SecurityHole;
 import org.candlepin.common.exceptions.BadRequestException;
 import org.candlepin.common.exceptions.NotFoundException;
@@ -118,8 +119,9 @@ public class OwnerProductResource {
      */
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public List<Product> list(@PathParam("owner_key") String ownerKey,
-                              @QueryParam("product") List<String> productIds) {
+    public List<Product> list(
+        @Verify(Owner.class) @PathParam("owner_key") String ownerKey,
+        @Verify(Product.class) @QueryParam("product") List<String> productIds) {
 
         Owner owner = this.getOwnerByKey(ownerKey);
 
@@ -159,8 +161,9 @@ public class OwnerProductResource {
     @Path("/{product_id}")
     @Produces(MediaType.APPLICATION_JSON)
     @SecurityHole
-    public Product getProduct(@PathParam("owner_key") String ownerKey,
-                              @PathParam("product_id") String productId) {
+    public Product getProduct(
+        @Verify(Owner.class) @PathParam("owner_key") String ownerKey,
+        @Verify(Product.class) @PathParam("product_id") String productId) {
 
         Owner owner = this.getOwnerByKey(ownerKey);
         Product product = productCurator.lookupById(owner, productId);
@@ -185,8 +188,10 @@ public class OwnerProductResource {
     @Path("/{product_id}/certificate")
     @Produces(MediaType.APPLICATION_JSON)
     @SecurityHole
-    public ProductCertificate getProductCertificate(@PathParam("owner_key") String ownerKey,
-                                                    @PathParam("product_id") String productId) {
+    public ProductCertificate getProductCertificate(
+        @Verify(Owner.class) @PathParam("owner_key") String ownerKey,
+        @Verify(Product.class) @PathParam("product_id") String productId) {
+
         Product product = this.getProduct(ownerKey, productId);
         return this.productCertCurator.getCertForProduct(product);
     }
@@ -202,7 +207,10 @@ public class OwnerProductResource {
      */
     @POST
     @Produces(MediaType.APPLICATION_JSON)
-    public Product createProduct(@PathParam("owner_key") String ownerKey, Product product) {
+    public Product createProduct(
+        @Verify(Owner.class) @PathParam("owner_key") String ownerKey,
+        Product product) {
+
         Owner owner = this.getOwnerByKey(ownerKey);
 
         product.setOwner(owner);
@@ -221,8 +229,8 @@ public class OwnerProductResource {
     @Path("/{product_id}")
     @Produces(MediaType.APPLICATION_JSON)
     public Product updateProduct(
-        @PathParam("owner_key") String ownerKey,
-        @PathParam("product_id") String productId,
+        @Verify(Owner.class) @PathParam("owner_key") String ownerKey,
+        @Verify(Product.class) @PathParam("product_id") String productId,
         Product product) {
 
         Product toUpdate = this.getProduct(ownerKey, productId);
@@ -322,9 +330,10 @@ public class OwnerProductResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/{product_id}/batch_content")
-    public Product addBatchContent(@PathParam("owner_key") String ownerKey,
-                                   @PathParam("product_id") String productId,
-                                   Map<String, Boolean> contentMap) {
+    public Product addBatchContent(
+        @Verify(Owner.class) @PathParam("owner_key") String ownerKey,
+        @Verify(Product.class) @PathParam("product_id") String productId,
+        Map<String, Boolean> contentMap) {
 
         Product product = this.getProduct(ownerKey, productId);
         List<ProductContent> productContent = new LinkedList<ProductContent>();
@@ -351,10 +360,11 @@ public class OwnerProductResource {
     @POST
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/{product_id}/content/{content_id}")
-    public Product addContent(@PathParam("owner_key") String ownerKey,
-                              @PathParam("product_id") String productId,
-                              @PathParam("content_id") String contentId,
-                              @QueryParam("enabled") Boolean enabled) {
+    public Product addContent(
+        @Verify(Owner.class) @PathParam("owner_key") String ownerKey,
+        @Verify(Product.class) @PathParam("product_id") String productId,
+        @PathParam("content_id") String contentId,
+        @QueryParam("enabled") Boolean enabled) {
 
         Product product = this.getProduct(ownerKey, productId);
         Content content = this.getContent(product.getOwner(), contentId);
@@ -378,9 +388,10 @@ public class OwnerProductResource {
     @DELETE
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/{product_id}/content/{content_id}")
-    public void removeContent(@PathParam("owner_key") String ownerKey,
-                              @PathParam("product_id") String productId,
-                              @PathParam("content_id") String contentId) {
+    public void removeContent(
+        @Verify(Owner.class) @PathParam("owner_key") String ownerKey,
+        @Verify(Product.class) @PathParam("product_id") String productId,
+        @PathParam("content_id") String contentId) {
 
         Product product = this.getProduct(ownerKey, productId);
         Content content = this.getContent(product.getOwner(), contentId);
@@ -398,8 +409,9 @@ public class OwnerProductResource {
     @DELETE
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/{product_id}")
-    public void deleteProduct(@PathParam("owner_key") String ownerKey,
-                              @PathParam("product_id") String productId) {
+    public void deleteProduct(
+        @Verify(Owner.class) @PathParam("owner_key") String ownerKey,
+        @Verify(Product.class) @PathParam("product_id") String productId) {
 
         Product product = this.getProduct(ownerKey, productId);
 
@@ -425,11 +437,13 @@ public class OwnerProductResource {
     @GET
     @Path("/{product_id}/statistics")
     @Produces(MediaType.APPLICATION_JSON)
-    public List<Statistic> getProductStats(@PathParam("owner_key") String ownerKey,
-                                           @PathParam("product_id") String productId,
-                                           @QueryParam("from") String from,
-                                           @QueryParam("to") String to,
-                                           @QueryParam("days") String days) {
+    public List<Statistic> getProductStats(
+        @Verify(Owner.class) @PathParam("owner_key") String ownerKey,
+        @Verify(Product.class) @PathParam("product_id") String productId,
+        @QueryParam("from") String from,
+        @QueryParam("to") String to,
+        @QueryParam("days") String days) {
+
         return this.getProductStats(ownerKey, productId, null, from, to, days);
     }
 
@@ -445,12 +459,13 @@ public class OwnerProductResource {
     @GET
     @Path("/{product_id}/statistics/{vtype}")
     @Produces(MediaType.APPLICATION_JSON)
-    public List<Statistic> getProductStats(@PathParam("owner_key") String ownerKey,
-                                           @PathParam("product_id") String productId,
-                                           @PathParam("vtype") String valueType,
-                                           @QueryParam("from") String from,
-                                           @QueryParam("to") String to,
-                                           @QueryParam("days") String days) {
+    public List<Statistic> getProductStats(
+        @Verify(Owner.class) @PathParam("owner_key") String ownerKey,
+        @Verify(Product.class) @PathParam("product_id") String productId,
+        @PathParam("vtype") String valueType,
+        @QueryParam("from") String from,
+        @QueryParam("to") String to,
+        @QueryParam("days") String days) {
 
         Owner owner = this.getOwnerByKey(ownerKey);
 
@@ -470,8 +485,8 @@ public class OwnerProductResource {
     @Path("/{product_id}/subscriptions")
     @Produces(MediaType.APPLICATION_JSON)
     public JobDetail refreshPoolsForProduct(
-        @PathParam("owner_key") String ownerKey,
-        @PathParam("product_id") String productId,
+        @Verify(Owner.class) @PathParam("owner_key") String ownerKey,
+        @Verify(Product.class) @PathParam("product_id") String productId,
         @QueryParam("lazy_regen") @DefaultValue("true") Boolean lazyRegen) {
 
         Product product = this.getProduct(ownerKey, productId);

--- a/server/src/main/java/org/candlepin/resource/OwnerProductResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerProductResource.java
@@ -189,8 +189,8 @@ public class OwnerProductResource {
     @Produces(MediaType.APPLICATION_JSON)
     @SecurityHole
     public ProductCertificate getProductCertificate(
-        @Verify(Owner.class) @PathParam("owner_key") String ownerKey,
-        @Verify(Product.class) @PathParam("product_id") String productId) {
+        @PathParam("owner_key") String ownerKey,
+        @PathParam("product_id") String productId) {
 
         Product product = this.getProduct(ownerKey, productId);
         return this.productCertCurator.getCertForProduct(product);
@@ -208,7 +208,7 @@ public class OwnerProductResource {
     @POST
     @Produces(MediaType.APPLICATION_JSON)
     public Product createProduct(
-        @Verify(Owner.class) @PathParam("owner_key") String ownerKey,
+        @PathParam("owner_key") String ownerKey,
         Product product) {
 
         Owner owner = this.getOwnerByKey(ownerKey);
@@ -229,8 +229,8 @@ public class OwnerProductResource {
     @Path("/{product_id}")
     @Produces(MediaType.APPLICATION_JSON)
     public Product updateProduct(
-        @Verify(Owner.class) @PathParam("owner_key") String ownerKey,
-        @Verify(Product.class) @PathParam("product_id") String productId,
+        @PathParam("owner_key") String ownerKey,
+        @PathParam("product_id") String productId,
         Product product) {
 
         Product toUpdate = this.getProduct(ownerKey, productId);
@@ -331,8 +331,8 @@ public class OwnerProductResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/{product_id}/batch_content")
     public Product addBatchContent(
-        @Verify(Owner.class) @PathParam("owner_key") String ownerKey,
-        @Verify(Product.class) @PathParam("product_id") String productId,
+        @PathParam("owner_key") String ownerKey,
+        @PathParam("product_id") String productId,
         Map<String, Boolean> contentMap) {
 
         Product product = this.getProduct(ownerKey, productId);
@@ -361,8 +361,8 @@ public class OwnerProductResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/{product_id}/content/{content_id}")
     public Product addContent(
-        @Verify(Owner.class) @PathParam("owner_key") String ownerKey,
-        @Verify(Product.class) @PathParam("product_id") String productId,
+        @PathParam("owner_key") String ownerKey,
+        @PathParam("product_id") String productId,
         @PathParam("content_id") String contentId,
         @QueryParam("enabled") Boolean enabled) {
 
@@ -389,8 +389,8 @@ public class OwnerProductResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/{product_id}/content/{content_id}")
     public void removeContent(
-        @Verify(Owner.class) @PathParam("owner_key") String ownerKey,
-        @Verify(Product.class) @PathParam("product_id") String productId,
+        @PathParam("owner_key") String ownerKey,
+        @PathParam("product_id") String productId,
         @PathParam("content_id") String contentId) {
 
         Product product = this.getProduct(ownerKey, productId);
@@ -410,8 +410,8 @@ public class OwnerProductResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/{product_id}")
     public void deleteProduct(
-        @Verify(Owner.class) @PathParam("owner_key") String ownerKey,
-        @Verify(Product.class) @PathParam("product_id") String productId) {
+        @PathParam("owner_key") String ownerKey,
+        @PathParam("product_id") String productId) {
 
         Product product = this.getProduct(ownerKey, productId);
 
@@ -438,8 +438,8 @@ public class OwnerProductResource {
     @Path("/{product_id}/statistics")
     @Produces(MediaType.APPLICATION_JSON)
     public List<Statistic> getProductStats(
-        @Verify(Owner.class) @PathParam("owner_key") String ownerKey,
-        @Verify(Product.class) @PathParam("product_id") String productId,
+        @PathParam("owner_key") String ownerKey,
+        @PathParam("product_id") String productId,
         @QueryParam("from") String from,
         @QueryParam("to") String to,
         @QueryParam("days") String days) {
@@ -460,8 +460,8 @@ public class OwnerProductResource {
     @Path("/{product_id}/statistics/{vtype}")
     @Produces(MediaType.APPLICATION_JSON)
     public List<Statistic> getProductStats(
-        @Verify(Owner.class) @PathParam("owner_key") String ownerKey,
-        @Verify(Product.class) @PathParam("product_id") String productId,
+        @PathParam("owner_key") String ownerKey,
+        @PathParam("product_id") String productId,
         @PathParam("vtype") String valueType,
         @QueryParam("from") String from,
         @QueryParam("to") String to,
@@ -485,8 +485,8 @@ public class OwnerProductResource {
     @Path("/{product_id}/subscriptions")
     @Produces(MediaType.APPLICATION_JSON)
     public JobDetail refreshPoolsForProduct(
-        @Verify(Owner.class) @PathParam("owner_key") String ownerKey,
-        @Verify(Product.class) @PathParam("product_id") String productId,
+        @PathParam("owner_key") String ownerKey,
+        @PathParam("product_id") String productId,
         @QueryParam("lazy_regen") @DefaultValue("true") Boolean lazyRegen) {
 
         Product product = this.getProduct(ownerKey, productId);

--- a/server/src/main/java/org/candlepin/resource/ProductResource.java
+++ b/server/src/main/java/org/candlepin/resource/ProductResource.java
@@ -173,9 +173,6 @@ public class ProductResource {
         throw new BadRequestException(this.i18n.tr(
             "Organization-agnostic product write operations are not supported."
         ));
-
-        // Product product = this.findProduct(productId);
-        // return this.productCertCurator.getCertForProduct(product);
     }
 
     /**

--- a/server/src/main/java/org/candlepin/resource/ProductResource.java
+++ b/server/src/main/java/org/candlepin/resource/ProductResource.java
@@ -298,7 +298,7 @@ public class ProductResource {
     @Path("/{product_id}/statistics")
     @Produces(MediaType.APPLICATION_JSON)
     public List<Statistic> getProductStats(
-        @Verify(Product.class) @PathParam("product_id") String productId,
+        @PathParam("product_id") String productId,
         @QueryParam("from") String from,
         @QueryParam("to") String to,
         @QueryParam("days") String days) {
@@ -319,7 +319,7 @@ public class ProductResource {
     @Path("/{product_id}/statistics/{vtype}")
     @Produces(MediaType.APPLICATION_JSON)
     public List<Statistic> getProductStats(
-        @Verify(Product.class) @PathParam("product_id") String productId,
+        @PathParam("product_id") String productId,
         @PathParam("vtype") String valueType,
         @QueryParam("from") String from,
         @QueryParam("to") String to,
@@ -356,7 +356,7 @@ public class ProductResource {
     @Path("/owners")
     @Produces(MediaType.APPLICATION_JSON)
     public List<Owner> getProductOwners(
-        @Verify(Product.class) @QueryParam("product") List<String> productIds) {
+        @QueryParam("product") List<String> productIds) {
 
         if (productIds.isEmpty()) {
             throw new BadRequestException(i18n.tr("No product IDs specified"));
@@ -376,7 +376,7 @@ public class ProductResource {
     @Path("/subscriptions")
     @Produces(MediaType.APPLICATION_JSON)
     public JobDetail[] refreshPoolsForProduct(
-        @Verify(Product.class) @QueryParam("product") List<String> productIds,
+        @QueryParam("product") List<String> productIds,
         @QueryParam("lazy_regen") @DefaultValue("true") Boolean lazyRegen) {
 
         if (productIds.isEmpty()) {

--- a/server/src/main/resources/logback.xml
+++ b/server/src/main/resources/logback.xml
@@ -38,7 +38,8 @@
         </filter>
     </appender>
 
-    <logger name="org.candlepin" level="INFO"/>
+    <!-- If you see this, I forgot to revert this file -->
+    <logger name="org.candlepin" level="DEBUG"/>
 
     <root level="WARN">
         <appender-ref ref="CandlepinAppender" />

--- a/server/src/test/java/org/candlepin/resource/ProductResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/ProductResourceTest.java
@@ -44,6 +44,7 @@ import org.xnap.commons.i18n.I18nFactory;
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -131,7 +132,7 @@ public class ProductResourceTest extends DatabaseTestFixture {
         assertEquals(actual, expected);
     }
 
-    @Test
+    @Test(expected = BadRequestException.class)
     public void getProductCertificate() {
         Owner owner = ownerCurator.create(new Owner("Example-Corporation"));
         Product p = productCurator.create(createProduct(owner));
@@ -187,22 +188,22 @@ public class ProductResourceTest extends DatabaseTestFixture {
         Owner owner2 = owners.get(1);
         Owner owner3 = owners.get(2);
 
-        owners = productResource.getProductOwners(new String[] { "p1" });
+        owners = productResource.getProductOwners(Arrays.asList("p1"));
         assertEquals(Arrays.asList(owner1, owner2), owners);
 
-        owners = productResource.getProductOwners(new String[] { "p1", "p2" });
+        owners = productResource.getProductOwners(Arrays.asList("p1", "p2"));
         assertEquals(Arrays.asList(owner1, owner2, owner3), owners);
 
-        owners = productResource.getProductOwners(new String[] { "p3" });
+        owners = productResource.getProductOwners(Arrays.asList("p3"));
         assertEquals(Arrays.asList(owner3), owners);
 
-        owners = productResource.getProductOwners(new String[] { "nope" });
+        owners = productResource.getProductOwners(Arrays.asList("nope"));
         assertEquals(0, owners.size());
     }
 
     @Test(expected = BadRequestException.class)
     public void testGetOwnersForProductsInputValidation() {
-        productResource.getProductOwners(new String[] {});
+        productResource.getProductOwners(new LinkedList<String>());
     }
 
     private void verifyRefreshPoolsJobs(JobDetail[] jobs, List<Owner> owners, boolean lazyRegen) {
@@ -241,28 +242,28 @@ public class ProductResourceTest extends DatabaseTestFixture {
 
         JobDetail[] jobs;
 
-        jobs = productResource.refreshPoolsForProduct(new String[] { "p1" }, true);
+        jobs = productResource.refreshPoolsForProduct(Arrays.asList("p1"), true);
         assertNotNull(jobs);
         assertEquals(2, jobs.length);
         this.verifyRefreshPoolsJobs(jobs, Arrays.asList(owner1, owner2), true);
 
-        jobs = productResource.refreshPoolsForProduct(new String[] { "p1", "p2" }, false);
+        jobs = productResource.refreshPoolsForProduct(Arrays.asList("p1", "p2"), false);
         assertNotNull(jobs);
         assertEquals(3, jobs.length);
         this.verifyRefreshPoolsJobs(jobs, Arrays.asList(owner1, owner2, owner3), false);
 
-        jobs = productResource.refreshPoolsForProduct(new String[] { "p3" }, false);
+        jobs = productResource.refreshPoolsForProduct(Arrays.asList("p3"), false);
         assertNotNull(jobs);
         assertEquals(1, jobs.length);
         this.verifyRefreshPoolsJobs(jobs, Arrays.asList(owner3), false);
 
-        jobs = productResource.refreshPoolsForProduct(new String[] { "nope" }, false);
+        jobs = productResource.refreshPoolsForProduct(Arrays.asList("nope"), false);
         assertNotNull(jobs);
         assertEquals(0, jobs.length);
     }
 
     @Test(expected = BadRequestException.class)
     public void testRefreshPoolsByProductInputValidation() {
-        productResource.refreshPoolsForProduct(new String[] {}, true);
+        productResource.refreshPoolsForProduct(new LinkedList<String>(), true);
     }
 }


### PR DESCRIPTION
- When using @Verify with both an owner and a product, the
  lookup on the product will be owner-specific
- Added @Verify to most requests in ProductResource and
  OwnerProductResource
- ProductResource.getProductCertificate now throws an exception along
  with the other org-agnostic write operations

Note that this change introduces its own set of oddities. Particularly, to ensure the proper permission is checked, a @Verify must be present on both an owner (that occurs in the argument list before the product) and the product; and due to the ordering, a user must meet both verify criteria to perform the action. As such, the @Verify tags may need to be adjusted to have the proper explicit permissions for this update.