### PR TITLE
Include derived modifier content in distributor ent cert

### DIFF
--- a/server/bin/test_data.json
+++ b/server/bin/test_data.json
@@ -953,7 +953,7 @@
             },
             "derived_product_id" : "awesomeos-server-basic-vdc",
             "derived_provided_products" : [
-                "37060"
+                "37080", "37060"
             ]
         },
         {
@@ -1954,3 +1954,4 @@
         }
     ]
 }
+


### PR DESCRIPTION
In the case of a distributor, derived products were not being
considered as entitled products. This would cause any content
specifying modified products to not be included in the
distributor's entitlement certificate, preventing content
sync downstream.

Candlepin now considers all derived products as entitled products
for a distributor. Standard rules governing inclusion of modifier
content still apply, but in the case of a distributor, modified
products specified on content can now be a derived/derived provided
product.

This means that in order for modifier content to be included in
the entitlement cert, the consumer must be entitled to the
modified product in one of the following ways:
- consumer currently has an entitlement providing the modified product
- the pool from which the entitlement cert is being generated from
  provides the modified product.
- the pool from which the entitlement cert is being generated from
  provides the modified product via derived products.

# Testing:

1. Copy the server/bin/test_data.json from this branch somewhere.
2. Checkout master branch
3. Copy the test_data.json file back to the original location and re-deploy.
4. Register the consumer as a distributor. You'll need to add a custom fact in order to do this. Create the file **/etc/rhsm/facts/custom.facts** with the contents below, before you register.
   ```json
   {
	"distributor_version":"sat-6.0"
   }
   ```

    ```bash
    sudo subscription-manager register --username admin --password admin --type candlepin --org admin
    ```
5. Search for the VDC sub:

    ```bash
    sudo subscription-manager list --available --all --matches "awesomeos-server-basic-dc"
    ```
6. Grab an entitlement from a pool in the results above:

    ```bash
    $ sudo subscription-manager attach --pool <POOL_ID_FROM_ABOVE>
    ```
7. Verify that the consumer does not have the modifier content:

    ```bash
    $ rct cat-cert /etc/pki/entitlement/<YOUR_ENTITLEMENT_CERT>.pem
    ```

Next re-test with this branch. No need to copy the test_data.json, obviously, but make sure that you re-deploy. When you are re-deployed, follow steps 4-7. At step 7, you should notice that the consumer has the modifier content (awesomeos-modifier).
