### PR TITLE
Fix provided product import.

### DIFF
--- a/server/spec/export_spec.rb
+++ b/server/spec/export_spec.rb
@@ -63,6 +63,23 @@ describe 'Export', :serial => true do
     end.should be_empty
   end
 
+  # We export the old style of provided product DTOs, not the full
+  # new reference to an actual product.
+  it 'exports candlepin 0.x backward compatable product definitions' do
+    Dir["#{@cp_export.export_dir}/entitlements/*.json"].find_all do |ent|
+      json = parse_file(ent)
+      pool = json['pool']
+      pool['providedProducts'].each do |pp|
+        pp['productId'].should_not be_nil
+        pp['productName'].should_not be_nil
+      end
+      pool['derivedProvidedProducts'].each do |pp|
+        pp['productId'].should_not be_nil
+        pp['productName'].should_not be_nil
+      end
+    end
+  end
+
   it 'exports entitlement certificates' do
     entitlement_certs_dir = File.join(@cp_export.export_dir,
       'entitlement_certificates')

--- a/server/src/main/java/org/candlepin/model/Pool.java
+++ b/server/src/main/java/org/candlepin/model/Pool.java
@@ -248,6 +248,22 @@ public class Pool extends AbstractHibernateObject implements Persisted, Owned, N
     )
     private Set<Product> derivedProvidedProducts = new HashSet<Product>();
 
+    /**
+     * Set of provided product DTOs used for compatibility with the pre-2.0 JSON.
+     * Used when serializing a pool to JSON over the API, and when importing a manifest.
+     * Collection is transient and should never make it to the database.
+     */
+    @Transient
+    private Set<ProvidedProduct> providedProductDtos = null;
+
+    /**
+     * Set of provided product DTOs used for compatibility with the pre-2.0 JSON.
+     * Used when serializing a pool to JSON over the API, and when importing a manifest.
+     * Collection is transient and should never make it to the database.
+     */
+    @Transient
+    private Set<ProvidedProduct> derivedProvidedProductDtos = null;
+
     @OneToMany(mappedBy = "pool")
     @Cascade({org.hibernate.annotations.CascadeType.ALL,
         org.hibernate.annotations.CascadeType.DELETE_ORPHAN})
@@ -294,17 +310,6 @@ public class Pool extends AbstractHibernateObject implements Persisted, Owned, N
 
     @Transient
     private boolean markedForDelete = false;
-
-    /*
-     * These DTO collections are only used when importing manifests. For backward
-     * compatability reasons we serialize a DTO for the provided products, not the full
-     * product object itself.
-     */
-    @Transient
-    private Set<ProvidedProduct> providedProductDtos = null;
-
-    @Transient
-    private Set<ProvidedProduct> derivedProvidedProductDtos = null;
 
     /*
      * Only used for importing legacy manifests.
@@ -722,6 +727,9 @@ public class Pool extends AbstractHibernateObject implements Persisted, Owned, N
         }
     }
 
+    /*
+     * Always exported as a DTO for API/import backward compatibility.
+     */
     @JsonProperty("providedProducts")
     public Set<ProvidedProduct> getProvidedProductDtos() {
         Set<ProvidedProduct> prods = new HashSet<ProvidedProduct>();
@@ -967,6 +975,9 @@ public class Pool extends AbstractHibernateObject implements Persisted, Owned, N
         }
     }
 
+    /*
+     * Always exported as a DTO for API/import backward compatibility.
+     */
     @JsonProperty("derivedProvidedProducts")
     public Set<ProvidedProduct> getDerivedProvidedProductDtos() {
         Set<ProvidedProduct> prods = new HashSet<ProvidedProduct>();


### PR DESCRIPTION
Provided products were not being imported at all due to looking at the wrong
collection in the entitlement importer. (derived provided products were fine)

Updated code to look at the correct collection, removed unused checks for the
wrong collection (as these should never be populated now).

Added extensive comments to hopefully help clarify this unfortunate hack done
during 2.0 development to maintain JSON compatability over the API and in
manifests. This allows us to not break clients, and to keep manifest import
working both from old servers to new, and from new to old.