### PR TITLE
Fixed duplicate results when using Entitlement matches filter

### DIFF
--- a/server/src/main/java/org/candlepin/model/EntitlementCurator.java
+++ b/server/src/main/java/org/candlepin/model/EntitlementCurator.java
@@ -80,6 +80,7 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
             query.createAlias("p.providedProducts", "provProd", CriteriaSpecification.LEFT_JOIN);
             query.createAlias("provProd.productContent", "ppcw", CriteriaSpecification.LEFT_JOIN);
             query.createAlias("ppcw.content", "ppContent", CriteriaSpecification.LEFT_JOIN);
+            query.setResultTransformer(Criteria.DISTINCT_ROOT_ENTITY);
         }
         query.add(Restrictions.eq("consumer", consumer));
         // Never show a consumer expired entitlements
@@ -110,6 +111,7 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
             c.createAlias("p.providedProducts", "provProd", CriteriaSpecification.LEFT_JOIN);
             c.createAlias("provProd.productContent", "ppcw", CriteriaSpecification.LEFT_JOIN);
             c.createAlias("ppcw.content", "ppContent", CriteriaSpecification.LEFT_JOIN);
+            c.setResultTransformer(Criteria.DISTINCT_ROOT_ENTITY);
         }
         c.add(Restrictions.eq("consumer", consumer));
         // Never show a consumer expired entitlements


### PR DESCRIPTION
Since we joining on content, we need to make sure we have a distinct root
entity when querying with the matches filter.


## Testing

Attach one of the stackable ram subsciptions from the test data. I used ram-2gb-stackable -- "RAM Limiting Package (2GB stackable)"

Then run the curl command below, and expect a singe result.

```bash
curl -k -u admin:admin "https://localhost:8443/candlepin/consumers/:consumer_uuid/entitlements?matches=*ram*"
```
