### PR TITLE
Added preconditions to custom change tasks

### DIFF
--- a/gutterball/src/main/resources/db/changelog/2015-06-02-10-26-compliance-status-products.xml
+++ b/gutterball/src/main/resources/db/changelog/2015-06-02-10-26-compliance-status-products.xml
@@ -29,10 +29,20 @@
     </changeSet>
 
     <changeSet id="20150602102655-4" author="crog">
+        <preConditions onSqlOutput="FAIL" onFail="CONTINUE"/>
+
         <customChange class="org.candlepin.gutterball.liquibase.ComplianceStatusProductIdMigrationTaskLiquibaseWrapper"/>
     </changeSet>
 
     <changeSet id="20150602102655-5" author="crog">
+        <preConditions onSqlOutput="TEST" onFail="CONTINUE">
+            <changeSetExecuted
+                changeLogFile="20150602102655-compliance-status-products.xml"
+                id="20150602102655-4"
+                author="crog"
+            />
+        </preConditions>
+
         <addPrimaryKey
             columnNames="id"
             constraintName="gb_compprod_snap_pk"
@@ -41,6 +51,14 @@
     </changeSet>
 
     <changeSet id="20150602102655-6" author="crog">
+        <preConditions onSqlOutput="TEST" onFail="CONTINUE">
+            <changeSetExecuted
+                changeLogFile="20150602102655-compliance-status-products.xml"
+                id="20150602102655-4"
+                author="crog"
+            />
+        </preConditions>
+
         <addPrimaryKey
             columnNames="id"
             constraintName="gb_partcompprod_snap_pk"
@@ -49,6 +67,14 @@
     </changeSet>
 
     <changeSet id="20150602102655-7" author="crog">
+        <preConditions onSqlOutput="TEST" onFail="CONTINUE">
+            <changeSetExecuted
+                changeLogFile="20150602102655-compliance-status-products.xml"
+                id="20150602102655-4"
+                author="crog"
+            />
+        </preConditions>
+
         <addPrimaryKey
             columnNames="id"
             constraintName="gb_noncompprod_snap_pk"

--- a/server/src/main/resources/db/changelog/20140408160212-add-pool-source-sub-table.xml
+++ b/server/src/main/resources/db/changelog/20140408160212-add-pool-source-sub-table.xml
@@ -87,12 +87,22 @@
     </changeSet>
 
     <changeSet id="20140408160212-3" author="ckozak">
+        <preConditions onSqlOutput="FAIL" onFail="CONTINUE"/>
+
         <comment>Migrate subscriptions on duplicate pools to a single pool per set</comment>
         <customChange class="org.candlepin.liquibase.FixDuplicatePoolsLiquibaseWrapper">
         </customChange>
     </changeSet>
 
     <changeSet id="20140408160212-4" author="ckozak">
+        <preConditions onSqlOutput="TEST" onFail="CONTINUE">
+            <changeSetExecuted
+                changeLogFile="20140408160212-add-pool-source-sub-table.xml"
+                id="20140408160212-3"
+                author="ckozak"
+            />
+        </preConditions>
+
         <comment>Copy all pool source subscription data to the new table</comment>
         <!-- Everything with non-null values for both subid and subkey can be copied directly assuming we have properly removed duplicates -->
         <sql>
@@ -115,6 +125,14 @@
     </changeSet>
 
     <changeSet id="20140408160212-5" author="ckozak">
+        <preConditions onSqlOutput="TEST" onFail="CONTINUE">
+            <changeSetExecuted
+                changeLogFile="20140408160212-add-pool-source-sub-table.xml"
+                id="20140408160212-4"
+                author="ckozak"
+            />
+        </preConditions>
+
         <comment>Remove unused columns</comment>
 
         <dropUniqueConstraint

--- a/server/src/main/resources/db/changelog/20150210094558-perorgproducts-phase-1.xml
+++ b/server/src/main/resources/db/changelog/20150210094558-perorgproducts-phase-1.xml
@@ -487,6 +487,8 @@
 
     <!-- migration task -->
     <changeSet id="20150210094558-40" author="crog">
+        <preConditions onSqlOutput="FAIL" onFail="CONTINUE"/>
+
         <comment>Migrate data from obsoleted tables to new org-specific tables.</comment>
 
         <customChange class="org.candlepin.liquibase.PerOrgProductsUpgradeLiquibaseWrapper"/>

--- a/server/src/main/resources/db/changelog/20150401140006-add-pool-type-to-db.xml
+++ b/server/src/main/resources/db/changelog/20150401140006-add-pool-type-to-db.xml
@@ -15,12 +15,22 @@
     </changeSet>
 
     <changeSet id="20150401140006-2" author="crog">
+        <preConditions onSqlOutput="FAIL" onFail="CONTINUE"/>
+
         <comment>Add pool types to the existing pools</comment>
 
         <customChange class="org.candlepin.liquibase.PoolTypeUpgradeLiquibaseWrapper"/>
     </changeSet>
 
     <changeSet id="20150401140006-3" author="crog">
+        <preConditions onSqlOutput="TEST" onFail="CONTINUE">
+            <changeSetExecuted
+                changeLogFile="20150401140006-add-pool-type-to-db.xml"
+                id="20150401140006-2"
+                author="crog"
+            />
+        </preConditions>
+
         <comment>Add the not-null constraint to the new pool type column</comment>
 
         <addNotNullConstraint tableName="cp_pool" columnDataType="varchar(32)" columnName="type"/>


### PR DESCRIPTION
- Added preconditions to custom change tasks, and any reliant task,
  to prevent them from running during offline/sql output mode

This update is primarily to help IT with their internal workflow that requires examining/processing the SQL statements to be run. This won't provide a 100% accurate representation (as the custom tasks tend to run quite a few statements), but it does allow updateSQL to run.