### PR TITLE
Fix derived product import with 0.9 manifests.

### DIFF
--- a/server/spec/import_spec.rb
+++ b/server/spec/import_spec.rb
@@ -36,6 +36,25 @@ describe 'Import', :serial => true do
   it 'creates pools' do
     pools = @import_owner_client.list_pools({:owner => @import_owner['id']})
     pools.length.should == 6
+
+    # Some of these pools must carry provided/derived provided products,
+    # don't care which pool just need to be sure that they're getting
+    # imported at all:
+    provided_found = false
+    derived_found = false
+    pools.each do |pool|
+      if pool['providedProducts'].size > 0
+        provided_found = true
+      end
+      if pool['derivedProvidedProducts'].size > 0
+        derived_found = true
+      end
+    end
+    provided_found.should be_true
+    derived_found.should be_true
+  end
+
+  it 'created unmapped guest derived pool' do
   end
 
   it 'ignores multiplier for pool quantity' do

--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -1262,7 +1262,8 @@ public class CandlepinPoolManager implements PoolManager {
         List<Entitlement> allEnvEnts = entitlementCurator.listByEnvironment(e);
         Set<Entitlement> entsToRegen = new HashSet<Entitlement>();
         for (Entitlement ent : allEnvEnts) {
-            Product prod = productCurator.lookupById(ent.getOwner(), ent.getProductId());
+            Product prod = productCurator.lookupById(ent.getOwner(),
+                    ent.getPool().getProductId());
             for (String contentId : affectedContent) {
                 if (prod.hasContent(contentId)) {
                     entsToRegen.add(ent);

--- a/server/src/main/java/org/candlepin/model/Entitlement.java
+++ b/server/src/main/java/org/candlepin/model/Entitlement.java
@@ -162,20 +162,6 @@ public class Entitlement extends AbstractHibernateObject
     }
 
     /**
-     * @return Returns the product.
-     */
-    @XmlTransient
-    public String getProductId() {
-        if (this.pool != null) {
-            if (pool.getImportedProductId() != null) {
-                return pool.getImportedProductId();
-            }
-            return this.pool.getProductId();
-        }
-        return null;
-    }
-
-    /**
      * @return Returns the pool.
      */
     public Pool getPool() {
@@ -285,7 +271,7 @@ public class Entitlement extends AbstractHibernateObject
     public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append("Entitlement[id=").append(id);
-        sb.append(", product=").append(getProductId());
+        sb.append(", product=").append(getPool().getProductId());
         if (pool != null) {
             sb.append(", pool=").append(pool.getId());
         }

--- a/server/src/main/java/org/candlepin/model/EntitlementCurator.java
+++ b/server/src/main/java/org/candlepin/model/EntitlementCurator.java
@@ -258,7 +258,7 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
         List<Product> products = productCurator.listAllByIds(entitlement.getOwner(), pidEnts.keySet());
 
         for (Product p : products) {
-            boolean modifies = p.modifies(entitlement.getProductId());
+            boolean modifies = p.modifies(entitlement.getPool().getProductId());
             Iterator<Product> ppit = entitlement.getPool().getProvidedProducts().iterator();
             // No need to continue checking once we have found a modified product
             while (!modifies && ppit.hasNext()) {
@@ -289,7 +289,7 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
      * productId as well as those if its provided products.
      */
     private void addToMap(Map<String, Set<Entitlement>> map, Entitlement e) {
-        addProductIdToMap(map, e.getProductId(), e);
+        addProductIdToMap(map, e.getPool().getProductId(), e);
         for (Product pp : e.getPool().getProvidedProducts()) {
             addProductIdToMap(map, pp.getId(), e);
         }

--- a/server/src/main/java/org/candlepin/model/Pool.java
+++ b/server/src/main/java/org/candlepin/model/Pool.java
@@ -316,6 +316,8 @@ public class Pool extends AbstractHibernateObject implements Persisted, Owned, N
      */
     @Transient
     private String importedProductId = null;
+    @Transient
+    private String importedDerivedProductId = null;
 
     @Column(name = "upstream_pool_id")
     @Size(max = 255)
@@ -817,7 +819,13 @@ public class Pool extends AbstractHibernateObject implements Persisted, Owned, N
      */
     @HateoasInclude
     public String getProductId() {
-        return (this.getProduct() != null ? this.getProduct().getId() : null);
+        if (getProduct() != null) {
+            return this.getProduct().getId();
+        }
+        else if (getImportedProductId() != null) {
+            return getImportedProductId();
+        }
+        return null;
     }
 
     public void setProductId(String productId) {
@@ -827,6 +835,15 @@ public class Pool extends AbstractHibernateObject implements Persisted, Owned, N
     @XmlTransient
     public String getImportedProductId() {
         return this.importedProductId;
+    }
+
+    public void setDerivedProductId(String productId) {
+        this.importedDerivedProductId = productId;
+    }
+
+    @XmlTransient
+    public String getDerivedImportedProductId() {
+        return this.importedDerivedProductId;
     }
 
     /**
@@ -921,10 +938,14 @@ public class Pool extends AbstractHibernateObject implements Persisted, Owned, N
     }
 
     public String getDerivedProductId() {
-        if (derivedProduct == null) {
-            return null;
+        if (getDerivedProduct() != null) {
+            return this.getDerivedProduct().getId();
         }
-        return this.derivedProduct.getId();
+        else if (getDerivedImportedProductId() != null) {
+            return getDerivedImportedProductId();
+        }
+        return null;
+
     }
 
     public Set<ProductAttribute> getProductAttributes() {

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -1177,7 +1177,7 @@ public class ConsumerResource {
             if (isVirtOnly(pool)) {
                 if (!requiredHost.equals(host.getUuid())) {
                     log.warn("Removing entitlement {} from guest {}.",
-                        entitlement.getProductId(), guest.getName());
+                        entitlement.getPool().getProductId(), guest.getName());
                     deletableGuestEntitlements.add(entitlement);
                 }
                 else if (isUnmappedGuestPool(pool)) {
@@ -1187,7 +1187,7 @@ public class ConsumerResource {
             }
             else {
                 log.info("Entitlement {} on {} is still valid and will not be removed.",
-                    entitlement.getProductId(), guest.getName());
+                    entitlement.getPool().getProductId(), guest.getName());
             }
         }
         // perform the entitlement revocation

--- a/server/src/main/java/org/candlepin/resource/EntitlementResource.java
+++ b/server/src/main/java/org/candlepin/resource/EntitlementResource.java
@@ -125,7 +125,7 @@ public class EntitlementResource {
         verifyExistence(consumer, consumerUuid);
 
         for (Entitlement e : consumer.getEntitlements()) {
-            if (e.getProductId().equals(productId)) {
+            if (e.getPool().getProductId().equals(productId)) {
                 return e;
             }
         }

--- a/server/src/main/java/org/candlepin/sync/EntitlementImporter.java
+++ b/server/src/main/java/org/candlepin/sync/EntitlementImporter.java
@@ -96,7 +96,7 @@ public class EntitlementImporter {
                 b.getName()));
         }
 
-        subscription.setProduct(findProduct(productsById, entitlement.getProductId()));
+        subscription.setProduct(findProduct(productsById, entitlement.getPool().getProductId()));
         String cdnLabel = meta.getCdnLabel();
         if (!StringUtils.isBlank(cdnLabel)) {
             Cdn cdn = cdnCurator.lookupByLabel(cdnLabel);
@@ -106,9 +106,9 @@ public class EntitlementImporter {
         }
 
         // Add any sub product data to the subscription.
-        if (entitlement.getPool().getDerivedProduct() != null) {
+        if (entitlement.getPool().getDerivedProductId() != null) {
             subscription.setDerivedProduct(findProduct(
-                productsById, entitlement.getPool().getDerivedProduct().getId()
+                productsById, entitlement.getPool().getDerivedProductId()
             ));
         }
 

--- a/server/src/main/java/org/candlepin/sync/Exporter.java
+++ b/server/src/main/java/org/candlepin/sync/Exporter.java
@@ -386,7 +386,7 @@ public class Exporter {
             if (manifest && !this.exportRules.canExport(cert.getEntitlement())) {
                 if (log.isDebugEnabled()) {
                     log.debug("Skipping export of entitlement cert with product:  " +
-                            cert.getEntitlement().getProductId());
+                            cert.getEntitlement().getPool().getProductId());
                 }
                 continue;
             }
@@ -447,14 +447,14 @@ public class Exporter {
             if (!this.exportRules.canExport(ent)) {
                 if (log.isDebugEnabled()) {
                     log.debug("Skipping export of entitlement with product:  " +
-                            ent.getProductId());
+                            ent.getPool().getProductId());
                 }
 
                 continue;
             }
 
             if (log.isDebugEnabled()) {
-                log.debug("Exporting entitlement for product" + ent.getProductId());
+                log.debug("Exporting entitlement for product" + ent.getPool().getProductId());
             }
             FileWriter writer = null;
             try {

--- a/server/src/test/java/org/candlepin/policy/js/compliance/hash/ComplianceStatusHasherTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/compliance/hash/ComplianceStatusHasherTest.java
@@ -98,7 +98,7 @@ public class ComplianceStatusHasherTest {
         Entitlement ent = createEntitlement(Calendar.getInstance(), owner, consumer, "test-ent");
         HashSet<Entitlement> ents = new HashSet<Entitlement>();
         ents.add(ent);
-        testStatus.getCompliantProducts().put(ent.getProductId(), ents);
+        testStatus.getCompliantProducts().put(ent.getPool().getProductId(), ents);
 
         assertNotEquals(initialHash, generateHash(testStatus, consumer));
     }
@@ -112,7 +112,7 @@ public class ComplianceStatusHasherTest {
         Entitlement ent = createEntitlement(Calendar.getInstance(), owner, consumer, "test-ent");
         HashSet<Entitlement> ents = new HashSet<Entitlement>();
         ents.add(ent);
-        testStatus.getPartiallyCompliantProducts().put(ent.getProductId(), ents);
+        testStatus.getPartiallyCompliantProducts().put(ent.getPool().getProductId(), ents);
 
         assertNotEquals(initialHash, generateHash(testStatus, consumer));
     }


### PR DESCRIPTION
We implemented some fixes to let old manifests import the main product ID from
a legacy manifest, but derived product ID was missed. Because this is the key
piece of data we check to trigger derived product behaviour, we ended up with
no derived product data importing or taking effect.

Implement the same hack required for product ID.