### PR TITLE
Fix InsufficientPermission error when checking HypervisorCheckIn Job

### DIFF
--- a/server/src/main/java/org/candlepin/pinsetter/tasks/HypervisorUpdateJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/HypervisorUpdateJob.java
@@ -187,6 +187,7 @@ public class HypervisorUpdateJob extends UniqueByOwnerJob {
         JobDataMap map = new JobDataMap();
         map.put(JobStatus.TARGET_TYPE, JobStatus.TargetType.OWNER);
         map.put(JobStatus.TARGET_ID, owner.getKey());
+        map.put(JobStatus.OWNER_ID, owner.getKey());
         map.put(CREATE, create);
         map.put(DATA, compress(data));
         map.put(PRINCIPAL, principal);


### PR DESCRIPTION
When virt-who created new HypervisorCheckIn job using new async API, it
couldn't check state of that job because it was not allowed. This commit
fixes the issue and virt-who can check state of job it created.