### PR TITLE
Fix EL7 docker rpm container test.

### DIFF
--- a/docker/candlepin-rhel6-base/startup.sh
+++ b/docker/candlepin-rhel6-base/startup.sh
@@ -27,7 +27,13 @@ fi
 # TODO: use env variables to check which database we're linked to, for now
 # we'll just assume postgres.
 
-/usr/share/candlepin/cpsetup -u postgres --dbhost $DB_PORT_5432_TCP_ADDR --dbport $DB_PORT_5432_TCP_PORT
+# Fetch the latest cpsetup and cpdb scripts and overwrite whatever came in the RPM so we don't have to tag
+# a build to get a change into the container. This should only be done in the base containers, not official
+# candlepin build containers.
+wget -O /usr/share/candlepin/cpsetup https://raw.githubusercontent.com/candlepin/candlepin/master/server/code/setup/cpsetup
+wget -O /usr/share/candlepin/cpsetup https://raw.githubusercontent.com/candlepin/candlepin/master/server/code/setup/cpsetup
+
+/usr/share/candlepin/cpsetup -u postgres --dbhost $DB_PORT_5432_TCP_ADDR --dbport $DB_PORT_5432_TCP_PORT --skip-service
 
 service tomcat6 start
 /usr/bin/supervisord -c /etc/supervisord.conf

--- a/docker/candlepin-rhel7-base/startup.sh
+++ b/docker/candlepin-rhel7-base/startup.sh
@@ -15,6 +15,12 @@ CANDLEPIN
 cat /etc/yum.repos.d/candlepin.repo
 yum install -y candlepin
 
-/usr/share/candlepin/cpsetup -u postgres --dbhost $DB_PORT_5432_TCP_ADDR --dbport $DB_PORT_5432_TCP_PORT
+# Fetch the latest cpsetup and cpdb scripts and overwrite whatever came in the RPM so we don't have to tag
+# a build to get a change into the container. This should only be done in the base containers, not official
+# candlepin build containers.
+wget -O /usr/share/candlepin/cpsetup https://raw.githubusercontent.com/candlepin/candlepin/master/server/code/setup/cpsetup
+wget -O /usr/share/candlepin/cpsetup https://raw.githubusercontent.com/candlepin/candlepin/master/server/code/setup/cpsetup
+
+/usr/share/candlepin/cpsetup -u postgres --dbhost $DB_PORT_5432_TCP_ADDR --dbport $DB_PORT_5432_TCP_PORT --skip-service
 
 /usr/bin/supervisord -c /etc/supervisord.conf

--- a/server/code/setup/cpsetup
+++ b/server/code/setup/cpsetup
@@ -111,21 +111,11 @@ class TomcatSetup(object):
         run_command("chown tomcat:tomcat -R /var/lib/" + TOMCAT)
         run_command("chown tomcat:tomcat -R /var/cache/" + TOMCAT)
 
-    # If supervisord tomcat.conf exists, assume this is a docker container
-    # and use supervisorctl to manage the service instead:
     def stop(self):
-        if os.path.exists('/etc/supervisor/conf.d/tomcat.conf'):
-            print("Supervisord tomcat config exists, using supervisorctl stop.")
-            run_command("supervisorctl stop tomcat")
-        else:
-            run_command("/sbin/service " + TOMCAT + " stop")
+        run_command("/sbin/service " + TOMCAT + " stop")
 
     def restart(self):
-        if os.path.exists('/etc/supervisor/conf.d/tomcat.conf'):
-            print("Supervisord tomcat config exists, using supervisorctl restart.")
-            #run_command("supervisorctl restart tomcat")
-        else:
-            run_command("/sbin/service " + TOMCAT + " restart")
+        run_command("/sbin/service " + TOMCAT + " restart")
 
     def wait_for_startup(self):
         print("Waiting for tomcat to restart...")
@@ -263,6 +253,8 @@ def main(argv):
     parser.add_option("--oracle-password",
                   dest="oracle_password",
                   help="Oracle DBA password")
+    parser.add_option("--skip-service", dest="skip_service", action="store_true",
+        default=False, help="Skip attempting to stop/restart tomcat service.")
 
     (options, args) = parser.parse_args()
 
@@ -273,7 +265,8 @@ def main(argv):
     # Stop tomcat before we wipe the DB otherwise you get errors from pg
     tsetup = TomcatSetup('/etc/' + TOMCAT, options.keystorepwd)
     tsetup.fix_perms()
-    tsetup.stop()
+    if not options.skip_service:
+        tsetup.stop()
 
     # Call the cpdb script to create the candlepin database. Database creation will be
     # skipped if it already exists. The --schema-only option can be used if the database
@@ -310,10 +303,11 @@ def main(argv):
 
     tsetup = TomcatSetup('/etc/' + TOMCAT, options.keystorepwd)
     tsetup.update_config()
-    tsetup.restart()
-    tsetup.wait_for_startup()
 
-    run_command("wget -qO- http://localhost:8080/candlepin/admin/init")
+    if not options.skip_service:
+        tsetup.restart()
+        tsetup.wait_for_startup()
+        run_command("wget -qO- http://localhost:8080/candlepin/admin/init")
 
     print("Candlepin has been configured.")
 


### PR DESCRIPTION
Addition of set -e introduced problems in the startup.sh script, as the cpsetup
command does error out on EL7 because the service it not yet running, thus we
can't check status and initialize. Previously this would fail and continue in
the script, starting supervisor.

Instead we'll keep the set -e, but add a new cpsetup option that skips service
stop/restart/init, and eliminates the failed command during startup.

Also added wget calls to fetch the latest cpsetup and cpdb for this base
container used for rpm installation tests. This isn't used by the more official
tagged containers with a build in them, only for the base image that doesn't
yet have cp installed.