### PR TITLE
Added a specific install for meld3 in the RHEL RPM docker containers

### DIFF
--- a/docker/candlepin-rhel6-base/setup-supervisor.sh
+++ b/docker/candlepin-rhel6-base/setup-supervisor.sh
@@ -3,6 +3,7 @@
 set -e
 
 setup_supervisor() {
+    pip install meld3==1.0.0
     pip install supervisor
     mkdir -p /var/log/supervisor
     mkdir -p /etc/supervisor/conf.d

--- a/docker/candlepin-rhel7-base/setup-supervisor.sh
+++ b/docker/candlepin-rhel7-base/setup-supervisor.sh
@@ -3,6 +3,7 @@
 set -e
 
 setup_supervisor() {
+    pip install meld3==1.0.0
     pip install supervisor
     mkdir -p /var/log/supervisor
     mkdir -p /etc/supervisor/conf.d


### PR DESCRIPTION
- Added a specific requirement for the meld3 package for installing
  supervisord via pip to work around an issue with the latest
  versions of meld3 causing dependency issues

Issue and workaround discussed here:
https://github.com/Supervisor/meld3/issues/21