### PR TITLE
1246636: Content labels need unique key per owner

### DIFF
--- a/server/bin/test_data.json
+++ b/server/bin/test_data.json
@@ -285,7 +285,7 @@
                 {
                     "name": "admin-content",
                     "id": 5000,
-                    "label": "content-label",
+                    "label": "admin-content-label",
                     "type": "yum",
                     "vendor": "test-vendor",
                     "content_url": "/admin/foo/path",
@@ -295,7 +295,7 @@
                 {
                     "name": "admin-tagged-content",
                     "id": 5001,
-                    "label": "tagged-content",
+                    "label": "admin-tagged-content",
                     "type": "yum",
                     "vendor": "test-vendor",
                     "content_url": "/admin/foo/path/always",
@@ -303,9 +303,9 @@
                     "required_tags": "TAG1,TAG2"
                 },
                 {
-                    "name": "never-enabled-content",
+                    "name": "admin-never-enabled-content",
                     "id": 5002,
-                    "label": "never-enabled-content",
+                    "label": "admin-never-enabled-content",
                     "type": "yum",
                     "vendor": "test-vendor",
                     "content_url": "/admin/foo/path/never",
@@ -392,7 +392,7 @@
                 {
                     "name": "snowy-content",
                     "id": 6000,
-                    "label": "content-label",
+                    "label": "snowy-content-label",
                     "type": "yum",
                     "vendor": "test-vendor",
                     "content_url": "/snowy/foo/path",
@@ -402,7 +402,7 @@
                 {
                     "name": "snowy-tagged-content",
                     "id": 6001,
-                    "label": "tagged-content",
+                    "label": "snowy-tagged-content",
                     "type": "yum",
                     "vendor": "test-vendor",
                     "content_url": "/snowy/foo/path/always",
@@ -410,9 +410,9 @@
                     "required_tags": "TAG1,TAG2"
                 },
                 {
-                    "name": "never-enabled-content",
+                    "name": "snowy-never-enabled-content",
                     "id": 6002,
-                    "label": "never-enabled-content",
+                    "label": "snowy-never-enabled-content",
                     "type": "yum",
                     "vendor": "test-vendor",
                     "content_url": "/snowy/foo/path/never",

--- a/server/src/main/resources/db/changelog/20150729082417-content-unique-owner-label.xml
+++ b/server/src/main/resources/db/changelog/20150729082417-content-unique-owner-label.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+    <changeSet id="20150729082417-1" author="wpoteat">
+        <addUniqueConstraint tableName="cpo_content"
+            columnNames="owner_id, label"
+            constraintName="cpo_content_unq2"
+        />
+    </changeSet>
+
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/server/src/main/resources/db/changelog/changelog-create.xml
+++ b/server/src/main/resources/db/changelog/changelog-create.xml
@@ -1,8 +1,6 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
-
     <property name="project.name" value="candlepin"/>
-
     <changeSet author="dgoodwin" id="1332854949306-1000" dbms="postgresql">
         <createTable tableName="cp_activation_key">
             <column name="id" type="VARCHAR(32)">
@@ -1182,4 +1180,5 @@
     <include file="db/changelog/20150430115844-job-status-result-data.xml"/>
     <include file="db/changelog/20150615155037-add-consumer-annotations.xml"/>
     <include file="db/changelog/20150616090156-per-org-products-column-def-fix.xml"/>
+    <include file="db/changelog/20150729082417-content-unique-owner-label.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-testing.xml
+++ b/server/src/main/resources/db/changelog/changelog-testing.xml
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
     <property name="project.name" value="candlepin"/>
-
     <!--
       This file should only run DDL statements.  For performance reasons the
       CandlepinLiquibaseResource only runs a Liquibase update at the beginning of a test
@@ -2271,4 +2270,5 @@
     <include file="db/changelog/20150430115844-job-status-result-data.xml"/>
     <include file="db/changelog/20150615155037-add-consumer-annotations.xml"/>
     <include file="db/changelog/20150616090156-per-org-products-column-def-fix.xml"/>
+    <include file="db/changelog/20150729082417-content-unique-owner-label.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-update.xml
+++ b/server/src/main/resources/db/changelog/changelog-update.xml
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
     <property name="project.name" value="candlepin"/>
-
     <include file="db/changelog/20120416134048-insert-uebercert-consumer-type.xml"/>
     <include file="db/changelog/20120420143629-consumer-release-to-varchar.xml"/>
     <include file="db/changelog/20120523102544-add-owner-default-sla.xml"/>
@@ -89,4 +88,5 @@
     <include file="db/changelog/20150430115844-job-status-result-data.xml"/>
     <include file="db/changelog/20150615155037-add-consumer-annotations.xml"/>
     <include file="db/changelog/20150616090156-per-org-products-column-def-fix.xml"/>
+    <include file="db/changelog/20150729082417-content-unique-owner-label.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
You will need to regenerate the database if the test data was previously loaded
 as the older data violates this constraint