### PR TITLE
Reduce database chatter in GET /status.

### DIFF
--- a/server/spec/rules_import_spec.rb
+++ b/server/spec/rules_import_spec.rb
@@ -6,31 +6,53 @@ require 'base64'
 
 describe 'Rules Import', :serial => true do
 
-  #include CandlepinMethods
+  before(:each) do
+    # Make sure we're using the rpm rules by deleting any custom
+    # ones that may have been left in the database:
+    @cp.delete_rules
+
+    @orig_ver = @cp.get_status()['rulesVersion']
+    rules_major_ver = @orig_ver.split(".")[0]
+    # Come up with a rules version we know is greater than the current:
+    @new_ver = "#{rules_major_ver}.10000"
+
+    # Dummy rules we can upload:
+    @rules = "//Version: #{@new_ver}\nvar a=1.0;"
+  end
+
+  after(:each) do
+    # Revert to rpm rules:
+    @cp.delete_rules
+  end
 
   it 'gets rules' do
     js_rules = @cp.list_rules
   end
 
-  it "posts and gets rules" do
-    rules_major_ver = @cp.get_status()['rulesVersion'].split(".")[0]
-    rules = "//Version: #{rules_major_ver}.10000\nvar a=1.0;"
-    encoded_rules = Base64.encode64(rules)
+  def upload_dummy_rules
+    encoded_rules = Base64.encode64(@rules)
     result = @cp.upload_rules(encoded_rules)
     fetched_rules = @cp.list_rules
     decoded_fetched_rules = Base64.decode64(fetched_rules)
-    (decoded_fetched_rules == rules).should be_true
+    (decoded_fetched_rules == @rules).should be_true
+    @cp.get_status()['rulesVersion'].should == @new_ver
+  end
+
+  it "posts and gets rules" do
+    upload_dummy_rules
   end
 
   it "deletes rules" do
-    rules_orig = @cp.list_rules
+    upload_dummy_rules
+
     deleted = @cp.delete_rules()
     rules = @cp.list_rules
-    @cp.delete_rules
-  end
 
-  it "deletes a rule" do
-    deleted = @cp.delete_rules()
+    # Version should be back to original:
+    @cp.get_status()['rulesVersion'].should == @orig_ver
+
+    # Shouldn't cause an error if there are none in db:
+    @cp.delete_rules
   end
 
 end

--- a/server/src/main/java/org/candlepin/model/RulesCurator.java
+++ b/server/src/main/java/org/candlepin/model/RulesCurator.java
@@ -106,7 +106,7 @@ public class RulesCurator extends AbstractHibernateCurator<Rules> {
         return dbRules;
     }
 
-    private Date getUpdatedFromDB() {
+    public Date getUpdatedFromDB() {
         return (Date) this.currentSession().createCriteria(Rules.class)
             .setProjection(Projections.projectionList()
                 .add(Projections.max("updated")))
@@ -158,4 +158,5 @@ public class RulesCurator extends AbstractHibernateCurator<Rules> {
     protected String getDefaultRulesFile() {
         return DEFAULT_RULES_FILE;
     }
+
 }

--- a/server/src/test/java/org/candlepin/resource/StatusResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/StatusResourceTest.java
@@ -14,19 +14,14 @@
  */
 package org.candlepin.resource;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 import org.candlepin.common.config.Configuration;
 import org.candlepin.model.Rules;
 import org.candlepin.model.RulesCurator;
 import org.candlepin.model.Status;
+import org.candlepin.policy.js.JsRunnerProvider;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -53,6 +48,7 @@ public class StatusResourceTest {
 
     @Mock private RulesCurator rulesCurator;
     @Mock private Configuration config;
+    @Mock private JsRunnerProvider jsProvider;
 
     @Before
     public void setUp() {
@@ -67,7 +63,7 @@ public class StatusResourceTest {
             .getClassLoader().getResource("version.properties").toURI()));
         ps.println("version=${version}");
         ps.println("release=${release}");
-        StatusResource sr = new StatusResource(rulesCurator, config);
+        StatusResource sr = new StatusResource(rulesCurator, config, jsProvider);
         Status s = sr.status();
         ps.close();
         assertNotNull(s);
@@ -81,7 +77,7 @@ public class StatusResourceTest {
         PrintStream ps = new PrintStream(new File(this.getClass()
             .getClassLoader().getResource("version.properties").toURI()));
         ps.println("foo");
-        StatusResource sr = new StatusResource(rulesCurator, config);
+        StatusResource sr = new StatusResource(rulesCurator, config, jsProvider);
         Status s = sr.status();
         ps.close();
         assertNotNull(s);
@@ -96,8 +92,8 @@ public class StatusResourceTest {
             .getClassLoader().getResource("version.properties").toURI()));
         ps.println("version=${version}");
         ps.println("release=${release}");
-        when(rulesCurator.listAll()).thenThrow(new RuntimeException());
-        StatusResource sr = new StatusResource(rulesCurator, config);
+        when(rulesCurator.getUpdatedFromDB()).thenThrow(new RuntimeException());
+        StatusResource sr = new StatusResource(rulesCurator, config, jsProvider);
         Status s = sr.status();
         ps.close();
         assertNotNull(s);
@@ -120,7 +116,7 @@ public class StatusResourceTest {
             .getClassLoader().getResource("version.properties").toURI()));
         ps.println("version=${version}");
         ps.println("release=${release}");
-        StatusResource sr = new StatusResource(rulesCurator, null);
+        StatusResource sr = new StatusResource(rulesCurator, null, jsProvider);
         Status s = sr.status();
         ps.close();
 

--- a/server/src/test/java/org/candlepin/sync/RulesImporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/RulesImporterTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.*;
 import org.candlepin.audit.EventSink;
 import org.candlepin.model.Rules;
 import org.candlepin.model.RulesCurator;
+import org.candlepin.policy.js.JsRunnerProvider;
 import org.candlepin.test.DatabaseTestFixture;
 
 import org.junit.Before;
@@ -42,11 +43,12 @@ public class RulesImporterTest extends DatabaseTestFixture {
     @Inject private EventSink sink;
 
     @Mock private RulesCurator curator;
+    @Mock private JsRunnerProvider jsProvider;
     private RulesImporter importer;
 
     @Before
     public void setUp() {
-        importer = new RulesImporter(curator, sink);
+        importer = new RulesImporter(curator, sink, jsProvider);
     }
 
     @Test


### PR DESCRIPTION
This looks like it might be the largest chunk of processing our app does in
prod. Client makes ample use of this, but IT also uses it as a health check.

First step drops querying of rules version and source, instead we set these on
the provider singleton whenever we recompile rules. (i.e. they changed) The two
places they can change (rules upload and import) are updated to immediately
recompile rather than wait for someone to attempt to use them.

Ideally we'd have dropped all db connectivity from the class, but unfortunately
we need to know if the db loses it's connection, so IT can drop the node from
rotation automatically. Instead, we'll reduce the query dramatically and just
query the updated timestamp.

A nice future enhancement would be to catch db errors (all of them somewhere)
and set some kind of flag once we see any.