### PR TITLE
Update required Qpid packages.

### DIFF
--- a/gutterball/bin/qpid/README.md
+++ b/gutterball/bin/qpid/README.md
@@ -1,6 +1,12 @@
 Install qpid:
 
-    sudo yum install qpid-cpp-server-store qpid-cpp-server qpid-tools
+    sudo yum install qpid-cpp-server qpid-tools
+    sudo yum install qpid-cpp-server-linearstore || sudo yum install qpid-cpp-server-store
+
+QPid requires a package to be installed to persist items to disk.  The old
+implementation was "qpid-cpp-server-store" and the newer one is
+"qpid-cpp-server-linearstore".  You need one of them or else everything vanishes
+once the service is restarted.
 
 Now configure qpid to work with SSL:
 

--- a/gutterball/bin/qpid/configure-qpid.sh
+++ b/gutterball/bin/qpid/configure-qpid.sh
@@ -256,9 +256,17 @@ while getopts ":c" opt; do
     esac
 done
 
-if ! is_rpm_installed qpid-cpp-server qpid-tools qpid-cpp-server qpid-cpp-server-store; then
+if ! is_rpm_installed qpid-cpp-server qpid-tools qpid-cpp-server; then
     echo "installing Qpid"
-    sudo yum -y install qpid-cpp-server qpid-tools qpid-cpp-server qpid-cpp-server-store
+    sudo yum -y install qpid-cpp-server qpid-tools qpid-cpp-server 
+fi
+
+# QPid needs a package to provide persistent storage or else everything
+# vanishes after a restart of the service.  Two different storage packages
+# exist depending on the version of RHEL or Fedora.  Try to get one of
+# them installed.  (The linearstore is the newer implementation).
+if ! is_rpm_installed qpid-cpp-server-linearstore || ! is_rpm_installed qpid-cpp-server-store; then
+    sudo yum -y install qpid-cpp-server-linearstore || sudo yum -y install qpid-cpp-server-store
 fi
 
 # create working directory


### PR DESCRIPTION
Based on information discovered in
http://projects.theforeman.org/issues/11285

QPid requires a package to be installed to persist items to disk.  The old implementation was "qpid-cpp-server-store" and the newer one is "qpid-cpp-server-linearstore".  You need one of them or else everything vanishes once the service is restarted.