### PR TITLE
Turn off compiler linting.  Too noisy.

### DIFF
--- a/buildfile
+++ b/buildfile
@@ -188,7 +188,8 @@ define "candlepin" do
 
   compile.options.target = '1.6'
   compile.options.source = '1.6'
-  compile.options.lint = 'all'
+  # Enable to turn on compiler linting
+  # compile.options.lint = 'all'
 
   # path_to() (and it's alias _()) simply provides the absolute path to
   # a directory relative to the project.


### PR DESCRIPTION
Eliminates the numerous warnings Buildr has been printing during compilation.