### PR TITLE
Docker build script updates

### DIFF
--- a/docker/build_container.sh
+++ b/docker/build_container.sh
@@ -66,7 +66,7 @@ if [ "$PUSH" == "1" ]; then
     CP_VERSION="$(docker run -ti --rm candlepin/$IMAGE_NAME:latest rpm -q --queryformat '%{VERSION}' candlepin)"
     if (! echo $CP_VERSION | grep -E -q --regex="^[0-9]+\.[0-9]+.*") then
         # We probably checked it out from git
-        CP_VERSION="$(docker run -ti --rm candlepin/$IMAGE_NAME:latest cd /candlepin && git describe | cut -d- -f 2)"
+        CP_VERSION="$(docker run -ti --rm candlepin/$IMAGE_NAME:latest /bin/sh cd /candlepin && git describe | cut -d- -f 2)"
     fi
 
     if (echo $CP_VERSION | grep -E -q --regex="^[0-9]+\.[0-9]+.*") then

--- a/docker/candlepin-base/cp-test
+++ b/docker/candlepin-base/cp-test
@@ -67,6 +67,7 @@ usage() {
         -t  populate Candlepin database with test data (implies -d)
         -r  run rspec test suite (implies -d)
         -u  run unit test suite
+        -l  run the linter against the code
         -s  run a bash shell when done
         -c  git reference to checkout
         -p  subproject to build (defaults to "server")
@@ -74,22 +75,23 @@ usage() {
 HELP
 }
 
-while getopts ":rusdtvc:p:" opt; do
+while getopts ":dtrulsc:p:v" opt; do
     case $opt in
-        r  )
-            RSPEC="1"
-            DEPLOY="1"
-            ;;
-        u  ) UNITTEST="1";;
-        s  ) LAUNCHSHELL="1";;
         d  ) DEPLOY="1";;
         t  )
             DEPLOY="1"
             TESTDATA="1"
             ;;
-        v  ) VERBOSE="1";;
+        r  )
+            RSPEC="1"
+            DEPLOY="1"
+            ;;
+        u  ) UNITTEST="1";;
+        l  ) LINTER="1";;
+        s  ) LAUNCHSHELL="1";;
         c  ) CHECKOUT="${OPTARG}";;
         p  ) PROJECT="${OPTARG}";;
+        v  ) VERBOSE="1";;
         ?  ) usage; exit;;
     esac
 done
@@ -125,6 +127,11 @@ bundle install
 
 # TODO: keep track of return code?
 cd $CP_HOME/$PROJECT
+
+if [ "$LINTER" == "1" ]; then
+    echo "Running linter..."
+    buildr checkstyle
+fi
 
 if [ "$UNITTEST" == "1" ]; then
     echo "Running unit tests."

--- a/docker/candlepin-oracle/build.sh
+++ b/docker/candlepin-oracle/build.sh
@@ -109,7 +109,7 @@ if [ "$PUSH" == "1" ]; then
     CP_VERSION="$(docker run -ti --rm candlepin/$IMAGE_NAME:latest rpm -q --queryformat '%{VERSION}' candlepin)"
     if (! echo $CP_VERSION | grep -E -q --regex="^[0-9]+\.[0-9]+.*") then
         # We probably checked it out from git
-        CP_VERSION="$(docker run -ti --rm candlepin/$IMAGE_NAME:latest cd /candlepin && git describe | cut -d- -f 2)"
+        CP_VERSION="$(docker run -ti --rm candlepin/$IMAGE_NAME:latest /bin/sh cd /candlepin && git describe | cut -d- -f 2)"
     fi
 
     if (echo $CP_VERSION | grep -E -q --regex="^[0-9]+\.[0-9]+.*") then

--- a/docker/container_version.sh
+++ b/docker/container_version.sh
@@ -8,11 +8,11 @@ else
 fi
 
 
-CP_VERSION="$(docker run -ti --rm candlepin/$IMAGE_NAME:latest rpm -q --queryformat '%{VERSION}' candlepin)"
+CP_VERSION="$(docker run -ti --rm $IMAGE_NAME:latest rpm -q --queryformat '%{VERSION}' candlepin)"
 
 if (! echo $CP_VERSION | grep -E -q --regex="^[0-9]+\.[0-9]+.*") then
   # We probably checked it out from git
-  CP_VERSION="$(docker run -ti --rm candlepin/$IMAGE_NAME:latest cd candlepin && git describe | cut -d- -f 2)"
+  CP_VERSION="$(docker run -ti --rm $IMAGE_NAME:latest /bin/sh cd /candlepin && git describe | cut -d- -f 2)"
 fi
 
 if (! echo $CP_VERSION | grep -E -q --regex="^[0-9]+\.[0-9]+.*") then


### PR DESCRIPTION
- Version checking now uses /bin/sh as the base command, rather than cd
- Added a linter option to cp-test