### PR TITLE
Docker build script updates

### DIFF
--- a/docker/candlepin-base/cp-test
+++ b/docker/candlepin-base/cp-test
@@ -66,6 +66,7 @@ usage() {
         -d  deploy a live candlepin
         -t  populate Candlepin database with test data (implies -d)
         -r  run rspec test suite (implies -d)
+        -f  run rspec tests in parallel (implies -r)
         -u  run unit test suite
         -l  run the linter against the code
         -s  run a bash shell when done
@@ -75,7 +76,7 @@ usage() {
 HELP
 }
 
-while getopts ":dtrulsc:p:v" opt; do
+while getopts ":dtrfulsc:p:v" opt; do
     case $opt in
         d  ) DEPLOY="1";;
         t  )
@@ -83,6 +84,11 @@ while getopts ":dtrulsc:p:v" opt; do
             TESTDATA="1"
             ;;
         r  )
+            RSPEC="1"
+            DEPLOY="1"
+            ;;
+        f  )
+            RSPEC_PARALLEL="1"
             RSPEC="1"
             DEPLOY="1"
             ;;
@@ -157,7 +163,12 @@ fi
 
 if [ "$RSPEC" == "1" ]; then
     echo "Running rspec tests."
-    buildr rspec
+
+    if [ "$RSPEC_PARALLEL" == "1" ]; then
+        buildr rspec:parallel
+    else
+        buildr rspec
+    fi
 
     # If the caller mounted a volume at /artifacts, copy server logs out:
     if [ -d "/artifacts" ]; then

--- a/docker/candlepin-oracle/build.sh
+++ b/docker/candlepin-oracle/build.sh
@@ -80,7 +80,7 @@ cleanup_docker() {
 echo "Running post-build setup tasks..."
 trap cleanup_docker EXIT SIGHUP SIGINT SIGTERM
 rm -f oracle.cid
-docker run --privileged --cidfile=oracle.cid -Pti candlepin/$IMAGE_NAME:latest /bin/bash -xev /root/setup-oracle-runtime.sh
+docker run --privileged --cidfile=oracle.cid -Pi candlepin/$IMAGE_NAME:latest /bin/bash -xev /root/setup-oracle-runtime.sh
 
 if [ "$?" != "0" ]; then
     echo "ERROR: Unable to run container post-build setup tasks" >&2

--- a/docker/jenkins-scripts/smoke-test.sh
+++ b/docker/jenkins-scripts/smoke-test.sh
@@ -53,11 +53,14 @@ def run_command(command, silent=True, ignore_error=False):
 
 parser = OptionParser()
 parser.add_option("-t", "--time",
-              action="store", dest="wait_time", default="600",
-              help="Amount of time to wait for a response from Candlepin; defaults to 600")
+  action="store", dest="wait_time", default="600",
+  help="Amount of time to wait for a response from Candlepin; defaults to 600")
 parser.add_option("-l", "--log-lines",
-              action="store", dest="log_lines", default="all",
-              help="The number of log lines to print on failure or if a response isn't received; defaults to \"all\"")
+  action="store", dest="log_lines", default="all",
+  help="The number of log lines to print on failure or if a response isn't received; defaults to \"all\"")
+parser.add_option("-r", "--rpm",
+  action="store_true", dest="rpm_url", default=False,
+  help="Whether or not the repo URL should be treated as a link to an RPM")
 
 (options, args) = parser.parse_args()
 
@@ -74,6 +77,7 @@ image_name = args[0]
 cp_repo_url = args[1]
 max_wait_time = int(options.wait_time) if re.match("\\A0*[123456789]\\d*\\Z", options.wait_time) else 600
 max_log_lines = options.log_lines if re.match("\\A(?:0*[123456789]\\d*)|(?:all)\\Z", options.wait_time) else "all"
+env_var_name = "RPM_URL" if options.rpm_url else "YUM_REPO"
 
 server_container_id = None
 db_container_id = None
@@ -106,8 +110,8 @@ try:
             time.sleep(10)
 
             # Launch the candlepin container:
-            output = run_command("docker run -P -d -e \"YUM_REPO=%s\" --link %s:db %s"
-                % (cp_repo_url, db_container_name, image_name))
+            output = run_command("docker run -P -d -e \"%s=%s\" --link %s:db %s"
+                % (env_var_name, cp_repo_url, db_container_name, image_name))
             server_container_id = output[-1]
             print "Candlepin container: %s" % server_container_id
             time.sleep(3)

--- a/docker/jenkins-scripts/smoke-test.sh
+++ b/docker/jenkins-scripts/smoke-test.sh
@@ -164,7 +164,7 @@ try:
                             print "ERROR: Unable to query Candlpin status: %s" % e
                             break
 
-                    remaining = int(max_wait_time - (time.time() - start_time))
+                    remaining = int(round(max_wait_time - (time.time() - start_time)))
 
                     if remaining > 0:
                         print "No response; will continue re-trying for another %s seconds..." % remaining


### PR DESCRIPTION
- Oracle's build script no longer attempts to use docker's tty mode 
- Added the -r/--rpm option to the Jenkins smoke test script to
  specify the repo URL (2nd parameter) is a direct reference to
  an RPM
- Added the -f (fast) option to cp-test to run rspec tests in parallel
- The smoke test now rounds the time remaining instead of truncating