### PR TITLE
Associating product content repeatedly from rspec can cause lock fail…

### DIFF
--- a/server/bin/import_products.rb
+++ b/server/bin/import_products.rb
@@ -243,9 +243,10 @@ def create_eng_product(cp, thread_pool, owner, product)
   cert_file = File.new(CERT_DIR + '/' + product_ret['id'] + '.pem', 'w+')
   cert_file.puts(product_cert['cert'])
 
-  product_content.each do |content|
-    cp.add_content_to_product(owner['name'], product_ret['id'], content[0], content[1])
+  if not product_content.empty?
+    cp.add_all_content_to_product(owner['name'], product_ret['id'], product_content)
   end
+
 end
 
 def create_mkt_product(cp, owner, product)

--- a/server/client/ruby/candlepin_api.rb
+++ b/server/client/ruby/candlepin_api.rb
@@ -598,6 +598,14 @@ class Candlepin
     post("/owners/#{owner_key}/products/#{product_id}/batch_content", data)
   end
 
+  def add_all_content_to_product(owner_key, product_id, content)
+    data = {}
+    content.each do |id, enabled|
+      data[id] = enabled
+    end
+    post("/owners/#{owner_key}/products/#{product_id}/batch_content", data)
+  end
+
   def remove_content_from_product(owner_key, product_id, content_id)
     delete("/owners/#{owner_key}/products/#{product_id}/content/#{content_id}")
   end

--- a/server/src/main/java/org/candlepin/model/Product.java
+++ b/server/src/main/java/org/candlepin/model/Product.java
@@ -389,7 +389,7 @@ public class Product extends AbstractHibernateObject implements Linkable, Clonea
 
     @Override
     public String toString() {
-        return "Product [id = " + id + ", name = " + name + "]";
+        return "Product [owner = " + owner.getKey() + ", id = " + id + ", name = " + name + "]";
     }
 
     @Override

--- a/server/src/main/java/org/candlepin/resource/OwnerProductResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerProductResource.java
@@ -338,6 +338,8 @@ public class OwnerProductResource {
         Product product = this.getProduct(ownerKey, productId);
         List<ProductContent> productContent = new LinkedList<ProductContent>();
 
+        this.productCurator.lock(product, LockModeType.PESSIMISTIC_WRITE);
+
         for (Entry<String, Boolean> entry : contentMap.entrySet()) {
             Content content = this.getContent(product.getOwner(), entry.getKey());
             productContent.add(new ProductContent(product, content, entry.getValue()));
@@ -345,8 +347,10 @@ public class OwnerProductResource {
 
         product.getProductContent().addAll(productContent);
 
-        // TODO: Why are we doing this instead of just returning the product we already have?
-        return productCurator.find((product.getUuid()));
+        this.productCurator.merge(product);
+        this.productCurator.flush();
+
+        return product;
     }
 
     /**


### PR DESCRIPTION
…ures

Each call to the API for adding content starts a new thread that will attempt a
pessimistic lock on the product. If they happen quickly enough, the lock fails. Now
all content gets added in one call for the test data load.