### PR TITLE
Push migration detection from virt-who checkin to system checkin.

### DIFF
--- a/server/client/ruby/candlepin_api.rb
+++ b/server/client/ruby/candlepin_api.rb
@@ -746,6 +746,7 @@ class Candlepin
     path << "per_page=#{params[:per_page]}&" if params[:per_page]
     path << "order=#{params[:order]}&" if params[:order]
     path << "sort_by=#{params[:sort_by]}&" if params[:sort_by]
+    path << "regen=false&" if params[:regen]
 
     attr_filters = params[:attr_filters] || []
     attr_filters.each do | attr_name, attr_value |

--- a/server/spec/guestid_resource_spec.rb
+++ b/server/spec/guestid_resource_spec.rb
@@ -192,6 +192,7 @@ describe 'GuestId Resource' do
 
     consumer_client.get_guestids().length.should == 0
     new_consumer_client.get_guestids().length.should == 1
+
     # The guests host limited entitlement should be gone
     guest_client.list_entitlements().length.should == 0
   end

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/HypervisorUpdateJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/HypervisorUpdateJob.java
@@ -14,7 +14,7 @@
  */
 package org.candlepin.pinsetter.tasks;
 
-import static org.quartz.JobBuilder.*;
+import static org.quartz.JobBuilder.newJob;
 
 import org.candlepin.auth.Principal;
 import org.candlepin.model.Consumer;
@@ -136,11 +136,6 @@ public class HypervisorUpdateJob extends UniqueByOwnerJob {
             VirtConsumerMap guestConsumersMap = consumerCurator.getGuestConsumersMap(
                     owner, guests);
 
-            // Maps virt guest ID to registered consumer for hypervisor, if one exists:
-            VirtConsumerMap guestHypervisorConsumers = consumerCurator.
-                    getGuestsHostMap(owner, guests);
-
-
             for (String hypervisorId : hosts) {
                 Consumer knownHost = hypervisorConsumersMap.get(hypervisorId);
                 Consumer incoming = incomingHosts.get(hypervisorId);
@@ -153,14 +148,14 @@ public class HypervisorUpdateJob extends UniqueByOwnerJob {
                         log.info("Registering new host consumer for hypervisor ID: {}", hypervisorId);
                         Consumer newHost = createConsumerForHypervisorId(hypervisorId, owner, principal);
                         consumerResource.performConsumerUpdates(incoming, newHost, guestConsumersMap,
-                                guestHypervisorConsumers, false);
+                                false);
                         consumerResource.create(newHost, principal, null, owner.getKey(), null, false);
                         hypervisorConsumersMap.add(hypervisorId, newHost);
                         result.created(newHost);
                     }
                 }
                 else if (consumerResource.performConsumerUpdates(incoming, knownHost,
-                        guestConsumersMap, guestHypervisorConsumers, false)) {
+                        guestConsumersMap, false)) {
                     consumerCurator.update(knownHost);
                     result.updated(knownHost);
                 }

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -813,7 +813,6 @@ public class ConsumerResource {
         Consumer toUpdate = consumerCurator.verifyAndLookupConsumer(uuid);
 
         VirtConsumerMap guestConsumerMap = new VirtConsumerMap();
-        VirtConsumerMap guestsHostConsumerMap = new VirtConsumerMap();
         if (consumer.getGuestIds() != null) {
             Set<String> allGuestIds = new HashSet<String>();
             for (GuestId gid : consumer.getGuestIds()) {
@@ -821,13 +820,10 @@ public class ConsumerResource {
             }
             guestConsumerMap = consumerCurator.getGuestConsumersMap(
                     toUpdate.getOwner(), allGuestIds);
-
-            guestsHostConsumerMap = consumerCurator.getGuestsHostMap(
-                    toUpdate.getOwner(), allGuestIds);
         }
 
         if (performConsumerUpdates(consumer, toUpdate,
-                guestConsumerMap, guestsHostConsumerMap)) {
+                guestConsumerMap)) {
             try {
                 consumerCurator.update(toUpdate);
             }
@@ -844,16 +840,14 @@ public class ConsumerResource {
     }
 
     public boolean performConsumerUpdates(Consumer updated, Consumer toUpdate,
-            VirtConsumerMap guestConsumerMap,
-            VirtConsumerMap guestHypervisorConsumers) {
-        return performConsumerUpdates(updated, toUpdate, guestConsumerMap, guestHypervisorConsumers, true);
+            VirtConsumerMap guestConsumerMap) {
+        return performConsumerUpdates(updated, toUpdate, guestConsumerMap,
+                true);
     }
 
     @Transactional
     public boolean performConsumerUpdates(Consumer updated, Consumer toUpdate,
-            VirtConsumerMap guestConsumerMap,
-            VirtConsumerMap guestHypervisorConsumers,
-            boolean isIdCert) {
+            VirtConsumerMap guestConsumerMap, boolean isIdCert) {
         if (log.isDebugEnabled()) {
             log.debug("Updating consumer: {}", toUpdate.getUuid());
         }
@@ -871,7 +865,7 @@ public class ConsumerResource {
         changesMade = checkForFactsUpdate(toUpdate, updated) || changesMade;
         changesMade = checkForInstalledProductsUpdate(toUpdate, updated) || changesMade;
         changesMade = checkForGuestsUpdate(toUpdate, updated,
-                guestConsumerMap, guestHypervisorConsumers) || changesMade;
+                guestConsumerMap) || changesMade;
         changesMade = checkForHypervisorIdUpdate(toUpdate, updated) || changesMade;
 
         if (updated.getContentTags() != null &&
@@ -1044,7 +1038,7 @@ public class ConsumerResource {
     }
 
     /**
-     * Check if the consumers guest IDs have changed. If they do not appear to
+     * Check if the host consumers guest IDs have changed. If they do not appear to
      * have been specified in this PUT, skip updating guest IDs entirely.
      *
      * If a consumer's guest was already reported by another consumer (host),
@@ -1058,8 +1052,7 @@ public class ConsumerResource {
      * @return a boolean
      */
     private boolean checkForGuestsUpdate(Consumer existing, Consumer incoming,
-            VirtConsumerMap guestConsumerMap,
-            VirtConsumerMap guestHypervisorConsumers) {
+            VirtConsumerMap guestConsumerMap) {
 
         if (incoming.getGuestIds() == null) {
             log.debug("Guests not included in this consumer update, skipping update.");
@@ -1089,7 +1082,6 @@ public class ConsumerResource {
         }
         // Check guests that are existing/added.
         for (GuestId guestId : incoming.getGuestIds()) {
-            Consumer host = guestHypervisorConsumers.get(guestId.getGuestId());
 
             if (addedGuests.contains(guestId)) {
                 // Add the guestId.
@@ -1104,28 +1096,6 @@ public class ConsumerResource {
             Consumer guest = guestConsumerMap.get(guestId.getGuestId());
             if (guest == null) {
                 continue;
-            }
-
-            // Check if the guest was already reported by another host.
-            if (host != null && !existing.equals(host)) {
-                // If the guest already existed and its host consumer is not the same
-                // as the one being updated, then log a warning.
-                if (!removedGuests.contains(guestId) && !addedGuests.contains(guestId)) {
-                    log.warn("Guest {} is currently being hosted by two hosts: {} and {}",
-                        guestId.getGuestId(), existing.getName(), host.getName());
-                }
-
-                // Revoke any entitlements related to the other host.
-                log.warn("Guest was associated with another host. Revoking " +
-                        "invalidated host-specific entitlements related to host: {}", host.getName());
-
-                revokeGuestEntitlementsNotMatchingHost(existing, guest);
-            }
-            else if (host == null) {
-                // now check for any entitlements that may have come from another host
-                // that properly reported the guest consumer as going away,
-                // and revoke those.
-                revokeGuestEntitlementsNotMatchingHost(existing, guest);
             }
         }
 
@@ -1160,7 +1130,25 @@ public class ConsumerResource {
         return removedGuests;
     }
 
-    protected void revokeGuestEntitlementsNotMatchingHost(Consumer host, Consumer guest) {
+    /*
+     * Check if this consumer is a guest, and if it appears to have migrated.
+     * We only check for existing entitlements, restricted to a host that does not match
+     * the guest's current host, as determined by the most recent guest ID report in the
+     * db.
+     */
+    protected void checkForGuestMigration(Consumer guest) {
+        if (!"true".equalsIgnoreCase(guest.getFact("virt.is_guest"))) {
+            // This isn't a guest, skip this entire step.
+            return;
+        }
+        else if (!guest.hasFact("virt.uuid")) {
+            return;
+        }
+
+        String guestVirtUuid = guest.getFact("virt.uuid");
+
+        Consumer host = consumerCurator.getHost(guestVirtUuid, guest.getOwner());
+
         // we need to create a list of entitlements to delete before actually
         // deleting, otherwise we are tampering with the loop iterator (BZ #786730)
         Set<Entitlement> deletableGuestEntitlements = new HashSet<Entitlement>();
@@ -1169,25 +1157,21 @@ public class ConsumerResource {
             Pool pool = entitlement.getPool();
 
             // If there is no host required or the pool isn't for unmapped guests, skip it
-            if (!(pool.hasAttribute("requires_host") || isUnmappedGuestPool(pool))) {
+            if (!(pool.hasAttribute("requires_host") || isUnmappedGuestPool(pool) || isVirtOnly(pool))) {
                 continue;
             }
 
-            String requiredHost = getRequiredHost(pool);
-            if (isVirtOnly(pool)) {
-                if (!requiredHost.equals(host.getUuid())) {
-                    log.warn("Removing entitlement {} from guest {}.",
-                        entitlement.getPool().getProductId(), guest.getName());
-                    deletableGuestEntitlements.add(entitlement);
-                }
-                else if (isUnmappedGuestPool(pool)) {
-                    log.info("Removing unmapped guest pool from {} now that it is mapped", guest.getName());
+            if (pool.hasAttribute("requires_host")) {
+                String requiredHost = getRequiredHost(pool);
+                if (host != null && !requiredHost.equals(host.getUuid())) {
+                    log.warn("Removing entitlement {} from guest {} due to host mismatch.",
+                        entitlement.getId(), guest.getUuid());
                     deletableGuestEntitlements.add(entitlement);
                 }
             }
-            else {
-                log.info("Entitlement {} on {} is still valid and will not be removed.",
-                    entitlement.getPool().getProductId(), guest.getName());
+            else if (isUnmappedGuestPool(pool) && host != null) {
+                log.info("Removing unmapped guest pool from {} now that it is mapped", guest.getUuid());
+                deletableGuestEntitlements.add(entitlement);
             }
         }
         // perform the entitlement revocation
@@ -1195,16 +1179,16 @@ public class ConsumerResource {
             poolManager.revokeEntitlement(entitlement);
         }
 
-        // auto heal guests after revocations
-        boolean hasInstalledProducts = guest.getInstalledProducts() != null &&
-                !guest.getInstalledProducts().isEmpty();
-        if (guest.isAutoheal() && !deletableGuestEntitlements.isEmpty() && hasInstalledProducts) {
-            AutobindData autobindData = AutobindData.create(guest).on(new Date());
-            List<Entitlement> ents = entitler.bindByProducts(autobindData);
-            entitler.sendEvents(ents);
+        if (deletableGuestEntitlements.size() > 0) {
+            // auto heal guests after revocations
+            boolean hasInstalledProducts = guest.getInstalledProducts() != null &&
+                    !guest.getInstalledProducts().isEmpty();
+            if (guest.isAutoheal() && !deletableGuestEntitlements.isEmpty() && hasInstalledProducts) {
+                AutobindData autobindData = AutobindData.create(guest).on(new Date());
+                List<Entitlement> ents = entitler.bindByProducts(autobindData);
+                entitler.sendEvents(ents);
+            }
         }
-
-
     }
 
     private String getRequiredHost(Pool pool) {
@@ -1275,7 +1259,9 @@ public class ConsumerResource {
 
         log.debug("Getting client certificates for consumer: {}", consumerUuid);
         Consumer consumer = consumerCurator.verifyAndLookupConsumer(consumerUuid);
-        poolManager.regenerateDirtyEntitlements(entitlementCurator.listByConsumer(consumer));
+        checkForGuestMigration(consumer);
+        poolManager.regenerateDirtyEntitlements(
+            entitlementCurator.listByConsumer(consumer));
 
         Set<Long> serialSet = this.extractSerials(serials);
 
@@ -1309,7 +1295,9 @@ public class ConsumerResource {
 
         log.debug("Getting client certificate zip file for consumer: {}", consumerUuid);
         Consumer consumer = consumerCurator.verifyAndLookupConsumer(consumerUuid);
-        poolManager.regenerateDirtyEntitlements(entitlementCurator.listByConsumer(consumer));
+        checkForGuestMigration(consumer);
+        poolManager.regenerateDirtyEntitlements(
+            entitlementCurator.listByConsumer(consumer));
 
         Set<Long> serialSet = this.extractSerials(serials);
         // filtering requires a null set, so make this null if it is
@@ -1376,7 +1364,9 @@ public class ConsumerResource {
 
         log.debug("Getting client certificate serials for consumer: {}", consumerUuid);
         Consumer consumer = consumerCurator.verifyAndLookupConsumer(consumerUuid);
-        poolManager.regenerateDirtyEntitlements(entitlementCurator.listByConsumer(consumer));
+        checkForGuestMigration(consumer);
+        poolManager.regenerateDirtyEntitlements(
+            entitlementCurator.listByConsumer(consumer));
 
         List<CertificateSerialDto> allCerts = new LinkedList<CertificateSerialDto>();
         for (EntitlementCertificate cert : entCertService
@@ -1616,6 +1606,11 @@ public class ConsumerResource {
         @Context PageRequest pageRequest) {
 
         Consumer consumer = consumerCurator.verifyAndLookupConsumer(consumerUuid);
+
+        if (regen) {
+            checkForGuestMigration(consumer);
+        }
+
         Page<List<Entitlement>> entitlementsPage;
         // No need to add filters when matching by product.
         if (productId != null) {

--- a/server/src/main/java/org/candlepin/resource/HypervisorResource.java
+++ b/server/src/main/java/org/candlepin/resource/HypervisorResource.java
@@ -137,10 +137,6 @@ public class HypervisorResource {
         VirtConsumerMap guestConsumersMap = consumerCurator.getGuestConsumersMap(
                 owner, allGuestIds);
 
-        // Maps virt guest ID to registered consumer for hypervisor, if one exists:
-        VirtConsumerMap guestHypervisorConsumers = consumerCurator.
-                getGuestsHostMap(owner, allGuestIds);
-
         HypervisorCheckInResult result = new HypervisorCheckInResult();
         for (Entry<String, List<GuestId>> hostEntry : hostGuestMap.entrySet()) {
             String hypervisorId = hostEntry.getKey();
@@ -171,7 +167,7 @@ public class HypervisorResource {
                 }
 
                 boolean guestIdsUpdated = addGuestIds(consumer, hostEntry.getValue(),
-                        guestConsumersMap, guestHypervisorConsumers);
+                        guestConsumersMap);
 
                 // Populate the result with the processed consumer.
                 if (hostConsumerCreated) {
@@ -256,13 +252,12 @@ public class HypervisorResource {
      * return whether or not there was any change
      */
     private boolean addGuestIds(Consumer consumer, List<GuestId> guestIds,
-            VirtConsumerMap guestConsumerMap,
-            VirtConsumerMap guestHypervisorConsumers) {
+            VirtConsumerMap guestConsumerMap) {
         Consumer withIds = new Consumer();
         withIds.setGuestIds(guestIds);
         boolean guestIdsUpdated =
             consumerResource.performConsumerUpdates(withIds, consumer,
-                    guestConsumerMap, guestHypervisorConsumers);
+                    guestConsumerMap);
         if (guestIdsUpdated) {
             consumerCurator.update(consumer);
         }

--- a/server/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
@@ -281,7 +281,7 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void twoHostsRegisteredPickFirst() {
+    public void twoHostsRegisteredPickFirst() throws Exception {
         Consumer host1 = new Consumer("hostConsumer", "testUser", owner, ct);
         consumerCurator.create(host1);
 
@@ -296,6 +296,8 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
         host2.addGuestId(host2Guest);
         host2.addGuestIdCheckIn();
         consumerCurator.update(host2);
+
+        Thread.sleep(1000);
 
         GuestId host1Guest = new GuestId("DAF0FE10-956B-7B4E-B7DC-B383CE681BA8");
         host1.addGuestId(host1Guest);
@@ -315,31 +317,6 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
 
         List<Consumer> guests = consumerCurator.getGuests(consumer);
         assertTrue(guests.size() == 0);
-    }
-
-    @Test
-    public void getGuestsHostMapChoosestLatestReporter() {
-        Consumer host1 = new Consumer("hostConsumer", "testUser", owner, ct);
-        consumerCurator.create(host1);
-
-        Consumer host2 = new Consumer("hostConsumer2", "testUser2", owner, ct);
-        consumerCurator.create(host2);
-
-        String virtUuid1 = "daf0fe10-956b-7b4e-b7dc-b383ce681ba8"; // on both hosts
-        String virtUuid2 = "faf0fe10-956b-7b4e-b7dc-b383ce681cc9"; // only on host 1
-        String virtUuid3 = "daf0fe10-956b-7b4e-b7dc-b383ce681ff8"; // only on host2
-        addGuestIdsTo(host2, virtUuid1, virtUuid3);
-        addGuestIdsTo(host1, virtUuid1, virtUuid2);
-
-        Set<String> guestIds = new HashSet<String>();
-        guestIds.add(virtUuid1);
-        guestIds.add(virtUuid2);
-        guestIds.add(virtUuid3);
-
-        VirtConsumerMap results = consumerCurator.getGuestsHostMap(owner, guestIds);
-        assertEquals(host1.getUuid(), results.get(virtUuid1.toUpperCase()).getUuid());
-        assertEquals(host1.getUuid(), results.get(virtUuid2.toUpperCase()).getUuid());
-        assertEquals(host2.getUuid(), results.get(virtUuid3.toUpperCase()).getUuid());
     }
 
     private void addGuestIdsTo(Consumer host, String... virtUuids) {

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/HypervisorUpdateJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/HypervisorUpdateJobTest.java
@@ -115,7 +115,7 @@ public class HypervisorUpdateJobTest {
         HypervisorUpdateJob job = new HypervisorUpdateJob(ownerCurator, consumerCurator, consumerResource);
         job.execute(ctx);
         verify(consumerResource).performConsumerUpdates(any(Consumer.class), eq(hypervisor),
-                any(VirtConsumerMap.class), any(VirtConsumerMap.class), eq(false));
+                any(VirtConsumerMap.class), eq(false));
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
@@ -322,8 +322,6 @@ public class ConsumerResourceUpdateTest {
 
         when(this.consumerCurator.getGuestConsumersMap(any(Owner.class), any(Set.class))).
             thenReturn(new VirtConsumerMap());
-        when(this.consumerCurator.getGuestsHostMap(any(Owner.class), any(Set.class))).
-            thenReturn(new VirtConsumerMap());
 
         this.resource.updateConsumer(existing.getUuid(), updated);
         assertEquals(1, existing.getGuestIds().size());
@@ -375,8 +373,6 @@ public class ConsumerResourceUpdateTest {
             .thenReturn(expectedEvent);
         when(this.consumerCurator.getGuestConsumersMap(any(Owner.class), any(Set.class))).
             thenReturn(new VirtConsumerMap());
-        when(this.consumerCurator.getGuestsHostMap(any(Owner.class), any(Set.class))).
-            thenReturn(new VirtConsumerMap());
 
         this.resource.updateConsumer(existing.getUuid(), updated);
         verify(sink).queueEvent(eq(expectedEvent));
@@ -398,8 +394,6 @@ public class ConsumerResourceUpdateTest {
             .thenReturn(expectedEvent);
 
         when(this.consumerCurator.getGuestConsumersMap(any(Owner.class), any(Set.class))).
-            thenReturn(new VirtConsumerMap());
-        when(this.consumerCurator.getGuestsHostMap(any(Owner.class), any(Set.class))).
             thenReturn(new VirtConsumerMap());
 
         this.resource.updateConsumer(existing.getUuid(), updated);
@@ -423,8 +417,6 @@ public class ConsumerResourceUpdateTest {
 
         when(this.consumerCurator.getGuestConsumersMap(any(Owner.class), any(Set.class))).
             thenReturn(new VirtConsumerMap());
-        when(this.consumerCurator.getGuestsHostMap(any(Owner.class), any(Set.class))).
-            thenReturn(new VirtConsumerMap());
 
         this.resource.updateConsumer(existing.getUuid(), updated);
         verify(sink, never()).queueEvent(any(Event.class));
@@ -447,8 +439,6 @@ public class ConsumerResourceUpdateTest {
         when(this.eventFactory.consumerModified(existing, updated)).thenReturn(event);
 
         when(this.consumerCurator.getGuestConsumersMap(any(Owner.class), any(Set.class))).
-            thenReturn(new VirtConsumerMap());
-        when(this.consumerCurator.getGuestsHostMap(any(Owner.class), any(Set.class))).
             thenReturn(new VirtConsumerMap());
 
         this.resource.updateConsumer(existing.getUuid(), updated);
@@ -512,8 +502,6 @@ public class ConsumerResourceUpdateTest {
         when(this.consumerCurator.getGuestConsumersMap(any(Owner.class), any(Set.class))).
             thenReturn(mockVirtConsumerMap("Guest 1", guest1));
         // Ensure that the guests host is the existing.
-        when(this.consumerCurator.getGuestsHostMap(any(Owner.class), any(Set.class))).
-            thenReturn(mockVirtConsumerMap("Guest 1", existingHost));
 
         Consumer existingMigratedTo = createConsumerWithGuests("Guest 1");
         existingMigratedTo.setUuid("MIGRATED_TO");
@@ -523,8 +511,6 @@ public class ConsumerResourceUpdateTest {
 
         this.resource.updateConsumer(existingMigratedTo.getUuid(),
             createConsumerWithGuests("Guest 1"));
-
-        verify(poolManager).revokeEntitlement(eq(entitlement));
     }
 
     @Test
@@ -550,8 +536,6 @@ public class ConsumerResourceUpdateTest {
         when(this.consumerCurator.getGuestConsumersMap(any(Owner.class), any(Set.class))).
             thenReturn(mockVirtConsumerMap("Guest 1", guest1));
         // Ensure that the guest was not reported by another host.
-        when(this.consumerCurator.getGuestsHostMap(any(Owner.class), any(Set.class))).
-            thenReturn(new VirtConsumerMap());
         when(this.consumerCurator.find(eq(guest1.getId()))).thenReturn(guest1);
 
         this.resource.updateConsumer(host.getUuid(), updatedHost);
@@ -580,8 +564,6 @@ public class ConsumerResourceUpdateTest {
         // Ensure that the guest was already reported by same host.
         when(this.consumerCurator.getGuestConsumersMap(any(Owner.class), any(Set.class))).
             thenReturn(mockVirtConsumerMap("Guest 1", guest1));
-        when(this.consumerCurator.getGuestsHostMap(any(Owner.class), any(Set.class))).
-            thenReturn(mockVirtConsumerMap("Guest 1", host));
 
         this.resource.updateConsumer(host.getUuid(), updatedHost);
         verify(poolManager, never()).revokeEntitlement(eq(entitlement));
@@ -608,8 +590,6 @@ public class ConsumerResourceUpdateTest {
 
         when(this.consumerCurator.getGuestConsumersMap(any(Owner.class), any(Set.class))).
             thenReturn(mockVirtConsumerMap("Guest 1", guest1));
-        when(this.consumerCurator.getGuestsHostMap(any(Owner.class), any(Set.class))).
-            thenReturn(new VirtConsumerMap());
 
         this.resource.updateConsumer(host.getUuid(), updatedHost);
         //verify(consumerCurator).findByVirtUuid(eq("Guest 1"));
@@ -643,9 +623,6 @@ public class ConsumerResourceUpdateTest {
 
         when(this.consumerCurator.getGuestConsumersMap(any(Owner.class), any(Set.class))).
             thenReturn(mockVirtConsumerMap("Guest 1", guest1));
-        when(this.consumerCurator.getGuestsHostMap(any(Owner.class), any(Set.class))).
-            thenReturn(mockVirtConsumerMap("Guest 1", host));
-
 
         this.resource.updateConsumer(host.getUuid(), updatedHost);
 
@@ -673,8 +650,6 @@ public class ConsumerResourceUpdateTest {
 
         when(this.consumerCurator.getGuestConsumersMap(any(Owner.class), any(Set.class))).
             thenReturn(mockVirtConsumerMap("Guest 1", guest1));
-        when(this.consumerCurator.getGuestsHostMap(any(Owner.class), any(Set.class))).
-            thenReturn(new VirtConsumerMap());
         when(this.consumerCurator.find(eq(guest1.getId()))).thenReturn(guest1);
 
         this.resource.updateConsumer(host.getUuid(), updatedHost);
@@ -704,8 +679,6 @@ public class ConsumerResourceUpdateTest {
         updated.addGuestId(expectedGuestId);
 
         when(this.consumerCurator.getGuestConsumersMap(any(Owner.class), any(Set.class))).
-            thenReturn(new VirtConsumerMap());
-        when(this.consumerCurator.getGuestsHostMap(any(Owner.class), any(Set.class))).
             thenReturn(new VirtConsumerMap());
 
         this.resource.updateConsumer(existing.getUuid(), updated);

--- a/server/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
@@ -16,7 +16,7 @@ package org.candlepin.resource;
 
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.when;
 
 import org.candlepin.audit.Event.Target;
 import org.candlepin.audit.Event.Type;
@@ -168,8 +168,6 @@ public class HypervisorResourceTest {
                 thenReturn(new VirtConsumerMap());
         when(consumerCurator.getGuestConsumersMap(any(Owner.class), any(Set.class))).
             thenReturn(new VirtConsumerMap());
-        when(consumerCurator.getGuestsHostMap(any(Owner.class), any(Set.class))).
-            thenReturn(new VirtConsumerMap());
 
         when(ownerCurator.lookupByKey(eq(owner.getKey()))).thenReturn(owner);
         when(principal.canAccess(eq(owner), eq(SubResource.CONSUMERS), eq(Access.CREATE))).
@@ -223,9 +221,6 @@ public class HypervisorResourceTest {
                 thenReturn(mockHypervisorConsumerMap(hypervisorId, existing));
         when(consumerCurator.getGuestConsumersMap(any(Owner.class), any(Set.class))).
                 thenReturn(new VirtConsumerMap());
-        when(consumerCurator.getGuestsHostMap(any(Owner.class), any(Set.class))).
-            thenReturn(new VirtConsumerMap());
-
 
         HypervisorCheckInResult result = hypervisorResource.hypervisorUpdate(hostGuestMap,
             principal, owner.getKey(), true);
@@ -251,8 +246,6 @@ public class HypervisorResourceTest {
                 any(Set.class))).
                 thenReturn(new VirtConsumerMap());
         when(consumerCurator.getGuestConsumersMap(any(Owner.class), any(Set.class))).
-            thenReturn(new VirtConsumerMap());
-        when(consumerCurator.getGuestsHostMap(any(Owner.class), any(Set.class))).
             thenReturn(new VirtConsumerMap());
 
         when(consumerTypeCurator.lookupByLabel(
@@ -292,8 +285,6 @@ public class HypervisorResourceTest {
                 any(Set.class))).
                 thenReturn(new VirtConsumerMap());
         when(consumerCurator.getGuestConsumersMap(any(Owner.class), any(Set.class))).
-            thenReturn(new VirtConsumerMap());
-        when(consumerCurator.getGuestsHostMap(any(Owner.class), any(Set.class))).
             thenReturn(new VirtConsumerMap());
 
         when(ownerCurator.lookupByKey(eq(owner.getKey()))).thenReturn(owner);


### PR DESCRIPTION
The lookup for the host to have most recently reported every guest UUID in a
virt-who checkin was showing up as a major performance bottleneck, exposing the
fact that there are virt-who deployments of far larger size than anything we
anticipated.

When reporting thousands of guest IDs into orgs with tens of thousands already
there, the performance very rapidly degrades beyond 60 second timeouts and
continues to scale up linearly as new guest IDs are added.

The check was done during virt-who checkins to detect migration, revoke
entitlements restricted to the previous host, and auto-heal if necessary.

We realized however that (a) most guest IDs never become registered consumers,
and (b) this behavior is causing bugs in revoking entitlements that the guest
systems are still attempting to use.

Instead, we push the logic to system check-in time when fetching entitlements,
certs, or serials, similar to when we regenerate dirty entitlements. This
eliminates all the wasted computation on guest IDs that never become consumers,
and the query becomes a small search for a guest UUID rather than thousands all
at once.