### PR TITLE
Log execution time of all jobs by default.

### DIFF
--- a/server/src/main/java/org/candlepin/pinsetter/tasks/CancelJobJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/CancelJobJob.java
@@ -83,4 +83,9 @@ public class CancelJobJob extends KingpinJob {
             log.error("Unable to cancel jobs", e);
         }
     }
+
+    @Override
+    protected boolean logExecutionTime() {
+        return false;
+    }
 }

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/ExpiredPoolsJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/ExpiredPoolsJob.java
@@ -46,8 +46,6 @@ public class ExpiredPoolsJob extends KingpinJob {
     }
 
     public void toExecute(JobExecutionContext ctx) throws JobExecutionException {
-
-        log.info("Executing ExpiredPoolsJob");
         poolManager.cleanupExpiredPools();
     }
 }

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/ImportRecordJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/ImportRecordJob.java
@@ -14,6 +14,7 @@
  */
 package org.candlepin.pinsetter.tasks;
 
+import org.candlepin.common.config.Configuration;
 import org.candlepin.model.ImportRecord;
 import org.candlepin.model.ImportRecordCurator;
 import org.candlepin.model.Owner;
@@ -23,6 +24,8 @@ import com.google.inject.Inject;
 
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
@@ -33,6 +36,7 @@ import java.util.List;
 public class ImportRecordJob extends KingpinJob {
 
     public static final String DEFAULT_SCHEDULE = "0 0 12 * * ?";
+    private static Logger log = LoggerFactory.getLogger(ImportRecordJob.class);
 
     // TODO:  Pull this in from the config?
     private static final int DEFAULT_KEEP = 10;
@@ -42,7 +46,7 @@ public class ImportRecordJob extends KingpinJob {
 
     @Inject
     public ImportRecordJob(ImportRecordCurator importRecordCurator,
-            OwnerCurator ownerCurator) {
+            OwnerCurator ownerCurator, Configuration config) {
         this.importRecordCurator = importRecordCurator;
         this.ownerCurator = ownerCurator;
     }

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/JobCleaner.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/JobCleaner.java
@@ -49,4 +49,9 @@ public class JobCleaner extends KingpinJob {
         this.jobCurator.cleanupAllOldJobs(failedJobDeadLineDt);
     }
 
+    @Override
+    protected boolean logExecutionTime() {
+        return false;
+    }
+
 }

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/KingpinJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/KingpinJob.java
@@ -62,6 +62,8 @@ public abstract class KingpinJob implements Job {
     @Override
     public void execute(JobExecutionContext context) throws JobExecutionException {
 
+        long startTime = System.currentTimeMillis();
+
         // Store the job's unique ID in log4j's thread local MDC, which will automatically
         // add it to all log entries executed for this job.
         try {
@@ -70,6 +72,10 @@ public abstract class KingpinJob implements Job {
         }
         catch (NullPointerException npe) {
             //this can occur in testing
+        }
+
+        if (logExecutionTime()) {
+            log.info("Starting job: {}", getClass().getName());
         }
 
         /*
@@ -106,6 +112,10 @@ public abstract class KingpinJob implements Job {
         finally {
             if (startedUow) {
                 endUnitOfWork();
+            }
+            if (logExecutionTime()) {
+                long executionTime = System.currentTimeMillis() - startTime;
+                log.info("Job completed: time={}", executionTime);
             }
         }
     }
@@ -200,5 +210,10 @@ public abstract class KingpinJob implements Job {
                 "' from candlepin config.  Using default of " + maxRetries);
         }
         return maxRetries;
+    }
+
+    // Override in jobs to disable execution time logging.
+    protected boolean logExecutionTime() {
+        return true;
     }
 }

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/StatisticHistoryTask.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/StatisticHistoryTask.java
@@ -48,8 +48,6 @@ public class StatisticHistoryTask extends KingpinJob {
 
     @Override
     public void toExecute(JobExecutionContext ctx) throws JobExecutionException {
-        log.info("Executing Statistic History Job.");
-
         try {
             statCurator.executeStatisticRun();
         }

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/UnpauseJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/UnpauseJob.java
@@ -79,4 +79,9 @@ public class UnpauseJob extends KingpinJob {
             }
         }
     }
+
+    @Override
+    protected boolean logExecutionTime() {
+        return false;
+    }
 }


### PR DESCRIPTION
Override logExecutionTime in the few jobs that run every 5 seconds to keep those quieter, everything else we log how long it ran for.