### PR TITLE
Forced refresh on the add/delete rules operations

### DIFF
--- a/server/spec/rules_import_spec.rb
+++ b/server/spec/rules_import_spec.rb
@@ -30,6 +30,8 @@ describe 'Rules Import', :serial => true do
   end
 
   def upload_dummy_rules
+    # need to ensure a different timestamp in mysql
+    sleep 2
     encoded_rules = Base64.encode64(@rules)
     result = @cp.upload_rules(encoded_rules)
     fetched_rules = @cp.list_rules

--- a/server/src/main/java/org/candlepin/policy/js/JsRunnerProvider.java
+++ b/server/src/main/java/org/candlepin/policy/js/JsRunnerProvider.java
@@ -91,12 +91,16 @@ public class JsRunnerProvider implements Provider<JsRunner> {
      * @param rulesCurator
      */
     public void compileRules() {
+        compileRules(false);
+    }
+
+    public void compileRules(boolean forceRefresh) {
         scriptLock.writeLock().lock();
         try {
             // Check to see if we need to recompile. we do this inside the write lock
             // just to avoid race conditions where we might double compile
             Date newUpdated = rulesCurator.getUpdated();
-            if (newUpdated.equals(this.updated)) {
+            if (!forceRefresh && newUpdated.equals(this.updated)) {
                 return;
             }
 

--- a/server/src/main/java/org/candlepin/resource/RulesResource.java
+++ b/server/src/main/java/org/candlepin/resource/RulesResource.java
@@ -98,7 +98,7 @@ public class RulesResource {
         sink.emitRulesModified(oldRules, rules);
 
         // Trigger a recompile of the JS rules so version/source are set correctly:
-        jsProvider.compileRules();
+        jsProvider.compileRules(true);
 
         return rulesBuffer;
     }
@@ -138,10 +138,11 @@ public class RulesResource {
     public void delete() {
         Rules deleteRules = rulesCurator.getRules();
         rulesCurator.delete(deleteRules);
+        log.warn("Deleting rules version: " + deleteRules.getVersion());
 
         sink.emitRulesDeleted(deleteRules);
 
         // Trigger a recompile of the JS rules so version/source are set correctly:
-        jsProvider.compileRules();
+        jsProvider.compileRules(true);
     }
 }


### PR DESCRIPTION
The cached rules data needs to be forced past the date checking to ensure
proper version use.
The spec test also required a sleep so that the rpm rules and the test update
rules do not have the same time in mysql.