### PR TITLE
Storage band implementation

### DIFF
--- a/server/bin/import_products.rb
+++ b/server/bin/import_products.rb
@@ -255,6 +255,12 @@ def create_mkt_product(cp, owner, product)
     return
   end
 
+  small_quantity = SMALL_SUB_QUANTITY
+  large_quantity = LARGE_SUB_QUANTITY
+  if product.has_key?('quantity')
+    small_quantity = large_quantity = product['quantity']
+  end
+
   provided_products = product['provided_products'] || []
   derived_product_id = product['derived_product_id']
   derived_provided_products = product['derived_provided_products'] || []
@@ -283,7 +289,7 @@ def create_mkt_product(cp, owner, product)
   subscription = cp.create_subscription(
     owner['name'],
     product_ret['id'],
-    SMALL_SUB_QUANTITY,
+    small_quantity,
     provided_products,
     contract_number,
     '12331131231',
@@ -301,7 +307,7 @@ def create_mkt_product(cp, owner, product)
   subscription = cp.create_subscription(
     owner['name'],
     product_ret['id'],
-    LARGE_SUB_QUANTITY,
+    large_quantity,
     provided_products,
     contract_number,
     '12331131231',

--- a/server/bin/test_data.json
+++ b/server/bin/test_data.json
@@ -1951,6 +1951,33 @@
             "provided_products": [
                 "900"
             ]
+        },
+        {
+            "name": "Band Limited Product",
+            "id": "908",
+            "version": "1.0",
+            "arch": "x86_64",
+            "attributes": {
+            },
+            "content": [
+            ]
+        },
+        {
+            "name": "Storage Limited (256 TB)",
+            "id": "storage-limited-256",
+            "type": "MKT",
+            "multiplier": 256,
+            "quantity": "1",
+            "attributes": {
+                "multi-entitlement": "yes",
+                "stacking_id": "STORAGELIMITED",
+                "storage_band": 1,
+                "support_level" : "Premium",
+                "support_type" : "Level 3"
+            },
+            "provided_products": [
+                "908"
+            ]
         }
     ]
 }

--- a/server/spec/storage_band_spec.rb
+++ b/server/spec/storage_band_spec.rb
@@ -1,0 +1,151 @@
+require 'spec_helper'
+require 'candlepin_scenarios'
+
+describe 'Band Limiting' do
+  include CandlepinMethods
+
+  before(:each) do
+
+    @owner = create_owner random_string('test_owner')
+
+    # Create a product limiting by band.
+    @ceph_product = create_product(
+        random_string("storage-limited-sku"),
+        random_string("Storage Limited"),
+        :multiplier => 256,
+        :attributes =>
+                {:version => '6.4',
+                 # storage_band will always be defined as 1, or not set.
+                 :storage_band => 1,
+                 :warning_period => 15,
+                 :stacking_id => "ceph-node",
+                 :'multi-entitlement' => "yes",
+                 :support_level => 'standard',
+                 :support_type => 'excellent'}
+         )
+    @ceph_sub = @cp.create_subscription(@owner['key'], @ceph_product.id, 2, [], '1888', '1234')
+    @cp.refresh_pools(@owner['key'])
+
+    @user = user_client(@owner, random_string('test-user'))
+
+  end
+
+  it 'pool should have the correct quantity based off of the product multiplier' do
+    pool = find_pool(@owner.id, @ceph_sub.id)
+    # sub.quantity * multiplier
+    pool.quantity.should == 512
+  end
+
+  # band.storage.usage fact is in TB.
+  it 'system status should be valid when all storage band usage is covered' do
+    system = consumer_client(@user, random_string("test_system"), :system, nil,
+                             { 'band.storage.usage' => "256" })
+    installed_products = [{ 'productId' => @ceph_product.id, 'productName' => @ceph_product.name }]
+    system.update_consumer({ :installedProducts => installed_products })
+
+    pool = find_pool(@owner.id, @ceph_sub.id)
+    pool.should_not be_nil
+
+    system.consume_pool(pool.id, {:quantity => 256}).should_not be_nil
+
+    status = system.get_compliance(consumer_id = system.uuid)
+    status['status'].should == 'valid'
+    status['compliant'].should == true
+  end
+
+  it 'system status should be partial when only part of the storage band usage is covered' do
+    system = consumer_client(@user, random_string("test_system"), :system, nil,
+                             { 'band.storage.usage' => "256" })
+    installed_products = [{ 'productId' => @ceph_product.id, 'productName' => @ceph_product.name }]
+    system.update_consumer({ :installedProducts => installed_products })
+
+    pool = find_pool(@owner.id, @ceph_sub.id)
+    pool.should_not be_nil
+
+    system.consume_pool(pool.id, {:quantity => 128}).should_not be_nil
+
+    status = system.get_compliance(consumer_id = system.uuid)
+    status['status'].should == 'partial'
+    status['compliant'].should == false
+  end
+
+  it 'storage band entitlements from same subscription can be stacked to cover entire system' do
+    system = consumer_client(@user, random_string("test_system"), :system, nil,
+                             { 'band.storage.usage' => "256" })
+    installed_products = [{ 'productId' => @ceph_product.id, 'productName' => @ceph_product.name }]
+    system.update_consumer({ :installedProducts => installed_products })
+
+    pool = find_pool(@owner.id, @ceph_sub.id)
+    pool.should_not be_nil
+
+    # Partial stack
+    system.consume_pool(pool.id, {:quantity => 128}).should_not be_nil
+    status = system.get_compliance(consumer_id = system.uuid)
+    status['status'].should == 'partial'
+    status['compliant'].should == false
+
+    # Complete the stack
+    system.consume_pool(pool.id, {:quantity => 128}).should_not be_nil
+    status = system.get_compliance(consumer_id = system.uuid)
+    status['status'].should == 'valid'
+    status['compliant'].should == true
+
+    entitlements = @cp.list_entitlements(:uuid => system.uuid)
+    entitlements.length.should == 2
+    entitlements[0].quantity.should == 128
+    entitlements[1].quantity.should == 128
+  end
+
+  it 'storage band entitlements will auto-attach correct quantity' do
+    system = consumer_client(@user, random_string("test_system"), :system, nil,
+                             { 'band.storage.usage' => "256" })
+    installed_products = [{ 'productId' => @ceph_product.id, 'productName' => @ceph_product.name }]
+    system.update_consumer({ :installedProducts => installed_products })
+
+    entitlements = system.consume_product()
+    entitlements.size.should == 1
+    entitlements[0].quantity.should == 256
+
+    status = system.get_compliance(consumer_id = system.uuid)
+    status['status'].should == 'valid'
+    status['compliant'].should == true
+
+  end
+
+  it 'storage band entitlements will auto-heal correctly' do
+    system = consumer_client(@user, random_string("test_system"), :system, nil,
+                             { 'band.storage.usage' => "256" })
+    installed_products = [{ 'productId' => @ceph_product.id, 'productName' => @ceph_product.name }]
+    system.update_consumer({ :installedProducts => installed_products })
+
+    pool = find_pool(@owner.id, @ceph_sub.id)
+    pool.should_not == nil
+
+    entitlement = system.consume_pool(pool.id, {:quantity => 56})
+    entitlement.should_not == nil
+
+    entitlements = system.consume_product()
+    entitlements.size.should == 1
+    entitlements[0].quantity.should == 200
+
+    status = system.get_compliance(consumer_id = system.uuid)
+    status['status'].should == 'valid'
+    status['compliant'].should == true
+  end
+
+  it 'storage band entitlement auto-attach without fact set consumes one entitlement' do
+    system = consumer_client(@user, random_string("test_system"), :system, nil,
+                             { })
+    installed_products = [{ 'productId' => @ceph_product.id, 'productName' => @ceph_product.name }]
+    system.update_consumer({ :installedProducts => installed_products })
+
+    entitlements = system.consume_product()
+    entitlements.size.should == 1
+    entitlements[0].quantity.should == 1
+
+    status = system.get_compliance(consumer_id = system.uuid)
+    status['status'].should == 'valid'
+    status['compliant'].should == true
+  end
+
+end

--- a/server/src/main/java/org/candlepin/model/Status.java
+++ b/server/src/main/java/org/candlepin/model/Status.java
@@ -37,7 +37,8 @@ public class Status {
     private boolean standalone;
     private Date timeUTC;
     private String[] managerCapabilities = {"cores", "ram", "instance_multiplier",
-        "derived_product", "cert_v3", "guest_limit", "vcpu", "hypervisors_async"};
+        "derived_product", "cert_v3", "guest_limit", "vcpu", "hypervisors_async",
+        "storage_band"};
 
     private RulesSourceEnum rulesSource;
 

--- a/server/src/main/java/org/candlepin/policy/js/compliance/StatusReasonMessageGenerator.java
+++ b/server/src/main/java/org/candlepin/policy/js/compliance/StatusReasonMessageGenerator.java
@@ -93,6 +93,11 @@ public class StatusReasonMessageGenerator {
             reason.setMessage(i18n.tr("Guest has not been reported on any host" +
                 " and is using a temporary unmapped guest subscription."));
         }
+        else if (reason.getKey().equals("STORAGE_BAND")) {
+            reason.setMessage(i18n.tr("Only supports {0}TB of {1}TB of storage.",
+                    reason.getAttributes().get("covered"),
+                    reason.getAttributes().get("has")));
+        }
         else { //default fallback
             reason.setMessage(i18n.tr("{2} COVERAGE PROBLEM.  Supports {0} of {1}",
                 reason.getAttributes().get("covered"),

--- a/server/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRulesTranslator.java
+++ b/server/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRulesTranslator.java
@@ -17,12 +17,9 @@ package org.candlepin.policy.js.entitlement;
 import org.candlepin.model.Entitlement;
 import org.candlepin.model.Pool;
 import org.candlepin.policy.ValidationError;
+import org.xnap.commons.i18n.I18n;
 
 import com.google.inject.Inject;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.xnap.commons.i18n.I18n;
 
 /**
  * Translates error keys returned from entitlement rules into translated error messages.
@@ -30,12 +27,10 @@ import org.xnap.commons.i18n.I18n;
 public class EntitlementRulesTranslator {
 
     private I18n i18n;
-    private Logger log;
 
     @Inject
     public EntitlementRulesTranslator(I18n i18n) {
         this.i18n = i18n;
-        log = LoggerFactory.getLogger(EntitlementRulesTranslator.class);
     }
 
     public String poolErrorToMessage(Pool pool, ValidationError error) {
@@ -94,6 +89,10 @@ public class EntitlementRulesTranslator {
         else if (errorKey.equals("rulefailed.instance.unsupported.by.consumer")) {
             msg = i18n.tr("Unit does not support instance based calculation " +
                 "required by pool ''{0}''", pool.getId());
+        }
+        else if (errorKey.equals("rulefailed.band.unsupported.by.consumer")) {
+            msg = i18n.tr("Unit does not support band calculation " +
+                    "required by pool ''{0}''", pool.getId());
         }
         else if (errorKey.equals("rulefailed.cores.unsupported.by.consumer")) {
             msg = i18n.tr("Unit does not support core calculation " +


### PR DESCRIPTION
Implemented storage band counting. Each entitlement
will equate to 1TB of coverage and marketing products
will use the multiplier such that sub quantity purchased
* multiplier will yeild pool quantity (total capacity in TB).

For example:
pool_quanity = sub_qty_bought * (storage_band_attr * multiplier)
             = 1 * (1 * 256)
             = 256

The resulting pool will have a quantity of 256, which can
cover 256TB of storage.

The rules will calculate a system's coverage based on a
band.storage.usage fact.

Consider a system is using 128TB:
- a quantity of 128 entitlements will cover the system (green).
- a quantity < 128 entitlements will partially cover the
  system (yellow)
- no entitlements (red)

Marketing Product (requirements)
---------------------------------
The marketing product should define a multiplier that is equal
to the total capacity in TBs. It must be stackable and must
define the storage_band attribute (should be set to 1).

- stacking_id: "product_stack_id"
- mutli-entitlement: "yes"
- storage_band: 1

Consumer Requirements
-------------------------
The consumer must have the band.storage.usage fact set to
the total TB that it is using.

NOTE: If this fact is not set, the rules will assume a value
      of 1TB.

- band.storage.usage: 128