### PR TITLE
1259248: Fixed issue with refresh pools removing ueber certs

### DIFF
--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -183,12 +183,17 @@ public class CandlepinPoolManager implements PoolManager {
             refreshPoolsForSubscription(sub, lazy, changedProducts);
         }
 
+        Pool ueberPool = this.findUeberPool(owner);
+        String ueberPoolId = ueberPool != null ? ueberPool.getId() : null;
+
         // We deleted some, need to take that into account so we
         // remove everything that isn't actually active
         subIds.removeAll(deletedSubs);
         // delete pools whose subscription disappeared:
         for (Pool pool : poolCurator.getPoolsFromBadSubs(owner, subIds)) {
-            if (pool.getSourceSubscription() != null && !pool.getType().isDerivedType()) {
+            if (pool.getSourceSubscription() != null && !pool.getType().isDerivedType() &&
+                (ueberPoolId == null || !ueberPoolId.equals(pool.getId()))) {
+
                 deletePool(pool);
             }
         }
@@ -1107,8 +1112,9 @@ public class CandlepinPoolManager implements PoolManager {
 
     @Override
     @Transactional
-    public Entitlement ueberCertEntitlement(Consumer consumer, Pool pool,
-        Integer quantity) throws EntitlementRefusedException {
+    public Entitlement ueberCertEntitlement(Consumer consumer, Pool pool, Integer quantity)
+        throws EntitlementRefusedException {
+
         return addOrUpdateEntitlement(consumer, pool, null, 1, true, CallerType.UNKNOWN);
     }
 

--- a/server/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -1475,22 +1475,23 @@ public class OwnerResource {
         Owner o = findOwner(ownerKey);
 
         if (o == null) {
-            throw new NotFoundException(i18n.tr(
-                "owner with key: {0} was not found.", ownerKey));
-        }
-
-        Consumer ueberConsumer = consumerCurator.findByName(o, Consumer.UEBER_CERT_CONSUMER);
-
-        // ueber cert has already been generated - re-generate it now
-        if (ueberConsumer != null) {
-            List<Entitlement> ueberEntitlement
-                = entitlementCurator.listByConsumer(ueberConsumer);
-            // Immediately revoke and regenerate ueber certificates:
-            poolManager.regenerateCertificatesOf(ueberEntitlement.get(0), true, false);
-            return entitlementCertCurator.listForConsumer(ueberConsumer).get(0);
+            throw new NotFoundException(i18n.tr("owner with key: {0} was not found.", ownerKey));
         }
 
         try {
+            Consumer ueberConsumer = consumerCurator.findByName(o, Consumer.UEBER_CERT_CONSUMER);
+
+            // ueber cert has already been generated - re-generate it now
+            if (ueberConsumer != null) {
+                List<Entitlement> ueberEntitlements = entitlementCurator.listByConsumer(ueberConsumer);
+
+                if (ueberEntitlements.size() > 0) {
+                    // Immediately revoke and regenerate ueber certificates:
+                    poolManager.regenerateCertificatesOf(ueberEntitlements.get(0), true, false);
+                    return entitlementCertCurator.listForConsumer(ueberConsumer).get(0);
+                }
+            }
+
             return ueberCertGenerator.generate(o, principal);
         }
         catch (Exception e) {

--- a/server/src/main/resources/logback.xml
+++ b/server/src/main/resources/logback.xml
@@ -38,7 +38,7 @@
         </filter>
     </appender>
 
-    <logger name="org.candlepin" level="INFO"/>
+    <logger name="org.candlepin" level="DEBUG"/>
 
     <root level="WARN">
         <appender-ref ref="CandlepinAppender" />


### PR DESCRIPTION
- Refresh pools, and anything making use of the function, will no
  longer remove any generate ueber certs
- Partial information for ueber certs or consumers will no longer
  cause 500 errors when generating or retrieving ueber certs