### PR TITLE
Update to Checkstyle 6.9

### DIFF
--- a/apicrawl/src/main/java/org/candlepin/util/apicrawl/ApiCrawler.java
+++ b/apicrawl/src/main/java/org/candlepin/util/apicrawl/ApiCrawler.java
@@ -239,6 +239,8 @@ public class ApiCrawler {
 
     /**
      * Hash map with a default value for any given key
+     * @param <K> key class
+     * @param <V> value class
      */
     public static final class DefaultHashMap<K, V> extends HashMap<K, V> {
         protected V defaultValue;

--- a/common/src/main/java/org/candlepin/common/config/Configuration.java
+++ b/common/src/main/java/org/candlepin/common/config/Configuration.java
@@ -31,7 +31,7 @@ public interface Configuration {
     /**
      * Enumeration that defines whether or not to trim whitespace from a String.
      */
-    public static enum TrimMode {
+    enum TrimMode {
         TRIM,
         NO_TRIM;
     }

--- a/project_conf/checks.xml
+++ b/project_conf/checks.xml
@@ -126,7 +126,9 @@
       <property name="option" value="text"/>
     </module>
     <!-- defaults to end of line -->
-    <module name="LeftCurly" />
+    <module name="LeftCurly">
+      <property name="tokens" value="ANNOTATION_DEF, CLASS_DEF, CTOR_DEF, ENUM_DEF, ENUM_CONSTANT_DEF, INTERFACE_DEF, LITERAL_CATCH, LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, METHOD_DEF, STATIC_INIT" />
+    </module>
     <module name="NeedBraces"/>
     <module name="RightCurly">
       <property name="option" value="alone"/>
@@ -274,7 +276,9 @@
     <module name="UpperEll"/>
     <!-- <module name="FinalParameters"/> -->
     <!-- <module name="DescendantToken"/> -->
-    <module name="Indentation"/>
+    <module name="Indentation">
+      <property name="lineWrappingIndentation" value="0" />
+    </module>
     <!-- <module name="TrailingComment"/> -->
     <!-- <module name="Regexp"/> -->
 

--- a/server/src/main/java/org/candlepin/auth/Access.java
+++ b/server/src/main/java/org/candlepin/auth/Access.java
@@ -26,7 +26,7 @@ public enum Access {
     ALL(5);
 
     private int level;
-    private Access(int level) {
+    Access(int level) {
         this.level = level;
     }
 

--- a/server/src/main/java/org/candlepin/guice/I18nProvider.java
+++ b/server/src/main/java/org/candlepin/guice/I18nProvider.java
@@ -41,7 +41,7 @@ public class I18nProvider extends CommonI18nProvider implements Provider<I18n> {
     private static Logger log = LoggerFactory.getLogger(I18nProvider.class);
 
     private static Map<Locale, I18n>
-    cache = new ConcurrentHashMap<Locale, I18n>();
+        cache = new ConcurrentHashMap<Locale, I18n>();
 
     @Inject
     public I18nProvider(Injector injector) {

--- a/server/src/main/java/org/candlepin/policy/js/entitlement/Enforcer.java
+++ b/server/src/main/java/org/candlepin/policy/js/entitlement/Enforcer.java
@@ -31,7 +31,7 @@ public interface Enforcer {
      * Enum representing context with which the rules are being called.
      * Currently being used by preEntitlement - 2013-05-06
      */
-    public enum CallerType {
+    enum CallerType {
         BIND("bind"),
         UNKNOWN("unknown"),
         LIST_POOLS("list_pools"),

--- a/tasks/checkstyle.rake
+++ b/tasks/checkstyle.rake
@@ -11,6 +11,7 @@ module AntTaskCheckstyle
           projects = [local_project] + local_project.projects
           fail_on_error = local_project.checkstyle.fail_on_error?
           projects.each do |p|
+            FileUtils.mkdir_p(p.path_to(:target))
             results[p] = p.task("checkstyle:#{format}").invoke if p.checkstyle.enabled?
           end
           results.each do |project, did_fail|
@@ -25,8 +26,7 @@ module AntTaskCheckstyle
     attr_reader :project
 
     def dependencies
-      # TODO - This is a pretty old version
-      Buildr.transitive('com.puppycrawl.tools:checkstyle:jar:5.7')
+      Buildr.transitive('com.puppycrawl.tools:checkstyle:jar:6.9')
     end
 
     def execute(*args)
@@ -60,7 +60,10 @@ module AntTaskCheckstyle
       # See http://checkstyle.sourceforge.net/anttask.html
       failed = false
       Buildr.ant('checkstyle') do |ant|
-        ant.taskdef(:classpath => cp, :resource => "checkstyletask.properties")
+        ant.taskdef(
+          :classpath => cp,
+          :resource => "com/puppycrawl/tools/checkstyle/ant/checkstyle-ant-task.properties"
+        )
         profiles.each do |profile|
           next unless profile.enabled == "true"
 


### PR DESCRIPTION
Users may need to start Eclipse with the `-clean` option if the were
using an old version of the Eclipse Checkstyle plugin.

Testing:

1. Run `buildr checkstyle`.  You should see some output about what is being checked but not see any errors.

2. Run `buildr eclipse`.

3. If you do not have the Eclipse Checkstyle plugin installed, it can be installed from `Help -> Eclipse Marketplace...` and then search for "checkstyle".

4. Go to `Project -> Clean...` and clean all your Candlepin projects.

5. If you see any errors complaining about classes that can't be found, close Eclipse, then run `eclipse -clean`

6. Go to a random file and type something like `if(true) { System.out.printline("hello");}`

7. A checkstyle warning should pop up immediately complaining about missing space between the if keyword and the left parenthesis.
