### PR TITLE
Persist reporter id for Hypervisor checkins

### DIFF
--- a/server/client/ruby/candlepin_api.rb
+++ b/server/client/ruby/candlepin_api.rb
@@ -112,10 +112,13 @@ class Candlepin
     return consumers
   end
 
-  def hypervisor_update(owner, json_data, create_missing=nil)
-    path = get_path("hypervisors") + "/#{owner}"
+  def hypervisor_update(owner, json_data, create_missing=nil, reporter_id=nil)
+    path = get_path("hypervisors") + "/#{owner}?"
     unless create_missing.nil?
-      path << "?create_missing=#{create_missing}"
+      path << "create_missing=#{create_missing}&"
+    end
+    unless reporter_id.nil?
+      path << "reporter_id=#{reporter_id}&"
     end
     job_detail = post_text(path, json_data, 'json')
     return job_detail

--- a/server/src/main/java/org/candlepin/model/HypervisorId.java
+++ b/server/src/main/java/org/candlepin/model/HypervisorId.java
@@ -70,6 +70,10 @@ public class HypervisorId extends AbstractHibernateObject {
     @NotNull
     private String hypervisorId;
 
+    @Column(name = "reporter_id")
+    @Size(max = 255)
+    private String reporterId;
+
     @OneToOne(fetch = FetchType.LAZY)
     @ForeignKey(name = "fk_hypervisor_consumer")
     @JoinColumn(nullable = false, unique = true)
@@ -126,6 +130,20 @@ public class HypervisorId extends AbstractHibernateObject {
             hypervisorId = hypervisorId.toLowerCase();
         }
         this.hypervisorId = hypervisorId;
+    }
+
+    /**
+     * @return the reporterId
+     */
+    public String getReporterId() {
+        return reporterId;
+    }
+
+    /**
+     * @param reporterId the reporterId to set
+     */
+    public void setReporterId(String reporterId) {
+        this.reporterId = reporterId;
     }
 
     /**

--- a/server/src/main/java/org/candlepin/resource/HypervisorResource.java
+++ b/server/src/main/java/org/candlepin/resource/HypervisorResource.java
@@ -220,7 +220,8 @@ public class HypervisorResource {
         @PathParam("owner") @Verify(value = Owner.class,
             require = Access.READ_ONLY,
             subResource = SubResource.HYPERVISOR) String ownerKey,
-        @QueryParam("create_missing") @DefaultValue("true") boolean createMissing) {
+        @QueryParam("create_missing") @DefaultValue("true") boolean createMissing,
+        @QueryParam("reporter_id") String reporterId) {
 
         if (hypervisorJson == null || hypervisorJson.isEmpty()) {
             log.debug("Host/Guest mapping provided during hypervisor update was null.");
@@ -231,7 +232,7 @@ public class HypervisorResource {
         log.info("Hypervisor update by principal: " + principal);
         Owner owner = this.getOwner(ownerKey);
 
-        return HypervisorUpdateJob.forOwner(owner, hypervisorJson, createMissing, principal);
+        return HypervisorUpdateJob.forOwner(owner, hypervisorJson, createMissing, principal, reporterId);
     }
 
     /*

--- a/server/src/main/resources/db/changelog/20150915094638-add-reporter-id-to-hypervisor-id.xml
+++ b/server/src/main/resources/db/changelog/20150915094638-add-reporter-id-to-hypervisor-id.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+    <changeSet id="20150915094638-1" author="vrjain">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists columnName="reporter_id" tableName="cp_consumer_hypervisor"/>
+            </not>
+        </preConditions>
+        <comment>add reporter id to hypervisor id</comment>
+        <addColumn tableName="cp_consumer_hypervisor">
+            <column name="reporter_id" type="VARCHAR(255)"/>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/server/src/main/resources/db/changelog/changelog-create.xml
+++ b/server/src/main/resources/db/changelog/changelog-create.xml
@@ -1183,4 +1183,5 @@
     <include file="db/changelog/20150729082417-content-unique-owner-label.xml"/>
     <include file="db/changelog/20150818110722-upgrade-to-quartz-2-dot-2.xml"/>
     <include file="db/changelog/20150820140403-revert-to-lastcheckin-column.xml"/>
+    <include file="db/changelog/20150915094638-add-reporter-id-to-hypervisor-id.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-testing.xml
+++ b/server/src/main/resources/db/changelog/changelog-testing.xml
@@ -2273,4 +2273,5 @@
     <include file="db/changelog/20150729082417-content-unique-owner-label.xml"/>
     <include file="db/changelog/20150818110722-upgrade-to-quartz-2-dot-2.xml"/>
     <include file="db/changelog/20150820140403-revert-to-lastcheckin-column.xml"/>
+    <include file="db/changelog/20150915094638-add-reporter-id-to-hypervisor-id.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-update.xml
+++ b/server/src/main/resources/db/changelog/changelog-update.xml
@@ -91,4 +91,5 @@
     <include file="db/changelog/20150729082417-content-unique-owner-label.xml"/>
     <include file="db/changelog/20150818110722-upgrade-to-quartz-2-dot-2.xml"/>
     <include file="db/changelog/20150820140403-revert-to-lastcheckin-column.xml"/>
+    <include file="db/changelog/20150915094638-add-reporter-id-to-hypervisor-id.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
While an owner can have multiple hypervisor - guest mapping reporters, Assumption is that at a given time, only one reporter reports hypervisor mappings for a particular hypervisor of an owner. This PR ensures that we:
* persist if reporter id is available in the request, else ignore.
* update if reporter id changed for the hypervisor
* warn if a hypervisor's reporter changed.
* dont warn if a reporter id was not set in the first place ( to avoid excessive warnings when this version first hits production )