### PR TITLE
1263474: Standalone candlepin now returns the expected error message …

### DIFF
--- a/server/src/main/java/org/candlepin/service/impl/ImportSubscriptionServiceAdapter.java
+++ b/server/src/main/java/org/candlepin/service/impl/ImportSubscriptionServiceAdapter.java
@@ -15,11 +15,15 @@
 
 package org.candlepin.service.impl;
 
+import org.candlepin.common.exceptions.ServiceUnavailableException;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.Owner;
 import org.candlepin.model.Product;
 import org.candlepin.model.dto.Subscription;
 import org.candlepin.service.SubscriptionServiceAdapter;
+import org.xnap.commons.i18n.I18n;
+
+import com.google.inject.Inject;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -36,6 +40,7 @@ public class ImportSubscriptionServiceAdapter implements
 
     private List<Subscription> subscriptions;
     private Map<String, Subscription> subsBySubId = new HashMap<String, Subscription>();
+    @Inject private I18n i18n;
 
     public ImportSubscriptionServiceAdapter() {
         this(new LinkedList<Subscription>());
@@ -71,6 +76,8 @@ public class ImportSubscriptionServiceAdapter implements
     @Override
     public void activateSubscription(Consumer consumer, String email,
             String emailLocale) {
+        throw new ServiceUnavailableException(
+                i18n.tr("Standalone candlepin does not support redeeming a subscription."));
     }
 
     @Override


### PR DESCRIPTION
…and code

When we removed the DefaultSubscriptionServiceAdapter, the activateSubscription method of its replacement (ImportSubscriptionServiceAdapter) became a no op. This causes a success response code to be sent to subscription manager with no content in the body. As subscription manager at this time has no default message to display this resulted in no feedback being displayed to the user.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1263474