### PR TITLE
 1256926: Fixed Pool match filter query

### DIFF
--- a/server/bin/performance-dataloader.rb
+++ b/server/bin/performance-dataloader.rb
@@ -80,7 +80,7 @@ def create_pools(cp, owner_key, count, attributes, quantity)
   time = Benchmark.realtime do
     (1..(count)).each do |i|
       mkt_prod_id = random_string('mkt-prod')
-      mkt_prod = cp.create_product(mkt_prod_id, mkt_prod_id, {
+      mkt_prod = cp.create_product(owner_key, mkt_prod_id, mkt_prod_id, {
         :attributes => attributes,
       })
       sub1 = cp.create_subscription(owner_key, mkt_prod['id'], quantity,

--- a/server/client/ruby/candlepin_api.rb
+++ b/server/client/ruby/candlepin_api.rb
@@ -428,6 +428,7 @@ class Candlepin
     path << "per_page=#{params[:per_page]}&" if params[:per_page]
     path << "order=#{params[:order]}&" if params[:order]
     path << "sort_by=#{params[:sort_by]}&" if params[:sort_by]
+    path << "matches=#{params[:matches]}&" if params[:matches]
 
     # Attribute filters are specified in the following format:
     #    {attributeName}:{attributeValue}

--- a/server/src/main/java/org/candlepin/model/PoolCurator.java
+++ b/server/src/main/java/org/candlepin/model/PoolCurator.java
@@ -30,7 +30,6 @@ import org.hibernate.Filter;
 import org.hibernate.LockOptions;
 import org.hibernate.Query;
 import org.hibernate.ReplicationMode;
-import org.hibernate.criterion.CriteriaSpecification;
 import org.hibernate.criterion.Criterion;
 import org.hibernate.criterion.Order;
 import org.hibernate.criterion.Projections;
@@ -213,9 +212,6 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
 
         Criteria crit = createSecureCriteria()
             .createAlias("product", "product")
-            .createAlias("providedProducts", "provProd", CriteriaSpecification.LEFT_JOIN)
-            .createAlias("provProd.productContent", "ppcw", CriteriaSpecification.LEFT_JOIN)
-            .createAlias("ppcw.content", "ppContent", CriteriaSpecification.LEFT_JOIN)
             .setResultTransformer(Criteria.DISTINCT_ROOT_ENTITY);
 
         if (activeOnly) {
@@ -245,11 +241,9 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
             crit.add(Restrictions.ge("endDate", activeOn));
         }
 
+        filters = filters == null ? new PoolFilterBuilder() : filters;
         if (productId != null) {
-            crit.add(Restrictions.or(
-                Restrictions.eq("product.id", productId),
-                Restrictions.eq("provProd.id", productId)
-            ));
+            filters.setProductIdFilter(productId);
         }
 
         // Append any specified filters


### PR DESCRIPTION
When using match parameters while listing available pools
hibernate would return a partially initialized list of
pool objects when matching on a collection of sub objects.

For example, if the match filter matched on 1 of 4 provided
products, only the matched provided product would be loaded
in the Pool's collection. Only a hibernate refresh would
bring the remainder in after the initial lookup.

This patch changes the query to use correlated subqueries
instead of left outer joins, which works around the partial
collection issue.

I tried implementing a unit test for the curator but
wasn't able to reproduce. I have a hunch that HSQLDB
may be dealing with joins a little differently than
postgres. A spec test easily reproduced this issue.

https://bugzilla.redhat.com/show_bug.cgi?id=1256926