### PR TITLE
Updated cpc to work with changes to Ruby's public_instance_methods me…

### DIFF
--- a/server/client/ruby/cpc
+++ b/server/client/ruby/cpc
@@ -26,8 +26,8 @@ class CandlepinCLI < Candlepin
 
   private
 
-  def self.callable_name?(method_name)
-    !method_name.end_with?('=')
+  def self.callable_name?(method)
+    !method.to_s.end_with?('=')
   end
 
 end


### PR DESCRIPTION
…thod

- CandlepinCLI.callable_name? now properly converts stringable objects
  to strings before attempting to use them as strings. This should fix
  an issue on versions of Ruby on which public_instance_methods returns
  Symbol objects instead of method name Strings.