### PR TITLE
Updated cp-test to run the linter from the top-level CP directory

### DIFF
--- a/docker/candlepin-base/cp-test
+++ b/docker/candlepin-base/cp-test
@@ -125,13 +125,14 @@ fi
 # Make sure we update the ruby bundle:
 bundle install
 
-# TODO: keep track of return code?
-cd $CP_HOME/$PROJECT
-
 if [ "$LINTER" == "1" ]; then
+    cd $CP_HOME
     echo "Running linter..."
     buildr checkstyle
 fi
+
+# TODO: keep track of return code?
+cd $CP_HOME/$PROJECT
 
 if [ "$UNITTEST" == "1" ]; then
     echo "Running unit tests."

--- a/docker/rebuild.sh
+++ b/docker/rebuild.sh
@@ -2,7 +2,16 @@
 #
 # Rebuilds all docker containers from base on down, and pushes each to the internal registry.
 
-
+# If you encounter:
+#
+#   v[12] ping attempt failed with error: Get https://*.usersys.redhat.com/v[12]/: dial tcp 10.3.10.70:443: connection refused
+#
+# ... then it's likely the register needs to be accessed insecurely. To do so, add:
+#
+#   INSECURE_REGISTRY='--insecure-registry *.usersys.redhat.com'
+#
+# to /etc/sysconfig/docker (F21+), where * is the subdomain being accessed, then restart docker and
+# re-run the rebuild command
 
 SCRIPT_NAME=$( basename "$0" )
 SCRIPT_HOME=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )


### PR DESCRIPTION
- cp-test now runs checkstyle from $CP_HOME rather than the individual
  project directory
- Re-added the note about the insecure registry