### PR TITLE
Added an option to specify the db name in the deploy scripts

### DIFF
--- a/bin/bash_functions
+++ b/bin/bash_functions
@@ -129,7 +129,7 @@ recreate_postgresql() {
     local db_name="$1"
     local db_user="${2:-$db_name}"
     # Check if candlepin db exists and drop it if so:
-    if [[ `psql -U $db_user -tAc "SELECT 1 FROM pg_database WHERE datname='$db_name'"` == "1" ]]; then
+    if [[ `psql -U postgres -tAc "SELECT 1 FROM pg_database WHERE datname='$db_name'"` == "1" ]]; then
         info_msg "Database '$db_name' exists.  Dropping it."
         dropdb -w -U "$db_user" "$db_name"
     fi

--- a/gutterball/bin/deploy
+++ b/gutterball/bin/deploy
@@ -15,7 +15,7 @@ usage: deploy [options]
 
 OPTIONS:
   -q          quiet; no notifications and minimal output
-  -t          hot deloy; do not stop and start Tomcat
+  -t          hot deploy; do not stop and start Tomcat
   -g          regenerate database
   -m          deploy to MySQL
   -o          deploy to Oracle

--- a/gutterball/bin/deploy
+++ b/gutterball/bin/deploy
@@ -1,6 +1,7 @@
 #! /bin/bash
 
 APP="gutterball"
+APP_DB_NAME="gutterball"
 
 # use tomcat 6, unless it doesnt exist and tomcat does
 TC=tomcat6
@@ -10,16 +11,18 @@ fi
 
 usage() {
     cat <<HELP
-    usage: deploy [options]
+usage: deploy [options]
 
-    OPTIONS:
-      -q  quiet; no notifications and minimal output
-      -t  hot deloy; do not stop and start Tomcat
-      -g  regenerate database
-      -m  deploy to MySQL
-      -o  deploy to Oracle
-      -l  logdriver; compile with Logdriver
-      -a  install an auto-generated gutterball.conf file
+OPTIONS:
+  -q          quiet; no notifications and minimal output
+  -t          hot deloy; do not stop and start Tomcat
+  -g          regenerate database
+  -m          deploy to MySQL
+  -o          deploy to Oracle
+  -l          logdriver; compile with Logdriver
+  -a          install an auto-generated gutterball.conf file
+  -d <name>   specify a database name to use when creating or updating the
+              Gutterball database
 HELP
 }
 
@@ -78,23 +81,23 @@ deploy() {
 
 generate_db() {
     if [ -n "$USE_ORACLE" ]; then
-        init_oracle_jdbc "gutterball"
+        init_oracle_jdbc $APP_DB_NAME
         [ -z "$DBPASSWORD" ] && DBPASSWORD="gutterball"
     elif [ -n "$USE_MYSQL" ]; then
-        init_mysql_jdbc "gutterball"
+        init_mysql_jdbc $APP_DB_NAME
     else
-        init_postgresql_jdbc "gutterball"
+        init_postgresql_jdbc $APP_DB_NAME
     fi
 
     CHANGELOG="changelog.xml"
     if [ -n "$GENDB" ]; then
         MESSAGE="Generating New Database"
         if [ -n "$USE_ORACLE" ]; then
-            recreate_oracle "gutterball"
+            recreate_oracle $APP_DB_NAME $DBUSER
         elif [ -n "$USE_MYSQL" ]; then
-            recreate_mysql "gutterball"
+            recreate_mysql $APP_DB_NAME $DBUSER
         else
-            recreate_postgresql "gutterball"
+            recreate_postgresql $APP_DB_NAME $DBUSER
         fi
     else
         MESSAGE="Updating Database"
@@ -159,8 +162,9 @@ trap clean_up EXIT INT TERM
 set -e
 
 LOGDRIVER=""
+DBUSER="gutterball"
 
-while getopts ":qtlmoga" opt; do
+while getopts ":qtlmogad:" opt; do
     case $opt in
         q  ) QUIET="1";;
         t  ) HOTDEPLOY="1";;
@@ -169,6 +173,7 @@ while getopts ":qtlmoga" opt; do
         o  ) USE_ORACLE="1";;
         g  ) GENDB="1";;
         a  ) AUTOCONF="1";;
+        d  ) APP_DB_NAME="${OPTARG}";;
         ?  ) usage; exit;;
     esac
 done

--- a/server/bin/deploy
+++ b/server/bin/deploy
@@ -1,24 +1,26 @@
 #!/bin/bash
 
+APP_DB_NAME="candlepin"
+
 gendb() {
     if [ "$USE_ORACLE" == "1" ]; then
-        init_oracle_jdbc "candlepin"
+        init_oracle_jdbc $APP_DB_NAME
         [ -z "$DBPASSWORD" ] && DBPASSWORD="candlepin"
     elif [ "$USE_MYSQL" == "1" ]; then
-        init_mysql_jdbc "candlepin"
+        init_mysql_jdbc $APP_DB_NAME
     else
-        init_postgresql_jdbc "candlepin"
+        init_postgresql_jdbc $APP_DB_NAME
     fi
 
     if [ "$GENDB" == "1" ]; then
         MESSAGE="Generating New Database"
         CHANGELOG="changelog-create.xml"
         if [ "$USE_ORACLE" == "1" ]; then
-            recreate_oracle "candlepin"
+            recreate_oracle $APP_DB_NAME $DBUSER
         elif [ "$USE_MYSQL" == "1" ]; then
-            recreate_mysql "candlepin"
+            recreate_mysql $APP_DB_NAME $DBUSER
         else
-            recreate_postgresql "candlepin"
+            recreate_postgresql $APP_DB_NAME $DBUSER
         fi
 
         # New database implies we probably don't want any events left laying around in the
@@ -124,18 +126,20 @@ autoconf() {
 
 usage() {
     cat <<HELP
-    usage: deploy [options]
+usage: deploy [options]
 
-    OPTIONS:
-        -f  force cert regeneration
-        -g  generate database
-        -h  include test resources for hosted mode
-        -t  import test data
-        -o  use Oracle
-        -l  use Logdriver
-        -m  use MySQL
-        -a  auto-deploy a generated candlepin.conf
-        -v  verbose output
+OPTIONS:
+  -f          force cert regeneration
+  -g          generate database
+  -t          import test data
+  -h          include test resources for hosted mode
+  -o          use Oracle
+  -l          use Logdriver
+  -m          use MySQL
+  -a          auto-deploy a generated candlepin.conf
+  -v          verbose output
+  -d <name>   specify a database name to use when creating or updating the
+              Candlepin database
 HELP
 }
 
@@ -179,7 +183,7 @@ init
 
 DBUSER="candlepin"
 
-while getopts ":fghtolmav" opt; do
+while getopts ":fgtholmavd:" opt; do
     case $opt in
         f  ) FORCECERT="1" ;;
         g  ) GENDB="1";;
@@ -190,6 +194,7 @@ while getopts ":fghtolmav" opt; do
         m  ) USE_MYSQL="1";;
         a  ) AUTOCONF="1";;
         v  ) VERBOSE="1";;
+        d  ) APP_DB_NAME="${OPTARG}";;
         ?  ) usage; exit;;
     esac
 done


### PR DESCRIPTION
- Specifying -d <name> on the command line for either Candlepin or
  Gutterball will now use the given name when performing any
  database operations