### PR TITLE
Added multiple formats to GB's date/time parser

### DIFF
--- a/gutterball/src/main/java/org/candlepin/gutterball/report/ConsumerStatusReport.java
+++ b/gutterball/src/main/java/org/candlepin/gutterball/report/ConsumerStatusReport.java
@@ -82,7 +82,7 @@ public class ConsumerStatusReport extends Report<ReportResult> {
 
         addParameter(
             builder.init("on_date", i18n.tr("The date to filter on. Defaults to NOW."))
-                .mustBeDate(REPORT_DATETIME_FORMAT)
+                .mustBeDate(REPORT_DATE_FORMATS)
                 .getParameter()
         );
 
@@ -142,7 +142,7 @@ public class ConsumerStatusReport extends Report<ReportResult> {
         List<String> subscriptionNameFilters = queryParams.get("subscription_name");
 
         Date targetDate = queryParams.containsKey("on_date") ?
-            parseDateTime(queryParams.getFirst("on_date")) :
+            this.parseDate(queryParams.getFirst("on_date")) :
             new Date();
 
         Map<String, String> attributeFilters = new HashMap<String, String>();

--- a/gutterball/src/main/java/org/candlepin/gutterball/report/ConsumerTrendReport.java
+++ b/gutterball/src/main/java/org/candlepin/gutterball/report/ConsumerTrendReport.java
@@ -77,14 +77,14 @@ public class ConsumerTrendReport extends Report<ReportResult> {
             builder.init("start_date", i18n.tr("The start date to filter on (used with {0}).", "end_date"))
                 .mustNotHave("hours")
                 .mustHave("end_date")
-                .mustBeDate(REPORT_DATETIME_FORMAT)
+                .mustBeDate(REPORT_DATETIME_FORMATS)
                 .getParameter());
 
         addParameter(
             builder.init("end_date", i18n.tr("The end date to filter on (used with {0})", "start_date"))
                 .mustNotHave("hours")
                 .mustHave("start_date")
-                .mustBeDate(REPORT_DATETIME_FORMAT)
+                .mustBeDate(REPORT_DATETIME_FORMATS)
                 .getParameter());
 
         addParameter(

--- a/gutterball/src/main/java/org/candlepin/gutterball/report/StatusTrendReport.java
+++ b/gutterball/src/main/java/org/candlepin/gutterball/report/StatusTrendReport.java
@@ -82,14 +82,14 @@ public class StatusTrendReport extends Report<StatusTrendReportResult> {
 
         this.addParameter(
             builder.init("start_date", i18n.tr("The start date on which to filter"))
-                .mustBeDate(REPORT_DATE_FORMAT)
+                .mustBeDate(REPORT_DATE_FORMATS)
                 .mustSatisfy(yearValidator)
                 .getParameter()
         );
 
         this.addParameter(
             builder.init("end_date", i18n.tr("The end date on which to filter"))
-                .mustBeDate(REPORT_DATE_FORMAT)
+                .mustBeDate(REPORT_DATE_FORMATS)
                 .mustSatisfy(yearValidator)
                 .getParameter()
         );

--- a/gutterball/src/test/java/org/candlepin/gutterball/report/ConsumerStatusReportTest.java
+++ b/gutterball/src/test/java/org/candlepin/gutterball/report/ConsumerStatusReportTest.java
@@ -85,8 +85,10 @@ public class ConsumerStatusReportTest {
         when(params.containsKey("on_date")).thenReturn(true);
         when(params.get("on_date")).thenReturn(Arrays.asList("13-21-2010"));
 
-        validateParams(params, "on_date", "Invalid date string. Expected format: " +
-                ConsumerStatusReport.REPORT_DATETIME_FORMAT);
+        validateParams(params, "on_date",
+            "Invalid date/time string: \"13-21-2010\". Accepted formats: " +
+            ConsumerStatusReport.REPORT_DATE_FORMATS
+        );
     }
 
     @Test

--- a/gutterball/src/test/java/org/candlepin/gutterball/report/ConsumerTrendReportTest.java
+++ b/gutterball/src/test/java/org/candlepin/gutterball/report/ConsumerTrendReportTest.java
@@ -121,8 +121,8 @@ public class ConsumerTrendReportTest extends DatabaseTestFixture {
         when(params.get("start_date")).thenReturn(Arrays.asList("13-21-2010"));
 
         validateParams(params, "start_date",
-            "Invalid date/time string: \"13-21-2010\". Accepted formats: [" +
-            ConsumerTrendReport.REPORT_DATETIME_FORMAT + ']'
+            "Invalid date/time string: \"13-21-2010\". Accepted formats: " +
+            ConsumerTrendReport.REPORT_DATETIME_FORMATS
         );
     }
 
@@ -138,8 +138,8 @@ public class ConsumerTrendReportTest extends DatabaseTestFixture {
         when(params.get("end_date")).thenReturn(Arrays.asList("13-21-2010"));
 
         validateParams(params, "end_date",
-            "Invalid date/time string: \"13-21-2010\". Accepted formats: [" +
-            ConsumerTrendReport.REPORT_DATETIME_FORMAT + ']'
+            "Invalid date/time string: \"13-21-2010\". Accepted formats: " +
+            ConsumerTrendReport.REPORT_DATETIME_FORMATS
         );
     }
 

--- a/gutterball/src/test/java/org/candlepin/gutterball/report/ConsumerTrendReportTest.java
+++ b/gutterball/src/test/java/org/candlepin/gutterball/report/ConsumerTrendReportTest.java
@@ -120,8 +120,10 @@ public class ConsumerTrendReportTest extends DatabaseTestFixture {
         when(params.containsKey("start_date")).thenReturn(true);
         when(params.get("start_date")).thenReturn(Arrays.asList("13-21-2010"));
 
-        validateParams(params, "start_date", "Invalid date string. Expected format: " +
-                ConsumerTrendReport.REPORT_DATETIME_FORMAT);
+        validateParams(params, "start_date",
+            "Invalid date/time string: \"13-21-2010\". Accepted formats: [" +
+            ConsumerTrendReport.REPORT_DATETIME_FORMAT + ']'
+        );
     }
 
     @Test
@@ -135,8 +137,10 @@ public class ConsumerTrendReportTest extends DatabaseTestFixture {
         when(params.containsKey("end_date")).thenReturn(true);
         when(params.get("end_date")).thenReturn(Arrays.asList("13-21-2010"));
 
-        validateParams(params, "end_date", "Invalid date string. Expected format: " +
-                ConsumerTrendReport.REPORT_DATETIME_FORMAT);
+        validateParams(params, "end_date",
+            "Invalid date/time string: \"13-21-2010\". Accepted formats: [" +
+            ConsumerTrendReport.REPORT_DATETIME_FORMAT + ']'
+        );
     }
 
     @Test

--- a/gutterball/src/test/java/org/candlepin/gutterball/report/ParameterDescriptorTest.java
+++ b/gutterball/src/test/java/org/candlepin/gutterball/report/ParameterDescriptorTest.java
@@ -107,7 +107,9 @@ public class ParameterDescriptorTest {
         when(params.get(desc.getName())).thenReturn(Arrays.asList("2014-04-nineteen19"));
 
         desc.mustBeDate("yyyy-MM-dd");
-        assertInvalidParameter(desc, params, "Invalid date string. Expected format: yyyy-MM-dd");
+        assertInvalidParameter(
+            desc, params, "Invalid date/time string: \"2014-04-nineteen19\". Accepted formats: [yyyy-MM-dd]"
+        );
     }
 
     @Test
@@ -128,7 +130,60 @@ public class ParameterDescriptorTest {
             "a2014-21-d04"));
 
         desc.mustBeDate("yyyy-MM-dd");
-        assertInvalidParameter(desc, params, "Invalid date string. Expected format: yyyy-MM-dd");
+        assertInvalidParameter(
+            desc, params, "Invalid date/time string: \"a2014-21-d04\". Accepted formats: [yyyy-MM-dd]"
+        );
+    }
+
+    @Test
+    public void validatesMultipleDateFormats() {
+        MultivaluedMap<String, String> params = mock(MultivaluedMap.class);
+        when(params.containsKey(desc.getName())).thenReturn(true);
+        when(params.get(desc.getName())).thenReturn(Arrays.asList("2014-04-f19"));
+
+        desc.mustBeDate(Arrays.asList("yyyy-MM-dd", "yyyy-MM-dd'T'HH"));
+        assertInvalidParameter(desc, params,
+            "Invalid date/time string: \"2014-04-f19\". Accepted formats: [yyyy-MM-dd, yyyy-MM-dd'T'HH]"
+        );
+    }
+
+    @Test
+    public void validatesDateFormatSingleCallPersistsMultipleValues() {
+        MultivaluedMap<String, String> params = mock(MultivaluedMap.class);
+        when(params.containsKey(desc.getName())).thenReturn(true);
+        when(params.get(desc.getName())).thenReturn(Arrays.asList("2014-04-f19"));
+
+        desc.mustBeDate(Arrays.asList("yyyy-MM-dd"));
+        desc.mustBeDate(Arrays.asList("yyyy-MM-dd", "yyyy-MM-dd'T'HH"));
+        assertInvalidParameter(desc, params,
+            "Invalid date/time string: \"2014-04-f19\". Accepted formats: [yyyy-MM-dd, yyyy-MM-dd'T'HH]"
+        );
+    }
+
+    @Test
+    public void validatesDateFormatSingleCallPersists() {
+        MultivaluedMap<String, String> params = mock(MultivaluedMap.class);
+        when(params.containsKey(desc.getName())).thenReturn(true);
+        when(params.get(desc.getName())).thenReturn(Arrays.asList("2014-04-f19"));
+
+        desc.mustBeDate(Arrays.asList("yyyy-MM-dd", "yyyy-MM-dd'T'HH"));
+        desc.mustBeDate("yyyy-MM-dd");
+
+        assertInvalidParameter(desc, params,
+            "Invalid date/time string: \"2014-04-f19\". Accepted formats: [yyyy-MM-dd]"
+        );
+    }
+
+    @Test
+    public void validatesMultipleDateFormatsWithMultipleValues() {
+        MultivaluedMap<String, String> params = mock(MultivaluedMap.class);
+        when(params.containsKey(desc.getName())).thenReturn(true);
+        when(params.get(desc.getName())).thenReturn(Arrays.asList("2014-04-19", "2015-10-12T12", "nope"));
+
+        desc.mustBeDate(Arrays.asList("yyyy-MM-dd", "yyyy-MM-dd'T'HH"));
+        assertInvalidParameter(desc, params,
+            "Invalid date/time string: \"nope\". Accepted formats: [yyyy-MM-dd, yyyy-MM-dd'T'HH]"
+        );
     }
 
     @Test

--- a/gutterball/src/test/java/org/candlepin/gutterball/report/StatusTrendReportTest.java
+++ b/gutterball/src/test/java/org/candlepin/gutterball/report/StatusTrendReportTest.java
@@ -104,15 +104,15 @@ public class StatusTrendReportTest {
     }
 
     public Object[] invalidDateProvider() {
-        String dateFormat = ConsumerStatusReport.REPORT_DATE_FORMAT;
+        String acceptedFormats = "Accepted formats: [" + StatusTrendReport.REPORT_DATE_FORMAT + ']';
 
         return $(
-            $("not a date", "Invalid date string. Expected format: " + dateFormat),
-            $("2014-10-20asdlkasf", "Invalid date string. Expected format: " + dateFormat),
-            $("2014-1nope0-20", "Invalid date string. Expected format: " + dateFormat),
+            $("not a date", "Invalid date/time string: \"not a date\". " + acceptedFormats),
+            $("2014-10-20asdlkasf", "Invalid date/time string: \"2014-10-20asdlkasf\". " + acceptedFormats),
+            $("2014-1nope0-20", "Invalid date/time string: \"2014-1nope0-20\". " + acceptedFormats),
             $("1999-10-20", "Invalid year; years must be no earlier than 2000."),
-            $("2014-13-20", "Invalid date string. Expected format: " + dateFormat),
-            $("2014-12-45", "Invalid date string. Expected format: " + dateFormat)
+            $("2014-13-20", "Invalid date/time string: \"2014-13-20\". " + acceptedFormats),
+            $("2014-12-45", "Invalid date/time string: \"2014-12-45\". " + acceptedFormats)
         );
     }
 

--- a/gutterball/src/test/java/org/candlepin/gutterball/report/StatusTrendReportTest.java
+++ b/gutterball/src/test/java/org/candlepin/gutterball/report/StatusTrendReportTest.java
@@ -104,7 +104,7 @@ public class StatusTrendReportTest {
     }
 
     public Object[] invalidDateProvider() {
-        String acceptedFormats = "Accepted formats: [" + StatusTrendReport.REPORT_DATE_FORMAT + ']';
+        String acceptedFormats = "Accepted formats: " + StatusTrendReport.REPORT_DATE_FORMATS;
 
         return $(
             $("not a date", "Invalid date/time string: \"not a date\". " + acceptedFormats),


### PR DESCRIPTION
- The .mustBeDate method on ParameterDescriptor will now accept a collection
  of strings to use while validating input dates. Multiple calls to
  .mustBeDate are destructive and do not persist previously provided formats.
- ConsumerStatusReport now accepts the date format in any of the following
  formats: yyyy-MM-dd'T'HH:mm:ss.SSSZ, yyyy-MM-dd HH:mm:ss.SSSZ,
  yyyy-MM-dd'T'HH:mm:ss or yyyy-MM-dd HH:mm:ss