### PR TITLE
createPools now mimics createSubscriptions in OwnerResource ( WIP )

### DIFF
--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -467,7 +467,7 @@ public class CandlepinPoolManager implements PoolManager {
 
         // BUG 1012386 This will regenerate master/derived for bonus scenarios
         //  if only one of the pair still exists.
-        createPoolsForSubscription(sub, subscriptionPools);
+        createAndEnrichPools(sub, subscriptionPools);
 
         // don't update floating here, we'll do that later
         // so we don't update anything twice
@@ -662,26 +662,28 @@ public class CandlepinPoolManager implements PoolManager {
      * @return the newly created Pools
      */
     @Override
-    public List<Pool> createPoolsForSubscription(Subscription sub) {
-        return createPoolsForSubscription(sub, new LinkedList<Pool>());
+    public List<Pool> createAndEnrichPools(Subscription sub) {
+        return createAndEnrichPools(sub, new LinkedList<Pool>());
     }
 
-    public List<Pool> createPoolsForSubscription(Subscription sub, List<Pool> existingPools) {
-        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(sub, existingPools);
-        log.debug("Creating {} pools: ", pools.size());
+    public List<Pool> createAndEnrichPools(Subscription sub, List<Pool> existingPools) {
+        List<Pool> pools = poolRules.createAndEnrichPools(sub, existingPools);
+        log.debug("Creating {} pools for subscription: ", pools.size());
         for (Pool pool : pools) {
             createPool(pool);
         }
+
         return pools;
     }
 
     @Override
-    public Pool createPools(Pool pool) {
-        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(pool, new ArrayList<Pool>());
+    public Pool createAndEnrichPools(Pool pool) {
+        List<Pool> pools = poolRules.createAndEnrichPools(pool, new ArrayList<Pool>());
         log.debug("Creating {} pools: ", pools.size());
         for (Pool p : pools) {
             createPool(p);
         }
+
         return pool;
     }
 

--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -667,13 +667,22 @@ public class CandlepinPoolManager implements PoolManager {
     }
 
     public List<Pool> createPoolsForSubscription(Subscription sub, List<Pool> existingPools) {
-        List<Pool> pools = poolRules.createPools(sub, existingPools);
-        log.debug("Creating {} pools for subscription: ", pools.size());
+        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(sub, existingPools);
+        log.debug("Creating {} pools: ", pools.size());
         for (Pool pool : pools) {
             createPool(pool);
         }
-
         return pools;
+    }
+
+    @Override
+    public Pool createPools(Pool pool) {
+        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(pool, new ArrayList<Pool>());
+        log.debug("Creating {} pools: ", pools.size());
+        for (Pool p : pools) {
+            createPool(p);
+        }
+        return pool;
     }
 
     @Override

--- a/server/src/main/java/org/candlepin/controller/PoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/PoolManager.java
@@ -45,9 +45,17 @@ public interface PoolManager {
 
     /**
      * @param sub
-     * @return the newly created Pool
+     * @return the newly created Pools
      */
     List<Pool> createPoolsForSubscription(Subscription sub);
+
+    /**
+     * Create any pools that need to be created for the given pool.
+     *
+     * @param pool
+     * @return original pool, enriched
+     */
+    Pool createPools(Pool pool);
 
     /**
      * Updates the pools associated with the specified subscription, using the information stored
@@ -299,4 +307,5 @@ public interface PoolManager {
      *  a list of known master pools
      */
     List<Pool> listMasterPools();
+
 }

--- a/server/src/main/java/org/candlepin/controller/PoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/PoolManager.java
@@ -45,9 +45,9 @@ public interface PoolManager {
 
     /**
      * @param sub
-     * @return the newly created Pools
+     * @return the newly created Pool(s)
      */
-    List<Pool> createPoolsForSubscription(Subscription sub);
+    List<Pool> createAndEnrichPools(Subscription sub);
 
     /**
      * Create any pools that need to be created for the given pool.
@@ -55,7 +55,7 @@ public interface PoolManager {
      * @param pool
      * @return original pool, enriched
      */
-    Pool createPools(Pool pool);
+    Pool createAndEnrichPools(Pool pool);
 
     /**
      * Updates the pools associated with the specified subscription, using the information stored

--- a/server/src/main/java/org/candlepin/controller/Refresher.java
+++ b/server/src/main/java/org/candlepin/controller/Refresher.java
@@ -130,7 +130,7 @@ public class Refresher {
     private void refreshPoolsForSubscription(Subscription subscription, List<Pool> pools) {
         poolManager.removeAndDeletePoolsOnOtherOwners(pools, subscription);
 
-        poolManager.createPoolsForSubscription(subscription, pools);
+        poolManager.createAndEnrichPools(subscription, pools);
         // Regenerate certificates here, that way if it fails, the whole thing rolls back.
         // We don't want to refresh without marking ents dirty, they will never get regenerated
         poolManager.regenerateCertificatesByEntIds(

--- a/server/src/main/java/org/candlepin/model/UeberCertificateGenerator.java
+++ b/server/src/main/java/org/candlepin/model/UeberCertificateGenerator.java
@@ -74,7 +74,7 @@ public class UeberCertificateGenerator {
 
         Product ueberProduct = createUeberProduct(o);
         Subscription ueberSubscription = createUeberSubscription(o, ueberProduct);
-        poolManager.createPoolsForSubscription(ueberSubscription);
+        poolManager.createAndEnrichPools(ueberSubscription);
         Consumer consumer = createUeberConsumer(principal, o);
 
         Pool ueberPool = poolCurator.findUeberPool(o);

--- a/server/src/main/java/org/candlepin/policy/js/pool/PoolHelper.java
+++ b/server/src/main/java/org/candlepin/policy/js/pool/PoolHelper.java
@@ -151,12 +151,12 @@ public class PoolHelper extends AttributeHelper {
     }
 
     /**
-     * Copies the provided products from a subscription to a derived pool.
+     * Copies the provided products from a source pool to a derived pool.
      *
      * @param source subscription
      * @param destination pool
      */
-    private void copyProvidedProducts(Subscription source, Pool destination,
+    private void copyProvidedProducts(Pool source, Pool destination,
         ProductCurator prodCurator) {
 
         Set<Product> products;
@@ -181,31 +181,27 @@ public class PoolHelper extends AttributeHelper {
         }
     }
 
-    public Pool createPool(Subscription sub, Product product, String quantity,
-        Map<String, String> attributes, ProductCurator prodCurator) {
+    public Pool clonePool(Pool sourcePool, Product product, String quantity,
+            Map<String, String> attributes, String subKey, ProductCurator prodCurator) {
 
-        Pool pool = createPool(
-            product,
-            sub.getOwner(),
-            quantity,
-            sub.getStartDate(),
-            sub.getEndDate(),
-            sub.getContractNumber(),
-            sub.getAccountNumber(),
-            sub.getOrderNumber(),
-            new HashSet<Product>()
-        );
+        Pool pool = createPool(product, sourcePool.getOwner(), quantity,
+                sourcePool.getStartDate(), sourcePool.getEndDate(),
+                sourcePool.getContractNumber(), sourcePool.getAccountNumber(),
+                sourcePool.getOrderNumber(), new HashSet<Product>());
 
-        pool.setSourceSubscription(new SourceSubscription(sub.getId(), "master"));
+        if (sourcePool.getSubscriptionId() != null) {
+            pool.setSourceSubscription(
+                    new SourceSubscription(sourcePool.getSubscriptionId(), subKey));
+        }
 
-        copyProvidedProducts(sub, pool, prodCurator);
+        copyProvidedProducts(sourcePool, pool, prodCurator);
 
         // Add in the new attributes
         for (Entry<String, String> entry : attributes.entrySet()) {
             pool.setAttribute(entry.getKey(), entry.getValue());
         }
 
-        for (Branding b : sub.getBranding()) {
+        for (Branding b : sourcePool.getBranding()) {
             pool.getBranding().add(new Branding(b.getProductId(), b.getType(),
                 b.getName()));
         }

--- a/server/src/main/java/org/candlepin/policy/js/pool/PoolHelper.java
+++ b/server/src/main/java/org/candlepin/policy/js/pool/PoolHelper.java
@@ -189,10 +189,8 @@ public class PoolHelper extends AttributeHelper {
                 sourcePool.getContractNumber(), sourcePool.getAccountNumber(),
                 sourcePool.getOrderNumber(), new HashSet<Product>());
 
-        if (sourcePool.getSubscriptionId() != null) {
-            pool.setSourceSubscription(
+        pool.setSourceSubscription(
                     new SourceSubscription(sourcePool.getSubscriptionId(), subKey));
-        }
 
         copyProvidedProducts(sourcePool, pool, prodCurator);
 

--- a/server/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
@@ -66,99 +66,124 @@ public class PoolRules {
         this.prodCurator = prodCurator;
     }
 
-    private long calculateQuantity(Subscription sub) {
-        long quantity = sub.getQuantity() * sub.getProduct().getMultiplier();
+    private long calculateQuantity(long quantity, Product product, String upstreamPoolId) {
+        long result = quantity * product.getMultiplier();
 
         // In hosted, we increase the quantity on the subscription. However in standalone,
         // we assume this already has happened in hosted and the accurate quantity was
         // exported:
-        if (sub.getProduct().hasAttribute("instance_multiplier") &&
-            sub.getUpstreamPoolId() == null) {
+        if (product.hasAttribute("instance_multiplier") &&
+                upstreamPoolId == null) {
 
             int instanceMultiplier = Integer.parseInt(
-                sub.getProduct().getAttributeValue("instance_multiplier"));
+                    product.getAttributeValue("instance_multiplier"));
             log.debug("Increasing pool quantity for instance multiplier: " +
                 instanceMultiplier);
-            quantity = quantity * instanceMultiplier;
+            result = result * instanceMultiplier;
         }
-        return quantity;
+        return result;
     }
 
-    public List<Pool> createPools(Subscription sub) {
-        return createPools(sub, new LinkedList<Pool>());
+    public List<Pool> enrichAndCreateAdditionalPools(Subscription sub) {
+        Pool pool = convertToPool(sub);
+        return enrichAndCreateAdditionalPools(pool, new LinkedList<Pool>());
+    }
+
+    public List<Pool> enrichAndCreateAdditionalPools(Subscription sub, List<Pool> existingPools) {
+        Pool pool = convertToPool(sub);
+        return enrichAndCreateAdditionalPools(pool, existingPools);
     }
 
     /**
-     * Create any pools that need to be created for the given subscription.
+     * Create any pools that need to be created for the given pool.
      *
      * In some scenarios, due to attribute changes, pools may need to be created even though
      * pools already exist for the subscription. A list of pre-existing pools for the given
      * sub are provided to help this method determine if something needs to be done or not.
      *
-     * For a genuine new subscription, the existing pools list will be empty.
+     * For a genuine new pool, the existing pools list will be empty.
      *
-     * @param sub
+     * @param pool
      * @param existingPools
-     * @return a list of pools created for the given subscription
+     * @return a list of pools created for the given pool
      */
-    public List<Pool> createPools(Subscription sub, List<Pool> existingPools) {
+    public List<Pool> enrichAndCreateAdditionalPools(Pool pool, List<Pool> existingPools) {
+        List<Pool> pools = new LinkedList<Pool>();
+        pool.setQuantity(calculateQuantity(pool.getQuantity(), pool.getProduct(), pool.getUpstreamPoolId()));
+        setVirtOnlyPoolAtrribute(pool);
+        log.info("Checking if pools need to be created for: {}", pool);
+        if (!hasMasterPool(existingPools)) {
+            pools.add(pool);
+            log.info("Creating new master pool: {}", pool);
+        }
+        Pool bonusPool = createBonusPool(pool, existingPools);
+        if (bonusPool != null) {
+            pools.add(bonusPool);
+        }
+        return pools;
+    }
+
+    /*
+     * if you are using this method, you might want to override the quantity
+     * with calculateQuantity
+     */
+    public Pool convertToPool(Subscription sub) {
         if (sub == null) {
             throw new IllegalArgumentException("subscription is null");
         }
+        Pool pool = new Pool(sub.getOwner(), sub.getProduct(), sub.getProvidedProducts(),
+                sub.getQuantity(), sub.getStartDate(), sub.getEndDate(), sub.getContractNumber(),
+                sub.getAccountNumber(), sub.getOrderNumber());
 
-        log.info("Checking if pools need to be created for subscription: {}", sub);
-        PoolHelper helper = new PoolHelper(this.poolManager, null);
+        // Add all product references
+        pool.setDerivedProduct(sub.getDerivedProduct());
+        pool.setDerivedProvidedProducts(sub.getDerivedProvidedProducts());
 
-        List<Pool> pools = new LinkedList<Pool>();
-        Map<String, String> attributes = helper.getFlattenedAttributes(sub.getProduct());
-        long quantity = calculateQuantity(sub);
-
-        if (!hasMasterPool(existingPools)) {
-            Pool newPool = new Pool(sub.getOwner(), sub.getProduct(), null, quantity,
-                sub.getStartDate(), sub.getEndDate(), sub.getContractNumber(),
-                sub.getAccountNumber(), sub.getOrderNumber()
-            );
-
-            // Add all product references
-            newPool.setProvidedProducts(sub.getProvidedProducts());
-            newPool.setDerivedProduct(sub.getDerivedProduct());
-            newPool.setDerivedProvidedProducts(sub.getDerivedProvidedProducts());
-
-            // Add in branding
-            for (Branding b : sub.getBranding()) {
-                newPool.getBranding().add(new Branding(b.getProductId(), b.getType(), b.getName()));
-            }
-
-            newPool.setSourceSubscription(new SourceSubscription(sub.getId(), "master"));
-            ProductAttribute virtAtt = sub.getProduct().getAttribute("virt_only");
-
-            // note: the product attributes are getting copied above, but the following will
-            // make virt_only a pool attribute. That makes the pool explicitly virt_only to
-            // subscription manager and any other downstream comsumer.
-            if (virtAtt != null && virtAtt.getValue() != null && !virtAtt.getValue().equals("")) {
-                newPool.addAttribute(new PoolAttribute("virt_only", virtAtt.getValue()));
-            }
-
-            // Copy over upstream details...?
-            newPool.setUpstreamPoolId(sub.getUpstreamPoolId());
-            newPool.setUpstreamEntitlementId(sub.getUpstreamEntitlementId());
-            newPool.setUpstreamConsumerId(sub.getUpstreamConsumerId());
-
-            newPool.setCdn(sub.getCdn());
-            newPool.setCertificate(sub.getCertificate());
-
-            pools.add(newPool);
-
-            log.info("Creating new master pool: {}", newPool);
+        // Add in branding
+        for (Branding b : sub.getBranding()) {
+            pool.getBranding().add(new Branding(b.getProductId(), b.getType(), b.getName()));
         }
+        pool.setSourceSubscription(new SourceSubscription(sub.getId(), "master"));
 
-        // If this subscription carries a virt_limit, we need to either create a bonus
-        // pool for any guest (legacy behavior, only in hosted), or a pool for temporary
-        // use of unmapped guests. (current behavior for any pool with virt_limit)
-        boolean hostLimited = attributes.containsKey("host_limited") &&
-            attributes.get("host_limited").equals("true");
-        if (attributes.containsKey("virt_limit") && !hasBonusPool(existingPools)) {
+        // Copy over upstream details...?
+        pool.setUpstreamPoolId(sub.getUpstreamPoolId());
+        pool.setUpstreamEntitlementId(sub.getUpstreamEntitlementId());
+        pool.setUpstreamConsumerId(sub.getUpstreamConsumerId());
+        pool.setCdn(sub.getCdn());
+        pool.setCertificate(sub.getCertificate());
+        return pool;
+    }
 
+    /*
+     * The following will make virt_only a pool attribute. That makes the pool
+     * explicitly virt_only to subscription manager and any other downstream
+     * consumer.
+     */
+    private void setVirtOnlyPoolAtrribute(Pool pool) {
+        ProductAttribute virtAtt = pool.getProduct().getAttribute("virt_only");
+
+        if (virtAtt != null && virtAtt.getValue() != null && !virtAtt.getValue().equals("")) {
+            pool.addAttribute(new PoolAttribute("virt_only", virtAtt.getValue()));
+        }
+    }
+
+    /*
+     * If this subscription carries a virt_limit, we need to either create a
+     * bonus pool for any guest (legacy behavior, only in hosted), or a pool for
+     * temporary use of unmapped guests. (current behavior for any pool with
+     * virt_limit)
+     */
+    private Pool createBonusPool(Pool masterPool, List<Pool> existingPools) {
+        PoolHelper helper = new PoolHelper(this.poolManager, null);
+        Map<String, String> attributes = helper.getFlattenedAttributes(masterPool.getProduct());
+        String virtQuantity = getVirtQuantity(attributes.get("virt_limit"), masterPool.getQuantity());
+
+        log.info("Checking if bonus pools need to be created for pool: {}", masterPool);
+
+        if (attributes.containsKey("virt_limit") && !hasBonusPool(existingPools) && virtQuantity != null) {
+
+            boolean hostLimited = attributes.containsKey("host_limited") &&
+                    attributes.get("host_limited").equals("true");
             HashMap<String, String> virtAttributes = new HashMap<String, String>();
             virtAttributes.put("virt_only", "true");
             virtAttributes.put("pool_derived", "true");
@@ -170,26 +195,19 @@ public class PoolRules {
             // otherwise this will recurse infinitely
             virtAttributes.put("virt_limit", "0");
 
-            String virtQuantity = getVirtQuantity(attributes.get("virt_limit"), quantity);
-            if (virtQuantity != null) {
-                // Favor derived products if they are available
-                Product sku = sub.getDerivedProduct() != null ?
-                    sub.getDerivedProduct() :
-                    sub.getProduct();
+            // Favor derived products if they are available
+            Product sku = masterPool.getDerivedProduct() != null ? masterPool.getDerivedProduct() :
+                    masterPool.getProduct();
 
-                Pool derivedPool = helper.createPool(
-                    sub, sku, virtQuantity, virtAttributes, prodCurator
-                );
+            // Using derived here because only one derived pool is created for
+            // this subscription
+            Pool bonusPool = helper.clonePool(masterPool, sku, virtQuantity, virtAttributes, "derived",
+                    prodCurator);
 
-                // Using derived here because only one derived pool
-                // is created for this subscription
-                derivedPool.setSourceSubscription(new SourceSubscription(sub.getId(), "derived"));
-                pools.add(derivedPool);
-                log.info("Creating new derived pool: {}", derivedPool);
-            }
+            log.info("Creating new derived pool: {}", bonusPool);
+            return bonusPool;
         }
-
-        return pools;
+        return null;
     }
 
     private boolean hasMasterPool(List<Pool> pools) {
@@ -565,7 +583,8 @@ public class PoolRules {
 
         // Expected quantity is normally the subscription's quantity, but for
         // virt only pools we expect it to be sub quantity * virt_limit:
-        long expectedQuantity = calculateQuantity(sub);
+        long expectedQuantity = calculateQuantity(sub.getQuantity(), sub.getProduct(),
+                sub.getUpstreamPoolId());
         expectedQuantity = processVirtLimitPools(existingPools,
             attributes, existingPool, expectedQuantity);
 

--- a/server/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
@@ -120,7 +120,8 @@ public class PoolRules {
 
         log.info("Checking if pools need to be created for: {}", pool);
         if (!hasMasterPool(existingPools)) {
-            if (pool.getSourceSubscription().getSubscriptionSubKey().contentEquals("derived")) {
+            if (pool.getSourceSubscription() != null &&
+                    pool.getSourceSubscription().getSubscriptionSubKey().contentEquals("derived")) {
                 // while we can create bonus pool from master pool, the reverse
                 // is not possible without the subscription itself
                 throw new IllegalStateException("Cannot create master pool from bonus pool");

--- a/server/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
@@ -143,6 +143,7 @@ public class PoolRules {
         for (Branding b : sub.getBranding()) {
             pool.getBranding().add(new Branding(b.getProductId(), b.getType(), b.getName()));
         }
+        pool.setSubscriptionId(sub.getId());
         pool.setSourceSubscription(new SourceSubscription(sub.getId(), "master"));
 
         // Copy over upstream details...?

--- a/server/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -1149,7 +1149,7 @@ public class OwnerResource {
         pool.setOwner(owner);
 
         pool = resolvePool(pool);
-        return poolManager.createPool(pool);
+        return poolManager.createPools(pool);
     }
 
     /**

--- a/server/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -1120,7 +1120,7 @@ public class OwnerResource {
             subscription.setId(Util.generateDbUUID());
         }
 
-        poolManager.createPoolsForSubscription(subscription);
+        poolManager.createAndEnrichPools(subscription);
         return subscription;
     }
 
@@ -1149,7 +1149,7 @@ public class OwnerResource {
         pool.setOwner(owner);
 
         pool = resolvePool(pool);
-        return poolManager.createPools(pool);
+        return poolManager.createAndEnrichPools(pool);
     }
 
     /**

--- a/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -375,7 +375,7 @@ public class PoolManagerTest {
         Pool p = TestUtil.createPool(s.getProduct());
         p.setSourceSubscription(new SourceSubscription(s.getId(), "master"));
         newPools.add(p);
-        when(poolRulesMock.createPools(eq(s), any(List.class))).thenReturn(newPools);
+        when(poolRulesMock.enrichAndCreateAdditionalPools(eq(s), any(List.class))).thenReturn(newPools);
 
         this.manager.getRefresher(mockSubAdapter).add(getOwner()).run();
         verify(this.mockPoolCurator, times(1)).create(any(Pool.class));
@@ -465,7 +465,7 @@ public class PoolManagerTest {
         Pool p = TestUtil.createPool(s.getProduct());
         p.setSourceSubscription(new SourceSubscription(s.getId(), "master"));
         newPools.add(p);
-        when(poolRulesMock.createPools(eq(s), any(List.class))).thenReturn(newPools);
+        when(poolRulesMock.enrichAndCreateAdditionalPools(eq(s), any(List.class))).thenReturn(newPools);
 
         this.manager.createPoolsForSubscription(s);
         verify(this.mockPoolCurator, times(1)).create(any(Pool.class));
@@ -797,7 +797,7 @@ public class PoolManagerTest {
         // Make sure pools that don't match the owner were removed from the list
         // They shouldn't cause us to attempt to update existing pools when we
         // haven't created them in the first place
-        verify(poolRulesMock).createPools(eq(sub), any(List.class));
+        verify(poolRulesMock).enrichAndCreateAdditionalPools(eq(sub), any(List.class));
     }
 
     private void mockSubsList(List<Subscription> subs) {
@@ -870,7 +870,7 @@ public class PoolManagerTest {
         when(mockConfig.getBoolean(ConfigProperties.STANDALONE)).thenReturn(false);
 
         List<Pool> existingPools = new LinkedList<Pool>();
-        List<Pool> newPools = pRules.createPools(s, existingPools);
+        List<Pool> newPools = pRules.enrichAndCreateAdditionalPools(s, existingPools);
 
         assertEquals(newPools.size(), 2);
         assert (newPools.get(0).getSourceSubscription().getSubscriptionSubKey()
@@ -905,7 +905,7 @@ public class PoolManagerTest {
         Pool p = TestUtil.createPool(s.getProduct());
         p.setSourceSubscription(new SourceSubscription(s.getId(), "master"));
         existingPools.add(p);
-        List<Pool> newPools = pRules.createPools(s, existingPools);
+        List<Pool> newPools = pRules.enrichAndCreateAdditionalPools(s, existingPools);
         assertEquals(newPools.size(), 1);
         assertEquals(newPools.get(0).getSourceSubscription().getSubscriptionSubKey(), "derived");
     }
@@ -932,8 +932,8 @@ public class PoolManagerTest {
         Pool p = TestUtil.createPool(s.getProduct());
         p.setSourceSubscription(new SourceSubscription(s.getId(), "derived"));
         existingPools.add(p);
-        pRules.createPools(s, existingPools);
-        List<Pool> newPools = pRules.createPools(s, existingPools);
+        pRules.enrichAndCreateAdditionalPools(s, existingPools);
+        List<Pool> newPools = pRules.enrichAndCreateAdditionalPools(s, existingPools);
         assertEquals(newPools.size(), 1);
         assertEquals(newPools.get(0).getSourceSubscription().getSubscriptionSubKey(), "master");
     }

--- a/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
@@ -500,7 +500,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
             TestUtil.createDate(2006, 10, 21), TestUtil.createDate(2020, 1, 1), new Date());
         sub.setId(Util.generateDbUUID());
 
-        Pool newPool = poolManager.createPoolsForSubscription(sub).get(0);
+        Pool newPool = poolManager.createAndEnrichPools(sub).get(0);
         List<Pool> pools = poolCurator.lookupBySubscriptionId(sub.getId());
 
         assertEquals(160L, pools.get(0).getQuantity().longValue());
@@ -915,7 +915,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
             TestUtil.createDate(2006, 10, 21), TestUtil.createDate(2020, 1, 1), new Date());
         sub.setId(Util.generateDbUUID());
 
-        Pool sourcePool = poolManager.createPoolsForSubscription(sub).get(0);
+        Pool sourcePool = poolManager.createAndEnrichPools(sub).get(0);
         poolCurator.create(sourcePool);
         Entitlement e = new Entitlement(sourcePool, consumer, 1);
         entitlementCurator.create(e);

--- a/server/src/test/java/org/candlepin/policy/PoolRulesInstanceTest.java
+++ b/server/src/test/java/org/candlepin/policy/PoolRulesInstanceTest.java
@@ -80,7 +80,7 @@ public class PoolRulesInstanceTest {
     @Test
     public void hostedCreateInstanceBasedPool() {
         Subscription s = createInstanceBasedSub("INSTANCEPROD", 100, 2, false);
-        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(s);
+        List<Pool> pools = poolRules.createAndEnrichPools(s);
         assertEquals(1, pools.size());
 
         Pool pool = pools.get(0);
@@ -92,7 +92,7 @@ public class PoolRulesInstanceTest {
     @Test
     public void standaloneCreateInstanceBasedPool() {
         Subscription s = createInstanceBasedSub("INSTANCEPROD", 100, 2, true);
-        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(s);
+        List<Pool> pools = poolRules.createAndEnrichPools(s);
         assertEquals(1, pools.size());
 
         Pool pool = pools.get(0);
@@ -106,7 +106,7 @@ public class PoolRulesInstanceTest {
     @Test
     public void hostedInstanceBasedUpdatePool() {
         Subscription s = createInstanceBasedSub("INSTANCEPROD", 100, 2, false);
-        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(s);
+        List<Pool> pools = poolRules.createAndEnrichPools(s);
         assertEquals(1, pools.size());
         Pool pool = pools.get(0);
 
@@ -129,7 +129,7 @@ public class PoolRulesInstanceTest {
     @Test
     public void hostedInstanceBasedRemoved() {
         Subscription s = createInstanceBasedSub("INSTANCEPROD", 100, 2, false);
-        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(s);
+        List<Pool> pools = poolRules.createAndEnrichPools(s);
         assertEquals(1, pools.size());
         Pool pool = pools.get(0);
 
@@ -154,7 +154,7 @@ public class PoolRulesInstanceTest {
     @Test
     public void standaloneInstanceBasedUpdatePool() {
         Subscription s = createInstanceBasedSub("INSTANCEPROD", 100, 2, true);
-        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(s);
+        List<Pool> pools = poolRules.createAndEnrichPools(s);
         assertEquals(1, pools.size());
         Pool pool = pools.get(0);
 

--- a/server/src/test/java/org/candlepin/policy/PoolRulesInstanceTest.java
+++ b/server/src/test/java/org/candlepin/policy/PoolRulesInstanceTest.java
@@ -80,7 +80,7 @@ public class PoolRulesInstanceTest {
     @Test
     public void hostedCreateInstanceBasedPool() {
         Subscription s = createInstanceBasedSub("INSTANCEPROD", 100, 2, false);
-        List<Pool> pools = poolRules.createPools(s);
+        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(s);
         assertEquals(1, pools.size());
 
         Pool pool = pools.get(0);
@@ -92,7 +92,7 @@ public class PoolRulesInstanceTest {
     @Test
     public void standaloneCreateInstanceBasedPool() {
         Subscription s = createInstanceBasedSub("INSTANCEPROD", 100, 2, true);
-        List<Pool> pools = poolRules.createPools(s);
+        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(s);
         assertEquals(1, pools.size());
 
         Pool pool = pools.get(0);
@@ -106,7 +106,7 @@ public class PoolRulesInstanceTest {
     @Test
     public void hostedInstanceBasedUpdatePool() {
         Subscription s = createInstanceBasedSub("INSTANCEPROD", 100, 2, false);
-        List<Pool> pools = poolRules.createPools(s);
+        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(s);
         assertEquals(1, pools.size());
         Pool pool = pools.get(0);
 
@@ -129,7 +129,7 @@ public class PoolRulesInstanceTest {
     @Test
     public void hostedInstanceBasedRemoved() {
         Subscription s = createInstanceBasedSub("INSTANCEPROD", 100, 2, false);
-        List<Pool> pools = poolRules.createPools(s);
+        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(s);
         assertEquals(1, pools.size());
         Pool pool = pools.get(0);
 
@@ -154,7 +154,7 @@ public class PoolRulesInstanceTest {
     @Test
     public void standaloneInstanceBasedUpdatePool() {
         Subscription s = createInstanceBasedSub("INSTANCEPROD", 100, 2, true);
-        List<Pool> pools = poolRules.createPools(s);
+        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(s);
         assertEquals(1, pools.size());
         Pool pool = pools.get(0);
 

--- a/server/src/test/java/org/candlepin/policy/PoolRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/PoolRulesTest.java
@@ -992,4 +992,41 @@ public class PoolRulesTest {
         assertEquals(0, updates.size());
     }
 
+    @Test
+    public void noPoolsCreatedTest() {
+        Product product = TestUtil.createProduct(owner);
+        List<Pool> existingPools = new ArrayList<Pool>();
+        Pool masterPool = TestUtil.createPool(product);
+        masterPool.setSubscriptionSubKey("master");
+        existingPools.add(masterPool);
+        Pool derivedPool = TestUtil.createPool(product);
+        derivedPool.setSubscriptionSubKey("derived");
+        existingPools.add(derivedPool);
+        List<Pool> pools = this.poolRules.createAndEnrichPools(masterPool, existingPools);
+        assertEquals(0, pools.size());
+    }
+
+    @Test
+    public void derivedPoolCreateCreatedTest() {
+        Product product = TestUtil.createProduct(owner);
+        product.setAttribute("virt_limit", "4");
+        List<Pool> existingPools = new ArrayList<Pool>();
+        Pool masterPool = TestUtil.createPool(product);
+        masterPool.setSubscriptionSubKey("master");
+        existingPools.add(masterPool);
+        List<Pool> pools = this.poolRules.createAndEnrichPools(masterPool, existingPools);
+        assertEquals(1, pools.size());
+        assertEquals("derived", pools.get(0).getSubscriptionSubKey());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void cantCreateMasterPoolFromDerivedPoolTest() {
+        Product product = TestUtil.createProduct(owner);
+        List<Pool> existingPools = new ArrayList<Pool>();
+        Pool masterPool = TestUtil.createPool(product);
+        masterPool.setSubscriptionSubKey("derived");
+        existingPools.add(masterPool);
+        List<Pool> pools = this.poolRules.createAndEnrichPools(masterPool, existingPools);
+    }
+
 }

--- a/server/src/test/java/org/candlepin/policy/PoolRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/PoolRulesTest.java
@@ -105,7 +105,7 @@ public class PoolRulesTest {
 
         List<Pool> pools = null;
         try {
-            pools = poolRules.enrichAndCreateAdditionalPools(s);
+            pools = poolRules.createAndEnrichPools(s);
         }
         catch (Exception e) {
             fail(
@@ -337,7 +337,7 @@ public class PoolRulesTest {
         when(prodCuratorMock.lookupById(product.getOwner(), product.getId()))
             .thenReturn(product);
 
-        List<Pool> pools = this.poolRules.enrichAndCreateAdditionalPools(sub);
+        List<Pool> pools = this.poolRules.createAndEnrichPools(sub);
         assertEquals(1, pools.size());
 
         Pool resultPool = pools.get(0);
@@ -362,7 +362,7 @@ public class PoolRulesTest {
         when(this.prodCuratorMock.lookupById(product.getOwner(), product.getId()))
             .thenReturn(product);
 
-        List<Pool> pools = this.poolRules.enrichAndCreateAdditionalPools(sub);
+        List<Pool> pools = this.poolRules.createAndEnrichPools(sub);
         assertEquals(1, pools.size());
 
         Pool resultPool = pools.get(0);
@@ -387,7 +387,7 @@ public class PoolRulesTest {
         when(this.prodCuratorMock.lookupById(subProduct.getOwner(), subProduct.getId()))
             .thenReturn(subProduct);
 
-        List<Pool> pools = this.poolRules.enrichAndCreateAdditionalPools(sub);
+        List<Pool> pools = this.poolRules.createAndEnrichPools(sub);
         assertEquals(1, pools.size());
 
         Pool resultPool = pools.get(0);
@@ -412,7 +412,7 @@ public class PoolRulesTest {
         when(this.prodCuratorMock.lookupById(subProduct.getOwner(), subProduct.getId()))
             .thenReturn(subProduct);
 
-        List<Pool> pools = this.poolRules.enrichAndCreateAdditionalPools(sub);
+        List<Pool> pools = this.poolRules.createAndEnrichPools(sub);
         assertEquals(1, pools.size());
 
         Pool resultPool = pools.get(0);
@@ -436,7 +436,7 @@ public class PoolRulesTest {
         when(this.prodCuratorMock.lookupById(subProduct.getOwner(), subProduct.getId()))
             .thenReturn(subProduct);
 
-        List<Pool> pools = this.poolRules.enrichAndCreateAdditionalPools(sub);
+        List<Pool> pools = this.poolRules.createAndEnrichPools(sub);
         assertEquals(1, pools.size());
 
         Pool resultPool = pools.get(0);
@@ -463,7 +463,7 @@ public class PoolRulesTest {
     public void virtLimitWithHostLimitedCreatesTaggedBonusPool() {
         Subscription s = createVirtLimitSub("virtLimitProduct", 10, 10);
         s.getProduct().setAttribute("host_limited", "true");
-        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(s);
+        List<Pool> pools = poolRules.createAndEnrichPools(s);
         assertEquals(2, pools.size());
         for (Pool p : pools) {
             if (p.getSourceSubscription().getSubscriptionSubKey().equals("derived")) {
@@ -479,7 +479,7 @@ public class PoolRulesTest {
         when(configMock.getBoolean(ConfigProperties.STANDALONE)).thenReturn(false);
         Subscription s = createVirtLimitSub("virtLimitProduct", 10, 10);
         s.getProduct().setAttribute("host_limited", "false");
-        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(s);
+        List<Pool> pools = poolRules.createAndEnrichPools(s);
         assertEquals(2, pools.size());
     }
 
@@ -487,7 +487,7 @@ public class PoolRulesTest {
     public void hostedVirtLimitSubCreatesBonusVirtOnlyPool() {
         when(configMock.getBoolean(ConfigProperties.STANDALONE)).thenReturn(false);
         Subscription s = createVirtLimitSub("virtLimitProduct", 10, 10);
-        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(s);
+        List<Pool> pools = poolRules.createAndEnrichPools(s);
         assertEquals(2, pools.size());
 
         Pool physicalPool = pools.get(0);
@@ -507,7 +507,7 @@ public class PoolRulesTest {
         when(configMock.getBoolean(ConfigProperties.STANDALONE)).thenReturn(false);
         Subscription s = createVirtLimitSub("virtLimitProduct", 10, 10);
         s.getProduct().setAttribute("virt_limit", "unlimited");
-        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(s);
+        List<Pool> pools = poolRules.createAndEnrichPools(s);
         assertEquals(2, pools.size());
 
         Pool virtBonusPool = pools.get(1);
@@ -521,7 +521,7 @@ public class PoolRulesTest {
         when(configMock.getBoolean(ConfigProperties.STANDALONE)).thenReturn(false);
         Subscription s = createVirtLimitSub("virtLimitProduct", 10, 10);
         s.getProduct().setAttribute("virt_limit", "unlimited");
-        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(s);
+        List<Pool> pools = poolRules.createAndEnrichPools(s);
         assertEquals(2, pools.size());
 
         Pool virtBonusPool = pools.get(1);
@@ -544,7 +544,7 @@ public class PoolRulesTest {
         when(configMock.getBoolean(ConfigProperties.STANDALONE)).thenReturn(false);
         Subscription s = createVirtLimitSub("virtLimitProduct", 10, 10);
         s.getProduct().setAttribute("virt_limit", "4");
-        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(s);
+        List<Pool> pools = poolRules.createAndEnrichPools(s);
         assertEquals(2, pools.size());
 
         // Now we remove virt_limit on the incoming subscription product and see if
@@ -572,7 +572,7 @@ public class PoolRulesTest {
         Subscription s = createVirtLimitSub("virtLimitProduct", 10, 10);
         s.getProduct().setAttribute("virt_limit", "unlimited");
         s.getProduct().setMultiplier(5L);
-        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(s);
+        List<Pool> pools = poolRules.createAndEnrichPools(s);
         assertEquals(2, pools.size());
 
         Pool virtBonusPool = pools.get(1);
@@ -586,7 +586,7 @@ public class PoolRulesTest {
         when(configMock.getBoolean(ConfigProperties.STANDALONE)).thenReturn(false);
         Subscription s = createVirtLimitSub("virtLimitProduct", 10, 10);
         s.getProduct().setAttribute("physical_only", "true");
-        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(s);
+        List<Pool> pools = poolRules.createAndEnrichPools(s);
 
         // Should be no virt_only bonus pool:
         assertEquals(2, pools.size());
@@ -627,7 +627,7 @@ public class PoolRulesTest {
         when(productAdapterMock.getProductById(owner, derivedProd.getId())).thenReturn(derivedProd);
         s.getDerivedProvidedProducts().add(derivedProvidedProd1);
         s.getDerivedProvidedProducts().add(derivedProvidedProd2);
-        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(s);
+        List<Pool> pools = poolRules.createAndEnrichPools(s);
 
         // Should be virt_only pool for unmapped guests:
         assertEquals(2, pools.size());
@@ -660,7 +660,7 @@ public class PoolRulesTest {
         when(configMock.getBoolean(ConfigProperties.STANDALONE)).thenReturn(true);
         Subscription s = createVirtLimitSubWithDerivedProducts("virtLimitProduct",
                 "derivedProd", 10, 10);
-        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(s);
+        List<Pool> pools = poolRules.createAndEnrichPools(s);
 
         // Should be virt_only pool for unmapped guests:
         assertEquals(2, pools.size());
@@ -745,7 +745,7 @@ public class PoolRulesTest {
     public void standaloneVirtLimitSubUpdate() {
         when(configMock.getBoolean(ConfigProperties.STANDALONE)).thenReturn(true);
         Subscription s = createVirtLimitSub("virtLimitProduct", 10, 10);
-        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(s);
+        List<Pool> pools = poolRules.createAndEnrichPools(s);
 
         // Should be unmapped virt_only pool:
         assertEquals(2, pools.size());
@@ -777,7 +777,7 @@ public class PoolRulesTest {
     public void hostedVirtOnlySubCreate() {
         when(configMock.getBoolean(ConfigProperties.STANDALONE)).thenReturn(true);
         Subscription s = createVirtOnlySub("virtOnlyProduct", 10);
-        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(s);
+        List<Pool> pools = poolRules.createAndEnrichPools(s);
         assertEquals(1, pools.size());
         assertEquals("true", pools.get(0).getProduct().getAttributeValue("virt_only"));
         assertEquals(new Long(10), pools.get(0).getQuantity());
@@ -788,7 +788,7 @@ public class PoolRulesTest {
         when(configMock.getBoolean(ConfigProperties.STANDALONE)).thenReturn(true);
         Subscription s = createVirtOnlySub("virtOnlyProduct", 10);
         s.getProduct().setMultiplier(new Long(5));
-        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(s);
+        List<Pool> pools = poolRules.createAndEnrichPools(s);
         assertEquals(1, pools.size());
         assertEquals("true", pools.get(0).getProduct().getAttributeValue("virt_only"));
         assertEquals(new Long(50), pools.get(0).getQuantity());
@@ -798,7 +798,7 @@ public class PoolRulesTest {
     public void hostedVirtOnlySubUpdate() {
         when(configMock.getBoolean(ConfigProperties.STANDALONE)).thenReturn(true);
         Subscription s = createVirtOnlySub("virtOnlyProduct", 10);
-        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(s);
+        List<Pool> pools = poolRules.createAndEnrichPools(s);
         assertEquals(1, pools.size());
         s.setQuantity(new Long(20));
 
@@ -813,7 +813,7 @@ public class PoolRulesTest {
     public void standaloneVirtSubPoolUpdateNoChanges() {
         when(configMock.getBoolean(ConfigProperties.STANDALONE)).thenReturn(true);
         Subscription s = createVirtLimitSub("virtLimitProduct", 10, 10);
-        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(s);
+        List<Pool> pools = poolRules.createAndEnrichPools(s);
         assertEquals(2, pools.size());
         Entitlement ent = mock(Entitlement.class);
         when(ent.getQuantity()).thenReturn(1);
@@ -837,7 +837,7 @@ public class PoolRulesTest {
     public void standaloneVirtSubPoolUpdateVirtLimitChanged() {
         when(configMock.getBoolean(ConfigProperties.STANDALONE)).thenReturn(true);
         Subscription s = createVirtLimitSub("virtLimitProduct", 10, 10);
-        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(s);
+        List<Pool> pools = poolRules.createAndEnrichPools(s);
         assertEquals(2, pools.size());
         s.setQuantity(new Long(20));
         Entitlement ent = mock(Entitlement.class);

--- a/server/src/test/java/org/candlepin/policy/PoolRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/PoolRulesTest.java
@@ -105,7 +105,7 @@ public class PoolRulesTest {
 
         List<Pool> pools = null;
         try {
-            pools = poolRules.createPools(s);
+            pools = poolRules.enrichAndCreateAdditionalPools(s);
         }
         catch (Exception e) {
             fail(
@@ -337,7 +337,7 @@ public class PoolRulesTest {
         when(prodCuratorMock.lookupById(product.getOwner(), product.getId()))
             .thenReturn(product);
 
-        List<Pool> pools = this.poolRules.createPools(sub);
+        List<Pool> pools = this.poolRules.enrichAndCreateAdditionalPools(sub);
         assertEquals(1, pools.size());
 
         Pool resultPool = pools.get(0);
@@ -362,7 +362,7 @@ public class PoolRulesTest {
         when(this.prodCuratorMock.lookupById(product.getOwner(), product.getId()))
             .thenReturn(product);
 
-        List<Pool> pools = this.poolRules.createPools(sub);
+        List<Pool> pools = this.poolRules.enrichAndCreateAdditionalPools(sub);
         assertEquals(1, pools.size());
 
         Pool resultPool = pools.get(0);
@@ -387,7 +387,7 @@ public class PoolRulesTest {
         when(this.prodCuratorMock.lookupById(subProduct.getOwner(), subProduct.getId()))
             .thenReturn(subProduct);
 
-        List<Pool> pools = this.poolRules.createPools(sub);
+        List<Pool> pools = this.poolRules.enrichAndCreateAdditionalPools(sub);
         assertEquals(1, pools.size());
 
         Pool resultPool = pools.get(0);
@@ -412,7 +412,7 @@ public class PoolRulesTest {
         when(this.prodCuratorMock.lookupById(subProduct.getOwner(), subProduct.getId()))
             .thenReturn(subProduct);
 
-        List<Pool> pools = this.poolRules.createPools(sub);
+        List<Pool> pools = this.poolRules.enrichAndCreateAdditionalPools(sub);
         assertEquals(1, pools.size());
 
         Pool resultPool = pools.get(0);
@@ -436,7 +436,7 @@ public class PoolRulesTest {
         when(this.prodCuratorMock.lookupById(subProduct.getOwner(), subProduct.getId()))
             .thenReturn(subProduct);
 
-        List<Pool> pools = this.poolRules.createPools(sub);
+        List<Pool> pools = this.poolRules.enrichAndCreateAdditionalPools(sub);
         assertEquals(1, pools.size());
 
         Pool resultPool = pools.get(0);
@@ -463,7 +463,7 @@ public class PoolRulesTest {
     public void virtLimitWithHostLimitedCreatesTaggedBonusPool() {
         Subscription s = createVirtLimitSub("virtLimitProduct", 10, 10);
         s.getProduct().setAttribute("host_limited", "true");
-        List<Pool> pools = poolRules.createPools(s);
+        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(s);
         assertEquals(2, pools.size());
         for (Pool p : pools) {
             if (p.getSourceSubscription().getSubscriptionSubKey().equals("derived")) {
@@ -479,7 +479,7 @@ public class PoolRulesTest {
         when(configMock.getBoolean(ConfigProperties.STANDALONE)).thenReturn(false);
         Subscription s = createVirtLimitSub("virtLimitProduct", 10, 10);
         s.getProduct().setAttribute("host_limited", "false");
-        List<Pool> pools = poolRules.createPools(s);
+        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(s);
         assertEquals(2, pools.size());
     }
 
@@ -487,7 +487,7 @@ public class PoolRulesTest {
     public void hostedVirtLimitSubCreatesBonusVirtOnlyPool() {
         when(configMock.getBoolean(ConfigProperties.STANDALONE)).thenReturn(false);
         Subscription s = createVirtLimitSub("virtLimitProduct", 10, 10);
-        List<Pool> pools = poolRules.createPools(s);
+        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(s);
         assertEquals(2, pools.size());
 
         Pool physicalPool = pools.get(0);
@@ -507,7 +507,7 @@ public class PoolRulesTest {
         when(configMock.getBoolean(ConfigProperties.STANDALONE)).thenReturn(false);
         Subscription s = createVirtLimitSub("virtLimitProduct", 10, 10);
         s.getProduct().setAttribute("virt_limit", "unlimited");
-        List<Pool> pools = poolRules.createPools(s);
+        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(s);
         assertEquals(2, pools.size());
 
         Pool virtBonusPool = pools.get(1);
@@ -521,7 +521,7 @@ public class PoolRulesTest {
         when(configMock.getBoolean(ConfigProperties.STANDALONE)).thenReturn(false);
         Subscription s = createVirtLimitSub("virtLimitProduct", 10, 10);
         s.getProduct().setAttribute("virt_limit", "unlimited");
-        List<Pool> pools = poolRules.createPools(s);
+        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(s);
         assertEquals(2, pools.size());
 
         Pool virtBonusPool = pools.get(1);
@@ -544,7 +544,7 @@ public class PoolRulesTest {
         when(configMock.getBoolean(ConfigProperties.STANDALONE)).thenReturn(false);
         Subscription s = createVirtLimitSub("virtLimitProduct", 10, 10);
         s.getProduct().setAttribute("virt_limit", "4");
-        List<Pool> pools = poolRules.createPools(s);
+        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(s);
         assertEquals(2, pools.size());
 
         // Now we remove virt_limit on the incoming subscription product and see if
@@ -572,7 +572,7 @@ public class PoolRulesTest {
         Subscription s = createVirtLimitSub("virtLimitProduct", 10, 10);
         s.getProduct().setAttribute("virt_limit", "unlimited");
         s.getProduct().setMultiplier(5L);
-        List<Pool> pools = poolRules.createPools(s);
+        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(s);
         assertEquals(2, pools.size());
 
         Pool virtBonusPool = pools.get(1);
@@ -586,7 +586,7 @@ public class PoolRulesTest {
         when(configMock.getBoolean(ConfigProperties.STANDALONE)).thenReturn(false);
         Subscription s = createVirtLimitSub("virtLimitProduct", 10, 10);
         s.getProduct().setAttribute("physical_only", "true");
-        List<Pool> pools = poolRules.createPools(s);
+        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(s);
 
         // Should be no virt_only bonus pool:
         assertEquals(2, pools.size());
@@ -627,7 +627,7 @@ public class PoolRulesTest {
         when(productAdapterMock.getProductById(owner, derivedProd.getId())).thenReturn(derivedProd);
         s.getDerivedProvidedProducts().add(derivedProvidedProd1);
         s.getDerivedProvidedProducts().add(derivedProvidedProd2);
-        List<Pool> pools = poolRules.createPools(s);
+        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(s);
 
         // Should be virt_only pool for unmapped guests:
         assertEquals(2, pools.size());
@@ -660,7 +660,7 @@ public class PoolRulesTest {
         when(configMock.getBoolean(ConfigProperties.STANDALONE)).thenReturn(true);
         Subscription s = createVirtLimitSubWithDerivedProducts("virtLimitProduct",
                 "derivedProd", 10, 10);
-        List<Pool> pools = poolRules.createPools(s);
+        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(s);
 
         // Should be virt_only pool for unmapped guests:
         assertEquals(2, pools.size());
@@ -745,7 +745,7 @@ public class PoolRulesTest {
     public void standaloneVirtLimitSubUpdate() {
         when(configMock.getBoolean(ConfigProperties.STANDALONE)).thenReturn(true);
         Subscription s = createVirtLimitSub("virtLimitProduct", 10, 10);
-        List<Pool> pools = poolRules.createPools(s);
+        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(s);
 
         // Should be unmapped virt_only pool:
         assertEquals(2, pools.size());
@@ -777,7 +777,7 @@ public class PoolRulesTest {
     public void hostedVirtOnlySubCreate() {
         when(configMock.getBoolean(ConfigProperties.STANDALONE)).thenReturn(true);
         Subscription s = createVirtOnlySub("virtOnlyProduct", 10);
-        List<Pool> pools = poolRules.createPools(s);
+        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(s);
         assertEquals(1, pools.size());
         assertEquals("true", pools.get(0).getProduct().getAttributeValue("virt_only"));
         assertEquals(new Long(10), pools.get(0).getQuantity());
@@ -788,7 +788,7 @@ public class PoolRulesTest {
         when(configMock.getBoolean(ConfigProperties.STANDALONE)).thenReturn(true);
         Subscription s = createVirtOnlySub("virtOnlyProduct", 10);
         s.getProduct().setMultiplier(new Long(5));
-        List<Pool> pools = poolRules.createPools(s);
+        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(s);
         assertEquals(1, pools.size());
         assertEquals("true", pools.get(0).getProduct().getAttributeValue("virt_only"));
         assertEquals(new Long(50), pools.get(0).getQuantity());
@@ -798,7 +798,7 @@ public class PoolRulesTest {
     public void hostedVirtOnlySubUpdate() {
         when(configMock.getBoolean(ConfigProperties.STANDALONE)).thenReturn(true);
         Subscription s = createVirtOnlySub("virtOnlyProduct", 10);
-        List<Pool> pools = poolRules.createPools(s);
+        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(s);
         assertEquals(1, pools.size());
         s.setQuantity(new Long(20));
 
@@ -813,7 +813,7 @@ public class PoolRulesTest {
     public void standaloneVirtSubPoolUpdateNoChanges() {
         when(configMock.getBoolean(ConfigProperties.STANDALONE)).thenReturn(true);
         Subscription s = createVirtLimitSub("virtLimitProduct", 10, 10);
-        List<Pool> pools = poolRules.createPools(s);
+        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(s);
         assertEquals(2, pools.size());
         Entitlement ent = mock(Entitlement.class);
         when(ent.getQuantity()).thenReturn(1);
@@ -837,7 +837,7 @@ public class PoolRulesTest {
     public void standaloneVirtSubPoolUpdateVirtLimitChanged() {
         when(configMock.getBoolean(ConfigProperties.STANDALONE)).thenReturn(true);
         Subscription s = createVirtLimitSub("virtLimitProduct", 10, 10);
-        List<Pool> pools = poolRules.createPools(s);
+        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(s);
         assertEquals(2, pools.size());
         s.setQuantity(new Long(20));
         Entitlement ent = mock(Entitlement.class);

--- a/server/src/test/java/org/candlepin/policy/js/entitlement/HostedVirtLimitEntitlementRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/entitlement/HostedVirtLimitEntitlementRulesTest.java
@@ -62,7 +62,7 @@ public class HostedVirtLimitEntitlementRulesTest extends EntitlementRulesTestFix
         when(config.getBoolean(ConfigProperties.STANDALONE)).thenReturn(false);
         Subscription s = createVirtLimitSub("virtLimitProduct", 10, "10");
         consumer.setType(new ConsumerType(ConsumerTypeEnum.CANDLEPIN));
-        List<Pool> pools = poolRules.createPools(s);
+        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(s);
         assertEquals(2, pools.size());
 
         Pool physicalPool = pools.get(0);
@@ -101,7 +101,7 @@ public class HostedVirtLimitEntitlementRulesTest extends EntitlementRulesTestFix
         when(config.getBoolean(ConfigProperties.STANDALONE)).thenReturn(false);
         Subscription s = createVirtLimitSub("virtLimitProduct", 10, "unlimited");
         s.getProduct().setAttribute("host_limited", "true");
-        List<Pool> pools = poolRules.createPools(s);
+        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(s);
         assertEquals(2, pools.size());
 
         Pool physicalPool = pools.get(0);
@@ -121,7 +121,7 @@ public class HostedVirtLimitEntitlementRulesTest extends EntitlementRulesTestFix
     public void hostedVirtLimitUnlimitedBonusPoolQuantity() {
         when(config.getBoolean(ConfigProperties.STANDALONE)).thenReturn(false);
         Subscription s = createVirtLimitSub("virtLimitProduct", 10, "unlimited");
-        List<Pool> pools = poolRules.createPools(s);
+        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(s);
         assertEquals(2, pools.size());
 
         Pool physicalPool = pools.get(0);
@@ -159,7 +159,7 @@ public class HostedVirtLimitEntitlementRulesTest extends EntitlementRulesTestFix
     public void noBonusPoolsForHostedNonDistributorBinds() {
         when(config.getBoolean(ConfigProperties.STANDALONE)).thenReturn(false);
         Subscription s = createVirtLimitSub("virtLimitProduct", 10, "unlimited");
-        List<Pool> pools = poolRules.createPools(s);
+        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(s);
         assertEquals(2, pools.size());
 
         Pool physicalPool = pools.get(0);
@@ -192,7 +192,7 @@ public class HostedVirtLimitEntitlementRulesTest extends EntitlementRulesTestFix
         when(config.getBoolean(ConfigProperties.STANDALONE)).thenReturn(false);
         consumer.setType(new ConsumerType(ConsumerTypeEnum.CANDLEPIN));
         Subscription s = createVirtLimitSub("virtLimitProduct", 10, "unlimited");
-        List<Pool> pools = poolRules.createPools(s);
+        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(s);
         assertEquals(2, pools.size());
 
         Pool physicalPool = pools.get(0);

--- a/server/src/test/java/org/candlepin/policy/js/entitlement/HostedVirtLimitEntitlementRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/entitlement/HostedVirtLimitEntitlementRulesTest.java
@@ -62,7 +62,7 @@ public class HostedVirtLimitEntitlementRulesTest extends EntitlementRulesTestFix
         when(config.getBoolean(ConfigProperties.STANDALONE)).thenReturn(false);
         Subscription s = createVirtLimitSub("virtLimitProduct", 10, "10");
         consumer.setType(new ConsumerType(ConsumerTypeEnum.CANDLEPIN));
-        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(s);
+        List<Pool> pools = poolRules.createAndEnrichPools(s);
         assertEquals(2, pools.size());
 
         Pool physicalPool = pools.get(0);
@@ -101,7 +101,7 @@ public class HostedVirtLimitEntitlementRulesTest extends EntitlementRulesTestFix
         when(config.getBoolean(ConfigProperties.STANDALONE)).thenReturn(false);
         Subscription s = createVirtLimitSub("virtLimitProduct", 10, "unlimited");
         s.getProduct().setAttribute("host_limited", "true");
-        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(s);
+        List<Pool> pools = poolRules.createAndEnrichPools(s);
         assertEquals(2, pools.size());
 
         Pool physicalPool = pools.get(0);
@@ -121,7 +121,7 @@ public class HostedVirtLimitEntitlementRulesTest extends EntitlementRulesTestFix
     public void hostedVirtLimitUnlimitedBonusPoolQuantity() {
         when(config.getBoolean(ConfigProperties.STANDALONE)).thenReturn(false);
         Subscription s = createVirtLimitSub("virtLimitProduct", 10, "unlimited");
-        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(s);
+        List<Pool> pools = poolRules.createAndEnrichPools(s);
         assertEquals(2, pools.size());
 
         Pool physicalPool = pools.get(0);
@@ -159,7 +159,7 @@ public class HostedVirtLimitEntitlementRulesTest extends EntitlementRulesTestFix
     public void noBonusPoolsForHostedNonDistributorBinds() {
         when(config.getBoolean(ConfigProperties.STANDALONE)).thenReturn(false);
         Subscription s = createVirtLimitSub("virtLimitProduct", 10, "unlimited");
-        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(s);
+        List<Pool> pools = poolRules.createAndEnrichPools(s);
         assertEquals(2, pools.size());
 
         Pool physicalPool = pools.get(0);
@@ -192,7 +192,7 @@ public class HostedVirtLimitEntitlementRulesTest extends EntitlementRulesTestFix
         when(config.getBoolean(ConfigProperties.STANDALONE)).thenReturn(false);
         consumer.setType(new ConsumerType(ConsumerTypeEnum.CANDLEPIN));
         Subscription s = createVirtLimitSub("virtLimitProduct", 10, "unlimited");
-        List<Pool> pools = poolRules.enrichAndCreateAdditionalPools(s);
+        List<Pool> pools = poolRules.createAndEnrichPools(s);
         assertEquals(2, pools.size());
 
         Pool physicalPool = pools.get(0);

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceVirtEntitlementTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceVirtEntitlementTest.java
@@ -110,7 +110,7 @@ public class ConsumerResourceVirtEntitlementTest extends DatabaseTestFixture {
         limitSub.setId(Util.generateDbUUID());
         subscriptions.add(limitSub);
 
-        limitPools = poolManager.createPoolsForSubscription(limitSub);
+        limitPools = poolManager.createAndEnrichPools(limitSub);
 
         // create a physical pool with unlimited virt_limit
         productUnlimit = TestUtil.createProduct(owner);
@@ -127,7 +127,7 @@ public class ConsumerResourceVirtEntitlementTest extends DatabaseTestFixture {
         unlimitSub.setId(Util.generateDbUUID());
         subscriptions.add(unlimitSub);
 
-        unlimitPools = poolManager.createPoolsForSubscription(unlimitSub);
+        unlimitPools = poolManager.createAndEnrichPools(unlimitSub);
     }
 
     /**

--- a/server/src/test/java/org/candlepin/resource/OwnerResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/OwnerResourceTest.java
@@ -880,7 +880,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         sub.setId(Util.generateDbUUID());
         subscriptions.add(sub);
 
-        List<Pool> pools = poolManager.createPoolsForSubscription(sub);
+        List<Pool> pools = poolManager.createAndEnrichPools(sub);
         assertTrue(pools.size() > 0);
         Pool pool = pools.get(0);
 

--- a/server/src/test/java/org/candlepin/resource/OwnerResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/OwnerResourceTest.java
@@ -1244,6 +1244,38 @@ public class OwnerResourceTest extends DatabaseTestFixture {
     }
 
     @Test
+    public void createBonusPool() {
+        Product prod = TestUtil.createProduct(owner);
+        prod.setAttribute("virt_limit", "2");
+        productCurator.create(prod);
+        Pool pool = TestUtil.createPool(owner, prod);
+        assertEquals(0, poolCurator.listByOwner(owner).size());
+        ownerResource.createPool(owner.getKey(), pool);
+        List<Pool> pools = poolCurator.listByOwner(owner);
+        assertEquals(2, pools.size());
+        assertTrue(pools.get(0).getSubscriptionSubKey().startsWith("master") ||
+                pools.get(1).getSubscriptionSubKey().startsWith("master"));
+        assertTrue(pools.get(0).getSubscriptionSubKey().equals("derived") ||
+                pools.get(1).getSubscriptionSubKey().equals("derived"));
+    }
+
+    @Test
+    public void enrichPool() {
+        Product prod = TestUtil.createProduct(owner);
+        prod.setAttribute("virt_only", "true");
+        prod.setMultiplier(2L);
+        productCurator.create(prod);
+        Pool pool = TestUtil.createPool(owner, prod);
+        pool.setQuantity(100L);
+        assertEquals(0, poolCurator.listByOwner(owner).size());
+        ownerResource.createPool(owner.getKey(), pool);
+        List<Pool> pools = poolCurator.listByOwner(owner);
+        assertEquals(1, pools.size());
+        assertTrue(Boolean.parseBoolean(pools.get(0).getAttributeValue("virt_only")));
+        assertEquals(200L, pools.get(0).getQuantity().intValue());
+    }
+
+    @Test
     public void getAllEntitlementsForOwner() {
         PageRequest req = new PageRequest();
         req.setPage(1);

--- a/server/src/test/java/org/candlepin/test/TestUtil.java
+++ b/server/src/test/java/org/candlepin/test/TestUtil.java
@@ -114,6 +114,10 @@ public class TestUtil {
         return Math.abs(RANDOM.nextInt());
     }
 
+    public static String randomString() {
+        return String.valueOf(randomInt());
+    }
+
     public static Content createContent(String id) {
         return createContent(TestUtil.createOwner(), id);
     }


### PR DESCRIPTION
ensure createPools ( an API introduced in 2.0 that was meant to replace createSubscription  ) does what createSubscription does.

dont merge yet, I wanna add unit tests.