### PR TITLE
Several optimizations in the CRL generation and retrievial

### DIFF
--- a/server/src/main/java/org/candlepin/controller/CrlGenerator.java
+++ b/server/src/main/java/org/candlepin/controller/CrlGenerator.java
@@ -115,14 +115,13 @@ public class CrlGenerator {
         List<CertificateSerial> serials =
             this.certificateSerialCurator.retrieveTobeCollectedSerials();
         for (CertificateSerial cs : serials) {
-            entries.add(new X509CRLEntryWrapper(cs.getSerial(),
-                   new Date()));
+            entries.add(new X509CRLEntryWrapper(cs.getSerial(), new Date()));
             cs.setCollected(true);
         }
+
         if (log.isTraceEnabled()) {
-            log.trace("Added #" + serials.size() + " new entries to the CRL");
-        }
-        if (log.isTraceEnabled()) {
+            log.trace("Added #{} new entries to the CRL", serials.size());
+
             StringBuilder builder = new StringBuilder("[ ");
             for (CertificateSerial cs : serials) {
                 builder.append(cs.getSerial()).append(", ");
@@ -130,11 +129,10 @@ public class CrlGenerator {
             builder.append(" ]");
             log.trace("Newly added serials = " + builder.toString());
         }
+
         this.certificateSerialCurator.saveOrUpdateAll(serials);
-        if (log.isDebugEnabled()) {
-            log.debug("Total number of serials retrieved from db: #" +
-                entries.size());
-        }
+
+        log.debug("Total number of serials retrieved from db: #{}", entries.size());
 
         return entries;
     }
@@ -154,15 +152,11 @@ public class CrlGenerator {
         for (X509CRLEntry entry : revokedEntries) {
             map.put(entry.getSerialNumber(), entry);
         }
-        for (CertificateSerial cs : this.certificateSerialCurator
-            .getExpiredSerials()) {
+        for (CertificateSerial cs : this.certificateSerialCurator.getExpiredSerials()) {
             X509CRLEntry entry = map.get(cs.getSerial());
             if (entry != null) {
                 revokedEntries.remove(entry);
-                if (log.isTraceEnabled()) {
-                    log.trace("Serial #" + cs.getId() +
-                        " has expired. Removing it from CRL");
-                }
+                log.trace("Serial #{} has expired. Removing it from CRL", cs.getId());
             }
         }
         return revokedEntries;
@@ -178,9 +172,7 @@ public class CrlGenerator {
     public X509CRL removeEntries(X509CRL x509crl, List<CertificateSerial> serials) {
         List<X509CRLEntryWrapper> crlEntries = null;
         BigInteger no = getCRLNumber(x509crl);
-        if (log.isDebugEnabled()) {
-            log.debug("Old CRLNumber is : " + no);
-        }
+        log.debug("Old CRLNumber is : {}", no);
 
         if (x509crl != null) {
             Set<? extends X509CRLEntry> revokedEntries = x509crl
@@ -202,10 +194,8 @@ public class CrlGenerator {
                 X509CRLEntry entry = map.get(cs.getSerial());
                 if (entry != null) {
                     map.remove(cs.getSerial());
-                    if (log.isTraceEnabled()) {
-                        log.trace("Serial #" + cs.getId() +
-                            " has been found. Removing it from CRL");
-                    }
+                    log.trace("Serial #{} has been found. Removing it from CRL", cs.getId());
+
                     // put them back in circulation
                     cs.setCollected(false);
                 }

--- a/server/src/main/java/org/candlepin/pki/PKIUtility.java
+++ b/server/src/main/java/org/candlepin/pki/PKIUtility.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.math.BigInteger;
 import java.security.GeneralSecurityException;
 import java.security.Key;
@@ -109,6 +110,48 @@ public abstract class PKIUtility {
     public abstract byte[] getPemEncoded(Key key) throws IOException;
 
     public abstract byte[] getPemEncoded(X509CRL crl) throws IOException;
+
+    /**
+     * Writes the specified certificate to the given output stream in PEM encoding.
+     *
+     * @param cert
+     *  The certificate to encode
+     *
+     * @param out
+     *  The output stream to which the certificate should be written
+     *
+     * @throws IOException
+     *  If an IOException occurs while writing the certificate
+     */
+    public abstract void writePemEncoded(X509Certificate cert, OutputStream out) throws IOException;
+
+    /**
+     * Writes the specified key to the given output stream in PEM encoding.
+     *
+     * @param key
+     *  The key to encode
+     *
+     * @param out
+     *  The output stream to which the key should be written
+     *
+     * @throws IOException
+     *  If an IOException occurs while writing the key
+     */
+    public abstract void writePemEncoded(Key key, OutputStream out) throws IOException;
+
+    /**
+     * Writes the specified certificate revocation list to the given output stream in PEM encoding.
+     *
+     * @param crl
+     *  The certificate revocation list to encode
+     *
+     * @param out
+     *  The output stream to which the certificate revocation list should be written
+     *
+     * @throws IOException
+     *  If an IOException occurs while writing the certificate revocation list
+     */
+    public abstract void writePemEncoded(X509CRL crl, OutputStream out) throws IOException;
 
     public static X509Certificate createCert(byte[] certData) {
         try {

--- a/server/src/main/java/org/candlepin/pki/impl/BouncyCastlePKIUtility.java
+++ b/server/src/main/java/org/candlepin/pki/impl/BouncyCastlePKIUtility.java
@@ -46,6 +46,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.math.BigInteger;
 import java.security.GeneralSecurityException;
@@ -197,13 +198,22 @@ public class BouncyCastlePKIUtility extends PKIUtility {
         }
     }
 
-    private byte[] getPemEncoded(Object obj) throws IOException {
-        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-        OutputStreamWriter oswriter = new OutputStreamWriter(byteArrayOutputStream);
+    private void writePemEncoded(Object obj, OutputStream out) throws IOException {
+        OutputStreamWriter oswriter = new OutputStreamWriter(out);
         PEMWriter writer = new PEMWriter(oswriter);
         writer.writeObject(obj);
-        writer.close();
-        return byteArrayOutputStream.toByteArray();
+        writer.flush();
+        // We're hoping close does nothing more than a flush and super.close() here
+    }
+
+    private byte[] getPemEncoded(Object obj) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        this.writePemEncoded(obj, out);
+
+        byte[] output = out.toByteArray();
+        out.close();
+
+        return output;
     }
 
     @Override
@@ -219,6 +229,21 @@ public class BouncyCastlePKIUtility extends PKIUtility {
     @Override
     public byte[] getPemEncoded(X509CRL crl) throws IOException {
         return getPemEncoded((Object) crl);
+    }
+
+    @Override
+    public void writePemEncoded(X509Certificate cert, OutputStream out) throws IOException {
+        this.writePemEncoded((Object) cert, out);
+    }
+
+    @Override
+    public void writePemEncoded(Key key, OutputStream out) throws IOException {
+        this.writePemEncoded((Object) key, out);
+    }
+
+    @Override
+    public void writePemEncoded(X509CRL crl, OutputStream out) throws IOException {
+        this.writePemEncoded((Object) crl, out);
     }
 
     @Override

--- a/server/src/test/java/org/candlepin/resource/CrlResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/CrlResourceTest.java
@@ -26,6 +26,7 @@ import org.candlepin.common.config.MapConfiguration;
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.controller.CrlGenerator;
 import org.candlepin.model.CertificateSerialCurator;
+import org.candlepin.pki.PKIUtility;
 import org.candlepin.util.CrlFileUtil;
 
 import org.junit.Test;
@@ -46,12 +47,13 @@ public class CrlResourceTest {
         CrlGenerator crlgen = mock(CrlGenerator.class);
         CrlFileUtil fileutil = mock(CrlFileUtil.class);
         CertificateSerialCurator sercur = mock(CertificateSerialCurator.class);
+        PKIUtility pkiUtil = mock(PKIUtility.class);
         Configuration config = new ConfigForTesting();
         X509CRL crl = mock(X509CRL.class);
         when(fileutil.readCRLFile(any(File.class))).thenReturn(crl);
         when(crlgen.removeEntries(eq(crl), any(List.class))).thenReturn(crl);
 
-        CrlResource res = new CrlResource(crlgen, fileutil, config, sercur);
+        CrlResource res = new CrlResource(crlgen, fileutil, config, sercur, pkiUtil);
         String[] ids = {"10"};
         res.unrevoke(ids);
         verify(crlgen, atLeastOnce()).removeEntries(eq(crl), any(List.class));

--- a/server/src/test/java/org/candlepin/util/CrlFileUtilTest.java
+++ b/server/src/test/java/org/candlepin/util/CrlFileUtilTest.java
@@ -27,10 +27,13 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.security.cert.CRLException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509CRL;
@@ -66,6 +69,21 @@ public class CrlFileUtilTest {
         when(crl.getEncoded()).thenReturn(Base64.encodeBase64("encoded".getBytes()));
         when(crlGenerator.syncCRLWithDB(any(X509CRL.class))).thenReturn(crl);
         when(pkiUtility.getPemEncoded(any(X509CRL.class))).thenReturn(new byte [2]);
+
+        doAnswer(new Answer() {
+            public Object answer(InvocationOnMock invocation) {
+                try {
+                    ((OutputStream) invocation.getArguments()[1]).write("some data".getBytes());
+                }
+                catch (Exception e) {
+                    // Don't care.
+                }
+
+                return null;
+            }
+        }).when(pkiUtility).writePemEncoded(any(X509CRL.class), any(OutputStream.class));
+
+
         cfu.writeCRLFile(crlFile, crl);
         File f = new File("/tmp/biteme.crl");
         assertTrue(f.exists());
@@ -82,7 +100,20 @@ public class CrlFileUtilTest {
             X509CRL crl = mock(X509CRL.class);
             when(crl.getEncoded()).thenReturn(Base64.encodeBase64("encoded".getBytes()));
             when(crlGenerator.syncCRLWithDB(any(X509CRL.class))).thenReturn(crl);
-            when(pkiUtility.getPemEncoded(any(X509CRL.class))).thenReturn(new byte [2]);
+
+            doAnswer(new Answer() {
+                public Object answer(InvocationOnMock invocation) {
+                    try {
+                        ((OutputStream) invocation.getArguments()[1]).write("some data".getBytes());
+                    }
+                    catch (Exception e) {
+                        // Don't care.
+                    }
+
+                    return null;
+                }
+            }).when(pkiUtility).writePemEncoded(any(X509CRL.class), any(OutputStream.class));
+
             X509CRL updatedcrl = cfu.readCRLFile(f);
             cfu.writeCRLFile(f, updatedcrl);
             assertTrue(f.length() > 0);
@@ -121,7 +152,20 @@ public class CrlFileUtilTest {
             assertEquals(0, f.length());
             X509CRL crl = mock(X509CRL.class);
             when(crl.getEncoded()).thenReturn(Base64.encodeBase64("encoded".getBytes()));
-            when(pkiUtility.getPemEncoded(any(X509CRL.class))).thenReturn(new byte [2]);
+
+            doAnswer(new Answer() {
+                public Object answer(InvocationOnMock invocation) {
+                    try {
+                        ((OutputStream) invocation.getArguments()[1]).write("some data".getBytes());
+                    }
+                    catch (Exception e) {
+                        // Don't care.
+                    }
+
+                    return null;
+                }
+            }).when(pkiUtility).writePemEncoded(any(X509CRL.class), any(OutputStream.class));
+
             cfu.writeCRLFile(f, crl);
             assertTrue(f.length() > 0);
         }


### PR DESCRIPTION
- The CRL write operation no longer juggles three+ buffers while writing
  the CRL to a file. Instead, a stream is provided to the PKIUtility class
  which performs the write directly
- Retrieving the CRL via rest no longer writes the PEM encoded CRL to
  memory and instead just writes the updated CRL to a file, then streams
  the file via JAX RS Response entity
- CrlFileUtil.writeCRLFile no longer returns the bytes represending the PEM
  encoded CRL. Additionally, it no longer writes the bytes to a BAOS for
  fun.