### PR TITLE
Adding configuration options for HornetQ to prevent server overload

### DIFF
--- a/server/src/main/java/org/candlepin/audit/HornetqContextListener.java
+++ b/server/src/main/java/org/candlepin/audit/HornetqContextListener.java
@@ -19,6 +19,7 @@ import org.candlepin.config.ConfigProperties;
 import com.google.common.collect.Lists;
 import com.google.inject.Injector;
 
+import org.apache.commons.io.FileUtils;
 import org.hornetq.api.core.HornetQException;
 import org.hornetq.api.core.SimpleString;
 import org.hornetq.api.core.TransportConfiguration;
@@ -32,19 +33,23 @@ import org.hornetq.core.remoting.impl.invm.InVMAcceptorFactory;
 import org.hornetq.core.remoting.impl.invm.InVMConnectorFactory;
 import org.hornetq.core.server.JournalType;
 import org.hornetq.core.server.embedded.EmbeddedHornetQ;
+import org.hornetq.core.settings.impl.AddressFullMessagePolicy;
+import org.hornetq.core.settings.impl.AddressSettings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+
 
 /**
  * HornetqContextListener - Invoked from our core CandlepinContextListener, thus
  * doesn't actually implement ServletContextListener.
  */
 public class HornetqContextListener {
-
     private static  Logger log = LoggerFactory.getLogger(HornetqContextListener.class);
 
     private EmbeddedHornetQ hornetqServer;
@@ -95,6 +100,58 @@ public class HornetqContextListener {
             config.setBindingsDirectory(new File(baseDir, "bindings").toString());
             config.setJournalDirectory(new File(baseDir, "journal").toString());
             config.setLargeMessagesDirectory(new File(baseDir, "largemsgs").toString());
+            config.setPagingDirectory(new File(baseDir, "paging").toString());
+
+            Map<String, AddressSettings> settings = new HashMap<String, AddressSettings>();
+            AddressSettings pagingConfig = new AddressSettings();
+
+            String addressPolicyString =
+                    candlepinConfig.getString(ConfigProperties.HORNETQ_ADDRESS_FULL_POLICY);
+            long maxQueueSizeInMb = candlepinConfig.getInt(ConfigProperties.HORNETQ_MAX_QUEUE_SIZE);
+            long maxPageSizeInMb = candlepinConfig.getInt(ConfigProperties.HORNETQ_MAX_PAGE_SIZE);
+
+            AddressFullMessagePolicy addressPolicy = null;
+            if (addressPolicyString.equals("PAGE")) {
+                addressPolicy = AddressFullMessagePolicy.PAGE;
+            }
+            else if (addressPolicyString.equals("BLOCK")) {
+                addressPolicy = AddressFullMessagePolicy.BLOCK;
+            }
+            else {
+                throw new IllegalArgumentException("Unknown HORNETQ_ADDRESS_FULL_POLICY: " +
+                        addressPolicyString + " . Please use one of: PAGE, BLOCK");
+            }
+
+            // Paging sizes need to be converted to bytes
+            pagingConfig.setMaxSizeBytes(maxQueueSizeInMb * FileUtils.ONE_MB);
+            if (addressPolicy == AddressFullMessagePolicy.PAGE) {
+                pagingConfig.setPageSizeBytes(maxPageSizeInMb * FileUtils.ONE_MB);
+            }
+            pagingConfig.setAddressFullMessagePolicy(addressPolicy);
+            //Enable for all the queues
+            settings.put("#", pagingConfig);
+            config.setAddressesSettings(settings);
+
+            int maxScheduledThreads = candlepinConfig.getInt(ConfigProperties.HORNETQ_MAX_SCHEDULED_THREADS);
+            int maxThreads = candlepinConfig.getInt(ConfigProperties.HORNETQ_MAX_THREADS);
+            if (maxThreads != -1) {
+                config.setThreadPoolMaxSize(maxThreads);
+            }
+
+            if (maxScheduledThreads != -1) {
+                config.setScheduledThreadPoolMaxSize(maxScheduledThreads);
+            }
+
+            /**
+             * Anything up to size of LARGE_MSG_SIZE may be needed to be written to the Journal,
+             * so we must set buffer size accordingly.
+             *
+             * If buffer size would be < LARGE_MSG_SIZE we may get exceptions such as this:
+             * Can't write records bigger than the bufferSize(XXXYYY) on the journal
+             */
+            int largeMsgSize = candlepinConfig.getInt(ConfigProperties.HORNETQ_LARGE_MSG_SIZE);
+            config.setJournalBufferSize_AIO(largeMsgSize);
+            config.setJournalBufferSize_NIO(largeMsgSize);
 
             hornetqServer = new EmbeddedHornetQ();
             hornetqServer.setConfiguration(config);

--- a/server/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/server/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -55,7 +55,43 @@ public class ConfigProperties {
 
     public static final String HORNETQ_ENABLED = "candlepin.audit.hornetq.enable";
     public static final String HORNETQ_BASE_DIR = "candlepin.audit.hornetq.base_dir";
+    /**
+     * This number is large message size. Any message
+     * that is bigger than this number is regarded as large.
+     * That means that HornetQ will page this message
+     * to a disk. Setting this number to something high
+     * e.g. 1 000 0000 will effectively disable the
+     * functionality. This is handy when you expect a lot of
+     * messages and you do not want to run out of disk space.
+     */
     public static final String HORNETQ_LARGE_MSG_SIZE = "candlepin.audit.hornetq.large_msg_size";
+
+    /**
+     * Setting number of server threads that will be
+     * created for Hornet. -1 means that default value
+     * will be used.
+     */
+    public static final String HORNETQ_MAX_SCHEDULED_THREADS =
+            "candlepin.audit.hornetq.max_scheduled_threads";
+    public static final String HORNETQ_MAX_THREADS = "candlepin.audit.hornetq.max_threads";
+    /**
+     * This can be either BLOCK or PAGE. When set to PAGE then
+     * Hornet will keep only up to HORNET_MAX_QUEUE_SIZE
+     * kilobytes of queue messages in memory. Anything above
+     * HORNET_MAX_QUEUE_SIZE will be paged to a hard disk.
+     * When set to BLOCK then after reaching
+     * HORNET_MAX_QUEUE_SIZE, all the producers will be blocked until
+     * the queues are freed up by consumers. Thus, BLOCK
+     * may be dangerous when consumers fail, because
+     * producers will timeout.
+     */
+    public static final String HORNETQ_ADDRESS_FULL_POLICY = "candlepin.audit.hornetq.address_full_policy";
+    public static final String HORNETQ_MAX_QUEUE_SIZE = "candlepin.audit.hornetq.max_queue_size";
+    /**
+     * This is applicable only for PAGE setting of HORNETQ_ADDRESS_FULL_POLICY.
+     */
+    public static final String HORNETQ_MAX_PAGE_SIZE = "candlepin.audit.hornetq.max_page_size";
+
     public static final String AUDIT_LISTENERS = "candlepin.audit.listeners";
     public static final String AUDIT_LOG_FILE = "candlepin.audit.log_file";
     public static final String AUDIT_LOG_VERBOSE = "candlepin.audit.log_verbose";
@@ -185,6 +221,12 @@ public class ConfigProperties {
                 this.put(HORNETQ_ENABLED, "true");
                 this.put(HORNETQ_BASE_DIR, "/var/lib/candlepin/hornetq");
                 this.put(HORNETQ_LARGE_MSG_SIZE, Integer.toString(100 * 1024));
+
+                this.put(HORNETQ_MAX_THREADS, "-1");
+                this.put(HORNETQ_MAX_SCHEDULED_THREADS, "-1");
+                this.put(HORNETQ_ADDRESS_FULL_POLICY, "PAGE");
+                this.put(HORNETQ_MAX_QUEUE_SIZE, "10");
+                this.put(HORNETQ_MAX_PAGE_SIZE, "1");
                 this.put(AUDIT_LISTENERS,
                     "org.candlepin.audit.DatabaseListener," +
                         "org.candlepin.audit.LoggingListener," +


### PR DESCRIPTION
Throttling and paging feature for our auditing HornetQ infrastructure.

Simultaneously with this branch I am also issuing PR with documentation so make sure to take a look at that as well: https://github.com/candlepin/candlepinproject.org/pull/60

To test these changes you can use stress test that is available in the following branch. Just cherry-pick commit with name "Auditing stress test"  https://github.com/nguyenfilip/candlepin/tree/auditing-stress
