### PR TITLE
1274074: Fix deadlock during highly concurrent entitlement jobs.

### DIFF
--- a/buildfile
+++ b/buildfile
@@ -192,8 +192,6 @@ define "candlepin" do
 
   compile.options.target = '1.6'
   compile.options.source = '1.6'
-  # Enable to turn on compiler linting
-  # compile.options.lint = 'all'
 
   # path_to() (and it's alias _()) simply provides the absolute path to
   # a directory relative to the project.

--- a/server/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/server/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -20,6 +20,7 @@ import static org.candlepin.common.config.ConfigurationPrefixes.JPA_CONFIG_PREFI
 import org.candlepin.pinsetter.tasks.ActiveEntitlementJob;
 import org.candlepin.pinsetter.tasks.CancelJobJob;
 import org.candlepin.pinsetter.tasks.CertificateRevocationListTask;
+import org.candlepin.pinsetter.tasks.EntitlerJob;
 import org.candlepin.pinsetter.tasks.ExpiredPoolsJob;
 import org.candlepin.pinsetter.tasks.ExportCleaner;
 import org.candlepin.pinsetter.tasks.ImportRecordJob;
@@ -167,6 +168,9 @@ public class ConfigProperties {
         UnmappedGuestEntitlementCleanerJob.class.getName(),
     };
 
+    public static final String ENTITLER_JOB_THROTTLE =
+        "pinsetter." + EntitlerJob.class.getName() + ".throttle";
+
     public static final String SYNC_WORK_DIR = "candlepin.sync.work_dir";
     public static final String CONSUMER_FACTS_MATCHER = "candlepin.consumer.facts.match_regex";
 
@@ -295,6 +299,7 @@ public class ConfigProperties {
                 this.put("org.quartz.threadPool.threadCount", "15");
                 this.put("org.quartz.threadPool.threadPriority", "5");
                 this.put(DEFAULT_TASKS, StringUtils.join(DEFAULT_TASK_LIST, ","));
+                this.put(ENTITLER_JOB_THROTTLE, "7");
 
                 // AMQP (Qpid) configuration used by events
                 this.put(AMQP_INTEGRATION_ENABLED, String.valueOf(false));

--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -847,9 +847,7 @@ public class CandlepinPoolManager implements PoolManager {
      */
     //
     // NOTE: after calling this method both entitlement pool and consumer
-    // parameters
-    // will most certainly be stale. beware!
-    //
+    // parameters will most certainly be stale. beware!
     @Override
     @Transactional
     public List<Entitlement> entitleByProducts(AutobindData data)
@@ -923,9 +921,7 @@ public class CandlepinPoolManager implements PoolManager {
      */
     //
     // NOTE: after calling this method both entitlement pool and consumer
-    // parameters
-    // will most certainly be stale. beware!
-    //
+    // parameters will most certainly be stale. beware!
     @Override
     @Transactional
     public List<Entitlement> entitleByProductsForHost(Consumer guest, Consumer host,
@@ -1220,7 +1216,6 @@ public class CandlepinPoolManager implements PoolManager {
      * @throws EntitlementRefusedException if entitlement is refused
      */
     @Override
-    @Transactional
     public Entitlement entitleByPool(Consumer consumer, Pool pool,
         Integer quantity) throws EntitlementRefusedException {
         return addOrUpdateEntitlement(consumer, pool, null, quantity,
@@ -1228,7 +1223,6 @@ public class CandlepinPoolManager implements PoolManager {
     }
 
     @Override
-    @Transactional
     public Entitlement ueberCertEntitlement(Consumer consumer, Pool pool, Integer quantity)
         throws EntitlementRefusedException {
 
@@ -1236,7 +1230,6 @@ public class CandlepinPoolManager implements PoolManager {
     }
 
     @Override
-    @Transactional
     public Entitlement adjustEntitlementQuantity(Consumer consumer,
         Entitlement entitlement, Integer quantity)
         throws EntitlementRefusedException {
@@ -1248,7 +1241,33 @@ public class CandlepinPoolManager implements PoolManager {
             change, true, CallerType.UNKNOWN);
     }
 
-    private Entitlement addOrUpdateEntitlement(Consumer consumer, Pool pool,
+    /**
+     * It is imperative that this entire method be within the same transaction.
+     * Otherwise multiple entitlement jobs will deadlock in MySQL.
+     *
+     * T1 and T2 are entitlement jobs
+     *
+     * 1. T1 grabs a shared lock on cp_consumer.id due to the FK in cp_entitlement
+     *    when inserting into cp_entitlement
+     * 2. T2 grabs a shared lock on cp_consumer.id due to the FK in cp_entitlement
+     *    when inserting into cp_entitlement
+     * 3. T1 attempts to grab an exclusive lock on cp_consumer.id for an
+     *    update to cp_consumer's compliance hash.  T1 blocks waiting for the T2's
+     *    shared lock to be released.
+     * 4. T2 attempts to grab an exclusive lock on cp_consumer.id for an
+     *    update to cp_consumer's compliance hash.
+     * 5. Deadlock.  T2 is waiting for T1's shared lock to be released but
+     *    T1 is waiting for T2's shared lock to be released.
+     *
+     * The solution is to create a longer transaction and grab an exclusive lock
+     * on the cp_consumer row (using a select for update) at the start of the transaction.
+     * The other thread will then wait for the exclusive lock to be released instead of
+     * deadlocking.
+     *
+     * See BZ #1274074
+     */
+    @Transactional
+    protected Entitlement addOrUpdateEntitlement(Consumer consumer, Pool pool,
         Entitlement entitlement, Integer quantity, boolean generateUeberCert,
         CallerType caller)
         throws EntitlementRefusedException {
@@ -1277,6 +1296,9 @@ public class CandlepinPoolManager implements PoolManager {
         else {
             handler = new UpdateHandler();
         }
+
+        // Grab an exclusive lock on the consumer to prevent deadlock.
+        consumer = consumerCurator.lockAndLoad(consumer);
 
         log.info("Processing entitlement.");
         entitlement = handler.handleEntitlement(consumer, pool, entitlement, quantity);

--- a/server/src/main/java/org/candlepin/controller/Entitler.java
+++ b/server/src/main/java/org/candlepin/controller/Entitler.java
@@ -126,8 +126,8 @@ public class Entitler {
 
     private Entitlement createEntitlementByPool(Consumer consumer, Pool pool,
         Integer quantity) {
-        // Attempt to create an entitlement:
         try {
+            // Attempt to create an entitlement:
             Entitlement e = poolManager.entitleByPool(consumer, pool, quantity);
             log.debug("Created entitlement: " + e);
             return e;

--- a/server/src/main/java/org/candlepin/guice/CandlepinModule.java
+++ b/server/src/main/java/org/candlepin/guice/CandlepinModule.java
@@ -255,6 +255,7 @@ public class CandlepinModule extends AbstractModule {
         // Async Jobs
         bind(RefreshPoolsJob.class);
         bind(EntitlerJob.class);
+        requestStaticInjection(EntitlerJob.class);
         bind(HypervisorUpdateJob.class);
 
         // UeberCerts

--- a/server/src/main/java/org/candlepin/model/ConsumerCurator.java
+++ b/server/src/main/java/org/candlepin/model/ConsumerCurator.java
@@ -57,6 +57,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import javax.persistence.LockModeType;
+
 /**
  * ConsumerCurator
  */
@@ -279,6 +281,21 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
         return getConsumer(uuid);
     }
 
+    /**
+     * Apply a SELECT FOR UPDATE on a consumer.
+     *
+     * Note this method is not transactional.  It is meant to be used within
+     * a larger transaction.  Starting a transaction, running a select for update,
+     * and then ending the transaction is pointless.
+     *
+     * @return A consumer locked in the database
+     */
+    public Consumer lockAndLoad(Consumer c) {
+        getEntityManager().lock(c, LockModeType.PESSIMISTIC_WRITE);
+        return c;
+
+    }
+
     @Transactional
     public List<Consumer> findByUuids(Collection<String> uuids) {
         return listByCriteria(
@@ -297,8 +314,10 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
     // to bypass the authentication. Do not call it!
     // TODO: Come up with a better way to do this!
     public Consumer getConsumer(String uuid) {
-        return (Consumer) createSecureCriteria()
-            .add(Restrictions.eq("uuid", uuid)).uniqueResult();
+        Criteria criteria = createSecureCriteria()
+            .add(Restrictions.eq("uuid", uuid));
+
+        return (Consumer) criteria.uniqueResult();
     }
 
     @SuppressWarnings("unchecked")

--- a/server/src/main/java/org/candlepin/model/JobCurator.java
+++ b/server/src/main/java/org/candlepin/model/JobCurator.java
@@ -137,19 +137,19 @@ public class JobCurator extends AbstractHibernateCurator<JobStatus> {
         .add(Restrictions.eq("state", JobState.WAITING)).list();
     }
 
-    public long findNumRunningByOwnerAndClass(
-            String ownerKey, Class<? extends KingpinJob> jobClass) {
+    public long findNumRunningByClassAndTarget(
+            String target, Class<? extends KingpinJob> jobClass) {
         return (Long) this.currentSession().createCriteria(JobStatus.class)
             .add(Restrictions.ge("updated", getBlockingCutoff()))
             .add(Restrictions.eq("state", JobState.RUNNING))
-            .add(Restrictions.eq("targetId", ownerKey))
+            .add(Restrictions.eq("targetId", target))
             .add(Restrictions.eq("jobClass", jobClass))
             .setProjection(Projections.count("id"))
             .uniqueResult();
     }
 
-    public JobStatus getByClassAndOwner(
-            String ownerKey, Class<? extends KingpinJob> jobClass) {
+    public JobStatus getByClassAndTarget(
+            String target, Class<? extends KingpinJob> jobClass) {
 
         return (JobStatus) this.currentSession().createCriteria(JobStatus.class)
             .addOrder(Order.desc("created"))
@@ -157,7 +157,7 @@ public class JobCurator extends AbstractHibernateCurator<JobStatus> {
             .add(Restrictions.ne("state", JobState.FINISHED))
             .add(Restrictions.ne("state", JobState.FAILED))
             .add(Restrictions.ne("state", JobState.CANCELED))
-            .add(Restrictions.eq("targetId", ownerKey))
+            .add(Restrictions.eq("targetId", target))
             .add(Restrictions.eq("jobClass", jobClass))
             .setMaxResults(1)
             .uniqueResult();

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/EntitlerJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/EntitlerJob.java
@@ -14,12 +14,15 @@
  */
 package org.candlepin.pinsetter.tasks;
 
-import static org.quartz.JobBuilder.*;
+import static org.quartz.JobBuilder.newJob;
 
+import org.candlepin.common.config.Configuration;
+import org.candlepin.config.ConfigProperties;
 import org.candlepin.controller.Entitler;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerCurator;
 import org.candlepin.model.Entitlement;
+import org.candlepin.model.JobCurator;
 import org.candlepin.pinsetter.core.model.JobStatus;
 import org.candlepin.util.Util;
 
@@ -29,6 +32,9 @@ import org.quartz.JobDataMap;
 import org.quartz.JobDetail;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.Trigger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,15 +44,17 @@ import java.util.List;
  * EntitlerJob
  */
 public class EntitlerJob extends KingpinJob {
-
     private static Logger log = LoggerFactory.getLogger(EntitlerJob.class);
+
+    @Inject private static Configuration conf;
+
     protected Entitler entitler;
     protected ConsumerCurator consumerCurator;
 
     @Inject
     public EntitlerJob(Entitler e, ConsumerCurator c) {
-        entitler = e;
-        consumerCurator = c;
+        this.entitler = e;
+        this.consumerCurator = c;
     }
 
     @Override
@@ -82,9 +90,32 @@ public class EntitlerJob extends KingpinJob {
         JobDetail detail = newJob(EntitlerJob.class)
             .withIdentity("bind_by_pool_" + Util.generateUUID())
             .requestRecovery(false) // do not recover the job upon restarts
+            .storeDurably()
             .usingJobData(map)
             .build();
 
         return detail;
+    }
+
+    public static boolean isSchedulable(JobCurator jobCurator, JobStatus status) {
+        long running = jobCurator.findNumRunningByClassAndTarget(
+            status.getTargetId(), status.getJobClass());
+        // We can start the job if there are less than N others running
+        int throttle = conf.getInt(ConfigProperties.ENTITLER_JOB_THROTTLE);
+        return running < throttle;
+    }
+
+    public static JobStatus scheduleJob(JobCurator jobCurator,
+        Scheduler scheduler, JobDetail detail, Trigger trigger) throws SchedulerException {
+
+        JobStatus status = jobCurator.getByClassAndTarget(
+            detail.getJobDataMap().getString(JobStatus.TARGET_ID),
+            EntitlerJob.class);
+
+        // Insert as a waiting job if a bunch of EntitlerJobs are already running
+        if (status != null && !isSchedulable(jobCurator, status)) {
+            trigger = null;
+        }
+        return KingpinJob.scheduleJob(jobCurator, scheduler, detail, trigger);
     }
 }

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/HypervisorUpdateJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/HypervisorUpdateJob.java
@@ -89,7 +89,7 @@ public class HypervisorUpdateJob extends KingpinJob {
     public static JobStatus scheduleJob(JobCurator jobCurator,
         Scheduler scheduler, JobDetail detail,
         Trigger trigger) throws SchedulerException {
-        JobStatus result = jobCurator.getByClassAndOwner(
+        JobStatus result = jobCurator.getByClassAndTarget(
             detail.getJobDataMap().getString(JobStatus.TARGET_ID),
             HypervisorUpdateJob.class);
         if (result == null) {
@@ -101,7 +101,7 @@ public class HypervisorUpdateJob extends KingpinJob {
     }
 
     public static boolean isSchedulable(JobCurator jobCurator, JobStatus status) {
-        long running = jobCurator.findNumRunningByOwnerAndClass(
+        long running = jobCurator.findNumRunningByClassAndTarget(
             status.getTargetId(), HypervisorUpdateJob.class);
         return running == 0;  // We can start the job if there are 0 like it running
     }

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/UniqueByOwnerJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/UniqueByOwnerJob.java
@@ -37,7 +37,7 @@ public abstract class UniqueByOwnerJob extends KingpinJob {
     public static JobStatus scheduleJob(JobCurator jobCurator,
         Scheduler scheduler, JobDetail detail,
         Trigger trigger) throws SchedulerException {
-        JobStatus result = jobCurator.getByClassAndOwner(
+        JobStatus result = jobCurator.getByClassAndTarget(
             detail.getJobDataMap().getString(JobStatus.TARGET_ID),
             (Class<? extends KingpinJob>) detail.getJobClass());
         if (result == null) {
@@ -55,7 +55,7 @@ public abstract class UniqueByOwnerJob extends KingpinJob {
     }
 
     public static boolean isSchedulable(JobCurator jobCurator, JobStatus status) {
-        long running = jobCurator.findNumRunningByOwnerAndClass(
+        long running = jobCurator.findNumRunningByClassAndTarget(
             status.getTargetId(), status.getJobClass());
         return running == 0;  // We can start the job if there are 0 like it running
     }

--- a/server/src/test/java/org/candlepin/controller/EntitlerTest.java
+++ b/server/src/test/java/org/candlepin/controller/EntitlerTest.java
@@ -43,11 +43,13 @@ import org.candlepin.policy.ValidationResult;
 import org.candlepin.policy.js.entitlement.EntitlementRulesTranslator;
 import org.candlepin.resource.dto.AutobindData;
 import org.candlepin.service.ProductServiceAdapter;
-import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.test.TestUtil;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 import org.xnap.commons.i18n.I18n;
 import org.xnap.commons.i18n.I18nFactory;
 
@@ -58,25 +60,26 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+
 /**
  * EntitlerTest
  */
+@RunWith(MockitoJUnitRunner.class)
 public class EntitlerTest {
-    private PoolManager pm;
-    private EventFactory ef;
-    private EventSink sink;
     private I18n i18n;
     private Entitler entitler;
-    private Consumer consumer;
-    private ConsumerCurator cc;
     private EntitlementRulesTranslator translator;
-    private SubscriptionServiceAdapter subAdapter;
-    private EntitlementCurator entitlementCurator;
-    private Configuration config;
-    private PoolCurator poolCurator;
-    private ProductCurator productCurator;
-    private ProductServiceAdapter productAdapter;
 
+    @Mock private PoolManager pm;
+    @Mock private EventFactory ef;
+    @Mock private EventSink sink;
+    @Mock private Consumer consumer;
+    @Mock private ConsumerCurator cc;
+    @Mock private EntitlementCurator entitlementCurator;
+    @Mock private Configuration config;
+    @Mock private PoolCurator poolCurator;
+    @Mock private ProductCurator productCurator;
+    @Mock private ProductServiceAdapter productAdapter;
 
     private ValidationResult fakeOutResult(String msg) {
         ValidationResult result = new ValidationResult();
@@ -87,23 +90,12 @@ public class EntitlerTest {
 
     @Before
     public void init() {
-        pm = mock(PoolManager.class);
-        ef = mock(EventFactory.class);
-        sink = mock(EventSink.class);
-        cc = mock(ConsumerCurator.class);
-        consumer = mock(Consumer.class);
-        entitlementCurator = mock(EntitlementCurator.class);
         i18n = I18nFactory.getI18n(
             getClass(),
             Locale.US,
             I18nFactory.READ_PROPERTIES | I18nFactory.FALLBACK
         );
         translator = new EntitlementRulesTranslator(i18n);
-        subAdapter = mock(SubscriptionServiceAdapter.class);
-        config = mock(Configuration.class);
-        poolCurator = mock(PoolCurator.class);
-        productCurator = mock(ProductCurator.class);
-        productAdapter = mock(ProductServiceAdapter.class);
 
         entitler = new Entitler(pm, cc, i18n, ef, sink, translator, entitlementCurator, config,
                 poolCurator, productCurator, productAdapter);
@@ -480,7 +472,6 @@ public class EntitlerTest {
         List<Product> devProds = new ArrayList<Product>();
         Product p = new Product("test-product", "Test Product", owner);
         devProds.add(p);
-        List<Pool> activeList = new ArrayList<Pool>();
 
         Consumer devSystem = TestUtil.createConsumer(owner);
         devSystem.setFact("dev_sku", p.getId());
@@ -547,7 +538,7 @@ public class EntitlerTest {
         Pool expectedPool = entitler.assembleDevPool(devSystem, p.getId());
         when(pm.createPool(any(Pool.class))).thenReturn(expectedPool);
         AutobindData ad = new AutobindData(devSystem);
-        List<Entitlement> ents = entitler.bindByProducts(ad);
+        entitler.bindByProducts(ad);
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -152,7 +152,6 @@ public class PoolManagerTest {
     private Pool pool;
     private Product product;
     private ComplianceStatus dummyComplianceStatus;
-    private PoolRules poolRules;
 
     protected static Map<String, List<Pool>> subToPools;
 
@@ -260,7 +259,6 @@ public class PoolManagerTest {
             .updatePoolsForSubscription(eq(expectedModified), eq(sub), eq(false), any(Set.class));
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Test
     public void testRefreshPoolsDeletesOrphanedPools() {
         List<Subscription> subscriptions = Util.newList();
@@ -277,7 +275,6 @@ public class PoolManagerTest {
         verify(this.manager).deletePool(same(p));
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Test
     public void testRefreshPoolsDeletesOrphanedHostedVirtBonusPool() {
         List<Subscription> subscriptions = Util.newList();
@@ -300,7 +297,6 @@ public class PoolManagerTest {
         verify(this.manager).deletePool(same(p));
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Test
     public void testRefreshPoolsSkipsOrphanedEntitlementDerivedPools() {
         List<Subscription> subscriptions = Util.newList();
@@ -323,7 +319,6 @@ public class PoolManagerTest {
         verify(this.manager, never()).deletePool(same(p));
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Test
     public void testRefreshPoolsSkipsOrphanedStackDerivedPools() {
         List<Subscription> subscriptions = Util.newList();
@@ -346,7 +341,6 @@ public class PoolManagerTest {
         verify(this.manager, never()).deletePool(same(p));
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Test
     public void testRefreshPoolsSkipsDevelopmentPools() {
         List<Subscription> subscriptions = Util.newList();
@@ -367,7 +361,7 @@ public class PoolManagerTest {
         verify(this.manager, never()).deletePool(same(p));
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @SuppressWarnings("rawtypes")
     @Test
     public void testRefreshPoolsSortsStackDerivedPools() {
         List<Subscription> subscriptions = Util.newList();
@@ -578,7 +572,6 @@ public class PoolManagerTest {
         pools.add(pool2);
         Date now = new Date();
 
-
         ValidationResult result = mock(ValidationResult.class);
         Page page = mock(Page.class);
 
@@ -609,7 +602,6 @@ public class PoolManagerTest {
         assertEquals(e.size(), 1);
     }
 
-    @SuppressWarnings("rawtypes")
     @Test
     public void testRefreshPoolsRemovesExpiredSubscriptionsAlongWithItsPoolsAndEnts() {
         PreUnbindHelper preHelper =  mock(PreUnbindHelper.class);
@@ -759,7 +751,7 @@ public class PoolManagerTest {
         return newPool;
     }
 
-    @SuppressWarnings("rawtypes")
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Test
     public void testEntitleByProductsEmptyArray() throws Exception {
         Product product = TestUtil.createProduct(o);
@@ -777,7 +769,6 @@ public class PoolManagerTest {
         mockCompliance.addNonCompliantProduct(installedPids[0]);
         when(complianceRules.getStatus(any(Consumer.class),
             any(Date.class), any(Boolean.class))).thenReturn(mockCompliance);
-
 
         Page page = mock(Page.class);
         when(page.getPageData()).thenReturn(pools);
@@ -891,7 +882,7 @@ public class PoolManagerTest {
         when(mockPoolCurator.getOwnersFloatingPools(any(Owner.class))).thenReturn(floating);
         when(mockPoolCurator.getPoolsFromBadSubs(any(Owner.class), any(Collection.class)))
             .thenAnswer(new Answer<List<Pool>>() {
-
+                @SuppressWarnings("unchecked")
                 @Override
                 public List<Pool> answer(InvocationOnMock iom) throws Throwable {
                     Collection<String> subIds = (Collection<String>) iom.getArguments()[1];
@@ -914,7 +905,6 @@ public class PoolManagerTest {
         PoolRules pRules = new PoolRules(manager, mockConfig, entitlementCurator,
                 productCuratorMock);
         List<Subscription> subscriptions = Util.newList();
-        List<Pool> pools = Util.newList();
         Product prod = TestUtil.createProduct(owner);
         Set<Product> products = new HashSet<Product>();
         products.add(prod);
@@ -963,7 +953,6 @@ public class PoolManagerTest {
         PoolRules pRules = new PoolRules(manager, mockConfig, entitlementCurator,
                 productCuratorMock);
         List<Subscription> subscriptions = Util.newList();
-        List<Pool> pools = Util.newList();
         Product prod = TestUtil.createProduct(owner);
         Set<Product> products = new HashSet<Product>();
         products.add(prod);

--- a/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -183,6 +183,14 @@ public class PoolManagerTest {
         dummyComplianceStatus = new ComplianceStatus(new Date());
         when(complianceRules.getStatus(any(Consumer.class), any(Date.class))).thenReturn(
             dummyComplianceStatus);
+
+        when(consumerCuratorMock.lockAndLoad(any(Consumer.class))).thenAnswer(new Answer<Consumer>() {
+            @Override
+            public Consumer answer(InvocationOnMock invocation) throws Throwable {
+                Object[] args = invocation.getArguments();
+                return (Consumer) args[0];
+            }
+        });
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })

--- a/server/src/test/java/org/candlepin/model/JobCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/JobCuratorTest.java
@@ -179,7 +179,7 @@ public class JobCuratorTest extends DatabaseTestFixture {
         newJobStatus().state(JobStatus.JobState.RUNNING)
             .jobClass(HealEntireOrgJob.class)
             .owner("my_owner").create();
-        long result = curator.findNumRunningByOwnerAndClass("my_owner",
+        long result = curator.findNumRunningByClassAndTarget("my_owner",
             RefreshPoolsJob.class);
         assertEquals(1, result);
     }
@@ -211,7 +211,7 @@ public class JobCuratorTest extends DatabaseTestFixture {
         newJobStatus().state(JobStatus.JobState.FINISHED)
             .jobClass(HealEntireOrgJob.class)
             .owner("my_owner").create();
-        JobStatus result = curator.getByClassAndOwner("my_owner",
+        JobStatus result = curator.getByClassAndTarget("my_owner",
             HealEntireOrgJob.class);
         assertEquals(expected, result);
     }

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/EntitlerJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/EntitlerJobTest.java
@@ -105,7 +105,7 @@ public class EntitlerJobTest {
     public void recoveryIsFalse() {
         JobDetail detail = EntitlerJob.bindByPool("pool10", consumer, 1);
         assertFalse(detail.requestsRecovery());
-        assertFalse(detail.isDurable());
+        assertTrue(detail.isDurable());
     }
 
     private void serialize(Object obj) throws IOException {

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/HypervisorUpdateJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/HypervisorUpdateJobTest.java
@@ -208,7 +208,7 @@ public class HypervisorUpdateJobTest {
         Scheduler scheduler = mock(Scheduler.class);
         ListenerManager lm = mock(ListenerManager.class);
 
-        when(jobCurator.getByClassAndOwner(anyString(), any(Class.class))).thenReturn(
+        when(jobCurator.getByClassAndTarget(anyString(), any(Class.class))).thenReturn(
                 preExistingJobStatus);
         when(scheduler.getListenerManager()).thenReturn(lm);
         when(jobCurator.create(any(JobStatus.class))).thenReturn(newlyScheduledJobStatus);
@@ -226,7 +226,7 @@ public class HypervisorUpdateJobTest {
         JobDetail detail = HypervisorUpdateJob.forOwner(owner, hypervisorJson, true, principal, null);
         JobStatus newJob = new JobStatus(detail);
         JobCurator jobCurator = mock(JobCurator.class);
-        when(jobCurator.findNumRunningByOwnerAndClass(owner.getKey(), HypervisorUpdateJob.class))
+        when(jobCurator.findNumRunningByClassAndTarget(owner.getKey(), HypervisorUpdateJob.class))
                 .thenReturn(1L);
         assertFalse(HypervisorUpdateJob.isSchedulable(jobCurator, newJob));
     }

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/UniqueByOwnerJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/UniqueByOwnerJobTest.java
@@ -64,7 +64,7 @@ public class UniqueByOwnerJobTest {
         JobStatus preExistingJobStatus = new JobStatus();
         preExistingJobStatus.setState(JobState.WAITING);
         TestUniqueByOwnerJob job = new TestUniqueByOwnerJob();
-        when(jobCurator.getByClassAndOwner(eq("TaylorSwift"), any(Class.class))).thenReturn(
+        when(jobCurator.getByClassAndTarget(eq("TaylorSwift"), any(Class.class))).thenReturn(
                 preExistingJobStatus);
 
         JobStatus resultStatus = job.scheduleJob(jobCurator, null, detail, null);


### PR DESCRIPTION
This PR should eliminate the possibility of deadlock on cp_consumer during a bind by pool.  It can, however, cause lock wait timeouts especially in hosted mode.  If several bind by pool jobs are all created at once, the compliance checking portion of CandlepinPoolManager.getStatus can easily result in some of the jobs not being able to acquire a lock in time.

The additional commits add a mechanism to throttle the number of concurrent Entitler jobs and to dispense with compliance checking on distributors.