### PR TITLE
Added correction to the output of some getters in Product; few misc bug fixes

### DIFF
--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -446,6 +446,7 @@ public class CandlepinPoolManager implements PoolManager {
             else {
                 if (hasProductChanged(existing, incoming)) {
                     log.info("Product changed for org {}: {}", o.getKey(), incoming.getId());
+                    incoming.setOwner(o);
                     prodCurator.createOrUpdate(incoming);
                     changedProducts.add(incoming);
                 }

--- a/server/src/main/java/org/candlepin/hostedtest/HostedTestSubscriptionServiceAdapter.java
+++ b/server/src/main/java/org/candlepin/hostedtest/HostedTestSubscriptionServiceAdapter.java
@@ -20,6 +20,9 @@ import org.candlepin.model.Product;
 import org.candlepin.model.dto.Subscription;
 import org.candlepin.service.SubscriptionServiceAdapter;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -32,6 +35,7 @@ import java.util.HashMap;
  * as the only purpose of this class is to support spec tests.
  */
 public class HostedTestSubscriptionServiceAdapter implements SubscriptionServiceAdapter {
+    private static Logger log = LoggerFactory.getLogger(HostedTestSubscriptionServiceAdapter.class);
 
     private static Map<String, Subscription> idMap = new HashMap<String, Subscription>();
     private static Map<String, List<Subscription>> ownerMap = new HashMap<String, List<Subscription>>();
@@ -109,6 +113,8 @@ public class HostedTestSubscriptionServiceAdapter implements SubscriptionService
         if (!productMap.containsKey(s.getProduct().getId())) {
             productMap.put(s.getProduct().getId(), new ArrayList<Subscription>());
         }
+
+        log.debug("STORING PRODUCT: {} (name: {})", s.getProduct(), s.getProduct().getName());
         productMap.get(s.getProduct().getId()).add(s);
         return s;
     }

--- a/server/src/main/java/org/candlepin/model/Product.java
+++ b/server/src/main/java/org/candlepin/model/Product.java
@@ -104,16 +104,11 @@ public class Product extends AbstractHibernateObject implements Linkable, Clonea
     @LazyCollection(LazyCollectionOption.EXTRA) // allows .size() without loading all data
     private List<ProductContent> productContent;
 
-    /*
-     * hibernate persists empty set as null, and tries to fetch
-     * dependentProductIds upon a fetch when we lazy load. to fix this, we eager
-     * fetch.
-     */
     @ElementCollection
     @CollectionTable(name = "cpo_product_dependent_products",
                      joinColumns = @JoinColumn(name = "product_uuid"))
     @Column(name = "element")
-    @LazyCollection(LazyCollectionOption.FALSE)
+    @LazyCollection(LazyCollectionOption.EXTRA)
     private Set<String> dependentProductIds; // Should these be product references?
 
     protected Product() {
@@ -329,6 +324,10 @@ public class Product extends AbstractHibernateObject implements Linkable, Clonea
     }
 
     public Set<ProductAttribute> getAttributes() {
+        if (this.attributes == null) {
+            this.attributes = new HashSet<ProductAttribute>();
+        }
+
         return attributes;
     }
 
@@ -395,7 +394,7 @@ public class Product extends AbstractHibernateObject implements Linkable, Clonea
 
     @Override
     public String toString() {
-        return "Product [owner = " + owner.getKey() + ", id = " + id + ", name = " + name + "]";
+        return "Product [owner = " + (owner != null ? owner.getKey() : null) + ", id = " + id + ", name = " + name + "]";
     }
 
     @Override
@@ -461,6 +460,10 @@ public class Product extends AbstractHibernateObject implements Linkable, Clonea
      * @return the productContent
      */
     public List<ProductContent> getProductContent() {
+        if (this.productContent == null) {
+            this.productContent = new LinkedList<ProductContent>();
+        }
+
         return productContent;
     }
 
@@ -504,6 +507,10 @@ public class Product extends AbstractHibernateObject implements Linkable, Clonea
      * @return the dependentProductIds
      */
     public Set<String> getDependentProductIds() {
+        if (this.dependentProductIds == null) {
+            this.dependentProductIds = new HashSet<String>();
+        }
+
         return dependentProductIds;
     }
 

--- a/server/src/main/java/org/candlepin/model/ProductCurator.java
+++ b/server/src/main/java/org/candlepin/model/ProductCurator.java
@@ -188,9 +188,12 @@ public class ProductCurator extends AbstractHibernateCurator<Product> {
         Product existing = this.lookupById(p.getOwner(), p.getId());
 
         if (existing == null) {
+            log.debug("Could not find product by owner/id: {}, {}", p.getOwner(), p.getId());
             create(p);
             return p;
         }
+
+        log.debug("Updating product by owner/id: {}, {}", p.getOwner(), p.getId());
 
         copy(p, existing);
         return merge(existing);


### PR DESCRIPTION
- getAttribute, getProductContent and getDependentProductIds will now
  set their collections if it is null at the time it is called
- Product.toString no longer causes NPEs if it is called before the
  product has an owner set
- Added additional logging to ProductCurator
- CandlepinPoolManager now sets the owner of a product even when it
  already exists

Not entirely sure if this will prove useful long-term. I feel like I recall some code that explicitly looked for a null value to perform certain actions. If so, and if the old code proves to be a better solution, this commit may need to be reverted/discarded.