### PR TITLE
Added support for running hosted tests against Candlepin's Docker containers

### DIFF
--- a/docker/candlepin-base/cp-test
+++ b/docker/candlepin-base/cp-test
@@ -66,6 +66,7 @@ usage() {
         -d  deploy a live candlepin
         -t  populate Candlepin database with test data (implies -d)
         -r  run rspec test suite (implies -d)
+        -h  run rspec tests in "hosted" mode (implies -r and -d)
         -u  run unit test suite
         -l  run the linter against the code
         -s  run a bash shell when done
@@ -75,7 +76,7 @@ usage() {
 HELP
 }
 
-while getopts ":dtrulsc:p:v" opt; do
+while getopts ":dtrhulsc:p:v" opt; do
     case $opt in
         d  ) DEPLOY="1";;
         t  )
@@ -83,6 +84,11 @@ while getopts ":dtrulsc:p:v" opt; do
             TESTDATA="1"
             ;;
         r  )
+            RSPEC="1"
+            DEPLOY="1"
+            ;;
+        h  )
+            HOSTED="1"
             RSPEC="1"
             DEPLOY="1"
             ;;
@@ -143,6 +149,10 @@ if [ "$DEPLOY" == "1" ]; then
     echo "Deploying candlepin."
 
     DEPLOY_FLAGS="-g"
+
+    if [ "$RSPEC" == "1" ] && [ "$HOSTED" == "1" ]; then
+        DEPLOY_FLAGS="$DEPLOY_FLAGS -h -a"
+    fi
 
     if [ "$TESTDATA" == "1" ]; then
         DEPLOY_FLAGS="$DEPLOY_FLAGS -t"

--- a/docker/candlepin-mysql/setup-mysql.sh
+++ b/docker/candlepin-mysql/setup-mysql.sh
@@ -20,7 +20,9 @@ setup_mysql() {
     sleep 5
 
     mysql --user=root mysql --execute="CREATE USER 'candlepin'@'localhost'; GRANT ALL PRIVILEGES on candlepin.* TO 'candlepin'@'localhost' WITH GRANT OPTION"
+    mysql --user=root mysql --execute="CREATE USER 'gutterball'@'localhost'; GRANT ALL PRIVILEGES on gutterball.* TO 'gutterball'@'localhost' WITH GRANT OPTION"
     mysqladmin --user="candlepin" create candlepin
+    mysqladmin --user="gutterball" create gutterball
 
     echo "USE_MYSQL=\"1\"" >> /root/.candlepinrc
 }

--- a/docker/candlepin-postgresql/setup-postgresql.sh
+++ b/docker/candlepin-postgresql/setup-postgresql.sh
@@ -21,6 +21,7 @@ POSTGRES_SUPERVISOR
     /usr/bin/supervisord -c /etc/supervisord.conf &
     sleep 5
     su - postgres -c 'createuser -dls candlepin'
+    su - postgres -c 'createuser -dls gutterball'
     supervisorctl stop postgres
 }
 


### PR DESCRIPTION
- Added the -h flag to cp-test, which sets up the spec tests to be run
  in "hosted" mode