### PR TITLE
Updates test to remove by pool id to use the new hosted methods

### DIFF
--- a/server/spec/unbind_spec.rb
+++ b/server/spec/unbind_spec.rb
@@ -28,8 +28,7 @@ describe 'Unbind' do
     consumer = consumer_client(@user, 'consumer')
 
     testing = create_product(nil, random_string('testing'))
-    @cp.create_subscription(@owner['key'], testing.id, 4)
-    @cp.refresh_pools @owner['key']
+    create_pool_and_subscription(@owner['key'], testing.id, 4)
 
     pool1 = consumer.list_pools(
       :product => @monitoring.id,


### PR DESCRIPTION
When writing this test, I did not use the new candlepin_scenarios.rb methods that ensure proper operation of tests while running in hosted mode. This PR updates that test to do so.