### PR TITLE
Updated property definition in Gutterball Event changeset

### DIFF
--- a/gutterball/src/main/resources/db/changelog/2015-10-20-13-20-change-event-entity-json-column-types.xml
+++ b/gutterball/src/main/resources/db/changelog/2015-10-20-13-20-change-event-entity-json-column-types.xml
@@ -6,8 +6,9 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
 
-    <property name="entitydata.type" value="mediumtext" dbms="mysql"/>
-    <property name="entitydata.type" value="text" dbms="postgresql"/>
+    <property name="entitydata.type" value="mediumtext" dbms="mysql, hsqldb"/>
+    <property name="entitydata.type" value="text"/>
+
 
     <changeSet id="20151020132045-1" author="mstead">
         <comment>Change Event newentity type from clob to mediumtext to avoid using large objects.</comment>


### PR DESCRIPTION
- Updated the entitydata.type property definition in the event entity
  changeset to now use "mediumtext" for mysql and hsqldb, but "text"
  for everything else. This fixes several unit test failures stemming
  from various side-effects of not having a default type.