### PR TITLE
Added a delay in the guest entitlement spec tests

### DIFF
--- a/server/spec/one_sub_pool_per_stack_spec.rb
+++ b/server/spec/one_sub_pool_per_stack_spec.rb
@@ -342,6 +342,9 @@ describe 'One Sub Pool Per Stack' do
     # Simulate migration
     @host2_client.update_consumer({:guestIds => [{'guestId' => @guest_uuid}]})
 
+    # Need to wait a moment here for MySQL to catch up
+    sleep 2
+
     # Guest entitlement should now be revoked.
     @guest_client.list_entitlements.length.should == 0
   end


### PR DESCRIPTION
- Added an additional delay in the one_sub_pool_per_stack_spec test
  'should remove guest entitlement when guest is migrated' to help
  alleviate some periodic failures when testing on MySQL