### PR TITLE
Ignore milliseconds for unbind by pool test

### DIFF
--- a/server/client/ruby/util.rb
+++ b/server/client/ruby/util.rb
@@ -1,38 +1,19 @@
+require 'date'
+
 # A file for utility functions and classes that are miscellaneous
-def remove_matching!(object, pattern)
-    # Recursively removes all string items matching a given regexp,
-    # deleting key's where appropriate
+def fix_times!(object, list_of_keys_to_check)
+    # Recursively fixes times for the list of keys provided
     if object.is_a? Hash
         object.each do |key, value|
-            new_value = remove_matching!(value, pattern)
-            if new_value.respond_to? :empty?
-                if new_value.empty?
-                    object.delete(key)
-                end
-            elsif new_value.nil?
-                object.delete(key)
+            if list_of_keys_to_check.include?(key) and value.is_a? String
+                object[key] = DateTime.strptime(value, "%Y-%m-%dT%H:%M:%S")
             else
-                object[key] = new_value
+                object[key] = fix_times!(value, list_of_keys_to_check)
             end
         end
     elsif object.is_a? Array
         object.each_with_index do |item, index|
-            new_value = remove_matching!(item, pattern)
-            if new_value.respond_to? :empty?
-                if new_value.empty?
-                    object.delete_at(index)
-                end
-            elsif new_value.nil?
-                object.delete_at(index)
-            else
-                object[index] = new_value
-            end
-        end
-    elsif object.is_a? String
-        if pattern.match(object)
-            return nil
-        else
-            return object
+            object[index] = fix_times!(item, list_of_keys_to_check)
         end
     else
         return object

--- a/server/client/ruby/util.rb
+++ b/server/client/ruby/util.rb
@@ -1,0 +1,40 @@
+# A file for utility functions and classes that are miscellaneous
+def remove_matching!(object, pattern)
+    # Recursively removes all string items matching a given regexp,
+    # deleting key's where appropriate
+    if object.is_a? Hash
+        object.each do |key, value|
+            new_value = remove_matching!(value, pattern)
+            if new_value.respond_to? :empty?
+                if new_value.empty?
+                    object.delete(key)
+                end
+            elsif new_value.nil?
+                object.delete(key)
+            else
+                object[key] = new_value
+            end
+        end
+    elsif object.is_a? Array
+        object.each_with_index do |item, index|
+            new_value = remove_matching!(item, pattern)
+            if new_value.respond_to? :empty?
+                if new_value.empty?
+                    object.delete_at(index)
+                end
+            elsif new_value.nil?
+                object.delete_at(index)
+            else
+                object[index] = new_value
+            end
+        end
+    elsif object.is_a? String
+        if pattern.match(object)
+            return nil
+        else
+            return object
+        end
+    else
+        return object
+    end
+end

--- a/server/spec/unbind_spec.rb
+++ b/server/spec/unbind_spec.rb
@@ -43,10 +43,9 @@ describe 'Unbind' do
     consumer.unbind_entitlements_by_pool(consumer.uuid, pool1.id)
     results = consumer.list_entitlements
     expected = [ent2]
-    date_time_pattern = /[0-9]+-[0-9]{0,2}-[0-9]{0,2}T[012]{0,1}[0-9]{1,1}:[0-5]{0,1}[0-9]{1,1}:[0-5]{0,1}[0-9]\.[0-9]{0,3}\+[0-9]{0,4}/
     # mysql does not support milliseconds. So remove time fields.
     [results, expected].each do |item|
-      remove_matching!(item, date_time_pattern)
+      fix_times!(item, ['updated', 'created','startDate','endDate', 'expiration'])
     end
     expect(results).to(match_array(expected))
   end

--- a/server/spec/unbind_spec.rb
+++ b/server/spec/unbind_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'candlepin_scenarios'
+require 'util'
 
 describe 'Unbind' do
   include CandlepinMethods
@@ -39,9 +40,15 @@ describe 'Unbind' do
 
     ent1 = consumer.consume_pool(pool1.id, {:quantity => 1}).first
     ent2 = consumer.consume_pool(pool2.id, {:quantity => 1}).first
-
     consumer.unbind_entitlements_by_pool(consumer.uuid, pool1.id)
-    expect(consumer.list_entitlements).to(match_array([ent2]))
+    results = consumer.list_entitlements
+    expected = [ent2]
+    date_time_pattern = /[0-9]+-[0-9]{0,2}-[0-9]{0,2}T[012]{0,1}[0-9]{1,1}:[0-5]{0,1}[0-9]{1,1}:[0-5]{0,1}[0-9]\.[0-9]{0,3}\+[0-9]{0,4}/
+    # mysql does not support milliseconds. So remove time fields.
+    [results, expected].each do |item|
+      remove_matching!(item, date_time_pattern)
+    end
+    expect(results).to(match_array(expected))
   end
 
   it 'should add unbound entitlements back to the pool' do


### PR DESCRIPTION
This PR adds a new ruby utility method 'remove_matching!' that recursively removes all strings contained within a given object while maintaining the order of the elements.
This new function is then used to remove all datetime like values from the broken unbind test so that we can pass on mysql.

NOTE: The reason we need to remove these values to begin with is we lose the millisecond value of the object after it has been committed to and retrieved from a mysql database.