### PR TITLE
1283401:  500 status (or an empty reply) when getting all consumers

### DIFF
--- a/server/client/ruby/candlepin_api.rb
+++ b/server/client/ruby/candlepin_api.rb
@@ -825,11 +825,7 @@ class Candlepin
   def list_consumers(args={})
     query = "/consumers?"
 
-    # Ideally, call this method with an owner parameter. Only
-    # super admins will be able to call without and list all
-    # consumers.
-    query = "/owners/#{args[:owner]}/consumers?" if args[:owner]
-
+    query << "owner=#{args[:owner]}&" if args[:owner]
     query << "username=#{args[:username]}&" if args[:username]
     query << "type=#{args[:type]}&" if args[:type]
     query << "page=#{args[:page]}&" if args[:page]

--- a/server/spec/authorization_spec.rb
+++ b/server/spec/authorization_spec.rb
@@ -52,7 +52,7 @@ describe 'Authorization' do
     end.should raise_exception(RestClient::Request::Unauthorized)
   end
 
-  it 'allows in trused users' do
+  it 'allows in trusted users' do
     ownerID = random_string('test_owner1')
     owner1 = create_owner ownerID
     username = random_string("user1")

--- a/server/spec/consumer_resource_spec.rb
+++ b/server/spec/consumer_resource_spec.rb
@@ -96,11 +96,11 @@ describe 'Consumer Resource' do
     }.should raise_exception(RestClient::ResourceNotFound)
   end
 
-  it 'should receive paged data back when requested' do
+  it 'should receive paged consumers back when requested' do
     (1..4).each do |i|
       consumer_client(@user1, random_string('system'))
     end
-    consumers = @cp.list_consumers({:page => 1, :per_page => 2, :sort_by => "id", :order => "asc"})
+    consumers = @cp.list_consumers({:owner => @owner1['key'], :page => 1, :per_page => 2, :sort_by => "id", :order => "asc"})
     consumers.length.should == 2
     (consumers[0].id <=> consumers[1].id).should == -1
   end
@@ -152,7 +152,7 @@ describe 'Consumer Resource' do
   #TODO Get this working in parallel
   it 'allows super admins to see all consumers', :serial => true do
     uuids = []
-    @cp.list_consumers.each do |c|
+    @cp.list_consumers({:type => 'system'}).each do |c|
       uuids << c['uuid']
       # Consumer lists should not have idCert or facts:
       c['facts'].should be_nil
@@ -174,19 +174,10 @@ describe 'Consumer Resource' do
     returned_uuids.length.should == 2
   end
 
-  it 'lets an owner admin see only their consumers' do
-    @user2.list_consumers({:owner => @owner2['key']}).length.should == 1
-  end
-
   #TODO Get this working in parallel
   it 'lets a super admin filter consumers by owner', :serial => true do
-    @cp.list_consumers.size.should be > 1
+    @cp.list_consumers({:type => 'system'}).size.should be > 1
     @cp.list_consumers({:owner => @owner1['key']}).size.should == 1
-  end
-
-
-  it 'lets an owner see only their system consumer types' do
-    @user1.list_consumers({:type => 'system', :owner => @owner1['key']}).length.should == 1
   end
 
   it 'lets a super admin see a peson consumer with a given username' do

--- a/server/spec/filter_response_spec.rb
+++ b/server/spec/filter_response_spec.rb
@@ -70,7 +70,7 @@ describe 'Response JSON Filtering' do
   it 'should allow filters on encapsulated lists' do
     consumer = @user1.register(random_string("test1"))
     consumer = @user1.register(random_string("test2"))
-    consumers = @cp.get("/consumers?include=id&include=owner.id")
+    consumers = @cp.get("/consumers?type=system&include=id&include=owner.id")
     consumers.each do |consumer|
       consumer.keys.size.should == 2
       consumer["id"].should_not == nil

--- a/server/spec/owner_resource_spec.rb
+++ b/server/spec/owner_resource_spec.rb
@@ -9,6 +9,26 @@ describe 'Owner Resource' do
 
   include CandlepinMethods
 
+  it 'lets an owner see only their system consumer types' do
+    owner1 = create_owner random_string('test_owner1')
+    username1 = random_string("user1")
+    consumername1 = random_string("consumer1")
+    user1 = user_client(owner1, username1)
+    consumer1 = consumer_client(user1, consumername1)
+
+    user1.list_owner_consumers(owner1['key'], ['system']).length.should == 1
+  end
+
+  it 'lets an owner admin see only their consumers' do
+    owner1 = create_owner random_string('test_owner1')
+    username1 = random_string("user1")
+    consumername1 = random_string("consumer1")
+    user1 = user_client(owner1, username1)
+    consumer1 = consumer_client(user1, consumername1)
+
+    user1.list_owner_consumers(owner1['key']).length.should == 1
+  end
+
   it 'allows consumers to view their service levels' do
     owner = create_owner random_string('owner1')
     owner_admin = user_client(owner, random_string('bill'))

--- a/server/spec/system_admin_spec.rb
+++ b/server/spec/system_admin_spec.rb
@@ -37,7 +37,7 @@ describe 'System Admins' do
     @cp.list_consumers({:owner => @owner['key']}).size.should == 2
 
     # User should just see one:
-    my_systems = @user_cp.list_consumers({:owner => @owner['key']})
+    my_systems = @user_cp.list_owner_consumers(@owner['key'])
     my_systems.size.should == 1
     my_systems[0]['uuid'].should == @consumer1['uuid']
 
@@ -169,7 +169,7 @@ describe 'System admins with read-only on org' do
     @cp.list_consumers({:owner => @owner['key']}).size.should == 2
 
     # User should just see one:
-    my_systems = @user_cp.list_consumers({:owner => @owner['key']})
+    my_systems = @user_cp.list_owner_consumers(@owner['key'])
     my_systems.size.should == 2
 
     lookedup = @user_cp.get_consumer(@consumer2['uuid'])

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -253,6 +253,12 @@ public class ConsumerResource {
             List<KeyValueParameter> attrFilters,
         @Context PageRequest pageRequest) {
 
+        if (userName == null && (typeLabels == null || typeLabels.isEmpty()) && ownerKey == null &&
+                (uuids == null || uuids.isEmpty()) && (hypervisorIds == null || hypervisorIds.isEmpty()) &&
+                (attrFilters == null || attrFilters.isEmpty())) {
+            throw new BadRequestException(i18n.tr("Must specify at least one search criteria."));
+        }
+
         Owner owner = null;
         if (ownerKey != null) {
             owner = ownerCurator.lookupByKey(ownerKey);

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
@@ -31,6 +31,8 @@ import org.candlepin.auth.SubResource;
 import org.candlepin.auth.UserPrincipal;
 import org.candlepin.common.exceptions.BadRequestException;
 import org.candlepin.common.exceptions.NotFoundException;
+import org.candlepin.common.paging.Page;
+import org.candlepin.common.paging.PageRequest;
 import org.candlepin.config.CandlepinCommonTestConfig;
 import org.candlepin.controller.CandlepinPoolManager;
 import org.candlepin.controller.Entitler;
@@ -68,6 +70,7 @@ import org.candlepin.service.UserServiceAdapter;
 import org.candlepin.test.TestUtil;
 import org.candlepin.util.ServiceLevelValidator;
 
+import org.hibernate.mapping.Collection;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -576,4 +579,83 @@ public class ConsumerResourceTest {
         cr.consumerExists("uuid");
     }
 
+    @Test(expected = BadRequestException.class)
+    public void testFetchAllConsumers() {
+        ConsumerResource cr = new ConsumerResource(null, null,
+                null, null, null, null, null, i18n, null, null, null,
+                null, null, null, null, null, null, null, null, null,
+                null, null, null, new CandlepinCommonTestConfig(),
+                null, null, null, null);
+        cr.list(null, null, null, null, null, null, null);
+    }
+
+    @Test
+    public void testFetchAllConsumersForUser() {
+        ConsumerResource cr = new ConsumerResource(mockedConsumerCurator, null,
+                null, null, null, null, null, i18n, null, null, null,
+                null, null, null, null, null, null, null, null, null,
+                null, null, null, new CandlepinCommonTestConfig(),
+                null, null, null, null);
+        Page<List<Consumer>> page = new Page<List<Consumer>>();
+        ArrayList<Consumer> consumers = new ArrayList<Consumer>();
+        page.setPageData(consumers);
+        when(mockedConsumerCurator.searchOwnerConsumers(
+                any(Owner.class), anyString(), (java.util.Collection<ConsumerType>) any(Collection.class),
+                any(List.class), any(List.class), any(List.class),
+                any(List.class), any(List.class), any(List.class),
+                any(PageRequest.class))).thenReturn(page);
+        List<Consumer> result = cr.list("TaylorSwift", null, null, null, null, null, null);
+        assertEquals(consumers, result);
+    }
+
+    public void testFetchAllConsumersForOwner() {
+        ConsumerResource cr = new ConsumerResource(mockedConsumerCurator, null,
+                null, null, null, null, null, i18n, null, null, null,
+                null, null, null, null, null, mockedOwnerCurator, null, null, null,
+                null, null, null, new CandlepinCommonTestConfig(),
+                null, null, null, null);
+        Page<List<Consumer>> page = new Page<List<Consumer>>();
+        ArrayList<Consumer> consumers = new ArrayList<Consumer>();
+        page.setPageData(consumers);
+
+        when(mockedOwnerCurator.lookupByKey(eq("taylorOwner"))).thenReturn(new Owner());
+        when(mockedConsumerCurator.searchOwnerConsumers(
+                any(Owner.class), anyString(), (java.util.Collection<ConsumerType>) any(Collection.class),
+                any(List.class), any(List.class), any(List.class),
+                any(List.class), any(List.class), any(List.class),
+                any(PageRequest.class))).thenReturn(page);
+        List<Consumer> result = cr.list(null, null, "taylorOwner", null, null, null, null);
+        assertEquals(consumers, result);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void testFetchAllConsumersForEmptyUUIDs() {
+        ConsumerResource cr = new ConsumerResource(mockedConsumerCurator, null,
+                null, null, null, null, null, i18n, null, null, null,
+                null, null, null, null, null, null, null, null, null,
+                null, null, null, new CandlepinCommonTestConfig(),
+                null, null, null, null);
+        List<Consumer> result = cr.list(null, null, null, new ArrayList<String>(), null, null, null);
+    }
+
+    @Test
+    public void testFetchAllConsumersForSomeUUIDs() {
+        ConsumerResource cr = new ConsumerResource(mockedConsumerCurator, null,
+                null, null, null, null, null, i18n, null, null, null,
+                null, null, null, null, null, null, null, null, null,
+                null, null, null, new CandlepinCommonTestConfig(),
+                null, null, null, null);
+        Page<List<Consumer>> page = new Page<List<Consumer>>();
+        ArrayList<Consumer> consumers = new ArrayList<Consumer>();
+        page.setPageData(consumers);
+        when(mockedConsumerCurator.searchOwnerConsumers(
+                any(Owner.class), anyString(), (java.util.Collection<ConsumerType>) any(Collection.class),
+                any(List.class), any(List.class), any(List.class),
+                any(List.class), any(List.class), any(List.class),
+                any(PageRequest.class))).thenReturn(page);
+        List<String> uuids = new ArrayList<String>();
+        uuids.add("swiftuuid");
+        List<Consumer> result = cr.list(null, null, null, uuids, null, null, null);
+        assertEquals(consumers, result);
+    }
 }


### PR DESCRIPTION
* simplest solution for this BZ is to simply enforce that the user mentions at least one search critera
* currently none of the consumers call this API without any search criteria ( please confirm )
* This PR does NOT address the problem where using a single criteria can match hundreds of thousands of consumers, but I don't think enforcing a default page limit is a good idea, as it may break existing consumers.
* if this implementation plan is acceptable, we could change [python-rhsm](https://github.com/candlepin/python-rhsm/blob/5426aca93722f562cae7d6245999d6e874d80f04/src/rhsm/connection.py#L1013) to not let owner be optional.
