### PR TITLE
Truncate timestamps on serialization

### DIFF
--- a/server/spec/consumer_resource_spec.rb
+++ b/server/spec/consumer_resource_spec.rb
@@ -308,8 +308,8 @@ describe 'Consumer Resource' do
     owner = create_owner(random_string('owner'))
     user_name = random_string('user')
     client = user_client(owner, user_name)
-    created_date = '2015-05-09T13:23:55.000+0000'
-    checkin_date = '2015-05-19T13:23:55.000+0000'
+    created_date = '2015-05-09T13:23:55+0000'
+    checkin_date = '2015-05-19T13:23:55+0000'
     consumer = client.register(random_string('system'), type=:system, nil, {}, user_name,
               owner['key'], [], [], nil, [], nil, [], created_date, checkin_date)
     consumer['lastCheckin'].should == checkin_date

--- a/server/spec/owner_product_resource_spec.rb
+++ b/server/spec/owner_product_resource_spec.rb
@@ -22,6 +22,8 @@ describe 'Owner Product Resource' do
 
   it 'updates individual product fields' do
     prod = create_product(nil, 'tacos', {:multiplier => 2, :dependentProductIds => [2, 4]})
+    #Ensure the dates are at least one second different
+    sleep 1
     prod2 = create_product(nil, 'enchiladas', {:multiplier => 4})
 
     prod.name.should_not == prod2.name

--- a/server/src/main/java/org/candlepin/jackson/DateSerializer.java
+++ b/server/src/main/java/org/candlepin/jackson/DateSerializer.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.jackson;
+
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+/**
+ * DateSerializer
+ *
+ * This serializer removes milliseconds from Date objects in order to be more compatible with MySql.
+ * The format used is ISO 8601
+ */
+public class DateSerializer extends JsonSerializer<Date> {
+    // This SimpleDateFormat is iso 8601 without milliseconds
+    public static final SimpleDateFormat ISO_8601_WITHOUT_MILLISECONDS =
+            new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
+    @Override
+    public void serialize(Date date, JsonGenerator jgen, SerializerProvider serializerProvider)
+            throws IOException, JsonProcessingException {
+        jgen.writeString(ISO_8601_WITHOUT_MILLISECONDS.format(date));
+    }
+}

--- a/server/src/main/java/org/candlepin/jackson/DateSerializer.java
+++ b/server/src/main/java/org/candlepin/jackson/DateSerializer.java
@@ -14,14 +14,14 @@
  */
 package org.candlepin.jackson;
 
-import java.io.IOException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
+
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 /**
  * DateSerializer
  *

--- a/server/src/main/java/org/candlepin/resteasy/JsonProvider.java
+++ b/server/src/main/java/org/candlepin/resteasy/JsonProvider.java
@@ -19,12 +19,15 @@ import org.candlepin.common.jackson.DynamicPropertyFilter;
 import org.candlepin.common.jackson.HateoasBeanPropertyFilter;
 import org.candlepin.common.jackson.MultiFilter;
 import org.candlepin.config.ConfigProperties;
+import org.candlepin.jackson.DateSerializer;
 
+import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.AnnotationIntrospector;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.introspect.AnnotationIntrospectorPair;
 import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 import com.fasterxml.jackson.datatype.hibernate4.Hibernate4Module;
 import com.fasterxml.jackson.jaxrs.cfg.Annotations;
@@ -34,6 +37,8 @@ import com.google.inject.Inject;
 
 import org.jboss.resteasy.plugins.providers.RegisterBuiltin;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
+
+import java.util.Date;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.Produces;
@@ -70,10 +75,13 @@ public class JsonProvider extends JacksonJsonProvider {
         Hibernate4Module hbm = new Hibernate4Module();
         hbm.enable(Hibernate4Module.Feature.FORCE_LAZY_LOADING);
         mapper.registerModule(hbm);
+        SimpleModule dateModule = new SimpleModule("DateModule", new Version(1, 0, 0, null, null, null));
+        // Ensure our DateSerializer is used for all Date objects
+        dateModule.addSerializer(Date.class, new DateSerializer());
+        mapper.registerModule(dateModule);
         configureHateoasObjectMapper(mapper, indentJson);
         setMapper(mapper);
     }
-
     private void configureHateoasObjectMapper(ObjectMapper mapper, boolean indentJson) {
         mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
 
@@ -101,3 +109,4 @@ public class JsonProvider extends JacksonJsonProvider {
         mapper.setAnnotationIntrospector(pair);
     }
 }
+

--- a/server/src/test/java/org/candlepin/resteasy/JsonProviderTest.java
+++ b/server/src/test/java/org/candlepin/resteasy/JsonProviderTest.java
@@ -15,9 +15,11 @@
 package org.candlepin.resteasy;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import org.candlepin.common.config.Configuration;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationConfig;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -26,6 +28,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
 
 import javax.ws.rs.core.MediaType;
 
@@ -43,6 +48,19 @@ public class JsonProviderTest {
                 SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 
         assertFalse(datesAsTimestamps);
+    }
+
+    // This tests to see that the ObjectMapper serializes Date objects to the proper format
+    @Test
+    public void serializedDateDoesNotIncludeMilliseconds() throws JsonProcessingException {
+        Date now = new Date();  // will be initialized to when it was allocated with millisecond precision
+        SimpleDateFormat iso8601WithoutMilliseconds = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
+        String expectedDate = "\"" + iso8601WithoutMilliseconds.format(now) + "\"";
+        JsonProvider provider = new JsonProvider(config);
+        ObjectMapper mapper = provider.locateMapper(Object.class,
+                MediaType.APPLICATION_JSON_TYPE);
+        String serializedDate = mapper.writeValueAsString(now);
+        assertTrue(serializedDate.equals(expectedDate));
     }
 
 


### PR DESCRIPTION
MySQL does not support milliseconds on time stamps. This has caused numerous issues with our spec tests. This PR removes milliseconds of Date objects on serialization. The dates are serialized to ISO 8601 format less the fractional seconds. This is done on serialization by a custom date serializer to ensure no dates are missed. This change fixes the broken unbind test in master (against MySQL) as well as includes fixes for two spec tests that required milliseconds.

I have checked python-rhsm, nothing there seems to be relying on the presence of milliseconds and as the new format is still ISO 8601 compliant seems to be well tolerated by pythons built-in time/datetime/timedelta functionality. As this would affect all clients and is not configurable it would definitely be worth it to have a second, or even third, set of eyes verify that nothing in python-rhsm breaks as a result of the removal of milliseconds from the serialized dates.

The removal of milliseconds would save a lot of trouble for supporting MySQL, that being said, we do lose the millisecond level of precision (not sure if we really need it anyways).