### PR TITLE
Data eager loading in ConsumerResource.bin

### DIFF
--- a/server/src/main/java/org/candlepin/model/ConsumerCurator.java
+++ b/server/src/main/java/org/candlepin/model/ConsumerCurator.java
@@ -29,6 +29,7 @@ import com.google.inject.persist.Transactional;
 import org.hibernate.Criteria;
 import org.hibernate.EntityMode;
 import org.hibernate.HibernateException;
+import org.hibernate.Hibernate;
 import org.hibernate.Query;
 import org.hibernate.ReplicationMode;
 import org.hibernate.criterion.CriteriaQuery;
@@ -626,6 +627,30 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
             throw new NotFoundException(i18n.tr(
                 "Unit with ID ''{0}'' could not be found.", consumerUuid));
         }
+        return consumer;
+    }
+
+    public Consumer verifyAndLookupConsumerWithEntitlements(
+            String consumerUuid) {
+        Consumer consumer = this.findByUuid(consumerUuid);
+        if (consumer == null) {
+            throw new NotFoundException(i18n.tr(
+                    "Unit with ID ''{0}'' could not be found.", consumerUuid));
+        }
+
+        for (Entitlement e : consumer.getEntitlements()) {
+            Hibernate.initialize(e.getCertificates());
+
+            if (e.getPool() != null) {
+                Hibernate.initialize(e.getPool().getBranding());
+                Hibernate.initialize(e.getPool().getDerivedProvidedProducts());
+                Hibernate.initialize(e.getPool().getProvidedProducts());
+                Hibernate.initialize(e.getPool().getProductAttributes());
+                Hibernate.initialize(e.getPool().getAttributes());
+                Hibernate.initialize(e.getPool().getDerivedProductAttributes());
+            }
+        }
+
         return consumer;
     }
 

--- a/server/src/main/java/org/candlepin/model/Entitlement.java
+++ b/server/src/main/java/org/candlepin/model/Entitlement.java
@@ -18,6 +18,7 @@ import org.candlepin.common.jackson.HateoasInclude;
 
 import com.fasterxml.jackson.annotation.JsonFilter;
 
+import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.ForeignKey;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Index;
@@ -98,7 +99,10 @@ public class Entitlement extends AbstractHibernateObject
     // Not positive this should be mapped here, not all entitlements will have
     // certificates.
     @OneToMany(mappedBy = "entitlement", cascade = CascadeType.ALL)
-    private Set<EntitlementCertificate> certificates = new HashSet<EntitlementCertificate>();
+    @BatchSize(size = 100)
+    private Set<EntitlementCertificate> certificates =
+        new HashSet<EntitlementCertificate>();
+
 
     private Integer quantity;
 

--- a/server/src/main/java/org/candlepin/model/Pool.java
+++ b/server/src/main/java/org/candlepin/model/Pool.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.apache.commons.lang.StringUtils;
+import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.Formula;
 import org.hibernate.annotations.GenericGenerator;
@@ -253,6 +254,7 @@ public class Pool extends AbstractHibernateObject implements Persisted, Owned, N
         joinColumns = {@JoinColumn(name = "pool_id", insertable = false, updatable = false)},
         inverseJoinColumns = {@JoinColumn(name = "product_uuid")}
     )
+    @BatchSize(size = 1000)
     private Set<Product> providedProducts = new HashSet<Product>();
 
     @ManyToMany
@@ -261,6 +263,7 @@ public class Pool extends AbstractHibernateObject implements Persisted, Owned, N
         joinColumns = {@JoinColumn(name = "pool_id", insertable = false, updatable = false)},
         inverseJoinColumns = {@JoinColumn(name = "product_uuid")}
     )
+    @BatchSize(size = 1000)
     private Set<Product> derivedProvidedProducts = new HashSet<Product>();
 
     /**
@@ -282,6 +285,7 @@ public class Pool extends AbstractHibernateObject implements Persisted, Owned, N
     @OneToMany(mappedBy = "pool")
     @Cascade({org.hibernate.annotations.CascadeType.ALL,
         org.hibernate.annotations.CascadeType.DELETE_ORPHAN})
+    @BatchSize(size = 1000)
     private Set<PoolAttribute> attributes = new HashSet<PoolAttribute>();
 
     @OneToMany(mappedBy = "pool", cascade = CascadeType.ALL)
@@ -315,6 +319,7 @@ public class Pool extends AbstractHibernateObject implements Persisted, Owned, N
         inverseJoinColumns = @JoinColumn(name = "branding_id"))
     @Cascade({org.hibernate.annotations.CascadeType.ALL,
         org.hibernate.annotations.CascadeType.DELETE_ORPHAN})
+    @BatchSize(size = 1000)
     private Set<Branding> branding = new HashSet<Branding>();
 
     @Version

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -1453,9 +1453,10 @@ public class ConsumerResource {
         Date entitleDate = ResourceDateParser.parseDateString(entitleDateStr);
 
         // Verify consumer exists:
-        Consumer consumer = consumerCurator.verifyAndLookupConsumer(consumerUuid);
+        Consumer consumer = consumerCurator.verifyAndLookupConsumerWithEntitlements(consumerUuid);
 
         log.debug("Consumer (post verify): {}", consumer);
+
         try {
             // I hate double negatives, but if they have accepted all
             // terms, we want comeToTerms to be true.

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
@@ -359,7 +359,7 @@ public class ConsumerResourceTest {
 
         when(c.getOwner()).thenReturn(o);
         when(sa.hasUnacceptedSubscriptionTerms(eq(o))).thenReturn(false);
-        when(cc.verifyAndLookupConsumer(eq("fakeConsumer"))).thenReturn(c);
+        when(cc.verifyAndLookupConsumerWithEntitlements(eq("fakeConsumer"))).thenReturn(c);
         when(e.bindByProducts(any(AutobindData.class))).thenReturn(null);
 
         ConsumerResource cr = new ConsumerResource(cc, null,
@@ -384,7 +384,7 @@ public class ConsumerResourceTest {
         when(c.getOwner()).thenReturn(o);
         when(cip.getProductId()).thenReturn("product-foo");
         when(sa.hasUnacceptedSubscriptionTerms(eq(o))).thenReturn(false);
-        when(cc.verifyAndLookupConsumer(eq("fakeConsumer"))).thenReturn(c);
+        when(cc.verifyAndLookupConsumerWithEntitlements(eq("fakeConsumer"))).thenReturn(c);
 
         ConsumerResource cr = new ConsumerResource(cc, null, null, sa,
             null, null, null, null, null, null, null, null, null, null,
@@ -453,7 +453,7 @@ public class ConsumerResourceTest {
     @Test(expected = NotFoundException.class)
     public void testBindByPoolBadConsumerUuid() throws Exception {
         ConsumerCurator consumerCurator = mock(ConsumerCurator.class);
-        when(consumerCurator.verifyAndLookupConsumer(any(String.class)))
+        when(consumerCurator.verifyAndLookupConsumerWithEntitlements(any(String.class)))
             .thenThrow(new NotFoundException(""));
         ConsumerResource consumerResource = new ConsumerResource(consumerCurator, null,
             null, null, null, null, null, i18n, null, null, null,


### PR DESCRIPTION
Improving performance of bind() operation by introducing Hibernate batching and adding a new method to Consumer currator that retrieves information related to the Consumer more eagerly in lower amount of queries