### PR TITLE
Resolving a timing issue in hosted spec tests

### DIFF
--- a/server/spec/candlepin_scenarios.rb
+++ b/server/spec/candlepin_scenarios.rb
@@ -211,7 +211,7 @@ module CandlepinMethods
       ensure_hostedtest_resource
       sub = get_hostedtest_subscription(pool.subscriptionId)
       update_hostedtest_subscription(sub)
-      @cp.refresh_pools(pool['owner']['key'], true)
+      @cp.refresh_pools(pool['owner']['key'])
     end
   end
 


### PR DESCRIPTION
Fix to timing issue [1] where entitlement_certificate_v3_spec.'encoded many content urls' has been failing sometimes on [2]. The problem was that async refresh_pool interleaved with delete_owner (our Ruby cleanup method) and refresh_pool created a new pool that caused [2].  You can see the interleaved threads [3].

The refresh_pool async call that caused this was entitlement_certificate_v3_spec.refresh_upstream_subscription. This can be deduced when enabling 'logging' of refresh pools with async param [4]


[1] https://rhsm-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/candlepin-pullrequest-spectests-hosted/34/
[2] ERROR: update or delete on table "cp_owner" violates foreign key constraint "fk_pool_owner" on table "cp_pool"  Detail: Key (id)=(2c91809a51642b0e0151642ba7b1011a) is still referenced from table "cp_pool"
[3] 
```
2015-12-02 19:29:40,819 [thread=http-bio-8443-exec-6] [req=d304c0ee-83d0-4b7c-9c6d-83a4f402fedf, org=] INFO  org.candlepin.resource.OwnerResource - Deleting pool:
2015-12-02 19:29:40,842 [thread=QuartzScheduler_Worker-8] [job=refresh_pools_75426ea6-0390-4b91-8d11-748fa0fcd6c1, org=] INFO  org.candlepin.policy.js.pool.PoolRules - Creating new master pool:
2015-12-02 19:29:41,132 [thread=QuartzScheduler_Worker-8] [job=refresh_pools_75426ea6-0390-4b91-8d11-748fa0fcd6c1, org=] INFO  org.candlepin.controller.CandlepinPoolManager - Refresh pools for owner: test_owner-NnoJUSaj completed in: 1571ms
2015-12-02 19:29:41,748 [thread=http-bio-8443-exec-6] [req=d304c0ee-83d0-4b7c-9c6d-83a4f402fedf, org=] INFO  org.candlepin.resource.OwnerResource - Deleting owner: Owner [id: 2c91809a51642b0e0151642ba7b1011a, key: test_owner-NnoJUSaj]
```
[4]
``` 
....
[refresh_pools async=false][refresh_pools async=false][refresh_pools async=false]  verify branding info is correct in json blob
[refresh_pools async=false][refresh_pools async=false][refresh_pools async=true]  encoded the content urls
[refresh_pools async=false][refresh_pools async=false]Starting encoded many content urls  encoded many content urls
....
```