### PR TITLE
1287609: Fixing race condition

### DIFF
--- a/common/src/main/java/org/candlepin/common/jackson/DynamicPropertyFilter.java
+++ b/common/src/main/java/org/candlepin/common/jackson/DynamicPropertyFilter.java
@@ -32,27 +32,26 @@ import java.util.List;
  */
 public class DynamicPropertyFilter extends CheckableBeanPropertyFilter {
 
-    private List<String> path = new ArrayList<String>(10);
-
     public boolean isSerializable(Object obj, JsonGenerator jsonGenerator,
         SerializerProvider serializerProvider, PropertyWriter writer) {
 
         DynamicFilterData filterData = ResteasyProviderFactory.getContextData(DynamicFilterData.class);
 
         if (filterData != null) {
-            this.path.clear();
-            this.path.add(0, writer.getName());
+            List<String> path = new ArrayList<String>(10);
+            path.clear();
+            path.add(0, writer.getName());
 
             // Build full path from the context...
             JsonStreamContext context = jsonGenerator.getOutputContext();
             while ((context = context.getParent()) != null) {
                 String cname = context.getCurrentName();
                 if (cname != null) {
-                    this.path.add(0, cname);
+                    path.add(0, cname);
                 }
             }
 
-            return !filterData.isAttributeExcluded(this.path);
+            return !filterData.isAttributeExcluded(path);
         }
 
         // Allow serialization by default

--- a/common/src/test/java/org/candlepin/common/jackson/DynamicPropertyFilterTest.java
+++ b/common/src/test/java/org/candlepin/common/jackson/DynamicPropertyFilterTest.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.common.jackson;
+
+import static org.mockito.Matchers.anyList;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonStreamContext;
+import com.fasterxml.jackson.databind.ser.PropertyWriter;
+
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Arrays;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DynamicPropertyFilterTest {
+
+    @Mock
+    private DynamicFilterData dynamicFilterData;
+
+    @Mock
+    private PropertyWriter writer;
+
+    @Mock
+    private JsonGenerator jsonGenerator;
+
+    @Mock
+    private JsonStreamContext context;
+
+    @Before
+    public void prepareMocks() {
+        when(jsonGenerator.getOutputContext()).thenReturn(context);
+        when(context.getParent()).thenReturn(context).thenReturn(null);
+        when(context.getCurrentName()).thenReturn("CONTEXT_NAME_1");
+        when(writer.getName()).thenReturn("WRITER_NAME");
+    }
+
+    @Test
+    public void emptyFilterData() {
+        ResteasyProviderFactory.pushContext(DynamicFilterData.class, null);
+        DynamicPropertyFilter propertyFilter = new DynamicPropertyFilter();
+        Assert.assertTrue(propertyFilter.isSerializable(null, jsonGenerator, null, writer));
+        verifyZeroInteractions(jsonGenerator, writer);
+    }
+
+    @Test
+    public void nonEmptyIsSerializable() {
+        //Implicitly return true
+        when(dynamicFilterData.isAttributeExcluded(anyList()))
+            .thenReturn(true);
+        when(dynamicFilterData.isAttributeExcluded(Arrays.asList("CONTEXT_NAME_1", "WRITER_NAME")))
+            .thenReturn(false);
+
+        ResteasyProviderFactory.pushContext(DynamicFilterData.class, dynamicFilterData);
+        DynamicPropertyFilter propertyFilter = new DynamicPropertyFilter();
+        Assert.assertTrue(propertyFilter.isSerializable(null, jsonGenerator, null, writer));
+        verify(jsonGenerator).getOutputContext();
+        verify(context, times(2)).getParent();
+        verify(context).getCurrentName();
+    }
+
+    @Test
+    public void nonEmptyIsNotSerializable() {
+        when(dynamicFilterData.isAttributeExcluded(Arrays.asList("CONTEXT_NAME_1", "WRITER_NAME")))
+            .thenReturn(true);
+
+        ResteasyProviderFactory.pushContext(DynamicFilterData.class, dynamicFilterData);
+        DynamicPropertyFilter propertyFilter = new DynamicPropertyFilter();
+        Assert.assertFalse(propertyFilter.isSerializable(null, jsonGenerator, null, writer));
+        verify(jsonGenerator).getOutputContext();
+        verify(context, times(2)).getParent();
+        verify(context).getCurrentName();
+    }
+
+}


### PR DESCRIPTION
Making DynamicPropertyFilter thread safe and adding a few unit tests for it since they were missing. Because this class wasn't thread safe a user could hit serialization server side error when invoking 
```
consumers/<UUID>/entitlements?exclude=certificates.key&exclude=certificates.cert
```