### PR TITLE
(0.9.51) Disabling spec tests that are intended for standalone mode

### DIFF
--- a/server/spec/derived_product_spec.rb
+++ b/server/spec/derived_product_spec.rb
@@ -102,6 +102,7 @@ describe 'Derived Products' do
   # SKU are available, the guest autobind will have it's host autobind to the derived and
   # prefer it's virt_only sub-pool to instance based.
   it 'prefers a host-autobind virt-only sub-pool to instance based pool during guest autobind' do
+    pending("candlepin running in standalone mode") if is_hosted?
     # create instance based subscription:
     instance_product = create_product(nil, nil, {
       :attributes => {
@@ -130,6 +131,7 @@ describe 'Derived Products' do
   end
 
   it 'transfers sub-product data to main pool' do
+    pending("candlepin running in standalone mode") if is_hosted?
     @main_pool['derivedProductId'].should == @derived_product['id']
     @main_pool['derivedProvidedProducts'].size.should == 1
     @main_pool['derivedProvidedProducts'][0]['productId'].should ==

--- a/server/spec/guestid_resource_spec.rb
+++ b/server/spec/guestid_resource_spec.rb
@@ -140,6 +140,8 @@ describe 'GuestId Resource' do
   end
 
   it 'should allow a single guest to be updated and revokes host-limited ents' do
+    # bonus pools are created on refresh in hosted mode.
+    pending("candlepin running in standalone mode") if is_hosted?
     uuid1 = random_string('system.uuid')
     guests = [{:guestId => uuid1}]
 
@@ -198,6 +200,8 @@ describe 'GuestId Resource' do
   end
 
   it 'should allow a single guest to be updated and not revoke host-limited ents' do
+    # bonus pools are created on refresh in hosted mode.
+    pending("candlepin running in standalone mode") if is_hosted?
     uuid1 = random_string('system.uuid')
     guests = [{:guestId => uuid1}]
 

--- a/server/spec/import_spec.rb
+++ b/server/spec/import_spec.rb
@@ -39,6 +39,8 @@ describe 'Import', :serial => true do
   end
 
   it 'ignores multiplier for pool quantity' do
+    # multiplier will not be ignored in hosted mode.
+    pending("candlepin running in standalone mode") if is_hosted?
     pools = @import_owner_client.list_pools({:owner => @import_owner['id']})
     pools.length.should == 6
 
@@ -48,7 +50,10 @@ describe 'Import', :serial => true do
     # remove unmapped guest pool, not part of test
     filter_unmapped_guest_pools(pools)
 
+    puts pools.size()
+
     pools.each do |p|
+      puts p['subscriptionSubKey']
       p['quantity'].should == 1
     end
   end


### PR DESCRIPTION
Some spec tests were failing in 0.9.51 in hosted mode that were intended to test standalone functionality. Only run these tests in standalone mode.