### PR TITLE
Port Developer Subscriptions from master to 0.9.51

### DIFF
--- a/server/bin/test_data.json
+++ b/server/bin/test_data.json
@@ -1756,6 +1756,20 @@
             "provided_products": [
                 "900"
             ]
+        },
+        {
+            "name": "Dev Product",
+            "id": "dev-sku-product",
+            "type": "MKT",
+            "skip_subs": "true",
+            "attributes": {
+                "multi-entitlement": "yes",
+                "support_level" : "Premium",
+                "support_type" : "Level 3",
+                "expires_after" : "75"
+            },
+            "provided_products": [
+            ]
         }
     ]
 }

--- a/server/spec/consumer_resource_dev_spec.rb
+++ b/server/spec/consumer_resource_dev_spec.rb
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+require 'spec_helper'
+require 'candlepin_scenarios'
+require 'rexml/document'
+
+describe 'Consumer Dev Resource' do
+
+  include CandlepinMethods
+
+  before(:each) do
+    @owner = create_owner random_string('test_owner')
+    @username = random_string("user")
+    @consumername = random_string("dev_consumer")
+    @user = user_client(@owner, @username)
+
+    # active subscription to allow this all to work
+    active_prod = create_product()
+    @active_sub = @cp.create_subscription(@owner['key'], active_prod.id, 10)
+    @cp.refresh_pools(@owner['key'])
+    pools = @cp.list_owner_pools(@owner['key'])
+    pools.length.should == 1
+
+  end
+
+  it 'should create entitlement to newly created dev pool' do
+    pending("candlepin running in standalone mode") if not is_hosted?
+    @dev_product = create_product("dev_product",
+                                  "Dev Product",
+                                  {:attributes => { :expires_after => "60"}})
+    @p_product1 = create_product("p_product_1",
+                                  "Provided Product 1")
+    @p_product2 = create_product("p_product",
+                                  "Provided Product 2")
+    @consumer = consumer_client(@user, @consumername, :system, 'dev_user', facts= {:dev_sku => "dev_product"})
+    installed = [
+        {'productId' => @p_product1.id, 'productName' => @p_product1.name},
+        {'productId' => @p_product2.id, 'productName' => @p_product2.name}]
+    @consumer.update_consumer({:installedProducts => installed})
+
+    @consumer.consume_product()
+    entitlements = @consumer.list_entitlements()
+    entitlements.length.should == 1
+    new_pool = entitlements[0].pool
+    new_pool.type.should == "DEVELOPMENT"
+    new_pool.productId.should == "dev_product"
+    new_pool.providedProducts.length.should == 2
+  end
+
+end

--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -475,8 +475,16 @@ public class CandlepinPoolManager implements PoolManager {
 
         List<Entitlement> entitlements = new LinkedList<Entitlement>();
 
-        List<PoolQuantity> bestPools = getBestPools(consumer, productIds,
-            entitleDate, owner, null, fromPools);
+        List<PoolQuantity> bestPools = new ArrayList<PoolQuantity>();
+        if (consumer != null && consumer.isDev() && !fromPools.isEmpty()) {
+            String poolId = fromPools.iterator().next();
+            PoolQuantity pq = new PoolQuantity(poolCurator.find(poolId), 1);
+            bestPools.add(pq);
+        }
+        else {
+            bestPools = getBestPools(consumer, productIds,
+                entitleDate, owner, null, fromPools);
+        }
 
         if (bestPools == null) {
             List<String> fullList = new ArrayList<String>();
@@ -703,7 +711,6 @@ public class CandlepinPoolManager implements PoolManager {
         String serviceLevelOverride, Collection<String> fromPools)
         throws EntitlementRefusedException {
 
-        boolean hasFromPools = fromPools != null && !fromPools.isEmpty();
         ValidationResult failedResult = null;
 
         Date activePoolDate = entitleDate;
@@ -1409,6 +1416,10 @@ public class CandlepinPoolManager implements PoolManager {
         PageRequest pageRequest) {
         // Only postfilter if we have to
         boolean postFilter = consumer != null || key != null;
+        if (consumer != null && !consumer.isDev()) {
+            filters.addAttributeFilter(Pool.DEVELOPMENT_POOL_ATTRIBUTE, "!true");
+        }
+
         Page<List<Pool>> page = this.poolCurator.listAvailableEntitlementPools(consumer,
             owner, productId, activeOn, activeOnly, filters, pageRequest, postFilter);
 

--- a/server/src/main/java/org/candlepin/model/Consumer.java
+++ b/server/src/main/java/org/candlepin/model/Consumer.java
@@ -21,6 +21,7 @@ import org.candlepin.util.Util;
 
 import com.fasterxml.jackson.annotation.JsonFilter;
 
+import org.apache.commons.lang.StringUtils;
 import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.ForeignKey;
 import org.hibernate.annotations.Formula;
@@ -696,4 +697,9 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
             return entitlementVersion != null && entitlementVersion.startsWith("3.");
         }
     }
+
+    public boolean isDev() {
+        return !StringUtils.isEmpty(getFact("dev_sku"));
+    }
+
 }

--- a/server/src/main/java/org/candlepin/policy/js/entitlement/AbstractEntitlementRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/entitlement/AbstractEntitlementRules.java
@@ -287,6 +287,9 @@ public abstract class AbstractEntitlementRules implements Enforcer {
             Consumer c = entitlement.getConsumer();
             postUnbindVirtLimit(postHelper, entitlement, pool, c, attributes);
         }
+        if (pool.isDevelopmentPool()) {
+            poolCurator.delete(pool);
+        }
     }
 
     private void postUnbindVirtLimit(PoolHelper postHelper,

--- a/server/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRulesTranslator.java
+++ b/server/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRulesTranslator.java
@@ -69,6 +69,10 @@ public class EntitlementRulesTranslator {
             msg = i18n.tr("Pool ''{0}'' is restricted to guests running on host: ''{1}''.",
                 pool.getId(), host);
         }
+        else if (errorKey.equals("consumer.does.not.match.pool.consumer.requirement")) {
+            msg = i18n.tr("Pool ''{0}'' is restricted to a specific consumer.",
+                pool.getId());
+        }
         else if (errorKey.equals("pool.not.available.to.manifest.consumers")) {
             msg = i18n.tr("Pool not available to subscription management " +
                     "applications.");

--- a/server/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
@@ -253,6 +253,9 @@ public class PoolRules {
                 // Should be filtered out before calling, but just in case we skip it:
                 continue;
             }
+            if (p.isDevelopmentPool()) {
+                continue;
+            }
 
             if (p.getSourceStack() != null) {
                 Consumer c = p.getSourceStack().getSourceConsumer();

--- a/server/src/test/java/org/candlepin/controller/PoolManagerFunctionalTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerFunctionalTest.java
@@ -14,11 +14,11 @@
  */
 package org.candlepin.controller;
 
-import static org.apache.commons.collections.CollectionUtils.containsAny;
-import static org.apache.commons.collections.TransformerUtils.invokerTransformer;
+import static org.apache.commons.collections.CollectionUtils.*;
+import static org.apache.commons.collections.TransformerUtils.*;
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.reset;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
 
 import org.candlepin.audit.Event;
 import org.candlepin.audit.EventSink;
@@ -26,6 +26,7 @@ import org.candlepin.common.paging.Page;
 import org.candlepin.common.paging.PageRequest;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerCurator;
+import org.candlepin.model.ConsumerInstalledProduct;
 import org.candlepin.model.ConsumerType;
 import org.candlepin.model.ConsumerType.ConsumerTypeEnum;
 import org.candlepin.model.ConsumerTypeCurator;
@@ -63,6 +64,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -481,5 +483,69 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
                 bind(EventSink.class).toInstance(eventSink);
             }
         };
+    }
+
+    @Test
+    public void testListConditionDevPools() {
+        Owner owner = createOwner();
+        Product p = new Product("test-product", "Test Product");
+        productCurator.create(p);
+
+        Pool pool1 = createPoolAndSub(owner, p, 10L,
+                TestUtil.createDate(2000, 3, 2), TestUtil.createDate(2050, 3, 2));
+        pool1.addAttribute(new PoolAttribute(Pool.DEVELOPMENT_POOL_ATTRIBUTE, "true"));
+        poolCurator.create(pool1);
+        Pool pool2 = createPoolAndSub(owner, p, 10L,
+                TestUtil.createDate(2000, 3, 2), TestUtil.createDate(2050, 3, 2));
+        poolCurator.create(pool2);
+
+        Consumer devSystem = new Consumer("dev", "user", owner, systemType);
+        devSystem.setFact("dev_sku", p.getId());
+        devSystem.addInstalledProduct(new ConsumerInstalledProduct(p.getId(), p.getName()));
+        Consumer nonDevSystem = new Consumer("system", "user", owner, systemType);
+        nonDevSystem.addInstalledProduct(new ConsumerInstalledProduct(p.getId(), p.getName()));
+
+        Page<List<Pool>> results = poolManager.listAvailableEntitlementPools(devSystem, null,
+                owner, null, null, true, true, new PoolFilterBuilder(), new PageRequest());
+        assertEquals(2, results.getPageData().size());
+
+        results = poolManager.listAvailableEntitlementPools(nonDevSystem, null,
+                owner, null, null, true, true, new PoolFilterBuilder(), new PageRequest());
+        assertEquals(1, results.getPageData().size());
+        Pool found2 = results.getPageData().get(0);
+        assertEquals(pool2, found2);
+    }
+
+    @Test
+    public void testDevPoolRemovalAtUnbind() throws EntitlementRefusedException {
+        Owner owner = createOwner();
+        Product p = new Product("test-product", "Test Product");
+        productCurator.create(p);
+
+        Consumer devSystem = new Consumer("dev", "user", owner, systemType);
+        devSystem.setFact("dev_sku", p.getId());
+        devSystem.addInstalledProduct(new ConsumerInstalledProduct(p.getId(), p.getName()));
+        consumerCurator.create(devSystem);
+
+        Pool pool1 = createPoolAndSub(owner, p, 10L,
+                TestUtil.createDate(2000, 3, 2), TestUtil.createDate(2050, 3, 2));
+        pool1.addAttribute(new PoolAttribute(Pool.DEVELOPMENT_POOL_ATTRIBUTE, "true"));
+        pool1.addAttribute(new PoolAttribute(Pool.REQUIRES_CONSUMER_ATTRIBUTE, devSystem.getUuid()));
+        poolCurator.create(pool1);
+        Pool pool2 = createPoolAndSub(owner, p, 10L,
+                TestUtil.createDate(2000, 3, 2), TestUtil.createDate(2050, 3, 2));
+        poolCurator.create(pool2);
+        List<String> possPools = new ArrayList<String>();
+        possPools.add(pool1.getId());
+
+        AutobindData ad = new AutobindData(devSystem);
+        ad.setPossiblePools(possPools);
+        List<Entitlement> results = poolManager.entitleByProducts(ad);
+        assertEquals(1, results.size());
+        assertEquals(results.get(0).getPool(), pool1);
+
+        poolManager.revokeEntitlement(results.get(0));
+        assertNull(poolCurator.find(pool1.getId()));
+        assertNotNull(poolCurator.find(pool2.getId()));
     }
 }

--- a/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -319,6 +319,25 @@ public class PoolManagerTest {
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Test
+    public void testRefreshPoolsSkipsDevelopmentPools() {
+        List<Subscription> subscriptions = Util.newList();
+        List<Pool> pools = Util.newList();
+        Pool p = TestUtil.createPool(TestUtil.createProduct());
+        p.setSourceSubscription(null);
+
+        // Mock a development pool
+        p.setAttribute("dev_pool", "true");
+
+        pools.add(p);
+        mockSubsList(subscriptions);
+
+        mockPoolsList(pools);
+        this.manager.getRefresher().add(getOwner()).run();
+        verify(this.manager, never()).deletePool(same(p));
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @Test
     public void testRefreshPoolsSortsStackDerivedPools() {
         List<Subscription> subscriptions = Util.newList();
         List<Pool> pools = Util.newList();

--- a/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
@@ -1080,6 +1081,54 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         assertEquals(expected, result);
     }
 
+    @Test
+    public void testLookupDevPoolForConsumer() throws Exception {
+        Pool pool = createPoolAndSub(owner, product, -1L, TestUtil.createDate(2010, 3, 2),
+            TestUtil.createDate(Calendar.getInstance().get(Calendar.YEAR) + 1, 3, 2));
+        pool.setAttribute("requires_consumer", consumer.getUuid());
+        pool.setAttribute("dev_pool", "true");
+        poolCurator.create(pool);
+
+        Pool found = poolCurator.findDevPool(consumer, product.getId());
+        assertNotNull(found);
+        assertEquals(pool.getId(), found.getId());
+    }
+
+    @Test
+    public void testDevPoolForConsumerNotFoundReturnsNullWhenNoMatchOnConsumer() throws Exception {
+        Pool pool = createPoolAndSub(owner, product, -1L, TestUtil.createDate(2010, 3, 2),
+            TestUtil.createDate(Calendar.getInstance().get(Calendar.YEAR) + 1, 3, 2));
+        pool.setAttribute("requires_consumer", "does-not-exist");
+        pool.setAttribute("dev_pool", "true");
+        poolCurator.create(pool);
+
+        Pool found = poolCurator.findDevPool(consumer, product.getId());
+        assertNull(found);
+    }
+
+    @Test
+    public void testDevPoolForConsumerNotFoundReturnsNullWhenNoMatchOnDevPool() throws Exception {
+        Pool pool = createPoolAndSub(owner, product, -1L, TestUtil.createDate(2010, 3, 2),
+            TestUtil.createDate(Calendar.getInstance().get(Calendar.YEAR) + 1, 3, 2));
+        pool.setAttribute("requires_consumer", consumer.getUuid());
+        poolCurator.create(pool);
+
+        Pool found = poolCurator.findDevPool(consumer, product.getId());
+        assertNull(found);
+    }
+
+    @Test
+    public void testDevPoolForConsumerNotFoundReturnsNullWhenNoMatchOnProductId() throws Exception {
+        Pool pool = createPoolAndSub(owner, product, -1L, TestUtil.createDate(2010, 3, 2),
+            TestUtil.createDate(Calendar.getInstance().get(Calendar.YEAR) + 1, 3, 2));
+        pool.setAttribute("requires_consumer", consumer.getUuid());
+        pool.setAttribute("dev_pool", "true");
+        poolCurator.create(pool);
+
+        Pool found = poolCurator.findDevPool(consumer, "does-not-exist");
+        assertNull(found);
+    }
+
     private Product generateProduct(String id, String name) {
         Product product = TestUtil.createProduct(id, name);
         this.productCurator.create(product);
@@ -1102,4 +1151,5 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         pool.setSourceSubscription(new SourceSubscription(subId, "master"));
         return poolCurator.create(pool);
     }
+
 }

--- a/server/src/test/java/org/candlepin/policy/PoolRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/PoolRulesTest.java
@@ -50,6 +50,7 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashSet;
@@ -1105,6 +1106,18 @@ public class PoolRulesTest {
         PoolUpdate update = updates.get(0);
         assertTrue(update.getOrderChanged());
         assertEquals("123", update.getPool().getAccountNumber());
+    }
+
+    @Test
+    public void productNameChangedDevPool() {
+        Pool p = TestUtil.createPool(TestUtil.createProduct());
+        p.setSourceSubscription(null);
+        p.setAttribute(Pool.DEVELOPMENT_POOL_ATTRIBUTE, "true");
+        List<Pool> floatingPools = new ArrayList<Pool>();
+        floatingPools.add(p);
+
+        List<PoolUpdate> updates = this.poolRules.updatePools(floatingPools);
+        assertEquals(0, updates.size());
     }
 
 }

--- a/server/src/test/java/org/candlepin/policy/js/compliance/StatusReasonMessageGeneratorTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/compliance/StatusReasonMessageGeneratorTest.java
@@ -23,6 +23,7 @@ import org.candlepin.model.Entitlement;
 import org.candlepin.model.Owner;
 import org.candlepin.model.Pool;
 import org.candlepin.model.ProductPoolAttribute;
+import org.candlepin.model.ProvidedProduct;
 import org.candlepin.test.TestUtil;
 
 import org.junit.Before;
@@ -33,6 +34,7 @@ import org.xnap.commons.i18n.I18nFactory;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
@@ -196,7 +198,7 @@ public class StatusReasonMessageGeneratorTest {
     }
 
     private Entitlement mockEntitlement(Consumer consumer, String productId, String name) {
-        Pool p = new Pool(owner, productId, name, null,
+        Pool p = new Pool(owner, productId, name, new HashSet<ProvidedProduct>(),
             new Long(1000), TestUtil.createDate(2000, 1, 1),
             TestUtil.createDate(2050, 1, 1), "1000", "1000", "1000");
         Entitlement e = new Entitlement(p, consumer, 1);

--- a/server/src/test/java/org/candlepin/resource/OwnerResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/OwnerResourceTest.java
@@ -510,6 +510,35 @@ public class OwnerResourceTest extends DatabaseTestFixture {
     }
 
 
+    @Test
+    public void testCanFilterOutDevPoolsByAttribute() throws Exception {
+        Principal principal = setupPrincipal(owner, Access.ALL);
+
+        Product p = TestUtil.createProduct();
+        productCurator.create(p);
+        Pool pool1 = TestUtil.createPool(owner, p);
+        pool1.setAttribute(Pool.DEVELOPMENT_POOL_ATTRIBUTE, "true");
+        poolCurator.create(pool1);
+
+        Product p2 = TestUtil.createProduct();
+        productCurator.create(p2);
+        Pool pool2 = TestUtil.createPool(owner, p2);
+        poolCurator.create(pool2);
+
+        List<KeyValueParameter> params = new ArrayList<KeyValueParameter>();
+        List<Pool> pools = ownerResource.listPools(owner.getKey(), null,
+            null, null, true, null, null, params, principal, null);
+        assertEquals(2, pools.size());
+
+        params = new ArrayList<KeyValueParameter>();
+        params.add(createKeyValueParam(Pool.DEVELOPMENT_POOL_ATTRIBUTE, "!true"));
+        pools = ownerResource.listPools(owner.getKey(), null,
+            null, null, true, null, null, params, principal, null);
+        assertEquals(1, pools.size());
+        assertEquals(pool2, pools.get(0));
+    }
+
+
     @Test(expected = NotFoundException.class)
     public void ownerAdminCannotAccessAnotherOwnersPools() {
         Owner evilOwner = new Owner("evilowner");

--- a/server/src/test/java/org/candlepin/test/TestUtil.java
+++ b/server/src/test/java/org/candlepin/test/TestUtil.java
@@ -94,6 +94,7 @@ public class TestUtil {
     public static Consumer createConsumer(Owner owner) {
         Consumer consumer = new Consumer("testconsumer" + randomInt(), "User",
             owner, createConsumerType());
+        consumer.setCreated(new Date());
         consumer.setFact("foo", "bar");
         consumer.setFact("foo1", "bar1");
 


### PR DESCRIPTION
This patch backports the developer subscription feature from the
master branch. This is a net new commit since the code in master
was added in a bunch of different commits and the merge was not
very smooth.

In hosted mode, a developer subscription will be granted to any
consumer during autobind that will cover all of the consumer's
installed products. An owner must have and active entitlement and
a match must be made on the dev_sku specified by the consumer
in order for the entitlement to be granted. The developer
entitlement comes from a special pool that is created
for that consumer only and will be deleted along with the
entitlement on manual removal or expiry. Multiple runs of the
auto-attach process that detect a change in coverage, will cause
the entitlement/pool to be removed and a new one created. The
duration of the entitlement/pool will be the consumer registration
date + expires_after duration attribute on the dev_sku product.