### PR TITLE
Sets timezone to UTC for date time serialization

### DIFF
--- a/server/src/main/java/org/candlepin/jackson/DateSerializer.java
+++ b/server/src/main/java/org/candlepin/jackson/DateSerializer.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.TimeZone;
 /**
  * DateSerializer
  *
@@ -30,8 +31,12 @@ import java.util.Date;
  */
 public class DateSerializer extends JsonSerializer<Date> {
     // This SimpleDateFormat is iso 8601 without milliseconds
-    public static final SimpleDateFormat ISO_8601_WITHOUT_MILLISECONDS =
-            new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
+    public static final SimpleDateFormat ISO_8601_WITHOUT_MILLISECONDS;
+    static {
+        ISO_8601_WITHOUT_MILLISECONDS = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
+        ISO_8601_WITHOUT_MILLISECONDS.setTimeZone(TimeZone.getTimeZone("UTC"));
+    }
+
     @Override
     public void serialize(Date date, JsonGenerator jgen, SerializerProvider serializerProvider)
             throws IOException, JsonProcessingException {


### PR DESCRIPTION
This sets the timezone to be used for our serialization format to UTC.