### PR TITLE
1292877: Do not delete dev pool before we are done with it

### DIFF
--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -1546,6 +1546,7 @@ public class CandlepinPoolManager implements PoolManager {
         pool.getEntitlements().remove(entitlement);
         poolCurator.merge(pool);
         entitlementCurator.delete(entitlement);
+
         Event event = eventFactory.entitlementDeleted(entitlement);
         if (!entitlement.isValid() &&
                 entitlement.getPool().isUnmappedGuestPool() &&
@@ -1596,6 +1597,12 @@ public class CandlepinPoolManager implements PoolManager {
             // and regenerate those to remove the content sets.
             // Lazy regeneration is ok here.
             this.regenerateCertificatesOf(entitlementCurator.listModifying(entitlement), true);
+        }
+
+        // If we are deleting a developer entitlement, be sure to delete the
+        // associated pool as well.
+        if (pool.isDevelopmentPool()) {
+            poolCurator.delete(pool);
         }
 
         log.info("Revoked entitlement: {}", entitlement.getId());

--- a/server/src/main/java/org/candlepin/policy/js/entitlement/AbstractEntitlementRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/entitlement/AbstractEntitlementRules.java
@@ -286,9 +286,6 @@ public abstract class AbstractEntitlementRules implements Enforcer {
             Consumer c = entitlement.getConsumer();
             postUnbindVirtLimit(postHelper, entitlement, pool, c, attributes);
         }
-        if (pool.isDevelopmentPool()) {
-            poolCurator.delete(pool);
-        }
     }
 
     private void postUnbindVirtLimit(PoolHelper postHelper,


### PR DESCRIPTION
Since we were deleting the dev pool before the derived products
were loaded (lazy), we couldn't look them up when addressing
modified entitlements.

Moved the dev pool deletion to the end of the remove entitlement
process to be sure we were done with it.