### PR TITLE
1295452: Look up dev sku by consumer only

### DIFF
--- a/server/spec/consumer_resource_dev_spec.rb
+++ b/server/spec/consumer_resource_dev_spec.rb
@@ -20,30 +20,51 @@ describe 'Consumer Dev Resource' do
     pools = @cp.list_owner_pools(@owner['key'])
     pools.length.should == 1
 
-  end
-
-  it 'should create entitlement to newly created dev pool' do
-    pending("candlepin running in standalone mode") if not is_hosted?
     @dev_product = create_product("dev_product",
+                                  "Dev Product",
+                                  {:attributes => { :expires_after => "60"}})
+    @dev_product_2 = create_product("2nd_dev_product",
                                   "Dev Product",
                                   {:attributes => { :expires_after => "60"}})
     @p_product1 = create_product("p_product_1",
                                   "Provided Product 1")
     @p_product2 = create_product("p_product",
                                   "Provided Product 2")
-    @consumer = consumer_client(@user, @consumername, :system, 'dev_user', facts= {:dev_sku => "dev_product"})
+    @consumer = consumer_client(@user, @consumername, :system, 'dev_user', facts = {:dev_sku => "dev_product"})
     installed = [
         {'productId' => @p_product1.id, 'productName' => @p_product1.name},
         {'productId' => @p_product2.id, 'productName' => @p_product2.name}]
     @consumer.update_consumer({:installedProducts => installed})
+  end
 
+  it 'should create entitlement to newly created dev pool' do
+    pending("candlepin running in standalone mode") if not is_hosted?
+    auto_attach_and_verify_dev_product("dev_product")
+  end
+
+  it 'should create new entitlement when dev pool already exists' do
+    pending("candlepin running in standalone mode") if not is_hosted?
+    initial_ent = auto_attach_and_verify_dev_product("dev_product")
+    auto_attach_and_verify_dev_product("dev_product", initial_ent.id)
+  end
+
+  it 'should create new entitlement when dev_sku attribute changes' do
+    pending("candlepin running in standalone mode") if not is_hosted?
+    ent = auto_attach_and_verify_dev_product("dev_product")
+    @consumer.update_consumer({:facts => {:dev_sku => "2nd_dev_product"}})
+    auto_attach_and_verify_dev_product("2nd_dev_product", ent.id)
+  end
+
+  def auto_attach_and_verify_dev_product(expected_product_id, old_ent_id=nil)
     @consumer.consume_product()
     entitlements = @consumer.list_entitlements()
     entitlements.length.should == 1
+    entitlements[0].id.should_not == old_ent_id unless old_ent_id == nil
     new_pool = entitlements[0].pool
     new_pool.type.should == "DEVELOPMENT"
-    new_pool.productId.should == "dev_product"
+    new_pool.productId.should == expected_product_id
     new_pool.providedProducts.length.should == 2
+    return entitlements[0]
   end
 
 end

--- a/server/src/main/java/org/candlepin/controller/Entitler.java
+++ b/server/src/main/java/org/candlepin/controller/Entitler.java
@@ -222,7 +222,7 @@ public class Entitler {
             // create one. If a dev pool already exists, remove it and
             // create a new one.
             String sku = consumer.getFact("dev_sku");
-            Pool devPool = poolCurator.findDevPool(consumer, sku);
+            Pool devPool = poolCurator.findDevPool(consumer);
             if (devPool != null) {
                 poolManager.deletePool(devPool);
             }

--- a/server/src/main/java/org/candlepin/model/PoolCurator.java
+++ b/server/src/main/java/org/candlepin/model/PoolCurator.java
@@ -704,13 +704,12 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
         return result;
     }
 
-    public Pool findDevPool(Consumer consumer, String sku) {
+    public Pool findDevPool(Consumer consumer) {
         PoolFilterBuilder filters = new PoolFilterBuilder();
         filters.addAttributeFilter(Pool.DEVELOPMENT_POOL_ATTRIBUTE, "true");
         filters.addAttributeFilter(Pool.REQUIRES_CONSUMER_ATTRIBUTE, consumer.getUuid());
 
-        Criteria criteria =  currentSession().createCriteria(Pool.class)
-                .add(Restrictions.eq("productId", sku));
+        Criteria criteria =  currentSession().createCriteria(Pool.class);
         filters.applyTo(criteria);
         criteria.setMaxResults(1).uniqueResult();
         return (Pool) criteria.uniqueResult();

--- a/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
@@ -1089,7 +1089,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         pool.setAttribute("dev_pool", "true");
         poolCurator.create(pool);
 
-        Pool found = poolCurator.findDevPool(consumer, product.getId());
+        Pool found = poolCurator.findDevPool(consumer);
         assertNotNull(found);
         assertEquals(pool.getId(), found.getId());
     }
@@ -1102,30 +1102,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         pool.setAttribute("dev_pool", "true");
         poolCurator.create(pool);
 
-        Pool found = poolCurator.findDevPool(consumer, product.getId());
-        assertNull(found);
-    }
-
-    @Test
-    public void testDevPoolForConsumerNotFoundReturnsNullWhenNoMatchOnDevPool() throws Exception {
-        Pool pool = createPoolAndSub(owner, product, -1L, TestUtil.createDate(2010, 3, 2),
-            TestUtil.createDate(Calendar.getInstance().get(Calendar.YEAR) + 1, 3, 2));
-        pool.setAttribute("requires_consumer", consumer.getUuid());
-        poolCurator.create(pool);
-
-        Pool found = poolCurator.findDevPool(consumer, product.getId());
-        assertNull(found);
-    }
-
-    @Test
-    public void testDevPoolForConsumerNotFoundReturnsNullWhenNoMatchOnProductId() throws Exception {
-        Pool pool = createPoolAndSub(owner, product, -1L, TestUtil.createDate(2010, 3, 2),
-            TestUtil.createDate(Calendar.getInstance().get(Calendar.YEAR) + 1, 3, 2));
-        pool.setAttribute("requires_consumer", consumer.getUuid());
-        pool.setAttribute("dev_pool", "true");
-        poolCurator.create(pool);
-
-        Pool found = poolCurator.findDevPool(consumer, "does-not-exist");
+        Pool found = poolCurator.findDevPool(consumer);
         assertNull(found);
     }
 


### PR DESCRIPTION
Since there should only ever be one dev pool per
consumer, look up the existing pool by dev_pool and
requires_consumer attributes, ignoring the dev_sku
fact. Otherwise, a change in the dev_sku fact will
result in multiple dev pools.

[BZ] https://bugzilla.redhat.com/show_bug.cgi?id=1295452