### PR TITLE
1294044, 1294049 : Allow Subscription Manager Gui register process to work with…

### DIFF
--- a/server/client/ruby/candlepin_api.rb
+++ b/server/client/ruby/candlepin_api.rb
@@ -892,7 +892,7 @@ class Candlepin
     delete("/consumers/#{consumer_id}/entitlements/pool/#{pool_id}")
   end
 
-  def autobind_dryrun(consumer_id, service_level=nil)
+  def autobind_dryrun(consumer_id=nil, service_level=nil)
     consumer_id ||= @uuid
     query = "/consumers/#{consumer_id}/entitlements/dry-run"
     query << "?service_level=#{service_level}" if service_level

--- a/server/spec/consumer_resource_dev_spec.rb
+++ b/server/spec/consumer_resource_dev_spec.rb
@@ -66,4 +66,19 @@ describe 'Consumer Dev Resource' do
     return entitlements[0]
   end
 
+  it 'should allow sub-man-gui process for auto-bind' do
+    pending("candlepin running in standalone mode") if not is_hosted?
+
+    pools = @consumer.autobind_dryrun()
+    pools.length.should == 1
+    ents = @consumer.consume_pool(pools[0].pool.id)
+    ents.length.should == 1
+    ent_pool = ents[0].pool
+    ent_pool.type.should == "DEVELOPMENT"
+    ent_pool.product.id.should == "dev_product"
+    ent_pool.providedProducts.length.should == 2
+    ent_pool.id.should == pools[0].pool.id
+  end
+
+
 end

--- a/server/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -115,6 +115,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -514,9 +515,18 @@ public class OwnerResource {
     public Set<String> ownerServiceLevels(
         @PathParam("owner_key") @Verify(value = Owner.class,
         subResource = SubResource.SERVICE_LEVELS) String ownerKey,
+        @Context Principal principal,
         @QueryParam("exempt") @DefaultValue("false") String exempt) {
         Owner owner = findOwner(ownerKey);
 
+        if (principal.getType().equals("consumer")) {
+            Consumer c = consumerCurator.findByUuid(principal.getName());
+            if (c.isDev()) {
+                Set<String> result = new HashSet<String>();
+                result.add("");
+                return result;
+            }
+        }
         // test is on the string "true" and is case insensitive.
         return poolManager.retrieveServiceLevelsForOwner(owner,
             Boolean.parseBoolean(exempt));


### PR DESCRIPTION
… Dev client

Stop the return of all available service levels and just return "". This way only
one dry run is attempted. The dev pool is created at dry run and available to use
on the bind step.