### PR TITLE
Storage Band Implementation Backport to candlepin-0.9.52

### DIFF
--- a/server/bin/import_products.rb
+++ b/server/bin/import_products.rb
@@ -182,7 +182,7 @@ admin_owner_key = 'admin'
 
 CERT_DIR='generated_certs'
 if not File.directory? CERT_DIR
-	Dir.mkdir(CERT_DIR)
+    Dir.mkdir(CERT_DIR)
 end
 
 puts
@@ -257,6 +257,12 @@ def create_mkt_product(cp, product, owner_keys)
     return
   end
 
+  small_quantity = SMALL_SUB_QUANTITY
+  large_quantity = LARGE_SUB_QUANTITY
+  if product.has_key?('quantity')
+    small_quantity = large_quantity = product['quantity']
+  end
+
   provided_products = product['provided_products'] || []
   derived_product_id = product['derived_product_id']
   derived_provided_products = product['derived_provided_products'] || []
@@ -283,7 +289,7 @@ def create_mkt_product(cp, product, owner_keys)
       end
       subscription = cp.create_subscription(owner_key,
                                             product_ret['id'],
-                                            SMALL_SUB_QUANTITY,
+                                            small_quantity,
                                             provided_products,
                                             contract_number, '12331131231',
                                             'order-8675309',
@@ -296,7 +302,7 @@ def create_mkt_product(cp, product, owner_keys)
       contract_number += 1
       subscription = cp.create_subscription(owner_key,
                                             product_ret['id'],
-                                            LARGE_SUB_QUANTITY,
+                                            large_quantity,
                                             provided_products,
                                             contract_number, '12331131231',
                                             'order-8675309',

--- a/server/bin/test_data.json
+++ b/server/bin/test_data.json
@@ -1758,6 +1758,33 @@
             ]
         },
         {
+            "name": "Band Limited Product",
+            "id": "908",
+            "version": "1.0",
+            "arch": "x86_64",
+            "attributes": {
+            },
+            "content": [
+            ]
+        },
+        {
+            "name": "Storage Limited (256 TB)",
+            "id": "storage-limited-256",
+            "type": "MKT",
+            "multiplier": 256,
+            "quantity": "1",
+            "attributes": {
+                "multi-entitlement": "yes",
+                "stacking_id": "STORAGELIMITED",
+                "storage_band": 1,
+                "support_level" : "Premium",
+                "support_type" : "Level 3"
+            },
+            "provided_products": [
+                "908"
+            ]
+        },
+        {
             "name": "Dev Product",
             "id": "dev-sku-product",
             "type": "MKT",
@@ -1773,4 +1800,3 @@
         }
     ]
 }
-

--- a/server/spec/storage_band_spec.rb
+++ b/server/spec/storage_band_spec.rb
@@ -1,0 +1,151 @@
+require 'spec_helper'
+require 'candlepin_scenarios'
+
+describe 'Band Limiting' do
+  include CandlepinMethods
+
+  before(:each) do
+
+    @owner = create_owner random_string('test_owner')
+
+    # Create a product limiting by band.
+    @ceph_product = create_product(
+        random_string("storage-limited-sku"),
+        random_string("Storage Limited"),
+        :multiplier => 256,
+        :attributes =>
+                {:version => '6.4',
+                 # storage_band will always be defined as 1, or not set.
+                 :storage_band => 1,
+                 :warning_period => 15,
+                 :stacking_id => "ceph-node",
+                 :'multi-entitlement' => "yes",
+                 :support_level => 'standard',
+                 :support_type => 'excellent'}
+         )
+    @ceph_sub = @cp.create_subscription(@owner['key'], @ceph_product.id, 2, [], '1888', '1234')
+    @cp.refresh_pools(@owner['key'])
+
+    @user = user_client(@owner, random_string('test-user'))
+
+  end
+
+  it 'pool should have the correct quantity based off of the product multiplier' do
+    pool = find_pool(@owner.id, @ceph_sub.id)
+    # sub.quantity * multiplier
+    pool.quantity.should == 512
+  end
+
+  # band.storage.usage fact is in TB.
+  it 'system status should be valid when all storage band usage is covered' do
+    system = consumer_client(@user, random_string("test_system"), :system, nil,
+                             { 'band.storage.usage' => "256" })
+    installed_products = [{ 'productId' => @ceph_product.id, 'productName' => @ceph_product.name }]
+    system.update_consumer({ :installedProducts => installed_products })
+
+    pool = find_pool(@owner.id, @ceph_sub.id)
+    pool.should_not be_nil
+
+    system.consume_pool(pool.id, {:quantity => 256}).should_not be_nil
+
+    status = system.get_compliance(consumer_id = system.uuid)
+    status['status'].should == 'valid'
+    status['compliant'].should == true
+  end
+
+  it 'system status should be partial when only part of the storage band usage is covered' do
+    system = consumer_client(@user, random_string("test_system"), :system, nil,
+                             { 'band.storage.usage' => "256" })
+    installed_products = [{ 'productId' => @ceph_product.id, 'productName' => @ceph_product.name }]
+    system.update_consumer({ :installedProducts => installed_products })
+
+    pool = find_pool(@owner.id, @ceph_sub.id)
+    pool.should_not be_nil
+
+    system.consume_pool(pool.id, {:quantity => 128}).should_not be_nil
+
+    status = system.get_compliance(consumer_id = system.uuid)
+    status['status'].should == 'partial'
+    status['compliant'].should == false
+  end
+
+  it 'storage band entitlements from same subscription can be stacked to cover entire system' do
+    system = consumer_client(@user, random_string("test_system"), :system, nil,
+                             { 'band.storage.usage' => "256" })
+    installed_products = [{ 'productId' => @ceph_product.id, 'productName' => @ceph_product.name }]
+    system.update_consumer({ :installedProducts => installed_products })
+
+    pool = find_pool(@owner.id, @ceph_sub.id)
+    pool.should_not be_nil
+
+    # Partial stack
+    system.consume_pool(pool.id, {:quantity => 128}).should_not be_nil
+    status = system.get_compliance(consumer_id = system.uuid)
+    status['status'].should == 'partial'
+    status['compliant'].should == false
+
+    # Complete the stack
+    system.consume_pool(pool.id, {:quantity => 128}).should_not be_nil
+    status = system.get_compliance(consumer_id = system.uuid)
+    status['status'].should == 'valid'
+    status['compliant'].should == true
+
+    entitlements = @cp.list_entitlements(:uuid => system.uuid)
+    entitlements.length.should == 2
+    entitlements[0].quantity.should == 128
+    entitlements[1].quantity.should == 128
+  end
+
+  it 'storage band entitlements will auto-attach correct quantity' do
+    system = consumer_client(@user, random_string("test_system"), :system, nil,
+                             { 'band.storage.usage' => "256" })
+    installed_products = [{ 'productId' => @ceph_product.id, 'productName' => @ceph_product.name }]
+    system.update_consumer({ :installedProducts => installed_products })
+
+    entitlements = system.consume_product()
+    entitlements.size.should == 1
+    entitlements[0].quantity.should == 256
+
+    status = system.get_compliance(consumer_id = system.uuid)
+    status['status'].should == 'valid'
+    status['compliant'].should == true
+
+  end
+
+  it 'storage band entitlements will auto-heal correctly' do
+    system = consumer_client(@user, random_string("test_system"), :system, nil,
+                             { 'band.storage.usage' => "256" })
+    installed_products = [{ 'productId' => @ceph_product.id, 'productName' => @ceph_product.name }]
+    system.update_consumer({ :installedProducts => installed_products })
+
+    pool = find_pool(@owner.id, @ceph_sub.id)
+    pool.should_not == nil
+
+    entitlement = system.consume_pool(pool.id, {:quantity => 56})
+    entitlement.should_not == nil
+
+    entitlements = system.consume_product()
+    entitlements.size.should == 1
+    entitlements[0].quantity.should == 200
+
+    status = system.get_compliance(consumer_id = system.uuid)
+    status['status'].should == 'valid'
+    status['compliant'].should == true
+  end
+
+  it 'storage band entitlement auto-attach without fact set consumes one entitlement' do
+    system = consumer_client(@user, random_string("test_system"), :system, nil,
+                             { })
+    installed_products = [{ 'productId' => @ceph_product.id, 'productName' => @ceph_product.name }]
+    system.update_consumer({ :installedProducts => installed_products })
+
+    entitlements = system.consume_product()
+    entitlements.size.should == 1
+    entitlements[0].quantity.should == 1
+
+    status = system.get_compliance(consumer_id = system.uuid)
+    status['status'].should == 'valid'
+    status['compliant'].should == true
+  end
+
+end

--- a/server/src/main/java/org/candlepin/model/Status.java
+++ b/server/src/main/java/org/candlepin/model/Status.java
@@ -37,7 +37,7 @@ public class Status {
     private boolean standalone;
     private Date timeUTC;
     private String[] managerCapabilities = {"cores", "ram", "instance_multiplier",
-        "derived_product", "cert_v3", "guest_limit", "vcpu"};
+        "derived_product", "cert_v3", "guest_limit", "vcpu", "storage_band"};
 
     private RulesSourceEnum rulesSource;
 

--- a/server/src/main/java/org/candlepin/policy/js/compliance/StatusReasonMessageGenerator.java
+++ b/server/src/main/java/org/candlepin/policy/js/compliance/StatusReasonMessageGenerator.java
@@ -93,6 +93,11 @@ public class StatusReasonMessageGenerator {
             reason.setMessage(i18n.tr("Guest has not been reported on any host" +
                 " and is using a temporary unmapped guest subscription."));
         }
+        else if (reason.getKey().equals("STORAGE_BAND")) {
+            reason.setMessage(i18n.tr("Only supports {0}TB of {1}TB of storage.",
+                    reason.getAttributes().get("covered"),
+                    reason.getAttributes().get("has")));
+        }
         else { //default fallback
             reason.setMessage(i18n.tr("{2} COVERAGE PROBLEM.  Supports {0} of {1}",
                 reason.getAttributes().get("covered"),

--- a/server/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRulesTranslator.java
+++ b/server/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRulesTranslator.java
@@ -17,12 +17,9 @@ package org.candlepin.policy.js.entitlement;
 import org.candlepin.model.Entitlement;
 import org.candlepin.model.Pool;
 import org.candlepin.policy.ValidationError;
+import org.xnap.commons.i18n.I18n;
 
 import com.google.inject.Inject;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.xnap.commons.i18n.I18n;
 
 /**
  * Translates error keys returned from entitlement rules into translated error messages.
@@ -30,12 +27,10 @@ import org.xnap.commons.i18n.I18n;
 public class EntitlementRulesTranslator {
 
     private I18n i18n;
-    private Logger log;
 
     @Inject
     public EntitlementRulesTranslator(I18n i18n) {
         this.i18n = i18n;
-        log = LoggerFactory.getLogger(EntitlementRulesTranslator.class);
     }
 
     public String poolErrorToMessage(Pool pool, ValidationError error) {
@@ -98,6 +93,10 @@ public class EntitlementRulesTranslator {
         else if (errorKey.equals("rulefailed.instance.unsupported.by.consumer")) {
             msg = i18n.tr("Unit does not support instance based calculation " +
                 "required by pool ''{0}''", pool.getId());
+        }
+        else if (errorKey.equals("rulefailed.band.unsupported.by.consumer")) {
+            msg = i18n.tr("Unit does not support band calculation " +
+                    "required by pool ''{0}''", pool.getId());
         }
         else if (errorKey.equals("rulefailed.cores.unsupported.by.consumer")) {
             msg = i18n.tr("Unit does not support core calculation " +

--- a/server/src/main/resources/rules/rules.js
+++ b/server/src/main/resources/rules/rules.js
@@ -1,4 +1,4 @@
-// Version: 5.15.1
+// Version: 5.15.2
 
 /*
  * Default Candlepin rule set.
@@ -49,6 +49,7 @@ var RAM_FACT = "memory.memtotal";
 var CORES_FACT = "cpu.core(s)_per_socket";
 var ARCH_FACT = "uname.machine";
 var IS_VIRT_GUEST_FACT = "virt.is_guest";
+var STORAGE_BAND_USAGE = "band.storage.usage";
 var PROD_ARCHITECTURE_SEPARATOR = ",";
 
 // Product attribute names
@@ -66,6 +67,7 @@ var UNMAPPED_GUESTS_ONLY = "unmapped_guests_only";
 var GUEST_LIMIT_ATTRIBUTE = "guest_limit";
 var VCPU_ATTRIBUTE = "vcpu";
 var MULTI_ENTITLEMENT_ATTRIBUTE = "multi-entitlement";
+var STORAGE_BAND_ATTRIBUTE = "storage_band";
 
 // caller types
 var BEST_POOLS_CALLER = "best_pools";
@@ -91,6 +93,7 @@ ATTRIBUTES_TO_CONSUMER_FACTS[CORES_ATTRIBUTE] = CORES_FACT;
 ATTRIBUTES_TO_CONSUMER_FACTS[ARCH_ATTRIBUTE] = ARCH_FACT;
 ATTRIBUTES_TO_CONSUMER_FACTS[RAM_ATTRIBUTE] = RAM_FACT;
 ATTRIBUTES_TO_CONSUMER_FACTS[VCPU_ATTRIBUTE] = CORES_FACT;
+ATTRIBUTES_TO_CONSUMER_FACTS[STORAGE_BAND_ATTRIBUTE] = STORAGE_BAND_USAGE;
 
 /**
  *  These product attributes are considered when determining
@@ -102,14 +105,20 @@ var PHYSICAL_ATTRIBUTES = [
     CORES_ATTRIBUTE,
     RAM_ATTRIBUTE,
     ARCH_ATTRIBUTE,
-    GUEST_LIMIT_ATTRIBUTE
+    GUEST_LIMIT_ATTRIBUTE,
+    STORAGE_BAND_ATTRIBUTE
 ];
 
+/**
+ * Attributes considered when determining coverage of a virtual
+ * guest.
+ */
 var VIRT_ATTRIBUTES = [
     VCPU_ATTRIBUTE,
     RAM_ATTRIBUTE,
     ARCH_ATTRIBUTE,
-    GUEST_LIMIT_ATTRIBUTE
+    GUEST_LIMIT_ATTRIBUTE,
+    STORAGE_BAND_ATTRIBUTE
 ];
 
 /**
@@ -1060,6 +1069,7 @@ function createComplianceTracker(consumer, id) {
                 guest_limit: function (currentStackValue, poolValue, pool, quantity) {
                     return -1; //Value doesn't matter, just need it to be enforced
                 }
+
             };
 
             var strategy = strategies.default;
@@ -1291,6 +1301,7 @@ var Entitlement = {
             "vcpu:1:vcpu," +
             "physical_only:1:physical_only," +
             "unmapped_guests_only:1:unmapped_guests_only," +
+            "storage_band:1:storage_band," +
             "requires_consumer:1:requires_consumer";
     },
 
@@ -1639,6 +1650,37 @@ var Entitlement = {
 
     pre_ram: function() {
         return this.build_func("do_pre_ram")();
+    },
+
+    do_pre_storage_band: function(context, result) {
+        var caller = context.caller;
+        var consumer = context.consumer;
+
+        if (!consumer.type.manifest) {
+            var consumerBandUsage = FactValueCalculator.getFact(STORAGE_BAND_ATTRIBUTE, consumer);
+            log.debug("Consumer is using " + consumerBandUsage + "TB of storage.");
+
+            var productBandStorage = parseInt(context.pool.getProductAttribute(STORAGE_BAND_ATTRIBUTE));
+            log.debug("Product has " + productBandStorage + "TB of storage.");
+            if (consumerBandUsage > productBandStorage && !context.pool.getProductAttribute("stacking_id")) {
+                result.addWarning("rulewarning.unsupported.storageband");
+            }
+        }
+        else {
+            if (!Utils.isCapable(consumer, STORAGE_BAND_ATTRIBUTE)) {
+                if (BEST_POOLS_CALLER == caller ||
+                    BIND_CALLER == caller) {
+                    result.addError("rulefailed.storageband.unsupported.by.consumer");
+                }
+                else {
+                    result.addWarning("rulewarning.storageband.unsupported.by.consumer");
+                }
+            }
+        }
+    },
+
+    pre_storage_band: function() {
+        return this.build_func("do_pre_storage_band")();
     },
 
     do_pre_instance_multiplier: function(context, result) {


### PR DESCRIPTION
Implemented storage band counting. Each entitlement
will equate to 1TB of coverage and marketing products
will use the multiplier such that sub quantity purchased
* multiplier will yeild pool quantity (total capacity in TB).

For example:
pool_quanity = sub_qty_bought * (storage_band_attr * multiplier)
             = 1 * (1 * 256)
             = 256

The resulting pool will have a quantity of 256, which can
cover 256TB of storage.

The rules will calculate a system's coverage based on a
band.storage.usage fact.

Consider a system is using 128TB:
- a quantity of 128 entitlements will cover the system (green).
- a quantity < 128 entitlements will partially cover the
  system (yellow)
- no entitlements (red)

Marketing Product (requirements)
---------------------------------
The marketing product should define a multiplier that is equal
to the total capacity in TBs. It must be stackable and must
define the storage_band attribute (should be set to 1).

- stacking_id: "product_stack_id"
- mutli-entitlement: "yes"
- storage_band: 1

Consumer Requirements
-------------------------
The consumer must have the band.storage.usage fact set to
the total TB that it is using.

NOTE: If this fact is not set, the rules will assume a value
      of 1TB.

- band.storage.usage: 128