### PR TITLE
Fixed the rules import spec tests on MySQL (0.9.51)

### DIFF
--- a/buildfile
+++ b/buildfile
@@ -126,8 +126,8 @@ SERVLET = 'javax.servlet:servlet-api:jar:2.5'
 GUICE =  [group('guice-assistedinject', 'guice-multibindings',
                 'guice-servlet', 'guice-throwingproviders', 'guice-persist',
                 :under=>'com.google.inject.extensions',
-                :version=>'4.0'),
-           'com.google.inject:guice:jar:4.0',
+                :version=>'3.0'),
+           'com.google.inject:guice:jar:3.0',
            'aopalliance:aopalliance:jar:1.0',
            'javax.inject:javax.inject:jar:1']
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -23,12 +23,12 @@
     <org.slf4j-jcl-over-slf4j.version>1.7.5</org.slf4j-jcl-over-slf4j.version>
     <org.slf4j-log4j-over-slf4j.version>1.7.5</org.slf4j-log4j-over-slf4j.version>
     <org.slf4j-slf4j-api.version>1.7.5</org.slf4j-slf4j-api.version>
-    <com.google.inject.extensions-guice-assistedinject.version>4.0</com.google.inject.extensions-guice-assistedinject.version>
-    <com.google.inject.extensions-guice-multibindings.version>4.0</com.google.inject.extensions-guice-multibindings.version>
-    <com.google.inject.extensions-guice-servlet.version>4.0</com.google.inject.extensions-guice-servlet.version>
-    <com.google.inject.extensions-guice-throwingproviders.version>4.0</com.google.inject.extensions-guice-throwingproviders.version>
-    <com.google.inject.extensions-guice-persist.version>4.0</com.google.inject.extensions-guice-persist.version>
-    <com.google.inject-guice.version>4.0</com.google.inject-guice.version>
+    <com.google.inject.extensions-guice-assistedinject.version>3.0</com.google.inject.extensions-guice-assistedinject.version>
+    <com.google.inject.extensions-guice-multibindings.version>3.0</com.google.inject.extensions-guice-multibindings.version>
+    <com.google.inject.extensions-guice-servlet.version>3.0</com.google.inject.extensions-guice-servlet.version>
+    <com.google.inject.extensions-guice-throwingproviders.version>3.0</com.google.inject.extensions-guice-throwingproviders.version>
+    <com.google.inject.extensions-guice-persist.version>3.0</com.google.inject.extensions-guice-persist.version>
+    <com.google.inject-guice.version>3.0</com.google.inject-guice.version>
     <aopalliance-aopalliance.version>1.0</aopalliance-aopalliance.version>
     <javax.inject-javax.inject.version>1</javax.inject-javax.inject.version>
     <com.googlecode.gettext-commons-gettext-commons.version>0.9.8</com.googlecode.gettext-commons-gettext-commons.version>

--- a/gutterball/pom.xml
+++ b/gutterball/pom.xml
@@ -28,12 +28,12 @@
     <postgresql-postgresql.version>9.0-801.jdbc4</postgresql-postgresql.version>
     <mysql-mysql-connector-java.version>5.1.26</mysql-mysql-connector-java.version>
     <com.googlecode.gettext-commons-gettext-commons.version>0.9.8</com.googlecode.gettext-commons-gettext-commons.version>
-    <com.google.inject.extensions-guice-assistedinject.version>4.0</com.google.inject.extensions-guice-assistedinject.version>
-    <com.google.inject.extensions-guice-multibindings.version>4.0</com.google.inject.extensions-guice-multibindings.version>
-    <com.google.inject.extensions-guice-servlet.version>4.0</com.google.inject.extensions-guice-servlet.version>
-    <com.google.inject.extensions-guice-throwingproviders.version>4.0</com.google.inject.extensions-guice-throwingproviders.version>
-    <com.google.inject.extensions-guice-persist.version>4.0</com.google.inject.extensions-guice-persist.version>
-    <com.google.inject-guice.version>4.0</com.google.inject-guice.version>
+    <com.google.inject.extensions-guice-assistedinject.version>3.0</com.google.inject.extensions-guice-assistedinject.version>
+    <com.google.inject.extensions-guice-multibindings.version>3.0</com.google.inject.extensions-guice-multibindings.version>
+    <com.google.inject.extensions-guice-servlet.version>3.0</com.google.inject.extensions-guice-servlet.version>
+    <com.google.inject.extensions-guice-throwingproviders.version>3.0</com.google.inject.extensions-guice-throwingproviders.version>
+    <com.google.inject.extensions-guice-persist.version>3.0</com.google.inject.extensions-guice-persist.version>
+    <com.google.inject-guice.version>3.0</com.google.inject-guice.version>
     <aopalliance-aopalliance.version>1.0</aopalliance-aopalliance.version>
     <javax.inject-javax.inject.version>1</javax.inject-javax.inject.version>
     <org.hibernate-hibernate-core.version>4.2.5.Final</org.hibernate-hibernate-core.version>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -27,12 +27,12 @@
     <commons-io-commons-io.version>1.3.2</commons-io-commons-io.version>
     <commons-lang-commons-lang.version>2.5</commons-lang-commons-lang.version>
     <com.googlecode.gettext-commons-gettext-commons.version>0.9.8</com.googlecode.gettext-commons-gettext-commons.version>
-    <com.google.inject.extensions-guice-assistedinject.version>4.0</com.google.inject.extensions-guice-assistedinject.version>
-    <com.google.inject.extensions-guice-multibindings.version>4.0</com.google.inject.extensions-guice-multibindings.version>
-    <com.google.inject.extensions-guice-servlet.version>4.0</com.google.inject.extensions-guice-servlet.version>
-    <com.google.inject.extensions-guice-throwingproviders.version>4.0</com.google.inject.extensions-guice-throwingproviders.version>
-    <com.google.inject.extensions-guice-persist.version>4.0</com.google.inject.extensions-guice-persist.version>
-    <com.google.inject-guice.version>4.0</com.google.inject-guice.version>
+    <com.google.inject.extensions-guice-assistedinject.version>3.0</com.google.inject.extensions-guice-assistedinject.version>
+    <com.google.inject.extensions-guice-multibindings.version>3.0</com.google.inject.extensions-guice-multibindings.version>
+    <com.google.inject.extensions-guice-servlet.version>3.0</com.google.inject.extensions-guice-servlet.version>
+    <com.google.inject.extensions-guice-throwingproviders.version>3.0</com.google.inject.extensions-guice-throwingproviders.version>
+    <com.google.inject.extensions-guice-persist.version>3.0</com.google.inject.extensions-guice-persist.version>
+    <com.google.inject-guice.version>3.0</com.google.inject-guice.version>
     <aopalliance-aopalliance.version>1.0</aopalliance-aopalliance.version>
     <javax.inject-javax.inject.version>1</javax.inject-javax.inject.version>
     <org.hibernate-hibernate-core.version>4.2.5.Final</org.hibernate-hibernate-core.version>

--- a/server/spec/rules_import_spec.rb
+++ b/server/spec/rules_import_spec.rb
@@ -30,6 +30,10 @@ describe 'Rules Import', :serial => true do
   end
 
   def upload_dummy_rules
+    # Wait a moment to ensure we get a different timestamp when using DBs without millisecond
+    # resolution (MySQL)
+    sleep 3
+
     encoded_rules = Base64.encode64(@rules)
     result = @cp.upload_rules(encoded_rules)
     fetched_rules = @cp.list_rules


### PR DESCRIPTION
- Added a delay to the rules upload function in the spec tests to
  work around a time resolution issue on databases like MySQL which
  don't store/use milliseconds