### PR TITLE
cp-test no longer sends -h to older Candlepin deploy scripts

### DIFF
--- a/docker/candlepin-base/cp-test
+++ b/docker/candlepin-base/cp-test
@@ -174,7 +174,7 @@ if [ "$DEPLOY" == "1" ]; then
 
     DEPLOY_FLAGS="-g"
 
-    if [ "$RSPEC" == "1" ] && [ "$HOSTED" == "1" ]; then
+    if [ "$RSPEC" == "1" ] && [ "$HOSTED" == "1" ] && (bin/deploy '-?' | grep -q -- '-h'); then
         DEPLOY_FLAGS="$DEPLOY_FLAGS -h -a"
     fi
 


### PR DESCRIPTION
If the current deploy script does not appear to have a -h flag, it will not be passed into the deploy script.