### PR TITLE
1259248: Fixed issue with refresh pools removing ueber certs (0.9.52)

### DIFF
--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -170,14 +170,17 @@ public class CandlepinPoolManager implements PoolManager {
             refreshPoolsForSubscription(sub, lazy);
         }
 
+        Pool ueberPool = this.findUeberPool(owner);
+        String ueberPoolId = ueberPool != null ? ueberPool.getId() : null;
+
         // We deleted some, need to take that into account so we
         // remove everything that isn't actually active
         subIds.removeAll(deletedSubs);
         // delete pools whose subscription disappeared:
-        for (Pool p : poolCurator.getPoolsFromBadSubs(owner, subIds)) {
-            if (p.getType() == PoolType.NORMAL || p.getType() == PoolType.BONUS ||
-                    p.getType() == PoolType.UNMAPPED_GUEST) {
-                deletePool(p);
+        for (Pool pool : poolCurator.getPoolsFromBadSubs(owner, subIds)) {
+            if (pool.getSourceSubscription() != null && !pool.getType().isDerivedType() &&
+                (ueberPoolId == null || !ueberPoolId.equals(pool.getId()))) {
+                deletePool(pool);
             }
         }
 

--- a/server/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -1264,23 +1264,23 @@ public class OwnerResource {
         Owner o = findOwner(ownerKey);
 
         if (o == null) {
-            throw new NotFoundException(i18n.tr(
-                "owner with key: {0} was not found.", ownerKey));
-        }
-
-        Consumer ueberConsumer =
-            consumerCurator.findByName(o, Consumer.UEBER_CERT_CONSUMER);
-
-        // ueber cert has already been generated - re-generate it now
-        if (ueberConsumer != null) {
-            List<Entitlement> ueberEntitlement
-                = entitlementCurator.listByConsumer(ueberConsumer);
-            // Immediately revoke and regenerate ueber certificates:
-            poolManager.regenerateCertificatesOf(ueberEntitlement.get(0), true, false);
-            return entitlementCertCurator.listForConsumer(ueberConsumer).get(0);
+            throw new NotFoundException(i18n.tr("owner with key: {0} was not found.", ownerKey));
         }
 
         try {
+            Consumer ueberConsumer = consumerCurator.findByName(o, Consumer.UEBER_CERT_CONSUMER);
+
+            // ueber cert has already been generated - re-generate it now
+            if (ueberConsumer != null) {
+                List<Entitlement> ueberEntitlements = entitlementCurator.listByConsumer(ueberConsumer);
+
+                if (ueberEntitlements.size() > 0) {
+                    // Immediately revoke and regenerate ueber certificates:
+                    poolManager.regenerateCertificatesOf(ueberEntitlements.get(0), true, false);
+                    return entitlementCertCurator.listForConsumer(ueberConsumer).get(0);
+                }
+            }
+
             return ueberCertGenerator.generate(o, principal);
         }
         catch (Exception e) {

--- a/server/src/test/java/org/candlepin/resource/OwnerResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/OwnerResourceTest.java
@@ -39,6 +39,8 @@ import org.candlepin.model.ConsumerCurator;
 import org.candlepin.model.ConsumerType;
 import org.candlepin.model.ConsumerTypeCurator;
 import org.candlepin.model.Entitlement;
+import org.candlepin.model.EntitlementCertificate;
+import org.candlepin.model.EntitlementCertificateCurator;
 import org.candlepin.model.EntitlementCurator;
 import org.candlepin.model.EventCurator;
 import org.candlepin.model.ExporterMetadata;
@@ -55,11 +57,13 @@ import org.candlepin.model.ProductCurator;
 import org.candlepin.model.Release;
 import org.candlepin.model.Role;
 import org.candlepin.model.RoleCurator;
+import org.candlepin.model.UeberCertificateGenerator;
 import org.candlepin.model.Subscription;
 import org.candlepin.model.SubscriptionCurator;
 import org.candlepin.model.UpstreamConsumer;
 import org.candlepin.model.activationkeys.ActivationKey;
 import org.candlepin.model.activationkeys.ActivationKeyCurator;
+import org.candlepin.policy.EntitlementRefusedException;
 import org.candlepin.resteasy.parameter.CandlepinParam;
 import org.candlepin.resteasy.parameter.CandlepinParameterUnmarshaller;
 import org.candlepin.resteasy.parameter.KeyValueParameter;
@@ -90,10 +94,12 @@ import java.lang.annotation.Annotation;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
@@ -1164,5 +1170,128 @@ public class OwnerResourceTest extends DatabaseTestFixture {
             new CandlepinParameterUnmarshaller();
         unmarshaller.setAnnotations(annotations);
         return (KeyValueParameter) unmarshaller.fromString(key + ":" + val);
+    }
+
+    @Test
+    public void testCreateUeberCertificateFromScratch() {
+        Principal principal = setupPrincipal(owner, Access.ALL);
+        Owner owner = TestUtil.createOwner();
+        Consumer consumer = TestUtil.createConsumer(owner);
+        EntitlementCertificate entCert = mock(EntitlementCertificate.class);
+
+
+        OwnerCurator oc = mock(OwnerCurator.class);
+        ConsumerCurator cc = mock(ConsumerCurator.class);
+        EntitlementCurator ec = mock(EntitlementCurator.class);
+        CandlepinPoolManager cpm = mock(CandlepinPoolManager.class);
+        EntitlementCertificateCurator ecc = mock(EntitlementCertificateCurator.class);
+        UeberCertificateGenerator ucg = mock(UeberCertificateGenerator.class);
+
+
+        OwnerResource resource = new OwnerResource(
+            oc, null, null, cc, null, i18n, null, null, null, null, null, cpm, null, null, null, null,
+            null, null, ecc, ec, ucg, null, null, null, null, null
+        );
+
+        try {
+            when(oc.lookupByKey(eq("admin"))).thenReturn(owner);
+            when(cc.findByName(eq(owner), eq(Consumer.UEBER_CERT_CONSUMER))).thenReturn(null);
+            when(ucg.generate(eq(owner), eq(principal))).thenReturn(entCert);
+        }
+        catch (EntitlementRefusedException ere) {
+            // ...
+        }
+
+        EntitlementCertificate result = resource.createUeberCertificate(principal, "admin");
+
+        assertEquals(entCert, result);
+    }
+
+    @Test
+    public void testCreateUeberCertificateRegenerate() {
+        Principal principal = setupPrincipal(owner, Access.ALL);
+        Owner owner = TestUtil.createOwner();
+        Consumer consumer = TestUtil.createConsumer(owner);
+        Entitlement ent = mock(Entitlement.class);
+        List<Entitlement> entList = Arrays.asList(ent);
+        EntitlementCertificate entCert = mock(EntitlementCertificate.class);
+        List<EntitlementCertificate> ecList = Arrays.asList(entCert);
+
+        OwnerCurator oc = mock(OwnerCurator.class);
+        ConsumerCurator cc = mock(ConsumerCurator.class);
+        EntitlementCurator ec = mock(EntitlementCurator.class);
+        CandlepinPoolManager cpm = mock(CandlepinPoolManager.class);
+        EntitlementCertificateCurator ecc = mock(EntitlementCertificateCurator.class);
+        UeberCertificateGenerator ucg = mock(UeberCertificateGenerator.class);
+
+        OwnerResource resource = new OwnerResource(
+            oc, null, null, cc, null, i18n, null, null, null, null, null, cpm, null, null, null, null,
+            null, null, ecc, ec, ucg, null, null, null, null, null
+        );
+
+        when(oc.lookupByKey(eq("admin"))).thenReturn(owner);
+        when(cc.findByName(eq(owner), eq(Consumer.UEBER_CERT_CONSUMER))).thenReturn(consumer);
+        when(ec.listByConsumer(eq(consumer))).thenReturn(entList);
+        when(ecc.listForConsumer(eq(consumer))).thenReturn(ecList);
+
+        EntitlementCertificate result = resource.createUeberCertificate(principal, "admin");
+
+        assertEquals(entCert, result);
+    }
+
+    @Test
+    public void testCreateUeberCertificateRegenerateWithNoEntitlement() {
+        Principal principal = setupPrincipal(owner, Access.ALL);
+        Owner owner = TestUtil.createOwner();
+        Consumer consumer = TestUtil.createConsumer(owner);
+        Entitlement ent = mock(Entitlement.class);
+        List<Entitlement> entList = new LinkedList<Entitlement>();
+        EntitlementCertificate entCert = mock(EntitlementCertificate.class);
+        List<EntitlementCertificate> ecList = Arrays.asList(entCert);
+
+        OwnerCurator oc = mock(OwnerCurator.class);
+        ConsumerCurator cc = mock(ConsumerCurator.class);
+        EntitlementCurator ec = mock(EntitlementCurator.class);
+        CandlepinPoolManager cpm = mock(CandlepinPoolManager.class);
+        EntitlementCertificateCurator ecc = mock(EntitlementCertificateCurator.class);
+        UeberCertificateGenerator ucg = mock(UeberCertificateGenerator.class);
+
+        OwnerResource resource = new OwnerResource(
+            oc, null, null, cc, null, i18n, null, null, null, null, null, cpm, null, null, null, null,
+            null, null, ecc, ec, ucg, null, null, null, null, null
+        );
+
+        try {
+            when(oc.lookupByKey(eq("admin"))).thenReturn(owner);
+            when(cc.findByName(eq(owner), eq(Consumer.UEBER_CERT_CONSUMER))).thenReturn(consumer);
+            when(ec.listByConsumer(eq(consumer))).thenReturn(entList);
+            when(ucg.generate(eq(owner), eq(principal))).thenReturn(entCert);
+        }
+        catch (EntitlementRefusedException ere) {
+            // ...
+        }
+
+        EntitlementCertificate result = resource.createUeberCertificate(principal, "admin");
+
+        assertEquals(entCert, result);
+    }
+
+    @Test(expected = NotFoundException.class)
+    public void testCreateUeberCertificateInvalidOwner() {
+        Principal principal = setupPrincipal(owner, Access.ALL);
+
+        OwnerCurator oc = mock(OwnerCurator.class);
+        ConsumerCurator cc = mock(ConsumerCurator.class);
+        EntitlementCurator ec = mock(EntitlementCurator.class);
+        CandlepinPoolManager cpm = mock(CandlepinPoolManager.class);
+        EntitlementCertificateCurator ecc = mock(EntitlementCertificateCurator.class);
+        UeberCertificateGenerator ucg = mock(UeberCertificateGenerator.class);
+
+        OwnerResource resource = new OwnerResource(
+            oc, null, null, cc, null, i18n, null, null, null, null, null, cpm, null, null, null, null,
+            null, null, ecc, ec, ucg, null, null, null, null, null
+        );
+
+        EntitlementCertificate result = resource.createUeberCertificate(principal, "admin");
     }
 }

--- a/server/src/test/java/org/candlepin/test/TestUtil.java
+++ b/server/src/test/java/org/candlepin/test/TestUtil.java
@@ -68,6 +68,10 @@ public class TestUtil {
     private TestUtil() {
     }
 
+    public static Owner createOwner() {
+        return new Owner("Test Owner " + randomInt());
+    }
+
     public static Consumer createConsumer(ConsumerType type, Owner owner) {
         return new Consumer("TestConsumer" + randomInt(), "User", owner, type);
     }


### PR DESCRIPTION
- Refresh pools, and anything making use of the function, will no
  longer remove any generate ueber certs
- Partial information for ueber certs or consumers will no longer
  cause 500 errors when generating or retrieving ueber certs