### PR TITLE
Allow the distribution version to exceed 20

### DIFF
--- a/server/candlepin.spec.tmpl
+++ b/server/candlepin.spec.tmpl
@@ -20,7 +20,7 @@
 %endif
 
 Name: candlepin
-Version: 0.9.53
+Version: 0.9.53.1
 Release: 1%{?dist}
 #if $epoch
 Epoch: $epoch

--- a/server/candlepin.spec.tmpl
+++ b/server/candlepin.spec.tmpl
@@ -20,7 +20,7 @@
 %endif
 
 Name: candlepin
-Version: 0.9.53.1
+Version: 0.9.53.2
 Release: 1%{?dist}
 #if $epoch
 Epoch: $epoch

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -11,7 +11,7 @@
   </parent>
   <groupId>org.candlepin</groupId>
   <artifactId>candlepin</artifactId>
-  <version>0.9.53</version>
+  <version>0.9.53.2</version>
   <packaging>war</packaging>
   <properties>
     <release>1</release>

--- a/server/src/main/java/org/candlepin/model/ConsumerInstalledProduct.java
+++ b/server/src/main/java/org/candlepin/model/ConsumerInstalledProduct.java
@@ -65,7 +65,7 @@ public class ConsumerInstalledProduct extends AbstractHibernateObject {
     private String productName;
 
     @Column(name = "product_version")
-    @Size(max = 20)
+    @Size(max = 99)
     private String version;
 
     @Column(name = "product_arch")


### PR DESCRIPTION
In order to allow Fedora workstations and servers to use Candlepin, the maximum version for the distribution must be allowed to exceed 20.