### PR TITLE
Allow the distribution version to exceed 20

### DIFF
--- a/server/src/main/java/org/candlepin/model/ConsumerInstalledProduct.java
+++ b/server/src/main/java/org/candlepin/model/ConsumerInstalledProduct.java
@@ -65,7 +65,7 @@ public class ConsumerInstalledProduct extends AbstractHibernateObject {
     private String productName;
 
     @Column(name = "product_version")
-    @Size(max = 20)
+    @Size(max = 99)
     private String version;
 
     @Column(name = "product_arch")


### PR DESCRIPTION
In order to allow Fedora workstations and servers to use Candlepin, the maximum version for the distribution must be allowed to exceed 20.