### PR TITLE
1301812: Fixed an issue with event generation for stack derived pools (0.9.49)

### DIFF
--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -319,6 +319,12 @@ public class CandlepinPoolManager implements PoolManager {
 
                 if (update.changed()) {
                     updatedPools.add(update);
+
+                    EventBuilder eventBuilder = eventFactory
+                            .getEventBuilder(Target.POOL, Type.MODIFIED)
+                            .setOldEntity(subPool);
+
+                    poolEvents.put(subPool.getId(), eventBuilder);
                 }
             }
         }
@@ -363,10 +369,15 @@ public class CandlepinPoolManager implements PoolManager {
                     .retrieveFreeEntitlementIdsOfPool(existingPool, true);
                 entitlementsToRegen.addAll(entitlements);
             }
-            Event event = poolEvents.get(existingPool.getId())
-                    .setNewEntity(existingPool)
-                    .buildEvent();
-            sink.queueEvent(event);
+
+            EventBuilder builder = poolEvents.get(existingPool.getId());
+            if (builder != null) {
+                Event event = builder.setNewEntity(existingPool).buildEvent();
+                sink.queueEvent(event);
+            }
+            else {
+                log.warn("Pool updated without an event builder: {}", existingPool);
+            }
         }
 
         return entitlementsToRegen;


### PR DESCRIPTION
- Changes made to a stack derived pool will no longer cause null
  pointer exceptions during manifest import or pool refresh