### PR TITLE
Fix server/bin scripts that have been broken since candlepin 2.0

### DIFF
--- a/server/bin/bulk-crl-test.rb
+++ b/server/bin/bulk-crl-test.rb
@@ -1,41 +1,49 @@
 #!/usr/bin/env ruby
 
 require  "../client/ruby/candlepin_api"
+require  "../client/ruby/hostedtest_api"
 require 'pp'
 
-cp = Candlepin.new('admin', 'admin')
+@cp = Candlepin.new('admin', 'admin')
+
+include HostedTest
+
+def random_string prefix=nil
+  prefix ||= "rand"
+  return "#{prefix}-#{rand(100000)}"
+end
 
 puts 'Creating Owner'
-owner = cp.create_owner('test_owner')
+owner = @cp.create_owner(random_string('test_owner'))
 
 puts 'Creating User'
-user = cp.create_user(owner['key'], 'test_user', 'password')
+user = @cp.create_user(random_string('test_user'), 'password')
 
 puts 'Creating Product'
-product = cp.create_product('new_product'.hash, 'new_product',
+product = @cp.create_product(owner['key'],'new_product'.hash, 'new_product',
   {:attributes => {'multi-entitlement' => 'yes'}})
 
 puts 'Creating Subscription'
-cp.create_subscription(owner['key'], product['id'], 3000000)
-cp.refresh_pools(owner['key'])
+create_pool_and_subscription(owner['key'], product['id'], 3000000)
 
 cp_user = Candlepin.new('test_user', 'password')
 
 puts 'Creating Consumer'
-consumer = cp_user.register('test-consumer')
+consumer = @cp.register('test-consumer', 'system', nil, {}, nil, owner['key'])
 cp_consumer = Candlepin.new(nil, nil, consumer['idCert']['cert'], consumer['idCert']['key'])
 
+puts 'Set up complete'
 threads = []
 
 50.times do |thread_id|
   threads << Thread.new(cp_consumer, thread_id) do |cp, thread_id|
     200.times do |loop_id|
       puts "Consuming new Entitlement:  #{thread_id}-#{loop_id}"
-      entitlement = cp.consume_product(product['id'])
+      entitlement = @cp.consume_product(product['id'], {:uuid => cp_consumer.uuid})
 
       ent_id = entitlement[0]['id']
       puts "Revoking entitlement:  #{ent_id}"
-      cp.unbind_entitlement(ent_id)
+      @cp.unbind_entitlement(ent_id, {:uuid => cp_consumer.uuid})
     end
   end
 end

--- a/server/bin/concurrent_reg_autobind_test.rb
+++ b/server/bin/concurrent_reg_autobind_test.rb
@@ -10,11 +10,14 @@
 require 'thread'
 
 require File.expand_path('candlepin_api', File.dirname(__FILE__) + '/../client/ruby')
+require File.expand_path('hostedtest_api', File.dirname(__FILE__) + '/../client/ruby')
+include HostedTest
 
 
 # Stolen from import_products
 # Originally from http://burgestrand.se/articles/quick-and-simple-ruby-thread-pool.html
 class Pool
+
   def initialize(size)
     @size = size
     @jobs = Queue.new
@@ -67,10 +70,9 @@ end
 owner = @cp.create_owner(random_string('owner'))
 prod1 = @cp.create_product(owner['key'], random_string('product1'), random_string('product1'), {})
 prod2 = @cp.create_product(owner['key'], random_string('product2'), random_string('product2'), {})
-subs1 = @cp.create_subscription(owner['key'], prod1["id"], 10)
-subs2 = @cp.create_subscription(owner['key'], prod2["id"], 1)
-subs3 = @cp.create_subscription(owner['key'], prod2["id"], 1)
-@cp.refresh_pools(owner['key'])
+create_pool_and_subscription(owner['key'], prod1["id"], 10, [], '', '', '', nil, nil, true)
+create_pool_and_subscription(owner['key'], prod2["id"], 1, [], '', '', '', nil, nil, true)
+create_pool_and_subscription(owner['key'], prod2["id"], 1)
 pools = @cp.list_pools(:owner => owner['id'])
 
 key1 = @cp.create_activation_key(owner['key'], 'key1')

--- a/server/bin/generate-export.rb
+++ b/server/bin/generate-export.rb
@@ -27,8 +27,8 @@ product1 = cp.create_product(owner['key'], random_string(), random_string())
 product2 = cp.create_product(owner['key'], random_string(), random_string())
 
 end_date = Date.new(2025, 5, 29)
-sub1 = cp.create_subscription(owner['key'], product1['id'], 20, [], '', '12345', nil, nil, end_date)
-sub2 = cp.create_subscription(owner['key'], product2['id'], 30, [], '', '76534', nil, nil, end_date)
+sub1 = cp.create_pool(owner['key'], product1['id'], { :quantity => 20, :account_number => '12345', :end_date => end_date })
+sub2 = cp.create_pool(owner['key'], product2['id'], { :quantity => 30, :account_number => '76534', :end_date => end_date })
 cp.refresh_pools(owner['key'])
 
 pool1 = cp.list_pools(:owner => owner['id'], :product => product1['id'])[0]

--- a/server/bin/generate-export.rb
+++ b/server/bin/generate-export.rb
@@ -7,6 +7,8 @@
 # None of the above will be cleaned up.
 
 require  "../client/ruby/candlepin_api"
+require  "../client/ruby/hostedtest_api"
+include HostedTest
 require 'pp'
 
 ADMIN_USERNAME = "admin"
@@ -19,24 +21,23 @@ def random_string prefix=nil
   return "#{prefix}-#{rand(100000)}"
 end
 
-cp = Candlepin.new(ADMIN_USERNAME, ADMIN_PASSWORD, nil, nil, HOST, PORT)
+@cp = Candlepin.new(ADMIN_USERNAME, ADMIN_PASSWORD, nil, nil, HOST, PORT)
 
-owner = cp.create_owner random_string("export_me")
+owner = @cp.create_owner random_string("export_me")
 
-product1 = cp.create_product(owner['key'], random_string(), random_string())
-product2 = cp.create_product(owner['key'], random_string(), random_string())
+product1 = @cp.create_product(owner['key'], random_string(), random_string())
+product2 = @cp.create_product(owner['key'], random_string(), random_string())
 
 end_date = Date.new(2025, 5, 29)
-sub1 = cp.create_pool(owner['key'], product1['id'], { :quantity => 20, :account_number => '12345', :end_date => end_date })
-sub2 = cp.create_pool(owner['key'], product2['id'], { :quantity => 30, :account_number => '76534', :end_date => end_date })
-cp.refresh_pools(owner['key'])
+create_pool_and_subscription(owner['key'], product1['id'], 20, [], '', '12345', '', nil, end_date, true)
+create_pool_and_subscription(owner['key'], product2['id'], 30, [], '', '76534', '', nil, end_date)
 
-pool1 = cp.list_pools(:owner => owner['id'], :product => product1['id'])[0]
-pool2 = cp.list_pools(:owner => owner['id'], :product => product2['id'])[0]
+pool1 = @cp.list_pools(:owner => owner['id'], :product => product1['id'])[0]
+pool2 = @cp.list_pools(:owner => owner['id'], :product => product2['id'])[0]
 
 org_admin_username = random_string("orgadmin")
 org_admin_password = 'password'
-cp.create_user(org_admin_username, org_admin_password, true)
+@cp.create_user(org_admin_username, org_admin_password, true)
 org_admin_cp = Candlepin.new(org_admin_username, org_admin_password)
 consumer = org_admin_cp.register(random_string('dummyconsumer'), "candlepin",
   nil, {}, nil, owner['key'])

--- a/server/client/ruby/candlepin_api.rb
+++ b/server/client/ruby/candlepin_api.rb
@@ -677,7 +677,6 @@ class Candlepin
   end
 
   def create_product(owner_key, id, name, params={})
-
     multiplier = params[:multiplier] || 1
     attributes = params[:attributes] || {}
     dependentProductIds = params[:dependentProductIds] || []
@@ -920,41 +919,15 @@ class Candlepin
                           provided_products=[], contract_number='',
                           account_number='', order_number='',
                           start_date=nil, end_date=nil, params={})
-    start_date ||= Date.today
-    end_date ||= start_date + 365
-
-    subscription = {
-      'startDate' => start_date,
-      'endDate'   => end_date,
-      'quantity'  =>  quantity,
-      'accountNumber' => account_number,
-      'orderNumber' => order_number,
-      'product' => { 'id' => product_id },
-      'providedProducts' => provided_products.collect { |pid| {'id' => pid} },
-      'contractNumber' => contract_number
-    }
-
-    if params[:branding]
-      subscription['branding'] = params[:branding]
-    end
-
-    if params['derived_product_id']
-      subscription['derivedProduct'] = { 'id' => params['derived_product_id'] }
-    end
-
-    if params['derived_provided_products']
-      subscription['derivedProvidedProducts'] = params['derived_provided_products'].collect { |pid| {'id' => pid} }
-    end
-
-    return post("/owners/#{owner_key}/subscriptions", subscription)
+      raise "Deprecated API. Please use create_pool or HostedTest resources"
   end
 
   def update_subscription(subscription)
-    return put("/owners/subscriptions", subscription)
+      raise "Deprecated API. Please use update_pool or HostedTest resources"
   end
 
   def delete_subscription(subscription_id)
-    return delete("/subscriptions/#{subscription_id}")
+      raise "Deprecated API. Please use delete_pool or HostedTest resources"
   end
 
   def create_pool(owner_key, product_id, params={})

--- a/server/client/ruby/hostedtest_api.rb
+++ b/server/client/ruby/hostedtest_api.rb
@@ -1,7 +1,6 @@
-require 'candlepin_api'
-
 module HostedTest
 
+  @@hosted_mode = nil
   @@hostedtest_alive = nil
 
   def is_hostedtest_alive?
@@ -82,6 +81,160 @@ module HostedTest
 
   def delete_all_hostedtest_subscriptions()
     @cp.delete('/hostedtest/subscriptions/', nil, true)
+  end
+
+  def is_hosted?
+    if @@hosted_mode.nil?
+      @@hosted_mode = ! @cp.get_status()['standalone']
+    end
+    return @@hosted_mode
+  end
+
+  def is_standalone?
+    if @@hosted_mode.nil?
+      @@hosted_mode = ! @cp.get_status()['standalone']
+    end
+    return !@@hosted_mode
+  end
+
+  def ensure_hostedtest_resource()
+    if is_hosted? && !is_hostedtest_alive?
+      raise "Could not find hostedtest rest API. Please run \'deploy -ha\' or add the following to candlepin.conf:\n" \
+          " module.config.hosted.configuration.module=org.candlepin.hostedtest.AdapterOverrideModule"
+    end
+  end
+
+  # Lets users be agnostic of what mode we are in, standalone or hosted.
+  # Always returns the main pool that was created ( unless running in hosted mode and refresh is skipped )
+  def create_pool_and_subscription(owner_key, product_id, quantity=1,
+                          provided_products=[], contract_number='',
+                          account_number='', order_number='',
+                          start_date=nil, end_date=nil, skip_refresh=false, params={})
+
+    params[:start_date] = start_date
+    params[:end_date] = end_date
+    params[:contract_number] = contract_number
+    params[:account_number] = account_number
+    params[:order_number] = order_number
+    params[:quantity] = quantity
+    params[:provided_products] = provided_products
+    pool = nil
+    if is_hosted?
+      ensure_hostedtest_resource
+      sub = create_hostedtest_subscription(owner_key, product_id, quantity, params)
+      if not skip_refresh
+        active_on = Date.strptime(sub['startDate'], "%Y-%m-%d")+1
+        @cp.refresh_pools(owner_key)
+        pool = find_main_pool(owner_key, sub['id'], activeon=active_on, true)
+      end
+    else
+      params[:source_subscription] = { 'id' => random_str('source_sub_') }
+      pool = @cp.create_pool(owner_key, product_id, params)
+    end
+    return pool
+  end
+
+  # Lets users be agnostic of what mode we are in, standalone or hosted.
+  # if we are running in hosted mode, delete the upstream subscription and refresh pools.
+  # else, simply delete the pool
+  def delete_pool_and_subscription(pool)
+    if is_hosted?
+      ensure_hostedtest_resource
+      delete_hostedtest_subscription(pool.subscriptionId)
+      @cp.refresh_pools(pool['owner']['key'], true)
+    else
+      @cp.delete_pool(pool.id)
+    end
+  end
+
+  # Lets users be agnostic of what mode we are in, standalone or hosted.
+  # This method is used when we need to update the upstream subscription's details.
+  # first we fetch the upstrean pool ( if standalone mode ) or subscription ( if hosted mode )
+  # using get_pool_or_subscription(pool) and then use update_pool_or_subscription
+  # to update the upstream entity.
+  #
+  # input is always a pool, but the out may be either a subscription or a pool
+  def get_pool_or_subscription(pool)
+    if is_hosted?
+      ensure_hostedtest_resource
+      return get_hostedtest_subscription(pool.subscriptionId)
+    else
+      return pool
+    end
+  end
+
+  # Lets users be agnostic of what mode we are in, standalone or hosted.
+  # This method is used when we need to update the upstream subscription's details.
+  # first we fetch the upstrean pool ( if standalone mode ) or subscription ( if hosted mode )
+  # using get_pool_or_subscription(pool) and then use update_pool_or_subscription
+  # to update the upstream entity.
+  #
+  # input may be either a subscription or a pool, and there is no output
+  def update_pool_or_subscription(subOrPool)
+    if is_hosted?
+      ensure_hostedtest_resource
+      update_hostedtest_subscription(subOrPool)
+      active_on = case subOrPool.startDate
+        when String then Date.strptime(subOrPool.startDate, "%Y-%m-%d")+1
+        when Date then subOrPool.startDate+1
+        else raise "invalid date format"
+      end
+      @cp.refresh_pools(subOrPool['owner']['key'], true)
+      sleep 1
+    else
+      @cp.update_pool(subOrPool['owner']['key'], subOrPool)
+    end
+  end
+
+  # Lets users be agnostic of what mode we are in, standalone or hosted.
+  # This method is used when we need to update the dependent entities of a 
+  # upstream subscription or pool. simply fetching and updating the subscription forces
+  # a re-resolve of products, owners, etc.
+  #
+  # input is alwasy a pool, and there is no output
+  def refresh_upstream_subscription(pool)
+    if is_hosted?
+      ensure_hostedtest_resource
+      sub = get_hostedtest_subscription(pool.subscriptionId)
+      update_hostedtest_subscription(sub)
+      @cp.refresh_pools(pool['owner']['key'])
+    end
+  end
+
+  # List all the pools for the given owner, and find one that matches
+  # a specific subscription ID. (we often want to verify what pool was used,
+  # but the pools are created indirectly after a refresh so it's hard to
+  # locate a specific reference without this)
+  def find_main_pool(owner_key, sub_id, activeon=nil, return_normal)
+    pools = @cp.list_owner_pools(owner_key, {:activeon => activeon})
+    pools.each do |pool|
+      if pool['subscriptionId'] == sub_id && (!return_normal || pool['type'] == 'NORMAL')
+        return pool
+      end
+    end
+    return nil
+  end
+
+  def random_str(prefix=nil, numeric_only=false)
+    if prefix
+      prefix = "#{prefix}-"
+    end
+
+    if numeric_only
+      suffix = rand(9999999)
+    else
+      # This is actually a bit faster than using SecureRandom.  Go figure.
+      o = [('a'..'z'), ('A'..'Z'), ('0'..'9')].map { |i| i.to_a }.flatten
+      suffix = (0..7).map { o[rand(o.length)] }.join
+    end
+    "#{prefix}#{suffix}"
+  end
+
+  def cleanup_subscriptions
+    if is_hosted?
+      ensure_hostedtest_resource
+      delete_all_hostedtest_subscriptions
+    end
   end
 
 end

--- a/server/client/ruby/hostedtest_api.rb
+++ b/server/client/ruby/hostedtest_api.rb
@@ -141,7 +141,7 @@ module HostedTest
     if is_hosted?
       ensure_hostedtest_resource
       delete_hostedtest_subscription(pool.subscriptionId)
-      @cp.refresh_pools(pool['owner']['key'], true)
+      @cp.refresh_pools(pool['owner']['key'])
     else
       @cp.delete_pool(pool.id)
     end

--- a/server/spec/candlepin_scenarios.rb
+++ b/server/spec/candlepin_scenarios.rb
@@ -8,8 +8,6 @@ module CandlepinMethods
 
   include HostedTest
 
-  @@hosted_mode = nil
-
   # Wrapper for ruby API so we can track all owners we created and clean them
   # up. Note that this entails cleanup of all objects beneath that owner, so
   # most other objects can be created using the ruby API.
@@ -111,117 +109,6 @@ module CandlepinMethods
     @cp.create_batch_content(owner, contents)
   end
 
-  def ensure_hostedtest_resource()
-    if is_hosted? && !is_hostedtest_alive?
-      raise "Could not find hostedtest rest API. Please run \'deploy -ha\' or add the following to candlepin.conf:\n" \
-          " module.config.hosted.configuration.module=org.candlepin.hostedtest.AdapterOverrideModule"
-    end
-  end
-
-  # Lets spec tests be agnostic of what mode we are testing in, standalone or hosted.
-  # Always returns the main pool that was created ( unless running in hosted mode and refresh is skipped )
-  def create_pool_and_subscription(owner_key, product_id, quantity=1,
-                          provided_products=[], contract_number='',
-                          account_number='', order_number='',
-                          start_date=nil, end_date=nil, skip_refresh=false, params={})
-
-    params[:start_date] = start_date
-    params[:end_date] = end_date
-    params[:contract_number] = contract_number
-    params[:account_number] = account_number
-    params[:order_number] = order_number
-    params[:quantity] = quantity
-    params[:provided_products] = provided_products
-    pool = nil
-    if is_hosted?
-      ensure_hostedtest_resource
-      sub = create_hostedtest_subscription(owner_key, product_id, quantity, params)
-      if not skip_refresh
-        active_on = Date.strptime(sub.startDate, "%Y-%m-%d")+1
-        @cp.refresh_pools(owner_key)
-        pool = find_main_pool(owner_key, sub['id'], activeon=active_on, true)
-      end
-    else
-      params[:source_subscription] = { 'id' => random_string('source_sub_') }
-      pool = @cp.create_pool(owner_key, product_id, params)
-    end
-    return pool
-  end
-
-  # Lets spec tests be agnostic of what mode we are testing in, standalone or hosted.
-  # if we are running in hosted mode, delete the upstream subscription and refresh pools.
-  # else, simply delete the pool
-  def delete_pool_and_subscription(pool)
-    if is_hosted?
-      ensure_hostedtest_resource
-      delete_hostedtest_subscription(pool.subscriptionId)
-      @cp.refresh_pools(pool['owner']['key'], true)
-    else
-      @cp.delete_pool(pool.id)
-    end
-  end
-
-  # Lets spec tests be agnostic of what mode we are testing in, standalone or hosted.
-  # This method is used when we need to update the upstream subscription's details.
-  # first we fetch the upstrean pool ( if standalone mode ) or subscription ( if hosted mode )
-  # using get_pool_or_subscription(pool) and then use update_pool_or_subscription
-  # to update the upstream entity.
-  #
-  # input is always a pool, but the out may be either a subscription or a pool
-  def get_pool_or_subscription(pool)
-    if is_hosted?
-      ensure_hostedtest_resource
-      return get_hostedtest_subscription(pool.subscriptionId)
-    else
-      return pool
-    end
-  end
-
-  # Lets spec tests be agnostic of what mode we are testing in, standalone or hosted.
-  # This method is used when we need to update the upstream subscription's details.
-  # first we fetch the upstrean pool ( if standalone mode ) or subscription ( if hosted mode )
-  # using get_pool_or_subscription(pool) and then use update_pool_or_subscription
-  # to update the upstream entity.
-  #
-  # input may be either a subscription or a pool, and there is no output
-  def update_pool_or_subscription(subOrPool)
-    if is_hosted?
-      ensure_hostedtest_resource
-      update_hostedtest_subscription(subOrPool)
-      active_on = case subOrPool.startDate
-        when String then Date.strptime(subOrPool.startDate, "%Y-%m-%d")+1
-        when Date then subOrPool.startDate+1
-        else raise "invalid date format"
-      end
-      @cp.refresh_pools(subOrPool['owner']['key'], true)
-      sleep 1
-    else
-      @cp.update_pool(subOrPool['owner']['key'], subOrPool)
-    end
-  end
-
-  # Lets spec tests be agnostic of what mode we are testing in, standalone or hosted.
-  # This method is used when we need to update the dependent entities of a 
-  # upstream subscription or pool. simply fetching and updating the subscription forces
-  # a re-resolve of products, owners, etc.
-  #
-  # input is alwasy a pool, and there is no output
-  def refresh_upstream_subscription(pool)
-    if is_hosted?
-      ensure_hostedtest_resource
-      sub = get_hostedtest_subscription(pool.subscriptionId)
-      update_hostedtest_subscription(sub)
-      @cp.refresh_pools(pool['owner']['key'])
-    end
-  end
-
-  def cleanup_subscriptions
-    if is_hosted?
-      ensure_hostedtest_resource
-      delete_all_hostedtest_subscriptions
-    end
-  end
-
   # Wrapper for ruby API so we can track all distributor versions we created and clean them up.
   def create_distributor_version(dist_name, display_name, capabilities=[])
     dist_version = @cp.create_distributor_version(dist_name, display_name, capabilities)
@@ -315,20 +202,6 @@ module CandlepinMethods
     Candlepin.new(nil, nil, consumer.idCert.cert, consumer.idCert['key'])
   end
 
-  # List all the pools for the given owner, and find one that matches
-  # a specific subscription ID. (we often want to verify what pool was used,
-  # but the pools are created indirectly after a refresh so it's hard to
-  # locate a specific reference without this)
-  def find_main_pool(owner_key, sub_id, activeon=nil, return_normal)
-    pools = @cp.list_owner_pools(owner_key, {:activeon => activeon})
-    pools.each do |pool|
-      if pool['subscriptionId'] == sub_id && (!return_normal || pool['type'] == 'NORMAL')
-        return pool
-      end
-    end
-    return nil
-  end
-
   def trusted_consumer_client(uuid)
     Candlepin.new(nil, nil, nil, nil, "localhost", "8443", nil, uuid)
   end
@@ -368,20 +241,6 @@ module CandlepinMethods
       end
     end
     asn1_body
-  end
-
-  def is_hosted?
-    if @@hosted_mode.nil?
-      @@hosted_mode = ! @cp.get_status()['standalone']
-    end
-    return @@hosted_mode
-  end
-
-  def is_standalone?
-    if @@hosted_mode.nil?
-      @@hosted_mode = ! @cp.get_status()['standalone']
-    end
-    return !@@hosted_mode
   end
 
 end

--- a/server/spec/consumer_resource_dev_spec.rb
+++ b/server/spec/consumer_resource_dev_spec.rb
@@ -15,7 +15,7 @@ describe 'Consumer Dev Resource' do
 
     # active subscription to allow this all to work
     active_prod = create_product()
-    @active_sub = @cp.create_subscription(@owner['key'], active_prod.id, 10)
+    @active_sub = create_pool_and_subscription(@owner['key'], active_prod.id, 10)
     pools = @cp.list_owner_pools(@owner['key'])
     pools.length.should == 1
 

--- a/server/spec/derived_product_import_spec.rb
+++ b/server/spec/derived_product_import_spec.rb
@@ -49,7 +49,6 @@ describe 'Import', :serial => true do
       {
         :derived_product_id => derived_product.id
       })
-    @cp.refresh_pools(@owner['key'])
     pool = @cp.list_owner_pools(@owner['key'], {:product => stacked_datacenter_product.id})[0]
 
     # create the distributor consumer
@@ -113,8 +112,10 @@ describe 'Import', :serial => true do
     upstream_cert[0..26].should == "-----BEGIN CERTIFICATE-----"
 
     # remove created subs
-    @cp.list_subscriptions(@dist_owner['key']).each do |s|
-        @cp.delete_subscription(s.id)
+    @cp.list_owner_pools(@dist_owner['key']).each do |p|
+        if p.type == 'NORMAL' then
+          delete_pool_and_subscription(p)
+        end
     end
   end
 end

--- a/server/spec/subscription_resource_spec.rb
+++ b/server/spec/subscription_resource_spec.rb
@@ -14,16 +14,18 @@ describe 'Subscription Resource' do
   end
 
   it 'should allow owners to create subscriptions and retrieve all' do
-      @cp.create_subscription(@owner['key'], @some_product.id, 2)
-      @cp.create_subscription(@owner['key'], @another_product.id, 3)
-      @cp.create_subscription(@owner['key'], @one_more_product.id, 2)
+      create_pool_and_subscription(@owner['key'], @some_product.id, 2,
+				[], '', '', '', nil, nil, true)
+      create_pool_and_subscription(@owner['key'], @another_product.id, 3,
+				[], '', '', '', nil, nil, true)
+      create_pool_and_subscription(@owner['key'], @one_more_product.id, 2)
       @cp.list_subscriptions(@owner['key']).size.should == 3
   end
 
   it 'should allow admins to delete subscriptions' do
-      subs = @cp.create_subscription(@owner['key'], @monitoring_product.id, 5)
+      pool = create_pool_and_subscription(@owner['key'], @monitoring_product.id, 5)
       @cp.list_subscriptions(@owner['key']).size.should == 1
-      @cp.delete_subscription(subs.id)
+      delete_pool_and_subscription(pool)
       @cp.list_subscriptions(@owner['key']).size.should == 0
   end
 


### PR DESCRIPTION
* fix scripts that were using older client versions
* bin scripts should now use HostedTest resources
* I have only fixed scripts that were using create_subscription. there may be other scripts still broken, no idea what is used and what is stale.
*  found that spec tests are still being written using create_subscription. Throw an error if that happens.
* move hosted test methods from candlepin scenarios to hostedtest_api so scripts can use them.