### PR TITLE
1300705: Fix perf issue finding dev pools

### DIFF
--- a/server/src/main/java/org/candlepin/model/PoolCurator.java
+++ b/server/src/main/java/org/candlepin/model/PoolCurator.java
@@ -766,6 +766,7 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
         filters.addAttributeFilter(Pool.REQUIRES_CONSUMER_ATTRIBUTE, consumer.getUuid());
 
         Criteria criteria =  currentSession().createCriteria(Pool.class);
+        criteria.add(Restrictions.eq("owner", consumer.getOwner()));
         filters.applyTo(criteria);
         criteria.setMaxResults(1).uniqueResult();
         return (Pool) criteria.uniqueResult();

--- a/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
@@ -1076,7 +1076,6 @@ public class PoolCuratorTest extends DatabaseTestFixture {
 
         assertEquals(expected, this.poolCurator.getAllKnownProductIdsForOwner(owners.get(0)));
 
-
         expected = new HashSet<String>();
         expected.add("p2");
         expected.add("dp2");
@@ -1221,9 +1220,13 @@ public class PoolCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void testLookupDevPoolForConsumer() throws Exception {
+        // Make sure that multiple pools exist.
+        createPool(owner, product, -1L, TestUtil.createDate(2010, 3, 2),
+                TestUtil.createDate(Calendar.getInstance().get(Calendar.YEAR) + 1, 3, 2));
         Pool pool = createPool(owner, product, -1L, TestUtil.createDate(2010, 3, 2),
             TestUtil.createDate(Calendar.getInstance().get(Calendar.YEAR) + 1, 3, 2));
         pool.setAttribute("requires_consumer", consumer.getUuid());
+        pool.setAttribute("another_attr", "20");
         pool.setAttribute("dev_pool", "true");
         poolCurator.create(pool);
 
@@ -1234,6 +1237,9 @@ public class PoolCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void testDevPoolForConsumerNotFoundReturnsNullWhenNoMatchOnConsumer() throws Exception {
+        // Make sure that multiple pools exist.
+        createPool(owner, product, -1L, TestUtil.createDate(2010, 3, 2),
+                TestUtil.createDate(Calendar.getInstance().get(Calendar.YEAR) + 1, 3, 2));
         Pool pool = createPool(owner, product, -1L, TestUtil.createDate(2010, 3, 2),
             TestUtil.createDate(Calendar.getInstance().get(Calendar.YEAR) + 1, 3, 2));
         pool.setAttribute("requires_consumer", "does-not-exist");


### PR DESCRIPTION
Auto-attach for a developer consumer was taking approx
2 minutes due to the query used to check if a development
pool existed for the consumer.

This patch improves the query time by adding an owner filter
to the Pools query.

**Testing Note**
This bug was only reproducible with a lot of pools already existing. I've tested this already against a large data set and since it takes a while to get set up, I'd suggest just doing a functionality check to verify this PR. 