### PR TITLE
Add special case code to handle empty CRLs.

### DIFF
--- a/buildfile
+++ b/buildfile
@@ -130,13 +130,6 @@ BOUNCYCASTLE = group('bcmail-jdk16', 'bcprov-jdk16',
                      :under => 'org.bouncycastle',
                      :version => '1.46')
 
-# Classes to generate ad-hoc X509 certs and CRLs
-# Beginning with 1.47 many of the classes in this artifact move to bcpkix
-# so any upgrade to Bouncy Castle will need to change the artifact name
-BOUNCYCASTLE_TESTING = group('bcmail-jdk15on',
-                             :under => 'org.bouncycastle',
-                             :version => '1.46')
-
 SERVLET = 'javax.servlet:servlet-api:jar:2.5'
 
 GUICE =  [group('guice-assistedinject', 'guice-multibindings',
@@ -463,7 +456,6 @@ define "candlepin" do
       JUKITO,
       HSQLDB,
       LIQUIBASE_SLF4J,
-      BOUNCYCASTLE_TESTING,
     ])
     test.using(:java_args => [ '-Xmx2g', '-XX:+HeapDumpOnOutOfMemoryError' ])
 

--- a/server/src/main/java/org/candlepin/util/DERUtil.java
+++ b/server/src/main/java/org/candlepin/util/DERUtil.java
@@ -202,7 +202,6 @@ public class DERUtil {
             // since indefinite length formats are forbidden in DER.
             throw new IOException("Indefinite length encoding detected." +
                 "  Check that input is DER and not BER/CER.");
-            // return -1;
         }
 
         if (length > 127) {
@@ -210,6 +209,15 @@ public class DERUtil {
 
             // Note: The invalid long form "0xff" (see X.690 8.1.3.5c) will be caught here
             if (size > 4) {
+                /* Long definite lengths can go up to 2^1008 - 1 but since we are storing
+                 * length in an integer, we can only store lengths up to 2^31 - 1 (the maximum
+                 * for a Java integer).
+                 *
+                 * ASN1 lengths use the last 7 bits of subsequent octets to encode the length value
+                 * for long form lengths.  Therefore, a 4 byte length translates to 2^(8*3) maximum
+                 * or around 16 million bytes of data but a 5 byte length is 2^(8*4)
+                 * and larger than what an int can handle.
+                 */
                 throw new IOException("DER length more than 4 bytes: " + size);
             }
 


### PR DESCRIPTION
Empty CRLs are missing the revokedCertificates sequence which creates a
difficult situation for the streaming code since it has to consume part
of the stream in order to determine if the list is empty or not.  If the
list isn't empty, then we've consumed part of the ASN1 that we actually
needed.  This state is especially problematic for the
X509CRLStreamWriter because it relies on X509CRLEntryStream to leave the
stream in a known state.