### PR TITLE
Allow X509CRLStreamWriter to change AuthorityKeyIdentifier extension.

### DIFF
--- a/server/src/main/java/org/candlepin/util/CrlFileUtil.java
+++ b/server/src/main/java/org/candlepin/util/CrlFileUtil.java
@@ -204,7 +204,7 @@ public class CrlFileUtil {
             // Note: This will break if we ever stop using RSA keys
             PrivateKey key = this.pkiReader.getCaKey();
             X509CRLStreamWriter writer = new X509CRLStreamWriter(
-                input, (RSAPrivateKey) key);
+                input, (RSAPrivateKey) key, this.pkiReader.getCACert());
 
             // Add new entries
             if (revoke != null) {

--- a/server/src/main/java/org/candlepin/util/X509CRLEntryStream.java
+++ b/server/src/main/java/org/candlepin/util/X509CRLEntryStream.java
@@ -117,6 +117,11 @@ public class X509CRLEntryStream implements Closeable, Iterator<X509CRLEntryObjec
         this(new BufferedInputStream(new FileInputStream(crlFile)));
     }
 
+    @Override
+    public void remove() {
+        throw new UnsupportedOperationException("Remove is not implemented.");
+    }
+
     /**
      * Strip off the CRL meta-data and drill down to the sequence containing the
      * revokedCertificates objects.

--- a/server/src/test/java/org/candlepin/util/CrlFileUtilTest.java
+++ b/server/src/test/java/org/candlepin/util/CrlFileUtilTest.java
@@ -43,7 +43,6 @@ import java.io.FileInputStream;
 import java.io.FileReader;
 import java.math.BigInteger;
 import java.net.URL;
-import java.security.Provider;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509CRL;
 import java.security.cert.X509CRLEntry;
@@ -59,7 +58,7 @@ import javax.inject.Inject;
 @RunWith(MockitoJUnitRunner.class)
 public class CrlFileUtilTest {
 
-    private static final Provider BC = new BouncyCastleProvider();
+    private static final BouncyCastleProvider BC = new BouncyCastleProvider();
     private CrlFileUtil cfu;
 
     @Inject private PKIReader pkiReader;
@@ -226,7 +225,7 @@ public class CrlFileUtilTest {
             try {
                 in = new BufferedInputStream(new FileInputStream(f));
                 x509crl = (X509CRL) CertificateFactory.getInstance("X.509").generateCRL(in);
-                x509crl.verify(pkiReader.getCACert().getPublicKey(), BC);
+                x509crl.verify(pkiReader.getCACert().getPublicKey(), BC.PROVIDER_NAME);
                 Set<BigInteger> s = new HashSet<BigInteger>();
 
                 for (X509CRLEntry entry : x509crl.getRevokedCertificates()) {


### PR DESCRIPTION
The AuthorityKeyIdentifier is an extension that identifies the public
key of the key pair used to sign the CRL.  If users change keys, in the
old implementation the AuthorityKeyIdentifier would not be updated to
reflect the new key pair.  This patch corrects that oversight.