### PR TITLE
Add missing RPM requires.

### DIFF
--- a/server/candlepin.spec.tmpl
+++ b/server/candlepin.spec.tmpl
@@ -47,6 +47,8 @@ Requires: java >= 0:1.6.0
 Requires: wget
 Requires: %{tomcat}
 Requires: liquibase >= 0:2.0.5
+# Need JDBC driver for cpdb
+Requires: postgresql-jdbc
 
 %description
 Candlepin is an open source entitlement management system.


### PR DESCRIPTION
The spec file was missing a requires on the JDBC driver which `cpdb` needs.