### PR TITLE
Remove some unnecessary code from the CRL streaming writer.

### DIFF
--- a/server/src/main/java/org/candlepin/util/X509CRLStreamWriter.java
+++ b/server/src/main/java/org/candlepin/util/X509CRLStreamWriter.java
@@ -479,36 +479,13 @@ public class X509CRLStreamWriter {
             }
         }
 
-        ASN1InputStream asn1In = null;
-        byte[] extensions = null;
-        try {
-            asn1In = new ASN1InputStream(crlIn);
-
-            DERObject o;
-            while ((o = asn1In.readObject()) != null) {
-                if (o instanceof DERSequence) {
-                    // Don't care about the old signatureAlorithm or signatureValue at this point
-                    break;
-                }
-                else {
-                    if (extensions != null) {
-                        throw new IllegalStateException("Already read in CRL extensions.");
-                    }
-                    extensions = o.getDEREncoded();
-                }
-            }
-        }
-        finally {
-            IOUtils.closeQuietly(asn1In);
-        }
-
         // Write the new entries into the new CRL
         for (DERSequence entry : newEntries) {
             writeBytes(out, entry.getDEREncoded(), signer);
         }
 
         // Copy the old extensions over
-        if (extensions != null) {
+        if (newExtensions != null) {
             out.write(newExtensions);
             signer.update(newExtensions, 0, newExtensions.length);
         }

--- a/server/src/test/java/org/candlepin/util/X509CRLStreamWriterTest.java
+++ b/server/src/test/java/org/candlepin/util/X509CRLStreamWriterTest.java
@@ -51,6 +51,7 @@ import java.math.BigInteger;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.PublicKey;
+import java.security.Security;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509CRL;
 import java.security.cert.X509CRLEntry;
@@ -92,6 +93,7 @@ public class X509CRLStreamWriterTest {
             .build(keyPair.getPrivate());
 
         outfile = new File(folder.getRoot(), "new.crl");
+        Security.addProvider(BC);
     }
 
     private X509v2CRLBuilder createCRLBuilder() throws Exception {


### PR DESCRIPTION
Add the BouncyCastle provider in the unit test.