### PR TITLE
Specify 'utf-8' as txt encoding for source files.

### DIFF
--- a/tasks/gettext.rake
+++ b/tasks/gettext.rake
@@ -72,7 +72,7 @@ module Gettext
             java_files << Dir[File.join(src, '**', '*.java')]
           end
 
-          args = %w[-k -F -ktrc:1c,2 -ktrnc:1c,2,3 -ktr -kmarktr -ktrn:1,2]
+          args = %w[-k -F -ktrc:1c,2 -ktrnc:1c,2,3 -ktr -kmarktr -ktrn:1,2 --from-code=utf-8]
           args << gettext.xgettext_args
           args << ['-o', gettext.keys_destination]
 


### PR DESCRIPTION
'builder gettext:extract" uses xgettext to extract string
catalogs, and sans '--from-code=utf-8', it assumes source
files are encoded as plain ASCII. If a file includes (valid)
utf-8 that is not also plain ASCII, xgettext fails with an
error like:

xgettext: Non-ASCII comment at or before
gutterball/src/main/java/org/candlepin/gutterball/util/cron/CronSchedule.java:39.
          Please specify the source encoding through --from-code.