### PR TITLE
Remove non-ascii characters from CronSchedule

### DIFF
--- a/gutterball/src/main/java/org/candlepin/gutterball/util/cron/CronSchedule.java
+++ b/gutterball/src/main/java/org/candlepin/gutterball/util/cron/CronSchedule.java
@@ -28,7 +28,7 @@ import java.util.regex.Pattern;
 
 
 
-/**
+ /**
  * The CronSchedule class represents a cron-like schedule parser and matcher. It accepts schedules
  * in a simplified cron format and can find dates matching the given schedule relative to other
  * dates.
@@ -36,13 +36,13 @@ import java.util.regex.Pattern;
  *
  * The schedule format accepted by this class is as follows:
  * <pre>
- *           ┌───────────── minutes (0 - 59)
- *           │ ┌────────────── hour (0 - 23)
- *           │ │ ┌─────────────── day of month (1 - 31)
- *           │ │ │ ┌──────────────── month (1 - 12)
- *           │ │ │ │ ┌───────────────── day of week (0 - 6, representing Sunday to Saturday)
- *           │ │ │ │ │
- *           │ │ │ │ │
+ *           +------------- minutes (0 - 59)
+ *           | +-------------- hour (0 - 23)
+ *           | | +--------------- day of month (1 - 31)
+ *           | | | +---------------- month (1 - 12)
+ *           | | | | +----------------- day of week (0 - 6, representing Sunday to Saturday)
+ *           | | | | |
+ *           | | | | |
  * schedule: * * * * *
  * </pre>
  *


### PR DESCRIPTION
Replaced the comment explaining the accepted format for the cron scheduler, with a similar comment using only ascii characters. (The new comment was provided by Ceiu).

This is needed to update the strings for translation with zanata.