### PR TITLE
Fix apicrawler

### DIFF
--- a/buildfile
+++ b/buildfile
@@ -183,6 +183,8 @@ PROVIDED = [SERVLET]
 # Buildr to include it in the Eclipse .classpath file.
 JAVA_TOOLS = file(Java.tools_jar)
 
+SCANNOTATION = 'org.scannotation:scannotation:jar:1.0.3'
+
 # Make Util available in all projects.  See http://buildr.apache.org/extending.html#extensions
 class Project
   include Candlepin::Util
@@ -280,6 +282,7 @@ define "candlepin" do
       GUICE,
       LOGGING,
       JAVA_TOOLS,
+      SCANNOTATION,
     ]
 
     compile.with(compile_classpath)
@@ -546,10 +549,10 @@ define "candlepin" do
 
       combined = Hash[api.collect { |a| [a['method'], a] }]
       comments.each do |c|
-        if combined.has_key? c['method']
+        if combined.key?(c['method'])
           combined[c['method']].merge!(c)
         else
-          combined[c['method']] = c
+          warn "Ignoring #{c['method']} as only its comments were found"
         end
       end
 

--- a/server/src/main/java/org/candlepin/resource/OwnerProductResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerProductResource.java
@@ -100,6 +100,9 @@ public class OwnerProductResource {
      *
      * @return
      *  the Owner instance for the owner with the specified key.
+     *
+     * @httpcode 200
+     * @httpcode 404
      */
     protected Owner getOwnerByKey(String key) {
         Owner owner = this.ownerCurator.lookupByKey(key);
@@ -309,6 +312,9 @@ public class OwnerProductResource {
      *
      * @return
      *  the Owner instance for the owner with the specified key.
+     *
+     * @httpcode 200
+     * @httpcode 404
      */
     protected Content getContent(Owner owner, String contentId) {
         Content content = this.contentCurator.lookupById(owner, contentId);
@@ -492,6 +498,7 @@ public class OwnerProductResource {
      * @param productId
      * @param lazyRegen
      * @return a JobDetail object
+     * @httpcode 200
      */
     @PUT
     @Path("/{product_id}/subscriptions")


### PR DESCRIPTION
The API crawler had several problems: resource classes not listed in
RootResource were not getting scanned and overloaded methods were not
being documented correctly.

This patch uses Scannotation to search for classes providing a REST
resource instead of relying on listing in the RootResource.

This patch should produce a "candlepin_methods.json" that no longer causes the Jekyll builder to throw warnings.