### PR TITLE
Correct error in SKU search SQL seen in MySQL.

### DIFF
--- a/project_conf/checks.xml
+++ b/project_conf/checks.xml
@@ -184,7 +184,6 @@
     <!-- <module name="IllegalCatch"/> -->
     <!-- <module name="IllegalThrows"/> -->
     <!-- <module name="PackageDeclaration"/> -->
-    <module name="JUnitTestCase"/>
     <!-- <module name="ReturnCount"/> -->
     <!-- <module name="IllegalType"/> -->
     <!-- <module name="DeclarationOrder"/> -->

--- a/server/src/main/java/org/candlepin/model/ConsumerCurator.java
+++ b/server/src/main/java/org/candlepin/model/ConsumerCurator.java
@@ -709,16 +709,17 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
                     }
 
                     Product p = productMap.get(sku);
-                    boolean isMkt = true;
+                    int isMkt = 1;
                     if (!p.getAttributeValue("type").equals("MKT")) {
-                        isMkt = false;
+                        log.info("Attempted to search for consumers with SKU " + sku + " which is not an MKT product");
+                        isMkt = 0;
                     }
 
                     // This is pretty ugly but it's not until Candlepin 2.x that we have a direct
                     // association to the Product object.
                     subCrit.createCriteria("entitlements").createCriteria("pool")
                         .add(Restrictions.eq("productId", sku))
-                        .add(Restrictions.sqlRestriction(String.valueOf(isMkt) + "='true'"));
+                        .add(Restrictions.sqlRestriction(String.valueOf(isMkt) + "=1"));
 
                     subCrit.add(Restrictions.eqProperty("this.id", "subquery_consumer.id"));
 


### PR DESCRIPTION
The '1=1' stipulation is to reject searches performed on non-marketing
product SKUs.  Originally the stipulation was "true='true'" which worked
on PostgreSQL but not on MySQL.