### PR TITLE
1242310: Do not issue ueber certs that expire after 2050.

### DIFF
--- a/server/spec/ueber_cert_spec.rb
+++ b/server/spec/ueber_cert_spec.rb
@@ -81,6 +81,9 @@ describe 'Uebercert' do
     ueber_entitlement["certificates"].length.should == 1
 
     x509 = OpenSSL::X509::Certificate.new(ueber_entitlement["certificates"][0]["cert"])
+
+    # See BZ 1242310
+    x509.not_after.should eq(Time.new(2049, 12, 1, 13, 0, 0, "+00:00"))
     extensions_hash = Hash[x509.extensions.collect { |ext| [ext.oid, ext.to_der()] }]
 
     cert_product = nil


### PR DESCRIPTION
RFC 5280 states in section 4.1.2.5:

    CAs conforming to this profile MUST always encode certificate
    validity dates through the year 2049 as UTCTime; certificate validity
    dates in 2050 or later MUST be encoded as GeneralizedTime.
    Conforming applications MUST be able to process validity dates that
    are encoded in either UTCTime or GeneralizedTime.

But currently, python-rhsm is parsing certificates with either M2Crypto
or a custom C binding (certificate.c) to OpenSSL's x509v3 (so that we can access
the raw octets in the custom X509 extensions used in version 3 entitlement
certificates).  Both M2Crypto and our binding contain code that automatically
converts the Not After time into a UTCTime.  The conversion "succeeds" but the
value of the resultant object is something like "Bad time value" which, when
fed into Python's datetime, causes an exception.

The quick fix is to not issue certificates that expire after January 1, 2050.