### PR TITLE
Fixed broken option parsing

### DIFF
--- a/server/bin/data_generator.rb
+++ b/server/bin/data_generator.rb
@@ -802,6 +802,7 @@ def safeParseInt(value, err_msg)
     if value < 1 then
       raise ArgumentError
     end
+    return value
   rescue ArgumentError
     $stderr.puts err_msg
     exit


### PR DESCRIPTION
When parsing safe ints, the value wasn't being
returned from the function causing nil option
values.

The script was broken if any int param value
was set.