### PR TITLE
Request scope caching of cp_rules.updated 

### DIFF
--- a/server/src/main/java/org/candlepin/guice/CandlepinModule.java
+++ b/server/src/main/java/org/candlepin/guice/CandlepinModule.java
@@ -14,6 +14,13 @@
  */
 package org.candlepin.guice;
 
+import java.util.Properties;
+
+import javax.inject.Provider;
+import javax.validation.MessageInterpolator;
+import javax.validation.Validation;
+import javax.validation.ValidatorFactory;
+
 import org.candlepin.audit.AMQPBusPublisher;
 import org.candlepin.audit.EventSink;
 import org.candlepin.audit.EventSinkImpl;
@@ -125,6 +132,12 @@ import org.candlepin.util.DateSource;
 import org.candlepin.util.DateSourceImpl;
 import org.candlepin.util.ExpiryDateFunction;
 import org.candlepin.util.X509ExtensionUtil;
+import org.hibernate.cfg.beanvalidation.BeanValidationEventListener;
+import org.hibernate.validator.HibernateValidator;
+import org.hibernate.validator.HibernateValidatorConfiguration;
+import org.quartz.JobListener;
+import org.quartz.spi.JobFactory;
+import org.xnap.commons.i18n.I18n;
 
 import com.google.common.base.Function;
 import com.google.inject.AbstractModule;
@@ -133,20 +146,6 @@ import com.google.inject.Singleton;
 import com.google.inject.name.Named;
 import com.google.inject.name.Names;
 import com.google.inject.persist.jpa.JpaPersistModule;
-
-import org.hibernate.cfg.beanvalidation.BeanValidationEventListener;
-import org.hibernate.validator.HibernateValidator;
-import org.hibernate.validator.HibernateValidatorConfiguration;
-import org.quartz.JobListener;
-import org.quartz.spi.JobFactory;
-import org.xnap.commons.i18n.I18n;
-
-import java.util.Properties;
-
-import javax.inject.Provider;
-import javax.validation.MessageInterpolator;
-import javax.validation.Validation;
-import javax.validation.ValidatorFactory;
 
 /**
  * CandlepinModule

--- a/server/src/main/java/org/candlepin/guice/CandlepinModule.java
+++ b/server/src/main/java/org/candlepin/guice/CandlepinModule.java
@@ -160,9 +160,9 @@ public class CandlepinModule extends AbstractModule {
     @Override
     public void configure() {
         // Bindings for our custom scope
-        CandlepinSingletonScope singletonScope = new CandlepinSingletonScope();
-        bindScope(CandlepinSingletonScoped.class, singletonScope);
-        bind(CandlepinSingletonScope.class).toInstance(singletonScope);
+        CandlepinRequestScope requestScope = new CandlepinRequestScope();
+        bindScope(CandlepinRequestScoped.class, requestScope);
+        bind(CandlepinRequestScope.class).toInstance(requestScope);
 
         bind(I18n.class).toProvider(I18nProvider.class);
         bind(BeanValidationEventListener.class).toProvider(

--- a/server/src/main/java/org/candlepin/guice/CandlepinRequestScope.java
+++ b/server/src/main/java/org/candlepin/guice/CandlepinRequestScope.java
@@ -25,19 +25,21 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * CandlepinSingletonScope
+ * CandlepinRequestScope
  *
- * A per-request / per-unit of work guice singleton scope.
+ * A per-request / per-unit of work scope. This implementation is
+ * more appropriate for Candlepin, because it works even in
+ * our Quartz jobs (standard Guice annotation RequestScoped doesn't).
  */
-public class CandlepinSingletonScope implements Scope {
+public class CandlepinRequestScope implements Scope {
 
     public void enter() {
-        ResteasyProviderFactory.pushContext(CandlepinSingletonScopeData.class,
-            new CandlepinSingletonScopeData());
+        ResteasyProviderFactory.pushContext(CandlepinRequestScopeData.class,
+            new CandlepinRequestScopeData());
     }
 
     public void exit() {
-        ResteasyProviderFactory.popContextData(CandlepinSingletonScopeData.class);
+        ResteasyProviderFactory.popContextData(CandlepinRequestScopeData.class);
     }
 
     public <T> Provider<T> scope(final Key<T> key, final Provider<T> unscoped) {
@@ -57,8 +59,8 @@ public class CandlepinSingletonScope implements Scope {
     }
 
     private <T> Map<Key<?>, Object> getScopedObjectMap(Key<T> key) {
-        CandlepinSingletonScopeData scopeData = ResteasyProviderFactory.getContextData(
-            CandlepinSingletonScopeData.class);
+        CandlepinRequestScopeData scopeData = ResteasyProviderFactory.getContextData(
+            CandlepinRequestScopeData.class);
         if (scopeData == null) {
             throw new OutOfScopeException("Cannot access " + key +
                 " outside of a scoping block");
@@ -67,11 +69,11 @@ public class CandlepinSingletonScope implements Scope {
     }
 
     /**
-     * CandlepinSingletonScopeData class to hold the local session scoped data map.
+     * CandlepinRequestScope class to hold the local session scoped data map.
      *
      * We really need single per resteasy session, so let resteasy handle scoping for us.
      */
-    private class CandlepinSingletonScopeData {
+    private class CandlepinRequestScopeData {
         private Map<Key<?>, Object> scopeData = new HashMap<Key<?>, Object>();
 
         public Map<Key<?>, Object> get() {

--- a/server/src/main/java/org/candlepin/guice/CandlepinRequestScoped.java
+++ b/server/src/main/java/org/candlepin/guice/CandlepinRequestScoped.java
@@ -24,10 +24,10 @@ import java.lang.annotation.Target;
 
 
 /**
- * CandlepinSingletonScoped
+ * CandlepinRequestScoped
  *
  * Apply this to implementation classes when you want one instance per
  * either request or pinsetter job.
  */
 @Target({ TYPE, METHOD }) @Retention(RUNTIME) @ScopeAnnotation
-public @interface CandlepinSingletonScoped {}
+public @interface CandlepinRequestScoped {}

--- a/server/src/main/java/org/candlepin/pinsetter/core/GuiceJobFactory.java
+++ b/server/src/main/java/org/candlepin/pinsetter/core/GuiceJobFactory.java
@@ -14,7 +14,7 @@
  */
 package org.candlepin.pinsetter.core;
 
-import org.candlepin.guice.CandlepinSingletonScope;
+import org.candlepin.guice.CandlepinRequestScope;
 
 import com.google.inject.Inject;
 import com.google.inject.Injector;
@@ -37,14 +37,14 @@ public class GuiceJobFactory implements JobFactory {
 
     private static Logger log = LoggerFactory.getLogger(GuiceJobFactory.class);
     private Injector injector;
-    private CandlepinSingletonScope candlepinSingletonScope;
+    private CandlepinRequestScope candlepinRequestScope;
     private UnitOfWork unitOfWork;
 
     @Inject
-    public GuiceJobFactory(Injector injector, CandlepinSingletonScope singletonScope,
+    public GuiceJobFactory(Injector injector, CandlepinRequestScope requestScope,
         UnitOfWork unitOfWork) {
         this.injector = injector;
-        this.candlepinSingletonScope = singletonScope;
+        this.candlepinRequestScope = requestScope;
         this.unitOfWork = unitOfWork;
     }
 
@@ -57,12 +57,12 @@ public class GuiceJobFactory implements JobFactory {
         Class<Job> jobClass = (Class<Job>) bundle.getJobDetail().getJobClass();
 
         boolean startedUow = startUnitOfWork();
-        candlepinSingletonScope.enter();
+        candlepinRequestScope.enter();
         try {
             return injector.getInstance(jobClass);
         }
         finally {
-            candlepinSingletonScope.exit();
+            candlepinRequestScope.exit();
             if (startedUow) {
                 endUnitOfWork();
             }

--- a/server/src/main/java/org/candlepin/policy/js/JsRunnerRequestCache.java
+++ b/server/src/main/java/org/candlepin/policy/js/JsRunnerRequestCache.java
@@ -16,7 +16,7 @@ package org.candlepin.policy.js;
 
 import java.util.Date;
 
-import org.candlepin.guice.CandlepinSingletonScoped;
+import org.candlepin.guice.CandlepinRequestScoped;
 
 /**
  * A request scoped cache that is used to mitigate repeated
@@ -24,7 +24,7 @@ import org.candlepin.guice.CandlepinSingletonScoped;
  * @author fnguyen
  *
  */
-@CandlepinSingletonScoped
+@CandlepinRequestScoped
 public class JsRunnerRequestCache {
 
     private Date updated = null;

--- a/server/src/main/java/org/candlepin/policy/js/JsRunnerRequestCache.java
+++ b/server/src/main/java/org/candlepin/policy/js/JsRunnerRequestCache.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.policy.js;
+
+import java.util.Date;
+
+import org.candlepin.guice.CandlepinSingletonScoped;
+
+/**
+ * A request scoped cache that is used to mitigate repeated
+ * DB requests for cp_rules.updated column.
+ * @author fnguyen
+ *
+ */
+@CandlepinSingletonScoped
+public class JsRunnerRequestCache {
+
+    private Date updated = null;
+
+    public void setUpdated(Date updated) {
+        this.updated = updated;
+    }
+
+    public Date getUpdated() {
+        return updated;
+    }
+}

--- a/server/src/main/java/org/candlepin/policy/js/JsRunnerRequestCacheProvider.java
+++ b/server/src/main/java/org/candlepin/policy/js/JsRunnerRequestCacheProvider.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.policy.js;
+
+import com.google.inject.Provider;
+
+/**
+ * Cache provider to do Google Guice Scope Mixing
+ * @author fnguyen
+ *
+ */
+public class JsRunnerRequestCacheProvider implements Provider<JsRunnerRequestCache> {
+
+    @Override
+    public JsRunnerRequestCache get() {
+        return new JsRunnerRequestCache();
+    }
+}

--- a/server/src/main/java/org/candlepin/servlet/filter/CandlepinScopeFilter.java
+++ b/server/src/main/java/org/candlepin/servlet/filter/CandlepinScopeFilter.java
@@ -14,7 +14,7 @@
  */
 package org.candlepin.servlet.filter;
 
-import org.candlepin.guice.CandlepinSingletonScope;
+import org.candlepin.guice.CandlepinRequestScope;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -47,11 +47,11 @@ public class CandlepinScopeFilter implements Filter {
 
     private static Logger log = LoggerFactory.getLogger(CandlepinScopeFilter.class);
 
-    private final CandlepinSingletonScope singletonScope;
+    private final CandlepinRequestScope requestScope;
 
     @Inject
-    public CandlepinScopeFilter(CandlepinSingletonScope singletonScope) {
-        this.singletonScope = singletonScope;
+    public CandlepinScopeFilter(CandlepinRequestScope requestScope) {
+        this.requestScope = requestScope;
     }
 
     @Override
@@ -63,12 +63,12 @@ public class CandlepinScopeFilter implements Filter {
             return;
         }
 
-        singletonScope.enter();
+        requestScope.enter();
         try {
             chain.doFilter(request, response);
         }
         finally {
-            singletonScope.exit();
+            requestScope.exit();
         }
     }
 

--- a/server/src/test/java/org/candlepin/TestingModules.java
+++ b/server/src/test/java/org/candlepin/TestingModules.java
@@ -27,8 +27,8 @@ import org.candlepin.common.validation.CandlepinMessageInterpolator;
 import org.candlepin.config.CandlepinCommonTestConfig;
 import org.candlepin.controller.CandlepinPoolManager;
 import org.candlepin.controller.PoolManager;
-import org.candlepin.guice.CandlepinSingletonScope;
-import org.candlepin.guice.CandlepinSingletonScoped;
+import org.candlepin.guice.CandlepinRequestScope;
+import org.candlepin.guice.CandlepinRequestScoped;
 import org.candlepin.guice.I18nProvider;
 import org.candlepin.guice.PrincipalProvider;
 import org.candlepin.guice.ScriptEngineProvider;
@@ -238,12 +238,12 @@ public class TestingModules {
             // context listener
             bind(Configuration.class).toInstance(config);
 
-            CandlepinSingletonScope singletonScope = new CandlepinSingletonScope();
-            bindScope(CandlepinSingletonScoped.class, singletonScope);
+            CandlepinRequestScope requestScope = new CandlepinRequestScope();
+            bindScope(CandlepinRequestScoped.class, requestScope);
             //RequestScoped doesn't exist in unit tests, so we must
             //define test alternative for it.
             bindScope(RequestScoped.class, new TestingRequestScope());
-            bind(CandlepinSingletonScope.class).toInstance(singletonScope);
+            bind(CandlepinRequestScope.class).toInstance(requestScope);
 
             bind(X509ExtensionUtil.class);
 

--- a/server/src/test/java/org/candlepin/TestingModules.java
+++ b/server/src/test/java/org/candlepin/TestingModules.java
@@ -33,6 +33,7 @@ import org.candlepin.guice.I18nProvider;
 import org.candlepin.guice.PrincipalProvider;
 import org.candlepin.guice.ScriptEngineProvider;
 import org.candlepin.guice.TestPrincipalProvider;
+import org.candlepin.guice.TestingRequestScope;
 import org.candlepin.guice.ValidationListenerProvider;
 import org.candlepin.model.Rules;
 import org.candlepin.model.RulesCurator;
@@ -92,6 +93,7 @@ import com.google.inject.name.Names;
 import com.google.inject.persist.PersistService;
 import com.google.inject.persist.UnitOfWork;
 import com.google.inject.persist.jpa.JpaPersistModule;
+import com.google.inject.servlet.RequestScoped;
 
 import org.hibernate.Session;
 import org.hibernate.cfg.beanvalidation.BeanValidationEventListener;
@@ -238,6 +240,9 @@ public class TestingModules {
 
             CandlepinSingletonScope singletonScope = new CandlepinSingletonScope();
             bindScope(CandlepinSingletonScoped.class, singletonScope);
+            //RequestScoped doesn't exist in unit tests, so we must
+            //define test alternative for it.
+            bindScope(RequestScoped.class, new TestingRequestScope());
             bind(CandlepinSingletonScope.class).toInstance(singletonScope);
 
             bind(X509ExtensionUtil.class);

--- a/server/src/test/java/org/candlepin/guice/TestingRequestScope.java
+++ b/server/src/test/java/org/candlepin/guice/TestingRequestScope.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.guice;
+
+import com.google.inject.Key;
+import com.google.inject.Provider;
+import com.google.inject.Scope;
+
+/**
+ * Noop scope
+ * @author fnguyen
+ *
+ */
+public class TestingRequestScope implements Scope {
+
+    @Override
+    public <T> Provider<T> scope(Key<T> key, Provider<T> unscoped) {
+        return unscoped;
+    }
+
+}

--- a/server/src/test/java/org/candlepin/policy/AutobindRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/AutobindRulesTest.java
@@ -35,6 +35,7 @@ import org.candlepin.model.RulesCurator;
 import org.candlepin.model.SourceSubscription;
 import org.candlepin.policy.js.JsRunner;
 import org.candlepin.policy.js.JsRunnerProvider;
+import org.candlepin.policy.js.JsRunnerRequestCache;
 import org.candlepin.policy.js.autobind.AutobindRules;
 import org.candlepin.policy.js.compliance.ComplianceStatus;
 import org.candlepin.test.TestDateUtil;
@@ -46,6 +47,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+
+import com.google.inject.Provider;
 
 import java.io.InputStream;
 import java.util.Arrays;
@@ -61,6 +64,8 @@ import java.util.Set;
  * AutobindRulesTest
  */
 public class AutobindRulesTest {
+    @Mock private Provider<JsRunnerRequestCache> cacheProvider;
+    @Mock private JsRunnerRequestCache cache;
     @Mock private Configuration config;
     @Mock private RulesCurator rulesCurator;
 
@@ -86,8 +91,8 @@ public class AutobindRulesTest {
         when(rulesCurator.getRules()).thenReturn(rules);
         when(rulesCurator.getUpdated()).thenReturn(
             TestDateUtil.date(2010, 1, 1));
-
-        JsRunner jsRules = new JsRunnerProvider(rulesCurator).get();
+        when(cacheProvider.get()).thenReturn(cache);
+        JsRunner jsRules = new JsRunnerProvider(rulesCurator, cacheProvider).get();
         autobindRules = new AutobindRules(jsRules);
 
         owner = new Owner();

--- a/server/src/test/java/org/candlepin/policy/EnforcerTest.java
+++ b/server/src/test/java/org/candlepin/policy/EnforcerTest.java
@@ -38,6 +38,7 @@ import org.candlepin.model.Rules;
 import org.candlepin.model.RulesCurator;
 import org.candlepin.policy.js.JsRunner;
 import org.candlepin.policy.js.JsRunnerProvider;
+import org.candlepin.policy.js.JsRunnerRequestCache;
 import org.candlepin.policy.js.RuleExecutionException;
 import org.candlepin.policy.js.entitlement.Enforcer;
 import org.candlepin.policy.js.entitlement.EntitlementRules;
@@ -52,6 +53,8 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.xnap.commons.i18n.I18n;
+
+import com.google.inject.Provider;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
@@ -78,6 +81,8 @@ public class EnforcerTest extends DatabaseTestFixture {
     @Mock private ProductServiceAdapter productAdapter;
     @Mock private RulesCurator rulesCurator;
     @Mock private Configuration config;
+    @Mock private Provider<JsRunnerRequestCache> cacheProvider;
+    @Mock private JsRunnerRequestCache cache;
 
     private Enforcer enforcer;
     private Owner owner;
@@ -112,8 +117,9 @@ public class EnforcerTest extends DatabaseTestFixture {
         when(rules.getRules()).thenReturn(builder.toString());
         when(rulesCurator.getRules()).thenReturn(rules);
         when(rulesCurator.getUpdated()).thenReturn(TestDateUtil.date(2010, 1, 1));
+        when(cacheProvider.get()).thenReturn(cache);
 
-        JsRunner jsRules = new JsRunnerProvider(rulesCurator).get();
+        JsRunner jsRules = new JsRunnerProvider(rulesCurator, cacheProvider).get();
 
         enforcer = new EntitlementRules(
             new DateSourceForTesting(2010, 1, 1), jsRules, i18n, config, consumerCurator, poolCurator

--- a/server/src/test/java/org/candlepin/policy/js/JsRunnerProviderTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/JsRunnerProviderTest.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.policy.js;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Date;
+
+import org.candlepin.model.Rules;
+import org.candlepin.model.Rules.RulesSourceEnum;
+import org.candlepin.model.RulesCurator;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.google.inject.Provider;
+/**
+ * JsRunnerProviderTest
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class JsRunnerProviderTest {
+    @Mock private Provider<JsRunnerRequestCache> cacheProvider;
+    @Mock private RulesCurator rulesCurator;
+    @Mock
+    private JsRunnerRequestCache mockedCache;
+    @Mock private Rules rules;
+    private Date time1;
+    private JsRunnerProvider provider;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        time1 = new Date();
+        when(rulesCurator.getUpdated()).thenReturn(time1);
+        when(rulesCurator.getRules()).thenReturn(rules);
+        when(rules.getRules()).thenReturn("");
+        when(rules.getRulesSource()).thenReturn(RulesSourceEnum.DATABASE);
+        provider = new JsRunnerProvider(rulesCurator, cacheProvider);
+    }
+
+    @Test
+    public void valueGetsCachedMockedTest() {
+        when(cacheProvider.get()).thenReturn(mockedCache);
+        when(mockedCache.getUpdated()).thenReturn(null).thenReturn(time1);
+        provider.get();
+        verify(mockedCache).getUpdated();
+        verify(mockedCache).setUpdated(time1);
+        provider.get();
+        verify(mockedCache, times(2)).getUpdated();
+        verifyNoMoreInteractions(mockedCache);
+    }
+
+    /**
+     * The rules curator is hit once during the initialization, but
+     * then subsequent calls to provider.get() will not hit it anymore
+     */
+    @Test
+    public void rulesCuratorIsNotHitMultipleTimes() {
+        when(cacheProvider.get()).thenReturn(new JsRunnerRequestCache());
+        provider.get();
+        provider.get();
+        provider.get();
+        provider.get();
+        provider.get();
+        verify(rulesCurator, times(2)).getUpdated();
+    }
+
+    @Test
+    public void cacheInvalidationOnNewRequest() {
+        when(cacheProvider.get()).thenReturn(new JsRunnerRequestCache());
+        provider.get();
+        provider.get();
+        provider.get();
+        JsRunnerRequestCache newCache = new JsRunnerRequestCache();
+        when(cacheProvider.get()).thenReturn(newCache);
+        Assert.assertEquals(null, newCache.getUpdated());
+        provider.get();
+        Assert.assertEquals(time1, newCache.getUpdated());
+        provider.get();
+        verify(rulesCurator, times(3)).getUpdated();
+    }
+
+}

--- a/server/src/test/java/org/candlepin/policy/js/activationkey/ActivationKeyRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/activationkey/ActivationKeyRulesTest.java
@@ -24,6 +24,7 @@ import org.candlepin.model.RulesCurator;
 import org.candlepin.model.activationkeys.ActivationKey;
 import org.candlepin.policy.ValidationResult;
 import org.candlepin.policy.js.JsRunnerProvider;
+import org.candlepin.policy.js.JsRunnerRequestCache;
 import org.candlepin.test.TestUtil;
 import org.candlepin.util.Util;
 
@@ -33,6 +34,8 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.xnap.commons.i18n.I18n;
 import org.xnap.commons.i18n.I18nFactory;
+
+import com.google.inject.Provider;
 
 import java.io.InputStream;
 import java.util.Date;
@@ -47,6 +50,8 @@ public class ActivationKeyRulesTest {
     private static int poolid = 0;
 
     @Mock private RulesCurator rulesCuratorMock;
+    @Mock private Provider<JsRunnerRequestCache> cacheProvider;
+    @Mock private JsRunnerRequestCache cache;
     private I18n i18n;
     private JsRunnerProvider provider;
     private Owner owner = TestUtil.createOwner();
@@ -63,7 +68,9 @@ public class ActivationKeyRulesTest {
         Rules rules = new Rules(Util.readFile(is));
         when(rulesCuratorMock.getUpdated()).thenReturn(new Date());
         when(rulesCuratorMock.getRules()).thenReturn(rules);
-        provider = new JsRunnerProvider(rulesCuratorMock);
+        when(cacheProvider.get()).thenReturn(cache);
+
+        provider = new JsRunnerProvider(rulesCuratorMock, cacheProvider);
         actKeyRules = new ActivationKeyRules(provider.get(), i18n);
     }
 

--- a/server/src/test/java/org/candlepin/policy/js/compliance/ComplianceRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/compliance/ComplianceRulesTest.java
@@ -14,9 +14,30 @@
  */
 package org.candlepin.policy.js.compliance;
 
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
 
 import org.candlepin.audit.EventSink;
 import org.candlepin.model.Consumer;
@@ -34,9 +55,9 @@ import org.candlepin.model.RulesCurator;
 import org.candlepin.policy.js.JsContext;
 import org.candlepin.policy.js.JsRunner;
 import org.candlepin.policy.js.JsRunnerProvider;
+import org.candlepin.policy.js.JsRunnerRequestCache;
 import org.candlepin.test.TestUtil;
 import org.candlepin.util.Util;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -44,18 +65,7 @@ import org.mockito.MockitoAnnotations;
 import org.xnap.commons.i18n.I18n;
 import org.xnap.commons.i18n.I18nFactory;
 
-import java.io.InputStream;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Random;
-import java.util.Set;
+import com.google.inject.Provider;
 
 
 
@@ -77,6 +87,9 @@ public class ComplianceRulesTest {
     @Mock private EntitlementCurator entCurator;
     @Mock private RulesCurator rulesCuratorMock;
     @Mock private EventSink eventSink;
+    @Mock private Provider<JsRunnerRequestCache> cacheProvider;
+    @Mock private JsRunnerRequestCache cache;
+
     private I18n i18n;
     private JsRunnerProvider provider;
 
@@ -94,7 +107,8 @@ public class ComplianceRulesTest {
         Rules rules = new Rules(Util.readFile(is));
         when(rulesCuratorMock.getUpdated()).thenReturn(new Date());
         when(rulesCuratorMock.getRules()).thenReturn(rules);
-        provider = new JsRunnerProvider(rulesCuratorMock);
+        when(cacheProvider.get()).thenReturn(cache);
+        provider = new JsRunnerProvider(rulesCuratorMock, cacheProvider);
         compliance = new ComplianceRules(provider.get(),
             entCurator, new StatusReasonMessageGenerator(i18n), eventSink,
             consumerCurator);

--- a/server/src/test/java/org/candlepin/policy/js/entitlement/EntitlementRulesTestFixture.java
+++ b/server/src/test/java/org/candlepin/policy/js/entitlement/EntitlementRulesTestFixture.java
@@ -37,6 +37,7 @@ import org.candlepin.model.dto.Subscription;
 import org.candlepin.policy.js.AttributeHelper;
 import org.candlepin.policy.js.JsRunner;
 import org.candlepin.policy.js.JsRunnerProvider;
+import org.candlepin.policy.js.JsRunnerRequestCache;
 import org.candlepin.policy.js.compliance.ComplianceStatus;
 import org.candlepin.policy.js.pool.PoolRules;
 import org.candlepin.service.ProductServiceAdapter;
@@ -49,6 +50,8 @@ import org.junit.Before;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.xnap.commons.i18n.I18nFactory;
+
+import com.google.inject.Provider;
 
 import java.io.InputStream;
 import java.util.Locale;
@@ -71,6 +74,10 @@ public class EntitlementRulesTestFixture {
     protected EntitlementCurator entCurMock;
     @Mock
     protected ProductCurator prodCuratorMock;
+    @Mock
+    private Provider<JsRunnerRequestCache> cacheProvider;
+    @Mock
+    private JsRunnerRequestCache cache;
 
     @Mock
     protected PoolCurator poolCurator;
@@ -94,8 +101,9 @@ public class EntitlementRulesTestFixture {
         when(rulesCurator.getRules()).thenReturn(rules);
         when(rulesCurator.getUpdated()).thenReturn(
             TestDateUtil.date(2010, 1, 1));
+        when(cacheProvider.get()).thenReturn(cache);
 
-        JsRunner jsRules = new JsRunnerProvider(rulesCurator).get();
+        JsRunner jsRules = new JsRunnerProvider(rulesCurator, cacheProvider).get();
         enforcer = new EntitlementRules(
             new DateSourceImpl(),
             jsRules,

--- a/server/src/test/java/org/candlepin/policy/js/override/OverrideRulesTests.java
+++ b/server/src/test/java/org/candlepin/policy/js/override/OverrideRulesTests.java
@@ -22,6 +22,7 @@ import org.candlepin.config.ConfigProperties;
 import org.candlepin.model.Rules;
 import org.candlepin.model.RulesCurator;
 import org.candlepin.policy.js.JsRunnerProvider;
+import org.candlepin.policy.js.JsRunnerRequestCache;
 import org.candlepin.util.Util;
 
 import org.junit.Before;
@@ -29,6 +30,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+
+import com.google.inject.Provider;
 
 import java.io.InputStream;
 import java.util.Date;
@@ -45,6 +48,10 @@ public class OverrideRulesTests {
     private OverrideRules overrideRules;
     @Mock
     private Configuration config;
+    @Mock
+    private Provider<JsRunnerRequestCache> cacheProvider;
+    @Mock
+    private JsRunnerRequestCache cache;
 
     @Before
     public void setupTest() {
@@ -53,8 +60,9 @@ public class OverrideRulesTests {
         Rules rules = new Rules(Util.readFile(is));
         when(rulesCuratorMock.getUpdated()).thenReturn(new Date());
         when(rulesCuratorMock.getRules()).thenReturn(rules);
+        when(cacheProvider.get()).thenReturn(cache);
 
-        provider = new JsRunnerProvider(rulesCuratorMock);
+        provider = new JsRunnerProvider(rulesCuratorMock, cacheProvider);
         overrideRules = new OverrideRules(provider.get(), config);
     }
 

--- a/server/src/test/java/org/candlepin/policy/js/quantity/QuantityRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/quantity/QuantityRulesTest.java
@@ -27,6 +27,7 @@ import org.candlepin.model.Product;
 import org.candlepin.model.Rules;
 import org.candlepin.model.RulesCurator;
 import org.candlepin.policy.js.JsRunnerProvider;
+import org.candlepin.policy.js.JsRunnerRequestCache;
 import org.candlepin.test.TestUtil;
 import org.candlepin.util.Util;
 
@@ -34,6 +35,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+
+import com.google.inject.Provider;
 
 import java.io.InputStream;
 import java.util.Calendar;
@@ -67,6 +70,8 @@ public class QuantityRulesTest {
     private JsRunnerProvider provider;
 
     @Mock private RulesCurator rulesCuratorMock;
+    @Mock private Provider<JsRunnerRequestCache> cacheProvider;
+    @Mock private JsRunnerRequestCache cache;
 
     @Before
     public void setUp() {
@@ -78,7 +83,8 @@ public class QuantityRulesTest {
         Rules rules = new Rules(Util.readFile(is));
         when(rulesCuratorMock.getUpdated()).thenReturn(new Date());
         when(rulesCuratorMock.getRules()).thenReturn(rules);
-        provider = new JsRunnerProvider(rulesCuratorMock);
+        when(cacheProvider.get()).thenReturn(cache);
+        provider = new JsRunnerProvider(rulesCuratorMock, cacheProvider);
         quantityRules = new QuantityRules(provider.get());
 
         owner = new Owner("Test Owner " + TestUtil.randomInt());

--- a/server/src/test/java/org/candlepin/resource/util/InstalledProductStatusCalculatorTest.java
+++ b/server/src/test/java/org/candlepin/resource/util/InstalledProductStatusCalculatorTest.java
@@ -32,6 +32,7 @@ import org.candlepin.model.Product;
 import org.candlepin.model.Rules;
 import org.candlepin.model.RulesCurator;
 import org.candlepin.policy.js.JsRunnerProvider;
+import org.candlepin.policy.js.JsRunnerRequestCache;
 import org.candlepin.policy.js.compliance.ComplianceRules;
 import org.candlepin.policy.js.compliance.ComplianceStatus;
 import org.candlepin.policy.js.compliance.StatusReasonMessageGenerator;
@@ -46,6 +47,8 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.xnap.commons.i18n.I18n;
 import org.xnap.commons.i18n.I18nFactory;
+
+import com.google.inject.Provider;
 
 import java.io.InputStream;
 import java.util.Calendar;
@@ -75,6 +78,9 @@ public class InstalledProductStatusCalculatorTest {
     @Mock private EntitlementCurator entCurator;
     @Mock private RulesCurator rulesCuratorMock;
     @Mock private EventSink eventSink;
+    @Mock private Provider<JsRunnerRequestCache> cacheProvider;
+    @Mock private JsRunnerRequestCache cache;
+
     private JsRunnerProvider provider;
     private I18n i18n;
 
@@ -88,7 +94,8 @@ public class InstalledProductStatusCalculatorTest {
         Rules rules = new Rules(Util.readFile(is));
         when(rulesCuratorMock.getUpdated()).thenReturn(new Date());
         when(rulesCuratorMock.getRules()).thenReturn(rules);
-        provider = new JsRunnerProvider(rulesCuratorMock);
+        when(cacheProvider.get()).thenReturn(cache);
+        provider = new JsRunnerProvider(rulesCuratorMock, cacheProvider);
         Locale locale = new Locale("en_US");
         i18n = I18nFactory.getI18n(getClass(), "org.candlepin.i18n.Messages", locale,
             I18nFactory.FALLBACK);

--- a/server/src/test/java/org/candlepin/servlet/filter/CandlepinScopeFilterTest.java
+++ b/server/src/test/java/org/candlepin/servlet/filter/CandlepinScopeFilterTest.java
@@ -17,7 +17,7 @@ package org.candlepin.servlet.filter;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
-import org.candlepin.guice.CandlepinSingletonScope;
+import org.candlepin.guice.CandlepinRequestScope;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -35,7 +35,7 @@ public class CandlepinScopeFilterTest {
 
     private HttpServletRequest request;
     private HttpServletResponse response;
-    private CandlepinSingletonScope scope;
+    private CandlepinRequestScope scope;
     private CandlepinScopeFilter filter;
     private FilterChain chain;
 
@@ -44,7 +44,7 @@ public class CandlepinScopeFilterTest {
         request = mock(HttpServletRequest.class);
         response = mock(HttpServletResponse.class);
         chain = mock(FilterChain.class);
-        scope = mock(CandlepinSingletonScope.class);
+        scope = mock(CandlepinRequestScope.class);
         filter = new CandlepinScopeFilter(scope);
     }
 

--- a/server/src/test/java/org/candlepin/test/DatabaseTestFixture.java
+++ b/server/src/test/java/org/candlepin/test/DatabaseTestFixture.java
@@ -25,7 +25,7 @@ import org.candlepin.auth.permissions.OwnerPermission;
 import org.candlepin.auth.permissions.Permission;
 import org.candlepin.auth.permissions.PermissionFactory.PermissionType;
 import org.candlepin.config.CandlepinCommonTestConfig;
-import org.candlepin.guice.CandlepinSingletonScope;
+import org.candlepin.guice.CandlepinRequestScope;
 import org.candlepin.guice.TestPrincipalProviderSetter;
 import org.candlepin.junit.CandlepinLiquibaseResource;
 import org.candlepin.model.CertificateSerial;
@@ -108,7 +108,7 @@ public class DatabaseTestFixture {
 
     private static Injector parentInjector;
     private Injector injector;
-    private CandlepinSingletonScope cpSingletonScope;
+    private CandlepinRequestScope cpRequestScope;
 
     protected TestingInterceptor securityInterceptor;
     protected DateSourceForTesting dateSource;
@@ -131,13 +131,13 @@ public class DatabaseTestFixture {
         locatorMap.init();
         securityInterceptor = injector.getInstance(TestingInterceptor.class);
 
-        cpSingletonScope = injector.getInstance(CandlepinSingletonScope.class);
+        cpRequestScope = injector.getInstance(CandlepinRequestScope.class);
 
-        // Because all candlepin operations are running in the CandlepinSingletonScope
+        // Because all candlepin operations are running in the CandlepinRequestScope
         // we'll force the instance creations to be done inside the scope.
         // Exit the scope to make sure that it is clean before starting the test.
-        cpSingletonScope.exit();
-        cpSingletonScope.enter();
+        cpRequestScope.exit();
+        cpRequestScope.enter();
         injector.injectMembers(this);
 
         dateSource = (DateSourceForTesting) injector.getInstance(DateSource.class);
@@ -149,7 +149,7 @@ public class DatabaseTestFixture {
 
     @After
     public void shutdown() {
-        cpSingletonScope.exit();
+        cpRequestScope.exit();
 
         // We are using a singleton for the principal in tests. Make sure we clear it out
         // after every test. TestPrincipalProvider controls the default behavior.

--- a/server/src/test/java/org/candlepin/util/ContentOverrideValidatorTest.java
+++ b/server/src/test/java/org/candlepin/util/ContentOverrideValidatorTest.java
@@ -25,12 +25,16 @@ import org.candlepin.model.ContentOverride;
 import org.candlepin.model.Rules;
 import org.candlepin.model.RulesCurator;
 import org.candlepin.policy.js.JsRunnerProvider;
+import org.candlepin.policy.js.JsRunnerRequestCache;
 import org.candlepin.policy.js.override.OverrideRules;
 import org.candlepin.test.DatabaseTestFixture;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
 import org.xnap.commons.i18n.I18n;
+
+import com.google.inject.Provider;
 
 import java.io.InputStream;
 import java.util.Date;
@@ -45,6 +49,10 @@ import javax.inject.Inject;
 public class ContentOverrideValidatorTest extends DatabaseTestFixture  {
     @Inject  private I18n i18n;
     private RulesCurator rulesCuratorMock;
+    @Mock
+    private Provider<JsRunnerRequestCache> cacheProvider;
+    @Mock
+    private JsRunnerRequestCache cache;
     private Configuration config;
 
     private ContentOverrideValidator validator;
@@ -57,11 +65,13 @@ public class ContentOverrideValidatorTest extends DatabaseTestFixture  {
             RulesCurator.DEFAULT_RULES_FILE);
         rulesCuratorMock = mock(RulesCurator.class);
         config = mock(Configuration.class);
+        cacheProvider = mock(Provider.class);
+        cache = mock(JsRunnerRequestCache.class);
         Rules rules = new Rules(Util.readFile(is));
         when(rulesCuratorMock.getUpdated()).thenReturn(new Date());
         when(rulesCuratorMock.getRules()).thenReturn(rules);
-
-        provider = new JsRunnerProvider(rulesCuratorMock);
+        when(cacheProvider.get()).thenReturn(cache);
+        provider = new JsRunnerProvider(rulesCuratorMock, cacheProvider);
         overrideRules = new OverrideRules(provider.get(), config);
         validator = new ContentOverrideValidator(i18n, overrideRules);
     }


### PR DESCRIPTION
In our configuration, Google Guice creates a new instance of JsRunner for every Inject annotation. it means that  JsRunner is being constructed ~36 times during every request. In each of these constructions, the provider JsRunnerProvider is checking to the database if cp_rules.updated changed. This brings significant overhead. 

This PR introduces request scoped caching of cp_rules.updated value. The JsRunnerProvider now uses request scoped bean JsRunnerRequestCache in order to cache the value of cp_rules.updated for the duration of the request.

We cannot cache the value longer. The reason is that in the clustered environment, any cluster node of Candlepin can updated the cp_rules table. We don't have any clustered in-memory cache, hence synchronization on database level seems to be inevitable. 

There is an alternative route to implement this request scoped cache. That is configuring JsRunner to be request scoped and thus not constructed for every Injection annotation. I rather not went that route, to keep consistent programming model in Candlepin, where every injected object is a new instance.
