### PR TITLE
Set nextUpdate correctly when modifying an empty CRL.

### DIFF
--- a/server/src/main/java/org/candlepin/util/X509CRLStreamWriter.java
+++ b/server/src/main/java/org/candlepin/util/X509CRLStreamWriter.java
@@ -372,11 +372,19 @@ public class X509CRLStreamWriter {
         ASN1InputStream asn1in = null;
         try {
             asn1in = new ASN1InputStream(crlIn);
-            DERSequence certList = (DERSequence) asn1in.readObject();
-            X509CRLHolder oldCrl = new X509CRLHolder(new CertificateList(certList));
+            DERSequence certListSeq = (DERSequence) asn1in.readObject();
+            CertificateList certList = new CertificateList(certListSeq);
+            X509CRLHolder oldCrl = new X509CRLHolder(certList);
 
             X509v2CRLBuilder crlBuilder = new X509v2CRLBuilder(oldCrl.getIssuer(), new Date());
             crlBuilder.addCRL(oldCrl);
+
+            Date now = new Date();
+            Date oldNextUpdate = certList.getNextUpdate().getDate();
+            Date oldThisUpdate = certList.getThisUpdate().getDate();
+
+            Date nextUpdate = new Date(now.getTime() + (oldNextUpdate.getTime() - oldThisUpdate.getTime()));
+            crlBuilder.setNextUpdate(nextUpdate);
 
             for (Object o : oldCrl.getExtensionOIDs()) {
                 ASN1ObjectIdentifier oid = (ASN1ObjectIdentifier) o;


### PR DESCRIPTION
Due to the way the streaming process works, when X509CRLStreamWriter is
asked to modify an empty CRL, it uses a different method than it would
normally.  This different method was failing to update the nextUpdate
field on the generated CRL.