### PR TITLE
Allow configurable delta for nextUpdate on the CRL.

### DIFF
--- a/server/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/server/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -229,6 +229,19 @@ public class ConfigProperties {
         "management_enabled," +
         "virt_only";
 
+    /**
+     * The number of days from today to set the nextUpdate date when generating the CRL.
+     * See http://security.stackexchange.com/a/55784
+     */
+    public static final String CRL_NEXT_UPDATE_DELTA = "candlepin.crl.nextupdate.delta_days";
+    public static final String CRL_FILE_PATH = "candlepin.crl.file";
+
+    public static final String IDENTITY_CERT_YEAR_ADDENDUM = "candlepin.identityCert.yr.addendum";
+    /**
+     * Identity certificate expiry threshold in days
+     */
+    public static final String IDENTITY_CERT_EXPIRY_THRESHOLD = "candlepin.identityCert.expiry.threshold";
+
     public static final Map<String, String> DEFAULT_PROPERTIES =
         new HashMap<String, String>() {
 
@@ -279,6 +292,7 @@ public class ConfigProperties {
                 this.put(PRETTY_PRINT, "false");
                 this.put(REVOKE_ENTITLEMENT_IN_FIFO_ORDER, "true");
                 this.put(CRL_FILE_PATH, "/var/lib/candlepin/candlepin-crl.crl");
+                this.put(CRL_NEXT_UPDATE_DELTA, "1");
 
                 this.put(SYNC_WORK_DIR, "/var/cache/candlepin/sync");
                 this.put(CONSUMER_FACTS_MATCHER, ".*");
@@ -363,13 +377,4 @@ public class ConfigProperties {
                 this.put(PINSETTER_MAX_RETRIES, Integer.toString(PINSETTER_MAX_RETRIES_DEFAULT));
             }
         };
-    public static final String CRL_FILE_PATH = "candlepin.crl.file";
-    public static final String IDENTITY_CERT_YEAR_ADDENDUM = "candlepin.identityCert.yr.addendum";
-    /**
-     * Identity certificate expiry threshold in days
-     */
-    public static final String IDENTITY_CERT_EXPIRY_THRESHOLD = "candlepin.identityCert.expiry.threshold";
-
-
-
 }

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/CertificateRevocationListTask.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/CertificateRevocationListTask.java
@@ -59,7 +59,7 @@ public class CertificateRevocationListTask extends KingpinJob {
 
     public void toExecute(JobExecutionContext ctx) throws JobExecutionException {
         String filePath = config.getString(ConfigProperties.CRL_FILE_PATH);
-        log.info("Executing CRL Job. CRL filePath=" + filePath);
+        log.info("Executing CRL Job. CRL filePath={}", filePath);
 
         if (filePath == null) {
             throw new JobExecutionException("Invalid " + ConfigProperties.CRL_FILE_PATH, false);

--- a/server/src/main/java/org/candlepin/pki/PKIUtility.java
+++ b/server/src/main/java/org/candlepin/pki/PKIUtility.java
@@ -14,6 +14,8 @@
  */
 package org.candlepin.pki;
 
+import org.candlepin.common.config.Configuration;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,10 +60,13 @@ public abstract class PKIUtility {
 
     protected PKIReader reader;
     protected SubjectKeyIdentifierWriter subjectKeyWriter;
+    protected Configuration config;
 
-    public PKIUtility(PKIReader reader, SubjectKeyIdentifierWriter subjectKeyWriter) {
+    public PKIUtility(PKIReader reader, SubjectKeyIdentifierWriter subjectKeyWriter,
+        Configuration config) {
         this.reader = reader;
         this.subjectKeyWriter = subjectKeyWriter;
+        this.config = config;
     }
 
     public abstract X509Certificate createX509Certificate(String dn,

--- a/server/src/main/java/org/candlepin/pki/impl/BouncyCastlePKIUtility.java
+++ b/server/src/main/java/org/candlepin/pki/impl/BouncyCastlePKIUtility.java
@@ -14,6 +14,8 @@
  */
 package org.candlepin.pki.impl;
 
+import org.candlepin.common.config.Configuration;
+import org.candlepin.config.ConfigProperties;
 import org.candlepin.pki.PKIReader;
 import org.candlepin.pki.PKIUtility;
 import org.candlepin.pki.SubjectKeyIdentifierWriter;
@@ -94,8 +96,9 @@ public class BouncyCastlePKIUtility extends PKIUtility {
 
     @Inject
     public BouncyCastlePKIUtility(PKIReader reader,
-        SubjectKeyIdentifierWriter subjectKeyWriter) {
-        super(reader, subjectKeyWriter);
+        SubjectKeyIdentifierWriter subjectKeyWriter,
+        Configuration config) {
+        super(reader, subjectKeyWriter, config);
     }
 
     @Override
@@ -179,7 +182,8 @@ public class BouncyCastlePKIUtility extends PKIUtility {
             X509V2CRLGenerator generator = new X509V2CRLGenerator();
             generator.setIssuerDN(caCert.getIssuerX500Principal());
             generator.setThisUpdate(new Date());
-            generator.setNextUpdate(Util.tomorrow());
+            generator.setNextUpdate(
+                Util.addDaysToDt(config.getInt(ConfigProperties.CRL_NEXT_UPDATE_DELTA)));
             generator.setSignatureAlgorithm(SIGNATURE_ALGO);
             // add all the CRL entries.
             for (X509CRLEntryWrapper entry : entries) {

--- a/server/src/test/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapterTest.java
+++ b/server/src/test/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapterTest.java
@@ -1610,10 +1610,8 @@ public class DefaultEntitlementCertServiceAdapterTest {
     }
 
     @Test
-    public void testDetachedEntitlementDataNotAddedToCertV1()
-        throws Exception {
-
-        KeyPair keyPair = new BouncyCastlePKIUtility(null, null).generateNewKeyPair();
+    public void testDetachedEntitlementDataNotAddedToCertV1() throws Exception {
+        KeyPair keyPair = new BouncyCastlePKIUtility(null, null, null).generateNewKeyPair();
         when(keyPairCurator.getConsumerKeyPair(any(Consumer.class))).thenReturn(keyPair);
 
         when(mockedPKI.getPemEncoded(any(X509Certificate.class))).thenReturn(

--- a/server/src/test/java/org/candlepin/sync/ImporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/ImporterTest.java
@@ -703,7 +703,7 @@ public class ImporterTest {
     public void importConsumer() throws Exception {
         Security.addProvider(new BouncyCastleProvider());
         PKIUtility pki = new BouncyCastlePKIUtility(null,
-            new DefaultSubjectKeyIdentifierWriter());
+            new DefaultSubjectKeyIdentifierWriter(), null);
 
         OwnerCurator oc = mock(OwnerCurator.class);
         ConsumerTypeCurator ctc = mock(ConsumerTypeCurator.class);


### PR DESCRIPTION
Although it's not the original intention, the nextUpdate value on a CRL
is frequently used to mean the expiration date for the CRL.  Previously,
Candlepin was setting nextUpdate to be one day away.  This patch makes
the number of days away configurable so that users can provide a little
more breathing room in case CRL generation fails or is delayed.

See http://security.stackexchange.com/a/55784