### PR TITLE
1320711: Fixed class cast exception in EntitleByProductsJob

### DIFF
--- a/server/spec/candlepin_scenarios.rb
+++ b/server/spec/candlepin_scenarios.rb
@@ -33,7 +33,7 @@ module CandlepinMethods
       total_taken += wait_interval
       status = @cp.get_job(job_id)
       if states.include? status['state']
-        return
+        return status
       end
     end
   end

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/EntitleByProductsJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/EntitleByProductsJob.java
@@ -34,7 +34,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.Date;
-import java.util.HashSet;
 import java.util.List;
 
 /**
@@ -60,7 +59,7 @@ public class EntitleByProductsJob extends KingpinJob {
             String uuid = (String) map.get(JobStatus.TARGET_ID);
             Date entitleDate = (Date) map.get("entitle_date");
             String[] prodIds = (String[]) map.get("product_ids");
-            HashSet<String> fromPools = (HashSet<String>) map.get("from_pools");
+            Collection<String> fromPools = (Collection<String>) map.get("from_pools");
 
             List<Entitlement> ents = entitler.bindByProducts(prodIds, uuid, entitleDate, fromPools);
             entitler.sendEvents(ents);


### PR DESCRIPTION
The job was being created with a List<String> for target pools,
but on execution, it was being casted to a HashSet.

Always cast to a Collection here, as that's what is passed
by the job creation's static method.