### PR TITLE
Awood/hanging indent

### DIFF
--- a/apicrawl/src/main/java/org/candlepin/util/apicrawl/ApiCrawler.java
+++ b/apicrawl/src/main/java/org/candlepin/util/apicrawl/ApiCrawler.java
@@ -58,8 +58,8 @@ public class ApiCrawler {
 
     // Let's just set it to pretty_print the output instead of having
     // to construct a configuration only to get a simple value.
-    private ObjectMapper mapper = new JsonProvider(true)
-            .locateMapper(Object.class, MediaType.APPLICATION_JSON_TYPE);
+    private ObjectMapper mapper =
+        new JsonProvider(true).locateMapper(Object.class, MediaType.APPLICATION_JSON_TYPE);
     private List<Class<?>> httpClasses;
     private NonRecursiveModule dontRecurse;
 

--- a/common/src/main/java/org/candlepin/common/config/PropertyConverter.java
+++ b/common/src/main/java/org/candlepin/common/config/PropertyConverter.java
@@ -56,8 +56,7 @@ public class PropertyConverter {
             return (Boolean) value;
         }
         else if (value instanceof String) {
-            if ("1".equalsIgnoreCase((String) value) ||
-                    "y".equalsIgnoreCase((String) value)) {
+            if ("1".equalsIgnoreCase((String) value) || "y".equalsIgnoreCase((String) value)) {
                 return true;
             }
 

--- a/common/src/main/java/org/candlepin/common/exceptions/mappers/BadRequestExceptionMapper.java
+++ b/common/src/main/java/org/candlepin/common/exceptions/mappers/BadRequestExceptionMapper.java
@@ -37,7 +37,7 @@ import javax.ws.rs.ext.Provider;
  */
 @Provider
 public class BadRequestExceptionMapper extends CandlepinExceptionMapper
-        implements ExceptionMapper<BadRequestException> {
+    implements ExceptionMapper<BadRequestException> {
 
     /**
      * Service that handles JAX-RS exceptions.
@@ -55,9 +55,8 @@ public class BadRequestExceptionMapper extends CandlepinExceptionMapper
             // It may be just as good to use getDefaultBuilder here
             Map<String, String> map = VersionUtil.getVersionMap();
             ResponseBuilder bldr = Response.status(Status.BAD_REQUEST)
-                    .type(determineBestMediaType())
-                    .header(VersionUtil.VERSION_HEADER,
-                            map.get("version") + "-" + map.get("release"));
+                .type(determineBestMediaType())
+                .header(VersionUtil.VERSION_HEADER, map.get("version") + "-" + map.get("release"));
             bldr.entity(new ExceptionMessage(i18n.get().tr("Bad Request")));
             return bldr.build();
         }

--- a/common/src/main/java/org/candlepin/common/exceptions/mappers/CandlepinExceptionMapper.java
+++ b/common/src/main/java/org/candlepin/common/exceptions/mappers/CandlepinExceptionMapper.java
@@ -75,8 +75,7 @@ public class CandlepinExceptionMapper {
                 getBestMatch(DESIRED_RESPONSE_TYPES, headerMediaTypes);
         }
 
-        if (mediaType == null || (mediaType.getType().equals("*") &&
-                mediaType.getSubtype().equals("*"))) {
+        if (mediaType == null || (mediaType.getType().equals("*") && mediaType.getSubtype().equals("*"))) {
             mediaType = MediaType.APPLICATION_JSON_TYPE;
         }
 

--- a/common/src/main/java/org/candlepin/common/exceptions/mappers/NotFoundExceptionMapper.java
+++ b/common/src/main/java/org/candlepin/common/exceptions/mappers/NotFoundExceptionMapper.java
@@ -30,7 +30,7 @@ import javax.ws.rs.ext.Provider;
  */
 @Provider
 public class NotFoundExceptionMapper extends CandlepinExceptionMapper
-        implements ExceptionMapper<NotFoundException> {
+    implements ExceptionMapper<NotFoundException> {
 
     /**
      * Service that handles JAX-RS exceptions.

--- a/common/src/main/java/org/candlepin/common/exceptions/mappers/RollbackExceptionMapper.java
+++ b/common/src/main/java/org/candlepin/common/exceptions/mappers/RollbackExceptionMapper.java
@@ -49,7 +49,7 @@ public class RollbackExceptionMapper extends CandlepinExceptionMapper
         Map<String, String> map = VersionUtil.getVersionMap();
         ResponseBuilder bldr = Response.status(Status.BAD_REQUEST).type(
             determineBestMediaType()).header(VersionUtil.VERSION_HEADER,
-                map.get("version") + "-" + map.get("release"));
+            map.get("version") + "-" + map.get("release"));
 
         Throwable cause = exception.getCause();
         if (ValidationException.class.isAssignableFrom(cause.getClass())) {

--- a/common/src/main/java/org/candlepin/common/exceptions/mappers/ValidationExceptionMapper.java
+++ b/common/src/main/java/org/candlepin/common/exceptions/mappers/ValidationExceptionMapper.java
@@ -42,7 +42,7 @@ public class ValidationExceptionMapper extends CandlepinExceptionMapper
         Map<String, String> map = VersionUtil.getVersionMap();
         ResponseBuilder bldr = Response.status(Status.BAD_REQUEST).type(
             determineBestMediaType()).header(VersionUtil.VERSION_HEADER,
-                map.get("version") + "-" + map.get("release"));
+            map.get("version") + "-" + map.get("release"));
 
         StringBuffer message = new StringBuffer();
         if (ConstraintViolationException.class.isAssignableFrom(exception.getClass())) {

--- a/common/src/main/java/org/candlepin/common/resteasy/auth/RestEasyOAuthMessage.java
+++ b/common/src/main/java/org/candlepin/common/resteasy/auth/RestEasyOAuthMessage.java
@@ -45,9 +45,9 @@ public class RestEasyOAuthMessage extends OAuthMessage{
     }
 
     private static void copyHeaders(HttpRequest request,
-                                    Collection<Map.Entry<String, String>> into) {
-        Iterator<String> names = request.getHttpHeaders()
-                                    .getRequestHeaders().keySet().iterator();
+        Collection<Map.Entry<String, String>> into) {
+        Iterator<String> names =
+            request.getHttpHeaders().getRequestHeaders().keySet().iterator();
         if (names != null) {
             while (names.hasNext()) {
                 String name = names.next();
@@ -79,14 +79,12 @@ public class RestEasyOAuthMessage extends OAuthMessage{
         }
 
         // we can't call getFormParameters when it's a PUT and not a form.
-        if (request.getHttpMethod().equals("PUT") &&
-            !request.getHttpHeaders().getMediaType().isCompatible(
-                MediaType.valueOf("application/x-www-form-urlencoded"))) {
+        if (request.getHttpMethod().equals("PUT") && !request.getHttpHeaders().getMediaType().isCompatible(
+            MediaType.valueOf("application/x-www-form-urlencoded"))) {
             return list;
         }
 
-        for (Map.Entry<String, List<String>> entry :
-                request.getFormParameters().entrySet()) {
+        for (Map.Entry<String, List<String>> entry : request.getFormParameters().entrySet()) {
             String name = entry.getKey();
             for (String value : entry.getValue()) {
                 list.add(new OAuth.Parameter(name, value));

--- a/common/src/main/java/org/candlepin/common/resteasy/filter/LinkHeaderResponseFilter.java
+++ b/common/src/main/java/org/candlepin/common/resteasy/filter/LinkHeaderResponseFilter.java
@@ -56,7 +56,7 @@ public class LinkHeaderResponseFilter implements ContainerResponseFilter {
 
     @Inject
     public LinkHeaderResponseFilter(Configuration config,
-            @Named("PREFIX_APIURL_KEY") String apiUrlPrefixKey) {
+        @Named("PREFIX_APIURL_KEY") String apiUrlPrefixKey) {
         this.config = config;
         this.apiUrlPrefixKey = apiUrlPrefixKey;
     }

--- a/common/src/main/java/org/candlepin/common/util/JaxRsExceptionResponseBuilder.java
+++ b/common/src/main/java/org/candlepin/common/util/JaxRsExceptionResponseBuilder.java
@@ -48,13 +48,13 @@ public class JaxRsExceptionResponseBuilder {
      * Regex for JAX-RS exception class names.
      */
     private static final Pattern PARAM_REGEX = Pattern
-            .compile("(?:javax\\.ws\\.rs\\.\\w+\\(\\\")([\\w\\s]+)(\\\"\\))");
+        .compile("(?:javax\\.ws\\.rs\\.\\w+\\(\\\")([\\w\\s]+)(\\\"\\))");
 
     /**
      * Regex to extract the errored values from the JAX-RS Exception.
      */
     private static final Pattern ILLEGAL_VAL_REGEX = Pattern
-            .compile(":?value\\sis\\s'([\\w\\s]+)(:?'\\sfor)");
+        .compile(":?value\\sis\\s'([\\w\\s]+)(:?'\\sfor)");
 
     /**
      * Service for i18n.
@@ -89,8 +89,7 @@ public class JaxRsExceptionResponseBuilder {
             Matcher paramMatcher = PARAM_REGEX.matcher(msg);
             Matcher illegalValMatcher = ILLEGAL_VAL_REGEX.matcher(msg);
             if (paramMatcher.find() && illegalValMatcher.find()) {
-                if ((paramMatcher.groupCount() == 2) &&
-                        (illegalValMatcher.groupCount() == 2)) {
+                if ((paramMatcher.groupCount() == 2) && (illegalValMatcher.groupCount() == 2)) {
                     return true;
                 }
             }
@@ -119,18 +118,14 @@ public class JaxRsExceptionResponseBuilder {
 
         Map<String, String> map = VersionUtil.getVersionMap();
         ResponseBuilder bldr = Response.status(Status.BAD_REQUEST)
-                .type(cem.determineBestMediaType())
-                .header(VersionUtil.VERSION_HEADER,
-                        map.get("version") + "-" + map.get("release"));
+            .type(cem.determineBestMediaType())
+            .header(VersionUtil.VERSION_HEADER, map.get("version") + "-" + map.get("release"));
 
         Throwable cause = exception.getCause();
         if (cause instanceof CandlepinParameterParseException) {
-            String msg = i18n.get()
-                    .tr("Invalid format for query parameter {0}. " +
-                            "Expected format: {1}",
-                    ((CandlepinParameterParseException) cause).getParamName(),
-                    ((CandlepinParameterParseException) cause)
-                            .getExpectedFormat());
+            String msg = i18n.get().tr("Invalid format for query parameter {0}. Expected format: {1}",
+                ((CandlepinParameterParseException) cause).getParamName(),
+                ((CandlepinParameterParseException) cause).getExpectedFormat());
             bldr.entity(new ExceptionMessage(msg));
         }
         else {
@@ -139,9 +134,8 @@ public class JaxRsExceptionResponseBuilder {
             Matcher illegalValMatcher = ILLEGAL_VAL_REGEX.matcher(msg);
             paramMatcher.find();
             illegalValMatcher.find();
-            String errorMessage = i18n.get().tr(
-                    "{0} is not a valid value for {1}",
-                    illegalValMatcher.group(1), paramMatcher.group(1));
+            String errorMessage = i18n.get().tr("{0} is not a valid value for {1}",
+                illegalValMatcher.group(1), paramMatcher.group(1));
             bldr.entity(new ExceptionMessage(errorMessage));
         }
         return bldr.build();

--- a/common/src/main/java/org/candlepin/common/validation/CandlepinMessageInterpolator.java
+++ b/common/src/main/java/org/candlepin/common/validation/CandlepinMessageInterpolator.java
@@ -33,6 +33,7 @@ import javax.validation.MessageInterpolator;
  * CandlepinMessageInterpolator
  */
 public class CandlepinMessageInterpolator implements MessageInterpolator {
+    @SuppressWarnings("checkstyle:indentation")
     public static final Map<String, ValidationMessage> MESSAGES =
         new HashMap<String, ValidationMessage>() {
             {
@@ -41,24 +42,19 @@ public class CandlepinMessageInterpolator implements MessageInterpolator {
                 put("{javax.validation.constraints.AssertTrue.message}",
                     new ValidationMessage(I18n.marktr("must be true")));
                 put("{javax.validation.constraints.DigitsMax.message}",
-                    new ValidationMessage(I18n.marktr("must be less than or equal to {0}"),
-                        "value"));
+                    new ValidationMessage(I18n.marktr("must be less than or equal to {0}"), "value"));
                 put("{javax.validation.constraints.DigitsMin.message}",
-                    new ValidationMessage(I18n.marktr("must be greater than or equal to {0}"),
-                        "value"));
+                    new ValidationMessage(I18n.marktr("must be greater than or equal to {0}"), "value"));
                 put("{javax.validation.constraints.Digits.message}",
                     new ValidationMessage(I18n.marktr(
-                        "numeric value out of bounds (<{integer} digits>" +
-                        ".<{fraction} digits> expected)"),
+                        "numeric value out of bounds (<{integer} digits>.<{fraction} digits> expected)"),
                         "integer", "fraction"));
                 put("{javax.validation.constraints.Future.message}",
                     new ValidationMessage(I18n.marktr("must be in the future")));
                 put("{javax.validation.constraints.Max.message}",
-                    new ValidationMessage(I18n.marktr("must be less than or equal to {0}"),
-                        "value"));
+                    new ValidationMessage(I18n.marktr("must be less than or equal to {0}"), "value"));
                 put("{javax.validation.constraints.Min.message}",
-                    new ValidationMessage(I18n.marktr("must be greater than or equal to {0}"),
-                        "value"));
+                    new ValidationMessage(I18n.marktr("must be greater than or equal to {0}"), "value"));
                 put("{javax.validation.constraints.NotNull.message}",
                     new ValidationMessage(I18n.marktr("may not be null")));
                 put("{javax.validation.constraints.Null.message}",
@@ -66,25 +62,21 @@ public class CandlepinMessageInterpolator implements MessageInterpolator {
                 put("{javax.validation.constraints.Past.message}",
                     new ValidationMessage(I18n.marktr("must be in the past")));
                 put("{javax.validation.constraints.Pattern.message}",
-                    new ValidationMessage(I18n.marktr("must match ''{regexp}''"),
-                        "regexp"));
+                    new ValidationMessage(I18n.marktr("must match ''{regexp}''"), "regexp"));
                 put("{javax.validation.constraints.Size.message}",
-                    new ValidationMessage(I18n.marktr("size must be between {0} and {1}"),
-                        "min", "max"));
+                    new ValidationMessage(I18n.marktr("size must be between {0} and {1}"), "min", "max"));
                 put("{org.hibernate.validator.constraints.CreditCardNumber.message}",
                     new ValidationMessage(I18n.marktr("invalid credit card number")));
                 put("{org.hibernate.validator.constraints.Email.message}",
                     new ValidationMessage(I18n.marktr("not a well-formed email address")));
                 put("{org.hibernate.validator.constraints.Length.message}",
-                    new ValidationMessage(I18n.marktr("size must be between {0} and {1}"),
-                        "min", "max"));
+                    new ValidationMessage(I18n.marktr("size must be between {0} and {1}"), "min", "max"));
                 put("{org.hibernate.validator.constraints.NotBlank.message}",
                     new ValidationMessage(I18n.marktr("may not be empty")));
                 put("{org.hibernate.validator.constraints.NotEmpty.message}",
                     new ValidationMessage(I18n.marktr("may not be empty")));
                 put("{org.hibernate.validator.constraints.Range.message}",
-                    new ValidationMessage(I18n.marktr("must be between {min} and {max}"),
-                        "min", "max"));
+                    new ValidationMessage(I18n.marktr("must be between {min} and {max}"), "min", "max"));
                 put("{org.hibernate.validator.constraints.SafeHtml.message}",
                     new ValidationMessage(I18n.marktr("may have unsafe HTML content")));
                 put("{org.hibernate.validator.constraints.ScriptAssert.message}",

--- a/common/src/test/java/org/candlepin/common/config/PropertiesFileConfigurationTest.java
+++ b/common/src/test/java/org/candlepin/common/config/PropertiesFileConfigurationTest.java
@@ -84,7 +84,7 @@ public class PropertiesFileConfigurationTest {
         config.setEncoding(UTF8);
         config.load(p);
         assertEquals(Arrays.asList("chocolate chip", "oatmeal", "peanut butter"),
-                config.getList("cookies"));
+            config.getList("cookies"));
         assertEquals("chocolate chip, oatmeal, peanut butter", config.getString("cookies"));
     }
 
@@ -97,9 +97,9 @@ public class PropertiesFileConfigurationTest {
         config.load(p);
 
         String poem = "The Assyrian came down like the wolf on the fold," +
-                "And his cohorts were gleaming in purple and gold;" +
-                "And the sheen of their spears was like stars on the sea," +
-                "When the blue wave rolls nightly on deep Galilee.";
+            "And his cohorts were gleaming in purple and gold;" +
+            "And the sheen of their spears was like stars on the sea," +
+            "When the blue wave rolls nightly on deep Galilee.";
         assertEquals(poem, config.getString("poem"));
     }
 

--- a/common/src/test/java/org/candlepin/common/config/PropertyConverterTest.java
+++ b/common/src/test/java/org/candlepin/common/config/PropertyConverterTest.java
@@ -92,7 +92,7 @@ public class PropertyConverterTest {
     @Test
     public void testToList() {
         assertEquals(Arrays.asList("Hello", "world", "how", "are you?"),
-                toList("Hello, world,how,  are you?"));
+            toList("Hello, world,how,  are you?"));
     }
 
     @Test

--- a/common/src/test/java/org/candlepin/common/exceptions/mappers/NotFoundExceptionMapperTest.java
+++ b/common/src/test/java/org/candlepin/common/exceptions/mappers/NotFoundExceptionMapperTest.java
@@ -30,8 +30,7 @@ public class NotFoundExceptionMapperTest extends TestExceptionMapperBase {
     @Test
     public void handleNotFoundException() {
         NotFoundException nfe = new NotFoundException("unacceptable");
-        NotFoundExceptionMapper nfem = injector
-                .getInstance(NotFoundExceptionMapper.class);
+        NotFoundExceptionMapper nfem = injector.getInstance(NotFoundExceptionMapper.class);
         Response r = nfem.toResponse(nfe);
         assertEquals(404, r.getStatus());
         verifyMessage(r, rtmsg("unacceptable"));
@@ -48,8 +47,7 @@ public class NotFoundExceptionMapperTest extends TestExceptionMapperBase {
      */
     @Test
     public void handleNotFoundQueryParameterException() {
-        NotFoundExceptionMapper nfem = injector
-                .getInstance(NotFoundExceptionMapper.class);
+        NotFoundExceptionMapper nfem = injector.getInstance(NotFoundExceptionMapper.class);
         String foo = "javax.ws.rs.SomeThing(\"paramName\") value is 'strVal' for";
         NotFoundException bre = new NotFoundException(foo);
         Response r = nfem.toResponse(bre);

--- a/common/src/test/java/org/candlepin/common/resteasy/filter/LinkHeaderResponseFilterTest.java
+++ b/common/src/test/java/org/candlepin/common/resteasy/filter/LinkHeaderResponseFilterTest.java
@@ -168,8 +168,7 @@ public class LinkHeaderResponseFilterTest {
         map.add("baz", "qu=ux");
         UriBuilder bu = UriBuilder.fromUri("https://localhost:8443/candlepin/resource");
         URI returned = interceptor.addUnchangingQueryParams(bu, map).build();
-        assertEquals(URI.create("https://localhost:8443/candlepin/resource?" +
-                "baz=qu%3Dux"), returned);
+        assertEquals(URI.create("https://localhost:8443/candlepin/resource?baz=qu%3Dux"), returned);
     }
 
     @Test

--- a/common/src/test/java/org/candlepin/common/util/JaxRsExceptionResponseBuilderTest.java
+++ b/common/src/test/java/org/candlepin/common/util/JaxRsExceptionResponseBuilderTest.java
@@ -67,7 +67,7 @@ public class JaxRsExceptionResponseBuilderTest {
     @Test
     public void candlepinParserError() {
         CandlepinParameterParseException parseEx =
-                new CandlepinParameterParseException("paramName", "thisFormat");
+            new CandlepinParameterParseException("paramName", "thisFormat");
         RuntimeException ex = new RuntimeException(parseEx);
         Response resp = exceptionBuilder.getResponse(ex);
         ExceptionMessage e =  (ExceptionMessage) resp.getEntity();

--- a/gutterball/src/main/java/org/candlepin/gutterball/config/ConfigProperties.java
+++ b/gutterball/src/main/java/org/candlepin/gutterball/config/ConfigProperties.java
@@ -60,13 +60,13 @@ public class ConfigProperties {
             {
                 // AMQP (Qpid) defaults
                 this.put(AMQP_CONNECT_STRING, "amqp://guest:guest@localhost/test?brokerlist=" +
-                        "'tcp://localhost:5671?ssl='true'&ssl_cert_alias='gutterball''");
+                    "'tcp://localhost:5671?ssl='true'&ssl_cert_alias='gutterball''");
                 this.put(AMQP_CONNECTION_RETRY_INTERVAL, "10"); // Every 10 seconds
                 this.put(AMQP_CONNECTION_RETRY_ATTEMPTS, "12"); // Try for 2 minutes (10s * 12)
                 this.put(AMQP_KEYSTORE, "/etc/gutterball/certs/amqp/gutterball.jks");
                 this.put(AMQP_KEYSTORE_PASSWORD, "password");
                 this.put(AMQP_TRUSTSTORE,
-                        "/etc/gutterball/certs/amqp/gutterball.truststore");
+                    "/etc/gutterball/certs/amqp/gutterball.truststore");
                 this.put(AMQP_TRUSTSTORE_PASSWORD, "password");
 
                 // JPA/hibernate Configuration

--- a/gutterball/src/main/java/org/candlepin/gutterball/curator/ComplianceSnapshotCurator.java
+++ b/gutterball/src/main/java/org/candlepin/gutterball/curator/ComplianceSnapshotCurator.java
@@ -193,6 +193,7 @@ public class ComplianceSnapshotCurator extends BaseCurator<Compliance> {
      *  A Page instance containing an iterator over the compliance snapshots for the target date and
      *  the paging information for the query.
      */
+    @SuppressWarnings("checkstyle:indentation")
     public Page<Iterator<Compliance>> getSnapshotIterator(Date targetDate, List<String> consumerUuids,
         List<String> ownerFilters, List<String> statusFilters, List<String> productNameFilters,
         List<String> subscriptionSkuFilters, List<String> subscriptionNameFilters,
@@ -250,7 +251,7 @@ public class ComplianceSnapshotCurator extends BaseCurator<Compliance> {
 
             if (attributeFilters != null && attributeFilters.containsKey("management_enabled")) {
                 boolean managementEnabledFilter =
-                        PropertyConverter.toBoolean(attributeFilters.get("management_enabled"));
+                    PropertyConverter.toBoolean(attributeFilters.get("management_enabled"));
                 query.add(Restrictions.eq("stat.managementEnabled", managementEnabledFilter));
             }
 
@@ -371,6 +372,7 @@ public class ComplianceSnapshotCurator extends BaseCurator<Compliance> {
      *  A Page instance containing an iterator over the snapshots for the specified consumer, and
      *  the paging information for the query.
      */
+    @SuppressWarnings("checkstyle:indentation")
     public Page<Iterator<Compliance>> getSnapshotIteratorForConsumer(String consumerUUID, Date startDate,
         Date endDate, PageRequest pageRequest) {
 
@@ -398,8 +400,7 @@ public class ComplianceSnapshotCurator extends BaseCurator<Compliance> {
             subquery.add(Restrictions.lt("comp2.date", startDate));
 
             subquery.setProjection(
-                Projections.projectionList()
-                    .add(Projections.max("comp2.date"))
+                Projections.projectionList().add(Projections.max("comp2.date"))
             );
 
             query.add(
@@ -853,7 +854,7 @@ public class ComplianceSnapshotCurator extends BaseCurator<Compliance> {
      * @return
      *  A Query object to be used for retrieving compliance status counts.
      */
-    @SuppressWarnings("checkstyle:methodlength")
+    @SuppressWarnings({"checkstyle:methodlength", "checkstyle:indentation"})
     private Query buildComplianceStatusCountQuery(Session session, Date startDate, Date endDate,
         String ownerKey, List<String> consumerUuids, String sku, String subscriptionName,
         String productName, Map<String, String> attributes) {

--- a/gutterball/src/main/java/org/candlepin/gutterball/guice/GutterballModule.java
+++ b/gutterball/src/main/java/org/candlepin/gutterball/guice/GutterballModule.java
@@ -187,7 +187,7 @@ public class GutterballModule extends AbstractModule {
 
     protected void configureEventHandlers() {
         MapBinder<String, EventHandler> eventBinder =
-                MapBinder.newMapBinder(binder(), String.class, EventHandler.class);
+            MapBinder.newMapBinder(binder(), String.class, EventHandler.class);
         for (Class<? extends EventHandler> clazz : EventHandlerLoader.getClasses()) {
             if (clazz.isAnnotationPresent(HandlerTarget.class)) {
                 HandlerTarget targetAnnotation = clazz.getAnnotation(HandlerTarget.class);

--- a/gutterball/src/main/java/org/candlepin/gutterball/jackson/EntitlementDeserializer.java
+++ b/gutterball/src/main/java/org/candlepin/gutterball/jackson/EntitlementDeserializer.java
@@ -90,7 +90,7 @@ public class EntitlementDeserializer extends JsonDeserializer<Entitlement> {
         while (elements.hasNext()) {
             JsonNode providedProductJson = elements.next();
             products.put(providedProductJson.get("productId").textValue(),
-                    getValue(providedProductJson, "productName"));
+                getValue(providedProductJson, "productName"));
         }
         return products;
     }

--- a/gutterball/src/main/java/org/candlepin/gutterball/model/snapshot/Compliance.java
+++ b/gutterball/src/main/java/org/candlepin/gutterball/model/snapshot/Compliance.java
@@ -124,8 +124,7 @@ public class Compliance {
         return status;
     }
 
-    public void setStatus(
-            ComplianceStatus complianceStatusSnapshot) {
+    public void setStatus(ComplianceStatus complianceStatusSnapshot) {
         this.status = complianceStatusSnapshot;
         this.status.setComplianceSnapshot(this);
     }
@@ -134,8 +133,7 @@ public class Compliance {
         return entitlements;
     }
 
-    public void setEntitlements(
-            Set<Entitlement> entitlementSnapshots) {
+    public void setEntitlements(Set<Entitlement> entitlementSnapshots) {
         this.entitlements = entitlementSnapshots;
 
         for (Entitlement snapshot : this.entitlements) {

--- a/gutterball/src/main/java/org/candlepin/gutterball/model/snapshot/ComplianceReason.java
+++ b/gutterball/src/main/java/org/candlepin/gutterball/model/snapshot/ComplianceReason.java
@@ -82,8 +82,7 @@ public class ComplianceReason {
 
     @ElementCollection(fetch = FetchType.LAZY)
     @BatchSize(size = 100)
-    @CollectionTable(name = "gb_reason_attr_snap",
-                     joinColumns = @JoinColumn(name = "reason_snap_id"))
+    @CollectionTable(name = "gb_reason_attr_snap", joinColumns = @JoinColumn(name = "reason_snap_id"))
     @MapKeyColumn(name = "mapkey")
     @Column(name = "element")
     @Cascade({org.hibernate.annotations.CascadeType.ALL})

--- a/gutterball/src/main/java/org/candlepin/gutterball/model/snapshot/Consumer.java
+++ b/gutterball/src/main/java/org/candlepin/gutterball/model/snapshot/Consumer.java
@@ -132,8 +132,7 @@ public class Consumer {
 
     @ElementCollection(fetch = FetchType.LAZY)
     @BatchSize(size = 100)
-    @CollectionTable(name = "gb_consumer_facts_snap",
-                     joinColumns = @JoinColumn(name = "consumer_snap_id"))
+    @CollectionTable(name = "gb_consumer_facts_snap", joinColumns = @JoinColumn(name = "consumer_snap_id"))
     @MapKeyColumn(name = "mapkey")
     @Column(name = "element")
     @Cascade({org.hibernate.annotations.CascadeType.ALL})

--- a/gutterball/src/main/java/org/candlepin/gutterball/model/snapshot/Entitlement.java
+++ b/gutterball/src/main/java/org/candlepin/gutterball/model/snapshot/Entitlement.java
@@ -117,8 +117,7 @@ public class Entitlement {
 
     @ElementCollection(fetch = FetchType.LAZY)
     @BatchSize(size = 100)
-    @CollectionTable(name = "gb_ent_attr_snap",
-                     joinColumns = @JoinColumn(name = "ent_snap_id"))
+    @CollectionTable(name = "gb_ent_attr_snap", joinColumns = @JoinColumn(name = "ent_snap_id"))
     @MapKeyColumn(name = "gb_ent_attr_name")
     @Column(name = "gb_ent_attr_value")
     @Cascade({org.hibernate.annotations.CascadeType.ALL})
@@ -126,8 +125,7 @@ public class Entitlement {
 
     @ElementCollection(fetch = FetchType.LAZY)
     @BatchSize(size = 25)
-    @CollectionTable(name = "gb_ent_prov_prod_snap",
-                     joinColumns = @JoinColumn(name = "ent_snap_id"))
+    @CollectionTable(name = "gb_ent_prov_prod_snap", joinColumns = @JoinColumn(name = "ent_snap_id"))
     @MapKeyColumn(name = "gb_ent_prov_prod_id")
     @Column(name = "gb_ent_prov_prod_name")
     @Cascade({org.hibernate.annotations.CascadeType.ALL})
@@ -135,8 +133,7 @@ public class Entitlement {
 
     @ElementCollection(fetch = FetchType.LAZY)
     @BatchSize(size = 100)
-    @CollectionTable(name = "gb_ent_der_prod_attr_snap",
-                     joinColumns = @JoinColumn(name = "ent_snap_id"))
+    @CollectionTable(name = "gb_ent_der_prod_attr_snap", joinColumns = @JoinColumn(name = "ent_snap_id"))
     @MapKeyColumn(name = "gb_ent_der_prod_attr_name")
     @Column(name = "gb_ent_der_prod_attr_value")
     @Cascade({org.hibernate.annotations.CascadeType.ALL})
@@ -144,8 +141,7 @@ public class Entitlement {
 
     @ElementCollection(fetch = FetchType.LAZY)
     @BatchSize(size = 25)
-    @CollectionTable(name = "gb_ent_der_prov_prod_snap",
-                     joinColumns = @JoinColumn(name = "ent_snap_id"))
+    @CollectionTable(name = "gb_ent_der_prov_prod_snap", joinColumns = @JoinColumn(name = "ent_snap_id"))
     @MapKeyColumn(name = "gb_ent_der_prov_prod_id")
     @Column(name = "gb_ent_der_prov_prod_name")
     @Cascade({org.hibernate.annotations.CascadeType.ALL})
@@ -291,8 +287,7 @@ public class Entitlement {
         return derivedProvidedProducts;
     }
 
-    public void setDerivedProvidedProducts(
-            Map<String, String> derivedProvidedProducts) {
+    public void setDerivedProvidedProducts(Map<String, String> derivedProvidedProducts) {
         this.derivedProvidedProducts = derivedProvidedProducts;
     }
 
@@ -300,8 +295,7 @@ public class Entitlement {
         return derivedProductAttributes;
     }
 
-    public void setDerivedProductAttributes(
-            Map<String, String> derivedProductAttributes) {
+    public void setDerivedProductAttributes(Map<String, String> derivedProductAttributes) {
         this.derivedProductAttributes = derivedProductAttributes;
     }
 

--- a/gutterball/src/main/java/org/candlepin/gutterball/model/snapshot/GuestId.java
+++ b/gutterball/src/main/java/org/candlepin/gutterball/model/snapshot/GuestId.java
@@ -77,7 +77,7 @@ public class GuestId {
     @ElementCollection(fetch = FetchType.LAZY)
     @BatchSize(size = 100)
     @CollectionTable(name = "gb_consumer_guest_attributes",
-                     joinColumns = @JoinColumn(name = "consumer_guest_id"))
+        joinColumns = @JoinColumn(name = "consumer_guest_id"))
     @MapKeyColumn(name = "mapkey")
     @Column(name = "element")
     @Cascade({org.hibernate.annotations.CascadeType.ALL})

--- a/gutterball/src/main/java/org/candlepin/gutterball/receiver/EventMessageListener.java
+++ b/gutterball/src/main/java/org/candlepin/gutterball/receiver/EventMessageListener.java
@@ -50,7 +50,7 @@ public class EventMessageListener implements MessageListener {
 
     @Inject
     public EventMessageListener(UnitOfWork unitOfWork, ObjectMapper mapper,
-            EventManager eventManager, EventCurator eventCurator) {
+        EventManager eventManager, EventCurator eventCurator) {
         this.unitOfWork = unitOfWork;
         this.eventManager = eventManager;
         this.mapper = mapper;

--- a/gutterball/src/main/java/org/candlepin/gutterball/report/ConsumerStatusReport.java
+++ b/gutterball/src/main/java/org/candlepin/gutterball/report/ConsumerStatusReport.java
@@ -51,7 +51,7 @@ public class ConsumerStatusReport extends Report<ReportResult> {
      */
     @Inject
     public ConsumerStatusReport(Provider<I18n> i18nProvider, ComplianceSnapshotCurator curator,
-            StatusReasonMessageGenerator messageGenerator) {
+        StatusReasonMessageGenerator messageGenerator) {
         super(i18nProvider, "consumer_status",
                 i18nProvider.get().tr("List the status of all consumers"));
         this.complianceSnapshotCurator = curator;
@@ -59,46 +59,47 @@ public class ConsumerStatusReport extends Report<ReportResult> {
     }
 
     @Override
+    @SuppressWarnings("checkstyle:indentation")
     protected void initParameters() {
         ReportParameterBuilder builder = new ReportParameterBuilder(i18n);
 
         addParameter(
             builder.init("consumer_uuid", i18n.tr("Filters the results by the specified consumer UUID."))
-                .multiValued()
-                .getParameter()
+            .multiValued()
+            .getParameter()
         );
 
         addParameter(
             builder.init("owner", i18n.tr("The Owner key(s) to filter on."))
-                .multiValued()
-                .getParameter());
+            .multiValued()
+            .getParameter());
 
         addParameter(
-            builder.init("status", i18n.tr("The subscription status to filter on [{0}, {1}, {2}].",
-                    "valid", "invalid", "partial"))
-                .multiValued()
-                .getParameter()
+            builder.init("status", i18n.tr(
+                "The subscription status to filter on [{0}, {1}, {2}].", "valid", "invalid", "partial"))
+            .multiValued()
+            .getParameter()
         );
 
         addParameter(
             builder.init("on_date", i18n.tr("The date to filter on. Defaults to NOW."))
-                .mustBeDate(REPORT_DATE_FORMATS)
-                .getParameter()
+            .mustBeDate(REPORT_DATE_FORMATS)
+            .getParameter()
         );
 
         this.addParameter(
             builder.init("product_name", i18n.tr("The name of a product on which to filter"))
-                .getParameter()
+            .getParameter()
         );
 
         this.addParameter(
             builder.init("sku", i18n.tr("The entitlement SKU on which to filter"))
-                .getParameter()
+            .getParameter()
         );
 
         this.addParameter(
             builder.init("subscription_name", i18n.tr("The name of a subscription on which to filter"))
-                .getParameter()
+            .getParameter()
         );
 
         this.addParameter(
@@ -106,7 +107,7 @@ public class ConsumerStatusReport extends Report<ReportResult> {
                 "management_enabled",
                 i18n.tr("Filter on subscriptions which have management enabled set to this value (Boolean)")
             )
-                .getParameter()
+            .getParameter()
         );
 
         addParameter(
@@ -114,20 +115,20 @@ public class ConsumerStatusReport extends Report<ReportResult> {
                     "functionality via attribute filtering (Boolean).")).getParameter());
 
         addParameter(builder.init("include_reasons", i18n.tr("Include status reasons in results"))
-                .mustNotHave(CUSTOM_RESULTS_PARAM)
-                .getParameter());
+            .mustNotHave(CUSTOM_RESULTS_PARAM)
+            .getParameter());
 
         addParameter(builder.init("include", i18n.tr("Includes the specified attribute in the result JSON"))
-                .mustHave(CUSTOM_RESULTS_PARAM)
-                .mustNotHave("exclude")
-                .multiValued()
-                .getParameter());
+            .mustHave(CUSTOM_RESULTS_PARAM)
+            .mustNotHave("exclude")
+            .multiValued()
+            .getParameter());
 
         addParameter(builder.init("exclude", i18n.tr("Excludes the specified attribute in the result JSON"))
-                .mustHave(CUSTOM_RESULTS_PARAM)
-                .mustNotHave("include")
-                .multiValued()
-                .getParameter());
+            .mustHave(CUSTOM_RESULTS_PARAM)
+            .mustNotHave("include")
+            .multiValued()
+            .getParameter());
     }
 
     @Override

--- a/gutterball/src/main/java/org/candlepin/gutterball/report/ConsumerTrendReport.java
+++ b/gutterball/src/main/java/org/candlepin/gutterball/report/ConsumerTrendReport.java
@@ -50,7 +50,7 @@ public class ConsumerTrendReport extends Report<ReportResult> {
      */
     @Inject
     public ConsumerTrendReport(Provider<I18n> i18nProvider, ComplianceSnapshotCurator snapshotCurator,
-            StatusReasonMessageGenerator messageGenerator) {
+        StatusReasonMessageGenerator messageGenerator) {
         super(i18nProvider, "consumer_trend",
                 i18nProvider.get().tr("Lists the status of each consumer over a date range"));
         this.snapshotCurator = snapshotCurator;
@@ -58,49 +58,49 @@ public class ConsumerTrendReport extends Report<ReportResult> {
     }
 
     @Override
+    @SuppressWarnings("checkstyle:indentation")
     protected void initParameters() {
         ReportParameterBuilder builder = new ReportParameterBuilder(i18n);
 
         addParameter(
             builder.init("consumer_uuid", i18n.tr("Filters the results by the specified consumer UUID."))
-                .mandatory()
-                .getParameter()
+            .mandatory()
+            .getParameter()
         );
 
         addParameter(
             builder.init("hours", i18n.tr(
-                        "The number of hours to filter on (used independent of date range)."))
-                   .mustBeInteger()
-                   .mustNotHave("start_date", "end_date")
-                   .getParameter());
+                "The number of hours to filter on (used independent of date range)."))
+           .mustBeInteger()
+           .mustNotHave("start_date", "end_date")
+           .getParameter());
 
         addParameter(
             builder.init("start_date", i18n.tr("The start date to filter on (used with {0}).", "end_date"))
-                .mustNotHave("hours")
-                .mustHave("end_date")
-                .mustBeDate(REPORT_DATETIME_FORMATS)
-                .getParameter());
+            .mustNotHave("hours")
+            .mustHave("end_date")
+            .mustBeDate(REPORT_DATETIME_FORMATS)
+            .getParameter());
 
         addParameter(
             builder.init("end_date", i18n.tr("The end date to filter on (used with {0})", "start_date"))
-                .mustNotHave("hours")
-                .mustHave("start_date")
-                .mustBeDate(REPORT_DATETIME_FORMATS)
-                .getParameter());
+            .mustNotHave("hours")
+            .mustHave("start_date")
+            .mustBeDate(REPORT_DATETIME_FORMATS)
+            .getParameter());
 
         addParameter(
             builder.init(CUSTOM_RESULTS_PARAM, i18n.tr("Enables/disables custom report result " +
-                        "functionality via attribute filtering (Boolean).")).getParameter());
+                "functionality via attribute filtering (Boolean)."))
+            .getParameter());
 
-        addParameter(builder.init("include",
-                i18n.tr("Includes the specified attribute in the result JSON"))
+        addParameter(builder.init("include", i18n.tr("Includes the specified attribute in the result JSON"))
             .multiValued()
             .mustHave(CUSTOM_RESULTS_PARAM)
             .mustNotHave("exclude")
             .getParameter());
 
-        addParameter(builder.init("exclude",
-                i18n.tr("Excludes the specified attribute in the result JSON"))
+        addParameter(builder.init("exclude", i18n.tr("Excludes the specified attribute in the result JSON"))
             .multiValued()
             .mustHave(CUSTOM_RESULTS_PARAM)
             .mustNotHave("include")
@@ -134,10 +134,7 @@ public class ConsumerTrendReport extends Report<ReportResult> {
         boolean useCustom = PropertyConverter.toBoolean(custom);
 
         Page<Iterator<Compliance>> page = this.snapshotCurator.getSnapshotIteratorForConsumer(
-                consumer,
-                startDate,
-                endDate,
-                pageRequest
+            consumer, startDate, endDate, pageRequest
         );
 
         ResteasyProviderFactory.pushContext(Page.class, page);

--- a/gutterball/src/main/java/org/candlepin/gutterball/report/StatusTrendReport.java
+++ b/gutterball/src/main/java/org/candlepin/gutterball/report/StatusTrendReport.java
@@ -66,6 +66,7 @@ public class StatusTrendReport extends Report<StatusTrendReportResult> {
     }
 
     @Override
+    @SuppressWarnings("checkstyle:indentation")
     protected void initParameters() {
         ReportParameterBuilder builder = new ReportParameterBuilder(i18n);
 
@@ -82,63 +83,59 @@ public class StatusTrendReport extends Report<StatusTrendReportResult> {
 
         this.addParameter(
             builder.init("start_date", i18n.tr("The start date on which to filter"))
-                .mustBeDate(REPORT_DATE_FORMATS)
-                .mustSatisfy(yearValidator)
-                .getParameter()
+            .mustBeDate(REPORT_DATE_FORMATS)
+            .mustSatisfy(yearValidator)
+            .getParameter()
         );
 
         this.addParameter(
             builder.init("end_date", i18n.tr("The end date on which to filter"))
-                .mustBeDate(REPORT_DATE_FORMATS)
-                .mustSatisfy(yearValidator)
-                .getParameter()
+            .mustBeDate(REPORT_DATE_FORMATS)
+            .mustSatisfy(yearValidator)
+            .getParameter()
         );
 
         this.addParameter(
             builder.init("consumer_uuid", i18n.tr("The consumer UUID(s) on which to filter"))
-                .multiValued()
-                .getParameter()
+            .multiValued()
+            .getParameter()
         );
 
         this.addParameter(
             builder.init("owner", i18n.tr("An owner key on which to filter"))
-                .getParameter()
+            .getParameter()
         );
 
         this.addParameter(
             builder.init("product_name", i18n.tr("The name of a product on which to filter"))
-                .mustNotHave("sku", "subscription_name", "management_enabled")
-                .getParameter()
+            .mustNotHave("sku", "subscription_name", "management_enabled")
+            .getParameter()
         );
 
         this.addParameter(
             builder.init("sku", i18n.tr("The entitlement SKU on which to filter"))
-                .mustNotHave("product_name", "subscription_name", "management_enabled")
-                .getParameter()
+            .mustNotHave("product_name", "subscription_name", "management_enabled")
+            .getParameter()
         );
 
         this.addParameter(
             builder.init("subscription_name", i18n.tr("The name of a subscription on which to filter"))
-                .mustNotHave("product_name", "sku", "management_enabled")
-                .getParameter()
+            .mustNotHave("product_name", "sku", "management_enabled")
+            .getParameter()
         );
 
         this.addParameter(
-            builder.init(
-                "management_enabled",
-                i18n.tr("Filter on subscriptions which have management enabled set to this value (Boolean)")
-            )
-                .mustNotHave("product_name", "sku", "subscription_name")
-                .getParameter()
+            builder.init("management_enabled", i18n.tr(
+                "Filter on subscriptions which have management enabled set to this value (Boolean)"))
+            .mustNotHave("product_name", "sku", "subscription_name")
+            .getParameter()
         );
 
         this.addParameter(
-            builder.init(
-                "timezone",
-                i18n.tr("The timezone to use when processing the request and returning results")
-            )
-                .mustBeTimeZone()
-                .getParameter()
+            builder.init("timezone", i18n.tr(
+                "The timezone to use when processing the request and returning results"))
+            .mustBeTimeZone()
+            .getParameter()
         );
     }
 

--- a/gutterball/src/main/java/org/candlepin/gutterball/util/EventHandlerLoader.java
+++ b/gutterball/src/main/java/org/candlepin/gutterball/util/EventHandlerLoader.java
@@ -73,7 +73,7 @@ public class EventHandlerLoader {
         else if (resource.endsWith(CLASS_SUFFIX)) {
             try {
                 Class<?> tmpClass = Class.forName(
-                        resource.substring(0, resource.length() - CLASS_SUFFIX.length()));
+                    resource.substring(0, resource.length() - CLASS_SUFFIX.length()));
                 if (!tmpClass.isInterface() && EventHandler.class.isAssignableFrom(tmpClass)) {
                     classes.add((Class<? extends EventHandler>) tmpClass);
                 }

--- a/gutterball/src/test/java/org/candlepin/gutterball/TestUtils.java
+++ b/gutterball/src/test/java/org/candlepin/gutterball/TestUtils.java
@@ -62,12 +62,12 @@ public class TestUtils {
     }
 
     public static Compliance createComplianceSnapshot(Date statusDate, String consumerUuid,
-            String owner, String statusString) {
+        String owner, String statusString) {
         return createComplianceSnapshot(statusDate, consumerUuid, owner, statusString, null);
     }
 
     public static Compliance createComplianceSnapshot(Date statusDate, String consumerUuid,
-            String owner, String statusString, ConsumerState state) {
+        String owner, String statusString, ConsumerState state) {
         Consumer consumerSnap = new Consumer(consumerUuid, null, createOwnerSnapshot(owner, owner));
         consumerSnap.setConsumerState(state);
         ComplianceStatus statusSnap = new ComplianceStatus(statusDate, statusString);
@@ -81,7 +81,7 @@ public class TestUtils {
     }
 
     public static Compliance createComplianceSnapshotWithProducts(Date statusDate, String consumerUuid,
-            String owner, String statusString, ConsumerState state, Set<String> products) {
+        String owner, String statusString, ConsumerState state, Set<String> products) {
 
         return createComplianceSnapshotWithProductsAndCompliances(statusDate, consumerUuid, owner,
             statusString, state, products, null, null, null);

--- a/gutterball/src/test/java/org/candlepin/gutterball/curator/ComplianceSnapshotCuratorTest.java
+++ b/gutterball/src/test/java/org/candlepin/gutterball/curator/ComplianceSnapshotCuratorTest.java
@@ -77,7 +77,7 @@ public class ComplianceSnapshotCuratorTest extends DatabaseTestFixture {
     }
 
     @Before
-    @SuppressWarnings("checkstyle:methodlength")
+    @SuppressWarnings({ "checkstyle:methodlength", "serial" })
     public void initData() {
         Compliance compliance;
         Calendar cal = this.getCalendar();
@@ -146,10 +146,10 @@ public class ComplianceSnapshotCuratorTest extends DatabaseTestFixture {
         this.beginTransaction();
 
         // Consumer products
-        Set<String> c1prods = new HashSet(Arrays.asList("p1"));
-        Set<String> c2prods = new HashSet(Arrays.asList("p1", "p2"));
-        Set<String> c3prods = new HashSet(Arrays.asList("p3", "p4"));
-        Set<String> c4prods = new HashSet(Arrays.asList("p1", "p4"));
+        Set<String> c1prods = new HashSet<String>(Arrays.asList("p1"));
+        Set<String> c2prods = new HashSet<String>(Arrays.asList("p1", "p2"));
+        Set<String> c3prods = new HashSet<String>(Arrays.asList("p3", "p4"));
+        Set<String> c4prods = new HashSet<String>(Arrays.asList("p1", "p4"));
 
         // Consumer created
         cal.set(Calendar.MONTH, Calendar.MARCH);
@@ -178,7 +178,8 @@ public class ComplianceSnapshotCuratorTest extends DatabaseTestFixture {
         attachEntitlement(compliance, entitlement2);
         cal.set(Calendar.MONTH, Calendar.JUNE);
         compliance = createSnapshotWithProductsAndCompliances(cal.getTime(), "c3", "o2", "partial",
-            c3prods, new HashSet(Arrays.asList("p3")), new HashSet(Arrays.asList("p4")), null);
+            c3prods, new HashSet<String>(Arrays.asList("p3")),
+            new HashSet<String>(Arrays.asList("p4")), null);
         attachEntitlement(compliance, entitlement2);
 
         cal.set(Calendar.MONTH, Calendar.MAY);
@@ -481,7 +482,7 @@ public class ComplianceSnapshotCuratorTest extends DatabaseTestFixture {
         for (Compliance cs : snaps) {
             String uuid = cs.getConsumer().getUuid();
             assertEquals("Invalid status found for " + uuid,
-                    expectedStatusDates.get(uuid), cs.getStatus().getDate());
+                expectedStatusDates.get(uuid), cs.getStatus().getDate());
         }
     }
 
@@ -769,6 +770,7 @@ public class ComplianceSnapshotCuratorTest extends DatabaseTestFixture {
     }
 
 
+    @SuppressWarnings("serial")
     @Test
     public void testGetAllStatusReports() {
         HashMap<String, Integer> expected = new HashMap<String, Integer>() {
@@ -783,6 +785,7 @@ public class ComplianceSnapshotCuratorTest extends DatabaseTestFixture {
         this.testConsumerTrendReport(expected, null, null);
     }
 
+    @SuppressWarnings("serial")
     @Test
     public void testGetStatusReportsTimeframe() {
         Calendar cal = this.getCalendar();
@@ -1112,6 +1115,7 @@ public class ComplianceSnapshotCuratorTest extends DatabaseTestFixture {
         return output;
     }
 
+    @SuppressWarnings({ "checkstyle:indentation", "unchecked" })
     public Object[] buildMapForStatusCountsBetweenDates() {
         LinkedList<Object[]> tests = new LinkedList<Object[]>();
         Object[][] beforeSet = this.buildMapForStatusCountsBeforeDate();
@@ -1133,6 +1137,7 @@ public class ComplianceSnapshotCuratorTest extends DatabaseTestFixture {
         return tests.toArray();
     }
 
+    @SuppressWarnings({ "checkstyle:indentation", "unchecked" })
     public Object[] buildMapForStatusCountsWithSku() {
         LinkedList<Object[]> tests = new LinkedList<Object[]>();
         Object[][] beforeSet = this.buildMapForStatusCountsBeforeDate();
@@ -1159,6 +1164,7 @@ public class ComplianceSnapshotCuratorTest extends DatabaseTestFixture {
         return tests.toArray();
     }
 
+    @SuppressWarnings({ "checkstyle:indentation", "unchecked" })
     public Object[] buildMapForStatusCountsWithSubscriptionName() {
         LinkedList<Object[]> tests = new LinkedList<Object[]>();
         Object[][] beforeSet = this.buildMapForStatusCountsBeforeDate();
@@ -1185,6 +1191,7 @@ public class ComplianceSnapshotCuratorTest extends DatabaseTestFixture {
         return tests.toArray();
     }
 
+    @SuppressWarnings({ "checkstyle:indentation", "unchecked" })
     public Object[] buildMapForStatusCountsWithProducts() {
         LinkedList<Object[]> tests = new LinkedList<Object[]>();
         Object[][] beforeSet = this.buildMapForStatusCountsBeforeDate();
@@ -1216,6 +1223,7 @@ public class ComplianceSnapshotCuratorTest extends DatabaseTestFixture {
         return tests.toArray();
     }
 
+    @SuppressWarnings({ "checkstyle:indentation", "unchecked" })
     public Object[] buildMapForStatusCountsWithAttributes() {
         LinkedList<Object[]> tests = new LinkedList<Object[]>();
         Object[][] beforeSet = this.buildMapForStatusCountsBeforeDate();
@@ -1587,6 +1595,7 @@ public class ComplianceSnapshotCuratorTest extends DatabaseTestFixture {
         return output;
     }
 
+    @SuppressWarnings({ "checkstyle:indentation", "unchecked" })
     public Object[] buildMapForStatusCountsForConsumersBetweenDates() {
         LinkedList<Object[]> tests = new LinkedList<Object[]>();
         Object[][] beforeSet = this.buildMapForStatusCountsBeforeDate();
@@ -1725,7 +1734,7 @@ public class ComplianceSnapshotCuratorTest extends DatabaseTestFixture {
         return output;
     }
 
-    @SuppressWarnings("checkstyle:methodlength")
+    @SuppressWarnings({ "checkstyle:methodlength", "serial" })
     private Object[][] buildSubMapForStatusCountsWithAttributes() {
         long millis;
         Calendar cal = this.getCalendar();

--- a/gutterball/src/test/java/org/candlepin/gutterball/report/ConsumerStatusReportTest.java
+++ b/gutterball/src/test/java/org/candlepin/gutterball/report/ConsumerStatusReportTest.java
@@ -305,7 +305,7 @@ public class ConsumerStatusReportTest {
     }
 
     private void validateParams(MultivaluedMap<String, String> params, String expectedParam,
-            String expectedMessage) {
+        String expectedMessage) {
         try {
             report.validateParameters(params);
             fail("Expected param validation error.");

--- a/gutterball/src/test/java/org/candlepin/gutterball/report/ConsumerTrendReportTest.java
+++ b/gutterball/src/test/java/org/candlepin/gutterball/report/ConsumerTrendReportTest.java
@@ -327,7 +327,7 @@ public class ConsumerTrendReportTest extends DatabaseTestFixture {
     }
 
     private void validateParams(MultivaluedMap<String, String> params, String expectedParam,
-            String expectedMessage) {
+        String expectedMessage) {
         try {
             report.validateParameters(params);
             fail("Expected param validation error.");

--- a/gutterball/src/test/java/org/candlepin/gutterball/report/ParameterDescriptorTest.java
+++ b/gutterball/src/test/java/org/candlepin/gutterball/report/ParameterDescriptorTest.java
@@ -306,7 +306,7 @@ public class ParameterDescriptorTest {
     }
 
     private void assertInvalidParameter(ParameterDescriptor descriptor,
-            MultivaluedMap<String, String> params, String expectedMessage) {
+        MultivaluedMap<String, String> params, String expectedMessage) {
         try {
             descriptor.validate(params);
             fail("Expected param validation error.");

--- a/gutterball/src/test/java/org/candlepin/gutterball/report/StatusTrendReportTest.java
+++ b/gutterball/src/test/java/org/candlepin/gutterball/report/StatusTrendReportTest.java
@@ -158,7 +158,7 @@ public class StatusTrendReportTest {
     }
 
     private void validateParams(MultivaluedMap<String, String> params, String expectedParam,
-            String expectedMessage) {
+        String expectedMessage) {
 
         StatusTrendReport report = new StatusTrendReport(this.i18nProvider, this.complianceSnapshotCurator);
 

--- a/gutterball/src/test/java/org/candlepin/gutterball/servlet/GutterballContextListenerTest.java
+++ b/gutterball/src/test/java/org/candlepin/gutterball/servlet/GutterballContextListenerTest.java
@@ -54,16 +54,14 @@ public class GutterballContextListenerTest {
 
                 return new MapConfiguration(
                     new HashMap<String, String>() {
-
-                        private static final long serialVersionUID = 1L;
-                        {
+                        private static final long serialVersionUID = 1L; {
                             put(ConfigProperties.AMQP_KEYSTORE, "value");
                             put(ConfigProperties.AMQP_CONNECT_STRING, "value");
                             put(ConfigProperties.AMQP_CONNECT_STRING,
-                                    "amqp://guest:guest@localhost/test");
+                                "amqp://guest:guest@localhost/test");
                             put(ConfigProperties.AMQP_KEYSTORE_PASSWORD, "password");
                             put(ConfigProperties.AMQP_TRUSTSTORE,
-                                    "/etc/gutterball/certs/amqp/gutterball.truststore");
+                                "/etc/gutterball/certs/amqp/gutterball.truststore");
                             put(ConfigProperties.AMQP_TRUSTSTORE_PASSWORD, "password");
                         }
                     });

--- a/project_conf/checks.xml
+++ b/project_conf/checks.xml
@@ -289,7 +289,9 @@
        #######################################################################
      -->
     <module name="ModifierOrder"/>
-    <module name="RedundantModifier"/>
+    <module name="RedundantModifier">
+      <property name="tokens" value="METHOD_DEF, VARIABLE_DEF, ANNOTATION_FIELD_DEF, INTERFACE_DEF, CLASS_DEF"/>
+    </module>
 
     <!--
        #######################################################################

--- a/project_conf/checks.xml
+++ b/project_conf/checks.xml
@@ -277,7 +277,7 @@
     <!-- <module name="FinalParameters"/> -->
     <!-- <module name="DescendantToken"/> -->
     <module name="Indentation">
-      <property name="lineWrappingIndentation" value="0" />
+      <property name="forceStrictCondition" value="true" />
     </module>
     <!-- <module name="TrailingComment"/> -->
     <!-- <module name="Regexp"/> -->

--- a/project_conf/eclipse/code_formatter_candlepin.xml
+++ b/project_conf/eclipse/code_formatter_candlepin.xml
@@ -37,7 +37,7 @@
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_while" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_package" value="1"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_parameters" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.continuation_indentation" value="2"/>
+<setting id="org.eclipse.jdt.core.formatter.continuation_indentation" value="1"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_postfix_operator" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_arguments" value="do not insert"/>
@@ -158,7 +158,7 @@
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_and_in_type_parameter" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_qualified_allocation_expression" value="16"/>
 <setting id="org.eclipse.jdt.core.compiler.compliance" value="1.5"/>
-<setting id="org.eclipse.jdt.core.formatter.continuation_indentation_for_array_initializer" value="2"/>
+<setting id="org.eclipse.jdt.core.formatter.continuation_indentation_for_array_initializer" value="1"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_brackets_in_array_allocation_expression" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_at_in_annotation_type_declaration" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression" value="16"/>

--- a/server/src/main/java/org/candlepin/audit/AMQPBusPublisher.java
+++ b/server/src/main/java/org/candlepin/audit/AMQPBusPublisher.java
@@ -43,7 +43,7 @@ public class AMQPBusPublisher implements EventListener {
 
     @Inject
     public AMQPBusPublisher(TopicSession session,
-            Map<Target, Map<Type, TopicPublisher>> producerMap, ObjectMapper omapper) {
+        Map<Target, Map<Type, TopicPublisher>> producerMap, ObjectMapper omapper) {
         this.session = session;
         this.producerMap = producerMap;
         this.mapper = omapper;

--- a/server/src/main/java/org/candlepin/audit/ActivationListener.java
+++ b/server/src/main/java/org/candlepin/audit/ActivationListener.java
@@ -55,7 +55,7 @@ public class ActivationListener implements EventListener {
     @Override
     public void onEvent(Event e) {
         if (e.getType().equals(Event.Type.CREATED) &&
-                e.getTarget().equals(Event.Target.POOL)) {
+            e.getTarget().equals(Event.Target.POOL)) {
             String poolJson = e.getNewEntity();
             Reader reader = new StringReader(poolJson);
             try {

--- a/server/src/main/java/org/candlepin/audit/EventAdapterImpl.java
+++ b/server/src/main/java/org/candlepin/audit/EventAdapterImpl.java
@@ -84,11 +84,7 @@ public class EventAdapterImpl implements EventAdapter {
                 // ignore, shouldn't happen
             }
             entry.setId(eventURI);
-            entry.getLinks().add(
-                new Link(
-                    "alternate",
-                    eventURI,
-                    MediaType.APPLICATION_JSON_TYPE));
+            entry.getLinks().add(new Link("alternate", eventURI, MediaType.APPLICATION_JSON_TYPE));
 
             Content content = new Content();
             content.setType(MediaType.APPLICATION_XML_TYPE);
@@ -136,7 +132,7 @@ public class EventAdapterImpl implements EventAdapter {
         MESSAGES.put("ENTITLEMENTDELETED",
             I18n.marktr("{0} returned the subscription for {1}"));
         MESSAGES.put("ENTITLEMENTEXPIRED",
-                I18n.marktr("{0} returned the subscription for {1}"));
+            I18n.marktr("{0} returned the subscription for {1}"));
         MESSAGES.put("POOLCREATED", I18n.marktr("{0} created a pool for product {1}"));
         MESSAGES.put("POOLMODIFIED", I18n.marktr("{0} modified a pool for product {1}"));
         MESSAGES.put("POOLDELETED", I18n.marktr("{0} deleted a pool for product {1}"));
@@ -166,7 +162,7 @@ public class EventAdapterImpl implements EventAdapter {
         MESSAGES.put("RULESDELETED",
             I18n.marktr("{0} removed the rules from the database"));
         MESSAGES.put("COMPLIANCECREATED",
-                I18n.marktr("Compliance recalculated for consumer {1}"));
+            I18n.marktr("Compliance recalculated for consumer {1}"));
     }
 
 }

--- a/server/src/main/java/org/candlepin/audit/EventFactory.java
+++ b/server/src/main/java/org/candlepin/audit/EventFactory.java
@@ -219,7 +219,7 @@ public class EventFactory {
     }
 
     public Event complianceCreated(Consumer consumer,
-            Set<Entitlement> entitlements, ComplianceStatus compliance) {
+        Set<Entitlement> entitlements, ComplianceStatus compliance) {
         return new Event(Event.Type.CREATED, Event.Target.COMPLIANCE,
                 consumer.getName(), principalProvider.get(),
                 consumer.getOwner().getId(), consumer.getId(),
@@ -229,7 +229,7 @@ public class EventFactory {
 
     // Jackson should think all 3 are root entities so hateoas doesn't bite us
     protected String buildComplianceDataJson(Consumer consumer,
-            Set<Entitlement> entitlements, ComplianceStatus status) {
+        Set<Entitlement> entitlements, ComplianceStatus status) {
         StringBuilder sb = new StringBuilder();
         sb.append("{\"consumer\": ");
         sb.append(entityToJson(consumer));

--- a/server/src/main/java/org/candlepin/audit/EventFilter.java
+++ b/server/src/main/java/org/candlepin/audit/EventFilter.java
@@ -92,8 +92,7 @@ public class EventFilter {
      * @param includes2
      * @param includesConfig
      */
-    private void fillEventTypeAndTargetFromConfig(
-            Set<EventTypeAndTarget> set, List<String> stringList) {
+    private void fillEventTypeAndTargetFromConfig(Set<EventTypeAndTarget> set, List<String> stringList) {
 
         for (String item : stringList) {
             if (item.trim().equals("")) {
@@ -123,8 +122,7 @@ public class EventFilter {
             return false;
         }
 
-        EventTypeAndTarget eventKey = new EventTypeAndTarget(event.getType(),
-                event.getTarget());
+        EventTypeAndTarget eventKey = new EventTypeAndTarget(event.getType(), event.getTarget());
 
         if (toNotFilter.contains(eventKey)) {
             return false;

--- a/server/src/main/java/org/candlepin/audit/EventSinkImpl.java
+++ b/server/src/main/java/org/candlepin/audit/EventSinkImpl.java
@@ -75,7 +75,7 @@ public class EventSinkImpl implements EventSink {
 
     @Inject
     public EventSinkImpl(EventFilter eventFilter, EventFactory eventFactory,
-            ObjectMapper mapper, Configuration config) {
+        ObjectMapper mapper, Configuration config) {
         this.eventFactory = eventFactory;
         this.mapper = mapper;
         this.config = config;
@@ -142,11 +142,9 @@ public class EventSinkImpl implements EventSink {
 
             ClientSession session = getClientSession();
             session.start();
-            for (String listenerClassName : HornetqContextListener.getHornetqListeners(
-                    config)) {
+            for (String listenerClassName : HornetqContextListener.getHornetqListeners(config)) {
                 String queueName = "event." + listenerClassName;
-                long msgCount = session.queueQuery(new SimpleString(queueName))
-                        .getMessageCount();
+                long msgCount = session.queueQuery(new SimpleString(queueName)).getMessageCount();
                 results.add(new QueueStatus(queueName, msgCount));
             }
         }
@@ -272,7 +270,7 @@ public class EventSinkImpl implements EventSink {
 
     @Override
     public void emitCompliance(Consumer consumer,
-            Set<Entitlement> entitlements, ComplianceStatus compliance) {
+        Set<Entitlement> entitlements, ComplianceStatus compliance) {
         queueEvent(eventFactory.complianceCreated(consumer, entitlements, compliance));
     }
 }

--- a/server/src/main/java/org/candlepin/audit/HornetqContextListener.java
+++ b/server/src/main/java/org/candlepin/audit/HornetqContextListener.java
@@ -106,7 +106,7 @@ public class HornetqContextListener {
             AddressSettings pagingConfig = new AddressSettings();
 
             String addressPolicyString =
-                    candlepinConfig.getString(ConfigProperties.HORNETQ_ADDRESS_FULL_POLICY);
+                candlepinConfig.getString(ConfigProperties.HORNETQ_ADDRESS_FULL_POLICY);
             long maxQueueSizeInMb = candlepinConfig.getInt(ConfigProperties.HORNETQ_MAX_QUEUE_SIZE);
             long maxPageSizeInMb = candlepinConfig.getInt(ConfigProperties.HORNETQ_MAX_PAGE_SIZE);
 
@@ -198,10 +198,10 @@ public class HornetqContextListener {
      * @return List of class names that will be configured as HornetQ listeners.
      */
     public static List<String> getHornetqListeners(
-            org.candlepin.common.config.Configuration candlepinConfig) {
+        org.candlepin.common.config.Configuration candlepinConfig) {
         //AMQP integration here - If it is disabled, don't add it to listeners.
         List<String> listeners = Lists.newArrayList(
-                candlepinConfig.getList(ConfigProperties.AUDIT_LISTENERS));
+            candlepinConfig.getList(ConfigProperties.AUDIT_LISTENERS));
 
         if (candlepinConfig
             .getBoolean(ConfigProperties.AMQP_INTEGRATION_ENABLED)) {

--- a/server/src/main/java/org/candlepin/audit/LoggingListener.java
+++ b/server/src/main/java/org/candlepin/audit/LoggingListener.java
@@ -75,6 +75,7 @@ public class LoggingListener implements EventListener {
     }
 
     @Override
+    @SuppressWarnings("checkstyle:indentation")
     public void onEvent(Event e) {
         auditLog.info(
             "{} principalType={} principal={} target={} entityId={} type={} owner={}\n",

--- a/server/src/main/java/org/candlepin/audit/NoopEventSinkImpl.java
+++ b/server/src/main/java/org/candlepin/audit/NoopEventSinkImpl.java
@@ -111,8 +111,8 @@ public class NoopEventSinkImpl implements EventSink {
 
     @Override
     public void emitCompliance(Consumer consumer,
-            Set<Entitlement> entitlements, ComplianceStatus compliance) {
-        log.debug("emitCompliance: entitlements:" + entitlements + " ComplianceStatus:" + compliance);
+        Set<Entitlement> entitlements, ComplianceStatus compliance) {
+        log.debug("emitCompliance: entitlements: {} ComplianceStatus: {}", entitlements, compliance);
     }
 
     @Override

--- a/server/src/main/java/org/candlepin/auth/ConsumerAuth.java
+++ b/server/src/main/java/org/candlepin/auth/ConsumerAuth.java
@@ -64,8 +64,7 @@ public abstract class ConsumerAuth implements AuthProvider {
                 principal = new ConsumerPrincipal(consumer);
 
                 if (log.isDebugEnabled() && principal != null) {
-                    log.debug("principal created for consumer '" +
-                            principal.getConsumer().getUuid());
+                    log.debug("principal created for consumer {}", principal.getConsumer().getUuid());
                 }
             }
         }

--- a/server/src/main/java/org/candlepin/auth/ConsumerPrincipal.java
+++ b/server/src/main/java/org/candlepin/auth/ConsumerPrincipal.java
@@ -70,7 +70,7 @@ public class ConsumerPrincipal extends Principal {
         }
         final ConsumerPrincipal other = (ConsumerPrincipal) obj;
         if (this.consumer != other.consumer &&
-                (this.consumer == null || !this.consumer.equals(other.consumer))) {
+            (this.consumer == null || !this.consumer.equals(other.consumer))) {
             return false;
         }
         return true;

--- a/server/src/main/java/org/candlepin/auth/Principal.java
+++ b/server/src/main/java/org/candlepin/auth/Principal.java
@@ -75,14 +75,14 @@ public abstract class Principal implements Serializable, java.security.Principal
     public boolean canAccessAll(Collection targets, SubResource subResource, Access access) {
         if (CollectionUtils.isEmpty(targets)) {
             log.debug(
-                    "{} principal checking for {} access to sub-resource: {}." +
-                    " Access to null or resource tried",
-                    this.getClass().getName(), access, subResource);
+                "{} principal checking for {} access to sub-resource: {}." +
+                " Access to null or resource tried",
+                this.getClass().getName(), access, subResource);
             return canAccess(null, subResource, access);
         }
 
-        log.debug("{} principal checking for {} access to targets: {} sub-resource: {}", this.getClass()
-                .getName(), access, Arrays.toString(targets.toArray()), subResource);
+        log.debug("{} principal checking for {} access to targets: {} sub-resource: {}",
+            this.getClass().getName(), access, Arrays.toString(targets.toArray()), subResource);
 
         if (hasFullAccess()) {
             return true;

--- a/server/src/main/java/org/candlepin/auth/permissions/CheckJobStatusPermission.java
+++ b/server/src/main/java/org/candlepin/auth/permissions/CheckJobStatusPermission.java
@@ -56,6 +56,7 @@ public class CheckJobStatusPermission extends TypedPermission<JobStatus> {
     }
 
     @Override
+    @SuppressWarnings("checkstyle:indentation")
     public Criterion getCriteriaRestrictions(Class entityClass) {
         if (!entityClass.equals(JobStatus.class)) {
             return null;
@@ -69,8 +70,7 @@ public class CheckJobStatusPermission extends TypedPermission<JobStatus> {
             Restrictions.ne("targetType", JobStatus.TargetType.OWNER),
             Restrictions.and(
                 Restrictions.eq("targetType", JobStatus.TargetType.OWNER),
-                Restrictions.eqProperty("ownerId", "targetId")
-            )
+                Restrictions.eqProperty("ownerId", "targetId"))
         ));
 
         // If the principal is not a user, make sure to enforce a principalName match.

--- a/server/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/server/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -72,7 +72,7 @@ public class ConfigProperties {
      * will be used.
      */
     public static final String HORNETQ_MAX_SCHEDULED_THREADS =
-            "candlepin.audit.hornetq.max_scheduled_threads";
+        "candlepin.audit.hornetq.max_scheduled_threads";
     public static final String HORNETQ_MAX_THREADS = "candlepin.audit.hornetq.max_threads";
     /**
      * This can be either BLOCK or PAGE. When set to PAGE then
@@ -266,8 +266,8 @@ public class ConfigProperties {
                 this.put(HORNETQ_MAX_PAGE_SIZE, "1");
                 this.put(AUDIT_LISTENERS,
                     "org.candlepin.audit.DatabaseListener," +
-                        "org.candlepin.audit.LoggingListener," +
-                        "org.candlepin.audit.ActivationListener");
+                    "org.candlepin.audit.LoggingListener," +
+                    "org.candlepin.audit.ActivationListener");
                 this.put(AUDIT_LOG_FILE, "/var/log/candlepin/audit.log");
                 this.put(AUDIT_LOG_VERBOSE, "false");
                 this.put(AUDIT_FILTER_ENABLED, "false");
@@ -280,11 +280,11 @@ public class ConfigProperties {
                 * SATELLITE-6.1.0/app/lib/actions/candlepin/reindex_pool_subscription_handler.rb#L43
                 */
                 this.put(AUDIT_FILTER_DO_NOT_FILTER,
-                        "CREATED-ENTITLEMENT," +
-                            "DELETED-ENTITLEMENT," +
-                            "CREATED-POOL," +
-                            "DELETED-POOL," +
-                            "CREATED-COMPLIANCE");
+                    "CREATED-ENTITLEMENT," +
+                    "DELETED-ENTITLEMENT," +
+                    "CREATED-POOL," +
+                    "DELETED-POOL," +
+                    "CREATED-COMPLIANCE");
 
                 this.put(AUDIT_FILTER_DO_FILTER, "");
                 this.put(AUDIT_FILTER_DEFAULT_POLICY, "DO_FILTER");

--- a/server/src/main/java/org/candlepin/controller/Entitler.java
+++ b/server/src/main/java/org/candlepin/controller/Entitler.java
@@ -100,7 +100,7 @@ public class Entitler {
     }
 
     public List<Entitlement> bindByPoolQuantities(String consumeruuid,
-            Map<String, Integer> poolIdAndQuantities) throws EntitlementRefusedException {
+        Map<String, Integer> poolIdAndQuantities) throws EntitlementRefusedException {
         Consumer c = consumerCurator.findByUuid(consumeruuid);
         return bindByPoolQuantities(c, poolIdAndQuantities);
     }
@@ -121,7 +121,7 @@ public class Entitler {
     }
 
     public List<Entitlement> bindByPoolQuantities(Consumer consumer,
-            Map<String, Integer> poolIdAndQuantities) throws EntitlementRefusedException {
+        Map<String, Integer> poolIdAndQuantities) throws EntitlementRefusedException {
         // Attempt to create entitlements:
         try {
             List<Entitlement> entitlementList = poolManager.entitleByPools(consumer, poolIdAndQuantities);
@@ -150,7 +150,7 @@ public class Entitler {
         String consumeruuid, Date entitleDate, Collection<String> fromPools) {
         Consumer c = consumerCurator.findByUuid(consumeruuid);
         AutobindData data = AutobindData.create(c).on(entitleDate)
-                .forProducts(productIds).withPools(fromPools);
+            .forProducts(productIds).withPools(fromPools);
         return bindByProducts(data);
     }
 
@@ -190,9 +190,8 @@ public class Entitler {
                     host.getUuid(), consumer.getUuid());
 
                 try {
-                    List<Entitlement> hostEntitlements =
-                        poolManager.entitleByProductsForHost(consumer, host,
-                                data.getOnDate(), data.getPossiblePools());
+                    List<Entitlement> hostEntitlements = poolManager.entitleByProductsForHost(
+                        consumer, host, data.getOnDate(), data.getPossiblePools());
                     log.debug("Granted host {} entitlements", hostEntitlements.size());
                     sendEvents(hostEntitlements);
                 }
@@ -212,7 +211,7 @@ public class Entitler {
         }
         if (consumer.isDev()) {
             if (config.getBoolean(ConfigProperties.STANDALONE) ||
-                    !poolCurator.hasActiveEntitlementPools(consumer.getOwner(), null)) {
+                !poolCurator.hasActiveEntitlementPools(consumer.getOwner(), null)) {
                 throw new ForbiddenException(i18n.tr(
                         "Development units may only be used on hosted servers" +
                         " and with orgs that have active subscriptions."));
@@ -281,7 +280,7 @@ public class Entitler {
         Date startDate = consumer.getCreated();
         Date endDate = getEndDate(skuProduct, startDate);
         Pool p = new Pool(consumer.getOwner(), skuProduct, devProducts.getProvided(), 1L, startDate,
-                endDate, "", "", "");
+            endDate, "", "", "");
         log.info("Created development pool with SKU {}", skuProduct.getId());
         p.setAttribute(Pool.DEVELOPMENT_POOL_ATTRIBUTE, "true");
         p.setAttribute(Pool.REQUIRES_CONSUMER_ATTRIBUTE, consumer.getUuid());
@@ -370,7 +369,7 @@ public class Entitler {
         for (ConsumerInstalledProduct ip : consumer.getInstalledProducts()) {
             if (!devProducts.containsProduct(ip.getProductId())) {
                 log.warn(i18n.tr("Installed product not available to this " +
-                        "development unit: ''{0}''", ip.getProductId()));
+                    "development unit: ''{0}''", ip.getProductId()));
             }
         }
     }
@@ -391,7 +390,7 @@ public class Entitler {
             Owner owner = consumer.getOwner();
             if (consumer.isDev()) {
                 if (config.getBoolean(ConfigProperties.STANDALONE) ||
-                        !poolCurator.hasActiveEntitlementPools(consumer.getOwner(), null)) {
+                    !poolCurator.hasActiveEntitlementPools(consumer.getOwner(), null)) {
                     throw new ForbiddenException(i18n.tr(
                             "Development units may only be used on hosted servers" +
                             " and with orgs that have active subscriptions."));

--- a/server/src/main/java/org/candlepin/controller/PoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/PoolManager.java
@@ -265,7 +265,7 @@ public interface PoolManager {
      * @throws EntitlementRefusedException if unable to bind
      */
     List<Entitlement> entitleByProductsForHost(Consumer guest, Consumer host,
-            Date entitleDate, Collection<String> possiblePools)
+        Date entitleDate, Collection<String> possiblePools)
         throws EntitlementRefusedException;
 
     /**

--- a/server/src/main/java/org/candlepin/controller/Refresher.java
+++ b/server/src/main/java/org/candlepin/controller/Refresher.java
@@ -96,7 +96,7 @@ public class Refresher {
             // given products to be refreshed.
             List<Subscription> subs = subAdapter.getSubscriptions(product);
             log.debug("Will refresh {} subscriptions in all orgs using product: ",
-                    subs.size(), product.getId());
+                subs.size(), product.getId());
 
             if (log.isDebugEnabled()) {
                 for (Subscription s : subs) {

--- a/server/src/main/java/org/candlepin/guice/CandlepinContextListener.java
+++ b/server/src/main/java/org/candlepin/guice/CandlepinContextListener.java
@@ -197,8 +197,7 @@ public class CandlepinContextListener extends GuiceResteasyBootstrapServletConte
     protected List<Module> getModules(ServletContext context) {
         List<Module> modules = new LinkedList<Module>();
 
-        modules.add(Modules.override(new DefaultConfig()).with(
-                new CustomizableModules().load(config)));
+        modules.add(Modules.override(new DefaultConfig()).with(new CustomizableModules().load(config)));
 
         modules.add(new AbstractModule() {
 

--- a/server/src/main/java/org/candlepin/guice/CandlepinModule.java
+++ b/server/src/main/java/org/candlepin/guice/CandlepinModule.java
@@ -166,8 +166,7 @@ public class CandlepinModule extends AbstractModule {
         bind(CandlepinRequestScope.class).toInstance(requestScope);
 
         bind(I18n.class).toProvider(I18nProvider.class);
-        bind(BeanValidationEventListener.class).toProvider(
-                ValidationListenerProvider.class);
+        bind(BeanValidationEventListener.class).toProvider(ValidationListenerProvider.class);
         bind(MessageInterpolator.class).to(CandlepinMessageInterpolator.class);
 
         configureJPA();
@@ -275,8 +274,7 @@ public class CandlepinModule extends AbstractModule {
     }
 
     @Provides
-    protected ValidatorFactory getValidationFactory(
-            Provider<MessageInterpolator> interpolatorProvider) {
+    protected ValidatorFactory getValidationFactory(Provider<MessageInterpolator> interpolatorProvider) {
         HibernateValidatorConfiguration configure =
             Validation.byProvider(HibernateValidator.class).configure();
 

--- a/server/src/main/java/org/candlepin/jackson/PoolEventFilter.java
+++ b/server/src/main/java/org/candlepin/jackson/PoolEventFilter.java
@@ -27,14 +27,14 @@ import com.fasterxml.jackson.databind.ser.PropertyWriter;
 public class PoolEventFilter extends HateoasBeanPropertyFilter {
 
     public boolean isSerializable(Object obj, JsonGenerator jsonGenerator,
-            SerializerProvider serializerProvider, PropertyWriter writer) {
+        SerializerProvider serializerProvider, PropertyWriter writer) {
         JsonStreamContext context = jsonGenerator.getOutputContext();
 
         // Special case list of entitlements to show full json
         if (context.getParent() != null && context.getParent().getParent() != null &&
-                context.getParent().getParent().getParent() != null &&
-                context.getParent().inObject() &&
-                context.getParent().getParent().getParent().inRoot()) {
+            context.getParent().getParent().getParent() != null &&
+            context.getParent().inObject() &&
+            context.getParent().getParent().getParent().inRoot()) {
             return true;
         }
         return super.isSerializable(obj, jsonGenerator, serializerProvider, writer);

--- a/server/src/main/java/org/candlepin/liquibase/LiquibaseCustomTaskWrapper.java
+++ b/server/src/main/java/org/candlepin/liquibase/LiquibaseCustomTaskWrapper.java
@@ -66,7 +66,7 @@ public abstract class LiquibaseCustomTaskWrapper<T extends LiquibaseCustomTask> 
     public void execute(Database database) throws CustomChangeException {
         try {
             T task = this.typeClass.getConstructor(Database.class, CustomTaskLogger.class)
-                        .newInstance(database, new LiquibaseCustomTaskLogger());
+                .newInstance(database, new LiquibaseCustomTaskLogger());
 
             task.execute();
         }

--- a/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
+++ b/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
@@ -585,8 +585,8 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
             int listSize = idsList.size();
             for (int i = 0; i < listSize; i += inClauseLimit) {
                 result.addAll(lockAndLoadInternalOnly(
-                        idsList.subList(i, Math.min(listSize, i + inClauseLimit)),
-                        entityName, keyName));
+                    idsList.subList(i, Math.min(listSize, i + inClauseLimit)),
+                    entityName, keyName));
             }
         }
         return result;

--- a/server/src/main/java/org/candlepin/model/CertificateSerialCurator.java
+++ b/server/src/main/java/org/candlepin/model/CertificateSerialCurator.java
@@ -127,10 +127,9 @@ public class CertificateSerialCurator extends AbstractHibernateCurator<Certifica
     private Criterion getRevokedCriteria() {
         Conjunction crit = Restrictions.conjunction();
         for (Class clazz : CERTCLASSES) {
-            DetachedCriteria certSerialQuery =
-                DetachedCriteria.forClass(clazz)
-                    .createCriteria("serial")
-                    .setProjection(Projections.property("id"));
+            DetachedCriteria certSerialQuery = DetachedCriteria.forClass(clazz)
+                .createCriteria("serial")
+                .setProjection(Projections.property("id"));
             crit.add(Subqueries.propertyNotIn("id", certSerialQuery));
         }
         return crit;

--- a/server/src/main/java/org/candlepin/model/Consumer.java
+++ b/server/src/main/java/org/candlepin/model/Consumer.java
@@ -77,7 +77,7 @@ import javax.xml.bind.annotation.XmlTransient;
 @Table(name = "cp_consumer")
 @JsonFilter("ConsumerFilter")
 public class Consumer extends AbstractHibernateObject implements Linkable, Owned, Named, ConsumerProperty,
-        Eventful {
+    Eventful {
 
     public static final String UEBER_CERT_CONSUMER = "ueber_cert_consumer";
 
@@ -163,8 +163,7 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
     private Set<Entitlement> entitlements;
 
     @ElementCollection
-    @CollectionTable(name = "cp_consumer_facts",
-                     joinColumns = @JoinColumn(name = "cp_consumer_id"))
+    @CollectionTable(name = "cp_consumer_facts", joinColumns = @JoinColumn(name = "cp_consumer_id"))
     @MapKeyColumn(name = "mapkey")
     @Column(name = "element")
     //FIXME A cascade shouldn't be necessary here as ElementCollections cascade by default
@@ -198,8 +197,7 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
 
     @Valid  // Enable validation.  See http://stackoverflow.com/a/13992948
     @ElementCollection
-    @CollectionTable(name = "cp_consumer_content_tags",
-                     joinColumns = @JoinColumn(name = "consumer_id"))
+    @CollectionTable(name = "cp_consumer_content_tags", joinColumns = @JoinColumn(name = "consumer_id"))
     @Column(name = "content_tag")
     private Set<String> contentTags;
 

--- a/server/src/main/java/org/candlepin/model/ConsumerCurator.java
+++ b/server/src/main/java/org/candlepin/model/ConsumerCurator.java
@@ -88,7 +88,6 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
         if (entity.getFacts() != null) {
             entity.setFacts(filterAndVerifyFacts(entity));
         }
-
         return super.create(entity);
     }
 
@@ -195,15 +194,13 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
      * none exists.
      */
     @Transactional
-    public VirtConsumerMap getGuestConsumersMap(Owner owner,
-            Set<String> guestIds) {
+    public VirtConsumerMap getGuestConsumersMap(Owner owner, Set<String> guestIds) {
         VirtConsumerMap guestConsumersMap = new VirtConsumerMap();
         if (guestIds.size() == 0) {
             return guestConsumersMap;
         }
 
-        List<String> possibleGuestIds = Util.getPossibleUuids(guestIds.toArray(
-                new String [guestIds.size()]));
+        List<String> possibleGuestIds = Util.getPossibleUuids(guestIds.toArray(new String [guestIds.size()]));
 
         String sql = "select cp_consumer.uuid from cp_consumer " +
             "inner join cp_consumer_facts " +
@@ -592,8 +589,7 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
      * @return VirtConsumerMap of hypervisor ID to it's consumer, or null if none exists.
      */
     @Transactional
-    public VirtConsumerMap getHostConsumersMap(Owner owner,
-            Set<String> hypervisorIds) {
+    public VirtConsumerMap getHostConsumersMap(Owner owner, Set<String> hypervisorIds) {
         List<String> idList = new ArrayList<String>();
         idList.addAll(hypervisorIds);
         List<Consumer> results = new ArrayList<Consumer>();
@@ -624,8 +620,7 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
      */
     @SuppressWarnings("unchecked")
     @Transactional
-    public List<Consumer> getHypervisorsBulk(Collection<String> hypervisorIds,
-            String ownerKey) {
+    public List<Consumer> getHypervisorsBulk(Collection<String> hypervisorIds, String ownerKey) {
         if (hypervisorIds == null || hypervisorIds.isEmpty()) {
             return new LinkedList<Consumer>();
         }
@@ -674,8 +669,7 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
         return consumer;
     }
 
-    public Consumer verifyAndLookupConsumerWithEntitlements(
-            String consumerUuid) {
+    public Consumer verifyAndLookupConsumerWithEntitlements(String consumerUuid) {
         Consumer consumer = this.findByUuid(consumerUuid);
         if (consumer == null) {
             throw new NotFoundException(i18n.tr(
@@ -698,10 +692,11 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
         return consumer;
     }
 
+    @SuppressWarnings("checkstyle:indentation")
     public Page<List<Consumer>> searchOwnerConsumers(Owner owner, String userName,
-            Collection<ConsumerType> types, List<String> uuids, List<String> hypervisorIds,
-            List<KeyValueParameter> factFilters, List<String> skus,
-            List<String> subscriptionIds, List<String> contracts, PageRequest pageRequest) {
+        Collection<ConsumerType> types, List<String> uuids, List<String> hypervisorIds,
+        List<KeyValueParameter> factFilters, List<String> skus,
+        List<String> subscriptionIds, List<String> contracts, PageRequest pageRequest) {
         Criteria crit = super.createSecureCriteria();
         if (owner != null) {
             crit.add(Restrictions.eq("owner", owner));
@@ -746,12 +741,14 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
                         subCrit.add(Restrictions.eq("owner", owner));
                     }
 
-                    subCrit.createCriteria("entitlements").createCriteria("pool")
-                        .createCriteria("product").add(
-                            Restrictions.eq("id", sku))
-                        .createCriteria("attributes").add(Restrictions.and(
-                            Restrictions.eq("name", "type"),
-                            Restrictions.eq("value", "MKT")));
+                    subCrit.createCriteria("entitlements")
+                        .createCriteria("pool")
+                        .createCriteria("product").add(Restrictions.eq("id", sku))
+                        .createCriteria("attributes").add(
+                            Restrictions.and(
+                                Restrictions.eq("name", "type"),
+                                Restrictions.eq("value", "MKT"))
+                        );
 
                     subCrit.add(Restrictions.eqProperty("this.id", "subquery_consumer.id"));
 
@@ -860,14 +857,14 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
             final String[] columns = criteriaQuery.findColumns(this.propertyName, criteria);
             final String[] wrappedLowerColumns = wrapLower(columns);
             if (criteriaQuery.getFactory().getDialect().supportsRowValueConstructorSyntaxInInList() ||
-                    columns.length <= 1) {
+                columns.length <= 1) {
 
                 String singleValueParam = StringHelper.repeat("lower(?), ", columns.length - 1) + "lower(?)";
                 if (columns.length > 1) {
                     singleValueParam = '(' + singleValueParam + ')';
                 }
                 final String params = this.values.length > 0 ? StringHelper.repeat(singleValueParam + ", ",
-                        this.values.length - 1) + singleValueParam : "";
+                    this.values.length - 1) + singleValueParam : "";
                 String cols = StringHelper.join(", ", wrappedLowerColumns);
                 if (columns.length > 1) {
                     cols = '(' + cols + ')';
@@ -876,7 +873,7 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
             }
             else {
                 String cols = " ( " + StringHelper.join(" = lower(?) and ",
-                        wrappedLowerColumns) + "= lower(?) ) ";
+                    wrappedLowerColumns) + "= lower(?) ) ";
                 cols = this.values.length > 0 ? StringHelper.repeat(cols + "or ",
                         this.values.length - 1) + cols : "";
                 cols = " ( " + cols + " ) ";

--- a/server/src/main/java/org/candlepin/model/Content.java
+++ b/server/src/main/java/org/candlepin/model/Content.java
@@ -91,8 +91,7 @@ public class Content extends AbstractHibernateObject implements SharedEntity, Cl
     @JoinTable(
         name = "cp2_owner_content",
         joinColumns = {@JoinColumn(name = "content_uuid", insertable = true, updatable = true)},
-        inverseJoinColumns = {@JoinColumn(name = "owner_id")}
-    )
+        inverseJoinColumns = {@JoinColumn(name = "owner_id")})
     @LazyCollection(LazyCollectionOption.FALSE)
     @XmlTransient
     private Set<Owner> owners;
@@ -129,8 +128,7 @@ public class Content extends AbstractHibernateObject implements SharedEntity, Cl
     private Long metadataExpire;
 
     @ElementCollection
-    @CollectionTable(name = "cp2_content_modified_products",
-                     joinColumns = @JoinColumn(name = "content_uuid"))
+    @CollectionTable(name = "cp2_content_modified_products", joinColumns = @JoinColumn(name = "content_uuid"))
     @Column(name = "element")
     @Size(max = 255)
     private Set<String> modifiedProductIds = new HashSet<String>();

--- a/server/src/main/java/org/candlepin/model/ContentOverrideCurator.java
+++ b/server/src/main/java/org/candlepin/model/ContentOverrideCurator.java
@@ -27,8 +27,8 @@ import java.util.List;
  * @param <Parent> parent of the content override, Consumer or ActivationKey for example
  */
 public abstract class ContentOverrideCurator
-        <T extends ContentOverride, Parent extends AbstractHibernateObject>
-        extends AbstractHibernateCurator<T> {
+    <T extends ContentOverride, Parent extends AbstractHibernateObject>
+    extends AbstractHibernateCurator<T> {
 
     private String parentAttr;
 

--- a/server/src/main/java/org/candlepin/model/DistributorVersionCurator.java
+++ b/server/src/main/java/org/candlepin/model/DistributorVersionCurator.java
@@ -79,8 +79,7 @@ public class DistributorVersionCurator
     }
 
     @SuppressWarnings("unchecked")
-    public Set<DistributorVersionCapability>
-    findCapabilitiesByDistVersion(String distVersion) {
+    public Set<DistributorVersionCapability> findCapabilitiesByDistVersion(String distVersion) {
         List<DistributorVersion> dvList = currentSession()
             .createCriteria(DistributorVersion.class)
             .add(Restrictions.eq("name", distVersion)).list();

--- a/server/src/main/java/org/candlepin/model/EntitlementCurator.java
+++ b/server/src/main/java/org/candlepin/model/EntitlementCurator.java
@@ -117,18 +117,18 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
     @SuppressWarnings("unchecked")
     public List<Entitlement> listByConsumerAndPoolId(Consumer consumer, String poolId) {
         Criteria query = currentSession().createCriteria(Entitlement.class)
-                    .add(Restrictions.eq("pool.id", poolId));
+            .add(Restrictions.eq("pool.id", poolId));
         query.add(Restrictions.eq("consumer", consumer));
         return listByCriteria(query);
     }
 
     public Page<List<Entitlement>> listByConsumer(Consumer consumer, String productId,
-            EntitlementFilterBuilder filters, PageRequest pageRequest) {
+        EntitlementFilterBuilder filters, PageRequest pageRequest) {
         return listFilteredPages(consumer, "consumer", productId, filters, pageRequest);
     }
 
     public Page<List<Entitlement>> listByOwner(Owner owner, String productId,
-            EntitlementFilterBuilder filters, PageRequest pageRequest) {
+        EntitlementFilterBuilder filters, PageRequest pageRequest) {
         return listFilteredPages(owner, "owner", productId, filters, pageRequest);
     }
 
@@ -137,7 +137,7 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
     }
 
     private Page<List<Entitlement>> listFilteredPages(AbstractHibernateObject object, String objectType,
-            String productId, EntitlementFilterBuilder filters, PageRequest pageRequest) {
+        String productId, EntitlementFilterBuilder filters, PageRequest pageRequest) {
         Page<List<Entitlement>> entitlementsPage;
         Owner owner = null;
         if (object != null) {
@@ -197,8 +197,8 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
         Criteria criteria = currentSession().createCriteria(Entitlement.class)
             .add(Restrictions.eq("consumer", consumer))
             .createCriteria("pool")
-                .add(Restrictions.le("startDate", activeOn))
-                .add(Restrictions.ge("endDate", activeOn));
+            .add(Restrictions.le("startDate", activeOn))
+            .add(Restrictions.ge("endDate", activeOn));
         List<Entitlement> entitlements = criteria.list();
         return entitlements;
     }
@@ -268,7 +268,7 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
      * with a "modifying" entitlement that has just been granted.
      */
     private Criteria createModifiesDateFilteringCriteria(Set<Consumer> consumers, Date startDate,
-            Date endDate, List<Entitlement> excludeEnts) {
+        Date endDate, List<Entitlement> excludeEnts) {
         Criteria criteria = currentSession().createCriteria(Entitlement.class)
             .add(unboundedInCriterion("consumer", consumers));
 
@@ -311,8 +311,7 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
             return modifying;
         }
 
-        List<Product> overlappingProducts =
-                productCurator.listAllByIds(pidEnts.getAllProductIds());
+        List<Product> overlappingProducts = productCurator.listAllByIds(pidEnts.getAllProductIds());
 
         Set<String> entitlementProducts = new HashSet<String>();
         for (Entitlement entitlement : entitlements) {
@@ -347,7 +346,7 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
     }
 
     public Map<Consumer, List<Entitlement>> getDistinctConsumers(
-            List<Entitlement> entsToRevoke) {
+        List<Entitlement> entsToRevoke) {
         Map<Consumer, List<Entitlement>> result = new HashMap<Consumer, List<Entitlement>>();
         for (Entitlement ent : entsToRevoke) {
             List<Entitlement> ents = result.get(ent.getConsumer());
@@ -366,8 +365,7 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
         Set<Consumer> consumers = getDistinctConsumers(e).keySet();
 
         List<Entitlement> overlapEnts = createModifiesDateFilteringCriteria(
-                consumers, earliestStartDate, latestEndDate, e)
-                .list();
+            consumers, earliestStartDate, latestEndDate, e).list();
 
         return new ProductEntitlements(overlapEnts);
     }
@@ -394,7 +392,7 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
     }
 
     public Page<List<Entitlement>> listByConsumerAndProduct(Consumer consumer,
-            String productId, PageRequest pageRequest) {
+        String productId, PageRequest pageRequest) {
         return listByProduct(consumer, "consumer", productId, pageRequest);
     }
 
@@ -406,12 +404,10 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
             .add(Restrictions.eq(objectType, object))
             .createAlias("pool", "p")
             .createAlias("p.product", "prod")
-            .createAlias("p.providedProducts", "pp",
-                CriteriaSpecification.LEFT_JOIN)
+            .createAlias("p.providedProducts", "pp", CriteriaSpecification.LEFT_JOIN)
             // Never show a consumer expired entitlements
             .add(Restrictions.ge("p.endDate", new Date()))
-            .add(Restrictions.or(Restrictions.eq("prod.id", productId),
-                Restrictions.eq("pp.id", productId)));
+            .add(Restrictions.or(Restrictions.eq("prod.id", productId), Restrictions.eq("pp.id", productId)));
 
         Page<List<Entitlement>> page = listByCriteria(query, pageRequest);
 
@@ -475,15 +471,15 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
     @SuppressWarnings("unchecked")
     public List<Entitlement> findByStackIds(Consumer consumer, Collection stackIds) {
         Criteria activeNowQuery = currentSession().createCriteria(Entitlement.class)
-                .add(Restrictions.eq("consumer", consumer))
-                .createAlias("pool", "ent_pool")
-                .createAlias("ent_pool.product", "product")
-                .createAlias("product.attributes", "attrs")
-                .add(Restrictions.eq("attrs.name", "stacking_id"))
-                .add(unboundedInCriterion("attrs.value", stackIds))
-                .add(Restrictions.isNull("ent_pool.sourceEntitlement"))
-                .createAlias("ent_pool.sourceStack", "ss", JoinType.LEFT_OUTER_JOIN)
-                .add(Restrictions.isNull("ss.id"));
+            .add(Restrictions.eq("consumer", consumer))
+            .createAlias("pool", "ent_pool")
+            .createAlias("ent_pool.product", "product")
+            .createAlias("product.attributes", "attrs")
+            .add(Restrictions.eq("attrs.name", "stacking_id"))
+            .add(unboundedInCriterion("attrs.value", stackIds))
+            .add(Restrictions.isNull("ent_pool.sourceEntitlement"))
+            .createAlias("ent_pool.sourceStack", "ss", JoinType.LEFT_OUTER_JOIN)
+            .add(Restrictions.isNull("ss.id"));
         return activeNowQuery.list();
     }
 
@@ -553,7 +549,7 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
             .add(Restrictions.eq("attrs.value", stackId))
             .add(Restrictions.isNull("ent_pool.sourceEntitlement"))
             .createAlias("ent_pool.sourceSubscription", "sourceSub")
-                .add(Restrictions.isNotNull("sourceSub.id"))
+            .add(Restrictions.isNotNull("sourceSub.id"))
             .addOrder(Order.asc("created")) // eldest entitlement
             .setMaxResults(1);
         return (Entitlement) activeNowQuery.uniqueResult();

--- a/server/src/main/java/org/candlepin/model/EnvironmentContentCurator.java
+++ b/server/src/main/java/org/candlepin/model/EnvironmentContentCurator.java
@@ -21,8 +21,7 @@ import java.util.List;
 /**
  * EnvironmentContentCurator
  */
-public class EnvironmentContentCurator extends
-        AbstractHibernateCurator<EnvironmentContent> {
+public class EnvironmentContentCurator extends AbstractHibernateCurator<EnvironmentContent> {
 
     public EnvironmentContentCurator() {
         super(EnvironmentContent.class);

--- a/server/src/main/java/org/candlepin/model/FilterBuilder.java
+++ b/server/src/main/java/org/candlepin/model/FilterBuilder.java
@@ -73,8 +73,7 @@ public abstract class FilterBuilder {
     }
 
     public void applyTo(Criteria parentCriteria) {
-        if (!attributeFilters.isEmpty() || !idFilters.isEmpty() ||
-                !otherCriteria.isEmpty()) {
+        if (!attributeFilters.isEmpty() || !idFilters.isEmpty() || !otherCriteria.isEmpty()) {
             parentCriteria.add(getCriteria());
         }
     }

--- a/server/src/main/java/org/candlepin/model/GuestId.java
+++ b/server/src/main/java/org/candlepin/model/GuestId.java
@@ -82,7 +82,7 @@ public class GuestId extends AbstractHibernateObject implements Owned, Named, Co
 
     @ElementCollection
     @CollectionTable(name = "cp_consumer_guests_attributes",
-                     joinColumns = @JoinColumn(name = "cp_consumer_guest_id"))
+        joinColumns = @JoinColumn(name = "cp_consumer_guest_id"))
     @MapKeyColumn(name = "mapkey")
     @Column(name = "element")
     @Cascade({org.hibernate.annotations.CascadeType.ALL})
@@ -103,8 +103,7 @@ public class GuestId extends AbstractHibernateObject implements Owned, Named, Co
         this.consumer = consumer;
     }
 
-    public GuestId(String guestId, Consumer consumer,
-            Map<String, String> attributes) {
+    public GuestId(String guestId, Consumer consumer, Map<String, String> attributes) {
         this(guestId, consumer);
         this.setAttributes(attributes);
     }
@@ -152,7 +151,7 @@ public class GuestId extends AbstractHibernateObject implements Owned, Named, Co
         }
         GuestId that = (GuestId) other;
         if (this.getGuestId().equalsIgnoreCase(that.getGuestId()) &&
-                this.getAttributes().equals(that.getAttributes())) {
+            this.getAttributes().equals(that.getAttributes())) {
             return true;
         }
         return false;

--- a/server/src/main/java/org/candlepin/model/GuestIdCurator.java
+++ b/server/src/main/java/org/candlepin/model/GuestIdCurator.java
@@ -35,8 +35,7 @@ public class GuestIdCurator extends AbstractHibernateCurator<GuestId> {
         super(GuestId.class);
     }
 
-    public Page<List<GuestId>> listByConsumer(Consumer consumer,
-            PageRequest pageRequest) {
+    public Page<List<GuestId>> listByConsumer(Consumer consumer, PageRequest pageRequest) {
         Criteria criteria = this.currentSession().createCriteria(GuestId.class)
             .add(Restrictions.eq("consumer", consumer));
         return listByCriteria(criteria, pageRequest);

--- a/server/src/main/java/org/candlepin/model/HypervisorId.java
+++ b/server/src/main/java/org/candlepin/model/HypervisorId.java
@@ -51,10 +51,8 @@ import javax.xml.bind.annotation.XmlTransient;
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @Entity
-@Table(name = "cp_consumer_hypervisor",
-    uniqueConstraints = @UniqueConstraint(
-        name = "cp_consumer_hypervisor_ukey",
-        columnNames = {"owner_id", "hypervisor_id"}))
+@Table(name = "cp_consumer_hypervisor", uniqueConstraints =
+    @UniqueConstraint(name = "cp_consumer_hypervisor_ukey", columnNames = {"owner_id", "hypervisor_id"}))
 public class HypervisorId extends AbstractHibernateObject {
 
     @Id

--- a/server/src/main/java/org/candlepin/model/JobCurator.java
+++ b/server/src/main/java/org/candlepin/model/JobCurator.java
@@ -144,8 +144,7 @@ public class JobCurator extends AbstractHibernateCurator<JobStatus> {
         .add(Restrictions.eq("state", JobState.WAITING)).list();
     }
 
-    public long findNumRunningByClassAndTarget(
-            String target, Class<? extends KingpinJob> jobClass) {
+    public long findNumRunningByClassAndTarget(String target, Class<? extends KingpinJob> jobClass) {
         return (Long) this.currentSession().createCriteria(JobStatus.class)
             .add(Restrictions.ge("updated", getBlockingCutoff()))
             .add(Restrictions.eq("state", JobState.RUNNING))
@@ -155,8 +154,7 @@ public class JobCurator extends AbstractHibernateCurator<JobStatus> {
             .uniqueResult();
     }
 
-    public JobStatus getByClassAndTarget(
-            String target, Class<? extends KingpinJob> jobClass) {
+    public JobStatus getByClassAndTarget(String target, Class<? extends KingpinJob> jobClass) {
 
         return (JobStatus) this.currentSession().createCriteria(JobStatus.class)
             .addOrder(Order.desc("created"))

--- a/server/src/main/java/org/candlepin/model/OwnerCurator.java
+++ b/server/src/main/java/org/candlepin/model/OwnerCurator.java
@@ -90,8 +90,7 @@ public class OwnerCurator extends AbstractHibernateCurator<Owner> {
 
         DetachedCriteria ownerIdQuery = DetachedCriteria.forClass(Entitlement.class, "e")
             .add(Subqueries.propertyIn("e.pool.id", poolIdQuery))
-            .createCriteria("pool")
-                .add(Restrictions.gt("endDate", new Date()))
+            .createCriteria("pool").add(Restrictions.gt("endDate", new Date()))
             .setProjection(Property.forName("e.owner.id"));
 
         DetachedCriteria distinctQuery = DetachedCriteria.forClass(Owner.class, "o2")
@@ -133,10 +132,8 @@ public class OwnerCurator extends AbstractHibernateCurator<Owner> {
 
     @SuppressWarnings("unchecked")
     public List<String> getConsumerUuids(String ownerKey) {
-        DetachedCriteria ownerQuery =
-            DetachedCriteria.forClass(Owner.class)
-                .add(Restrictions.eq("key", ownerKey))
-                .setProjection(Property.forName("id"));
+        DetachedCriteria ownerQuery = DetachedCriteria.forClass(Owner.class).add(
+            Restrictions.eq("key", ownerKey)).setProjection(Property.forName("id"));
 
         return this.currentSession().createCriteria(Consumer.class)
             .add(Subqueries.propertyEq("owner.id", ownerQuery))

--- a/server/src/main/java/org/candlepin/model/OwnerInfoCurator.java
+++ b/server/src/main/java/org/candlepin/model/OwnerInfoCurator.java
@@ -124,6 +124,7 @@ public class OwnerInfoCurator {
         info.setPhysicalCount(physicalCount);
     }
 
+    @SuppressWarnings("checkstyle:indentation")
     private void setConsumerCountsByComplianceStatus(Owner owner, OwnerInfo info) {
         // We exclude the following types since they are fake/transparent consumers
         // and we do not want them included in the totals.

--- a/server/src/main/java/org/candlepin/model/Pool.java
+++ b/server/src/main/java/org/candlepin/model/Pool.java
@@ -264,8 +264,7 @@ public class Pool extends AbstractHibernateObject implements Persisted, Owned, N
     @JoinTable(
         name = "cp2_pool_provided_products",
         joinColumns = {@JoinColumn(name = "pool_id", insertable = false, updatable = false)},
-        inverseJoinColumns = {@JoinColumn(name = "product_uuid")}
-    )
+        inverseJoinColumns = {@JoinColumn(name = "product_uuid")})
     @BatchSize(size = 1000)
     private Set<Product> providedProducts = new HashSet<Product>();
 
@@ -273,8 +272,7 @@ public class Pool extends AbstractHibernateObject implements Persisted, Owned, N
     @JoinTable(
         name = "cp2_pool_derprov_products",
         joinColumns = {@JoinColumn(name = "pool_id", insertable = false, updatable = false)},
-        inverseJoinColumns = {@JoinColumn(name = "product_uuid")}
-    )
+        inverseJoinColumns = {@JoinColumn(name = "product_uuid")})
     @BatchSize(size = 1000)
     private Set<Product> derivedProvidedProducts = new HashSet<Product>();
 
@@ -318,8 +316,7 @@ public class Pool extends AbstractHibernateObject implements Persisted, Owned, N
 
     // leave FROM capitalized until hibernate 5.0.3
     // https://hibernate.atlassian.net/browse/HHH-1400
-    @Formula("(select sum(ent.quantity) FROM cp_entitlement ent " +
-             "where ent.pool_id = id)")
+    @Formula("(select sum(ent.quantity) FROM cp_entitlement ent where ent.pool_id = id)")
     private Long consumed;
 
     // leave FROM capitalized until hibernate 5.0.3

--- a/server/src/main/java/org/candlepin/model/PoolCurator.java
+++ b/server/src/main/java/org/candlepin/model/PoolCurator.java
@@ -192,8 +192,7 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
      * @return list of EntitlementPools
      */
     @Transactional
-    public List<Pool> listByOwnerAndProduct(Owner owner,
-            String productId) {
+    public List<Pool> listByOwnerAndProduct(Owner owner, String productId) {
         return listAvailableEntitlementPools(null, owner, productId, null, false);
     }
 
@@ -445,10 +444,9 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
         Criterion[] exampleCriteria = new Criterion[0];
         for (Entry<String, Entitlement> entry : subIdMap.entrySet()) {
             SimpleExpression subscriptionExpr = Restrictions.eq("sourceSub.subscriptionId", entry.getKey());
-            Junction subscriptionJunction =
-                    Restrictions.and(subscriptionExpr)
-                    .add(Restrictions.or(Restrictions.isNull("sourceEntitlement"),
-                                         Restrictions.eqOrIsNull("sourceEntitlement", entry.getValue())));
+            Junction subscriptionJunction = Restrictions.and(subscriptionExpr).add(Restrictions.or(
+                Restrictions.isNull("sourceEntitlement"),
+                Restrictions.eqOrIsNull("sourceEntitlement", entry.getValue())));
             subIdMapCriteria.add(subscriptionJunction);
         }
 
@@ -490,15 +488,15 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
 
     private static final String CONSUMER_FILTER = "Entitlement_CONSUMER_FILTER";
 
+    @SuppressWarnings("checkstyle:indentation")
     public int getNoOfDependentEntitlements(String entitlementId) {
         Filter consumerFilter = disableConsumerFilter();
-        Integer result = (Integer)
-            currentSession().createCriteria(Entitlement.class)
-                .setProjection(Projections.rowCount())
-                .createCriteria("pool")
-                    .createCriteria("sourceEntitlement")
-                        .add(Restrictions.idEq(entitlementId))
-                .list().get(0);
+        Integer result = (Integer) currentSession().createCriteria(Entitlement.class)
+            .setProjection(Projections.rowCount())
+            .createCriteria("pool")
+                .createCriteria("sourceEntitlement")
+                    .add(Restrictions.idEq(entitlementId))
+            .list().get(0);
         enableIfPrevEnabled(consumerFilter);
         return result;
     }
@@ -680,12 +678,12 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
      * @param stackIds
      * @return Derived pools which exist for the given consumer and stack ids
      */
+    @SuppressWarnings("checkstyle:indentation")
     public List<Pool> getSubPoolForStackIds(Consumer consumer, Collection stackIds) {
-        Criteria getPools = createSecureCriteria()
-                .createAlias("sourceStack", "ss")
-                .add(Restrictions.eq("ss.sourceConsumer", consumer))
-                .add(Restrictions.and(Restrictions.isNotNull("ss.sourceStackId"),
-                        unboundedInCriterion("ss.sourceStackId", stackIds)));
+        Criteria getPools = createSecureCriteria().createAlias("sourceStack", "ss")
+            .add(Restrictions.eq("ss.sourceConsumer", consumer))
+            .add(Restrictions.and(Restrictions.isNotNull("ss.sourceStackId"),
+                unboundedInCriterion("ss.sourceStackId", stackIds)));
         return (List<Pool>) getPools.list();
     }
 
@@ -708,8 +706,7 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
      */
     @SuppressWarnings("unchecked")
     public List<Pool> getPoolsFromBadSubs(Owner owner, Collection<String> expectedSubIds) {
-        Criteria crit = currentSession().createCriteria(Pool.class)
-                .add(Restrictions.eq("owner", owner));
+        Criteria crit = currentSession().createCriteria(Pool.class).add(Restrictions.eq("owner", owner));
 
         if (!expectedSubIds.isEmpty()) {
             crit.createAlias("sourceSubscription", "sourceSub");

--- a/server/src/main/java/org/candlepin/model/PoolFilterBuilder.java
+++ b/server/src/main/java/org/candlepin/model/PoolFilterBuilder.java
@@ -97,6 +97,7 @@ public class PoolFilterBuilder extends FilterBuilder {
         return !matchFilters.isEmpty();
     }
 
+    @SuppressWarnings("checkstyle:indentation")
     private void applyProductIdFilter(Criteria parent) {
         String originalPoolAlias = this.alias.isEmpty() ? "this." : alias;
         DetachedCriteria prodCrit = DetachedCriteria.forClass(Pool.class, "Pool2")
@@ -111,6 +112,7 @@ public class PoolFilterBuilder extends FilterBuilder {
         parent.add(Subqueries.exists(prodCrit));
     }
 
+    @SuppressWarnings("checkstyle:indentation")
     private void applySubscriptionIdFilter(Criteria parent) {
         String originalPoolAlias = this.alias.isEmpty() ? "this." : alias;
         DetachedCriteria subCrit = DetachedCriteria.forClass(Pool.class, "Pool2")
@@ -122,6 +124,7 @@ public class PoolFilterBuilder extends FilterBuilder {
         parent.add(Subqueries.exists(subCrit));
     }
 
+    @SuppressWarnings("checkstyle:indentation")
     private void applyMatchFilter(String matches) {
         String originalPoolAlias = this.alias.isEmpty() ? "this." : alias;
 
@@ -132,24 +135,20 @@ public class PoolFilterBuilder extends FilterBuilder {
         textOr.add(new FilterLikeExpression(alias + "orderNumber", matches, true));
 
         DetachedCriteria ppCriteria = DetachedCriteria.forClass(Pool.class, "Pool2")
-                .createAlias("providedProducts", "provided", JoinType.INNER_JOIN)
-                .createAlias("provided.productContent", "ppcw", JoinType.LEFT_OUTER_JOIN)
-                .createAlias("ppcw.content", "ppContent", JoinType.LEFT_OUTER_JOIN)
-                .add(Property.forName(originalPoolAlias + "id").eqProperty("Pool2.id"))
-                .add(Restrictions.disjunction()
-                   .add(new FilterLikeExpression("provided.id", matches, true))
-                   .add(new FilterLikeExpression("provided.name", matches, true))
-                   .add(new FilterLikeExpression("ppContent.name", matches, true))
-                   .add(new FilterLikeExpression("ppContent.label", matches, true)))
-                .setProjection(Projections.property("Pool2.id"));
+            .createAlias("providedProducts", "provided", JoinType.INNER_JOIN)
+            .createAlias("provided.productContent", "ppcw", JoinType.LEFT_OUTER_JOIN)
+            .createAlias("ppcw.content", "ppContent", JoinType.LEFT_OUTER_JOIN)
+            .add(Property.forName(originalPoolAlias + "id").eqProperty("Pool2.id"))
+            .add(Restrictions.disjunction()
+               .add(new FilterLikeExpression("provided.id", matches, true))
+               .add(new FilterLikeExpression("provided.name", matches, true))
+               .add(new FilterLikeExpression("ppContent.name", matches, true))
+               .add(new FilterLikeExpression("ppContent.label", matches, true)))
+            .setProjection(Projections.property("Pool2.id"));
         textOr.add(Subqueries.exists(ppCriteria));
 
         textOr.add(Subqueries.exists(
-            this.createProductAttributeCriteria(
-                "support_level",
-                Arrays.asList(matches)
-            )
-        ));
+            this.createProductAttributeCriteria("support_level", Arrays.asList(matches))));
 
         this.otherCriteria.add(textOr);
     }
@@ -176,23 +175,15 @@ public class PoolFilterBuilder extends FilterBuilder {
         Conjunction conjunction = new Conjunction();
 
         if (!values.isEmpty()) {
-            conjunction.add(
-                Restrictions.or(
-                    Subqueries.exists(this.createPoolAttributeCriteria(key, values)),
-                    Subqueries.exists(this.createProductAttributeCriteria(key, values))
-                )
-            );
+            conjunction.add(Restrictions.or(
+                Subqueries.exists(this.createPoolAttributeCriteria(key, values)),
+                Subqueries.exists(this.createProductAttributeCriteria(key, values))));
         }
 
         if (!negatives.isEmpty()) {
-            conjunction.add(
-                Restrictions.not(
-                    Restrictions.or(
-                        Subqueries.exists(this.createProductAttributeCriteria(key, negatives)),
-                        Subqueries.exists(this.createPoolAttributeCriteria(key, negatives))
-                    )
-                )
-            );
+            conjunction.add(Restrictions.not(Restrictions.or(
+                Subqueries.exists(this.createProductAttributeCriteria(key, negatives)),
+                Subqueries.exists(this.createPoolAttributeCriteria(key, negatives)))));
         }
 
         return conjunction;

--- a/server/src/main/java/org/candlepin/model/Product.java
+++ b/server/src/main/java/org/candlepin/model/Product.java
@@ -98,8 +98,7 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
     @JoinTable(
         name = "cp2_owner_products",
         joinColumns = {@JoinColumn(name = "product_uuid", insertable = true, updatable = true)},
-        inverseJoinColumns = {@JoinColumn(name = "owner_id")}
-    )
+        inverseJoinColumns = {@JoinColumn(name = "owner_id")})
     @LazyCollection(LazyCollectionOption.FALSE)
     @XmlTransient
     private Set<Owner> owners;
@@ -117,8 +116,7 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
     private Set<ProductAttribute> attributes;
 
     @ElementCollection
-    @CollectionTable(name = "cp2_product_content",
-                     joinColumns = @JoinColumn(name = "product_uuid"))
+    @CollectionTable(name = "cp2_product_content", joinColumns = @JoinColumn(name = "product_uuid"))
     @Column(name = "element")
     @LazyCollection(LazyCollectionOption.EXTRA) // allows .size() without loading all data
     private List<ProductContent> productContent;
@@ -130,7 +128,7 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
      */
     @ElementCollection
     @CollectionTable(name = "cp2_product_dependent_products",
-                     joinColumns = @JoinColumn(name = "product_uuid"))
+        joinColumns = @JoinColumn(name = "product_uuid"))
     @Column(name = "element")
     @LazyCollection(LazyCollectionOption.FALSE)
     private Set<String> dependentProductIds; // Should these be product references?
@@ -887,9 +885,9 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
     public List<String> getSkuDisabledContentIds() {
         List<String> skuDisabled = new ArrayList<String>();
         if (this.hasAttribute("content_override_disabled") &&
-               this.getAttributeValue("content_override_disabled").length() > 0) {
+            this.getAttributeValue("content_override_disabled").length() > 0) {
             StringTokenizer stDisable = new StringTokenizer(
-                    this.getAttributeValue("content_override_disabled"), ",");
+                this.getAttributeValue("content_override_disabled"), ",");
             while (stDisable.hasMoreElements()) {
                 skuDisabled.add((String) stDisable.nextElement());
             }
@@ -901,9 +899,9 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
     public List<String> getSkuEnabledContentIds() {
         List<String> skuEnabled = new ArrayList<String>();
         if (this.hasAttribute("content_override_enabled") &&
-               this.getAttributeValue("content_override_enabled").length() > 0) {
+            this.getAttributeValue("content_override_enabled").length() > 0) {
             StringTokenizer stActive = new StringTokenizer(
-                    this.getAttributeValue("content_override_enabled"), ",");
+                this.getAttributeValue("content_override_enabled"), ",");
             while (stActive.hasMoreElements()) {
                 skuEnabled.add((String) stActive.nextElement());
             }

--- a/server/src/main/java/org/candlepin/model/RulesCurator.java
+++ b/server/src/main/java/org/candlepin/model/RulesCurator.java
@@ -66,7 +66,7 @@ public class RulesCurator extends AbstractHibernateCurator<Rules> {
     public Rules create(Rules toCreate) {
         Rules current = getDbRules();
         if (current != null && !VersionUtil.getRulesVersionCompatibility(
-                current.getVersion(), toCreate.getVersion())) {
+            current.getVersion(), toCreate.getVersion())) {
             return current;
         }
         return super.create(toCreate);
@@ -88,8 +88,7 @@ public class RulesCurator extends AbstractHibernateCurator<Rules> {
         log.debug("RPM Rules version: " + rpmRules.getVersion());
 
         if (dbRules == null ||
-            !VersionUtil.getRulesVersionCompatibility(rpmRules.getVersion(),
-                dbRules.getVersion())) {
+            !VersionUtil.getRulesVersionCompatibility(rpmRules.getVersion(), dbRules.getVersion())) {
             this.resetToRpmRules();
         }
     }

--- a/server/src/main/java/org/candlepin/model/SourceStack.java
+++ b/server/src/main/java/org/candlepin/model/SourceStack.java
@@ -28,7 +28,6 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
-import javax.persistence.UniqueConstraint;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import javax.xml.bind.annotation.XmlAccessType;
@@ -44,14 +43,7 @@ import javax.xml.bind.annotation.XmlTransient;
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @Entity
-@Table(name = "cp_pool_source_stack",
-    uniqueConstraints = {
-        @UniqueConstraint(
-            name = "cp_pool_source_stack_ukey",
-            columnNames = {"sourceconsumer_id", "sourcestackid"}),
-        @UniqueConstraint(
-            name = "cp_pool_source_stack_pool_ukey",
-            columnNames = {"derivedpool_id"})})
+@Table(name = "cp_pool_source_stack")
 public class SourceStack extends AbstractHibernateObject {
 
     @Id

--- a/server/src/main/java/org/candlepin/model/activationkeys/ActivationKey.java
+++ b/server/src/main/java/org/candlepin/model/activationkeys/ActivationKey.java
@@ -54,8 +54,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @Entity
 @Table(name = "cp_activation_key",
-    uniqueConstraints = {@UniqueConstraint(columnNames = {"name", "owner_id"})}
-)
+    uniqueConstraints = {@UniqueConstraint(columnNames = {"name", "owner_id"})})
 public class ActivationKey extends AbstractHibernateObject implements Owned, Named, Eventful {
 
     public static final int RELEASE_VERSION_LENGTH = 255;
@@ -90,8 +89,7 @@ public class ActivationKey extends AbstractHibernateObject implements Owned, Nam
     @JoinTable(
         name = "cp2_activation_key_products",
         joinColumns = {@JoinColumn(name = "key_id")},
-        inverseJoinColumns = {@JoinColumn(name = "product_uuid")}
-    )
+        inverseJoinColumns = {@JoinColumn(name = "product_uuid")})
     private Set<Product> products = new HashSet<Product>();
 
     @OneToMany(targetEntity = ActivationKeyContentOverride.class, mappedBy = "key")
@@ -282,8 +280,7 @@ public class ActivationKey extends AbstractHibernateObject implements Owned, Nam
     /**
      * @param contentOverrides the contentOverrides to set
      */
-    public void setContentOverrides(
-            Set<ActivationKeyContentOverride> contentOverrides) {
+    public void setContentOverrides(Set<ActivationKeyContentOverride> contentOverrides) {
         this.contentOverrides.clear();
         this.addContentOverrides(contentOverrides);
     }
@@ -363,7 +360,7 @@ public class ActivationKey extends AbstractHibernateObject implements Owned, Nam
         boolean found = false;
         for (ActivationKeyContentOverride existing : this.getContentOverrides()) {
             if (existing.getContentLabel().equalsIgnoreCase(override.getContentLabel()) &&
-                    existing.getName().equalsIgnoreCase(override.getName())) {
+                existing.getName().equalsIgnoreCase(override.getName())) {
                 existing.setValue(override.getValue());
                 found = true;
                 break;

--- a/server/src/main/java/org/candlepin/model/activationkeys/ActivationKeyContentOverride.java
+++ b/server/src/main/java/org/candlepin/model/activationkeys/ActivationKeyContentOverride.java
@@ -47,8 +47,7 @@ public class ActivationKeyContentOverride extends ContentOverride {
     public ActivationKeyContentOverride() {
     }
 
-    public ActivationKeyContentOverride(ActivationKey key,
-            String contentLabel, String name, String value) {
+    public ActivationKeyContentOverride(ActivationKey key, String contentLabel, String name, String value) {
         super(contentLabel, name, value);
         this.setKey(key);
     }

--- a/server/src/main/java/org/candlepin/model/activationkeys/ActivationKeyPool.java
+++ b/server/src/main/java/org/candlepin/model/activationkeys/ActivationKeyPool.java
@@ -42,8 +42,7 @@ import javax.xml.bind.annotation.XmlTransient;
 @Entity
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @Table(name = "cp_activationkey_pool",
-    uniqueConstraints = {@UniqueConstraint(columnNames = {"key_id", "pool_id"})}
-)
+    uniqueConstraints = {@UniqueConstraint(columnNames = {"key_id", "pool_id"})})
 public class ActivationKeyPool extends AbstractHibernateObject implements Comparable<ActivationKeyPool> {
 
     @Id

--- a/server/src/main/java/org/candlepin/model/dto/Subscription.java
+++ b/server/src/main/java/org/candlepin/model/dto/Subscription.java
@@ -76,7 +76,7 @@ public class Subscription implements Owned, Named, Eventful {
     }
 
     public Subscription(Owner ownerIn, Product productIn, Set<Product> providedProducts,
-            Long maxMembersIn, Date startDateIn, Date endDateIn, Date modified) {
+        Long maxMembersIn, Date startDateIn, Date endDateIn, Date modified) {
         this.owner = ownerIn;
         this.product = productIn;
         this.providedProducts = providedProducts;

--- a/server/src/main/java/org/candlepin/pinsetter/core/PinsetterJobListener.java
+++ b/server/src/main/java/org/candlepin/pinsetter/core/PinsetterJobListener.java
@@ -94,8 +94,7 @@ public class PinsetterJobListener implements JobListener {
             updateJob(context, exception);
         }
         catch (Exception e) {
-            if (UniqueByEntityJob.class.isAssignableFrom(
-                    context.getJobDetail().getJobClass())) {
+            if (UniqueByEntityJob.class.isAssignableFrom(context.getJobDetail().getJobClass())) {
                 log.error("jobWasExecuted encountered a problem on a blocking job." +
                     " This can block other jobs.  Marking finished, if possible", e);
                 try {

--- a/server/src/main/java/org/candlepin/pinsetter/core/PinsetterKernel.java
+++ b/server/src/main/java/org/candlepin/pinsetter/core/PinsetterKernel.java
@@ -294,6 +294,7 @@ public class PinsetterKernel {
         }
     }
 
+    @SuppressWarnings("checkstyle:indentation")
     private void scheduleJobs(List<JobEntry> pendingJobs) {
         if (pendingJobs.size() == 0) {
             return;
@@ -317,6 +318,7 @@ public class PinsetterKernel {
         }
     }
 
+    @SuppressWarnings("checkstyle:indentation")
     public void scheduleJob(Class job, String jobName, String crontab)
         throws PinsetterException {
 
@@ -355,8 +357,7 @@ public class PinsetterKernel {
 
         try {
             JobStatus status = (JobStatus) (detail.getJobClass()
-                .getMethod("scheduleJob", JobCurator.class,
-                    Scheduler.class, JobDetail.class, Trigger.class)
+                .getMethod("scheduleJob", JobCurator.class, Scheduler.class, JobDetail.class, Trigger.class)
                 .invoke(null, jobCurator, scheduler, detail, trigger));
 
             if (log.isDebugEnabled()) {

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/ActiveEntitlementJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/ActiveEntitlementJob.java
@@ -37,8 +37,7 @@ public class ActiveEntitlementJob extends KingpinJob {
     private ComplianceRules complianceRules;
 
     @Inject
-    public ActiveEntitlementJob(ConsumerCurator consumerCurator,
-            ComplianceRules complianceRules) {
+    public ActiveEntitlementJob(ConsumerCurator consumerCurator, ComplianceRules complianceRules) {
         this.consumerCurator = consumerCurator;
         this.complianceRules = complianceRules;
     }

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/CancelJobJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/CancelJobJob.java
@@ -47,8 +47,7 @@ public class CancelJobJob extends KingpinJob {
     private PinsetterKernel pinsetterKernel;
 
     @Inject
-    public CancelJobJob(JobCurator jobCurator,
-            PinsetterKernel pinsetterKernel) {
+    public CancelJobJob(JobCurator jobCurator, PinsetterKernel pinsetterKernel) {
         this.jobCurator = jobCurator;
         this.pinsetterKernel = pinsetterKernel;
     }

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/ConsumerComplianceJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/ConsumerComplianceJob.java
@@ -92,7 +92,7 @@ public class ConsumerComplianceJob extends UniqueByEntityJob {
      * Simple check, passes arguments as is, and updates consumer only if needed
      */
     public static JobDetail scheduleStatusCheck(Consumer consumer, Date date,
-            boolean calculateCompliantUntil, boolean updateConsumer) {
+        boolean calculateCompliantUntil, boolean updateConsumer) {
         JobDataMap map = new JobDataMap();
         if (date != null) {
             map.put("onDate", date);
@@ -123,9 +123,8 @@ public class ConsumerComplianceJob extends UniqueByEntityJob {
         map.put(JobStatus.TARGET_ID, consumer.getUuid());
 
         JobDetail detail = newJob(ConsumerComplianceJob.class).withIdentity(prefix + Util.generateUUID())
-                .usingJobData(map).storeDurably(true) // required if we have to
-                                                      // postpone the job
-                .build();
+            .usingJobData(map).storeDurably(true) // required if we have to postpone the job
+            .build();
 
         return detail;
     }

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/HealEntireOrgJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/HealEntireOrgJob.java
@@ -49,8 +49,7 @@ public class HealEntireOrgJob extends UniqueByEntityJob {
     protected static String prefix = "heal_entire_org_";
 
     @Inject
-    public HealEntireOrgJob(Entitler e,
-            ConsumerCurator c, OwnerCurator o) {
+    public HealEntireOrgJob(Entitler e, ConsumerCurator c, OwnerCurator o) {
         this.entitler = e;
         this.consumerCurator = c;
         this.ownerCurator = o;

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/HypervisorUpdateJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/HypervisorUpdateJob.java
@@ -81,13 +81,12 @@ public class HypervisorUpdateJob extends KingpinJob {
 
     @Inject
     public HypervisorUpdateJob(OwnerCurator ownerCurator, ConsumerCurator consumerCurator,
-            ConsumerResource consumerResource) {
+        ConsumerResource consumerResource) {
         this.ownerCurator = ownerCurator;
         this.consumerCurator = consumerCurator;
         this.consumerResource = consumerResource;
     }
 
-    @SuppressWarnings("unchecked")
     public static JobStatus scheduleJob(JobCurator jobCurator,
         Scheduler scheduler, JobDetail detail,
         Trigger trigger) throws SchedulerException {
@@ -176,6 +175,7 @@ public class HypervisorUpdateJob extends KingpinJob {
      * @param context the job's execution context
      */
     @Transactional
+    @SuppressWarnings("checkstyle:indentation")
     public void toExecute(JobExecutionContext context) throws JobExecutionException {
         try {
             JobDataMap map = context.getMergedJobDataMap();
@@ -221,8 +221,7 @@ public class HypervisorUpdateJob extends KingpinJob {
                     else {
                         log.debug("Registering new host consumer for hypervisor ID: {}", hypervisorId);
                         Consumer newHost = createConsumerForHypervisorId(hypervisorId, owner, principal);
-                        consumerResource.performConsumerUpdates(incoming, newHost, guestConsumersMap,
-                            false);
+                        consumerResource.performConsumerUpdates(incoming, newHost, guestConsumersMap, false);
                         consumerResource.create(newHost, principal, null, owner.getKey(), null, false);
                         hypervisorConsumersMap.add(hypervisorId, newHost);
                         result.created(newHost);
@@ -232,16 +231,15 @@ public class HypervisorUpdateJob extends KingpinJob {
                 else {
                     reportedOnConsumer = knownHost;
                     if (jobReporterId != null && knownHost.getHypervisorId() != null &&
-                            hypervisorId.equalsIgnoreCase(knownHost.getHypervisorId().getHypervisorId()) &&
-                            knownHost.getHypervisorId().getReporterId() != null &&
-                            !jobReporterId.equalsIgnoreCase(
-                                    knownHost.getHypervisorId().getReporterId())) {
+                        hypervisorId.equalsIgnoreCase(knownHost.getHypervisorId().getHypervisorId()) &&
+                        knownHost.getHypervisorId().getReporterId() != null &&
+                        !jobReporterId.equalsIgnoreCase(knownHost.getHypervisorId().getReporterId())) {
                         log.warn("Reporter changed for Hypervisor {} of Owner {} from {} to {}",
-                                hypervisorId, ownerKey, knownHost.getHypervisorId().getReporterId(),
-                                jobReporterId);
+                            hypervisorId, ownerKey, knownHost.getHypervisorId().getReporterId(),
+                            jobReporterId);
                     }
                     if (consumerResource.performConsumerUpdates(incoming, knownHost, guestConsumersMap,
-                            false)) {
+                        false)) {
                         consumerCurator.update(knownHost);
                         result.updated(knownHost);
                     }
@@ -251,15 +249,14 @@ public class HypervisorUpdateJob extends KingpinJob {
                 }
                 // update reporter id if it changed
                 if (jobReporterId != null && reportedOnConsumer != null &&
-                        reportedOnConsumer.getHypervisorId() != null &&
-                        (reportedOnConsumer.getHypervisorId().getReporterId() == null || !jobReporterId
-                                .contentEquals(reportedOnConsumer.getHypervisorId().getReporterId()))) {
+                    reportedOnConsumer.getHypervisorId() != null &&
+                    (reportedOnConsumer.getHypervisorId().getReporterId() == null ||
+                    !jobReporterId.contentEquals(reportedOnConsumer.getHypervisorId().getReporterId()))) {
                     reportedOnConsumer.getHypervisorId().setReporterId(jobReporterId);
                 }
                 else if (jobReporterId == null) {
-                    log.debug("hypervisor checkin reported asynchronously" +
-                              " without reporter id for hypervisor:{} of owner:{}",
-                            hypervisorId, ownerKey);
+                    log.debug("hypervisor checkin reported asynchronously without reporter id " +
+                        "for hypervisor:{} of owner:{}", hypervisorId, ownerKey);
                 }
             }
             log.info("Summary for report from {} by principal {}\n {}", jobReporterId, principal, result);
@@ -279,7 +276,7 @@ public class HypervisorUpdateJob extends KingpinJob {
      * @return a {@link JobDetail} that describes the job run
      */
     public static JobDetail forOwner(Owner owner, String data, Boolean create, Principal principal,
-            String reporterId) {
+        String reporterId) {
         JobDataMap map = new JobDataMap();
         map.put(JobStatus.TARGET_TYPE, JobStatus.TargetType.OWNER);
         map.put(JobStatus.TARGET_ID, owner.getKey());
@@ -336,7 +333,7 @@ public class HypervisorUpdateJob extends KingpinJob {
      * Create a new hypervisor type consumer to represent the incoming hypervisorId
      */
     private Consumer createConsumerForHypervisorId(String incHypervisorId,
-            Owner owner, Principal principal) {
+        Owner owner, Principal principal) {
         Consumer consumer = new Consumer();
         consumer.setName(incHypervisorId);
         consumer.setType(new ConsumerType(ConsumerTypeEnum.HYPERVISOR));

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/ImportRecordJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/ImportRecordJob.java
@@ -46,7 +46,7 @@ public class ImportRecordJob extends KingpinJob {
 
     @Inject
     public ImportRecordJob(ImportRecordCurator importRecordCurator,
-            OwnerCurator ownerCurator, Configuration config) {
+        OwnerCurator ownerCurator, Configuration config) {
         this.importRecordCurator = importRecordCurator;
         this.ownerCurator = ownerCurator;
     }
@@ -62,8 +62,7 @@ public class ImportRecordJob extends KingpinJob {
 
             if (DEFAULT_KEEP < records.size()) {
                 // records are already sorted by date, so just shave off of the end
-                this.importRecordCurator.bulkDelete(
-                        records.subList(DEFAULT_KEEP, records.size()));
+                this.importRecordCurator.bulkDelete(records.subList(DEFAULT_KEEP, records.size()));
             }
         }
     }

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/KingpinJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/KingpinJob.java
@@ -143,8 +143,7 @@ public abstract class KingpinJob implements Job {
         throws JobExecutionException;
 
     public static JobStatus scheduleJob(JobCurator jobCurator,
-            Scheduler scheduler, JobDetail detail,
-            Trigger trigger) throws SchedulerException {
+        Scheduler scheduler, JobDetail detail, Trigger trigger) throws SchedulerException {
 
         scheduler.getListenerManager().addJobListenerMatcher(
             PinsetterJobListener.LISTENER_NAME,

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/RefreshPoolsJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/RefreshPoolsJob.java
@@ -53,7 +53,7 @@ public class RefreshPoolsJob extends UniqueByEntityJob {
 
     @Inject
     public RefreshPoolsJob(OwnerCurator ownerCurator, PoolManager poolManager,
-            SubscriptionServiceAdapter subAdapter) {
+        SubscriptionServiceAdapter subAdapter) {
 
         this.ownerCurator = ownerCurator;
         this.poolManager = poolManager;

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/RegenProductEntitlementCertsJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/RegenProductEntitlementCertsJob.java
@@ -35,8 +35,7 @@ public class RegenProductEntitlementCertsJob extends KingpinJob {
     private OwnerCurator ownerCurator;
 
     @Inject
-    public RegenProductEntitlementCertsJob(PoolManager poolManager,
-            OwnerCurator ownerCurator) {
+    public RegenProductEntitlementCertsJob(PoolManager poolManager, OwnerCurator ownerCurator) {
 
         this.poolManager = poolManager;
         this.ownerCurator = ownerCurator;

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/UnpauseJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/UnpauseJob.java
@@ -45,8 +45,7 @@ public class UnpauseJob extends KingpinJob {
     private PinsetterKernel pinsetterKernel;
 
     @Inject
-    public UnpauseJob(JobCurator jobCurator,
-            PinsetterKernel pinsetterKernel) {
+    public UnpauseJob(JobCurator jobCurator, PinsetterKernel pinsetterKernel) {
         this.jobCurator = jobCurator;
         this.pinsetterKernel = pinsetterKernel;
     }

--- a/server/src/main/java/org/candlepin/pki/PKIUtility.java
+++ b/server/src/main/java/org/candlepin/pki/PKIUtility.java
@@ -162,8 +162,8 @@ public abstract class PKIUtility {
     public static X509Certificate createCert(byte[] certData) {
         try {
             CertificateFactory cf = CertificateFactory.getInstance("X509");
-            X509Certificate cert = (X509Certificate) cf
-            .generateCertificate(new ByteArrayInputStream(certData));
+            X509Certificate cert =
+                (X509Certificate) cf.generateCertificate(new ByteArrayInputStream(certData));
             return cert;
         }
         catch (Exception e) {
@@ -201,8 +201,8 @@ public abstract class PKIUtility {
         return false;
     }
 
-    public boolean verifySHA256WithRSAHash(
-            InputStream input, byte[] signedHash, Certificate certificate) {
+    public boolean verifySHA256WithRSAHash(InputStream input,
+        byte[] signedHash, Certificate certificate) {
         try {
             Signature signature = Signature.getInstance("SHA256withRSA");
             signature.initVerify(certificate);

--- a/server/src/main/java/org/candlepin/pki/impl/BouncyCastlePKIUtility.java
+++ b/server/src/main/java/org/candlepin/pki/impl/BouncyCastlePKIUtility.java
@@ -137,7 +137,7 @@ public class BouncyCastlePKIUtility extends PKIUtility {
         certGen.addExtension(X509Extensions.AuthorityKeyIdentifier, false,
             new AuthorityKeyIdentifierStructure(caCert));
         certGen.addExtension(X509Extensions.SubjectKeyIdentifier, false,
-              subjectKeyWriter.getSubjectKeyIdentifier(clientKeyPair, extensions));
+            subjectKeyWriter.getSubjectKeyIdentifier(clientKeyPair, extensions));
         certGen.addExtension(X509Extensions.ExtendedKeyUsage, false,
             new ExtendedKeyUsage(KeyPurposeId.id_kp_clientAuth));
 

--- a/server/src/main/java/org/candlepin/pki/impl/DefaultSubjectKeyIdentifierWriter.java
+++ b/server/src/main/java/org/candlepin/pki/impl/DefaultSubjectKeyIdentifierWriter.java
@@ -33,7 +33,7 @@ public class DefaultSubjectKeyIdentifierWriter implements SubjectKeyIdentifierWr
 
     @Override
     public DEREncodable getSubjectKeyIdentifier(KeyPair clientKeyPair,
-                                                Set<X509ExtensionWrapper> extensions)
+        Set<X509ExtensionWrapper> extensions)
         throws CertificateParsingException, IOException, InvalidKeyException {
 
         return new SubjectKeyIdentifierStructure(clientKeyPair.getPublic());

--- a/server/src/main/java/org/candlepin/policy/criteria/CriteriaRules.java
+++ b/server/src/main/java/org/candlepin/policy/criteria/CriteriaRules.java
@@ -46,8 +46,7 @@ public class CriteriaRules  {
     protected ConsumerCurator consumerCurator;
 
     @Inject
-    public CriteriaRules(Configuration config,
-            ConsumerCurator consumerCurator) {
+    public CriteriaRules(Configuration config, ConsumerCurator consumerCurator) {
         this.config = config;
         this.consumerCurator = consumerCurator;
     }
@@ -60,6 +59,7 @@ public class CriteriaRules  {
      * @param consumer The consumer we are filtering pools for
      * @return List of Criterion
      */
+    @SuppressWarnings("checkstyle:indentation")
     public List<Criterion> availableEntitlementCriteria(Consumer consumer) {
 
         // avoid passing in a consumerCurator just to get the host
@@ -75,8 +75,7 @@ public class CriteriaRules  {
         // Don't load virt_only pools if this consumer isn't a guest
         // or a manifest consumer
         if (consumer.getType().isManifest()) {
-            DetachedCriteria requiresHost = DetachedCriteria.forClass(
-                    PoolAttribute.class, "attr")
+            DetachedCriteria requiresHost = DetachedCriteria.forClass(PoolAttribute.class, "attr")
                 .add(Restrictions.eq("name", "requires_host"))
                 .add(Property.forName("this.id").eqProperty("attr.pool.id"))
                 .setProjection(Projections.property("attr.id"));

--- a/server/src/main/java/org/candlepin/policy/js/autobind/AutobindRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/autobind/AutobindRules.java
@@ -69,7 +69,7 @@ public class AutobindRules {
         int poolsBeforeContentFilter = pools.size();
         pools = filterPoolsForV1Certificates(consumer, pools);
         log.debug("pools.size() before V1 certificate filter: {}, after: {}",
-                poolsBeforeContentFilter, pools.size());
+            poolsBeforeContentFilter, pools.size());
 
         if (pools.size() == 0) {
             List<String> fullList = new ArrayList<String>();

--- a/server/src/main/java/org/candlepin/policy/js/compliance/ComplianceRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/compliance/ComplianceRules.java
@@ -93,8 +93,7 @@ public class ComplianceRules {
      * @param calculateCompliantUntil calculate how long the system will remain compliant (expensive)
      * @return Compliance status.
      */
-    public ComplianceStatus getStatus(Consumer c, Date date,
-            boolean calculateCompliantUntil) {
+    public ComplianceStatus getStatus(Consumer c, Date date, boolean calculateCompliantUntil) {
         return getStatus(c, date, calculateCompliantUntil, true);
     }
 

--- a/server/src/main/java/org/candlepin/policy/js/compliance/StatusReasonMessageGenerator.java
+++ b/server/src/main/java/org/candlepin/policy/js/compliance/StatusReasonMessageGenerator.java
@@ -95,8 +95,8 @@ public class StatusReasonMessageGenerator {
         }
         else if (reason.getKey().equals("STORAGE_BAND")) {
             reason.setMessage(i18n.tr("Only supports {0}TB of {1}TB of storage.",
-                    reason.getAttributes().get("covered"),
-                    reason.getAttributes().get("has")));
+                reason.getAttributes().get("covered"),
+                reason.getAttributes().get("has")));
         }
         else { //default fallback
             reason.setMessage(i18n.tr("{2} COVERAGE PROBLEM.  Supports {0} of {1}",

--- a/server/src/main/java/org/candlepin/policy/js/compliance/hash/HashableStringGenerators.java
+++ b/server/src/main/java/org/candlepin/policy/js/compliance/hash/HashableStringGenerators.java
@@ -62,7 +62,7 @@ public class HashableStringGenerators {
      * @return the generated string
      */
     public static <T extends Object> String generateFromCollection(
-            Collection<T> target, HashableStringGenerator<T> generator) {
+        Collection<T> target, HashableStringGenerator<T> generator) {
         // Just append null if the collection was null.
         if (target == null) {
             return null;

--- a/server/src/main/java/org/candlepin/policy/js/entitlement/AbstractEntitlementRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/entitlement/AbstractEntitlementRules.java
@@ -268,7 +268,7 @@ public abstract class AbstractEntitlementRules implements Enforcer {
     }
 
     protected void runPostEntitlement(PoolManager poolManager, Consumer consumer,
-            Map<String, Entitlement> entitlementMap, List<Pool> subPoolsForStackIds) {
+        Map<String, Entitlement> entitlementMap, List<Pool> subPoolsForStackIds) {
         Map<String, Map<String, String>> flatAttributeMaps = new HashMap<String, Map<String, String>>();
         Map<String, Entitlement> virtLimitEntitlements = new HashMap<String, Entitlement>();
         for (Entry<String, Entitlement> entry : entitlementMap.entrySet()) {
@@ -281,7 +281,7 @@ public abstract class AbstractEntitlementRules implements Enforcer {
         }
         // Perform pool management based on the attributes of the pool:
         postBindVirtLimit(poolManager, consumer, virtLimitEntitlements, flatAttributeMaps,
-                subPoolsForStackIds);
+            subPoolsForStackIds);
     }
 
     protected void runPostUnbind(PoolManager poolManager, Entitlement entitlement) {
@@ -301,7 +301,7 @@ public abstract class AbstractEntitlementRules implements Enforcer {
         boolean hostLimited = attributes.containsKey("host_limited") &&
             attributes.get("host_limited").equals("true");
         if (!config.getBoolean(ConfigProperties.STANDALONE) && !hostLimited &&
-                c.getType().isManifest()) {
+            c.getType().isManifest()) {
             String virtLimit = attributes.get("virt_limit");
             if (!"unlimited".equals(virtLimit)) {
                 // As we have unbound an entitlement from a physical pool that
@@ -341,8 +341,8 @@ public abstract class AbstractEntitlementRules implements Enforcer {
     }
 
     private void postBindVirtLimit(PoolManager poolManager, Consumer c,
-            Map<String, Entitlement> entitlementMap, Map<String, Map<String, String>> attributeMaps,
-            List<Pool> subPoolsForStackIds) {
+        Map<String, Entitlement> entitlementMap, Map<String, Map<String, String>> attributeMaps,
+        List<Pool> subPoolsForStackIds) {
         Set<String> stackIdsThathaveSubPools = new HashSet<String>();
         if (CollectionUtils.isNotEmpty(subPoolsForStackIds)) {
             for (Pool pool : subPoolsForStackIds) {
@@ -353,7 +353,7 @@ public abstract class AbstractEntitlementRules implements Enforcer {
         log.debug("Running virt_limit post-bind.");
 
         boolean consumerFactExpression = !c.getType().isManifest() &&
-                !"true".equalsIgnoreCase(c.getFact("virt.is_guest"));
+            !"true".equalsIgnoreCase(c.getFact("virt.is_guest"));
 
         boolean isStandalone = config.getBoolean(ConfigProperties.STANDALONE);
 
@@ -396,12 +396,12 @@ public abstract class AbstractEntitlementRules implements Enforcer {
         if (CollectionUtils.isNotEmpty(createHostRestrictedPoolFor)) {
             log.debug("creating host restricted pools for: {}", createHostRestrictedPoolFor);
             PoolHelper.createHostRestrictedPools(poolManager, c, createHostRestrictedPoolFor,
-                    entitlementMap, attributeMaps);
+                entitlementMap, attributeMaps);
         }
         if (CollectionUtils.isNotEmpty(decrementHostedBonusPoolQuantityFor)) {
             log.debug("decrementHostedBonusPoolQuantity for: {}", decrementHostedBonusPoolQuantityFor);
             decrementHostedBonusPoolQuantity(poolManager, c, decrementHostedBonusPoolQuantityFor,
-                    attributeMaps);
+                attributeMaps);
         }
     }
 
@@ -410,9 +410,9 @@ public abstract class AbstractEntitlementRules implements Enforcer {
      * quantity on the bonus pool, as those entitlements have now been exported to on-site.
      */
     private void decrementHostedBonusPoolQuantity(PoolManager poolManager, Consumer c,
-            List<Entitlement> entitlements, Map<String, Map<String, String>> attributesMaps) {
+        List<Entitlement> entitlements, Map<String, Map<String, String>> attributesMaps) {
         boolean consumerFactExpression = c.getType().isManifest() &&
-                !config.getBoolean(ConfigProperties.STANDALONE);
+            !config.getBoolean(ConfigProperties.STANDALONE);
 
         // pre-fetch subscription and respective pools in a batch
         Set<String> subscriptionIds = new HashSet<String>();
@@ -476,7 +476,7 @@ public abstract class AbstractEntitlementRules implements Enforcer {
     }
 
     public void postEntitlement(PoolManager poolManager, Consumer consumer,
-            Map<String, Entitlement> entitlements, List<Pool> subPoolsForStackIds) {
+        Map<String, Entitlement> entitlements, List<Pool> subPoolsForStackIds) {
         runPostEntitlement(poolManager, consumer, entitlements, subPoolsForStackIds);
     }
 

--- a/server/src/main/java/org/candlepin/policy/js/entitlement/Enforcer.java
+++ b/server/src/main/java/org/candlepin/policy/js/entitlement/Enforcer.java
@@ -105,8 +105,8 @@ public interface Enforcer {
      *         pre-entitlement run.
      */
     Map<String, ValidationResult> preEntitlement(Consumer consumer,
-            Collection<PoolQuantity> entitlementPoolQuantities,
-            CallerType caller);
+        Collection<PoolQuantity> entitlementPoolQuantities,
+        CallerType caller);
 
     /**
      * Run pre-entitlement checks on a batch of pools.
@@ -123,7 +123,7 @@ public interface Enforcer {
      *         pre-entitlement run.
      */
     Map<String, ValidationResult> preEntitlement(Consumer consumer, Consumer host,
-            Collection<PoolQuantity> entitlementPoolQuantities, CallerType caller);
+        Collection<PoolQuantity> entitlementPoolQuantities, CallerType caller);
 
     /**
      * @param consumer Consumer who wishes to consume an entitlement.
@@ -141,7 +141,7 @@ public interface Enforcer {
      * @param ents The entitlement that was just granted.
      */
     void postEntitlement(PoolManager poolManager, Consumer c, Map<String, Entitlement> ents,
-            List<Pool> subPoolsForStackIds);
+        List<Pool> subPoolsForStackIds);
 
     /**
      * Run post-entitlement actions.

--- a/server/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRules.java
@@ -84,14 +84,14 @@ public class EntitlementRules extends AbstractEntitlementRules implements Enforc
 
     @Override
     public Map<String, ValidationResult> preEntitlement(Consumer consumer,
-            Collection<PoolQuantity> entitlementPoolQuantities,
-            CallerType caller) {
+        Collection<PoolQuantity> entitlementPoolQuantities,
+        CallerType caller) {
         return preEntitlement(consumer, getHost(consumer), entitlementPoolQuantities, caller);
     }
 
     @Override
     public Map<String, ValidationResult> preEntitlement(Consumer consumer, Consumer host,
-            Collection<PoolQuantity> entitlementPoolQuantities, CallerType caller) {
+        Collection<PoolQuantity> entitlementPoolQuantities, CallerType caller) {
         JsonJsContext args = new JsonJsContext(objectMapper);
         args.put("consumer", consumer);
         args.put("hostConsumer", host);
@@ -104,7 +104,7 @@ public class EntitlementRules extends AbstractEntitlementRules implements Enforc
         String json = jsRules.runJsFunction(String.class, "validate_pools_batch", args);
         Map<String, ValidationResult> resultMap;
         TypeReference<Map<String, ValidationResult>> typeref =
-                new TypeReference<Map<String, ValidationResult>>() {};
+            new TypeReference<Map<String, ValidationResult>>() {};
         try {
             resultMap = objectMapper.toObject(json, typeref);
             for (PoolQuantity poolQuantity : entitlementPoolQuantities) {
@@ -113,7 +113,7 @@ public class EntitlementRules extends AbstractEntitlementRules implements Enforc
                     log.info("no result returned for pool: {}", poolQuantity.getPool());
                 }
                 finishValidation(resultMap.get(poolQuantity.getPool().getId()), poolQuantity.getPool(),
-                        poolQuantity.getQuantity());
+                    poolQuantity.getQuantity());
             }
         }
         catch (Exception e) {
@@ -167,17 +167,16 @@ public class EntitlementRules extends AbstractEntitlementRules implements Enforc
 
     private Consumer getHost(Consumer consumer) {
         Consumer host = consumer.hasFact("virt.uuid") ? consumerCurator.getHost(
-                consumer.getFact("virt.uuid"), consumer.getOwner()) : null;
+            consumer.getFact("virt.uuid"), consumer.getOwner()) : null;
         return host;
     }
 
     private void finishValidation(ValidationResult result, Pool pool, Integer quantity) {
         validatePoolQuantity(result, pool, quantity);
         if (pool.isExpired(dateSource)) {
-            result.addError(
-                new ValidationError(i18n.tr("Subscriptions for {0} expired on: {1}",
-                    pool.getProductId(),
-                    pool.getEndDate())));
+            result.addError(new ValidationError(i18n.tr("Subscriptions for {0} expired on: {1}",
+                pool.getProductId(),
+                pool.getEndDate())));
         }
     }
 }

--- a/server/src/main/java/org/candlepin/policy/js/pool/PoolHelper.java
+++ b/server/src/main/java/org/candlepin/policy/js/pool/PoolHelper.java
@@ -86,8 +86,8 @@ public class PoolHelper {
      * @return pools the created pools
      */
     public static List<Pool> createHostRestrictedPools(PoolManager poolManager, Consumer consumer,
-            List<Pool> pools, Map<String, Entitlement> sourceEntitlements,
-            Map<String, Map<String, String>> attributeMaps) {
+        List<Pool> pools, Map<String, Entitlement> sourceEntitlements,
+        Map<String, Map<String, String>> attributeMaps) {
         List<Pool> poolsToCreate = new ArrayList<Pool>();
         List<Pool> poolsToUpdateFromStack = new ArrayList<Pool>();
         for (Pool pool : pools) {
@@ -143,7 +143,7 @@ public class PoolHelper {
                 // attribute per 795431, useful for rolling up pool info in headpin
                 consumerSpecificPool.setAttribute("source_pool_id", pool.getId());
                 consumerSpecificPool.setSourceSubscription(new SourceSubscription(pool.getSubscriptionId(),
-                        sourceEntitlements.get(pool.getId()).getId()));
+                    sourceEntitlements.get(pool.getId()).getId()));
             }
             poolsToCreate.add(consumerSpecificPool);
         }
@@ -185,15 +185,15 @@ public class PoolHelper {
     }
 
     public static Pool clonePool(Pool sourcePool, Product product, String quantity,
-            Map<String, String> attributes, String subKey, ProductCurator prodCurator,
-            Entitlement sourceEntitlement) {
+        Map<String, String> attributes, String subKey, ProductCurator prodCurator,
+        Entitlement sourceEntitlement) {
         Pool pool = createPool(product, sourcePool.getOwner(), quantity,
-                sourcePool.getStartDate(), sourcePool.getEndDate(),
-                sourcePool.getContractNumber(), sourcePool.getAccountNumber(),
-                sourcePool.getOrderNumber(), new HashSet<Product>(), sourceEntitlement);
+            sourcePool.getStartDate(), sourcePool.getEndDate(),
+            sourcePool.getContractNumber(), sourcePool.getAccountNumber(),
+            sourcePool.getOrderNumber(), new HashSet<Product>(), sourceEntitlement);
 
         pool.setSourceSubscription(
-                    new SourceSubscription(sourcePool.getSubscriptionId(), subKey));
+            new SourceSubscription(sourcePool.getSubscriptionId(), subKey));
 
         copyProvidedProducts(sourcePool, pool, prodCurator);
 
@@ -211,7 +211,8 @@ public class PoolHelper {
 
     private static Pool createPool(Product product, Owner owner, String quantity, Date startDate,
         Date endDate, String contractNumber, String accountNumber, String orderNumber,
-            Set<Product> providedProducts, Entitlement sourceEntitlement) {
+        Set<Product> providedProducts, Entitlement sourceEntitlement) {
+
         Long q = null;
         if (quantity.equalsIgnoreCase("unlimited")) {
             q = -1L;

--- a/server/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
@@ -73,11 +73,9 @@ public class PoolRules {
         // In hosted, we increase the quantity on the subscription. However in standalone,
         // we assume this already has happened in hosted and the accurate quantity was
         // exported:
-        if (product.hasAttribute("instance_multiplier") &&
-                upstreamPoolId == null) {
+        if (product.hasAttribute("instance_multiplier") && upstreamPoolId == null) {
 
-            int instanceMultiplier = Integer.parseInt(
-                    product.getAttributeValue("instance_multiplier"));
+            int instanceMultiplier = Integer.parseInt(product.getAttributeValue("instance_multiplier"));
             log.debug("Increasing pool quantity for instance multiplier: " +
                 instanceMultiplier);
             result = result * instanceMultiplier;
@@ -110,8 +108,7 @@ public class PoolRules {
     public List<Pool> createAndEnrichPools(Pool masterPool, List<Pool> existingPools) {
         List<Pool> pools = new LinkedList<Pool>();
         masterPool.setQuantity(calculateQuantity(masterPool.getQuantity(),
-                                                 masterPool.getProduct(),
-                                                 masterPool.getUpstreamPoolId()));
+            masterPool.getProduct(), masterPool.getUpstreamPoolId()));
 
         ProductAttribute virtAtt = masterPool.getProduct().getAttribute("virt_only");
         // The following will make virt_only a pool attribute. That makes the
@@ -124,7 +121,7 @@ public class PoolRules {
         log.info("Checking if pools need to be created for: {}", masterPool);
         if (!hasMasterPool(existingPools)) {
             if (masterPool.getSourceSubscription() != null &&
-                    masterPool.getSourceSubscription().getSubscriptionSubKey().contentEquals("derived")) {
+                masterPool.getSourceSubscription().getSubscriptionSubKey().contentEquals("derived")) {
                 // while we can create bonus pool from master pool, the reverse
                 // is not possible without the subscription itself
                 throw new IllegalStateException("Cannot create master pool from bonus pool");
@@ -154,7 +151,7 @@ public class PoolRules {
         if (attributes.containsKey("virt_limit") && !hasBonusPool(existingPools) && virtQuantity != null) {
 
             boolean hostLimited = attributes.containsKey("host_limited") &&
-                    attributes.get("host_limited").equals("true");
+                attributes.get("host_limited").equals("true");
             HashMap<String, String> virtAttributes = new HashMap<String, String>();
             virtAttributes.put("virt_only", "true");
             virtAttributes.put("pool_derived", "true");
@@ -168,12 +165,12 @@ public class PoolRules {
 
             // Favor derived products if they are available
             Product sku = masterPool.getDerivedProduct() != null ? masterPool.getDerivedProduct() :
-                    masterPool.getProduct();
+                masterPool.getProduct();
 
             // Using derived here because only one derived pool is created for
             // this subscription
             Pool bonusPool = PoolHelper.clonePool(masterPool, sku, virtQuantity, virtAttributes, "derived",
-                    prodCurator, null);
+                prodCurator, null);
 
             log.info("Creating new derived pool: {}", bonusPool);
             return bonusPool;
@@ -230,7 +227,7 @@ public class PoolRules {
      * @return pool updates
      */
     public List<PoolUpdate> updatePools(List<Pool> floatingPools,
-            Set<Product> changedProducts) {
+        Set<Product> changedProducts) {
         List<PoolUpdate> updates = new LinkedList<PoolUpdate>();
         for (Pool p : floatingPools) {
 
@@ -259,7 +256,7 @@ public class PoolRules {
     }
 
     public List<PoolUpdate> updatePools(Pool masterPool, List<Pool> existingPools, Long originalQuantity,
-            Set<Product> changedProducts) {
+        Set<Product> changedProducts) {
         //local.setCertificate(subscription.getCertificate());
 
         log.debug("Refreshing pools for existing master pool: {}", masterPool);
@@ -284,22 +281,21 @@ public class PoolRules {
             PoolUpdate update = new PoolUpdate(existingPool);
 
             update.setDatesChanged(checkForDateChange(masterPool.getStartDate(), masterPool.getEndDate(),
-                    existingPool));
+                existingPool));
 
             update.setQuantityChanged(checkForQuantityChange(masterPool, existingPool, originalQuantity,
-                    existingPools, attributes));
+                existingPools, attributes));
 
             if (!existingPool.isMarkedForDelete()) {
                 boolean useDerived = BooleanUtils.toBoolean(
-                                         existingPool.getAttributeValue("pool_derived")) &&
-                                     masterPool.getDerivedProduct() != null;
+                    existingPool.getAttributeValue("pool_derived")) &&
+                    masterPool.getDerivedProduct() != null;
 
-                update.setProductsChanged(
-                        checkForChangedProducts(
-                                useDerived ? masterPool.getDerivedProduct() : masterPool.getProduct(),
-                                getExpectedProvidedProducts(masterPool, useDerived),
-                                existingPool,
-                                changedProducts));
+                update.setProductsChanged(checkForChangedProducts(
+                    useDerived ? masterPool.getDerivedProduct() : masterPool.getProduct(),
+                    getExpectedProvidedProducts(masterPool, useDerived),
+                    existingPool,
+                    changedProducts));
 
                 if (!useDerived) {
                     update.setDerivedProductsChanged(
@@ -345,7 +341,7 @@ public class PoolRules {
      * @return updates
      */
     public List<PoolUpdate> updatePoolsFromStack(Consumer consumer, List<Pool> pools,
-            boolean deleteIfNoStackedEnts) {
+        boolean deleteIfNoStackedEnts) {
         Map<String, List<Entitlement>> entitlementMap = new HashMap<String, List<Entitlement>>();
         Set<String> sourceStackIds = new HashSet<String>();
         List<PoolUpdate> result = new ArrayList<PoolUpdate>();
@@ -368,7 +364,7 @@ public class PoolRules {
             List<Entitlement> entitlements = entitlementMap.get(pool.getSourceStackId());
             if (CollectionUtils.isNotEmpty(entitlements)) {
                 result.add(this.updatePoolFromStackedEntitlements(pool, entitlements,
-                        new HashSet<Product>()));
+                    new HashSet<Product>()));
             }
             else if (deleteIfNoStackedEnts) {
                 poolsToDelete.add(pool);
@@ -529,7 +525,7 @@ public class PoolRules {
     }
 
     private boolean checkForChangedDerivedProducts(Pool pool, Pool existingPool,
-            Set<Product> changedProducts) {
+        Set<Product> changedProducts) {
 
         boolean productsChanged = false;
         if (pool.getDerivedProduct() != null) {
@@ -588,7 +584,7 @@ public class PoolRules {
         // Expected quantity is normally the main pool's quantity, but for
         // virt only pools we expect it to be main pool quantity * virt_limit:
         long expectedQuantity = calculateQuantity(originalQuantity, pool.getProduct(),
-                pool.getUpstreamPoolId());
+            pool.getUpstreamPoolId());
         expectedQuantity = processVirtLimitPools(existingPools,
             attributes, existingPool, expectedQuantity);
 

--- a/server/src/main/java/org/candlepin/policy/js/quantity/QuantityRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/quantity/QuantityRules.java
@@ -86,7 +86,7 @@ public class QuantityRules {
      * @return suggested quantities for all pools requested
      */
     public Map<String, SuggestedQuantity> getSuggestedQuantities(List<Pool> pools,
-            Consumer c, Date date) {
+        Consumer c, Date date) {
 
         JsonJsContext args = new JsonJsContext(mapper);
 

--- a/server/src/main/java/org/candlepin/resource/ActivationKeyContentOverrideResource.java
+++ b/server/src/main/java/org/candlepin/resource/ActivationKeyContentOverrideResource.java
@@ -31,9 +31,9 @@ import javax.ws.rs.Path;
  */
 @Path("/activation_keys/{activation_key_id}/content_overrides")
 public class ActivationKeyContentOverrideResource extends
-        ContentOverrideResource<ActivationKeyContentOverride,
-        ActivationKeyContentOverrideCurator,
-        ActivationKey> {
+    ContentOverrideResource<ActivationKeyContentOverride,
+    ActivationKeyContentOverrideCurator,
+    ActivationKey> {
 
     private ActivationKeyCurator activationKeyCurator;
 

--- a/server/src/main/java/org/candlepin/resource/AdminResource.java
+++ b/server/src/main/java/org/candlepin/resource/AdminResource.java
@@ -53,7 +53,7 @@ public class AdminResource {
 
     @Inject
     public AdminResource(UserServiceAdapter userService, UserCurator userCurator,
-            EventSink dispatcher, Configuration config) {
+        EventSink dispatcher, Configuration config) {
         this.userService = userService;
         this.userCurator = userCurator;
         this.sink = dispatcher;

--- a/server/src/main/java/org/candlepin/resource/ConsumerContentOverrideResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerContentOverrideResource.java
@@ -31,16 +31,16 @@ import javax.ws.rs.Path;
  */
 @Path("/consumers/{consumer_uuid}/content_overrides")
 public class ConsumerContentOverrideResource extends
-        ContentOverrideResource<ConsumerContentOverride,
-        ConsumerContentOverrideCurator, Consumer> {
+    ContentOverrideResource<ConsumerContentOverride,
+    ConsumerContentOverrideCurator, Consumer> {
 
     private ConsumerCurator consumerCurator;
 
     @Inject
     public ConsumerContentOverrideResource(
-            ConsumerContentOverrideCurator consumerContentOverrideCurator,
-            ConsumerCurator consumerCurator,
-            ContentOverrideValidator contentOverrideValidator, I18n i18n) {
+        ConsumerContentOverrideCurator consumerContentOverrideCurator,
+        ConsumerCurator consumerCurator,
+        ContentOverrideValidator contentOverrideValidator, I18n i18n) {
         super(consumerContentOverrideCurator, contentOverrideValidator,
             i18n, "consumer_uuid");
         this.consumerCurator = consumerCurator;

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -247,6 +247,7 @@ public class ConsumerResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Wrapped(element = "consumers")
     @Paginate
+    @SuppressWarnings("checkstyle:indentation")
     public List<Consumer> list(@QueryParam("username") String userName,
         @QueryParam("type") Set<String> typeLabels,
         @QueryParam("owner") String ownerKey,
@@ -257,8 +258,8 @@ public class ConsumerResource {
         @Context PageRequest pageRequest) {
 
         if (userName == null && (typeLabels == null || typeLabels.isEmpty()) && ownerKey == null &&
-                (uuids == null || uuids.isEmpty()) && (hypervisorIds == null || hypervisorIds.isEmpty()) &&
-                (attrFilters == null || attrFilters.isEmpty())) {
+            (uuids == null || uuids.isEmpty()) && (hypervisorIds == null || hypervisorIds.isEmpty()) &&
+            (attrFilters == null || attrFilters.isEmpty())) {
             throw new BadRequestException(i18n.tr("Must specify at least one search criteria."));
         }
 
@@ -357,17 +358,15 @@ public class ConsumerResource {
             IdentityCertificate idcert = consumer.getIdCert();
             if (idcert != null) {
                 Date expire = idcert.getSerial().getExpiration();
-                int days = config.getInt(
-                        ConfigProperties.IDENTITY_CERT_EXPIRY_THRESHOLD, 90);
+                int days = config.getInt(ConfigProperties.IDENTITY_CERT_EXPIRY_THRESHOLD, 90);
                 Date futureExpire = Util.addDaysToDt(days);
                 // if expiration is within 90 days, regenerate it
                 log.debug("Threshold [{}] expires on [{}] futureExpire [{}]",
-                        days, expire, futureExpire);
+                    days, expire, futureExpire);
 
                 if (expire.before(futureExpire)) {
-                    log.info(
-                            "Regenerating identity certificate for consumer: {}, expiry: {}",
-                            uuid, expire);
+                    log.info("Regenerating identity certificate for consumer: {}, expiry: {}",
+                        uuid, expire);
                     consumer = this.regenerateIdentityCertificate(consumer);
                 }
             }
@@ -500,8 +499,7 @@ public class ConsumerResource {
                 consumer.setCreated(createdDate);
             }
             if (lastCheckIn != null) {
-                log.info("Creating with specific last checkin time: {}",
-                        consumer.getLastCheckin());
+                log.info("Creating with specific last checkin time: {}", consumer.getLastCheckin());
                 consumer.setLastCheckin(lastCheckIn);
             }
             if (identityCertCreation) {
@@ -536,7 +534,7 @@ public class ConsumerResource {
     }
 
     private List<ActivationKey>  checkActivationKeys(Principal principal, Owner owner,
-            Set<String> keyStrings) throws BadRequestException {
+        Set<String> keyStrings) throws BadRequestException {
         List<ActivationKey> keys = new ArrayList<ActivationKey>();
         for (String keyString : keyStrings) {
             ActivationKey key = null;
@@ -836,8 +834,7 @@ public class ConsumerResource {
                     toUpdate.getOwner(), allGuestIds);
         }
 
-        if (performConsumerUpdates(consumer, toUpdate,
-                guestConsumerMap)) {
+        if (performConsumerUpdates(consumer, toUpdate, guestConsumerMap)) {
             try {
                 consumerCurator.update(toUpdate);
             }
@@ -854,14 +851,14 @@ public class ConsumerResource {
     }
 
     public boolean performConsumerUpdates(Consumer updated, Consumer toUpdate,
-            VirtConsumerMap guestConsumerMap) {
+        VirtConsumerMap guestConsumerMap) {
         return performConsumerUpdates(updated, toUpdate, guestConsumerMap,
                 true);
     }
 
     @Transactional
     public boolean performConsumerUpdates(Consumer updated, Consumer toUpdate,
-            VirtConsumerMap guestConsumerMap, boolean isIdCert) {
+        VirtConsumerMap guestConsumerMap, boolean isIdCert) {
         if (log.isDebugEnabled()) {
             log.debug("Updating consumer: {}", toUpdate.getUuid());
         }
@@ -870,7 +867,7 @@ public class ConsumerResource {
         // If nothing changes we won't send.  The new entity needs to be correct though,
         // so we should get a Jsonstring now, and finish it off if we're going to send
         EventBuilder eventBuilder = eventFactory.getEventBuilder(Target.CONSUMER, Type.MODIFIED)
-                .setOldEntity(toUpdate);
+            .setOldEntity(toUpdate);
 
         // version changed on non-checked in consumer, or list of capabilities
         // changed on checked in consumer
@@ -891,7 +888,7 @@ public class ConsumerResource {
 
         // Allow optional setting of the autoheal attribute:
         if (updated.isAutoheal() != null &&
-             !updated.isAutoheal().equals(toUpdate.isAutoheal())) {
+            !updated.isAutoheal().equals(toUpdate.isAutoheal())) {
             log.info("   Updating consumer autoheal setting.");
             toUpdate.setAutoheal(updated.isAutoheal());
             changesMade = true;
@@ -918,7 +915,7 @@ public class ConsumerResource {
         String environmentId =
             updated.getEnvironment() == null ? null : updated.getEnvironment().getId();
         if (environmentId != null && (toUpdate.getEnvironment() == null ||
-                    !toUpdate.getEnvironment().getId().equals(environmentId))) {
+            !toUpdate.getEnvironment().getId().equals(environmentId))) {
             Environment e = environmentCurator.find(environmentId);
             if (e == null) {
                 throw new NotFoundException(i18n.tr(
@@ -937,8 +934,7 @@ public class ConsumerResource {
         if (updated.getName() != null && !toUpdate.getName().equals(updated.getName())) {
             checkConsumerName(updated);
 
-            log.info("Updating consumer name: {} -> {}",
-                    toUpdate.getName(), updated.getName());
+            log.info("Updating consumer name: {} -> {}", toUpdate.getName(), updated.getName());
             toUpdate.setName(updated.getName());
 
             // get the new name into the id cert if we are using the cert
@@ -949,8 +945,7 @@ public class ConsumerResource {
         }
 
         if (updated.getLastCheckin() != null) {
-            log.info("Updating to specific last checkin time: {}",
-                    updated.getLastCheckin());
+            log.info("Updating to specific last checkin time: {}", updated.getLastCheckin());
             toUpdate.setLastCheckin(updated.getLastCheckin());
             changesMade = true;
         }
@@ -975,8 +970,7 @@ public class ConsumerResource {
         HypervisorId incomingId = incoming.getHypervisorId();
         if (incomingId != null) {
             HypervisorId existingId = existing.getHypervisorId();
-            if (incomingId.getHypervisorId() == null ||
-                    incomingId.getHypervisorId().isEmpty()) {
+            if (incomingId.getHypervisorId() == null || incomingId.getHypervisorId().isEmpty()) {
                 // Allow hypervisorId to be removed
                 existing.setHypervisorId(null);
             }
@@ -1066,7 +1060,7 @@ public class ConsumerResource {
      * @return a boolean
      */
     private boolean checkForGuestsUpdate(Consumer existing, Consumer incoming,
-            VirtConsumerMap guestConsumerMap) {
+        VirtConsumerMap guestConsumerMap) {
 
         if (incoming.getGuestIds() == null) {
             log.debug("Guests not included in this consumer update, skipping update.");
@@ -1192,7 +1186,7 @@ public class ConsumerResource {
         if (deletableGuestEntitlements.size() > 0) {
             // auto heal guests after revocations
             boolean hasInstalledProducts = guest.getInstalledProducts() != null &&
-                    !guest.getInstalledProducts().isEmpty();
+                !guest.getInstalledProducts().isEmpty();
             if (guest.isAutoheal() && !deletableGuestEntitlements.isEmpty() && hasInstalledProducts) {
                 AutobindData autobindData = AutobindData.create(guest).on(new Date());
                 List<Entitlement> ents = entitler.bindByProducts(autobindData);
@@ -1388,7 +1382,7 @@ public class ConsumerResource {
     }
 
     private void validateBindArguments(boolean hasPoolQuantities, String poolIdString, Integer quantity,
-            String[] productIds, List<String> fromPools, Date entitleDate, boolean async) {
+        String[] productIds, List<String> fromPools, Date entitleDate, boolean async) {
         short parameters = 0;
 
         if (hasPoolQuantities) {
@@ -1398,7 +1392,7 @@ public class ConsumerResource {
             parameters++;
         }
         if (ArrayUtils.isNotEmpty(productIds) || CollectionUtils.isNotEmpty(fromPools) ||
-                entitleDate != null) {
+            entitleDate != null) {
             parameters++;
         }
         if (parameters > 1) {
@@ -1455,11 +1449,11 @@ public class ConsumerResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/{consumer_uuid}/entitlements")
+    @SuppressWarnings("checkstyle:indentation")
     public Response bind(
         @PathParam("consumer_uuid") @Verify(Consumer.class) String consumerUuid,
         @QueryParam("pool") @Verify(value = Pool.class, nullable = true,
-            subResource = SubResource.ENTITLEMENTS)
-                String poolIdString,
+            subResource = SubResource.ENTITLEMENTS) String poolIdString,
         @QueryParam("product") String[] productIds,
         @QueryParam("quantity") Integer quantity,
         @QueryParam("email") String email,
@@ -1476,7 +1470,7 @@ public class ConsumerResource {
 
         // Check that only one query param was set, and some other validations
         validateBindArguments(hasPoolQuantities, poolIdString, quantity, productIds, fromPools,
-                entitleDate, async);
+            entitleDate, async);
 
         // Verify consumer exists:
         Consumer consumer = consumerCurator.verifyAndLookupConsumerWithEntitlements(consumerUuid);
@@ -1514,7 +1508,7 @@ public class ConsumerResource {
                 return Response.serverError().build();
             }
             log.info("Checked if consumer has unaccepted subscription terms in {}ms",
-                    (System.currentTimeMillis() - subTermsStart));
+                (System.currentTimeMillis() - subTermsStart));
         }
         catch (CandlepinException e) {
             log.debug(e.getMessage());
@@ -1563,7 +1557,7 @@ public class ConsumerResource {
         }
         else {
             AutobindData autobindData = AutobindData.create(consumer).on(entitleDate)
-                    .forProducts(productIds).withPools(fromPools);
+                .forProducts(productIds).withPools(fromPools);
             entitlements = entitler.bindByProducts(autobindData);
         }
 
@@ -1674,7 +1668,7 @@ public class ConsumerResource {
 
         EntitlementFilterBuilder filters = EntitlementFinderUtil.createFilter(matches, attrFilters);
         Page<List<Entitlement>> entitlementsPage = entitlementCurator.listByConsumer(consumer, productId,
-                filters, pageRequest);
+            filters, pageRequest);
 
         // Store the page for the LinkHeaderPostInterceptor
         ResteasyProviderFactory.pushContext(Page.class, entitlementsPage);
@@ -1982,8 +1976,8 @@ public class ConsumerResource {
      */
     private Consumer regenerateIdentityCertificate(Consumer consumer) {
         EventBuilder eventBuilder = eventFactory
-                .getEventBuilder(Target.CONSUMER, Type.MODIFIED)
-                .setOldEntity(consumer);
+            .getEventBuilder(Target.CONSUMER, Type.MODIFIED)
+            .setOldEntity(consumer);
 
         IdentityCertificate ic = generateIdCert(consumer, true);
         consumer.setIdCert(ic);
@@ -2130,8 +2124,7 @@ public class ConsumerResource {
     @Path("/compliance")
     @Transactional
     public Map<String, ComplianceStatus> getComplianceStatusList(
-        @QueryParam("uuid") @Verify(value = Consumer.class, nullable = true)
-            List<String> uuids) {
+        @QueryParam("uuid") @Verify(value = Consumer.class, nullable = true) List<String> uuids) {
         List<Consumer> consumers = uuids == null ? new LinkedList<Consumer>() :
             consumerCurator.findByUuids(uuids);
         Map<String, ComplianceStatus> results = new HashMap<String, ComplianceStatus>();

--- a/server/src/main/java/org/candlepin/resource/ContentOverrideResource.java
+++ b/server/src/main/java/org/candlepin/resource/ContentOverrideResource.java
@@ -48,8 +48,8 @@ import javax.ws.rs.core.UriInfo;
  * @param <Parent> parent of the content override, Consumer or ActivationKey for example
  */
 public abstract class ContentOverrideResource<T extends ContentOverride,
-        Curator extends ContentOverrideCurator<T, Parent>,
-        Parent extends AbstractHibernateObject> {
+    Curator extends ContentOverrideCurator<T, Parent>,
+    Parent extends AbstractHibernateObject> {
 
     private Curator contentOverrideCurator;
     private ContentOverrideValidator contentOverrideValidator;
@@ -57,8 +57,8 @@ public abstract class ContentOverrideResource<T extends ContentOverride,
     private I18n i18n;
 
     public ContentOverrideResource(Curator contentOverrideCurator,
-            ContentOverrideValidator contentOverrideValidator,
-            I18n i18n, String parentPath) {
+        ContentOverrideValidator contentOverrideValidator,
+        I18n i18n, String parentPath) {
         this.contentOverrideCurator = contentOverrideCurator;
         this.contentOverrideValidator = contentOverrideValidator;
         this.parentPath = parentPath;

--- a/server/src/main/java/org/candlepin/resource/EntitlementResource.java
+++ b/server/src/main/java/org/candlepin/resource/EntitlementResource.java
@@ -86,10 +86,10 @@ public class EntitlementResource {
 
     @Inject
     public EntitlementResource(EntitlementCurator entitlementCurator,
-            ConsumerCurator consumerCurator,
-            PoolManager poolManager,
-            I18n i18n,
-            Entitler entitler, Enforcer enforcer, EntitlementRulesTranslator messageTranslator) {
+        ConsumerCurator consumerCurator,
+        PoolManager poolManager,
+        I18n i18n,
+        Entitler entitler, Enforcer enforcer, EntitlementRulesTranslator messageTranslator) {
 
         this.entitlementCurator = entitlementCurator;
         this.consumerCurator = consumerCurator;
@@ -120,7 +120,7 @@ public class EntitlementResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Path("consumer/{consumer_uuid}/product/{product_id}")
     public Entitlement hasEntitlement(@PathParam("consumer_uuid") String consumerUuid,
-            @PathParam("product_id") String productId) {
+        @PathParam("product_id") String productId) {
 
         Consumer consumer = consumerCurator.findByUuid(consumerUuid);
         verifyExistence(consumer, consumerUuid);
@@ -334,8 +334,8 @@ public class EntitlementResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Path("product/{product_id}")
     public JobDetail regenerateEntitlementCertificatesForProduct(
-            @PathParam("product_id") String productId,
-            @QueryParam("lazy_regen") @DefaultValue("true") boolean lazyRegen) {
+        @PathParam("product_id") String productId,
+        @QueryParam("lazy_regen") @DefaultValue("true") boolean lazyRegen) {
 
         JobDataMap map = new JobDataMap();
         map.put(RegenProductEntitlementCertsJob.PROD_ID, productId);
@@ -376,8 +376,7 @@ public class EntitlementResource {
             }
             if (quantity > 0 && quantity <= entitlement.getQuantity()) {
                 Consumer sourceConsumer = entitlement.getConsumer();
-                Consumer destinationConsumer = consumerCurator.verifyAndLookupConsumer(
-                        uuid);
+                Consumer destinationConsumer = consumerCurator.verifyAndLookupConsumer(uuid);
                 if (!sourceConsumer.getType().isManifest()) {
                     throw new BadRequestException(i18n.tr(
                         "Entitlement migration is not permissible for units of type ''{0}''",
@@ -394,7 +393,7 @@ public class EntitlementResource {
                 }
                 // test to ensure destination can use the pool
                 ValidationResult result = enforcer.preEntitlement(destinationConsumer,
-                        entitlement.getPool(), 0, CallerType.BIND);
+                    entitlement.getPool(), 0, CallerType.BIND);
                 if (!result.isSuccessful()) {
                     throw new BadRequestException(i18n.tr(
                         "The entitlement cannot be utilized by the destination unit: ") +
@@ -406,11 +405,11 @@ public class EntitlementResource {
                 }
                 else {
                     entitler.adjustEntitlementQuantity(sourceConsumer, entitlement,
-                            entitlement.getQuantity() - quantity);
+                        entitlement.getQuantity() - quantity);
                 }
                 Pool pool = entitlement.getPool();
                 entitlements.addAll(entitler.bindByPoolQuantity(destinationConsumer, pool.getId(),
-                        quantity));
+                    quantity));
 
                 // Trigger events:
                 entitler.sendEvents(entitlements);

--- a/server/src/main/java/org/candlepin/resource/EnvironmentResource.java
+++ b/server/src/main/java/org/candlepin/resource/EnvironmentResource.java
@@ -221,9 +221,9 @@ public class EnvironmentResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/{env_id}/content")
     public JobDetail promoteContent(
-            @PathParam("env_id") @Verify(Environment.class) String envId,
-            List<org.candlepin.model.dto.EnvironmentContent> contentToPromote,
-            @QueryParam("lazy_regen") @DefaultValue("true") Boolean lazyRegen) {
+        @PathParam("env_id") @Verify(Environment.class) String envId,
+        List<org.candlepin.model.dto.EnvironmentContent> contentToPromote,
+        @QueryParam("lazy_regen") @DefaultValue("true") Boolean lazyRegen) {
 
         Environment env = lookupEnvironment(envId);
 

--- a/server/src/main/java/org/candlepin/resource/GuestIdResource.java
+++ b/server/src/main/java/org/candlepin/resource/GuestIdResource.java
@@ -70,8 +70,8 @@ public class GuestIdResource {
 
     @Inject
     public GuestIdResource(GuestIdCurator guestIdCurator,
-            ConsumerCurator consumerCurator, ConsumerResource consumerResource,
-            I18n i18n, EventFactory eventFactory, EventSink sink) {
+        ConsumerCurator consumerCurator, ConsumerResource consumerResource,
+        I18n i18n, EventFactory eventFactory, EventSink sink) {
         this.guestIdCurator = guestIdCurator;
         this.consumerCurator = consumerCurator;
         this.consumerResource = consumerResource;
@@ -91,8 +91,8 @@ public class GuestIdResource {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public List<GuestId> getGuestIds(
-            @PathParam("consumer_uuid") @Verify(Consumer.class) String consumerUuid,
-            @Context PageRequest pageRequest) {
+        @PathParam("consumer_uuid") @Verify(Consumer.class) String consumerUuid,
+        @Context PageRequest pageRequest) {
         Consumer consumer = consumerCurator.findByUuid(consumerUuid);
         Page<List<GuestId>> page = guestIdCurator.listByConsumer(consumer, pageRequest);
 
@@ -115,8 +115,8 @@ public class GuestIdResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/{guest_id}")
     public GuestId getGuestId(
-            @PathParam("consumer_uuid") @Verify(Consumer.class) String consumerUuid,
-            @PathParam("guest_id") String guestId) {
+        @PathParam("consumer_uuid") @Verify(Consumer.class) String consumerUuid,
+        @PathParam("guest_id") String guestId) {
         Consumer consumer = consumerCurator.findByUuid(consumerUuid);
         GuestId result = validateGuestId(
             guestIdCurator.findByConsumerAndId(consumer, guestId), guestId);
@@ -136,8 +136,8 @@ public class GuestIdResource {
     @PUT
     @Produces(MediaType.APPLICATION_JSON)
     public void updateGuests(
-            @PathParam("consumer_uuid") @Verify(Consumer.class) String consumerUuid,
-            List<GuestId> guestIds) {
+        @PathParam("consumer_uuid") @Verify(Consumer.class) String consumerUuid,
+        List<GuestId> guestIds) {
         Consumer toUpdate = consumerCurator.findByUuid(consumerUuid);
 
         // Create a skeleton consumer for consumerResource.performConsumerUpdates
@@ -149,10 +149,9 @@ public class GuestIdResource {
             allGuestIds.add(gid.getGuestId());
         }
         VirtConsumerMap guestConsumerMap = consumerCurator.getGuestConsumersMap(
-                toUpdate.getOwner(), allGuestIds);
+            toUpdate.getOwner(), allGuestIds);
 
-        if (consumerResource.performConsumerUpdates(consumer, toUpdate,
-                guestConsumerMap)) {
+        if (consumerResource.performConsumerUpdates(consumer, toUpdate, guestConsumerMap)) {
             consumerCurator.update(toUpdate);
         }
     }
@@ -170,9 +169,9 @@ public class GuestIdResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/{guest_id}")
     public void updateGuest(
-            @PathParam("consumer_uuid") @Verify(Consumer.class) String consumerUuid,
-            @PathParam("guest_id") String guestId,
-            GuestId updated) {
+        @PathParam("consumer_uuid") @Verify(Consumer.class) String consumerUuid,
+        @PathParam("guest_id") String guestId,
+        GuestId updated) {
 
         // I'm not sure this can happen
         if (guestId == null || guestId.isEmpty()) {
@@ -219,10 +218,10 @@ public class GuestIdResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/{guest_id}")
     public void deleteGuest(
-            @PathParam("consumer_uuid") @Verify(Consumer.class) String consumerUuid,
-            @PathParam("guest_id") String guestId,
-            @QueryParam("unregister") @DefaultValue("false") boolean unregister,
-            @Context Principal principal) {
+        @PathParam("consumer_uuid") @Verify(Consumer.class) String consumerUuid,
+        @PathParam("guest_id") String guestId,
+        @QueryParam("unregister") @DefaultValue("false") boolean unregister,
+        @Context Principal principal) {
 
         Consumer consumer = consumerCurator.verifyAndLookupConsumer(consumerUuid);
         GuestId toDelete = validateGuestId(
@@ -249,7 +248,7 @@ public class GuestIdResource {
             guest.getConsumer().getOwner().getId());
         if (guestConsumer != null) {
             if ((principal == null) ||
-                    principal.canAccess(guestConsumer, SubResource.NONE, Access.ALL)) {
+                principal.canAccess(guestConsumer, SubResource.NONE, Access.ALL)) {
                 consumerResource.deleteConsumer(guestConsumer.getUuid(), principal);
             }
             else {

--- a/server/src/main/java/org/candlepin/resource/HypervisorResource.java
+++ b/server/src/main/java/org/candlepin/resource/HypervisorResource.java
@@ -110,6 +110,7 @@ public class HypervisorResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Deprecated
     @Transactional
+    @SuppressWarnings("checkstyle:indentation")
     public HypervisorCheckInResult hypervisorUpdate(
         Map<String, List<GuestId>> hostGuestMap, @Context Principal principal,
         @QueryParam("owner") @Verify(value = Owner.class,
@@ -132,7 +133,7 @@ public class HypervisorResource {
 
         // Maps virt hypervisor ID to registered consumer for that hypervisor, should one exist:
         VirtConsumerMap hypervisorConsumersMap =
-                consumerCurator.getHostConsumersMap(owner, hostGuestMap.keySet());
+            consumerCurator.getHostConsumersMap(owner, hostGuestMap.keySet());
 
         int emptyGuestIdCount = 0;
         Set<String> allGuestIds = new HashSet<String>();
@@ -158,7 +159,7 @@ public class HypervisorResource {
 
         // Maps virt guest ID to registered consumer for guest, if one exists:
         VirtConsumerMap guestConsumersMap = consumerCurator.getGuestConsumersMap(
-                owner, allGuestIds);
+            owner, allGuestIds);
 
         HypervisorCheckInResult result = new HypervisorCheckInResult();
         for (Entry<String, List<GuestId>> hostEntry : hostGuestMap.entrySet()) {
@@ -234,6 +235,7 @@ public class HypervisorResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Transactional
     @Path("/{owner}")
+    @SuppressWarnings("checkstyle:indentation")
     public JobDetail hypervisorUpdateAsync(
         String hypervisorJson, @Context Principal principal,
         @PathParam("owner") @Verify(value = Owner.class,
@@ -271,12 +273,11 @@ public class HypervisorResource {
      * return whether or not there was any change
      */
     private boolean addGuestIds(Consumer consumer, List<GuestId> guestIds,
-            VirtConsumerMap guestConsumerMap) {
+        VirtConsumerMap guestConsumerMap) {
         Consumer withIds = new Consumer();
         withIds.setGuestIds(guestIds);
         boolean guestIdsUpdated =
-            consumerResource.performConsumerUpdates(withIds, consumer,
-                    guestConsumerMap);
+            consumerResource.performConsumerUpdates(withIds, consumer, guestConsumerMap);
         if (guestIdsUpdated) {
             consumerCurator.update(consumer);
         }
@@ -287,7 +288,7 @@ public class HypervisorResource {
      * Create a new hypervisor type consumer to represent the incoming hypervisorId
      */
     private Consumer createConsumerForHypervisorId(String incHypervisorId,
-            Owner owner, Principal principal) {
+        Owner owner, Principal principal) {
         Consumer consumer = new Consumer();
         consumer.setName(incHypervisorId);
         consumer.setType(new ConsumerType(ConsumerTypeEnum.HYPERVISOR));

--- a/server/src/main/java/org/candlepin/resource/JobResource.java
+++ b/server/src/main/java/org/candlepin/resource/JobResource.java
@@ -105,8 +105,8 @@ public class JobResource {
         @QueryParam("principal") String principalName) {
 
         boolean allParamsEmpty = StringUtils.isEmpty(ownerKey) &&
-                                 StringUtils.isEmpty(uuid) &&
-                                 StringUtils.isEmpty(principalName);
+            StringUtils.isEmpty(uuid) &&
+            StringUtils.isEmpty(principalName);
 
         // make sure we only specified one
         if (allParamsEmpty || !ensureOnlyOne(ownerKey, uuid, principalName)) {
@@ -210,7 +210,7 @@ public class JobResource {
     @Path("/{job_id}")
     @Produces(MediaType.APPLICATION_JSON)
     public JobStatus getStatus(@PathParam("job_id") @Verify(JobStatus.class) String jobId,
-                               @QueryParam("result_data") @DefaultValue("false") boolean resultData) {
+        @QueryParam("result_data") @DefaultValue("false") boolean resultData) {
         JobStatus js = curator.find(jobId);
         js.cloakResultData(!resultData);
         return js;

--- a/server/src/main/java/org/candlepin/resource/OwnerContentResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerContentResource.java
@@ -143,7 +143,7 @@ public class OwnerContentResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/{content_id}")
     public Content getContent(@PathParam("owner_key") String ownerKey,
-                              @PathParam("content_id") String contentId) {
+        @PathParam("content_id") String contentId) {
 
         Owner owner = this.getOwnerByKey(ownerKey);
         Content content = this.contentCurator.lookupById(owner, contentId);
@@ -238,8 +238,8 @@ public class OwnerContentResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/{content_id}")
     public Content updateContent(@PathParam("owner_key") String ownerKey,
-                                 @PathParam("content_id") String contentId,
-                                 Content content) {
+        @PathParam("content_id") String contentId,
+        Content content) {
 
         Owner owner = this.getOwnerByKey(ownerKey);
         Content existing  = this.getContent(ownerKey, contentId);
@@ -270,7 +270,7 @@ public class OwnerContentResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/{content_id}")
     public void remove(@PathParam("owner_key") String ownerKey,
-                       @PathParam("content_id") String contentId) {
+        @PathParam("content_id") String contentId) {
 
         Owner owner = this.getOwnerByKey(ownerKey);
         Content content = this.getContent(ownerKey, contentId);

--- a/server/src/main/java/org/candlepin/resource/OwnerProductResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerProductResource.java
@@ -75,7 +75,7 @@ public class OwnerProductResource {
 
     @Inject
     public OwnerProductResource(ProductCurator productCurator, ContentCurator contentCurator,
-            OwnerCurator ownerCurator, ProductCertificateCurator productCertCurator, I18n i18n) {
+        OwnerCurator ownerCurator, ProductCertificateCurator productCertCurator, I18n i18n) {
 
         this.productCurator = productCurator;
         this.contentCurator = contentCurator;

--- a/server/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -375,7 +375,7 @@ public class OwnerResource {
 
         EntitlementFilterBuilder filters = EntitlementFinderUtil.createFilter(matches, attrFilters);
         Page<List<Entitlement>> entitlementsPage = entitlementCurator.listByOwner(owner, productId, filters,
-                pageRequest);
+            pageRequest);
 
         // Store the page for the LinkHeaderPostInterceptor
         ResteasyProviderFactory.pushContext(Page.class, entitlementsPage);
@@ -484,8 +484,7 @@ public class OwnerResource {
                 i18n.tr("Must provide a name for activation key."));
         }
 
-        String testName = activationKey.getName().replace("-", "0")
-                          .replace("_", "0");
+        String testName = activationKey.getName().replace("-", "0").replace("_", "0");
         if (!testName.matches("[a-zA-Z0-9]*")) {
             throw new BadRequestException(
                 i18n.tr("The activation key name ''{0}'' must be alphanumeric or " +
@@ -613,21 +612,20 @@ public class OwnerResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Path("{owner_key}/consumers")
     @Paginate
+    @SuppressWarnings("checkstyle:indentation")
     public List<Consumer> listConsumers(
-            @PathParam("owner_key")
-            @Verify(value = Owner.class,
-                subResource = SubResource.CONSUMERS) String ownerKey,
-            @QueryParam("username") String userName,
-            @QueryParam("type") Set<String> typeLabels,
-            @QueryParam("uuid") @Verify(value = Consumer.class, nullable = true)
-                List<String> uuids,
-            @QueryParam("hypervisor_id") List<String> hypervisorIds,
-            @QueryParam("fact") @CandlepinParam(type = KeyValueParameter.class)
-                List<KeyValueParameter> attrFilters,
-            @QueryParam("sku") List<String> skus,
-            @QueryParam("subscription_id") List<String> subscriptionIds,
-            @QueryParam("contract") List<String> contracts,
-            @Context PageRequest pageRequest) {
+        @PathParam("owner_key")
+        @Verify(value = Owner.class, subResource = SubResource.CONSUMERS) String ownerKey,
+        @QueryParam("username") String userName,
+        @QueryParam("type") Set<String> typeLabels,
+        @QueryParam("uuid") @Verify(value = Consumer.class, nullable = true) List<String> uuids,
+        @QueryParam("hypervisor_id") List<String> hypervisorIds,
+        @QueryParam("fact") @CandlepinParam(type = KeyValueParameter.class)
+            List<KeyValueParameter> attrFilters,
+        @QueryParam("sku") List<String> skus,
+        @QueryParam("subscription_id") List<String> subscriptionIds,
+        @QueryParam("contract") List<String> contracts,
+        @Context PageRequest pageRequest) {
         Owner owner = findOwner(ownerKey);
         List<ConsumerType> types = null;
         if (typeLabels != null && !typeLabels.isEmpty()) {
@@ -659,9 +657,9 @@ public class OwnerResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Path("{owner_key}/pools")
     @Paginate
+    @SuppressWarnings("checkstyle:indentation")
     public List<Pool> listPools(
-        @PathParam("owner_key")
-            @Verify(value = Owner.class, subResource = SubResource.POOLS) String ownerKey,
+        @PathParam("owner_key") @Verify(value = Owner.class, subResource = SubResource.POOLS) String ownerKey,
         @QueryParam("consumer") String consumerUuid,
         @QueryParam("activation_key") String activationKeyName,
         @QueryParam("product") String productId,
@@ -720,7 +718,7 @@ public class OwnerResource {
         }
 
         Page<List<Pool>> page = poolManager.listAvailableEntitlementPools(c, key, owner, productId,
-                subscriptionId, activeOnDate, true, listAll, poolFilters, pageRequest
+            subscriptionId, activeOnDate, true, listAll, poolFilters, pageRequest
         );
         List<Pool> poolList = page.getPageData();
         calculatedAttributesUtil.setCalculatedAttributes(poolList, activeOnDate);
@@ -742,7 +740,7 @@ public class OwnerResource {
     @Produces("application/atom+xml")
     @Path("{owner_key}/atom")
     public Feed getOwnerAtomFeed(@PathParam("owner_key")
-            @Verify(Owner.class) String ownerKey) {
+        @Verify(Owner.class) String ownerKey) {
         Owner o = findOwner(ownerKey);
         String path = String.format("/owners/%s/atom", ownerKey);
         Feed feed = this.eventAdapter.toFeed(
@@ -1008,7 +1006,7 @@ public class OwnerResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Path("{owner_key}/pools")
     public void updatePool(@PathParam("owner_key") @Verify(Owner.class) String ownerKey,
-            Pool newPool) {
+        Pool newPool) {
 
         Pool currentPool = this.poolManager.find(newPool.getId());
         if (currentPool == null) {
@@ -1018,7 +1016,7 @@ public class OwnerResource {
         }
 
         if (currentPool.getType() != PoolType.NORMAL ||
-                newPool.getType() != PoolType.NORMAL) {
+            newPool.getType() != PoolType.NORMAL) {
             throw new BadRequestException(i18n.tr("Cannot update bonus pools, as they are auto generated"));
         }
 

--- a/server/src/main/java/org/candlepin/resource/PoolResource.java
+++ b/server/src/main/java/org/candlepin/resource/PoolResource.java
@@ -277,9 +277,8 @@ public class PoolResource {
     @Path("{pool_id}/entitlements")
     @Produces(MediaType.APPLICATION_JSON)
     public List<Entitlement> getPoolEntitlements(@PathParam("pool_id")
-                            @Verify(value = Pool.class,
-                                subResource = SubResource.ENTITLEMENTS) String id,
-                            @Context Principal principal) {
+        @Verify(value = Pool.class, subResource = SubResource.ENTITLEMENTS) String id,
+        @Context Principal principal) {
 
         Pool pool = poolManager.find(id);
 

--- a/server/src/main/java/org/candlepin/resource/ProductResource.java
+++ b/server/src/main/java/org/candlepin/resource/ProductResource.java
@@ -64,7 +64,7 @@ public class ProductResource {
 
     @Inject
     public ProductResource(ProductCurator productCurator, OwnerCurator ownerCurator,
-            ProductCertificateCurator productCertCurator, I18n i18n) {
+        ProductCertificateCurator productCertCurator, I18n i18n) {
 
         this.productCurator = productCurator;
         this.productCertCurator = productCertCurator;

--- a/server/src/main/java/org/candlepin/resource/RoleResource.java
+++ b/server/src/main/java/org/candlepin/resource/RoleResource.java
@@ -166,7 +166,7 @@ public class RoleResource {
     @Path("{role_id}/permissions/{perm_id}")
     @Produces(MediaType.APPLICATION_JSON)
     public Role removeRolePermission(@PathParam("role_id") String roleId,
-                                      @PathParam("perm_id") String permissionId) {
+        @PathParam("perm_id") String permissionId) {
 
         Role existingRole = lookupRole(roleId);
         Set<PermissionBlueprint> picks = new HashSet<PermissionBlueprint>();

--- a/server/src/main/java/org/candlepin/resource/StatusResource.java
+++ b/server/src/main/java/org/candlepin/resource/StatusResource.java
@@ -57,8 +57,7 @@ public class StatusResource {
     private JsRunnerProvider jsProvider;
 
     @Inject
-    public StatusResource(RulesCurator rulesCurator,
-                          Configuration config, JsRunnerProvider jsProvider) {
+    public StatusResource(RulesCurator rulesCurator, Configuration config, JsRunnerProvider jsProvider) {
         this.rulesCurator = rulesCurator;
 
         Map<String, String> map = VersionUtil.getVersionMap();

--- a/server/src/main/java/org/candlepin/resource/util/CalculatedAttributesUtil.java
+++ b/server/src/main/java/org/candlepin/resource/util/CalculatedAttributesUtil.java
@@ -81,7 +81,7 @@ public class CalculatedAttributesUtil {
             return;
         }
         Map<String, SuggestedQuantity> results = quantityRules.getSuggestedQuantities(
-                poolList, c, date);
+            poolList, c, date);
 
         for (Pool p : poolList) {
             SuggestedQuantity suggested = results.get(p.getId());

--- a/server/src/main/java/org/candlepin/resource/util/ConsumerBindUtil.java
+++ b/server/src/main/java/org/candlepin/resource/util/ConsumerBindUtil.java
@@ -63,11 +63,9 @@ public class ConsumerBindUtil {
     private static Logger log = LoggerFactory.getLogger(ConsumerBindUtil.class);
 
     @Inject
-    public ConsumerBindUtil(Entitler entitler,
-                            I18n i18n,
-                            ConsumerContentOverrideCurator consumerContentOverrideCurator,
-                            QuantityRules quantityRules,
-                            ServiceLevelValidator serviceLevelValidator) {
+    public ConsumerBindUtil(Entitler entitler, I18n i18n,
+        ConsumerContentOverrideCurator consumerContentOverrideCurator,
+        QuantityRules quantityRules, ServiceLevelValidator serviceLevelValidator) {
         this.entitler = entitler;
         this.i18n = i18n;
         this.consumerContentOverrideCurator = consumerContentOverrideCurator;
@@ -115,14 +113,14 @@ public class ConsumerBindUtil {
         for (ActivationKeyPool akp : toBind) {
             int quantity = (akp.getQuantity() == null) ?
                 getQuantityToBind(akp.getPool(), consumer) :
-                    akp.getQuantity().intValue();
+                akp.getQuantity().intValue();
             try {
                 entitler.sendEvents(entitler.bindByPoolQuantity(consumer, akp.getPool().getId(), quantity));
                 onePassed = true;
             }
             catch (ForbiddenException e) {
                 log.warn(i18n.tr("Cannot bind to pool ''{0}'' in activation key ''{1}'': {2}",
-                        akp.getPool().getId(), akp.getKey().getName(), e.getMessage()));
+                    akp.getPool().getId(), akp.getKey().getName(), e.getMessage()));
             }
         }
         return onePassed;
@@ -143,8 +141,8 @@ public class ConsumerBindUtil {
                 poolIds.add(p.getPool().getId());
             }
             AutobindData autobindData = AutobindData.create(consumer)
-                    .forProducts(productIds.toArray(new String[0]))
-                    .withPools(poolIds);
+                .forProducts(productIds.toArray(new String[0]))
+                .withPools(poolIds);
             List<Entitlement> ents = entitler.bindByProducts(autobindData);
             entitler.sendEvents(ents);
         }
@@ -161,7 +159,7 @@ public class ConsumerBindUtil {
     }
 
     private void handleActivationKeyOverrides(Consumer consumer,
-            Set<ActivationKeyContentOverride> overrides) {
+        Set<ActivationKeyContentOverride> overrides) {
         for (ActivationKeyContentOverride akco : overrides) {
             ConsumerContentOverride consumerOverride =
                 akco.buildConsumerContentOverride(consumer);
@@ -176,8 +174,7 @@ public class ConsumerBindUtil {
         }
     }
 
-    private boolean handleActivationKeyServiceLevel(Consumer consumer,
-            String level, Owner owner) {
+    private boolean handleActivationKeyServiceLevel(Consumer consumer, String level, Owner owner) {
         if (!StringUtils.isBlank(level)) {
             try {
                 serviceLevelValidator.validate(owner, level);

--- a/server/src/main/java/org/candlepin/resource/util/ResourceDateParser.java
+++ b/server/src/main/java/org/candlepin/resource/util/ResourceDateParser.java
@@ -34,7 +34,7 @@ public class ResourceDateParser {
     public static Date getFromDate(String from, String to, String days) {
         if (days != null && !days.trim().equals("") &&
             (to != null && !to.trim().equals("") ||
-                from != null && !from.trim().equals(""))) {
+            from != null && !from.trim().equals(""))) {
             throw new BadRequestException("You can use either the to/from " +
                                            "date parameters or the number of " +
                                            "days parameter, but not both");

--- a/server/src/main/java/org/candlepin/service/EntitlementCertServiceAdapter.java
+++ b/server/src/main/java/org/candlepin/service/EntitlementCertServiceAdapter.java
@@ -73,7 +73,7 @@ public interface EntitlementCertServiceAdapter {
      * @throws GeneralSecurityException thrown security problem
      */
     Map<String, EntitlementCertificate> generateEntitlementCerts(Consumer consumer,
-            Map<String, Entitlement> entitlements, Map<String, Product> products)
+        Map<String, Entitlement> entitlements, Map<String, Product> products)
         throws GeneralSecurityException, IOException;
 
     /**
@@ -92,7 +92,7 @@ public interface EntitlementCertServiceAdapter {
      * @throws GeneralSecurityException thrown security problem
      */
     Map<String, EntitlementCertificate> generateUeberCerts(Consumer consumer,
-            Map<String, Entitlement> entitlements, Map<String, Product> products)
+        Map<String, Entitlement> entitlements, Map<String, Product> products)
         throws GeneralSecurityException, IOException;
 
     /**

--- a/server/src/main/java/org/candlepin/service/SubscriptionServiceAdapter.java
+++ b/server/src/main/java/org/candlepin/service/SubscriptionServiceAdapter.java
@@ -90,8 +90,7 @@ public interface SubscriptionServiceAdapter {
      * @param email the email address tied to this consumer
      * @param emailLocale the i18n locale for the email
      */
-    void activateSubscription(Consumer consumer, String email,
-            String emailLocale);
+    void activateSubscription(Consumer consumer, String email, String emailLocale);
 
     /**
      * Create the given subscription.

--- a/server/src/main/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapter.java
+++ b/server/src/main/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapter.java
@@ -118,27 +118,27 @@ public class DefaultEntitlementCertServiceAdapter extends
     }
 
     private EntitlementCertificate generateSingleCert(Entitlement entitlement, Product product,
-            Boolean isUber) throws GeneralSecurityException, IOException {
+        Boolean isUber) throws GeneralSecurityException, IOException {
         Map<String, Entitlement> entitlements = new HashMap<String, Entitlement>();
         entitlements.put(entitlement.getPool().getId(), entitlement);
         Map<String, Product> products = new HashMap<String, Product>();
         products.put(entitlement.getPool().getId(), product);
         Map<String, EntitlementCertificate> result = generateEntitlementCerts(entitlement.getConsumer(),
-                entitlements, products, false);
+            entitlements, products, false);
 
         return result.get(entitlement.getPool().getId());
     }
 
     @Override
     public Map<String, EntitlementCertificate> generateEntitlementCerts(Consumer consumer,
-            Map<String, Entitlement> entitlements, Map<String, Product> products)
+        Map<String, Entitlement> entitlements, Map<String, Product> products)
         throws GeneralSecurityException, IOException {
         return generateEntitlementCerts(consumer, entitlements, products, false);
     }
 
     @Override
     public Map<String, EntitlementCertificate> generateUeberCerts(Consumer consumer,
-            Map<String, Entitlement> entitlements, Map<String, Product> products)
+        Map<String, Entitlement> entitlements, Map<String, Product> products)
         throws GeneralSecurityException, IOException {
         return generateEntitlementCerts(consumer, entitlements, products, true);
     }
@@ -186,8 +186,8 @@ public class DefaultEntitlementCertServiceAdapter extends
 
         setupEntitlementEndDate(ent);
         X509Certificate x509Cert =  this.pki.createX509Certificate(
-                createDN(ent), extensions, byteExtensions, ent.getStartDate(),
-                ent.getEndDate(), keyPair, serialNumber, null);
+            createDN(ent), extensions, byteExtensions, ent.getStartDate(),
+            ent.getEndDate(), keyPair, serialNumber, null);
         return x509Cert;
     }
 
@@ -205,12 +205,11 @@ public class DefaultEntitlementCertServiceAdapter extends
         }
 
         boolean isUnmappedGuestPool = BooleanUtils.toBoolean(
-                pool.getAttributeValue("unmapped_guests_only"));
+            pool.getAttributeValue("unmapped_guests_only"));
 
         if (isUnmappedGuestPool) {
             Date oneDayFromRegistration = new Date(startDate.getTime() + 24L * 60L * 60L * 1000L);
-            log.info("Setting 24h expiration for unmapped guest pool entilement: " +
-                    oneDayFromRegistration);
+            log.info("Setting 24h expiration for unmapped guest pool entilement: {}", oneDayFromRegistration);
             ent.setEndDateOverride(oneDayFromRegistration);
             entCurator.merge(ent);
         }
@@ -256,7 +255,7 @@ public class DefaultEntitlementCertServiceAdapter extends
             log.debug("Consumer has environment, checking for promoted content in: " +
                 ent.getConsumer().getEnvironment());
             for (EnvironmentContent envContent :
-                    ent.getConsumer().getEnvironment().getEnvironmentContent()) {
+                ent.getConsumer().getEnvironment().getEnvironmentContent()) {
                 log.debug("  promoted content: " + envContent.getContent().getId());
                 promotedContent.put(envContent.getContent().getId(), envContent);
             }
@@ -270,8 +269,8 @@ public class DefaultEntitlementCertServiceAdapter extends
         Set<X509ExtensionWrapper> result =  new LinkedHashSet<X509ExtensionWrapper>();
 
         Set<String> entitledProductIds = entCurator.listEntitledProductIds(
-                ent.getConsumer(), ent.getPool().getStartDate(),
-                ent.getPool().getEndDate());
+            ent.getConsumer(), ent.getPool().getStartDate(),
+            ent.getPool().getEndDate());
 
         int contentCounter = 0;
         boolean enableEnvironmentFiltering = config.getBoolean(ConfigProperties.ENV_CONTENT_FILTERING);
@@ -282,9 +281,8 @@ public class DefaultEntitlementCertServiceAdapter extends
             log.debug("Adding X509 extensions for product: {}", prod);
             result.addAll(extensionUtil.productExtensions(prod));
 
-            Set<ProductContent> filteredContent =
-                extensionUtil.filterProductContent(prod, ent, entCurator,
-                    promotedContent, enableEnvironmentFiltering, entitledProductIds);
+            Set<ProductContent> filteredContent = extensionUtil.filterProductContent(
+                prod, ent, entCurator, promotedContent, enableEnvironmentFiltering, entitledProductIds);
 
             filteredContent = extensionUtil.filterContentByContentArch(filteredContent,
                 ent.getConsumer(), prod);
@@ -302,9 +300,9 @@ public class DefaultEntitlementCertServiceAdapter extends
         // informative error message to the user.
         if (contentCounter > X509ExtensionUtil.V1_CONTENT_LIMIT) {
             String cause = i18n.tr("Too many content sets for certificate {0}. A newer " +
-                    "client may be available to address this problem. " +
-                    "See knowledge database https://access.redhat.com/knowledge/node/129003 for more " +
-                    "information.", ent.getPool().getProductName());
+                "client may be available to address this problem. " +
+                "See knowledge database https://access.redhat.com/knowledge/node/129003 for more " +
+                "information.", ent.getPool().getProductName());
             throw new CertificateSizeException(cause);
         }
 
@@ -323,18 +321,18 @@ public class DefaultEntitlementCertServiceAdapter extends
 
     public Set<X509ExtensionWrapper> prepareV3Extensions(Entitlement ent,
         String contentPrefix, Map<String, EnvironmentContent> promotedContent) {
-        Set<X509ExtensionWrapper> result =  v3extensionUtil.getExtensions(ent,
+        Set<X509ExtensionWrapper> result = v3extensionUtil.getExtensions(ent,
             contentPrefix, promotedContent);
         return result;
     }
 
     public Set<X509ByteExtensionWrapper> prepareV3ByteExtensions(Product sku,
-            List<org.candlepin.model.dto.Product> productModels,
-            Entitlement ent, String contentPrefix,
-            Map<String, EnvironmentContent> promotedContent) throws IOException {
+        List<org.candlepin.model.dto.Product> productModels,
+        Entitlement ent, String contentPrefix,
+        Map<String, EnvironmentContent> promotedContent) throws IOException {
 
-        Set<X509ByteExtensionWrapper> result =  v3extensionUtil.getByteExtensions(sku,
-                productModels, ent, contentPrefix, promotedContent);
+        Set<X509ByteExtensionWrapper> result = v3extensionUtil.getByteExtensions(sku,
+            productModels, ent, contentPrefix, promotedContent);
         return result;
     }
 
@@ -364,7 +362,7 @@ public class DefaultEntitlementCertServiceAdapter extends
      *         id
      */
     private Map<String, EntitlementCertificate> generateEntitlementCerts(Consumer consumer,
-            Map<String, Entitlement> entitlements, Map<String, Product> productMap, boolean thisIsUeberCert)
+        Map<String, Entitlement> entitlements, Map<String, Product> productMap, boolean thisIsUeberCert)
         throws GeneralSecurityException, IOException {
         log.info("Generating entitlement cert for entitlements");
         KeyPair keyPair = keyPairCurator.getConsumerKeyPair(consumer);
@@ -402,10 +400,10 @@ public class DefaultEntitlementCertServiceAdapter extends
             log.info("Creating X509 cert for product: {}", product);
             log.debug("Provided products: {}", products);
             List<org.candlepin.model.dto.Product> productModels = v3extensionUtil.createProducts(product,
-                    products, contentPrefix, promotedContent, entitlement.getConsumer(), entitlement);
+                products, contentPrefix, promotedContent, entitlement.getConsumer(), entitlement);
 
             X509Certificate x509Cert = createX509Certificate(entitlement, product, products, productModels,
-                    BigInteger.valueOf(serial.getId()), keyPair, !thisIsUeberCert);
+                BigInteger.valueOf(serial.getId()), keyPair, !thisIsUeberCert);
 
             EntitlementCertificate cert = new EntitlementCertificate();
             cert.setSerial(serial);

--- a/server/src/main/java/org/candlepin/service/impl/DefaultIdentityCertServiceAdapter.java
+++ b/server/src/main/java/org/candlepin/service/impl/DefaultIdentityCertServiceAdapter.java
@@ -67,8 +67,7 @@ public class DefaultIdentityCertServiceAdapter implements
     @Override
     public void deleteIdentityCert(Consumer consumer) {
         if (consumer.getIdCert() == null) {
-            log.warn("Unable to delete null identity cert for consumer: " +
-                    consumer.getUuid());
+            log.warn("Unable to delete null identity cert for consumer: {}", consumer.getUuid());
             return;
         }
         IdentityCertificate certificate = idCertCurator

--- a/server/src/main/java/org/candlepin/service/impl/DefaultOwnerServiceAdapter.java
+++ b/server/src/main/java/org/candlepin/service/impl/DefaultOwnerServiceAdapter.java
@@ -26,8 +26,7 @@ import org.xnap.commons.i18n.I18n;
 /**
  * default SubscriptionAdapter implementation
  */
-public class DefaultOwnerServiceAdapter implements
-        OwnerServiceAdapter {
+public class DefaultOwnerServiceAdapter implements OwnerServiceAdapter {
 
     private static Logger log =
         LoggerFactory.getLogger(DefaultOwnerServiceAdapter.class);

--- a/server/src/main/java/org/candlepin/service/impl/ImportSubscriptionServiceAdapter.java
+++ b/server/src/main/java/org/candlepin/service/impl/ImportSubscriptionServiceAdapter.java
@@ -35,8 +35,7 @@ import java.util.Map;
  * @author mstead
  *
  */
-public class ImportSubscriptionServiceAdapter implements
-        SubscriptionServiceAdapter {
+public class ImportSubscriptionServiceAdapter implements SubscriptionServiceAdapter {
 
     private List<Subscription> subscriptions;
     private Map<String, Subscription> subsBySubId = new HashMap<String, Subscription>();
@@ -74,8 +73,7 @@ public class ImportSubscriptionServiceAdapter implements
     }
 
     @Override
-    public void activateSubscription(Consumer consumer, String email,
-            String emailLocale) {
+    public void activateSubscription(Consumer consumer, String email, String emailLocale) {
         throw new ServiceUnavailableException(
                 i18n.tr("Standalone candlepin does not support redeeming a subscription."));
     }

--- a/server/src/main/java/org/candlepin/servlet/filter/EventFilter.java
+++ b/server/src/main/java/org/candlepin/servlet/filter/EventFilter.java
@@ -57,8 +57,7 @@ public class EventFilter implements Filter {
     public void doFilter(ServletRequest request, ServletResponse response,
         FilterChain chain) throws IOException, ServletException {
 
-        TeeHttpServletResponse resp = new TeeHttpServletResponse(
-                (HttpServletResponse) response);
+        TeeHttpServletResponse resp = new TeeHttpServletResponse((HttpServletResponse) response);
         chain.doFilter(request, resp);
         Status status = Status.fromStatusCode(resp.getStatus());
         if (status.getFamily() == Status.Family.SUCCESSFUL) {

--- a/server/src/main/java/org/candlepin/sync/ConsumerImporter.java
+++ b/server/src/main/java/org/candlepin/sync/ConsumerImporter.java
@@ -87,8 +87,7 @@ public class ConsumerImporter {
                     Importer.Conflict.DISTRIBUTOR_CONFLICT);
             }
             else {
-                log.warn("Forcing import from a new distributor for org: " +
-                        owner.getKey());
+                log.warn("Forcing import from a new distributor for org: {}", owner.getKey());
                 log.warn("Old distributor UUID: " + owner.getUpstreamUuid());
                 log.warn("New distributor UUID: " + consumer.getUuid());
             }

--- a/server/src/main/java/org/candlepin/sync/EntitlementImporter.java
+++ b/server/src/main/java/org/candlepin/sync/EntitlementImporter.java
@@ -158,7 +158,7 @@ public class EntitlementImporter {
      * to the actual persisted location.
      */
     public void associateProvidedProducts(Map<String, Product> productsById,
-            Entitlement entitlement, Subscription subscription)
+        Entitlement entitlement, Subscription subscription)
         throws SyncDataFormatException {
 
         // Associate main provided products:

--- a/server/src/main/java/org/candlepin/sync/Exporter.java
+++ b/server/src/main/java/org/candlepin/sync/Exporter.java
@@ -162,8 +162,7 @@ public class Exporter {
         }
     }
 
-    public File getEntitlementExport(Consumer consumer,
-                        Set<Long> serials) throws ExportCreationException {
+    public File getEntitlementExport(Consumer consumer, Set<Long> serials) throws ExportCreationException {
         // TODO: need to delete tmpDir (which contains the archive,
         // which we need to return...)
         try {
@@ -373,10 +372,8 @@ public class Exporter {
         }
     }
 
-    private void exportEntitlementsCerts(File baseDir,
-                                         Consumer consumer,
-                                         Set<Long> serials,
-                                         boolean manifest)
+    private void exportEntitlementsCerts(File baseDir, Consumer consumer,
+        Set<Long> serials, boolean manifest)
         throws IOException {
 
         File entCertDir = new File(baseDir.getCanonicalPath(), "entitlement_certificates");
@@ -385,8 +382,8 @@ public class Exporter {
         for (EntitlementCertificate cert : entCertAdapter.listForConsumer(consumer)) {
             if (manifest && !this.exportRules.canExport(cert.getEntitlement())) {
                 if (log.isDebugEnabled()) {
-                    log.debug("Skipping export of entitlement cert with product:  " +
-                            cert.getEntitlement().getPool().getProductId());
+                    log.debug("Skipping export of entitlement cert with product: {}",
+                        cert.getEntitlement().getPool().getProductId());
                 }
                 continue;
             }
@@ -446,8 +443,8 @@ public class Exporter {
 
             if (!this.exportRules.canExport(ent)) {
                 if (log.isDebugEnabled()) {
-                    log.debug("Skipping export of entitlement with product:  " +
-                            ent.getPool().getProductId());
+                    log.debug("Skipping export of entitlement with product: {}",
+                        ent.getPool().getProductId());
                 }
 
                 continue;

--- a/server/src/main/java/org/candlepin/sync/Importer.java
+++ b/server/src/main/java/org/candlepin/sync/Importer.java
@@ -332,7 +332,7 @@ public class Importer {
     }
 
     @Transactional(rollbackOn = {IOException.class, ImporterException.class,
-            RuntimeException.class, ImportConflictException.class})
+        RuntimeException.class, ImportConflictException.class})
     // WARNING: Keep this method public, otherwise @Transactional is ignored:
     List<Subscription> importObjects(Owner owner, Map<String, File> importFiles,
         ConflictOverrides overrides)
@@ -447,7 +447,7 @@ public class Importer {
 
         // Setup our import subscription adapter with the subscriptions imported:
         SubscriptionServiceAdapter adapter =
-                new ImportSubscriptionServiceAdapter(importSubs);
+            new ImportSubscriptionServiceAdapter(importSubs);
         Refresher refresher = poolManager.getRefresher(adapter);
         refresher.add(owner);
         refresher.run();

--- a/server/src/main/java/org/candlepin/sync/Meta.java
+++ b/server/src/main/java/org/candlepin/sync/Meta.java
@@ -30,9 +30,7 @@ public class Meta {
         this("0.0.0", new Date(), "", null, null);
     }
 
-    public Meta(String version, Date creation,
-                String userName, String webAppPrefix,
-                String cdnLabel) {
+    public Meta(String version, Date creation, String userName, String webAppPrefix, String cdnLabel) {
         this.version = version;
         this.created = creation;
 

--- a/server/src/main/java/org/candlepin/sync/SubscriptionReconciler.java
+++ b/server/src/main/java/org/candlepin/sync/SubscriptionReconciler.java
@@ -72,8 +72,7 @@ public class SubscriptionReconciler {
      *  Remaining incoming subscriptions that did not match any pools per the above are
      *  treated as new subscriptions.
      */
-    public void reconcile(Owner owner, List<Subscription> subsToImport,
-            PoolCurator poolCurator) {
+    public void reconcile(Owner owner, List<Subscription> subsToImport, PoolCurator poolCurator) {
 
         Map<String, Map<String, Pool>> existingPoolsByUpstreamPool =
             mapPoolsByUpstreamPool(owner, poolCurator);
@@ -123,8 +122,7 @@ public class SubscriptionReconciler {
             }
             for (Pool localSub : map.values()) {
                 // TODO quantity
-                Long quantity = localSub.getQuantity() /
-                        localSub.getProduct().getMultiplier();
+                Long quantity = localSub.getQuantity() / localSub.getProduct().getMultiplier();
                 if (quantity.equals(subscription.getQuantity())) {
                     local = localSub;
                     break;
@@ -180,8 +178,7 @@ public class SubscriptionReconciler {
     /*
      * Maps upstream pool ID to a map of upstream entitlement ID to Subscription.
      */
-    private Map<String, Map<String, Pool>> mapPoolsByUpstreamPool(Owner owner,
-            PoolCurator poolCurator) {
+    private Map<String, Map<String, Pool>> mapPoolsByUpstreamPool(Owner owner, PoolCurator poolCurator) {
         Map<String, Map<String, Pool>> existingSubsByUpstreamPool =
             new HashMap<String, Map<String, Pool>>();
         int idx = 0;

--- a/server/src/main/java/org/candlepin/util/ContentOverrideValidator.java
+++ b/server/src/main/java/org/candlepin/util/ContentOverrideValidator.java
@@ -42,8 +42,7 @@ public class ContentOverrideValidator {
     private OverrideRules overrideRules;
 
     @Inject
-    public ContentOverrideValidator(I18n i18n,
-            OverrideRules overrideRules) {
+    public ContentOverrideValidator(I18n i18n, OverrideRules overrideRules) {
         this.i18n = i18n;
         this.overrideRules = overrideRules;
     }

--- a/server/src/main/java/org/candlepin/util/X509ExtensionUtil.java
+++ b/server/src/main/java/org/candlepin/util/X509ExtensionUtil.java
@@ -231,8 +231,7 @@ public class X509ExtensionUtil  extends X509Util{
             }
             String contentOid = OIDUtil.REDHAT_OID +
                 "." +
-                OIDUtil.TOPLEVEL_NAMESPACES
-                    .get(OIDUtil.CHANNEL_FAMILY_NAMESPACE_KEY) + "." +
+                OIDUtil.TOPLEVEL_NAMESPACES.get(OIDUtil.CHANNEL_FAMILY_NAMESPACE_KEY) + "." +
                 pc.getContent().getId().toString() + "." +
                 OIDUtil.CF_REPO_TYPE.get(pc.getContent().getType());
             toReturn.add(new X509ExtensionWrapper(contentOid, false, pc
@@ -282,11 +281,9 @@ public class X509ExtensionUtil  extends X509Util{
 
             // Include metadata expiry if specified on the content:
             if (pc.getContent().getMetadataExpire() != null) {
-                toReturn.add(new X509ExtensionWrapper(
-                    contentOid +
-                        "." +
-                        OIDUtil.CHANNEL_FAMILY_OIDS.get(OIDUtil.CF_METADATA_EXPIRE),
-                        false, pc.getContent().getMetadataExpire().toString()));
+                toReturn.add(new X509ExtensionWrapper(contentOid + "." +
+                    OIDUtil.CHANNEL_FAMILY_OIDS.get(OIDUtil.CF_METADATA_EXPIRE),
+                    false, pc.getContent().getMetadataExpire().toString()));
             }
 
             // Include required tags if specified on the content set:

--- a/server/src/main/java/org/candlepin/util/X509Util.java
+++ b/server/src/main/java/org/candlepin/util/X509Util.java
@@ -39,8 +39,7 @@ public abstract class X509Util {
 
     private static Logger log = LoggerFactory.getLogger(X509Util.class);
 
-    public static final Predicate<Product>
-    PROD_FILTER_PREDICATE = new Predicate<Product>() {
+    public static final Predicate<Product> PROD_FILTER_PREDICATE = new Predicate<Product>() {
         @Override
         public boolean apply(Product product) {
             return product != null && StringUtils.isNumeric(product.getId());
@@ -75,7 +74,7 @@ public abstract class X509Util {
             // Filter any content not promoted to environment.
             if (filterEnvironment &&
                 (ent.getConsumer().getEnvironment() != null &&
-                    !promotedContent.containsKey(pc.getContent().getId()))) {
+                !promotedContent.containsKey(pc.getContent().getId()))) {
 
                 log.debug("Skipping content not promoted to environment: " +
                     pc.getContent().getId());

--- a/server/src/main/java/org/candlepin/util/X509V3ExtensionUtil.java
+++ b/server/src/main/java/org/candlepin/util/X509V3ExtensionUtil.java
@@ -87,10 +87,8 @@ public class X509V3ExtensionUtil extends X509Util {
         String contentPrefix, Map<String, EnvironmentContent> promotedContent) {
         Set<X509ExtensionWrapper> toReturn = new LinkedHashSet<X509ExtensionWrapper>();
 
-        X509ExtensionWrapper versionExtension =
-            new X509ExtensionWrapper(OIDUtil.REDHAT_OID + "." +
-                OIDUtil.TOPLEVEL_NAMESPACES.get(OIDUtil.ENTITLEMENT_VERSION_KEY),
-                false, thisVersion);
+        X509ExtensionWrapper versionExtension = new X509ExtensionWrapper(OIDUtil.REDHAT_OID + "." +
+            OIDUtil.TOPLEVEL_NAMESPACES.get(OIDUtil.ENTITLEMENT_VERSION_KEY), false, thisVersion);
 
         toReturn.add(versionExtension);
 
@@ -98,8 +96,8 @@ public class X509V3ExtensionUtil extends X509Util {
     }
 
     public Set<X509ByteExtensionWrapper> getByteExtensions(Product sku,
-            List<org.candlepin.model.dto.Product> productModels,
-            Entitlement ent, String contentPrefix,
+        List<org.candlepin.model.dto.Product> productModels,
+        Entitlement ent, String contentPrefix,
         Map<String, EnvironmentContent> promotedContent) throws IOException {
         Set<X509ByteExtensionWrapper> toReturn =
             new LinkedHashSet<X509ByteExtensionWrapper>();
@@ -107,23 +105,21 @@ public class X509V3ExtensionUtil extends X509Util {
         EntitlementBody eb = createEntitlementBodyContent(sku, productModels, ent,
             contentPrefix, promotedContent);
 
-        X509ByteExtensionWrapper bodyExtension =
-            new X509ByteExtensionWrapper(OIDUtil.REDHAT_OID + "." +
-                OIDUtil.TOPLEVEL_NAMESPACES.get(OIDUtil.ENTITLEMENT_DATA_KEY),
-                false, retreiveContentValue(eb));
+        X509ByteExtensionWrapper bodyExtension = new X509ByteExtensionWrapper(OIDUtil.REDHAT_OID + "." +
+            OIDUtil.TOPLEVEL_NAMESPACES.get(OIDUtil.ENTITLEMENT_DATA_KEY), false, retreiveContentValue(eb));
         toReturn.add(bodyExtension);
 
         return toReturn;
     }
 
     public byte[] createEntitlementDataPayload(Product skuProduct,
-            List<org.candlepin.model.dto.Product> productModels,
-            Entitlement ent, String contentPrefix,
-            Map<String, EnvironmentContent> promotedContent)
+        List<org.candlepin.model.dto.Product> productModels,
+        Entitlement ent, String contentPrefix,
+        Map<String, EnvironmentContent> promotedContent)
         throws UnsupportedEncodingException, IOException {
 
-        EntitlementBody map = createEntitlementBody(skuProduct, productModels,
-                ent, contentPrefix, promotedContent);
+        EntitlementBody map = createEntitlementBody(skuProduct, productModels, ent,
+            contentPrefix, promotedContent);
 
         String json = toJson(map);
         return processPayload(json);
@@ -151,9 +147,9 @@ public class X509V3ExtensionUtil extends X509Util {
     }
 
     public EntitlementBody createEntitlementBody(Product skuProduct,
-            List<org.candlepin.model.dto.Product> productModels,
-            Entitlement ent, String contentPrefix,
-            Map<String, EnvironmentContent> promotedContent) {
+        List<org.candlepin.model.dto.Product> productModels,
+        Entitlement ent, String contentPrefix,
+        Map<String, EnvironmentContent> promotedContent) {
 
         EntitlementBody toReturn = new EntitlementBody();
         toReturn.setConsumer(ent.getConsumer().getUuid());
@@ -167,7 +163,7 @@ public class X509V3ExtensionUtil extends X509Util {
     }
 
     public EntitlementBody createEntitlementBodyContent(Product sku,
-            List<org.candlepin.model.dto.Product> productModels,
+        List<org.candlepin.model.dto.Product> productModels,
         Entitlement ent, String contentPrefix,
         Map<String, EnvironmentContent> promotedContent) {
 
@@ -212,8 +208,7 @@ public class X509V3ExtensionUtil extends X509Util {
         String management = product.getAttributeValue("management_enabled");
         if (management != null && !management.trim().equals("")) {
             // only included if not the default value of false
-            if (management.equalsIgnoreCase("true") ||
-                    management.equalsIgnoreCase("1")) {
+            if (management.equalsIgnoreCase("true") || management.equalsIgnoreCase("1")) {
                 toReturn.setManagement(Boolean.TRUE);
             }
         }
@@ -272,8 +267,8 @@ public class X509V3ExtensionUtil extends X509Util {
     }
 
     public List<org.candlepin.model.dto.Product> createProducts(Product sku,
-            Set<Product> products, String contentPrefix,
-            Map<String, EnvironmentContent> promotedContent, Consumer consumer, Entitlement ent) {
+        Set<Product> products, String contentPrefix,
+        Map<String, EnvironmentContent> promotedContent, Consumer consumer, Entitlement ent) {
 
         List<org.candlepin.model.dto.Product> toReturn =
             new ArrayList<org.candlepin.model.dto.Product>();
@@ -322,8 +317,7 @@ public class X509V3ExtensionUtil extends X509Util {
             archList.add(arch);
         }
         toReturn.setArchitectures(archList);
-        toReturn.setContent(createContent(filterProductContent(engProduct, ent,
-                entitledProductIds), sku,
+        toReturn.setContent(createContent(filterProductContent(engProduct, ent, entitledProductIds), sku,
             contentPrefix, promotedContent, consumer, engProduct, ent));
 
         return toReturn;
@@ -366,8 +360,7 @@ public class X509V3ExtensionUtil extends X509Util {
 
         List<Content> toReturn = new ArrayList<Content>();
 
-        boolean enableEnvironmentFiltering = config.getBoolean(
-                ConfigProperties.ENV_CONTENT_FILTERING);
+        boolean enableEnvironmentFiltering = config.getBoolean(ConfigProperties.ENV_CONTENT_FILTERING);
 
         // Return only the contents that are arch appropriate
         Set<ProductContent> archApproriateProductContent = filterContentByContentArch(
@@ -468,7 +461,7 @@ public class X509V3ExtensionUtil extends X509Util {
      * @return ProductContent to include in the certificate.
      */
     public Set<ProductContent> filterProductContent(Product prod, Entitlement ent,
-            Set<String> entitledProductIds) {
+        Set<String> entitledProductIds) {
         Set<ProductContent> filtered = new HashSet<ProductContent>();
 
         for (ProductContent pc : prod.getProductContent()) {

--- a/server/src/test/java/org/candlepin/TestingModules.java
+++ b/server/src/test/java/org/candlepin/TestingModules.java
@@ -156,7 +156,7 @@ public class TestingModules {
 
         @Provides
         protected ValidatorFactory getValidationFactory(
-                Provider<MessageInterpolator> interpolatorProvider) {
+            Provider<MessageInterpolator> interpolatorProvider) {
             HibernateValidatorConfiguration configure =
                 Validation.byProvider(HibernateValidator.class).configure();
 

--- a/server/src/test/java/org/candlepin/audit/EventFilterTest.java
+++ b/server/src/test/java/org/candlepin/audit/EventFilterTest.java
@@ -53,31 +53,32 @@ public class EventFilterTest {
     private Configuration configurationDoNotFilter;
 
     @Before
+    @SuppressWarnings("checkstyle:indentation")
     public void init() throws Exception {
         when(configurationAuditEnabled
                 .getBoolean(eq(ConfigProperties.AUDIT_FILTER_ENABLED))).thenReturn(true);
         when(configurationAuditEnabled
-                .getList(eq(ConfigProperties.AUDIT_FILTER_DO_NOT_FILTER))).thenReturn(
-                        Arrays.asList("CREATED-ENTITLEMENT",
-                        "DELETED-ENTITLEMENT",
-                        "CREATED-POOL",
-                        "DELETED-POOL",
-                        "CREATED-COMPLIANCE"));
+            .getList(eq(ConfigProperties.AUDIT_FILTER_DO_NOT_FILTER))).thenReturn(
+                Arrays.asList("CREATED-ENTITLEMENT",
+                "DELETED-ENTITLEMENT",
+                "CREATED-POOL",
+                "DELETED-POOL",
+                "CREATED-COMPLIANCE"));
         when(configurationAuditEnabled
                 .getString(eq(ConfigProperties.AUDIT_FILTER_DEFAULT_POLICY))).thenReturn("DO_FILTER");
 
         when(configurationDoNotFilter
                 .getBoolean(eq(ConfigProperties.AUDIT_FILTER_ENABLED))).thenReturn(true);
         when(configurationDoNotFilter
-                .getList(eq(ConfigProperties.AUDIT_FILTER_DO_NOT_FILTER))).thenReturn(
-                        Arrays.asList("CREATED-ENTITLEMENT",
-                        "DELETED-ENTITLEMENT",
-                        "CREATED-POOL",
-                        "DELETED-POOL",
-                        "CREATED-COMPLIANCE"));
+            .getList(eq(ConfigProperties.AUDIT_FILTER_DO_NOT_FILTER))).thenReturn(
+                Arrays.asList("CREATED-ENTITLEMENT",
+                "DELETED-ENTITLEMENT",
+                "CREATED-POOL",
+                "DELETED-POOL",
+                "CREATED-COMPLIANCE"));
         when(configurationDoNotFilter
-                .getList(eq(ConfigProperties.AUDIT_FILTER_DO_FILTER))).thenReturn(
-                        Arrays.asList("MODIFIED-EXPORT"));
+            .getList(eq(ConfigProperties.AUDIT_FILTER_DO_FILTER))).thenReturn(
+                Arrays.asList("MODIFIED-EXPORT"));
         when(configurationDoNotFilter
                 .getString(eq(ConfigProperties.AUDIT_FILTER_DEFAULT_POLICY))).thenReturn("DO_NOT_FILTER");
 

--- a/server/src/test/java/org/candlepin/audit/EventSinkImplTest.java
+++ b/server/src/test/java/org/candlepin/audit/EventSinkImplTest.java
@@ -87,10 +87,9 @@ public class EventSinkImplTest {
      * @return
      * @throws Exception
      */
-    private EventSinkImpl createEventSink(
-            final ClientSessionFactory sessionFactory) throws Exception {
-        EventSinkImpl sink = new EventSinkImpl(eventFilter,
-                factory, mapper, new CandlepinCommonTestConfig()) {
+    private EventSinkImpl createEventSink(final ClientSessionFactory sessionFactory) throws Exception {
+        EventSinkImpl sink =
+            new EventSinkImpl(eventFilter, factory, mapper, new CandlepinCommonTestConfig()) {
 
             @Override
             protected ClientSessionFactory createClientSessionFactory() {

--- a/server/src/test/java/org/candlepin/auth/BasicAuthViaUserServiceTest.java
+++ b/server/src/test/java/org/candlepin/auth/BasicAuthViaUserServiceTest.java
@@ -128,7 +128,7 @@ public class BasicAuthViaUserServiceTest {
         when(userService.findByLogin("user")).thenReturn(new User());
 
         UserPrincipal expected = new UserPrincipal("user",
-                new ArrayList<Permission>(permissions), false);
+            new ArrayList<Permission>(permissions), false);
         assertEquals(expected, this.auth.getPrincipal(request));
     }
 
@@ -145,7 +145,7 @@ public class BasicAuthViaUserServiceTest {
         when(userService.findByLogin("user")).thenReturn(new User());
 
         UserPrincipal expected = new UserPrincipal("user",
-                new ArrayList<Permission>(permissions), false);
+            new ArrayList<Permission>(permissions), false);
         assertEquals(expected, this.auth.getPrincipal(request));
     }
     @Test
@@ -162,7 +162,7 @@ public class BasicAuthViaUserServiceTest {
         when(userService.findByLogin("user")).thenReturn(new User());
 
         UserPrincipal expected = new UserPrincipal("user",
-                new ArrayList<Permission>(permissions), false);
+            new ArrayList<Permission>(permissions), false);
         assertEquals(expected, this.auth.getPrincipal(request));
     }
 

--- a/server/src/test/java/org/candlepin/auth/SSLAuthTest.java
+++ b/server/src/test/java/org/candlepin/auth/SSLAuthTest.java
@@ -71,7 +71,7 @@ public class SSLAuthTest {
     public void correctUserName() throws Exception {
         Owner owner = new Owner("test owner");
         Consumer consumer = new Consumer("machine_name", "test user", owner,
-                new ConsumerType(ConsumerTypeEnum.SYSTEM));
+            new ConsumerType(ConsumerTypeEnum.SYSTEM));
         ConsumerPrincipal expected = new ConsumerPrincipal(consumer);
 
         String dn = "CN=453-44423-235";
@@ -90,7 +90,7 @@ public class SSLAuthTest {
     public void noUuidOnCert() throws Exception {
         mockCert("OU=something");
         when(this.consumerCurator.findByUuid(anyString())).thenReturn(
-                new Consumer("machine_name", "test user", null, null));
+            new Consumer("machine_name", "test user", null, null));
         assertNull(this.auth.getPrincipal(httpRequest));
     }
 

--- a/server/src/test/java/org/candlepin/controller/EntitlerTest.java
+++ b/server/src/test/java/org/candlepin/controller/EntitlerTest.java
@@ -530,7 +530,7 @@ public class EntitlerTest {
         }
         catch (ForbiddenException fe) {
             assertEquals(i18n.tr("SKU product not available to this development unit: ''{0}''",
-                    p.getId()), fe.getMessage());
+                p.getId()), fe.getMessage());
         }
     }
 

--- a/server/src/test/java/org/candlepin/controller/PoolManagerFunctionalTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerFunctionalTest.java
@@ -201,7 +201,7 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
         Pool monitoringPool = poolCurator.listByOwnerAndProduct(o, monitoring.getId()).get(0);
         assertEquals(Long.valueOf(5), monitoringPool.getQuantity());
         AutobindData data = AutobindData.create(parentSystem).on(new Date())
-                .forProducts(new String [] {monitoring.getId()});
+            .forProducts(new String [] {monitoring.getId()});
         for (int i = 0; i < 5; i++) {
             List<Entitlement> entitlements = poolManager.entitleByProducts(data);
             assertEquals(1, entitlements.size());
@@ -230,7 +230,7 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
     @Test
     public void testRevocation() throws Exception {
         AutobindData data = AutobindData.create(parentSystem).on(new Date())
-                .forProducts(new String [] {monitoring.getId()});
+            .forProducts(new String [] {monitoring.getId()});
         Entitlement e = poolManager.entitleByProducts(data).get(0);
         poolManager.revokeEntitlement(e);
 
@@ -258,7 +258,7 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
     public void testRegenerateEntitlementCertificatesWithSingleEntitlement()
         throws Exception {
         AutobindData data = AutobindData.create(childVirtSystem).on(new Date())
-                .forProducts(new String [] {provisioning.getId()});
+            .forProducts(new String [] {provisioning.getId()});
         this.entitlementCurator.refresh(poolManager.entitleByProducts(data).get(0));
         regenerateECAndAssertNotSameCertificates();
     }
@@ -293,7 +293,7 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
     public void testRegenerateEntitlementCertificatesWithMultipleEntitlements()
         throws EntitlementRefusedException {
         AutobindData data = AutobindData.create(childVirtSystem).on(new Date())
-                .forProducts(new String [] {provisioning.getId()});
+            .forProducts(new String [] {provisioning.getId()});
         this.entitlementCurator.refresh(poolManager.entitleByProducts(data).get(0));
         this.entitlementCurator.refresh(poolManager.entitleByProducts(data).get(0));
         regenerateECAndAssertNotSameCertificates();
@@ -341,7 +341,7 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
         // but it hasn't been saved yet). Since getting the pool ordering right is tricky
         // inside an entitleByProducts call, we do it in two singular calls here.
         AutobindData data = AutobindData.create(parentSystem).on(new Date())
-                .forProducts(new String [] {"modifier"});
+            .forProducts(new String [] {"modifier"});
         poolManager.entitleByProducts(data);
 
         try {
@@ -392,10 +392,9 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
 
     @Test
     public void testListAllForConsumerIncludesWarnings() {
-        Page<List<Pool>> results =
-            poolManager.listAvailableEntitlementPools(parentSystem, null,
-                parentSystem.getOwner(), null, null, null, true, true,
-                new PoolFilterBuilder(), new PageRequest());
+        Page<List<Pool>> results = poolManager.listAvailableEntitlementPools(
+            parentSystem, null, parentSystem.getOwner(), null, null, null, true, true,
+            new PoolFilterBuilder(), new PageRequest());
         assertEquals(4, results.getPageData().size());
 
         Pool pool = createPool(o, socketLimitedProduct, 100L,
@@ -415,10 +414,9 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
         Product p = new Product("test-product", "Test Product", o);
         productCurator.create(p);
 
-        Page<List<Pool>> results =
-            poolManager.listAvailableEntitlementPools(parentSystem, null,
-                parentSystem.getOwner(), null, null, null, true, true,
-                new PoolFilterBuilder(), new PageRequest());
+        Page<List<Pool>> results = poolManager.listAvailableEntitlementPools(
+            parentSystem, null, parentSystem.getOwner(), null, null, null, true, true,
+            new PoolFilterBuilder(), new PageRequest());
         assertEquals(4, results.getPageData().size());
 
         // Creating a pool with no entitlements available, which will trigger
@@ -444,10 +442,9 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
         Pool akpool = new Pool();
         akpool.setAttribute("physical_only", "true");
         ak.addPool(akpool, 1L);
-        Page<List<Pool>> results =
-            poolManager.listAvailableEntitlementPools(null, ak,
-                parentSystem.getOwner(), null, null, null, true, true,
-                new PoolFilterBuilder(), new PageRequest());
+        Page<List<Pool>> results = poolManager.listAvailableEntitlementPools(
+            null, ak, parentSystem.getOwner(), null, null, null, true, true,
+            new PoolFilterBuilder(), new PageRequest());
         assertEquals(4, results.getPageData().size());
 
         // Creating a pool with no entitlements available, which does not trigger
@@ -466,10 +463,9 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
 
     @Test
     public void testListForConsumerExcludesWarnings() {
-        Page<List<Pool>> results =
-            poolManager.listAvailableEntitlementPools(parentSystem, null,
-                parentSystem.getOwner(), (String) null, null, null, true, false,
-                new PoolFilterBuilder(), new PageRequest());
+        Page<List<Pool>> results = poolManager.listAvailableEntitlementPools(
+            parentSystem, null, parentSystem.getOwner(), (String) null, null, null, true, false,
+            new PoolFilterBuilder(), new PageRequest());
         assertEquals(4, results.getPageData().size());
 
         Pool pool = createPool(o, socketLimitedProduct, 100L,
@@ -568,11 +564,11 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
         productCurator.create(p);
 
         Pool pool1 = createPool(owner, p, 10L,
-                TestUtil.createDate(2000, 3, 2), TestUtil.createDate(2050, 3, 2));
+            TestUtil.createDate(2000, 3, 2), TestUtil.createDate(2050, 3, 2));
         pool1.addAttribute(new PoolAttribute(Pool.DEVELOPMENT_POOL_ATTRIBUTE, "true"));
         poolCurator.create(pool1);
         Pool pool2 = createPool(owner, p, 10L,
-                TestUtil.createDate(2000, 3, 2), TestUtil.createDate(2050, 3, 2));
+            TestUtil.createDate(2000, 3, 2), TestUtil.createDate(2050, 3, 2));
         poolCurator.create(pool2);
 
         Consumer devSystem = new Consumer("dev", "user", owner, systemType);
@@ -582,7 +578,7 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
         nonDevSystem.addInstalledProduct(new ConsumerInstalledProduct(p));
 
         Page<List<Pool>> results = poolManager.listAvailableEntitlementPools(devSystem, null,
-                owner, null, null, null, true, true, new PoolFilterBuilder(), new PageRequest());
+            owner, null, null, null, true, true, new PoolFilterBuilder(), new PageRequest());
         assertEquals(2, results.getPageData().size());
 
         results = poolManager.listAvailableEntitlementPools(nonDevSystem, null,
@@ -604,12 +600,12 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
         consumerCurator.create(devSystem);
 
         Pool pool1 = createPool(owner, p, 10L,
-                TestUtil.createDate(2000, 3, 2), TestUtil.createDate(2050, 3, 2));
+            TestUtil.createDate(2000, 3, 2), TestUtil.createDate(2050, 3, 2));
         pool1.addAttribute(new PoolAttribute(Pool.DEVELOPMENT_POOL_ATTRIBUTE, "true"));
         pool1.addAttribute(new PoolAttribute(Pool.REQUIRES_CONSUMER_ATTRIBUTE, devSystem.getUuid()));
         poolCurator.create(pool1);
         Pool pool2 = createPool(owner, p, 10L,
-                TestUtil.createDate(2000, 3, 2), TestUtil.createDate(2050, 3, 2));
+            TestUtil.createDate(2000, 3, 2), TestUtil.createDate(2050, 3, 2));
         poolCurator.create(pool2);
         List<String> possPools = new ArrayList<String>();
         possPools.add(pool1.getId());
@@ -638,12 +634,12 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
         consumerCurator.create(devSystem);
 
         Pool pool1 = createPool(owner, p, 10L, TestUtil.createDate(2000, 3, 2),
-                TestUtil.createDate(2050, 3, 2));
+            TestUtil.createDate(2050, 3, 2));
         pool1.addAttribute(new PoolAttribute(Pool.DEVELOPMENT_POOL_ATTRIBUTE, "true"));
         pool1.addAttribute(new PoolAttribute(Pool.REQUIRES_CONSUMER_ATTRIBUTE, devSystem.getUuid()));
         poolCurator.create(pool1);
         Pool pool2 = createPool(owner, p, 10L, TestUtil.createDate(2000, 3, 2),
-                TestUtil.createDate(2050, 3, 2));
+            TestUtil.createDate(2050, 3, 2));
         poolCurator.create(pool2);
 
         Map<String, Integer> poolQuantities = new HashMap<String, Integer>();
@@ -675,7 +671,7 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
         consumerCurator.create(devSystem);
 
         Pool pool1 = createPool(owner, p, 1L, TestUtil.createDate(2000, 3, 2),
-                TestUtil.createDate(2050, 3, 2));
+            TestUtil.createDate(2050, 3, 2));
         pool1.addAttribute(new PoolAttribute(Pool.DEVELOPMENT_POOL_ATTRIBUTE, "true"));
         pool1.addAttribute(new PoolAttribute(Pool.REQUIRES_CONSUMER_ATTRIBUTE, devSystem.getUuid()));
         pool1.setConsumed(1L);
@@ -683,7 +679,7 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
 
         assertEquals(1, poolCurator.find(pool1.getId()).getConsumed().intValue());
         Pool pool2 = createPool(owner, p, 1L, TestUtil.createDate(2000, 3, 2),
-                TestUtil.createDate(2050, 3, 2));
+            TestUtil.createDate(2050, 3, 2));
         pool2.setConsumed(1L);
         poolCurator.create(pool2);
 
@@ -699,9 +695,9 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
             assertNotNull(e.getResults());
             assertEquals(2, e.getResults().entrySet().size());
             assertEquals("rulefailed.no.entitlements.available", e.getResults().get(pool1.getId())
-                    .getErrors().get(0).getResourceKey());
+                .getErrors().get(0).getResourceKey());
             assertEquals("rulefailed.no.entitlements.available", e.getResults().get(pool2.getId())
-                    .getErrors().get(0).getResourceKey());
+                .getErrors().get(0).getResourceKey());
         }
 
     }
@@ -718,7 +714,7 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
         consumerCurator.create(devSystem);
 
         Pool pool1 = createPool(owner, p, 1L, TestUtil.createDate(2000, 3, 2),
-                TestUtil.createDate(2050, 3, 2));
+            TestUtil.createDate(2050, 3, 2));
         pool1.addAttribute(new PoolAttribute(Pool.DEVELOPMENT_POOL_ATTRIBUTE, "true"));
         pool1.addAttribute(new PoolAttribute(Pool.REQUIRES_CONSUMER_ATTRIBUTE, devSystem.getUuid()));
         pool1.setConsumed(1L);
@@ -726,7 +722,7 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
 
         assertEquals(1, poolCurator.find(pool1.getId()).getConsumed().intValue());
         Pool pool2 = createPool(owner, p, 1L, TestUtil.createDate(2000, 3, 2),
-                TestUtil.createDate(2050, 3, 2));
+            TestUtil.createDate(2050, 3, 2));
         pool2.setConsumed(1L);
         poolCurator.create(pool2);
 

--- a/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -294,7 +294,7 @@ public class PoolManagerTest {
             .updateFloatingPools(eq(new LinkedList()), eq(true), any(Set.class));
         ArgumentCaptor<Pool> argPool = ArgumentCaptor.forClass(Pool.class);
         verify(this.manager).updatePoolsForMasterPool(eq(expectedModified), argPool.capture(),
-                eq(sub.getQuantity()), eq(false), any(Set.class));
+            eq(sub.getQuantity()), eq(false), any(Set.class));
         TestUtil.assertPoolsAreEqual(TestUtil.copyFromSub(sub), argPool.getValue());
     }
 
@@ -332,7 +332,7 @@ public class PoolManagerTest {
 
         when(this.mockProductCurator.lookupById(o, product.getId())).thenReturn(product);
         when(this.mockProductCurator.lookupById(o, subProduct.getId())).thenReturn(
-                subProduct);
+            subProduct);
 
         PoolRules pRules = new PoolRules(manager, mockConfig, entitlementCurator, productCuratorMock);
         List<Pool> pools = pRules.createAndEnrichPools(sub);
@@ -342,7 +342,7 @@ public class PoolManagerTest {
         assertNotNull(resultPool.getDerivedProduct());
         assertTrue(resultPool.getDerivedProduct().hasAttribute(testAttributeKey));
         assertEquals(expectedAttributeValue,
-                resultPool.getDerivedProduct().getAttributeValue(testAttributeKey));
+            resultPool.getDerivedProduct().getAttributeValue(testAttributeKey));
     }
 
     @Test
@@ -355,7 +355,7 @@ public class PoolManagerTest {
 
         when(this.mockProductCurator.lookupById(o, product.getId())).thenReturn(product);
         when(this.mockProductCurator.lookupById(o, subProduct.getId())).thenReturn(
-                subProduct);
+            subProduct);
 
         PoolRules pRules = new PoolRules(manager, mockConfig, entitlementCurator, productCuratorMock);
         List<Pool> pools = pRules.createAndEnrichPools(sub);
@@ -379,7 +379,7 @@ public class PoolManagerTest {
 
         when(this.mockProductCurator.lookupById(o, product.getId())).thenReturn(product);
         when(this.mockProductCurator.lookupById(o, subProduct.getId())).thenReturn(
-                subProduct);
+            subProduct);
 
         PoolRules pRules = new PoolRules(manager, mockConfig, entitlementCurator, productCuratorMock);
         List<Pool> pools = pRules.createAndEnrichPools(sub);
@@ -642,7 +642,7 @@ public class PoolManagerTest {
         assertFalse(e.getDirty());
 
         verify(entCertAdapterMock).generateEntitlementCerts(eq(con), entMapCaptor.capture(),
-                productMapCaptor.capture());
+            productMapCaptor.capture());
         assertEquals(e, entMapCaptor.getValue().get(pool.getId()));
         assertEquals(product, productMapCaptor.getValue().get(pool.getId()));
 
@@ -793,7 +793,7 @@ public class PoolManagerTest {
             .thenReturn(bestPools);
 
         AutobindData data = AutobindData.create(TestUtil.createConsumer(o))
-                .forProducts(new String[] { product.getUuid() }).on(now);
+            .forProducts(new String[] { product.getUuid() }).on(now);
 
         doNothing().when(mockPoolCurator).flush();
         doNothing().when(mockPoolCurator).clear();
@@ -822,11 +822,9 @@ public class PoolManagerTest {
         Page page = mock(Page.class);
 
         when(page.getPageData()).thenReturn(pools);
-        when(
-                mockPoolCurator.listAvailableEntitlementPools(any(Consumer.class), any(Owner.class),
-                        any(String.class), any(String.class), eq(now), anyBoolean(),
-                        any(PoolFilterBuilder.class), any(PageRequest.class), anyBoolean())).thenReturn(
-                page);
+        when(mockPoolCurator.listAvailableEntitlementPools(any(Consumer.class), any(Owner.class),
+            any(String.class), any(String.class), eq(now), anyBoolean(),
+            any(PoolFilterBuilder.class), any(PageRequest.class), anyBoolean())).thenReturn(page);
 
         when(mockPoolCurator.lockAndLoadBatch(any(List.class))).thenReturn(Arrays.asList(pool1));
         when(
@@ -845,7 +843,7 @@ public class PoolManagerTest {
                 .thenReturn(bestPools);
 
         AutobindData data = AutobindData.create(TestUtil.createConsumer(o))
-                .forProducts(new String[] { product.getUuid() }).on(now);
+            .forProducts(new String[] { product.getUuid() }).on(now);
 
         doNothing().when(mockPoolCurator).flush();
 
@@ -856,8 +854,8 @@ public class PoolManagerTest {
         catch (EntitlementRefusedException e) {
             assertNotNull(e);
             verify(autobindRules, times(4)).selectBestPools(any(Consumer.class), any(String[].class),
-                    any(List.class), any(ComplianceStatus.class), any(String.class), any(Set.class),
-                    eq(false));
+                any(List.class), any(ComplianceStatus.class), any(String.class), any(Set.class),
+                eq(false));
         }
 
     }
@@ -929,7 +927,7 @@ public class PoolManagerTest {
 
         when(mockPoolCurator.lockAndLoad(any(Pool.class))).thenReturn(p);
         when(mockPoolCurator.entitlementsIn(p)).thenReturn(
-                new ArrayList<Entitlement>(p.getEntitlements()));
+            new ArrayList<Entitlement>(p.getEntitlements()));
         PreUnbindHelper preHelper =  mock(PreUnbindHelper.class);
         ValidationResult result = new ValidationResult();
         when(preHelper.getResult()).thenReturn(result);
@@ -954,7 +952,7 @@ public class PoolManagerTest {
         when(mockPoolCurator.lockAndLoad(any(Pool.class))).thenReturn(p);
         when(mockPoolCurator.listExpiredPools()).thenReturn(pools);
         when(mockPoolCurator.entitlementsIn(p)).thenReturn(
-                new ArrayList<Entitlement>(p.getEntitlements()));
+            new ArrayList<Entitlement>(p.getEntitlements()));
         Subscription sub = new Subscription();
         sub.setId(p.getSubscriptionId());
         when(mockSubAdapter.getSubscription(any(String.class))).thenReturn(sub);
@@ -979,7 +977,7 @@ public class PoolManagerTest {
         when(mockPoolCurator.lockAndLoad(any(Pool.class))).thenReturn(p);
         when(mockPoolCurator.listExpiredPools()).thenReturn(pools);
         when(mockPoolCurator.entitlementsIn(p)).thenReturn(
-                new ArrayList<Entitlement>(p.getEntitlements()));
+            new ArrayList<Entitlement>(p.getEntitlements()));
         Subscription sub = new Subscription();
         sub.setId(p.getSubscriptionId());
         when(mockSubAdapter.getSubscription(any(String.class))).thenReturn(sub);
@@ -1168,7 +1166,7 @@ public class PoolManagerTest {
     public void createPoolsForExistingSubscriptionsNoneExist() {
         Owner owner = this.getOwner();
         PoolRules pRules = new PoolRules(manager, mockConfig, entitlementCurator,
-                productCuratorMock);
+            productCuratorMock);
         List<Subscription> subscriptions = Util.newList();
         Product prod = TestUtil.createProduct(owner);
         Set<Product> products = new HashSet<Product>();
@@ -1189,9 +1187,9 @@ public class PoolManagerTest {
 
         assertEquals(newPools.size(), 2);
         assertTrue(newPools.get(0).getSourceSubscription().getSubscriptionSubKey().equals("derived") ||
-                newPools.get(1).getSourceSubscription().getSubscriptionSubKey().equals("derived"));
+            newPools.get(1).getSourceSubscription().getSubscriptionSubKey().equals("derived"));
         assertTrue(newPools.get(0).getSourceSubscription().getSubscriptionSubKey().startsWith("master") ||
-                newPools.get(1).getSourceSubscription().getSubscriptionSubKey().startsWith("master"));
+            newPools.get(1).getSourceSubscription().getSubscriptionSubKey().startsWith("master"));
     }
 
     @Test
@@ -1207,16 +1205,16 @@ public class PoolManagerTest {
         assertEquals(2, newPools.size());
 
         assertTrue(newPools.get(0).getSourceSubscription().getSubscriptionSubKey().equals("derived") ||
-                newPools.get(1).getSourceSubscription().getSubscriptionSubKey().equals("derived"));
+            newPools.get(1).getSourceSubscription().getSubscriptionSubKey().equals("derived"));
         assertTrue(newPools.get(0).getSourceSubscription().getSubscriptionSubKey().startsWith("master") ||
-                newPools.get(1).getSourceSubscription().getSubscriptionSubKey().startsWith("master"));
+            newPools.get(1).getSourceSubscription().getSubscriptionSubKey().startsWith("master"));
     }
 
     @Test
     public void createPoolsForExistingSubscriptionsMasterExist() {
         Owner owner = this.getOwner();
         PoolRules pRules = new PoolRules(manager, mockConfig, entitlementCurator,
-                productCuratorMock);
+            productCuratorMock);
         List<Subscription> subscriptions = Util.newList();
         Product prod = TestUtil.createProduct(owner);
         Set<Product> products = new HashSet<Product>();
@@ -1258,7 +1256,7 @@ public class PoolManagerTest {
     public void createPoolsForExistingSubscriptionsBonusExist() {
         Owner owner = this.getOwner();
         PoolRules pRules = new PoolRules(manager, mockConfig, entitlementCurator,
-                productCuratorMock);
+            productCuratorMock);
         List<Subscription> subscriptions = Util.newList();
         Product prod = TestUtil.createProduct(owner);
         Set<Product> products = new HashSet<Product>();
@@ -2002,7 +2000,7 @@ public class PoolManagerTest {
         assertNotNull(message);
         message = message.split(": ")[1];
         assertEquals(message,
-                i18n.tr("Unmapped guest entitlement expired without establishing a host/guest mapping."));
+            i18n.tr("Unmapped guest entitlement expired without establishing a host/guest mapping."));
     }
 
     @Test
@@ -2032,9 +2030,9 @@ public class PoolManagerTest {
         when(mockPoolCurator.lockAndLoadBatch(anyCollection())).thenReturn(Arrays.asList(pool));
 
         when(mockPoolCurator.lookupOversubscribedBySubscriptionIds(anyMap())).thenReturn(
-                Arrays.asList(derivedPool));
+            Arrays.asList(derivedPool));
         when(mockPoolCurator.retrieveFreeEntitlementsOfPools(anyListOf(Pool.class), eq(true))).thenReturn(
-                Arrays.asList(derivedEnt));
+            Arrays.asList(derivedEnt));
         when(mockPoolCurator.lockAndLoad(eq(derivedPool))).thenReturn(derivedPool);
         pool.setId("masterpool");
 
@@ -2101,9 +2099,9 @@ public class PoolManagerTest {
         when(mockPoolCurator.lockAndLoadBatch(anyCollection())).thenReturn(Arrays.asList(pool));
 
         when(mockPoolCurator.lookupOversubscribedBySubscriptionIds(anyMap())).thenReturn(
-                Arrays.asList(derivedPool, derivedPool2, derivedPool3));
+            Arrays.asList(derivedPool, derivedPool2, derivedPool3));
         when(mockPoolCurator.retrieveFreeEntitlementsOfPools(anyListOf(Pool.class), eq(true))).thenReturn(
-                Arrays.asList(derivedEnt, derivedEnt2, derivedEnt3));
+            Arrays.asList(derivedEnt, derivedEnt2, derivedEnt3));
         when(mockPoolCurator.lockAndLoad(eq(derivedPool))).thenReturn(derivedPool);
         when(mockPoolCurator.lockAndLoad(eq(derivedPool2))).thenReturn(derivedPool2);
         pool.setId("masterpool");

--- a/server/src/test/java/org/candlepin/controller/RefresherTest.java
+++ b/server/src/test/java/org/candlepin/controller/RefresherTest.java
@@ -140,6 +140,6 @@ public class RefresherTest {
         refresher.run();
 
         verify(poolManager, times(1)).refreshPoolsForMasterPool(eq(mainPool), eq(true), eq(false),
-                any(Set.class));
+            any(Set.class));
     }
 }

--- a/server/src/test/java/org/candlepin/guice/CandlepinContextListenerTest.java
+++ b/server/src/test/java/org/candlepin/guice/CandlepinContextListenerTest.java
@@ -71,7 +71,7 @@ public class CandlepinContextListenerTest {
         config = mock(Configuration.class);
 
         when(config.subset(eq("org.quartz"))).thenReturn(
-                new MapConfiguration(ConfigProperties.DEFAULT_PROPERTIES));
+            new MapConfiguration(ConfigProperties.DEFAULT_PROPERTIES));
         when(config.strippedSubset(eq(ConfigurationPrefixes.LOGGING_CONFIG_PREFIX)))
             .thenReturn(new MapConfiguration());
         hqlistener = mock(HornetqContextListener.class);
@@ -116,7 +116,7 @@ public class CandlepinContextListenerTest {
         verify(hqlistener).contextInitialized(any(Injector.class));
         verify(pinlistener).contextInitialized();
         verify(ctx).setAttribute(
-                eq(CandlepinContextListener.CONFIGURATION_NAME), eq(config));
+            eq(CandlepinContextListener.CONFIGURATION_NAME), eq(config));
         verify(configRead).verify(eq(ctx));
     }
 

--- a/server/src/test/java/org/candlepin/model/ActivationKeyContentOverrideCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ActivationKeyContentOverrideCuratorTest.java
@@ -80,8 +80,7 @@ public class ActivationKeyContentOverrideCuratorTest extends DatabaseTestFixture
         activationKeyContentOverrideCurator.merge(cco);
 
         ActivationKeyContentOverride cco2 =
-                activationKeyContentOverrideCurator.retrieve(
-                    key, "test-content", "name");
+            activationKeyContentOverrideCurator.retrieve(key, "test-content", "name");
         assert (cco2 != null);
         assertEquals("value-update", cco2.getValue());
     }

--- a/server/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
@@ -77,7 +77,7 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
         consumerCurator.create(consumer);
 
         List<Consumer> results = entityManager().createQuery(
-                "select c from Consumer as c", Consumer.class).getResultList();
+            "select c from Consumer as c", Consumer.class).getResultList();
         assertEquals(1, results.size());
     }
 
@@ -498,19 +498,19 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
         guestIds.add(guestId1ReverseEndian); // reversed endian match
         guestIds.add(guestId2); // direct match
         VirtConsumerMap guestMap = consumerCurator.getGuestConsumersMap(
-                owner, guestIds);
+            owner, guestIds);
 
         assertEquals(2, guestMap.size());
 
         assertEquals(gConsumer1.getId(), guestMap.get(
-                guestId1.toLowerCase()).getId());
+            guestId1.toLowerCase()).getId());
         assertEquals(gConsumer1.getId(), guestMap.get(
-                guestId1ReverseEndian).getId());
+            guestId1ReverseEndian).getId());
 
         assertEquals(gConsumer2.getId(), guestMap.get(
-                guestId2.toLowerCase()).getId());
+            guestId2.toLowerCase()).getId());
         assertEquals(gConsumer2.getId(), guestMap.get(
-                Util.transformUuid(guestId2.toLowerCase())).getId());
+            Util.transformUuid(guestId2.toLowerCase())).getId());
     }
 
     @Test
@@ -602,8 +602,7 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
         hypervisorIds.add(hypervisorId2);
         hypervisorIds.add("not really a hypervisor");
 
-        VirtConsumerMap hypervisorMap =
-                consumerCurator.getHostConsumersMap(owner, hypervisorIds);
+        VirtConsumerMap hypervisorMap = consumerCurator.getHostConsumersMap(owner, hypervisorIds);
         assertEquals(2, hypervisorMap.size());
         assertEquals(consumer1.getId(), hypervisorMap.get(hypervisorId1).getId());
         assertEquals(consumer2.getId(), hypervisorMap.get(hypervisorId2).getId());
@@ -659,7 +658,7 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
         this.productCurator.create(prod);
         Pool p = createPool(owner, prod, 5L, Util.yesterday(), Util.tomorrow());
         Entitlement ent = this.createEntitlement(owner, consumer, p,
-                createEntitlementCertificate("entkey", "ecert"));
+            createEntitlementCertificate("entkey", "ecert"));
         ent.setUpdatedOnStart(false);
         entitlementCurator.create(ent);
 
@@ -676,7 +675,7 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
         this.productCurator.create(prod);
         Pool p = createPool(owner, prod, 5L, Util.yesterday(), Util.tomorrow());
         Entitlement ent = this.createEntitlement(owner, consumer, p,
-                createEntitlementCertificate("entkey", "ecert"));
+            createEntitlementCertificate("entkey", "ecert"));
         // Already taken care of
         ent.setUpdatedOnStart(true);
         entitlementCurator.create(ent);

--- a/server/src/test/java/org/candlepin/model/ConsumerTest.java
+++ b/server/src/test/java/org/candlepin/model/ConsumerTest.java
@@ -112,8 +112,7 @@ public class ConsumerTest extends DatabaseTestFixture {
         Consumer lookedUp = consumerCurator.find(consumer.getId());
         assertEquals(consumer.getId(), lookedUp.getId());
         assertEquals(consumer.getName(), lookedUp.getName());
-        assertEquals(consumer.getType().getLabel(), lookedUp.getType()
-                .getLabel());
+        assertEquals(consumer.getType().getLabel(), lookedUp.getType().getLabel());
         assertNotNull(consumer.getUuid());
     }
 

--- a/server/src/test/java/org/candlepin/model/ConsumerTypeTest.java
+++ b/server/src/test/java/org/candlepin/model/ConsumerTypeTest.java
@@ -35,8 +35,7 @@ public class ConsumerTypeTest extends DatabaseTestFixture {
 
         commitTransaction();
 
-        List<?> results = entityManager().createQuery(
-                "select ct from ConsumerType as ct").getResultList();
+        List<?> results = entityManager().createQuery("select ct from ConsumerType as ct").getResultList();
         assertEquals(1, results.size());
     }
 

--- a/server/src/test/java/org/candlepin/model/ContentCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ContentCuratorTest.java
@@ -83,11 +83,10 @@ public class ContentCuratorTest extends DatabaseTestFixture {
         // method that needs to work on the same content twice.
 
         Content c1 = new Content(owner, "mycontent", "5006", "mycontent", "yum",
-                "vendor", "nobodycares", "nobodystillcares", "x86_64");
+            "vendor", "nobodycares", "nobodystillcares", "x86_64");
         Content c2 = new Content(owner, "mycontent", "5006", "mycontent", "yum",
-                "vendor", "nobodycares", "nobodystillcares", "x86_64");
+            "vendor", "nobodycares", "nobodystillcares", "x86_64");
         contentCurator.createContent(c1, owner);
         contentCurator.updateContent(c2, owner);
-
     }
 }

--- a/server/src/test/java/org/candlepin/model/ContentTest.java
+++ b/server/src/test/java/org/candlepin/model/ContentTest.java
@@ -42,9 +42,9 @@ public class ContentTest extends DatabaseTestFixture {
         String  contentHash = String.valueOf(
             Math.abs(Long.valueOf("test-content".hashCode())));
         Content content = new Content(owner, "test-content", contentHash,
-                            "test-content-label", "yum", "test-vendor",
-                             "test-content-url", "test-gpg-url",
-                             "test-arch1,test-arch2");
+            "test-content-label", "yum", "test-vendor",
+            "test-content-url", "test-gpg-url",
+            "test-arch1,test-arch2");
         HashSet<String> modifiedProductIds = new HashSet<String>();
         modifiedProductIds.add("ProductA");
         modifiedProductIds.add("ProductB");
@@ -69,8 +69,8 @@ public class ContentTest extends DatabaseTestFixture {
             Math.abs(Long.valueOf("test-content-arches".hashCode())));
 
         Content content = new Content(owner, "test-content-arches", contentHash,
-                            "test-content-arches-label", "yum", "test-vendor",
-                             "test-content-url", "test-gpg-url", "");
+            "test-content-arches-label", "yum", "test-vendor",
+            "test-content-url", "test-gpg-url", "");
         String arches = "x86_64, i386";
         content.setArches(arches);
         contentCurator.create(content);
@@ -86,7 +86,7 @@ public class ContentTest extends DatabaseTestFixture {
 
         Content content = new Content(owner, "Test Content", "100",
             "test-content-label", "yum", "test-vendor",
-             "test-content-url", "test-gpg-url", "test-arch1");
+            "test-content-url", "test-gpg-url", "test-arch1");
         contentCurator.create(content);
 
         // Same ID, but label changed:

--- a/server/src/test/java/org/candlepin/model/EntitlementCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/EntitlementCuratorTest.java
@@ -105,7 +105,7 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
         }
         catch (Exception ex) {
             assertEquals(ex.getCause().getCause().getClass(),
-                    SQLIntegrityConstraintViolationException.class);
+                SQLIntegrityConstraintViolationException.class);
         }
         finally {
             rollbackTransaction();
@@ -187,7 +187,7 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
 
         // Provided product 2 will modify 1, both will be on the pool:
         Content c = new Content(this.owner, "fakecontent", "fakecontent", "facecontent",
-                "yum", "RH", "http://", "http://", "x86_64");
+            "yum", "RH", "http://", "http://", "x86_64");
         Set<String> modifiedIds = new HashSet<String>();
         modifiedIds.add(providedProduct1.getId());
         c.setModifiedProductIds(modifiedIds);
@@ -319,7 +319,7 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
     }
 
     private Entitlement setUpModifyingEntitlements(Date startDate, Date endDate, Integer howMany,
-            String contentId) {
+        String contentId) {
         Product parentProductForTest = TestUtil.createProduct(owner);
         Product providedProduct1ForTest = TestUtil.createProduct(owner);
         Product providedProduct2ForTest = TestUtil.createProduct(owner);
@@ -331,7 +331,7 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
 
         // Provided product 2 will modify 1, both will be on the pool:
         Content c = new Content(this.owner, "fakecontent", contentId, contentId, "yum", "RH",
-                "http://", "http://", "x86_64");
+            "http://", "http://", "x86_64");
         Set<String> modifiedIds = new HashSet<String>();
         modifiedIds.add(providedProduct1ForTest.getId());
         c.setModifiedProductIds(modifiedIds);
@@ -361,11 +361,11 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
 
     public void prepareEntitlementsForModifying() {
         Content contentPool1 = new Content(owner, "fakecontent", "fakecontent",
-                "facecontent", "yum", "RH", "http://", "http://",
-                "x86_64");
+            "facecontent", "yum", "RH", "http://", "http://",
+            "x86_64");
         Content contentPool2 = new Content(owner, "fakecontent2", "fakecontent2",
-                "facecontent2", "yum", "RH", "http://",
-                "http://", "x86_64");
+            "facecontent2", "yum", "RH", "http://",
+            "http://", "x86_64");
 
         /**
          * Each of these products are provided by respective Entitlements
@@ -408,9 +408,9 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
         providedProductEnt4.addContent(contentPool2);
 
         createPool("p3", createDate(1998, 1, 1), createDate(2003, 2, 1),
-                providedProductEnt3);
+            providedProductEnt3);
         createPool("p4", createDate(2001, 2, 30), createDate(2002, 1, 10),
-                providedProductEnt4);
+            providedProductEnt4);
 
         createPool("p5", createDate(2000, 5, 5), createDate(2000, 5, 10), null);
 
@@ -423,13 +423,13 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
         prepareEntitlementsForModifying();
 
         ProductEntitlements pents = entitlementCurator.getOverlappingForModifying(
-                Arrays.asList(ent1modif, ent2modif));
+            Arrays.asList(ent1modif, ent2modif));
 
         assertTrue(!pents.isEmpty());
         assertEquals(5, pents.getAllProductIds().size());
         for (String id : Arrays.asList("prod-p3", "prod-p4", "prod-p5", "ppent3", "ppent4")) {
             assertTrue("Overlapping entitlements [" + pents + "] " +
-                     "doesn't contain product id [" + id + "]", pents.getAllProductIds().contains(id));
+                "doesn't contain product id [" + id + "]", pents.getAllProductIds().contains(id));
         }
     }
 
@@ -461,7 +461,7 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
 
         for (Entitlement ent : ents) {
             assertTrue(ent.getPool().getProductId().equals("prod-p3") ||
-                    ent.getPool().getProductId().equals("prod-p4"));
+                ent.getPool().getProductId().equals("prod-p4"));
         }
     }
 
@@ -488,7 +488,7 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
     public void listEntitledProductIds() {
         Entitlement ent = setupListProvidingEntitlement();
         Set<String> results = entitlementCurator.listEntitledProductIds(consumer,
-                ent.getStartDate(), ent.getEndDate());
+            ent.getStartDate(), ent.getEndDate());
         assertEquals(3, results.size());
         assertTrue(results.contains(providedProduct1.getId()));
         assertTrue(results.contains(providedProduct2.getId()));
@@ -508,7 +508,7 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
     public void listEntitledProductIdsEndDateOverlap() {
         Entitlement ent = setupListProvidingEntitlement();
         Set<String> results = entitlementCurator.listEntitledProductIds(consumer,
-                pastDate, createDate(2002, 1, 1));
+            pastDate, createDate(2002, 1, 1));
         assertEquals(3, results.size());
         assertTrue(results.contains(ent.getPool().getProductId()));
     }
@@ -517,7 +517,7 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
     public void listEntitledProductIdsTotalOverlap() {
         Entitlement ent = setupListProvidingEntitlement();
         Set<String> results = entitlementCurator.listEntitledProductIds(consumer,
-                pastDate, futureDate);
+            pastDate, futureDate);
         // Picks up suite pools as well:
         assertEquals(5, results.size());
         assertTrue(results.contains(ent.getPool().getProductId()));
@@ -527,7 +527,7 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
     public void listEntitledProductIdsNoOverlap() {
         setupListProvidingEntitlement();
         Set<String> results = entitlementCurator.listEntitledProductIds(consumer,
-                pastDate, pastDate);
+            pastDate, pastDate);
         assertEquals(0, results.size());
     }
 

--- a/server/src/test/java/org/candlepin/model/EventCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/EventCuratorTest.java
@@ -70,7 +70,7 @@ public class EventCuratorTest extends DatabaseTestFixture {
     public void testSecondarySorting() {
 
         Consumer newConsumer = new Consumer("consumername", "user", owner,
-                new ConsumerType("system"));
+            new ConsumerType("system"));
         consumerTypeCurator.create(newConsumer.getType());
         consumerCurator.create(newConsumer);
 
@@ -80,7 +80,7 @@ public class EventCuratorTest extends DatabaseTestFixture {
         Date forcedDate = new Date();
 
         EventBuilder builder = eventFactory.getEventBuilder(Event.Target.RULES,
-                Event.Type.DELETED);
+            Event.Type.DELETED);
         Event rulesDeletedEvent = builder.setOldEntity(new Rules()).buildEvent();
         rulesDeletedEvent.setTimestamp(forcedDate);
 
@@ -92,7 +92,7 @@ public class EventCuratorTest extends DatabaseTestFixture {
         builder = eventFactory.getEventBuilder(Event.Target.CONSUMER,
                 Event.Type.MODIFIED);
         Event consumerModifiedEvent = builder.setNewEntity(newConsumer).
-                setOldEntity(newConsumer).buildEvent();
+            setOldEntity(newConsumer).buildEvent();
         consumerModifiedEvent.setTimestamp(forcedDate);
 
         eventCurator.create(rulesDeletedEvent);

--- a/server/src/test/java/org/candlepin/model/OwnerCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/OwnerCuratorTest.java
@@ -51,8 +51,7 @@ public class OwnerCuratorTest extends DatabaseTestFixture {
 
         this.ownerCurator.replicate(owner);
 
-        assertEquals("testing",
-                this.ownerCurator.find("testing-primary-key").getKey());
+        assertEquals("testing", this.ownerCurator.find("testing-primary-key").getKey());
     }
 
     @Test(expected = RollbackException.class)
@@ -184,8 +183,7 @@ public class OwnerCuratorTest extends DatabaseTestFixture {
         owner = ownerCurator.create(owner);
         ConsumerType type = new ConsumerType(ConsumerTypeEnum.CANDLEPIN);
         consumerTypeCurator.create(type);
-        UpstreamConsumer uc = new UpstreamConsumer("test-upstream-consumer",
-               owner, type, "someuuid");
+        UpstreamConsumer uc = new UpstreamConsumer("test-upstream-consumer", owner, type, "someuuid");
         owner.setUpstreamConsumer(uc);
         ownerCurator.merge(owner);
 

--- a/server/src/test/java/org/candlepin/model/OwnerInfoCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/OwnerInfoCuratorTest.java
@@ -432,8 +432,7 @@ public class OwnerInfoCuratorTest extends DatabaseTestFixture {
     public void testOwnerPoolMultiEnabledCount() {
         ConsumerType type1 = consumerTypeCurator.lookupByLabel("domain");
         ConsumerType type2 = consumerTypeCurator.lookupByLabel("system");
-        pool1.setAttribute("enabled_consumer_types", type1.getLabel() +
-                           "," + type2.getLabel());
+        pool1.setAttribute("enabled_consumer_types", type1.getLabel() + "," + type2.getLabel());
         owner.addEntitlementPool(pool1);
 
         OwnerInfo info = ownerInfoCurator.lookupByOwner(owner);

--- a/server/src/test/java/org/candlepin/model/OwnerTest.java
+++ b/server/src/test/java/org/candlepin/model/OwnerTest.java
@@ -43,8 +43,8 @@ public class OwnerTest extends DatabaseTestFixture {
         ownerCurator.create(o);
 
         Owner result = (Owner) entityManager().createQuery(
-                "select o from Owner o where o.key = :key").setParameter(
-                "key", ownerName).getSingleResult();
+            "select o from Owner o where o.key = :key").setParameter(
+            "key", ownerName).getSingleResult();
 
         assertNotNull(result);
         assertEquals(ownerName, result.getKey());
@@ -57,14 +57,13 @@ public class OwnerTest extends DatabaseTestFixture {
     @Test
     public void testList() throws Exception {
         int beforeCount = entityManager().createQuery(
-                "select o from Owner as o").getResultList().size();
+            "select o from Owner as o").getResultList().size();
 
         for (int i = 0; i < 10; i++) {
             ownerCurator.create(new Owner("Corp " + i));
         }
 
-        int afterCount = entityManager()
-                .createQuery("select o from Owner as o").getResultList().size();
+        int afterCount = entityManager().createQuery("select o from Owner as o").getResultList().size();
         assertEquals(10, afterCount - beforeCount);
     }
 
@@ -72,8 +71,7 @@ public class OwnerTest extends DatabaseTestFixture {
     public void testObjectRelationships() throws Exception {
         Owner owner = new Owner("test-owner");
         // Product
-        Product rhel = new Product("Red Hat Enterprise Linux",
-                "Red Hat Enterprise Linux", owner);
+        Product rhel = new Product("Red Hat Enterprise Linux", "Red Hat Enterprise Linux", owner);
 
         // Consumer
         Consumer c = new Consumer();

--- a/server/src/test/java/org/candlepin/model/PoolCuratorEntitlementRulesTest.java
+++ b/server/src/test/java/org/candlepin/model/PoolCuratorEntitlementRulesTest.java
@@ -90,8 +90,7 @@ public class PoolCuratorEntitlementRulesTest extends DatabaseTestFixture {
         poolQuantities.put(consumerPool.getId(), 1);
         anotherEntitler.entitleByPools(consumer, poolQuantities);
 
-        assertFalse(poolCurator.find(consumerPool.getId())
-                .entitlementsAvailable(1));
+        assertFalse(poolCurator.find(consumerPool.getId()).entitlementsAvailable(1));
     }
 
     @Test(expected = EntitlementRefusedException.class)

--- a/server/src/test/java/org/candlepin/model/PoolCuratorFilterTest.java
+++ b/server/src/test/java/org/candlepin/model/PoolCuratorFilterTest.java
@@ -66,7 +66,7 @@ public class PoolCuratorFilterTest extends DatabaseTestFixture {
         productCurator.create(searchProduct);
 
         Pool searchPool = createPool(owner, searchProduct, 100L,
-                TestUtil.createDate(2005, 3, 2), TestUtil.createDate(2050, 3, 2));
+            TestUtil.createDate(2005, 3, 2), TestUtil.createDate(2050, 3, 2));
 
         Product provided = TestUtil.createProduct("101111", "Server Bits", owner);
         provided.addContent(content);

--- a/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
@@ -89,24 +89,22 @@ public class PoolCuratorTest extends DatabaseTestFixture {
     @Test
     public void testPoolNotYetActive() {
         Pool pool = createPool(owner, product, 100L,
-                TestUtil.createDate(2050, 3, 2), TestUtil.createDate(2055, 3, 2));
+            TestUtil.createDate(2050, 3, 2), TestUtil.createDate(2055, 3, 2));
         poolCurator.create(pool);
 
-        List<Pool> results =
-            poolCurator.listAvailableEntitlementPools(consumer, consumer.getOwner(),
-                (String) null, TestUtil.createDate(20450, 3, 2), true);
+        List<Pool> results = poolCurator.listAvailableEntitlementPools(
+            consumer, consumer.getOwner(), null, TestUtil.createDate(20450, 3, 2), true);
         assertEquals(0, results.size());
     }
 
     @Test
     public void testPoolExpired() {
         Pool pool = createPool(owner, product, 100L,
-                TestUtil.createDate(2000, 3, 2), TestUtil.createDate(2005, 3, 2));
+            TestUtil.createDate(2000, 3, 2), TestUtil.createDate(2005, 3, 2));
         poolCurator.create(pool);
 
-        List<Pool> results =
-            poolCurator.listAvailableEntitlementPools(consumer, consumer.getOwner(),
-                (String) null, TestUtil.createDate(2005, 3, 3), true);
+        List<Pool> results = poolCurator.listAvailableEntitlementPools(
+            consumer, consumer.getOwner(), null, TestUtil.createDate(2005, 3, 3), true);
         assertEquals(0, results.size());
 
         // If we specify no date filtering, the expired pool should be returned:
@@ -124,9 +122,8 @@ public class PoolCuratorTest extends DatabaseTestFixture {
 
         ueberCertGenerator.generate(owner, new NoAuthPrincipal());
 
-        List<Pool> results =
-            poolCurator.listAvailableEntitlementPools(consumer, consumer.getOwner(),
-                (String) null, null, true);
+        List<Pool> results = poolCurator.listAvailableEntitlementPools(
+            consumer, consumer.getOwner(), null, null, true);
         assertEquals(1, results.size());
     }
 
@@ -521,20 +518,20 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         productCurator.create(product);
 
         Pool p = new Pool(owner, product, new HashSet<Product>(), 1L, new Date(), new Date(), "contract",
-                "account", "order");
+            "account", "order");
 
         String subId1 = Util.generateDbUUID();
         p.setSourceSubscription(new SourceSubscription(subId1, "master"));
         poolCurator.create(p);
 
         Pool p2 = new Pool(owner, product, new HashSet<Product>(), 1L, new Date(), new Date(), "contract",
-                "account", "order");
+            "account", "order");
         String subId2 = Util.generateDbUUID();
         p2.setSourceSubscription(new SourceSubscription(subId2, "master"));
         poolCurator.create(p2);
 
         Pool p3 = new Pool(owner, product, new HashSet<Product>(), 1L, new Date(), new Date(), "contract",
-                "account", "order");
+            "account", "order");
         String subId3 = Util.generateDbUUID();
         p3.setSourceSubscription(new SourceSubscription(subId3, "master"));
         poolCurator.create(p3);
@@ -567,7 +564,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         String subId1 = Util.generateDbUUID();
 
         Pool p = new Pool(owner, product, new HashSet<Product>(), 1L, new Date(), new Date(), "contract",
-                "account", "order");
+            "account", "order");
 
         p.setSourceSubscription(new SourceSubscription(subId1, "master"));
         poolCurator.create(p);
@@ -579,10 +576,9 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         poolCurator.overrideInClauseLimit(5);
         List<String> items = new ArrayList<String>();
         String expected = "taylor in (0, 1, 2, 3, 4)" +
-                " or taylor in (5, 6, 7, 8, 9)" +
-                " or taylor in (10, 11, 12, 13, 14)" +
-                " or taylor in (15)";
-        boolean first = false;
+            " or taylor in (5, 6, 7, 8, 9)" +
+            " or taylor in (10, 11, 12, 13, 14)" +
+            " or taylor in (15)";
         for (int i = 0; i < 16; i++) {
             items.add("" + i);
         }
@@ -597,7 +593,6 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         List<String> items = new ArrayList<String>();
         String expected = "swift in (";
         int i = 0;
-        boolean first = false;
         for (; i < 998; i++) {
             expected += i + ", ";
             items.add("" + i);
@@ -683,8 +678,8 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         Entitlement ent31 = new Entitlement(pool3, consumer, 1);
         entitlementCurator.create(ent31);
 
-        List<Entitlement> ents = poolCurator.retrieveFreeEntitlementsOfPools(Arrays.asList(pool1, pool2),
-                true);
+        List<Entitlement> ents = poolCurator.retrieveFreeEntitlementsOfPools(
+            Arrays.asList(pool1, pool2), true);
         assertEquals(4, ents.size());
         assertThat(ents, hasItems(ent11, ent12, ent13, ent21));
         assertThat(ents, not(hasItems(ent31)));
@@ -717,7 +712,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         List<Pool> expectedPools = new ArrayList<Pool>();
         for (Integer i = 0; i < 5; i++) {
             Pool pool = createPool(owner, product, 1L, TestUtil.createDate(2050, 3, 2),
-                    TestUtil.createDate(2055, 3, 2));
+                TestUtil.createDate(2055, 3, 2));
             poolCurator.create(pool);
             expectedPools.add(pool);
             String subid = pool.getSubscriptionId();
@@ -728,16 +723,16 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         }
 
         Pool unconsumedPool = createPool(owner, product, 1L, TestUtil.createDate(2050, 3, 2),
-                TestUtil.createDate(2055, 3, 2));
+            TestUtil.createDate(2055, 3, 2));
         poolCurator.create(unconsumedPool);
 
         Pool notOverConsumedPool = createPool(owner, product, 1L, TestUtil.createDate(2050, 3, 2),
-                TestUtil.createDate(2055, 3, 2));
+            TestUtil.createDate(2055, 3, 2));
         poolCurator.create(notOverConsumedPool);
         entitlementCurator.create(new Entitlement(notOverConsumedPool, consumer, 1));
 
         Pool overConsumedPool = createPool(owner, product, 1L, TestUtil.createDate(2050, 3, 2),
-                TestUtil.createDate(2055, 3, 2));
+            TestUtil.createDate(2055, 3, 2));
         poolCurator.create(overConsumedPool);
         entitlementCurator.create(new Entitlement(overConsumedPool, consumer, 2));
 
@@ -1124,8 +1119,8 @@ public class PoolCuratorTest extends DatabaseTestFixture {
             productCurator.create(product);
 
             // Create derived pool referencing the entitlement just made:
-            Pool derivedPool = new Pool(owner, product, new HashSet<Product>(), 1L, TestUtil.createDate(
-                    2011, 3, 2), TestUtil.createDate(2055, 3, 2), "", "", "");
+            Pool derivedPool = new Pool(owner, product, new HashSet<Product>(), 1L,
+                TestUtil.createDate(2011, 3, 2), TestUtil.createDate(2055, 3, 2), "", "", "");
             derivedPool.setSourceStack(new SourceStack(consumer, stackId));
             derivedPool.setAttribute("requires_host", consumer.getUuid());
 
@@ -1333,7 +1328,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         this.poolCurator.create(p2);
 
         Page<List<Pool>> result = this.poolCurator.listAvailableEntitlementPools(null, owner1, null,
-                "subscriptionId-phil", new Date(), false, null, null, false);
+            "subscriptionId-phil", new Date(), false, null, null, false);
         assertEquals("subscriptionId-phil", result.getPageData().get(0).getSubscriptionId());
     }
 
@@ -1470,7 +1465,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
     public void testLookupDevPoolForConsumer() throws Exception {
         // Make sure that multiple pools exist.
         createPool(owner, product, -1L, TestUtil.createDate(2010, 3, 2),
-                TestUtil.createDate(Calendar.getInstance().get(Calendar.YEAR) + 1, 3, 2));
+            TestUtil.createDate(Calendar.getInstance().get(Calendar.YEAR) + 1, 3, 2));
         Pool pool = createPool(owner, product, -1L, TestUtil.createDate(2010, 3, 2),
             TestUtil.createDate(Calendar.getInstance().get(Calendar.YEAR) + 1, 3, 2));
         pool.setAttribute("requires_consumer", consumer.getUuid());
@@ -1487,7 +1482,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
     public void testDevPoolForConsumerNotFoundReturnsNullWhenNoMatchOnConsumer() throws Exception {
         // Make sure that multiple pools exist.
         createPool(owner, product, -1L, TestUtil.createDate(2010, 3, 2),
-                TestUtil.createDate(Calendar.getInstance().get(Calendar.YEAR) + 1, 3, 2));
+            TestUtil.createDate(Calendar.getInstance().get(Calendar.YEAR) + 1, 3, 2));
         Pool pool = createPool(owner, product, -1L, TestUtil.createDate(2010, 3, 2),
             TestUtil.createDate(Calendar.getInstance().get(Calendar.YEAR) + 1, 3, 2));
         pool.setAttribute("requires_consumer", "does-not-exist");

--- a/server/src/test/java/org/candlepin/model/PoolTest.java
+++ b/server/src/test/java/org/candlepin/model/PoolTest.java
@@ -122,8 +122,8 @@ public class PoolTest extends DatabaseTestFixture {
     @Test
     public void testMultiplePoolsForOwnerProductAllowed() {
         Pool duplicatePool = createPool(owner,
-                prod1, -1L, TestUtil.createDate(2009, 11, 30),
-                TestUtil.createDate(2050, 11, 30));
+            prod1, -1L, TestUtil.createDate(2009, 11, 30),
+            TestUtil.createDate(2050, 11, 30));
         // Just need to see no exception is thrown.
         poolCurator.create(duplicatePool);
     }
@@ -131,8 +131,8 @@ public class PoolTest extends DatabaseTestFixture {
     @Test
     public void testIsOverflowing() {
         Pool duplicatePool = createPool(owner,
-                prod1, -1L, TestUtil.createDate(2009, 11, 30),
-                TestUtil.createDate(2050, 11, 30));
+            prod1, -1L, TestUtil.createDate(2009, 11, 30),
+            TestUtil.createDate(2050, 11, 30));
         assertFalse(duplicatePool.isOverflowing());
     }
 
@@ -141,8 +141,8 @@ public class PoolTest extends DatabaseTestFixture {
         Product newProduct = TestUtil.createProduct(owner);
         productCurator.create(newProduct);
         Pool unlimitedPool = createPool(owner, newProduct,
-                -1L, TestUtil.createDate(2009, 11, 30),
-                TestUtil.createDate(2050, 11, 30));
+            -1L, TestUtil.createDate(2009, 11, 30),
+            TestUtil.createDate(2050, 11, 30));
         poolCurator.create(unlimitedPool);
         assertTrue(unlimitedPool.entitlementsAvailable(1));
     }
@@ -154,8 +154,8 @@ public class PoolTest extends DatabaseTestFixture {
 
         productCurator.create(newProduct);
         Pool consumerPool = createPool(owner, newProduct,
-                numAvailEntitlements, TestUtil.createDate(2009, 11, 30),
-                TestUtil.createDate(2050, 11, 30));
+            numAvailEntitlements, TestUtil.createDate(2009, 11, 30),
+            TestUtil.createDate(2050, 11, 30));
         consumerPool = poolCurator.create(consumerPool);
 
         Map<String, Integer> pQs = new HashMap<String, Integer>();

--- a/server/src/test/java/org/candlepin/model/ProductCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ProductCuratorTest.java
@@ -125,7 +125,7 @@ public class ProductCuratorTest extends DatabaseTestFixture {
         productCurator.createProduct(prod, owner);
 
         List<Product> results = entityManager().createQuery(
-                "select p from Product as p").getResultList();
+            "select p from Product as p").getResultList();
         assertEquals(5, results.size());
     }
 
@@ -172,9 +172,9 @@ public class ProductCuratorTest extends DatabaseTestFixture {
         assertEquals(new Product("label", "name", owner), new Product("label", "name", owner));
         assertFalse(new Product("label", "name", owner).equals(null));
         assertFalse(new Product("label", "name", owner).equals(new Product("label",
-                "another_name", owner)));
+            "another_name", owner)));
         assertFalse(new Product("label", "name", owner).equals(new Product(
-                "another_label", "name", owner)));
+            "another_label", "name", owner)));
     }
 
     @Test
@@ -290,8 +290,7 @@ public class ProductCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void testProductFullConstructor() {
-        Product prod = new Product("cp_test-label", "variant", owner,
-                                   "version", "arch", "", "SVC");
+        Product prod = new Product("cp_test-label", "variant", owner, "version", "arch", "", "SVC");
         productCurator.createProduct(prod, owner);
 
         productCurator.find(prod.getUuid());

--- a/server/src/test/java/org/candlepin/pinsetter/core/PinsetterKernelTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/core/PinsetterKernelTest.java
@@ -380,8 +380,8 @@ public class PinsetterKernelTest {
         pk = new PinsetterKernel(config, jfactory, jlistener, jcurator, sfactory);
         pk.scheduleSingleJob(detail);
         verify(detail).setGroup(eq(singlegrp));
-        verify(lm).addJobListenerMatcher(PinsetterJobListener.LISTENER_NAME
-                , jobNameEquals(detail.getKey().getName()));
+        verify(lm).addJobListenerMatcher(PinsetterJobListener.LISTENER_NAME,
+            jobNameEquals(detail.getKey().getName()));
         verify(sched).scheduleJob(eq(detail), any(Trigger.class));
     }
 

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/ActiveEntitlementJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/ActiveEntitlementJobTest.java
@@ -67,7 +67,7 @@ public class ActiveEntitlementJobTest extends DatabaseTestFixture {
 
         consumer = new Consumer("a consumer", "username", owner, ct);
         consumer.addInstalledProduct(new ConsumerInstalledProduct(
-                prod.getId(), prod.getName()));
+            prod.getId(), prod.getName()));
         consumerCurator.create(consumer);
     }
 
@@ -75,7 +75,7 @@ public class ActiveEntitlementJobTest extends DatabaseTestFixture {
     public void testActiveEntitlementJob() throws JobExecutionException {
         Pool p = createPool(owner, prod, 5L, Util.yesterday(), Util.tomorrow());
         Entitlement ent = this.createEntitlement(owner, consumer, p,
-                createEntitlementCertificate("entkey", "ecert"));
+            createEntitlementCertificate("entkey", "ecert"));
         // Needs to be flipped
         ent.setUpdatedOnStart(false);
         entitlementCurator.create(ent);
@@ -95,7 +95,7 @@ public class ActiveEntitlementJobTest extends DatabaseTestFixture {
     public void testActiveEntitlementJobNoChange() throws JobExecutionException {
         Pool p = createPool(owner, prod, 5L, Util.yesterday(), Util.tomorrow());
         Entitlement ent = this.createEntitlement(owner, consumer, p,
-                createEntitlementCertificate("entkey", "ecert"));
+            createEntitlementCertificate("entkey", "ecert"));
         // Already done
         ent.setUpdatedOnStart(true);
         entitlementCurator.create(ent);
@@ -111,7 +111,7 @@ public class ActiveEntitlementJobTest extends DatabaseTestFixture {
         // Future pool
         Pool p = createPool(owner, prod, 5L, Util.tomorrow(), Util.addDaysToDt(10));
         Entitlement ent = this.createEntitlement(owner, consumer, p,
-                createEntitlementCertificate("entkey", "ecert"));
+            createEntitlementCertificate("entkey", "ecert"));
         // Needs to be flipped, eventually
         ent.setUpdatedOnStart(false);
         entitlementCurator.create(ent);

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/ConsumerComplianceJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/ConsumerComplianceJobTest.java
@@ -88,7 +88,7 @@ public class ConsumerComplianceJobTest {
         when(ctx.getMergedJobDataMap()).thenReturn(detail.getJobDataMap());
         when(curator.lockAndLoadByUuid(consumerUuid)).thenReturn(consumer);
         when(rules.getStatus(eq(consumer), any(Date.class), eq(false), eq(false))).thenThrow(
-                new RuleExecutionException("random exception"));
+            new RuleExecutionException("random exception"));
         job.execute(ctx);
     }
 
@@ -101,9 +101,9 @@ public class ConsumerComplianceJobTest {
         when(curator.lockAndLoadByUuid(consumerUuid)).thenReturn(null);
         job.execute(ctx);
 
-        verify(ctx).setResult(
-            eq(String.format("Compliance status update was not required as Consumer {} no longer exists.",
-                consumerUuid)));
+        verify(ctx).setResult(eq(String.format(
+            "Compliance status update was not required as Consumer {} no longer exists.",
+            consumerUuid)));
     }
 
 }

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/EntitleByProductsJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/EntitleByProductsJobTest.java
@@ -85,7 +85,7 @@ public class EntitleByProductsJobTest {
         EntitleByProductsJob job = new EntitleByProductsJob(e, null);
         job.execute(ctx);
         verify(e).bindByProducts(eq(pids), eq(consumerUuid), eq((Date) null),
-                eq((Collection<String>) null));
+            eq((Collection<String>) null));
         verify(e).sendEvents(eq(ents));
     }
 

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/EntitlerJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/EntitlerJobTest.java
@@ -109,8 +109,8 @@ public class EntitlerJobTest {
         ent.setPool(p);
         ent.setQuantity(100);
         ents.add(ent);
-        when(e.bindByPoolQuantities(eq(consumerUuid), anyMapOf(String.class, Integer.class))).thenReturn(
-                ents);
+        when(e.bindByPoolQuantities(eq(consumerUuid), anyMapOf(String.class, Integer.class)))
+            .thenReturn(ents);
 
         EntitlerJob job = new EntitlerJob(e, null, pC, null);
         job.execute(ctx);
@@ -164,8 +164,8 @@ public class EntitlerJobTest {
         when(ctx.getMergedJobDataMap()).thenReturn(detail.getJobDataMap());
         Class<HashMap<String, Integer>> className = (Class<HashMap<String, Integer>>) (Class) Map.class;
         ArgumentCaptor<HashMap<String, Integer>> pqMapCaptor = ArgumentCaptor.forClass(className);
-        when(e.bindByPoolQuantities(eq(consumerUuid), pqMapCaptor.capture())).thenThrow(
-                new ForbiddenException("job should fail"));
+        when(e.bindByPoolQuantities(eq(consumerUuid), pqMapCaptor.capture()))
+            .thenThrow(new ForbiddenException("job should fail"));
 
         EntitlerJob job = new EntitlerJob(e, null, null, null);
         job.execute(ctx);
@@ -183,8 +183,8 @@ public class EntitlerJobTest {
         ValidationResult result = new ValidationResult();
         result.addError("rulefailed.no.entitlements.available");
         mapResult.put("hello", result);
-        when(e.bindByPoolQuantities(eq(consumerUuid), anyMapOf(String.class, Integer.class))).thenThrow(
-                new EntitlementRefusedException(mapResult));
+        when(e.bindByPoolQuantities(eq(consumerUuid), anyMapOf(String.class, Integer.class)))
+            .thenThrow(new EntitlementRefusedException(mapResult));
 
         EntitlerJob job = new EntitlerJob(e, null, pC, i18n);
         Pool p = new Pool();
@@ -198,7 +198,7 @@ public class EntitlerJobTest {
         assertEquals("hello", resultErrors.get(0).getPoolId());
         assertEquals(1, resultErrors.get(0).getErrors().size());
         assertEquals("No subscriptions are available from the pool with ID 'hello'.", resultErrors.get(0)
-                .getErrors().get(0));
+            .getErrors().get(0));
     }
 
     @After

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/HypervisorUpdateJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/HypervisorUpdateJobTest.java
@@ -97,12 +97,8 @@ public class HypervisorUpdateJobTest {
 
         HypervisorUpdateJob job = new HypervisorUpdateJob(ownerCurator, consumerCurator, consumerResource);
         job.execute(ctx);
-        verify(consumerResource).create(any(Consumer.class),
-                                        eq(principal),
-                                        anyString(),
-                                        eq("joe"),
-                                        anyString(),
-                                        eq(false));
+        verify(consumerResource).create(any(Consumer.class), eq(principal), anyString(), eq("joe"),
+            anyString(), eq(false));
     }
 
     @Test
@@ -110,21 +106,17 @@ public class HypervisorUpdateJobTest {
         when(ownerCurator.lookupByKey(eq("joe"))).thenReturn(owner);
 
         JobDetail detail = HypervisorUpdateJob.forOwner(owner, hypervisorJson, true, principal,
-                "createReporterId");
+            "createReporterId");
         JobExecutionContext ctx = mock(JobExecutionContext.class);
         when(ctx.getMergedJobDataMap()).thenReturn(detail.getJobDataMap());
         when(consumerCurator.getHostConsumersMap(eq(owner), any(Set.class))).thenReturn(
-                new VirtConsumerMap());
+            new VirtConsumerMap());
 
         HypervisorUpdateJob job = new HypervisorUpdateJob(ownerCurator, consumerCurator, consumerResource);
         job.execute(ctx);
         ArgumentCaptor<Consumer> argument = ArgumentCaptor.forClass(Consumer.class);
-        verify(consumerResource).create(argument.capture(),
-                                        eq(principal),
-                                        anyString(),
-                                        eq("joe"),
-                                        anyString(),
-                                        eq(false));
+        verify(consumerResource).create(argument.capture(), eq(principal), anyString(), eq("joe"),
+            anyString(), eq(false));
         assertEquals("createReporterId", argument.getValue().getHypervisorId().getReporterId());
     }
 
@@ -145,7 +137,7 @@ public class HypervisorUpdateJobTest {
         HypervisorUpdateJob job = new HypervisorUpdateJob(ownerCurator, consumerCurator, consumerResource);
         job.execute(ctx);
         verify(consumerResource).performConsumerUpdates(any(Consumer.class), eq(hypervisor),
-                any(VirtConsumerMap.class), eq(false));
+            any(VirtConsumerMap.class), eq(false));
     }
 
     @Test
@@ -159,7 +151,7 @@ public class HypervisorUpdateJobTest {
         when(consumerCurator.getHostConsumersMap(eq(owner), any(Set.class))).thenReturn(vcm);
 
         JobDetail detail = HypervisorUpdateJob.forOwner(owner, hypervisorJson, true, principal,
-                "updateReporterId");
+            "updateReporterId");
         JobExecutionContext ctx = mock(JobExecutionContext.class);
         when(ctx.getMergedJobDataMap()).thenReturn(detail.getJobDataMap());
 
@@ -185,12 +177,8 @@ public class HypervisorUpdateJobTest {
 
         HypervisorUpdateJob job = new HypervisorUpdateJob(ownerCurator, consumerCurator, consumerResource);
         job.execute(ctx);
-        verify(consumerResource, never()).create(any(Consumer.class),
-                                        any(Principal.class),
-                                        anyString(),
-                                        anyString(),
-                                        anyString(),
-                                        eq(false));
+        verify(consumerResource, never()).create(any(Consumer.class), any(Principal.class),
+            anyString(), anyString(), anyString(), eq(false));
     }
 
     @Test
@@ -239,7 +227,7 @@ public class HypervisorUpdateJobTest {
         ListenerManager lm = mock(ListenerManager.class);
 
         when(jobCurator.getByClassAndTarget(anyString(), any(Class.class))).thenReturn(
-                preExistingJobStatus);
+            preExistingJobStatus);
         when(scheduler.getListenerManager()).thenReturn(lm);
         when(jobCurator.create(any(JobStatus.class))).thenReturn(newlyScheduledJobStatus);
 

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/UniqueByEntityJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/UniqueByEntityJobTest.java
@@ -56,15 +56,15 @@ public class UniqueByEntityJobTest {
         map.put(JobStatus.TARGET_ID, "TaylorSwift");
         JobKey jobKey = new JobKey("name", "group");
         JobDetail detail = newJob(TestUniqueByEntityJob.class)
-                .withIdentity(jobKey)
-                .requestRecovery(true)
-                .usingJobData(map).storeDurably(true)
-                .build();
+            .withIdentity(jobKey)
+            .requestRecovery(true)
+            .usingJobData(map).storeDurably(true)
+            .build();
         JobStatus preExistingJobStatus = new JobStatus();
         preExistingJobStatus.setState(JobState.WAITING);
         TestUniqueByEntityJob job = new TestUniqueByEntityJob();
         when(jobCurator.getByClassAndTarget(eq("TaylorSwift"), any(Class.class))).thenReturn(
-                preExistingJobStatus);
+            preExistingJobStatus);
 
         JobStatus resultStatus = job.scheduleJob(jobCurator, null, detail, null);
         assertEquals(preExistingJobStatus, resultStatus);

--- a/server/src/test/java/org/candlepin/policy/AutobindRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/AutobindRulesTest.java
@@ -167,8 +167,7 @@ public class AutobindRulesTest {
                 new ConsumerType(ConsumerTypeEnum.HYPERVISOR));
 
         List<PoolQuantity> results = autobindRules.selectBestPools(consumer,
-                new String[]{ productId }, pools, compliance, null, new HashSet<String>(),
-                false);
+            new String[]{ productId }, pools, compliance, null, new HashSet<String>(), false);
         assertEquals(1, results.size());
     }
 

--- a/server/src/test/java/org/candlepin/policy/PoolRulesInstanceTest.java
+++ b/server/src/test/java/org/candlepin/policy/PoolRulesInstanceTest.java
@@ -122,7 +122,7 @@ public class PoolRulesInstanceTest {
         List<Pool> existingPools = new LinkedList<Pool>();
         existingPools.add(pool);
         List<PoolUpdate> updates = poolRules.updatePools(p, existingPools, p.getQuantity(),
-                TestUtil.stubChangedProducts(p.getProduct()));
+            TestUtil.stubChangedProducts(p.getProduct()));
 
         assertEquals(1, updates.size());
         PoolUpdate update = updates.get(0);
@@ -148,7 +148,7 @@ public class PoolRulesInstanceTest {
         List<Pool> existingPools = new LinkedList<Pool>();
         existingPools.add(pool);
         List<PoolUpdate> updates = poolRules.updatePools(masterPool, existingPools, s.getQuantity(),
-                TestUtil.stubChangedProducts(masterPool.getProduct()));
+            TestUtil.stubChangedProducts(masterPool.getProduct()));
 
         assertEquals(1, updates.size());
         PoolUpdate update = updates.get(0);
@@ -174,7 +174,7 @@ public class PoolRulesInstanceTest {
         List<Pool> existingPools = new LinkedList<Pool>();
         existingPools.add(pool);
         List<PoolUpdate> updates = poolRules.updatePools(masterPool, existingPools,
-                masterPool.getQuantity(), TestUtil.stubChangedProducts(masterPool.getProduct()));
+            masterPool.getQuantity(), TestUtil.stubChangedProducts(masterPool.getProduct()));
 
         assertEquals(1, updates.size());
         PoolUpdate update = updates.get(0);
@@ -186,7 +186,7 @@ public class PoolRulesInstanceTest {
     }
 
     private Subscription createInstanceBasedSub(String productId, int quantity, int instanceMultiplier,
-            boolean exported) {
+        boolean exported) {
         Owner owner = new Owner("Test Corporation");
         Product product = new Product(productId, productId, owner);
         product.setAttribute("instance_multiplier", Integer.toString(instanceMultiplier));

--- a/server/src/test/java/org/candlepin/policy/PoolRulesStackDerivedTest.java
+++ b/server/src/test/java/org/candlepin/policy/PoolRulesStackDerivedTest.java
@@ -193,7 +193,7 @@ public class PoolRulesStackDerivedTest {
         attributes.put(pool2.getId(), PoolHelper.getFlattenedAttributes(pool2));
         when(poolManagerMock.createPools(Matchers.anyListOf(Pool.class))).then(returnsFirstArg());
         List<Pool> resPools = PoolHelper.createHostRestrictedPools(poolManagerMock, consumer, reqPools,
-                entitlements, attributes);
+            entitlements, attributes);
         stackDerivedPool = resPools.get(0);
 
         reqPools.clear();
@@ -372,7 +372,7 @@ public class PoolRulesStackDerivedTest {
         when(entCurMock.findByStackIds(eq(consumer), arg.capture())).thenReturn(stackedEnts);
 
         List<PoolUpdate> updates = poolRules.updatePoolsFromStack(consumer,
-                Arrays.asList(stackDerivedPool, stackDerivedPool2), false);
+            Arrays.asList(stackDerivedPool, stackDerivedPool2), false);
         Set<String> stackIds = arg.getValue();
         assertEquals(2, stackIds.size());
         assertThat(stackIds, hasItems(STACK, STACK + "3"));

--- a/server/src/test/java/org/candlepin/policy/PoolRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/PoolRulesTest.java
@@ -138,7 +138,7 @@ public class PoolRulesTest {
         List<Pool> existingPools = new LinkedList<Pool>();
         existingPools.add(p1);
         List<PoolUpdate> updates = this.poolRules.updatePools(p, existingPools, p.getQuantity(),
-                new HashSet<Product>());
+            new HashSet<Product>());
         assertEquals(1, updates.size());
         PoolUpdate update = updates.get(0);
         assertTrue(update.getProductsChanged());
@@ -156,7 +156,7 @@ public class PoolRulesTest {
 
         List<Pool> existingPools = Arrays.asList(p1);
         List<PoolUpdate> updates = this.poolRules.updatePools(p, existingPools, p.getQuantity(),
-                TestUtil.stubChangedProducts(p.getProduct()));
+            TestUtil.stubChangedProducts(p.getProduct()));
 
         assertEquals(1, updates.size());
         PoolUpdate update = updates.get(0);
@@ -176,7 +176,7 @@ public class PoolRulesTest {
 
         List<Pool> existingPools = Arrays.asList(p1);
         List<PoolUpdate> updates = this.poolRules.updatePools(p, existingPools, p.getQuantity(),
-                new HashSet<Product>());
+            new HashSet<Product>());
 
         assertEquals(1, updates.size());
         PoolUpdate update = updates.get(0);
@@ -196,7 +196,7 @@ public class PoolRulesTest {
 
         List<Pool> existingPools = Arrays.asList(p1);
         List<PoolUpdate> updates = this.poolRules.updatePools(p, existingPools, p.getQuantity(),
-                new HashSet<Product>());
+            new HashSet<Product>());
 
         assertEquals(1, updates.size());
         PoolUpdate update = updates.get(0);
@@ -220,7 +220,7 @@ public class PoolRulesTest {
 
         List<Pool> existingPools = Arrays.asList(p1);
         List<PoolUpdate> updates = this.poolRules.updatePools(p, existingPools, p.getQuantity(),
-                new HashSet<Product>());
+            new HashSet<Product>());
 
         assertEquals(1, updates.size());
         PoolUpdate update = updates.get(0);
@@ -252,7 +252,7 @@ public class PoolRulesTest {
 
         List<Pool> existingPools = Arrays.asList(p1);
         List<PoolUpdate> updates = this.poolRules.updatePools(p, existingPools, p.getQuantity(),
-                new HashSet<Product>());
+            new HashSet<Product>());
 
         assertEquals(0, updates.size());
     }
@@ -270,8 +270,7 @@ public class PoolRulesTest {
         p1.setQuantity(40L);
 
         List<Pool> existingPools = Arrays.asList(p1);
-        List<PoolUpdate> updates = this.poolRules.updatePools(p, existingPools, p.getQuantity(),
-                null);
+        List<PoolUpdate> updates = this.poolRules.updatePools(p, existingPools, p.getQuantity(), null);
 
         assertEquals(1, updates.size());
         PoolUpdate update = updates.get(0);
@@ -302,7 +301,7 @@ public class PoolRulesTest {
         List<Pool> existingPools = Arrays.asList(p1);
 
         List<PoolUpdate> updates = this.poolRules.updatePools(p, existingPools, p.getQuantity(),
-                new HashSet<Product>());
+            new HashSet<Product>());
         assertEquals(1, updates.size());
         assertEquals(2, updates.get(0).getPool().getDerivedProvidedProducts().size());
     }
@@ -394,7 +393,7 @@ public class PoolRulesTest {
         // Now we update the sub and see if that unlimited pool gets adjusted:
         p.getProduct().setAttribute("virt_limit", "10");
         List<PoolUpdate> updates = poolRules.updatePools(p, pools, p.getQuantity(),
-                TestUtil.stubChangedProducts(p.getProduct()));
+            TestUtil.stubChangedProducts(p.getProduct()));
         assertEquals(2, updates.size());
 
         PoolUpdate virtUpdate = updates.get(1);
@@ -413,7 +412,7 @@ public class PoolRulesTest {
         // the unlimited pool gets adjusted and flagged for cleanup:
         p.setProduct(TestUtil.createProduct(p.getProduct().getId(), p.getProduct().getName(), owner));
         List<PoolUpdate> updates = poolRules.updatePools(p, pools, p.getQuantity(),
-                TestUtil.stubChangedProducts(p.getProduct()));
+            TestUtil.stubChangedProducts(p.getProduct()));
         assertEquals(2, updates.size());
 
         // Regular pool should be in a sane state:
@@ -454,8 +453,7 @@ public class PoolRulesTest {
 
         int virtOnlyCount = 0;
         for (Pool pool : pools) {
-            if (pool.hasAttribute("virt_only") &&
-                    pool.attributeEquals("virt_only", "true")) {
+            if (pool.hasAttribute("virt_only") && pool.attributeEquals("virt_only", "true")) {
                 virtOnlyCount++;
                 assertEquals("false", pool.getAttributeValue("physical_only"));
             }
@@ -496,7 +494,7 @@ public class PoolRulesTest {
         assertEquals(0, physicalPool.getAttributes().size());
         assertProvidedProducts(p.getProvidedProducts(), physicalPool.getProvidedProducts());
         assertProvidedProducts(p.getDerivedProvidedProducts(),
-                physicalPool.getDerivedProvidedProducts());
+            physicalPool.getDerivedProvidedProducts());
 
         Pool unmappedVirtPool = pools.get(1);
         assert ("true".equals(unmappedVirtPool.getAttributeValue("virt_only")));
@@ -505,9 +503,9 @@ public class PoolRulesTest {
         // The derived provided products of the sub should be promoted to provided products
         // on the unmappedVirtPool
         assertProvidedProducts(p.getDerivedProvidedProducts(),
-                unmappedVirtPool.getProvidedProducts());
+            unmappedVirtPool.getProvidedProducts());
         assertProvidedProducts(new HashSet<Product>(),
-                unmappedVirtPool.getDerivedProvidedProducts());
+            unmappedVirtPool.getDerivedProvidedProducts());
 
         // Test for BZ 1204311 - Refreshing pools should not change unmapped guest pools
         // Refresh is a no-op in multiorg
@@ -519,7 +517,7 @@ public class PoolRulesTest {
     public void standaloneVirtLimitSubCreateDerived() {
         when(configMock.getBoolean(ConfigProperties.STANDALONE)).thenReturn(true);
         Subscription s = createVirtLimitSubWithDerivedProducts("virtLimitProduct",
-                "derivedProd", 10, 10);
+            "derivedProd", 10, 10);
         Pool p = TestUtil.copyFromSub(s);
         List<Pool> pools = poolRules.createAndEnrichPools(p, new LinkedList<Pool>());
 
@@ -536,14 +534,13 @@ public class PoolRulesTest {
         assertEquals("derivedProd", unmappedVirtPool.getProductId());
 
         assertProvidedProducts(s.getDerivedProvidedProducts(),
-                unmappedVirtPool.getProvidedProducts());
+            unmappedVirtPool.getProvidedProducts());
         assertProvidedProducts(new HashSet<Product>(),
-                unmappedVirtPool.getDerivedProvidedProducts());
+            unmappedVirtPool.getDerivedProvidedProducts());
         assertTrue(unmappedVirtPool.getProduct().hasAttribute(DERIVED_ATTR));
     }
 
-    private void assertProvidedProducts(Set<Product> expectedProducts,
-            Set<Product> providedProducts) {
+    private void assertProvidedProducts(Set<Product> expectedProducts, Set<Product> providedProducts) {
         assertEquals(expectedProducts.size(), providedProducts.size());
         for (Product expected : expectedProducts) {
             boolean found = false;
@@ -559,7 +556,7 @@ public class PoolRulesTest {
     }
 
     private Subscription createVirtLimitSubWithDerivedProducts(String productId,
-            String derivedProductId, int quantity, int virtLimit) {
+        String derivedProductId, int quantity, int virtLimit) {
 
         Product product = new Product(productId, productId, owner);
         product.setAttribute("virt_limit", Integer.toString(virtLimit));
@@ -616,8 +613,7 @@ public class PoolRulesTest {
 
         p = createVirtLimitPool("virtLimitProduct", 10, 10);
         p.setQuantity(50L);
-        List<PoolUpdate> updates = poolRules.updatePools(p, pools, p.getQuantity(),
-                new HashSet<Product>());
+        List<PoolUpdate> updates = poolRules.updatePools(p, pools, p.getQuantity(), new HashSet<Product>());
         assertEquals(2, updates.size());
         physicalPool = updates.get(0).getPool();
         assertEquals(new Long(50), physicalPool.getQuantity());
@@ -661,8 +657,7 @@ public class PoolRulesTest {
         assertEquals(1, pools.size());
 
         p = createVirtOnlyPool("virtOnlyProduct", 20);
-        List<PoolUpdate> updates = poolRules.updatePools(p, pools, p.getQuantity(),
-                new HashSet<Product>());
+        List<PoolUpdate> updates = poolRules.updatePools(p, pools, p.getQuantity(), new HashSet<Product>());
         assertEquals(1, updates.size());
         Pool updated = updates.get(0).getPool();
         assertEquals(new Long(20), updated.getQuantity());
@@ -687,8 +682,7 @@ public class PoolRulesTest {
         consumerSpecificPool.setSourceEntitlement(ent);
         pools.add(consumerSpecificPool);
 
-        List<PoolUpdate> updates = poolRules.updatePools(p, pools, p.getQuantity(),
-                new HashSet<Product>());
+        List<PoolUpdate> updates = poolRules.updatePools(p, pools, p.getQuantity(), new HashSet<Product>());
         assertEquals(0, updates.size());
     }
 
@@ -714,7 +708,7 @@ public class PoolRulesTest {
 
         p.getProduct().setAttribute("virt_limit", "40");
         List<PoolUpdate> updates = poolRules.updatePools(p, pools, p.getQuantity(),
-                TestUtil.stubChangedProducts(p.getProduct()));
+            TestUtil.stubChangedProducts(p.getProduct()));
         assertEquals(3, updates.size());
         Pool regular = updates.get(0).getPool();
         Pool unmappedSubPool = updates.get(1).getPool();
@@ -739,7 +733,7 @@ public class PoolRulesTest {
         List<Pool> existingPools = new LinkedList<Pool>();
         existingPools.add(p1);
         List<PoolUpdate> updates = this.poolRules.updatePools(p, existingPools, p.getQuantity(),
-                new HashSet<Product>());
+            new HashSet<Product>());
 
         assertEquals(0, updates.size());
     }
@@ -759,7 +753,7 @@ public class PoolRulesTest {
         List<Pool> existingPools = new LinkedList<Pool>();
         existingPools.add(p1);
         List<PoolUpdate> updates = this.poolRules.updatePools(p, existingPools, p.getQuantity(),
-                new HashSet<Product>());
+            new HashSet<Product>());
 
         assertEquals(1, updates.size());
         PoolUpdate update = updates.get(0);
@@ -782,7 +776,7 @@ public class PoolRulesTest {
         List<Pool> existingPools = new LinkedList<Pool>();
         existingPools.add(p1);
         List<PoolUpdate> updates = this.poolRules.updatePools(p, existingPools, p.getQuantity(),
-                new HashSet<Product>());
+            new HashSet<Product>());
 
         assertEquals(1, updates.size());
         PoolUpdate update = updates.get(0);
@@ -803,7 +797,7 @@ public class PoolRulesTest {
         List<Pool> existingPools = new LinkedList<Pool>();
         existingPools.add(p1);
         List<PoolUpdate> updates = this.poolRules.updatePools(p, existingPools, p.getQuantity(),
-                new HashSet<Product>());
+            new HashSet<Product>());
 
         assertEquals(1, updates.size());
         PoolUpdate update = updates.get(0);
@@ -824,7 +818,7 @@ public class PoolRulesTest {
         List<Pool> existingPools = new LinkedList<Pool>();
         existingPools.add(p1);
         List<PoolUpdate> updates = this.poolRules.updatePools(p, existingPools, p.getQuantity(),
-                new HashSet<Product>());
+            new HashSet<Product>());
 
         assertEquals(1, updates.size());
         PoolUpdate update = updates.get(0);

--- a/server/src/test/java/org/candlepin/policy/js/compliance/ComplianceRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/compliance/ComplianceRulesTest.java
@@ -141,7 +141,7 @@ public class ComplianceRulesTest {
         consumer.setType(new ConsumerType(ConsumerType.ConsumerTypeEnum.SYSTEM));
         for (Product product : installedProducts) {
             consumer.addInstalledProduct(new ConsumerInstalledProduct(product.getId(),
-                    product.getName()));
+                product.getName()));
         }
         consumer.setFact("cpu.cpu_socket(s)", "8"); // 8 socket machine
         return consumer;
@@ -589,15 +589,11 @@ public class ComplianceRulesTest {
         assertEquals(0, status.getPartiallyCompliantProducts().size());
 
         assertEquals(2, status.getCompliantProducts().size());
-        assertTrue(status.getCompliantProducts().keySet().contains(
-                PRODUCT_1.getId()));
-        assertTrue(status.getCompliantProducts().keySet().contains(
-                PRODUCT_2.getId()));
+        assertTrue(status.getCompliantProducts().keySet().contains(PRODUCT_1.getId()));
+        assertTrue(status.getCompliantProducts().keySet().contains(PRODUCT_2.getId()));
 
-        assertEquals(4, status.getCompliantProducts().get(
-                PRODUCT_1.getId()).size());
-        assertEquals(4, status.getCompliantProducts().get(
-                PRODUCT_2.getId()).size());
+        assertEquals(4, status.getCompliantProducts().get(PRODUCT_1.getId()).size());
+        assertEquals(4, status.getCompliantProducts().get(PRODUCT_2.getId()).size());
     }
 
     @Test
@@ -624,10 +620,8 @@ public class ComplianceRulesTest {
         assertEquals(0, status.getCompliantProducts().size());
         assertEquals(0, status.getNonCompliantProducts().size());
         assertEquals(2, status.getPartiallyCompliantProducts().size());
-        assertEquals(4, status.getPartiallyCompliantProducts().get(
-                PRODUCT_1.getId()).size());
-        assertEquals(4, status.getPartiallyCompliantProducts().get(
-                PRODUCT_2.getId()).size());
+        assertEquals(4, status.getPartiallyCompliantProducts().get(PRODUCT_1.getId()).size());
+        assertEquals(4, status.getPartiallyCompliantProducts().get(PRODUCT_2.getId()).size());
         assertEquals(1, status.getPartialStacks().size());
         assertTrue(status.getPartialStacks().keySet().contains(STACK_ID_1));
         assertEquals("partial", status.getStatus());
@@ -1173,8 +1167,7 @@ public class ComplianceRulesTest {
         assertEquals(0, status.getNonCompliantProducts().size());
         assertEquals(0, status.getPartiallyCompliantProducts().size());
         assertEquals(1, status.getCompliantProducts().size());
-        assertTrue(status.getCompliantProducts().keySet().contains(
-                PRODUCT_1.getId()));
+        assertTrue(status.getCompliantProducts().keySet().contains(PRODUCT_1.getId()));
         assertEquals(ComplianceStatus.GREEN, status.getStatus());
     }
 

--- a/server/src/test/java/org/candlepin/policy/js/compliance/StatusReasonMessageGeneratorTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/compliance/StatusReasonMessageGeneratorTest.java
@@ -153,7 +153,7 @@ public class StatusReasonMessageGeneratorTest {
         Owner owner = new Owner("test");
         Product product = TestUtil.createProduct("prod1", "NonCovered Product", owner);
         ConsumerInstalledProduct installed = new ConsumerInstalledProduct(product.getId(),
-                product.getName());
+            product.getName());
 
         consumer.addInstalledProduct(installed);
         generator.setMessage(consumer, reason, new Date());

--- a/server/src/test/java/org/candlepin/policy/js/compliance/hash/ComplianceStatusHasherTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/compliance/hash/ComplianceStatusHasherTest.java
@@ -236,7 +236,7 @@ public class ComplianceStatusHasherTest {
         consumer.setInstalledProducts(new HashSet<ConsumerInstalledProduct>(initialInstalled));
         assertEquals(initialHash, generateHash(testStatus, consumer));
         ConsumerInstalledProduct installed = new ConsumerInstalledProduct(product.getUuid(),
-                product.getName());
+            product.getName());
         consumer.addInstalledProduct(installed);
 
         String updatedHash = generateHash(testStatus, consumer);
@@ -323,7 +323,7 @@ public class ComplianceStatusHasherTest {
 
     private Consumer createConsumer(Owner owner) {
         Consumer consumer = new Consumer("test-consumer", "test-consumer", owner,
-                new ConsumerType(ConsumerType.ConsumerTypeEnum.SYSTEM));
+            new ConsumerType(ConsumerType.ConsumerTypeEnum.SYSTEM));
         consumer.setId("1");
         consumer.setUuid("12345");
         consumer.setFact("ram", "4");

--- a/server/src/test/java/org/candlepin/policy/js/entitlement/HostedVirtLimitEntitlementRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/entitlement/HostedVirtLimitEntitlementRulesTest.java
@@ -137,8 +137,7 @@ public class HostedVirtLimitEntitlementRulesTest extends EntitlementRulesTestFix
 
         Subscription s2 = createVirtLimitSub("virtLimitProduct2", 10, "10");
         s2.setId("subId2");
-        List<Pool> pools2 = poolRules
-                .createAndEnrichPools(TestUtil.copyFromSub(s2), new LinkedList<Pool>());
+        List<Pool> pools2 = poolRules.createAndEnrichPools(TestUtil.copyFromSub(s2), new LinkedList<Pool>());
         assertEquals(2, pools.size());
 
         Pool physicalPool2 = pools2.get(0);
@@ -163,10 +162,10 @@ public class HostedVirtLimitEntitlementRulesTest extends EntitlementRulesTestFix
 
         ArgumentCaptor<Set> captor = ArgumentCaptor.forClass(Set.class);
         when(poolManagerMock.lookupBySubscriptionIds(captor.capture())).thenReturn(poolList);
-        when(poolManagerMock.lookupBySubscriptionId(eq(physicalPool.getSubscriptionId()))).thenReturn(
-                poolList);
-        when(poolManagerMock.lookupBySubscriptionId(eq(physicalPool2.getSubscriptionId()))).thenReturn(
-                poolList2);
+        when(poolManagerMock.lookupBySubscriptionId(eq(physicalPool.getSubscriptionId())))
+            .thenReturn(poolList);
+        when(poolManagerMock.lookupBySubscriptionId(eq(physicalPool2.getSubscriptionId())))
+            .thenReturn(poolList2);
 
         Map<String, Entitlement> entitlements = new HashMap<String, Entitlement>();
         entitlements.put(physicalPool.getId(), e);

--- a/server/src/test/java/org/candlepin/policy/js/entitlement/PreEntitlementRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/entitlement/PreEntitlementRulesTest.java
@@ -187,8 +187,7 @@ public class PreEntitlementRulesTest extends EntitlementRulesTestFixture {
         pool2.setQuantity(new Long(100));
 
         Map<String, ValidationResult> results = enforcer.preEntitlement(consumer,
-                createPoolQuantities(100, pool, pool2),
-                CallerType.UNKNOWN);
+            createPoolQuantities(100, pool, pool2), CallerType.UNKNOWN);
 
         assertEquals(2, results.size());
         for (ValidationResult result : results.values()) {
@@ -409,8 +408,7 @@ public class PreEntitlementRulesTest extends EntitlementRulesTestFixture {
         Pool pool2 = setupArchTest("sockets", "2", "cpu.cpu_socket(s)", "2");
 
         Map<String, ValidationResult> results = enforcer.preEntitlement(consumer,
-                createPoolQuantities(1, pool, pool2),
-                CallerType.UNKNOWN);
+            createPoolQuantities(1, pool, pool2), CallerType.UNKNOWN);
         assertEquals(2, results.size());
         for (ValidationResult result : results.values()) {
             assertFalse(result.hasErrors());
@@ -669,7 +667,7 @@ public class PreEntitlementRulesTest extends EntitlementRulesTestFixture {
     public void unmappedGuestGoodDate() {
         Pool pool = setupUnmappedGuestPool();
         Consumer newborn = new Consumer("test newborn consumer", "test user", owner,
-                new ConsumerType(ConsumerTypeEnum.SYSTEM));
+            new ConsumerType(ConsumerTypeEnum.SYSTEM));
         newborn.setFact("virt.is_guest", "true");
         newborn.setCreated(new Date());
         ValidationResult result = enforcer.preEntitlement(newborn, pool, 1);
@@ -681,7 +679,7 @@ public class PreEntitlementRulesTest extends EntitlementRulesTestFixture {
     public void unmappedGuestBadDate() {
         Pool pool = setupUnmappedGuestPool();
         Consumer tooOld = new Consumer("test newborn consumer", "test user", owner,
-                new ConsumerType(ConsumerTypeEnum.SYSTEM));
+            new ConsumerType(ConsumerTypeEnum.SYSTEM));
         tooOld.setFact("virt.is_guest", "true");
         Date twentyFiveHoursAgo = new Date(new Date().getTime() - 25L * 60L * 60L * 1000L);
         tooOld.setCreated(twentyFiveHoursAgo);
@@ -699,7 +697,7 @@ public class PreEntitlementRulesTest extends EntitlementRulesTestFixture {
         pool.setStartDate(fourHoursFromNow);
 
         Consumer consumer = new Consumer("test newborn consumer", "test user", owner,
-                new ConsumerType(ConsumerTypeEnum.SYSTEM));
+            new ConsumerType(ConsumerTypeEnum.SYSTEM));
         consumer.setFact("virt.is_guest", "true");
         consumer.setCreated(new Date());
         ValidationResult result = enforcer.preEntitlement(consumer, pool, 1, CallerType.BIND);
@@ -712,9 +710,9 @@ public class PreEntitlementRulesTest extends EntitlementRulesTestFixture {
     @Test
     public void mappedGuest() {
         Consumer parent = new Consumer("test parent consumer", "test user", owner,
-                new ConsumerType(ConsumerTypeEnum.SYSTEM));
+            new ConsumerType(ConsumerTypeEnum.SYSTEM));
         Consumer newborn = new Consumer("test newborn consumer", "test user", owner,
-                new ConsumerType(ConsumerTypeEnum.SYSTEM));
+            new ConsumerType(ConsumerTypeEnum.SYSTEM));
         newborn.setCreated(new java.util.Date());
         Pool pool = setupUnmappedGuestPool();
 

--- a/server/src/test/java/org/candlepin/policy/js/pool/PoolHelperTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/pool/PoolHelperTest.java
@@ -170,7 +170,7 @@ public class PoolHelperTest {
 
         when(pm.createPools(anyListOf(Pool.class))).then(returnsFirstArg());
         List<Pool> pools = PoolHelper.createHostRestrictedPools(pm, cons, targetPools, entitlements,
-                attributes);
+            attributes);
 
         assertEquals(2, pools.size());
         Pool first = null, second = null;
@@ -232,7 +232,7 @@ public class PoolHelperTest {
         attributes.put(targetPool.getId(), PoolHelper.getFlattenedAttributes(targetPool));
         when(pm.createPools(anyListOf(Pool.class))).then(returnsFirstArg());
         List<Pool> hostRestrictedPools = PoolHelper.createHostRestrictedPools(pm, cons, targetPools,
-                entitlements, attributes);
+            entitlements, attributes);
 
         assertEquals(1, hostRestrictedPools.size());
         Pool hostRestrictedPool = hostRestrictedPools.get(0);
@@ -275,9 +275,9 @@ public class PoolHelperTest {
         assertNotEquals(pool.getSourceSubscription(), clone);
         assertEquals(pool.getSourceSubscription().getSubscriptionId(), clone.getSubscriptionId());
         assertEquals(pool.getSourceSubscription().getSubscriptionId(),
-                clone.getSourceSubscription().getSubscriptionId());
+            clone.getSourceSubscription().getSubscriptionId());
         assertEquals("TaylorSwift",
-                clone.getSourceSubscription().getSubscriptionSubKey());
+            clone.getSourceSubscription().getSubscriptionSubKey());
 
         assertEquals(1, clone.getBranding().size());
         Branding brandingClone = clone.getBranding().iterator().next();

--- a/server/src/test/java/org/candlepin/policy/js/quantity/QuantityRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/quantity/QuantityRulesTest.java
@@ -134,9 +134,8 @@ public class QuantityRulesTest {
         pool.getProduct().setAttribute("multi-entitlement", "no");
         List<Pool> pools = new LinkedList<Pool>();
         pools.add(pool);
-        Map<String, SuggestedQuantity> results =
-                quantityRules.getSuggestedQuantities(pools,
-                        new Consumer(), new Date());
+        Map<String, SuggestedQuantity> results = quantityRules.getSuggestedQuantities(
+            pools, new Consumer(), new Date());
         assertTrue(results.containsKey(pool.getId()));
         SuggestedQuantity suggested = results.get(pool.getId());
         assertEquals(new Long(1), suggested.getSuggested());
@@ -413,9 +412,8 @@ public class QuantityRulesTest {
 
         consumer.setEntitlements(ents);
 
-        SuggestedQuantity suggested =
-            quantityRules.getSuggestedQuantity(pool, consumer,
-                TestUtil.createDate(2010, 1, 1));
+        SuggestedQuantity suggested = quantityRules.getSuggestedQuantity(
+            pool, consumer, TestUtil.createDate(2010, 1, 1));
         assertEquals(new Long(2), suggested.getSuggested());
     }
 
@@ -443,9 +441,8 @@ public class QuantityRulesTest {
         ents.add(currentEntitlement);
         consumer.setEntitlements(ents);
 
-        SuggestedQuantity suggested =
-            quantityRules.getSuggestedQuantity(currentPool,
-                consumer, TestUtil.createDate(2010, 6, 1));
+        SuggestedQuantity suggested = quantityRules.getSuggestedQuantity(
+            currentPool, consumer, TestUtil.createDate(2010, 6, 1));
         assertEquals(new Long(0), suggested.getSuggested());
 
         // Make sure current coverage does not affect the future

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
@@ -200,6 +200,7 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
     }
 
     @Test
+    @SuppressWarnings("checkstyle:indentation")
     public void testCreateConsumer() {
         Consumer toSubmit = new Consumer(CONSUMER_NAME, USER_NAME, null,
             standardSystemType);
@@ -219,6 +220,7 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
     }
 
     @Test
+    @SuppressWarnings("checkstyle:indentation")
     public void testCreateConsumerVsDefaultServiceLevelForOwner() {
         Consumer toSubmit = new Consumer(CONSUMER_NAME, USER_NAME, null,
             standardSystemType);
@@ -243,7 +245,7 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
         toSubmit.getFacts().put(METADATA_NAME, METADATA_VALUE);
 
         Consumer submitted = consumerResource.create(toSubmit, principal, null,
-                owner.getKey(), null, true);
+            owner.getKey(), null, true);
         assertNotNull(submitted);
         assertNotNull(submitted.getId());
         assertNotNull(consumerCurator.find(submitted.getId()));
@@ -366,9 +368,8 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
 
         consumerResource.unbindBySerial(consumer.getUuid(), serials.get(0)
             .getSerial().getId());
-        assertEquals(0,
-            consumerResource.listEntitlements(consumer.getUuid(), null, true,
-                    "", new ArrayList<KeyValueParameter>(), null).size());
+        assertEquals(0, consumerResource.listEntitlements(
+            consumer.getUuid(), null, true, "", new ArrayList<KeyValueParameter>(), null).size());
     }
 
     @Test(expected = NotFoundException.class)
@@ -401,10 +402,8 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
 
         setupPrincipal(new ConsumerPrincipal(consumer));
 
-        assertEquals(
-            3,
-            consumerResource.getEntitlementCertificates(consumer.getUuid(),
-                null).size());
+        assertEquals(3, consumerResource.getEntitlementCertificates(
+            consumer.getUuid(), null).size());
     }
 
     @Test(expected = NotFoundException.class)
@@ -439,9 +438,8 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
         setupAdminPrincipal("admin");
         securityInterceptor.enable();
 
-        assertEquals(0,
-            consumerResource.getEntitlementCertificates(consumer.getUuid(),
-                null).size());
+        assertEquals(0, consumerResource.getEntitlementCertificates(
+            consumer.getUuid(), null).size());
     }
 
     @Test(expected = NotFoundException.class)
@@ -492,9 +490,8 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
         setupPrincipal(new ConsumerPrincipal(consumer));
         securityInterceptor.enable();
 
-        assertEquals(3,
-            consumerResource.listEntitlements(consumer.getUuid(), null, true,
-                    "", new ArrayList<KeyValueParameter>(), null).size());
+        assertEquals(3, consumerResource.listEntitlements(
+            consumer.getUuid(), null, true, "", new ArrayList<KeyValueParameter>(), null).size());
     }
 
     @Test(expected = NotFoundException.class)
@@ -514,7 +511,7 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
         securityInterceptor.enable();
 
         consumerResource.listEntitlements(consumer.getUuid(), null, true,
-                "", new ArrayList<KeyValueParameter>(), null);
+            "", new ArrayList<KeyValueParameter>(), null);
     }
 
     @Test(expected = NotFoundException.class)
@@ -533,7 +530,7 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
         setupPrincipal(evilOwner, Access.ALL);
 
         consumerResource.listEntitlements(consumer.getUuid(), null, true,
-                "", new ArrayList<KeyValueParameter>(), null);
+            "", new ArrayList<KeyValueParameter>(), null);
     }
 
     @Test
@@ -547,9 +544,8 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
 
         securityInterceptor.enable();
 
-        assertEquals(3,
-            consumerResource.listEntitlements(consumer.getUuid(), null, true,
-                    "", new ArrayList<KeyValueParameter>(), null).size());
+        assertEquals(3, consumerResource.listEntitlements(
+            consumer.getUuid(), null, true, "", new ArrayList<KeyValueParameter>(), null).size());
     }
 
     @Test
@@ -598,10 +594,10 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
     @Test
     public void testRegenerateEntitlementCertificateWithValidConsumerByEntitlement() {
         ConsumerResource cr = new ConsumerResource(this.consumerCurator, null,
-                null, null, this.entitlementCurator, null, null, null, null, null,
-                null, null, null, null, this.poolManager, null, null, null,
-                null, null, null, null, null, new CandlepinCommonTestConfig(), null,
-                null, null, mock(ConsumerBindUtil.class));
+            null, null, this.entitlementCurator, null, null, null, null, null,
+            null, null, null, null, this.poolManager, null, null, null,
+            null, null, null, null, null, new CandlepinCommonTestConfig(), null,
+            null, null, mock(ConsumerBindUtil.class));
 
         Response rsp = consumerResource.bind(
             consumer.getUuid(), pool.getId().toString(), null, 1, null,

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
@@ -106,30 +106,18 @@ public class ConsumerResourceTest {
 
     private I18n i18n;
 
-    @Mock
-    private ConsumerCurator mockedConsumerCurator;
-    @Mock
-    private OwnerCurator mockedOwnerCurator;
-    @Mock
-    private EntitlementCertServiceAdapter mockedEntitlementCertServiceAdapter;
-    @Mock
-    private SubscriptionServiceAdapter mockedSubscriptionServiceAdapter;
-    @Mock
-    private PoolManager mockedPoolManager;
-    @Mock
-    private EntitlementCurator mockedEntitlementCurator;
-    @Mock
-    private ComplianceRules mockedComplianceRules;
-    @Mock
-    private ServiceLevelValidator mockedServiceLevelValidator;
-    @Mock
-    private ActivationKeyRules mockedActivationKeyRules;
-    @Mock
-    private EventFactory eventFactory;
-    @Mock
-    private EventBuilder eventBuilder;
-    @Mock
-    private ConsumerBindUtil consumerBindUtil;
+    @Mock private ConsumerCurator mockedConsumerCurator;
+    @Mock private OwnerCurator mockedOwnerCurator;
+    @Mock private EntitlementCertServiceAdapter mockedEntitlementCertServiceAdapter;
+    @Mock private SubscriptionServiceAdapter mockedSubscriptionServiceAdapter;
+    @Mock private PoolManager mockedPoolManager;
+    @Mock private EntitlementCurator mockedEntitlementCurator;
+    @Mock private ComplianceRules mockedComplianceRules;
+    @Mock private ServiceLevelValidator mockedServiceLevelValidator;
+    @Mock private ActivationKeyRules mockedActivationKeyRules;
+    @Mock private EventFactory eventFactory;
+    @Mock private EventBuilder eventBuilder;
+    @Mock private ConsumerBindUtil consumerBindUtil;
 
     @Before
     public void setUp() {
@@ -372,8 +360,8 @@ public class ConsumerResourceTest {
             null, sa, null, null, null, i18n, null, null, null, null, null,
             null, null, null, null, null, e, null, null, null, null,
             new CandlepinCommonTestConfig(), null, null, null, consumerBindUtil);
-        Response r = cr
-                .bind("fakeConsumer", null, prodIds, null, null, null, false, null, null, null, null);
+        Response r = cr.bind(
+            "fakeConsumer", null, prodIds, null, null, null, false, null, null, null, null);
         assertEquals(null, r.getEntity());
     }
 
@@ -389,16 +377,15 @@ public class ConsumerResourceTest {
         Owner owner = TestUtil.createOwner();
         Consumer consumer = TestUtil.createConsumer(owner);
 
-        when(cc.verifyAndLookupConsumerWithEntitlements(eq("fakeConsumer"))).thenReturn(
-                consumer);
+        when(cc.verifyAndLookupConsumerWithEntitlements(eq("fakeConsumer"))).thenReturn(consumer);
         when(sa.hasUnacceptedSubscriptionTerms(any(Owner.class))).thenReturn(false);
 
         ConsumerResource cr = new ConsumerResource(cc, null, null, sa, null, null, null, i18n, null,
-                null, null, null, null, null, pm, null, null, null, null, null, null, null, null,
-                new CandlepinCommonTestConfig(), null, null, null, consumerBindUtil);
+            null, null, null, null, null, pm, null, null, null, null, null, null, null, null,
+            new CandlepinCommonTestConfig(), null, null, null, consumerBindUtil);
 
         Response rsp = cr.bind("fakeConsumer", null, null, null, null, null, true, null,
-                null, pools, new TrustedUserPrincipal("TaylorSwift"));
+            null, pools, new TrustedUserPrincipal("TaylorSwift"));
 
         JobDetail detail = (JobDetail) rsp.getEntity();
         PoolIdAndQuantity[] pQs = (PoolIdAndQuantity[]) detail.getJobDataMap().get("pool_and_quantities");
@@ -479,9 +466,9 @@ public class ConsumerResourceTest {
                         any(String.class))).thenReturn(new ArrayList<Entitlement>());
 
         ConsumerResource consumerResource = new ConsumerResource(consumerCurator, null,
-                null, null, entitlementCurator, null, null, i18n, null, null, null,
-                null, null, null, null, null, null, null, null, null, null, null,
-                null, new CandlepinCommonTestConfig(), null, null, null, consumerBindUtil);
+            null, null, entitlementCurator, null, null, i18n, null, null, null,
+            null, null, null, null, null, null, null, null, null, null, null,
+            null, new CandlepinCommonTestConfig(), null, null, null, consumerBindUtil);
         consumerResource.unbindByPool("fake-uuid", "Run Forest!");
     }
 
@@ -690,20 +677,20 @@ public class ConsumerResourceTest {
     @Test(expected = BadRequestException.class)
     public void testFetchAllConsumers() {
         ConsumerResource cr = new ConsumerResource(null, null,
-                null, null, null, null, null, i18n, null, null, null,
-                null, null, null, null, null, null, null, null, null,
-                null, null, null, new CandlepinCommonTestConfig(),
-                null, null, null, null);
+            null, null, null, null, null, i18n, null, null, null,
+            null, null, null, null, null, null, null, null, null,
+            null, null, null, new CandlepinCommonTestConfig(),
+            null, null, null, null);
         cr.list(null, null, null, null, null, null, null);
     }
 
     @Test
     public void testFetchAllConsumersForUser() {
         ConsumerResource cr = new ConsumerResource(mockedConsumerCurator, null,
-                null, null, null, null, null, i18n, null, null, null,
-                null, null, null, null, null, null, null, null, null,
-                null, null, null, new CandlepinCommonTestConfig(),
-                null, null, null, null);
+            null, null, null, null, null, i18n, null, null, null,
+            null, null, null, null, null, null, null, null, null,
+            null, null, null, new CandlepinCommonTestConfig(),
+            null, null, null, null);
         Page<List<Consumer>> page = new Page<List<Consumer>>();
         ArrayList<Consumer> consumers = new ArrayList<Consumer>();
         page.setPageData(consumers);
@@ -718,10 +705,10 @@ public class ConsumerResourceTest {
 
     public void testFetchAllConsumersForOwner() {
         ConsumerResource cr = new ConsumerResource(mockedConsumerCurator, null,
-                null, null, null, null, null, i18n, null, null, null,
-                null, null, null, null, null, mockedOwnerCurator, null, null, null,
-                null, null, null, new CandlepinCommonTestConfig(),
-                null, null, null, null);
+            null, null, null, null, null, i18n, null, null, null,
+            null, null, null, null, null, mockedOwnerCurator, null, null, null,
+            null, null, null, new CandlepinCommonTestConfig(),
+            null, null, null, null);
         Page<List<Consumer>> page = new Page<List<Consumer>>();
         ArrayList<Consumer> consumers = new ArrayList<Consumer>();
         page.setPageData(consumers);
@@ -739,20 +726,20 @@ public class ConsumerResourceTest {
     @Test(expected = BadRequestException.class)
     public void testFetchAllConsumersForEmptyUUIDs() {
         ConsumerResource cr = new ConsumerResource(mockedConsumerCurator, null,
-                null, null, null, null, null, i18n, null, null, null,
-                null, null, null, null, null, null, null, null, null,
-                null, null, null, new CandlepinCommonTestConfig(),
-                null, null, null, null);
+            null, null, null, null, null, i18n, null, null, null,
+            null, null, null, null, null, null, null, null, null,
+            null, null, null, new CandlepinCommonTestConfig(),
+            null, null, null, null);
         List<Consumer> result = cr.list(null, null, null, new ArrayList<String>(), null, null, null);
     }
 
     @Test
     public void testFetchAllConsumersForSomeUUIDs() {
         ConsumerResource cr = new ConsumerResource(mockedConsumerCurator, null,
-                null, null, null, null, null, i18n, null, null, null,
-                null, null, null, null, null, null, null, null, null,
-                null, null, null, new CandlepinCommonTestConfig(),
-                null, null, null, null);
+            null, null, null, null, null, i18n, null, null, null,
+            null, null, null, null, null, null, null, null, null,
+            null, null, null, new CandlepinCommonTestConfig(),
+            null, null, null, null);
         Page<List<Consumer>> page = new Page<List<Consumer>>();
         ArrayList<Consumer> consumers = new ArrayList<Consumer>();
         page.setPageData(consumers);

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
@@ -247,7 +247,7 @@ public class ConsumerResourceUpdateTest {
         this.resource.updateConsumer(consumer.getUuid(), incoming);
         verify(sink).queueEvent((Event) any());
         verify(complianceRules).getStatus(eq(consumer), any(Date.class),
-                any(Boolean.class), any(Boolean.class));
+            any(Boolean.class), any(Boolean.class));
     }
 
     @Test
@@ -699,8 +699,7 @@ public class ConsumerResourceUpdateTest {
         Consumer updated = new Consumer();
         updated.setEnvironment(changedEnvironment);
 
-        when(environmentCurator.find(changedEnvironment.getId())).thenReturn(
-                changedEnvironment);
+        when(environmentCurator.find(changedEnvironment.getId())).thenReturn(changedEnvironment);
 
         resource.updateConsumer(existing.getUuid(), updated);
 

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceVirtEntitlementTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceVirtEntitlementTest.java
@@ -252,7 +252,7 @@ public class ConsumerResourceVirtEntitlementTest extends DatabaseTestFixture {
             when(config.getString(eq(ConfigProperties.CONSUMER_PERSON_NAME_PATTERN)))
                 .thenReturn("[\\#\\?\\'\\`\\!@{}()\\[\\]\\?&\\w-\\.]+");
             when(config.subset(eq("org.quartz"))).thenReturn(
-                    new MapConfiguration(ConfigProperties.DEFAULT_PROPERTIES));
+                new MapConfiguration(ConfigProperties.DEFAULT_PROPERTIES));
             bind(Configuration.class).toInstance(config);
             bind(Enforcer.class).to(EntitlementRules.class);
         }

--- a/server/src/test/java/org/candlepin/resource/GuestIdResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/GuestIdResourceTest.java
@@ -56,23 +56,12 @@ public class GuestIdResourceTest {
 
     private I18n i18n;
 
-    @Mock
-    private ConsumerCurator consumerCurator;
-
-    @Mock
-    private GuestIdCurator guestIdCurator;
-
-    @Mock
-    private ConsumerResourceForTesting consumerResource;
-
-    @Mock
-    private EventFactory eventFactory;
-
-    @Mock
-    private EventSink sink;
-
-    @Mock
-    private ServiceLevelValidator mockedServiceLevelValidator;
+    @Mock private ConsumerCurator consumerCurator;
+    @Mock private GuestIdCurator guestIdCurator;
+    @Mock private ConsumerResourceForTesting consumerResource;
+    @Mock private EventFactory eventFactory;
+    @Mock private EventSink sink;
+    @Mock private ServiceLevelValidator mockedServiceLevelValidator;
 
     private GuestIdResource guestIdResource;
 
@@ -139,8 +128,7 @@ public class GuestIdResourceTest {
 
         guestIdResource.updateGuests(consumer.getUuid(), guestIds);
         Mockito.verify(consumerResource, Mockito.times(1))
-            .performConsumerUpdates(any(Consumer.class), eq(consumer),
-                    any(VirtConsumerMap.class));
+            .performConsumerUpdates(any(Consumer.class), eq(consumer), any(VirtConsumerMap.class));
         // consumerResource returned true, so the consumer should be updated
         Mockito.verify(consumerCurator, Mockito.times(1)).update(eq(consumer));
     }
@@ -157,8 +145,7 @@ public class GuestIdResourceTest {
 
         guestIdResource.updateGuests(consumer.getUuid(), guestIds);
         Mockito.verify(consumerResource, Mockito.times(1))
-            .performConsumerUpdates(any(Consumer.class), eq(consumer),
-                    any(VirtConsumerMap.class));
+            .performConsumerUpdates(any(Consumer.class), eq(consumer), any(VirtConsumerMap.class));
         Mockito.verify(consumerCurator, Mockito.never()).update(eq(consumer));
     }
 
@@ -222,8 +209,7 @@ public class GuestIdResourceTest {
 
         // We now check for migration when the system checks in, not during guest ID updates.
         Mockito.verify(consumerResource, Mockito.times(0))
-            .checkForMigration(any(Consumer.class),
-                any(Consumer.class));
+            .checkForMigration(any(Consumer.class), any(Consumer.class));
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/resource/OwnerProductResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/OwnerProductResourceTest.java
@@ -60,8 +60,7 @@ public class OwnerProductResourceTest extends DatabaseTestFixture {
         String version = "1.0";
         String arch = "ALL";
         String type = "SVC";
-        Product prod = new Product(label, name, owner, variant,
-                version, arch, type);
+        Product prod = new Product(label, name, owner, variant, version, arch, type);
         return prod;
     }
 
@@ -81,8 +80,8 @@ public class OwnerProductResourceTest extends DatabaseTestFixture {
         String  contentHash = String.valueOf(
             Math.abs(Long.valueOf("test-content".hashCode())));
         Content testContent = new Content(owner, "test-content", contentHash,
-                            "test-content-label", "yum", "test-vendor",
-                             "test-content-url", "test-gpg-url", "test-arch");
+            "test-content-label", "yum", "test-vendor",
+            "test-content-url", "test-gpg-url", "test-arch");
 
         HashSet<Content> contentSet = new HashSet<Content>();
         testContent = contentCurator.create(testContent);

--- a/server/src/test/java/org/candlepin/resource/OwnerResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/OwnerResourceTest.java
@@ -494,14 +494,14 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         poolCurator.create(pool2);
 
         List<Pool> nowList = ownerResource.listPools(owner.getKey(), c.getUuid(), null, null, null, false,
-                null, null, new ArrayList<KeyValueParameter>(), principal, null);
+            null, null, new ArrayList<KeyValueParameter>(), principal, null);
         assertEquals(1, nowList.size());
         assert (nowList.get(0).getId().equals(pool1.getId()));
 
         Date activeOn = new Date(pool2.getStartDate().getTime() + 1000L * 60 * 60 * 24);
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
         List<Pool> futureList = ownerResource.listPools(owner.getKey(), c.getUuid(), null, null, null,
-                false, sdf.format(activeOn), null, new ArrayList<KeyValueParameter>(), principal, null);
+            false, sdf.format(activeOn), null, new ArrayList<KeyValueParameter>(), principal, null);
         assertEquals(1, futureList.size());
         assert (futureList.get(0).getId().equals(pool2.getId()));
     }
@@ -741,7 +741,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
 
         assertEquals(1,
             ownerResource.listConsumers(owner.getKey(), null, null,
-                uuids, null, null, null, null, null, null).size());
+            uuids, null, null, null, null, null, null).size());
     }
 
     /**
@@ -930,8 +930,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         createEntitlementWithQ(pool, retrieved, consumer1, e2, "01/01/2010");
         assertEquals(pool.getConsumed(), Long.valueOf(e1 + e2));
         this.config.setProperty(
-            ConfigProperties.REVOKE_ENTITLEMENT_IN_FIFO_ORDER, fifo ? "true" :
-                "false");
+            ConfigProperties.REVOKE_ENTITLEMENT_IN_FIFO_ORDER, fifo ? "true" : "false");
 
         poolManager.getRefresher(subAdapter).add(retrieved).run();
         pool = poolCurator.find(pool.getId());
@@ -1201,7 +1200,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         ImportRecord record = thisOwnerResource.importManifest(owner.getKey(), new String[0], input);
         assertEquals(ImportRecord.Status.SUCCESS_WITH_WARNING, record.getStatus());
         assertEquals(owner.getKey() + " file imported successfully." +
-                "No active subscriptions found in the file.", record.getStatusMessage());
+            "No active subscriptions found in the file.", record.getStatusMessage());
     }
 
     @Test
@@ -1226,13 +1225,12 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         ImportRecord record = thisOwnerResource.importManifest(owner.getKey(), new String[0], input);
         assertEquals(ImportRecord.Status.SUCCESS_WITH_WARNING, record.getStatus());
         assertEquals(owner.getKey() + " file imported successfully." +
-                "One or more inactive subscriptions found in the file.", record.getStatusMessage());
+            "One or more inactive subscriptions found in the file.", record.getStatusMessage());
         verify(es).emitSubscriptionExpired(subscription);
     }
 
     private OwnerResource setUpSuccesfullImport(MultipartInput input, Map<String, Object> result,
-            EventSink es)
-        throws IOException, ImporterException {
+        EventSink es) throws IOException, ImporterException {
 
         Importer importer = mock(Importer.class);
         OwnerResource thisOwnerResource = new OwnerResource(ownerCurator, null,
@@ -1405,9 +1403,9 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         List<Pool> pools = poolCurator.listByOwner(owner);
         assertEquals(2, pools.size());
         assertTrue(pools.get(0).getSubscriptionSubKey().startsWith("master") ||
-                pools.get(1).getSubscriptionSubKey().startsWith("master"));
+            pools.get(1).getSubscriptionSubKey().startsWith("master"));
         assertTrue(pools.get(0).getSubscriptionSubKey().equals("derived") ||
-                pools.get(1).getSubscriptionSubKey().equals("derived"));
+            pools.get(1).getSubscriptionSubKey().equals("derived"));
     }
 
     @Test
@@ -1423,9 +1421,9 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         List<Pool> pools = poolCurator.listByOwner(owner);
         assertEquals(2, pools.size());
         assertTrue(pools.get(0).getSubscriptionSubKey().startsWith("master") ||
-                pools.get(1).getSubscriptionSubKey().startsWith("master"));
+            pools.get(1).getSubscriptionSubKey().startsWith("master"));
         assertTrue(pools.get(0).getSubscriptionSubKey().equals("derived") ||
-                pools.get(1).getSubscriptionSubKey().equals("derived"));
+            pools.get(1).getSubscriptionSubKey().equals("derived"));
         assertEquals(100L, pools.get(0).getQuantity().longValue());
         assertEquals(300L, pools.get(1).getQuantity().longValue());
     }
@@ -1503,9 +1501,9 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         OwnerCurator oc = mock(OwnerCurator.class);
         EntitlementCurator ec = mock(EntitlementCurator.class);
         OwnerResource ownerres = new OwnerResource(oc, null,
-                null, i18n, null, null, null, null, null, null, null,
-                null, null, null, null, null, ec, null, null, null,
-                null, null, null, null, null);
+            null, i18n, null, null, null, null, null, null, null,
+            null, null, null, null, null, ec, null, null, null,
+            null, null, null, null, null);
 
         when(oc.lookupByKey(owner.getKey())).thenReturn(owner);
         when(
@@ -1526,9 +1524,9 @@ public class OwnerResourceTest extends DatabaseTestFixture {
 
         OwnerCurator oc = mock(OwnerCurator.class);
         OwnerResource ownerres = new OwnerResource(oc, null,
-                null, i18n, null, null, null, null, null, null, null,
-                null, null, null, null, null, null, null, null, null,
-                null, null, null, null, null);
+            null, i18n, null, null, null, null, null, null, null,
+            null, null, null, null, null, null, null, null, null,
+            null, null, null, null, null);
 
         ownerres.ownerEntitlements("Taylor Swift", null, null, null, req);
     }
@@ -1677,9 +1675,8 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         when(pm.retrieveServiceLevelsForOwner(eq(o), eq(false))).thenReturn(levels);
 
         OwnerResource resource = new OwnerResource(
-                oc, null, cc, i18n, null, null, null, null, null, pm, null, null, null, null,
-                null, null, null, null, null, null, null, null, null, null, null
-            );
+            oc, null, cc, i18n, null, null, null, null, null, pm, null, null, null, null,
+            null, null, null, null, null, null, null, null, null, null, null);
         Set<String> returnLevels = resource.ownerServiceLevels("owner-A", p, "false");
         assert (returnLevels.size() == 1);
         for (String s : returnLevels) {

--- a/server/src/test/java/org/candlepin/resource/ProductResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/ProductResourceTest.java
@@ -69,8 +69,7 @@ public class ProductResourceTest extends DatabaseTestFixture {
         String version = "1.0";
         String arch = "ALL";
         String type = "SVC";
-        Product prod = new Product(label, name, owner, variant,
-                version, arch, type);
+        Product prod = new Product(label, name, owner, variant, version, arch, type);
         return prod;
     }
 
@@ -90,8 +89,8 @@ public class ProductResourceTest extends DatabaseTestFixture {
         String  contentHash = String.valueOf(
             Math.abs(Long.valueOf("test-content".hashCode())));
         Content testContent = new Content(owner, "test-content", contentHash,
-                            "test-content-label", "yum", "test-vendor",
-                             "test-content-url", "test-gpg-url", "test-arch");
+            "test-content-label", "yum", "test-vendor",
+            "test-content-url", "test-gpg-url", "test-arch");
 
         HashSet<Content> contentSet = new HashSet<Content>();
         testContent = contentCurator.create(testContent);

--- a/server/src/test/java/org/candlepin/resource/SubscriptionResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/SubscriptionResourceTest.java
@@ -80,14 +80,12 @@ public class SubscriptionResourceTest  {
 
     @Test(expected = BadRequestException.class)
     public void activateNoEmailLocale() {
-        subResource.activateSubscription("random", "random@somthing.com",
-                null);
+        subResource.activateSubscription("random", "random@somthing.com", null);
     }
 
     @Test(expected = BadRequestException.class)
     public void activateBadConsumer() {
-        subResource.activateSubscription("test_consumer", "email@whatever.net",
-                "en_us");
+        subResource.activateSubscription("test_consumer", "email@whatever.net", "en_us");
     }
 
     @Test
@@ -95,8 +93,7 @@ public class SubscriptionResourceTest  {
         Consumer consumer = new Consumer("test_consumer", "alf", null, null);
         when(consumerCurator.findByUuid("ae843603bdc73")).thenReturn(consumer);
 
-        subResource.activateSubscription("ae843603bdc73", "alf@alfnet.com",
-                "en");
+        subResource.activateSubscription("ae843603bdc73", "alf@alfnet.com", "en");
 
         verify(subService).activateSubscription(consumer, "alf@alfnet.com", "en");
     }
@@ -106,8 +103,7 @@ public class SubscriptionResourceTest  {
         Consumer consumer = new Consumer("test_consumer", "alf", null, null);
         when(consumerCurator.findByUuid("ae843603bdc73")).thenReturn(consumer);
 
-        Response result = subResource.activateSubscription("ae843603bdc73", "alf@alfnet.com",
-                "en");
+        Response result = subResource.activateSubscription("ae843603bdc73", "alf@alfnet.com", "en");
 
         assertEquals(result.getStatus(), 202);
     }

--- a/server/src/test/java/org/candlepin/resource/util/InstalledProductStatusCalculatorTest.java
+++ b/server/src/test/java/org/candlepin/resource/util/InstalledProductStatusCalculatorTest.java
@@ -817,7 +817,7 @@ public class InstalledProductStatusCalculatorTest {
     }
 
     private Entitlement mockUnmappedGuestEntitlement(Consumer consumer, Product product,
-            DateRange range, Product ... providedProducts) {
+        DateRange range, Product ... providedProducts) {
 
         consumer.setFact("virt.is_guest", "True");
         Entitlement e = mockEntitlement(consumer, product, range, providedProducts);

--- a/server/src/test/java/org/candlepin/resteasy/JsonProviderTest.java
+++ b/server/src/test/java/org/candlepin/resteasy/JsonProviderTest.java
@@ -45,8 +45,7 @@ public class JsonProviderTest {
     public void dateFormat() {
         JsonProvider provider = new JsonProvider(config);
 
-        boolean datesAsTimestamps = isEnabled(provider,
-                SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        boolean datesAsTimestamps = isEnabled(provider, SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 
         assertFalse(datesAsTimestamps);
     }
@@ -59,16 +58,14 @@ public class JsonProviderTest {
         iso8601WithoutMilliseconds.setTimeZone(TimeZone.getTimeZone("UTC"));
         String expectedDate = "\"" + iso8601WithoutMilliseconds.format(now) + "\"";
         JsonProvider provider = new JsonProvider(config);
-        ObjectMapper mapper = provider.locateMapper(Object.class,
-                MediaType.APPLICATION_JSON_TYPE);
+        ObjectMapper mapper = provider.locateMapper(Object.class, MediaType.APPLICATION_JSON_TYPE);
         String serializedDate = mapper.writeValueAsString(now);
         assertTrue(serializedDate.equals(expectedDate));
     }
 
 
     private boolean isEnabled(JsonProvider provider, SerializationFeature feature) {
-        ObjectMapper mapper = provider.locateMapper(Object.class,
-                MediaType.APPLICATION_JSON_TYPE);
+        ObjectMapper mapper = provider.locateMapper(Object.class, MediaType.APPLICATION_JSON_TYPE);
         SerializationConfig sConfig = mapper.getSerializationConfig();
         return sConfig.isEnabled(feature);
     }

--- a/server/src/test/java/org/candlepin/resteasy/filter/PinsetterAsyncFilterTest.java
+++ b/server/src/test/java/org/candlepin/resteasy/filter/PinsetterAsyncFilterTest.java
@@ -77,8 +77,7 @@ public class PinsetterAsyncFilterTest {
 
         this.interceptor.postProcess(response);
 
-        Assert.assertEquals(principal,
-                detail.getJobDataMap().get(PinsetterJobListener.PRINCIPAL_KEY));
+        Assert.assertEquals(principal, detail.getJobDataMap().get(PinsetterJobListener.PRINCIPAL_KEY));
     }
 
     @Test
@@ -98,8 +97,7 @@ public class PinsetterAsyncFilterTest {
 
         this.interceptor.postProcess(response);
 
-        Assert.assertSame(principal,
-                detail.getJobDataMap().get(PinsetterJobListener.PRINCIPAL_KEY));
+        Assert.assertSame(principal, detail.getJobDataMap().get(PinsetterJobListener.PRINCIPAL_KEY));
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapterTest.java
+++ b/server/src/test/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapterTest.java
@@ -331,8 +331,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
 
         X509Certificate result = certServiceAdapter.createX509Certificate(entitlement,
             product, new HashSet<Product>(),
-            getProductModels(product, new HashSet<Product>(), "prefix",
-                    entitlement),
+            getProductModels(product, new HashSet<Product>(), "prefix", entitlement),
             new BigInteger("1234"), keyPair, true);
 
         Date twentyFiveHoursOut = new Date(now.getTime() + 25 * 60 * 60 * 1000);
@@ -369,13 +368,13 @@ public class DefaultEntitlementCertServiceAdapterTest {
         Set<Content> productContent = new HashSet<Content>();
         for (int i = 0; i < numberToGenerate; i++) {
             productContent.add(createContent(prefix + CONTENT_NAME + i,
-                                             prefix + CONTENT_ID + i,
-                                             prefix + CONTENT_LABEL + i,
-                                             CONTENT_TYPE,
-                                             CONTENT_VENDOR,
-                                             CONTENT_URL,
-                                             CONTENT_GPG_URL,
-                                             ARCH_LABEL));
+                prefix + CONTENT_ID + i,
+                prefix + CONTENT_LABEL + i,
+                CONTENT_TYPE,
+                CONTENT_VENDOR,
+                CONTENT_URL,
+                CONTENT_GPG_URL,
+                ARCH_LABEL));
         }
         return productContent;
     }
@@ -394,9 +393,9 @@ public class DefaultEntitlementCertServiceAdapterTest {
 
     @Test
     public void testContentExtentionCreation() throws CertificateSizeException {
-        Set<X509ExtensionWrapper> contentExtensions = extensionUtil
-            .contentExtensions(product.getProductContent(), null,
-                new HashMap<String, EnvironmentContent>(), entitlement.getConsumer(), product);
+        Set<X509ExtensionWrapper> contentExtensions = extensionUtil.contentExtensions(
+            product.getProductContent(), null, new HashMap<String, EnvironmentContent>(),
+            entitlement.getConsumer(), product);
         Map<String, X509ExtensionWrapper> encodedContent = getEncodedContent(
             contentExtensions);
         assertTrue(isEncodedContentValid(encodedContent));
@@ -425,9 +424,8 @@ public class DefaultEntitlementCertServiceAdapterTest {
         Map<String, EnvironmentContent> promotedContent =
             new HashMap<String, EnvironmentContent>();
         promotedContent.put(content.getId(), e.getEnvironmentContent().iterator().next());
-        Set<X509ExtensionWrapper> contentExtensions = extensionUtil
-            .contentExtensions(product.getProductContent(), null,
-                promotedContent, entitlement.getConsumer(), product);
+        Set<X509ExtensionWrapper> contentExtensions = extensionUtil.contentExtensions(
+            product.getProductContent(), null, promotedContent, entitlement.getConsumer(), product);
         Map<String, X509ExtensionWrapper> encodedContent = getEncodedContent(
             contentExtensions);
         assertTrue(isEncodedContentValid(encodedContent));
@@ -437,9 +435,9 @@ public class DefaultEntitlementCertServiceAdapterTest {
 
     @Test
     public void testContentRequiredTagsExtention()  throws CertificateSizeException {
-        Set<X509ExtensionWrapper> contentExtensions = extensionUtil
-            .contentExtensions(product.getProductContent(), null,
-                new HashMap<String, EnvironmentContent>(), entitlement.getConsumer(), product);
+        Set<X509ExtensionWrapper> contentExtensions = extensionUtil.contentExtensions(
+            product.getProductContent(), null, new HashMap<String, EnvironmentContent>(),
+            entitlement.getConsumer(), product);
         Map<String, X509ExtensionWrapper> encodedContent = getEncodedContent(
             contentExtensions);
         assertTrue(isEncodedContentValid(encodedContent));
@@ -473,14 +471,14 @@ public class DefaultEntitlementCertServiceAdapterTest {
             getProductModels(product, new HashSet<Product>(), "prefix", entitlement),
             new BigInteger("1234"), keyPair, true);
 
-        verify(mockedPKI).createX509Certificate(
-            any(String.class),
-            argThat(new ListContainsContentUrl("/somePrefix" + CONTENT_URL,
-                CONTENT_ID)), any(Set.class), any(Date.class), any(Date.class),
-            any(KeyPair.class), any(BigInteger.class), any(String.class));
+        verify(mockedPKI).createX509Certificate(any(String.class),
+            argThat(new ListContainsContentUrl("/somePrefix" + CONTENT_URL, CONTENT_ID)),
+            any(Set.class), any(Date.class), any(Date.class), any(KeyPair.class),
+            any(BigInteger.class), any(String.class));
     }
 
     @Test
+    @SuppressWarnings("checkstyle:indentation")
     public void testPrefixExpandsEnvIfConsumerHasOne() throws Exception {
         owner.setContentPrefix("/someorg/$env/");
 
@@ -494,15 +492,16 @@ public class DefaultEntitlementCertServiceAdapterTest {
             getProductModels(product, new HashSet<Product>(), "prefix", entitlement),
             new BigInteger("1234"), keyPair, true);
 
-        verify(mockedPKI).createX509Certificate(
-            any(String.class),
-            argThat(new ListContainsContentUrl("/someorg/Awesome+Environment+%231" +
-                CONTENT_URL, CONTENT_ID)), any(Set.class), any(Date.class),
-                any(Date.class), any(KeyPair.class), any(BigInteger.class),
-                any(String.class));
+        verify(mockedPKI).createX509Certificate(any(String.class),
+            argThat(
+                new ListContainsContentUrl("/someorg/Awesome+Environment+%231" + CONTENT_URL, CONTENT_ID)
+            ),
+            any(Set.class), any(Date.class), any(Date.class), any(KeyPair.class),
+            any(BigInteger.class), any(String.class));
     }
 
     @Test
+    @SuppressWarnings("checkstyle:indentation")
     public void testURLEncoding() throws Exception {
         owner.setContentPrefix("/some org/$env/");
 
@@ -516,11 +515,12 @@ public class DefaultEntitlementCertServiceAdapterTest {
             getProductModels(product, new HashSet<Product>(), "prefix", entitlement),
             new BigInteger("1234"), keyPair, true);
 
-        verify(mockedPKI).createX509Certificate(
-            any(String.class),
-            argThat(new ListContainsContentUrl("/some+org/Awesome+Environment+%231" +
-                CONTENT_URL, CONTENT_ID)), any(Set.class), any(Date.class), any(Date.class),
-                any(KeyPair.class), any(BigInteger.class), any(String.class));
+        verify(mockedPKI).createX509Certificate(any(String.class),
+            argThat(
+                new ListContainsContentUrl("/some+org/Awesome+Environment+%231" + CONTENT_URL, CONTENT_ID)
+            ),
+            any(Set.class), any(Date.class), any(Date.class),
+            any(KeyPair.class), any(BigInteger.class), any(String.class));
     }
 
     @Test
@@ -532,11 +532,10 @@ public class DefaultEntitlementCertServiceAdapterTest {
             getProductModels(product, new HashSet<Product>(), "prefix", entitlement),
             new BigInteger("1234"), keyPair, true);
 
-        verify(mockedPKI).createX509Certificate(
-            any(String.class),
-            argThat(new ListContainsContentUrl("/someorg/$env" + CONTENT_URL,
-                CONTENT_ID)), any(Set.class), any(Date.class), any(Date.class),
-            any(KeyPair.class), any(BigInteger.class), any(String.class));
+        verify(mockedPKI).createX509Certificate(any(String.class),
+            argThat(new ListContainsContentUrl("/someorg/$env" + CONTENT_URL, CONTENT_ID)),
+            any(Set.class), any(Date.class), any(Date.class), any(KeyPair.class),
+            any(BigInteger.class), any(String.class));
     }
 
     @Test
@@ -548,11 +547,10 @@ public class DefaultEntitlementCertServiceAdapterTest {
             getProductModels(product, new HashSet<Product>(), "prefix", entitlement),
             new BigInteger("1234"), keyPair, false);
 
-        verify(mockedPKI).createX509Certificate(
-            any(String.class),
-            argThat(new ListContainsContentUrl(CONTENT_URL,
-                CONTENT_ID)), any(Set.class), any(Date.class), any(Date.class),
-            any(KeyPair.class), any(BigInteger.class), any(String.class));
+        verify(mockedPKI).createX509Certificate(any(String.class),
+            argThat(new ListContainsContentUrl(CONTENT_URL, CONTENT_ID)),
+            any(Set.class), any(Date.class), any(Date.class), any(KeyPair.class),
+            any(BigInteger.class), any(String.class));
     }
 
     @Test
@@ -613,20 +611,18 @@ public class DefaultEntitlementCertServiceAdapterTest {
         // the content set is filtered out:
         // Mod content should get filtered out because we have no ents providing
         // the product it modifies:
-        assertEquals(1,
-            extensionUtil.filterProductContent(modProduct, entitlement, entCurator,
-                new HashMap<String, EnvironmentContent>(), false, new HashSet<String>())
-                .size());
+        assertEquals(1, extensionUtil.filterProductContent(
+            modProduct, entitlement, entCurator, new HashMap<String, EnvironmentContent>(), false,
+            new HashSet<String>()).size());
 
         // Now mock that we have an entitlement providing one of the modified
         // products,
         // and we should see both content sets included in the cert:
         Set<String> entitledProdIds = new HashSet<String>();
         entitledProdIds.add("product2");
-        assertEquals(2,
-            extensionUtil.filterProductContent(modProduct, entitlement, entCurator,
-                new HashMap<String, EnvironmentContent>(), false, entitledProdIds)
-                .size());
+        assertEquals(2, extensionUtil.filterProductContent(
+            modProduct, entitlement, entCurator, new HashMap<String, EnvironmentContent>(), false,
+            entitledProdIds).size());
 
         // Make sure that we filter by environment when asked.
         Environment environment = new Environment();
@@ -638,10 +634,8 @@ public class DefaultEntitlementCertServiceAdapterTest {
             new EnvironmentContent(environment, normalContent, true)
         );
 
-        assertEquals(1,
-            extensionUtil.filterProductContent(modProduct, entitlement, entCurator,
-                promotedContent, true, entitledProdIds)
-                .size());
+        assertEquals(1, extensionUtil.filterProductContent(
+            modProduct, entitlement, entCurator, promotedContent, true, entitledProdIds).size());
     }
 
     @Test
@@ -781,13 +775,12 @@ public class DefaultEntitlementCertServiceAdapterTest {
         X509V3ExtensionUtil mockV3extensionUtil = mock(X509V3ExtensionUtil.class);
         X509ExtensionUtil mockExtensionUtil = mock(X509ExtensionUtil.class);
 
-        DefaultEntitlementCertServiceAdapter entAdapter =
-            new DefaultEntitlementCertServiceAdapter(
-                mockedPKI, mockExtensionUtil, mockV3extensionUtil,
-                mock(EntitlementCertificateCurator.class),
-                keyPairCurator, serialCurator, entCurator,
-                I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK),
-                mockConfig);
+        DefaultEntitlementCertServiceAdapter entAdapter = new DefaultEntitlementCertServiceAdapter(
+            mockedPKI, mockExtensionUtil, mockV3extensionUtil,
+            mock(EntitlementCertificateCurator.class),
+            keyPairCurator, serialCurator, entCurator,
+            I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK),
+            mockConfig);
 
         entAdapter.createX509Certificate(entitlement, product,
             new HashSet<Product>(),
@@ -823,13 +816,12 @@ public class DefaultEntitlementCertServiceAdapterTest {
         X509V3ExtensionUtil mockV3extensionUtil = mock(X509V3ExtensionUtil.class);
         X509ExtensionUtil mockExtensionUtil = mock(X509ExtensionUtil.class);
 
-        DefaultEntitlementCertServiceAdapter entAdapter =
-            new DefaultEntitlementCertServiceAdapter(
-                mockedPKI, mockExtensionUtil, mockV3extensionUtil,
-                mock(EntitlementCertificateCurator.class),
-                keyPairCurator, serialCurator, entCurator,
-                I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK),
-                mockConfig);
+        DefaultEntitlementCertServiceAdapter entAdapter = new DefaultEntitlementCertServiceAdapter(
+            mockedPKI, mockExtensionUtil, mockV3extensionUtil,
+            mock(EntitlementCertificateCurator.class),
+            keyPairCurator, serialCurator, entCurator,
+            I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK),
+            mockConfig);
 
         entAdapter.createX509Certificate(entitlement,
             product, new HashSet<Product>(),
@@ -838,7 +830,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
         verify(mockV3extensionUtil).getExtensions(eq(entitlement), any(String.class),
             any(Map.class));
         verify(mockV3extensionUtil).getByteExtensions(eq(product),
-                any(List.class), eq(entitlement), any(String.class), any(Map.class));
+            any(List.class), eq(entitlement), any(String.class), any(Map.class));
         verifyZeroInteractions(mockExtensionUtil);
     }
 
@@ -855,13 +847,12 @@ public class DefaultEntitlementCertServiceAdapterTest {
         X509V3ExtensionUtil mockV3extensionUtil = mock(X509V3ExtensionUtil.class);
         X509ExtensionUtil mockExtensionUtil = mock(X509ExtensionUtil.class);
 
-        DefaultEntitlementCertServiceAdapter entAdapter =
-            new DefaultEntitlementCertServiceAdapter(
-                mockedPKI, mockExtensionUtil, mockV3extensionUtil,
-                mock(EntitlementCertificateCurator.class),
-                keyPairCurator, serialCurator, entCurator,
-                I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK),
-                mockConfig);
+        DefaultEntitlementCertServiceAdapter entAdapter = new DefaultEntitlementCertServiceAdapter(
+            mockedPKI, mockExtensionUtil, mockV3extensionUtil,
+            mock(EntitlementCertificateCurator.class),
+            keyPairCurator, serialCurator, entCurator,
+            I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK),
+            mockConfig);
 
         entAdapter.createX509Certificate(entitlement,
             product, new HashSet<Product>(),
@@ -884,13 +875,12 @@ public class DefaultEntitlementCertServiceAdapterTest {
         X509V3ExtensionUtil mockV3extensionUtil = mock(X509V3ExtensionUtil.class);
         X509ExtensionUtil mockExtensionUtil = mock(X509ExtensionUtil.class);
 
-        DefaultEntitlementCertServiceAdapter entAdapter =
-            new DefaultEntitlementCertServiceAdapter(
-                mockedPKI, mockExtensionUtil, mockV3extensionUtil,
-                mock(EntitlementCertificateCurator.class),
-                keyPairCurator, serialCurator, entCurator,
-                I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK),
-                mockConfig);
+        DefaultEntitlementCertServiceAdapter entAdapter = new DefaultEntitlementCertServiceAdapter(
+            mockedPKI, mockExtensionUtil, mockV3extensionUtil,
+            mock(EntitlementCertificateCurator.class),
+            keyPairCurator, serialCurator, entCurator,
+            I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK),
+            mockConfig);
 
         entAdapter.createX509Certificate(entitlement,
             product, new HashSet<Product>(),
@@ -910,13 +900,12 @@ public class DefaultEntitlementCertServiceAdapterTest {
         X509V3ExtensionUtil mockV3extensionUtil = mock(X509V3ExtensionUtil.class);
         X509ExtensionUtil mockExtensionUtil = mock(X509ExtensionUtil.class);
 
-        DefaultEntitlementCertServiceAdapter entAdapter =
-            new DefaultEntitlementCertServiceAdapter(
-                mockedPKI, mockExtensionUtil, mockV3extensionUtil,
-                mock(EntitlementCertificateCurator.class),
-                keyPairCurator, serialCurator, entCurator,
-                I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK),
-                mockConfig);
+        DefaultEntitlementCertServiceAdapter entAdapter = new DefaultEntitlementCertServiceAdapter(
+            mockedPKI, mockExtensionUtil, mockV3extensionUtil,
+            mock(EntitlementCertificateCurator.class),
+            keyPairCurator, serialCurator, entCurator,
+            I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK),
+            mockConfig);
 
         entAdapter.createX509Certificate(entitlement,
             product, new HashSet<Product>(),
@@ -971,8 +960,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
         setupEntitlements(ARCH_LABEL, "1.0");
 
         Set<X509ExtensionWrapper> extensions =
-            certServiceAdapter.prepareV1Extensions(products, entitlement, "",
-                null);
+            certServiceAdapter.prepareV1Extensions(products, entitlement, "", null);
         Map<String, X509ExtensionWrapper> map = getEncodedContent(extensions);
         Map<String, String> extMap = getEncodedContentMap(extensions);
 
@@ -995,8 +983,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
         setupEntitlements(ARCH_LABEL, "1.0");
 
         Set<X509ExtensionWrapper> extensions =
-            certServiceAdapter.prepareV1Extensions(products, entitlement, "",
-                null);
+            certServiceAdapter.prepareV1Extensions(products, entitlement, "", null);
         Map<String, X509ExtensionWrapper> map = getEncodedContent(extensions);
         Map<String, String> extMap = getEncodedContentMap(extensions);
 
@@ -1026,8 +1013,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
         setupEntitlements(ARCH_LABEL, "1.0");
 
         Set<X509ExtensionWrapper> extensions =
-            certServiceAdapter.prepareV1Extensions(products, entitlement, "",
-                null);
+            certServiceAdapter.prepareV1Extensions(products, entitlement, "", null);
         Map<String, X509ExtensionWrapper> map = getEncodedContent(extensions);
         Map<String, String> extMap = getEncodedContentMap(extensions);
 
@@ -1052,8 +1038,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
         setupEntitlements(ARCH_LABEL, "1.0");
 
         Set<X509ExtensionWrapper> extensions =
-            certServiceAdapter.prepareV1Extensions(products, entitlement, "",
-                null);
+            certServiceAdapter.prepareV1Extensions(products, entitlement, "", null);
         Map<String, X509ExtensionWrapper> map = getEncodedContent(extensions);
         Map<String, String> extMap = getEncodedContentMap(extensions);
 
@@ -1083,8 +1068,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
         setupEntitlements(ARCH_LABEL, "1.0");
 
         Set<X509ExtensionWrapper> extensions =
-            certServiceAdapter.prepareV1Extensions(products, entitlement, "",
-                null);
+            certServiceAdapter.prepareV1Extensions(products, entitlement, "", null);
         Map<String, X509ExtensionWrapper> map = getEncodedContent(extensions);
         Map<String, String> extMap = getEncodedContentMap(extensions);
 
@@ -1115,8 +1099,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
         setupEntitlements(ARCH_LABEL, "1.0");
 
         Set<X509ExtensionWrapper> extensions =
-            certServiceAdapter.prepareV1Extensions(products, entitlement, "",
-                null);
+            certServiceAdapter.prepareV1Extensions(products, entitlement, "", null);
         Map<String, X509ExtensionWrapper> map = getEncodedContent(extensions);
         Map<String, String> extMap = getEncodedContentMap(extensions);
 
@@ -1154,8 +1137,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
         setupEntitlements(ARCH_LABEL, "1.0");
 
         Set<X509ExtensionWrapper> extensions =
-            certServiceAdapter.prepareV1Extensions(products, entitlement, "",
-                null);
+            certServiceAdapter.prepareV1Extensions(products, entitlement, "", null);
         Map<String, X509ExtensionWrapper> map = getEncodedContent(extensions);
         Map<String, String> extMap = getEncodedContentMap(extensions);
 
@@ -1185,11 +1167,11 @@ public class DefaultEntitlementCertServiceAdapterTest {
     }
 
     private List<org.candlepin.model.dto.Product> getProductModels(Product sku,
-            Set<Product> providedProducts, String prefix, Entitlement e) {
-        List<org.candlepin.model.dto.Product> productModels =
-                v3extensionUtil.createProducts(sku, providedProducts, prefix,
-                        new HashMap<String, EnvironmentContent>(),
-                        e.getConsumer(), e);
+        Set<Product> providedProducts, String prefix, Entitlement e) {
+
+        List<org.candlepin.model.dto.Product> productModels = v3extensionUtil.createProducts(
+            sku, providedProducts, prefix, new HashMap<String, EnvironmentContent>(),
+            e.getConsumer(), e);
         return productModels;
     }
 
@@ -1641,10 +1623,9 @@ public class DefaultEntitlementCertServiceAdapterTest {
         consumer.setFact("system.certificate_version", "3.2");
         consumer.setFact("uname.machine", "x86_64");
 
-        Set<X509ByteExtensionWrapper> byteExtensions =
-            certServiceAdapter.prepareV3ByteExtensions(product,
-                    getProductModels(product, products, "prefix", entitlement), entitlement,
-                    "prefix", null);
+        Set<X509ByteExtensionWrapper> byteExtensions = certServiceAdapter.prepareV3ByteExtensions(
+            product, getProductModels(product, products, "prefix", entitlement), entitlement,
+            "prefix", null);
         Map<String, X509ByteExtensionWrapper> byteMap =
             new HashMap<String, X509ByteExtensionWrapper>();
         for (X509ByteExtensionWrapper ext : byteExtensions) {
@@ -1684,11 +1665,9 @@ public class DefaultEntitlementCertServiceAdapterTest {
 
         consumer.setFact("system.certificate_version", "3.2");
 
-        Set<X509ByteExtensionWrapper> byteExtensions =
-            certServiceAdapter.prepareV3ByteExtensions(product,
-                    getProductModels(product, products, "prefix", entitlement),
-                    entitlement,
-                    "prefix", null);
+        Set<X509ByteExtensionWrapper> byteExtensions = certServiceAdapter.prepareV3ByteExtensions(
+            product, getProductModels(product, products, "prefix", entitlement),
+            entitlement, "prefix", null);
         Map<String, X509ByteExtensionWrapper> byteMap =
             new HashMap<String, X509ByteExtensionWrapper>();
         for (X509ByteExtensionWrapper ext : byteExtensions) {
@@ -1721,10 +1700,9 @@ public class DefaultEntitlementCertServiceAdapterTest {
         largeContentProduct.setContent(largeContent);
         consumer.setFact("system.certificate_version", "3.2");
 
-        Set<X509ByteExtensionWrapper> byteExtensions =
-            certServiceAdapter.prepareV3ByteExtensions(product,
-                    getProductModels(product, products, "prefix", largeContentEntitlement),
-                    largeContentEntitlement, "prefix", null);
+        Set<X509ByteExtensionWrapper> byteExtensions = certServiceAdapter.prepareV3ByteExtensions(
+            product, getProductModels(product, products, "prefix", largeContentEntitlement),
+            largeContentEntitlement, "prefix", null);
         Map<String, X509ByteExtensionWrapper> byteMap =
             new HashMap<String, X509ByteExtensionWrapper>();
         for (X509ByteExtensionWrapper ext : byteExtensions) {
@@ -1770,10 +1748,9 @@ public class DefaultEntitlementCertServiceAdapterTest {
         consumer.setFact("uname.machine", "x86_64");
 
         certServiceAdapter.prepareV3Extensions(entitlement, "prefix", null);
-        Set<X509ByteExtensionWrapper> byteExtensions =
-            certServiceAdapter.prepareV3ByteExtensions(extremeProduct,
-                    getProductModels(extremeProduct, products, "prefix", entitlement),
-                    entitlement, "prefix", null);
+        Set<X509ByteExtensionWrapper> byteExtensions = certServiceAdapter.prepareV3ByteExtensions(
+            extremeProduct, getProductModels(extremeProduct, products, "prefix", entitlement),
+            entitlement, "prefix", null);
         Map<String, X509ByteExtensionWrapper> byteMap =
             new HashMap<String, X509ByteExtensionWrapper>();
         for (X509ByteExtensionWrapper ext : byteExtensions) {
@@ -1989,8 +1966,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
         return isEncodedContentValid(encodedContent);
     }
 
-    private boolean isEncodedContentValid(Map<String,
-            X509ExtensionWrapper> encodedContent) {
+    private boolean isEncodedContentValid(Map<String, X509ExtensionWrapper> encodedContent) {
 
         return encodedContent.containsKey(CONTENT_LABEL) &&
             // encodedContent.containsKey(CONTENT_ENABLED) &&

--- a/server/src/test/java/org/candlepin/service/impl/DefaultUserServiceAdapterTest.java
+++ b/server/src/test/java/org/candlepin/service/impl/DefaultUserServiceAdapterTest.java
@@ -155,8 +155,7 @@ public class DefaultUserServiceAdapterTest extends DatabaseTestFixture {
         User u = mock(User.class);
         UserCurator curator = mock(UserCurator.class);
         RoleCurator roleCurator = mock(RoleCurator.class);
-        UserServiceAdapter dusa = new DefaultUserServiceAdapter(curator,
-                roleCurator);
+        UserServiceAdapter dusa = new DefaultUserServiceAdapter(curator, roleCurator);
         when(curator.findByLogin(anyString())).thenReturn(u);
 
         User foo = dusa.findByLogin("foo");

--- a/server/src/test/java/org/candlepin/service/impl/stub/StubEntitlementCertServiceAdapter.java
+++ b/server/src/test/java/org/candlepin/service/impl/stub/StubEntitlementCertServiceAdapter.java
@@ -93,12 +93,13 @@ public class StubEntitlementCertServiceAdapter extends BaseEntitlementCertServic
 
     @Override
     public Map<String, EntitlementCertificate> generateEntitlementCerts(Consumer consumer,
-            Map<String, Entitlement> entitlements, Map<String, Product> products)
+        Map<String, Entitlement> entitlements, Map<String, Product> products)
         throws GeneralSecurityException, IOException {
+
         Map<String, EntitlementCertificate> result = new HashMap<String, EntitlementCertificate>();
         for (Entry<String, Entitlement> entry : entitlements.entrySet()) {
             EntitlementCertificate cert = generateEntitlementCert(entry.getValue(),
-                    products.get(entry.getKey()));
+                products.get(entry.getKey()));
             result.put(entry.getKey(), cert);
         }
         return result;
@@ -106,12 +107,13 @@ public class StubEntitlementCertServiceAdapter extends BaseEntitlementCertServic
 
     @Override
     public Map<String, EntitlementCertificate> generateUeberCerts(Consumer consumer,
-            Map<String, Entitlement> entitlements, Map<String, Product> products)
+        Map<String, Entitlement> entitlements, Map<String, Product> products)
         throws GeneralSecurityException, IOException {
+
         Map<String, EntitlementCertificate> result = new HashMap<String, EntitlementCertificate>();
         for (Entry<String, Entitlement> entry : entitlements.entrySet()) {
             EntitlementCertificate cert = generateUeberCert(entry.getValue(),
-                    products.get(entry.getKey()));
+                products.get(entry.getKey()));
             result.put(entry.getKey(), cert);
         }
         return result;

--- a/server/src/test/java/org/candlepin/sync/ConsumerExporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/ConsumerExporterTest.java
@@ -37,13 +37,11 @@ public class ConsumerExporterTest {
     @Test
     public void testConsumerExport() throws IOException {
         ObjectMapper mapper = SyncUtils.getObjectMapper(new MapConfiguration(
-                new HashMap<String, String>() {
-
-                    {
-                        put(ConfigProperties.FAIL_ON_UNKNOWN_IMPORT_PROPERTIES,
-                                "false");
-                    }
-                }));
+            new HashMap<String, String>() {
+                {
+                    put(ConfigProperties.FAIL_ON_UNKNOWN_IMPORT_PROPERTIES, "false");
+                }
+            }));
 
 
         ConsumerExporter exporter = new ConsumerExporter();

--- a/server/src/test/java/org/candlepin/sync/ConsumerImporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/ConsumerImporterTest.java
@@ -67,13 +67,12 @@ public class ConsumerImporterTest {
         i18n = I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK);
         importer = new ConsumerImporter(curator, idCertCurator, i18n, serialCurator);
         mapper = SyncUtils.getObjectMapper(new MapConfiguration(
-                new HashMap<String, String>() {
-
-                    {
-                        put(ConfigProperties.FAIL_ON_UNKNOWN_IMPORT_PROPERTIES,
-                                "false");
-                    }
-                }));
+            new HashMap<String, String>() {
+                {
+                    put(ConfigProperties.FAIL_ON_UNKNOWN_IMPORT_PROPERTIES, "false");
+                }
+            }
+        ));
     }
 
     @Test
@@ -93,9 +92,8 @@ public class ConsumerImporterTest {
         configProps.put(ConfigProperties.FAIL_ON_UNKNOWN_IMPORT_PROPERTIES, "false");
         mapper = SyncUtils.getObjectMapper(new MapConfiguration(configProps));
 
-        ConsumerDto consumer =
-            importer.createObject(mapper, new StringReader(
-                "{\"uuid\":\"test-uuid\", \"unknown\":\"notreal\"}"));
+        ConsumerDto consumer = importer.createObject(
+            mapper, new StringReader("{\"uuid\":\"test-uuid\", \"unknown\":\"notreal\"}"));
         assertEquals("test-uuid", consumer.getUuid());
     }
 

--- a/server/src/test/java/org/candlepin/sync/ConsumerTypeExporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/ConsumerTypeExporterTest.java
@@ -37,13 +37,12 @@ public class ConsumerTypeExporterTest {
     @Test
     public void testConsumerTypeExport() throws IOException {
         ObjectMapper mapper = SyncUtils.getObjectMapper(new MapConfiguration(
-                new HashMap<String, String>() {
-
-                    {
-                        put(ConfigProperties.FAIL_ON_UNKNOWN_IMPORT_PROPERTIES,
-                                "false");
-                    }
-                }));
+            new HashMap<String, String>() {
+                {
+                    put(ConfigProperties.FAIL_ON_UNKNOWN_IMPORT_PROPERTIES, "false");
+                }
+            }
+        ));
 
         ConsumerTypeExporter consumerType = new ConsumerTypeExporter();
 

--- a/server/src/test/java/org/candlepin/sync/EntitlementImporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/EntitlementImporterTest.java
@@ -122,10 +122,10 @@ public class EntitlementImporterTest {
 
         // Create our expected products
         Map<String, Product> productsById = buildProductCache(
-                parentProduct, provided1, derivedProduct, derivedProvided1);
+            parentProduct, provided1, derivedProduct, derivedProvided1);
 
         Subscription sub = importer.importObject(om, reader, owner, productsById,
-                consumerDto, meta);
+            consumerDto, meta);
 
         assertEquals(pool.getId(), sub.getUpstreamPoolId());
         assertEquals(consumer.getUuid(), sub.getUpstreamConsumerId());

--- a/server/src/test/java/org/candlepin/sync/ExporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/ExporterTest.java
@@ -599,13 +599,12 @@ public class ExporterTest {
             os.flush();
             os.close();
             ObjectMapper om = SyncUtils.getObjectMapper(new MapConfiguration(
-                    new HashMap<String, String>() {
-
-                        {
-                            put(ConfigProperties.FAIL_ON_UNKNOWN_IMPORT_PROPERTIES,
-                                    "false");
-                        }
-                    }));
+                new HashMap<String, String>() {
+                    {
+                        put(ConfigProperties.FAIL_ON_UNKNOWN_IMPORT_PROPERTIES, "false");
+                    }
+                }
+            ));
             Meta m = om.readValue(
                 new FileInputStream("/tmp/meta.json"), Meta.class);
             assertNotNull(m);
@@ -693,13 +692,12 @@ public class ExporterTest {
             os.close();
 
             ObjectMapper om = SyncUtils.getObjectMapper(new MapConfiguration(
-                    new HashMap<String, String>() {
-
-                        {
-                            put(ConfigProperties.FAIL_ON_UNKNOWN_IMPORT_PROPERTIES,
-                                    "false");
-                        }
-                    }));
+                new HashMap<String, String>() {
+                    {
+                        put(ConfigProperties.FAIL_ON_UNKNOWN_IMPORT_PROPERTIES, "false");
+                    }
+                }
+            ));
 
             ConsumerDto c = om.readValue(
                 new FileInputStream("/tmp/" + filename), ConsumerDto.class);
@@ -728,13 +726,12 @@ public class ExporterTest {
             os.flush();
             os.close();
             ObjectMapper om = SyncUtils.getObjectMapper(new MapConfiguration(
-                    new HashMap<String, String>() {
-
-                        {
-                            put(ConfigProperties.FAIL_ON_UNKNOWN_IMPORT_PROPERTIES,
-                                    "false");
-                        }
-                    }));
+                new HashMap<String, String>() {
+                    {
+                        put(ConfigProperties.FAIL_ON_UNKNOWN_IMPORT_PROPERTIES, "false");
+                    }
+                }
+            ));
             DistributorVersion dv = om.readValue(
                 new FileInputStream("/tmp/" + filename),
                 DistributorVersion.class);

--- a/server/src/test/java/org/candlepin/sync/ImporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/ImporterTest.java
@@ -105,13 +105,12 @@ public class ImporterTest {
     @Before
     public void init() throws URISyntaxException, IOException {
         mapper = SyncUtils.getObjectMapper(new MapConfiguration(
-                new HashMap<String, String>() {
-
-                    {
-                        put(ConfigProperties.FAIL_ON_UNKNOWN_IMPORT_PROPERTIES,
-                                "false");
-                    }
-                }));
+            new HashMap<String, String>() {
+                {
+                    put(ConfigProperties.FAIL_ON_UNKNOWN_IMPORT_PROPERTIES, "false");
+                }
+            }
+        ));
         i18n = I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK);
         config = new CandlepinCommonTestConfig();
         PrintStream ps = new PrintStream(new File(this.getClass()
@@ -581,8 +580,8 @@ public class ImporterTest {
         importFiles.put(ImportFile.META.fileName(), actualmeta);
 
         ConsumerDto consumer = new ConsumerDto("eb5e04bf-be27-44cf-abe3-0c0b1edd523e", "mymachine",
-                new ConsumerType(ConsumerTypeEnum.CANDLEPIN), owner, "foo.example.com/subscription",
-                "/candlepin");
+            new ConsumerType(ConsumerTypeEnum.CANDLEPIN), owner, "foo.example.com/subscription",
+            "/candlepin");
         File consumerFile = new File(folder.getRoot(), "consumer.json");
         mapper.writeValue(consumerFile, consumer);
         importFiles.put(ImportFile.CONSUMER.fileName(), consumerFile);
@@ -616,7 +615,7 @@ public class ImporterTest {
         ConflictOverrides co = mock(ConflictOverrides.class);
 
         Importer i = new Importer(ctc, null, ri, oc, null, null, pm,
-                null, config, emc, null, null, i18n, null, null);
+            null, config, emc, null, null, i18n, null, null);
         List<Subscription> subscriptions = i.importObjects(owner, importFiles, co);
 
         assertEquals(1, subscriptions.size());
@@ -656,7 +655,7 @@ public class ImporterTest {
     }
 
     private File createFile(String filename, String version, Date date,
-                 String username, String prefix)
+        String username, String prefix)
         throws JsonGenerationException, JsonMappingException, IOException {
 
         File f = new File(folder.getRoot(), filename);
@@ -715,15 +714,14 @@ public class ImporterTest {
             pki, null, null, mock(CertificateSerialCurator.class), null, i18n, null,
             null);
         File[] upstream = new File[2];
-        File idcertfile = new File(classLoader.getResource("upstream/testidcert.json")
-                .toURI());
+        File idcertfile = new File(classLoader.getResource("upstream/testidcert.json").toURI());
         File kpfile = new File(classLoader.getResource("upstream/keypair.pem").toURI());
         upstream[0] = idcertfile;
         upstream[1] = kpfile;
         Owner owner = new Owner("admin", "Admin Owner");
         ConsumerDto consumer = new ConsumerDto("eb5e04bf-be27-44cf-abe3-0c0b1edd523e",
-                "mymachine", new ConsumerType(ConsumerTypeEnum.CANDLEPIN), owner,
-                "foo.example.com/subscription", "/candlepin");
+            "mymachine", new ConsumerType(ConsumerTypeEnum.CANDLEPIN), owner,
+            "foo.example.com/subscription", "/candlepin");
         File consumerfile = new File(folder.getRoot(), "consumer.json");
         mapper.writeValue(consumerfile, consumer);
         ConflictOverrides forcedConflicts = mock(ConflictOverrides.class);

--- a/server/src/test/java/org/candlepin/sync/MetaExporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/MetaExporterTest.java
@@ -37,13 +37,12 @@ public class MetaExporterTest {
     @Test
     public void testMetaExporter() throws IOException {
         ObjectMapper mapper = SyncUtils.getObjectMapper(new MapConfiguration(
-                new HashMap<String, String>() {
-
-                    {
-                        put(ConfigProperties.FAIL_ON_UNKNOWN_IMPORT_PROPERTIES,
-                                "false");
-                    }
-                }));
+            new HashMap<String, String>() {
+                {
+                    put(ConfigProperties.FAIL_ON_UNKNOWN_IMPORT_PROPERTIES, "false");
+                }
+            }
+        ));
 
         MetaExporter metaEx = new MetaExporter();
         StringWriter writer = new StringWriter();

--- a/server/src/test/java/org/candlepin/sync/ProductExporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/ProductExporterTest.java
@@ -36,13 +36,12 @@ public class ProductExporterTest {
     @Test
     public void testProductExport() throws IOException {
         ObjectMapper mapper = SyncUtils.getObjectMapper(new MapConfiguration(
-                new HashMap<String, String>() {
-
-                    {
-                        put(ConfigProperties.FAIL_ON_UNKNOWN_IMPORT_PROPERTIES,
-                                "false");
-                    }
-                }));
+            new HashMap<String, String>() {
+                {
+                    put(ConfigProperties.FAIL_ON_UNKNOWN_IMPORT_PROPERTIES, "false");
+                }
+            }
+        ));
 
         ProductExporter exporter = new ProductExporter();
 

--- a/server/src/test/java/org/candlepin/sync/ProductImporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/ProductImporterTest.java
@@ -54,13 +54,12 @@ public class ProductImporterTest {
     @Before
     public void setUp() throws IOException {
         mapper = SyncUtils.getObjectMapper(new MapConfiguration(
-                new HashMap<String, String>() {
-
-                    {
-                        put(ConfigProperties.FAIL_ON_UNKNOWN_IMPORT_PROPERTIES,
-                                "false");
-                    }
-                }));
+            new HashMap<String, String>() {
+                {
+                    put(ConfigProperties.FAIL_ON_UNKNOWN_IMPORT_PROPERTIES, "false");
+                }
+            }
+        ));
         productCuratorMock = mock(ProductCurator.class);
         contentCuratorMock = mock(ContentCurator.class);
         importer = new ProductImporter(productCuratorMock, contentCuratorMock);

--- a/server/src/test/java/org/candlepin/sync/SubscriptionReconcilerTest.java
+++ b/server/src/test/java/org/candlepin/sync/SubscriptionReconcilerTest.java
@@ -88,8 +88,8 @@ public class SubscriptionReconcilerTest {
         List<Pool> pools = new LinkedList<Pool>();
         for (Subscription sub : subs) {
             Pool p = new Pool(sub.getOwner(), sub.getProduct(), sub.getProvidedProducts(),
-                    sub.getQuantity(), sub.getStartDate(), sub.getEndDate(),
-                    sub.getContractNumber(), sub.getAccountNumber(), sub.getOrderNumber());
+                sub.getQuantity(), sub.getStartDate(), sub.getEndDate(),
+                sub.getContractNumber(), sub.getAccountNumber(), sub.getOrderNumber());
             p.setSourceSubscription(new SourceSubscription(sub.getId(), "master"));
             p.setUpstreamPoolId(sub.getUpstreamPoolId());
             p.setUpstreamConsumerId(sub.getUpstreamConsumerId());
@@ -110,8 +110,7 @@ public class SubscriptionReconcilerTest {
 
     @Test
     public void oneExistsUnchanged() {
-        Subscription testSub1 = createSubscription(owner, "test-prod-1",
-                "up1", "ue1", "uc1", 25);
+        Subscription testSub1 = createSubscription(owner, "test-prod-1", "up1", "ue1", "uc1", 25);
         createPoolsFor(testSub1);
 
         reconciler.reconcile(owner, Arrays.asList(testSub1), poolCurator);
@@ -293,11 +292,11 @@ public class SubscriptionReconcilerTest {
         Subscription testSub34 = createSubscription(owner, "test-prod-1", "up3", "ue34", "uc1", 5);
 
         createPoolsFor(testSub1, testSub2, testSub3, testSub4, testSub5,
-                testSub20, testSub21, testSub22, testSub24);
+            testSub20, testSub21, testSub22, testSub24);
 
         reconciler.reconcile(owner, Arrays.asList(testSub1, testSub2, testSub3, testSub4,
-                testSub5, testSub30, testSub31, testSub32, testSub33, testSub34),
-                poolCurator);
+            testSub5, testSub30, testSub31, testSub32, testSub33, testSub34),
+            poolCurator);
 
         // 20-24 have no matchup with 30-34 due to different upstream pool ID:
         assertUpstream(testSub1, testSub1.getId());
@@ -313,7 +312,8 @@ public class SubscriptionReconcilerTest {
     }
 
     private Subscription createSubscription(Owner daOwner, String productId,
-            String poolId, String entId, String conId, long quantity) {
+        String poolId, String entId, String conId, long quantity) {
+
         Subscription sub = new Subscription();
         sub.setProduct(new Product(productId, productId, owner));
         sub.setUpstreamPoolId(poolId);

--- a/server/src/test/java/org/candlepin/test/EnforcerForTesting.java
+++ b/server/src/test/java/org/candlepin/test/EnforcerForTesting.java
@@ -36,18 +36,18 @@ public class EnforcerForTesting implements Enforcer {
 
     @Override
     public void postEntitlement(PoolManager manager, Consumer consumer, Map<String, Entitlement> ent,
-            List<Pool> subPoolsForStackIds) {
+        List<Pool> subPoolsForStackIds) {
     }
 
     @Override
     public ValidationResult preEntitlement(Consumer consumer, Pool enitlementPool,
-            Integer quantity) {
+        Integer quantity) {
         return new ValidationResult();
     }
 
     @Override
     public ValidationResult preEntitlement(Consumer consumer, Pool enitlementPool,
-            Integer quantity, CallerType caller) {
+        Integer quantity, CallerType caller) {
         return new ValidationResult();
     }
 
@@ -57,7 +57,7 @@ public class EnforcerForTesting implements Enforcer {
 
     @Override
     public void postUnbind(Consumer consumer, PoolManager poolManager,
-            Entitlement ent) {
+        Entitlement ent) {
     }
 
     @Override
@@ -68,7 +68,7 @@ public class EnforcerForTesting implements Enforcer {
 
     @Override
     public Map<String, ValidationResult> preEntitlement(Consumer consumer,
-            Collection<PoolQuantity> entitlementPoolQuantities, CallerType caller) {
+        Collection<PoolQuantity> entitlementPoolQuantities, CallerType caller) {
         Map<String, ValidationResult> result = new HashMap<String, ValidationResult>();
         for (PoolQuantity pool : entitlementPoolQuantities) {
             result.put(pool.getPool().getId(), preEntitlement(consumer, pool.getPool(), pool.getQuantity()));
@@ -78,7 +78,7 @@ public class EnforcerForTesting implements Enforcer {
 
     @Override
     public Map<String, ValidationResult> preEntitlement(Consumer consumer, Consumer host,
-            Collection<PoolQuantity> entitlementPoolQuantities, CallerType caller) {
+        Collection<PoolQuantity> entitlementPoolQuantities, CallerType caller) {
         return preEntitlement(consumer, entitlementPoolQuantities, caller);
     }
 }

--- a/server/src/test/java/org/candlepin/test/TestUtil.java
+++ b/server/src/test/java/org/candlepin/test/TestUtil.java
@@ -387,8 +387,8 @@ public class TestUtil {
             pool.getOrderNumber()
         );
 
-        p.setSourceSubscription(new SourceSubscription(pool.getSubscriptionId(),
-                pool.getSubscriptionSubKey()));
+        p.setSourceSubscription(
+            new SourceSubscription(pool.getSubscriptionId(), pool.getSubscriptionSubKey()));
 
         // Copy sub-product data if there is any:
         p.setDerivedProduct(pool.getDerivedProduct());

--- a/server/src/test/java/org/candlepin/util/CertTest.java
+++ b/server/src/test/java/org/candlepin/util/CertTest.java
@@ -152,10 +152,8 @@ public class CertTest {
         // the CA for the attribute certificate should be different to that of
         // the client certificate
         //
-        X509Certificate caCert = AttrCertExample.createAcIssuerCert(caPubKey,
-                caPrivKey);
-        X509Certificate clientCert = AttrCertExample.createClientCert(pubKey,
-                caPrivKey, caPubKey);
+        X509Certificate caCert = AttrCertExample.createAcIssuerCert(caPubKey, caPrivKey);
+        X509Certificate clientCert = AttrCertExample.createClientCert(pubKey, caPrivKey, caPubKey);
         // Instantiate a new AC generator
         X509V2AttributeCertificateGenerator acGen =
             new X509V2AttributeCertificateGenerator();
@@ -168,8 +166,7 @@ public class CertTest {
         acGen.setHolder(new AttributeCertificateHolder(clientCert));
 
         // set the Issuer
-        acGen.setIssuer(new AttributeCertificateIssuer(caCert
-                .getSubjectX500Principal()));
+        acGen.setIssuer(new AttributeCertificateIssuer(caCert.getSubjectX500Principal()));
 
         //
         // serial number (as it's an example we don't have to keep track of the
@@ -187,20 +184,17 @@ public class CertTest {
         acGen.setSignatureAlgorithm("SHA1WithRSAEncryption");
 
         // the actual attributes
-        GeneralName roleName = new GeneralName(GeneralName.rfc822Name,
-                "DAU123456789");
+        GeneralName roleName = new GeneralName(GeneralName.rfc822Name, "DAU123456789");
         ASN1EncodableVector roleSyntax = new ASN1EncodableVector();
         roleSyntax.add(roleName);
 
         // roleSyntax OID: 2.5.24.72
-        X509Attribute attributes = new X509Attribute("2.5.24.72",
-                new DERSequence(roleSyntax));
+        X509Attribute attributes = new X509Attribute("2.5.24.72", new DERSequence(roleSyntax));
 
         acGen.addAttribute(attributes);
 
         // finally create the AC
-        X509V2AttributeCertificate att = (X509V2AttributeCertificate) acGen
-                .generate(caPrivKey, "BC");
+        X509V2AttributeCertificate att = (X509V2AttributeCertificate) acGen.generate(caPrivKey, "BC");
 
 
 

--- a/server/src/test/java/org/candlepin/util/X509V3ExtensionUtilTest.java
+++ b/server/src/test/java/org/candlepin/util/X509V3ExtensionUtilTest.java
@@ -146,7 +146,7 @@ public class X509V3ExtensionUtilTest {
         Entitlement e = new Entitlement(pool, consumer, 10);
 
         List<org.candlepin.model.dto.Product> certProds = util.createProducts(mktProd,
-                prods, "", new HashMap<String, EnvironmentContent>(),  new Consumer(), e);
+            prods, "", new HashMap<String, EnvironmentContent>(),  new Consumer(), e);
 
         assertEquals(1, certProds.size());
         assertEquals(brandedName, certProds.get(0).getBrandName());
@@ -174,7 +174,7 @@ public class X509V3ExtensionUtilTest {
         Entitlement e = new Entitlement(pool, consumer, 10);
 
         List<org.candlepin.model.dto.Product> certProds = util.createProducts(mktProd,
-                prods, "", new HashMap<String, EnvironmentContent>(),  new Consumer(), e);
+            prods, "", new HashMap<String, EnvironmentContent>(),  new Consumer(), e);
 
         assertEquals(1, certProds.size());
         // Should get the first name we encountered


### PR DESCRIPTION
This fun little PR corrects line continuation indentation throughout our code base.  I've set Checkstyle to only allow one level of indentation on a continuation.  Annoyingly though, Checkstyle doesn't really do the right thing when it comes to nested method chains.  In those circumstances, I tagged the method `@SuppressWarnings("checkstyle:indentation")`.  My goal is to keep this particular check in enforcing mode for a week or so while everyone gets their editors configured accordingly.  Once everyone is set up, we can drop the check and the `SuppressWarnings` and just rely on everyone's editors to do the right thing for the most part.