### PR TITLE
Fixed Optimistic Lock issue with ConsumerComplianceJob

### DIFF
--- a/server/src/main/java/org/candlepin/model/ConsumerCurator.java
+++ b/server/src/main/java/org/candlepin/model/ConsumerCurator.java
@@ -59,6 +59,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 
 import javax.persistence.LockModeType;
+import javax.persistence.NoResultException;
 
 /**
  * ConsumerCurator
@@ -295,6 +296,27 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
         getEntityManager().lock(c, LockModeType.PESSIMISTIC_WRITE);
         return c;
 
+    }
+
+    /**
+     * Find a consumer by uuid and immediately lock it.
+     *
+     * @param consumerUuid the uuid of the target consumer.
+     *
+     * @return the Consumer matching the given uuid, null if the consumer was not found.
+     */
+    public Consumer lockAndLoadByUuid(String consumerUuid) {
+        String jpql = "select c from Consumer c where c.uuid = :consumerUuid";
+
+        try {
+            return getEntityManager().createQuery(jpql, Consumer.class)
+                .setParameter("consumerUuid", consumerUuid)
+                .setLockMode(LockModeType.PESSIMISTIC_WRITE)
+                .getSingleResult();
+        }
+        catch (NoResultException nre) {
+            return null;
+        }
     }
 
     @Transactional


### PR DESCRIPTION
If a consumer was updated or deleted before the job was run
an OptimisticLockException was thrown and the job would fail.
Losing a compliance can be problematic as the consumer
status would be out of date.

The OLE would occur if the consumer was updated/deleted after
it was looked up and before it was locked.

This PR locks the consumer isntance on lookup, eliminating the
gap between fetch and lock.

If the Consumer does not exist, the job will now finish
successfully with an appropriate result message stating that
the targeted consumer could no longer be found.