### PR TITLE
Added config option for enabling/disabling per-org products

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'stringex'
 gem 'digest-murmurhash'
 gem 'httpclient'
 gem 'activesupport'
+gem 'dot-properties'
 
 # Remove this once we are fully using the new Ruby bindings
 gem 'rest-client', '~> 1.6.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,7 @@ GEM
     debug_inspector (0.0.2)
     diff-lcs (1.2.4)
     digest-murmurhash (1.1.1)
+    dot-properties (0.1.3)
     hoe (3.7.1)
       rake (>= 0.8, < 11.0)
     httpclient (2.7.1)
@@ -108,6 +109,7 @@ DEPENDENCIES
   buildr (= 1.4.19)
   buildr-findBugs
   digest-murmurhash
+  dot-properties
   httpclient
   mime-types (~> 1.25.0)
   oauth

--- a/server/spec/content_versioning_spec.rb
+++ b/server/spec/content_versioning_spec.rb
@@ -1,12 +1,20 @@
 require 'date'
 require 'spec_helper'
 require 'candlepin_scenarios'
+require 'dot_properties'
 
 
 
 describe 'Content Versioning' do
 
   include CandlepinMethods
+
+  before(:all) do
+    props = DotProperties.load('/etc/candlepin/candlepin.conf')
+    per_org = props['candlepin.per_org_products']
+
+    @per_org = [nil, '1', 't', 'true', 'y', 'yes'].include?(per_org)
+  end
 
   it "creates one content instance when shared by multiple orgs" do
     owner1 = create_owner random_string('test_owner')
@@ -43,6 +51,8 @@ describe 'Content Versioning' do
   end
 
   it "creates a new content instance when an org updates a shared instance" do
+    pending("candlepin is not running with per-org products") if !@per_org
+
     owner1 = create_owner random_string('test_owner')
     owner2 = create_owner random_string('test_owner')
     owner3 = create_owner random_string('test_owner')
@@ -68,6 +78,44 @@ describe 'Content Versioning' do
     content.size.should == 1
     content[0]["uuid"].should == content4["uuid"]
     content[0]["uuid"].should_not == content2["uuid"]
+
+    content = @cp.list_content(owner1["key"])
+    content.size.should == 1
+    content[0]["uuid"].should == content1["uuid"]
+
+    content = @cp.list_content(owner3["key"])
+    content.size.should == 1
+    content[0]["uuid"].should == content3["uuid"]
+  end
+
+  it "updates in-place when per-org products is disabled" do
+    pending("candlepin is not running with per-org products") if @per_org
+
+    owner1 = create_owner random_string('test_owner')
+    owner2 = create_owner random_string('test_owner')
+    owner3 = create_owner random_string('test_owner')
+
+    id = random_string("content")
+    name = "shared_content"
+    label = "shared content"
+    type = "shared_content_type"
+    vendor = "generous vendor"
+    updated_upstream = Date.today
+
+    content1 = @cp.create_content(owner1["key"], name, id, label, type, vendor)
+    content2 = @cp.create_content(owner2["key"], name, id, label, type, vendor)
+    content3 = @cp.create_content(owner3["key"], name, id, label, type, vendor)
+
+    content1["uuid"].should == content2["uuid"]
+    content1["uuid"].should == content3["uuid"]
+
+    content4 = @cp.update_content(owner2["key"], id, { :name => "new content name" })
+    content4["uuid"].should == content1["uuid"]
+
+    content = @cp.list_content(owner2["key"])
+    content.size.should == 1
+    content[0]["uuid"].should == content4["uuid"]
+    content[0]["uuid"].should == content2["uuid"]
 
     content = @cp.list_content(owner1["key"])
     content.size.should == 1
@@ -144,6 +192,4 @@ describe 'Content Versioning' do
     content[0]["uuid"].should == content2["uuid"]
   end
 
-
 end
-

--- a/server/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/server/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -242,6 +242,12 @@ public class ConfigProperties {
      */
     public static final String IDENTITY_CERT_EXPIRY_THRESHOLD = "candlepin.identityCert.expiry.threshold";
 
+    /**
+     * Whether or not per-org products should be enabled. If set to false, all products and content
+     * will be updated in-place.
+     */
+    public static final String PER_ORG_PRODUCTS = "candlepin.per_org_products";
+
     public static final Map<String, String> DEFAULT_PROPERTIES =
         new HashMap<String, String>() {
 
@@ -359,6 +365,8 @@ public class ConfigProperties {
                  *  a larger memory footprint as the cache fills up.
                  */
                 this.put(PRODUCT_CACHE_MAX, "100");
+
+                this.put(PER_ORG_PRODUCTS, "true");
 
                 /**
                  * As we do math on some facts and attributes, we need to constrain

--- a/server/src/main/java/org/candlepin/model/ConsumerCurator.java
+++ b/server/src/main/java/org/candlepin/model/ConsumerCurator.java
@@ -86,7 +86,7 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
         if (entity.getFacts() != null) {
             entity.setFacts(filterAndVerifyFacts(entity));
         }
-        
+
         return super.create(entity);
     }
 

--- a/server/src/main/java/org/candlepin/model/Product.java
+++ b/server/src/main/java/org/candlepin/model/Product.java
@@ -749,14 +749,14 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
      *  The content to add to this product
      *
      * @return
-     *  a reference to this Product instance
+     *  true if the content is added successfully; false otherwise
      */
-    public Product addContent(Content content) {
+    public boolean addContent(Content content) {
         return this.addContent(content, false);
     }
 
     /**
-     * Adds the specified content to this product.
+     * Adds the specified content to this product, if it doesn't already exist.
      *
      * @param content
      *  The content to add to this product
@@ -765,17 +765,19 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
      *  Whether or not the content should be added as an enabled or disabled source
      *
      * @return
-     *  a reference to this Product instance
+     *  true if the content is added successfully; false otherwise
      */
-    public Product addContent(Content content, boolean enabled) {
-        this.addProductContent(new ProductContent(this, content, enabled));
-        return this;
+    public boolean addContent(Content content, boolean enabled) {
+        return this.addProductContent(new ProductContent(this, content, enabled));
     }
 
     /**
      * @param productContent the productContent to set
+     *
+     * @return
+     *  a reference to this Product instance
      */
-    public void setProductContent(Collection<ProductContent> productContent) {
+    public Product setProductContent(Collection<ProductContent> productContent) {
         if (this.productContent == null) {
             this.productContent = new LinkedList<ProductContent>();
         }
@@ -787,6 +789,8 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
                 this.addProductContent(pc);
             }
         }
+
+        return this;
     }
 
     /**
@@ -796,15 +800,39 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
         return productContent;
     }
 
-    public void addProductContent(ProductContent content) {
+    /**
+     * Adds the specified ProductContent to this product. If the content has already been added,
+     * this method does nothing.
+     *
+     * @param content
+     *  The ProductContent instance to add to this product
+     *
+     * @return
+     *  true if the ProductContent is added successfully; false otherwise
+     */
+    public boolean addProductContent(ProductContent content) {
         if (this.productContent == null) {
             this.productContent = new LinkedList<ProductContent>();
         }
 
         if (content != null) {
-            content.setProduct(this);
-            this.productContent.add(content);
+            boolean found = false;
+            for (ProductContent pc : this.productContent) {
+                if (pc.getContent().equals(content.getContent())) {
+                    found = true;
+                    break;
+                }
+            }
+
+            if (!found) {
+                content.setProduct(this);
+                this.productContent.add(content);
+
+                return true;
+            }
         }
+
+        return false;
     }
 
     public void setContent(Set<Content> content) {
@@ -816,7 +844,7 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
 
         if (content != null) {
             for (Content newContent : content) {
-                this.productContent.add(new ProductContent(this, newContent, false));
+                this.addContent(newContent, false);
             }
         }
     }


### PR DESCRIPTION
- Added a new boolean property "candlepin.per_org_products" to candlepin.conf.
  This property can be used to configure whether or not products are treated
  as global (updating a product/content affects every org using it) or
  per-org (each org gets their own instance when they differ). The value is
  set to true by default.
- Added the dot-properties to handle reading from Candlepin configuration
  during our spec tests
- Added some new tests for verifying that toggling per-org products does
  not act unexpectedly
- Adding content to a product that already has the content being added is
  now a no-op