### PR TITLE
Products and Content now check the lock state when checking equality

### DIFF
--- a/server/src/main/java/org/candlepin/model/Content.java
+++ b/server/src/main/java/org/candlepin/model/Content.java
@@ -522,6 +522,7 @@ public class Content extends AbstractHibernateObject implements SharedEntity, Cl
                 .append(this.gpgUrl, that.gpgUrl)
                 .append(this.metadataExpire, that.metadataExpire)
                 .append(this.arches, that.arches)
+                .append(this.locked, that.locked)
                 .isEquals();
 
             if (equals) {
@@ -554,7 +555,8 @@ public class Content extends AbstractHibernateObject implements SharedEntity, Cl
             .append(this.releaseVer)
             .append(this.gpgUrl)
             .append(this.metadataExpire)
-            .append(this.arches);
+            .append(this.arches)
+            .append(this.locked);
 
         // Impl note:
         // Because we handle the collections specially in .equals, we have to do the same special

--- a/server/src/main/java/org/candlepin/model/Product.java
+++ b/server/src/main/java/org/candlepin/model/Product.java
@@ -656,6 +656,7 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
                 .append(this.id, that.id)
                 .append(this.name, that.name)
                 .append(this.multiplier, that.multiplier)
+                .append(this.locked, that.locked)
                 .isEquals();
 
             if (equals) {
@@ -703,7 +704,8 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
         HashCodeBuilder builder = new HashCodeBuilder(37, 7)
             .append(this.id)
             .append(this.name)
-            .append(this.multiplier);
+            .append(this.multiplier)
+            .append(this.locked);
 
         // Impl note:
         // Because we handle the collections specially in .equals, we have to do the same special

--- a/server/src/test/java/org/candlepin/model/ContentTest.java
+++ b/server/src/test/java/org/candlepin/model/ContentTest.java
@@ -104,4 +104,38 @@ public class ContentTest extends DatabaseTestFixture {
         assertEquals(newLabel, content.getLabel());
         assertEquals(newName, content.getName());
     }
+
+    @Test
+    public void testLockStateAffectsEquality() {
+        Owner owner = new Owner("Example-Corporation");
+        Content c1 = new Content(owner, "Test Content", "100", "test-content-label", "yum",
+            "test-vendor", "test-content-url", "test-gpg-url", "test-arch1");
+        Content c2 = new Content(owner, "Test Content", "100", "test-content-label", "yum",
+            "test-vendor", "test-content-url", "test-gpg-url", "test-arch1");
+
+        assertEquals(c1, c2);
+
+        c2.setLocked(true);
+        assertNotEquals(c1, c2);
+
+        c1.setLocked(true);
+        assertEquals(c1, c2);
+    }
+
+    @Test
+    public void testLockStateAffectsHashCode() {
+        Owner owner = new Owner("Example-Corporation");
+        Content c1 = new Content(owner, "Test Content", "100", "test-content-label", "yum",
+            "test-vendor", "test-content-url", "test-gpg-url", "test-arch1");
+        Content c2 = new Content(owner, "Test Content", "100", "test-content-label", "yum",
+            "test-vendor", "test-content-url", "test-gpg-url", "test-arch1");
+
+        assertEquals(c1.hashCode(), c2.hashCode());
+
+        c2.setLocked(true);
+        assertNotEquals(c1.hashCode(), c2.hashCode());
+
+        c1.setLocked(true);
+        assertEquals(c1.hashCode(), c2.hashCode());
+    }
 }

--- a/server/src/test/java/org/candlepin/model/ProductTest.java
+++ b/server/src/test/java/org/candlepin/model/ProductTest.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.model;
+
+import static org.junit.Assert.*;
+
+import org.candlepin.test.DatabaseTestFixture;
+
+import org.junit.Test;
+
+import javax.inject.Inject;
+
+
+/**
+ * ProductTest
+ */
+public class ProductTest extends DatabaseTestFixture {
+    @Inject private OwnerCurator ownerCurator;
+
+    @Test
+    public void testLockStateAffectsEquality() {
+        Owner owner = new Owner("Example-Corporation");
+        Product p1 = new Product("test-prod", "test-prod-name", owner, "variant", "1.0.0", "x86", "type");
+        Product p2 = new Product("test-prod", "test-prod-name", owner, "variant", "1.0.0", "x86", "type");
+
+        assertEquals(p1, p2);
+
+        p2.setLocked(true);
+        assertNotEquals(p1, p2);
+
+        p1.setLocked(true);
+        assertEquals(p1, p2);
+    }
+
+    @Test
+    public void testLockStateAffectsHashCode() {
+        Owner owner = new Owner("Example-Corporation");
+        Product p1 = new Product("test-prod", "test-prod-name", owner, "variant", "1.0.0", "x86", "type");
+        Product p2 = new Product("test-prod", "test-prod-name", owner, "variant", "1.0.0", "x86", "type");
+
+        assertEquals(p1.hashCode(), p2.hashCode());
+
+        p2.setLocked(true);
+        assertNotEquals(p1.hashCode(), p2.hashCode());
+
+        p1.setLocked(true);
+        assertEquals(p1.hashCode(), p2.hashCode());
+    }
+}


### PR DESCRIPTION
- Products and Content will now check their lock state when checking
  for equality or generating hash codes. This should prevent an issue
  where an entity could become locked or unlocked by merging or
  diverging from another entity in a different lock state.