### PR TITLE
Increase sleep time for one sub pool per stack spec

### DIFF
--- a/server/spec/one_sub_pool_per_stack_spec.rb
+++ b/server/spec/one_sub_pool_per_stack_spec.rb
@@ -345,7 +345,7 @@ describe 'One Sub Pool Per Stack' do
     @host2_client.update_consumer({:guestIds => [{'guestId' => @guest_uuid}]})
 
     # Need to wait a moment here for MySQL to catch up
-    sleep 2
+    sleep 4
 
     # Guest entitlement should now be revoked.
     @guest_client.list_entitlements.length.should == 0


### PR DESCRIPTION
Apparently two seconds was not enough. spec test still failed some times , look at build 246 in jenkins for example.