### PR TITLE
Added automatic entitlement certificate regeneration on product/content update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,7 +30,7 @@ GEM
       xml-simple (= 1.1.2)
     buildr-findBugs (0.1.1)
       buildr (>= 1.4.0)
-    byebug (8.2.2)
+    byebug (8.2.4)
     coderay (1.1.1)
     debug_inspector (0.0.2)
     diff-lcs (1.2.4)
@@ -51,7 +51,7 @@ GEM
     oauth (0.5.1)
     orderedhash (0.0.6)
     parallel (1.8.0)
-    parallel_tests (2.4.1)
+    parallel_tests (2.5.0)
       parallel
     parser (2.3.0.7)
       ast (~> 2.2)

--- a/server/client/ruby/candlepin_api.rb
+++ b/server/client/ruby/candlepin_api.rb
@@ -674,7 +674,7 @@ class Candlepin
     return async_call(immediate) do
       url="/owners/#{owner_key}/products/#{product_id}/subscriptions?"
       url += "lazy_regen=false&" if !lazy_regen
-      put(url)
+      return put(url)
     end
   end
 

--- a/server/spec/content_versioning_spec.rb
+++ b/server/spec/content_versioning_spec.rb
@@ -22,7 +22,7 @@ describe 'Content Versioning' do
     content1 = @cp.create_content(owner1["key"], name, id, label, type, vendor)
     content2 = @cp.create_content(owner2["key"], name, id, label, type, vendor)
 
-    content1["uuid"].should == content2["uuid"]
+    content1["uuid"].should eq(content2["uuid"])
   end
 
   it "creates two distinct content instances when details differ" do
@@ -39,7 +39,7 @@ describe 'Content Versioning' do
     content1 = @cp.create_content(owner1["key"], name, id, label, type, vendor)
     content2 = @cp.create_content(owner2["key"], name + "-2", id, label, type, vendor)
 
-    content1["uuid"].should_not == content2["uuid"]
+    content1["uuid"].should_not eq(content2["uuid"])
   end
 
   it "creates a new content instance when an org updates a shared instance" do
@@ -58,24 +58,24 @@ describe 'Content Versioning' do
     content2 = @cp.create_content(owner2["key"], name, id, label, type, vendor)
     content3 = @cp.create_content(owner3["key"], name, id, label, type, vendor)
 
-    content1["uuid"].should == content2["uuid"]
-    content1["uuid"].should == content3["uuid"]
+    content1["uuid"].should eq(content2["uuid"])
+    content1["uuid"].should eq(content3["uuid"])
 
     content4 = @cp.update_content(owner2["key"], id, { :name => "new content name" })
-    content4["uuid"].should_not == content1["uuid"]
+    content4["uuid"].should_not eq(content1["uuid"])
 
     content = @cp.list_content(owner2["key"])
-    content.size.should == 1
-    content[0]["uuid"].should == content4["uuid"]
-    content[0]["uuid"].should_not == content2["uuid"]
+    content.size.should eq(1)
+    content[0]["uuid"].should eq(content4["uuid"])
+    content[0]["uuid"].should_not eq(content2["uuid"])
 
     content = @cp.list_content(owner1["key"])
-    content.size.should == 1
-    content[0]["uuid"].should == content1["uuid"]
+    content.size.should eq(1)
+    content[0]["uuid"].should eq(content1["uuid"])
 
     content = @cp.list_content(owner3["key"])
-    content.size.should == 1
-    content[0]["uuid"].should == content3["uuid"]
+    content.size.should eq(1)
+    content[0]["uuid"].should eq(content3["uuid"])
   end
 
   it "converges content when a given version already exists" do
@@ -93,25 +93,25 @@ describe 'Content Versioning' do
     content1 = @cp.create_content(owner1["key"], name, id, label, type, vendor)
     content2 = @cp.create_content(owner2["key"], name, id, label, type, vendor)
     content3 = @cp.create_content(owner3["key"], name + "-2", id, label, type, vendor)
-    content1["uuid"].should == content2["uuid"]
-    content2["uuid"].should_not == content3["uuid"]
+    content1["uuid"].should eq(content2["uuid"])
+    content2["uuid"].should_not eq(content3["uuid"])
 
     content4 = @cp.update_content(owner3["key"], id, { :name => name })
 
-    content4["uuid"].should == content1["uuid"]
+    content4["uuid"].should eq(content1["uuid"])
 
     content = @cp.list_content(owner1["key"])
-    content.size.should == 1
-    content[0]["uuid"].should == content1["uuid"]
+    content.size.should eq(1)
+    content[0]["uuid"].should eq(content1["uuid"])
 
     content = @cp.list_content(owner2["key"])
-    content.size.should == 1
-    content[0]["uuid"].should == content2["uuid"]
+    content.size.should eq(1)
+    content[0]["uuid"].should eq(content2["uuid"])
 
     content = @cp.list_content(owner3["key"])
-    content.size.should == 1
-    content[0]["uuid"].should == content1["uuid"]
-    content[0]["uuid"].should_not == content3["uuid"]
+    content.size.should eq(1)
+    content[0]["uuid"].should eq(content1["uuid"])
+    content[0]["uuid"].should_not eq(content3["uuid"])
   end
 
   it "deletes content without affecting other orgs" do
@@ -128,22 +128,20 @@ describe 'Content Versioning' do
     content1 = @cp.create_content(owner1["key"], name, id, label, type, vendor)
     content2 = @cp.create_content(owner2["key"], name, id, label, type, vendor)
 
-    content1["uuid"].should == content2["uuid"]
+    content1["uuid"].should eq(content2["uuid"])
 
     @cp.delete_content(owner1["key"], id)
 
     content = @cp.list_content(owner1["key"])
-    content.size.should == 0
+    content.size.should eq(0)
 
     lambda do
       @cp.get_content(owner1["key"], id)
     end.should raise_exception(RestClient::ResourceNotFound)
 
     content = @cp.list_content(owner2["key"])
-    content.size.should == 1
-    content[0]["uuid"].should == content2["uuid"]
+    content.size.should eq(1)
+    content[0]["uuid"].should eq(content2["uuid"])
   end
 
-
 end
-

--- a/server/spec/owner_product_resource_spec.rb
+++ b/server/spec/owner_product_resource_spec.rb
@@ -132,6 +132,83 @@ describe 'Owner Product Resource' do
     pool.length.should eq(0)
   end
 
+  def setupOrgProductsAndPools()
+    owner1 = create_owner(random_string("owner"))
+    owner2 = create_owner(random_string("owner"))
+    owner3 = create_owner(random_string("owner"))
+
+    prod1o1 = create_product("p1", "p1", { :owner => owner1['key'] })
+    prod1o2 = create_product("p1", "p1", { :owner => owner2['key'] })
+    prod1o3 = create_product("p1", "p1", { :owner => owner3['key'] })
+
+    prod2o1 = create_product("p2", "p2", { :owner => owner1['key'] })
+    prod2o2 = create_product("p2", "p2", { :owner => owner2['key'] })
+
+    prod3o2 = create_product("p3", "p3", { :owner => owner2['key'] })
+    prod3o3 = create_product("p3", "p3", { :owner => owner3['key'] })
+
+    prod4 = create_product("p4", "p4", { :owner => owner1['key'] })
+    prod4d = create_product("p4d", "p4d", { :owner => owner1['key'] })
+    prod5 = create_product("p5", "p5", { :owner => owner2['key'] })
+    prod5d = create_product("p5d", "p5d", { :owner => owner2['key'] })
+    prod6 = create_product("p6", "p6", { :owner => owner3['key'] })
+    prod6d = create_product("p6d", "p6d", { :owner => owner3['key'] })
+
+    @cp.create_pool(owner1['key'], "p4", {
+      :derived_product_id         => "p4d",
+      :provided_products          => ["p1"],
+      :derived_provided_products  => ["p2"]
+    });
+
+    @cp.create_pool(owner2['key'], "p5", {
+      :derived_product_id         => "p5d",
+      :provided_products          => ["p1", "p2"],
+      :derived_provided_products  => ["p3"]
+    });
+
+    @cp.create_pool(owner3['key'], "p6", {
+      :derived_product_id         => "p6d",
+      :provided_products          => ["p1"],
+      :derived_provided_products  => ["p3"]
+    });
+
+    return [owner1, owner2, owner3]
+  end
+
+  it "refreshes pools for orgs owning products" do
+    pending("candlepin running in standalone mode") if not is_hosted?
+
+    owners = setupOrgProductsAndPools()
+    owner1 = owners[0]
+    owner2 = owners[1]
+    owner3 = owners[2]
+
+    # Override enabled to true:
+    job = @cp.refresh_pools_for_product(owner1['key'], "p4")
+    job.should_not be_nil
+    job['id'].should include("refresh_pools")
+    wait_for_job(job['id'], 15)
+
+    job = @cp.refresh_pools_for_product(owner2['key'], "p5d")
+    job.should_not be_nil
+    job['id'].should include("refresh_pools")
+    wait_for_job(job['id'], 15)
+
+    job = @cp.refresh_pools_for_product(owner3['key'], "p1")
+    job.should_not be_nil
+    job['id'].should include("refresh_pools")
+    wait_for_job(job['id'], 15)
+
+    job = @cp.refresh_pools_for_product(owner3['key'], "p3")
+    job.should_not be_nil
+    job['id'].should include("refresh_pools")
+    wait_for_job(job['id'], 15)
+
+    lambda do
+      @cp.refresh_pools_for_product(owner1['key'], "nope")
+    end.should raise_exception(RestClient::ResourceNotFound)
+  end
+
   it 'lists all products in bulk fetch' do
     prod1_id = random_string("test_id")
     prod2_id = random_string("test_id")

--- a/server/spec/product_resource_spec.rb
+++ b/server/spec/product_resource_spec.rb
@@ -161,6 +161,8 @@ describe 'Product Resource' do
   end
 
   it "refreshes pools for orgs owning products" do
+    pending("candlepin running in standalone mode") if not is_hosted?
+
     owners = setupOrgProductsAndPools()
     owner1 = owners[0]
     owner2 = owners[1]

--- a/server/spec/product_versioning_spec.rb
+++ b/server/spec/product_versioning_spec.rb
@@ -20,7 +20,7 @@ describe 'Product Versioning' do
     prod1 = @cp.create_product(owner1["key"], id, name)
     prod2 = @cp.create_product(owner2["key"], id, name)
 
-    prod1["uuid"].should == prod2["uuid"]
+    prod1["uuid"].should eq(prod2["uuid"])
   end
 
   it "creates two distinct product instances when details differ" do
@@ -35,7 +35,7 @@ describe 'Product Versioning' do
     prod1 = @cp.create_product(owner1["key"], id, name)
     prod2 = @cp.create_product(owner2["key"], id, name + "2")
 
-    prod1["uuid"].should_not == prod2["uuid"]
+    prod1["uuid"].should_not eq(prod2["uuid"])
   end
 
   it "creates a new product instance when an org updates a shared instance" do
@@ -52,24 +52,24 @@ describe 'Product Versioning' do
     prod2 = @cp.create_product(owner2["key"], id, name)
     prod3 = @cp.create_product(owner3["key"], id, name)
 
-    prod1["uuid"].should == prod2["uuid"]
-    prod1["uuid"].should == prod3["uuid"]
+    prod1["uuid"].should eq(prod2["uuid"])
+    prod1["uuid"].should eq(prod3["uuid"])
 
     prod4 = @cp.update_product(owner2["key"], id, { :name => "new product name" })
-    prod4["uuid"].should_not == prod1["uuid"]
+    prod4["uuid"].should_not eq(prod1["uuid"])
 
     prods = @cp.list_products_by_owner(owner2["key"])
-    prods.size.should == 1
-    prods[0]["uuid"].should == prod4["uuid"]
-    prods[0]["uuid"].should_not == prod2["uuid"]
+    prods.size.should eq(1)
+    prods[0]["uuid"].should eq(prod4["uuid"])
+    prods[0]["uuid"].should_not eq(prod2["uuid"])
 
     prods = @cp.list_products_by_owner(owner1["key"])
-    prods.size.should == 1
-    prods[0]["uuid"].should == prod1["uuid"]
+    prods.size.should eq(1)
+    prods[0]["uuid"].should eq(prod1["uuid"])
 
     prods = @cp.list_products_by_owner(owner3["key"])
-    prods.size.should == 1
-    prods[0]["uuid"].should == prod3["uuid"]
+    prods.size.should eq(1)
+    prods[0]["uuid"].should eq(prod3["uuid"])
   end
 
   it "converges products when a given version already exists" do
@@ -86,25 +86,25 @@ describe 'Product Versioning' do
     prod2 = @cp.create_product(owner2["key"], id, name)
     prod3 = @cp.create_product(owner3["key"], id, "differing product name")
 
-    prod1["uuid"].should == prod2["uuid"]
-    prod2["uuid"].should_not == prod3["uuid"]
+    prod1["uuid"].should eq(prod2["uuid"])
+    prod2["uuid"].should_not eq(prod3["uuid"])
 
     prod4 = @cp.update_product(owner3["key"], id, { :name => name })
 
-    prod4["uuid"].should == prod1["uuid"]
+    prod4["uuid"].should eq(prod1["uuid"])
 
     prods = @cp.list_products_by_owner(owner1["key"])
-    prods.size.should == 1
-    prods[0]["uuid"].should == prod1["uuid"]
+    prods.size.should eq(1)
+    prods[0]["uuid"].should eq(prod1["uuid"])
 
     prods = @cp.list_products_by_owner(owner2["key"])
-    prods.size.should == 1
-    prods[0]["uuid"].should == prod2["uuid"]
+    prods.size.should eq(1)
+    prods[0]["uuid"].should eq(prod2["uuid"])
 
     prods = @cp.list_products_by_owner(owner3["key"])
-    prods.size.should == 1
-    prods[0]["uuid"].should == prod1["uuid"]
-    prods[0]["uuid"].should_not == prod3["uuid"]
+    prods.size.should eq(1)
+    prods[0]["uuid"].should eq(prod1["uuid"])
+    prods[0]["uuid"].should_not eq(prod3["uuid"])
   end
 
   it "deletes products without affecting other orgs" do
@@ -119,20 +119,20 @@ describe 'Product Versioning' do
     prod1 = @cp.create_product(owner1["key"], id, name)
     prod2 = @cp.create_product(owner2["key"], id, name)
 
-    prod1["uuid"].should == prod2["uuid"]
+    prod1["uuid"].should eq(prod2["uuid"])
 
     @cp.delete_product(owner1["key"], id)
 
     prods = @cp.list_products_by_owner(owner1["key"])
-    prods.size.should == 0
+    prods.size.should eq(0)
 
     lambda do
       @cp.get_product(owner1["key"], id)
     end.should raise_exception(RestClient::ResourceNotFound)
 
     prods = @cp.list_products_by_owner(owner2["key"])
-    prods.size.should == 1
-    prods[0]["uuid"].should == prod2["uuid"]
+    prods.size.should eq(1)
+    prods[0]["uuid"].should eq(prod2["uuid"])
   end
 
   it "creates new products when adding content to shared products" do
@@ -147,7 +147,7 @@ describe 'Product Versioning' do
     prod1 = @cp.create_product(owner1["key"], id, name)
     prod2 = @cp.create_product(owner2["key"], id, name)
 
-    prod1["uuid"].should == prod2["uuid"]
+    prod1["uuid"].should eq(prod2["uuid"])
 
 
     content_id = random_string("content")
@@ -161,19 +161,19 @@ describe 'Product Versioning' do
     )
 
     prod3 = @cp.add_content_to_product(owner1["key"], id, content_id)
-    prod3["uuid"].should_not == prod1["uuid"]
-    prod3["uuid"].should_not == prod2["uuid"]
+    prod3["uuid"].should_not eq(prod1["uuid"])
+    prod3["uuid"].should_not eq(prod2["uuid"])
 
     prods = @cp.list_products_by_owner(owner1["key"])
-    prods.size.should == 1
-    prods[0]["uuid"].should == prod3["uuid"]
-    prods[0]["uuid"].should_not == prod1["uuid"]
-    prods[0]["uuid"].should_not == prod2["uuid"]
+    prods.size.should eq(1)
+    prods[0]["uuid"].should eq(prod3["uuid"])
+    prods[0]["uuid"].should_not eq(prod1["uuid"])
+    prods[0]["uuid"].should_not eq(prod2["uuid"])
 
     prods = @cp.list_products_by_owner(owner2["key"])
-    prods.size.should == 1
-    prods[0]["uuid"].should == prod2["uuid"]
-    prods[0]["uuid"].should_not == prod3["uuid"]
+    prods.size.should eq(1)
+    prods[0]["uuid"].should eq(prod2["uuid"])
+    prods[0]["uuid"].should_not eq(prod3["uuid"])
   end
 
   it "creates new products when updating content used by shared products" do
@@ -188,7 +188,7 @@ describe 'Product Versioning' do
     prod1 = @cp.create_product(owner1["key"], id, name)
     prod2 = @cp.create_product(owner2["key"], id, name)
 
-    prod1["uuid"].should == prod2["uuid"]
+    prod1["uuid"].should eq(prod2["uuid"])
 
 
     content_id = random_string("content")
@@ -206,43 +206,181 @@ describe 'Product Versioning' do
 
     prod3 = @cp.add_content_to_product(owner1["key"], id, content_id)
     prod4 = @cp.add_content_to_product(owner2["key"], id, content_id)
-    prod3["uuid"].should_not == prod1["uuid"]
-    prod3["uuid"].should_not == prod2["uuid"]
-    prod4["uuid"].should_not == prod1["uuid"]
-    prod4["uuid"].should_not == prod2["uuid"]
-    prod3["uuid"].should == prod4["uuid"]
+    prod3["uuid"].should_not eq(prod1["uuid"])
+    prod3["uuid"].should_not eq(prod2["uuid"])
+    prod4["uuid"].should_not eq(prod1["uuid"])
+    prod4["uuid"].should_not eq(prod2["uuid"])
+    prod3["uuid"].should eq(prod4["uuid"])
 
     prods = @cp.list_products_by_owner(owner1["key"])
-    prods.size.should == 1
-    prods[0]["uuid"].should == prod3["uuid"]
-    prods[0]["uuid"].should_not == prod1["uuid"]
-    prods[0]["uuid"].should_not == prod2["uuid"]
+    prods.size.should eq(1)
+    prods[0]["uuid"].should eq(prod3["uuid"])
+    prods[0]["uuid"].should_not eq(prod1["uuid"])
+    prods[0]["uuid"].should_not eq(prod2["uuid"])
 
     prods = @cp.list_products_by_owner(owner2["key"])
-    prods.size.should == 1
-    prods[0]["uuid"].should == prod4["uuid"]
-    prods[0]["uuid"].should_not == prod1["uuid"]
-    prods[0]["uuid"].should_not == prod2["uuid"]
+    prods.size.should eq(1)
+    prods[0]["uuid"].should eq(prod4["uuid"])
+    prods[0]["uuid"].should_not eq(prod1["uuid"])
+    prods[0]["uuid"].should_not eq(prod2["uuid"])
 
     # Actual test starts here
     content3 = @cp.update_content(owner1["key"], content_id, {:label => "new label"})
+    content3["uuid"].should_not eq(content1["uuid"])
+    content3["uuid"].should_not eq(content2["uuid"])
 
     prods = @cp.list_products_by_owner(owner1["key"])
-    prods.size.should == 1
-    prods[0]["uuid"].should_not == prod1["uuid"]
-    prods[0]["uuid"].should_not == prod2["uuid"]
-    prods[0]["uuid"].should_not == prod3["uuid"]
-    prods[0]["uuid"].should_not == prod4["uuid"]
+    prods.size.should eq(1)
+    prods[0]["uuid"].should_not eq(prod1["uuid"])
+    prods[0]["uuid"].should_not eq(prod2["uuid"])
+    prods[0]["uuid"].should_not eq(prod3["uuid"])
+    prods[0]["uuid"].should_not eq(prod4["uuid"])
 
     prods = @cp.list_products_by_owner(owner2["key"])
-    prods.size.should == 1
-    prods[0]["uuid"].should == prod4["uuid"]
-    prods[0]["uuid"].should_not == prod1["uuid"]
-    prods[0]["uuid"].should_not == prod2["uuid"]
+    prods.size.should eq(1)
+    prods[0]["uuid"].should eq(prod4["uuid"])
+    prods[0]["uuid"].should_not eq(prod1["uuid"])
+    prods[0]["uuid"].should_not eq(prod2["uuid"])
+  end
+
+  it "creates new products when removing content used by shared products" do
+    owner1 = create_owner random_string('test_owner')
+    owner2 = create_owner random_string('test_owner')
+
+    id = random_string("product")
+    name = "shared_product"
+
+    updated_upstream = Date.today
+
+    prod1 = @cp.create_product(owner1["key"], id, name)
+    prod2 = @cp.create_product(owner2["key"], id, name)
+
+    prod1["uuid"].should eq(prod2["uuid"])
+
+
+    content_id = random_string("content")
+    content_name = "shared_content"
+    content_label = "shared content"
+    content_type = "shared_content_type"
+    content_vendor = "generous vendor"
+
+    content1 = @cp.create_content(
+        owner1["key"], content_name, content_id, content_label, content_type, content_vendor
+    )
+    content2 = @cp.create_content(
+        owner2["key"], content_name, content_id, content_label, content_type, content_vendor
+    )
+
+    prod3 = @cp.add_content_to_product(owner1["key"], id, content_id)
+    prod4 = @cp.add_content_to_product(owner2["key"], id, content_id)
+    prod3["uuid"].should_not eq(prod1["uuid"])
+    prod3["uuid"].should_not eq(prod2["uuid"])
+    prod4["uuid"].should_not eq(prod1["uuid"])
+    prod4["uuid"].should_not eq(prod2["uuid"])
+    prod4["uuid"].should eq(prod3["uuid"])
+
+    prods = @cp.list_products_by_owner(owner1["key"])
+    prods.size.should eq(1)
+    prods[0]["uuid"].should eq(prod3["uuid"])
+    prods[0]["uuid"].should_not eq(prod1["uuid"])
+    prods[0]["uuid"].should_not eq(prod2["uuid"])
+
+    prods = @cp.list_products_by_owner(owner2["key"])
+    prods.size.should eq(1)
+    prods[0]["uuid"].should_not eq(prod1["uuid"])
+    prods[0]["uuid"].should_not eq(prod2["uuid"])
+    prods[0]["uuid"].should eq(prod4["uuid"])
+
+    # Actual test starts here
+    content3 = @cp.delete_content(owner1["key"], content_id)
+
+    prods = @cp.list_products_by_owner(owner1["key"])
+    prods.size.should eq(1)
+
+    # This is an interesting case. Due to our current implementation, these will be equal, but it's
+    # by coincedence, not intent. At the time of writing, it is not a requirement for a given state
+    # to have a defined version/hash, but it does. As a result, we can't test that they shouldn't
+    # be equal (because they will be), but testing that they are equal is wrong. We'll just comment
+    # these out and leave this message here for future maintaners.
+    # prods[0]["uuid"].should_not eq(prod1["uuid"])
+    # prods[0]["uuid"].should_not eq(prod2["uuid"])
+    prods[0]["uuid"].should_not eq(prod3["uuid"])
+    prods[0]["uuid"].should_not eq(prod4["uuid"])
+
+    prods = @cp.list_products_by_owner(owner2["key"])
+    prods.size.should eq(1)
+    prods[0]["uuid"].should_not eq(prod1["uuid"])
+    prods[0]["uuid"].should_not eq(prod2["uuid"])
+    prods[0]["uuid"].should eq(prod3["uuid"])
+    prods[0]["uuid"].should eq(prod4["uuid"])
+  end
+
+  it "converges identical products when converging content" do
+    owner1 = create_owner random_string('test_owner')
+    owner2 = create_owner random_string('test_owner')
+
+    id = random_string("product")
+    name = "shared_product"
+
+    updated_upstream = Date.today
+
+    prod1 = @cp.create_product(owner1["key"], id, name)
+    prod2 = @cp.create_product(owner2["key"], id, name)
+
+    prod1["uuid"].should eq(prod2["uuid"])
+
+    content_id = random_string("content")
+    content_name = "shared_content"
+    content_label = "shared content"
+    content_type = "shared_content_type"
+    content_vendor = "generous vendor"
+
+    content1 = @cp.create_content(
+        owner1["key"], content_name, content_id, content_label, content_type, content_vendor
+    )
+    content2 = @cp.create_content(
+        owner2["key"], content_name, content_id, "different label", content_type, content_vendor
+    )
+
+    content1["uuid"].should_not eq(content2["uuid"])
+
+    prod3 = @cp.add_content_to_product(owner1["key"], id, content_id)
+    prod4 = @cp.add_content_to_product(owner2["key"], id, content_id)
+    prod3["uuid"].should_not eq(prod1["uuid"])
+    prod3["uuid"].should_not eq(prod2["uuid"])
+
+    # Another interesting case here. While it may appear that these should be different, the
+    # addition of the content to prod1 triggered the generation of a new product for org1 (prod3),
+    # leaving org2 as the only owner for prod2. That being the case, prod2 was updated in-place,
+    # allowing it to retain its UUID, and make this test look strange
+    prod4["uuid"].should eq(prod1["uuid"])
+    prod4["uuid"].should eq(prod2["uuid"])
+    prod4["uuid"].should_not eq(prod3["uuid"])
+
+    # Actual test starts here
+    content3 = @cp.update_content(owner2["key"], content_id, {:label => content_label})
+    content3["uuid"].should eq(content1["uuid"])
+    content3["uuid"].should_not eq(content2["uuid"])
+
+    prods = @cp.list_products_by_owner(owner1["key"])
+    prods.size.should eq(1)
+    prod5 = prods[0]
+    prod5["uuid"].should_not eq(prod1["uuid"])
+    prod5["uuid"].should_not eq(prod2["uuid"])
+    prod5["uuid"].should eq(prod3["uuid"])
+    prod5["uuid"].should_not eq(prod4["uuid"])
+
+    prods = @cp.list_products_by_owner(owner2["key"])
+    prods.size.should eq(1)
+    prod6 = prods[0]
+    prod6["uuid"].should_not eq(prod1["uuid"])
+    prod6["uuid"].should_not eq(prod2["uuid"])
+    prod6["uuid"].should eq(prod3["uuid"])
+    prod6["uuid"].should_not eq(prod4["uuid"])
+    prod6["uuid"].should eq(prod5["uuid"])
   end
 
   # TODO ? :
   # - Updating a shared product used by another resource properly links the new product
 
 end
-

--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -32,7 +32,6 @@ import org.candlepin.model.ConsumerInstalledProduct;
 import org.candlepin.model.Content;
 import org.candlepin.model.ContentCurator;
 import org.candlepin.model.Entitlement;
-import org.candlepin.model.EntitlementCertificate;
 import org.candlepin.model.EntitlementCertificateCurator;
 import org.candlepin.model.EntitlementCurator;
 import org.candlepin.model.Environment;
@@ -65,12 +64,9 @@ import org.candlepin.policy.js.entitlement.Enforcer.CallerType;
 import org.candlepin.policy.js.pool.PoolRules;
 import org.candlepin.policy.js.pool.PoolUpdate;
 import org.candlepin.resource.dto.AutobindData;
-import org.candlepin.service.EntitlementCertServiceAdapter;
 import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.sync.SubscriptionReconciler;
-import org.candlepin.util.CertificateSizeException;
 import org.candlepin.util.Util;
-import org.candlepin.version.CertVersionConflictException;
 
 import com.google.inject.Inject;
 import com.google.inject.persist.Transactional;
@@ -117,14 +113,15 @@ public class CandlepinPoolManager implements PoolManager {
     private PoolRules poolRules;
     private EntitlementCurator entitlementCurator;
     private ConsumerCurator consumerCurator;
-    private EntitlementCertServiceAdapter entCertAdapter;
     private EntitlementCertificateCurator entitlementCertificateCurator;
+    private EntitlementCertificateGenerator ecGenerator;
     private ComplianceRules complianceRules;
     private ProductCurator productCurator;
+    private ProductManager productManager;
     private AutobindRules autobindRules;
     private ActivationKeyRules activationKeyRules;
-    private ProductCurator prodCurator;
     private ContentCurator contentCurator;
+    private ContentManager contentManager;
     private OwnerCurator ownerCurator;
     private PinsetterKernel pinsetterKernel;
 
@@ -136,32 +133,46 @@ public class CandlepinPoolManager implements PoolManager {
      * @param config
      */
     @Inject
-    public CandlepinPoolManager(PoolCurator poolCurator,
+    public CandlepinPoolManager(
+        PoolCurator poolCurator,
+        EventSink sink,
+        EventFactory eventFactory,
+        Configuration config,
+        Enforcer enforcer,
+        PoolRules poolRules,
+        EntitlementCurator entitlementCurator,
+        ConsumerCurator consumerCurator,
+        EntitlementCertificateCurator entitlementCertCurator,
+        EntitlementCertificateGenerator ecGenerator,
+        ComplianceRules complianceRules,
+        AutobindRules autobindRules,
+        ActivationKeyRules activationKeyRules,
         ProductCurator productCurator,
-        EntitlementCertServiceAdapter entCertAdapter, EventSink sink,
-        EventFactory eventFactory, Configuration config, Enforcer enforcer,
-        PoolRules poolRules, EntitlementCurator curator1, ConsumerCurator consumerCurator,
-        EntitlementCertificateCurator ecC, ComplianceRules complianceRules,
-        AutobindRules autobindRules, ActivationKeyRules activationKeyRules,
-        ProductCurator prodCurator, ContentCurator contentCurator, OwnerCurator ownerCurator,
-        PinsetterKernel pinsetterKernel, I18n i18n) {
+        ProductManager productManager,
+        ContentCurator contentCurator,
+        ContentManager contentManager,
+        OwnerCurator ownerCurator,
+        PinsetterKernel pinsetterKernel,
+        I18n i18n) {
 
         this.poolCurator = poolCurator;
         this.sink = sink;
         this.eventFactory = eventFactory;
         this.config = config;
-        this.entitlementCurator = curator1;
+        this.entitlementCurator = entitlementCurator;
         this.consumerCurator = consumerCurator;
         this.enforcer = enforcer;
         this.poolRules = poolRules;
-        this.entCertAdapter = entCertAdapter;
-        this.entitlementCertificateCurator = ecC;
+        this.entitlementCertificateCurator = entitlementCertCurator;
+        this.ecGenerator = ecGenerator;
         this.complianceRules = complianceRules;
         this.productCurator = productCurator;
         this.autobindRules = autobindRules;
         this.activationKeyRules = activationKeyRules;
-        this.prodCurator = prodCurator;
+        this.productCurator = productCurator;
+        this.productManager = productManager;
         this.contentCurator = contentCurator;
+        this.contentManager = contentManager;
         this.ownerCurator = ownerCurator;
         this.pinsetterKernel = pinsetterKernel;
         this.i18n = i18n;
@@ -223,7 +234,7 @@ public class CandlepinPoolManager implements PoolManager {
 
         deletePools(poolsToDelete);
 
-        // TODO: break this call into smaller pieces.  There may be lots of floating pools
+        // TODO: break this call into smaller pieces. There may be lots of floating pools
         List<Pool> floatingPools = poolCurator.getOwnersFloatingPools(owner);
         updateFloatingPools(floatingPools, lazy, changedProducts);
         log.info("Refresh pools for owner: {} completed in: {}ms", owner.getKey(),
@@ -396,12 +407,12 @@ public class CandlepinPoolManager implements PoolManager {
                 // with the API
                 incoming.setLocked(true);
 
-                incoming = this.contentCurator.createContent(incoming, owner);
+                incoming = this.contentManager.createContent(incoming, owner);
             }
             else if (!incoming.equals(existing)) {
                 log.info("Updating existing content for org {}: {}", owner.getKey(), cid);
 
-                incoming = this.contentCurator.updateContent(incoming, owner);
+                incoming = this.contentManager.updateContent(incoming, owner, false);
 
                 changed.add(incoming);
             }
@@ -437,7 +448,7 @@ public class CandlepinPoolManager implements PoolManager {
 
         // We need to flush here to make sure our pending persists and merges get pushed to the DB
         // so our reference updates don't fail.
-        this.prodCurator.flush();
+        this.productCurator.flush();
 
         // Go back through each sub and update product references so we don't end up with dangling,
         // transient or duplicate references on any of the subs.
@@ -485,7 +496,7 @@ public class CandlepinPoolManager implements PoolManager {
         Product resolved = null;
 
         if (product != null) {
-            resolved = this.prodCurator.lookupById(owner, product.getId());
+            resolved = this.productCurator.lookupById(owner, product.getId());
 
             if (resolved == null) {
                 // This should never happen.
@@ -507,7 +518,7 @@ public class CandlepinPoolManager implements PoolManager {
         for (String pid : productCache.keySet()) {
             // If the pid key and product.getId() don't match, we'll have some serious issues here.
             Product incoming = productCache.get(pid);
-            Product existing = this.prodCurator.lookupById(owner, pid);
+            Product existing = this.productCurator.lookupById(owner, pid);
 
             // Ensure the inbound product is linked to the owner that initiated the refresh
             incoming.addOwner(owner);
@@ -519,12 +530,12 @@ public class CandlepinPoolManager implements PoolManager {
                 // with the API
                 incoming.setLocked(true);
 
-                incoming = this.prodCurator.createProduct(incoming, owner);
+                incoming = this.productManager.createProduct(incoming, owner);
             }
             else if (!existing.equals(incoming)) {
                 log.info("Product changed for org {}: {}", owner.getKey(), pid);
 
-                incoming = this.prodCurator.updateProduct(incoming, owner);
+                incoming = this.productManager.updateProduct(incoming, owner, false);
 
                 changedProducts.add(incoming);
             }
@@ -536,6 +547,7 @@ public class CandlepinPoolManager implements PoolManager {
     @Transactional
     void refreshPoolsForMasterPool(Pool pool, boolean updateStackDerived, boolean lazy,
         Set<Product> changedProducts) {
+
         // These don't all necessarily belong to this owner
         List<Pool> subscriptionPools = poolCurator.getPoolsBySubscriptionId(pool.getSubscriptionId());
         log.debug("Found {} pools for subscription {}", subscriptionPools.size(), pool.getSubscriptionId());
@@ -550,13 +562,15 @@ public class CandlepinPoolManager implements PoolManager {
 
         // capture the original quantity to check for updates later
         Long originalQuantity = pool.getQuantity();
-        // BUG 1012386 This will regenerate master/derived for bonus scenarios
-        //  if only one of the pair still exists.
+
+        // BZ 1012386: This will regenerate master/derived for bonus scenarios if only one of the
+        // pair still exists.
         createAndEnrichPools(pool, subscriptionPools);
 
         // don't update floating here, we'll do that later so we don't update anything twice
         Set<String> updatedMasterPools = updatePoolsForMasterPool(
             subscriptionPools, pool, originalQuantity, updateStackDerived, changedProducts);
+
         regenerateCertificatesByEntIds(updatedMasterPools, lazy);
     }
 
@@ -1361,12 +1375,14 @@ public class CandlepinPoolManager implements PoolManager {
         Map<String, Entitlement> entitlements = new HashMap<String, Entitlement>();
         entitlements.put(entitlement.getPool().getId(), entitlement);
 
-        List<Entitlement> result = addOrUpdateEntitlements(consumer, poolQuantities, entitlements, true,
-            CallerType.UNKNOWN);
+        List<Entitlement> result = addOrUpdateEntitlements(
+            consumer, poolQuantities, entitlements, true, CallerType.UNKNOWN);
+
         if (CollectionUtils.isNotEmpty(result)) {
             // always going to be one entitlement for a single pool
             return result.get(0);
         }
+
         return null;
     }
 
@@ -1402,8 +1418,8 @@ public class CandlepinPoolManager implements PoolManager {
     @Transactional
     protected List<Entitlement> addOrUpdateEntitlements(Consumer consumer,
         Map<String, Integer> poolQuantityMap, Map<String, Entitlement> entitlements,
-        boolean generateUeberCert, CallerType caller)
-        throws EntitlementRefusedException {
+        boolean generateUeberCert, CallerType caller) throws EntitlementRefusedException {
+
         // Because there are several paths to this one place where entitlements
         // are granted, we cannot be positive the caller obtained a lock on the
         // pool when it was read. As such we're going to reload it with a lock
@@ -1426,13 +1442,14 @@ public class CandlepinPoolManager implements PoolManager {
             if (quantity > 0) {
                 quantityFound = true;
             }
+
             poolQuantities.put(pool.getId(), new PoolQuantity(pool, quantity));
             poolQuantityMap.remove(pool.getId());
         }
 
         if (!poolQuantityMap.isEmpty()) {
             throw new IllegalArgumentException(i18n.tr("Subscription pool(s) {0} do not exist.",
-                    poolQuantityMap.keySet()));
+                poolQuantityMap.keySet()));
         }
         if (quantityFound) {
             log.info("Running pre-entitlement rules.");
@@ -1445,6 +1462,7 @@ public class CandlepinPoolManager implements PoolManager {
                 if (!result.isSuccessful()) {
                     log.warn("Entitlement not granted: {} for pool: {}",
                         result.getErrors().toString(), entry.getKey());
+
                     throw new EntitlementRefusedException(results);
                 }
             }
@@ -1455,10 +1473,10 @@ public class CandlepinPoolManager implements PoolManager {
             handler = new NewHandler();
         }
         else if (!poolQuantities.keySet().equals(entitlements.keySet())) {
-            throw new IllegalArgumentException(
-                            i18n.tr("Argument mismatch in entitlement update, number of pools: {}," +
-                            " number of entitlements: {}",
-                            entitlements.keySet().size(), poolQuantityMap.keySet().size()));
+            throw new IllegalArgumentException(i18n.tr(
+                "Argument mismatch in entitlement update, number of pools: {}, number of entitlements: {}",
+                entitlements.keySet().size(), poolQuantityMap.keySet().size()
+            ));
         }
         else {
             handler = new UpdateHandler();
@@ -1496,6 +1514,7 @@ public class CandlepinPoolManager implements PoolManager {
 
         log.info("Triggering ConsumerComplianceJob: {} for consumer: {}", detail.getKey(),
             consumer.getUuid());
+
         try {
             pinsetterKernel.scheduleSingleJob(detail);
         }
@@ -1517,12 +1536,12 @@ public class CandlepinPoolManager implements PoolManager {
      */
     private void checkBonusPoolQuantities(Map<String, PoolQuantity> poolQuantities,
         Map<String, Entitlement> entitlements) {
+
         Set<String> excludePoolIds = new HashSet<String>();
         Map<String, Entitlement> subEntitlementMap = new HashMap<String, Entitlement>();
         for (Entry<String, PoolQuantity> entry : poolQuantities.entrySet()) {
             Pool pool = entry.getValue().getPool();
-            subEntitlementMap.put(pool.getSubscriptionId(),
-                entitlements.get(entry.getKey()));
+            subEntitlementMap.put(pool.getSubscriptionId(), entitlements.get(entry.getKey()));
             excludePoolIds.add(pool.getId());
         }
 
@@ -1537,78 +1556,19 @@ public class CandlepinPoolManager implements PoolManager {
         deleteExcessEntitlements(derivedPools);
     }
 
-    /**
-     * @param consumer
-     * @param pool
-     * @param e
-     * @param mergedPool
-     * @return
-     */
-    private EntitlementCertificate generateEntitlementCertificate(
-        Pool pool, Entitlement e, boolean generateUeberCert) {
-        Map<String, Product> products = new HashMap<String, Product>();
-        products.put(pool.getId(), pool.getProduct());
-        Map<String, Entitlement> entitlements = new HashMap<String, Entitlement>();
-        entitlements.put(pool.getId(), e);
-
-        return generateEntitlementCertificates(e.getConsumer(), products, entitlements, generateUeberCert)
-                .get(pool.getId());
-    }
-
-    /**
-     * @param consumer
-     * @param pool
-     * @param e
-     * @param mergedPool
-     * @return
-     */
-    private Map<String, EntitlementCertificate> generateEntitlementCertificates(Consumer consumer,
-        Map<String, Product> products, Map<String, Entitlement> entitlements, boolean generateUeberCert) {
-        try {
-            return generateUeberCert ? entCertAdapter.generateUeberCerts(consumer, entitlements, products) :
-                entCertAdapter.generateEntitlementCerts(consumer, entitlements, products);
-        }
-        catch (CertVersionConflictException cvce) {
-            throw cvce;
-        }
-        catch (CertificateSizeException cse) {
-            throw cse;
-        }
-        catch (Exception ex) {
-            throw new RuntimeException(ex);
-        }
-    }
-
     @Override
-    public void regenerateEntitlementCertificates(Consumer consumer, boolean lazy) {
-        log.info(
-            "Regenerating #{}, entitlement certificates for consumer: {}",
-            consumer.getEntitlements().size(), consumer
-        );
-
-        // TODO - Assumes only 1 entitlement certificate exists per entitlement
-        this.regenerateCertificatesOf(consumer.getEntitlements(), lazy);
+    public void regenerateCertificatesOf(Consumer consumer, boolean lazy) {
+        this.ecGenerator.regenerateCertificatesOf(consumer, lazy);
     }
 
     @Transactional
     void regenerateCertificatesOf(Iterable<Entitlement> iterable, boolean lazy) {
-        for (Entitlement e : iterable) {
-            regenerateCertificatesOf(e, false, lazy);
-        }
+        this.ecGenerator.regenerateCertificatesOf(iterable, lazy);
     }
 
     @Transactional
     void regenerateCertificatesByEntIds(Iterable<String> iterable, boolean lazy) {
-        for (String entId : iterable) {
-            Entitlement e = entitlementCurator.find(entId);
-            if (e != null) {
-                regenerateCertificatesOf(e, false, lazy);
-            }
-            else {
-                // If it has been deleted, that's fine, one less to regenerate
-                log.info("Couldn't load Entitlement \"{}\" to regenerate, assuming deleted", entId);
-            }
-        }
+        this.ecGenerator.regenerateCertificatesByEntitlementIds(iterable, lazy);
     }
 
     /**
@@ -1624,31 +1584,7 @@ public class CandlepinPoolManager implements PoolManager {
     @Override
     @Transactional
     public void regenerateCertificatesOf(Environment e, Set<String> affectedContent, boolean lazy) {
-        log.info("Regenerating relevant certificates in environment: {}", e.getId());
-
-        List<Entitlement> allEnvEnts = entitlementCurator.listByEnvironment(e);
-        Set<Entitlement> entsToRegen = new HashSet<Entitlement>();
-        for (Entitlement ent : allEnvEnts) {
-            Product prod = productCurator.lookupById(ent.getOwner(),
-                ent.getPool().getProductId());
-            for (String contentId : affectedContent) {
-                if (prod.hasContent(contentId)) {
-                    entsToRegen.add(ent);
-                }
-            }
-
-            // Now the provided products:
-            for (Product provided : ent.getPool().getProvidedProducts()) {
-                for (String contentId : affectedContent) {
-                    if (provided.hasContent(contentId)) {
-                        entsToRegen.add(ent);
-                    }
-                }
-            }
-        }
-
-        log.info("Found {} certificates to regenerate.", entsToRegen.size());
-        regenerateCertificatesOf(entsToRegen, lazy);
+        this.ecGenerator.regenerateCertificatesOf(e, affectedContent, lazy);
     }
 
     /**
@@ -1657,52 +1593,13 @@ public class CandlepinPoolManager implements PoolManager {
     @Override
     @Transactional
     public void regenerateCertificatesOf(Entitlement e, boolean ueberCertificate, boolean lazy) {
-
-        if (lazy) {
-            log.info("Marking certificates dirty for entitlement: {}", e);
-            e.setDirty(true);
-            return;
-        }
-
-        log.debug("Revoking entitlementCertificates of: {}", e);
-
-        Entitlement tempE = new Entitlement();
-        tempE.setCertificates(e.getCertificates());
-        e.setCertificates(null);
-
-        // below call creates new certificates and saves it to the backend.
-        try {
-            EntitlementCertificate generated = this.generateEntitlementCertificate(
-                e.getPool(), e, ueberCertificate
-            );
-
-            e.setDirty(false);
-            entitlementCurator.merge(e);
-            for (EntitlementCertificate ec : tempE.getCertificates()) {
-                log.debug("Deleting entitlementCertificate: #{}", ec.getId());
-                this.entitlementCertificateCurator.delete(ec);
-            }
-
-            // send entitlement changed event.
-            this.sink.queueEvent(this.eventFactory.entitlementChanged(e));
-            log.debug("Generated entitlementCertificate: #{}", generated.getId());
-        }
-        catch (CertificateSizeException cse) {
-            e.setCertificates(tempE.getCertificates());
-            log.warn("The certificate cannot be regenerated at this time: {}", cse.getMessage());
-        }
+        this.ecGenerator.regenerateCertificatesOf(e, ueberCertificate, lazy);
     }
 
     @Override
     @Transactional
     public void regenerateCertificatesOf(Owner owner, String productId, boolean lazy) {
-        List<Pool> poolsForProduct = this.listAvailableEntitlementPools(null, null, owner,
-            productId, null, new Date(), false, false, new PoolFilterBuilder(), null)
-            .getPageData();
-
-        for (Pool pool : poolsForProduct) {
-            regenerateCertificatesOf(pool.getEntitlements(), lazy);
-        }
+        this.ecGenerator.regenerateCertificatesOf(owner, productId, lazy);
     }
 
     @Override
@@ -2073,15 +1970,20 @@ public class CandlepinPoolManager implements PoolManager {
     /**
      * NewHandler
      */
-    private class NewHandler implements EntitlementHandler{
+    private class NewHandler implements EntitlementHandler {
+
         @Override
         public Map<String, Entitlement> handleEntitlement(Consumer consumer,
             Map<String, PoolQuantity> poolQuantities, Map<String, Entitlement> entitlements) {
+
             List<Entitlement> entsToPersist = new ArrayList<Entitlement>();
             Map<String, Entitlement> result = new HashMap<String, Entitlement>();
+
             for (Entry<String, PoolQuantity> entry : poolQuantities.entrySet()) {
-                Entitlement newEntitlement = new Entitlement(entry.getValue().getPool(), consumer,
-                    entry.getValue().getQuantity());
+                Entitlement newEntitlement = new Entitlement(
+                    entry.getValue().getPool(), consumer, entry.getValue().getQuantity()
+                );
+
                 entsToPersist.add(newEntitlement);
                 result.put(entry.getKey(), newEntitlement);
             }
@@ -2098,6 +2000,7 @@ public class CandlepinPoolManager implements PoolManager {
                 consumer.addEntitlement(e);
                 entry.getValue().getPool().getEntitlements().add(e);
             }
+
             return result;
         }
 
@@ -2133,8 +2036,10 @@ public class CandlepinPoolManager implements PoolManager {
                 Pool pool = poolQuantity.getPool();
                 products.put(pool.getId(), pool.getProduct());
             }
-            generateEntitlementCertificates(consumer, products, entitlements, generateUeberCert);
+
+            ecGenerator.generateEntitlementCertificates(consumer, products, entitlements, generateUeberCert);
         }
+
         @Override
         public void handleBonusPools(Map<String, PoolQuantity> pools, Map<String, Entitlement> entitlements) {
             checkBonusPoolQuantities(pools, entitlements);
@@ -2183,6 +2088,7 @@ public class CandlepinPoolManager implements PoolManager {
         ActivationKey key, Owner owner, String productId, String subscriptionId, Date activeOn,
         boolean activeOnly, boolean includeWarnings, PoolFilterBuilder filters,
         PageRequest pageRequest) {
+
         // Only postfilter if we have to
         boolean postFilter = consumer != null || key != null;
         if (consumer != null && !consumer.isDev()) {

--- a/server/src/main/java/org/candlepin/controller/ContentManager.java
+++ b/server/src/main/java/org/candlepin/controller/ContentManager.java
@@ -1,0 +1,341 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.controller;
+
+import org.candlepin.common.config.Configuration;
+import org.candlepin.model.Content;
+import org.candlepin.model.ContentCurator;
+import org.candlepin.model.Owner;
+import org.candlepin.model.Product;
+import org.candlepin.model.ProductContent;
+import org.candlepin.model.ProductCurator;
+
+import com.google.inject.Inject;
+import com.google.inject.persist.Transactional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+
+
+/**
+ * The ContentManager class provides methods for creating, updating and removing content instances
+ * which also perform the cleanup and general maintenance necessary to keep content state in sync
+ * with other objects which reference them.
+ * <p/>
+ * The methods provided by this class are the prefered methods to use for CRUD operations on
+ * content, to ensure content versioning and linking is handled properly.
+ */
+public class ContentManager {
+    private static Logger log = LoggerFactory.getLogger(ContentManager.class);
+
+    private ContentCurator contentCurator;
+    private ProductCurator productCurator;
+    private ProductManager productManager;
+    private EntitlementCertificateGenerator entitlementCertGenerator;
+
+    @Inject
+    public ContentManager(ContentCurator contentCurator, ProductCurator productCurator,
+        ProductManager productManager, EntitlementCertificateGenerator entitlementCertGenerator,
+        Configuration config) {
+
+        this.contentCurator = contentCurator;
+        this.productCurator = productCurator;
+        this.productManager = productManager;
+        this.entitlementCertGenerator = entitlementCertGenerator;
+    }
+
+    /**
+     * Creates a new Content for the given owner, potentially using a different version than the
+     * entity provided if a matching entity has already been registered for another owner.
+     *
+     * @param entity
+     *  A Content instance representing the content to create
+     *
+     * @param owner
+     *  The owner for which to create the content
+     *
+     * @throws IllegalStateException
+     *  if this method is called with an entity that already exists in the backing database for the
+     *  given owner
+     *
+     * @throws NullPointerException
+     *  if the provided content entity is null
+     *
+     * @return
+     *  a new Content instance representing the specified content for the given owner
+     */
+    @Transactional
+    public Content createContent(Content entity, Owner owner) {
+        log.debug("Creating new content for org: {}, {}", entity, owner);
+
+        if (entity == null) {
+            throw new NullPointerException("entity");
+        }
+
+        Content existing = this.contentCurator.lookupById(owner, entity.getId());
+
+        if (existing != null) {
+            // If we're doing an exclusive creation, this should be an error condition
+            throw new IllegalStateException("Content has already been created");
+        }
+
+        // Check if we have an alternate version we can use instead.
+
+        // TODO: Not sure if we really even need the version check. If we have any other matching
+        // content, we should probably use it -- regardless of the actual version value.
+        List<Content> alternateVersions = this.contentCurator.getContentByVersion(
+            entity.getId(), entity.hashCode()
+        );
+
+        for (Content alt : alternateVersions) {
+            if (alt.equals(entity)) {
+                // If we're "creating" a content, we shouldn't have any other object references to
+                // update for this content. Instead, we'll just add the new owner to the content.
+                alt.addOwner(owner);
+                return this.contentCurator.merge(alt);
+            }
+        }
+
+        entity.addOwner(owner);
+        return this.contentCurator.create(entity);
+    }
+
+    /**
+     * Updates the specified content instance, creating a new version of the content as necessary.
+     * The content instance returned by this method is not guaranteed to be the same instance passed
+     * in. As such, once this method has been called, callers should only use the instance output by
+     * this method.
+     *
+     * @param entity
+     *  The content entity to update
+     *
+     * @param owner
+     *  The owner for which to update the content
+     *
+     * @param regenerateEntitlementCerts
+     *  Whether or not changes made to the content should trigger the regeneration of entitlement
+     *  certificates for affected consumers
+     *
+     * @throws IllegalStateException
+     *  if this method is called with an entity does not exist in the backing database for the given
+     *  owner
+     *
+     * @throws NullPointerException
+     *  if the provided content entity is null
+     *
+     * @return
+     *  the updated content entity, or a new content entity
+     */
+    @Transactional
+    public Content updateContent(Content entity, Owner owner, boolean regenerateEntitlementCerts) {
+        log.debug("Applying content update for org: {}, {}", entity, owner);
+
+        if (entity == null) {
+            throw new NullPointerException("entity");
+        }
+
+        // This has to fetch a new instance, or we'll be unable to compare the objects
+        Content existing = this.contentCurator.lookupById(owner, entity.getId());
+
+        if (existing == null) {
+            // If we're doing an exclusive update, this should be an error condition
+            throw new IllegalStateException("Content has not yet been created");
+        }
+
+        if (existing == entity) {
+            // Nothing to do, really. The caller likely intends for the changes to be persisted, so
+            // we can do that for them.
+            return this.contentCurator.merge(entity);
+        }
+
+        // Check for newer versions of the same content. We want to try to dedupe as much data as we
+        // can, and if we have a newer version of the content (which matches the version provided by
+        // the caller), we can just point the given orgs to the new content instead of giving them
+        // their own version.
+        // This is probably going to be a very expensive operation, though.
+        List<Content> alternateVersions = this.contentCurator.getContentByVersion(
+            entity.getId(), entity.hashCode()
+        );
+
+        for (Content alt : alternateVersions) {
+            if (alt.equals(entity)) {
+                log.debug("Merging content with existing version: {} => {}", entity, alt);
+
+                alt.addOwner(owner);
+                this.contentCurator.merge(alt);
+
+                // Make sure every product using the old version/entity are updated to use the new one
+                List<Product> affectedProducts = this.productCurator.getProductsWithContent(
+                    owner, Arrays.asList(entity.getId())
+                );
+
+                entity = this.contentCurator.updateOwnerContentReferences(
+                    existing, alt, Arrays.asList(owner)
+                );
+
+                for (Product product : affectedProducts) {
+                    product = (Product) product.clone();
+
+                    for (ProductContent pc : product.getProductContent()) {
+                        if (entity.equals(pc.getContent())) {
+                            pc.setContent(alt);
+                        }
+                    }
+
+                    // Impl note: This should also take care of our entitlement cert regeneration
+                    this.productManager.updateProduct(product, owner, regenerateEntitlementCerts);
+                }
+
+                return entity;
+            }
+        }
+
+        // Make sure we actually have something to update.
+        if (!existing.equals(entity)) {
+            // If we're making the update for every owner using the content, don't bother creating
+            // a new version -- just do a raw update.
+            if (existing.getOwners().size() == 1) {
+                log.debug("Applying in-place update to content: {}", entity);
+
+                existing.merge(entity);
+                entity = existing;
+
+                this.contentCurator.merge(entity);
+
+                if (regenerateEntitlementCerts) {
+                    // Every owner with a pool using any of the affected products needs an update.
+                    this.entitlementCertGenerator.regenerateCertificatesOf(
+                        this.productCurator.getProductsWithContent(Arrays.asList(existing.getUuid())), true
+                    );
+                }
+            }
+            else {
+                log.debug("Forking content and applying update: {}", entity);
+
+                // This org isn't the only org using the content. We need to create a new content
+                // instance and move the org over to the new content.
+                List<Owner> owners = Arrays.asList(owner);
+                Content copy = (Content) entity.clone();
+
+                // Clear the UUID so Hibernate doesn't think our copy is a detached entity
+                copy.setUuid(null);
+
+                // Get products that currently use this content...
+                List<Product> affectedProducts = this.productCurator.getProductsWithContent(
+                    owner, Arrays.asList(existing.getId())
+                );
+
+                // Set the owner so when we create it, we don't end up with duplicate keys...
+                existing.removeOwner(owner);
+                copy.setOwners(owners);
+
+                this.contentCurator.merge(existing);
+                copy = this.contentCurator.create(copy);
+
+                // Update the products using this content so they are regenerated using the new
+                // content
+                for (Product product : affectedProducts) {
+                    product = (Product) product.clone();
+
+                    for (ProductContent pc : product.getProductContent()) {
+                        if (existing.equals(pc.getContent())) {
+                            pc.setContent(copy);
+                        }
+                    }
+
+                    // Impl note: This should also take care of our entitlement cert regeneration ??
+                    this.productManager.updateProduct(product, owner, regenerateEntitlementCerts);
+                }
+
+                entity = this.contentCurator.updateOwnerContentReferences(existing, copy, owners);
+            }
+        }
+
+        return entity;
+    }
+
+    /**
+     * Removes the specified content from the given owner, deleting the content instance if able.
+     *
+     * @param entity
+     *  The content entity to remove
+     *
+     * @param owner
+     *  The owner for which to remove the content
+     *
+     * @param regenerateEntitlementCerts
+     *  Whether or not changes made to the content should trigger the regeneration of entitlement
+     *  certificates for affected consumers
+     *
+     * @throws IllegalStateException
+     *  if this method is called with an entity does not exist in the backing database for the given
+     *  owner
+     *
+     * @throws NullPointerException
+     *  if the provided content entity is null
+     *
+     * @return
+     *  a list of products affected by the removal of the given content
+     */
+    @Transactional
+    public List<Product> removeContent(Content entity, Owner owner, boolean regenerateEntitlementCerts) {
+        log.debug("Removing content for org: {}, {}", entity, owner);
+
+        if (entity == null) {
+            throw new NullPointerException("entity");
+        }
+
+        // This has to fetch a new instance, or we'll be unable to compare the objects
+        Content existing = this.contentCurator.lookupById(owner, entity.getId());
+
+        if (existing == null) {
+            // If we're doing an exclusive update, this should be an error condition
+            throw new IllegalStateException("Content has not yet been created");
+        }
+
+        List<Product> affectedProducts =
+            this.productCurator.getProductsWithContent(owner, Arrays.asList(existing.getId()));
+
+        // Update affected products and regenerate their certs
+        List<Product> updatedAffectedProducts = new LinkedList<Product>();
+        List<Content> contentList = Arrays.asList(existing);
+
+        for (Product product : affectedProducts) {
+            product = this.productManager.removeProductContent(
+                product, contentList, owner, regenerateEntitlementCerts
+            );
+
+            updatedAffectedProducts.add(product);
+        }
+
+        existing.removeOwner(owner);
+        if (existing.getOwners().size() == 0) {
+            this.contentCurator.delete(existing);
+        }
+        else {
+            this.contentCurator.merge(existing);
+        }
+
+        // Clean up any dangling references to content
+        this.contentCurator.removeOwnerContentReferences(existing, Arrays.asList(owner));
+
+        return updatedAffectedProducts;
+    }
+
+}

--- a/server/src/main/java/org/candlepin/controller/EntitlementCertificateGenerator.java
+++ b/server/src/main/java/org/candlepin/controller/EntitlementCertificateGenerator.java
@@ -1,0 +1,423 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.controller;
+
+import org.candlepin.audit.EventFactory;
+import org.candlepin.audit.EventSink;
+import org.candlepin.model.Consumer;
+import org.candlepin.model.Entitlement;
+import org.candlepin.model.EntitlementCertificate;
+import org.candlepin.model.EntitlementCertificateCurator;
+import org.candlepin.model.EntitlementCurator;
+import org.candlepin.model.Environment;
+import org.candlepin.model.Owner;
+import org.candlepin.model.Pool;
+import org.candlepin.model.PoolCurator;
+import org.candlepin.model.Product;
+import org.candlepin.service.EntitlementCertServiceAdapter;
+import org.candlepin.util.CertificateSizeException;
+import org.candlepin.version.CertVersionConflictException;
+
+import com.google.inject.Inject;
+import com.google.inject.persist.Transactional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.Date;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+
+
+
+/**
+ * The EntitlementCertificateGenerator class provides utility methods for regenerating the
+ * certificates for entitlements associated with various model objects.
+ * <p/>
+ * It should be noted that due to the amount of graph traversal that can occur when performing these
+ * operations, the number of calls to methods provided by this class should be minimized. The majority
+ * are incredibly expensive and, in the case of immediate regeneration, can hold database locks for the
+ * duration. Usage of these methods should be carefully evaluated, and bulk operations should be
+ * preferred to singular ones.
+ */
+public class EntitlementCertificateGenerator {
+    private static Logger log = LoggerFactory.getLogger(EntitlementCertificateGenerator.class);
+
+    private EntitlementCertificateCurator entitlementCertificateCurator;
+    private EntitlementCertServiceAdapter entCertServiceAdapter;
+    private EntitlementCurator entitlementCurator;
+    private PoolCurator poolCurator;
+
+    private EventSink eventSink;
+    private EventFactory eventFactory;
+
+    @Inject
+    public EntitlementCertificateGenerator(EntitlementCertificateCurator entitlementCertificateCurator,
+        EntitlementCertServiceAdapter entCertServiceAdapter, EntitlementCurator entitlementCurator,
+        PoolCurator poolCurator, EventSink eventSink, EventFactory eventFactory) {
+
+        this.entitlementCertificateCurator = entitlementCertificateCurator;
+        this.entCertServiceAdapter = entCertServiceAdapter;
+        this.entitlementCurator = entitlementCurator;
+        this.poolCurator = poolCurator;
+
+        this.eventSink = eventSink;
+        this.eventFactory = eventFactory;
+    }
+
+    /**
+     * Generates new entitlement certificates for the given consumer using the provided products and
+     * entitlements.
+     *
+     * @param consumer
+     *  The consumer for which to generate new entitlement certificates
+     *
+     * @param products
+     *  A mapping of products, indexed by pool ID, to use when generating certificates
+     *
+     * @param entitlements
+     *  A mapping of entitlements, indexed by pool ID, to use when generating certificates
+     *
+     * @param generateUeberCert
+     *  Whether or not to generate ueber certs
+     *
+     * @return
+     *  A map of generated entitlement certificates, indexed by pool ID
+     */
+    @Transactional
+    public Map<String, EntitlementCertificate> generateEntitlementCertificates(Consumer consumer,
+        Map<String, Product> products, Map<String, Entitlement> entitlements, boolean generateUeberCert) {
+
+        try {
+            return generateUeberCert ?
+                this.entCertServiceAdapter.generateUeberCerts(consumer, entitlements, products) :
+                this.entCertServiceAdapter.generateEntitlementCerts(consumer, entitlements, products);
+        }
+        catch (CertVersionConflictException cvce) {
+            throw cvce;
+        }
+        catch (CertificateSizeException cse) {
+            throw cse;
+        }
+        catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    /**
+     * Generates a new entitlement certificate for the given entitlement and pool.
+     *
+     * @param pool
+     *  The pool for which to generate an entitlement certificate
+     *
+     * @param entitlement
+     *  The entitlement to use when generating the certificate
+     *
+     * @param generateUeberCert
+     *  Whether or not to generate an ueber cert
+     *
+     * @return
+     *  The newly generate entitlement certificate
+     */
+    @Transactional
+    public EntitlementCertificate generateEntitlementCertificate(Pool pool, Entitlement entitlement,
+        boolean generateUeberCert) {
+
+        Map<String, Product> products = new HashMap<String, Product>();
+        Map<String, Entitlement> entitlements = new HashMap<String, Entitlement>();
+
+        products.put(pool.getId(), pool.getProduct());
+        entitlements.put(pool.getId(), entitlement);
+
+        return this.generateEntitlementCertificates(entitlement.getConsumer(), products, entitlements,
+            generateUeberCert).get(pool.getId());
+    }
+
+    /**
+     * Regenerates the certificates for the specified entitlement.
+     *
+     * @param entitlement
+     *  The entitlement for which to regenerate certificates
+     *
+     * @param ueberCertificate
+     *  Whether or not to generate an ueber certificate
+     *
+     * @param lazy
+     *  Whether or not to generate the certificate immediately, or mark it dirty and allow it to be
+     *  regenerated on-demand
+     */
+    @Transactional
+    public void regenerateCertificatesOf(Entitlement entitlement, boolean ueberCertificate, boolean lazy) {
+        if (lazy) {
+            log.info("Marking certificates dirty for entitlement: {}", entitlement);
+            entitlement.setDirty(true);
+            return;
+        }
+
+        log.debug("Revoking entitlementCertificates of: {}", entitlement);
+
+        Entitlement tempE = new Entitlement();
+        tempE.setCertificates(entitlement.getCertificates());
+        entitlement.setCertificates(null);
+
+        // below call creates new certificates and saves it to the backend.
+        try {
+            EntitlementCertificate generated = this.generateEntitlementCertificate(
+                entitlement.getPool(), entitlement, ueberCertificate
+            );
+
+            entitlement.setDirty(false);
+            this.entitlementCurator.merge(entitlement);
+            for (EntitlementCertificate ec : tempE.getCertificates()) {
+                log.debug("Deleting entitlementCertificate: #{}", ec.getId());
+                this.entitlementCertificateCurator.delete(ec);
+            }
+
+            // send entitlement changed event.
+            this.eventSink.queueEvent(this.eventFactory.entitlementChanged(entitlement));
+            log.debug("Generated entitlementCertificate: #{}", generated.getId());
+        }
+        catch (CertificateSizeException cse) {
+            entitlement.setCertificates(tempE.getCertificates());
+            log.warn("The certificate cannot be regenerated at this time: {}", cse.getMessage());
+        }
+    }
+
+    /**
+     * Regenerates the certificates for the specified entitlements. This method is a utility method
+     * which individually regenerates certificates for each entitlement in the provided collection.
+     *
+     * @param entitlements
+     *  An iterable collection of entitlements for which to regenerate certificates
+     *
+     * @param lazy
+     *  Whether or not to generate the certificate immediately, or mark it dirty and allow it to be
+     *  regenerated on-demand
+     */
+    @Transactional
+    public void regenerateCertificatesOf(Iterable<Entitlement> entitlements, boolean lazy) {
+        for (Entitlement entitlement : entitlements) {
+            this.regenerateCertificatesOf(entitlement, false, lazy);
+        }
+    }
+
+    /**
+     * Regenerates the certificates for the specified entitlements. This method is a utility method
+     * which individually regenerates certificates for each entitlement in the provided collection.
+     *
+     * @param entitlementIds
+     *  An iterable collection of entitlement IDs for which to regenerate certificates
+     *
+     * @param lazy
+     *  Whether or not to generate the certificate immediately, or mark it dirty and allow it to be
+     *  regenerated on-demand
+     */
+    @Transactional
+    void regenerateCertificatesByEntitlementIds(Iterable<String> entitlementIds, boolean lazy) {
+        for (String entitlementId : entitlementIds) {
+            Entitlement entitlement = entitlementCurator.find(entitlementId);
+
+            if (entitlement != null) {
+                this.regenerateCertificatesOf(entitlement, false, lazy);
+            }
+            else {
+                // If it has been deleted, that's fine, one less to regenerate
+                log.info("Couldn't load Entitlement \"{}\" to regenerate, assuming deleted", entitlementId);
+            }
+        }
+    }
+
+    /**
+     * Regenerates all known certificates for the given consumer.
+     *
+     * @param consumer
+     *  The consumer for which to regenerate entitlement certificates
+     *
+     * @param lazy
+     *  Whether or not to generate the certificate immediately, or mark it dirty and allow it to be
+     *  regenerated on-demand
+     */
+    @Transactional
+    public void regenerateCertificatesOf(Consumer consumer, boolean lazy) {
+        log.info(
+            "Regenerating #{}, entitlement certificates for consumer: {}",
+            consumer.getEntitlements().size(), consumer
+        );
+
+        // TODO - Assumes only 1 entitlement certificate exists per entitlement
+        this.regenerateCertificatesOf(consumer.getEntitlements(), lazy);
+    }
+
+    /**
+     * Regenerates the certificates for the specified contents in a given environment.
+     *
+     * @param environment
+     *  The environment in which the entitlements should be regenerated
+     *
+     * @param contentIds
+     *  A collection of content Ids for which to regenerate entitlement certificates
+     *
+     * @param lazy
+     *  Whether or not to generate the certificate immediately, or mark them dirty and allow them to
+     *  be regenerated on-demand
+     */
+    @Transactional
+    public void regenerateCertificatesOf(Environment environment, Collection<String> contentIds,
+        boolean lazy) {
+
+        log.info("Regenerating relevant certificates in environment: {}", environment);
+
+        List<Entitlement> entitlements = this.entitlementCurator.listByEnvironment(environment);
+        Set<Entitlement> entsToRegen = new HashSet<Entitlement>();
+
+        entLoop: for (Entitlement entitlement : entitlements) {
+            // Impl note:
+            // Since the entitlements came from the DB, we should be safe to traverse the graph as
+            // necessary without any sanity checks (so long as our model's restrictions aren't
+            // broken).
+
+            for (String contentId : contentIds) {
+                if (entitlement.getPool().getProduct().hasContent(contentId)) {
+                    entsToRegen.add(entitlement);
+                    continue entLoop;
+                }
+
+                for (Product provided : entitlement.getPool().getProvidedProducts()) {
+                    if (provided.hasContent(contentId)) {
+                        entsToRegen.add(entitlement);
+                        continue entLoop;
+                    }
+                }
+            }
+        }
+
+        log.info("Found {} certificates to regenerate.", entsToRegen.size());
+        this.regenerateCertificatesOf(entsToRegen, lazy);
+    }
+
+    /**
+     * Regenerates the entitlement certificates of all entitlements for pools using the specified
+     * product.
+     *
+     * @param owner
+     *  The owner for which to regenerate entitlement certificates
+     *
+     * @param productId
+     *  The Red Hat ID of the product for which to regenerate certificates
+     *
+     * @param lazy
+     *  Whether or not to generate the certificate immediately, or mark it dirty and allow it to be
+     *  regenerated on-demand
+     */
+    @Transactional
+    public void regenerateCertificatesOf(Owner owner, String productId, boolean lazy) {
+        List<Pool> pools = this.poolCurator.listAvailableEntitlementPools(
+            null, owner, productId, new Date(), false
+        );
+
+        for (Pool pool : pools) {
+            this.regenerateCertificatesOf(pool.getEntitlements(), lazy);
+        }
+    }
+
+    /**
+     * Regenerates the entitlement certificates of all entitlements for pools using the specified
+     * product.
+     *
+     * @param owner
+     *  The owner for which to regenerate entitlement certificates
+     *
+     * @param product
+     *  The product for which to regenerate certificates
+     *
+     * @param lazy
+     *  Whether or not to generate the certificate immediately, or mark it dirty and allow it to be
+     *  regenerated on-demand
+     */
+    @Transactional
+    public void regenerateCertificatesOf(Owner owner, Product product, boolean lazy) {
+        this.regenerateCertificatesOf(owner, product.getId(), lazy);
+    }
+
+    /**
+     * Regenerates the entitlement certificates for all pools using any of the the specified
+     * product(s), effective for the given owners.
+     *
+     * @param owners
+     *  A collection of owners for which the certificates should be generated. Pools using the given
+     *  products but not owned by an owner within this collection will not have their certificates
+     *  regenerated.
+     *
+     * @param products
+     *  A collection of products for which to regenerate affected certificates
+     *
+     * @param lazy
+     *  Whether or not to generate the certificate immediately, or mark it dirty and allow it to be
+     *  regenerated on-demand
+     */
+    @Transactional
+    public void regenerateCertificatesOf(Collection<Owner> owners, Collection<Product> products,
+        boolean lazy) {
+
+        List<Pool> pools = new LinkedList<Pool>();
+
+        Set<String> productIds = new HashSet<String>();
+        Date now = new Date();
+
+        for (Product product : products) {
+            productIds.add(product.getId());
+        }
+
+        // TODO: This is a very expensive operation. Update pool curator with something to let us
+        // do this without hitting the DB several times over.
+        for (Owner owner : owners) {
+            pools.addAll(
+                this.poolCurator.listAvailableEntitlementPools(null, owner, productIds, now, false)
+            );
+        }
+
+        for (Pool pool : pools) {
+            this.regenerateCertificatesOf(pool.getEntitlements(), lazy);
+        }
+    }
+
+    /**
+     * Regenerates the entitlement certificates for all pools using any of the the specified
+     * product(s), effective for the all owners using them.
+     *
+     * @param products
+     *  A collection of products for which to regenerate affected certificates
+     *
+     * @param lazy
+     *  Whether or not to generate the certificate immediately, or mark it dirty and allow it to be
+     *  regenerated on-demand
+     */
+    @Transactional
+    public void regenerateCertificatesOf(Collection<Product> products, boolean lazy) {
+        Set<Owner> owners = new HashSet<Owner>();
+
+        for (Product product : products) {
+            owners.addAll(product.getOwners());
+        }
+
+        this.regenerateCertificatesOf(owners, products, lazy);
+    }
+
+}

--- a/server/src/main/java/org/candlepin/controller/OwnerManager.java
+++ b/server/src/main/java/org/candlepin/controller/OwnerManager.java
@@ -48,28 +48,19 @@ import java.util.List;
  */
 public class OwnerManager {
 
-    @Inject
-    private static Logger log = LoggerFactory.getLogger(OwnerManager.class);
-    @Inject
-    private ConsumerCurator consumerCurator;
-    @Inject
-    private PoolManager poolManager;
-    @Inject
-    private ActivationKeyCurator activationKeyCurator;
-    @Inject
-    private EnvironmentCurator envCurator;
-    @Inject
-    private ExporterMetadataCurator exportCurator;
-    @Inject
-    private ImportRecordCurator importRecordCurator;
-    @Inject
-    private PermissionBlueprintCurator permissionCurator;
-    @Inject
-    private ProductCurator prodCurator;
-    @Inject
-    private ContentCurator contentCurator;
-    @Inject
-    private OwnerCurator ownerCurator;
+    @Inject private static Logger log = LoggerFactory.getLogger(OwnerManager.class);
+    @Inject private ConsumerCurator consumerCurator;
+    @Inject private PoolManager poolManager;
+    @Inject private ActivationKeyCurator activationKeyCurator;
+    @Inject private EnvironmentCurator envCurator;
+    @Inject private ExporterMetadataCurator exportCurator;
+    @Inject private ImportRecordCurator importRecordCurator;
+    @Inject private PermissionBlueprintCurator permissionCurator;
+    @Inject private ProductCurator prodCurator;
+    @Inject private ProductManager prodManager;
+    @Inject private ContentCurator contentCurator;
+    @Inject private ContentManager contentManager;
+    @Inject private OwnerCurator ownerCurator;
 
     @Transactional
     public void cleanupAndDelete(Owner owner, boolean revokeCerts) {
@@ -144,7 +135,7 @@ public class OwnerManager {
 
         for (Product p : prodCurator.listByOwner(owner)) {
             log.info("Deleting product: {}", p);
-            prodCurator.removeProduct(p, owner);
+            this.prodManager.removeProduct(p, owner);
         }
 
         /*
@@ -153,7 +144,7 @@ public class OwnerManager {
         contentCurator.flush();
         for (Content c : contentCurator.listByOwner(owner)) {
             log.info("Deleting content: {}", c);
-            contentCurator.removeContent(c, owner);
+            this.contentManager.removeContent(c, owner, false);
         }
 
         log.info("Deleting owner: {}", owner);

--- a/server/src/main/java/org/candlepin/controller/PoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/PoolManager.java
@@ -143,7 +143,7 @@ public interface PoolManager {
 
     void regenerateCertificatesOf(Owner owner, String productId, boolean lazy);
 
-    void regenerateEntitlementCertificates(Consumer consumer, boolean lazy);
+    void regenerateCertificatesOf(Consumer consumer, boolean lazy);
 
     int revokeAllEntitlements(Consumer consumer);
     int revokeAllEntitlements(Consumer consumer, boolean regenCertsAndStatuses);

--- a/server/src/main/java/org/candlepin/controller/ProductManager.java
+++ b/server/src/main/java/org/candlepin/controller/ProductManager.java
@@ -1,0 +1,336 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.controller;
+
+import org.candlepin.common.config.Configuration;
+import org.candlepin.model.Content;
+import org.candlepin.model.Owner;
+import org.candlepin.model.Product;
+import org.candlepin.model.ProductContent;
+import org.candlepin.model.ProductCurator;
+
+import com.google.inject.Inject;
+import com.google.inject.persist.Transactional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+
+
+/**
+ * The ProductManager class provides methods for creating, updating and removing product instances
+ * which also perform the cleanup and general maintenance necessary to keep product state in sync
+ * with other objects which reference them.
+ * <p/>
+ * The methods provided by this class are the prefered methods to use for CRUD operations on
+ * products, to ensure product versioning and linking is handled properly.
+ */
+public class ProductManager {
+    private static Logger log = LoggerFactory.getLogger(ProductManager.class);
+
+    private ProductCurator productCurator;
+    private EntitlementCertificateGenerator entitlementCertGenerator;
+
+    @Inject
+    public ProductManager(ProductCurator productCurator,
+        EntitlementCertificateGenerator entitlementCertGenerator, Configuration config) {
+
+        this.productCurator = productCurator;
+        this.entitlementCertGenerator = entitlementCertGenerator;
+    }
+
+    /**
+     * Creates a new Product for the given owner, potentially using a different version than the
+     * entity provided if a matching entity has already been registered for another owner.
+     *
+     * @param entity
+     *  A Product instance representing the product to create
+     *
+     * @param owner
+     *  The owner for which to create the product
+     *
+     * @throws IllegalStateException
+     *  if this method is called with an entity already exists in the backing database for the given
+     *  owner
+     *
+     * @throws NullPointerException
+     *  if the provided product entity is null
+     *
+     * @return
+     *  a new Product instance representing the specified product for the given owner
+     */
+    @Transactional
+    public Product createProduct(Product entity, Owner owner) {
+        log.debug("Creating new product for org: {}, {}", entity, owner);
+
+        Product existing = this.productCurator.lookupById(owner, entity.getId());
+
+        if (existing != null) {
+            // If we're doing an exclusive creation, this should be an error condition
+            throw new IllegalStateException("Product has already been created");
+        }
+
+        // Check if we have an alternate version we can use instead.
+
+        // TODO: Not sure if we really even need the version check. If we have any other matching
+        // product, we should probably use it -- regardless of the actual version value.
+        List<Product> alternateVersions = this.productCurator.getProductsByVersion(
+            entity.getId(), entity.hashCode()
+        );
+
+        for (Product alt : alternateVersions) {
+            if (alt.equals(entity)) {
+                // If we're "creating" a product, we shouldn't have any other object references to
+                // update for this product. Instead, we'll just add the new owner to the product.
+                alt.addOwner(owner);
+
+                return this.productCurator.merge(alt);
+            }
+        }
+
+        entity.addOwner(owner);
+        return this.productCurator.create(entity);
+    }
+
+    /**
+     * Updates the specified product instance, creating a new version of the product as necessary.
+     * The product instance returned by this method is not guaranteed to be the same instance passed
+     * in. As such, once this method has been called, callers should only use the instance output by
+     * this method.
+     *
+     * @param entity
+     *  The product entity to update
+     *
+     * @param owner
+     *  The owner for which to update the product
+     *
+     * @param regenerateEntitlementCerts
+     *  Whether or not changes made to the product should trigger the regeneration of entitlement
+     *  certificates for affected consumers
+     *
+     * @throws IllegalStateException
+     *  if this method is called with an entity does not exist in the backing database for the given
+     *  owner
+     *
+     * @throws NullPointerException
+     *  if the provided product entity is null
+     *
+     * @return
+     *  the updated product entity, or a new product entity
+     */
+    @Transactional
+    public Product updateProduct(Product entity, Owner owner, boolean regenerateEntitlementCerts) {
+        log.debug("Applying product update for org: {}, {}", entity, owner);
+
+        if (entity == null) {
+            throw new NullPointerException("entity");
+        }
+
+        // This has to fetch a new instance, or we'll be unable to compare the objects
+        Product existing = this.productCurator.lookupById(owner, entity.getId());
+
+        if (existing == null) {
+            // If we're doing an exclusive update, this should be an error condition
+            throw new IllegalStateException("Product has not yet been created");
+        }
+
+        if (existing == entity) {
+            // Nothing to do, really. The caller likely intends for the changes to be persisted, so
+            // we can do that for them.
+            return this.productCurator.merge(entity);
+        }
+
+        // Check for newer versions of the same product. We want to try to dedupe as much data as we
+        // can, and if we have a newer version of the product (which matches the version provided by
+        // the caller), we can just point the given orgs to the new product instead of giving them
+        // their own version.
+        // This is probably going to be a very expensive operation, though.
+        List<Product> alternateVersions = this.productCurator.getProductsByVersion(
+            entity.getId(), entity.hashCode()
+        );
+
+        for (Product alt : alternateVersions) {
+            if (alt.equals(entity)) {
+                log.debug("Converging product with existing: {} => {}", entity, alt);
+
+                List<Owner> owners = Arrays.asList(owner);
+
+                alt.addOwner(owner);
+                this.productCurator.merge(alt);
+
+                entity = this.productCurator.updateOwnerProductReferences(existing, alt, owners);
+
+                if (regenerateEntitlementCerts) {
+                    this.entitlementCertGenerator.regenerateCertificatesOf(
+                        owners, Arrays.asList(entity), true
+                    );
+                }
+
+                return entity;
+            }
+        }
+
+        // Make sure we actually have something to update.
+        if (!existing.equals(entity)) {
+            // If we're making the update for every owner using the product, don't bother creating
+            // a new version -- just do a raw update.
+            if (existing.getOwners().size() == 1) {
+                log.debug("Applying in-place update to product: {}", entity);
+
+                existing.merge(entity);
+                entity = existing;
+
+                this.productCurator.merge(entity);
+
+                if (regenerateEntitlementCerts) {
+                    this.entitlementCertGenerator.regenerateCertificatesOf(Arrays.asList(entity), true);
+                }
+            }
+            else {
+                log.debug("Forking product and applying update: {}", entity);
+
+                // This org isn't the only org using the product. We need to create a new product
+                // instance and move the org over to the new product.
+                List<Owner> owners = Arrays.asList(owner);
+                Product copy = (Product) entity.clone();
+
+                // Clear the UUID so Hibernate doesn't think our copy is a detached entity
+                copy.setUuid(null);
+
+                // Set the owner so when we create it, we don't end up with duplicate keys...
+                existing.removeOwner(owner);
+                copy.setOwners(owners);
+
+                this.productCurator.merge(existing);
+                copy = this.productCurator.create(copy);
+                entity = this.productCurator.updateOwnerProductReferences(existing, copy, owners);
+
+                if (regenerateEntitlementCerts) {
+                    this.entitlementCertGenerator.regenerateCertificatesOf(
+                        owners, Arrays.asList(entity), true
+                    );
+                }
+            }
+        }
+        else {
+            log.debug("Somehow they were equal...? Something's not quite right here.");
+        }
+
+        return entity;
+    }
+
+    /**
+     * Removes the specified product from the given owner. If the product is in use by multiple
+     * owners, the product will not actually be deleted, but, instead, will simply by removed from
+     * the given owner's visibility.
+     *
+     * @param entity
+     *  The product entity to remove
+     *
+     * @param owner
+     *  The owner for which to remove the product
+     *
+     * @throws IllegalStateException
+     *  if this method is called with an entity does not exist in the backing database for the given
+     *  owner, or if the product is currently in use by one or more subscriptions/pools
+     *
+     * @throws NullPointerException
+     *  if the provided product entity is null
+     */
+    @Transactional
+    public void removeProduct(Product entity, Owner owner) {
+        log.debug("Removing product from owner: {}, {}", entity, owner);
+
+        if (entity == null) {
+            throw new NullPointerException("entity");
+        }
+
+        // This has to fetch a new instance, or we'll be unable to compare the objects
+        Product existing = this.productCurator.lookupById(owner, entity.getId());
+
+        if (existing == null) {
+            // If we're doing an exclusive update, this should be an error condition
+            throw new IllegalStateException("Product has not yet been created");
+        }
+
+        if (this.productCurator.productHasSubscriptions(existing, owner)) {
+            throw new IllegalStateException("Product is currently in use by one or more pools");
+        }
+
+        existing.removeOwner(owner);
+        if (existing.getOwners().size() == 0) {
+            this.productCurator.delete(existing);
+        }
+        else {
+            this.productCurator.merge(existing);
+        }
+
+        // Clean up any dangling references to content
+        this.productCurator.removeOwnerProductReferences(existing, Arrays.asList(owner));
+    }
+
+    /**
+     * Removes the specified content from the given product for a single owner. The changes made to
+     * the product may result in the convergence or divergence of product versions.
+     *
+     * @param product
+     *  the product from which to remove content
+     *
+     * @param content
+     *  the content to remove
+     *
+     * @param owner
+     *  the owner for which the change should take effect
+     *
+     * @param regenerateEntitlementCerts
+     *  Whether or not changes made to the product should trigger the regeneration of entitlement
+     *  certificates for affected consumers
+     *
+     * @return
+     *  the updated product instance
+     */
+    @Transactional
+    public Product removeProductContent(Product product, Collection<Content> content, Owner owner,
+        boolean regenerateEntitlementCerts) {
+
+        Set<ProductContent> remove = new HashSet<ProductContent>();
+
+        if (product.getOwners().contains(owner)) {
+            for (Content test : content) {
+                for (ProductContent pc : product.getProductContent()) {
+                    if (test == pc.getContent() || test.equals(pc.getContent())) {
+                        remove.add(pc);
+                    }
+                }
+            }
+
+            if (remove.size() > 0) {
+                product = (Product) product.clone();
+                product.getProductContent().removeAll(remove);
+
+                return this.updateProduct(product, owner, regenerateEntitlementCerts);
+            }
+        }
+
+        return product;
+    }
+
+}

--- a/server/src/main/java/org/candlepin/model/ConsumerCurator.java
+++ b/server/src/main/java/org/candlepin/model/ConsumerCurator.java
@@ -88,6 +88,7 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
         if (entity.getFacts() != null) {
             entity.setFacts(filterAndVerifyFacts(entity));
         }
+
         return super.create(entity);
     }
 

--- a/server/src/main/java/org/candlepin/model/Environment.java
+++ b/server/src/main/java/org/candlepin/model/Environment.java
@@ -155,4 +155,9 @@ public class Environment extends AbstractHibernateObject implements Serializable
     public int hashCode() {
         return id.hashCode();
     }
+
+    @Override
+    public String toString() {
+        return String.format("Environment [id: %s, name: %s, owner: %s]", this.id, this.name, this.owner);
+    }
 }

--- a/server/src/main/java/org/candlepin/model/PoolFilterBuilder.java
+++ b/server/src/main/java/org/candlepin/model/PoolFilterBuilder.java
@@ -30,7 +30,10 @@ import org.hibernate.sql.JoinType;
 
 import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 
 
@@ -43,7 +46,7 @@ public class PoolFilterBuilder extends FilterBuilder {
 
     private String alias = "";
     private List<String> matchFilters = new ArrayList<String>();
-    private String productIdFilter;
+    private Set<String> productIds;
     private String subscriptionIdFilter;
 
     public PoolFilterBuilder() {
@@ -56,8 +59,8 @@ public class PoolFilterBuilder extends FilterBuilder {
 
     @Override
     public void applyTo(Criteria parentCriteria) {
-        if (productIdFilter != null && !productIdFilter.isEmpty()) {
-            applyProductIdFilter(parentCriteria);
+        if (productIds != null && productIds.size() > 0) {
+            this.applyProductIdFilter(parentCriteria);
         }
 
         if (subscriptionIdFilter != null && !subscriptionIdFilter.isEmpty()) {
@@ -71,7 +74,21 @@ public class PoolFilterBuilder extends FilterBuilder {
     }
 
     public void setProductIdFilter(String productId) {
-        this.productIdFilter = productId;
+        if (this.productIds == null) {
+            this.productIds = new HashSet<String>();
+        }
+
+        this.productIds.clear();
+        this.productIds.add(productId);
+    }
+
+    public void setProductIdFilter(Collection<String> productIds) {
+        if (this.productIds == null) {
+            this.productIds = new HashSet<String>();
+        }
+
+        this.productIds.clear();
+        this.productIds.addAll(productIds);
     }
 
     public void setSubscriptionIdFilter(String subscriptionId) {
@@ -105,8 +122,8 @@ public class PoolFilterBuilder extends FilterBuilder {
             .createAlias("providedProducts", "provided", JoinType.LEFT_OUTER_JOIN)
             .add(Property.forName(originalPoolAlias + "id").eqProperty("Pool2.id"))
             .add(Restrictions.disjunction()
-                .add(Restrictions.eq("product.id", this.productIdFilter))
-                .add(Restrictions.eq("provided.id", productIdFilter)))
+                .add(Restrictions.in("product.id", this.productIds))
+                .add(Restrictions.in("provided.id", this.productIds)))
             .setProjection(Projections.property("Pool2.id"));
 
         parent.add(Subqueries.exists(prodCrit));

--- a/server/src/main/java/org/candlepin/model/Product.java
+++ b/server/src/main/java/org/candlepin/model/Product.java
@@ -747,14 +747,14 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
      *  The content to add to this product
      *
      * @return
-     *  a reference to this Product instance
+     *  true if the content is added successfully; false otherwise
      */
-    public Product addContent(Content content) {
+    public boolean addContent(Content content) {
         return this.addContent(content, false);
     }
 
     /**
-     * Adds the specified content to this product.
+     * Adds the specified content to this product, if it doesn't already exist.
      *
      * @param content
      *  The content to add to this product
@@ -763,17 +763,19 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
      *  Whether or not the content should be added as an enabled or disabled source
      *
      * @return
-     *  a reference to this Product instance
+     *  true if the content is added successfully; false otherwise
      */
-    public Product addContent(Content content, boolean enabled) {
-        this.addProductContent(new ProductContent(this, content, enabled));
-        return this;
+    public boolean addContent(Content content, boolean enabled) {
+        return this.addProductContent(new ProductContent(this, content, enabled));
     }
 
     /**
      * @param productContent the productContent to set
+     *
+     * @return
+     *  a reference to this Product instance
      */
-    public void setProductContent(Collection<ProductContent> productContent) {
+    public Product setProductContent(Collection<ProductContent> productContent) {
         if (this.productContent == null) {
             this.productContent = new LinkedList<ProductContent>();
         }
@@ -785,6 +787,8 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
                 this.addProductContent(pc);
             }
         }
+
+        return this;
     }
 
     /**
@@ -794,15 +798,39 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
         return productContent;
     }
 
-    public void addProductContent(ProductContent content) {
+    /**
+     * Adds the specified ProductContent to this product. If the content has already been added,
+     * this method does nothing.
+     *
+     * @param content
+     *  The ProductContent instance to add to this product
+     *
+     * @return
+     *  true if the ProductContent is added successfully; false otherwise
+     */
+    public boolean addProductContent(ProductContent content) {
         if (this.productContent == null) {
             this.productContent = new LinkedList<ProductContent>();
         }
 
         if (content != null) {
-            content.setProduct(this);
-            this.productContent.add(content);
+            boolean found = false;
+            for (ProductContent pc : this.productContent) {
+                if (pc.getContent().equals(content.getContent())) {
+                    found = true;
+                    break;
+                }
+            }
+
+            if (!found) {
+                content.setProduct(this);
+                this.productContent.add(content);
+
+                return true;
+            }
         }
+
+        return false;
     }
 
     public void setContent(Set<Content> content) {
@@ -814,7 +842,7 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
 
         if (content != null) {
             for (Content newContent : content) {
-                this.productContent.add(new ProductContent(this, newContent, false));
+                this.addContent(newContent, false);
             }
         }
     }

--- a/server/src/main/java/org/candlepin/model/UeberCertificateGenerator.java
+++ b/server/src/main/java/org/candlepin/model/UeberCertificateGenerator.java
@@ -15,7 +15,9 @@
 package org.candlepin.model;
 
 import org.candlepin.auth.Principal;
+import org.candlepin.controller.ContentManager;
 import org.candlepin.controller.PoolManager;
+import org.candlepin.controller.ProductManager;
 import org.candlepin.model.ConsumerType.ConsumerTypeEnum;
 import org.candlepin.model.dto.Subscription;
 import org.candlepin.policy.EntitlementRefusedException;
@@ -39,7 +41,9 @@ public class UeberCertificateGenerator {
     private PoolManager poolManager;
     private PoolCurator poolCurator;
     private ProductCurator productCurator;
+    private ProductManager productManager;
     private ContentCurator contentCurator;
+    private ContentManager contentManager;
     private UniqueIdGenerator idGenerator;
     private SubscriptionServiceAdapter subService;
     private ConsumerTypeCurator consumerTypeCurator;
@@ -50,7 +54,9 @@ public class UeberCertificateGenerator {
     public UeberCertificateGenerator(PoolManager poolManager,
         PoolCurator poolCurator,
         ProductCurator productCurator,
+        ProductManager productManager,
         ContentCurator contentCurator,
+        ContentManager contentManager,
         UniqueIdGenerator idGenerator,
         SubscriptionServiceAdapter subService,
         ConsumerTypeCurator consumerTypeCurator,
@@ -60,7 +66,9 @@ public class UeberCertificateGenerator {
         this.poolManager = poolManager;
         this.poolCurator = poolCurator;
         this.productCurator = productCurator;
+        this.productManager = productManager;
         this.contentCurator = contentCurator;
+        this.contentManager = contentManager;
         this.idGenerator = idGenerator;
         this.subService = subService;
         this.consumerTypeCurator = consumerTypeCurator;
@@ -88,10 +96,10 @@ public class UeberCertificateGenerator {
         // generated with numeric IDs.
 
         Product ueberProduct = Product.createUeberProductForOwner(idGenerator, o);
-        productCurator.createProduct(ueberProduct, o);
+        this.productManager.createProduct(ueberProduct, o);
 
         Content ueberContent = Content.createUeberContent(idGenerator, o, ueberProduct);
-        contentCurator.createContent(ueberContent, o);
+        this.contentManager.createContent(ueberContent, o);
 
         ProductContent productContent = new ProductContent(ueberProduct, ueberContent, true);
         ueberProduct.getProductContent().add(productContent);

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -926,7 +926,7 @@ public class ConsumerResource {
             toUpdate.setEnvironment(e);
 
             // lazily regenerate certs, so the client can still work
-            poolManager.regenerateEntitlementCertificates(toUpdate, true);
+            poolManager.regenerateCertificatesOf(toUpdate, true);
             changesMade = true;
         }
 
@@ -1894,7 +1894,7 @@ public class ConsumerResource {
         }
         else {
             Consumer c = consumerCurator.verifyAndLookupConsumer(consumerUuid);
-            poolManager.regenerateEntitlementCertificates(c, lazyRegen);
+            poolManager.regenerateCertificatesOf(c, lazyRegen);
         }
     }
 

--- a/server/src/main/java/org/candlepin/resource/ContentResource.java
+++ b/server/src/main/java/org/candlepin/resource/ContentResource.java
@@ -55,9 +55,10 @@ public class ContentResource {
     private OwnerCurator ownerCurator;
 
     @Inject
-    public ContentResource(ContentCurator contentCurator, I18n i18n,
-        UniqueIdGenerator idGenerator, EnvironmentContentCurator envContentCurator,
-        PoolManager poolManager, ProductCurator productCurator, OwnerCurator ownerCurator) {
+    public ContentResource(ContentCurator contentCurator, I18n i18n, UniqueIdGenerator idGenerator,
+        EnvironmentContentCurator envContentCurator, PoolManager poolManager,
+        ProductCurator productCurator, OwnerCurator ownerCurator) {
+
         this.i18n = i18n;
         this.contentCurator = contentCurator;
         this.idGenerator = idGenerator;

--- a/server/src/main/java/org/candlepin/resource/ProductResource.java
+++ b/server/src/main/java/org/candlepin/resource/ProductResource.java
@@ -15,8 +15,10 @@
 package org.candlepin.resource;
 
 import org.candlepin.common.auth.SecurityHole;
+import org.candlepin.common.config.Configuration;
 import org.candlepin.common.exceptions.BadRequestException;
 import org.candlepin.common.exceptions.NotFoundException;
+import org.candlepin.config.ConfigProperties;
 import org.candlepin.model.Owner;
 import org.candlepin.model.OwnerCurator;
 import org.candlepin.model.Product;
@@ -60,15 +62,17 @@ public class ProductResource {
     private ProductCurator productCurator;
     private OwnerCurator ownerCurator;
     private ProductCertificateCurator productCertCurator;
+    private Configuration config;
     private I18n i18n;
 
     @Inject
     public ProductResource(ProductCurator productCurator, OwnerCurator ownerCurator,
-        ProductCertificateCurator productCertCurator, I18n i18n) {
+        ProductCertificateCurator productCertCurator, Configuration config, I18n i18n) {
 
         this.productCurator = productCurator;
         this.productCertCurator = productCertCurator;
         this.ownerCurator = ownerCurator;
+        this.config = config;
         this.i18n = i18n;
     }
 
@@ -315,6 +319,11 @@ public class ProductResource {
 
         if (productUuids.isEmpty()) {
             throw new BadRequestException(i18n.tr("No product IDs specified"));
+        }
+
+        if (config.getBoolean(ConfigProperties.STANDALONE)) {
+            log.warn("Ignoring refresh pools request due to standalone config.");
+            return null;
         }
 
         List<Owner> owners = this.ownerCurator.lookupOwnersWithProduct(productUuids);

--- a/server/src/main/resources/db/changelog/20150210094558-perorgproducts-phase-1.xml
+++ b/server/src/main/resources/db/changelog/20150210094558-perorgproducts-phase-1.xml
@@ -559,4 +559,64 @@
             referencedColumnNames="id"
         />
     </changeSet>
+
+    <changeSet id="20150210094558-42" author="crog">
+        <addForeignKeyConstraint constraintName="cp2_owner_products_fk1"
+            baseTableName="cp2_owner_products"
+            baseColumnNames="owner_id"
+            referencedTableName="cp_owner"
+            referencedColumnNames="id"
+        />
+    </changeSet>
+
+    <changeSet id="20150210094558-43" author="crog">
+        <addForeignKeyConstraint constraintName="cp2_owner_products_fk2"
+            baseTableName="cp2_owner_products"
+            baseColumnNames="product_uuid"
+            referencedTableName="cp2_products"
+            referencedColumnNames="uuid"
+        />
+    </changeSet>
+
+    <changeSet id="20150210094558-44" author="crog">
+        <addForeignKeyConstraint constraintName="cp2_owner_content_fk1"
+            baseTableName="cp2_owner_content"
+            baseColumnNames="owner_id"
+            referencedTableName="cp_owner"
+            referencedColumnNames="id"
+        />
+    </changeSet>
+
+    <changeSet id="20150210094558-45" author="crog">
+        <addForeignKeyConstraint constraintName="cp2_owner_content_fk2"
+            baseTableName="cp2_owner_content"
+            baseColumnNames="content_uuid"
+            referencedTableName="cp2_content"
+            referencedColumnNames="uuid"
+        />
+    </changeSet>
+
+    <changeSet id="20150210094558-46" author="crog" dbms="oracle">
+        <createIndex indexName="cp2_owner_products_idx1" tableName="cp2_owner_products" unique="false">
+            <column name="owner_id"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="20150210094558-47" author="crog" dbms="oracle">
+        <createIndex indexName="cp2_owner_products_idx2" tableName="cp2_owner_products" unique="false">
+            <column name="product_uuid"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="20150210094558-48" author="crog" dbms="oracle">
+        <createIndex indexName="cp2_owner_content_idx1" tableName="cp2_owner_content" unique="false">
+            <column name="owner_id"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="20150210094558-49" author="crog" dbms="oracle">
+        <createIndex indexName="cp2_owner_content_idx2" tableName="cp2_owner_content" unique="false">
+            <column name="content_uuid"/>
+        </createIndex>
+    </changeSet>
 </databaseChangeLog>

--- a/server/src/test/java/org/candlepin/controller/ContentManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/ContentManagerTest.java
@@ -1,0 +1,385 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.controller;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
+import static org.mockito.AdditionalAnswers.*;
+
+import org.candlepin.common.config.Configuration;
+import org.candlepin.config.CandlepinCommonTestConfig;
+import org.candlepin.model.Content;
+import org.candlepin.model.ContentCurator;
+import org.candlepin.model.Owner;
+import org.candlepin.model.Product;
+import org.candlepin.model.ProductCurator;
+import org.candlepin.test.TestUtil;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+
+
+/**
+ * ContentManagerTest
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ContentManagerTest {
+
+    private Configuration config;
+
+    @Mock private ContentCurator mockContentCurator;
+    @Mock private ProductCurator mockProductCurator;
+    @Mock private ProductManager mockProductManager;
+    @Mock private EntitlementCertificateGenerator mockEntCertGenerator;
+
+    private ContentManager contentManager;
+
+    @Before
+    public void init() throws Exception {
+        this.config = new CandlepinCommonTestConfig();
+
+        this.contentManager = new ContentManager(
+            this.mockContentCurator, this.mockProductCurator, this.mockProductManager,
+            this.mockEntCertGenerator, this.config
+        );
+
+        doAnswer(returnsFirstArg()).when(this.mockContentCurator).merge(any(Content.class));
+        doAnswer(returnsFirstArg()).when(this.mockContentCurator).create(any(Content.class));
+        doAnswer(returnsSecondArg()).when(this.mockContentCurator)
+            .updateOwnerContentReferences(any(Content.class), any(Content.class), any(Collection.class));
+    }
+
+    @Test
+    public void testCreateContent() {
+        Owner owner = TestUtil.createOwner("test-owner", "Test Owner");
+        Content content = TestUtil.createContent(owner, "c1");
+
+        Content output = this.contentManager.createContent(content, owner);
+
+        assertEquals(output, content);
+        verify(this.mockContentCurator, times(1)).create(eq(content));
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testCreateContentThatAlreadyExists() {
+        Owner owner = TestUtil.createOwner("test-owner", "Test Owner");
+        Content content = TestUtil.createContent(owner, "c1");
+
+        when(this.mockContentCurator.lookupById(eq(owner), eq(content.getId()))).thenReturn(content);
+
+        Content output = this.contentManager.createContent(content, owner);
+    }
+
+    @Test
+    public void testCreateContentMergeWithExisting() {
+        Owner owner1 = TestUtil.createOwner("test-owner-1", "Test Owner 1");
+        Owner owner2 = TestUtil.createOwner("test-owner-2", "Test Owner 2");
+
+        Content content1 = TestUtil.createContent(owner1, "c1", "test content");
+        Content content2 = TestUtil.createContent(owner2, "c1", "test content");
+
+        when(this.mockContentCurator.getContentByVersion(eq(content2.getId()), eq(content2.hashCode())))
+            .thenReturn(Arrays.asList(content2));
+
+        Content output = this.contentManager.createContent(content1, owner1);
+
+        assertEquals(output, content2);
+        assertTrue(output.getOwners().contains(owner1));
+        assertTrue(output.getOwners().contains(owner2));
+
+        verify(this.mockContentCurator, times(1)).merge(eq(content2));
+        verify(this.mockContentCurator, never()).create(eq(content1));
+    }
+
+    @Test
+    public void testUpdateContentNoChange() {
+        Owner owner = TestUtil.createOwner("test-owner", "Test Owner");
+        Content content = TestUtil.createContent(owner, "c1", "content-1");
+
+        when(this.mockContentCurator.lookupById(eq(owner), eq(content.getId()))).thenReturn(content);
+
+        Content output = this.contentManager.updateContent(content, owner, true);
+
+        assertTrue(output == content);
+
+        verify(this.mockContentCurator, times(1)).merge(eq(content));
+        verifyZeroInteractions(this.mockEntCertGenerator);
+    }
+
+    @Test
+    public void testUpdateContent() {
+        Owner owner = TestUtil.createOwner("test-owner", "Test Owner");
+        Content content = TestUtil.createContent(owner, "c1", "content-1");
+        content.setUuid("test-uuid");
+
+        Content update = TestUtil.createContent(owner, "c1", "new content name");
+        update.setUuid("test-uuid");
+
+        when(this.mockContentCurator.lookupById(eq(owner), eq(content.getId()))).thenReturn(content);
+
+        Content output = this.contentManager.updateContent(update, owner, false);
+
+        assertEquals(output, update);
+
+        verify(this.mockContentCurator, times(1)).merge(eq(content));
+        verifyZeroInteractions(this.mockEntCertGenerator);
+    }
+
+    @Test
+    public void testUpdateContentWithCertRegeneration() {
+        Owner owner = TestUtil.createOwner("test-owner", "Test Owner");
+        Content content = TestUtil.createContent(owner, "c1", "content-1");
+        content.setUuid("test-uuid");
+
+        Content update = TestUtil.createContent(owner, "c1", "new content name");
+        update.setUuid("test-uuid");
+
+        Product product = TestUtil.createProduct("p1", "test product", owner);
+
+        when(this.mockContentCurator.lookupById(eq(owner), eq(content.getId()))).thenReturn(content);
+        when(this.mockProductCurator.getProductsWithContent(eq(Arrays.asList(content.getUuid()))))
+            .thenReturn(Arrays.asList(product));
+
+        Content output = this.contentManager.updateContent(update, owner, true);
+
+        assertEquals(output, update);
+
+        verify(this.mockContentCurator, times(1)).merge(eq(content));
+        verify(this.mockEntCertGenerator, times(1))
+            .regenerateCertificatesOf(eq(Arrays.asList(product)), anyBoolean());
+    }
+
+    @Test
+    public void testUpdateContentConvergeWithExisting() {
+        Owner owner1 = TestUtil.createOwner("test-owner-1", "Test Owner 1");
+        Owner owner2 = TestUtil.createOwner("test-owner-2", "Test Owner 2");
+        Content content1 = TestUtil.createContent(owner1, "c1", "content-1");
+        Content content2 = TestUtil.createContent(owner2, "c1", "updated content");
+        Content update = TestUtil.createContent(owner1, "c1", "updated content");
+        Product product = TestUtil.createProduct("p1", "test product", owner1);
+
+        when(this.mockContentCurator.lookupById(eq(owner1), eq(content1.getId()))).thenReturn(content1);
+        when(this.mockContentCurator.lookupById(eq(owner2), eq(content2.getId()))).thenReturn(content2);
+        when(this.mockContentCurator.getContentByVersion(eq(update.getId()), eq(update.hashCode())))
+            .thenReturn(Arrays.asList(content2));
+        when(this.mockProductCurator.getProductsWithContent(eq(owner1), eq(Arrays.asList(content1.getId()))))
+            .thenReturn(Arrays.asList(product));
+
+        Content output = this.contentManager.updateContent(update, owner1, false);
+
+        assertTrue(output == content2);
+        assertTrue(output.getOwners().contains(owner1));
+        assertTrue(output.getOwners().contains(owner2));
+
+        verify(this.mockProductManager, times(1)).updateProduct(any(Product.class), eq(owner1), eq(false));
+    }
+
+    @Test
+    public void testUpdateContentConvergeWithExistingWithCertRegeneration() {
+        Owner owner1 = TestUtil.createOwner("test-owner-1", "Test Owner 1");
+        Owner owner2 = TestUtil.createOwner("test-owner-2", "Test Owner 2");
+        Content content1 = TestUtil.createContent(owner1, "c1", "content-1");
+        Content content2 = TestUtil.createContent(owner2, "c1", "updated content");
+        Content update = TestUtil.createContent(owner1, "c1", "updated content");
+        Product product = TestUtil.createProduct("p1", "test product", owner1);
+
+        when(this.mockContentCurator.lookupById(eq(owner1), eq(content1.getId()))).thenReturn(content1);
+        when(this.mockContentCurator.lookupById(eq(owner2), eq(content2.getId()))).thenReturn(content2);
+        when(this.mockContentCurator.getContentByVersion(eq(update.getId()), eq(update.hashCode())))
+            .thenReturn(Arrays.asList(content2));
+        when(this.mockProductCurator.getProductsWithContent(eq(owner1), eq(Arrays.asList(content1.getId()))))
+            .thenReturn(Arrays.asList(product));
+
+        Content output = this.contentManager.updateContent(update, owner1, true);
+
+        assertTrue(output == content2);
+        assertTrue(output.getOwners().contains(owner1));
+        assertTrue(output.getOwners().contains(owner2));
+
+        verify(this.mockProductManager, times(1)).updateProduct(eq(product), eq(owner1), eq(true));
+    }
+
+    @Test
+    public void testUpdateContentDivergeFromExisting() {
+        Owner owner1 = TestUtil.createOwner("test-owner-1", "Test Owner 1");
+        Owner owner2 = TestUtil.createOwner("test-owner-2", "Test Owner 2");
+        Content content = TestUtil.createContent(owner1, "c1", "content-1");
+        content.addOwner(owner2);
+        Content update = TestUtil.createContent(owner1, "c1", "updated content");
+        Product product = TestUtil.createProduct("p1", "test product", owner1);
+        product.addOwner(owner2);
+        product.addContent(content);
+
+        when(this.mockContentCurator.lookupById(eq(owner1), eq(content.getId()))).thenReturn(content);
+        when(this.mockProductCurator.getProductsWithContent(eq(owner1), eq(Arrays.asList(content.getId()))))
+            .thenReturn(Arrays.asList(product));
+
+        Content output = this.contentManager.updateContent(update, owner1, false);
+
+        assertTrue(output != content);
+        assertTrue(output.getOwners().contains(owner1));
+        assertFalse(output.getOwners().contains(owner2));
+        assertFalse(content.getOwners().contains(owner1));
+        assertTrue(content.getOwners().contains(owner2));
+
+        verify(this.mockProductManager, times(1)).updateProduct(any(Product.class), eq(owner1), eq(false));
+    }
+
+    @Test
+    public void testUpdateContentDivergeFromExistingWithCertRegeneration() {
+        Owner owner1 = TestUtil.createOwner("test-owner-1", "Test Owner 1");
+        Owner owner2 = TestUtil.createOwner("test-owner-2", "Test Owner 2");
+        Content content = TestUtil.createContent(owner1, "c1", "content-1");
+        content.addOwner(owner2);
+        Content update = TestUtil.createContent(owner1, "c1", "updated content");
+        Product product = TestUtil.createProduct("p1", "test product", owner1);
+        product.addOwner(owner2);
+
+        when(this.mockContentCurator.lookupById(eq(owner1), eq(content.getId()))).thenReturn(content);
+        when(this.mockProductCurator.getProductsWithContent(eq(owner1), eq(Arrays.asList(content.getId()))))
+            .thenReturn(Arrays.asList(product));
+
+        Content output = this.contentManager.updateContent(update, owner1, true);
+
+        assertTrue(output != content);
+        assertTrue(output.getOwners().contains(owner1));
+        assertFalse(output.getOwners().contains(owner2));
+        assertFalse(content.getOwners().contains(owner1));
+        assertTrue(content.getOwners().contains(owner2));
+
+        verify(this.mockProductManager, times(1)).updateProduct(eq(product), eq(owner1), eq(true));
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testUpdateContentThatDoesntExist() {
+        Owner owner = TestUtil.createOwner("test-owner", "Test Owner");
+        Content content = TestUtil.createContent(owner, "c1", "content-1");
+
+        this.contentManager.updateContent(content, owner, false);
+    }
+
+    @Test
+    public void testRemoveContent() {
+        Owner owner = TestUtil.createOwner("test-owner-1", "Test Owner 1");
+        Content content = TestUtil.createContent(owner, "c1", "content-1");
+        Product product = TestUtil.createProduct("p1", "test prod", owner);
+
+        when(this.mockContentCurator.lookupById(eq(owner), eq(content.getId()))).thenReturn(content);
+        when(this.mockProductCurator.getProductsWithContent(eq(owner), eq(Arrays.asList(content.getId()))))
+            .thenReturn(Arrays.asList(product));
+
+        this.contentManager.removeContent(content, owner, false);
+
+        assertFalse(content.getOwners().contains(owner));
+
+        verify(this.mockProductManager, times(1))
+            .removeProductContent(eq(product), eq(Arrays.asList(content)), eq(owner), eq(false));
+        verify(this.mockContentCurator, never()).merge(eq(content));
+        verify(this.mockContentCurator, times(1)).delete(eq(content));
+    }
+
+    @Test
+    public void testRemoveContentWithCertRegeneration() {
+        Owner owner = TestUtil.createOwner("test-owner-1", "Test Owner 1");
+        Content content = TestUtil.createContent(owner, "c1", "content-1");
+        Product product = TestUtil.createProduct("p1", "test prod", owner);
+
+        when(this.mockContentCurator.lookupById(eq(owner), eq(content.getId()))).thenReturn(content);
+        when(this.mockProductCurator.getProductsWithContent(eq(owner), eq(Arrays.asList(content.getId()))))
+            .thenReturn(Arrays.asList(product));
+
+        this.contentManager.removeContent(content, owner, true);
+
+        assertFalse(content.getOwners().contains(owner));
+
+        verify(this.mockProductManager, times(1))
+            .removeProductContent(eq(product), eq(Arrays.asList(content)), eq(owner), eq(true));
+        verify(this.mockContentCurator, never()).merge(eq(content));
+        verify(this.mockContentCurator, times(1)).delete(eq(content));
+    }
+
+    @Test
+    public void testRemoveContentDivergeFromExisting() {
+        Owner owner1 = TestUtil.createOwner("test-owner-1", "Test Owner 1");
+        Owner owner2 = TestUtil.createOwner("test-owner-2", "Test Owner 2");
+        Content content = TestUtil.createContent(owner1, "c1", "content-1");
+        content.addOwner(owner2);
+        Product product = TestUtil.createProduct("p1", "test prod", owner1);
+        product.addOwner(owner2);
+
+        when(this.mockContentCurator.lookupById(eq(owner1), eq(content.getId()))).thenReturn(content);
+        when(this.mockProductCurator.getProductsWithContent(eq(owner1), eq(Arrays.asList(content.getId()))))
+            .thenReturn(Arrays.asList(product));
+
+        this.contentManager.removeContent(content, owner1, false);
+
+        assertFalse(content.getOwners().contains(owner1));
+        assertTrue(content.getOwners().contains(owner2));
+
+        verify(this.mockProductManager, times(1))
+            .removeProductContent(eq(product), eq(Arrays.asList(content)), eq(owner1), eq(false));
+        verify(this.mockContentCurator, times(1)).merge(eq(content));
+        verify(this.mockContentCurator, never()).delete(eq(content));
+    }
+
+    @Test
+    public void testRemoveContentDivergeFromExistingWithCertRegeneration() {
+        Owner owner1 = TestUtil.createOwner("test-owner-1", "Test Owner 1");
+        Owner owner2 = TestUtil.createOwner("test-owner-2", "Test Owner 2");
+        Content content = TestUtil.createContent(owner1, "c1", "content-1");
+        content.addOwner(owner2);
+        Product product = TestUtil.createProduct("p1", "test prod", owner1);
+        product.addOwner(owner2);
+
+        when(this.mockContentCurator.lookupById(eq(owner1), eq(content.getId()))).thenReturn(content);
+        when(this.mockProductCurator.getProductsWithContent(eq(owner1), eq(Arrays.asList(content.getId()))))
+            .thenReturn(Arrays.asList(product));
+
+        this.contentManager.removeContent(content, owner1, true);
+
+        assertFalse(content.getOwners().contains(owner1));
+        assertTrue(content.getOwners().contains(owner2));
+
+        verify(this.mockProductManager, times(1))
+            .removeProductContent(eq(product), eq(Arrays.asList(content)), eq(owner1), eq(true));
+        verify(this.mockContentCurator, times(1)).merge(eq(content));
+        verify(this.mockContentCurator, never()).delete(eq(content));
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testRemoveContentThatDoesntExist() {
+        Owner owner = TestUtil.createOwner("test-owner", "Test Owner");
+        Content content = TestUtil.createContent(owner, "c1", "content-1");
+
+        this.contentManager.removeContent(content, owner, false);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testRemoveContentThatDoesntExistWithRegeneration() {
+        Owner owner = TestUtil.createOwner("test-owner", "Test Owner");
+        Content content = TestUtil.createContent(owner, "c1", "content-1");
+
+        this.contentManager.removeContent(content, owner, true);
+    }
+}

--- a/server/src/test/java/org/candlepin/controller/EntitlementCertificateGeneratorTest.java
+++ b/server/src/test/java/org/candlepin/controller/EntitlementCertificateGeneratorTest.java
@@ -1,0 +1,335 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.controller;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
+
+import org.candlepin.audit.Event;
+import org.candlepin.audit.EventFactory;
+import org.candlepin.audit.EventSink;
+import org.candlepin.model.Consumer;
+import org.candlepin.model.Content;
+import org.candlepin.model.Entitlement;
+import org.candlepin.model.EntitlementCertificate;
+import org.candlepin.model.EntitlementCertificateCurator;
+import org.candlepin.model.EntitlementCurator;
+import org.candlepin.model.Environment;
+import org.candlepin.model.Owner;
+import org.candlepin.model.Pool;
+import org.candlepin.model.PoolCurator;
+import org.candlepin.model.Product;
+import org.candlepin.model.SourceSubscription;
+import org.candlepin.service.EntitlementCertServiceAdapter;
+import org.candlepin.test.TestUtil;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+
+
+/**
+ * PoolManagerTest
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class EntitlementCertificateGeneratorTest {
+
+    @Mock private EntitlementCertServiceAdapter mockEntCertAdapter;
+    @Mock private EntitlementCertificateCurator mockEntCertCurator;
+    @Mock private EntitlementCurator mockEntitlementCurator;
+    @Mock private PoolCurator mockPoolCurator;
+    @Mock private EventSink mockEventSink;
+    @Mock private EventFactory mockEventFactory;
+
+    @Captor private ArgumentCaptor<Map<String, Entitlement>> entMapCaptor;
+    @Captor private ArgumentCaptor<Map<String, Product>> productMapCaptor;
+
+    private EntitlementCertificateGenerator ecGenerator;
+
+    @Before
+    public void init() throws Exception {
+        this.ecGenerator = new EntitlementCertificateGenerator(
+            this.mockEntCertCurator, this.mockEntCertAdapter, this.mockEntitlementCurator,
+            this.mockPoolCurator, this.mockEventSink, this.mockEventFactory
+        );
+    }
+
+    @Test
+    public void testGenerateEntitlementCertificate() throws GeneralSecurityException, IOException {
+        this.ecGenerator = new EntitlementCertificateGenerator(this.mockEntCertCurator,
+                this.mockEntCertAdapter, this.mockEntitlementCurator, this.mockPoolCurator,
+                this.mockEventSink, this.mockEventFactory);
+        Consumer consumer = mock(Consumer.class);
+        Pool pool = mock(Pool.class);
+        Product product = mock(Product.class);
+        when(pool.getId()).thenReturn("Swift");
+        when(pool.getProduct()).thenReturn(product);
+        Entitlement entitlement = mock(Entitlement.class);
+        when(entitlement.getConsumer()).thenReturn(consumer);
+        EntitlementCertificate entitlementCert = mock(EntitlementCertificate.class);
+        Map<String, EntitlementCertificate> expected = new HashMap<String, EntitlementCertificate>();
+        expected.put("Swift", entitlementCert);
+        when(mockEntCertAdapter.generateUeberCerts(eq(consumer), entMapCaptor.capture(),
+                        productMapCaptor.capture())).thenReturn(expected);
+        EntitlementCertificate result = ecGenerator.generateEntitlementCertificate(pool, entitlement, true);
+        assertEquals(entitlementCert, result);
+    }
+
+    @Test
+    public void testGenerateEntitlementCertificatesUber() throws GeneralSecurityException, IOException {
+        this.ecGenerator = new EntitlementCertificateGenerator(this.mockEntCertCurator,
+                this.mockEntCertAdapter, this.mockEntitlementCurator, this.mockPoolCurator,
+                this.mockEventSink, this.mockEventFactory);
+        Consumer consumer = mock(Consumer.class);
+        Product product = mock(Product.class);
+        Entitlement entitlement = mock(Entitlement.class);
+        Map<String, Product> products = new HashMap<String, Product>();
+        products.put("Taylor", product);
+        Map<String, Entitlement> entitlements = new HashMap<String, Entitlement>();
+        entitlements.put("Taylor", entitlement);
+        ecGenerator.generateEntitlementCertificates(consumer, products, entitlements, true);
+        verify(mockEntCertAdapter).generateUeberCerts(eq(consumer), eq(entitlements), eq(products));
+    }
+
+    @Test
+    public void testGenerateEntitlementCertificates() throws GeneralSecurityException, IOException {
+        this.ecGenerator = new EntitlementCertificateGenerator(this.mockEntCertCurator,
+            this.mockEntCertAdapter, this.mockEntitlementCurator, this.mockPoolCurator,
+            this.mockEventSink, this.mockEventFactory);
+        Consumer consumer = mock(Consumer.class);
+        Product product = mock(Product.class);
+        Entitlement entitlement = mock(Entitlement.class);
+        Map<String, Product> products = new HashMap<String, Product>();
+        products.put("Taylor", product);
+        Map<String, Entitlement> entitlements = new HashMap<String, Entitlement>();
+        entitlements.put("Taylor", entitlement);
+        ecGenerator.generateEntitlementCertificates(consumer, products, entitlements, false);
+        verify(mockEntCertAdapter).generateEntitlementCerts(eq(consumer), eq(entitlements), eq(products));
+    }
+
+    @Test
+    public void testLazyRegenerateForEntitlement() {
+        Entitlement entitlement = new Entitlement();
+        this.ecGenerator.regenerateCertificatesOf(entitlement, false, true);
+        assertTrue(entitlement.getDirty());
+        verifyZeroInteractions(this.mockEntCertAdapter);
+    }
+
+    @Test
+    public void testLazyRegenerateForEntitlementCollection() {
+        List<Entitlement> entitlements = Arrays.asList(
+            new Entitlement(), new Entitlement(), new Entitlement()
+        );
+
+        this.ecGenerator.regenerateCertificatesOf(entitlements, true);
+
+        for (Entitlement entitlement : entitlements) {
+            assertTrue(entitlement.getDirty());
+        }
+
+        verifyZeroInteractions(this.mockEntCertAdapter);
+    }
+
+    /**
+     * Generates some entitlements and the necessary objects for testing entitlement regeneration
+     *
+     * @return
+     *  A list of entitlements
+     */
+    private List<Entitlement> generateEntitlements() {
+        Owner owner = TestUtil.createOwner("test-owner", "Test Owner");
+
+        Content c1 = TestUtil.createContent(owner, "c1");
+        Content c2 = TestUtil.createContent(owner, "c2");
+        Content c3 = TestUtil.createContent(owner, "c3");
+
+        Product prod1 = TestUtil.createProduct(owner);
+        Product prod2 = TestUtil.createProduct(owner);
+        Product prod3 = TestUtil.createProduct(owner);
+        Product pprod1 = TestUtil.createProduct(owner);
+        Product pprod2 = TestUtil.createProduct(owner);
+        Product pprod3 = TestUtil.createProduct(owner);
+
+        prod1.addContent(c1);
+        pprod2.addContent(c2);
+        prod3.addContent(c3);
+
+        Pool pool1 = TestUtil.createPool(owner, prod1, Arrays.asList(pprod1), 1);
+        Pool pool2 = TestUtil.createPool(owner, prod2, Arrays.asList(pprod2), 1);
+        Pool pool3 = TestUtil.createPool(owner, prod3, Arrays.asList(pprod3), 1);
+
+        Consumer consumer = TestUtil.createConsumer(owner);
+
+        Entitlement ent1 = TestUtil.createEntitlement(owner, consumer, pool1, null);
+        Entitlement ent2 = TestUtil.createEntitlement(owner, consumer, pool2, null);
+        Entitlement ent3 = TestUtil.createEntitlement(owner, consumer, pool3, null);
+        ent1.setId("ent1");
+        ent2.setId("ent2");
+        ent3.setId("ent3");
+
+        return Arrays.asList(ent1, ent2, ent3);
+    }
+
+    @Test
+    public void testLazyRegnerateForEnvironmentContent() {
+        Environment environment = new Environment();
+        List<Entitlement> entitlements = this.generateEntitlements();
+        when(this.mockEntitlementCurator.listByEnvironment(environment)).thenReturn(entitlements);
+
+        this.ecGenerator.regenerateCertificatesOf(environment, Arrays.asList("c1", "c2", "c4"), true);
+
+        assertTrue(entitlements.get(0).getDirty());
+        assertTrue(entitlements.get(1).getDirty());
+        assertFalse(entitlements.get(2).getDirty());
+
+        verifyZeroInteractions(this.mockEntCertAdapter);
+    }
+
+    @Test
+    public void testNonLazyRegnerateForEnvironmentContent() throws Exception {
+        Environment environment = new Environment();
+        List<Entitlement> entitlements = this.generateEntitlements();
+
+        HashMap<String, EntitlementCertificate> ecMap = new HashMap<String, EntitlementCertificate>();
+        for (Entitlement entitlement : entitlements) {
+            ecMap.put(entitlement.getPool().getId(), new EntitlementCertificate());
+        }
+
+        when(this.mockEntitlementCurator.listByEnvironment(environment)).thenReturn(entitlements);
+        when(this.mockEntCertAdapter.generateEntitlementCerts(any(Consumer.class), any(Map.class),
+            any(Map.class))).thenReturn(ecMap);
+
+        this.ecGenerator.regenerateCertificatesOf(environment, Arrays.asList("c1", "c2", "c4"), false);
+
+        assertFalse(entitlements.get(0).getDirty());
+        assertFalse(entitlements.get(1).getDirty());
+        assertFalse(entitlements.get(2).getDirty());
+
+        verify(this.mockEntCertAdapter, times(2)).generateEntitlementCerts(any(Consumer.class),
+            this.entMapCaptor.capture(), this.productMapCaptor.capture());
+
+        verify(this.mockEventSink, times(2)).queueEvent(any(Event.class));
+    }
+
+    @Test
+    public void testLazyRegenerationForProductById() throws Exception {
+        Owner owner = TestUtil.createOwner("test-owner", "Test Owner");
+        Consumer consumer = TestUtil.createConsumer(owner);
+        Product product = TestUtil.createProduct(owner);
+        Pool pool = TestUtil.createPool(owner, product);
+        Entitlement entitlement = TestUtil.createEntitlement(owner, consumer, pool, null);
+        Set<Entitlement> entitlements = new HashSet<Entitlement>();
+        entitlements.add(entitlement);
+        pool.setEntitlements(entitlements);
+
+        when(this.mockPoolCurator.listAvailableEntitlementPools(any(Consumer.class), eq(owner),
+            eq(product.getId()), any(Date.class), anyBoolean())).thenReturn(Arrays.asList(pool));
+
+        this.ecGenerator.regenerateCertificatesOf(owner, product.getId(), true);
+
+        assertTrue(entitlement.getDirty());
+
+        verifyZeroInteractions(this.mockEntCertAdapter);
+    }
+
+    @Test
+    public void testNonLazyRegenerationForProductById() throws Exception {
+        Owner owner = TestUtil.createOwner("test-owner", "Test Owner");
+        Consumer consumer = TestUtil.createConsumer(owner);
+        Product product = TestUtil.createProduct(owner);
+        Pool pool = TestUtil.createPool(owner, product);
+        Entitlement entitlement = TestUtil.createEntitlement(owner, consumer, pool, null);
+        Set<Entitlement> entitlements = new HashSet<Entitlement>();
+        entitlements.add(entitlement);
+        pool.setEntitlements(entitlements);
+
+        HashMap<String, EntitlementCertificate> ecMap = new HashMap<String, EntitlementCertificate>();
+        ecMap.put(pool.getId(), new EntitlementCertificate());
+
+        when(this.mockPoolCurator.listAvailableEntitlementPools(any(Consumer.class), eq(owner),
+            eq(product.getId()), any(Date.class), anyBoolean())).thenReturn(Arrays.asList(pool));
+        when(this.mockEntCertAdapter.generateEntitlementCerts(any(Consumer.class), any(Map.class),
+            any(Map.class))).thenReturn(ecMap);
+
+        this.ecGenerator.regenerateCertificatesOf(owner, product.getId(), false);
+
+        assertFalse(entitlement.getDirty());
+
+        verify(this.mockEntCertAdapter, times(1)).generateEntitlementCerts(any(Consumer.class),
+            this.entMapCaptor.capture(), this.productMapCaptor.capture());
+
+        verify(this.mockEventSink, times(1)).queueEvent(any(Event.class));
+    }
+
+    @Test
+    public void testLazyRegenerateForConsumer() {
+        Entitlement entitlement = new Entitlement();
+        Consumer consumer = new Consumer();
+        consumer.addEntitlement(entitlement);
+
+        this.ecGenerator.regenerateCertificatesOf(consumer, true);
+
+        assertTrue(entitlement.getDirty());
+        verifyZeroInteractions(this.mockEntCertAdapter);
+    }
+
+    @Test
+    public void testNonLazyRegenerate() throws Exception {
+        Owner owner = TestUtil.createOwner("test-owner", "Test Owner");
+        Product product = TestUtil.createProduct(owner);
+
+        Pool pool = TestUtil.createPool(owner, product);
+        pool.setSourceSubscription(new SourceSubscription("source-sub-id", "master"));
+
+        Map<String, EntitlementCertificate> entCerts = new HashMap<String, EntitlementCertificate>();
+        entCerts.put(pool.getId(), new EntitlementCertificate());
+
+        when(this.mockEntCertAdapter.generateEntitlementCerts(
+            any(Consumer.class), anyMapOf(String.class, Entitlement.class),
+            anyMapOf(String.class, Product.class))).thenReturn(entCerts);
+
+        Consumer consumer = TestUtil.createConsumer(owner);
+        Entitlement entitlement = new Entitlement(pool, consumer, 1);
+        entitlement.setDirty(true);
+
+        this.ecGenerator.regenerateCertificatesOf(entitlement, false, false);
+        assertFalse(entitlement.getDirty());
+
+        verify(this.mockEntCertAdapter).generateEntitlementCerts(eq(consumer),
+            this.entMapCaptor.capture(), this.productMapCaptor.capture());
+
+        assertEquals(entitlement, this.entMapCaptor.getValue().get(pool.getId()));
+        assertEquals(product, this.productMapCaptor.getValue().get(pool.getId()));
+
+        verify(this.mockEventSink, times(1)).queueEvent(any(Event.class));
+    }
+
+}

--- a/server/src/test/java/org/candlepin/controller/EntitlerTest.java
+++ b/server/src/test/java/org/candlepin/controller/EntitlerTest.java
@@ -83,6 +83,7 @@ public class EntitlerTest {
     @Mock private PoolCurator poolCurator;
     @Mock private ProductCurator productCurator;
     @Mock private ProductServiceAdapter productAdapter;
+    @Mock private ProductManager productManager;
 
     private ValidationResult fakeOutResult(String msg) {
         ValidationResult result = new ValidationResult();
@@ -101,7 +102,7 @@ public class EntitlerTest {
         translator = new EntitlementRulesTranslator(i18n);
 
         entitler = new Entitler(pm, cc, i18n, ef, sink, translator, entitlementCurator, config,
-                poolCurator, productCurator, productAdapter);
+            poolCurator, productCurator, productManager, productAdapter);
     }
 
     @Test
@@ -452,7 +453,7 @@ public class EntitlerTest {
         when(config.getBoolean(eq(ConfigProperties.STANDALONE))).thenReturn(false);
         when(poolCurator.hasActiveEntitlementPools(eq(owner), any(Date.class))).thenReturn(true);
         when(productAdapter.getProductsByIds(eq(owner), any(List.class))).thenReturn(devProds);
-        when(productCurator.updateProduct(eq(p), eq(owner))).thenReturn(p);
+        when(productManager.updateProduct(eq(p), eq(owner), anyBoolean())).thenReturn(p);
         when(pm.createPool(any(Pool.class))).thenReturn(devPool);
         when(devPool.getId()).thenReturn("test_pool_id");
 
@@ -521,8 +522,8 @@ public class EntitlerTest {
         when(poolCurator.hasActiveEntitlementPools(eq(owner), any(Date.class))).thenReturn(true);
         when(productAdapter.getProductsByIds(any(Owner.class), any(List.class))).thenReturn(devProds);
 
-        when(productCurator.updateProduct(eq(p), any(Owner.class))).thenReturn(p);
-        when(productCurator.updateProduct(eq(ip), any(Owner.class))).thenReturn(ip);
+        when(productManager.updateProduct(eq(p), any(Owner.class), anyBoolean())).thenReturn(p);
+        when(productManager.updateProduct(eq(ip), any(Owner.class), anyBoolean())).thenReturn(ip);
 
         AutobindData ad = new AutobindData(devSystem);
         try {
@@ -557,9 +558,9 @@ public class EntitlerTest {
         when(poolCurator.hasActiveEntitlementPools(eq(owner), any(Date.class))).thenReturn(true);
         when(productAdapter.getProductsByIds(any(Owner.class), any(List.class))).thenReturn(devProds);
 
-        when(productCurator.updateProduct(eq(p), any(Owner.class))).thenReturn(p);
-        when(productCurator.updateProduct(eq(ip1), any(Owner.class))).thenReturn(ip1);
-        when(productCurator.updateProduct(eq(ip2), any(Owner.class))).thenReturn(ip2);
+        when(productManager.updateProduct(eq(p), any(Owner.class), anyBoolean())).thenReturn(p);
+        when(productManager.updateProduct(eq(ip1), any(Owner.class), anyBoolean())).thenReturn(ip1);
+        when(productManager.updateProduct(eq(ip2), any(Owner.class), anyBoolean())).thenReturn(ip2);
 
         Pool expectedPool = entitler.assembleDevPool(devSystem, p.getId());
         when(pm.createPool(any(Pool.class))).thenReturn(expectedPool);
@@ -584,9 +585,9 @@ public class EntitlerTest {
         devSystem.addInstalledProduct(new ConsumerInstalledProduct(p2));
         devSystem.addInstalledProduct(new ConsumerInstalledProduct(p3));
         when(productAdapter.getProductsByIds(eq(owner), any(List.class))).thenReturn(devProds);
-        when(productCurator.updateProduct(eq(p1), eq(owner))).thenReturn(p1);
-        when(productCurator.updateProduct(eq(p2), eq(owner))).thenReturn(p2);
-        when(productCurator.updateProduct(eq(p3), eq(owner))).thenReturn(p3);
+        when(productManager.updateProduct(eq(p1), eq(owner), anyBoolean())).thenReturn(p1);
+        when(productManager.updateProduct(eq(p2), eq(owner), anyBoolean())).thenReturn(p2);
+        when(productManager.updateProduct(eq(p3), eq(owner), anyBoolean())).thenReturn(p3);
 
         Pool created = entitler.assembleDevPool(devSystem, devSystem.getFact("dev_sku"));
         Calendar cal = Calendar.getInstance();
@@ -610,7 +611,7 @@ public class EntitlerTest {
         Consumer devSystem = TestUtil.createConsumer(owner);
         devSystem.setFact("dev_sku", p1.getId());
         when(productAdapter.getProductsByIds(eq(owner), any(List.class))).thenReturn(devProds);
-        when(productCurator.updateProduct(eq(p1), eq(owner))).thenReturn(p1);
+        when(productManager.updateProduct(eq(p1), eq(owner), anyBoolean())).thenReturn(p1);
 
         Pool created = entitler.assembleDevPool(devSystem, devSystem.getFact("dev_sku"));
         assertEquals(entitler.DEFAULT_DEV_SLA, created.getProduct().getAttributeValue("support_level"));
@@ -633,8 +634,8 @@ public class EntitlerTest {
         devSystem.addInstalledProduct(new ConsumerInstalledProduct(p2));
 
         when(productAdapter.getProductsByIds(eq(owner), any(List.class))).thenReturn(devProds);
-        when(productCurator.updateProduct(eq(p1), eq(owner))).thenReturn(p1);
-        when(productCurator.updateProduct(eq(p2), eq(owner))).thenReturn(p2);
+        when(productManager.updateProduct(eq(p1), eq(owner), anyBoolean())).thenReturn(p1);
+        when(productManager.updateProduct(eq(p2), eq(owner), anyBoolean())).thenReturn(p2);
 
         Pool created = entitler.assembleDevPool(devSystem, devSystem.getFact("dev_sku"));
 

--- a/server/src/test/java/org/candlepin/controller/PoolManagerFunctionalTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerFunctionalTest.java
@@ -302,7 +302,7 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
     @Test
     public void testRegenerateEntitlementCertificatesWithNoEntitlement() {
         reset(this.eventSink); // pool creation events went out from setup
-        poolManager.regenerateEntitlementCertificates(childVirtSystem, true);
+        poolManager.regenerateCertificatesOf(childVirtSystem, true);
         assertEquals(0, collectEntitlementCertIds(this.childVirtSystem).size());
         Mockito.verifyZeroInteractions(this.eventSink);
     }
@@ -509,7 +509,7 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
     private void regenerateECAndAssertNotSameCertificates() {
         Set<EntitlementCertificate> oldsIds =
             collectEntitlementCertIds(this.childVirtSystem);
-        poolManager.regenerateEntitlementCertificates(childVirtSystem, false);
+        poolManager.regenerateCertificatesOf(childVirtSystem, false);
         Mockito.verify(this.eventSink, Mockito.times(oldsIds.size()))
             .queueEvent(any(Event.class));
         Set<EntitlementCertificate> newIds =

--- a/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -69,8 +69,6 @@ import org.candlepin.policy.js.entitlement.PreUnbindHelper;
 import org.candlepin.policy.js.pool.PoolRules;
 import org.candlepin.policy.js.pool.PoolUpdate;
 import org.candlepin.resource.dto.AutobindData;
-import org.candlepin.service.EntitlementCertServiceAdapter;
-import org.candlepin.service.ProductServiceAdapter;
 import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.test.TestUtil;
 import org.candlepin.util.Util;
@@ -107,58 +105,31 @@ import java.util.Set;
 public class PoolManagerTest {
     private I18n i18n;
 
-    @Mock
-    private PoolCurator mockPoolCurator;
-    @Mock
-    private SubscriptionServiceAdapter mockSubAdapter;
-    @Mock
-    private ProductCurator mockProductCurator;
-    @Mock
-    private ProductServiceAdapter mockProductAdapter;
-    @Mock
-    private EventSink mockEventSink;
-    @Mock
-    private Configuration mockConfig;
-    @Mock
-    private EntitlementCurator entitlementCurator;
-    @Mock
-    private EntitlementCertificateCurator certCuratorMock;
-    @Mock
-    private EntitlementCertServiceAdapter entCertAdapterMock;
-    @Mock
-    private Enforcer enforcerMock;
-    @Mock
-    private AutobindRules autobindRules;
-    @Mock
-    private PoolRules poolRulesMock;
-    @Mock
-    private ConsumerCurator consumerCuratorMock;
-    @Mock
-    private EnvironmentCurator envCurator;
+    @Mock private PoolCurator mockPoolCurator;
+    @Mock private SubscriptionServiceAdapter mockSubAdapter;
+    @Mock private ProductCurator mockProductCurator;
+    @Mock private ProductManager mockProductManager;
+    @Mock private EventSink mockEventSink;
+    @Mock private Configuration mockConfig;
+    @Mock private EntitlementCurator entitlementCurator;
+    @Mock private EntitlementCertificateCurator certCuratorMock;
+    @Mock private EntitlementCertificateGenerator mockECGenerator;
+    @Mock private Enforcer enforcerMock;
+    @Mock private AutobindRules autobindRules;
+    @Mock private PoolRules poolRulesMock;
+    @Mock private ConsumerCurator consumerCuratorMock;
+    @Mock private EnvironmentCurator envCurator;
+    @Mock private EventFactory eventFactory;
+    @Mock private EventBuilder eventBuilder;
+    @Mock private ComplianceRules complianceRules;
+    @Mock private ActivationKeyRules activationKeyRules;
+    @Mock private ContentCurator mockContentCurator;
+    @Mock private ContentManager mockContentManager;
+    @Mock private OwnerCurator ownerCuratorMock;
+    @Mock private PinsetterKernel pinsetterKernel;
 
-    @Mock
-    private EventFactory eventFactory;
-    @Mock
-    private EventBuilder eventBuilder;
-
-    @Mock
-    private ComplianceRules complianceRules;
-
-    @Mock
-    private ActivationKeyRules activationKeyRules;
-    @Mock
-    private ProductCurator productCuratorMock;
-    @Mock
-    private ContentCurator contentCuratorMock;
-    @Mock
-    private OwnerCurator ownerCuratorMock;
-    @Mock
-    private PinsetterKernel pinsetterKernel;
-    @Captor
-    private ArgumentCaptor<Map<String, Entitlement>> entMapCaptor;
-
-    @Captor
-    private ArgumentCaptor<Map<String, Product>> productMapCaptor;
+    @Captor private ArgumentCaptor<Map<String, Entitlement>> entMapCaptor;
+    @Captor private ArgumentCaptor<Map<String, Product>> productMapCaptor;
 
     private CandlepinPoolManager manager;
     private UserPrincipal principal;
@@ -186,19 +157,14 @@ public class PoolManagerTest {
 
         this.principal = TestUtil.createOwnerPrincipal();
         this.manager = spy(new CandlepinPoolManager(
-            mockPoolCurator, mockProductCurator, entCertAdapterMock, mockEventSink,
-            eventFactory, mockConfig, enforcerMock, poolRulesMock, entitlementCurator,
-            consumerCuratorMock, certCuratorMock, complianceRules, autobindRules,
-            activationKeyRules, productCuratorMock, contentCuratorMock, ownerCuratorMock,
-            pinsetterKernel, i18n)
-        );
+            mockPoolCurator, mockEventSink, eventFactory, mockConfig, enforcerMock, poolRulesMock,
+            entitlementCurator, consumerCuratorMock, certCuratorMock, mockECGenerator,
+            complianceRules, autobindRules, activationKeyRules, mockProductCurator, mockProductManager,
+            mockContentCurator, mockContentManager, ownerCuratorMock, pinsetterKernel, i18n
+        ));
 
         Map<String, EntitlementCertificate> entCerts = new HashMap<String, EntitlementCertificate>();
         entCerts.put(pool.getId(), new EntitlementCertificate());
-        when(entCertAdapterMock.generateEntitlementCerts(any(Consumer.class),
-                 anyMapOf(String.class, Entitlement.class),
-                 anyMapOf(String.class, Product.class)))
-                    .thenReturn(entCerts);
 
         dummyComplianceStatus = new ComplianceStatus(new Date());
         when(complianceRules.getStatus(any(Consumer.class), any(Date.class))).thenReturn(
@@ -249,7 +215,7 @@ public class PoolManagerTest {
 
         mockPoolsList(pools);
         when(ownerCuratorMock.lookupByKey(owner.getKey())).thenReturn(owner);
-        when(productCuratorMock.lookupById(owner, product.getId())).thenReturn(product);
+        when(mockProductCurator.lookupById(owner, product.getId())).thenReturn(product);
 
         this.manager.getRefresher(mockSubAdapter).add(owner).run();
         List<Pool> expectedFloating = new LinkedList();
@@ -283,7 +249,7 @@ public class PoolManagerTest {
         mockSubsList(subscriptions);
         mockPoolsList(pools);
         when(ownerCuratorMock.lookupByKey(owner.getKey())).thenReturn(owner);
-        when(productCuratorMock.lookupById(owner, product.getId())).thenReturn(product);
+        when(mockProductCurator.lookupById(owner, product.getId())).thenReturn(product);
 
         this.manager.getRefresher(mockSubAdapter).add(owner).run();
         List<Pool> expectedModified = new LinkedList();
@@ -301,7 +267,7 @@ public class PoolManagerTest {
     @Test
     public void productAttributesCopiedOntoPoolWhenCreatingNewPool() {
 
-        PoolRules pRules = new PoolRules(manager, mockConfig, entitlementCurator, productCuratorMock);
+        PoolRules pRules = new PoolRules(manager, mockConfig, entitlementCurator, mockProductCurator);
         Product product = TestUtil.createProduct(o);
         Subscription sub = TestUtil.createSubscription(o, product);
         String testAttributeKey = "multi-entitlement";
@@ -331,10 +297,9 @@ public class PoolManagerTest {
         subProduct.setAttribute(testAttributeKey, expectedAttributeValue);
 
         when(this.mockProductCurator.lookupById(o, product.getId())).thenReturn(product);
-        when(this.mockProductCurator.lookupById(o, subProduct.getId())).thenReturn(
-            subProduct);
+        when(this.mockProductCurator.lookupById(o, subProduct.getId())).thenReturn(subProduct);
 
-        PoolRules pRules = new PoolRules(manager, mockConfig, entitlementCurator, productCuratorMock);
+        PoolRules pRules = new PoolRules(manager, mockConfig, entitlementCurator, mockProductCurator);
         List<Pool> pools = pRules.createAndEnrichPools(sub);
         assertEquals(1, pools.size());
 
@@ -354,10 +319,9 @@ public class PoolManagerTest {
         sub.setDerivedProduct(subProduct);
 
         when(this.mockProductCurator.lookupById(o, product.getId())).thenReturn(product);
-        when(this.mockProductCurator.lookupById(o, subProduct.getId())).thenReturn(
-            subProduct);
+        when(this.mockProductCurator.lookupById(o, subProduct.getId())).thenReturn(subProduct);
 
-        PoolRules pRules = new PoolRules(manager, mockConfig, entitlementCurator, productCuratorMock);
+        PoolRules pRules = new PoolRules(manager, mockConfig, entitlementCurator, mockProductCurator);
         List<Pool> pools = pRules.createAndEnrichPools(sub);
         assertEquals(1, pools.size());
 
@@ -378,10 +342,9 @@ public class PoolManagerTest {
         sub.setDerivedProvidedProducts(subProvided);
 
         when(this.mockProductCurator.lookupById(o, product.getId())).thenReturn(product);
-        when(this.mockProductCurator.lookupById(o, subProduct.getId())).thenReturn(
-            subProduct);
+        when(this.mockProductCurator.lookupById(o, subProduct.getId())).thenReturn(subProduct);
 
-        PoolRules pRules = new PoolRules(manager, mockConfig, entitlementCurator, productCuratorMock);
+        PoolRules pRules = new PoolRules(manager, mockConfig, entitlementCurator, mockProductCurator);
         List<Pool> pools = pRules.createAndEnrichPools(sub);
         assertEquals(1, pools.size());
 
@@ -401,7 +364,7 @@ public class PoolManagerTest {
 
         when(this.mockProductCurator.lookupById(o, product.getId())).thenReturn(product);
 
-        PoolRules pRules = new PoolRules(manager, mockConfig, entitlementCurator, productCuratorMock);
+        PoolRules pRules = new PoolRules(manager, mockConfig, entitlementCurator, mockProductCurator);
         List<Pool> pools = pRules.createAndEnrichPools(sub);
         assertEquals(1, pools.size());
 
@@ -564,7 +527,7 @@ public class PoolManagerTest {
         ArgumentCaptor<Pool> argPool = ArgumentCaptor.forClass(Pool.class);
         when(poolRulesMock.createAndEnrichPools(argPool.capture(), any(List.class))).thenReturn(newPools);
         when(ownerCuratorMock.lookupByKey(owner.getKey())).thenReturn(owner);
-        when(productCuratorMock.lookupById(owner, product.getId())).thenReturn(product);
+        when(mockProductCurator.lookupById(owner, product.getId())).thenReturn(product);
         this.manager.getRefresher(mockSubAdapter).add(owner).run();
         TestUtil.assertPoolsAreEqual(TestUtil.copyFromSub(s), argPool.getValue());
         verify(this.mockPoolCurator, times(1)).create(any(Pool.class));
@@ -599,54 +562,14 @@ public class PoolManagerTest {
         updates.add(u);
         ArgumentCaptor<Pool> argPool = ArgumentCaptor.forClass(Pool.class);
         when(poolRulesMock.updatePools(argPool.capture(), eq(pools), eq(s.getQuantity()), any(Set.class)))
-                .thenReturn(updates);
+            .thenReturn(updates);
+
         when(ownerCuratorMock.lookupByKey(owner.getKey())).thenReturn(owner);
-        when(productCuratorMock.lookupById(owner, product.getId())).thenReturn(product);
+        when(mockProductCurator.lookupById(owner, product.getId())).thenReturn(product);
 
         this.manager.getRefresher(mockSubAdapter).add(owner).run();
         verify(poolRulesMock).createAndEnrichPools(argPool.capture(), any(List.class));
         TestUtil.assertPoolsAreEqual(TestUtil.copyFromSub(s), argPool.getValue());
-    }
-
-    @Test
-    public void testLazyRegenerate() {
-        Entitlement e = new Entitlement();
-        manager.regenerateCertificatesOf(e, false, true);
-        assertTrue(e.getDirty());
-        verifyZeroInteractions(entCertAdapterMock);
-    }
-
-    @Test
-    public void testLazyRegenerateForConsumer() {
-        Entitlement e = new Entitlement();
-        Consumer c = new Consumer();
-        c.addEntitlement(e);
-        manager.regenerateEntitlementCertificates(c, true);
-        assertTrue(e.getDirty());
-        verifyZeroInteractions(entCertAdapterMock);
-    }
-
-    @Test
-    public void testNonLazyRegenerate() throws Exception {
-        Subscription s = TestUtil.createSubscription(getOwner(),
-            product);
-        s.setId("testSubId");
-        pool.setSourceSubscription(new SourceSubscription(s.getId(), "master"));
-        Consumer con = TestUtil.createConsumer(o);
-        Entitlement e = new Entitlement(pool, con, 1);
-        e.setDirty(true);
-
-        when(mockSubAdapter.getSubscription(pool.getSubscriptionId())).thenReturn(s);
-
-        manager.regenerateCertificatesOf(e, false, false);
-        assertFalse(e.getDirty());
-
-        verify(entCertAdapterMock).generateEntitlementCerts(eq(con), entMapCaptor.capture(),
-            productMapCaptor.capture());
-        assertEquals(e, entMapCaptor.getValue().get(pool.getId()));
-        assertEquals(product, productMapCaptor.getValue().get(pool.getId()));
-
-        verify(mockEventSink, times(1)).queueEvent(any(Event.class));
     }
 
     /**
@@ -659,8 +582,7 @@ public class PoolManagerTest {
 
     @Test
     public void testCreatePoolForSubscription() {
-        final Subscription s = TestUtil.createSubscription(getOwner(),
-            TestUtil.createProduct(o));
+        final Subscription s = TestUtil.createSubscription(getOwner(), TestUtil.createProduct(o));
 
         List<Pool> newPools = new LinkedList<Pool>();
         Pool p = TestUtil.createPool(s.getProduct());
@@ -687,10 +609,8 @@ public class PoolManagerTest {
     public void testRevokeAllEntitlements() {
         Consumer c = TestUtil.createConsumer(o);
 
-        Entitlement e1 = new Entitlement(pool, c,
-            1);
-        Entitlement e2 = new Entitlement(pool, c,
-            1);
+        Entitlement e1 = new Entitlement(pool, c, 1);
+        Entitlement e2 = new Entitlement(pool, c, 1);
         List<Entitlement> entitlementList = new ArrayList<Entitlement>();
         entitlementList.add(e1);
         entitlementList.add(e2);
@@ -711,8 +631,7 @@ public class PoolManagerTest {
 
     @Test
     public void testRevokeCleansUpPoolsWithSourceEnt() throws Exception {
-        Entitlement e = new Entitlement(pool, TestUtil.createConsumer(o),
-            1);
+        Entitlement e = new Entitlement(pool, TestUtil.createConsumer(o), 1);
         List<Pool> poolsWithSource = createPoolsWithSourceEntitlement(e, product);
         when(mockPoolCurator.listBySourceEntitlement(e)).thenReturn(poolsWithSource);
         PreUnbindHelper preHelper =  mock(PreUnbindHelper.class);
@@ -826,10 +745,10 @@ public class PoolManagerTest {
             any(String.class), any(String.class), eq(now), anyBoolean(),
             any(PoolFilterBuilder.class), any(PageRequest.class), anyBoolean())).thenReturn(page);
 
+        when(mockPoolCurator.lockAndLoad(any(Pool.class))).thenReturn(pool1);
         when(mockPoolCurator.lockAndLoadBatch(any(List.class))).thenReturn(Arrays.asList(pool1));
-        when(
-                enforcerMock.preEntitlement(any(Consumer.class), anyCollectionOf(PoolQuantity.class),
-                        any(CallerType.class))).thenReturn(resultMap);
+        when(enforcerMock.preEntitlement(any(Consumer.class), anyCollectionOf(PoolQuantity.class),
+            any(CallerType.class))).thenReturn(resultMap);
 
         when(result.isSuccessful()).thenReturn(false);
         List<ValidationError> errors = new ArrayList<ValidationError>();
@@ -837,10 +756,8 @@ public class PoolManagerTest {
         when(result.getErrors()).thenReturn(errors);
         List<PoolQuantity> bestPools = new ArrayList<PoolQuantity>();
         bestPools.add(new PoolQuantity(pool1, 1));
-        when(
-                autobindRules.selectBestPools(any(Consumer.class), any(String[].class), any(List.class),
-                        any(ComplianceStatus.class), any(String.class), any(Set.class), eq(false)))
-                .thenReturn(bestPools);
+        when(autobindRules.selectBestPools(any(Consumer.class), any(String[].class), any(List.class),
+            any(ComplianceStatus.class), any(String.class), any(Set.class), eq(false))).thenReturn(bestPools);
 
         AutobindData data = AutobindData.create(TestUtil.createConsumer(o))
             .forProducts(new String[] { product.getUuid() }).on(now);
@@ -857,7 +774,6 @@ public class PoolManagerTest {
                 any(List.class), any(ComplianceStatus.class), any(String.class), any(Set.class),
                 eq(false));
         }
-
     }
 
     @Test
@@ -902,7 +818,7 @@ public class PoolManagerTest {
         ValidationResult result = new ValidationResult();
         when(preHelper.getResult()).thenReturn(result);
         when(ownerCuratorMock.lookupByKey(owner.getKey())).thenReturn(owner);
-        when(productCuratorMock.lookupById(owner, product.getId())).thenReturn(product);
+        when(mockProductCurator.lookupById(owner, product.getId())).thenReturn(product);
 
         this.manager.getRefresher(mockSubAdapter).add(owner).run();
 
@@ -926,8 +842,7 @@ public class PoolManagerTest {
         Pool p = createPoolWithEntitlements();
 
         when(mockPoolCurator.lockAndLoad(any(Pool.class))).thenReturn(p);
-        when(mockPoolCurator.entitlementsIn(p)).thenReturn(
-            new ArrayList<Entitlement>(p.getEntitlements()));
+        when(mockPoolCurator.entitlementsIn(p)).thenReturn(new ArrayList<Entitlement>(p.getEntitlements()));
         PreUnbindHelper preHelper =  mock(PreUnbindHelper.class);
         ValidationResult result = new ValidationResult();
         when(preHelper.getResult()).thenReturn(result);
@@ -951,8 +866,7 @@ public class PoolManagerTest {
 
         when(mockPoolCurator.lockAndLoad(any(Pool.class))).thenReturn(p);
         when(mockPoolCurator.listExpiredPools()).thenReturn(pools);
-        when(mockPoolCurator.entitlementsIn(p)).thenReturn(
-            new ArrayList<Entitlement>(p.getEntitlements()));
+        when(mockPoolCurator.entitlementsIn(p)).thenReturn(new ArrayList<Entitlement>(p.getEntitlements()));
         Subscription sub = new Subscription();
         sub.setId(p.getSubscriptionId());
         when(mockSubAdapter.getSubscription(any(String.class))).thenReturn(sub);
@@ -976,8 +890,7 @@ public class PoolManagerTest {
 
         when(mockPoolCurator.lockAndLoad(any(Pool.class))).thenReturn(p);
         when(mockPoolCurator.listExpiredPools()).thenReturn(pools);
-        when(mockPoolCurator.entitlementsIn(p)).thenReturn(
-            new ArrayList<Entitlement>(p.getEntitlements()));
+        when(mockPoolCurator.entitlementsIn(p)).thenReturn(new ArrayList<Entitlement>(p.getEntitlements()));
         Subscription sub = new Subscription();
         sub.setId(p.getSubscriptionId());
         when(mockSubAdapter.getSubscription(any(String.class))).thenReturn(sub);
@@ -996,12 +909,10 @@ public class PoolManagerTest {
 
     private Pool createPoolWithEntitlements() {
         Pool newPool = TestUtil.createPool(o, product);
-        Entitlement e1 = new Entitlement(newPool, TestUtil.createConsumer(o),
-            1);
+        Entitlement e1 = new Entitlement(newPool, TestUtil.createConsumer(o), 1);
         e1.setId("1");
 
-        Entitlement e2 = new Entitlement(newPool, TestUtil.createConsumer(o),
-            1);
+        Entitlement e2 = new Entitlement(newPool, TestUtil.createConsumer(o), 1);
         e2.setId("2");
 
         newPool.getEntitlements().add(e1);
@@ -1096,7 +1007,7 @@ public class PoolManagerTest {
         ValidationResult result = new ValidationResult();
         when(preHelper.getResult()).thenReturn(result);
         when(ownerCuratorMock.lookupByKey(owner.getKey())).thenReturn(owner);
-        when(productCuratorMock.lookupById(owner, product.getId())).thenReturn(product);
+        when(mockProductCurator.lookupById(owner, product.getId())).thenReturn(product);
 
         this.manager.getRefresher(mockSubAdapter).add(owner).run();
 
@@ -1165,8 +1076,7 @@ public class PoolManagerTest {
     @Test
     public void createPoolsForExistingSubscriptionsNoneExist() {
         Owner owner = this.getOwner();
-        PoolRules pRules = new PoolRules(manager, mockConfig, entitlementCurator,
-            productCuratorMock);
+        PoolRules pRules = new PoolRules(manager, mockConfig, entitlementCurator, mockProductCurator);
         List<Subscription> subscriptions = Util.newList();
         Product prod = TestUtil.createProduct(owner);
         Set<Product> products = new HashSet<Product>();
@@ -1176,7 +1086,7 @@ public class PoolManagerTest {
         Subscription s = TestUtil.createSubscription(owner, prod);
         subscriptions.add(s);
 
-        when(productCuratorMock.lookupById(owner, prod.getId())).thenReturn(prod);
+        when(mockProductCurator.lookupById(owner, prod.getId())).thenReturn(prod);
 
         when(mockSubAdapter.getSubscriptions(any(Owner.class))).thenReturn(
             subscriptions);
@@ -1195,7 +1105,7 @@ public class PoolManagerTest {
     @Test
     public void createPoolsForExistingPoolNoneExist() {
         Owner owner = this.getOwner();
-        PoolRules pRules = new PoolRules(manager, mockConfig, entitlementCurator, productCuratorMock);
+        PoolRules pRules = new PoolRules(manager, mockConfig, entitlementCurator, mockProductCurator);
         Product prod = TestUtil.createProduct(owner);
         prod.setAttribute("virt_limit", "4");
         Pool p = TestUtil.createPool(owner, prod);
@@ -1213,8 +1123,7 @@ public class PoolManagerTest {
     @Test
     public void createPoolsForExistingSubscriptionsMasterExist() {
         Owner owner = this.getOwner();
-        PoolRules pRules = new PoolRules(manager, mockConfig, entitlementCurator,
-            productCuratorMock);
+        PoolRules pRules = new PoolRules(manager, mockConfig, entitlementCurator, mockProductCurator);
         List<Subscription> subscriptions = Util.newList();
         Product prod = TestUtil.createProduct(owner);
         Set<Product> products = new HashSet<Product>();
@@ -1224,7 +1133,7 @@ public class PoolManagerTest {
         Subscription s = TestUtil.createSubscription(owner, prod);
         subscriptions.add(s);
 
-        when(productCuratorMock.lookupById(owner, prod.getId())).thenReturn(prod);
+        when(mockProductCurator.lookupById(owner, prod.getId())).thenReturn(prod);
         when(mockSubAdapter.getSubscriptions(any(Owner.class))).thenReturn(subscriptions);
         when(mockConfig.getBoolean(ConfigProperties.STANDALONE)).thenReturn(false);
 
@@ -1242,7 +1151,7 @@ public class PoolManagerTest {
         Owner owner = this.getOwner();
         Product prod = TestUtil.createProduct(owner);
         prod.setAttribute("virt_limit", "4");
-        PoolRules pRules = new PoolRules(manager, mockConfig, entitlementCurator, productCuratorMock);
+        PoolRules pRules = new PoolRules(manager, mockConfig, entitlementCurator, mockProductCurator);
         List<Pool> existingPools = new LinkedList<Pool>();
         Pool p = TestUtil.createPool(prod);
         p.setSourceSubscription(new SourceSubscription(TestUtil.randomString(), "master"));
@@ -1255,8 +1164,7 @@ public class PoolManagerTest {
     @Test
     public void createPoolsForExistingSubscriptionsBonusExist() {
         Owner owner = this.getOwner();
-        PoolRules pRules = new PoolRules(manager, mockConfig, entitlementCurator,
-            productCuratorMock);
+        PoolRules pRules = new PoolRules(manager, mockConfig, entitlementCurator, mockProductCurator);
         List<Subscription> subscriptions = Util.newList();
         Product prod = TestUtil.createProduct(owner);
         Set<Product> products = new HashSet<Product>();
@@ -1265,7 +1173,7 @@ public class PoolManagerTest {
         prod.setAttribute("virt_limit", "4");
         Subscription s = TestUtil.createSubscription(owner, prod);
         subscriptions.add(s);
-        when(productCuratorMock.lookupById(owner, prod.getId())).thenReturn(prod);
+        when(mockProductCurator.lookupById(owner, prod.getId())).thenReturn(prod);
         when(mockSubAdapter.getSubscriptions(any(Owner.class))).thenReturn(subscriptions);
         when(mockConfig.getBoolean(ConfigProperties.STANDALONE)).thenReturn(false);
 
@@ -1282,7 +1190,7 @@ public class PoolManagerTest {
     @Test(expected = IllegalStateException.class)
     public void createPoolsForPoolBonusExist() {
         Owner owner = this.getOwner();
-        PoolRules pRules = new PoolRules(manager, mockConfig, entitlementCurator, productCuratorMock);
+        PoolRules pRules = new PoolRules(manager, mockConfig, entitlementCurator, mockProductCurator);
         Product prod = TestUtil.createProduct(owner);
         prod.setAttribute("virt_limit", "4");
         List<Pool> existingPools = new LinkedList<Pool>();
@@ -1301,12 +1209,11 @@ public class PoolManagerTest {
 
         Map<String, Product> products = new HashMap<String, Product>();
 
-        when(productCuratorMock.lookupById(o, oldProduct.getId()))
-            .thenReturn(oldProduct);
+        when(mockProductCurator.lookupById(o, oldProduct.getId())) .thenReturn(oldProduct);
 
         Set<Product> changed = manager.getChangedProducts(o, products);
 
-        verify(productCuratorMock, times(0)).lookupById(o, oldProduct.getId());
+        verify(mockProductCurator, times(0)).lookupById(o, oldProduct.getId());
 
         assertTrue(changed.isEmpty());
     }
@@ -1318,8 +1225,7 @@ public class PoolManagerTest {
         Map<String, Product> products = new HashMap<String, Product>();
         products.put(newProduct.getId(), newProduct);
 
-        when(productCuratorMock.lookupById(o, newProduct.getId()))
-            .thenReturn(null);
+        when(mockProductCurator.lookupById(o, newProduct.getId())) .thenReturn(null);
 
         Set<Product> changed = manager.getChangedProducts(o, products);
 
@@ -1327,7 +1233,7 @@ public class PoolManagerTest {
     }
 
     private void mockProduct(Owner owner, Product p) {
-        when(productCuratorMock.lookupById(owner, p.getId())).thenReturn(p);
+        when(mockProductCurator.lookupById(owner, p.getId())).thenReturn(p);
     }
 
     @Test
@@ -1652,9 +1558,9 @@ public class PoolManagerTest {
     }
 
     private Content mockContent(Owner owner, Content content) {
-        when(contentCuratorMock.lookupById(owner, content.getId())).thenReturn(content);
-        when(contentCuratorMock.createContent(content, owner)).thenReturn(content);
-        when(contentCuratorMock.updateContent(content, owner)).thenReturn(content);
+        when(mockContentCurator.lookupById(owner, content.getId())).thenReturn(content);
+        when(mockContentManager.createContent(content, owner)).thenReturn(content);
+        when(mockContentManager.updateContent(eq(content), eq(owner), anyBoolean())).thenReturn(content);
 
         return content;
     }
@@ -1689,8 +1595,8 @@ public class PoolManagerTest {
 
         c1m.setContentUrl("modified_value");
 
-        when(contentCuratorMock.updateContent(c1m, owner)).thenReturn(c1m);
-        when(contentCuratorMock.updateContent(c2m, owner)).thenReturn(c2m);
+        when(mockContentManager.updateContent(eq(c1m), eq(owner), anyBoolean())).thenReturn(c1m);
+        when(mockContentManager.updateContent(eq(c2m), eq(owner), anyBoolean())).thenReturn(c2m);
 
         Map<String, Content> content = new HashMap<String, Content>();
         content.put(c1m.getId(), c1m);
@@ -1714,8 +1620,8 @@ public class PoolManagerTest {
 
         c1m.setGpgUrl("modified_value");
 
-        when(contentCuratorMock.updateContent(c1m, owner)).thenReturn(c1m);
-        when(contentCuratorMock.updateContent(c2m, owner)).thenReturn(c2m);
+        when(mockContentManager.updateContent(eq(c1m), eq(owner), anyBoolean())).thenReturn(c1m);
+        when(mockContentManager.updateContent(eq(c2m), eq(owner), anyBoolean())).thenReturn(c2m);
 
         Map<String, Content> content = new HashMap<String, Content>();
         content.put(c1m.getId(), c1m);
@@ -1739,8 +1645,8 @@ public class PoolManagerTest {
 
         c1m.setLabel("modified_value");
 
-        when(contentCuratorMock.updateContent(c1m, owner)).thenReturn(c1m);
-        when(contentCuratorMock.updateContent(c2m, owner)).thenReturn(c2m);
+        when(mockContentManager.updateContent(eq(c1m), eq(owner), anyBoolean())).thenReturn(c1m);
+        when(mockContentManager.updateContent(eq(c2m), eq(owner), anyBoolean())).thenReturn(c2m);
 
         Map<String, Content> content = new HashMap<String, Content>();
         content.put(c1m.getId(), c1m);
@@ -1762,8 +1668,8 @@ public class PoolManagerTest {
         Content c1m = (Content) c1.clone();
         Content c2m = (Content) c2.clone();
 
-        when(contentCuratorMock.updateContent(c1m, owner)).thenReturn(c1m);
-        when(contentCuratorMock.updateContent(c2m, owner)).thenReturn(c2m);
+        when(mockContentManager.updateContent(eq(c1m), eq(owner), anyBoolean())).thenReturn(c1m);
+        when(mockContentManager.updateContent(eq(c2m), eq(owner), anyBoolean())).thenReturn(c2m);
 
         c1m.setName("modified_value");
 
@@ -1787,8 +1693,8 @@ public class PoolManagerTest {
         Content c1m = (Content) c1.clone();
         Content c2m = (Content) c2.clone();
 
-        when(contentCuratorMock.updateContent(c1m, owner)).thenReturn(c1m);
-        when(contentCuratorMock.updateContent(c2m, owner)).thenReturn(c2m);
+        when(mockContentManager.updateContent(eq(c1m), eq(owner), anyBoolean())).thenReturn(c1m);
+        when(mockContentManager.updateContent(eq(c2m), eq(owner), anyBoolean())).thenReturn(c2m);
 
         c1m.setReleaseVer("modified_value");
 
@@ -1814,8 +1720,8 @@ public class PoolManagerTest {
 
         c1m.setRequiredTags("modified_value");
 
-        when(contentCuratorMock.updateContent(c1m, owner)).thenReturn(c1m);
-        when(contentCuratorMock.updateContent(c2m, owner)).thenReturn(c2m);
+        when(mockContentManager.updateContent(eq(c1m), eq(owner), anyBoolean())).thenReturn(c1m);
+        when(mockContentManager.updateContent(eq(c2m), eq(owner), anyBoolean())).thenReturn(c2m);
 
         Map<String, Content> content = new HashMap<String, Content>();
         content.put(c1m.getId(), c1m);
@@ -1837,8 +1743,8 @@ public class PoolManagerTest {
         Content c1m = (Content) c1.clone();
         Content c2m = (Content) c2.clone();
 
-        when(contentCuratorMock.updateContent(c1m, owner)).thenReturn(c1m);
-        when(contentCuratorMock.updateContent(c2m, owner)).thenReturn(c2m);
+        when(mockContentManager.updateContent(eq(c1m), eq(owner), anyBoolean())).thenReturn(c1m);
+        when(mockContentManager.updateContent(eq(c2m), eq(owner), anyBoolean())).thenReturn(c2m);
 
         c1m.setType("modified_value");
 
@@ -1862,8 +1768,8 @@ public class PoolManagerTest {
         Content c1m = (Content) c1.clone();
         Content c2m = (Content) c2.clone();
 
-        when(contentCuratorMock.updateContent(c1m, owner)).thenReturn(c1m);
-        when(contentCuratorMock.updateContent(c2m, owner)).thenReturn(c2m);
+        when(mockContentManager.updateContent(eq(c1m), eq(owner), anyBoolean())).thenReturn(c1m);
+        when(mockContentManager.updateContent(eq(c2m), eq(owner), anyBoolean())).thenReturn(c2m);
 
         c1m.setVendor("modified_value");
 
@@ -1889,8 +1795,8 @@ public class PoolManagerTest {
 
         c1m.setArches("modified_value");
 
-        when(contentCuratorMock.updateContent(c1m, owner)).thenReturn(c1m);
-        when(contentCuratorMock.updateContent(c2m, owner)).thenReturn(c2m);
+        when(mockContentManager.updateContent(eq(c1m), eq(owner), anyBoolean())).thenReturn(c1m);
+        when(mockContentManager.updateContent(eq(c2m), eq(owner), anyBoolean())).thenReturn(c2m);
 
         Map<String, Content> content = new HashMap<String, Content>();
         content.put(c1m.getId(), c1m);
@@ -1912,8 +1818,8 @@ public class PoolManagerTest {
         Content c1m = (Content) c1.clone();
         Content c2m = (Content) c2.clone();
 
-        when(contentCuratorMock.updateContent(c1m, owner)).thenReturn(c1m);
-        when(contentCuratorMock.updateContent(c2m, owner)).thenReturn(c2m);
+        when(mockContentManager.updateContent(eq(c1m), eq(owner), anyBoolean())).thenReturn(c1m);
+        when(mockContentManager.updateContent(eq(c2m), eq(owner), anyBoolean())).thenReturn(c2m);
 
         HashSet<String> modifiedProductIds = new HashSet<String>();
         Set<Content> result;
@@ -2029,10 +1935,10 @@ public class PoolManagerTest {
 
         when(mockPoolCurator.lockAndLoadBatch(anyCollection())).thenReturn(Arrays.asList(pool));
 
-        when(mockPoolCurator.lookupOversubscribedBySubscriptionIds(anyMap())).thenReturn(
-            Arrays.asList(derivedPool));
-        when(mockPoolCurator.retrieveFreeEntitlementsOfPools(anyListOf(Pool.class), eq(true))).thenReturn(
-            Arrays.asList(derivedEnt));
+        when(mockPoolCurator.lookupOversubscribedBySubscriptionIds(anyMap()))
+            .thenReturn(Arrays.asList(derivedPool));
+        when(mockPoolCurator.retrieveFreeEntitlementsOfPools(anyListOf(Pool.class), eq(true)))
+            .thenReturn(Arrays.asList(derivedEnt));
         when(mockPoolCurator.lockAndLoad(eq(derivedPool))).thenReturn(derivedPool);
         pool.setId("masterpool");
 

--- a/server/src/test/java/org/candlepin/controller/ProductManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/ProductManagerTest.java
@@ -1,0 +1,417 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.controller;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
+import static org.mockito.AdditionalAnswers.*;
+
+import org.candlepin.common.config.Configuration;
+import org.candlepin.config.CandlepinCommonTestConfig;
+import org.candlepin.model.Content;
+import org.candlepin.model.Owner;
+import org.candlepin.model.Product;
+import org.candlepin.model.ProductCurator;
+import org.candlepin.test.TestUtil;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+
+
+/**
+ * ProductManagerTest
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ProductManagerTest {
+
+    private Configuration config;
+
+    @Mock private ProductCurator mockProductCurator;
+    @Mock private EntitlementCertificateGenerator mockEntCertGenerator;
+
+    private ProductManager productManager;
+
+    @Before
+    public void init() throws Exception {
+        this.config = new CandlepinCommonTestConfig();
+
+        this.productManager = new ProductManager(
+            this.mockProductCurator, this.mockEntCertGenerator, this.config
+        );
+
+        doAnswer(returnsFirstArg()).when(this.mockProductCurator).merge(any(Product.class));
+        doAnswer(returnsFirstArg()).when(this.mockProductCurator).create(any(Product.class));
+        doAnswer(returnsSecondArg()).when(this.mockProductCurator)
+            .updateOwnerProductReferences(any(Product.class), any(Product.class), any(Collection.class));
+    }
+
+    @Test
+    public void testCreateProduct() {
+        Owner owner = TestUtil.createOwner("test-owner", "Test Owner");
+        Product product = TestUtil.createProduct("p1", "prod1", owner);
+
+        Product output = this.productManager.createProduct(product, owner);
+
+        assertEquals(output, product);
+        verify(this.mockProductCurator, times(1)).create(eq(product));
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testCreateProductThatAlreadyExists() {
+        Owner owner = TestUtil.createOwner("test-owner", "Test Owner");
+        Product product = TestUtil.createProduct("p1", "prod1", owner);
+
+        when(this.mockProductCurator.lookupById(eq(owner), eq(product.getId()))).thenReturn(product);
+
+        Product output = this.productManager.createProduct(product, owner);
+    }
+
+    @Test
+    public void testCreateProductMergeWithExisting() {
+        Owner owner1 = TestUtil.createOwner("test-owner-1", "Test Owner 1");
+        Owner owner2 = TestUtil.createOwner("test-owner-2", "Test Owner 2");
+
+        Product product1 = TestUtil.createProduct("p1", "prod1", owner1);
+        Product product2 = TestUtil.createProduct("p1", "prod1", owner2);
+
+        when(this.mockProductCurator.getProductsByVersion(eq(product2.getId()), eq(product2.hashCode())))
+            .thenReturn(Arrays.asList(product2));
+
+        Product output = this.productManager.createProduct(product1, owner1);
+
+        assertEquals(output, product2);
+        assertTrue(output.getOwners().contains(owner1));
+        assertTrue(output.getOwners().contains(owner2));
+
+        verify(this.mockProductCurator, times(1)).merge(eq(product2));
+        verify(this.mockProductCurator, never()).create(eq(product1));
+    }
+
+    @Test
+    public void testUpdateProductNoChange() {
+        Owner owner = TestUtil.createOwner("test-owner", "Test Owner");
+        Product product = TestUtil.createProduct("p1", "prod1", owner);
+
+        when(this.mockProductCurator.lookupById(eq(owner), eq(product.getId()))).thenReturn(product);
+
+        Product output = this.productManager.updateProduct(product, owner, true);
+
+        assertTrue(output == product);
+
+        verify(this.mockProductCurator, times(1)).merge(eq(product));
+        verifyZeroInteractions(this.mockEntCertGenerator);
+    }
+
+    @Test
+    public void testUpdateProduct() {
+        Owner owner = TestUtil.createOwner("test-owner", "Test Owner");
+        Product product = TestUtil.createProduct("p1", "prod1", owner);
+        Product update = TestUtil.createProduct("p1", "new product name", owner);
+
+        when(this.mockProductCurator.lookupById(eq(owner), eq(product.getId()))).thenReturn(product);
+
+        Product output = this.productManager.updateProduct(update, owner, false);
+
+        assertEquals(output, update);
+
+        verify(this.mockProductCurator, times(1)).merge(eq(product));
+        verifyZeroInteractions(this.mockEntCertGenerator);
+    }
+
+    @Test
+    public void testUpdateProductWithCertRegeneration() {
+        Owner owner = TestUtil.createOwner("test-owner", "Test Owner");
+        Product product = TestUtil.createProduct("p1", "prod1", owner);
+        Product update = TestUtil.createProduct("p1", "new product name", owner);
+
+        when(this.mockProductCurator.lookupById(eq(owner), eq(product.getId()))).thenReturn(product);
+
+        Product output = this.productManager.updateProduct(update, owner, true);
+
+        assertEquals(output, update);
+
+        verify(this.mockProductCurator, times(1)).merge(eq(product));
+        verify(this.mockEntCertGenerator, times(1))
+            .regenerateCertificatesOf(eq(Arrays.asList(product)), anyBoolean());
+    }
+
+    @Test
+    public void testUpdateProductConvergeWithExisting() {
+        Owner owner1 = TestUtil.createOwner("test-owner-1", "Test Owner 1");
+        Owner owner2 = TestUtil.createOwner("test-owner-2", "Test Owner 2");
+        Product product1 = TestUtil.createProduct("p1", "prod1", owner1);
+        Product product2 = TestUtil.createProduct("p1", "updated product", owner2);
+        Product update = TestUtil.createProduct("p1", "updated product", owner1);
+
+        when(this.mockProductCurator.lookupById(eq(owner1), eq(product1.getId()))).thenReturn(product1);
+        when(this.mockProductCurator.lookupById(eq(owner2), eq(product2.getId()))).thenReturn(product2);
+        when(this.mockProductCurator.getProductsByVersion(eq(update.getId()), eq(update.hashCode())))
+            .thenReturn(Arrays.asList(product2));
+
+        Product output = this.productManager.updateProduct(update, owner1, false);
+
+        assertTrue(output == product2);
+        assertTrue(output.getOwners().contains(owner1));
+        assertTrue(output.getOwners().contains(owner2));
+
+        verifyZeroInteractions(this.mockEntCertGenerator);
+    }
+
+    @Test
+    public void testUpdateProductConvergeWithExistingWithCertRegeneration() {
+        Owner owner1 = TestUtil.createOwner("test-owner-1", "Test Owner 1");
+        Owner owner2 = TestUtil.createOwner("test-owner-2", "Test Owner 2");
+        Product product1 = TestUtil.createProduct("p1", "prod1", owner1);
+        Product product2 = TestUtil.createProduct("p1", "updated product", owner2);
+        Product update = TestUtil.createProduct("p1", "updated product", owner1);
+
+        when(this.mockProductCurator.lookupById(eq(owner1), eq(product1.getId()))).thenReturn(product1);
+        when(this.mockProductCurator.lookupById(eq(owner2), eq(product2.getId()))).thenReturn(product2);
+        when(this.mockProductCurator.getProductsByVersion(eq(update.getId()), eq(update.hashCode())))
+            .thenReturn(Arrays.asList(product2));
+
+        Product output = this.productManager.updateProduct(update, owner1, true);
+
+        assertTrue(output == product2);
+        assertTrue(output.getOwners().contains(owner1));
+        assertTrue(output.getOwners().contains(owner2));
+
+        verify(this.mockEntCertGenerator, times(1))
+            .regenerateCertificatesOf(eq(Arrays.asList(owner1)), eq(Arrays.asList(product2)), anyBoolean());
+    }
+
+    @Test
+    public void testUpdateProductDivergeFromExisting() {
+        Owner owner1 = TestUtil.createOwner("test-owner-1", "Test Owner 1");
+        Owner owner2 = TestUtil.createOwner("test-owner-2", "Test Owner 2");
+        Product product = TestUtil.createProduct("p1", "prod1", owner1);
+        product.addOwner(owner2);
+        Product update = TestUtil.createProduct("p1", "updated product", owner1);
+
+        when(this.mockProductCurator.lookupById(eq(owner1), eq(product.getId()))).thenReturn(product);
+
+        Product output = this.productManager.updateProduct(update, owner1, false);
+
+        assertTrue(output != product);
+        assertTrue(output.getOwners().contains(owner1));
+        assertFalse(output.getOwners().contains(owner2));
+        assertFalse(product.getOwners().contains(owner1));
+        assertTrue(product.getOwners().contains(owner2));
+
+        verifyZeroInteractions(this.mockEntCertGenerator);
+    }
+
+    @Test
+    public void testUpdateProductDivergeFromExistingWithCertRegeneration() {
+        Owner owner1 = TestUtil.createOwner("test-owner-1", "Test Owner 1");
+        Owner owner2 = TestUtil.createOwner("test-owner-2", "Test Owner 2");
+        Product product = TestUtil.createProduct("p1", "prod1", owner1);
+        product.addOwner(owner2);
+        Product update = TestUtil.createProduct("p1", "updated product", owner1);
+
+        when(this.mockProductCurator.lookupById(eq(owner1), eq(product.getId()))).thenReturn(product);
+
+        Product output = this.productManager.updateProduct(update, owner1, true);
+
+        assertTrue(output != product);
+        assertTrue(output.getOwners().contains(owner1));
+        assertFalse(output.getOwners().contains(owner2));
+        assertFalse(product.getOwners().contains(owner1));
+        assertTrue(product.getOwners().contains(owner2));
+
+        verify(this.mockEntCertGenerator, times(1))
+            .regenerateCertificatesOf(eq(Arrays.asList(owner1)), eq(Arrays.asList(output)), anyBoolean());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testUpdateProductThatDoesntExist() {
+        Owner owner = TestUtil.createOwner("test-owner", "Test Owner");
+        Product product = TestUtil.createProduct("p1", "prod1", owner);
+
+        this.productManager.updateProduct(product, owner, false);
+    }
+
+    @Test
+    public void testRemoveProduct() {
+        Owner owner = TestUtil.createOwner("test-owner-1", "Test Owner 1");
+        Product product = TestUtil.createProduct("p1", "prod1", owner);
+
+        when(this.mockProductCurator.lookupById(eq(owner), eq(product.getId()))).thenReturn(product);
+
+        this.productManager.removeProduct(product, owner);
+
+        assertFalse(product.getOwners().contains(owner));
+
+        verify(this.mockProductCurator, times(1)).delete(eq(product));
+        verifyZeroInteractions(this.mockEntCertGenerator);
+    }
+
+    @Test
+    public void testRemoveProductDivergeFromExisting() {
+        Owner owner1 = TestUtil.createOwner("test-owner-1", "Test Owner 1");
+        Owner owner2 = TestUtil.createOwner("test-owner-2", "Test Owner 2");
+        Product product = TestUtil.createProduct("p1", "prod1", owner1);
+        product.addOwner(owner2);
+
+        when(this.mockProductCurator.lookupById(eq(owner1), eq(product.getId()))).thenReturn(product);
+
+        this.productManager.removeProduct(product, owner1);
+
+        assertFalse(product.getOwners().contains(owner1));
+        assertTrue(product.getOwners().contains(owner2));
+
+        verify(this.mockProductCurator, never()).delete(eq(product));
+        verifyZeroInteractions(this.mockEntCertGenerator);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testRemoveProductThatDoesntExist() {
+        Owner owner = TestUtil.createOwner("test-owner", "Test Owner");
+        Product product = TestUtil.createProduct("p1", "prod1", owner);
+
+        this.productManager.removeProduct(product, owner);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testRemoveProductWithSubscriptions() {
+        Owner owner = TestUtil.createOwner("test-owner", "Test Owner");
+        Product product = TestUtil.createProduct("p1", "prod1", owner);
+
+        when(this.mockProductCurator.productHasSubscriptions(eq(product), eq(owner))).thenReturn(true);
+
+        this.productManager.removeProduct(product, owner);
+    }
+
+    @Test
+    public void testRemoveProductContent() {
+        Owner owner = TestUtil.createOwner("test-owner", "Test Owner");
+        Product product = TestUtil.createProduct("p1", "prod1", owner);
+        Content content = TestUtil.createContent(owner, "c1");
+        product.addContent(content);
+
+        when(this.mockProductCurator.lookupById(eq(owner), eq(product.getId()))).thenReturn(product);
+
+        Product output = this.productManager.removeProductContent(
+            product, Arrays.asList(content), owner, false
+        );
+
+        assertFalse(output.hasContent(content.getId()));
+
+        verifyZeroInteractions(this.mockEntCertGenerator);
+    }
+
+    @Test
+    public void testRemoveProductContentWithCertRegeneration() {
+        Owner owner = TestUtil.createOwner("test-owner", "Test Owner");
+        Product product = TestUtil.createProduct("p1", "prod1", owner);
+        Content content = TestUtil.createContent(owner, "c1");
+        product.addContent(content);
+
+        when(this.mockProductCurator.lookupById(eq(owner), eq(product.getId()))).thenReturn(product);
+
+        Product output = this.productManager.removeProductContent(
+            product, Arrays.asList(content), owner, true
+        );
+
+        assertFalse(output.hasContent(content.getId()));
+
+        verify(this.mockEntCertGenerator, times(1))
+            .regenerateCertificatesOf(eq(Arrays.asList(output)), anyBoolean());
+    }
+
+    @Test
+    public void testRemoveContentFromSharedProduct() {
+        Owner owner1 = TestUtil.createOwner("test-owner-1", "Test Owner 1");
+        Owner owner2 = TestUtil.createOwner("test-owner-2", "Test Owner 2");
+        Product product = TestUtil.createProduct("p1", "prod1", owner1);
+        product.addOwner(owner2);
+
+        Content content = TestUtil.createContent(owner1, "c1");
+        content.addOwner(owner2);
+        product.addContent(content);
+
+        when(this.mockProductCurator.lookupById(eq(owner1), eq(product.getId()))).thenReturn(product);
+
+        Product output = this.productManager.removeProductContent(
+            product, Arrays.asList(content), owner1, false
+        );
+
+        assertNotEquals(product, output);
+        assertFalse(output.hasContent(content.getId()));
+        assertTrue(product.hasContent(content.getId()));
+
+        assertFalse(product.getOwners().contains(owner1));
+        assertTrue(product.getOwners().contains(owner2));
+        assertTrue(output.getOwners().contains(owner1));
+        assertFalse(output.getOwners().contains(owner2));
+
+        verifyZeroInteractions(this.mockEntCertGenerator);
+    }
+
+    @Test
+    public void testRemoveContentFromSharedProductWithCertRegeneration() {
+        Owner owner1 = TestUtil.createOwner("test-owner-1", "Test Owner 1");
+        Owner owner2 = TestUtil.createOwner("test-owner-2", "Test Owner 2");
+        Product product = TestUtil.createProduct("p1", "prod1", owner1);
+        product.addOwner(owner2);
+
+        Content content = TestUtil.createContent(owner1, "c1");
+        content.addOwner(owner2);
+        product.addContent(content);
+
+        when(this.mockProductCurator.lookupById(eq(owner1), eq(product.getId()))).thenReturn(product);
+
+        Product output = this.productManager.removeProductContent(
+            product, Arrays.asList(content), owner1, true
+        );
+
+        assertNotEquals(product, output);
+        assertFalse(output.hasContent(content.getId()));
+        assertTrue(product.hasContent(content.getId()));
+
+        assertFalse(product.getOwners().contains(owner1));
+        assertTrue(product.getOwners().contains(owner2));
+        assertTrue(output.getOwners().contains(owner1));
+        assertFalse(output.getOwners().contains(owner2));
+
+        verify(this.mockEntCertGenerator, times(1))
+            .regenerateCertificatesOf(eq(Arrays.asList(owner1)), eq(Arrays.asList(output)), anyBoolean());
+    }
+
+    @Test
+    public void testRemoveContentFromProductForBadOwner() {
+        Owner owner = TestUtil.createOwner("test-owner", "Test Owner");
+        Owner owner2 = TestUtil.createOwner("test-owner-2", "Test Owner");
+        Product product = TestUtil.createProduct("p1", "prod1", owner);
+        Content content = TestUtil.createContent(owner, "c1");
+        product.addContent(content);
+
+        Product output = this.productManager.removeProductContent(
+            product, Arrays.asList(content), owner2, false
+        );
+
+        assertTrue(output == product);
+        assertTrue(product.hasContent(content.getId()));
+    }
+}

--- a/server/src/test/java/org/candlepin/model/ContentCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ContentCuratorTest.java
@@ -43,10 +43,10 @@ public class ContentCuratorTest extends DatabaseTestFixture {
         ownerCurator.create(owner);
 
         updates = new Content(
-            this.owner,
-            "Test Content 1", "100",
-            "test-content-label-1", "yum-1", "test-vendor-1",
-            "test-content-url-1", "test-gpg-url-1", "test-arch1,test-arch2");
+            this.owner, "Test Content 1", "100", "test-content-label-1", "yum-1", "test-vendor-1",
+            "test-content-url-1", "test-gpg-url-1", "test-arch1,test-arch2"
+        );
+
         updates.setRequiredTags("required-tags");
         updates.setReleaseVer("releaseVer");
         updates.setMetadataExpire(new Long(1));
@@ -56,14 +56,14 @@ public class ContentCuratorTest extends DatabaseTestFixture {
     @Test
     public void shouldUpdateContentWithNewValues() {
         Content toBeUpdated = new Content(
-            this.owner,
-            "Test Content", updates.getId(),
-            "test-content-label", "yum", "test-vendor",
-            "test-content-url", "test-gpg-url", "test-arch1");
-        contentCurator.createContent(toBeUpdated, owner);
+            this.owner, "Test Content", updates.getId(), "test-content-label", "yum", "test-vendor",
+            "test-content-url", "test-gpg-url", "test-arch1"
+        );
+
+        contentCurator.create(toBeUpdated);
 
         updates.setUuid(toBeUpdated.getUuid());
-        toBeUpdated = contentCurator.updateContent(updates, owner);
+        toBeUpdated = contentCurator.merge(updates);
 
         assertEquals(toBeUpdated.getName(), updates.getName());
         assertEquals(toBeUpdated.getLabel(), updates.getLabel());
@@ -75,18 +75,5 @@ public class ContentCuratorTest extends DatabaseTestFixture {
         assertEquals(toBeUpdated.getMetadataExpire(), updates.getMetadataExpire());
         assertEquals(toBeUpdated.getModifiedProductIds(), updates.getModifiedProductIds());
         assertEquals(toBeUpdated.getArches(), updates.getArches());
-    }
-
-    @Test
-    public void importSameContentForMultipleProducts() {
-        // TODO: This test may not have any value now since we no longer have a createOrUpdate
-        // method that needs to work on the same content twice.
-
-        Content c1 = new Content(owner, "mycontent", "5006", "mycontent", "yum",
-            "vendor", "nobodycares", "nobodystillcares", "x86_64");
-        Content c2 = new Content(owner, "mycontent", "5006", "mycontent", "yum",
-            "vendor", "nobodycares", "nobodystillcares", "x86_64");
-        contentCurator.createContent(c1, owner);
-        contentCurator.updateContent(c2, owner);
     }
 }

--- a/server/src/test/java/org/candlepin/model/ContentTest.java
+++ b/server/src/test/java/org/candlepin/model/ContentTest.java
@@ -98,7 +98,7 @@ public class ContentTest extends DatabaseTestFixture {
 
         modifiedContent.setUuid(content.getUuid());
 
-        contentCurator.updateContent(modifiedContent, owner);
+        contentCurator.merge(modifiedContent);
 
         content = contentCurator.lookupById(owner, "100");
         assertEquals(newLabel, content.getLabel());

--- a/server/src/test/java/org/candlepin/model/PoolCuratorFilterTest.java
+++ b/server/src/test/java/org/candlepin/model/PoolCuratorFilterTest.java
@@ -24,6 +24,7 @@ import org.candlepin.test.TestUtil;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Collection;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -101,7 +102,7 @@ public class PoolCuratorFilterTest extends DatabaseTestFixture {
 
     private void searchTest(PoolFilterBuilder filters, int expectedResults, String ... expectedIds) {
         Page<List<Pool>> page = poolCurator.listAvailableEntitlementPools(
-            null, owner, null, null, null, false, filters, req, false
+            null, owner, (Collection<String>) null, null, null, false, filters, req, false
         );
         List<Pool> results = page.getPageData();
 

--- a/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
@@ -39,6 +39,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
+import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -92,7 +93,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         poolCurator.create(pool);
 
         List<Pool> results = poolCurator.listAvailableEntitlementPools(
-            consumer, consumer.getOwner(), null, TestUtil.createDate(20450, 3, 2), true);
+            consumer, consumer.getOwner(), (Collection<String>) null, TestUtil.createDate(20450, 3, 2), true);
         assertEquals(0, results.size());
     }
 
@@ -103,7 +104,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         poolCurator.create(pool);
 
         List<Pool> results = poolCurator.listAvailableEntitlementPools(
-            consumer, consumer.getOwner(), null, TestUtil.createDate(2005, 3, 3), true);
+            consumer, consumer.getOwner(), (Collection<String>) null, TestUtil.createDate(2005, 3, 3), true);
         assertEquals(0, results.size());
 
         // If we specify no date filtering, the expired pool should be returned:
@@ -122,7 +123,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         ueberCertGenerator.generate(owner, new NoAuthPrincipal());
 
         List<Pool> results = poolCurator.listAvailableEntitlementPools(
-            consumer, consumer.getOwner(), null, null, true);
+            consumer, consumer.getOwner(), (Collection<String>) null, null, true);
         assertEquals(1, results.size());
     }
 
@@ -152,7 +153,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         filters.addAttributeFilter("cores", "8");
 
         Page<List<Pool>> page = poolCurator.listAvailableEntitlementPools(
-            null, owner, null, null, activeDate, false, filters,
+            null, owner, (Collection<String>) null, null, activeDate, false, filters,
             req, false);
         List<Pool> results = page.getPageData();
         assertEquals(1, results.size());
@@ -182,7 +183,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         filters.addAttributeFilter("virt_only", "true");
 
         Page<List<Pool>> page = poolCurator.listAvailableEntitlementPools(
-            null, owner, null, null, activeDate, false, filters,
+            null, owner, (Collection<String>) null, null, activeDate, false, filters,
             req, false);
         List<Pool> results = page.getPageData();
         assertEquals(1, results.size());
@@ -211,8 +212,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         filters.addIdFilter(pool2.getId());
 
         Page<List<Pool>> page = poolCurator.listAvailableEntitlementPools(
-            null, owner, null, null, activeDate, false, filters,
-            req, false);
+            null, owner, (Collection<String>) null, null, activeDate, false, filters, req, false);
         List<Pool> results = page.getPageData();
         assertEquals(1, results.size());
         assertEquals(pool2.getId(), results.get(0).getId());
@@ -222,8 +222,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         filters.addIdFilter(pool2.getId());
 
         page = poolCurator.listAvailableEntitlementPools(
-            null, owner, null, null, activeDate, false, filters,
-            req, false);
+            null, owner, (Collection<String>) null, null, activeDate, false, filters, req, false);
         results = page.getPageData();
         assertEquals(2, results.size());
     }
@@ -250,8 +249,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         filters.addAttributeFilter("virt_only", "true");
 
         Page<List<Pool>> page = poolCurator.listAvailableEntitlementPools(
-            null, owner, null, null, activeDate, false, filters,
-            null, false);
+            null, owner, (Collection<String>) null, null, activeDate, false, filters, null, false);
         List<Pool> results = page.getPageData();
 
         assertEquals(1, results.size());
@@ -287,8 +285,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         filters.addAttributeFilter("cores", "4");
 
         Page<List<Pool>> page = poolCurator.listAvailableEntitlementPools(
-            null, owner, null, null, activeDate, false, filters,
-            req, false);
+            null, owner, (Collection<String>) null, null, activeDate, false, filters, req, false);
         List<Pool> results = page.getPageData();
         assertEquals(1, results.size());
         assertEquals(pool2.getId(), results.get(0).getId());
@@ -320,8 +317,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         filters.addAttributeFilter("empty-attr", "");
 
         Page<List<Pool>> page = poolCurator.listAvailableEntitlementPools(
-            null, owner, null, null, activeDate, false, filters,
-            req, false);
+            null, owner, (Collection<String>) null, null, activeDate, false, filters, req, false);
         List<Pool> results = page.getPageData();
         assertEquals(1, results.size());
         assertEquals(pool2.getId(), results.get(0).getId());
@@ -350,8 +346,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         filters.addAttributeFilter("A", "FOO");
 
         Page<List<Pool>> page = poolCurator.listAvailableEntitlementPools(
-            null, owner, null, null, activeDate, false, filters,
-            req, false);
+            null, owner, (Collection<String>) null, null, activeDate, false, filters, req, false);
         List<Pool> results = page.getPageData();
         assertEquals(1, results.size());
         assertEquals(pool, results.get(0));
@@ -415,8 +410,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         filters.addAttributeFilter("B", "zoo");
 
         Page<List<Pool>> page = poolCurator.listAvailableEntitlementPools(
-            null, owner, null, null, activeDate, false, filters,
-            req, false);
+            null, owner, (Collection<String>) null, null, activeDate, false, filters, req, false);
         List<Pool> results = page.getPageData();
         assertEquals(2, results.size());
 
@@ -820,7 +814,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         pool.setStartDate(activeOn);
         poolCurator.create(pool);
 
-        assertEquals(1, poolCurator.listAvailableEntitlementPools(null, owner, null,
+        assertEquals(1, poolCurator.listAvailableEntitlementPools(null, owner, (Collection<String>) null,
             activeOn, false).size());
     }
 
@@ -832,7 +826,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         pool.setEndDate(activeOn);
         poolCurator.create(pool);
 
-        assertEquals(1, poolCurator.listAvailableEntitlementPools(null, owner, null,
+        assertEquals(1, poolCurator.listAvailableEntitlementPools(null, owner, (Collection<String>) null,
             activeOn, false).size());
     }
 
@@ -845,7 +839,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         pool.setEndDate(TestUtil.createDate(2011, 3, 2));
         poolCurator.create(pool);
 
-        assertEquals(1, poolCurator.listAvailableEntitlementPools(null, owner, null,
+        assertEquals(1, poolCurator.listAvailableEntitlementPools(null, owner, (Collection<String>) null,
             activeOn, false).size());
     }
 
@@ -1326,8 +1320,8 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         this.poolCurator.create(p1);
         this.poolCurator.create(p2);
 
-        Page<List<Pool>> result = this.poolCurator.listAvailableEntitlementPools(null, owner1, null,
-            "subscriptionId-phil", new Date(), false, null, null, false);
+        Page<List<Pool>> result = this.poolCurator.listAvailableEntitlementPools(null, owner1,
+            (Collection<String>) null, "subscriptionId-phil", new Date(), false, null, null, false);
         assertEquals("subscriptionId-phil", result.getPageData().get(0).getSubscriptionId());
     }
 

--- a/server/src/test/java/org/candlepin/model/PoolTest.java
+++ b/server/src/test/java/org/candlepin/model/PoolTest.java
@@ -112,27 +112,27 @@ public class PoolTest extends DatabaseTestFixture {
 
         Pool lookedUp = entityManager().find(Pool.class, p.getId());
         assertEquals(1, lookedUp.getProvidedProducts().size());
-        assertEquals(prod2.getId(),
-            lookedUp.getProvidedProducts().iterator().next().getId());
+        assertEquals(prod2.getId(), lookedUp.getProvidedProducts().iterator().next().getId());
         assertEquals(1, lookedUp.getDerivedProvidedProducts().size());
-        assertEquals(derivedProd.getId(),
-            lookedUp.getDerivedProvidedProducts().iterator().next().getId());
+        assertEquals(derivedProd.getId(), lookedUp.getDerivedProvidedProducts().iterator().next().getId());
     }
 
     @Test
     public void testMultiplePoolsForOwnerProductAllowed() {
-        Pool duplicatePool = createPool(owner,
-            prod1, -1L, TestUtil.createDate(2009, 11, 30),
-            TestUtil.createDate(2050, 11, 30));
+        Pool duplicatePool = createPool(
+            owner, prod1, -1L, TestUtil.createDate(2009, 11, 30), TestUtil.createDate(2050, 11, 30)
+        );
+
         // Just need to see no exception is thrown.
         poolCurator.create(duplicatePool);
     }
 
     @Test
     public void testIsOverflowing() {
-        Pool duplicatePool = createPool(owner,
-            prod1, -1L, TestUtil.createDate(2009, 11, 30),
-            TestUtil.createDate(2050, 11, 30));
+        Pool duplicatePool = createPool(
+            owner, prod1, -1L, TestUtil.createDate(2009, 11, 30), TestUtil.createDate(2050, 11, 30)
+        );
+
         assertFalse(duplicatePool.isOverflowing());
     }
 
@@ -140,9 +140,11 @@ public class PoolTest extends DatabaseTestFixture {
     public void testUnlimitedPool() {
         Product newProduct = TestUtil.createProduct(owner);
         productCurator.create(newProduct);
-        Pool unlimitedPool = createPool(owner, newProduct,
-            -1L, TestUtil.createDate(2009, 11, 30),
-            TestUtil.createDate(2050, 11, 30));
+
+        Pool unlimitedPool = createPool(
+            owner, newProduct, -1L, TestUtil.createDate(2009, 11, 30), TestUtil.createDate(2050, 11, 30)
+        );
+
         poolCurator.create(unlimitedPool);
         assertTrue(unlimitedPool.entitlementsAvailable(1));
     }
@@ -153,9 +155,9 @@ public class PoolTest extends DatabaseTestFixture {
         Product newProduct = TestUtil.createProduct(owner);
 
         productCurator.create(newProduct);
-        Pool consumerPool = createPool(owner, newProduct,
-            numAvailEntitlements, TestUtil.createDate(2009, 11, 30),
-            TestUtil.createDate(2050, 11, 30));
+        Pool consumerPool = createPool(owner, newProduct, numAvailEntitlements,
+            TestUtil.createDate(2009, 11, 30), TestUtil.createDate(2050, 11, 30));
+
         consumerPool = poolCurator.create(consumerPool);
 
         Map<String, Integer> pQs = new HashMap<String, Integer>();
@@ -223,11 +225,12 @@ public class PoolTest extends DatabaseTestFixture {
     public void testCreationTimestamp() {
         Product newProduct = TestUtil.createProduct(owner);
         productCurator.create(newProduct);
-        Pool pool = createPool(owner, newProduct, 1L,
-            TestUtil.createDate(2011, 3, 30),
-            TestUtil.createDate(2022, 11, 29));
-        poolCurator.create(pool);
 
+        Pool pool = createPool(
+            owner, newProduct, 1L, TestUtil.createDate(2011, 3, 30), TestUtil.createDate(2022, 11, 29)
+        );
+
+        poolCurator.create(pool);
         assertNotNull(pool.getCreated());
     }
 
@@ -235,11 +238,11 @@ public class PoolTest extends DatabaseTestFixture {
     public void testInitialUpdateTimestamp() {
         Product newProduct = TestUtil.createProduct(owner);
         productCurator.create(newProduct);
-        Pool pool = createPool(owner, newProduct, 1L,
-            TestUtil.createDate(2011, 3, 30),
-            TestUtil.createDate(2022, 11, 29));
-        pool = poolCurator.create(pool);
+        Pool pool = createPool(
+            owner, newProduct, 1L, TestUtil.createDate(2011, 3, 30), TestUtil.createDate(2022, 11, 29)
+        );
 
+        pool = poolCurator.create(pool);
         assertNotNull(pool.getUpdated());
     }
 
@@ -251,9 +254,9 @@ public class PoolTest extends DatabaseTestFixture {
     public void testSubsequentUpdateTimestamp() {
         Product newProduct = TestUtil.createProduct(owner);
         productCurator.create(newProduct);
-        Pool pool = createPool(owner, newProduct, 1L,
-            TestUtil.createDate(2011, 3, 30),
-            TestUtil.createDate(2022, 11, 29));
+        Pool pool = createPool(
+            owner, newProduct, 1L, TestUtil.createDate(2011, 3, 30), TestUtil.createDate(2022, 11, 29)
+        );
 
         pool = poolCurator.create(pool);
 

--- a/server/src/test/java/org/candlepin/model/ProductCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ProductCuratorTest.java
@@ -32,7 +32,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Calendar;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -80,19 +79,19 @@ public class ProductCuratorTest extends DatabaseTestFixture {
         ownerCurator.create(owner);
 
         product = TestUtil.createProduct(owner);
-        productCurator.createProduct(product, owner);
+        productCurator.create(product);
 
         providedProduct = TestUtil.createProduct(owner);
-        productCurator.createProduct(providedProduct, owner);
+        productCurator.create(providedProduct);
 
         Set<Product> providedProducts = new HashSet<Product>();
         providedProducts.add(providedProduct);
 
         derivedProduct = TestUtil.createProduct(owner);
-        productCurator.createProduct(derivedProduct, owner);
+        productCurator.create(derivedProduct);
 
         derivedProvidedProduct = TestUtil.createProduct(owner);
-        productCurator.createProduct(derivedProvidedProduct, owner);
+        productCurator.create(derivedProvidedProduct);
 
         Set<Product> derivedProvidedProducts = new HashSet<Product>();
         derivedProvidedProducts.add(derivedProvidedProduct);
@@ -119,7 +118,7 @@ public class ProductCuratorTest extends DatabaseTestFixture {
     public void normalCreate() {
 
         Product prod = new Product("cptest-label", "My Product", owner);
-        productCurator.createProduct(prod, owner);
+        productCurator.create(prod);
 
         List<Product> results = entityManager().createQuery(
             "select p from Product as p").getResultList();
@@ -130,7 +129,7 @@ public class ProductCuratorTest extends DatabaseTestFixture {
     public void nameRequired() {
 
         Product prod = new Product("someproductlabel", null, owner);
-        productCurator.createProduct(prod, owner);
+        productCurator.create(prod);
 
     }
 
@@ -138,30 +137,20 @@ public class ProductCuratorTest extends DatabaseTestFixture {
     public void labelRequired() {
 
         Product prod = new Product(null, "My Product Name", owner);
-        productCurator.createProduct(prod, owner);
+        productCurator.create(prod);
     }
 
     @Test
     public void nameNonUnique() {
 
         Product prod = new Product("label1", "name", owner);
-        productCurator.createProduct(prod, owner);
+        productCurator.create(prod);
 
         Product prod2 = new Product("label2", "name", owner);
-        productCurator.createProduct(prod2, owner);
+        productCurator.create(prod2);
 
         assertEquals(prod.getName(), prod2.getName());
         assertFalse(prod.getUuid().equals(prod2.getUuid()));
-    }
-
-    @Test(expected = IllegalStateException.class)
-    public void redhatIDsAreUnique() {
-
-        Product prod = new Product("label1", "name", owner);
-        Product prod2 = new Product("label1", "name2", owner);
-        productCurator.createProduct(prod, owner);
-
-        productCurator.createProduct(prod2, owner);
     }
 
     @Test
@@ -185,7 +174,7 @@ public class ProductCuratorTest extends DatabaseTestFixture {
         Product prod = new Product("cptest-label", "My Product", owner);
         ProductAttribute a = new ProductAttribute("content_sets", jsonData);
         prod.addAttribute(a);
-        productCurator.createProduct(prod, owner);
+        productCurator.create(prod);
         attributeCurator.create(a);
 
         Product lookedUp = productCurator.find(prod.getUuid());
@@ -217,7 +206,7 @@ public class ProductCuratorTest extends DatabaseTestFixture {
         Product prod = new Product("cptest-label", "My Product", owner);
         ProductAttribute a = new ProductAttribute("content_sets", jsonData);
         prod.addAttribute(a);
-        productCurator.createProduct(prod, owner);
+        productCurator.create(prod);
         attributeCurator.create(a);
 
         Product lookedUp = productCurator.find(prod.getUuid());
@@ -239,7 +228,7 @@ public class ProductCuratorTest extends DatabaseTestFixture {
     @Test
     public void testCreationDate() {
         Product prod = new Product("test-label", "test-product-name", owner);
-        productCurator.createProduct(prod, owner);
+        productCurator.create(prod);
 
         assertNotNull(prod.getCreated());
     }
@@ -247,7 +236,7 @@ public class ProductCuratorTest extends DatabaseTestFixture {
     @Test
     public void testInitialUpdate() {
         Product prod = new Product("test-label", "test-product-name", owner);
-        productCurator.createProduct(prod, owner);
+        productCurator.create(prod);
 
         assertNotNull(prod.getUpdated());
     }
@@ -258,7 +247,7 @@ public class ProductCuratorTest extends DatabaseTestFixture {
         HashSet<String> dependentProductIds = new HashSet<String>();
         dependentProductIds.add("ProductX");
         prod.setDependentProductIds(dependentProductIds);
-        productCurator.createProduct(prod, owner);
+        productCurator.create(prod);
 
         Product lookedUp = productCurator.find(prod.getUuid());
         assertThat(lookedUp.getDependentProductIds(), hasItem("ProductX"));
@@ -270,7 +259,7 @@ public class ProductCuratorTest extends DatabaseTestFixture {
     @Test
     public void testSubsequentUpdate() {
         Product prod = new Product("test-label", "test-product-name", owner);
-        productCurator.createProduct(prod, owner);
+        productCurator.create(prod);
 
         Calendar calendar = Calendar.getInstance();
         calendar.add(Calendar.MONTH, -2);
@@ -279,7 +268,7 @@ public class ProductCuratorTest extends DatabaseTestFixture {
         long updated = prod.getUpdated().getTime();
 
         prod.setName("test-changed-name");
-        prod = this.productCurator.updateProduct(prod, owner);
+        prod = this.productCurator.merge(prod);
         assertTrue(prod.getUpdated().getTime() > updated);
     }
 
@@ -287,7 +276,7 @@ public class ProductCuratorTest extends DatabaseTestFixture {
     @Test
     public void testProductFullConstructor() {
         Product prod = new Product("cp_test-label", "variant", owner, "version", "arch", "", "SVC");
-        productCurator.createProduct(prod, owner);
+        productCurator.create(prod);
 
         productCurator.find(prod.getUuid());
     }
@@ -335,9 +324,9 @@ public class ProductCuratorTest extends DatabaseTestFixture {
     @Test
     public void testUpdateProduct() {
         Product original = createTestProduct();
-        productCurator.createProduct(original, owner);
-        // Will have same ID, but we'll modify other data:
-        Product modified = createTestProduct();
+        productCurator.create(original);
+
+        Product modified = productCurator.lookupById(owner, original.getId());
         String newName = "new name";
         modified.setName(newName);
 
@@ -354,7 +343,7 @@ public class ProductCuratorTest extends DatabaseTestFixture {
         modified.setAttributes(newAttributes);
 
         int initialAttrCount = attributeCurator.listAll().size();
-        productCurator.updateProduct(modified, owner);
+        productCurator.merge(modified);
 
         Product lookedUp = productCurator.lookupById(owner, original.getId());
         assertEquals(newName, lookedUp.getName());
@@ -379,14 +368,14 @@ public class ProductCuratorTest extends DatabaseTestFixture {
         original.addAttribute(new ProductAttribute("product.long_pos_count", "23"));
         original.addAttribute(new ProductAttribute("product.bool_val_str", "true"));
         original.addAttribute(new ProductAttribute("product.bool_val_num", "0"));
-        productCurator.createProduct(original, owner);
+        productCurator.create(original);
         assertTrue(original.getUuid() != null);
     }
 
     @Test
     public void testProductAttributeValidationSuccessUpdate() {
         Product original = createTestProduct();
-        productCurator.createProduct(original, owner);
+        productCurator.create(original);
         assertTrue(original.getUuid() != null);
         original.setAttribute("product.count", "134");
         original.setAttribute("product.pos_count", "333");
@@ -395,28 +384,28 @@ public class ProductCuratorTest extends DatabaseTestFixture {
         original.setAttribute("product.long_pos_count", "10");
         original.setAttribute("product.bool_val_str", "false");
         original.setAttribute("product.bool_val_num", "1");
-        productCurator.updateProduct(original, owner);
+        productCurator.merge(original);
     }
 
     @Test(expected = BadRequestException.class)
     public void testProductAttributeCreationFailBadInt() {
         Product original = createTestProduct();
         original.addAttribute(new ProductAttribute("product.count", "1.0"));
-        productCurator.createProduct(original, owner);
+        productCurator.create(original);
     }
 
     @Test
     public void testProductAttributeCreationSuccessZeroInt() {
         Product original = createTestProduct();
         original.addAttribute(new ProductAttribute("product.pos_count", "0"));
-        productCurator.createProduct(original, owner);
+        productCurator.create(original);
     }
 
     @Test(expected = BadRequestException.class)
     public void testProductAttributeCreationFailBadPosInt() {
         Product original = createTestProduct();
         original.addAttribute(new ProductAttribute("product.pos_count", "-5"));
-        productCurator.createProduct(original, owner);
+        productCurator.create(original);
     }
 
     @Test(expected = BadRequestException.class)
@@ -424,7 +413,7 @@ public class ProductCuratorTest extends DatabaseTestFixture {
         Product original = createTestProduct();
         original.addAttribute(new ProductAttribute("product.long_multiplier",
             "ZZ"));
-        productCurator.createProduct(original, owner);
+        productCurator.create(original);
     }
 
     @Test(expected = BadRequestException.class)
@@ -432,110 +421,93 @@ public class ProductCuratorTest extends DatabaseTestFixture {
         Product original = createTestProduct();
         original.addAttribute(new ProductAttribute("product.long_pos_count",
             "-1"));
-        productCurator.createProduct(original, owner);
+        productCurator.create(original);
     }
 
     @Test(expected = BadRequestException.class)
     public void testProductAttributeCreationFailBadStringBool() {
         Product original = createTestProduct();
         original.addAttribute(new ProductAttribute("product.bool_val_str", "yes"));
-        productCurator.createProduct(original, owner);
+        productCurator.create(original);
     }
 
     @Test(expected = BadRequestException.class)
     public void testProductAttributeCreationFailNumberBool() {
         Product original = createTestProduct();
         original.addAttribute(new ProductAttribute("product.bool_val_num", "2"));
-        productCurator.createProduct(original, owner);
+        productCurator.create(original);
     }
 
     @Test(expected = BadRequestException.class)
     public void testProductAttributeUpdateFailInt() {
         Product original = createTestProduct();
-        productCurator.createProduct(original, owner);
+        productCurator.create(original);
         assertTrue(original.getUuid() != null);
         original.addAttribute(new ProductAttribute("product.count", "one"));
-        productCurator.updateProduct(original, owner);
+        productCurator.merge(original);
     }
 
     @Test(expected = BadRequestException.class)
     public void testProductAttributeUpdateFailPosInt() {
         Product original = createTestProduct();
-        productCurator.createProduct(original, owner);
+        productCurator.create(original);
         assertTrue(original.getUuid() != null);
         original.addAttribute(new ProductAttribute("product.pos_count", "-44"));
-        productCurator.updateProduct(original, owner);
+        productCurator.merge(original);
     }
 
     @Test
     public void testProductAttributeUpdateSuccessZeroInt() {
         Product original = createTestProduct();
-        productCurator.createProduct(original, owner);
+        productCurator.create(original);
         assertTrue(original.getUuid() != null);
         original.addAttribute(new ProductAttribute("product.pos_count", "0"));
-        productCurator.updateProduct(original, owner);
+        productCurator.merge(original);
     }
 
     @Test(expected = BadRequestException.class)
     public void testProductAttributeUpdateFailLong() {
         Product original = createTestProduct();
-        productCurator.createProduct(original, owner);
+        productCurator.create(original);
         assertTrue(original.getUuid() != null);
         original.addAttribute(new ProductAttribute("product.long_multiplier",
             "10^23"));
-        productCurator.updateProduct(original, owner);
+        productCurator.merge(original);
     }
 
     @Test(expected = BadRequestException.class)
     public void testProductAttributeUpdateFailPosLong() {
         Product original = createTestProduct();
-        productCurator.createProduct(original, owner);
+        productCurator.create(original);
         assertTrue(original.getUuid() != null);
         original.addAttribute(new ProductAttribute("product.long_pos_count",
             "-23"));
-        productCurator.updateProduct(original, owner);
+        productCurator.merge(original);
     }
 
     @Test(expected = BadRequestException.class)
     public void testProductAttributeUpdateFailStringBool() {
         Product original = createTestProduct();
-        productCurator.createProduct(original, owner);
+        productCurator.create(original);
         assertTrue(original.getUuid() != null);
         original.addAttribute(new ProductAttribute("product.bool_val_str", "flase"));
-        productCurator.updateProduct(original, owner);
+        productCurator.merge(original);
     }
 
     @Test(expected = BadRequestException.class)
     public void testProductAttributeUpdateFailNumberBool() {
         Product original = createTestProduct();
-        productCurator.createProduct(original, owner);
+        productCurator.create(original);
         assertTrue(original.getUuid() != null);
         original.addAttribute(new ProductAttribute("product.bool_val_num", "6"));
-        productCurator.updateProduct(original, owner);
+        productCurator.merge(original);
     }
 
     @Test
     public void testSubstringConfigList() {
         Product original = createTestProduct();
         original.addAttribute(new ProductAttribute("product.pos", "-5"));
-        productCurator.createProduct(original, owner);
-    }
-
-    @Test
-    public void testRemoveProductContent() {
-        Product p = createTestProduct();
-        Content content = new Content(this.owner, "test-content", "test-content",
-            "test-content", "yum", "us", "here", "here", "test-arch");
-        p.addContent(content);
-        contentCurator.createContent(content, owner);
-        productCurator.createProduct(p, owner);
-
-        p = productCurator.find(p.getUuid());
-        assertEquals(1, p.getProductContent().size());
-
-        productCurator.removeProductContent(p, Arrays.asList(content), this.owner);
-        p = productCurator.find(p.getUuid());
-        assertEquals(0, p.getProductContent().size());
+        productCurator.create(original);
     }
 
     @Test
@@ -544,7 +516,7 @@ public class ProductCuratorTest extends DatabaseTestFixture {
         List<String> pids = new ArrayList<String>();
         for (int i = 0; i < 5; i++) {
             Product p = TestUtil.createProduct(owner);
-            productCurator.createProduct(p, owner);
+            productCurator.create(p);
             products.add(p);
             pids.add(p.getId());
         }
@@ -567,8 +539,8 @@ public class ProductCuratorTest extends DatabaseTestFixture {
         Content content = new Content(this.owner, "best-content", "best-content",
             "best-content", "yum", "us", "here", "here", "test-arch");
         p.addContent(content);
-        contentCurator.createContent(content, owner);
-        productCurator.createProduct(p, owner);
+        contentCurator.create(content);
+        productCurator.create(p);
 
         List<String> contentIds = new LinkedList<String>();
         contentIds.add(content.getId());
@@ -583,8 +555,8 @@ public class ProductCuratorTest extends DatabaseTestFixture {
         Content content = new Content(this.owner, "best-content", "best-content",
             "best-content", "yum", "us", "here", "here", "test-arch");
         p.addContent(content);
-        contentCurator.createContent(content, owner);
-        productCurator.createProduct(p, owner);
+        contentCurator.create(content);
+        productCurator.create(p);
 
         List<String> contentUuids = new LinkedList<String>();
         contentUuids.add(content.getUuid());
@@ -616,7 +588,7 @@ public class ProductCuratorTest extends DatabaseTestFixture {
     @Test
     public void ensureDoesNotHaveSubscription() {
         Product doesNotHave = TestUtil.createProduct(owner);
-        productCurator.createProduct(doesNotHave, owner);
+        productCurator.create(doesNotHave);
         assertFalse(productCurator.productHasSubscriptions(doesNotHave, owner));
     }
 
@@ -628,8 +600,8 @@ public class ProductCuratorTest extends DatabaseTestFixture {
         );
 
         p.addContent(content);
-        contentCurator.createContent(content, this.owner);
-        productCurator.createProduct(p, this.owner);
+        contentCurator.create(content);
+        productCurator.create(p);
 
         // Technically the same product:
         Product p2 = createTestProduct();
@@ -643,7 +615,7 @@ public class ProductCuratorTest extends DatabaseTestFixture {
         contentUpdate.setUuid(content.getUuid());
 
         p2.addContent(contentUpdate);
-        productCurator.updateProduct(p2, this.owner);
+        productCurator.merge(p2);
 
         Product result = productCurator.find(p.getUuid());
         assertEquals(1, result.getProductContent().size());

--- a/server/src/test/java/org/candlepin/policy/CriteriaRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/CriteriaRulesTest.java
@@ -34,6 +34,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 
@@ -74,7 +75,7 @@ public class CriteriaRulesTest extends DatabaseTestFixture {
         poolCurator.merge(virtPool);
 
         List<Pool> results = poolCurator.listAvailableEntitlementPools(consumer, null,
-            null, null, false);
+            (Collection<String>) null, null, false);
 
         assertEquals(1, results.size());
         assertEquals(physicalPool.getId(), results.get(0).getId());
@@ -82,7 +83,7 @@ public class CriteriaRulesTest extends DatabaseTestFixture {
         // Make the consumer a guest and try again:
         consumer.setFact("virt.is_guest", "true");
         results = poolCurator.listAvailableEntitlementPools(consumer, null,
-            null, null, false);
+            (Collection<String>) null, null, false);
 
         assertEquals(2, results.size());
 
@@ -102,13 +103,13 @@ public class CriteriaRulesTest extends DatabaseTestFixture {
             new Date());
 
         List<Pool> results = poolCurator.listAvailableEntitlementPools(consumer, null,
-            null, null, false);
+            (Collection<String>) null, null, false);
 
         assertEquals(0, results.size());
         // Make the consumer a guest and try again:
         consumer.setFact("virt.is_guest", "true");
         results = poolCurator.listAvailableEntitlementPools(consumer, null,
-            null, null, false);
+            (Collection<String>) null, null, false);
 
         assertEquals(2, results.size());
     }
@@ -139,7 +140,7 @@ public class CriteriaRulesTest extends DatabaseTestFixture {
         poolCurator.merge(anotherVirtPool);
 
         List<Pool> results = poolCurator.listAvailableEntitlementPools(consumer, null,
-            null, null, false);
+            (Collection<String>) null, null, false);
 
         assertEquals(0, results.size());
 
@@ -149,7 +150,7 @@ public class CriteriaRulesTest extends DatabaseTestFixture {
         consumerCurator.update(consumer);
         assertEquals(host.getUuid(), consumerCurator.getHost("GUESTUUID", owner).getUuid());
         results = poolCurator.listAvailableEntitlementPools(consumer, null,
-            null, null, false);
+            (Collection<String>) null, null, false);
 
         assertEquals(1, results.size());
         assertEquals(virtPool.getId(), results.get(0).getId());
@@ -176,8 +177,8 @@ public class CriteriaRulesTest extends DatabaseTestFixture {
         virtPool.setAttribute("requires_host", host.getUuid());
         poolCurator.merge(virtPool);
 
-        List<Pool> results = poolCurator.listAvailableEntitlementPools(
-            c, null, null, null, false);
+        List<Pool> results = poolCurator.listAvailableEntitlementPools(c, null, (Collection<String>) null,
+            null, false);
         assertEquals(0, results.size());
     }
 
@@ -201,8 +202,8 @@ public class CriteriaRulesTest extends DatabaseTestFixture {
         virtPool.setAttribute("virt_only", "true");
         poolCurator.merge(virtPool);
 
-        List<Pool> results = poolCurator.listAvailableEntitlementPools(
-            c, null, null, null, false);
+        List<Pool> results = poolCurator.listAvailableEntitlementPools(c, null, (Collection<String>) null,
+            null, false);
         assertEquals(1, results.size());
     }
 }

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
@@ -122,12 +122,9 @@ public class ConsumerResourceTest {
     @Before
     public void setUp() {
         i18n = I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK);
-        when(eventBuilder.setOldEntity(any(Consumer.class)))
-            .thenReturn(eventBuilder);
-        when(eventBuilder.setNewEntity(any(Consumer.class)))
-            .thenReturn(eventBuilder);
-        when(eventFactory.getEventBuilder(any(Target.class), any(Type.class)))
-            .thenReturn(eventBuilder);
+        when(eventBuilder.setOldEntity(any(Consumer.class))).thenReturn(eventBuilder);
+        when(eventBuilder.setNewEntity(any(Consumer.class))).thenReturn(eventBuilder);
+        when(eventFactory.getEventBuilder(any(Target.class), any(Type.class))).thenReturn(eventBuilder);
     }
 
     @Test
@@ -135,19 +132,15 @@ public class ConsumerResourceTest {
         Consumer consumer = createConsumer();
         List<EntitlementCertificate> certificates = createEntitlementCertificates();
 
-        when(mockedEntitlementCertServiceAdapter.listForConsumer(consumer))
-            .thenReturn(certificates);
-        when(mockedConsumerCurator.verifyAndLookupConsumer(consumer.getUuid())).thenReturn(
-            consumer);
-        when(mockedEntitlementCurator.listByConsumer(consumer)).thenReturn(
-            new ArrayList<Entitlement>());
+        when(mockedEntitlementCertServiceAdapter.listForConsumer(consumer)) .thenReturn(certificates);
+        when(mockedConsumerCurator.verifyAndLookupConsumer(consumer.getUuid())).thenReturn(consumer);
+        when(mockedEntitlementCurator.listByConsumer(consumer)).thenReturn(new ArrayList<Entitlement>());
 
         ConsumerResource consumerResource = new ConsumerResource(
             mockedConsumerCurator, null, null, null, mockedEntitlementCurator, null,
-            mockedEntitlementCertServiceAdapter, null, null, null, null, null,
-            null, null, mockedPoolManager, null, null, null, null, null,
-            null, null, null, new CandlepinCommonTestConfig(), null, null, null,
-            consumerBindUtil);
+            mockedEntitlementCertServiceAdapter, null, null, null, null, null, null, null,
+            mockedPoolManager, null, null, null, null, null, null, null, null,
+            new CandlepinCommonTestConfig(), null, null, null, consumerBindUtil);
 
         List<CertificateSerialDto> serials = consumerResource
             .getEntitlementCertificateSerials(consumer.getUuid());
@@ -165,28 +158,24 @@ public class ConsumerResourceTest {
         when(e.getPool()).thenReturn(p);
         when(p.getSubscriptionId()).thenReturn("4444");
 
-        when(mockedConsumerCurator.verifyAndLookupConsumer(consumer.getUuid())).thenReturn(
-            consumer);
+        when(mockedConsumerCurator.verifyAndLookupConsumer(consumer.getUuid())).thenReturn(consumer);
         when(mockedEntitlementCurator.find(eq("9999"))).thenReturn(e);
         when(mockedSubscriptionServiceAdapter.getSubscription(eq("4444"))).thenReturn(s);
-        when(mockedEntitlementCertServiceAdapter.generateEntitlementCert(
-            any(Entitlement.class), any(Product.class)))
-            .thenThrow(new IOException());
+        when(mockedEntitlementCertServiceAdapter.generateEntitlementCert(any(Entitlement.class),
+            any(Product.class))).thenThrow(new IOException());
 
-        CandlepinPoolManager poolManager = new CandlepinPoolManager(null,
-            null, mockedEntitlementCertServiceAdapter, null, null,
-            new CandlepinCommonTestConfig(), null, null,
-            mockedEntitlementCurator, mockedConsumerCurator, null, null, null,
-            mockedActivationKeyRules, null, null, null, null, null);
+        CandlepinPoolManager poolManager = new CandlepinPoolManager(
+            null, null, null, new CandlepinCommonTestConfig(), null, null, mockedEntitlementCurator,
+            mockedConsumerCurator, null, null, null, null, mockedActivationKeyRules, null, null,
+            null, null, null, null, null
+        );
 
-        ConsumerResource consumerResource = new ConsumerResource(
-            mockedConsumerCurator, null, null, null, mockedEntitlementCurator, null,
-            mockedEntitlementCertServiceAdapter, null, null, null, null, null, null,
-            null, poolManager, null, null, null, null, null, null, null, null,
-            new CandlepinCommonTestConfig(), null, null, null, consumerBindUtil);
+        ConsumerResource consumerResource = new ConsumerResource(mockedConsumerCurator, null, null,
+            null, mockedEntitlementCurator, null, mockedEntitlementCertServiceAdapter, null, null,
+            null, null, null, null, null, poolManager, null, null, null, null, null, null, null,
+            null, new CandlepinCommonTestConfig(), null, null, null, consumerBindUtil);
 
-        consumerResource.regenerateEntitlementCertificates(consumer.getUuid(), "9999",
-            false);
+        consumerResource.regenerateEntitlementCertificates(consumer.getUuid(), "9999", false);
     }
 
     private void verifyCertificateSerialNumbers(
@@ -211,17 +200,16 @@ public class ConsumerResourceTest {
     public void testRegenerateEntitlementCertificateWithValidConsumer() {
         Consumer consumer = createConsumer();
 
-        when(mockedConsumerCurator.verifyAndLookupConsumer(consumer.getUuid())).thenReturn(
-            consumer);
+        when(mockedConsumerCurator.verifyAndLookupConsumer(consumer.getUuid())).thenReturn(consumer);
 
         CandlepinPoolManager mgr = mock(CandlepinPoolManager.class);
         ConsumerResource cr = new ConsumerResource(mockedConsumerCurator, null,
             null, mockedSubscriptionServiceAdapter, null, null, null, null, null, null, null, null, null,
             null, mgr, null, null, null, null, null, null, null, null,
             new CandlepinCommonTestConfig(), null, null, null, consumerBindUtil);
+
         cr.regenerateEntitlementCertificates(consumer.getUuid(), null, true);
-        Mockito.verify(mgr, Mockito.times(1))
-            .regenerateEntitlementCertificates(eq(consumer), eq(true));
+        Mockito.verify(mgr, Mockito.times(1)).regenerateCertificatesOf(eq(consumer), eq(true));
     }
 
     @Test
@@ -240,10 +228,8 @@ public class ConsumerResourceTest {
         IdentityCertificate ic = consumer.getIdCert();
         assertNotNull(ic);
 
-        when(mockedConsumerCurator.verifyAndLookupConsumer(consumer.getUuid())).thenReturn(
-            consumer);
-        when(mockedIdSvc.regenerateIdentityCert(consumer)).thenReturn(
-            createIdCert());
+        when(mockedConsumerCurator.verifyAndLookupConsumer(consumer.getUuid())).thenReturn(consumer);
+        when(mockedIdSvc.regenerateIdentityCert(consumer)).thenReturn(createIdCert());
 
         ConsumerResource cr = new ConsumerResource(mockedConsumerCurator, null,
             null, null, null, mockedIdSvc, null, null, sink, eventFactory, null, null,
@@ -262,8 +248,7 @@ public class ConsumerResourceTest {
     public void testIdCertGetsRegenerated() throws Exception {
         // using lconsumer simply to avoid hiding consumer. This should
         // get renamed once we refactor this test suite.
-        IdentityCertServiceAdapter mockedIdSvc = Mockito
-            .mock(IdentityCertServiceAdapter.class);
+        IdentityCertServiceAdapter mockedIdSvc = Mockito.mock(IdentityCertServiceAdapter.class);
 
         EventSink sink = Mockito.mock(EventSinkImpl.class);
 
@@ -277,10 +262,8 @@ public class ConsumerResourceTest {
         consumer.setIdCert(createIdCert());
         BigInteger origserial = consumer.getIdCert().getSerial().getSerial();
 
-        when(mockedConsumerCurator.verifyAndLookupConsumer(consumer.getUuid())).thenReturn(
-            consumer);
-        when(mockedIdSvc.regenerateIdentityCert(consumer)).thenReturn(
-            createIdCert());
+        when(mockedConsumerCurator.verifyAndLookupConsumer(consumer.getUuid())).thenReturn(consumer);
+        when(mockedIdSvc.regenerateIdentityCert(consumer)).thenReturn(createIdCert());
 
         ConsumerResource cr = new ConsumerResource(mockedConsumerCurator, null,
             null, ssa, null, mockedIdSvc, null, null, sink, eventFactory, null, null,
@@ -302,8 +285,7 @@ public class ConsumerResourceTest {
         consumer.setIdCert(createIdCert(TestUtil.createDate(2025, 6, 9)));
         BigInteger origserial = consumer.getIdCert().getSerial().getSerial();
 
-        when(mockedConsumerCurator.verifyAndLookupConsumer(consumer.getUuid())).thenReturn(
-            consumer);
+        when(mockedConsumerCurator.verifyAndLookupConsumer(consumer.getUuid())).thenReturn(consumer);
 
         ConsumerResource cr = new ConsumerResource(mockedConsumerCurator, null,
             null, ssa, null, null, null, null, null, null, null, null, null, null,
@@ -461,14 +443,14 @@ public class ConsumerResourceTest {
         when(consumerCurator.verifyAndLookupConsumer(eq("fake-uuid"))).thenReturn(consumer);
         EntitlementCurator entitlementCurator = mock(EntitlementCurator.class);
 
-        when(entitlementCurator
-                .listByConsumerAndPoolId(eq(consumer),
-                        any(String.class))).thenReturn(new ArrayList<Entitlement>());
+        when(entitlementCurator.listByConsumerAndPoolId(eq(consumer), any(String.class)))
+            .thenReturn(new ArrayList<Entitlement>());
 
         ConsumerResource consumerResource = new ConsumerResource(consumerCurator, null,
             null, null, entitlementCurator, null, null, i18n, null, null, null,
             null, null, null, null, null, null, null, null, null, null, null,
             null, new CandlepinCommonTestConfig(), null, null, null, consumerBindUtil);
+
         consumerResource.unbindByPool("fake-uuid", "Run Forest!");
     }
 
@@ -676,70 +658,74 @@ public class ConsumerResourceTest {
 
     @Test(expected = BadRequestException.class)
     public void testFetchAllConsumers() {
-        ConsumerResource cr = new ConsumerResource(null, null,
-            null, null, null, null, null, i18n, null, null, null,
-            null, null, null, null, null, null, null, null, null,
-            null, null, null, new CandlepinCommonTestConfig(),
-            null, null, null, null);
+        ConsumerResource cr = new ConsumerResource(
+            null, null, null, null, null, null, null, i18n, null, null, null,  null, null, null,
+            null, null, null, null, null, null, null, null, null, new CandlepinCommonTestConfig(),
+            null, null, null, null
+        );
+
         cr.list(null, null, null, null, null, null, null);
     }
 
     @Test
     public void testFetchAllConsumersForUser() {
-        ConsumerResource cr = new ConsumerResource(mockedConsumerCurator, null,
-            null, null, null, null, null, i18n, null, null, null,
-            null, null, null, null, null, null, null, null, null,
-            null, null, null, new CandlepinCommonTestConfig(),
-            null, null, null, null);
+        ConsumerResource cr = new ConsumerResource(
+            mockedConsumerCurator, null, null, null, null, null, null, i18n, null, null, null, null,
+            null, null, null, null, null, null, null, null, null, null, null,
+            new CandlepinCommonTestConfig(), null, null, null, null
+        );
+
         Page<List<Consumer>> page = new Page<List<Consumer>>();
         ArrayList<Consumer> consumers = new ArrayList<Consumer>();
         page.setPageData(consumers);
         when(mockedConsumerCurator.searchOwnerConsumers(
-                any(Owner.class), anyString(), (java.util.Collection<ConsumerType>) any(Collection.class),
-                any(List.class), any(List.class), any(List.class),
-                any(List.class), any(List.class), any(List.class),
-                any(PageRequest.class))).thenReturn(page);
+            any(Owner.class), anyString(), (java.util.Collection<ConsumerType>) any(Collection.class),
+            any(List.class), any(List.class), any(List.class), any(List.class), any(List.class),
+            any(List.class), any(PageRequest.class))).thenReturn(page);
+
         List<Consumer> result = cr.list("TaylorSwift", null, null, null, null, null, null);
         assertEquals(consumers, result);
     }
 
     public void testFetchAllConsumersForOwner() {
-        ConsumerResource cr = new ConsumerResource(mockedConsumerCurator, null,
-            null, null, null, null, null, i18n, null, null, null,
-            null, null, null, null, null, mockedOwnerCurator, null, null, null,
-            null, null, null, new CandlepinCommonTestConfig(),
-            null, null, null, null);
+        ConsumerResource cr = new ConsumerResource(
+            mockedConsumerCurator, null, null, null, null, null, null, i18n, null, null, null, null,
+            null, null, null, null, mockedOwnerCurator, null, null, null, null, null, null,
+            new CandlepinCommonTestConfig(), null, null, null, null
+        );
+
         Page<List<Consumer>> page = new Page<List<Consumer>>();
         ArrayList<Consumer> consumers = new ArrayList<Consumer>();
         page.setPageData(consumers);
 
         when(mockedOwnerCurator.lookupByKey(eq("taylorOwner"))).thenReturn(new Owner());
         when(mockedConsumerCurator.searchOwnerConsumers(
-                any(Owner.class), anyString(), (java.util.Collection<ConsumerType>) any(Collection.class),
-                any(List.class), any(List.class), any(List.class),
-                any(List.class), any(List.class), any(List.class),
-                any(PageRequest.class))).thenReturn(page);
+            any(Owner.class), anyString(), (java.util.Collection<ConsumerType>) any(Collection.class),
+            any(List.class), any(List.class), any(List.class), any(List.class), any(List.class),
+            any(List.class), any(PageRequest.class))).thenReturn(page);
         List<Consumer> result = cr.list(null, null, "taylorOwner", null, null, null, null);
         assertEquals(consumers, result);
     }
 
     @Test(expected = BadRequestException.class)
     public void testFetchAllConsumersForEmptyUUIDs() {
-        ConsumerResource cr = new ConsumerResource(mockedConsumerCurator, null,
-            null, null, null, null, null, i18n, null, null, null,
-            null, null, null, null, null, null, null, null, null,
-            null, null, null, new CandlepinCommonTestConfig(),
-            null, null, null, null);
+        ConsumerResource cr = new ConsumerResource(
+            mockedConsumerCurator, null, null, null, null, null, null, i18n, null, null, null, null,
+            null, null, null, null, null, null, null, null, null, null, null,
+            new CandlepinCommonTestConfig(), null, null, null, null
+        );
+
         List<Consumer> result = cr.list(null, null, null, new ArrayList<String>(), null, null, null);
     }
 
     @Test
     public void testFetchAllConsumersForSomeUUIDs() {
-        ConsumerResource cr = new ConsumerResource(mockedConsumerCurator, null,
-            null, null, null, null, null, i18n, null, null, null,
-            null, null, null, null, null, null, null, null, null,
-            null, null, null, new CandlepinCommonTestConfig(),
-            null, null, null, null);
+        ConsumerResource cr = new ConsumerResource(
+            mockedConsumerCurator, null, null, null, null, null, null, i18n, null, null, null, null,
+            null, null, null, null, null, null, null, null, null, null, null,
+            new CandlepinCommonTestConfig(), null, null, null, null
+        );
+
         Page<List<Consumer>> page = new Page<List<Consumer>>();
         ArrayList<Consumer> consumers = new ArrayList<Consumer>();
         page.setPageData(consumers);

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
@@ -703,7 +703,7 @@ public class ConsumerResourceUpdateTest {
 
         resource.updateConsumer(existing.getUuid(), updated);
 
-        verify(poolManager, atMost(1)).regenerateEntitlementCertificates(existing, true);
+        verify(poolManager, atMost(1)).regenerateCertificatesOf(existing, true);
         verify(sink).queueEvent((Event) any());
     }
 

--- a/server/src/test/java/org/candlepin/resource/ContentResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/ContentResourceTest.java
@@ -62,9 +62,8 @@ public class ContentResourceTest {
         oc = mock(OwnerCurator.class);
         productCurator = mock(ProductCurator.class);
 
-        cr = new ContentResource(
-            cc, i18n, new DefaultUniqueIdGenerator(), envContentCurator, poolManager, productCurator, oc
-        );
+        cr = new ContentResource(cc, i18n, new DefaultUniqueIdGenerator(), envContentCurator,
+            poolManager, productCurator, oc);
     }
 
     @Test
@@ -149,14 +148,14 @@ public class ContentResourceTest {
         when(content.getId()).thenReturn(contentId);
 
         when(cc.find(any(String.class))).thenReturn(content);
-        when(cc.updateContent(any(Content.class), eq(owner))).thenReturn(content);
+        when(cc.merge(any(Content.class))).thenReturn(content);
         when(productCurator.getProductsWithContent(eq(owner), eq(Arrays.asList(contentId))))
             .thenReturn(Arrays.asList(product));
 
         cr.updateContent(contentId, content);
 
         verify(cc, never()).find(eq(contentId));
-        verify(cc, never()).updateContent(eq(content), eq(owner));
+        verify(cc, never()).merge(eq(content));
         verify(productCurator, never()).getProductsWithContent(owner, Arrays.asList(contentId));
     }
 

--- a/server/src/test/java/org/candlepin/resource/OwnerContentResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/OwnerContentResourceTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 
 import org.candlepin.common.exceptions.NotFoundException;
+import org.candlepin.controller.ContentManager;
 import org.candlepin.controller.PoolManager;
 import org.candlepin.model.Content;
 import org.candlepin.model.ContentCurator;
@@ -45,6 +46,7 @@ import java.util.Locale;
 public class OwnerContentResourceTest {
 
     private ContentCurator cc;
+    private ContentManager cm;
     private OwnerContentResource ocr;
     private I18n i18n;
     private EnvironmentContentCurator envContentCurator;
@@ -56,13 +58,14 @@ public class OwnerContentResourceTest {
     public void init() {
         i18n = I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK);
         cc = mock(ContentCurator.class);
+        cm = mock(ContentManager.class);
         envContentCurator = mock(EnvironmentContentCurator.class);
         poolManager = mock(PoolManager.class);
         oc = mock(OwnerCurator.class);
         productCurator = mock(ProductCurator.class);
 
         ocr = new OwnerContentResource(cc, i18n, new DefaultUniqueIdGenerator(),
-            envContentCurator, poolManager, productCurator, oc);
+            envContentCurator, poolManager, productCurator, oc, cm);
 
     }
 
@@ -102,7 +105,7 @@ public class OwnerContentResourceTest {
 
         when(content.getId()).thenReturn("10");
         when(oc.lookupByKey(eq("owner"))).thenReturn(owner);
-        when(cc.createContent(eq(content), eq(owner))).thenReturn(content);
+        when(cm.createContent(eq(content), eq(owner))).thenReturn(content);
 
         assertEquals(content, ocr.createContent("owner", content));
     }
@@ -117,7 +120,7 @@ public class OwnerContentResourceTest {
         when(cc.lookupById(eq(owner), eq("10"))).thenReturn(null);
 
         ocr.createContent("owner", content);
-        verify(cc, atLeastOnce()).createContent(content, owner);
+        verify(cm, atLeastOnce()).createContent(content, owner);
     }
 
     @Test
@@ -136,7 +139,7 @@ public class OwnerContentResourceTest {
 
         ocr.remove("owner", "10");
 
-        verify(cc, atLeastOnce()).removeContent(eq(content), eq(owner));
+        verify(cm, atLeastOnce()).removeContent(eq(content), eq(owner), anyBoolean());
     }
 
     @Test(expected = NotFoundException.class)
@@ -149,7 +152,7 @@ public class OwnerContentResourceTest {
         when(cc.lookupById(eq(owner), eq("10"))).thenReturn(null);
 
         ocr.remove("owner", "10");
-        verify(cc, never()).removeContent(eq(content), eq(owner));
+        verify(cm, never()).removeContent(eq(content), eq(owner), anyBoolean());
     }
 
     @Test
@@ -157,10 +160,12 @@ public class OwnerContentResourceTest {
         final String ownerId = "owner";
         final String productId = "productId";
         final String contentId = "10";
+        String contentUuid = "testuuid";
 
         Owner owner = mock(Owner.class);
         Product product = mock(Product.class);
         Content content = new Content(contentId);
+        content.setUuid(contentUuid);
 
         when(product.getId()).thenReturn(productId);
         when(product.getOwners()).thenReturn(Util.asSet(owner));
@@ -169,16 +174,16 @@ public class OwnerContentResourceTest {
 
         when(oc.lookupByKey(eq(ownerId))).thenReturn(owner);
         when(cc.lookupById(eq(owner), eq(contentId))).thenReturn(content);
-        when(cc.updateContent(eq(content), eq(owner))).thenReturn(content);
-        when(productCurator.getProductsWithContent(eq(owner), eq(Arrays.asList(contentId))))
+        when(cm.updateContent(eq(content), eq(owner), anyBoolean())).thenReturn(content);
+        when(productCurator.getProductsWithContent(eq(Arrays.asList(contentUuid))))
             .thenReturn(Arrays.asList(product));
 
         ocr.updateContent(ownerId, contentId, content);
 
         verify(cc).lookupById(eq(owner), eq(contentId));
-        verify(cc).updateContent(eq(content), eq(owner));
-        verify(productCurator).getProductsWithContent(eq(owner), eq(Arrays.asList(contentId)));
-        verify(poolManager).regenerateCertificatesOf(eq(owner), eq(productId), eq(true));
+        verify(cm).updateContent(eq(content), eq(owner), anyBoolean());
+        // verify(productCurator).getProductsWithContent(eq(Arrays.asList(contentUuid)));
+        // verify(poolManager).regenerateCertificatesOf(eq(owner), eq(productId), eq(true));
     }
 
     @Test(expected = NotFoundException.class)

--- a/server/src/test/java/org/candlepin/resource/OwnerProductResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/OwnerProductResourceTest.java
@@ -20,7 +20,9 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import org.candlepin.common.config.Configuration;
 import org.candlepin.common.exceptions.BadRequestException;
+import org.candlepin.controller.ProductManager;
 import org.candlepin.model.Content;
 import org.candlepin.model.ContentCurator;
 import org.candlepin.model.Product;
@@ -44,6 +46,7 @@ import java.util.Set;
 import javax.inject.Inject;
 
 
+
 /**
  * OwnerProductResourceTest
  */
@@ -52,6 +55,8 @@ public class OwnerProductResourceTest extends DatabaseTestFixture {
     @Inject private ContentCurator contentCurator;
     @Inject private OwnerProductResource ownerProductResource;
     @Inject private OwnerCurator ownerCurator;
+    @Inject private ProductManager productManager;
+    @Inject private Configuration config;
 
     private Product createProduct(Owner owner) {
         String label = "test_product";
@@ -79,9 +84,11 @@ public class OwnerProductResourceTest extends DatabaseTestFixture {
         Product toSubmit = createProduct(owner);
         String  contentHash = String.valueOf(
             Math.abs(Long.valueOf("test-content".hashCode())));
-        Content testContent = new Content(owner, "test-content", contentHash,
-            "test-content-label", "yum", "test-vendor",
-            "test-content-url", "test-gpg-url", "test-arch");
+
+        Content testContent = new Content(
+            owner, "test-content", contentHash, "test-content-label", "yum", "test-vendor",
+            "test-content-url", "test-gpg-url", "test-arch"
+        );
 
         HashSet<Content> contentSet = new HashSet<Content>();
         testContent = contentCurator.create(testContent);
@@ -96,7 +103,8 @@ public class OwnerProductResourceTest extends DatabaseTestFixture {
         ProductCurator pc = mock(ProductCurator.class);
         OwnerCurator oc = mock(OwnerCurator.class);
         I18n i18n = I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK);
-        OwnerProductResource pr = new OwnerProductResource(pc, null, oc, null, i18n);
+        OwnerProductResource pr = new OwnerProductResource(pc, null, oc, null, productManager,
+            config, i18n);
 
         Owner o = mock(Owner.class);
         Product p = mock(Product.class);

--- a/server/src/test/java/org/candlepin/resource/OwnerResourceUeberCertOperationsTest.java
+++ b/server/src/test/java/org/candlepin/resource/OwnerResourceUeberCertOperationsTest.java
@@ -22,6 +22,8 @@ import org.candlepin.auth.permissions.Permission;
 import org.candlepin.auth.permissions.PermissionFactory;
 import org.candlepin.common.exceptions.NotFoundException;
 import org.candlepin.controller.CandlepinPoolManager;
+import org.candlepin.controller.ContentManager;
+import org.candlepin.controller.ProductManager;
 import org.candlepin.model.ConsumerCurator;
 import org.candlepin.model.ConsumerType;
 import org.candlepin.model.ConsumerType.ConsumerTypeEnum;
@@ -71,6 +73,8 @@ public class OwnerResourceUeberCertOperationsTest extends DatabaseTestFixture {
     @Inject private ServiceLevelValidator serviceLevelValidator;
     @Inject private I18n i18n;
     @Inject private ContentOverrideValidator contentOverrideValidator;
+    @Inject private ProductManager productManager;
+    @Inject private ContentManager contentManager;
 
     private Owner owner;
     private OwnerResource or;
@@ -93,12 +97,12 @@ public class OwnerResourceUeberCertOperationsTest extends DatabaseTestFixture {
         ConsumerType ueberCertType = new ConsumerType(ConsumerTypeEnum.UEBER_CERT);
         consumerTypeCurator.create(ueberCertType);
 
-        or = new OwnerResource(ownerCurator,
-            null, consumerCurator, i18n, null, null, null,
-            null, null, poolManager, null, null, null,
-            null, consumerTypeCurator, entCertCurator, entitlementCurator,
-            ueberCertGenerator, null, null, contentOverrideValidator,
-            serviceLevelValidator, null, null, null);
+        or = new OwnerResource(
+            ownerCurator, null, consumerCurator, i18n, null, null, null, null, null, poolManager, null, null,
+            null, null, consumerTypeCurator, entCertCurator, entitlementCurator, ueberCertGenerator, null,
+            null, contentOverrideValidator, serviceLevelValidator, null, null, null, productManager,
+            contentManager
+        );
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/test/TestUtil.java
+++ b/server/src/test/java/org/candlepin/test/TestUtil.java
@@ -50,6 +50,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Calendar;
+import java.util.Collection;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
@@ -68,6 +69,14 @@ public class TestUtil {
 
     public static Owner createOwner() {
         return new Owner("Test Owner " + randomInt());
+    }
+
+    public static Owner createOwner(String key) {
+        return new Owner(key);
+    }
+
+    public static Owner createOwner(String key, String name) {
+        return new Owner(key, name);
     }
 
     public static Consumer createConsumer(ConsumerType type, Owner owner) {
@@ -125,12 +134,14 @@ public class TestUtil {
     }
 
     public static Content createContent(Owner owner, String id) {
-        String name = "test-content-" + randomInt();
+        return createContent(owner, id, "test-content-" + randomInt());
+    }
 
+    public static Content createContent(Owner owner, String id, String name) {
         return new Content(
             owner,
             name,
-            name,
+            id,
             name,
             "test-type",
             "test-vendor",
@@ -192,6 +203,10 @@ public class TestUtil {
         return sub;
     }
 
+    public static Pool createPool(Owner owner) {
+        return createPool(owner, createProduct(owner));
+    }
+
     public static Pool createPool(Product product) {
         return createPool(new Owner("Test Owner " + randomInt()), product);
     }
@@ -201,18 +216,23 @@ public class TestUtil {
     }
 
     public static Pool createPool(Owner owner, Product product, int quantity) {
-        return createPool(owner, product, new HashSet<Product>(), quantity);
+        return createPool(owner, product, null, quantity);
     }
 
-    public static Pool createPool(Owner owner, Product product, Set<Product> providedProducts,
+    public static Pool createPool(Owner owner, Product product, Collection<Product> providedProducts,
         int quantity) {
 
         String random = String.valueOf(randomInt());
 
+        Set<Product> provided = new HashSet<Product>();
+        if (providedProducts != null) {
+            provided.addAll(providedProducts);
+        }
+
         Pool pool = new Pool(
             owner,
             product,
-            providedProducts,
+            provided,
             Long.valueOf(quantity),
             TestUtil.createDate(2009, 11, 30),
             TestUtil.createDate(Calendar.getInstance().get(Calendar.YEAR) + 10, 11, 30),
@@ -226,12 +246,17 @@ public class TestUtil {
         return pool;
     }
 
-    public static Pool createPool(Owner owner, Product product, Set<Product> providedProducts,
-        Product derivedProduct, Set<Product> subProvidedProducts, int quantity) {
+    public static Pool createPool(Owner owner, Product product, Collection<Product> providedProducts,
+        Product derivedProduct, Collection<Product> subProvidedProducts, int quantity) {
 
         Pool pool = createPool(owner, product, providedProducts, quantity);
+        Set<Product> subProvided = new HashSet<Product>();
+        if (subProvidedProducts != null) {
+            subProvided.addAll(subProvidedProducts);
+        }
+
         pool.setDerivedProduct(derivedProduct);
-        pool.setDerivedProvidedProducts(subProvidedProducts);
+        pool.setDerivedProvidedProducts(subProvided);
 
         return pool;
     }
@@ -310,17 +335,20 @@ public class TestUtil {
         return idCert;
     }
 
-    public static Entitlement createEntitlement(Owner owner, Consumer consumer,
-        Pool pool, EntitlementCertificate cert) {
+    public static Entitlement createEntitlement(Owner owner, Consumer consumer, Pool pool,
+        EntitlementCertificate cert) {
+
         Entitlement toReturn = new Entitlement();
         toReturn.setOwner(owner);
         toReturn.setPool(pool);
-        toReturn.setOwner(owner);
+
         consumer.addEntitlement(toReturn);
+
         if (cert != null) {
             cert.setEntitlement(toReturn);
             toReturn.getCertificates().add(cert);
         }
+
         return toReturn;
     }
 


### PR DESCRIPTION
- Entitlement certificates will now be regenerated when an associated
  products or content are updated or removed
- Refactored much of the entitlement certificate regeneration code. A
  new class, EntitlementCertificateGenerator, now houses most of the
  regeneration bits that were previously in CandlepinPoolManager.
- Moved the product and content CRUD operations from the curators
  to the new ProductManager and ContentManager classes
- Several other stylistic and checkstyle related code changes
- Added tests to improve or complete test coverage on several
  methods which were previously overlooked