### PR TITLE
Alikins/gen certs bootstrap ca

### DIFF
--- a/server/bin/gen-certs
+++ b/server/bin/gen-certs
@@ -2,20 +2,28 @@
 
 CERTS_HOME=/etc/candlepin/certs
 UPSTREAM_CERTS_HOME=$CERTS_HOME/upstream
+
 KEYSTORE_PASSWORD=$CERTS_HOME/keystore-password.txt
 CA_KEY=$CERTS_HOME/candlepin-ca.key
+CA_KEY_PASSWORD=$CERTS_HOME/candlepin-ca-password.txt
+
 CA_REDHAT_CERT=conf/candlepin-redhat-ca.crt
 CA_UPSTREAM_CERT=$UPSTREAM_CERTS_HOME/candlepin-redhat-ca.crt
+CA_CERT_BASE=$CERTS_HOME/candlepin-ca
+CA_CERT=$CA_CERT_BASE.crt
+CA_CERT_CSR=$CA_CERT_BASE.csr
+CA_CERT_P7=$CA_CERT_BASE.p7
+# private?
+CA_KEY=$CA_CERT_BASE.key
 CA_PUB_KEY=$CERTS_HOME/candlepin-ca-pub.key
-CA_CERT=$CERTS_HOME/candlepin-ca.crt
-CA_CERT_P7=$CA_CERT.p7
 # for mod_ssl testing
 SERVER_KEY_PASSWORD=$CERTS_HOME/candlepin-server-password.txt
 SERVER_KEY=$CERTS_HOME/candlepin-server.key
 SERVER_KEY_FULL=$SERVER_KEY.orig
-SERVER_CERT=$CERTS_HOME/candlepin-server.crt
-SERVER_CERT_REQ=$SERVER_CERT.req
-SERVER_CERT_P7=$SERVER_CERT.p7
+SERVER_CERT_BASE=$CERTS_HOME/candlepin-server
+SERVER_CERT=$SERVER_CERT_BASE.crt
+SERVER_CERT_CSR=$SERVER_CERT_BASE.csr
+SERVER_CERT_P7=$SERVER_CERT_BASE.p7
 KEYSTORE=$CERTS_HOME/keystore
 
 if [ -z "$CA_CERT_DAYS" ]; then
@@ -60,67 +68,95 @@ HOSTNAME=${HOSTNAME:-$(hostname)}
 if [ -f $CA_KEY ] && [ -f $CA_CERT ] && [ "$FORCECERT" != "1" ]; then
     echo "Certificates are already present."
 else
+    echo
     echo "Creating CA private key password"
     sudo su -c "echo $RANDOM > $CA_KEY_PASSWORD"
 
+    echo
     echo "Creating CA private key"
     sudo openssl genrsa -out $CA_KEY -passout "file:$CA_KEY_PASSWORD" 1024
 
+    echo
     echo "Creating CA public key"
     sudo openssl rsa -pubout -in $CA_KEY -out $CA_PUB_KEY
 
-    echo "Creating CA certificate"
-    sudo openssl req -new -x509 -days 365 -key $CA_KEY -out $CA_CERT -subj \
-        "/O=candlepinproject.org/OU=Candlepin CA/"
+    echo
+    echo "Creating CA csr"
+    sudo openssl req -config /etc/pki/tls/openssl.cnf -new -days 365 -key $CA_KEY -out $CA_CERT_CSR \
+       -subj "/O=candlepinproject.org/OU=Candlepin CA/" \
+       -extensions v3_ca
 
+    echo
+    echo "Creating CA certificate"
+#    sudo openssl req -new -x509 -days 365 -key $CA_KEY -out $CA_CERT -subj \
+#        "/O=candlepinproject.org/OU=Candlepin CA/"
+    sudo openssl x509 -extfile /etc/pki/tls/openssl.cnf -extensions v3_ca \
+        -trustout -signkey $CA_KEY -days 365 -req -in $CA_CERT_CSR -out $CA_CERT
+
+    echo
     echo "Creating server certs and keystores"
     echo "Creating server private key password"
     sudo su -c "echo $RANDOM > $SERVER_KEY_PASSWORD"
 
+    echo
     echo "Creating server cert private key"
     sudo openssl genrsa -out $SERVER_KEY -passout "file:$SERVER_KEY_PASSWORD" 1024
     sudo cp $SERVER_KEY $SERVER_KEY_FULL
 
+    echo
     echo "Creating server cert signing request"
-    sudo openssl req -new -key $SERVER_KEY_FULL -out $SERVER_CERT_REQ \
-        -subj "/CN=$HOSTNAME/O=candlepinproject.org/OU=Candlepin Server" -keyout $
+    sudo openssl req -new -key $SERVER_KEY_FULL -out $SERVER_CERT_CSR \
+        -subj "/CN=$HOSTNAME/O=candlepinproject.org/OU=Candlepin Server/" -nodes
 
     sudo openssl rsa -in $SERVER_KEY_FULL -out $SERVER_KEY
 
+    echo
     echo "Creating server cert, signing with CA key"
     #sudo openssl ca -in $SERVER_CERT_REQ -cert $CA_CERT -keyfile $CA_KEY -out $SERVER_CERT
-    sudo openssl x509 -req -days 365 -in $SERVER_CERT_REQ -CA $CA_CERT -CAkey $CA_KEY \
-        -CAcreateserial -out $SERVER_CERT 
+    sudo openssl x509 -req -days 365 -in $SERVER_CERT_CSR -CA $CA_CERT -CAkey $CA_KEY \
+        -CAcreateserial -out $SERVER_CERT
 
+    echo
+    echo "Verifying cert"
+    sudo openssl verify -purpose sslserver -CAfile $CA_CERT $SERVER_CERT
+
+    echo
     echo "Adding the CA cert to tomcats keystore, and create a pkcs keystore"
     #sudo openssl pkcs12 -export -in $CA_CERT -inkey $CA_KEY -out $KEYSTORE \
-    sudo openssl pkcs12 -export -in $CA_CERT -inkey $CA_KEY -out $KEYSTORE \
-        -name "candlepin-ca" -CAfile $CA_CERT -caname "candlepin-ca" -chain -password pass:password 
+    #sudo openssl pkcs12 -export -noiter -nomaciter -in $CA_CERT -inkey $CA_KEY -out $KEYSTORE \
+    #    -name "candlepin-ca" -CAfile $CA_CERT -caname root -chain 
+    sudo openssl pkcs12 -export -in $SERVER_CERT -inkey $SERVER_KEY -out $KEYSTORE \
+        -CAfile $CA_CERT -name "tomcat" -certfile $CA_CERT  -password pass:password -chain -caname root
     #sudo keytool -import -trustcacerts -alias "sensible-name-for-ca" -file CAcert.crt -keystore $JAVA_HOME/lib/security/cacerts 
 
     #echo "Create a keystore"
     #sudo keytool -genkey -alias tomcat -keystore $KEYSTORE
 
+    echo
     echo "convert ca cert to pkcs7"
     sudo openssl crl2pkcs7 -nocrl -certfile $CA_CERT \
       -out $CA_CERT_P7
 
+    echo
     echo "import pk7 ca cert into keystore"
-    #sudo keytool -importcert -trustcacerts -v -v -v -keystore $KEYSTORE \
-    #    -storepass password  -file $CA_CERT_P7 -storetype pkcs12 -alias "candlepin-ca"
+#    sudo keytool -importcert -v -v -v -keystore $KEYSTORE \
+#        -storepass password -file $CA_CERT_P7 -storetype pkcs12 -alias tomcat
 
+    echo
     echo "convert server cert pkcs12 to pkcs7 for import to keystore"
     # import again as an intmt cert?
     # convert server-cert to pkc7 so we can import to candlepin keystore?
-    sudo openssl crl2pkcs7  -nocrl -certfile $SERVER_CERT \
-      -out $SERVER_CERT_P7 -certfile $CA_CERT_P7
+#    sudo openssl crl2pkcs7  -nocrl -certfile $SERVER_CERT \
+#      -out $SERVER_CERT_P7 -certfile $CA_CERT_P7
 
+     echo
      echo "import pk7 server cert into candlepin keystore"
      # import pck7 version into keystore?
-     sudo keytool -importcert -trustcacerts -v -v -v -keystore $KEYSTORE \
-        -storepass password  -file $SERVER_CERT_P7 -storetype pkcs12 -alias "candlepin-ca"
+#     sudo keytool -importcert -trustcacerts -v -v -v -keystore $KEYSTORE #\
+#        -storepass password  -file $SERVER_CERT_P7 -storetype pkcs12 -alias "tomcat"
 
     # think we need keystore for this
+    echo
     echo "Adding the server cert to tomcats keystore"
 #    sudo openssl pkcs12 -export -in $SERVER_CERT -inkey $SERVER_KEY_FULL -out $KEYSTORE \
 #        -name tomcat -CAfile $CA_CERT -caname "Candlepin CA" -password pass:password

--- a/server/bin/gen-certs
+++ b/server/bin/gen-certs
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 
 CERTS_HOME=/etc/candlepin/certs
 UPSTREAM_CERTS_HOME=$CERTS_HOME/upstream
@@ -8,6 +8,14 @@ CA_REDHAT_CERT=conf/candlepin-redhat-ca.crt
 CA_UPSTREAM_CERT=$UPSTREAM_CERTS_HOME/candlepin-redhat-ca.crt
 CA_PUB_KEY=$CERTS_HOME/candlepin-ca-pub.key
 CA_CERT=$CERTS_HOME/candlepin-ca.crt
+CA_CERT_P7=$CA_CERT.p7
+# for mod_ssl testing
+SERVER_KEY_PASSWORD=$CERTS_HOME/candlepin-server-password.txt
+SERVER_KEY=$CERTS_HOME/candlepin-server.key
+SERVER_KEY_FULL=$SERVER_KEY.orig
+SERVER_CERT=$CERTS_HOME/candlepin-server.crt
+SERVER_CERT_REQ=$SERVER_CERT.req
+SERVER_CERT_P7=$SERVER_CERT.p7
 KEYSTORE=$CERTS_HOME/keystore
 
 if [ -z "$CA_CERT_DAYS" ]; then
@@ -52,14 +60,76 @@ HOSTNAME=${HOSTNAME:-$(hostname)}
 if [ -f $CA_KEY ] && [ -f $CA_CERT ] && [ "$FORCECERT" != "1" ]; then
     echo "Certificates are already present."
 else
+    echo "Creating CA private key password"
+    sudo su -c "echo $RANDOM > $CA_KEY_PASSWORD"
+
     echo "Creating CA private key"
-    $SUDO openssl genrsa -out $CA_KEY 1024
+    sudo openssl genrsa -out $CA_KEY -passout "file:$CA_KEY_PASSWORD" 1024
+
     echo "Creating CA public key"
-    $SUDO openssl rsa -pubout -in $CA_KEY -out $CA_PUB_KEY
+    sudo openssl rsa -pubout -in $CA_KEY -out $CA_PUB_KEY
+
     echo "Creating CA certificate"
-    $SUDO openssl req -new -x509 -days $CA_CERT_DAYS -key $CA_KEY -out $CA_CERT -subj "/CN=$HOSTNAME/C=US/L=Raleigh/"
-    $SUDO su -c "echo -n "password" > $KEYSTORE_PASSWORD"
-    $SUDO openssl pkcs12 -export -in $CA_CERT -inkey $CA_KEY -out $KEYSTORE -name tomcat -CAfile $CA_CERT -caname root -chain -password file:$KEYSTORE_PASSWORD
-    $SUDO cp $CA_REDHAT_CERT $CA_UPSTREAM_CERT
-    $SUDO chmod a+r $KEYSTORE
+    sudo openssl req -new -x509 -days 365 -key $CA_KEY -out $CA_CERT -subj \
+        "/O=candlepinproject.org/OU=Candlepin CA/"
+
+    echo "Creating server certs and keystores"
+    echo "Creating server private key password"
+    sudo su -c "echo $RANDOM > $SERVER_KEY_PASSWORD"
+
+    echo "Creating server cert private key"
+    sudo openssl genrsa -out $SERVER_KEY -passout "file:$SERVER_KEY_PASSWORD" 1024
+    sudo cp $SERVER_KEY $SERVER_KEY_FULL
+
+    echo "Creating server cert signing request"
+    sudo openssl req -new -key $SERVER_KEY_FULL -out $SERVER_CERT_REQ \
+        -subj "/CN=$HOSTNAME/O=candlepinproject.org/OU=Candlepin Server" -keyout $
+
+    sudo openssl rsa -in $SERVER_KEY_FULL -out $SERVER_KEY
+
+    echo "Creating server cert, signing with CA key"
+    #sudo openssl ca -in $SERVER_CERT_REQ -cert $CA_CERT -keyfile $CA_KEY -out $SERVER_CERT
+    sudo openssl x509 -req -days 365 -in $SERVER_CERT_REQ -CA $CA_CERT -CAkey $CA_KEY \
+        -CAcreateserial -out $SERVER_CERT 
+
+    echo "Adding the CA cert to tomcats keystore, and create a pkcs keystore"
+    #sudo openssl pkcs12 -export -in $CA_CERT -inkey $CA_KEY -out $KEYSTORE \
+    sudo openssl pkcs12 -export -in $CA_CERT -inkey $CA_KEY -out $KEYSTORE \
+        -name "candlepin-ca" -CAfile $CA_CERT -caname "candlepin-ca" -chain -password pass:password 
+    #sudo keytool -import -trustcacerts -alias "sensible-name-for-ca" -file CAcert.crt -keystore $JAVA_HOME/lib/security/cacerts 
+
+    #echo "Create a keystore"
+    #sudo keytool -genkey -alias tomcat -keystore $KEYSTORE
+
+    echo "convert ca cert to pkcs7"
+    sudo openssl crl2pkcs7 -nocrl -certfile $CA_CERT \
+      -out $CA_CERT_P7
+
+    echo "import pk7 ca cert into keystore"
+    #sudo keytool -importcert -trustcacerts -v -v -v -keystore $KEYSTORE \
+    #    -storepass password  -file $CA_CERT_P7 -storetype pkcs12 -alias "candlepin-ca"
+
+    echo "convert server cert pkcs12 to pkcs7 for import to keystore"
+    # import again as an intmt cert?
+    # convert server-cert to pkc7 so we can import to candlepin keystore?
+    sudo openssl crl2pkcs7  -nocrl -certfile $SERVER_CERT \
+      -out $SERVER_CERT_P7 -certfile $CA_CERT_P7
+
+     echo "import pk7 server cert into candlepin keystore"
+     # import pck7 version into keystore?
+     sudo keytool -importcert -trustcacerts -v -v -v -keystore $KEYSTORE \
+        -storepass password  -file $SERVER_CERT_P7 -storetype pkcs12 -alias "candlepin-ca"
+
+    # think we need keystore for this
+    echo "Adding the server cert to tomcats keystore"
+#    sudo openssl pkcs12 -export -in $SERVER_CERT -inkey $SERVER_KEY_FULL -out $KEYSTORE \
+#        -name tomcat -CAfile $CA_CERT -caname "Candlepin CA" -password pass:password
+
+
+    #echo "Creating a server cert $SERVER_CERT"
+    #sudo openssl x509 -req -nodes -days 365 -newkey rsa:1024  \
+    #    -keyout $SERVER_CERT -out $SERVER_CERT -subj "/CN=$HOSTNAME/O=candlepin server/OU=my candlepin server"
+    
+    sudo cp $CA_REDHAT_CERT $CA_UPSTREAM_CERT
+    sudo chmod a+r $KEYSTORE
 fi

--- a/server/bin/gen-certs
+++ b/server/bin/gen-certs
@@ -92,6 +92,7 @@ else
 
     echo
     echo "Creating CA csr"
+    # this openssl.cnf is
     sudo openssl req -config /etc/pki/tls/openssl.cnf -new -days 365 -key $CA_KEY -out $CA_CERT_CSR \
        -subj "/OU=Candlepin CA/O=candlepinproject.org/" \
        -extensions v3_ca
@@ -100,16 +101,17 @@ else
     echo "Creating CA certificate"
 #    sudo openssl req -new -x509 -days 365 -key $CA_KEY -out $CA_CERT -subj \
 #        "/O=candlepinproject.org/OU=Candlepin CA/"
+    # this openssl.cnf is tweak to let us use lets DN info for our CA cert and signing requests
     sudo openssl x509 -extfile /etc/pki/tls/openssl.cnf -extensions v3_ca \
         -trustout -signkey $CA_KEY -days 365 -req -in $CA_CERT_CSR -out $CA_CERT
 
     echo
-    echo "Creating server certs and keystores"
-    echo "Creating server private key password"
+    echo "Creating apache server certs"
+    echo "Creating apache server private key password"
     sudo su -c "echo $RANDOM > $SERVER_KEY_PASSWORD"
 
     echo
-    echo "Creating server cert private key"
+    echo "Creating apache server cert private key"
     sudo openssl genrsa -out $SERVER_KEY -passout "file:$SERVER_KEY_PASSWORD" 1024
     sudo cp $SERVER_KEY $SERVER_KEY_FULL
 
@@ -128,7 +130,7 @@ else
         -extfile /etc/pki/tls/openssl.cnf -extensions usr_cert
 
     echo
-    echo "Verifying cert"
+    echo "Verifying apache server cert"
     sudo openssl verify -purpose sslserver -CAfile $CA_CERT $SERVER_CERT
 
 #     echo
@@ -148,7 +150,7 @@ else
     #    -CAfile $CA_CERT -name "tomcat" -certfile $CA_CERT  -password pass:password -chain -caname root
     #sudo keytool -import -trustcacerts -alias "candlepin-ca" -file CAcert.crt -keystore $JAVA_HOME/lib/security/cacerts 
 
-    echo "Create a keystore"
+    echo "Create a keystore for tomcat"
     sudo keytool -genkey -keystore $KEYSTORE \
         -dname "CN=$HOSTNAME , OU=Candlepin Server, O=candlepinproject.org" \
         -keypass $KEY_PASS \
@@ -165,7 +167,7 @@ else
 
 
     echo
-    echo "import $CA_CERT ca cert into keystore"
+    echo "import $CA_CERT ca cert into tomcat keystore"
     sudo keytool -importcert -v -v -v -keystore $KEYSTORE \
         -storepass $KEYSTORE_PASS -file $CA_CERT  -alias serverCA \
         -keypass $KEY_PASS -storetype $STORETYPE -trustcacerts 

--- a/server/bin/gen-certs
+++ b/server/bin/gen-certs
@@ -24,7 +24,13 @@ SERVER_CERT_BASE=$CERTS_HOME/candlepin-server
 SERVER_CERT=$SERVER_CERT_BASE.crt
 SERVER_CERT_CSR=$SERVER_CERT_BASE.csr
 SERVER_CERT_P7=$SERVER_CERT_BASE.p7
+
 KEYSTORE=$CERTS_HOME/keystore
+STORETYPE="JKS"
+KEYSTORE_PASS=password
+# these need to be the same, see
+# http://tomcat.apache.org/tomcat-6.0-doc/ssl-howto.html
+KEY_PASS=$KEYSTORE_PASS
 
 if [ -z "$CA_CERT_DAYS" ]; then
     CA_CERT_DAYS=365
@@ -83,7 +89,7 @@ else
     echo
     echo "Creating CA csr"
     sudo openssl req -config /etc/pki/tls/openssl.cnf -new -days 365 -key $CA_KEY -out $CA_CERT_CSR \
-       -subj "/O=candlepinproject.org/OU=Candlepin CA/" \
+       -subj "/OU=Candlepin CA/O=candlepinproject.org/" \
        -extensions v3_ca
 
     echo
@@ -106,58 +112,90 @@ else
     echo
     echo "Creating server cert signing request"
     sudo openssl req -new -key $SERVER_KEY_FULL -out $SERVER_CERT_CSR \
-        -subj "/CN=$HOSTNAME/O=candlepinproject.org/OU=Candlepin Server/" -nodes
-
+        -subj "/CN=$HOSTNAME/O=candlepinproject.org/" -nodes \
+        -config /etc/pki/tls/openssl.cnf -extensions v3_req
     sudo openssl rsa -in $SERVER_KEY_FULL -out $SERVER_KEY
 
     echo
     echo "Creating server cert, signing with CA key"
     #sudo openssl ca -in $SERVER_CERT_REQ -cert $CA_CERT -keyfile $CA_KEY -out $SERVER_CERT
     sudo openssl x509 -req -days 365 -in $SERVER_CERT_CSR -CA $CA_CERT -CAkey $CA_KEY \
-        -CAcreateserial -out $SERVER_CERT
+        -CAcreateserial -out $SERVER_CERT \
+        -extfile /etc/pki/tls/openssl.cnf -extensions usr_cert
 
     echo
     echo "Verifying cert"
     sudo openssl verify -purpose sslserver -CAfile $CA_CERT $SERVER_CERT
 
+     echo
+     echo "import $SERVER_CERT server cert into candlepin keystore"
+     # import pck7 version into keystore?
+#     sudo keytool -importcert -trustcacerts -v -v -v -keystore $KEYSTORE \
+#        -storepass $KEYSTORE_PASS  -file $SERVER_CERT  -alias "tomcat" \
+#        -keypass $KEY_PASS -storetype $STORETYPE
     echo
+    
+    
     echo "Adding the CA cert to tomcats keystore, and create a pkcs keystore"
     #sudo openssl pkcs12 -export -in $CA_CERT -inkey $CA_KEY -out $KEYSTORE \
     #sudo openssl pkcs12 -export -noiter -nomaciter -in $CA_CERT -inkey $CA_KEY -out $KEYSTORE \
     #    -name "candlepin-ca" -CAfile $CA_CERT -caname root -chain 
-    sudo openssl pkcs12 -export -in $SERVER_CERT -inkey $SERVER_KEY -out $KEYSTORE \
-        -CAfile $CA_CERT -name "tomcat" -certfile $CA_CERT  -password pass:password -chain -caname root
-    #sudo keytool -import -trustcacerts -alias "sensible-name-for-ca" -file CAcert.crt -keystore $JAVA_HOME/lib/security/cacerts 
+    #sudo openssl pkcs12 -export -in $SERVER_CERT -inkey $SERVER_KEY -out $KEYSTORE \
+    #    -CAfile $CA_CERT -name "tomcat" -certfile $CA_CERT  -password pass:password -chain -caname root
+    #sudo keytool -import -trustcacerts -alias "candlepin-ca" -file CAcert.crt -keystore $JAVA_HOME/lib/security/cacerts 
 
-    #echo "Create a keystore"
-    #sudo keytool -genkey -alias tomcat -keystore $KEYSTORE
+    echo "Create a keystore"
+   sudo keytool -genkey -keystore $KEYSTORE \
+        -dname "CN=$HOSTNAME , OU=Candlepin Server, O=candlepinproject.org" \
+        -keypass $KEY_PASS \
+        -storepass $KEYSTORE_PASS \
+        -keyalg RSA \
+        -alias "tomcat" -storetype $STORETYPE
+
+    echo "CA CERT $CA_CERT"
+    sudo keytool -printcert -v -file $CA_CERT
+
+    echo 
+    echo "SERVER CERT $SERVER_CERT"
+    sudo keytool -printcert -v -file $SERVER_CERT
+
+
 
     echo
     echo "convert ca cert to pkcs7"
-    sudo openssl crl2pkcs7 -nocrl -certfile $CA_CERT \
-      -out $CA_CERT_P7
+#    sudo openssl crl2pkcs7 -nocrl -certfile $CA_CERT \
+#      -out $CA_CERT_P7
 
     echo
-    echo "import pk7 ca cert into keystore"
-#    sudo keytool -importcert -v -v -v -keystore $KEYSTORE \
-#        -storepass password -file $CA_CERT_P7 -storetype pkcs12 -alias tomcat
+    echo "import $CA_CERT ca cert into keystore"
+    sudo keytool -importcert -v -v -v -keystore $KEYSTORE \
+        -storepass $KEYSTORE_PASS -file $CA_CERT  -alias serverCA \
+        -keypass $KEY_PASS -storetype $STORETYPE -trustcacerts 
 
     echo
-    echo "convert server cert pkcs12 to pkcs7 for import to keystore"
+    echo "keystore "
+    sudo keytool -list -v -keystore $KEYSTORE -storepass $KEYSTORE_PASS \
+        -storetype $STORETYPE
+    #echo "convert server cert pkcs12 to pkcs7 for import to keystore"
     # import again as an intmt cert?
     # convert server-cert to pkc7 so we can import to candlepin keystore?
-#    sudo openssl crl2pkcs7  -nocrl -certfile $SERVER_CERT \
-#      -out $SERVER_CERT_P7 -certfile $CA_CERT_P7
+ #   sudo openssl crl2pkcs7  -nocrl -certfile $SERVER_CERT \
+ #     -out $SERVER_CERT_P7 -certfile $CA_CERT_P7
 
-     echo
-     echo "import pk7 server cert into candlepin keystore"
-     # import pck7 version into keystore?
-#     sudo keytool -importcert -trustcacerts -v -v -v -keystore $KEYSTORE #\
-#        -storepass password  -file $SERVER_CERT_P7 -storetype pkcs12 -alias "tomcat"
+    echo "Create a server cert signing request based on keystore"
+    sudo keytool -certreq -v -alias "tomcat" -keystore $KEYSTORE -storepass $KEYSTORE_PASS -file $SERVER_CERT_CSR
+
+    echo "Sign the server cert with the CA cert/key $CA_CERT/$CA_KEY"
+    sudo openssl x509 -req -in $SERVER_CERT_CSR -CA $CA_CERT -CAkey $CA_KEY -CAcreateserial -out $SERVER_CERT -days 365
+
+    echo "Import the signed server cert $SERVER_CERT into keystore $KEYSTORE"
+    sudo keytool -importcert -trustcacerts -v -v -v -keystore $KEYSTORE \
+        -storepass $KEYSTORE_PASS  -file $SERVER_CERT  -alias "tomcat" \
+        -keypass $KEY_PASS -storetype $STORETYPE
 
     # think we need keystore for this
-    echo
-    echo "Adding the server cert to tomcats keystore"
+#    echo
+#    echo "Adding the server cert to tomcats keystore"
 #    sudo openssl pkcs12 -export -in $SERVER_CERT -inkey $SERVER_KEY_FULL -out $KEYSTORE \
 #        -name tomcat -CAfile $CA_CERT -caname "Candlepin CA" -password pass:password
 

--- a/server/bin/gen-certs
+++ b/server/bin/gen-certs
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 
 CERTS_HOME=/etc/candlepin/certs
 UPSTREAM_CERTS_HOME=$CERTS_HOME/upstream
@@ -37,11 +37,13 @@ KEYSTORE_PASS=password
 KEY_PASS=$KEYSTORE_PASS
 
 
+
 if [ -z "$CA_CERT_DAYS" ]; then
     CA_CERT_DAYS=365
 fi
 
 OPENSSL_CONF=/etc/pki/tls/openssl.cnf
+
 CANDLEPIN_CA_ALIAS="candlepin-ca"
 CANDLEPIN_CA_SUBJ="/OU=Candlepin CA/O=candlepinproject.org/"
 
@@ -81,6 +83,9 @@ if [ ! -d $UPSTREAM_CERTS_HOME ]; then
 fi
 
 HOSTNAME=${HOSTNAME:-$(hostname)}
+
+
+OPENSSL_CONF=${OPENSSL_CONF:-/etc/pki/tls/openssl.cnf}
 
 if [ -f $CA_KEY ] && [ -f $CA_CERT ] && [ "$FORCECERT" != "1" ]; then
     echo "Certificates are already present."

--- a/server/bin/gen-certs
+++ b/server/bin/gen-certs
@@ -25,6 +25,10 @@ SERVER_CERT=$SERVER_CERT_BASE.crt
 SERVER_CERT_CSR=$SERVER_CERT_BASE.csr
 SERVER_CERT_P7=$SERVER_CERT_BASE.p7
 
+TOMCAT_SERVER_CERT_BASE=$CERTS_HOME/candlepin-apache-server
+TOMCAT_SERVER_CERT=$TOMCAT_SERVER_CERT_BASE.crt
+TOMCAT_SERVER_CERT_CSR=$TOMCAT_SERVER_CERT_BASE.csr
+
 KEYSTORE=$CERTS_HOME/keystore
 STORETYPE="JKS"
 KEYSTORE_PASS=password
@@ -110,14 +114,14 @@ else
     sudo cp $SERVER_KEY $SERVER_KEY_FULL
 
     echo
-    echo "Creating server cert signing request"
+    echo "Creating apache/mod_ssl server cert signing request"
     sudo openssl req -new -key $SERVER_KEY_FULL -out $SERVER_CERT_CSR \
         -subj "/CN=$HOSTNAME/O=candlepinproject.org/" -nodes \
         -config /etc/pki/tls/openssl.cnf -extensions v3_req
     sudo openssl rsa -in $SERVER_KEY_FULL -out $SERVER_KEY
 
     echo
-    echo "Creating server cert, signing with CA key"
+    echo "Creating apache server cert, signing with CA key"
     #sudo openssl ca -in $SERVER_CERT_REQ -cert $CA_CERT -keyfile $CA_KEY -out $SERVER_CERT
     sudo openssl x509 -req -days 365 -in $SERVER_CERT_CSR -CA $CA_CERT -CAkey $CA_KEY \
         -CAcreateserial -out $SERVER_CERT \
@@ -127,8 +131,8 @@ else
     echo "Verifying cert"
     sudo openssl verify -purpose sslserver -CAfile $CA_CERT $SERVER_CERT
 
-     echo
-     echo "import $SERVER_CERT server cert into candlepin keystore"
+#     echo
+#     echo "import $SERVER_CERT server cert into candlepin keystore"
      # import pck7 version into keystore?
 #     sudo keytool -importcert -trustcacerts -v -v -v -keystore $KEYSTORE \
 #        -storepass $KEYSTORE_PASS  -file $SERVER_CERT  -alias "tomcat" \
@@ -136,7 +140,7 @@ else
     echo
     
     
-    echo "Adding the CA cert to tomcats keystore, and create a pkcs keystore"
+    #echo "Adding the CA cert to tomcats keystore, and create a pkcs keystore"
     #sudo openssl pkcs12 -export -in $CA_CERT -inkey $CA_KEY -out $KEYSTORE \
     #sudo openssl pkcs12 -export -noiter -nomaciter -in $CA_CERT -inkey $CA_KEY -out $KEYSTORE \
     #    -name "candlepin-ca" -CAfile $CA_CERT -caname root -chain 
@@ -145,7 +149,7 @@ else
     #sudo keytool -import -trustcacerts -alias "candlepin-ca" -file CAcert.crt -keystore $JAVA_HOME/lib/security/cacerts 
 
     echo "Create a keystore"
-   sudo keytool -genkey -keystore $KEYSTORE \
+    sudo keytool -genkey -keystore $KEYSTORE \
         -dname "CN=$HOSTNAME , OU=Candlepin Server, O=candlepinproject.org" \
         -keypass $KEY_PASS \
         -storepass $KEYSTORE_PASS \
@@ -156,15 +160,9 @@ else
     sudo keytool -printcert -v -file $CA_CERT
 
     echo 
-    echo "SERVER CERT $SERVER_CERT"
+    echo "apache SERVER CERT $SERVER_CERT"
     sudo keytool -printcert -v -file $SERVER_CERT
 
-
-
-    echo
-    echo "convert ca cert to pkcs7"
-#    sudo openssl crl2pkcs7 -nocrl -certfile $CA_CERT \
-#      -out $CA_CERT_P7
 
     echo
     echo "import $CA_CERT ca cert into keystore"
@@ -182,17 +180,18 @@ else
  #   sudo openssl crl2pkcs7  -nocrl -certfile $SERVER_CERT \
  #     -out $SERVER_CERT_P7 -certfile $CA_CERT_P7
 
-    echo "Create a server cert signing request based on keystore"
-    sudo keytool -certreq -v -alias "tomcat" -keystore $KEYSTORE -storepass $KEYSTORE_PASS -file $SERVER_CERT_CSR
+    echo "Create a tomcat server cert signing request based on keystore"
+    sudo keytool -certreq -v -alias "tomcat" -keystore $KEYSTORE -storepass $KEYSTORE_PASS -file $TOMCAT_SERVER_CERT_CSR
 
-    echo "Sign the server cert with the CA cert/key $CA_CERT/$CA_KEY"
-    sudo openssl x509 -req -in $SERVER_CERT_CSR -CA $CA_CERT -CAkey $CA_KEY -CAcreateserial -out $SERVER_CERT -days 365
+    echo "Sign the tomcat server cert with the CA cert/key $CA_CERT/$CA_KEY"
+    sudo openssl x509 -req -in $TOMCAT_SERVER_CERT_CSR -CA $CA_CERT -CAkey $CA_KEY -CAcreateserial -out $TOMCAT_SERVER_CERT -days 365
 
-    echo "Import the signed server cert $SERVER_CERT into keystore $KEYSTORE"
+    echo "Import the signed tomcat server cert $TOMCAT_SERVER_CERT into keystore $KEYSTORE"
     sudo keytool -importcert -trustcacerts -v -v -v -keystore $KEYSTORE \
-        -storepass $KEYSTORE_PASS  -file $SERVER_CERT  -alias "tomcat" \
+        -storepass $KEYSTORE_PASS  -file $TOMCAT_SERVER_CERT  -alias "tomcat" \
         -keypass $KEY_PASS -storetype $STORETYPE
 
+#     sudo keytool -export -alias tomcat -keystore $KEYSTORE -file  $SERVER_CERT_EXPORT
     # think we need keystore for this
 #    echo
 #    echo "Adding the server cert to tomcats keystore"

--- a/server/bin/gen-certs
+++ b/server/bin/gen-certs
@@ -7,7 +7,7 @@ KEYSTORE_PASSWORD=$CERTS_HOME/keystore-password.txt
 CA_KEY=$CERTS_HOME/candlepin-ca.key
 CA_KEY_PASSWORD=$CERTS_HOME/candlepin-ca-password.txt
 
-CA_REDHAT_CERT=conf/candlepin-redhat-ca.crt
+CA_REDHAT_CERT=server/conf/candlepin-redhat-ca.crt
 CA_UPSTREAM_CERT=$UPSTREAM_CERTS_HOME/candlepin-redhat-ca.crt
 CA_CERT_BASE=$CERTS_HOME/candlepin-ca
 CA_CERT=$CA_CERT_BASE.crt
@@ -37,15 +37,14 @@ KEYSTORE_PASS=password
 KEY_PASS=$KEYSTORE_PASS
 
 
-
-if [ -z "$CA_CERT_DAYS" ]; then
-    CA_CERT_DAYS=365
-fi
-
-OPENSSL_CONF=/etc/pki/tls/openssl.cnf
+HOSTNAME=${HOSTNAME:-$(hostname)}
+USERNAME=${USERNAME:-$USER)}
 
 CANDLEPIN_CA_ALIAS="candlepin-ca"
-CANDLEPIN_CA_SUBJ="/OU=Candlepin CA/O=candlepinproject.org/"
+CANDLEPIN_CA_CN="${USERNAME}@${HOSTNAME}"
+CANDLEPIN_CA_SUBJ="/CN=${CANDLEPIN_CA_CN}/OU=Candlepin CA/O=candlepinproject.org/"
+
+OPENSSL_CONF=${OPENSSL_CONF:-/etc/pki/tls/openssl.cnf}
 
 
 while getopts ":f" opt; do
@@ -82,10 +81,6 @@ if [ ! -d $UPSTREAM_CERTS_HOME ]; then
     $SUDO mkdir -p $UPSTREAM_CERTS_HOME
 fi
 
-HOSTNAME=${HOSTNAME:-$(hostname)}
-
-
-OPENSSL_CONF=${OPENSSL_CONF:-/etc/pki/tls/openssl.cnf}
 
 if [ -f $CA_KEY ] && [ -f $CA_CERT ] && [ "$FORCECERT" != "1" ]; then
     echo "Certificates are already present."
@@ -161,6 +156,7 @@ else
     #    -CAfile $CA_CERT -name "tomcat" -certfile $CA_CERT  -password pass:password -chain -caname root
     #sudo keytool -import -trustcacerts -alias "candlepin-ca" -file CAcert.crt -keystore $JAVA_HOME/lib/security/cacerts 
 
+
     echo "Create a keystore for tomcat"
     sudo keytool -genkey -keystore $KEYSTORE \
         -dname "CN=$HOSTNAME , OU=Candlepin Server, O=candlepinproject.org" \
@@ -195,8 +191,8 @@ else
     #echo "convert server cert pkcs12 to pkcs7 for import to keystore"
     # import again as an intmt cert?
     # convert server-cert to pkc7 so we can import to candlepin keystore?
- #   sudo openssl crl2pkcs7  -nocrl -certfile $SERVER_CERT \
- #     -out $SERVER_CERT_P7 -certfile $CA_CERT_P7
+    #   sudo openssl crl2pkcs7  -nocrl -certfile $SERVER_CERT \
+    #     -out $SERVER_CERT_P7 -certfile $CA_CERT_P7
 
     echo
     echo "Create a tomcat server cert signing request based on keystore"
@@ -208,17 +204,25 @@ else
 
     echo
     echo "Import the signed tomcat server cert $TOMCAT_SERVER_CERT into keystore $KEYSTORE"
-    sudo keytool -importcert -trustcacerts -v -v -v -keystore $KEYSTORE \
-        -storepass $KEYSTORE_PASS  -file $TOMCAT_SERVER_CERT  -alias "tomcat" \
-        -keypass $KEY_PASS -storetype $STORETYPE
+    #    sudo keytool -importcert -trustcacerts -v -v -v -keystore $KEYSTORE \
+    #        -storepass $KEYSTORE_PASS  -file $TOMCAT_SERVER_CERT  -alias "tomcat" \
+    #        -keypass $KEY_PASS -storetype $STORETYPE
 
-#     sudo keytool -export -alias tomcat -keystore $KEYSTORE -file  $SERVER_CERT_EXPORT
+    # $SUDO openssl pkcs12 -export -in $CA_CERT -inkey $CA_KEY -out $KEYSTORE -name tomcat
+    #  -CAfile $CA_CERT -caname roo
+    #     sudo keytool -export -alias tomcat -keystore $KEYSTORE -file  $SERVER_CERT_EXPORT
     # think we need keystore for this
-#    echo
-#    echo "Adding the server cert to tomcats keystore"
-#    sudo openssl pkcs12 -export -in $SERVER_CERT -inkey $SERVER_KEY_FULL -out $KEYSTORE \
-#        -name tomcat -CAfile $CA_CERT -caname "Candlepin CA" -password pass:password
+    #    echo
+    #    echo "Adding the server cert to tomcats keystore"
+    sudo openssl pkcs12 -export -in $SERVER_CERT -inkey $SERVER_KEY_FULL -out $KEYSTORE \
+        -name tomcat -CAfile $CA_CERT -caname "$CANDLEPIN_CA_ALIAS" -password "pass:$KEYSTORE_PASS"
 
+    if [ -n "$VERBOSE" ] ; then
+        echo
+        echo "tomcat keystore "
+        sudo keytool -list -v -keystore $KEYSTORE -storepass $KEYSTORE_PASS \
+            -storetype $STORETYPE
+    fi
 
     #echo "Creating a server cert $SERVER_CERT"
     #sudo openssl x509 -req -nodes -days 365 -newkey rsa:1024  \

--- a/server/bin/gen-certs
+++ b/server/bin/gen-certs
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 
 CERTS_HOME=/etc/candlepin/certs
 UPSTREAM_CERTS_HOME=$CERTS_HOME/upstream
@@ -36,13 +36,20 @@ KEYSTORE_PASS=password
 # http://tomcat.apache.org/tomcat-6.0-doc/ssl-howto.html
 KEY_PASS=$KEYSTORE_PASS
 
+
 if [ -z "$CA_CERT_DAYS" ]; then
     CA_CERT_DAYS=365
 fi
 
+OPENSSL_CONF=/etc/pki/tls/openssl.cnf
+CANDLEPIN_CA_ALIAS="candlepin-ca"
+CANDLEPIN_CA_SUBJ="/OU=Candlepin CA/O=candlepinproject.org/"
+
+
 while getopts ":f" opt; do
     case $opt in
         f  ) FORCECERT="1" ;;
+        v  ) VERBOSE="1" ;;
     esac
 done
 
@@ -93,8 +100,8 @@ else
     echo
     echo "Creating CA csr"
     # this openssl.cnf is
-    sudo openssl req -config /etc/pki/tls/openssl.cnf -new -days 365 -key $CA_KEY -out $CA_CERT_CSR \
-       -subj "/OU=Candlepin CA/O=candlepinproject.org/" \
+    sudo openssl req -config $OPENSSL_CONF -new -days 365 -key $CA_KEY -out $CA_CERT_CSR \
+       -subj "$CANDLEPIN_CA_SUBJ" \
        -extensions v3_ca
 
     echo
@@ -102,7 +109,7 @@ else
 #    sudo openssl req -new -x509 -days 365 -key $CA_KEY -out $CA_CERT -subj \
 #        "/O=candlepinproject.org/OU=Candlepin CA/"
     # this openssl.cnf is tweak to let us use lets DN info for our CA cert and signing requests
-    sudo openssl x509 -extfile /etc/pki/tls/openssl.cnf -extensions v3_ca \
+    sudo openssl x509 -extfile $OPENSSL_CONF -extensions v3_ca \
         -trustout -signkey $CA_KEY -days 365 -req -in $CA_CERT_CSR -out $CA_CERT
 
     echo
@@ -119,7 +126,7 @@ else
     echo "Creating apache/mod_ssl server cert signing request"
     sudo openssl req -new -key $SERVER_KEY_FULL -out $SERVER_CERT_CSR \
         -subj "/CN=$HOSTNAME/O=candlepinproject.org/" -nodes \
-        -config /etc/pki/tls/openssl.cnf -extensions v3_req
+        -config $OPENSSL_CONF -extensions v3_req
     sudo openssl rsa -in $SERVER_KEY_FULL -out $SERVER_KEY
 
     echo
@@ -127,7 +134,7 @@ else
     #sudo openssl ca -in $SERVER_CERT_REQ -cert $CA_CERT -keyfile $CA_KEY -out $SERVER_CERT
     sudo openssl x509 -req -days 365 -in $SERVER_CERT_CSR -CA $CA_CERT -CAkey $CA_KEY \
         -CAcreateserial -out $SERVER_CERT \
-        -extfile /etc/pki/tls/openssl.cnf -extensions usr_cert
+        -extfile $OPENSSL_CONF -extensions usr_cert
 
     echo
     echo "Verifying apache server cert"
@@ -139,7 +146,6 @@ else
 #     sudo keytool -importcert -trustcacerts -v -v -v -keystore $KEYSTORE \
 #        -storepass $KEYSTORE_PASS  -file $SERVER_CERT  -alias "tomcat" \
 #        -keypass $KEY_PASS -storetype $STORETYPE
-    echo
     
     
     #echo "Adding the CA cert to tomcats keystore, and create a pkcs keystore"
@@ -158,36 +164,44 @@ else
         -keyalg RSA \
         -alias "tomcat" -storetype $STORETYPE
 
-    echo "CA CERT $CA_CERT"
-    sudo keytool -printcert -v -file $CA_CERT
+    if [ -n "$VERBOSE" ] ; then
+        echo
+        echo "CA CERT $CA_CERT"
+        sudo keytool -printcert -v -file $CA_CERT
 
-    echo 
-    echo "apache SERVER CERT $SERVER_CERT"
-    sudo keytool -printcert -v -file $SERVER_CERT
-
+        echo
+        echo "apache SERVER CERT $SERVER_CERT"
+        sudo keytool -printcert -v -file $SERVER_CERT
+    fi
 
     echo
     echo "import $CA_CERT ca cert into tomcat keystore"
     sudo keytool -importcert -v -v -v -keystore $KEYSTORE \
-        -storepass $KEYSTORE_PASS -file $CA_CERT  -alias serverCA \
-        -keypass $KEY_PASS -storetype $STORETYPE -trustcacerts 
+        -storepass $KEYSTORE_PASS -file $CA_CERT  -alias $CANDLEPIN_CA_ALIAS \
+        -keypass $KEY_PASS -storetype $STORETYPE -trustcacerts \
+        -noprompt
 
-    echo
-    echo "keystore "
-    sudo keytool -list -v -keystore $KEYSTORE -storepass $KEYSTORE_PASS \
-        -storetype $STORETYPE
+    if [ -n "$VERBOSE" ] ; then
+        echo
+        echo "keystore "
+        sudo keytool -list -v -keystore $KEYSTORE -storepass $KEYSTORE_PASS \
+            -storetype $STORETYPE
+    fi
     #echo "convert server cert pkcs12 to pkcs7 for import to keystore"
     # import again as an intmt cert?
     # convert server-cert to pkc7 so we can import to candlepin keystore?
  #   sudo openssl crl2pkcs7  -nocrl -certfile $SERVER_CERT \
  #     -out $SERVER_CERT_P7 -certfile $CA_CERT_P7
 
+    echo
     echo "Create a tomcat server cert signing request based on keystore"
     sudo keytool -certreq -v -alias "tomcat" -keystore $KEYSTORE -storepass $KEYSTORE_PASS -file $TOMCAT_SERVER_CERT_CSR
 
+    echo
     echo "Sign the tomcat server cert with the CA cert/key $CA_CERT/$CA_KEY"
     sudo openssl x509 -req -in $TOMCAT_SERVER_CERT_CSR -CA $CA_CERT -CAkey $CA_KEY -CAcreateserial -out $TOMCAT_SERVER_CERT -days 365
 
+    echo
     echo "Import the signed tomcat server cert $TOMCAT_SERVER_CERT into keystore $KEYSTORE"
     sudo keytool -importcert -trustcacerts -v -v -v -keystore $KEYSTORE \
         -storepass $KEYSTORE_PASS  -file $TOMCAT_SERVER_CERT  -alias "tomcat" \

--- a/server/src/main/java/org/candlepin/service/impl/DefaultIdentityCertServiceAdapter.java
+++ b/server/src/main/java/org/candlepin/service/impl/DefaultIdentityCertServiceAdapter.java
@@ -145,7 +145,10 @@ public class DefaultIdentityCertServiceAdapter implements
 
     private String createDN(Consumer consumer) {
         StringBuilder sb = new StringBuilder("CN=");
+
         sb.append(consumer.getUuid());
+        sb.append(",O=" + consumer.getOwner().getKey());
+
 
         return sb.toString();
     }


### PR DESCRIPTION

various tweaks to gen-certs, mostly for generating a root ca key/csr/ca cert, and signing
server certs with it (ie, no self-signed certs except for the ca root). Also creates an apache
style cert for use with mod_ssl.

Known issues:
- largely redundant upstream, since sat6 setup stuff does most of this
- kind of assumes a meaning openssl.cnf , which the script doesn't setup
- could go ahead and copy ca cert to /etc/rhsm/ca for dev 
- 300 lines of shell script seems like a totally reasonable way to bootstrap a CA right?