### PR TITLE
Added @JsonIgnore to getComplianceType and isUnmappedGuestPool

### DIFF
--- a/server/src/main/java/org/candlepin/model/Pool.java
+++ b/server/src/main/java/org/candlepin/model/Pool.java
@@ -1142,6 +1142,7 @@ public class Pool extends AbstractHibernateObject implements Persisted, Owned, N
         return PoolType.NORMAL;
     }
 
+    @JsonIgnore
     public PoolComplianceType getComplianceType() {
         Product product = this.getProduct();
 
@@ -1176,6 +1177,7 @@ public class Pool extends AbstractHibernateObject implements Persisted, Owned, N
         return (this.getProduct() != null ? this.getProduct().getAttributeValue(STACKING_ATTRIBUTE) : null);
     }
 
+    @JsonIgnore
     public boolean isUnmappedGuestPool() {
         return "true".equalsIgnoreCase(this.getAttributeValue(UNMAPPED_GUESTS_ATTRIBUTE));
     }


### PR DESCRIPTION
- Added the @JsonIgnore annotation to getComplianceType and
  isUnmappedGuestPool as these methods were never intended to
  be exposed to JSON serialization