### PR TITLE
Updated how rspec filters are specified

### DIFF
--- a/docker/candlepin-base/Dockerfile
+++ b/docker/candlepin-base/Dockerfile
@@ -1,5 +1,6 @@
 FROM centos:7
 MAINTAINER Devan Goodwin <dgoodwin@redhat.com>
+MAINTAINER Chris Rog <crog@redhat.com>
 
 ENV LANG en_US.UTF-8
 

--- a/docker/candlepin-base/cp-test
+++ b/docker/candlepin-base/cp-test
@@ -96,24 +96,24 @@ cleanup() {
 
 usage() {
     cat <<HELP
-    usage: cp-test [options]
+usage: cp-test [options]
 
-    OPTIONS:
-        -d  deploy a live candlepin
-        -t  populate Candlepin database with test data (implies -d)
-        -r  run rspec test suite (implies -d)
-        -H  run rspec tests in "hosted" mode (implies -r and -d)
-        -u  run unit test suite
-        -l  run the linter against the code
-        -s  run a bash shell when done
-        -c  git reference to checkout
-        -p  subproject to build (defaults to "server")
-        -v  enable verbose/debug output
+OPTIONS:
+  -d               deploy a live candlepin
+  -t               populate Candlepin database with test data (implies -d)
+  -r [filter]      run rspec test suite (implies -d); may be filtered by test
+                   suite and name
+  -H               run rspec tests in "hosted" mode (implies -r and -d)
+  -u               run unit test suite
+  -l               run the linter against the code
+  -s               run a bash shell when done
+  -c <ref>         git reference to checkout
+  -p <project>     subproject to build (defaults to "server")
+  -v               enable verbose/debug output
 HELP
 }
 
 ARGV=("$@")
-
 while getopts ":dtrHulsc:p:v" opt; do
     case $opt in
         d  ) DEPLOY="1";;

--- a/docker/candlepin-base/cp-test
+++ b/docker/candlepin-base/cp-test
@@ -112,6 +112,8 @@ usage() {
 HELP
 }
 
+ARGV=("$@")
+
 while getopts ":dtrHulsc:p:v" opt; do
     case $opt in
         d  ) DEPLOY="1";;
@@ -122,8 +124,13 @@ while getopts ":dtrHulsc:p:v" opt; do
         r  )
             RSPEC="1"
             DEPLOY="1"
+
+            ARG="${ARGV[$OPTIND - 1]}"
+            if [ "${ARG:0:1}" != "-" ] && [ "${ARG:0:1}" != "" ]; then
+                RSPEC_FILTER="$ARG"
+                OPTIND=$((OPTIND + 1))
+            fi
             ;;
-        T  ) RSPEC_FILTER="${OPTARG}";;
         H  )
             HOSTED="1"
             RSPEC="1"
@@ -184,14 +191,14 @@ fi
 cd "$CP_HOME/$PROJECT"
 
 if [ "$UNITTEST" == "1" ]; then
-    echo "Running unit tests."
+    echo "Running unit tests..."
 
     tee /var/log/candlepin/unit_tests.log < /tmp/teepipe &
     buildr test > /tmp/teepipe 2>&1
 fi
 
 if [ "$DEPLOY" == "1" ]; then
-    echo "Deploying candlepin."
+    echo "Deploying candlepin..."
 
     DEPLOY_FLAGS="-g"
 
@@ -212,7 +219,7 @@ if [ "$DEPLOY" == "1" ]; then
 fi
 
 if [ "$RSPEC" == "1" ]; then
-    echo "Running rspec tests."
+    echo "Running rspec tests..."
 
     tee /var/log/candlepin/rspec.log < /tmp/teepipe &
 
@@ -220,6 +227,7 @@ if [ "$RSPEC" == "1" ]; then
     if [ ! -z "$RSPEC_FILTER" ]; then
         BUILDR_ARGS="rspec:${RSPEC_FILTER}"
     fi
+
     buildr "${BUILDR_ARGS}" > /tmp/teepipe 2>&1
 fi
 

--- a/docker/candlepin-postgresql/Dockerfile
+++ b/docker/candlepin-postgresql/Dockerfile
@@ -1,5 +1,6 @@
 FROM candlepin/candlepin-base
 MAINTAINER Devan Goodwin <dgoodwin@redhat.com>
+MAINTAINER Chris Rog <crog@redhat.com>
 
 # Configure postgresql:
 ADD postgresql-setup /root/


### PR DESCRIPTION
- The rspec tests may now be filtered from the cp-test command by adding
  the filter string with the -r option
- Updated usage text for cp-test