### PR TITLE
Add missing @Consumes annotations.

### DIFF
--- a/server/src/main/java/org/candlepin/resource/ActivationKeyResource.java
+++ b/server/src/main/java/org/candlepin/resource/ActivationKeyResource.java
@@ -36,6 +36,7 @@ import org.xnap.commons.i18n.I18n;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -138,6 +139,7 @@ public class ActivationKeyResource {
     @PUT
     @Path("{activation_key_id}")
     @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
     public ActivationKey updateActivationKey(
         @PathParam("activation_key_id") @Verify(ActivationKey.class) String activationKeyId,
         ActivationKey key) {
@@ -174,6 +176,7 @@ public class ActivationKeyResource {
     @POST
     @Path("{activation_key_id}/pools/{pool_id}")
     @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.WILDCARD)
     public ActivationKey addPoolToKey(
         @PathParam("activation_key_id") @Verify(ActivationKey.class) String activationKeyId,
         @PathParam("pool_id") @Verify(Pool.class) String poolId,
@@ -228,6 +231,7 @@ public class ActivationKeyResource {
     @POST
     @Path("{activation_key_id}/product/{product_id}")
     @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.WILDCARD)
     public ActivationKey addProductIdToKey(
         @PathParam("activation_key_id") @Verify(ActivationKey.class) String activationKeyId,
         @PathParam("product_id") String productId) {

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -817,6 +817,7 @@ public class ConsumerResource {
     // to be set.
     @PUT
     @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
     @Path("{consumer_uuid}")
     @Transactional
     public void updateConsumer(
@@ -1881,6 +1882,7 @@ public class ConsumerResource {
      */
     @PUT
     @Produces(MediaType.WILDCARD)
+    @Consumes(MediaType.WILDCARD)
     @Path("/{consumer_uuid}/certificates")
     public void regenerateEntitlementCertificates(
         @PathParam("consumer_uuid") @Verify(Consumer.class) String consumerUuid,
@@ -1959,6 +1961,7 @@ public class ConsumerResource {
      */
     @POST
     @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.WILDCARD)
     @Path("{consumer_uuid}")
     public Consumer regenerateIdentityCertificates(
         @PathParam("consumer_uuid") @Verify(Consumer.class) String uuid) {

--- a/server/src/main/java/org/candlepin/resource/ContentResource.java
+++ b/server/src/main/java/org/candlepin/resource/ContentResource.java
@@ -30,6 +30,7 @@ import org.xnap.commons.i18n.I18n;
 
 import java.util.List;
 
+import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -126,6 +127,7 @@ public class ContentResource {
      */
     @POST
     @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
     public Content createContent(Content content) {
         throw new BadRequestException(this.i18n.tr(
             "Organization-agnostic content write operations are not supported."
@@ -140,6 +142,7 @@ public class ContentResource {
      */
     @POST
     @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
     @Path("/batch")
     public List<Content> createBatchContent(List<Content> contents) {
         throw new BadRequestException(this.i18n.tr(
@@ -156,6 +159,7 @@ public class ContentResource {
      */
     @PUT
     @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
     @Path("/{content_uuid}")
     public Content updateContent(@PathParam("content_uuid") String contentUuid, Content changes) {
         throw new BadRequestException(this.i18n.tr(

--- a/server/src/main/java/org/candlepin/resource/EntitlementResource.java
+++ b/server/src/main/java/org/candlepin/resource/EntitlementResource.java
@@ -332,6 +332,7 @@ public class EntitlementResource {
      */
     @PUT
     @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.WILDCARD)
     @Path("product/{product_id}")
     public JobDetail regenerateEntitlementCertificatesForProduct(
         @PathParam("product_id") String productId,
@@ -361,6 +362,7 @@ public class EntitlementResource {
      */
     @PUT
     @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.WILDCARD)
     @Path("{entitlement_id}/migrate")
     public Response migrateEntitlement(
         @PathParam("entitlement_id") @Verify(Entitlement.class) String id,

--- a/server/src/main/java/org/candlepin/resource/EnvironmentResource.java
+++ b/server/src/main/java/org/candlepin/resource/EnvironmentResource.java
@@ -219,6 +219,7 @@ public class EnvironmentResource {
      */
     @POST
     @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
     @Path("/{env_id}/content")
     public JobDetail promoteContent(
         @PathParam("env_id") @Verify(Environment.class) String envId,

--- a/server/src/main/java/org/candlepin/resource/GuestIdResource.java
+++ b/server/src/main/java/org/candlepin/resource/GuestIdResource.java
@@ -42,6 +42,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
@@ -135,6 +136,7 @@ public class GuestIdResource {
      */
     @PUT
     @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
     public void updateGuests(
         @PathParam("consumer_uuid") @Verify(Consumer.class) String consumerUuid,
         List<GuestId> guestIds) {
@@ -167,6 +169,7 @@ public class GuestIdResource {
      */
     @PUT
     @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
     @Path("/{guest_id}")
     public void updateGuest(
         @PathParam("consumer_uuid") @Verify(Consumer.class) String consumerUuid,

--- a/server/src/main/java/org/candlepin/resource/JobResource.java
+++ b/server/src/main/java/org/candlepin/resource/JobResource.java
@@ -33,6 +33,7 @@ import org.xnap.commons.i18n.I18n;
 import java.util.Collection;
 import java.util.List;
 
+import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
@@ -167,6 +168,7 @@ public class JobResource {
     @POST
     @Path("scheduler")
     @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
     public SchedulerStatus setSchedulerStatus(boolean running) {
         try {
             if (running) {
@@ -248,6 +250,7 @@ public class JobResource {
     @POST
     @Path("/{job_id}")
     @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.WILDCARD)
     public JobStatus getStatusAndDeleteIfFinished(
         @PathParam("job_id") @Verify(JobStatus.class) String jobId) {
         JobStatus status = curator.find(jobId);

--- a/server/src/main/java/org/candlepin/resource/OwnerContentResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerContentResource.java
@@ -37,6 +37,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -202,6 +203,7 @@ public class OwnerContentResource {
      */
     @POST
     @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
     public Content createContent(@PathParam("owner_key") String ownerKey, Content content) {
         Owner owner = this.getOwnerByKey(ownerKey);
         return this.createContentImpl(owner, content);
@@ -215,6 +217,7 @@ public class OwnerContentResource {
      */
     @POST
     @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
     @Path("/batch")
     public List<Content> createBatchContent(@PathParam("owner_key") String ownerKey,
         List<Content> contents) {
@@ -238,6 +241,7 @@ public class OwnerContentResource {
      */
     @PUT
     @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
     @Path("/{content_id}")
     public Content updateContent(@PathParam("owner_key") String ownerKey,
         @PathParam("content_id") String contentId,

--- a/server/src/main/java/org/candlepin/resource/OwnerProductResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerProductResource.java
@@ -256,6 +256,7 @@ public class OwnerProductResource {
      */
     @POST
     @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
     @Transactional
     public Product createProduct(
         @PathParam("owner_key") String ownerKey,
@@ -276,6 +277,7 @@ public class OwnerProductResource {
     @PUT
     @Path("/{product_id}")
     @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
     @Transactional
     public Product updateProduct(
         @PathParam("owner_key") String ownerKey,
@@ -339,6 +341,7 @@ public class OwnerProductResource {
      */
     @POST
     @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.WILDCARD)
     @Path("/{product_id}/content/{content_id}")
     @Transactional
     public Product addContent(
@@ -434,6 +437,7 @@ public class OwnerProductResource {
     @PUT
     @Path("/{product_id}/subscriptions")
     @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.WILDCARD)
     @Transactional
     public JobDetail refreshPoolsForProduct(
         @PathParam("owner_key") String ownerKey,

--- a/server/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -303,6 +303,7 @@ public class OwnerResource {
      */
     @POST
     @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
     public Owner createOwner(Owner owner) {
         Owner parent = owner.getParentOwner();
         if (parent != null && ownerCurator.find(parent.getId()) == null) {
@@ -397,6 +398,7 @@ public class OwnerResource {
      */
     @POST
     @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.WILDCARD)
     @Path("{owner_key}/entitlements")
     public JobDetail healEntire(
         @PathParam("owner_key") @Verify(Owner.class) String ownerKey) {
@@ -471,6 +473,7 @@ public class OwnerResource {
      */
     @POST
     @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
     @Path("{owner_key}/activation_keys")
     public ActivationKey createActivationKey(
         @PathParam("owner_key") @Verify(Owner.class) String ownerKey,
@@ -561,6 +564,7 @@ public class OwnerResource {
      */
     @PUT
     @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.WILDCARD)
     @Path("{owner_key}/log")
     public Owner setLogLevel(@PathParam("owner_key") String ownerKey,
         @QueryParam("level") @DefaultValue("DEBUG") String level) {
@@ -802,6 +806,7 @@ public class OwnerResource {
      */
     @PUT
     @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
     @Path("{owner_key}")
     @Transactional
     public Owner updateOwner(@PathParam("owner_key") @Verify(Owner.class) String key, Owner owner) {
@@ -906,6 +911,7 @@ public class OwnerResource {
      */
     @PUT
     @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
     @Path("/subscriptions")
     @Deprecated
     public void updateSubscription(Subscription subscription) {
@@ -939,6 +945,7 @@ public class OwnerResource {
      */
     @PUT
     @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.WILDCARD)
     @Path("{owner_key}/subscriptions")
     public JobDetail refreshPools(
         // TODO: Can we verify with autocreate?

--- a/server/src/main/java/org/candlepin/resource/ProductResource.java
+++ b/server/src/main/java/org/candlepin/resource/ProductResource.java
@@ -156,6 +156,7 @@ public class ProductResource {
      * <p>
      * Returns either the new created Product or the Product that already existed.
      *
+     * @deprecated Use per-org version
      * @param product
      * @return a Product object
      * @httpcode 200
@@ -163,6 +164,7 @@ public class ProductResource {
     @POST
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
+    @Deprecated
     public Product createProduct(Product product) {
         throw new BadRequestException(this.i18n.tr(
             "Organization-agnostic product write operations are not supported."
@@ -172,6 +174,7 @@ public class ProductResource {
     /**
      * Updates a Product
      *
+     * @deprecated Use per-org version
      * @return a Product object
      * @httpcode 400
      * @httpcode 200
@@ -179,7 +182,8 @@ public class ProductResource {
     @PUT
     @Path("/{product_uuid}")
     @Produces(MediaType.APPLICATION_JSON)
-    @Consumes(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.WILDCARD)
+    @Deprecated
     public Product updateProduct(
         @PathParam("product_uuid") String productUuid,
         Product product) {
@@ -193,6 +197,7 @@ public class ProductResource {
      * <p>
      * Batch mode
      *
+     * @deprecated Use per-org version
      * @return a Product object
      * @httpcode 200
      */
@@ -200,6 +205,7 @@ public class ProductResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/{product_uuid}/batch_content")
+    @Deprecated
     public Product addBatchContent(
         @PathParam("product_uuid") String productUuid,
         Map<String, Boolean> contentMap) {
@@ -214,6 +220,7 @@ public class ProductResource {
      * <p>
      * Single mode
      *
+     * @deprecated Use per-org version
      * @return a Product object
      * @httpcode 200
      */
@@ -221,6 +228,7 @@ public class ProductResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.WILDCARD)
     @Path("/{product_uuid}/content/{content_id}")
+    @Deprecated
     public Product addContent(
         @PathParam("product_uuid") String productUuid,
         @PathParam("content_id") String contentId,
@@ -234,11 +242,13 @@ public class ProductResource {
     /**
      * Removes Content from a Product
      *
+     * @deprecated Use per-org version
      * @httpcode 200
      */
     @DELETE
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/{product_uuid}/content/{content_id}")
+    @Deprecated
     public void removeContent(
         @PathParam("product_uuid") String productUuid,
         @PathParam("content_id") String contentId) {
@@ -251,6 +261,7 @@ public class ProductResource {
     /**
      * Removes a Product
      *
+     * @deprecated Use per-org version
      * @httpcode 400
      * @httpcode 404
      * @httpcode 200
@@ -258,6 +269,7 @@ public class ProductResource {
     @DELETE
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/{product_uuid}")
+    @Deprecated
     public void deleteProduct(
         @PathParam("product_uuid") String productUuid) {
 

--- a/server/src/main/java/org/candlepin/resource/ProductResource.java
+++ b/server/src/main/java/org/candlepin/resource/ProductResource.java
@@ -162,6 +162,7 @@ public class ProductResource {
      */
     @POST
     @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
     public Product createProduct(Product product) {
         throw new BadRequestException(this.i18n.tr(
             "Organization-agnostic product write operations are not supported."
@@ -178,6 +179,7 @@ public class ProductResource {
     @PUT
     @Path("/{product_uuid}")
     @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
     public Product updateProduct(
         @PathParam("product_uuid") String productUuid,
         Product product) {
@@ -217,6 +219,7 @@ public class ProductResource {
      */
     @POST
     @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.WILDCARD)
     @Path("/{product_uuid}/content/{content_id}")
     public Product addContent(
         @PathParam("product_uuid") String productUuid,
@@ -293,6 +296,7 @@ public class ProductResource {
     @PUT
     @Path("/subscriptions")
     @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.WILDCARD)
     public JobDetail[] refreshPoolsForProduct(
         @QueryParam("product") List<String> productUuids,
         @QueryParam("lazy_regen") @DefaultValue("true") Boolean lazyRegen) {

--- a/server/src/main/java/org/candlepin/resource/RoleResource.java
+++ b/server/src/main/java/org/candlepin/resource/RoleResource.java
@@ -256,6 +256,7 @@ public class RoleResource {
     @POST
     @Path("/{role_id}/users/{username}")
     @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.WILDCARD)
     public Role addUser(@PathParam("role_id") String roleId,
         @PathParam("username") String username) {
         Role role = lookupRole(roleId);

--- a/server/src/main/java/org/candlepin/resource/SubscriptionResource.java
+++ b/server/src/main/java/org/candlepin/resource/SubscriptionResource.java
@@ -234,6 +234,7 @@ public class SubscriptionResource {
      */
     @POST
     @Produces(MediaType.WILDCARD)
+    @Consumes(MediaType.WILDCARD)
     public Response activateSubscription(
         @QueryParam("consumer_uuid") @Verify(Consumer.class) String consumerUuid,
         @QueryParam("email") String email,

--- a/server/src/main/java/org/candlepin/resteasy/ResourceLocatorMap.java
+++ b/server/src/main/java/org/candlepin/resteasy/ResourceLocatorMap.java
@@ -214,12 +214,15 @@ public class ResourceLocatorMap implements Map<Method, ResourceLocator> {
 
             if (m.isAnnotationPresent(GET.class) ||
                 m.isAnnotationPresent(HEAD.class) ||
-                m.isAnnotationPresent(DELETE.class)) {
+                m.isAnnotationPresent(DELETE.class) ||
+                m.isAnnotationPresent(Deprecated.class)) {
                 /* Technically GET, HEAD, and DELETE are allowed to have bodies (and therefore would
                  * need a Consumes annotation, but the HTTP 1.1 spec states in section 4.3 that any
                  * such body should be ignored.  See http://stackoverflow.com/a/983458/6124862
                  *
                  * Therefore, we won't print warnings on unannotated GET, HEAD, and DELETE methods.
+                 *
+                 * Deprecated methods are not expected to be updated.
                  */
                 continue;
             }


### PR DESCRIPTION
Also add warning when a @Consumes is set to the */* media type but
actually reads the request body.  Currently, Candlepin only consumes
JSON so methods should be specific about that instead of using the
wildcard type as a shortcut.