### PR TITLE
unit test thrice to catch non deterministic tests

### DIFF
--- a/buildfile
+++ b/buildfile
@@ -584,5 +584,11 @@ define "candlepin" do
   end
 end
 
+desc 'Run all the linters'
+task :lint => [:checkstyle, :rubocop, :rpmlint]
+
 desc 'Make sure eventhing is working as it should'
-task :check_all => [:clean, :checkstyle, :validate_translation, :rubocop, :rpmlint, :test]
+task :check_all => [:clean, :lint, :validate_translation, :test]
+
+desc 'Miscellaneous validation tasks to be run on jenkins with every pull request'
+task :jenkins => [:validate_translation]

--- a/docker/candlepin-base/cp-test
+++ b/docker/candlepin-base/cp-test
@@ -106,7 +106,8 @@ OPTIONS:
   -r [filter]      run rspec test suite (implies -d); may be filtered by test
                    suite and name
   -H               run rspec tests in "hosted" mode (implies -r and -d)
-  -u               run unit test suite
+  -u               run unit test suite N number of times, where N is number
+                   of times u was specifed in the arguments
   -l               run the linters against the code
   -s               run a bash shell when done
   -b <task>        execute arbitrary buildr task
@@ -243,10 +244,9 @@ fi
 
 if [ ! -z "$ARBITRARY" ]; then
     cd "$CP_HOME"
-    echo "Running buildr $ARBITRARY..."
     tee /var/log/candlepin/buildr.log < /tmp/teepipe &
-
-    buildr "${ARBITRARY}" > /tmp/teepipe 2>&1
+    echo "Running buildr $ARBITRARY..."
+    buildr $ARBITRARY > /tmp/teepipe 2>&1
 fi
 
 cleanup

--- a/docker/candlepin-base/cp-test
+++ b/docker/candlepin-base/cp-test
@@ -23,6 +23,7 @@ export JAVA_HOME=/usr/lib/jvm/java-$JAVA_VERSION
 export SUPERVISOR=1
 export AUTOCONF=1
 export FORCECERT=1
+export UNITTEST=0
 
 trapex() {
     target="$1"
@@ -51,7 +52,8 @@ collect_artifacts() {
         move_artifact '/var/log/candlepin/audit.log' '/artifacts/'
         move_artifact '/var/log/candlepin/candlepin.log' '/artifacts/'
         move_artifact '/var/log/candlepin/error.log' '/artifacts/'
-        move_artifact '/var/log/candlepin/checkstyle.log' '/artifacts/'
+        move_artifact '/var/log/candlepin/lint.log' '/artifacts/'
+        move_artifact '/var/log/candlepin/buildr.log' '/artifacts/'
         move_artifact '/var/log/candlepin/unit_tests.log' '/artifacts/'
         move_artifact '/var/log/candlepin/rspec.log' '/artifacts/'
     fi
@@ -105,8 +107,9 @@ OPTIONS:
                    suite and name
   -H               run rspec tests in "hosted" mode (implies -r and -d)
   -u               run unit test suite
-  -l               run the linter against the code
+  -l               run the linters against the code
   -s               run a bash shell when done
+  -b <task>        execute arbitrary buildr task
   -c <ref>         git reference to checkout
   -p <project>     subproject to build (defaults to "server")
   -v               enable verbose/debug output
@@ -114,7 +117,7 @@ HELP
 }
 
 ARGV=("$@")
-while getopts ":dtrHulsc:p:v" opt; do
+while getopts ":dtrHulsb:c:p:v" opt; do
     case $opt in
         d  ) DEPLOY="1";;
         t  )
@@ -136,9 +139,10 @@ while getopts ":dtrHulsc:p:v" opt; do
             RSPEC="1"
             DEPLOY="1"
             ;;
-        u  ) UNITTEST="1";;
+        u  ) UNITTEST=$((UNITTEST + 1));;
         l  ) LINTER="1";;
         s  ) LAUNCHSHELL="1";;
+        b  ) ARBITRARY="${OPTARG}";;
         c  ) CHECKOUT="${OPTARG}";;
         p  ) PROJECT="${OPTARG}";;
         v  ) VERBOSE="1";;
@@ -183,18 +187,24 @@ if [ "$LINTER" == "1" ]; then
     cd $CP_HOME
     echo "Running linter..."
 
-    tee /var/log/candlepin/checkstyle.log < /tmp/teepipe &
-    buildr checkstyle > /tmp/teepipe 2>&1
+    tee /var/log/candlepin/lint.log < /tmp/teepipe &
+    buildr lint > /tmp/teepipe 2>&1
 fi
 
 # TODO: keep track of return code?
 cd "$CP_HOME/$PROJECT"
 
-if [ "$UNITTEST" == "1" ]; then
-    echo "Running unit tests..."
-
-    tee /var/log/candlepin/unit_tests.log < /tmp/teepipe &
-    buildr test > /tmp/teepipe 2>&1
+if [ "$UNITTEST" -gt 0 ]; then
+    echo "Running unit tests $UNITTEST time(s)"
+    # run $UNITTEST time(s) to increase chance of capturing
+    # non deterministic unit test failures.
+    for (( i=1; i<=$UNITTEST; i++ ))
+    do 
+        tee /var/log/candlepin/unit_tests.log < /tmp/teepipe &
+        buildr test > /tmp/teepipe 2>&1
+        rm -f /tmp/teepipe
+        mkfifo /tmp/teepipe
+    done
 fi
 
 if [ "$DEPLOY" == "1" ]; then
@@ -229,6 +239,14 @@ if [ "$RSPEC" == "1" ]; then
     fi
 
     buildr "${BUILDR_ARGS}" > /tmp/teepipe 2>&1
+fi
+
+if [ ! -z "$ARBITRARY" ]; then
+    cd "$CP_HOME"
+    echo "Running buildr $ARBITRARY..."
+    tee /var/log/candlepin/buildr.log < /tmp/teepipe &
+
+    buildr "${ARBITRARY}" > /tmp/teepipe 2>&1
 fi
 
 cleanup


### PR DESCRIPTION
- Unit test as many times as needed using `cp-test -uuuu`
- This helps to catch non-deterministic unit tests
- create buildr lint task to checkstyle, rubocop, and rpmlint
- add jenkins buildr task to do misc. validation
- add -b option to cp-test to execute arbitrary buildr task
- now you can run arbitrary buildr commands like:
  - `cp-test -b test:PoolManagerTest`
  - `cp-test -b jenkins`

if accepted, we will need to :
- [ ] re-build docker images
- [ ] rename checkstyle job and update it to execute `cp-test -b jenkins -l` instead of just `cp-test -l`