### PR TITLE
Authenticate over SSL only

### DIFF
--- a/server/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/server/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -46,6 +46,16 @@ public class ConfigProperties {
 
     public static final String CANDLEPIN_URL = "candlepin.url";
 
+    /**
+     * Whether we allow users to authenticate (e.g. HTTP Basic) over insecure
+     * channel such as HTTP.
+     * The default is false.
+     * A user might set this to 'true' for easier debugging of the Candlepin
+     * server.
+     * If kept in default (false) setting, then Candlepin will disallow any
+     * attempt to authenticate over insecure channel.
+     */
+    public static final String AUTH_OVER_HTTP = "candlepin.allow_auth_over_http";
     public static final String CA_KEY = "candlepin.ca_key";
     public static final String CA_CERT = "candlepin.ca_cert";
     public static final String FAIL_ON_UNKNOWN_IMPORT_PROPERTIES =
@@ -300,7 +310,7 @@ public class ConfigProperties {
                 this.put(SSL_AUTHENTICATION, "true");
                 this.put(OAUTH_AUTHENTICATION, "false");
                 this.put(BASIC_AUTHENTICATION, "true");
-
+                this.put(AUTH_OVER_HTTP, "false");
                 // By default, environments should be hidden so clients do not need to
                 // submit one when registering.
                 this.put(HIDDEN_RESOURCES, "environments");
@@ -377,4 +387,6 @@ public class ConfigProperties {
                 this.put(PINSETTER_MAX_RETRIES, Integer.toString(PINSETTER_MAX_RETRIES_DEFAULT));
             }
         };
+
+
 }

--- a/server/src/main/java/org/candlepin/resteasy/filter/AuthenticationFilter.java
+++ b/server/src/main/java/org/candlepin/resteasy/filter/AuthenticationFilter.java
@@ -142,7 +142,7 @@ public class AuthenticationFilter implements ContainerRequestFilter {
                 log.debug("No auth allowed for resource; setting NoAuth principal");
                 principal = new NoAuthPrincipal();
             }
-            else if (!request.isSecure()) {
+            else if (!config.getBoolean(ConfigProperties.AUTH_OVER_HTTP) && !request.isSecure()) {
                 throw new BadRequestException("Please use SSL when accessing protected resources");
             }
             else {
@@ -164,4 +164,5 @@ public class AuthenticationFilter implements ContainerRequestFilter {
         // Push the principal into the context for the PrincipalProvider to access directly
         ResteasyProviderFactory.pushContext(Principal.class, principal);
     }
+
 }

--- a/server/src/main/java/org/candlepin/resteasy/filter/AuthenticationFilter.java
+++ b/server/src/main/java/org/candlepin/resteasy/filter/AuthenticationFilter.java
@@ -25,6 +25,7 @@ import org.candlepin.auth.TrustedConsumerAuth;
 import org.candlepin.auth.TrustedUserAuth;
 import org.candlepin.common.auth.SecurityHole;
 import org.candlepin.common.config.Configuration;
+import org.candlepin.common.exceptions.BadRequestException;
 import org.candlepin.common.exceptions.NotAuthorizedException;
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.model.ConsumerCurator;
@@ -44,10 +45,12 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.annotation.Priority;
+import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Priorities;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.ext.Provider;
 
@@ -59,6 +62,9 @@ import javax.ws.rs.ext.Provider;
 @Provider
 public class AuthenticationFilter implements ContainerRequestFilter {
     private static Logger log = LoggerFactory.getLogger(AuthenticationFilter.class);
+
+    @Context
+    private HttpServletRequest request;
 
     private ConsumerCurator consumerCurator;
     private Injector injector;
@@ -74,6 +80,13 @@ public class AuthenticationFilter implements ContainerRequestFilter {
         this.config = config;
 
         setupAuthStrategies();
+    }
+
+    /**
+     * Used to pass mock object during unit testing
+     */
+    public void setHttpServletRequest(HttpServletRequest request) {
+        this.request = request;
     }
 
     public void setupAuthStrategies() {
@@ -128,6 +141,9 @@ public class AuthenticationFilter implements ContainerRequestFilter {
             if (hole != null && hole.noAuth()) {
                 log.debug("No auth allowed for resource; setting NoAuth principal");
                 principal = new NoAuthPrincipal();
+            }
+            else if (!request.isSecure()) {
+                throw new BadRequestException("Please use SSL when accessing protected resources");
             }
             else {
                 throw new NotAuthorizedException("Invalid credentials.");

--- a/server/src/test/java/org/candlepin/resteasy/filter/AuthenticationFilterTest.java
+++ b/server/src/test/java/org/candlepin/resteasy/filter/AuthenticationFilterTest.java
@@ -132,6 +132,23 @@ public class AuthenticationFilterTest extends DatabaseTestFixture {
     }
 
     @Test(expected = NotAuthorizedException.class)
+    public void noSecurityHoleNoPrincipalNoSslButOverridenByConfig() throws Exception {
+        config.setProperty(ConfigProperties.AUTH_OVER_HTTP, "true");
+        try {
+            when(mockHttpServletRequest.isSecure()).thenReturn(false);
+            Method method = FakeResource.class.getMethod("someMethod", String.class);
+            mockResourceMethod(method);
+            interceptor.filter(getContext());
+        }
+        finally {
+            /**
+             * Revert default settings
+             */
+            config.setProperty(ConfigProperties.AUTH_OVER_HTTP, "false");
+        }
+    }
+
+    @Test(expected = NotAuthorizedException.class)
     public void noSecurityHoleNoPrincipal() throws Exception {
         when(mockHttpServletRequest.isSecure()).thenReturn(true);
         Method method = FakeResource.class.getMethod("someMethod", String.class);


### PR DESCRIPTION
Candlepin shouldn't send WWW-Authenticate when the client communicates using
insecure channel, instead Candlepin should send back 403 Forbidden