### PR TITLE
Updated component versions for commons-io and httpclient

### DIFF
--- a/buildfile
+++ b/buildfile
@@ -40,7 +40,7 @@ RESTEASY = [group('jaxrs-api',
                   # servlet spec 3.0 which Tomcat 6 does not support
                   :version => '3.0.10.Final'),
             'org.scannotation:scannotation:jar:1.0.3',
-            'org.apache.httpcomponents:httpclient:jar:4.2.1',
+            'org.apache.httpcomponents:httpclient:jar:4.3.2',
             'org.apache.james:apache-mime4j:jar:0.6',
             'javax.mail:mail:jar:1.4.4',
             'javax.ws.rs:javax.ws.rs-api:jar:2.0.1']
@@ -117,7 +117,7 @@ ORACLE = ['com.oracle:ojdbc6:jar:11.2.0', 'org.quartz-scheduler:quartz-oracle:ja
 
 COMMONS = ['commons-codec:commons-codec:jar:1.4',
            'commons-collections:commons-collections:jar:3.2',
-           'commons-io:commons-io:jar:1.3.2',
+           'commons-io:commons-io:jar:1.4',
            'commons-lang:commons-lang:jar:2.5']
 
 LIQUIBASE = 'org.liquibase:liquibase-core:jar:3.1.0'

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -16,7 +16,7 @@
   <properties>
     <commons-codec-commons-codec.version>1.4</commons-codec-commons-codec.version>
     <commons-collections-commons-collections.version>3.2</commons-collections-commons-collections.version>
-    <commons-io-commons-io.version>1.3.2</commons-io-commons-io.version>
+    <commons-io-commons-io.version>1.4</commons-io-commons-io.version>
     <commons-lang-commons-lang.version>2.5</commons-lang-commons-lang.version>
     <ch.qos.logback-logback-core.version>1.1.3</ch.qos.logback-logback-core.version>
     <ch.qos.logback-logback-classic.version>1.1.3</ch.qos.logback-logback-classic.version>
@@ -41,7 +41,7 @@
     <org.jboss.resteasy-resteasy-atom-provider.version>3.0.10.Final</org.jboss.resteasy-resteasy-atom-provider.version>
     <org.jboss.resteasy-resteasy-multipart-provider.version>3.0.10.Final</org.jboss.resteasy-resteasy-multipart-provider.version>
     <org.scannotation-scannotation.version>1.0.3</org.scannotation-scannotation.version>
-    <org.apache.httpcomponents-httpclient.version>4.2.1</org.apache.httpcomponents-httpclient.version>
+    <org.apache.httpcomponents-httpclient.version>4.3.2</org.apache.httpcomponents-httpclient.version>
     <org.apache.james-apache-mime4j.version>0.6</org.apache.james-apache-mime4j.version>
     <javax.mail-mail.version>1.4.4</javax.mail-mail.version>
     <javax.ws.rs-javax.ws.rs-api.version>2.0.1</javax.ws.rs-javax.ws.rs-api.version>

--- a/gutterball/pom.xml
+++ b/gutterball/pom.xml
@@ -23,7 +23,7 @@
     <com.google.guava-guava.version>13.0</com.google.guava-guava.version>
     <commons-codec-commons-codec.version>1.4</commons-codec-commons-codec.version>
     <commons-collections-commons-collections.version>3.2</commons-collections-commons-collections.version>
-    <commons-io-commons-io.version>1.3.2</commons-io-commons-io.version>
+    <commons-io-commons-io.version>1.4</commons-io-commons-io.version>
     <commons-lang-commons-lang.version>2.5</commons-lang-commons-lang.version>
     <postgresql-postgresql.version>9.0-801.jdbc4</postgresql-postgresql.version>
     <mysql-mysql-connector-java.version>5.1.26</mysql-mysql-connector-java.version>
@@ -75,7 +75,7 @@
     <org.jboss.resteasy-resteasy-atom-provider.version>3.0.10.Final</org.jboss.resteasy-resteasy-atom-provider.version>
     <org.jboss.resteasy-resteasy-multipart-provider.version>3.0.10.Final</org.jboss.resteasy-resteasy-multipart-provider.version>
     <org.scannotation-scannotation.version>1.0.3</org.scannotation-scannotation.version>
-    <org.apache.httpcomponents-httpclient.version>4.2.1</org.apache.httpcomponents-httpclient.version>
+    <org.apache.httpcomponents-httpclient.version>4.3.2</org.apache.httpcomponents-httpclient.version>
     <org.apache.james-apache-mime4j.version>0.6</org.apache.james-apache-mime4j.version>
     <javax.mail-mail.version>1.4.4</javax.mail-mail.version>
     <javax.ws.rs-javax.ws.rs-api.version>2.0.1</javax.ws.rs-javax.ws.rs-api.version>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -25,7 +25,7 @@
     <com.google.guava-guava.version>13.0</com.google.guava-guava.version>
     <commons-codec-commons-codec.version>1.4</commons-codec-commons-codec.version>
     <commons-collections-commons-collections.version>3.2</commons-collections-commons-collections.version>
-    <commons-io-commons-io.version>1.3.2</commons-io-commons-io.version>
+    <commons-io-commons-io.version>1.4</commons-io-commons-io.version>
     <commons-lang-commons-lang.version>2.5</commons-lang-commons-lang.version>
     <com.googlecode.gettext-commons-gettext-commons.version>0.9.8</com.googlecode.gettext-commons-gettext-commons.version>
     <com.google.inject.extensions-guice-assistedinject.version>3.0</com.google.inject.extensions-guice-assistedinject.version>
@@ -83,7 +83,7 @@
     <org.jboss.resteasy-resteasy-atom-provider.version>3.0.10.Final</org.jboss.resteasy-resteasy-atom-provider.version>
     <org.jboss.resteasy-resteasy-multipart-provider.version>3.0.10.Final</org.jboss.resteasy-resteasy-multipart-provider.version>
     <org.scannotation-scannotation.version>1.0.3</org.scannotation-scannotation.version>
-    <org.apache.httpcomponents-httpclient.version>4.2.1</org.apache.httpcomponents-httpclient.version>
+    <org.apache.httpcomponents-httpclient.version>4.3.2</org.apache.httpcomponents-httpclient.version>
     <org.apache.james-apache-mime4j.version>0.6</org.apache.james-apache-mime4j.version>
     <javax.mail-mail.version>1.4.4</javax.mail-mail.version>
     <javax.ws.rs-javax.ws.rs-api.version>2.0.1</javax.ws.rs-javax.ws.rs-api.version>


### PR DESCRIPTION
- Candlepin now uses commons-io 1.4 and httpclient 4.3.2