### PR TITLE
1330262: Subject Alternative Name not respected

### DIFF
--- a/buildfile
+++ b/buildfile
@@ -164,7 +164,7 @@ SCHEMASPY = 'net.sourceforge:schemaSpy:jar:4.1.1'
 
 AMQP  = [group('qpid-common', 'qpid-client',
                :under => 'org.apache.qpid',
-               :version => '0.30'),
+               :version => '0.32'),
          group('mina-core', 'mina-filter-ssl',
                :under => 'org.apache.mina',
                :version => '1.0.1'),


### PR DESCRIPTION
Since qpid-client version 0.32 the qpid-client respects extension X509v3
Subject Alternative Name