### PR TITLE
1330246: Candlepin logrotate error on RHEL6.7

### DIFF
--- a/server/candlepin.spec.tmpl
+++ b/server/candlepin.spec.tmpl
@@ -120,6 +120,11 @@ rm -rf %{buildroot}
 
 %{__install} -d 755 %{buildroot}%{_sysconfdir}/logrotate.d/
 %{__install} -m 644 conf/logrotate.conf %{buildroot}%{_sysconfdir}/logrotate.d/%{name}
+## logrotate 3.8 requires the su directive,
+## where as prior versions do not recognize it.
+%if 0%{?fedora} || 0%{?rhel} > 6
+sed -i 's/#LOGROTATE-3.8#//' %{buildroot}%{_sysconfdir}/logrotate.d/%{name}
+%endif
 
 %{__install} -d -m 755 %{buildroot}/%{_datadir}/%{name}/
 

--- a/server/conf/logrotate.conf
+++ b/server/conf/logrotate.conf
@@ -1,5 +1,7 @@
 /var/log/candlepin/*.log {
-    su tomcat tomcat
+# logrotate 3.8 requires the su directive,
+# where as prior versions do not recognize it.
+#LOGROTATE-3.8#    su tomcat tomcat
     copytruncate
     daily
     rotate 52


### PR DESCRIPTION
There is a precedent to this solution in [spacewalk](https://github.com/spacewalkproject/spacewalk/blob/master/backend/spacewalk-backend.spec#L357).

Please try the following steps both in master and my branch to observe the difference:

Easiest steps I can think of, to test:
##### To verify that the appropriate logrotate conf is deployed in both rhel versions:
1. build a source rpm using tito:
`tito build --rpm --test`
2. copy over the **source** rpm to your RHEL6 and RHEL7 vms.
3. rebuild the rpm on each vm using the source rpm(there might be some dependencies you may have to install for this step to work):
`rpmbuild --rebuild mycandlepin.src.rpm`
4. extract the rpm that was created in the step above:
`rpm2cpio mycandlepin.noarch.rpm  | cpio -dium`
5. verify that the appropriate logrotate conf is installed:

on RHEL6: 

> 
cat etc/logrotate.d/candlepin  | grep "su tomcat"
#LOGROTATE-3.8#    su tomcat tomcat

on RHEL7:

>
cat etc/logrotate.d/candlepin  | grep "su tomcat"
     su tomcat tomcat

##### To verify that the logrotate actually works:

1. on both the vms, copy the logrotate conf to the appropriate place:

`cp etc/logrotate.d/candlepin /etc/logrotate.d/`
2. create a large log file:

`dd if=/dev/urandom of=/var/log/candlepin/candlepin.log bs=$(( 1024 * 1024 )) count=10000`
3. force a logrotate execution:

`logrotate -vvf /etc/logrotate.d/candlepin`