### PR TITLE
1306628: Added additional logging to environment deletion

### DIFF
--- a/server/src/main/java/org/candlepin/resource/EnvironmentResource.java
+++ b/server/src/main/java/org/candlepin/resource/EnvironmentResource.java
@@ -130,11 +130,15 @@ public class EnvironmentResource {
         }
 
         // Cleanup all consumers and their entitlements:
+        log.info("Deleting consumers in environment {}", e);
         for (Consumer c : e.getConsumers()) {
+            log.info("Deleting consumer: {}", c);
+
             poolManager.revokeAllEntitlements(c);
             consumerCurator.delete(c);
         }
 
+        log.info("Deleting environment: {}", e);
         envCurator.delete(e);
     }
 


### PR DESCRIPTION
This is a smaller, more immediate patch to a much bigger issue involving auditing on operations that cascade to other model objects. For this PR, only the details in the BZ were addressed due to the massive scope of the underlying issue which will be fixed in another PR to come.