### PR TITLE
1306628: Added additional logging to environment deletion (0.9.54)

### DIFF
--- a/server/src/main/java/org/candlepin/model/Environment.java
+++ b/server/src/main/java/org/candlepin/model/Environment.java
@@ -155,4 +155,9 @@ public class Environment extends AbstractHibernateObject implements Serializable
     public int hashCode() {
         return id.hashCode();
     }
+
+    @Override
+    public String toString() {
+        return String.format("Environment [id: %s, name: %s, owner: %s]", this.id, this.name, this.owner);
+    }
 }

--- a/server/src/main/java/org/candlepin/resource/EnvironmentResource.java
+++ b/server/src/main/java/org/candlepin/resource/EnvironmentResource.java
@@ -37,6 +37,8 @@ import com.google.inject.Inject;
 import org.jboss.resteasy.annotations.providers.jaxb.Wrapped;
 import org.quartz.JobDataMap;
 import org.quartz.JobDetail;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xnap.commons.i18n.I18n;
 
 import java.util.HashSet;
@@ -60,6 +62,7 @@ import javax.ws.rs.core.MediaType;
  */
 @Path("/environments")
 public class EnvironmentResource {
+    private static Logger log = LoggerFactory.getLogger(EnvironmentResource.class);
 
     private EnvironmentCurator envCurator;
     private I18n i18n;
@@ -120,11 +123,15 @@ public class EnvironmentResource {
         }
 
         // Cleanup all consumers and their entitlements:
+        log.info("Deleting consumers in environment {}", e);
         for (Consumer c : e.getConsumers()) {
+            log.info("Deleting consumer: {}", c);
+
             poolManager.revokeAllEntitlements(c);
             consumerCurator.delete(c);
         }
 
+        log.info("Deleting environment: {}", e);
         envCurator.delete(e);
     }
 


### PR DESCRIPTION
This is a smaller, more immediate patch to a much bigger issue involving auditing on operations that cascade to other model objects. For this PR, only the details in the BZ were addressed due to the massive scope of the underlying issue which will be fixed in another PR to come.