### PR TITLE
1332637: Treat null guest lists as empty guest lists

### DIFF
--- a/server/src/main/java/org/candlepin/resource/HypervisorResource.java
+++ b/server/src/main/java/org/candlepin/resource/HypervisorResource.java
@@ -140,6 +140,11 @@ public class HypervisorResource {
 
         Collection<List<GuestId>> idsLists = hostGuestMap.values();
         for (List<GuestId> guestIds : idsLists) {
+            // ignore null guest lists
+            // See bzs 1332637, 1332635
+            if (guestIds == null) {
+                continue;
+            }
             for (Iterator<GuestId> guestIdsItr = guestIds.iterator(); guestIdsItr.hasNext();) {
                 String id = guestIdsItr.next().getGuestId();
 
@@ -164,6 +169,14 @@ public class HypervisorResource {
         HypervisorCheckInResult result = new HypervisorCheckInResult();
         for (Entry<String, List<GuestId>> hostEntry : hostGuestMap.entrySet()) {
             String hypervisorId = hostEntry.getKey();
+            // Treat null guest list as an empty list.
+            // We can get an empty list here from katello due to an update
+            // to ruby on rails.
+            // (https://github.com/rails/rails/issues/13766#issuecomment-32730270)
+            // See bzs 1332637, 1332635
+            if (hostEntry.getValue() == null) {
+                hostEntry.setValue(new ArrayList<GuestId>());
+            }
             try {
                 log.debug("Syncing virt host: {} ({} guest IDs)", hypervisorId, hostEntry.getValue().size());
 

--- a/server/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
@@ -349,4 +349,36 @@ public class HypervisorResourceTest {
         List<GuestId> gids = created.get(0).getGuestIds();
         assertEquals(1, gids.size());
     }
+
+    @SuppressWarnings({ "rawtypes", "unchecked", "deprecation" })
+    @Test
+    public void treatNullGuestListsAsEmptyGuestLists() throws Exception {
+        Owner owner = new Owner("admin");
+
+        Map<String, List<GuestId>> hostGuestMap = new HashMap<String, List<GuestId>>();
+        hostGuestMap.put("HYPERVISOR_A", null);
+        when(ownerCurator.lookupByKey(eq(owner.getKey()))).thenReturn(owner);
+
+        when(consumerCurator.getHostConsumersMap(any(Owner.class), any(Set.class)))
+            .thenReturn(new VirtConsumerMap());
+        when(consumerCurator.getGuestConsumersMap(any(Owner.class), any(Set.class)))
+            .thenReturn(new VirtConsumerMap());
+
+        when(ownerCurator.lookupByKey(eq(owner.getKey()))).thenReturn(owner);
+        when(principal.canAccess(eq(owner), eq(SubResource.CONSUMERS), eq(Access.CREATE)))
+            .thenReturn(true);
+        when(consumerTypeCurator.lookupByLabel(eq(ConsumerTypeEnum.HYPERVISOR.getLabel())))
+            .thenReturn(hypervisorType);
+        when(idCertService.generateIdentityCert(any(Consumer.class)))
+            .thenReturn(new IdentityCertificate());
+
+        HypervisorCheckInResult result = hypervisorResource.hypervisorUpdate(
+            hostGuestMap, principal, owner.getKey(), true);
+        assertNotNull(result);
+        assertNotNull(result.getCreated());
+        List<Consumer> created = new ArrayList<Consumer>(result.getCreated());
+        assertEquals(1, created.size());
+        List<GuestId> gids = created.get(0).getGuestIds();
+        assertEquals(0, gids.size());
+    }
 }


### PR DESCRIPTION
This is the forward port of the fix for bz 1332635. There is really nothing much different here about the fix than there was in candlepin version 0.9.54. The async logic did not have the same flaw as the synchronous logic did.