### PR TITLE
1331793: Improved performace of expired pool cleanup task

### DIFF
--- a/server/src/main/java/org/candlepin/controller/PoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/PoolManager.java
@@ -155,7 +155,7 @@ public interface PoolManager {
 
     Pool setPoolQuantity(Pool pool, long set);
 
-    void regenerateDirtyEntitlements(List<Entitlement> entitlements);
+    void regenerateDirtyEntitlements(Iterable<Entitlement> entitlements);
 
     Entitlement adjustEntitlementQuantity(Consumer consumer, Entitlement entitlement,
         Integer quantity) throws EntitlementRefusedException;

--- a/server/src/main/java/org/candlepin/model/Entitlement.java
+++ b/server/src/main/java/org/candlepin/model/Entitlement.java
@@ -324,7 +324,7 @@ public class Entitlement extends AbstractHibernateObject
     }
 
     @XmlTransient
-    public boolean getDirty() {
+    public boolean isDirty() {
         return dirty;
     }
 

--- a/server/src/main/java/org/candlepin/model/EntitlementCertificateCurator.java
+++ b/server/src/main/java/org/candlepin/model/EntitlementCertificateCurator.java
@@ -22,11 +22,12 @@ import org.hibernate.criterion.Restrictions;
 import java.util.Date;
 import java.util.List;
 
+
+
 /**
  * EntitlementCertificateCurator
  */
-public class EntitlementCertificateCurator extends
-    AbstractHibernateCurator<EntitlementCertificate> {
+public class EntitlementCertificateCurator extends AbstractHibernateCurator<EntitlementCertificate> {
 
     @Inject
     public EntitlementCertificateCurator() {

--- a/server/src/main/java/org/candlepin/sync/Exporter.java
+++ b/server/src/main/java/org/candlepin/sync/Exporter.java
@@ -436,7 +436,7 @@ public class Exporter {
         entCertDir.mkdir();
 
         for (Entitlement ent : entitlementCurator.listByConsumer(consumer)) {
-            if (ent.getDirty()) {
+            if (ent.isDirty()) {
                 log.error("Entitlement " + ent.getId() + " is marked as dirty.");
                 throw new ExportCreationException("Attempted to export dirty entitlements");
             }

--- a/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -865,7 +865,7 @@ public class PoolManagerTest {
         pools.add(p);
 
         when(mockPoolCurator.lockAndLoad(any(Pool.class))).thenReturn(p);
-        when(mockPoolCurator.listExpiredPools()).thenReturn(pools);
+        when(mockPoolCurator.listExpiredPools(anyInt())).thenReturn(pools);
         when(mockPoolCurator.entitlementsIn(p)).thenReturn(new ArrayList<Entitlement>(p.getEntitlements()));
         Subscription sub = new Subscription();
         sub.setId(p.getSubscriptionId());
@@ -889,7 +889,7 @@ public class PoolManagerTest {
         pools.add(p);
 
         when(mockPoolCurator.lockAndLoad(any(Pool.class))).thenReturn(p);
-        when(mockPoolCurator.listExpiredPools()).thenReturn(pools);
+        when(mockPoolCurator.listExpiredPools(anyInt())).thenReturn(pools);
         when(mockPoolCurator.entitlementsIn(p)).thenReturn(new ArrayList<Entitlement>(p.getEntitlements()));
         Subscription sub = new Subscription();
         sub.setId(p.getSubscriptionId());

--- a/server/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
@@ -497,7 +497,6 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void getGuestConsumerMap() {
-
         String guestId1 = "06F81B41-AAC0-7685-FBE9-79AA4A326511";
         String guestId1ReverseEndian = "411bf806-c0aa-8576-fbe9-79aa4a326511";
         Consumer gConsumer1 = new Consumer("guestConsumer1", "testUser", owner, ct);
@@ -512,20 +511,15 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
         Set<String> guestIds = new HashSet<String>();
         guestIds.add(guestId1ReverseEndian); // reversed endian match
         guestIds.add(guestId2); // direct match
-        VirtConsumerMap guestMap = consumerCurator.getGuestConsumersMap(
-            owner, guestIds);
+        VirtConsumerMap guestMap = consumerCurator.getGuestConsumersMap(owner, guestIds);
 
         assertEquals(2, guestMap.size());
 
-        assertEquals(gConsumer1.getId(), guestMap.get(
-            guestId1.toLowerCase()).getId());
-        assertEquals(gConsumer1.getId(), guestMap.get(
-            guestId1ReverseEndian).getId());
+        assertEquals(gConsumer1.getId(), guestMap.get(guestId1.toLowerCase()).getId());
+        assertEquals(gConsumer1.getId(), guestMap.get(guestId1ReverseEndian).getId());
 
-        assertEquals(gConsumer2.getId(), guestMap.get(
-            guestId2.toLowerCase()).getId());
-        assertEquals(gConsumer2.getId(), guestMap.get(
-            Util.transformUuid(guestId2.toLowerCase())).getId());
+        assertEquals(gConsumer2.getId(), guestMap.get(guestId2.toLowerCase()).getId());
+        assertEquals(gConsumer2.getId(), guestMap.get(Util.transformUuid(guestId2.toLowerCase())).getId());
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/sync/ExporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/ExporterTest.java
@@ -271,7 +271,7 @@ public class ExporterTest {
         when(principal.getUsername()).thenReturn("testUser");
 
         when(ec.listByConsumer(consumer)).thenReturn(entitlements);
-        when(ent.getDirty()).thenReturn(true);
+        when(ent.isDirty()).thenReturn(true);
         idcert.setSerial(new CertificateSerial(10L, new Date()));
         idcert.setKey("euh0876puhapodifbvj094");
         idcert.setCert("hpj-08ha-w4gpoknpon*)&^%#");


### PR DESCRIPTION
- Added a limit to the number of pools the expired pools query will fetch
  per "block." The cleanup expired pools operation will now fetch and
  cleanup pools in blocks of 2048 (by default) rather than fetching
  every known pool and running out of memory
- Hibernate queries which make use of the IN operator no longer create
  new lists when the source collection is not a List instance
- Several redundant blocks of code were removed in favour of the updated
  in-operator handling
- Added explicit handling of iterable entitlement IDs when regenerating
  certificates; it is now performed with a bulk update rather than
  loading the entire entitlement set one-by-one
- Retrieval of modifier products by a query instead of using iteration over
  overlapping entitlements (which consumes a lot of memory)
- cleanupExpiredPools, and the query behind it, no longer pull
  pools which are derived, as they were ignored by the process
  anyway
- cleanupExpiredPools will no longer delete pools that have an
  entitlement which overrides the end date such that it ends
  after the pool's base end date
- The regeneration of certificates of modifying entitlements
  during entitlement revocation is now performed in bulk on
  the DB
- Entitlement.getDirty is now Entitlement.isDirty
- Added new tests to cover untested methods
  EntitlementCurator.markEntitlementsDirty and
  EntitlementCertificateGenerator.regenerateCertificatesByEntitlementId
- Updated CandlepinPoolManager.regenerateDirtyCertificates to no longer
  copy entitlements to a separate list to iterate