### PR TITLE
Fixed periodic failures in some unit tests

### DIFF
--- a/server/src/main/java/org/candlepin/model/JobCurator.java
+++ b/server/src/main/java/org/candlepin/model/JobCurator.java
@@ -155,6 +155,9 @@ public class JobCurator extends AbstractHibernateCurator<JobStatus> {
     }
 
     public JobStatus getByClassAndTarget(String target, Class<? extends KingpinJob> jobClass) {
+        // FIXME:
+        // This is not guaranteed to find the intended target if more than one job in the DB
+        // matches the input criteria
 
         return (JobStatus) this.currentSession().createCriteria(JobStatus.class)
             .addOrder(Order.desc("created"))

--- a/server/src/main/java/org/candlepin/pinsetter/core/model/JobStatus.java
+++ b/server/src/main/java/org/candlepin/pinsetter/core/model/JobStatus.java
@@ -319,10 +319,22 @@ public class JobStatus extends AbstractHibernateObject {
                 // unable to close streams
             }
         }
+
         return result;
     }
 
     public void cloakResultData(boolean cloak) {
         this.cloakData = cloak;
+    }
+
+    public String toString() {
+        return String.format("JobStatus [id: %s, type: %s, owner: %s, target: %s (%s), state: %s]",
+            this.id,
+            this.jobClass != null ? this.jobClass.getSimpleName() : null,
+            this.ownerId,
+            this.targetId,
+            this.targetType,
+            this.state
+        );
     }
 }

--- a/server/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
@@ -245,55 +245,70 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void twoHostsRegisteredPickSecond() {
+    public void twoHostsRegisteredPickSecond() throws Exception {
+        long base = System.currentTimeMillis() - 10000;
+
         Consumer host1 = new Consumer("hostConsumer", "testUser", owner, ct);
+        host1.setCreated(new Date(base));
         consumerCurator.create(host1);
 
         Consumer host2 = new Consumer("hostConsumer2", "testUser2", owner, ct);
+        host2.setCreated(new Date(base + 1000));
         consumerCurator.create(host2);
 
         Consumer gConsumer1 = new Consumer("guestConsumer1", "testUser", owner, ct);
+        gConsumer1.setCreated(new Date(base + 2000));
         gConsumer1.getFacts().put("virt.uuid", "daf0fe10-956b-7b4e-b7dc-b383ce681ba8");
         consumerCurator.create(gConsumer1);
 
         GuestId host1Guest = new GuestId("DAF0FE10-956B-7B4E-B7DC-B383CE681BA8");
+        host1Guest.setCreated(new Date(base + 3000));
         host1.addGuestId(host1Guest);
         consumerCurator.update(host1);
 
+        Thread.sleep(1000);
+
         GuestId host2Guest = new GuestId("DAF0FE10-956B-7B4E-B7DC-B383CE681BA8");
+        host2Guest.setCreated(new Date(base + 4000));
         host2.addGuestId(host2Guest);
         consumerCurator.update(host2);
 
-        Consumer guestHost = consumerCurator.getHost(
-            "daf0fe10-956b-7b4e-b7dc-b383ce681ba8", owner);
+        Consumer guestHost = consumerCurator.getHost("daf0fe10-956b-7b4e-b7dc-b383ce681ba8", owner);
+
         assertTrue(host1Guest.getUpdated().before(host2Guest.getUpdated()));
         assertEquals(host2.getUuid(), guestHost.getUuid());
     }
 
     @Test
     public void twoHostsRegisteredPickFirst() throws Exception {
+        long base = System.currentTimeMillis() - 10000;
+
         Consumer host1 = new Consumer("hostConsumer", "testUser", owner, ct);
+        host1.setCreated(new Date(base));
         consumerCurator.create(host1);
 
         Consumer host2 = new Consumer("hostConsumer2", "testUser2", owner, ct);
+        host2.setCreated(new Date(base + 1000));
         consumerCurator.create(host2);
 
         Consumer gConsumer1 = new Consumer("guestConsumer1", "testUser", owner, ct);
+        gConsumer1.setCreated(new Date(base + 2000));
         gConsumer1.getFacts().put("virt.uuid", "daf0fe10-956b-7b4e-b7dc-b383ce681ba8");
         consumerCurator.create(gConsumer1);
 
         GuestId host2Guest = new GuestId("DAF0FE10-956B-7B4E-B7DC-B383CE681BA8");
+        host2Guest.setCreated(new Date(base + 3000));
         host2.addGuestId(host2Guest);
         consumerCurator.update(host2);
 
         Thread.sleep(1000);
 
         GuestId host1Guest = new GuestId("DAF0FE10-956B-7B4E-B7DC-B383CE681BA8");
+        host1Guest.setCreated(new Date(base + 4000));
         host1.addGuestId(host1Guest);
         consumerCurator.update(host1);
 
-        Consumer guestHost = consumerCurator.getHost(
-            "daf0fe10-956b-7b4e-b7dc-b383ce681ba8", owner);
+        Consumer guestHost = consumerCurator.getHost("daf0fe10-956b-7b4e-b7dc-b383ce681ba8", owner);
         assertTrue(host1Guest.getUpdated().after(host2Guest.getUpdated()));
         assertEquals(host1.getUuid(), guestHost.getUuid());
     }

--- a/server/src/test/java/org/candlepin/util/X509CRLStreamWriterTest.java
+++ b/server/src/test/java/org/candlepin/util/X509CRLStreamWriterTest.java
@@ -302,7 +302,11 @@ public class X509CRLStreamWriterTest {
         long changedCrlUpdateDelta =
             changedCrl.getNextUpdate().getTime() - changedCrl.getThisUpdate().getTime();
 
-        assertEquals(changedCrlUpdateDelta, oneHourHence.getTime() - oneHourAgo.getTime());
+        // We're allowing a tolerance of a few milliseconds to deal with minor timing issues
+        long deltaTolerance = 3;
+        long deltaDiff = changedCrlUpdateDelta - (oneHourHence.getTime() - oneHourAgo.getTime());
+
+        assertTrue(Math.abs(deltaDiff) <= deltaTolerance);
         assertThat(changedCrl.getThisUpdate(), greaterThan(originalCrl.getThisUpdate()));
 
         assertEquals(newSerials, discoveredSerials);


### PR DESCRIPTION
- Fixed an issue in the JobCuratorTest which allowed two jobs to have the
  same time for the purposes of ordering
- Fixed an issue in the ConsumerCuratorTest where the update date could
  end up identical unintentionally
- Added a tolerance of three milliseconds to the time check in
  X509CRLStreamWriterTest to account for minor slowdowns or scheduling
  issues during testing