### PR TITLE
Added filtering to the unit test parameter in cp-test

### DIFF
--- a/docker/candlepin-base/cp-test
+++ b/docker/candlepin-base/cp-test
@@ -140,7 +140,14 @@ while getopts ":dtrHulsb:c:p:v" opt; do
             RSPEC="1"
             DEPLOY="1"
             ;;
-        u  ) UNITTEST=$((UNITTEST + 1));;
+        u  ) UNITTEST=$((UNITTEST + 1))
+
+            ARG="${ARGV[$OPTIND - 1]}"
+            if [ "${ARG:0:1}" != "-" ] && [ "${ARG:0:1}" != "" ]; then
+                UNITTEST_FILTER="$ARG"
+                OPTIND=$((OPTIND + 1))
+            fi
+            ;;
         l  ) LINTER="1";;
         s  ) LAUNCHSHELL="1";;
         b  ) ARBITRARY="${OPTARG}";;
@@ -204,11 +211,18 @@ cd "$CP_HOME/$PROJECT"
 if [ "$UNITTEST" -gt 0 ]; then
     echo "Running unit tests $UNITTEST time(s)"
     # run $UNITTEST time(s) to increase chance of capturing
-    # non deterministic unit test failures.
+    # non-deterministic unit test failures.
+
+    UTCMD="test"
+
+    if [ ! -z "${UNITTEST_FILTER}" ]; then
+        UTCMD="${UTCMD}:${UNITTEST_FILTER}"
+    fi
+
     for (( i=1; i<=$UNITTEST; i++ ))
     do
         tee /var/log/candlepin/unit_tests.log < /tmp/teepipe &
-        buildr test > /tmp/teepipe 2>&1
+        buildr $UTCMD > /tmp/teepipe 2>&1
         rm -f /tmp/teepipe
         mkfifo /tmp/teepipe
     done


### PR DESCRIPTION
This can be tested by building the candlepin-base image, then running unit tests against it with filters, without filters, with varying number of unit test runs

```
cd devel/candlepin/docker
mkdir artifacts
sudo ./candlepin-base/build.sh

# Should run all the unit tests once
sudo docker run -Pti --rm -v $PWD/artifacts/:/artifacts/ candlepin/candlepin-base cp-test -u

# Should run the JobCurator unit tests once
sudo docker run -Pti --rm -v $PWD/artifacts/:/artifacts/ candlepin/candlepin-base cp-test -u JobCuratorTest

# Should run the ConsumerCurator unit tests three times
sudo docker run -Pti --rm -v $PWD/artifacts/:/artifacts/ candlepin/candlepin-base cp-test -uuu ConsumerCuratorTest
```