### PR TITLE
Clean working copy before checkout

### DIFF
--- a/docker/candlepin-base/cp-test
+++ b/docker/candlepin-base/cp-test
@@ -170,7 +170,11 @@ else
     echo "Using /candlepin."
     CP_HOME="/candlepin"
     cd $CP_HOME
-    git pull
+    # In case $CP_HOME contains local changes its better to use 'clean'
+    # to remove any untracked files before proceeding
+    git fetch
+    git reset --hard origin master
+    git clean -df
     if [ ! -z "$CHECKOUT" ]; then
         echo "Checking out: $CHECKOUT"
         git checkout "$CHECKOUT"


### PR DESCRIPTION
Our script that pulls Github PR branches was using 'git pull' which may leave
untracked files and local changes in the working copy. That may result in errors
during checkouts. It is safer to fetch+reset and then clean the working copy.