### PR TITLE
Docker containers now use rvm for Ruby management

### DIFF
--- a/docker/candlepin-base/cp-test
+++ b/docker/candlepin-base/cp-test
@@ -170,11 +170,13 @@ else
     echo "Using /candlepin."
     CP_HOME="/candlepin"
     cd $CP_HOME
+
     # In case $CP_HOME contains local changes its better to use 'clean'
     # to remove any untracked files before proceeding
     git fetch
-    git reset --hard origin master
+    git reset --hard
     git clean -df
+
     if [ ! -z "$CHECKOUT" ]; then
         echo "Checking out: $CHECKOUT"
         git checkout "$CHECKOUT"
@@ -204,7 +206,7 @@ if [ "$UNITTEST" -gt 0 ]; then
     # run $UNITTEST time(s) to increase chance of capturing
     # non deterministic unit test failures.
     for (( i=1; i<=$UNITTEST; i++ ))
-    do 
+    do
         tee /var/log/candlepin/unit_tests.log < /tmp/teepipe &
         buildr test > /tmp/teepipe 2>&1
         rm -f /tmp/teepipe

--- a/docker/candlepin-base/setup-devel-env.sh
+++ b/docker/candlepin-base/setup-devel-env.sh
@@ -19,8 +19,6 @@ PACKAGES=(
     python-pip
     git
     tig
-    rubygems
-    ruby-devel
     gcc
     tomcat
     java-$JAVA_VERSION-openjdk-devel
@@ -55,7 +53,15 @@ cd /candlepin
 git config --add remote.origin.fetch "+refs/pull/*:refs/remotes/origin/pr/*"
 git pull
 
-# Install all ruby deps:
+# Setup and install rvm, ruby and pals
+gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
+curl -sSL https://get.rvm.io | bash -s stable
+source /etc/profile.d/rvm.sh
+
+rvm install 2.0.0
+rvm use --default 2.0.0
+
+# Install all ruby deps
 gem install bundler
 bundle install
 


### PR DESCRIPTION
This can be tested building candlepin-base, then using the new image to test an old build of Candlepin:

```
cd devel/candlepin/docker
mkdir artifacts
sudo ./candlepin-base/build.sh

# The next commands should both complete successfully
sudo docker run -Pti --rm -v $PWD/artifacts/:/artifacts/ candlepin/candlepin-base cp-test -u

sudo docker run -Pti --rm -v $PWD/artifacts/:/artifacts/ candlepin/candlepin-base cp-test -u -c candlepin-0.9.51-HOTFIX
```