### PR TITLE
Updated query backing the PoolCurator.listExpiredPools method

### DIFF
--- a/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
+++ b/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
@@ -568,6 +568,20 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
         return object;
     }
 
+    /**
+     * Evicts all of the given entities from the level-one cache.
+     *
+     * @param collection
+     *  An iterable collection of entities to evict from the session
+     */
+    public void evictAll(Iterable<E> collection) {
+        Session session = this.currentSession();
+
+        for (E entity : collection) {
+            session.evict(entity);
+        }
+    }
+
     public List<E> takeSubList(PageRequest pageRequest, List<E> results) {
         int fromIndex = (pageRequest.getPage() - 1) * pageRequest.getPerPage();
         if (fromIndex >= results.size()) {

--- a/server/src/main/java/org/candlepin/model/EntitlementCurator.java
+++ b/server/src/main/java/org/candlepin/model/EntitlementCurator.java
@@ -43,6 +43,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.persistence.EntityManager;
 import javax.persistence.Query;
 
 
@@ -364,16 +365,65 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
         return page;
     }
 
+    /**
+     * Deletes the given entitlement.
+     *
+     * @param entity
+     *  The entitlement entity to delete
+     */
     @Transactional
     public void delete(Entitlement entity) {
         Entitlement toDelete = find(entity.getId());
-        log.debug("Deleting entitlement: {}", toDelete);
-        log.debug("certs.size = {}", toDelete.getCertificates().size());
 
-        for (EntitlementCertificate cert : toDelete.getCertificates()) {
-            currentSession().delete(cert);
+        if (toDelete != null) {
+            this.deleteImpl(toDelete);
+
+            // Maintain runtime consistency.
+            entity.getCertificates().clear();
+            entity.getConsumer().getEntitlements().remove(entity);
+            entity.getPool().getEntitlements().remove(entity);
         }
-        currentSession().delete(toDelete);
+    }
+
+    /**
+     * Deletes the given collection of entitlements.
+     * <p/></p>
+     * Note: Unlike the standard delete method, this method does not perform a lookup on an entity
+     * before deleting it.
+     *
+     * @param entitlements
+     *  The collection of entitlement entities to delete
+     */
+    public void batchDelete(Collection<Entitlement> entitlements) {
+        for (Entitlement entitlement : entitlements) {
+            this.deleteImpl(entitlement);
+
+            // Maintain runtime consistency.
+            entitlement.getCertificates().clear();
+
+            if (Hibernate.isInitialized(entitlement.getConsumer().getEntitlements())) {
+                entitlement.getConsumer().getEntitlements().remove(entitlement);
+            }
+
+            if (Hibernate.isInitialized(entitlement.getPool().getEntitlements())) {
+                entitlement.getPool().getEntitlements().remove(entitlement);
+            }
+        }
+    }
+
+    private void deleteImpl(Entitlement entity) {
+        log.debug("Deleting entitlement: {}", entity);
+        EntityManager entityManager = this.getEntityManager();
+
+        if (entity.getCertificates() != null) {
+            log.debug("certs.size = {}", entity.getCertificates().size());
+
+            for (EntitlementCertificate cert : entity.getCertificates()) {
+                entityManager.remove(cert);
+            }
+        }
+
+        entityManager.remove(entity);
     }
 
     @Transactional
@@ -446,31 +496,6 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
         }
 
         return criteria.list();
-    }
-
-    /**
-     * Batch deletes a list of entitlements.
-     * @param pools
-     */
-    public void batchDelete(List<Entitlement> entitlements) {
-        for (Entitlement ent : entitlements) {
-            log.debug("Deleting entitlement: {}", ent);
-            log.debug("certs.size = {}", ent.getCertificates().size());
-
-            for (EntitlementCertificate cert : ent.getCertificates()) {
-                getEntityManager().remove(cert);
-            }
-            ent.getCertificates().clear();
-            getEntityManager().remove(ent);
-
-            // Maintain runtime consistency.
-            ent.getCertificates().clear();
-            ent.getConsumer().getEntitlements().remove(ent);
-
-            if (Hibernate.isInitialized(ent.getPool().getEntitlements())) {
-                ent.getPool().getEntitlements().remove(ent);
-            }
-        }
     }
 
     @SuppressWarnings("unchecked")

--- a/server/src/test/java/org/candlepin/controller/PoolManagerFunctionalTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerFunctionalTest.java
@@ -117,8 +117,7 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
         provisioning.addAttribute(new ProductAttribute("instance-multiplier", "4"));
 
         virtHost.addAttribute(new ProductAttribute(PRODUCT_VIRT_HOST, ""));
-        virtHostPlatform.addAttribute(new ProductAttribute(PRODUCT_VIRT_HOST_PLATFORM,
-            ""));
+        virtHostPlatform.addAttribute(new ProductAttribute(PRODUCT_VIRT_HOST_PLATFORM, ""));
         virtGuest.addAttribute(new ProductAttribute(PRODUCT_VIRT_GUEST, ""));
         monitoring.addAttribute(new ProductAttribute(PRODUCT_MONITORING, ""));
         provisioning.addAttribute(new ProductAttribute(PRODUCT_PROVISIONING, ""));
@@ -753,5 +752,103 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
         assertEquals(1, results.get(1).getQuantity().intValue());
     }
 
+    @Test
+    public void testCleanupExpiredPools() {
+        long ct = System.currentTimeMillis();
+        Date activeStart = new Date(ct + 3600000);
+        Date activeEnd = new Date(ct + 7200000);
+        Date expiredStart = new Date(ct - 7200000);
+        Date expiredEnd = new Date(ct - 3600000);
+
+        Owner owner = this.createOwner();
+        Product product1 = this.createProduct("test-product-1", "Test Product 1", owner);
+        Product product2 = this.createProduct("test-product-2", "Test Product 2", owner);
+        Pool activePool = this.createPool(owner, product1, 1L, activeStart, activeEnd);
+        Pool expiredPool = this.createPool(owner, product2, 1L, expiredStart, expiredEnd);
+
+        this.poolManager.cleanupExpiredPools();
+
+        assertNotNull(this.poolCurator.find(activePool.getId()));
+        assertNull(this.poolCurator.find(expiredPool.getId()));
+    }
+
+    @Test
+    public void testCleanupExpiredPoolsWithEntitlementEndDateOverrides() {
+        long ct = System.currentTimeMillis();
+        Date activeStart = new Date(ct + 3600000);
+        Date activeEnd = new Date(ct + 7200000);
+        Date expiredStart = new Date(ct - 7200000);
+        Date expiredEnd = new Date(ct - 3600000);
+
+        Owner owner = this.createOwner();
+        List<Consumer> consumers = new LinkedList<Consumer>();
+        List<Product> products = new LinkedList<Product>();
+        List<Pool> pools = new LinkedList<Pool>();
+        List<Entitlement> entitlements = new LinkedList<Entitlement>();
+
+        int objCount = 6;
+
+        for (int i = 0; i < objCount; ++i) {
+            Consumer consumer = this.createConsumer(owner);
+            Product product = this.createProduct("test-product-" + i, "Test Product " + i, owner);
+            Pool pool = (i % 2 == 0) ? this.createPool(owner, product, 1L, activeStart, activeEnd) :
+                this.createPool(owner, product, 1L, expiredStart, expiredEnd);
+
+            consumers.add(consumer);
+            products.add(product);
+            pools.add(pool);
+        }
+
+        entitlements.add(this.createEntitlement(owner, consumers.get(0), pools.get(2), null));
+        entitlements.add(this.createEntitlement(owner, consumers.get(1), pools.get(3), null));
+        entitlements.add(this.createEntitlement(owner, consumers.get(2), pools.get(4), null));
+        entitlements.add(this.createEntitlement(owner, consumers.get(3), pools.get(5), null));
+        entitlements.get(0).setEndDateOverride(activeEnd);
+        entitlements.get(1).setEndDateOverride(activeEnd);
+        entitlements.get(2).setEndDateOverride(expiredEnd);
+        entitlements.get(3).setEndDateOverride(expiredEnd);
+
+        for (Entitlement entitlement : entitlements) {
+            this.entitlementCurator.merge(entitlement);
+        }
+
+        this.poolManager.cleanupExpiredPools();
+
+        assertNotNull(this.poolCurator.find(pools.get(0).getId())); // Active pool, no ent
+        assertNull(this.poolCurator.find(pools.get(1).getId()));    // Expired pool, no ent
+        assertNotNull(this.poolCurator.find(pools.get(2).getId())); // Active pool, active ent
+        assertNotNull(this.poolCurator.find(pools.get(3).getId())); // Expired pool, active ent
+        assertNotNull(this.poolCurator.find(pools.get(4).getId())); // Active pool, expired ent
+        assertNull(this.poolCurator.find(pools.get(5).getId()));    // Expired pool, expired ent
+    }
+
+    @Test
+    public void testCleanupExpiredNonDerivedPools() {
+        long ct = System.currentTimeMillis();
+        Date activeStart = new Date(ct + 3600000);
+        Date activeEnd = new Date(ct + 7200000);
+        Date expiredStart = new Date(ct - 7200000);
+        Date expiredEnd = new Date(ct - 3600000);
+
+        Owner owner = this.createOwner();
+        Product product1 = this.createProduct("test-product-1", "Test Product 1", owner);
+        Product product2 = this.createProduct("test-product-2", "Test Product 2", owner);
+        Pool pool1 = this.createPool(owner, product1, 1L, activeStart, activeEnd);
+        Pool pool2 = this.createPool(owner, product2, 1L, expiredStart, expiredEnd);
+        Pool pool3 = this.createPool(owner, product2, 1L, activeStart, activeEnd);
+        Pool pool4 = this.createPool(owner, product2, 1L, expiredStart, expiredEnd);
+
+        pool3.setAttribute(Pool.DERIVED_POOL_ATTRIBUTE, "true");
+        pool4.setAttribute(Pool.DERIVED_POOL_ATTRIBUTE, "true");
+        this.poolCurator.merge(pool3);
+        this.poolCurator.merge(pool4);
+
+        this.poolManager.cleanupExpiredPools();
+
+        assertNotNull(this.poolCurator.find(pool1.getId()));        // Active pool, no attrib
+        assertNull(this.poolCurator.find(pool2.getId()));           // Expired pool, no attrib
+        assertNotNull(this.poolCurator.find(pool3.getId()));        // Active pool, derived attrib
+        assertNotNull(this.poolCurator.find(pool4.getId()));        // Expired pool, derived attrib
+    }
 }
 

--- a/server/src/test/java/org/candlepin/model/EntitlementCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/EntitlementCuratorTest.java
@@ -420,17 +420,17 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
     private Entitlement createPool(String id, Date startDate, Date endDate, Product provided) {
         EntitlementCertificate cert = createEntitlementCertificate("key", "certificate");
         Product poolProd = this.createProduct("prod-" + id, "prod-" + id, owner);
-        Pool p = TestUtil.createPool(owner, poolProd);
+        Pool pool = TestUtil.createPool(owner, poolProd);
 
         if (provided != null) {
-            p.addProvidedProduct(provided);
+            pool.addProvidedProduct(provided);
         }
 
-        p.setStartDate(startDate);
-        p.setEndDate(endDate);
-        Entitlement e1 = createEntitlement(owner, consumer, p, cert);
-        poolCurator.create(p);
-        entitlementCurator.create(e1);
+        pool.setStartDate(startDate);
+        pool.setEndDate(endDate);
+        poolCurator.create(pool);
+
+        Entitlement e1 = createEntitlement(owner, consumer, pool, cert);
 
         return e1;
     }

--- a/server/src/test/resources/logback-test.xml
+++ b/server/src/test/resources/logback-test.xml
@@ -15,6 +15,7 @@
 <!--
   <logger name="org.hibernate.SQL" level="DEBUG"/>
   <logger name="org.hibernate.type" level="TRACE"/>
+  <logger name="org.hibernate.event.internal.DefaultPersistEventListener" level="TRACE"/>
 -->
 
   <root level="WARN">


### PR DESCRIPTION
- PoolCurator.findExpiredPools now uses left joins and null checks
  when comparing entitlements and attributes, fixing an issue where
  pools without entitlements or attributes would not be found
- CandlepinPoolManager.cleanupExpiredPools now uses a transaction for
  each block of pools rather than the entire cleanup operation
- Added AbstractHibernateCurator.evictAll for performing bulk eviction
  on entity collections