### PR TITLE
addOwner in Product and Content now replace equal owners on call

### DIFF
--- a/server/src/main/java/org/candlepin/model/Content.java
+++ b/server/src/main/java/org/candlepin/model/Content.java
@@ -380,7 +380,7 @@ public class Content extends AbstractHibernateObject implements SharedEntity, Cl
 
     /**
      * Associates this content with the specified owner. If the given owner is already associated
-     * with this content, the request is silently ignored.
+     * with this content, the association will be updated with the given owner instance.
      *
      * @param owner
      *  An owner to be associated with this content
@@ -394,6 +394,7 @@ public class Content extends AbstractHibernateObject implements SharedEntity, Cl
                 this.owners = new HashSet<Owner>();
             }
 
+            this.owners.remove(owner);
             return this.owners.add(owner);
         }
 

--- a/server/src/main/java/org/candlepin/model/Product.java
+++ b/server/src/main/java/org/candlepin/model/Product.java
@@ -452,7 +452,7 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
 
     /**
      * Associates this product with the specified owner. If the given owner is already associated
-     * with this product, the request is silently ignored.
+     * with this product, the association will be updated with the given owner instance.
      *
      * @param owner
      *  An owner to be associated with this product
@@ -466,6 +466,7 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
                 this.owners = new HashSet<Owner>();
             }
 
+            this.owners.remove(owner);
             return this.owners.add(owner);
         }
 


### PR DESCRIPTION
- .addOwner in Product and Content will now update an
  owner-product/content relation when called with an owner that is
  already mapped to the given product or content