### PR TITLE
CandlepinPoolManager now removes extraneous product owners during refresh

### DIFF
--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -185,7 +185,7 @@ public class CandlepinPoolManager implements PoolManager {
     @Transactional
     void refreshPoolsWithRegeneration(SubscriptionServiceAdapter subAdapter, Owner owner, boolean lazy) {
         long start = System.currentTimeMillis();
-        owner = refreshOwner(owner);
+        owner = this.refreshOwner(owner);
         log.info("Refreshing pools for owner: {}", owner);
         List<Subscription> subs = subAdapter.getSubscriptions(owner);
 
@@ -244,7 +244,8 @@ public class CandlepinPoolManager implements PoolManager {
     private Owner refreshOwner(Owner owner) {
         if (owner == null || (owner.getKey() == null && owner.getId() == null)) {
             throw new IllegalArgumentException(
-                    i18n.tr("No owner specified, or owner lacks identifying information"));
+                i18n.tr("No owner specified, or owner lacks identifying information")
+            );
         }
 
         if (owner.getKey() != null) {
@@ -252,8 +253,9 @@ public class CandlepinPoolManager implements PoolManager {
             owner = ownerCurator.lookupByKey(owner.getKey());
 
             if (owner == null) {
-                throw new IllegalStateException(i18n.tr("Unable to find an owner with the key \"{0}\"",
-                        ownerKey));
+                throw new IllegalStateException(
+                    i18n.tr("Unable to find an owner with the key \"{0}\"", ownerKey)
+                );
             }
         }
         else {
@@ -397,8 +399,8 @@ public class CandlepinPoolManager implements PoolManager {
             Content incoming = contentCache.get(cid);
             Content existing = this.contentCurator.lookupById(owner, cid);
 
-            // Ensure the incoming product is linked to the owner that initiated the refresh
-            incoming.addOwner(owner);
+            // Ensure the incoming content is linked to the owner that initiated the refresh
+            incoming.setOwners(Arrays.asList(owner));
 
             if (existing == null) {
                 log.info("Creating new content for org {}: {}", owner.getKey(), cid);
@@ -520,8 +522,8 @@ public class CandlepinPoolManager implements PoolManager {
             Product incoming = productCache.get(pid);
             Product existing = this.productCurator.lookupById(owner, pid);
 
-            // Ensure the inbound product is linked to the owner that initiated the refresh
-            incoming.addOwner(owner);
+            // Ensure the incoming content is linked to the owner that initiated the refresh
+            incoming.setOwners(Arrays.asList(owner));
 
             if (existing == null) {
                 log.info("Creating new product for org {}: {}", owner.getKey(), pid);

--- a/server/src/main/java/org/candlepin/controller/ContentManager.java
+++ b/server/src/main/java/org/candlepin/controller/ContentManager.java
@@ -96,9 +96,6 @@ public class ContentManager {
         }
 
         // Check if we have an alternate version we can use instead.
-
-        // TODO: Not sure if we really even need the version check. If we have any other matching
-        // content, we should probably use it -- regardless of the actual version value.
         List<Content> alternateVersions = this.contentCurator.getContentByVersion(
             entity.getId(), entity.hashCode()
         );
@@ -112,7 +109,10 @@ public class ContentManager {
             }
         }
 
-        entity.addOwner(owner);
+        // No other owners have matching version of this content. Since it's net new, we set the
+        // owners explicitly to the owner given to ensure we don't accidentally clobber other owner
+        // mappings
+        entity.setOwners(Arrays.asList(owner));
         return this.contentCurator.create(entity);
     }
 

--- a/server/src/main/java/org/candlepin/controller/ProductManager.java
+++ b/server/src/main/java/org/candlepin/controller/ProductManager.java
@@ -89,9 +89,6 @@ public class ProductManager {
         }
 
         // Check if we have an alternate version we can use instead.
-
-        // TODO: Not sure if we really even need the version check. If we have any other matching
-        // product, we should probably use it -- regardless of the actual version value.
         List<Product> alternateVersions = this.productCurator.getProductsByVersion(
             entity.getId(), entity.hashCode()
         );
@@ -106,7 +103,10 @@ public class ProductManager {
             }
         }
 
-        entity.addOwner(owner);
+        // No other owners have matching version of this product. Since it's net new, we set the
+        // owners explicitly to the owner given to ensure we don't accidentally clobber other owner
+        // mappings
+        entity.setOwners(Arrays.asList(owner));
         return this.productCurator.create(entity);
     }
 
@@ -229,9 +229,6 @@ public class ProductManager {
                     );
                 }
             }
-        }
-        else {
-            log.debug("Somehow they were equal...? Something's not quite right here.");
         }
 
         return entity;


### PR DESCRIPTION
- During pool refresh, any owners other than the owner for which pools
  are being refreshed are removed from incoming products and content.
  This should address an issue where we could receive transient owners
  on an entity, and currently does not impact equality checks.