### PR TITLE
Lazy Load for Product.owners

### DIFF
--- a/server/src/main/java/org/candlepin/model/Product.java
+++ b/server/src/main/java/org/candlepin/model/Product.java
@@ -97,7 +97,7 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
         name = "cp2_owner_products",
         joinColumns = {@JoinColumn(name = "product_uuid", insertable = true, updatable = true)},
         inverseJoinColumns = {@JoinColumn(name = "owner_id")})
-    @LazyCollection(LazyCollectionOption.FALSE)
+    @LazyCollection(LazyCollectionOption.EXTRA)
     @XmlTransient
     private Set<Owner> owners;
 


### PR DESCRIPTION
Turning EXTRA lazy load for Product.owners so that we do not pull all
the owners with every product.