### PR TITLE
1337906: Stack derived pool cleanup

### DIFF
--- a/server/src/main/java/org/candlepin/model/EntitlementCurator.java
+++ b/server/src/main/java/org/candlepin/model/EntitlementCurator.java
@@ -25,6 +25,7 @@ import com.google.inject.persist.Transactional;
 
 import org.apache.commons.lang.StringUtils;
 import org.hibernate.Criteria;
+import org.hibernate.Hibernate;
 import org.hibernate.ReplicationMode;
 import org.hibernate.criterion.CriteriaSpecification;
 import org.hibernate.criterion.Order;
@@ -569,6 +570,10 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
         for (Entitlement ent : entitlements) {
             ent.getCertificates().clear();
             ent.getConsumer().getEntitlements().remove(ent);
+    
+            if (Hibernate.isInitialized(ent.getPool().getEntitlements())) {
+                ent.getPool().getEntitlements().remove(ent);
+            }
         }
     }
 


### PR DESCRIPTION
Refresh pools hasn't been cleaning up stack derived pools. This happened
when entitlements were deleted in batch during
refreshPoolsWithRegeneration method.

The underlying issue here is with collection Pool.entitlements. Because
this collection has cascade set to PERSIST, one must be very careful
when deleting entitlement to also remove it from the collection.
Otherwise, Hibernate will un-schedule the deletion.