### PR TITLE
1337906: Stack derived pool cleanup

### DIFF
--- a/server/spec/candlepin_scenarios.rb
+++ b/server/spec/candlepin_scenarios.rb
@@ -384,6 +384,12 @@ class StandardExporter < Exporter
     @products[:product3] = create_product(random_string('sub-prod'), random_string(), {
         :attributes => { :arch => "x86_64", :virt_limit => "unlimited"}
     })
+    @products[:product_vdc] = create_product(random_string('prod-vdc'), random_string(), {
+        :attributes => { :arch => "x86_64", :virt_limit => "unlimited", 'stacking_id' => 'stack-vdc'}
+    })
+    @products[:product_dc] = create_product(random_string('prod-dc'), random_string(), {
+        :attributes => { :arch => "x86_64", 'stacking_id' => 'stack-dc', 'stacking_id' => 'stack-dc'}
+    })
 
     @products[:derived_product] = create_product(random_string('sub-prov-prod'), random_string(),
         {"sockets" => "2"})
@@ -423,11 +429,13 @@ class StandardExporter < Exporter
     create_pool_and_subscription(@owner['key'], @products[:virt_product].id, 10, [], '', '12345', '6789', nil, end_date, true)
     create_pool_and_subscription(@owner['key'], @products[:product3].id, 5, [], '', '12345', '6789', nil, end_date, true,
       {:derived_product_id => @products[:derived_product]['id'],  :derived_provided_products => [@products[:derived_provided_prod]['id']]})
-    create_pool_and_subscription(@owner['key'], @products[:product_up].id, 10, [], '', '12345', '6789', nil, end_date)
-
+    create_pool_and_subscription(@owner['key'], @products[:product_up].id, 10, [], '', '12345', '6789', nil, end_date, true)
+    create_pool_and_subscription(@owner['key'], @products[:product_vdc].id, 5, [], '', '12345', '6789', nil, end_date, false,
+      {:derived_product_id => @products[:product_dc]['id']})
+ 
     # Pool names is a list of names of instance variables that will be created
-    pool_names = ["pool1", "pool2", "pool3", "pool4", "pool_up"]
-    pool_products = [:product1, :product2, :product3, :virt_product, :product_up]
+    pool_names = ["pool1", "pool2", "pool3", "pool4", "pool_up", "pool_vdc"]
+    pool_products = [:product1, :product2, :product3, :virt_product, :product_up, :product_vdc]
 
     # Take the names and couple them together with keys in the @products hash.
     # Then for each pair, set an instance variable with the value of the list_pools
@@ -439,8 +447,8 @@ class StandardExporter < Exporter
     @candlepin_client.update_consumer({:facts => {"distributor_version" => "sam-1.3"}})
     @candlepin_consumer = @candlepin_client.get_consumer()
 
-    ent_names = ["entitlement1", "entitlement2", "entitlement3", "entitlement_up"]
-    ent_names.zip([@pool1, @pool2, @pool4, @pool_up]).each do |ent_name, pool|
+    ent_names = ["entitlement1", "entitlement2", "entitlement3", "entitlement_up", "entitlement_vdc"]
+    ent_names.zip([@pool1, @pool2, @pool4, @pool_up, @pool_vdc]).each do |ent_name, pool|
       instance_variable_set("@#{ent_name}", @candlepin_client.consume_pool(pool.id, {:quantity => 1})[0])
     end
     # pool3 is special

--- a/server/spec/export_spec.rb
+++ b/server/spec/export_spec.rb
@@ -91,7 +91,7 @@ describe 'Export', :serial => true do
       available_certs[c['serial']] = c
     end
 
-    exported_entitlement_certs.size.should == 5
+    exported_entitlement_certs.size.should == 6
 
     exported_entitlement_certs.each do |file|
       exported_cert = File.read(File.join(entitlement_certs_dir, file))
@@ -126,7 +126,7 @@ describe 'Export', :serial => true do
     end
 
     # All 5 should be there, despite one cert is for a virt product
-    exported_entitlement_certs.size.should == 5
+    exported_entitlement_certs.size.should == 6
 
     exported_entitlement_certs.each do |file|
       exported_cert = File.read(File.join(entitlement_certs_dir, file))

--- a/server/spec/import_cleanup_spec.rb
+++ b/server/spec/import_cleanup_spec.rb
@@ -1,0 +1,73 @@
+require 'spec_helper'
+require 'candlepin_scenarios'
+require 'json'
+
+describe 'Import cleanup', :serial => true do
+
+  include CandlepinMethods
+  include VirtHelper
+
+  before(:all) do
+    @cp = Candlepin.new('admin', 'admin')
+    skip("candlepin running in hosted mode") if is_hosted?
+
+    @cp_export = StandardExporter.new
+    @cp_export.create_candlepin_export()
+    @cp_export_file = @cp_export.export_filename
+
+    @candlepin_consumer = @cp_export.candlepin_client.get_consumer()
+    @candlepin_consumer.unregister @candlepin_consumer['uuid']
+
+    @import_owner = @cp.create_owner(random_string("test_owner"))
+    @import_username = random_string("import-user")
+    @import_owner_client = user_client(@import_owner, @import_username)
+    import_record = @cp.import(@import_owner['key'], @cp_export_file)
+    import_record.status.should == 'SUCCESS'
+    import_record.statusMessage.should == "#{@import_owner['key']} file imported successfully."
+    @exporters = [@cp_export]
+  end
+
+  after(:all) do
+    @cp.delete_user(@import_username)
+    @cp.delete_owner(@import_owner['key'])
+    @exporters.each do |e|
+      e.cleanup()
+    end
+  end
+
+  it 'should remove stack derived pool when parent ent is gone' do
+    normal = @import_owner_client.list_pools({
+           :owner => @import_owner['id'],
+           :product => @cp_export.products[:product_vdc].id})
+    # NORMAL pool
+    normal.length.should == 1
+ 
+    unmapped = @import_owner_client.list_pools({
+           :owner => @import_owner['id'],
+           :product => @cp_export.products[:product_dc].id})
+    # UNMAPPED GUEST POOL 
+    unmapped.length.should == 1
+    
+    consumer = consumer_client(@import_owner_client, 'test-consumer')
+    # Consume NORMAL Pool 
+    entitlement = consumer.consume_pool(normal[0].id, {:quantity => 1})
+    entitlement.length.should == 1
+    
+    # STACK DERIVED POOL is created 
+    stack = @import_owner_client.list_pools({
+           :owner => @import_owner['id'],
+           :product => @cp_export.products[:product_dc].id})
+           .select{ |p| p.type=="STACK_DERIVED"}
+    stack.length.should == 1
+    
+    #Create a new manifest without product_vdc subscription!
+    updated_export = @cp_export.create_candlepin_export_update_no_ent()
+    @cp.import(@import_owner['key'], updated_export.export_filename)
+    
+    # All the pools for that owner should be removed
+    normal = @import_owner_client.list_pools({
+           :owner => @import_owner['id']} )
+    normal.length.should == 0
+  end
+
+end

--- a/server/spec/import_spec.rb
+++ b/server/spec/import_spec.rb
@@ -37,7 +37,7 @@ describe 'Import', :serial => true do
 
   it 'creates pools' do
     pools = @import_owner_client.list_pools({:owner => @import_owner['id']})
-    pools.length.should == 6
+    pools.length.should == 8
 
     # Some of these pools must carry provided/derived provided products,
     # don't care which pool just need to be sure that they're getting
@@ -56,12 +56,13 @@ describe 'Import', :serial => true do
     derived_found.should be true
   end
 
-  it 'created unmapped guest derived pool' do
+  it 'create unmapped guest pool' do
+     
   end
 
   it 'ignores multiplier for pool quantity' do
     pools = @import_owner_client.list_pools({:owner => @import_owner['id']})
-    pools.length.should == 6
+    pools.length.should == 8
     # 1 product has a multiplier of 2 upstream, the others 1.
     # 1 entitlement is consumed from each pool for the export, so
     # quantity should be 1 on each.

--- a/server/spec/import_update_spec.rb
+++ b/server/spec/import_update_spec.rb
@@ -28,9 +28,9 @@ describe 'Import Update', :serial => true do
 
     @cp.import(@import_owner['key'], updated_export.export_filename)
 
-    @sublist.size().should == 5
+    @sublist.size().should == 6
     new_sublist = @cp.list_subscriptions(@import_owner['key'])
-    new_sublist.size().should == 6
+    new_sublist.size().should == 7
 
     new_sublist.each do |new_sub|
       @sublist.each do |sub|

--- a/server/src/main/java/org/candlepin/model/EntitlementCurator.java
+++ b/server/src/main/java/org/candlepin/model/EntitlementCurator.java
@@ -23,6 +23,7 @@ import com.google.inject.Inject;
 import com.google.inject.persist.Transactional;
 
 import org.hibernate.Criteria;
+import org.hibernate.Hibernate;
 import org.hibernate.ReplicationMode;
 import org.hibernate.criterion.CriteriaSpecification;
 import org.hibernate.criterion.Order;
@@ -464,6 +465,10 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
             // Maintain runtime consistency.
             ent.getCertificates().clear();
             ent.getConsumer().getEntitlements().remove(ent);
+
+            if (Hibernate.isInitialized(ent.getPool().getEntitlements())) {
+                ent.getPool().getEntitlements().remove(ent);
+            }
         }
     }
 


### PR DESCRIPTION
In some code paths, it may be possible that deletion of entitlements
might not succeed (DELETE statement is not issued to the database).
The underlying issue here is with collection Pool.entitlements. Because
this collection has cascade set to PERSIST, one must be very careful
when deleting entitlement to also remove it from the collection.
Otherwise, Hibernate will un-schedule the deletion.