### PR TITLE
Case insensitive username consumers permission

### DIFF
--- a/server/src/main/java/org/candlepin/auth/permissions/UsernameConsumersPermission.java
+++ b/server/src/main/java/org/candlepin/auth/permissions/UsernameConsumersPermission.java
@@ -53,7 +53,7 @@ public class UsernameConsumersPermission implements Permission, Serializable {
         // Implied full access to the relevant Consumers:
         if (target.getClass().equals(Consumer.class)) {
             return ((Consumer) target).getOwner().getKey().equals(owner.getKey()) &&
-                ((Consumer) target).getUsername().equals(user.getUsername()) &&
+                ((Consumer) target).getUsername().equalsIgnoreCase(user.getUsername()) &&
                 Access.ALL.provides(required);
         }
 

--- a/server/src/test/java/org/candlepin/auth/permissions/UsernameConsumersPermissionTest.java
+++ b/server/src/test/java/org/candlepin/auth/permissions/UsernameConsumersPermissionTest.java
@@ -48,6 +48,14 @@ public class UsernameConsumersPermissionTest {
     }
 
     @Test
+    public void allowsMismatchedUsernameComparisons() {
+        Consumer c = new Consumer("consumer", username.toUpperCase(), owner, null);
+        assertTrue(perm.canAccess(c, SubResource.NONE, Access.ALL));
+        assertTrue(perm.canAccess(c, SubResource.NONE, Access.CREATE));
+        assertTrue(perm.canAccess(c, SubResource.NONE, Access.READ_ONLY));
+    }
+
+    @Test
     public void allowsRegisterOrgConsumers() {
         Consumer c = new Consumer("consumer", username, owner, null);
         assertTrue(perm.canAccess(owner, SubResource.CONSUMERS, Access.CREATE));

--- a/server/src/test/java/org/candlepin/auth/permissions/UsernameConsumersPermissionTest.java
+++ b/server/src/test/java/org/candlepin/auth/permissions/UsernameConsumersPermissionTest.java
@@ -48,7 +48,7 @@ public class UsernameConsumersPermissionTest {
     }
 
     @Test
-    public void allowsMismatchedUsernameComparisons() {
+    public void allowsMismatchedUsernameCaseComparison() {
         Consumer c = new Consumer("consumer", username.toUpperCase(), owner, null);
         assertTrue(perm.canAccess(c, SubResource.NONE, Access.ALL));
         assertTrue(perm.canAccess(c, SubResource.NONE, Access.CREATE));


### PR DESCRIPTION
I don't have a working Java environment to see if my test passes but nevertheless I'm not sure there was a reason to not have this comparison use equalsIgnoreCase.

My expectation is that I will get a 200 rather than 4xx for issuing this request where the consumer in question has the 'username' attribute of (for example) 'jTuReL', and I pass 'jturel' as the value of the cp-user header.

`curl -H 'cp-user: jturel' -H 'cp-lookup-permissions: true' "$CP_DEV/owners/consumers/aaaaaaa-9a0b-4937-ad72-658fc2cbb98d"`



