### PR TITLE
1344402: Unique product content violation

### DIFF
--- a/server/src/main/java/org/candlepin/model/Product.java
+++ b/server/src/main/java/org/candlepin/model/Product.java
@@ -86,7 +86,7 @@ public class Product extends AbstractHibernateObject implements Linkable {
                      joinColumns = @JoinColumn(name = "product_id"))
     @Column(name = "element")
     @LazyCollection(LazyCollectionOption.EXTRA) // allows .size() without loading all data
-    private List<ProductContent> productContent;
+    private Set<ProductContent> productContent;
 
     @ManyToMany(mappedBy = "providedProducts")
     private List<Subscription> subscriptions;
@@ -112,7 +112,7 @@ public class Product extends AbstractHibernateObject implements Linkable {
         setName(name);
         setMultiplier(multiplier);
         setAttributes(new HashSet<ProductAttribute>());
-        setProductContent(new LinkedList<ProductContent>());
+        setProductContent(new HashSet<ProductContent>());
         setSubscriptions(new LinkedList<Subscription>());
         setDependentProductIds(new HashSet<String>());
     }
@@ -123,7 +123,7 @@ public class Product extends AbstractHibernateObject implements Linkable {
         setName(name);
         setMultiplier(1L);
         setAttributes(new HashSet<ProductAttribute>());
-        setProductContent(new LinkedList<ProductContent>());
+        setProductContent(new HashSet<ProductContent>());
         setSubscriptions(new LinkedList<Subscription>());
         setDependentProductIds(new HashSet<String>());
         setAttribute("version", version);
@@ -300,7 +300,7 @@ public class Product extends AbstractHibernateObject implements Linkable {
      */
     public void addContent(Content content) {
         if (productContent == null) {
-            productContent = new LinkedList<ProductContent>();
+            productContent = new HashSet<ProductContent>();
         }
         productContent.add(new ProductContent(this, content, false));
     }
@@ -310,7 +310,7 @@ public class Product extends AbstractHibernateObject implements Linkable {
      */
     public void addEnabledContent(Content content) {
         if (productContent == null) {
-            productContent = new LinkedList<ProductContent>();
+            productContent = new HashSet<ProductContent>();
         }
         productContent.add(new ProductContent(this, content, true));
     }
@@ -318,14 +318,14 @@ public class Product extends AbstractHibernateObject implements Linkable {
     /**
      * @param productContent the productContent to set
      */
-    public void setProductContent(List<ProductContent> productContent) {
+    public void setProductContent(Set<ProductContent> productContent) {
         this.productContent = productContent;
     }
 
     /**
      * @return the productContent
      */
-    public List<ProductContent> getProductContent() {
+    public Set<ProductContent> getProductContent() {
         return productContent;
     }
 
@@ -336,7 +336,7 @@ public class Product extends AbstractHibernateObject implements Linkable {
             return;
         }
         if (productContent == null) {
-            productContent = new LinkedList<ProductContent>();
+            productContent = new HashSet<ProductContent>();
         }
         for (Content newContent : content) {
             productContent.add(new ProductContent(this, newContent, false));
@@ -348,7 +348,7 @@ public class Product extends AbstractHibernateObject implements Linkable {
             return;
         }
         if (productContent == null) {
-            productContent = new LinkedList<ProductContent>();
+            productContent = new HashSet<ProductContent>();
         }
         for (Content newContent : content) {
             productContent.add(new ProductContent(this, newContent, true));


### PR DESCRIPTION
Upon concurrent ProductResource.removeContent requests we were getting
unique constraint violation errors for table "cp_product_content_pkey".

The reason for this is that productContent collection is a
ElementCollection and when such collection is declared as List, then
Hibernate has no way of tracking changes to this collection and then
updating database correctly (List may contain duplicates). Hibernate's
strategy in this case is to (upon every merge) delete everything from
the collection table and then insert in memory entities from that
collection back. In concurrent situations this resulted same rows
being inserted duplicitly.

Besides this solution it's also possible to use OrderColumn annotation,
but that would require schema changes.