### PR TITLE
1345918: Unique product content violation

### DIFF
--- a/server/src/main/java/org/candlepin/model/Product.java
+++ b/server/src/main/java/org/candlepin/model/Product.java
@@ -117,7 +117,7 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
     @CollectionTable(name = "cp2_product_content", joinColumns = @JoinColumn(name = "product_uuid"))
     @Column(name = "element")
     @LazyCollection(LazyCollectionOption.EXTRA) // allows .size() without loading all data
-    private List<ProductContent> productContent;
+    private Set<ProductContent> productContent;
 
     /*
      * hibernate persists empty set as null, and tries to fetch
@@ -777,7 +777,7 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
      */
     public Product setProductContent(Collection<ProductContent> productContent) {
         if (this.productContent == null) {
-            this.productContent = new LinkedList<ProductContent>();
+            this.productContent = new HashSet<ProductContent>();
         }
 
         this.productContent.clear();
@@ -794,7 +794,7 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
     /**
      * @return the productContent
      */
-    public List<ProductContent> getProductContent() {
+    public Set<ProductContent> getProductContent() {
         return productContent;
     }
 
@@ -810,7 +810,7 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
      */
     public boolean addProductContent(ProductContent content) {
         if (this.productContent == null) {
-            this.productContent = new LinkedList<ProductContent>();
+            this.productContent = new HashSet<ProductContent>();
         }
 
         if (content != null) {
@@ -835,7 +835,7 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
 
     public void setContent(Set<Content> content) {
         if (this.productContent == null) {
-            this.productContent = new LinkedList<ProductContent>();
+            this.productContent = new HashSet<ProductContent>();
         }
 
         this.productContent.clear();


### PR DESCRIPTION
Upon concurrent ProductResource.removeContent requests we were getting
unique constraint violation errors for table "cp_product_content_pkey".

The reason for this is that productContent collection is a
ElementCollection and when such collection is declared as List, then
Hibernate has no way of tracking changes to this collection and then
updating database correctly (List may contain duplicates). Hibernate's
strategy in this case is to (upon every merge) delete everything from
the collection table and then insert in memory entities from that
collection back. In concurrent situations this resulted same rows
being inserted duplicitly.

Besides this solution it's also possible to use OrderColumn annotation,
but that would require schema changes.