### PR TITLE
1338950: prevent successful concurrent imports

### DIFF
--- a/server/src/main/resources/db/changelog/20160614113932-add-owner-and-type-constraint-export-metadata.xml
+++ b/server/src/main/resources/db/changelog/20160614113932-add-owner-and-type-constraint-export-metadata.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+    <changeSet id="20160614113932-1" author="vrjain">
+        <comment> add-owner-and-type-constraint-export-metadata</comment>
+        <addUniqueConstraint columnNames="owner_id, type" constraintName="cp_export_metadata_unique_import" deferrable="false" disabled="false" initiallyDeferred="false" tableName="cp_export_metadata"/>
+    </changeSet>
+
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/server/src/main/resources/db/changelog/changelog-create.xml
+++ b/server/src/main/resources/db/changelog/changelog-create.xml
@@ -1176,4 +1176,5 @@
     <include file="db/changelog/20150424150412-add-owner-id-to-jobstatus.xml"/>
     <include file="db/changelog/20150818110722-upgrade-to-quartz-2-dot-2.xml"/>
     <include file="db/changelog/20150820140403-revert-to-lastcheckin-column.xml"/>
+    <include file="db/changelog/20160614113932-add-owner-and-type-constraint-export-metadata.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-testing.xml
+++ b/server/src/main/resources/db/changelog/changelog-testing.xml
@@ -2266,4 +2266,5 @@
     <include file="db/changelog/20150424150412-add-owner-id-to-jobstatus.xml"/>
     <include file="db/changelog/20150818110722-upgrade-to-quartz-2-dot-2.xml"/>
     <include file="db/changelog/20150820140403-revert-to-lastcheckin-column.xml"/>
+    <include file="db/changelog/20160614113932-add-owner-and-type-constraint-export-metadata.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-update.xml
+++ b/server/src/main/resources/db/changelog/changelog-update.xml
@@ -84,4 +84,5 @@
     <include file="db/changelog/20150424150412-add-owner-id-to-jobstatus.xml"/>
     <include file="db/changelog/20150818110722-upgrade-to-quartz-2-dot-2.xml"/>
     <include file="db/changelog/20150820140403-revert-to-lastcheckin-column.xml"/>
+    <include file="db/changelog/20160614113932-add-owner-and-type-constraint-export-metadata.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
in 0.9.54, there is a rare chance ( not reproducable ) that two concurrent reports can result in two records in the cp_export_metadata table for the same "type" . Given the current code, this prevents any future manifest activity ( delete / import / refresh ) because our query expects there to be a unique owner and type  ( user / system ) combination for every record.
we are adding a constraint that prevents this situation in the reported branch. in candlepin 2.0, we shall lock the owner and more.
more details in the bz!
