### PR TITLE
1314904: SASL mechanism ANONYMOUS

### DIFF
--- a/server/src/main/java/org/candlepin/guice/AMQPBusPubProvider.java
+++ b/server/src/main/java/org/candlepin/guice/AMQPBusPubProvider.java
@@ -100,6 +100,7 @@ public class AMQPBusPubProvider implements Provider<AMQPBusPublisher> {
         for (BrokerDetails broker : connectionFactory.getConnectionURL().getAllBrokerDetails()) {
             broker.setProperty("trust_store",
                 config.getString(ConfigProperties.AMQP_TRUSTSTORE));
+            broker.setProperty("sasl_mechs", "ANONYMOUS");
             broker.setProperty("trust_store_password",
                 config.getString(ConfigProperties.AMQP_TRUSTSTORE_PASSWORD));
             broker.setProperty("key_store", config.getString(ConfigProperties.AMQP_KEYSTORE));


### PR DESCRIPTION
Candlepin should use SASL mechanism ANONYMOUS when communicating with
Qpid.