### PR TITLE
1345765 - Concurrent content demotions cause 400

### DIFF
--- a/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
+++ b/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
@@ -364,6 +364,13 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
         }
     }
 
+    @Transactional
+    public void bulkDeleteTransactional(List<E> entities) {
+        for (E entity : entities) {
+            delete(entity);
+        }
+    }
+
     /**
      * @param entity entity to be merged.
      * @return merged entity.

--- a/server/src/main/java/org/candlepin/model/EnvironmentContent.java
+++ b/server/src/main/java/org/candlepin/model/EnvironmentContent.java
@@ -120,4 +120,12 @@ public class EnvironmentContent extends AbstractHibernateObject {
         return false;
     }
 
+    @Override
+    public String toString() {
+        return "EnvironmentContent [id=" + id + ", environment=" +
+                 (environment != null ?  environment.getId() : "") +
+                 ", content=" +
+                 (content != null ? content.getId() : "" + "]");
+    }
+
 }

--- a/server/src/main/java/org/candlepin/model/dto/EnvironmentContent.java
+++ b/server/src/main/java/org/candlepin/model/dto/EnvironmentContent.java
@@ -115,4 +115,10 @@ public class EnvironmentContent {
         this.enabled = enabled;
     }
 
+    @Override
+    public String toString() {
+        return "EnvironmentContent [environmentId=" + environmentId + ", contentId=" + contentId + "]";
+    }
+
+
 }

--- a/server/src/main/java/org/candlepin/util/RdbmsExceptionTranslator.java
+++ b/server/src/main/java/org/candlepin/util/RdbmsExceptionTranslator.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.util;
+
+import org.hibernate.StaleStateException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.persistence.OptimisticLockException;
+import javax.persistence.RollbackException;
+
+/**
+ * This utility class allows to determine what an exception thrown by Hibernate or
+ * SQL driver means.
+ *
+ * One situation where this is useful is detection of constraint violations.
+ * It's much easier to catch constraint violation (possibly caused by
+ * concurrent requests) than to utilize pessimistic locking.
+ *
+ * @author fnguyen
+ */
+public class RdbmsExceptionTranslator {
+    private static Logger log = LoggerFactory.getLogger(RdbmsExceptionTranslator.class);
+
+    /**
+     * Decides if the sqlException was thrown because of the update/delete statement
+     * had no effect in the database
+     *
+     * @param sqlException the exception thrown by Hibernate (RDMBs Driver)
+     * @return true if the SQL exception meets the criteria
+     */
+    public boolean isUpdateHadNoEffectException(RollbackException sqlException) {
+        log.debug("Translating {}", sqlException);
+        if (sqlException.getCause() != null &&
+            sqlException.getCause() instanceof OptimisticLockException) {
+            Exception e = (OptimisticLockException) sqlException.getCause();
+            if (e.getCause() != null && e.getCause() instanceof StaleStateException) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+}


### PR DESCRIPTION
Under concurrent demotion requests, we were getting StaleStateException
from hibernate indicating that a request is trying to delete already
deleted instance. Also, the demotion of content was using one
transaction per content demotion, so request could demote some content,
then throw exception and never get into the part of the code that is
responsible for regeneration of environment certs.

In this commit I introduce RdbmsExceptionTraslator that can help to
determine a reason for a Hibernate Exception. Also I use batch
operation for database operation (demotion of content) to mitigate a
possibility of partial demotion.