### PR TITLE
Allow manifest exports to be extended

### DIFF
--- a/server/src/main/java/org/candlepin/guice/DefaultConfig.java
+++ b/server/src/main/java/org/candlepin/guice/DefaultConfig.java
@@ -17,12 +17,14 @@ package org.candlepin.guice;
 import org.candlepin.pki.SubjectKeyIdentifierWriter;
 import org.candlepin.pki.impl.DefaultSubjectKeyIdentifierWriter;
 import org.candlepin.service.EntitlementCertServiceAdapter;
+import org.candlepin.service.ExportExtensionAdapter;
 import org.candlepin.service.IdentityCertServiceAdapter;
 import org.candlepin.service.OwnerServiceAdapter;
 import org.candlepin.service.ProductServiceAdapter;
 import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.service.UserServiceAdapter;
 import org.candlepin.service.impl.DefaultEntitlementCertServiceAdapter;
+import org.candlepin.service.impl.DefaultExportExtensionAdapter;
 import org.candlepin.service.impl.DefaultIdentityCertServiceAdapter;
 import org.candlepin.service.impl.DefaultOwnerServiceAdapter;
 import org.candlepin.service.impl.DefaultProductServiceAdapter;
@@ -54,7 +56,7 @@ class DefaultConfig extends AbstractModule {
         bind(ProductServiceAdapter.class).to(DefaultProductServiceAdapter.class);
         bind(ManifestFileService.class).to(DBManifestService.class);
         bind(SubjectKeyIdentifierWriter.class).to(DefaultSubjectKeyIdentifierWriter.class);
-
+        bind(ExportExtensionAdapter.class).to(DefaultExportExtensionAdapter.class);
         bind(SubscriptionServiceAdapter.class).to(ImportSubscriptionServiceAdapter.class);
     }
 }

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -1782,7 +1782,8 @@ public class ConsumerResource {
         @QueryParam("api_url") String apiUrl) {
 
         try {
-            File archive = manifestManager.generateManifest(consumerUuid, cdnLabel, webAppPrefix, apiUrl);
+            File archive = manifestManager.generateManifest(consumerUuid, cdnLabel, webAppPrefix, apiUrl,
+                new HashMap<String, String>());
             response.addHeader("Content-Disposition", "attachment; filename=" + archive.getName());
             return archive;
         }
@@ -1796,11 +1797,11 @@ public class ConsumerResource {
      * The response will contain the id of the job from which its result data will contain the href to
      * download the generated file.
      *
-     * @param response
+     * @param response the response to send back from the server.
      * @param consumerUuid the uuid of the target consumer.
-     * @param cdnLabel
-     * @param webAppPrefix
-     * @param apiUrl
+     * @param cdnLabel the CDN label to store in the meta file.
+     * @param webAppPrefix the URL pointing to the manifest's originating web application.
+     * @param apiUrl the API URL pointing to the manifest's originating candlepin API.
      * @return the details of the async export job that is to be started.
      */
     @ApiOperation(
@@ -1816,11 +1817,38 @@ public class ConsumerResource {
     @Path("{consumer_uuid}/export/async")
     public JobDetail exportDataAsync(
         @Context HttpServletResponse response,
-        @PathParam("consumer_uuid") @Verify(Consumer.class) String consumerUuid,
-        @QueryParam("cdn_label") String cdnLabel,
-        @QueryParam("webapp_prefix") String webAppPrefix,
-        @QueryParam("api_url") String apiUrl) {
-        return manifestManager.generateManifestAsync(consumerUuid, cdnLabel, webAppPrefix, apiUrl);
+        @PathParam("consumer_uuid") @Verify(Consumer.class)
+        @ApiParam(value = "The UUID of the target consumer", required = true) String consumerUuid,
+        @QueryParam("cdn_label")
+        @ApiParam(value = "The lable of the target CDN", required = false)
+        String cdnLabel,
+        @QueryParam("webapp_prefix")
+        @ApiParam(value = "the URL pointing to the manifest's originating web application", required = false)
+        String webAppPrefix,
+        @QueryParam("api_url")
+        @ApiParam(value = "the URL pointing to the manifest's originating candlepin API", required = false)
+        String apiUrl,
+        @QueryParam("ext") @CandlepinParam(type = KeyValueParameter.class)
+        @ApiParam(value = "Key/Value pairs to be passed to the extension adapter when generating a manifest",
+        required = false, example = "ext=version:1.2.3&ext=extension_key:EXT1")
+        List<KeyValueParameter> extensionArgs) {
+        return manifestManager.generateManifestAsync(consumerUuid, cdnLabel, webAppPrefix, apiUrl,
+            getExtensionParamMap(extensionArgs));
+    }
+
+    /**
+     * Builds a map of String -> String from a list of {@link KeyValueParameter} query parameters
+     * where param.key is the map key and param.value is the map value.
+     *
+     * @param params the query parameters to build the map from.
+     * @return a Map<String, String> of the key/value pairs in the specified parameters.
+     */
+    private Map<String, String> getExtensionParamMap(List<KeyValueParameter> params) {
+        Map<String, String> paramMap = new HashMap<String, String>();
+        for (KeyValueParameter param : params) {
+            paramMap.put(param.key(), param.value());
+        }
+        return paramMap;
     }
 
     /**

--- a/server/src/main/java/org/candlepin/service/ExportExtensionAdapter.java
+++ b/server/src/main/java/org/candlepin/service/ExportExtensionAdapter.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2009 - 2016 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+
+import org.candlepin.model.Consumer;
+
+/**
+ * <p>This adapter provides a hook for allowing the extension of what is
+ * stored in a manifest file. Any extras should be added to the extensions
+ * directory so that anything that is added externally can be easily identified.</p>
+ *
+ * <p>
+ * The following code shows how a simple file could be created and added to the
+ * generated manifest:
+ * </p>
+ *
+ * <pre>
+ * void extendManifest(File extensionDir, Consumer targetConsumer, Map<String, String> extensionData)
+ *    throws IOException {
+ *    String version = (String) extensionData.get("version");
+ *    File extension = new File(extensionDir, String.format("my-extension-%s.txt", version));
+ *    PrintWriter writer = new PrintWriter(extension);
+ *    writer.write("An extension was created for consumer " + targetConsumer.getUuid() + ".\n");
+ *    writer.write("Version: " + version);
+ *    writer.close();
+ * }
+ * </pre>
+ *
+ */
+public interface ExportExtensionAdapter {
+
+    /**
+     * Extends the contents of an export archive file. Implementors can write files to the extension
+     * directory which will be included in the resulting export archive.
+     *
+     * @param extensionDir the directory where export extension data should be placed
+     *                     ( ./extensions in the resulting archive)
+     * @param targetConsumer the {@link Consumer} that is being exported.
+     * @param extensionData data passed via the ext query param when the initial request was made.
+     * @throws IOException if there were any issues creating the extension files.
+     */
+    void extendManifest(File extensionDir, Consumer targetConsumer, Map<String, String> extensionData)
+        throws IOException;
+
+}

--- a/server/src/main/java/org/candlepin/service/impl/DefaultExportExtensionAdapter.java
+++ b/server/src/main/java/org/candlepin/service/impl/DefaultExportExtensionAdapter.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2009 - 2016 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.impl;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+
+import org.candlepin.model.Consumer;
+import org.candlepin.service.ExportExtensionAdapter;
+
+/**
+ * The default implementation of the {@link ExportExtensionAdapter}. This adapter adds
+ * nothing to the manifest.
+ *
+ */
+public class DefaultExportExtensionAdapter implements ExportExtensionAdapter {
+
+    @Override
+    public void extendManifest(File extensionDir, Consumer targetConsumer, Map<String, String> extensionData)
+        throws IOException {
+        // The default implementation does nothing.
+    }
+
+}

--- a/server/src/test/java/org/candlepin/TestingModules.java
+++ b/server/src/test/java/org/candlepin/TestingModules.java
@@ -61,12 +61,14 @@ import org.candlepin.resource.SubscriptionResource;
 import org.candlepin.resteasy.ResourceLocatorMap;
 import org.candlepin.resteasy.filter.StoreFactory;
 import org.candlepin.service.EntitlementCertServiceAdapter;
+import org.candlepin.service.ExportExtensionAdapter;
 import org.candlepin.service.IdentityCertServiceAdapter;
 import org.candlepin.service.OwnerServiceAdapter;
 import org.candlepin.service.ProductServiceAdapter;
 import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.service.UniqueIdGenerator;
 import org.candlepin.service.UserServiceAdapter;
+import org.candlepin.service.impl.DefaultExportExtensionAdapter;
 import org.candlepin.service.impl.DefaultIdentityCertServiceAdapter;
 import org.candlepin.service.impl.DefaultOwnerServiceAdapter;
 import org.candlepin.service.impl.DefaultProductServiceAdapter;
@@ -284,6 +286,8 @@ public class TestingModules {
             bind(PrincipalProvider.class).to(TestPrincipalProvider.class);
             bind(Principal.class).toProvider(TestPrincipalProvider.class);
             bind(EventSink.class).to(NoopEventSinkImpl.class);
+
+            bind(ExportExtensionAdapter.class).to(DefaultExportExtensionAdapter.class);
 
             bind(ResourceLocatorMap.class);
             bind(StoreFactory.class);

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/ExportJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/ExportJobTest.java
@@ -17,6 +17,9 @@ package org.candlepin.pinsetter.tasks;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.candlepin.controller.ManifestManager;
 import org.candlepin.model.Consumer;
 import org.candlepin.pinsetter.core.model.JobStatus;
@@ -51,7 +54,10 @@ public class ExportJobTest {
         String webappPrefix = "webapp-prefix";
         String apiUrl = "url";
 
-        JobDetail detail = job.scheduleExport(distributor, cdnLabel, webappPrefix, apiUrl);
+        Map<String, String> extData = new HashMap<String, String>();
+        extData.put("version", "sat-6.2");
+
+        JobDetail detail = job.scheduleExport(distributor, cdnLabel, webappPrefix, apiUrl, extData);
         JobDataMap dataMap = detail.getJobDataMap();
 
         assertEquals(dataMap.get(JobStatus.OWNER_ID), distributor.getOwner().getKey());
@@ -60,6 +66,7 @@ public class ExportJobTest {
         assertEquals(dataMap.get(ExportJob.CDN_LABEL), cdnLabel);
         assertEquals(dataMap.get(ExportJob.WEBAPP_PREFIX), webappPrefix);
         assertEquals(dataMap.get(ExportJob.API_URL), apiUrl);
+        assertEquals(dataMap.get(ExportJob.EXTENSION_DATA), extData);
     }
 
     @Test
@@ -69,17 +76,18 @@ public class ExportJobTest {
         String webappPrefix = "webapp-prefix";
         String apiUrl = "url";
         String manifestId = "1234";
+        Map<String, String> extData = new HashMap<String, String>();
 
         ExportResult result = new ExportResult(distributor.getUuid(), manifestId);
         when(manifestManager.generateAndStoreManifest(eq(distributor.getUuid()), eq(cdnLabel),
-            eq(webappPrefix), eq(apiUrl))).thenReturn(result);
+            eq(webappPrefix), eq(apiUrl),  eq(extData))).thenReturn(result);
 
-        JobDetail detail = job.scheduleExport(distributor, cdnLabel, webappPrefix, apiUrl);
+        JobDetail detail = job.scheduleExport(distributor, cdnLabel, webappPrefix, apiUrl, extData);
         when(ctx.getMergedJobDataMap()).thenReturn(detail.getJobDataMap());
         job.execute(ctx);
 
         verify(manifestManager).generateAndStoreManifest(eq(distributor.getUuid()), eq(cdnLabel),
-            eq(webappPrefix), eq(apiUrl));
+            eq(webappPrefix), eq(apiUrl), eq(extData));
         verify(ctx).setResult(eq(result));
     }
 

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
@@ -70,6 +70,7 @@ import org.candlepin.policy.js.compliance.ComplianceStatus;
 import org.candlepin.resource.dto.AutobindData;
 import org.candlepin.resource.util.ConsumerBindUtil;
 import org.candlepin.resource.util.ResourceDateParser;
+import org.candlepin.resteasy.parameter.KeyValueParameter;
 import org.candlepin.service.EntitlementCertServiceAdapter;
 import org.candlepin.service.IdentityCertServiceAdapter;
 import org.candlepin.service.SubscriptionServiceAdapter;
@@ -796,6 +797,7 @@ public class ConsumerResourceTest {
             null, null, null, new CandlepinCommonTestConfig(),
             null, mockedCdnCurator, null, null, manifestManager);
 
+        List<KeyValueParameter> extParams = new ArrayList<KeyValueParameter>();
         Owner owner = TestUtil.createOwner();
         Consumer consumer = TestUtil.createConsumer(
             new ConsumerType(ConsumerType.ConsumerTypeEnum.CANDLEPIN), owner);
@@ -804,9 +806,9 @@ public class ConsumerResourceTest {
         when(mockedConsumerCurator.verifyAndLookupConsumer(eq(consumer.getUuid()))).thenReturn(consumer);
         when(mockedCdnCurator.lookupByLabel(eq(cdn.getLabel()))).thenReturn(cdn);
 
-        cr.exportDataAsync(null, consumer.getUuid(), cdn.getLabel(), "prefix", cdn.getUrl());
+        cr.exportDataAsync(null, consumer.getUuid(), cdn.getLabel(), "prefix", cdn.getUrl(), extParams);
         verify(manifestManager).generateManifestAsync(eq(consumer.getUuid()), eq(cdn.getLabel()),
-            eq("prefix"), eq(cdn.getUrl()));
+            eq("prefix"), eq(cdn.getUrl()), any(Map.class));
     }
 
 }


### PR DESCRIPTION
Added a ManifestExtensionAdapter interface that allows implementations
to add files to an export. The default implementation does nothing.