### PR TITLE
1345766: Concurrent content promotion cause 400

### DIFF
--- a/server/src/main/java/org/candlepin/resource/EnvironmentResource.java
+++ b/server/src/main/java/org/candlepin/resource/EnvironmentResource.java
@@ -214,7 +214,7 @@ public class EnvironmentResource {
 
         Environment env = lookupEnvironment(envId);
 
-        Set<String> contentIds = new HashSet<String>();
+
         // Make sure this content has not already been promoted within this environment
         // Impl note:
         // We have to do this in a separate loop or we'll end up with an undefined state, should
@@ -237,8 +237,10 @@ public class EnvironmentResource {
             }
         }
 
+        Set<String> contentIds = new HashSet<String>();
+
         try {
-            batchCreate(contentToPromote, env, contentIds);
+            contentIds = batchCreate(contentToPromote, env);
         }
         catch (PersistenceException pe) {
             if (rdbmsExceptionTranslator.isConstraintViolationDuplicateEntry(pe)) {
@@ -334,11 +336,14 @@ public class EnvironmentResource {
      * To make promotion transactional
      * @param contentToPromote
      * @param env
-     * @param contentIds
+     * @return contentIds Ids of the promoted content
      */
     @Transactional
-    public void batchCreate(List<org.candlepin.model.dto.EnvironmentContent> contentToPromote,
-        Environment env, Set<String> contentIds) {
+    public Set<String>  batchCreate(List<org.candlepin.model.dto.EnvironmentContent> contentToPromote,
+        Environment env) {
+
+        Set<String> contentIds = new HashSet<String>();
+
         for (org.candlepin.model.dto.EnvironmentContent promoteMe : contentToPromote) {
             // Make sure the content exists:
             EnvironmentContent envcontent = new EnvironmentContent();
@@ -351,6 +356,8 @@ public class EnvironmentResource {
             env.getEnvironmentContent().add(envcontent);
             contentIds.add(promoteMe.getContentId());
         }
+
+        return contentIds;
     }
 
     private Environment lookupEnvironment(String envId) {

--- a/server/src/main/java/org/candlepin/util/RdbmsExceptionTranslator.java
+++ b/server/src/main/java/org/candlepin/util/RdbmsExceptionTranslator.java
@@ -15,10 +15,12 @@
 package org.candlepin.util;
 
 import org.hibernate.StaleStateException;
+import org.hibernate.exception.ConstraintViolationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.persistence.OptimisticLockException;
+import javax.persistence.PersistenceException;
 import javax.persistence.RollbackException;
 
 /**
@@ -51,6 +53,33 @@ public class RdbmsExceptionTranslator {
             }
         }
 
+        return false;
+    }
+
+    public boolean isConstraintViolationDuplicateEntry(PersistenceException pe) {
+        log.debug("Translating {}", pe);
+
+        if (pe.getCause() != null &&
+            pe.getCause() instanceof ConstraintViolationException) {
+
+            ConstraintViolationException cve = (ConstraintViolationException) pe.getCause();
+            log.info("ConstraintViolationException error code:" + cve.getErrorCode());
+
+            //MySQL error code ER_DUP_ENTRY
+            //http://dev.mysql.com/doc/refman/5.7/en/error-messages-server.html
+            if (cve.getSQLState() != null &&
+                cve.getSQLState().equals("23000") &&
+                cve.getErrorCode() == 1062) {
+                return true;
+            }
+
+            //Postgres error code DUPLICATE OBJECT
+            //https://www.postgresql.org/docs/8.3/static/errcodes-appendix.html
+            if (cve.getSQLState() != null &&
+                cve.getSQLState().equals("23505")) {
+                return true;
+            }
+        }
         return false;
     }
 

--- a/server/src/main/java/org/candlepin/util/RdbmsExceptionTranslator.java
+++ b/server/src/main/java/org/candlepin/util/RdbmsExceptionTranslator.java
@@ -79,6 +79,8 @@ public class RdbmsExceptionTranslator {
                 cve.getSQLState().equals("23505")) {
                 return true;
             }
+
+            //TODO add Oracle
         }
         return false;
     }


### PR DESCRIPTION
Similar to 1345765. This method was designed in the past to throw 409 in
case when a content has already been promoted to an environment. This
wasn't working sometimes under concurrent access. Also the method allows
to pass in a set of content ids to promote but it is possible that
method just partially promotes a subset of those ids.

Adding transactionality and exception handling.