### PR TITLE
1350771: ExclusiveLock held by Candlepin

### DIFF
--- a/server/src/main/java/org/candlepin/model/CheckIn.java
+++ b/server/src/main/java/org/candlepin/model/CheckIn.java
@@ -14,7 +14,6 @@
  */
 package org.candlepin.model;
 
-import org.hibernate.annotations.ForeignKey;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Index;
 
@@ -54,7 +53,6 @@ public class CheckIn extends AbstractHibernateObject {
     private String id;
 
     @ManyToOne
-    @ForeignKey(name = "fk_consumer_checkin_consumer")
     @JoinColumn(nullable = false)
     @Index(name = "idx_consumer_checkin_consumer")
     @NotNull

--- a/server/src/main/java/org/candlepin/model/GuestIdsCheckIn.java
+++ b/server/src/main/java/org/candlepin/model/GuestIdsCheckIn.java
@@ -14,7 +14,6 @@
  */
 package org.candlepin.model;
 
-import org.hibernate.annotations.ForeignKey;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Index;
 
@@ -53,7 +52,6 @@ public class GuestIdsCheckIn extends AbstractHibernateObject {
     private String id;
 
     @ManyToOne
-    @ForeignKey(name = "fk_guest_ids_checkin_consumer")
     @JoinColumn(nullable = false)
     @Index(name = "idx_guest_ids_checkin_consumer")
     @NotNull

--- a/server/src/main/resources/db/changelog/20160711104547-remove-fk-checkins.xml
+++ b/server/src/main/resources/db/changelog/20160711104547-remove-fk-checkins.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+    <changeSet id="20160711104547-1" author="fnguyen">
+        <comment>Drop foreign keys to help fixing lock waits, e.g. BZ1350771</comment>
+
+        <dropForeignKeyConstraint
+           baseTableName="cp_consumer_checkin"
+           constraintName="fk_consumer_checkin_consumer"/>
+
+        <dropForeignKeyConstraint
+           baseTableName="cp_guest_ids_checkin"
+           constraintName="fk_guest_ids_checkin_consumer"/>
+
+    </changeSet>
+
+</databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-create.xml
+++ b/server/src/main/resources/db/changelog/changelog-create.xml
@@ -1172,4 +1172,5 @@
     <include file="db/changelog/20150211111319-add-last-guest-update-table.xml"/>
     <include file="db/changelog/20150316122833-add-entitlement-end-date-override.xml"/>
     <include file="db/changelog/20150311151612-force-all-content-metadataexpire-to-0.xml"/>
+    <include file="db/changelog/20160711104547-remove-fk-checkins.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-testing.xml
+++ b/server/src/main/resources/db/changelog/changelog-testing.xml
@@ -2027,7 +2027,7 @@
     </changeSet>
     <changeSet author="awood" id="1413225753032-290">
         <comment>
-             Add the default quartz lock columns.
+             Add the default quartz lock columns. 
         </comment>
         <insert tableName="QRTZ_LOCKS">
             <column name="LOCK_NAME" value="TRIGGER_ACCESS"/>
@@ -2262,4 +2262,5 @@
     <include file="db/changelog/20150211111319-add-last-guest-update-table.xml"/>
     <include file="db/changelog/20150316122833-add-entitlement-end-date-override.xml"/>
     <include file="db/changelog/20150311151612-force-all-content-metadataexpire-to-0.xml"/>
+    <include file="db/changelog/20160711104547-remove-fk-checkins.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-update.xml
+++ b/server/src/main/resources/db/changelog/changelog-update.xml
@@ -80,4 +80,5 @@
     <include file="db/changelog/20150211111319-add-last-guest-update-table.xml"/>
     <include file="db/changelog/20150316122833-add-entitlement-end-date-override.xml"/>
     <include file="db/changelog/20150311151612-force-all-content-metadataexpire-to-0.xml"/>
+    <include file="db/changelog/20160711104547-remove-fk-checkins.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
Removing foreign key constraints on checkin tables to mitigate a
posisibility of lock waits during GET requests.

When a long running request acquires X lock on a consumer, then any
other requests by the consumer (even GET) will get blocked. This is
because we update consumer checkin tables that have foreign key to
consumer table. This behavior is specific to Postgres 9.2, newer
Postgres has a new feature that is less strict to updates to foreign
tables.