### PR TITLE
fix deletePools - delete derived pools

### DIFF
--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -1599,19 +1599,25 @@ public class CandlepinPoolManager implements PoolManager {
 
     @Override
     public void revokeEntitlements(List<Entitlement> entsToRevoke) {
-        revokeEntitlements(entsToRevoke, true);
+        revokeEntitlements(entsToRevoke, null, true);
+    }
+
+    public void revokeEntitlements(List<Entitlement> entsToRevoke, Set<String> alreadyDeletedPools) {
+        revokeEntitlements(entsToRevoke, alreadyDeletedPools, true);
     }
 
     /**
      * Revokes the given set of entitlements.
      *
      * @param entsToRevoke entitlements to revoke
+     * @param alreadyDeletedPools pools to skip deletion as they have already been deleted
      * @param regenCertsAndStatuses if this revocation should also trigger regeneration of certificates
      * and recomputation of statuses. For performance reasons some callers might
      * choose to set this to false.
      */
     @Transactional
-    public void revokeEntitlements(List<Entitlement> entsToRevoke, boolean regenCertsAndStatuses) {
+    public void revokeEntitlements(List<Entitlement> entsToRevoke, Set<String> alreadyDeletedPools,
+        boolean regenCertsAndStatuses) {
         if (log.isDebugEnabled()) {
             log.debug("Starting batch revoke of entitlements: {}", getEntIds(entsToRevoke));
         }
@@ -1674,7 +1680,7 @@ public class CandlepinPoolManager implements PoolManager {
         }
 
         log.info("Starting batch delete of pools");
-        poolCurator.batchDelete(poolsToDelete);
+        poolCurator.batchDelete(poolsToDelete, alreadyDeletedPools);
         log.info("Starting batch delete of entitlements");
         entitlementCurator.batchDelete(entsToRevoke);
         log.info("Starting delete flush");
@@ -1684,7 +1690,7 @@ public class CandlepinPoolManager implements PoolManager {
         Map<Consumer, List<Entitlement>> consumerSortedEntitlements = entitlementCurator
             .getDistinctConsumers(entsToRevoke);
 
-        filterAndUpdateStackingEntitlements(consumerSortedEntitlements);
+        filterAndUpdateStackingEntitlements(consumerSortedEntitlements, alreadyDeletedPools);
 
         // post unbind actions
         for (Entitlement ent : entsToRevoke) {
@@ -1760,10 +1766,11 @@ public class CandlepinPoolManager implements PoolManager {
      * accordingly
      *
      * @param consumerSortedEntitlements Entitlements to be filtered
+     * @param alreadyDeletedPools pools to skip deletion as they have already been deleted
      * @return Entitlements that are stacked
      */
     private void filterAndUpdateStackingEntitlements(
-        Map<Consumer, List<Entitlement>> consumerSortedEntitlements) {
+        Map<Consumer, List<Entitlement>> consumerSortedEntitlements, Set<String> alreadyDeletedPools) {
         Map<Consumer, List<Entitlement>> stackingEntitlements = new HashMap<Consumer, List<Entitlement>>();
 
         for (Consumer consumer : consumerSortedEntitlements.keySet()) {
@@ -1797,7 +1804,7 @@ public class CandlepinPoolManager implements PoolManager {
             }
             List<Pool> subPools = poolCurator.getSubPoolForStackIds(entry.getKey(), stackIds);
             if (CollectionUtils.isNotEmpty(subPools)) {
-                poolRules.updatePoolsFromStack(entry.getKey(), subPools, true);
+                poolRules.updatePoolsFromStack(entry.getKey(), subPools, alreadyDeletedPools, true);
             }
         }
     }
@@ -1818,7 +1825,7 @@ public class CandlepinPoolManager implements PoolManager {
     @Transactional
     public int revokeAllEntitlements(Consumer consumer, boolean regenCertsAndStatuses) {
         List<Entitlement> entsToDelete = entitlementCurator.listByConsumer(consumer);
-        revokeEntitlements(entsToDelete, regenCertsAndStatuses);
+        revokeEntitlements(entsToDelete, null, regenCertsAndStatuses);
         return entsToDelete.size();
     }
 
@@ -1842,10 +1849,19 @@ public class CandlepinPoolManager implements PoolManager {
     }
 
     @Override
-    @Transactional
     public void deletePools(List<Pool> pools) {
+        deletePools(pools, null);
+    }
+
+    @Override
+    @Transactional
+    public void deletePools(List<Pool> pools, Set<String> alreadyDeletedPools) {
         if (pools.isEmpty()) {
             return;
+        }
+
+        if (alreadyDeletedPools == null) {
+            alreadyDeletedPools = new HashSet<String>();
         }
 
         if (log.isDebugEnabled()) {
@@ -1863,9 +1879,9 @@ public class CandlepinPoolManager implements PoolManager {
         }
 
         if (!pools.isEmpty()) {
-            revokeEntitlements(entitlementsToRevoke);
+            revokeEntitlements(entitlementsToRevoke, alreadyDeletedPools);
             log.debug("Batch deleting pools after successful revocation");
-            poolCurator.batchDelete(pools);
+            poolCurator.batchDelete(pools, alreadyDeletedPools);
         }
 
         for (Pool pool : pools) {

--- a/server/src/main/java/org/candlepin/controller/PoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/PoolManager.java
@@ -313,4 +313,6 @@ public interface PoolManager {
     List<Pool> listMasterPools();
 
     void deletePools(List<Pool> pools);
+
+    void deletePools(List<Pool> pools, Set<String> alreadyDeletedPools);
 }

--- a/server/src/main/java/org/candlepin/model/PoolCurator.java
+++ b/server/src/main/java/org/candlepin/model/PoolCurator.java
@@ -232,12 +232,6 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
     public List<Pool> listExpiredPools(int blockSize) {
         Date now = new Date();
 
-        DetachedCriteria attribCheck = DetachedCriteria.forClass(Pool.class, "attribPool")
-            .createAlias("attributes", "attrib", JoinType.INNER_JOIN)
-            .add(Restrictions.eqProperty("attribPool.id", "tgtPool.id"))
-            .add(Restrictions.eq("attrib.name", Pool.DERIVED_POOL_ATTRIBUTE))
-            .setProjection(Projections.property("attribPool.id"));
-
         DetachedCriteria entCheck = DetachedCriteria.forClass(Pool.class, "entPool")
             .createAlias("entitlements", "ent", JoinType.INNER_JOIN)
             .add(Restrictions.eqProperty("entPool.id", "tgtPool.id"))
@@ -246,7 +240,6 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
 
         Criteria criteria = this.createSecureCriteria("tgtPool")
             .add(Restrictions.lt("tgtPool.endDate", now))
-            .add(Subqueries.notExists(attribCheck))
             .add(Subqueries.notExists(entCheck));
 
         if (blockSize > 0) {
@@ -726,10 +719,25 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
 
     /**
      * Batch deletes a list of pools.
-     * @param pools
+     *
+     * @param pools pools to delete
+     * @param alreadyDeletedPools pools to skip, they have already been deleted.
      */
-    public void batchDelete(List<Pool> pools) {
+    public void batchDelete(List<Pool> pools, Set<String> alreadyDeletedPools) {
+        if (alreadyDeletedPools == null) {
+            alreadyDeletedPools = new HashSet<String>();
+        }
+
         for (Pool pool : pools) {
+
+            // As we batch pool operations, pools may be deleted at multiple places in the code path.
+            // We may request to delete the same pool in multiple places too, for example if an expired
+            // stack derived pool has no entitlements, ExpiredPoolsJob will request to delete it twice,
+            // for each reason.
+            if (alreadyDeletedPools.contains(pool.getId())) {
+                continue;
+            }
+            alreadyDeletedPools.add(pool.getId());
             this.currentSession().delete(pool);
 
             // Maintain runtime consistency. The entitlements for the pool have been deleted on the

--- a/server/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
@@ -343,6 +343,18 @@ public class PoolRules {
      */
     public List<PoolUpdate> updatePoolsFromStack(Consumer consumer, List<Pool> pools,
         boolean deleteIfNoStackedEnts) {
+        return updatePoolsFromStack(consumer, pools, null, deleteIfNoStackedEnts);
+    }
+
+    /**
+     * Updates the pool based on the entitlements in the specified stack.
+     *
+     * @param pools
+     * @param consumer
+     * @return updates
+     */
+    public List<PoolUpdate> updatePoolsFromStack(Consumer consumer, List<Pool> pools,
+        Set<String> alreadyDeletedPools, boolean deleteIfNoStackedEnts) {
         Map<String, List<Entitlement>> entitlementMap = new HashMap<String, List<Entitlement>>();
         Set<String> sourceStackIds = new HashSet<String>();
         List<PoolUpdate> result = new ArrayList<PoolUpdate>();
@@ -373,7 +385,7 @@ public class PoolRules {
         }
 
         if (!poolsToDelete.isEmpty()) {
-            this.poolManager.deletePools(poolsToDelete);
+            this.poolManager.deletePools(poolsToDelete, alreadyDeletedPools);
         }
 
         return result;

--- a/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -190,9 +190,9 @@ public class PoolManagerTest {
     public void deletePoolsTest() {
         List<Pool> pools = new ArrayList<Pool>();
         pools.add(TestUtil.createPool(TestUtil.createProduct()));
-        doNothing().when(mockPoolCurator).batchDelete(pools);
+        doNothing().when(mockPoolCurator).batchDelete(eq(pools), anySetOf(String.class));
         manager.deletePools(pools);
-        verify(mockPoolCurator).batchDelete(eq(pools));
+        verify(mockPoolCurator).batchDelete(eq(pools), anySetOf(String.class));
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
@@ -696,7 +696,7 @@ public class PoolManagerTest {
         manager.revokeEntitlements(entsToDelete);
         entsToDelete.add(e3);
         verify(entitlementCurator).batchDelete(eq(entsToDelete));
-        verify(mockPoolCurator).batchDelete(eq(poolsWithSource));
+        verify(mockPoolCurator).batchDelete(eq(poolsWithSource), anySetOf(String.class));
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
@@ -845,7 +845,7 @@ public class PoolManagerTest {
 
         List<Entitlement> entsToDelete = Arrays.asList(ent);
         List<Pool> poolsToDelete = Arrays.asList(p);
-        verify(mockPoolCurator).batchDelete(eq(poolsToDelete));
+        verify(mockPoolCurator).batchDelete(eq(poolsToDelete), anySetOf(String.class));
         verify(entitlementCurator).batchDelete(eq(entsToDelete));
     }
 
@@ -899,7 +899,7 @@ public class PoolManagerTest {
         manager.cleanupExpiredPools();
 
         // And the pool should be deleted:
-        verify(mockPoolCurator).batchDelete(pools);
+        verify(mockPoolCurator).batchDelete(eq(pools), anySetOf(String.class));
     }
 
     @Test
@@ -923,7 +923,7 @@ public class PoolManagerTest {
         manager.cleanupExpiredPools();
 
         // And the pool should be deleted:
-        verify(mockPoolCurator).batchDelete(pools);
+        verify(mockPoolCurator).batchDelete(eq(pools), anySetOf(String.class));
         verify(mockSubAdapter, never()).getSubscription(any(String.class));
         verify(mockSubAdapter, never()).deleteSubscription(any(Subscription.class));
     }

--- a/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
@@ -1154,6 +1154,47 @@ public class PoolCuratorTest extends DatabaseTestFixture {
     }
 
     @Test
+    public void batchDeleteTest() {
+        Owner owner2 = createOwner();
+        ownerCurator.create(owner2);
+
+        List<Pool> pools = new ArrayList<Pool>();
+        for (int i = 0; i < 10; i++) {
+            pools.add(createPool(owner2, "id123"));
+        }
+
+        for (Pool pool : pools) {
+            assertNotNull(poolCurator.find(pool.getId()));
+        }
+        poolCurator.batchDelete(pools, null);
+        for (Pool pool : pools) {
+            assertNull(poolCurator.find(pool.getId()));
+        }
+    }
+
+    @Test
+    public void batchDeleteAlreadyDeletedTest() {
+        Owner owner2 = createOwner();
+        ownerCurator.create(owner2);
+
+        List<Pool> pools = new ArrayList<Pool>();
+        Set<String> ids = new HashSet<String>();
+        for (int i = 0; i < 10; i++) {
+            Pool p = createPool(owner2, "id123");
+            pools.add(p);
+            ids.add(p.getId());
+        }
+
+        for (Pool pool : pools) {
+            assertNotNull(poolCurator.find(pool.getId()));
+        }
+        poolCurator.batchDelete(pools, ids);
+        for (Pool pool : pools) {
+            assertNotNull(poolCurator.find(pool.getId()));
+        }
+    }
+
+    @Test
     public void handleNull() {
         Pool noexist = new Pool(
             owner,

--- a/server/src/test/java/org/candlepin/test/DatabaseTestFixture.java
+++ b/server/src/test/java/org/candlepin/test/DatabaseTestFixture.java
@@ -290,6 +290,24 @@ public class DatabaseTestFixture {
         return poolCurator.create(pool);
     }
 
+    protected Pool createPool(Owner owner, Product product, Long quantity, String subscriptionId,
+        String subscriptionSubKey, Date startDate, Date endDate) {
+        Pool pool = new Pool(
+            owner,
+            product,
+            new HashSet<Product>(),
+            quantity,
+            startDate,
+            endDate,
+            DEFAULT_CONTRACT,
+            DEFAULT_ACCOUNT,
+            DEFAULT_ORDER
+        );
+
+        pool.setSourceSubscription(new SourceSubscription(subscriptionId, subscriptionSubKey));
+        return poolCurator.create(pool);
+    }
+
     protected Owner createOwner() {
         return this.createOwner("Test Owner " + TestUtil.randomInt());
     }


### PR DESCRIPTION
- Skipping derived pools from listExpiredPools leads to a few edge cases ( derived pools that dont have source entitlements are skipped )
- Batching deletion also complicates things as often we delete pools in intermediate steps that are already in the current batch, so the second attempt to delete them errors out.
- This PR appears to be the safest way to delete all pools that should be deleted.
- I have tested this against deletion of 100000 pools over a weekend.