### PR TITLE
1350455: Adding lower indexes

### DIFF
--- a/server/src/main/resources/db/changelog/20160714130753-lower-index-guest-hypervisor-element.xml
+++ b/server/src/main/resources/db/changelog/20160714130753-lower-index-guest-hypervisor-element.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+    <changeSet id="20160714130753-1" author="fnguyen">
+        <comment>Indexes on results of lower() function. There are code paths in
+                 hypervisor checkin that benefit off these
+        </comment>
+        
+        <createIndex indexName="cp_cnsmr_guests_lower_guest_id_idx" tableName="cp_consumer_guests" unique="false">
+            <column name="lower(guest_id)"/>
+        </createIndex>
+
+        <createIndex indexName="cp_cnsmr_hyp_lower_hyp_id_idx" tableName="cp_consumer_hypervisor" unique="false">
+            <column name="lower(hypervisor_id)"/>
+        </createIndex>
+
+        <createIndex indexName="cp_cnsmr_facts_lower_element_idx" tableName="cp_consumer_facts" unique="false">
+            <column name="lower(element)"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-create.xml
+++ b/server/src/main/resources/db/changelog/changelog-create.xml
@@ -1187,4 +1187,5 @@
     <include file="db/changelog/20160224171417-drop-stat-history-table.xml"/>
     <include file="db/changelog/20160412131122-add-unique-constraint-to-product-certificate-rows.xml"/>
     <include file="db/changelog/20160419110701-oracle-add-indexes-for-foreign-keys.xml"/>
+    <include file="db/changelog/20160714130753-lower-index-guest-hypervisor-element.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-testing.xml
+++ b/server/src/main/resources/db/changelog/changelog-testing.xml
@@ -2277,4 +2277,5 @@
     <include file="db/changelog/20160224171417-drop-stat-history-table.xml"/>
     <include file="db/changelog/20160412131122-add-unique-constraint-to-product-certificate-rows.xml"/>
     <include file="db/changelog/20160419110701-oracle-add-indexes-for-foreign-keys.xml"/>
+    <include file="db/changelog/20160714130753-lower-index-guest-hypervisor-element.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-update.xml
+++ b/server/src/main/resources/db/changelog/changelog-update.xml
@@ -95,4 +95,5 @@
     <include file="db/changelog/20160224171417-drop-stat-history-table.xml"/>
     <include file="db/changelog/20160412131122-add-unique-constraint-to-product-certificate-rows.xml"/>
     <include file="db/changelog/20160419110701-oracle-add-indexes-for-foreign-keys.xml"/>
+    <include file="db/changelog/20160714130753-lower-index-guest-hypervisor-element.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
Hypervisor checkin uses lower() function in many queries. Indexes on the
columns that are being used in the code paths boost performance quite a
bit. Micro-benchmarks shown at least 20 fold speed up.