### PR TITLE
Allow manifest exports to be extended

### DIFF
--- a/server/src/main/java/org/candlepin/guice/DefaultConfig.java
+++ b/server/src/main/java/org/candlepin/guice/DefaultConfig.java
@@ -17,12 +17,14 @@ package org.candlepin.guice;
 import org.candlepin.pki.SubjectKeyIdentifierWriter;
 import org.candlepin.pki.impl.DefaultSubjectKeyIdentifierWriter;
 import org.candlepin.service.EntitlementCertServiceAdapter;
+import org.candlepin.service.ExportExtensionAdapter;
 import org.candlepin.service.IdentityCertServiceAdapter;
 import org.candlepin.service.OwnerServiceAdapter;
 import org.candlepin.service.ProductServiceAdapter;
 import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.service.UserServiceAdapter;
 import org.candlepin.service.impl.DefaultEntitlementCertServiceAdapter;
+import org.candlepin.service.impl.DefaultExportExtensionAdapter;
 import org.candlepin.service.impl.DefaultIdentityCertServiceAdapter;
 import org.candlepin.service.impl.DefaultOwnerServiceAdapter;
 import org.candlepin.service.impl.DefaultProductServiceAdapter;
@@ -53,5 +55,6 @@ class DefaultConfig extends AbstractModule {
         bind(UserServiceAdapter.class).to(DefaultUserServiceAdapter.class);
         bind(ProductServiceAdapter.class).to(DefaultProductServiceAdapter.class);
         bind(SubjectKeyIdentifierWriter.class).to(DefaultSubjectKeyIdentifierWriter.class);
+        bind(ExportExtensionAdapter.class).to(DefaultExportExtensionAdapter.class);
     }
 }

--- a/server/src/main/java/org/candlepin/model/EntitlementCurator.java
+++ b/server/src/main/java/org/candlepin/model/EntitlementCurator.java
@@ -570,7 +570,7 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
         for (Entitlement ent : entitlements) {
             ent.getCertificates().clear();
             ent.getConsumer().getEntitlements().remove(ent);
-    
+
             if (Hibernate.isInitialized(ent.getPool().getEntitlements())) {
                 ent.getPool().getEntitlements().remove(ent);
             }

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -1781,7 +1781,9 @@ public class ConsumerResource {
         @PathParam("consumer_uuid") @Verify(Consumer.class) String consumerUuid,
         @QueryParam("cdn_label") String cdnLabel,
         @QueryParam("webapp_prefix") String webAppPrefix,
-        @QueryParam("api_url") String apiUrl) {
+        @QueryParam("api_url") String apiUrl,
+        @QueryParam("ext") @CandlepinParam(type = KeyValueParameter.class)
+        List<KeyValueParameter> extensionArgs) {
 
         Consumer consumer = consumerCurator.verifyAndLookupConsumer(consumerUuid);
         if (consumer.getType() == null ||
@@ -1804,7 +1806,8 @@ public class ConsumerResource {
 
         File archive;
         try {
-            archive = exporter.getFullExport(consumer, cdnLabel, webAppPrefix, apiUrl);
+            archive = exporter.getFullExport(consumer, cdnLabel, webAppPrefix, apiUrl,
+                getExtensionParamMap(extensionArgs));
             response.addHeader("Content-Disposition", "attachment; filename=" +
                 archive.getName());
 
@@ -2053,6 +2056,21 @@ public class ConsumerResource {
         Map<String, String> calculatedAttributes =
             calculatedAttributesUtil.buildCalculatedAttributes(ent.getPool(), null, null);
         ent.getPool().setCalculatedAttributes(calculatedAttributes);
+    }
+
+    /**
+     * Builds a map of String -> String from a list of {@link KeyValueParameter} query parameters
+     * where param.key is the map key and param.value is the map value.
+     *
+     * @param params the query parameters to build the map from.
+     * @return a Map<String, String> of the key/value pairs in the specified parameters.
+     */
+    private Map<String, String> getExtensionParamMap(List<KeyValueParameter> params) {
+        Map<String, String> paramMap = new HashMap<String, String>();
+        for (KeyValueParameter param : params) {
+            paramMap.put(param.key(), param.value());
+        }
+        return paramMap;
     }
 
 }

--- a/server/src/main/java/org/candlepin/service/ExportExtensionAdapter.java
+++ b/server/src/main/java/org/candlepin/service/ExportExtensionAdapter.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+
+import org.candlepin.model.Consumer;
+
+/**
+ * <p>This adapter provides a hook for allowing the extension of what is
+ * stored in a manifest file. Any extras should be added to the extensions
+ * directory so that anything that is added externally can be easily identified.</p>
+ *
+ * <p>
+ * The following code shows how a simple file could be created and added to the
+ * generated manifest:
+ * </p>
+ *
+ * <pre>
+ * void extendManifest(File extensionDir, Consumer targetConsumer, Map<String, String> extensionData)
+ *    throws IOException {
+ *    String version = (String) extensionData.get("version");
+ *    File extension = new File(extensionDir, String.format("my-extension-%s.txt", version));
+ *    PrintWriter writer = new PrintWriter(extension);
+ *    writer.write("An extension was created for consumer " + targetConsumer.getUuid() + ".\n");
+ *    writer.write("Version: " + version);
+ *    writer.close();
+ * }
+ * </pre>
+ *
+ */
+public interface ExportExtensionAdapter {
+
+    /**
+     * Extends the contents of an export archive file. Implementors can write files to the extension
+     * directory which will be included in the resulting export archive.
+     *
+     * @param extensionDir the directory where export extension data should be placed
+     *                     ( ./extensions in the resulting archive)
+     * @param targetConsumer the {@link Consumer} that is being exported.
+     * @param extensionData data passed via the ext query param when the initial request was made.
+     * @throws IOException if there were any issues creating the extension files.
+     */
+    void extendManifest(File extensionDir, Consumer targetConsumer, Map<String, String> extensionData)
+        throws IOException;
+
+}

--- a/server/src/main/java/org/candlepin/service/impl/DefaultExportExtensionAdapter.java
+++ b/server/src/main/java/org/candlepin/service/impl/DefaultExportExtensionAdapter.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.impl;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+
+import org.candlepin.model.Consumer;
+import org.candlepin.service.ExportExtensionAdapter;
+
+/**
+ * The default implementation of the {@link ExportExtensionAdapter}. This adapter adds
+ * nothing to the manifest.
+ *
+ */
+public class DefaultExportExtensionAdapter implements ExportExtensionAdapter {
+
+    @Override
+    public void extendManifest(File extensionDir, Consumer targetConsumer, Map<String, String> extensionData)
+        throws IOException {
+        // The default implementation does nothing.
+    }
+
+}

--- a/server/src/test/java/org/candlepin/TestingModules.java
+++ b/server/src/test/java/org/candlepin/TestingModules.java
@@ -59,12 +59,14 @@ import org.candlepin.resource.PoolResource;
 import org.candlepin.resource.ProductResource;
 import org.candlepin.resource.SubscriptionResource;
 import org.candlepin.service.EntitlementCertServiceAdapter;
+import org.candlepin.service.ExportExtensionAdapter;
 import org.candlepin.service.IdentityCertServiceAdapter;
 import org.candlepin.service.OwnerServiceAdapter;
 import org.candlepin.service.ProductServiceAdapter;
 import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.service.UniqueIdGenerator;
 import org.candlepin.service.UserServiceAdapter;
+import org.candlepin.service.impl.DefaultExportExtensionAdapter;
 import org.candlepin.service.impl.DefaultIdentityCertServiceAdapter;
 import org.candlepin.service.impl.DefaultOwnerServiceAdapter;
 import org.candlepin.service.impl.DefaultProductServiceAdapter;
@@ -283,8 +285,8 @@ public class TestingModules {
 
             bind(CertificateRevocationListTask.class);
             // temporary
-            bind(IdentityCertServiceAdapter.class).to(
-                DefaultIdentityCertServiceAdapter.class);
+            bind(IdentityCertServiceAdapter.class).to(DefaultIdentityCertServiceAdapter.class);
+            bind(ExportExtensionAdapter.class).to(DefaultExportExtensionAdapter.class);
             bind(PoolRules.class);
             bind(CriteriaRules.class);
             bind(PoolManager.class).to(CandlepinPoolManager.class);

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
@@ -301,7 +301,7 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
         setupPrincipal(owner, Access.READ_ONLY);
         securityInterceptor.enable();
         consumerResource.exportData(mock(HttpServletResponse.class),
-            consumer.getUuid(), null, null, null);
+            consumer.getUuid(), null, null, null, new ArrayList<KeyValueParameter>());
         // if no exception, we're good
     }
 

--- a/server/src/test/java/org/candlepin/sync/ExporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/ExporterTest.java
@@ -14,13 +14,9 @@
  */
 package org.candlepin.sync;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
 
 import org.candlepin.auth.Principal;
 import org.candlepin.common.config.MapConfiguration;
@@ -50,6 +46,7 @@ import org.candlepin.model.RulesCurator;
 import org.candlepin.pki.PKIUtility;
 import org.candlepin.policy.js.export.ExportRules;
 import org.candlepin.service.EntitlementCertServiceAdapter;
+import org.candlepin.service.ExportExtensionAdapter;
 import org.candlepin.service.ProductServiceAdapter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -75,6 +72,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
@@ -106,6 +104,7 @@ public class ExporterTest {
     private CandlepinCommonTestConfig config;
     private ExportRules exportRules;
     private PrincipalProvider pprov;
+    private ExportExtensionAdapter exportExtensionAdapter;
 
     @Before
     public void setUp() {
@@ -130,6 +129,7 @@ public class ExporterTest {
         dve = new DistributorVersionExporter();
         cdnc = mock(CdnCurator.class);
         cdne = new CdnExporter();
+        exportExtensionAdapter = mock(ExportExtensionAdapter.class);
 
         when(exportRules.canExport(any(Entitlement.class))).thenReturn(Boolean.TRUE);
     }
@@ -243,7 +243,7 @@ public class ExporterTest {
 
         // FINALLY test this badboy
         Exporter e = new Exporter(ctc, me, ce, cte, re, ece, ecsa, pe, psa,
-            pce, ec, ee, pki, config, exportRules, pprov, dvc, dve, cdnc, cdne);
+            pce, ec, ee, pki, config, exportRules, pprov, dvc, dve, cdnc, cdne, exportExtensionAdapter);
 
         File export = e.getFullExport(consumer);
 
@@ -296,7 +296,7 @@ public class ExporterTest {
             .thenReturn("publicKey".getBytes());
 
         Exporter e = new Exporter(ctc, me, ce, cte, re, ece, ecsa, pe, psa,
-            pce, ec, ee, pki, config, exportRules, pprov, dvc, dve, cdnc, cdne);
+            pce, ec, ee, pki, config, exportRules, pprov, dvc, dve, cdnc, cdne, exportExtensionAdapter);
 
         e.getFullExport(consumer);
     }
@@ -333,7 +333,7 @@ public class ExporterTest {
 
         // FINALLY test this badboy
         Exporter e = new Exporter(ctc, me, ce, cte, re, ece, ecsa, pe, psa,
-            pce, ec, ee, pki, config, exportRules, pprov, dvc, dve, cdnc, cdne);
+            pce, ec, ee, pki, config, exportRules, pprov, dvc, dve, cdnc, cdne, exportExtensionAdapter);
         File export = e.getFullExport(consumer);
 
         // VERIFY
@@ -379,7 +379,7 @@ public class ExporterTest {
 
         // FINALLY test this badboy
         Exporter e = new Exporter(ctc, me, ce, cte, re, ece, ecsa, pe, psa,
-            pce, ec, ee, pki, config, exportRules, pprov, dvc, dve, cdnc, cdne);
+            pce, ec, ee, pki, config, exportRules, pprov, dvc, dve, cdnc, cdne, exportExtensionAdapter);
         File export = e.getFullExport(consumer);
 
         // VERIFY
@@ -426,7 +426,7 @@ public class ExporterTest {
 
         // FINALLY test this badboy
         Exporter e = new Exporter(ctc, me, ce, cte, re, ece, ecsa, pe, psa,
-            pce, ec, ee, pki, config, exportRules, pprov, dvc, dve, cdnc, cdne);
+            pce, ec, ee, pki, config, exportRules, pprov, dvc, dve, cdnc, cdne, exportExtensionAdapter);
         File export = e.getFullExport(consumer);
 
         verifyContent(export, "export/consumer.json",
@@ -480,11 +480,44 @@ public class ExporterTest {
 
         // FINALLY test this badboy
         Exporter e = new Exporter(ctc, me, ce, cte, re, ece, ecsa, pe, psa,
-            pce, ec, ee, pki, config, exportRules, pprov, dvc, dve, cdnc, cdne);
+            pce, ec, ee, pki, config, exportRules, pprov, dvc, dve, cdnc, cdne, exportExtensionAdapter);
         File export = e.getFullExport(consumer);
 
         verifyContent(export, "export/distributor_version/test-dist-ver.json",
             new VerifyDistributorVersion("test-dist-ver.json"));
+    }
+
+    @Test
+    public void verifyExportExtension() throws Exception {
+        Map<String, String> extensionData = new HashMap<String, String>();
+        Exporter e = new Exporter(ctc, me, ce, cte, re, ece, ecsa, pe, psa,
+            pce, ec, ee, pki, config, exportRules, pprov, dvc, dve, cdnc, cdne, exportExtensionAdapter);
+
+        Principal principal = mock(Principal.class);
+        when(pprov.get()).thenReturn(principal);
+        when(principal.getUsername()).thenReturn("testUser");
+
+        Consumer consumer = mock(Consumer.class);
+
+        Rules mrules = mock(Rules.class);
+        when(mrules.getRules()).thenReturn("foobar");
+        when(pki.getSHA256WithRSAHash(any(InputStream.class))).thenReturn(
+            "signature".getBytes());
+        when(rc.getRules()).thenReturn(mrules);
+
+        // specific to this test
+        IdentityCertificate idcert = new IdentityCertificate();
+        idcert.setSerial(new CertificateSerial(10L, new Date()));
+        idcert.setKey("euh0876puhapodifbvj094");
+        idcert.setCert("hpj-08ha-w4gpoknpon*)&^%#");
+        idcert.setCreated(new Date());
+        idcert.setUpdated(new Date());
+        when(consumer.getIdCert()).thenReturn(idcert);
+
+        e.getFullExport(consumer, "cdn-key", "webapp-prefix", "api-url", extensionData);
+        // Default implementation of the ExportExtensionAdapter does nothing so
+        // we only verify that the extension method was invoked.
+        verify(exportExtensionAdapter).extendManifest(any(File.class), eq(consumer), eq(extensionData));
     }
 
     /**


### PR DESCRIPTION
Added a ManifestExtensionAdapter interface that allows implementations
to add files to an export. The default implementation does nothing.

##Testing
Make the following changes to the DefaultExportExtensionAdapter and restart candlepin

```java
import java.io.File;
import java.io.IOException;
import java.io.PrintWriter;
import java.util.Map;
import java.util.Map.Entry;

import org.candlepin.model.Consumer;
import org.candlepin.service.ExportExtensionAdapter;

public class DefaultExportExtensionAdapter implements ExportExtensionAdapter {

    public void extendManifest(File extensionDir, Consumer targetConsumer, Map<String, String> extensionData)
       throws IOException {
        String version = extensionData.containsKey("version") ? "-" + extensionData.get("version") : "";

        File extension = new File(extensionDir, String.format("my-extension%s.txt", version));
        PrintWriter writer = new PrintWriter(extension);
        writer.write("An extension was created for consumer " + targetConsumer.getUuid() + ".\n");

        for (Entry<String, String> next : extensionData.entrySet()) {
            writer.write(String.format("%s: %s\n", next.getKey(), next.getValue()));
        }
        writer.close();
    }

}
```

2. Register a distributor consumer (make note of the uuid)
```bash
$ sudo subscription-manager register --user admin --pass admin --type candlepin --org admin
Registering to: bluestar:8443/candlepin
The system has been registered with ID: bdb609fd-e9fc-4595-9a91-62b748ac48fe
```

3. Attach a pool
```bash
$ sudo subscription-manager list --avail --pool-only
402882e755eab09a0155eab0f4f411ed
402882e755eab09a0155eab0f2f50fce
402882e755eab09a0155eab101b21d58
402882e755eab09a0155eab0f66f132f
...


$ sudo subscription-manager attach --pool 402882e755eab09a0155eab0f4f411ed
Successfully attached a subscription for: Awesome OS with up to 4 virtual guests
```

4. Export a manifest for that consumer. Make sure to include some ext=pname:pval to have them printed out to a file in the manifest.
```bash
$ wget --no-check-certificate --content-disposition --user admin --password admin "https://localhost:8443/candlepin/consumers/bdb609fd-e9fc-4595-9a91-62b748ac48fe/export?ext=username:mstead&ext=version:1.2.3.4"
```

5. Unpack the export.zip and then the consumer_export.zip.
export.zip --> consumer_export.zip --> export

6. Make sure that the extension was added.
```bash
$ cat export/extensions/my-extension-1.2.3.4.txt

An extension was created for consumer bdb609fd-e9fc-4595-9a91-62b748ac48fe.
version: 1.2.3.4
username: mstead

```
