### PR TITLE
1357036: N+1 fix for Content.modifiedProductIds

### DIFF
--- a/server/src/main/java/org/candlepin/model/Consumer.java
+++ b/server/src/main/java/org/candlepin/model/Consumer.java
@@ -22,6 +22,7 @@ import org.candlepin.util.Util;
 import com.fasterxml.jackson.annotation.JsonFilter;
 
 import org.apache.commons.lang.StringUtils;
+import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.ForeignKey;
 import org.hibernate.annotations.Formula;
@@ -180,6 +181,7 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
     @Transient
     private boolean canActivate;
 
+    @BatchSize(size = 32)
     @OneToMany(mappedBy = "consumer",
         orphanRemoval = true, cascade = { CascadeType.ALL })
     private List<GuestId> guestIds;

--- a/server/src/main/java/org/candlepin/model/Content.java
+++ b/server/src/main/java/org/candlepin/model/Content.java
@@ -20,7 +20,7 @@ import org.candlepin.util.Util;
 
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
-
+import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Type;
 
@@ -116,6 +116,7 @@ public class Content extends AbstractHibernateObject implements SharedEntity, Cl
     @Column(nullable = true)
     private Long metadataExpire;
 
+    @BatchSize(size = 128)
     @ElementCollection
     @CollectionTable(name = "cp2_content_modified_products", joinColumns = @JoinColumn(name = "content_uuid"))
     @Column(name = "element")

--- a/server/src/main/java/org/candlepin/model/Product.java
+++ b/server/src/main/java/org/candlepin/model/Product.java
@@ -21,6 +21,7 @@ import org.candlepin.service.UniqueIdGenerator;
 import org.candlepin.util.Util;
 
 import org.hibernate.LazyInitializationException;
+import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.CascadeType;
 import org.hibernate.annotations.Fetch;
@@ -105,11 +106,13 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
     private Long multiplier;
 
     @OneToMany(mappedBy = "product", orphanRemoval = true)
+    @BatchSize(size = 32)
     @Cascade({ CascadeType.ALL })
     @Fetch(FetchMode.SUBSELECT)
     private List<ProductAttribute> attributes;
 
     @ElementCollection
+    @BatchSize(size = 32)
     @CollectionTable(name = "cp2_product_content", joinColumns = @JoinColumn(name = "product_uuid"))
     @Column(name = "element")
     @LazyCollection(LazyCollectionOption.EXTRA) // allows .size() without loading all data
@@ -124,6 +127,7 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
     @CollectionTable(name = "cp2_product_dependent_products",
         joinColumns = @JoinColumn(name = "product_uuid"))
     @Column(name = "element")
+    @BatchSize(size = 32)
     @LazyCollection(LazyCollectionOption.FALSE)
     private Set<String> dependentProductIds;
 


### PR DESCRIPTION
ConsumerResource.getConsumer() was taking a long time because compliance
check needs to check the whole object graph down to the
Content.modifiedProductIds collection. We observed number of queries run
for some consumers - even thousands. Batching alleviates the issue.