### PR TITLE
Optimized hash code calculation to use cached values for some collections

### DIFF
--- a/server/src/main/java/org/candlepin/auth/UserPrincipal.java
+++ b/server/src/main/java/org/candlepin/auth/UserPrincipal.java
@@ -23,10 +23,13 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 
+
+
 /**
  *
  */
 public class UserPrincipal extends Principal {
+    private static final long serialVersionUID = 4000009253180011323L;
 
     private String username;
     private boolean admin;

--- a/server/src/main/resources/db/changelog/20150210094558-perorgproducts-phase-1.xml
+++ b/server/src/main/resources/db/changelog/20150210094558-perorgproducts-phase-1.xml
@@ -29,6 +29,7 @@
             </column>
             <column name="entity_version" type="int"/>
             <column name="locked" type="smallint"/>
+            <column name="dependent_products_hash" type="int"/>
         </createTable>
     </changeSet>
 
@@ -119,6 +120,7 @@
             <column name="arches" type="varchar(255)"/>
             <column name="entity_version" type="int"/>
             <column name="locked" type="smallint"/>
+            <column name="modified_products_hash" type="int"/>
         </createTable>
     </changeSet>
 

--- a/server/src/test/java/org/candlepin/model/ContentTest.java
+++ b/server/src/test/java/org/candlepin/model/ContentTest.java
@@ -21,15 +21,24 @@ import static org.junit.Assert.*;
 import org.candlepin.test.DatabaseTestFixture;
 import org.candlepin.test.TestUtil;
 
-import org.junit.Test;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
 
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashSet;
+
 
 
 
 /**
  * ContentTest
  */
+@RunWith(JUnitParamsRunner.class)
 public class ContentTest extends DatabaseTestFixture {
 
     @Test
@@ -121,5 +130,95 @@ public class ContentTest extends DatabaseTestFixture {
 
         c1.setLocked(true);
         assertEquals(c1.hashCode(), c2.hashCode());
+    }
+
+    protected Object[][] getValuesForEqualityAndReplication() {
+        return new Object[][] {
+            new Object[] { "Id", "test_value", "alt_value" },
+            new Object[] { "Type", "test_value", "alt_value" },
+            new Object[] { "Label", "test_value", "alt_value" },
+            new Object[] { "Name", "test_value", "alt_value" },
+            new Object[] { "Vendor", "test_value", "alt_value" },
+            new Object[] { "ContentUrl", "test_value", "alt_value" },
+            new Object[] { "RequiredTags", "test_value", "alt_value" },
+            new Object[] { "ReleaseVersion", "test_value", "alt_value" },
+            new Object[] { "GpgUrl", "test_value", "alt_value" },
+            new Object[] { "MetadataExpire", 1234L, 5678L },
+            new Object[] { "ModifiedProductIds", Arrays.asList("1", "2", "3"), Arrays.asList("4", "5", "6") },
+            new Object[] { "Arches", "test_value", "alt_value" },
+            new Object[] { "Locked", Boolean.TRUE, Boolean.FALSE }
+        };
+    }
+
+    protected Method[] getAccessorAndMutator(String methodSuffix, Class mutatorInputClass)
+        throws Exception {
+
+        Method accessor = null;
+        Method mutator = null;
+
+        try {
+            accessor = Content.class.getDeclaredMethod("get" + methodSuffix, null);
+        }
+        catch (NoSuchMethodException e) {
+            accessor = Content.class.getDeclaredMethod("is" + methodSuffix, null);
+        }
+
+        try {
+            mutator = Content.class.getDeclaredMethod("set" + methodSuffix, mutatorInputClass);
+        }
+        catch (NoSuchMethodException e) {
+            if (Collection.class.isAssignableFrom(mutatorInputClass)) {
+                mutator = Content.class.getDeclaredMethod("set" + methodSuffix, Collection.class);
+            }
+            else if (Boolean.class.isAssignableFrom(mutatorInputClass)) {
+                mutator = Content.class.getDeclaredMethod("set" + methodSuffix, boolean.class);
+            }
+            else {
+                throw e;
+            }
+        }
+
+        return new Method[] { accessor, mutator };
+    }
+
+    @Test
+    public void testBaseEquality() {
+        Content lhs = new Content();
+        Content rhs = new Content();
+
+        assertFalse(lhs.equals(null));
+        assertTrue(lhs.equals(lhs));
+        assertTrue(rhs.equals(rhs));
+        assertTrue(lhs.equals(rhs));
+        assertTrue(rhs.equals(lhs));
+    }
+
+    @Test
+    @Parameters(method = "getValuesForEqualityAndReplication")
+    public void testEquality(String valueName, Object value1, Object value2) throws Exception {
+        Method[] methods = this.getAccessorAndMutator(valueName, value1.getClass());
+        Method accessor = methods[0];
+        Method mutator = methods[1];
+
+        Content lhs = new Content();
+        Content rhs = new Content();
+
+        mutator.invoke(lhs, value1);
+        mutator.invoke(rhs, value1);
+
+        assertEquals(accessor.invoke(lhs), accessor.invoke(rhs));
+        assertTrue(lhs.equals(rhs));
+        assertTrue(rhs.equals(lhs));
+        assertTrue(lhs.equals(lhs));
+        assertTrue(rhs.equals(rhs));
+        assertEquals(lhs.hashCode(), rhs.hashCode());
+
+        mutator.invoke(rhs, value2);
+
+        assertNotEquals(accessor.invoke(lhs), accessor.invoke(rhs));
+        assertFalse(lhs.equals(rhs));
+        assertFalse(rhs.equals(lhs));
+        assertTrue(lhs.equals(lhs));
+        assertTrue(rhs.equals(rhs));
     }
 }

--- a/server/src/test/java/org/candlepin/model/ProductTest.java
+++ b/server/src/test/java/org/candlepin/model/ProductTest.java
@@ -18,7 +18,15 @@ import static org.junit.Assert.*;
 
 import org.candlepin.test.DatabaseTestFixture;
 
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+
 import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collection;
 
 import javax.inject.Inject;
 
@@ -26,6 +34,7 @@ import javax.inject.Inject;
 /**
  * ProductTest
  */
+@RunWith(JUnitParamsRunner.class)
 public class ProductTest extends DatabaseTestFixture {
     @Inject private OwnerCurator ownerCurator;
 
@@ -57,5 +66,123 @@ public class ProductTest extends DatabaseTestFixture {
 
         p1.setLocked(true);
         assertEquals(p1.hashCode(), p2.hashCode());
+    }
+
+    protected Object[][] getValuesForEqualityAndReplication() {
+        Collection<ProductAttribute> attributes1 = Arrays.asList(
+            new ProductAttribute("a1", "v1"),
+            new ProductAttribute("a2", "v2"),
+            new ProductAttribute("a3", "v3")
+        );
+
+        Collection<ProductAttribute> attributes2 = Arrays.asList(
+            new ProductAttribute("a4", "v4"),
+            new ProductAttribute("a5", "v5"),
+            new ProductAttribute("a6", "v6")
+        );
+
+        Content[] content = new Content[] {
+            new Content("c1", "content-1", "test_type", "test_label-1", "test_vendor-1"),
+            new Content("c2", "content-2", "test_type", "test_label-2", "test_vendor-2"),
+            new Content("c3", "content-3", "test_type", "test_label-3", "test_vendor-3"),
+            new Content("c4", "content-4", "test_type", "test_label-4", "test_vendor-4"),
+            new Content("c5", "content-5", "test_type", "test_label-5", "test_vendor-5"),
+            new Content("c6", "content-6", "test_type", "test_label-6", "test_vendor-6")
+        };
+
+        Collection<ProductContent> productContent1 = Arrays.asList(
+            new ProductContent(null, content[0], true),
+            new ProductContent(null, content[1], false),
+            new ProductContent(null, content[2], true)
+        );
+
+        Collection<ProductContent> productContent2 = Arrays.asList(
+            new ProductContent(null, content[3], true),
+            new ProductContent(null, content[4], false),
+            new ProductContent(null, content[5], true)
+        );
+
+        return new Object[][] {
+            new Object[] { "Id", "test_value", "alt_value" },
+            new Object[] { "Name", "test_value", "alt_value" },
+            new Object[] { "Multiplier", 1234L, 4567L },
+            new Object[] { "Attributes", attributes1, attributes2 },
+            new Object[] { "ProductContent", productContent1, productContent2 },
+            new Object[] { "DependentProductIds", Arrays.asList("1", "2", "3"), Arrays.asList("4", "5") },
+            // new Object[] { "Href", "test_value", null },
+            new Object[] { "Locked", Boolean.TRUE, false }
+        };
+    }
+
+    protected Method[] getAccessorAndMutator(String methodSuffix, Class mutatorInputClass)
+        throws Exception {
+
+        Method accessor = null;
+        Method mutator = null;
+
+        try {
+            accessor = Product.class.getDeclaredMethod("get" + methodSuffix, null);
+        }
+        catch (NoSuchMethodException e) {
+            accessor = Product.class.getDeclaredMethod("is" + methodSuffix, null);
+        }
+
+        try {
+            mutator = Product.class.getDeclaredMethod("set" + methodSuffix, mutatorInputClass);
+        }
+        catch (NoSuchMethodException e) {
+            if (Collection.class.isAssignableFrom(mutatorInputClass)) {
+                mutator = Product.class.getDeclaredMethod("set" + methodSuffix, Collection.class);
+            }
+            else if (Boolean.class.isAssignableFrom(mutatorInputClass)) {
+                mutator = Product.class.getDeclaredMethod("set" + methodSuffix, boolean.class);
+            }
+            else {
+                throw e;
+            }
+        }
+
+        return new Method[] { accessor, mutator };
+    }
+
+    @Test
+    public void testBaseEquality() {
+        Product lhs = new Product();
+        Product rhs = new Product();
+
+        assertFalse(lhs.equals(null));
+        assertTrue(lhs.equals(lhs));
+        assertTrue(rhs.equals(rhs));
+        assertTrue(lhs.equals(rhs));
+        assertTrue(rhs.equals(lhs));
+    }
+
+    @Test
+    @Parameters(method = "getValuesForEqualityAndReplication")
+    public void testEquality(String valueName, Object value1, Object value2) throws Exception {
+        Method[] methods = this.getAccessorAndMutator(valueName, value1.getClass());
+        Method accessor = methods[0];
+        Method mutator = methods[1];
+
+        Product lhs = new Product();
+        Product rhs = new Product();
+
+        mutator.invoke(lhs, value1);
+        mutator.invoke(rhs, value1);
+
+        assertEquals(accessor.invoke(lhs), accessor.invoke(rhs));
+        assertTrue(lhs.equals(rhs));
+        assertTrue(rhs.equals(lhs));
+        assertTrue(lhs.equals(lhs));
+        assertTrue(rhs.equals(rhs));
+        assertEquals(lhs.hashCode(), rhs.hashCode());
+
+        mutator.invoke(rhs, value2);
+
+        assertNotEquals(accessor.invoke(lhs), accessor.invoke(rhs));
+        assertFalse(lhs.equals(rhs));
+        assertFalse(rhs.equals(lhs));
+        assertTrue(lhs.equals(lhs));
+        assertTrue(rhs.equals(rhs));
     }
 }


### PR DESCRIPTION
- When calculating the hash code of a product or content instance, the hash
  of collections of immutable values is cached and reused
- Methods that mutate the collections which have cached hashes will also
  clear any stored hash
- The Candlepin 2.0 migration task now precalculates the modified
  products and dependent products hash for each content and product that
  is migrated
- Added tests for equality checks and hash code generation for products
  and content