### PR TITLE
Refactored hashCode implementations in certain high-traffic entities

### DIFF
--- a/server/src/main/java/org/candlepin/controller/ContentManager.java
+++ b/server/src/main/java/org/candlepin/controller/ContentManager.java
@@ -149,7 +149,7 @@ public class ContentManager {
 
         // Check if we have an alternate version we can use instead.
         List<Content> alternateVersions = this.contentCurator
-            .getContentByVersion(entity.getId(), entity.hashCode())
+            .getContentByVersion(entity.getId(), entity.getEntityVersion())
             .list();
 
         log.debug("Checking {} alternate content versions", alternateVersions.size());
@@ -229,7 +229,7 @@ public class ContentManager {
         Content updated = this.applyContentChanges((Content) entity.clone(), update, owner);
 
         List<Content> alternateVersions = this.contentCurator
-            .getContentByVersion(update.getId(), updated.hashCode())
+            .getContentByVersion(update.getId(), updated.getEntityVersion())
             .list();
 
         log.debug("Checking {} alternate content versions", alternateVersions.size());

--- a/server/src/main/java/org/candlepin/controller/ProductManager.java
+++ b/server/src/main/java/org/candlepin/controller/ProductManager.java
@@ -152,7 +152,7 @@ public class ProductManager {
 
         // Check if we have an alternate version we can use instead.
         List<Product> alternateVersions = this.productCurator
-            .getProductsByVersion(entity.getId(), entity.hashCode())
+            .getProductsByVersion(entity.getId(), entity.getEntityVersion())
             .list();
 
         for (Product alt : alternateVersions) {
@@ -291,13 +291,12 @@ public class ProductManager {
         // their own version.
         // This is probably going to be a very expensive operation, though.
         List<Product> alternateVersions = this.productCurator
-            .getProductsByVersion(update.getId(), updated.hashCode())
+            .getProductsByVersion(update.getId(), updated.getEntityVersion())
             .list();
 
         log.debug("Checking {} alternate product versions", alternateVersions.size());
         for (Product alt : alternateVersions) {
             if (alt.equals(updated)) {
-                log.debug("UUIDS: {} => {}", entity, alt);
                 log.debug("Converging product with existing: {} => {}", updated, alt);
 
                 List<Owner> owners = Arrays.asList(owner);

--- a/server/src/main/java/org/candlepin/model/Content.java
+++ b/server/src/main/java/org/candlepin/model/Content.java
@@ -528,6 +528,20 @@ public class Content extends AbstractHibernateObject implements SharedEntity, Cl
 
     @Override
     public int hashCode() {
+        HashCodeBuilder builder = new HashCodeBuilder(7, 17)
+            .append(this.id);
+
+        return builder.toHashCode();
+    }
+
+    /**
+     * Calculates and returns a version hash for this entity. This method operates much like the
+     * hashCode method, except that it is more accurate and should have fewer collisions.
+     *
+     * @return
+     *  a version hash for this entity
+     */
+    public int getEntityVersion() {
         // This must always be a subset of equals
         HashCodeBuilder builder = new HashCodeBuilder(37, 7)
             .append(this.id)
@@ -541,14 +555,23 @@ public class Content extends AbstractHibernateObject implements SharedEntity, Cl
             .append(this.gpgUrl)
             .append(this.metadataExpire)
             .append(this.arches)
-            .append(this.locked)
-            .append(this.modifiedProductIds);
+            .append(this.locked);
 
         // Impl note:
-        // Because we handle the collections specially in .equals, we have to do the same special
-        // treatment here to ensure our output doesn't give us wonky results when compared to the
-        // output of .equals
+        // We need to be certain that the hash code is calculated in a way that's order
+        // independent and not subject to Hibernate's poor hashCode implementation on proxy
+        // collections. This calculation follows that defined by the Set.hashCode method.
+        int accumulator = 0;
 
+        if (!this.modifiedProductIds.isEmpty()) {
+            for (String pid : this.modifiedProductIds) {
+                accumulator += (pid != null ? pid.hashCode() : 0);
+            }
+
+            builder.append(accumulator);
+        }
+
+        // Return
         return builder.toHashCode();
     }
 
@@ -636,6 +659,6 @@ public class Content extends AbstractHibernateObject implements SharedEntity, Cl
     @PrePersist
     @PreUpdate
     public void updateEntityVersion() {
-        this.entityVersion = this.hashCode();
+        this.entityVersion = this.getEntityVersion();
     }
 }

--- a/server/src/main/java/org/candlepin/model/Product.java
+++ b/server/src/main/java/org/candlepin/model/Product.java
@@ -20,7 +20,6 @@ import org.candlepin.model.dto.ProductData;
 import org.candlepin.service.UniqueIdGenerator;
 import org.candlepin.util.Util;
 
-import org.hibernate.LazyInitializationException;
 import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.CascadeType;
@@ -1124,6 +1123,20 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
 
     @Override
     public int hashCode() {
+        HashCodeBuilder builder = new HashCodeBuilder(7, 17)
+            .append(this.id);
+
+        return builder.toHashCode();
+    }
+
+    /**
+     * Calculates and returns a version hash for this entity. This method operates much like the
+     * hashCode method, except that it is more accurate and should have fewer collisions.
+     *
+     * @return
+     *  a version hash for this entity
+     */
+    public int getEntityVersion() {
         // This must always be a subset of equals
         HashCodeBuilder builder = new HashCodeBuilder(37, 7)
             .append(this.id)
@@ -1131,46 +1144,40 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
             .append(this.multiplier)
             .append(this.locked);
 
+        // We need to be certain that the hash code is calculated in a way that's order
+        // independent and not subject to Hibernate's poor hashCode implementation on proxy
+        // collections. This calculation follows that defined by the Set.hashCode method.
+        int accumulator = 0;
+
+        if (this.attributes.size() > 0) {
+            for (ProductAttribute attrib : this.attributes) {
+                accumulator += (attrib != null ? attrib.getEntityVersion() : 0);
+            }
+
+            builder.append(accumulator);
+        }
+
         // Impl note:
-        // Because we handle the collections specially in .equals, we have to do the same special
-        // treatment here to ensure our output doesn't give us wonky results when compared to the
-        // output of .equals
-        for (ProductAttribute attrib : this.attributes) {
-            builder.append(attrib);
-        }
-
-        try {
-            // Impl note:
-            // Stepping through the collections here is as painful as it looks, but Hibernate, once
-            // again, doesn't implement .hashCode reliably on the proxy collections. So, we have to
-            // manually step through these and add the elements to ensure the hash code is
-            // generated properly.
-            if (this.dependentProductIds.size() > 0) {
-                for (String pid : this.dependentProductIds) {
-                    builder.append(pid);
-                }
+        // Stepping through the collections here is as painful as it looks, but Hibernate, once
+        // again, doesn't implement .hashCode reliably on the proxy collections. So, we have to
+        // manually step through these and add the elements to ensure the hash code is
+        // generated properly.
+        if (!this.dependentProductIds.isEmpty()) {
+            accumulator = 0;
+            for (String pid : this.dependentProductIds) {
+                accumulator += (pid != null ? pid.hashCode() : 0);
             }
 
-            if (this.productContent.size() > 0) {
-                for (ProductContent pc : this.productContent) {
-                    builder.append(pc);
-                }
-            }
+            builder.append(accumulator);
         }
-        catch (LazyInitializationException e) {
-            // One of the above collections (likely the first) has not been initialized and we're
-            // not able to fetch them. We still need a hashCode, and the caller is likely to run
-            // into this exception in the very near future, but we still need to generate
-            // something here. We'll treat it as if they were empty (and not added).
 
-            // This typically only occurs when we're initially pulling the entity down from a normal
-            // lookup. Hibernate stores the entity in a hashmap, which triggers a call to this
-            // method before Hibernate has fully hydrated it and before it's assigned it to an
-            // entity manager or session. As such, as soon as we try to use one of the above
-            // collections, things explode.
+        if (!this.productContent.isEmpty()) {
+            accumulator = 0;
+            for (ProductContent pc : this.productContent) {
+                accumulator += (pc != null ? pc.getEntityVersion() : 0);
+            }
 
-            // Note that this only applies to lazy collections, so the product attributes are safe
-            // to check for now.
+            builder.append(accumulator);
         }
 
         return builder.toHashCode();
@@ -1254,7 +1261,7 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
     @PrePersist
     @PreUpdate
     public void updateEntityVersion() {
-        this.entityVersion = this.hashCode();
+        this.entityVersion = this.getEntityVersion();
     }
 
 }

--- a/server/src/main/java/org/candlepin/model/ProductAttribute.java
+++ b/server/src/main/java/org/candlepin/model/ProductAttribute.java
@@ -163,6 +163,17 @@ public class ProductAttribute extends AbstractHibernateObject implements Attribu
     }
 
     /**
+     * Calculates and returns a version hash for this entity. This method operates much like the
+     * hashCode method, except that it is more accurate and should have fewer collisions.
+     *
+     * @return
+     *  a version hash for this entity
+     */
+    public int getEntityVersion() {
+        return this.hashCode();
+    }
+
+    /**
      * Determines whether or not this entity would be changed if the given DTO were applied to this
      * object.
      *

--- a/server/src/main/java/org/candlepin/model/ProductContent.java
+++ b/server/src/main/java/org/candlepin/model/ProductContent.java
@@ -144,6 +144,22 @@ public class ProductContent extends AbstractHibernateObject {
     }
 
     /**
+     * Calculates and returns a version hash for this entity. This method operates much like the
+     * hashCode method, except that it is more accurate and should have fewer collisions.
+     *
+     * @return
+     *  a version hash for this entity
+     */
+    public int getEntityVersion() {
+        int hash = 17;
+
+        hash = 7 * hash + (this.content != null ? this.content.getEntityVersion() : 0);
+        hash = 7 * hash + (this.enabled ? 1 : 0);
+
+        return hash;
+    }
+
+    /**
      * Determines whether or not this entity would be changed if the given DTO were applied to this
      * object.
      *

--- a/server/src/test/java/org/candlepin/model/ContentTest.java
+++ b/server/src/test/java/org/candlepin/model/ContentTest.java
@@ -21,8 +21,15 @@ import static org.junit.Assert.*;
 import org.candlepin.test.DatabaseTestFixture;
 import org.candlepin.test.TestUtil;
 
-import org.junit.Test;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
 
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashSet;
 
 
@@ -30,6 +37,7 @@ import java.util.HashSet;
 /**
  * ContentTest
  */
+@RunWith(JUnitParamsRunner.class)
 public class ContentTest extends DatabaseTestFixture {
 
     @Test
@@ -108,18 +116,122 @@ public class ContentTest extends DatabaseTestFixture {
         assertEquals(c1, c2);
     }
 
+    protected Object[][] getValuesForEqualityAndReplication() {
+        return new Object[][] {
+            new Object[] { "Id", "test_value", "alt_value" },
+            new Object[] { "Type", "test_value", "alt_value" },
+            new Object[] { "Label", "test_value", "alt_value" },
+            new Object[] { "Name", "test_value", "alt_value" },
+            new Object[] { "Vendor", "test_value", "alt_value" },
+            new Object[] { "ContentUrl", "test_value", "alt_value" },
+            new Object[] { "RequiredTags", "test_value", "alt_value" },
+            new Object[] { "ReleaseVersion", "test_value", "alt_value" },
+            new Object[] { "GpgUrl", "test_value", "alt_value" },
+            new Object[] { "MetadataExpire", 1234L, 5678L },
+            new Object[] { "ModifiedProductIds", Arrays.asList("1", "2", "3"), Arrays.asList("4", "5", "6") },
+            new Object[] { "Arches", "test_value", "alt_value" },
+            new Object[] { "Locked", Boolean.TRUE, Boolean.FALSE }
+        };
+    }
+
+    protected Method[] getAccessorAndMutator(String methodSuffix, Class mutatorInputClass)
+        throws Exception {
+
+        Method accessor = null;
+        Method mutator = null;
+
+        try {
+            accessor = Content.class.getDeclaredMethod("get" + methodSuffix, null);
+        }
+        catch (NoSuchMethodException e) {
+            accessor = Content.class.getDeclaredMethod("is" + methodSuffix, null);
+        }
+
+        try {
+            mutator = Content.class.getDeclaredMethod("set" + methodSuffix, mutatorInputClass);
+        }
+        catch (NoSuchMethodException e) {
+            if (Collection.class.isAssignableFrom(mutatorInputClass)) {
+                mutator = Content.class.getDeclaredMethod("set" + methodSuffix, Collection.class);
+            }
+            else if (Boolean.class.isAssignableFrom(mutatorInputClass)) {
+                mutator = Content.class.getDeclaredMethod("set" + methodSuffix, boolean.class);
+            }
+            else {
+                throw e;
+            }
+        }
+
+        return new Method[] { accessor, mutator };
+    }
+
     @Test
-    public void testLockStateAffectsHashCode() {
-        Owner owner = new Owner("Example-Corporation");
-        Content c1 = TestUtil.createContent("test_content-1");
-        Content c2 = TestUtil.createContent("test_content-1");
+    public void testBaseEquality() {
+        Content lhs = new Content();
+        Content rhs = new Content();
 
-        assertEquals(c1.hashCode(), c2.hashCode());
+        assertFalse(lhs.equals(null));
+        assertTrue(lhs.equals(lhs));
+        assertTrue(rhs.equals(rhs));
+        assertTrue(lhs.equals(rhs));
+        assertTrue(rhs.equals(lhs));
+    }
 
-        c2.setLocked(true);
-        assertNotEquals(c1.hashCode(), c2.hashCode());
+    @Test
+    @Parameters(method = "getValuesForEqualityAndReplication")
+    public void testEquality(String valueName, Object value1, Object value2) throws Exception {
+        Method[] methods = this.getAccessorAndMutator(valueName, value1.getClass());
+        Method accessor = methods[0];
+        Method mutator = methods[1];
 
-        c1.setLocked(true);
-        assertEquals(c1.hashCode(), c2.hashCode());
+        Content lhs = new Content();
+        Content rhs = new Content();
+
+        mutator.invoke(lhs, value1);
+        mutator.invoke(rhs, value1);
+
+        assertEquals(accessor.invoke(lhs), accessor.invoke(rhs));
+        assertTrue(lhs.equals(rhs));
+        assertTrue(rhs.equals(lhs));
+        assertTrue(lhs.equals(lhs));
+        assertTrue(rhs.equals(rhs));
+
+        mutator.invoke(rhs, value2);
+
+        assertNotEquals(accessor.invoke(lhs), accessor.invoke(rhs));
+        assertFalse(lhs.equals(rhs));
+        assertFalse(rhs.equals(lhs));
+        assertTrue(lhs.equals(lhs));
+        assertTrue(rhs.equals(rhs));
+    }
+
+    @Test
+    public void testBaseEntityVersion() {
+        Content lhs = new Content();
+        Content rhs = new Content();
+
+        assertEquals(lhs.getEntityVersion(), rhs.getEntityVersion());
+    }
+
+    @Test
+    @Parameters(method = "getValuesForEqualityAndReplication")
+    public void testEntityVersion(String valueName, Object value1, Object value2) throws Exception {
+        Method[] methods = this.getAccessorAndMutator(valueName, value1.getClass());
+        Method accessor = methods[0];
+        Method mutator = methods[1];
+
+        Content lhs = new Content();
+        Content rhs = new Content();
+
+        mutator.invoke(lhs, value1);
+        mutator.invoke(rhs, value1);
+
+        assertEquals(accessor.invoke(lhs), accessor.invoke(rhs));
+        assertEquals(lhs.getEntityVersion(), rhs.getEntityVersion());
+
+        mutator.invoke(rhs, value2);
+
+        assertNotEquals(accessor.invoke(lhs), accessor.invoke(rhs));
+        assertNotEquals(lhs.getEntityVersion(), rhs.getEntityVersion());
     }
 }

--- a/server/src/test/java/org/candlepin/model/ProductTest.java
+++ b/server/src/test/java/org/candlepin/model/ProductTest.java
@@ -18,7 +18,15 @@ import static org.junit.Assert.*;
 
 import org.candlepin.test.DatabaseTestFixture;
 
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+
 import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collection;
 
 import javax.inject.Inject;
 
@@ -26,6 +34,7 @@ import javax.inject.Inject;
 /**
  * ProductTest
  */
+@RunWith(JUnitParamsRunner.class)
 public class ProductTest extends DatabaseTestFixture {
     @Inject private OwnerCurator ownerCurator;
 
@@ -44,18 +53,151 @@ public class ProductTest extends DatabaseTestFixture {
         assertEquals(p1, p2);
     }
 
+    protected Object[][] getValuesForEqualityAndReplication() {
+        Collection<ProductAttribute> attributes1 = Arrays.asList(
+            new ProductAttribute("a1", "v1"),
+            new ProductAttribute("a2", "v2"),
+            new ProductAttribute("a3", "v3")
+        );
+
+        Collection<ProductAttribute> attributes2 = Arrays.asList(
+            new ProductAttribute("a4", "v4"),
+            new ProductAttribute("a5", "v5"),
+            new ProductAttribute("a6", "v6")
+        );
+
+        Content[] content = new Content[] {
+            new Content("c1", "content-1", "test_type", "test_label-1", "test_vendor-1"),
+            new Content("c2", "content-2", "test_type", "test_label-2", "test_vendor-2"),
+            new Content("c3", "content-3", "test_type", "test_label-3", "test_vendor-3"),
+            new Content("c4", "content-4", "test_type", "test_label-4", "test_vendor-4"),
+            new Content("c5", "content-5", "test_type", "test_label-5", "test_vendor-5"),
+            new Content("c6", "content-6", "test_type", "test_label-6", "test_vendor-6")
+        };
+
+        Collection<ProductContent> productContent1 = Arrays.asList(
+            new ProductContent(null, content[0], true),
+            new ProductContent(null, content[1], false),
+            new ProductContent(null, content[2], true)
+        );
+
+        Collection<ProductContent> productContent2 = Arrays.asList(
+            new ProductContent(null, content[3], true),
+            new ProductContent(null, content[4], false),
+            new ProductContent(null, content[5], true)
+        );
+
+        return new Object[][] {
+            new Object[] { "Id", "test_value", "alt_value" },
+            new Object[] { "Name", "test_value", "alt_value" },
+            new Object[] { "Multiplier", 1234L, 4567L },
+            new Object[] { "Attributes", attributes1, attributes2 },
+            new Object[] { "ProductContent", productContent1, productContent2 },
+            new Object[] { "DependentProductIds", Arrays.asList("1", "2", "3"), Arrays.asList("4", "5") },
+            // new Object[] { "Href", "test_value", null },
+            new Object[] { "Locked", Boolean.TRUE, false }
+        };
+    }
+
+    protected Method[] getAccessorAndMutator(String methodSuffix, Class mutatorInputClass)
+        throws Exception {
+
+        Method accessor = null;
+        Method mutator = null;
+
+        try {
+            accessor = Product.class.getDeclaredMethod("get" + methodSuffix, null);
+        }
+        catch (NoSuchMethodException e) {
+            accessor = Product.class.getDeclaredMethod("is" + methodSuffix, null);
+        }
+
+        try {
+            mutator = Product.class.getDeclaredMethod("set" + methodSuffix, mutatorInputClass);
+        }
+        catch (NoSuchMethodException e) {
+            if (Collection.class.isAssignableFrom(mutatorInputClass)) {
+                mutator = Product.class.getDeclaredMethod("set" + methodSuffix, Collection.class);
+            }
+            else if (Boolean.class.isAssignableFrom(mutatorInputClass)) {
+                mutator = Product.class.getDeclaredMethod("set" + methodSuffix, boolean.class);
+            }
+            else {
+                throw e;
+            }
+        }
+
+        return new Method[] { accessor, mutator };
+    }
+
     @Test
-    public void testLockStateAffectsHashCode() {
-        Owner owner = new Owner("Example-Corporation");
-        Product p1 = new Product("test-prod", "test-prod-name", "variant", "1.0.0", "x86", "type");
-        Product p2 = new Product("test-prod", "test-prod-name", "variant", "1.0.0", "x86", "type");
+    public void testBaseEquality() {
+        Product lhs = new Product();
+        Product rhs = new Product();
 
-        assertEquals(p1.hashCode(), p2.hashCode());
+        assertFalse(lhs.equals(null));
+        assertTrue(lhs.equals(lhs));
+        assertTrue(rhs.equals(rhs));
+        assertTrue(lhs.equals(rhs));
+        assertTrue(rhs.equals(lhs));
+    }
 
-        p2.setLocked(true);
-        assertNotEquals(p1.hashCode(), p2.hashCode());
+    @Test
+    @Parameters(method = "getValuesForEqualityAndReplication")
+    public void testEquality(String valueName, Object value1, Object value2) throws Exception {
+        Method[] methods = this.getAccessorAndMutator(valueName, value1.getClass());
+        Method accessor = methods[0];
+        Method mutator = methods[1];
 
-        p1.setLocked(true);
-        assertEquals(p1.hashCode(), p2.hashCode());
+        Product lhs = new Product();
+        Product rhs = new Product();
+
+        mutator.invoke(lhs, value1);
+        mutator.invoke(rhs, value1);
+
+        assertEquals(accessor.invoke(lhs), accessor.invoke(rhs));
+        assertTrue(lhs.equals(rhs));
+        assertTrue(rhs.equals(lhs));
+        assertTrue(lhs.equals(lhs));
+        assertTrue(rhs.equals(rhs));
+        assertEquals(lhs.hashCode(), rhs.hashCode());
+
+        mutator.invoke(rhs, value2);
+
+        assertNotEquals(accessor.invoke(lhs), accessor.invoke(rhs));
+        assertFalse(lhs.equals(rhs));
+        assertFalse(rhs.equals(lhs));
+        assertTrue(lhs.equals(lhs));
+        assertTrue(rhs.equals(rhs));
+    }
+
+    @Test
+    public void testBaseEntityVersion() {
+        Product lhs = new Product();
+        Product rhs = new Product();
+
+        assertEquals(lhs.getEntityVersion(), rhs.getEntityVersion());
+    }
+
+    @Test
+    @Parameters(method = "getValuesForEqualityAndReplication")
+    public void testEntityVersion(String valueName, Object value1, Object value2) throws Exception {
+        Method[] methods = this.getAccessorAndMutator(valueName, value1.getClass());
+        Method accessor = methods[0];
+        Method mutator = methods[1];
+
+        Product lhs = new Product();
+        Product rhs = new Product();
+
+        mutator.invoke(lhs, value1);
+        mutator.invoke(rhs, value1);
+
+        assertEquals(accessor.invoke(lhs), accessor.invoke(rhs));
+        assertEquals(lhs.getEntityVersion(), rhs.getEntityVersion());
+
+        mutator.invoke(rhs, value2);
+
+        assertNotEquals(accessor.invoke(lhs), accessor.invoke(rhs));
+        assertNotEquals(lhs.getEntityVersion(), rhs.getEntityVersion());
     }
 }


### PR DESCRIPTION
- The existing hashCode implementations for Product and Content entities
  (as well as related join- and sub-objects) has been moved to the new
  getEntityVersion method
- The new hashCode implementation for Product and Content now use the
  Red Hat ID for the entity
- Improved equality and hashcode testing in Product and Content