### PR TITLE
1358742: UniqueTag cannot be cast to Function

### DIFF
--- a/server/src/main/java/org/candlepin/policy/js/JsRunnerProvider.java
+++ b/server/src/main/java/org/candlepin/policy/js/JsRunnerProvider.java
@@ -83,20 +83,25 @@ public class JsRunnerProvider implements Provider<JsRunner> {
         this.compileRules();
     }
 
+    public void compileRules() {
+        compileRules(false);
+    }
+
     /**
      * These are the expensive operations (initStandardObjects and compileReader/exec).
      *  We do them once here, and define this provider as a singleton, so it's only
      *  done at provider creation or whenever rules are refreshed.
      *
-     * @param rulesCurator
+     * @param force If true, then compilation will be forced even when updated timestamp
+     * indicatese that the compilation is not necessary
      */
-    public void compileRules() {
+    public void compileRules(boolean force) {
         scriptLock.writeLock().lock();
         try {
             // Check to see if we need to recompile. we do this inside the write lock
             // just to avoid race conditions where we might double compile
             Date newUpdated = rulesCurator.getUpdated();
-            if (newUpdated.equals(this.updated)) {
+            if (!force && newUpdated.equals(this.updated)) {
                 return;
             }
 

--- a/server/src/main/java/org/candlepin/resource/RulesResource.java
+++ b/server/src/main/java/org/candlepin/resource/RulesResource.java
@@ -98,7 +98,7 @@ public class RulesResource {
         sink.emitRulesModified(oldRules, rules);
 
         // Trigger a recompile of the JS rules so version/source are set correctly:
-        jsProvider.compileRules();
+        jsProvider.compileRules(true);
 
         return rulesBuffer;
     }
@@ -142,6 +142,6 @@ public class RulesResource {
         sink.emitRulesDeleted(deleteRules);
 
         // Trigger a recompile of the JS rules so version/source are set correctly:
-        jsProvider.compileRules();
+        jsProvider.compileRules(true);
     }
 }


### PR DESCRIPTION
When RulesResource methods were run in quick succession, it was possible
that rules compliation might have been skipped. Adding a 'force' flag to
compileRules. The reasoning is that RulesResource.upload or
RulesResource.delete should always result in recompilation of the rules.