### PR TITLE
1350455: Improve performance of case insensitive search

### DIFF
--- a/server/src/main/java/org/candlepin/model/Consumer.java
+++ b/server/src/main/java/org/candlepin/model/Consumer.java
@@ -169,6 +169,13 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
     @Cascade({org.hibernate.annotations.CascadeType.ALL})
     private Map<String, String> facts;
 
+    @ElementCollection
+    @CollectionTable(name = "cp_consumer_facts_lower", joinColumns = @JoinColumn(name = "cp_consumer_id"))
+    @MapKeyColumn(name = "mapkey")
+    @Column(name = "element")
+    @Cascade({org.hibernate.annotations.CascadeType.ALL})
+    private Map<String, String> factsLower;
+
     @OneToOne(cascade = CascadeType.ALL)
     private KeyPair keyPair;
 
@@ -220,6 +227,7 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
         this.owner = owner;
         this.type = type;
         this.facts = new HashMap<String, String>();
+        this.factsLower = new HashMap<String, String>();
         this.installedProducts = new HashSet<ConsumerInstalledProduct>();
         this.guestIds = new ArrayList<GuestId>();
         this.autoheal = true;
@@ -375,6 +383,21 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
      */
     public void setFacts(Map<String, String> factsIn) {
         facts = factsIn;
+        if (factsIn == null) {
+            factsLower = null;
+        }
+        else {
+            factsLower = new HashMap<String, String>();
+            for (Entry<String, String> f : factsIn.entrySet()) {
+                String val = f.getValue();
+                if (val != null) {
+                    val = val.toLowerCase();
+                }
+
+                factsLower.put(f.getKey(), val);
+            }
+        }
+
     }
 
     /**
@@ -425,8 +448,15 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
     public void setFact(String name, String value) {
         if (facts == null) {
             facts = new HashMap<String, String>();
+            factsLower = new HashMap<String, String>();
         }
         this.facts.put(name, value);
+
+        String lowVal = value;
+        if (lowVal != null) {
+            lowVal = lowVal.toLowerCase();
+        }
+        this.factsLower.put(name, lowVal);
     }
 
     public long getEntitlementCount() {

--- a/server/src/main/java/org/candlepin/model/ConsumerCurator.java
+++ b/server/src/main/java/org/candlepin/model/ConsumerCurator.java
@@ -29,12 +29,9 @@ import com.google.inject.persist.Transactional;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.hibernate.Criteria;
-import org.hibernate.EntityMode;
 import org.hibernate.Hibernate;
-import org.hibernate.HibernateException;
 import org.hibernate.Query;
 import org.hibernate.ReplicationMode;
-import org.hibernate.criterion.CriteriaQuery;
 import org.hibernate.criterion.Criterion;
 import org.hibernate.criterion.DetachedCriteria;
 import org.hibernate.criterion.Disjunction;
@@ -42,10 +39,6 @@ import org.hibernate.criterion.Order;
 import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
 import org.hibernate.criterion.Subqueries;
-import org.hibernate.engine.spi.TypedValue;
-import org.hibernate.internal.util.StringHelper;
-import org.hibernate.type.CompositeType;
-import org.hibernate.type.Type;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -162,10 +155,10 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
         List<String> possibleGuestIds = Util.getPossibleUuids(uuid);
 
         String sql = "select cp_consumer.id from cp_consumer " +
-            "inner join cp_consumer_facts " +
-            "on cp_consumer.id = cp_consumer_facts.cp_consumer_id " +
-            "where cp_consumer_facts.mapkey = 'virt.uuid' and " +
-            "lower(cp_consumer_facts.element) in (:guestids) " +
+            "inner join cp_consumer_facts_lower " +
+            "on cp_consumer.id = cp_consumer_facts_lower.cp_consumer_id " +
+            "where cp_consumer_facts_lower.mapkey = 'virt.uuid' and " +
+            "cp_consumer_facts_lower.element in (:guestids) " +
             "and cp_consumer.owner_id = :ownerid " +
             "order by cp_consumer.updated desc";
 
@@ -206,10 +199,10 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
         List<String> possibleGuestIds = Util.getPossibleUuids(guestIds.toArray(new String [guestIds.size()]));
 
         String sql = "select cp_consumer.uuid from cp_consumer " +
-            "inner join cp_consumer_facts " +
-            "on cp_consumer.id = cp_consumer_facts.cp_consumer_id " +
-            "where cp_consumer_facts.mapkey = 'virt.uuid' and " +
-            "lower(cp_consumer_facts.element) in (:guestids) " +
+            "inner join cp_consumer_facts_lower " +
+            "on cp_consumer.id = cp_consumer_facts_lower.cp_consumer_id " +
+            "where cp_consumer_facts_lower.mapkey = 'virt.uuid' and " +
+            "cp_consumer_facts_lower.element in (:guestids) " +
             "and cp_consumer.owner_id = :ownerid " +
             "order by cp_consumer.updated desc";
 
@@ -510,7 +503,7 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
     public Consumer getHost(String guestId, Owner owner) {
         Disjunction guestIdCrit = Restrictions.disjunction();
         for (String possibleId : Util.getPossibleUuids(guestId)) {
-            guestIdCrit.add(Restrictions.eq("guestId", possibleId).ignoreCase());
+            guestIdCrit.add(Restrictions.eq("guestIdLower", possibleId.toLowerCase()));
         }
         Criteria crit = currentSession()
             .createCriteria(GuestId.class)
@@ -572,7 +565,7 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
         return (Consumer) currentSession().createCriteria(Consumer.class)
             .add(Restrictions.eq("owner", owner))
             .createAlias("hypervisorId", "hvsr")
-            .add(Restrictions.eq("hvsr.hypervisorId", hypervisorId).ignoreCase())
+            .add(Restrictions.eq("hvsr.hypervisorId", hypervisorId.toLowerCase()))
             .setMaxResults(1)
             .uniqueResult();
     }
@@ -626,7 +619,7 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
     private Criterion getHypervisorIdRestriction(Iterable<String> hypervisorIds) {
         List<Criterion> ors = new LinkedList<Criterion>();
         for (String hypervisorId : hypervisorIds) {
-            ors.add(Restrictions.eq("hvsr.hypervisorId", hypervisorId).ignoreCase());
+            ors.add(Restrictions.eq("hvsr.hypervisorId", hypervisorId.toLowerCase()));
         }
         return Restrictions.or(ors.toArray(new Criterion[0]));
     }
@@ -705,7 +698,7 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
             // Cannot use Restrictions.in here because hypervisorId is case insensitive
             Set<Criterion> ors = new HashSet<Criterion>();
             for (String hypervisorId : hypervisorIds) {
-                ors.add(Restrictions.eq("hvsr.hypervisorId", hypervisorId).ignoreCase());
+                ors.add(Restrictions.eq("hvsr.hypervisorId", hypervisorId.toLowerCase()));
             }
             crit.createAlias("hypervisorId", "hvsr");
             crit.add(Restrictions.or(ors.toArray(new Criterion[ors.size()])));
@@ -826,87 +819,5 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
             .list();
     }
 
-    /**
-     * InExpressionIgnoringCase
-     *
-     * Allows Criterion for case insensitive comparison to list of values
-     *
-     * @author wpoteat
-     */
-    public class InExpressionIgnoringCase implements Criterion {
-
-        private final String propertyName;
-        private final Object[] values;
-
-        public InExpressionIgnoringCase(final String propertyName, final Object[] values) {
-            this.propertyName = propertyName;
-            this.values = values;
-        }
-
-        public String toSqlString(final Criteria criteria, final CriteriaQuery criteriaQuery)
-            throws HibernateException {
-            final String[] columns = criteriaQuery.findColumns(this.propertyName, criteria);
-            final String[] wrappedLowerColumns = wrapLower(columns);
-            if (criteriaQuery.getFactory().getDialect().supportsRowValueConstructorSyntaxInInList() ||
-                columns.length <= 1) {
-
-                String singleValueParam = StringHelper.repeat("lower(?), ", columns.length - 1) + "lower(?)";
-                if (columns.length > 1) {
-                    singleValueParam = '(' + singleValueParam + ')';
-                }
-                final String params = this.values.length > 0 ? StringHelper.repeat(singleValueParam + ", ",
-                    this.values.length - 1) + singleValueParam : "";
-                String cols = StringHelper.join(", ", wrappedLowerColumns);
-                if (columns.length > 1) {
-                    cols = '(' + cols + ')';
-                }
-                return cols + " in (" + params + ')';
-            }
-            else {
-                String cols = " ( " + StringHelper.join(" = lower(?) and ",
-                    wrappedLowerColumns) + "= lower(?) ) ";
-                cols = this.values.length > 0 ? StringHelper.repeat(cols + "or ",
-                        this.values.length - 1) + cols : "";
-                cols = " ( " + cols + " ) ";
-                return cols;
-            }
-        }
-
-        public TypedValue[] getTypedValues(final Criteria criteria, final CriteriaQuery criteriaQuery)
-            throws HibernateException {
-            final ArrayList<TypedValue> list = new ArrayList<TypedValue>();
-            final Type type = criteriaQuery.getTypeUsingProjection(criteria, this.propertyName);
-            if (type.isComponentType()) {
-                final CompositeType actype = (CompositeType) type;
-                final Type[] types = actype.getSubtypes();
-                for (int j = 0; j < this.values.length; j++) {
-                    for (int i = 0; i < types.length; i++) {
-                        final Object subval = this.values[j] == null ? null :
-                            actype.getPropertyValues(this.values[j], EntityMode.POJO)[i];
-                        list.add(new TypedValue(types[i], subval, EntityMode.POJO));
-                    }
-                }
-            }
-            else {
-                for (int j = 0; j < this.values.length; j++) {
-                    list.add(new TypedValue(type, this.values[j], EntityMode.POJO));
-                }
-            }
-            return list.toArray(new TypedValue[list.size()]);
-        }
-
-        @Override
-        public String toString() {
-            return this.propertyName + " in (" + StringHelper.toString(this.values) + ')';
-        }
-
-        private String[] wrapLower(final String[] columns) {
-            final String[] wrappedColumns = new String[columns.length];
-            for (int i = 0; i < columns.length; i++) {
-                wrappedColumns[i] = "lower(" + columns[i] + ")";
-            }
-            return wrappedColumns;
-        }
-    }
 
 }

--- a/server/src/main/java/org/candlepin/model/GuestId.java
+++ b/server/src/main/java/org/candlepin/model/GuestId.java
@@ -71,6 +71,11 @@ public class GuestId extends AbstractHibernateObject implements Owned, Named, Co
     @NotNull
     private String guestId;
 
+    @Column(name = "guest_id_lower", nullable = false)
+    @Size(max = 255)
+    @NotNull
+    private String guestIdLower;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @ForeignKey(name = "fk_consumer_guests")
     @JoinColumn(nullable = false)
@@ -94,7 +99,7 @@ public class GuestId extends AbstractHibernateObject implements Owned, Named, Co
 
     public GuestId(String guestId) {
         this();
-        this.guestId = guestId;
+        setGuestId(guestId);
     }
 
     public GuestId(String guestId, Consumer consumer) {
@@ -114,6 +119,13 @@ public class GuestId extends AbstractHibernateObject implements Owned, Named, Co
 
     public void setGuestId(String guestId) {
         this.guestId = guestId;
+
+        if (guestId != null) {
+            guestIdLower = guestId.toLowerCase();
+        }
+        else {
+            guestIdLower = null;
+        }
     }
 
     @HateoasInclude

--- a/server/src/main/java/org/candlepin/model/GuestIdCurator.java
+++ b/server/src/main/java/org/candlepin/model/GuestIdCurator.java
@@ -48,14 +48,14 @@ public class GuestIdCurator extends AbstractHibernateCurator<GuestId> {
     public GuestId findByConsumerAndId(Consumer consumer, String guestId) {
         return (GuestId) this.currentSession().createCriteria(GuestId.class)
             .add(Restrictions.eq("consumer", consumer))
-            .add(Restrictions.eq("guestId", guestId).ignoreCase())
+            .add(Restrictions.eq("guestIdLower", guestId.toLowerCase()))
             .setMaxResults(1)
             .uniqueResult();
     }
 
     public GuestId findByGuestIdAndOrg(String guestUuid, Owner owner) {
         return (GuestId) this.currentSession().createCriteria(GuestId.class)
-            .add(Restrictions.eq("guestId", guestUuid).ignoreCase())
+            .add(Restrictions.eq("guestIdLower", guestUuid.toLowerCase()))
             .createAlias("consumer", "gconsumer")
             .add(Restrictions.eq("gconsumer.owner", owner))
             .setMaxResults(1)

--- a/server/src/main/java/org/candlepin/model/HypervisorId.java
+++ b/server/src/main/java/org/candlepin/model/HypervisorId.java
@@ -124,6 +124,9 @@ public class HypervisorId extends AbstractHibernateObject {
     public void setHypervisorId(String hypervisorId) {
         // Hypervisor uuid is case insensitive, we need to force it to lower
         // case in order to enforce the unique hypervisorId per org constraint
+        //
+        // Queries in Candlepin are dependent on the fact this attribute is
+        // being stored in lower case.
         if (hypervisorId != null) {
             hypervisorId = hypervisorId.toLowerCase();
         }

--- a/server/src/main/java/org/candlepin/model/PoolAttribute.java
+++ b/server/src/main/java/org/candlepin/model/PoolAttribute.java
@@ -59,7 +59,11 @@ public class PoolAttribute extends AbstractHibernateObject implements Attribute 
 
     @Column
     @Size(max = 255)
-    protected String value;
+    private String value;
+
+    @Column(name = "value_lower")
+    @Size(max = 255)
+    private String valueLower;
 
     /*
      * After Jackson version is upgraded:
@@ -75,7 +79,7 @@ public class PoolAttribute extends AbstractHibernateObject implements Attribute 
 
     public PoolAttribute(String name, String val) {
         this.name = name;
-        this.value = val;
+        setValue(val);
     }
 
     public String getId() {
@@ -111,6 +115,12 @@ public class PoolAttribute extends AbstractHibernateObject implements Attribute 
 
     public void setValue(String value) {
         this.value = value;
+        if (value != null) {
+            valueLower = value.toLowerCase();
+        }
+        else {
+            valueLower = null;
+        }
     }
 
     @Override

--- a/server/src/main/java/org/candlepin/policy/criteria/CriteriaRules.java
+++ b/server/src/main/java/org/candlepin/policy/criteria/CriteriaRules.java
@@ -100,7 +100,7 @@ public class CriteriaRules  {
                         PoolAttribute.class, "attr")
                         .add(Restrictions.eq("name", "requires_host"))
                         //  Note: looking for pools that are not for this guest
-                        .add(Restrictions.ne("value", hostUuid).ignoreCase())
+                        .add(Restrictions.ne("valueLower", hostUuid.toLowerCase()))
                         .add(Property.forName("this.id")
                                 .eqProperty("attr.pool.id"))
                                 .setProjection(Projections.property("attr.id"));

--- a/server/src/main/resources/db/changelog/20160714130753-add_lower_columns.xml
+++ b/server/src/main/resources/db/changelog/20160714130753-add_lower_columns.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+    <changeSet id="20160714130753-1" author="fnguyen">
+        <comment>Adding columns to hold lower case data. This allows 
+                 case-insensitive querying that is independent of database
+                 engine and allows us to place indexes on those lower columns.
+        </comment>
+ 
+        <addColumn tableName="cp_consumer_guests">
+          <column name="guest_id_lower" type="VARCHAR(255)"/>
+        </addColumn>
+ 
+        <addColumn tableName="cp_pool_attribute">
+          <column name="value_lower" type="VARCHAR(255)">
+         </column>      
+        </addColumn>
+               
+        <createTable tableName="cp_consumer_facts_lower">
+             <column name="cp_consumer_id" type="VARCHAR(32)">
+                 <constraints nullable="false"/>
+             </column>
+             <column name="element" type="VARCHAR(255)"/>
+             <column name="mapkey" type="VARCHAR(255)">
+                 <constraints nullable="false"/>
+             </column>
+        </createTable>
+
+        <addPrimaryKey columnNames="cp_consumer_id, mapkey" constraintName="cp_consumer_facts_lower_pkey" tableName="cp_consumer_facts_lower"/>
+
+        <sql>UPDATE cp_consumer_guests SET guest_id_lower = lower(guest_id)</sql>
+        <sql>UPDATE cp_pool_attribute SET value_lower = lower(value)</sql>
+        <sql>INSERT INTO cp_consumer_facts_lower(cp_consumer_id, element, mapkey) SELECT cp_consumer_id, lower(element), mapkey FROM cp_consumer_facts</sql>
+        
+        <createIndex indexName="cp_cnsmr_guests_lower_guest_id_idx" tableName="cp_consumer_guests" unique="false">
+            <column name="guest_id_lower"/>
+        </createIndex>
+
+        <createIndex indexName="cp_pool_attribute_value_lower_idx" tableName="cp_pool_attribute" unique="false">
+            <column name="value_lower"/>
+        </createIndex>
+
+        <createIndex indexName="consumer_fact_lower_consumer_id_idx" tableName="cp_consumer_facts_lower" unique="false">
+            <column name="cp_consumer_id"/>
+        </createIndex>
+
+        <createIndex indexName="consumer_fact_lower_element_idx" tableName="cp_consumer_facts_lower" unique="false">
+            <column name="element"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-create.xml
+++ b/server/src/main/resources/db/changelog/changelog-create.xml
@@ -1187,4 +1187,5 @@
     <include file="db/changelog/20160224171417-drop-stat-history-table.xml"/>
     <include file="db/changelog/20160412131122-add-unique-constraint-to-product-certificate-rows.xml"/>
     <include file="db/changelog/20160419110701-oracle-add-indexes-for-foreign-keys.xml"/>
+    <include file="db/changelog/20160714130753-add_lower_columns.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-testing.xml
+++ b/server/src/main/resources/db/changelog/changelog-testing.xml
@@ -2277,4 +2277,5 @@
     <include file="db/changelog/20160224171417-drop-stat-history-table.xml"/>
     <include file="db/changelog/20160412131122-add-unique-constraint-to-product-certificate-rows.xml"/>
     <include file="db/changelog/20160419110701-oracle-add-indexes-for-foreign-keys.xml"/>
+    <include file="db/changelog/20160714130753-add_lower_columns.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-update.xml
+++ b/server/src/main/resources/db/changelog/changelog-update.xml
@@ -95,4 +95,5 @@
     <include file="db/changelog/20160224171417-drop-stat-history-table.xml"/>
     <include file="db/changelog/20160412131122-add-unique-constraint-to-product-certificate-rows.xml"/>
     <include file="db/changelog/20160419110701-oracle-add-indexes-for-foreign-keys.xml"/>
+    <include file="db/changelog/20160714130753-add_lower_columns.xml"/>
 </databaseChangeLog>

--- a/server/src/test/java/org/candlepin/model/ConsumerContentOverrideCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ConsumerContentOverrideCuratorTest.java
@@ -92,6 +92,32 @@ public class ConsumerContentOverrideCuratorTest extends DatabaseTestFixture {
     }
 
     @Test
+    public void deleteByNameCaseInsensitive() {
+        ConsumerContentOverride cco = new ConsumerContentOverride(
+            consumer, "test-content", "naME", "value");
+        consumerContentOverrideCurator.create(cco);
+
+        consumerContentOverrideCurator.removeByName(consumer, "test-content", "nAMe");
+        ConsumerContentOverride cco2 = consumerContentOverrideCurator.retrieve(
+            consumer, "test-content", "naME");
+        assertNull(cco2);
+    }
+
+    @Test
+    public void retrieveByNameCaseInsensitive() {
+        ConsumerContentOverride cco = new ConsumerContentOverride(
+            consumer, "test-content", "naME", "value");
+        consumerContentOverrideCurator.create(cco);
+
+        ConsumerContentOverride ccof1 = consumerContentOverrideCurator.retrieve(
+            consumer, "test-content", "naME");
+        ConsumerContentOverride ccof2 = consumerContentOverrideCurator.retrieve(
+            consumer, "test-content", "Name");
+        assertNotNull(ccof1);
+        assertNotNull(ccof2);
+    }
+
+    @Test
     public void deleteByLabel() {
         ConsumerContentOverride cco1 = new ConsumerContentOverride(
             consumer, "test-content", "name1", "value");

--- a/server/src/test/java/org/candlepin/model/ConsumerCuratorSearchTest.java
+++ b/server/src/test/java/org/candlepin/model/ConsumerCuratorSearchTest.java
@@ -136,6 +136,29 @@ public class ConsumerCuratorSearchTest extends DatabaseTestFixture {
     }
 
     @Test
+    public void testSearchHypervisorIdsCaseInsensitive() {
+        String hypervisorid = "HyPuUiD";
+        String hypervisorid2 = "HyPuUiD2";
+        Consumer consumer = new Consumer("testConsumer", "testUser", owner, ct);
+        consumer.setHypervisorId(new HypervisorId(hypervisorid));
+        consumer = consumerCurator.create(consumer);
+
+        Consumer consumer2 = new Consumer("testConsumer2", "testUser2", owner, ct);
+        consumer2.setHypervisorId(new HypervisorId(hypervisorid2));
+        consumer2 = consumerCurator.create(consumer2);
+
+        List<String> hypervisorIds = new ArrayList<String>();
+        hypervisorIds.add(hypervisorid.toUpperCase());
+
+        Page<List<Consumer>> results = consumerCurator.searchOwnerConsumers(
+            null, null, null, null, hypervisorIds, null, null, null, null, null);
+
+        List<Consumer> resultList = results.getPageData();
+        assertEquals(1, resultList.size());
+        assertEquals(consumer, resultList.get(0));
+    }
+
+    @Test
     public void testSearchConsumersUuidsAndOwner() {
         Consumer consumer = new Consumer("testConsumer", "testUser", owner, ct);
         Map<String, String> facts = new HashMap<String, String>();

--- a/server/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
@@ -224,6 +224,23 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
     }
 
     @Test
+    public void caseInsensitiveGetHost() {
+        Consumer host = new Consumer("hostConsumer", "testUser", owner, ct);
+        consumerCurator.create(host);
+
+        Consumer gConsumer1 = new Consumer("guestConsumer1", "testUser", owner, ct);
+        gConsumer1.getFacts().put("virt.uuid", "daf0fe10-956b-7b4e-b7dc-b383ce681ba8");
+        consumerCurator.create(gConsumer1);
+
+        host.addGuestId(new GuestId("DAF0FE10-956B-7B4E-B7DC-B383CE681BA8"));
+        consumerCurator.update(host);
+
+        Consumer guestHost = consumerCurator.getHost(
+            "Daf0fe10-956b-7b4e-b7dc-B383CE681ba8", owner);
+        assertEquals(host, guestHost);
+    }
+
+    @Test
     public void oneHostRegisteredReverseEndian() {
         Consumer host = new Consumer("hostConsumer", "testUser", owner, ct);
         consumerCurator.create(host);
@@ -519,6 +536,33 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
     }
 
     @Test
+    public void getGuestConsumerMapCaseInsensitive() {
+        String guestId1 = "06f81b41-AAC0-7685-FBE9-79AA4A326511";
+        String guestId1ReverseEndian = "411bf806-c0aa-8576-fbe9-79aa4a326511";
+        Consumer gConsumer1 = new Consumer("guestConsumer1", "testUser", owner, ct);
+        gConsumer1.getFacts().put("virt.uuid", guestId1);
+        consumerCurator.create(gConsumer1);
+
+        String guestId2 = "4c4c4544-0046-4210-8031-C7C04F445831";
+        Consumer gConsumer2 = new Consumer("guestConsumer2", "testUser", owner, ct);
+        gConsumer2.getFacts().put("virt.uuid", guestId2);
+        consumerCurator.create(gConsumer2);
+
+        Set<String> guestIds = new HashSet<String>();
+        guestIds.add(guestId1ReverseEndian.toUpperCase()); // reversed endian match
+        guestIds.add(guestId2.toUpperCase()); // direct match
+        VirtConsumerMap guestMap = consumerCurator.getGuestConsumersMap(owner, guestIds);
+
+        assertEquals(2, guestMap.size());
+
+        assertEquals(gConsumer1.getId(), guestMap.get(guestId1.toLowerCase()).getId());
+        assertEquals(gConsumer1.getId(), guestMap.get(guestId1ReverseEndian).getId());
+
+        assertEquals(gConsumer2.getId(), guestMap.get(guestId2.toLowerCase()).getId());
+        assertEquals(gConsumer2.getId(), guestMap.get(Util.transformUuid(guestId2.toLowerCase())).getId());
+    }
+
+    @Test
     public void testDoesConsumerExistNo() {
         Consumer consumer = new Consumer("testConsumer", "testUser", owner, ct);
         consumer.setUuid("1");
@@ -579,6 +623,16 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
     }
 
     @Test
+    public void testGetHypervisorCaseInsensitive() {
+        String hypervisorid = "HYpervisor";
+        Consumer consumer = new Consumer("testConsumer", "testUser", owner, ct);
+        consumer.setHypervisorId(new HypervisorId(hypervisorid));
+        consumer = consumerCurator.create(consumer);
+        Consumer result = consumerCurator.getHypervisor(hypervisorid.toUpperCase(), owner);
+        assertEquals(consumer, result);
+    }
+
+    @Test
     public void testGetHypervisorWrongOwner() {
         Owner otherOwner = new Owner("test-owner-other", "Test Other Owner");
         otherOwner = ownerCurator.create(otherOwner);
@@ -627,6 +681,22 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
         assertEquals(1, results.size());
         assertEquals(consumer, results.get(0));
     }
+
+    @Test
+    public void testGetHypervisorsBulkCaseInsensitive() {
+        String hypervisorid = "hYPervisor";
+        Consumer consumer = new Consumer("testConsumer", "testUser", owner, ct);
+        consumer.setHypervisorId(new HypervisorId(hypervisorid));
+        consumer = consumerCurator.create(consumer);
+        List<String> hypervisorIds = new LinkedList<String>();
+        hypervisorIds.add(hypervisorid.toUpperCase());
+        hypervisorIds.add("NOT really a hypervisor");
+        List<Consumer> results = consumerCurator.getHypervisorsBulk(
+            hypervisorIds, owner.getKey());
+        assertEquals(1, results.size());
+        assertEquals(consumer, results.get(0));
+    }
+
 
     @Test
     public void testGetHypervisorsBulkEmpty() {

--- a/server/src/test/java/org/candlepin/model/GuestIdCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/GuestIdCuratorTest.java
@@ -107,4 +107,35 @@ public class GuestIdCuratorTest extends DatabaseTestFixture {
         GuestId result = curator.findByConsumerAndId(consumer, "1");
         assertEquals(new GuestId("1"), result);
     }
+
+    @Test
+    public void findByConsumerAndIdCaseInsensitive() {
+        String guestId = "GuEsTiD";
+        Consumer consumer = new Consumer("testConsumer", "testUser", owner, ct);
+        consumer.addGuestId(new GuestId(guestId));
+        consumerCurator.create(consumer);
+
+        GuestId result = curator.findByConsumerAndId(consumer, guestId.toUpperCase());
+        /**
+         * Note that we keep the original case of the guestId, we only search
+         * in case insensitive way
+         */
+        assertEquals(new GuestId(guestId), result);
+    }
+
+
+    @Test
+    public void findByGuestIdAndOrgCaseInsensitive() {
+        String guestId = "GuEsTiD";
+        Consumer consumer = new Consumer("testConsumer", "testUser", owner, ct);
+        consumer.addGuestId(new GuestId(guestId));
+        consumerCurator.create(consumer);
+
+        GuestId result = curator.findByGuestIdAndOrg(guestId.toUpperCase(), owner);
+        /**
+         * Note that we keep the original case of the guestId, we only search
+         * in case insensitive way
+         */
+        assertEquals(new GuestId(guestId), result);
+    }
 }


### PR DESCRIPTION
Changing strategy for case insensitive searches. In the past we
used ignoreCase() and lower() to perform case insensitive search.
That strategy was performing poorly in the absence of an database
index. Adding such index was not possible in database agnostic way
so the new strategy is to use columns suffixed '_lower'. These
columns have index created and they contain only lower case data.