### PR TITLE
1354633: Cleanup stray ueber objects

### DIFF
--- a/server/spec/one_sub_pool_per_stack_spec.rb
+++ b/server/spec/one_sub_pool_per_stack_spec.rb
@@ -345,6 +345,9 @@ describe 'One Sub Pool Per Stack' do
     # Simulate migration
     @host2_client.update_consumer({:guestIds => [{'guestId' => @guest_uuid}]})
 
+    # Need to wait a moment here for MySQL to catch up
+    sleep 4
+
     # Guest entitlement should now be revoked.
     @guest_client.list_entitlements.length.should == 0
   end

--- a/server/src/main/java/org/candlepin/policy/js/JsRunnerProvider.java
+++ b/server/src/main/java/org/candlepin/policy/js/JsRunnerProvider.java
@@ -83,20 +83,25 @@ public class JsRunnerProvider implements Provider<JsRunner> {
         this.compileRules();
     }
 
+    public void compileRules() {
+        compileRules(false);
+    }
+
     /**
      * These are the expensive operations (initStandardObjects and compileReader/exec).
      *  We do them once here, and define this provider as a singleton, so it's only
      *  done at provider creation or whenever rules are refreshed.
      *
-     * @param rulesCurator
+     * @param force If true, then compilation will be forced even when updated timestamp
+     * indicatese that the compilation is not necessary
      */
-    public void compileRules() {
+    public void compileRules(boolean force) {
         scriptLock.writeLock().lock();
         try {
             // Check to see if we need to recompile. we do this inside the write lock
             // just to avoid race conditions where we might double compile
             Date newUpdated = rulesCurator.getUpdated();
-            if (newUpdated.equals(this.updated)) {
+            if (!force && newUpdated.equals(this.updated)) {
                 return;
             }
 

--- a/server/src/main/java/org/candlepin/resource/RulesResource.java
+++ b/server/src/main/java/org/candlepin/resource/RulesResource.java
@@ -98,7 +98,7 @@ public class RulesResource {
         sink.emitRulesModified(oldRules, rules);
 
         // Trigger a recompile of the JS rules so version/source are set correctly:
-        jsProvider.compileRules();
+        jsProvider.compileRules(true);
 
         return rulesBuffer;
     }
@@ -142,6 +142,6 @@ public class RulesResource {
         sink.emitRulesDeleted(deleteRules);
 
         // Trigger a recompile of the JS rules so version/source are set correctly:
-        jsProvider.compileRules();
+        jsProvider.compileRules(true);
     }
 }

--- a/server/src/main/resources/db/changelog/20160720104426-remove-bad-ueber-cert-data.xml
+++ b/server/src/main/resources/db/changelog/20160720104426-remove-bad-ueber-cert-data.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+    <!-- POSTGRES/ORACLE QUERIES -->
+    <property
+        dbms="postgresql,oracle,hsqldb"
+        name="delete_stray_ueber_consumers"
+        value="delete from cp_consumer
+               where id IN (
+                    select c.id from cp_consumer c
+                    left outer join cp_entitlement e on e.consumer_id = c.id
+                    where c.name = 'ueber_cert_consumer' and e.id is null);"/>
+
+    <property
+        dbms="postgresql,oracle,hsqldb"
+        name="delete_stray_ueber_subs"
+        value="delete from cp_subscription
+               where id in (
+                 select s.id from cp_subscription s
+                 inner join cp_product p on s.product_id = p.id
+                 left outer join cp_pool pool on pool.productid = p.id
+                 where p.name LIKE '%_ueber_product' and pool.id is null
+               );"/>
+
+    <property
+        dbms="postgresql,oracle,hsqldb"
+        name="delete_stray_ueber_content"
+        value="delete from cp_content
+               where id in (
+                   select c.id from cp_content c
+                   inner join cp_product_content pc on pc.content_id=c.id
+                   inner join cp_product p on p.id=pc.product_id
+                   left outer join cp_pool pool on pool.productid = p.id
+                   where p.name LIKE '%_ueber_product' and pool.id is null
+               );"/>
+
+    <property
+        dbms="postgresql,oracle,hsqldb"
+        name="delete_stray_ueber_products"
+        value="delete from cp_product
+                  where id in (
+                      select p.id from cp_product p
+                      left outer join cp_pool pool on pool.productid = p.id
+                      where p.name LIKE '%ueber%' and pool.id is null
+                  );"/>
+
+    <!-- MYSQL QUERIES -->
+
+    <property
+        dbms="mysql"
+        name="delete_stray_ueber_consumers"
+        value="delete c from cp_consumer c
+               left outer join cp_entitlement e on e.consumer_id = c.id
+               where c.name = 'ueber_cert_consumer' and e.id is null;"/>
+
+    <property
+        dbms="mysql"
+        name="delete_stray_ueber_subs"
+        value="delete s from cp_subscription s
+               inner join cp_product p on s.product_id = p.id
+               left outer join cp_pool pool on pool.productid = p.id
+               where p.name LIKE '%_ueber_product' and pool.id is null;"/>
+
+    <property
+        dbms="mysql"
+        name="delete_stray_ueber_content"
+        value="delete c from cp_content c
+               inner join cp_product_content pc on pc.content_id=c.id
+               inner join cp_product p on p.id=pc.product_id
+               left outer join cp_pool pool on pool.productid = p.id
+               where p.name LIKE '%_ueber_product' and pool.id is null;"/>
+
+    <property
+        dbms="mysql"
+        name="delete_stray_ueber_products"
+        value="delete p from cp_product p
+               left outer join cp_pool pool on pool.productid = p.id
+               where p.name LIKE '%ueber%' and pool.id is null;"/>
+
+
+    <changeSet id="20160720104426-1" author="mstead">
+        <comment>
+            Cleans up stray ueber consumers, subscriptions, products and content that gets left
+            around due to BZ#####. The fix for this BZ prevents the data from becoming stray,
+            but does not address a situation where the stray data already exists as reported
+            by BZ 1354633. Cleaning up the stray records will allow for a clean debug cert to
+            be created without error.
+        </comment>
+        <sql>${delete_stray_ueber_consumers}</sql>
+        <sql>${delete_stray_ueber_subs}</sql>
+        <sql>${delete_stray_ueber_content}</sql>
+        <sql>${delete_stray_ueber_products}</sql>
+    </changeSet>
+
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/server/src/main/resources/db/changelog/changelog-create.xml
+++ b/server/src/main/resources/db/changelog/changelog-create.xml
@@ -1177,4 +1177,5 @@
     <include file="db/changelog/20150818110722-upgrade-to-quartz-2-dot-2.xml"/>
     <include file="db/changelog/20150820140403-revert-to-lastcheckin-column.xml"/>
     <include file="db/changelog/20160614113932-add-owner-and-type-constraint-export-metadata.xml"/>
+    <include file="db/changelog/20160720104426-remove-bad-ueber-cert-data.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-testing.xml
+++ b/server/src/main/resources/db/changelog/changelog-testing.xml
@@ -2027,7 +2027,7 @@
     </changeSet>
     <changeSet author="awood" id="1413225753032-290">
         <comment>
-             Add the default quartz lock columns.
+             Add the default quartz lock columns. 
         </comment>
         <insert tableName="QRTZ_LOCKS">
             <column name="LOCK_NAME" value="TRIGGER_ACCESS"/>
@@ -2267,4 +2267,5 @@
     <include file="db/changelog/20150818110722-upgrade-to-quartz-2-dot-2.xml"/>
     <include file="db/changelog/20150820140403-revert-to-lastcheckin-column.xml"/>
     <include file="db/changelog/20160614113932-add-owner-and-type-constraint-export-metadata.xml"/>
+    <include file="db/changelog/20160720104426-remove-bad-ueber-cert-data.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-update.xml
+++ b/server/src/main/resources/db/changelog/changelog-update.xml
@@ -85,4 +85,5 @@
     <include file="db/changelog/20150818110722-upgrade-to-quartz-2-dot-2.xml"/>
     <include file="db/changelog/20150820140403-revert-to-lastcheckin-column.xml"/>
     <include file="db/changelog/20160614113932-add-owner-and-type-constraint-export-metadata.xml"/>
+    <include file="db/changelog/20160720104426-remove-bad-ueber-cert-data.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
An old bug that caused the ueber cert pools
to be deleted was fixed but did not correct
the state of any owners that were affected.
All required ueber objects (sub, product,
content, consumer) were not cleaned up.

Subsequent attempts to get or create a new
debug cert would fail because the data was
in a new state.

This patch adds a new liquibase changeset to
clean up the data. This patch plus the old
bug fix should make sure that this doesn't
happen again.

## Testing Details

**Before starting, make sure that you have a manifest handy! You will have to import it in one of the steps below!!!**


1) Check out the branch that first introduced the bug and deploy.
```bash
$ git co -b ueber-broken 64b74191499e60de17162f56e10a090c74de5b87
$ bin/deploy -gt
```
2) Generate the debug cert for the 'admin' owner.
```bash
$ curl -X POST -k -u admin:admin https://localhost:8443/candlepin/owners/admin/uebercert
```
3) Import a manifest and then attempt to GET the existing ueber cert to trigger the OLD bug. It should complain about an IndexOutOfBounds or something of the likes.
```bash
$ ./cpc import admin /path/to/your/manifest.zip
$ curl -k -u admin:admin https://localhost:8443/candlepin/owners/admin/uebercert
```
4) Check out the HEAD of candlepin-0.9.54-HOTFIX and redeploy leaving the DB unchanged.
```bash
$ git co -b 0954-debug-old-fix-applied --track origin/candlepin-0.9.54-HOTFIX
$ bin/deploy
```
5) After redeploying with the fix, create a new owner and generate a debug cert for it. Verify that the new owner can create and get the new cert but the old still can't because of the bad data.
```bash
# Should fail with the same error
$ curl -k -u admin:admin https://localhost:8443/candlepin/owners/admin/uebercert
# Do another post to REALLY mess things up. The POST will indeed create a new cert for you
# but trying to fetch it breaks becuse there are now 2 ueber consumers!!!!!
$ curl -X POST -k -u admin:admin https://localhost:8443/candlepin/owners/admin/uebercert
$ curl -k -u admin:admin https://localhost:8443/candlepin/owners/admin/uebercert

# Create new owner and verify POST and GET works.
$ ./cpc create_owner zombie
$ curl -X POST -k -u admin:admin https://localhost:8443/candlepin/owners/zombie/uebercert
$ curl -k -u admin:admin https://localhost:8443/candlepin/owners/zombie/uebercert

6) At this point you are in the state that our katello friend had his system in. Let's test
the patch! Checkout the branch for this PR. Simply redeploy this patched version of
candlepin and liquibase will kick in, clean out all the bogus data, and should leave
BOTH owners in a state to be able to create and get certs without any issues. Run
POST as much as you'd like and all should be well with only one copy of the ueber
objects in the DB per owner.
```bash
# ALL OF THESE SHOULD WORK WITHOUT ISSUES
$ curl -k -u admin:admin https://localhost:8443/candlepin/owners/admin/uebercert
$ curl -X POST -k -u admin:admin https://localhost:8443/candlepin/owners/admin/uebercert
$ curl -X POST -k -u admin:admin https://localhost:8443/candlepin/owners/admin/uebercert
$ curl -k -u admin:admin https://localhost:8443/candlepin/owners/zombie/uebercert
$ curl -X POST -k -u admin:admin https://localhost:8443/candlepin/owners/zombie/uebercert
```
