### PR TITLE
1354633: Cleanup stray ueber objects (CP 2.0)

### DIFF
--- a/server/src/main/java/org/candlepin/model/UeberCertificateGenerator.java
+++ b/server/src/main/java/org/candlepin/model/UeberCertificateGenerator.java
@@ -22,7 +22,6 @@ import org.candlepin.model.ConsumerType.ConsumerTypeEnum;
 import org.candlepin.model.dto.ProductData;
 import org.candlepin.model.dto.Subscription;
 import org.candlepin.policy.EntitlementRefusedException;
-import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.service.UniqueIdGenerator;
 
 import com.google.inject.Inject;
@@ -41,12 +40,9 @@ public class UeberCertificateGenerator {
 
     private PoolManager poolManager;
     private PoolCurator poolCurator;
-    private ProductCurator productCurator;
     private ProductManager productManager;
-    private ContentCurator contentCurator;
     private ContentManager contentManager;
     private UniqueIdGenerator idGenerator;
-    private SubscriptionServiceAdapter subService;
     private ConsumerTypeCurator consumerTypeCurator;
     private ConsumerCurator consumerCurator;
     private I18n i18n;
@@ -54,24 +50,18 @@ public class UeberCertificateGenerator {
     @Inject
     public UeberCertificateGenerator(PoolManager poolManager,
         PoolCurator poolCurator,
-        ProductCurator productCurator,
         ProductManager productManager,
-        ContentCurator contentCurator,
         ContentManager contentManager,
         UniqueIdGenerator idGenerator,
-        SubscriptionServiceAdapter subService,
         ConsumerTypeCurator consumerTypeCurator,
         ConsumerCurator consumerCurator,
         I18n i18n) {
 
         this.poolManager = poolManager;
         this.poolCurator = poolCurator;
-        this.productCurator = productCurator;
         this.productManager = productManager;
-        this.contentCurator = contentCurator;
         this.contentManager = contentManager;
         this.idGenerator = idGenerator;
-        this.subService = subService;
         this.consumerTypeCurator = consumerTypeCurator;
         this.consumerCurator = consumerCurator;
         this.i18n = i18n;
@@ -116,8 +106,6 @@ public class UeberCertificateGenerator {
         subscription.setId(idGenerator.generateId());
         subscription.setCreated(now);
         subscription.setUpdated(now);
-
-        // return subService.createSubscription(subscription);
         return subscription;
     }
 

--- a/server/src/main/resources/db/changelog/20160722162105-remove-bad-ueber-cert-data.xml
+++ b/server/src/main/resources/db/changelog/20160722162105-remove-bad-ueber-cert-data.xml
@@ -1,0 +1,182 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+    <!-- POSTGRES/ORACLE QUERIES -->
+    <property
+        dbms="postgresql,oracle,hsqldb"
+        name="delete_stray_ueber_consumers"
+        value="delete from cp_consumer
+               where id IN (
+                    select c.id from cp_consumer c
+                    left outer join cp_entitlement e on e.consumer_id = c.id
+                    where c.name = 'ueber_cert_consumer' and e.id is null);"/>
+
+    <property
+        dbms="postgresql,oracle,hsqldb"
+        name="delete_stray_ueber_subs"
+        value="delete from cp_subscription
+               where id in (
+                 select s.id from cp_subscription s
+                 inner join cp_product p on s.product_id = p.id
+                 left outer join cp_pool pool on pool.product_id_old = p.id
+                 where p.name LIKE '%_ueber_product' and pool.id is null
+               );"/>
+
+    <property
+        dbms="postgresql,oracle,hsqldb"
+        name="delete_stray_ueber_content"
+        value="delete from cp_content
+               where id in (
+                   select c.id from cp_content c
+                   inner join cp_product_content pc on pc.content_id=c.id
+                   inner join cp_product p on p.id=pc.product_id
+                   left outer join cp_pool pool on pool.product_id_old = p.id
+                   where p.name LIKE '%_ueber_product' and pool.id is null
+               );"/>
+
+    <property
+        dbms="postgresql,oracle,hsqldb"
+        name="delete_stray_ueber_owner_content_2_0"
+        value="delete from cp2_owner_content
+               where content_uuid in (
+                 select c.uuid from cp2_content c
+                 inner join cp2_product_content pc on pc.content_uuid=c.uuid
+                 inner join cp2_products p on p.uuid=pc.product_uuid
+                 left outer join cp_pool pool on pool.product_uuid = p.uuid
+                 where p.name LIKE '%ueber_product' and pool.id is null
+               );"/>
+
+    <property
+        dbms="postgresql,oracle,hsqldb"
+        name="delete_stray_ueber_content_2_0"
+        value="delete from cp2_content
+               where uuid in (
+                 select c.uuid from cp2_content c
+                 inner join cp2_product_content pc on pc.content_uuid=c.uuid
+                 inner join cp2_products p on p.uuid=pc.product_uuid
+                 left outer join cp_pool pool on pool.product_uuid = p.uuid
+                 where p.name LIKE '%ueber_product' and pool.id is null
+               );"/>
+
+    <property
+        dbms="postgresql,oracle,hsqldb"
+        name="delete_stray_ueber_products"
+        value="delete from cp_product
+                  where id in (
+                      select p.id from cp_product p
+                      left outer join cp_pool pool on pool.product_id_old = p.id
+                      where p.name LIKE '%ueber%' and pool.id is null
+                  );"/>
+
+    <property
+        dbms="postgresql,oracle,hsqldb"
+        name="delete_stray_ueber_owner_product_2_0"
+        value="delete from cp2_owner_products
+               where product_uuid in (
+                 select p.uuid from cp2_products p
+                 left outer join cp_pool pool on pool.product_uuid = p.uuid
+                 where p.name LIKE '%ueber_product' and pool.id is null
+               );"/>
+
+    <property
+        dbms="postgresql,oracle,hsqldb"
+        name="delete_stray_ueber_product_2_0"
+        value="delete from cp2_products
+               where uuid in (
+                 select p.uuid from cp2_products p
+                 left outer join cp_pool pool on pool.product_uuid = p.uuid
+                 where p.name LIKE '%ueber_product' and pool.id is null
+               );"/>
+
+    <!-- MYSQL QUERIES -->
+
+    <property
+        dbms="mysql"
+        name="delete_stray_ueber_consumers"
+        value="delete c from cp_consumer c
+               left outer join cp_entitlement e on e.consumer_id = c.id
+               where c.name = 'ueber_cert_consumer' and e.id is null;"/>
+
+    <property
+        dbms="mysql"
+        name="delete_stray_ueber_subs"
+        value="delete s from cp_subscription s
+               inner join cp_product p on s.product_id = p.id
+               left outer join cp_pool pool on pool.product_id_old = p.id
+               where p.name LIKE '%_ueber_product' and pool.id is null;"/>
+
+    <property
+        dbms="mysql"
+        name="delete_stray_ueber_content"
+        value="delete c from cp_content c
+               inner join cp_product_content pc on pc.content_id=c.id
+               inner join cp_product p on p.id=pc.product_id
+               left outer join cp_pool pool on pool.product_id_old = p.id
+               where p.name LIKE '%_ueber_product' and pool.id is null;"/>
+
+    <property
+        dbms="mysql"
+        name="delete_stray_ueber_owner_content_2_0"
+        value="delete oc from cp2_owner_content oc
+               inner join cp2_content c on c.uuid=oc.content_uuid
+               inner join cp2_product_content pc on pc.content_uuid=c.uuid
+               inner join cp2_products p on p.uuid=pc.product_uuid
+               left outer join cp_pool pool on pool.product_uuid=p.uuid
+               where p.name LIKE '%ueber_product' and pool.id is null;"/>
+
+    <property
+        dbms="mysql"
+        name="delete_stray_ueber_content_2_0"
+        value="delete c from cp2_content c
+               inner join cp2_product_content pc on pc.content_uuid=c.uuid
+               inner join cp2_products p on p.uuid=pc.product_uuid
+               left outer join cp_pool pool on pool.product_uuid=p.uuid
+               where p.name LIKE '%ueber_product' and pool.id is null;"/>
+
+    <property
+        dbms="mysql"
+        name="delete_stray_ueber_products"
+        value="delete p from cp_product p
+               left outer join cp_pool pool on pool.product_id_old = p.id
+               where p.name LIKE '%ueber%' and pool.id is null;"/>
+
+    <property
+        dbms="mysql"
+        name="delete_stray_ueber_owner_product_2_0"
+        value="delete op from cp2_owner_products op
+               inner join cp2_products p on p.uuid=op.product_uuid
+               left outer join cp_pool pool on pool.product_uuid=p.uuid
+               where p.name LIKE '%ueber_product' and pool.id is null;"/>
+
+    <property
+        dbms="mysql"
+        name="delete_stray_ueber_product_2_0"
+        value="delete p from cp2_products p
+               left outer join cp_pool pool on pool.product_uuid=p.uuid
+               where p.name LIKE '%ueber_product' and pool.id is null;"/>
+
+
+    <changeSet id="20160720104426-1" author="mstead">
+        <comment>
+            Cleans up stray ueber consumers, subscriptions, products and content that gets left
+            around due to BZ#####. The fix for this BZ prevents the data from becoming stray,
+            but does not address a situation where the stray data already exists as reported
+            by BZ 1354633. Cleaning up the stray records will allow for a clean debug cert to
+            be created without error.
+        </comment>
+        <sql>${delete_stray_ueber_consumers}</sql>
+        <sql>${delete_stray_ueber_subs}</sql>
+        <sql>${delete_stray_ueber_content}</sql>
+        <sql>${delete_stray_ueber_owner_content_2_0}</sql>
+        <sql>${delete_stray_ueber_content_2_0}</sql>
+        <sql>${delete_stray_ueber_products}</sql>
+        <sql>${delete_stray_ueber_owner_product_2_0}</sql>
+        <sql>${delete_stray_ueber_product_2_0}</sql>
+    </changeSet>
+
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/server/src/main/resources/db/changelog/changelog-create.xml
+++ b/server/src/main/resources/db/changelog/changelog-create.xml
@@ -1188,4 +1188,5 @@
     <include file="db/changelog/20160412131122-add-unique-constraint-to-product-certificate-rows.xml"/>
     <include file="db/changelog/20160419110701-oracle-add-indexes-for-foreign-keys.xml"/>
     <include file="db/changelog/20160714130753-add_lower_columns.xml"/>
+    <include file="db/changelog/20160722162105-remove-bad-ueber-cert-data.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-testing.xml
+++ b/server/src/main/resources/db/changelog/changelog-testing.xml
@@ -2278,4 +2278,5 @@
     <include file="db/changelog/20160412131122-add-unique-constraint-to-product-certificate-rows.xml"/>
     <include file="db/changelog/20160419110701-oracle-add-indexes-for-foreign-keys.xml"/>
     <include file="db/changelog/20160714130753-add_lower_columns.xml"/>
+    <include file="db/changelog/20160722162105-remove-bad-ueber-cert-data.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-update.xml
+++ b/server/src/main/resources/db/changelog/changelog-update.xml
@@ -96,4 +96,5 @@
     <include file="db/changelog/20160412131122-add-unique-constraint-to-product-certificate-rows.xml"/>
     <include file="db/changelog/20160419110701-oracle-add-indexes-for-foreign-keys.xml"/>
     <include file="db/changelog/20160714130753-add_lower_columns.xml"/>
+    <include file="db/changelog/20160722162105-remove-bad-ueber-cert-data.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
An old bug that caused the ueber cert pools
to be deleted was fixed but did not correct
the state of any owners that were affected.
All required ueber objects (sub, product,
content, consumer) were not cleaned up.

Subsequent attempts to get or create a new
debug cert would fail because the data was
in a new state.

This patch adds a new liquibase changeset to
clean up the data. This patch plus the old
bug fix should make sure that this doesn't
happen again.

## Testing Details

**Before starting, make sure that you have a manifest handy! You will have to import it in one of the steps below!!!**


1) Check out the branch that first introduced the bug and deploy.
```bash
$ git co -b ueber-broken 64b74191499e60de17162f56e10a090c74de5b87
$ bin/deploy -gt
```
2) Generate the debug cert for the 'admin' owner.
```bash
$ curl -X POST -k -u admin:admin https://localhost:8443/candlepin/owners/admin/uebercert
```
3) Import a manifest and then attempt to GET the existing ueber cert to trigger the OLD bug. It should complain about an IndexOutOfBounds or something of the likes.
```bash
$ ./cpc import admin /path/to/your/manifest.zip
$ curl -k -u admin:admin https://localhost:8443/candlepin/owners/admin/uebercert
```
4) Check out the HEAD of candlepin-0.9.54-HOTFIX and redeploy leaving the DB unchanged. We test from 0954 to simulate an update of candlepin to 2.0 later (should work the same if you do the next step from the HEAD of master).
```bash
$ git co -b 0954-debug-old-fix-applied --track origin/candlepin-0.9.54-HOTFIX
$ bin/deploy
```
5) After redeploying with the fix, create a new owner and generate a debug cert for it. Verify that the new owner can create and get the new cert but the old still can't because of the bad data.
```bash
# Should fail with the same error
$ curl -k -u admin:admin https://localhost:8443/candlepin/owners/admin/uebercert
# Do another post to REALLY mess things up. The POST will indeed create a new cert for you
# but trying to fetch it breaks becuse there are now 2 ueber consumers!!!!!
$ curl -X POST -k -u admin:admin https://localhost:8443/candlepin/owners/admin/uebercert
$ curl -k -u admin:admin https://localhost:8443/candlepin/owners/admin/uebercert

# Create new owner and verify POST and GET works.
$ ./cpc create_owner zombie
$ curl -X POST -k -u admin:admin https://localhost:8443/candlepin/owners/zombie/uebercert
$ curl -k -u admin:admin https://localhost:8443/candlepin/owners/zombie/uebercert
```

6) At this point you are in the state that our katello friend had his system in. Let's test
the patch! Checkout the branch for this PR. Simply redeploy this patched version of
candlepin and liquibase will kick in, clean out all the bogus data, and should leave
BOTH owners in a state to be able to create and get certs without any issues. Run
POST as much as you'd like and all should be well with only one copy of the ueber
objects in the DB per owner.
```bash
# ALL OF THESE SHOULD WORK WITHOUT ISSUES
$ curl -k -u admin:admin https://localhost:8443/candlepin/owners/admin/uebercert
$ curl -X POST -k -u admin:admin https://localhost:8443/candlepin/owners/admin/uebercert
$ curl -X POST -k -u admin:admin https://localhost:8443/candlepin/owners/admin/uebercert
$ curl -k -u admin:admin https://localhost:8443/candlepin/owners/zombie/uebercert
$ curl -X POST -k -u admin:admin https://localhost:8443/candlepin/owners/zombie/uebercert
```
