### PR TITLE
1359814: Import manifest fail with excess entitlement (0.9.49)

### DIFF
--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -338,10 +338,16 @@ public class CandlepinPoolManager implements PoolManager {
     private Set<String> processPoolUpdates(
         Map<String, EventBuilder> poolEvents, List<PoolUpdate> updatedPools) {
         Set<String> entitlementsToRegen = Util.newSet();
+
         for (PoolUpdate updatedPool : updatedPools) {
 
             Pool existingPool = updatedPool.getPool();
             log.info("Pool changed: " + updatedPool.toString());
+
+            if (!poolCurator.exists(existingPool)) {
+                log.info("Pool has already been deleted from the database.");
+                continue;
+            }
 
             // Delete pools the rules signal needed to be cleaned up:
             if (existingPool.isMarkedForDelete()) {

--- a/server/src/main/java/org/candlepin/model/ConsumerCurator.java
+++ b/server/src/main/java/org/candlepin/model/ConsumerCurator.java
@@ -29,7 +29,6 @@ import com.google.inject.persist.Transactional;
 import org.hibernate.Criteria;
 import org.hibernate.EntityMode;
 import org.hibernate.HibernateException;
-import org.hibernate.Hibernate;
 import org.hibernate.Query;
 import org.hibernate.ReplicationMode;
 import org.hibernate.criterion.CriteriaQuery;

--- a/server/src/main/java/org/candlepin/model/EntitlementCurator.java
+++ b/server/src/main/java/org/candlepin/model/EntitlementCurator.java
@@ -500,7 +500,7 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
         for (Entitlement ent : entitlements) {
             ent.getCertificates().clear();
             ent.getConsumer().getEntitlements().remove(ent);
-    
+
             if (Hibernate.isInitialized(ent.getPool().getEntitlements())) {
                 ent.getPool().getEntitlements().remove(ent);
             }

--- a/server/src/main/java/org/candlepin/model/PoolCurator.java
+++ b/server/src/main/java/org/candlepin/model/PoolCurator.java
@@ -663,15 +663,27 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
     }
 
     public void lock(List<Pool> poolsToLock) {
-        if (poolsToLock.isEmpty()) { 
+        if (poolsToLock.isEmpty()) {
             log.debug("Nothing to lock");
             return;
         }
-            
+
         log.debug("Locking pools");
         getEntityManager().createQuery("SELECT p FROM Pool p WHERE p in :pools")
         .setParameter("pools", poolsToLock)
                 .setLockMode(LockModeType.PESSIMISTIC_WRITE).getResultList();
         log.debug("Done locking pools");
+    }
+    /**
+     * Uses a database query to check if the pool is still
+     * in the database.
+     * @param pool pool to be searched in the database
+     * @return true if and only if the pool is still in the database
+     */
+    public boolean exists(Pool pool) {
+        return getEntityManager()
+                .createQuery("SELECT COUNT(p) FROM Pool p WHERE p=:pool", Long.class)
+                .setParameter("pool", pool)
+                .getSingleResult() > 0;
     }
 }

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
@@ -69,7 +69,6 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 


### PR DESCRIPTION
Fixes in processPoolUpdate which is part of import code path.
Defensively checking to determine if the pool has already been deleted.
In such cases, we need to skip processing updates for it.