### PR TITLE
1361537: Import manifest fail with excess entitlement (2.0)

### DIFF
--- a/server/spec/candlepin_scenarios.rb
+++ b/server/spec/candlepin_scenarios.rb
@@ -502,3 +502,43 @@ class StandardExporter < Exporter
     create_candlepin_export()
   end
 end
+
+#To test virt_limit subscriptions and revocation of excess
+#ENTITLEMENT_DERIVED pools
+class VirtLimitExporter < Exporter
+
+  def initialize
+    @cdn_label = random_string("test-cdn")
+    super({:cdn_label => @cdn_label, :webapp_prefix => "webapp1", :api_url => "api1"})
+    # the before(:each) is not initialized yet, call create_product sans wrapper
+    @product3 = create_product(random_string('p3'), random_string(), {
+        :attributes => { :arch => "x86_64", :virt_limit => "2", :'multi-entitlement' => 'yes'}
+    })
+    end_date = Date.new(2025, 5, 29)
+    create_pool_and_subscription(@owner['key'], @product3.id, 2, [], '', '12345', '6789', nil, end_date, false,
+      {})
+    # Pool names is a list of names of instance variables that will be created
+    @pools = @cp.list_pools(:owner => @owner.id, :product => @product3.id)
+    @pool3 = @pools.select{|i| i['type']=='NORMAL'}[0]
+    @candlepin_client.update_consumer({:facts => {"distributor_version" => "sam-1.3"}})
+    @candlepin_consumer = @candlepin_client.get_consumer()
+
+    @candlepin_client.consume_pool(@pool3.id, {:quantity => 2})
+
+    @cdn = create_cdn(@cdn_label,
+                "Test CDN",
+                "https://cdn.test.com")
+
+  end
+
+  def create_candlepin_export_update
+    ents = @candlepin_client.list_entitlements()
+    ents.each do |ent|
+      @cp.unbind_entitlement(ent.id, {:uuid => @candlepin_client.uuid})
+    end
+
+    @candlepin_client.consume_pool(@pool3.id, {:quantity => 1})
+    create_candlepin_export()
+  end
+
+end

--- a/server/spec/import_excess_spec.rb
+++ b/server/spec/import_excess_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+require 'candlepin_scenarios'
+
+describe 'Import Update', :serial => true do
+
+  include CandlepinMethods
+
+  before(:all) do
+    @cp = Candlepin.new('admin', 'admin')
+    skip("candlepin running in hosted mode") if is_hosted?
+    @exporter = VirtLimitExporter.new
+    base_export = @exporter.create_candlepin_export()
+
+    @import_owner = @cp.create_owner(random_string("test_owner"))
+    @import_username = random_string("import-user")
+    @import_owner_client = user_client(@import_owner, @import_username)
+    @cp.import(@import_owner['key'], base_export.export_filename)
+    @sublist = @cp.list_subscriptions(@import_owner['key'])
+  end
+
+  after(:all) do
+    @cp.delete_user(@import_username)
+    @cp.delete_owner(@import_owner['key'])
+    @exporter.cleanup()
+  end
+
+  it 'should successfully update the import' do
+    @user = user_client(@import_owner, random_string('user'))
+    @host1 = @user.register(random_string('host'), :system, nil,
+      {}, nil, nil, [], [])
+    @host1_client = Candlepin.new(nil, nil, @host1['idCert']['cert'], @host1['idCert']['key'])
+    all_pools = @user.list_pools :owner => @import_owner.id
+    normal_pool = all_pools.select{|i| i['type']=='NORMAL'}[0]
+    all_pools.size.should == 2  
+    @host1_client.consume_pool(normal_pool.id, {:quantity => 2})
+    all_pools = @user.list_pools :owner => @import_owner.id
+    all_pools.size.should == 3  
+    
+    # Now lets import 
+    updated_export = @exporter.create_candlepin_export_update()
+    @cp.import(@import_owner['key'], updated_export.export_filename)
+
+  end
+
+end

--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -680,13 +680,18 @@ public class CandlepinPoolManager implements PoolManager {
         return entsToRegen;
     }
 
-    private Set<String> processPoolUpdates(
+    protected Set<String> processPoolUpdates(
         Map<String, EventBuilder> poolEvents, List<PoolUpdate> updatedPools) {
         Set<String> entitlementsToRegen = Util.newSet();
         for (PoolUpdate updatedPool : updatedPools) {
 
             Pool existingPool = updatedPool.getPool();
             log.info("Pool changed: {}", updatedPool.toString());
+
+            if (!poolCurator.exists(existingPool)) {
+                log.info("Pool has already been deleted from the database.");
+                continue;
+            }
 
             // Delete pools the rules signal needed to be cleaned up:
             if (existingPool.isMarkedForDelete()) {

--- a/server/src/main/java/org/candlepin/model/PoolCurator.java
+++ b/server/src/main/java/org/candlepin/model/PoolCurator.java
@@ -963,4 +963,16 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
         return (Pool) criteria.uniqueResult();
     }
 
+    /**
+    * Uses a database query to check if the pool is still
+    * in the database.
+    * @param pool pool to be searched in the database
+    * @return true if and only if the pool is still in the database
+    */
+    public boolean exists(Pool pool) {
+        return getEntityManager()
+                .createQuery("SELECT COUNT(p) FROM Pool p WHERE p=:pool", Long.class)
+                .setParameter("pool", pool).getSingleResult() > 0;
+    }
+
 }


### PR DESCRIPTION
Fixes in processPoolUpdate which is part of import code path.
Defensively checking to determine if the pool has already been deleted.
In such cases, we need to skip processing updates for it.