### PR TITLE
1361491: Import manifest fail with excess entitlement (0.9.54)

### DIFF
--- a/server/spec/one_sub_pool_per_stack_spec.rb
+++ b/server/spec/one_sub_pool_per_stack_spec.rb
@@ -340,13 +340,15 @@ describe 'One Sub Pool Per Stack' do
     sub_pool.should_not be_nil
 
     @guest_client.consume_pool(sub_pool['id'], {:quantity => 1})
-    @guest_client.list_entitlements.length.should == 1
+    @guest_client.list_entitlements.length.should == 1 
+
+    # MySQL before 5.6.4 doesn't store fractional seconds on timestamps
+    # and getHost() method in ConsumerCurator (which is what tells us which
+    # host a guest is associated with) sorts results by updated time.
+    sleep 1
 
     # Simulate migration
     @host2_client.update_consumer({:guestIds => [{'guestId' => @guest_uuid}]})
-
-    # Need to wait a moment here for MySQL to catch up
-    sleep 4
 
     # Guest entitlement should now be revoked.
     @guest_client.list_entitlements.length.should == 0

--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -346,13 +346,19 @@ public class CandlepinPoolManager implements PoolManager {
         return processPoolUpdates(poolEvents, updatedPools);
     }
 
-    private Set<String> processPoolUpdates(
+    protected Set<String> processPoolUpdates(
         Map<String, EventBuilder> poolEvents, List<PoolUpdate> updatedPools) {
         Set<String> entitlementsToRegen = Util.newSet();
+
         for (PoolUpdate updatedPool : updatedPools) {
 
             Pool existingPool = updatedPool.getPool();
             log.info("Pool changed: " + updatedPool.toString());
+
+            if (!poolCurator.exists(existingPool)) {
+                log.info("Pool has already been deleted from the database.");
+                continue;
+            }
 
             // Delete pools the rules signal needed to be cleaned up:
             if (existingPool.isMarkedForDelete()) {

--- a/server/src/main/java/org/candlepin/model/EntitlementCurator.java
+++ b/server/src/main/java/org/candlepin/model/EntitlementCurator.java
@@ -518,7 +518,7 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
         for (Entitlement ent : entitlements) {
             ent.getCertificates().clear();
             ent.getConsumer().getEntitlements().remove(ent);
-    
+
             if (Hibernate.isInitialized(ent.getPool().getEntitlements())) {
                 ent.getPool().getEntitlements().remove(ent);
             }

--- a/server/src/main/java/org/candlepin/model/PoolCurator.java
+++ b/server/src/main/java/org/candlepin/model/PoolCurator.java
@@ -789,4 +789,16 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
                 .setLockMode(LockModeType.PESSIMISTIC_WRITE).getResultList();
         log.debug("Done locking pools");
     }
+    /**
+     * Uses a database query to check if the pool is still
+     * in the database.
+     * @param pool pool to be searched in the database
+     * @return true if and only if the pool is still in the database
+     */
+    public boolean exists(Pool pool) {
+        return getEntityManager()
+                .createQuery("SELECT COUNT(p) FROM Pool p WHERE p=:pool", Long.class)
+                .setParameter("pool", pool)
+                .getSingleResult() > 0;
+    }
 }


### PR DESCRIPTION
Fixes in processPoolUpdate which is part of import code path.
Defensively checking to determine if the pool has already been deleted.
In such cases, we need to skip processing updates for it.