### PR TITLE
1363647: Can't deploy on PostgreSQL 9.5.3

### DIFF
--- a/server/src/main/resources/db/changelog/20160803113238-change-locked-col-type-to-int.xml
+++ b/server/src/main/resources/db/changelog/20160803113238-change-locked-col-type-to-int.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+  <changeSet id="20160803113238-1" author="fnguyen">
+    <comment>Former smallint type was causing problems on some PostgreSql versions</comment>
+    <modifyDataType 
+      tableName="cp2_products"
+      columnName="locked" 
+      newDataType="int" 
+      />
+ 
+     <modifyDataType 
+      tableName="cp2_content"
+      columnName="locked" 
+      newDataType="int" 
+      />
+       
+  </changeSet>
+</databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-create.xml
+++ b/server/src/main/resources/db/changelog/changelog-create.xml
@@ -1189,4 +1189,5 @@
     <include file="db/changelog/20160419110701-oracle-add-indexes-for-foreign-keys.xml"/>
     <include file="db/changelog/20160714130753-add_lower_columns.xml"/>
     <include file="db/changelog/20160722162105-remove-bad-ueber-cert-data.xml"/>
+    <include file="db/changelog/20160803113238-change-locked-col-type-to-int.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-testing.xml
+++ b/server/src/main/resources/db/changelog/changelog-testing.xml
@@ -2279,4 +2279,5 @@
     <include file="db/changelog/20160419110701-oracle-add-indexes-for-foreign-keys.xml"/>
     <include file="db/changelog/20160714130753-add_lower_columns.xml"/>
     <include file="db/changelog/20160722162105-remove-bad-ueber-cert-data.xml"/>
+    <include file="db/changelog/20160803113238-change-locked-col-type-to-int.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-update.xml
+++ b/server/src/main/resources/db/changelog/changelog-update.xml
@@ -97,4 +97,5 @@
     <include file="db/changelog/20160419110701-oracle-add-indexes-for-foreign-keys.xml"/>
     <include file="db/changelog/20160714130753-add_lower_columns.xml"/>
     <include file="db/changelog/20160722162105-remove-bad-ueber-cert-data.xml"/>
+    <include file="db/changelog/20160803113238-change-locked-col-type-to-int.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
Database datatype smallint was causing issues when
deploying on Postgresql