### PR TITLE
Oracle index name length

### DIFF
--- a/server/src/main/resources/db/changelog/20160714130753-add_lower_columns.xml
+++ b/server/src/main/resources/db/changelog/20160714130753-add_lower_columns.xml
@@ -37,19 +37,19 @@
         <sql>UPDATE cp_pool_attribute SET value_lower = lower(value)</sql>
         <sql>INSERT INTO cp_consumer_facts_lower(cp_consumer_id, element, mapkey) SELECT cp_consumer_id, lower(element), mapkey FROM cp_consumer_facts</sql>
         
-        <createIndex indexName="cp_cnsmr_guests_lower_guest_id_idx" tableName="cp_consumer_guests" unique="false">
+        <createIndex indexName="cp_cnsmr_guests_lower_idx" tableName="cp_consumer_guests" unique="false">
             <column name="guest_id_lower"/>
         </createIndex>
 
-        <createIndex indexName="cp_pool_attribute_value_lower_idx" tableName="cp_pool_attribute" unique="false">
+        <createIndex indexName="cp_pool_attr_lower_idx" tableName="cp_pool_attribute" unique="false">
             <column name="value_lower"/>
         </createIndex>
 
-        <createIndex indexName="consumer_fact_lower_consumer_id_idx" tableName="cp_consumer_facts_lower" unique="false">
+        <createIndex indexName="fact_lower_consumer_id_idx" tableName="cp_consumer_facts_lower" unique="false">
             <column name="cp_consumer_id"/>
         </createIndex>
 
-        <createIndex indexName="consumer_fact_lower_element_idx" tableName="cp_consumer_facts_lower" unique="false">
+        <createIndex indexName="fact_lower_element_idx" tableName="cp_consumer_facts_lower" unique="false">
             <column name="element"/>
         </createIndex>
     </changeSet>


### PR DESCRIPTION
Oracle accepts index name lengths only up to
32 characters.