### PR TITLE
updating activesupport to have a version compatible with rhel7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'buildr', '1.4.24'
-# Not a typo - we use both buildr and buildr
+# Not a typo - we use both buildr and builder
 gem 'builder'
 gem 'rspec', '~> 3.0'
 gem 'mime-types', '~> 1.25.0'
@@ -12,7 +12,7 @@ gem 'pmd'
 gem 'stringex'
 gem 'digest-murmurhash'
 gem 'httpclient'
-gem 'activesupport'
+gem 'activesupport', '~> 4.2'
 
 # Remove this once we are fully using the new Ruby bindings
 gem 'rest-client', '~> 1.6.0'


### PR DESCRIPTION
With the latest version of activesupport, there is an error on RHEL7 machines using ruby 2.0 while running a bundle update:
```
candlepin@jmolet-cp1 [10:23:16 AM] [~/candlepin] [master *]
-> % bundle update
Fetching gem metadata from https://rubygems.org/
Fetching version metadata from https://rubygems.org/
Resolving dependencies...
<... snip .. >
Installing activesupport 5.0.0 (was 4.2.6)

Gem::InstallError: activesupport requires Ruby version >= 2.2.2.

An error occurred while installing activesupport (5.0.0), and Bundler cannot continue.
Make sure that `gem install activesupport -v '5.0.0'` succeeds before bundling.
```

With this fix it'll keep activesupport below 5.0 which requires ruby 2.2.2:

```
candlepin@jmolet-cp1 [10:26:05 AM] [~/candlepin] [master *]
-> % bundle update
Fetching gem metadata from https://rubygems.org/
Fetching version metadata from https://rubygems.org/
Resolving dependencies...
<... snip... >
Installing activesupport 4.2.7 (was 4.2.6)
Bundle updated!
```
