### PR TITLE
1344100: servicelevels returned by candlepin should exclude values from expired pools

### DIFF
--- a/server/spec/consumer_resource_spec.rb
+++ b/server/spec/consumer_resource_spec.rb
@@ -671,6 +671,24 @@ describe 'Consumer Resource' do
 
   end
 
+  it 'should not list service levels from expired pools' do
+    product = create_product(random_string('product'),
+                              random_string('product'),
+                              {:attributes => {:support_level => 'Expired'},
+                               :owner => @owner1['key']})
+    create_pool_and_subscription(@owner1['key'], product.id,
+                                 1, [], '', '', '', Date.today - 2, Date.today - 1)
+
+    user_cp = user_client(@owner1, random_string('billy'))
+    consumer = user_cp.register(random_string('system'), :system, nil,
+                                {}, nil, nil, [], [])
+    consumer_client = Candlepin.new(nil, nil, consumer['idCert']['cert'], consumer['idCert']['key'])
+    consumer = @cp.get_consumer(consumer['uuid'])
+
+    service_levels = consumer_client.list_owner_service_levels(@owner1['key'])
+    service_levels.length.should eq(0)
+  end
+
   it 'should allow a consumer dry run an autosubscribe based on service level' do
     product1 = create_product(random_string('product'),
       random_string('product'),

--- a/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
@@ -1034,6 +1034,61 @@ public class PoolCuratorTest extends DatabaseTestFixture {
     }
 
     @Test
+    public void testListServiceLevelForOwnersWithExpiredPool() {
+        Product product1 = TestUtil.createProduct();
+        product1.addAttribute(new ProductAttribute("support_level", "expired"));
+        product1 = this.createProduct(product1, owner);
+
+        Product product2 = TestUtil.createProduct();
+        product2.addAttribute(new ProductAttribute("support_level", "fresh"));
+        product2 = this.createProduct(product2, owner);
+
+        int year = Calendar.getInstance().get(Calendar.YEAR);
+        Date pastDate = TestUtil.createDate(year - 2, 3, 2);
+        Date expiredDate = TestUtil.createDate(year - 1, 3, 2);
+        Date futureDate = TestUtil.createDate(year + 10, 3, 2);
+
+        Pool pool1 = createPool(owner, product1, 100L, pastDate, expiredDate);
+        poolCurator.create(pool1);
+        Pool pool2 = createPool(owner, product2, 100L, pastDate, futureDate);
+        poolCurator.create(pool2);
+
+        Set<String> levels = poolCurator.retrieveServiceLevelsForOwner(owner, false);
+        // list should only include levels from pools that are not expired
+        assertEquals(1, levels.size());
+    }
+
+    @Test
+    public void testListServiceLevelForOwnersWithExpiredPoolAndEndDateOverride() {
+        Product product1 = TestUtil.createProduct();
+        product1.addAttribute(new ProductAttribute("support_level", "expired"));
+        product1 = this.createProduct(product1, owner);
+
+        Product product2 = TestUtil.createProduct();
+        product2.addAttribute(new ProductAttribute("support_level", "fresh"));
+        product2 = this.createProduct(product2, owner);
+
+        int year = Calendar.getInstance().get(Calendar.YEAR);
+        Date pastDate = TestUtil.createDate(year - 2, 3, 2);
+        Date expiredDate = TestUtil.createDate(year - 1, 3, 2);
+        Date futureDate = TestUtil.createDate(year + 10, 3, 2);
+
+        Pool pool1 = createPool(owner, product1, 100L, pastDate, expiredDate);
+        poolCurator.create(pool1);
+        Pool pool2 = createPool(owner, product2, 100L, pastDate, futureDate);
+        poolCurator.create(pool2);
+
+        Entitlement e = new Entitlement(pool1, consumer, 1);
+        e.setEndDateOverride(futureDate);
+        entitlementCurator.create(e);
+
+        Set<String> levels = poolCurator.retrieveServiceLevelsForOwner(owner, false);
+        // list should only include levels from pools that are not expired
+        // (except when the pool has entitlement with valid endDateOverride)
+        assertEquals(2, levels.size());
+    }
+
+    @Test
     public void testExempt() {
         Product product1 = TestUtil.createProduct();
         product1.addAttribute(new ProductAttribute("support_level", "premium"));


### PR DESCRIPTION
Changed corresponding HQL query to take into account pools endDate, and also pools entitlements endDateOverride.