### PR TITLE
1356566: Shortening Transactions during Hypervisor checkin

### DIFF
--- a/server/spec/hypervisor_check_in_spec.rb
+++ b/server/spec/hypervisor_check_in_spec.rb
@@ -48,12 +48,114 @@ describe 'Hypervisor Resource', :type => :virt do
     host_hyp_id = random_string('host')
     host_name = random_string('name')
     job_detail = async_update_hypervisor(@owner, @consumer, host_name, host_hyp_id, [])
-    job_detail['result'].should == 'Created: 1, Updated: 0, Unchanged:0, Failed: 0'
+    job_detail['result'].should == 'Created: 1, Updated: 0, Unchanged:0, Failed: 0, Partial: false'
     result_data = job_detail['resultData']
     hyp_consumer = @cp.get_consumer(result_data.created[0]['uuid'])
     hyp_consumer.facts['test_fact'].should == 'fact_value'
     should_add_consumer_to_created_when_new_host_id_and_no_guests_reported(result_data, host_name, host_hyp_id)
   end
+
+  it 'should create first host even if second fails - async' do
+    data = {"hypervisors" => [
+         {"name" => "h1", 
+           "hypervisorId" => {"hypervisorId" => "h1id"}, 
+           "guestIds" => [{"guestId" => "g1"}],
+           "facts" => {"test_fact" => "t1"}
+         },
+         {"name" => "h2", 
+           "hypervisorId" => {"hypervisorId" => "h2id"}, 
+           "guestIds" => [{"guestId" => "g2"}], 
+           "facts" => {"test_fact" => "EXCEPTION_HYPERVISOR"}
+         }
+      ]}
+
+    job_detail = JSON.parse(@consumer.hypervisor_update(@owner['key'], data.to_json))
+    wait_for_job(job_detail['id'], 60)
+    job_detail = @cp.get_job(job_detail['id'], true)
+    job_detail['state'].should == 'FINISHED'
+    job_detail['result'].should_not be_nil
+    job_detail['result'].should == 'Created: 1, Updated: 0, Unchanged:0, Failed: 0, Partial: true'
+    partial_data = job_detail['resultData']['partialSuccessDetails']
+    partial_data.should_not be_nil
+    partial_data['failedConsumer']['name'].should == 'h2'
+  end
+
+  it 'should update two hosts even if third has failures during guest migration - async' do
+    user = user_client(@owner, random_string("user"))
+    ["g1", "g2", "g3", "g4", "g5"].each do |x| 
+        user.register(random_string('guest'), :system, nil,
+        {'virt.uuid' => x, 'virt.is_guest' => 'true'}, nil, @owner['key'], [], [])
+    end
+    ex_guest = user.register(random_string('guest'), :system, nil,
+        {'virt.uuid' => "EXCEPTION_INJECTED_GUEST", 'virt.is_guest' => 'true'}, nil, @owner['key'], [], [])
+ 
+    data = {"hypervisors" => [
+         {"name" => "h1", 
+           "hypervisorId" => {"hypervisorId" => "h1id"}, 
+           "guestIds" => [{"guestId" => "g1"}],
+         },
+         {"name" => "h2", 
+           "hypervisorId" => {"hypervisorId" => "h2id"}, 
+           "guestIds" => [{"guestId" => "g2"}], 
+         },
+         {"name" => "h3", 
+           "hypervisorId" => {"hypervisorId" => "h3id"}, 
+           "guestIds" => [{"guestId" => "g3"}], 
+         },
+         {"name" => "h4", 
+           "hypervisorId" => {"hypervisorId" => "h4id"}, 
+           "guestIds" => [{"guestId" => "g4"}], 
+         },
+         {"name" => "h5", 
+           "hypervisorId" => {"hypervisorId" => "h5id"}, 
+           "guestIds" => [{"guestId" => "g5"}], 
+         }
+      ]}
+
+    job_detail = JSON.parse(@consumer.hypervisor_update(@owner['key'], data.to_json))
+    wait_for_job(job_detail['id'], 60)
+    job_detail = @cp.get_job(job_detail['id'], true)
+    job_detail['state'].should == 'FINISHED'
+    job_detail['result'].should_not be_nil
+    job_detail['result'].should == 'Created: 5, Updated: 0, Unchanged:0, Failed: 0, Partial: false'
+   
+     data = {"hypervisors" => [
+         {"name" => "h1", 
+           "hypervisorId" => {"hypervisorId" => "h1id"}, 
+           "guestIds" => [{"guestId" => "g2"}, {"guestId" => "g3"}],
+         },
+         {"name" => "h2", 
+           "hypervisorId" => {"hypervisorId" => "h2id"}, 
+           "guestIds" => [{"guestId" => "g1"}], 
+         },
+         {"name" => "h3", 
+           "hypervisorId" => {"hypervisorId" => "h3id"}, 
+           "guestIds" => [{"guestId" => "EXCEPTION_INJECTED_GUEST"}], 
+         },
+         {"name" => "h4", 
+           "hypervisorId" => {"hypervisorId" => "h4id"}, 
+           "guestIds" => [{"guestId" => "g5"}], 
+         },
+         {"name" => "h5", 
+           "hypervisorId" => {"hypervisorId" => "h5id"}, 
+           "guestIds" => [{"guestId" => "g4"}], 
+         }
+      ]}
+
+
+    job_detail = JSON.parse(@consumer.hypervisor_update(@owner['key'], data.to_json))
+    wait_for_job(job_detail['id'], 60)
+    job_detail = @cp.get_job(job_detail['id'], true)
+    job_detail['state'].should == 'FINISHED'
+    job_detail['result'].should_not be_nil
+    # 3 hypervisors will be updated. But during the migration of the third hypervisor,
+    # the exception will be thrown, so no further hypervisors will be updated
+    job_detail['result'].should == 'Created: 0, Updated: 3, Unchanged:0, Failed: 0, Partial: true'
+    partial_data = job_detail['resultData']['partialSuccessDetails']
+    partial_data.should_not be_nil
+    partial_data['failedConsumer']['uuid'].should == ex_guest.uuid
+  end
+
 
   def should_add_consumer_to_created_when_new_host_id_and_no_guests_reported(result, host_name, host_hyp_id)
     # Should only  have a result entry for created.
@@ -87,7 +189,7 @@ describe 'Hypervisor Resource', :type => :virt do
     host_hyp_id = random_string('host')
     host_name = random_string('name')
     job_detail = async_update_hypervisor(@owner, @consumer, host_name, host_hyp_id, ['g1'])
-    job_detail['result'].should == 'Created: 1, Updated: 0, Unchanged:0, Failed: 0'
+    job_detail['result'].should == 'Created: 1, Updated: 0, Unchanged:0, Failed: 0, Partial: false'
     result_data = job_detail['resultData']
     should_add_consumer_to_created_when_new_host_id_and_guests_were_reported(result_data, host_name)
   end
@@ -113,7 +215,7 @@ describe 'Hypervisor Resource', :type => :virt do
     host_hyp_id = random_string('host')
     host_name = random_string('name')
     job_detail = async_update_hypervisor(@owner, @consumer, host_name, host_hyp_id, ['g1'], false)
-    job_detail['result'].should == 'Created: 0, Updated: 0, Unchanged:0, Failed: 1'
+    job_detail['result'].should == 'Created: 0, Updated: 0, Unchanged:0, Failed: 1, Partial: false'
     result_data = job_detail['resultData']
     should_not_add_new_consumer_when_create_missing_is_false(result_data)
   end
@@ -134,7 +236,7 @@ describe 'Hypervisor Resource', :type => :virt do
 
   it 'should add consumer to updated when guest ids are updated - async' do
     job_detail = async_update_hypervisor(@owner, @consumer, @expected_host_name, @expected_host_hyp_id,  ['g1', 'g2'])
-    job_detail['result'].should == 'Created: 0, Updated: 1, Unchanged:0, Failed: 0'
+    job_detail['result'].should == 'Created: 0, Updated: 1, Unchanged:0, Failed: 0, Partial: false'
     result_data = job_detail['resultData']
     should_add_consumer_to_updated_when_guest_ids_are_updated(result_data)
   end
@@ -157,7 +259,7 @@ describe 'Hypervisor Resource', :type => :virt do
 
   it 'should add consumer to unchanged when same guest ids are sent - async' do
     job_detail = async_update_hypervisor(@owner, @consumer, @expected_host_name, @expected_host_hyp_id, @expected_guest_ids)
-    job_detail['result'].should == 'Created: 0, Updated: 0, Unchanged:1, Failed: 0'
+    job_detail['result'].should == 'Created: 0, Updated: 0, Unchanged:1, Failed: 0, Partial: false'
     result_data = job_detail['resultData']
     should_add_consumer_to_unchanged_when_same_guest_ids_are_sent(result_data)
   end
@@ -188,7 +290,7 @@ describe 'Hypervisor Resource', :type => :virt do
     host_hyp_id = random_string('host')
     host_name = random_string('host')
     job_detail = async_update_hypervisor(@owner, @consumer, host_name, host_hyp_id, [])
-    job_detail['result'].should == 'Created: 1, Updated: 0, Unchanged:0, Failed: 0'
+    job_detail['result'].should == 'Created: 1, Updated: 0, Unchanged:0, Failed: 0, Partial: false'
     result_data = job_detail['resultData']
     result_data.created.size.should == 1
     result_data.created[0].name.should == host_name

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -818,9 +818,10 @@ public class ConsumerResource {
      * @param startGuests
      * @param updatedGuests
      * @param guestConsumerMap
+     * @throws GuestMigrationException in case that the migration fails
      */
     public void checkForGuestsMigration(Consumer host, List<GuestId> startGuests, List<GuestId> updatedGuests,
-        VirtConsumerMap guestConsumerMap) {
+        VirtConsumerMap guestConsumerMap) throws GuestMigrationException {
         Set<GuestId> toCheck = new HashSet<GuestId>();
         if (startGuests != null) {
             toCheck.addAll(startGuests);
@@ -832,7 +833,12 @@ public class ConsumerResource {
             Consumer guest = guestConsumerMap == null ?
                 null : guestConsumerMap.get(guestId.getGuestId());
             if (guest != null) {
-                checkForGuestMigration(host, guest);
+                try {
+                    checkForGuestMigration(host, guest);
+                }
+                catch (Exception e) {
+                    throw new GuestMigrationException(guest, e);
+                }
             }
         }
     }
@@ -1121,6 +1127,7 @@ public class ConsumerResource {
      * db. If autobind has been disabled for the guest's owner, the host_restricted entitlements
      * from the old host are still removed, but no auto-bind occurs.
      */
+    @Transactional
     public void checkForGuestMigration(Consumer host, Consumer guest) {
         if (!"true".equalsIgnoreCase(guest.getFact("virt.is_guest"))) {
             // This isn't a guest, skip this entire step.
@@ -1131,6 +1138,10 @@ public class ConsumerResource {
         }
 
         String guestVirtUuid = guest.getFact("virt.uuid");
+
+        if ("EXCEPTION_INJECTED_GUEST".equals(guestVirtUuid)) {
+            throw new NullPointerException("EXCEPTION_INJECTED_GUEST");
+        }
 
         // Consumer host = consumerCurator.getHost(guestVirtUuid, guest.getOwner());
 

--- a/server/src/main/java/org/candlepin/resource/GuestIdResource.java
+++ b/server/src/main/java/org/candlepin/resource/GuestIdResource.java
@@ -126,7 +126,7 @@ public class GuestIdResource {
     @Consumes(MediaType.APPLICATION_JSON)
     public void updateGuests(
         @PathParam("consumer_uuid") @Verify(Consumer.class) String consumerUuid,
-        List<GuestId> guestIds) {
+        List<GuestId> guestIds) throws GuestMigrationException {
         Consumer toUpdate = consumerCurator.findByUuid(consumerUuid);
         List<GuestId> startGuests = toUpdate.getGuestIds();
 

--- a/server/src/main/java/org/candlepin/resource/GuestMigrationException.java
+++ b/server/src/main/java/org/candlepin/resource/GuestMigrationException.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.resource;
+
+import org.candlepin.model.Consumer;
+
+/**
+ * Thrown when migration of a guest fails during Hypervisor Checkin
+ * @author fnguyen
+ *
+ */
+public class GuestMigrationException extends Exception {
+    private Consumer guest;
+    private Exception causeException;
+
+    public GuestMigrationException(Consumer guest, Exception cause) {
+        this.guest = guest;
+        this.causeException = cause;
+    }
+
+    public Consumer getGuest() {
+        return guest;
+    }
+
+    public Exception getCauseException() {
+        return causeException;
+    }
+
+
+
+
+}

--- a/server/src/main/java/org/candlepin/resource/dto/HypervisorUpdateResult.java
+++ b/server/src/main/java/org/candlepin/resource/dto/HypervisorUpdateResult.java
@@ -38,6 +38,8 @@ public class HypervisorUpdateResult implements Serializable {
     private Set<Consumer> updated;
     private Set<Consumer> unchanged;
     private Set<String> failed;
+    private String errorMessage;
+    private PartialSuccessDetails partialSuccessDetails;
 
     public HypervisorUpdateResult() {
         this.created = new HashSet<Consumer>();
@@ -79,9 +81,29 @@ public class HypervisorUpdateResult implements Serializable {
         return failed;
     }
 
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+
+    public PartialSuccessDetails getPartialSuccessDetails() {
+        return partialSuccessDetails;
+    }
+
+    public void setPartialSuccessDetails(PartialSuccessDetails partialSuccessDetails) {
+        this.partialSuccessDetails = partialSuccessDetails;
+    }
+
     @Override
     public String toString() {
         return "Created: " + created.size() + ", Updated: " + updated.size() +
-                ", Unchanged:" + unchanged.size() + ", Failed: " + failed.size();
+                ", Unchanged:" + unchanged.size() + ", Failed: " + failed.size() +
+                ", Partial: " + Boolean.toString(partialSuccessDetails != null);
     }
+
+
+
 }

--- a/server/src/main/java/org/candlepin/resource/dto/PartialSuccessDetails.java
+++ b/server/src/main/java/org/candlepin/resource/dto/PartialSuccessDetails.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.resource.dto;
+
+import org.candlepin.model.Consumer;
+
+import java.io.Serializable;
+
+/**
+ * Async HypervisorUpdateJob can finish with three distinct outcomes:
+ *  - Success, the checkin went through without any error
+ *  - Error, the checkin was unsuccessfull updating/creating any Hypervisor
+ *  - Partial Success, the checkin successfully created/updated some Hypervisors but
+ *    the Checkin failed at some point because of a particular Consumer (either
+ *    Hypervisor or Guest)
+ *
+ * In case of Partial Success, we populate the HypervisorUpdateResult field
+ * partialSuccessDetails with an instance of this class.
+ *
+ * @author fnguyen
+ *
+ */
+public class PartialSuccessDetails implements Serializable {
+    private Consumer failedConsumer;
+    private String displayMessage;
+    private Exception exception;
+
+    public PartialSuccessDetails(Consumer failedGuest, String displayMessage, Exception exception) {
+        super();
+        this.failedConsumer = failedGuest;
+        this.displayMessage = displayMessage;
+        this.exception = exception;
+    }
+
+    public Consumer getFailedConsumer() {
+        return failedConsumer;
+    }
+
+    public String getDisplayMessage() {
+        return displayMessage;
+    }
+
+    public Exception getException() {
+        return exception;
+    }
+}

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
@@ -748,7 +748,7 @@ public class ConsumerResourceTest {
     }
 
     @Test
-    public void testcheckForGuestsMigration() {
+    public void testcheckForGuestsMigration() throws GuestMigrationException {
         ConsumerResource cr = Mockito.spy(new ConsumerResource(mockedConsumerCurator, null,
             null, null, null, null, null, i18n, null, null, null,
             null, null, null, null, null, null, null, null,

--- a/server/src/test/java/org/candlepin/resource/GuestIdResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/GuestIdResourceTest.java
@@ -121,7 +121,7 @@ public class GuestIdResourceTest {
     }
 
     @Test
-    public void updateGuests() {
+    public void updateGuests() throws GuestMigrationException {
         List<GuestId> guestIds = new LinkedList<GuestId>();
         guestIds.add(new GuestId("1"));
         when(consumerResource.performConsumerUpdates(any(Consumer.class),
@@ -136,7 +136,7 @@ public class GuestIdResourceTest {
     }
 
     @Test
-    public void updateGuestsNoUpdate() {
+    public void updateGuestsNoUpdate() throws GuestMigrationException {
         List<GuestId> guestIds = new LinkedList<GuestId>();
         guestIds.add(new GuestId("1"));
 


### PR DESCRIPTION
A Hypervisor checkin has been running in one transaction. This has been
causing long lock waits with potential to deadlock or at least slow down
Candlepin (e.g. 1350771).

The most time intensive operation during the checkin is guest migration. Also,
the number of migrations per checkin is dependent on how many guest migrations
are reported. The intent of this change is to create one transaction per guest
migration.
