### PR TITLE
Cache the host on a guest on the first lookup

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,7 +104,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport
+  activesupport (~> 4.2)
   builder
   buildr (= 1.4.24)
   buildr-findBugs

--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -1726,7 +1726,7 @@ public class CandlepinPoolManager implements PoolManager {
             Consumer consumer = entitlement.getConsumer();
             Event event = eventFactory.entitlementDeleted(entitlement);
             if (!entitlement.isValid() && entitlement.getPool().isUnmappedGuestPool() &&
-                consumerCurator.getHost(consumer.getFact("virt.uuid"), consumer.getOwner()) == null) {
+                consumerCurator.getHost(consumer) == null) {
                 event = eventFactory.entitlementExpired(entitlement);
                 event.setMessageText(event.getMessageText() + ": " +
                     i18n.tr("Unmapped guest entitlement expired without establishing a host/guest mapping."));

--- a/server/src/main/java/org/candlepin/controller/Entitler.java
+++ b/server/src/main/java/org/candlepin/controller/Entitler.java
@@ -189,11 +189,10 @@ public class Entitler {
         // Dev consumers should not need to worry about the host or unmapped guest
         // entitlements based on the planned design of the subscriptions
         if (consumer.hasFact("virt.uuid") && !consumer.isDev()) {
-            String guestUuid = consumer.getFact("virt.uuid");
             // Remove any expired unmapped guest entitlements
             revokeUnmappedGuestEntitlements(consumer);
 
-            Consumer host = consumerCurator.getHost(guestUuid, consumer.getOwner());
+            Consumer host = consumerCurator.getHost(consumer);
             if (host != null && (force || host.isAutoheal())) {
                 log.info("Attempting to heal host machine with UUID \"{}\" for guest with UUID \"{}\"",
                     host.getUuid(), consumer.getUuid());

--- a/server/src/main/java/org/candlepin/model/Consumer.java
+++ b/server/src/main/java/org/candlepin/model/Consumer.java
@@ -221,6 +221,13 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
     @Column(name = "annotations", length = 4194304)
     private String annotations;
 
+    @Transient
+    private boolean hasHost = true;
+
+    @Transient
+    private Consumer host;
+
+
     public Consumer(String name, String userName, Owner owner, ConsumerType type) {
         this();
 
@@ -748,5 +755,23 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
 
     public boolean isDev() {
         return !StringUtils.isEmpty(getFact("dev_sku"));
+    }
+
+    @XmlTransient
+    public Consumer getHost() {
+        return this.host;
+    }
+
+    public void setHost(Consumer host) {
+        this.host = host;
+    }
+
+    @XmlTransient
+    public boolean hasHost() {
+        return this.hasHost;
+    }
+
+    public void setHasHost(boolean hasHost) {
+        this.hasHost = hasHost;
     }
 }

--- a/server/src/main/java/org/candlepin/model/ConsumerCurator.java
+++ b/server/src/main/java/org/candlepin/model/ConsumerCurator.java
@@ -487,6 +487,21 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
         return toReturn;
     }
 
+    public Consumer getHost(Consumer consumer) {
+        if (!consumer.hasFact("virt.uuid")) { return null; }
+        Consumer host = consumer.getHost();
+        if (host == null && consumer.hasHost()) {
+            host = getHost(consumer.getFact("virt.uuid"), consumer.getOwner());
+            if (host == null) {
+                consumer.setHasHost(false);
+            }
+            else {
+                consumer.setHost(host);
+            }
+        }
+        return host;
+    }
+
     /**
      * Get host consumer for a guest system id.
      *

--- a/server/src/main/java/org/candlepin/policy/criteria/CriteriaRules.java
+++ b/server/src/main/java/org/candlepin/policy/criteria/CriteriaRules.java
@@ -66,8 +66,7 @@ public class CriteriaRules  {
         // consumer UUID
         Consumer hostConsumer = null;
         if (consumer.getFact("virt.uuid") != null) {
-            hostConsumer = consumerCurator.getHost(
-                consumer.getFact("virt.uuid"), consumer.getOwner());
+            hostConsumer = consumerCurator.getHost(consumer);
         }
 
         List<Criterion> criteriaFilters = new LinkedList<Criterion>();

--- a/server/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRules.java
@@ -72,7 +72,7 @@ public class EntitlementRules extends AbstractEntitlementRules implements Enforc
     @Override
     public ValidationResult preEntitlement(Consumer consumer, Pool entitlementPool,
         Integer quantity, CallerType caller) {
-        return preEntitlement(consumer, getHost(consumer), entitlementPool, quantity, caller);
+        return preEntitlement(consumer, consumerCurator.getHost(consumer), entitlementPool, quantity, caller);
     }
 
     public ValidationResult preEntitlement(Consumer consumer, Consumer host,
@@ -86,7 +86,7 @@ public class EntitlementRules extends AbstractEntitlementRules implements Enforc
     public Map<String, ValidationResult> preEntitlement(Consumer consumer,
         Collection<PoolQuantity> entitlementPoolQuantities,
         CallerType caller) {
-        return preEntitlement(consumer, getHost(consumer), entitlementPoolQuantities, caller);
+        return preEntitlement(consumer, consumerCurator.getHost(consumer), entitlementPoolQuantities, caller);
     }
 
     @Override
@@ -126,7 +126,7 @@ public class EntitlementRules extends AbstractEntitlementRules implements Enforc
     public List<Pool> filterPools(Consumer consumer, List<Pool> pools, boolean showAll) {
         JsonJsContext args = new JsonJsContext(objectMapper);
         args.put("consumer", consumer);
-        args.put("hostConsumer", getHost(consumer));
+        args.put("hostConsumer", consumerCurator.getHost(consumer));
         args.put("consumerEntitlements", consumer.getEntitlements());
         args.put("standalone", config.getBoolean(ConfigProperties.STANDALONE));
         args.put("pools", pools);
@@ -163,12 +163,6 @@ public class EntitlementRules extends AbstractEntitlementRules implements Enforc
             }
         }
         return filteredPools;
-    }
-
-    private Consumer getHost(Consumer consumer) {
-        Consumer host = consumer.hasFact("virt.uuid") ? consumerCurator.getHost(
-            consumer.getFact("virt.uuid"), consumer.getOwner()) : null;
-        return host;
     }
 
     private void finishValidation(ValidationResult result, Pool pool, Integer quantity) {

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -1913,7 +1913,7 @@ public class ConsumerResource {
                 "The system with UUID {0} is not a virtual guest.",
                 consumer.getUuid()));
         }
-        return consumerCurator.getHost(consumer.getFact("virt.uuid"), consumer.getOwner());
+        return consumerCurator.getHost(consumer);
     }
 
     @ApiOperation(notes = "Retrieves the Release of a Consumer", value = "getRelease")

--- a/server/src/test/java/org/candlepin/policy/CriteriaRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/CriteriaRulesTest.java
@@ -133,7 +133,7 @@ public class CriteriaRulesTest extends DatabaseTestFixture {
         consumer.setFact("virt.is_guest", "true");
         consumer.setFact("virt.uuid", "GUESTUUID");
         consumerCurator.update(consumer);
-        assertEquals(host.getUuid(), consumerCurator.getHost("GUESTUUID", owner).getUuid());
+        assertEquals(host.getUuid(), consumerCurator.getHost(consumer).getUuid());
         results = poolCurator.listAvailableEntitlementPools(consumer, null,
             (Collection<String>) null, null, false);
 

--- a/server/src/test/java/org/candlepin/policy/js/entitlement/PreEntitlementRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/entitlement/PreEntitlementRulesTest.java
@@ -563,11 +563,10 @@ public class PreEntitlementRulesTest extends EntitlementRulesTestFixture {
             new ConsumerType(ConsumerTypeEnum.SYSTEM));
         Pool pool = setupHostRestrictedPool(parent);
 
-        String guestId = "virtguestuuid";
         consumer.setFact("virt.is_guest", "true");
-        consumer.setFact("virt.uuid", guestId);
+        consumer.setFact("virt.uuid", "virtguestuuid");
 
-        when(consumerCurator.getHost(guestId, owner)).thenReturn(parent);
+        when(consumerCurator.getHost(consumer)).thenReturn(parent);
 
         ValidationResult result = enforcer.preEntitlement(consumer, pool, 1);
         assertFalse(result.hasErrors());
@@ -586,11 +585,10 @@ public class PreEntitlementRulesTest extends EntitlementRulesTestFixture {
             new ConsumerType(ConsumerTypeEnum.SYSTEM));
         Pool pool = setupHostRestrictedPool(otherParent);
 
-        String guestId = "virtguestuuid";
         consumer.setFact("virt.is_guest", "true");
-        consumer.setFact("virt.uuid", guestId);
+        consumer.setFact("virt.uuid", "virtguestuuid");
 
-        when(consumerCurator.getHost(guestId, owner)).thenReturn(parent);
+        when(consumerCurator.getHost(consumer)).thenReturn(parent);
 
         ValidationResult result = enforcer.preEntitlement(consumer, pool, 1);
         assertFalse(result.hasWarnings());
@@ -608,11 +606,10 @@ public class PreEntitlementRulesTest extends EntitlementRulesTestFixture {
             new ConsumerType(ConsumerTypeEnum.SYSTEM));
         Pool pool = setupHostRestrictedPool(otherParent);
 
-        String guestId = "virtguestuuid";
         consumer.setFact("virt.is_guest", "true");
-        consumer.setFact("virt.uuid", guestId);
+        consumer.setFact("virt.uuid", "virtguestuuid");
 
-        when(consumerCurator.getHost(guestId, owner)).thenReturn(null);
+        when(consumerCurator.getHost(consumer)).thenReturn(null);
 
         ValidationResult result = enforcer.preEntitlement(consumer, pool, 1);
         assertFalse(result.hasWarnings());
@@ -716,10 +713,9 @@ public class PreEntitlementRulesTest extends EntitlementRulesTestFixture {
         newborn.setCreated(new java.util.Date());
         Pool pool = setupUnmappedGuestPool();
 
-        String guestId = "virtguestuuid";
         newborn.setFact("virt.is_guest", "true");
-        newborn.setFact("virt.uuid", guestId);
-        when(consumerCurator.getHost(guestId, owner)).thenReturn(parent);
+        newborn.setFact("virt.uuid", "virtguestuuid");
+        when(consumerCurator.getHost(newborn)).thenReturn(parent);
 
         ValidationResult result = enforcer.preEntitlement(newborn, pool, 1);
         assertTrue(result.hasErrors());

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
@@ -466,8 +466,7 @@ public class ConsumerResourceUpdateTest {
         when(consumerCurator.findByVirtUuid("Guest 1",
             existingHost.getOwner().getId())).thenReturn(guest1);
         // Ensure that the guests host is the existing.
-        when(consumerCurator.getHost("Guest 1",
-            existingHost.getOwner())).thenReturn(existingHost);
+        when(consumerCurator.getHost(guest1)).thenReturn(existingHost);
         when(consumerCurator.findByUuid("Guest 1")).thenReturn(guest1);
 
         Consumer existingMigratedTo = createConsumerWithGuests();


### PR DESCRIPTION
Improves performace where the host was retrieved repeatedly directly
from the database each time.