### PR TITLE
Fix potential double entitlement issue by locking earlier in the transaction (0.9.54)

### DIFF
--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -545,6 +545,7 @@ public class CandlepinPoolManager implements PoolManager {
     public List<Entitlement> entitleByProductsForHost(Consumer guest, Consumer host,
             Date entitleDate, Collection<String> possiblePools)
         throws EntitlementRefusedException {
+        host = consumerCurator.lockAndLoad(host);
         List<Entitlement> entitlements = new LinkedList<Entitlement>();
         if (!host.getOwner().equals(guest.getOwner())) {
             log.debug("Host " + host.getUuid() + " and guest " +


### PR DESCRIPTION
If there are more than one guest on the same hypervisor that checkin or autobind at near the same time it is possible for the hypervisor to end up with more than one of an entitlement necessary to cover the guests.

I was able to replicate this by autobinding multiple guests at the same time. When done with 2 guests the hypervisor ends up with 2 of the same entitlement.

The solution to this is to lock the hypervisor consumer earlier in the transaction to ensure only one autobind modifies the entitlements of the hypervisor at any time.

The performance implications seem to be minimal with a failure rate of 7% when auto attaching 500 guests (that are on the same hypervisor) at the same time. (For reference the failure rate is around 10% in my tests on 0.9.54-HOTFIX currently).