### PR TITLE
Add ansible automation to optionally setup yourkit profiling

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,14 +6,14 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
  # explicitly mount the code using NFSv4.
  config.vm.synced_folder ".", "/vagrant", type: "nfs", nfs_version: 4, nfs_udp: false
 
- # Set up the hostmanager plugin to automatically configure host & guest hostnames 
+ # Set up the hostmanager plugin to automatically configure host & guest hostnames
  if Vagrant.has_plugin?("vagrant-hostmanager")
    config.hostmanager.enabled = true
    config.hostmanager.manage_host = true
    config.hostmanager.manage_guest = true
    config.hostmanager.include_offline = true
  end
- 
+
  # Create the "candlepin" box
  config.vm.define "dev" do |dev|
     dev.vm.host_name = "candlepin.example.com"
@@ -40,6 +40,22 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     config.vm.provision "ansible" do |ansible|
       ansible.playbook = "vagrant/candlepin.yml"
+      ansible.extra_vars = {}
+      # This will pass any environment variables beginning with "CANDLEPIN_" or
+      # "candlepin_" (less the prefix) along with their values to ansible for
+      # use in our playbooks.
+      # An example: to setup yourkit you can add CANDLEPIN_SETUP_YOURKIT=true
+      # to your environment along with CANDLEPIN_YOURKIT_LIBRARY=/path/to/libyjpagent.so
+      # Ansible will receive setup_yourkit=true and yourkit_library=/path/to/libyjpagent.so
+      # Check the playbooks to see how these variables are used.
+      env_prefix = "candlepin_"
+      ENV.each do |key, value|
+        if key.downcase.start_with?(env_prefix)
+            new_var_key = key[env_prefix.length, key.length - env_prefix.length]
+            new_var_key = new_var_key.downcase()
+            ansible.extra_vars[new_var_key] = value
+        end
+      end
     end
  end
 end

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -2,25 +2,26 @@
 The vagrant test setup performs the following actions:
 * Deploy a Centos 7 vm
 * NFS mount your local source directory into the VM
-* Configure Tomcat remote debugging 
+* Configure Tomcat remote debugging
 * Install Postgres and configure the candlepin user
   without an external messaging broker).
 * Compile & install Candlepin
 * Forward Ports to your local system for debugging
   * Tomcat remote debug on port 8000
   * REST access for Candlepin on port 8080 and 8443
+* Optionally, setup yourkit profiler to enable profiling of the vm
 
-## Prerequisits
-Running the Candlepin Vagrant deployer needs an up to date version of Vagrant 
+## Prerequisites
+Running the Candlepin Vagrant deployer needs an up to date version of Vagrant
 and Ansible. If the vagrant-hostmanager pluign is installed then the hostname
-for the development candlepin box will automatically be added to your hosts file. 
+for the development candlepin box will automatically be added to your hosts file.
 
-The NFS service requires +x attribute on all parent directories in order to mount 
-the source directory. If you are running into problems with the NFS mount this would 
+The NFS service requires +x attribute on all parent directories in order to mount
+the source directory. If you are running into problems with the NFS mount this would
 be the first thing to check.  
 
-If you have other services running on ports 8000, 8080, or 8443 they will either have 
-to be stopped or you will have to edit the Vagrantfile and choose different ports. 
+If you have other services running on ports 8000, 8080, or 8443 they will either have
+to be stopped or you will have to edit the Vagrantfile and choose different ports.
 
 ## Getting Started
 1. From the root directory of your Candlepin checkout run `vagrant up`
@@ -38,3 +39,21 @@ to be stopped or you will have to edit the Vagrantfile and choose different port
 1. `cd /vagrant`
 1. `buildr clean test=no package`
 1. `./server/bin/deploy`
+
+## Use of environment variables
+Any environment variables set starting with 'CANDLEPIN_' will be  passed to
+the ansible playbook as their name less the prefix of 'CANDLEPIN_'.
+As an example, if you have set 'CANDLEPIN_TEST=2' then a variable named 'test'
+will be passed to ansible with value '2'. These vars are used to modify the
+behavior of our ansible playbooks.
+
+NOTE TO DEVS: If you'd like to add any optional behavior to the ansible
+playbooks, add something like 'when: my_cool_var is defined' to the optional
+tasks that are dependant on the existance of the variable 'my_cool_var'.
+
+## Profiling the vagrant machine using YourKit
+1. `export CANDLEPIN_SETUP_YOURKIT=True`
+1. `export CANDLEPIN_YOURKIT_LIBRARY=/path/to/libyjpagent.so`
+1. Optionally specify the port to connect to the profiling agent by setting the `CANDLEPIN_YOURKIT_AGENT_PORT`.
+   The default port is 35675.
+1. Run `vagrant up`

--- a/vagrant/roles/candlepin-root/defaults/main.yml
+++ b/vagrant/roles/candlepin-root/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+yourkit_agent_port: 35675

--- a/vagrant/roles/candlepin-root/tasks/main.yml
+++ b/vagrant/roles/candlepin-root/tasks/main.yml
@@ -51,6 +51,43 @@
   tags:
     - candlepin-root
 
+- name: Create directory for YourKit profiling library
+  file:
+    path: /opt/yjp/bin/linux-x86-64
+    state: directory
+  when: setup_yourkit is defined
+  tags:
+    - candlepin-root
+    - yourkit-setup
+
+- name: Copy YourKit profiling library from host
+  copy:
+    src: "{{yourkit_library}}"
+    dest: /opt/yjp/bin/linux-x86-64/libyjpagent.so
+    mode: 0755
+  when: setup_yourkit is defined
+  tags:
+    - candlepin-root
+    - yourkit-setup
+
+- name: Add YourKit profiling library
+  lineinfile:
+    dest: /etc/tomcat/tomcat.conf
+    line: "LD_LIBRARY_PATH=/opt/yjp/bin/linux-x86-64"
+  when: setup_yourkit is defined
+  tags:
+    - candlepin-root
+    - yourkit-setup
+
+- name: Add YourKit profiling config to tomcat
+  lineinfile:
+    dest: /etc/tomcat/tomcat.conf
+    line: 'CATALINA_OPTS="-agentlib:yjpagent=port={{yourkit_agent_port}}"'
+  when: setup_yourkit is defined
+  tags:
+    - candlepin-root
+    - yourkit-setup
+
 - name: Initiate database
   command: service postgresql initdb
   args:


### PR DESCRIPTION
To use this all you need to do is uncomment the setup_yourkit var (ensuring it is set to True) and uncomment the yourkit_library var. The latter must be set to the location of the libyjpagent.so file on your system that you would like to have installed in the remote tomcat.

After doing the above, start the virtual machine and provision as you normally would (using vagrant).
