### PR TITLE
Integrate EHCache as 2LC and JCache

### DIFF
--- a/buildfile
+++ b/buildfile
@@ -90,6 +90,11 @@ JAVAX = ['org.hibernate.javax.persistence:hibernate-jpa-2.1-api:jar:1.0.0.Final'
          'javax.transaction:jta:jar:1.1']
 ANTLR = ['antlr:antlr:jar:2.7.7']
 
+EHCACHE = ['org.hibernate:hibernate-ehcache:jar:5.1.1.Final', 
+           'net.sf.ehcache:ehcache:jar:2.10.1', 
+           'org.ehcache:jcache:jar:1.0.0', 'javax.cache:cache-api:jar:1.0.0',
+           'net.sf.ehcache:management-ehcache-v2:jar:2.10.1']
+
 HIBERNATE = [group('hibernate-core', 'hibernate-entitymanager', 'hibernate-c3p0',
                    :under => 'org.hibernate',
                    :version => '5.1.1.Final'),
@@ -97,6 +102,7 @@ HIBERNATE = [group('hibernate-core', 'hibernate-entitymanager', 'hibernate-c3p0'
              'org.hibernate:hibernate-tools:jar:3.2.4.GA',
              'org.hibernate:hibernate-validator:jar:4.3.1.Final',
              ANTLR,
+             EHCACHE,
              'asm:asm:jar:3.0',
              'cglib:cglib:jar:2.2',
              'org.javassist:javassist:jar:3.20.0-GA',

--- a/gutterball/pom.xml
+++ b/gutterball/pom.xml
@@ -43,6 +43,11 @@
     <org.hibernate-hibernate-tools.version>3.2.4.GA</org.hibernate-hibernate-tools.version>
     <org.hibernate-hibernate-validator.version>4.3.1.Final</org.hibernate-hibernate-validator.version>
     <antlr-antlr.version>2.7.7</antlr-antlr.version>
+    <org.hibernate-hibernate-ehcache.version>5.1.1.Final</org.hibernate-hibernate-ehcache.version>
+    <net.sf.ehcache-ehcache.version>2.10.1</net.sf.ehcache-ehcache.version>
+    <org.ehcache-jcache.version>1.0.0</org.ehcache-jcache.version>
+    <javax.cache-cache-api.version>1.0.0</javax.cache-cache-api.version>
+    <net.sf.ehcache-management-ehcache-v2.version>2.10.1</net.sf.ehcache-management-ehcache-v2.version>
     <asm-asm.version>3.0</asm-asm.version>
     <cglib-cglib.version>2.2</cglib-cglib.version>
     <org.javassist-javassist.version>3.20.0-GA</org.javassist-javassist.version>
@@ -389,6 +394,61 @@
       <groupId>antlr</groupId>
       <artifactId>antlr</artifactId>
       <version>${antlr-antlr.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-ehcache</artifactId>
+      <version>${org.hibernate-hibernate-ehcache.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>net.sf.ehcache</groupId>
+      <artifactId>ehcache</artifactId>
+      <version>${net.sf.ehcache-ehcache.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.ehcache</groupId>
+      <artifactId>jcache</artifactId>
+      <version>${org.ehcache-jcache.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>javax.cache</groupId>
+      <artifactId>cache-api</artifactId>
+      <version>${javax.cache-cache-api.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>net.sf.ehcache</groupId>
+      <artifactId>management-ehcache-v2</artifactId>
+      <version>${net.sf.ehcache-management-ehcache-v2.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -43,6 +43,11 @@
     <org.hibernate-hibernate-tools.version>3.2.4.GA</org.hibernate-hibernate-tools.version>
     <org.hibernate-hibernate-validator.version>4.3.1.Final</org.hibernate-hibernate-validator.version>
     <antlr-antlr.version>2.7.7</antlr-antlr.version>
+    <org.hibernate-hibernate-ehcache.version>5.1.1.Final</org.hibernate-hibernate-ehcache.version>
+    <net.sf.ehcache-ehcache.version>2.10.1</net.sf.ehcache-ehcache.version>
+    <org.ehcache-jcache.version>1.0.0</org.ehcache-jcache.version>
+    <javax.cache-cache-api.version>1.0.0</javax.cache-cache-api.version>
+    <net.sf.ehcache-management-ehcache-v2.version>2.10.1</net.sf.ehcache-management-ehcache-v2.version>
     <asm-asm.version>3.0</asm-asm.version>
     <cglib-cglib.version>2.2</cglib-cglib.version>
     <org.javassist-javassist.version>3.20.0-GA</org.javassist-javassist.version>
@@ -406,6 +411,61 @@
       <groupId>antlr</groupId>
       <artifactId>antlr</artifactId>
       <version>${antlr-antlr.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-ehcache</artifactId>
+      <version>${org.hibernate-hibernate-ehcache.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>net.sf.ehcache</groupId>
+      <artifactId>ehcache</artifactId>
+      <version>${net.sf.ehcache-ehcache.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.ehcache</groupId>
+      <artifactId>jcache</artifactId>
+      <version>${org.ehcache-jcache.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>javax.cache</groupId>
+      <artifactId>cache-api</artifactId>
+      <version>${javax.cache-cache-api.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>net.sf.ehcache</groupId>
+      <artifactId>management-ehcache-v2</artifactId>
+      <version>${net.sf.ehcache-management-ehcache-v2.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>

--- a/server/src/main/java/org/candlepin/cache/CacheContextListener.java
+++ b/server/src/main/java/org/candlepin/cache/CacheContextListener.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.cache;
+
+import com.google.inject.Injector;
+
+/**
+ * Configuration of caches in candlepin. This is configuration according to JCache API.
+ * Additional, EHCache specific, configurations are in ehcache.xml and ehcache-stats.xml
+ * configuration.
+ * @author fnguyen
+ *
+ */
+public class CacheContextListener {
+
+    public void contextInitialized(Injector injector) {
+    }
+}

--- a/server/src/main/java/org/candlepin/cache/CandlepinCache.java
+++ b/server/src/main/java/org/candlepin/cache/CandlepinCache.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.cache;
+
+import com.google.inject.Inject;
+
+import javax.cache.CacheManager;
+
+/**
+ * Wrapper that makes it easier to retrieve various caches in Candlepin
+ * @author fnguyen
+ *
+ */
+public class CandlepinCache {
+    private CacheManager cacheManager;
+
+    @Inject
+    public CandlepinCache(CacheManager cacheManager) {
+        this.cacheManager = cacheManager;
+    }
+}

--- a/server/src/main/java/org/candlepin/cache/JCacheManagerProvider.java
+++ b/server/src/main/java/org/candlepin/cache/JCacheManagerProvider.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.cache;
+
+import com.google.inject.Provider;
+
+import javax.cache.CacheManager;
+import javax.cache.Caching;
+import javax.cache.spi.CachingProvider;
+
+/**
+ * Provides object cache by indexed by String.
+ * @author fnguyen
+ *
+ */
+public class JCacheManagerProvider implements Provider<CacheManager> {
+
+    /**
+     * It is safe to bind this as singleton, the CacheManager is supposed to
+     * be thread safe.
+     * https://github.com/ehcache/ehcache-jcache/issues/41
+     */
+    @Override
+    public CacheManager get() {
+        CachingProvider cachingProvider = Caching.getCachingProvider();
+        CacheManager cacheManager = cachingProvider.getCacheManager();
+        return cacheManager;
+    }
+
+}

--- a/server/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/server/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -147,7 +147,10 @@ public class ConfigProperties {
     public static final String AMQP_CONNECTION_RETRY_ATTEMPTS = "gutterball.amqp.connection.retry_attempts";
     public static final String AMQP_CONNECTION_RETRY_INTERVAL = "gutterball.amqp.connection.retry_interval";
 
+    // Hibernate
     public static final String DB_PASSWORD = JPA_CONFIG_PREFIX + "hibernate.connection.password";
+    // Cache
+    public static final String CACHE_JMX_STATS = "cache.jmx.statistics";
 
     public static final String[] ENCRYPTED_PROPERTIES = new String[] {
         DB_PASSWORD,
@@ -312,6 +315,8 @@ public class ConfigProperties {
             this.put(HIDDEN_RESOURCES, "environments");
 
             this.put(FAIL_ON_UNKNOWN_IMPORT_PROPERTIES, "false");
+
+            this.put(CACHE_JMX_STATS, "false");
 
             // Pinsetter
             // prevent Quartz from checking for updates

--- a/server/src/main/java/org/candlepin/guice/CandlepinModule.java
+++ b/server/src/main/java/org/candlepin/guice/CandlepinModule.java
@@ -19,6 +19,7 @@ import org.candlepin.audit.EventSink;
 import org.candlepin.audit.EventSinkImpl;
 import org.candlepin.audit.NoopEventSinkImpl;
 import org.candlepin.auth.Principal;
+import org.candlepin.cache.JCacheManagerProvider;
 import org.candlepin.common.config.Configuration;
 import org.candlepin.common.config.ConfigurationPrefixes;
 import org.candlepin.common.exceptions.mappers.BadRequestExceptionMapper;
@@ -146,6 +147,7 @@ import org.xnap.commons.i18n.I18n;
 
 import java.util.Properties;
 
+import javax.cache.CacheManager;
 import javax.inject.Provider;
 import javax.validation.MessageInterpolator;
 import javax.validation.Validation;
@@ -273,6 +275,7 @@ public class CandlepinModule extends AbstractModule {
             configureAmqp();
         }
 
+        bind(CacheManager.class).toProvider(JCacheManagerProvider.class).in(Singleton.class);
     }
 
     @Provides @Named("ValidationProperties")

--- a/server/src/main/resources/META-INF/persistence.xml
+++ b/server/src/main/resources/META-INF/persistence.xml
@@ -19,6 +19,10 @@
             <property name="hibernate.c3p0.min_size" value="5" />
             <property name="hibernate.c3p0.max_size" value="20" />
             <property name="hibernate.c3p0.timeout" value="300" />
+            <property name="hibernate.cache.use_second_level_cache" value="true" />
+            <property name="hibernate.cache.use_query_cache" value="true" />
+            <property name="hibernate.cache.region.factory_class" value="org.hibernate.cache.ehcache.EhCacheRegionFactory" />
+            <property name="net.sf.ehcache.configurationResourceName" value="ehcache.xml" />
             <!-- test period in seconds -->
             <property name="hibernate.c3p0.idle_test_period" value="300" />
             <!-- max_statements should always be 0 -->

--- a/server/src/main/resources/ehcache-stats.xml
+++ b/server/src/main/resources/ehcache-stats.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<ehcache
+    maxBytesLocalHeap="300M"
+    >
+
+    <defaultCache 
+        eternal="false" 
+        timeToIdleSeconds="86400" 
+        timeToLiveSeconds="86400"/>    
+     <cache
+        name="query-5-seconds"
+        eternal="false"
+        timeToIdleSeconds="5"
+        timeToLiveSeconds="5"
+    />
+</ehcache>

--- a/server/src/main/resources/ehcache.xml
+++ b/server/src/main/resources/ehcache.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<ehcache
+    maxBytesLocalHeap="300M"
+    >
+
+    <defaultCache 
+        eternal="false" 
+        timeToIdleSeconds="86400" 
+        timeToLiveSeconds="86400"/>    
+     <cache
+        name="query-5-seconds"
+        eternal="false"
+        timeToIdleSeconds="5"
+        timeToLiveSeconds="5"
+    />
+</ehcache>

--- a/server/src/test/java/org/candlepin/guice/CandlepinContextListenerTest.java
+++ b/server/src/test/java/org/candlepin/guice/CandlepinContextListenerTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.*;
 import org.candlepin.TestingModules;
 import org.candlepin.audit.AMQPBusPublisher;
 import org.candlepin.audit.HornetqContextListener;
+import org.candlepin.cache.CacheContextListener;
 import org.candlepin.common.config.Configuration;
 import org.candlepin.common.config.ConfigurationException;
 import org.candlepin.common.config.ConfigurationPrefixes;
@@ -54,6 +55,7 @@ public class CandlepinContextListenerTest {
     private Configuration config;
     private CandlepinContextListener listener;
     private HornetqContextListener hqlistener;
+    private CacheContextListener cacheListener;
     private PinsetterContextListener pinlistener;
     private AMQPBusPublisher buspublisher;
     private AMQPBusPubProvider busprovider;
@@ -79,6 +81,7 @@ public class CandlepinContextListenerTest {
         buspublisher = mock(AMQPBusPublisher.class);
         busprovider = mock(AMQPBusPubProvider.class);
         configRead = mock(VerifyConfigRead.class);
+        cacheListener = mock(CacheContextListener.class);
 
         // for testing we override the getModules and readConfiguration methods
         // so we can insert our mock versions of listeners to verify
@@ -210,6 +213,7 @@ public class CandlepinContextListenerTest {
             bind(HornetqContextListener.class).toInstance(hqlistener);
             bind(AMQPBusPublisher.class).toInstance(buspublisher);
             bind(AMQPBusPubProvider.class).toInstance(busprovider);
+            bind(CacheContextListener.class).toInstance(cacheListener);
         }
     }
 


### PR DESCRIPTION
Integration of EHCache as 2LC and JCache. This PR depends on #1331 

This is only integration of the caches, together with a possibility to configure statistics over JMX in candlepin.conf:
```
cache.jmx.statistics=true
jpa.config.hibernate.generate_statistics=true
jpa.config.hibernate.use_structured_entries=true
jpa.config.net.sf.ehcache.configurationResourceName=ehcache-stats.xml
```
This PR doesn't introduce any caching.