### PR TITLE
Ruby Client - Create Pool bug

### DIFF
--- a/server/client/ruby/candlepin.rb
+++ b/server/client/ruby/candlepin.rb
@@ -1663,7 +1663,7 @@ module Candlepin
           prods = []
           v = [v] unless v.is_a?(Array)
           v.each do |p|
-            prods << { :id => p }
+            prods << { :productId => p }
           end
           body[camel_case(k)] = prods unless prods.empty?
         end


### PR DESCRIPTION
Provided products must be specified with productId not id.

providedProducts nad derivedProvidedProducts are specified to use ProvidedProduct class!
```
  @JsonProperty("providedProducts")
  @JsonProperty("derivedProvidedProducts")
```

The ruby client mentions :derived_products but that collection is not on Pool at all.