### PR TITLE
Lock the hypervisor consumer earlier to avoid over entitlement (2.x)

### DIFF
--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -1046,6 +1046,7 @@ public class CandlepinPoolManager implements PoolManager {
     public List<Entitlement> entitleByProductsForHost(Consumer guest, Consumer host,
         Date entitleDate, Collection<String> possiblePools)
         throws EntitlementRefusedException {
+        host = consumerCurator.lockAndLoad(host);
         List<Entitlement> entitlements = new LinkedList<Entitlement>();
         if (!host.getOwner().equals(guest.getOwner())) {
             log.debug("Host {} and guest {} have different owners", host.getUuid(), guest.getUuid());


### PR DESCRIPTION
This is the same fix as in #1333 except against master.