### PR TITLE
Role shouldn't be cached

### DIFF
--- a/server/src/main/java/org/candlepin/model/Role.java
+++ b/server/src/main/java/org/candlepin/model/Role.java
@@ -14,15 +14,12 @@
  */
 package org.candlepin.model;
 
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.ForeignKey;
 import org.hibernate.annotations.GenericGenerator;
 
 import java.util.HashSet;
 import java.util.Set;
 
-import javax.persistence.Cacheable;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -41,8 +38,6 @@ import javax.validation.constraints.Size;
  */
 @Entity
 @Table(name = "cp_role")
-@Cacheable(true)
-@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 public class Role extends AbstractHibernateObject implements Linkable {
 
     @Id


### PR DESCRIPTION
@mstead I left the Cacheable on Role by accident. Shouldn't be there though as in cluster environment Role can get stale