### PR TITLE
Revert of cp_consumer_facts_lower

### DIFF
--- a/server/src/main/java/org/candlepin/model/Consumer.java
+++ b/server/src/main/java/org/candlepin/model/Consumer.java
@@ -170,13 +170,6 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
     @Cascade({org.hibernate.annotations.CascadeType.ALL})
     private Map<String, String> facts;
 
-    @ElementCollection
-    @CollectionTable(name = "cp_consumer_facts_lower", joinColumns = @JoinColumn(name = "cp_consumer_id"))
-    @MapKeyColumn(name = "mapkey")
-    @Column(name = "element")
-    @Cascade({org.hibernate.annotations.CascadeType.ALL})
-    private Map<String, String> factsLower;
-
     @OneToOne(cascade = CascadeType.ALL)
     private KeyPair keyPair;
 
@@ -229,7 +222,6 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
         this.owner = owner;
         this.type = type;
         this.facts = new HashMap<String, String>();
-        this.factsLower = new HashMap<String, String>();
         this.installedProducts = new HashSet<ConsumerInstalledProduct>();
         this.guestIds = new ArrayList<GuestId>();
         this.autoheal = true;
@@ -385,21 +377,6 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
      */
     public void setFacts(Map<String, String> factsIn) {
         facts = factsIn;
-        if (factsIn == null) {
-            factsLower = null;
-        }
-        else {
-            factsLower = new HashMap<String, String>();
-            for (Entry<String, String> f : factsIn.entrySet()) {
-                String val = f.getValue();
-                if (val != null) {
-                    val = val.toLowerCase();
-                }
-
-                factsLower.put(f.getKey(), val);
-            }
-        }
-
     }
 
     /**
@@ -450,15 +427,8 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
     public void setFact(String name, String value) {
         if (facts == null) {
             facts = new HashMap<String, String>();
-            factsLower = new HashMap<String, String>();
         }
         this.facts.put(name, value);
-
-        String lowVal = value;
-        if (lowVal != null) {
-            lowVal = lowVal.toLowerCase();
-        }
-        this.factsLower.put(name, lowVal);
     }
 
     public long getEntitlementCount() {

--- a/server/src/main/java/org/candlepin/model/ConsumerCurator.java
+++ b/server/src/main/java/org/candlepin/model/ConsumerCurator.java
@@ -157,10 +157,10 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
         List<String> possibleGuestIds = Util.getPossibleUuids(uuid);
 
         String sql = "select cp_consumer.id from cp_consumer " +
-            "inner join cp_consumer_facts_lower " +
-            "on cp_consumer.id = cp_consumer_facts_lower.cp_consumer_id " +
-            "where cp_consumer_facts_lower.mapkey = 'virt.uuid' and " +
-            "cp_consumer_facts_lower.element in (:guestids) " +
+            "inner join cp_consumer_facts " +
+            "on cp_consumer.id = cp_consumer_facts.cp_consumer_id " +
+            "where cp_consumer_facts.mapkey = 'virt.uuid' and " +
+            "lower(cp_consumer_facts.element) in (:guestids) " +
             "and cp_consumer.owner_id = :ownerid " +
             "order by cp_consumer.updated desc";
 
@@ -201,10 +201,10 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
         List<String> possibleGuestIds = Util.getPossibleUuids(guestIds.toArray(new String [guestIds.size()]));
 
         String sql = "select cp_consumer.uuid from cp_consumer " +
-            "inner join cp_consumer_facts_lower " +
-            "on cp_consumer.id = cp_consumer_facts_lower.cp_consumer_id " +
-            "where cp_consumer_facts_lower.mapkey = 'virt.uuid' and " +
-            "cp_consumer_facts_lower.element in (:guestids) " +
+            "inner join cp_consumer_facts " +
+            "on cp_consumer.id = cp_consumer_facts.cp_consumer_id " +
+            "where cp_consumer_facts.mapkey = 'virt.uuid' and " +
+            "lower(cp_consumer_facts.element) in (:guestids) " +
             "and cp_consumer.owner_id = :ownerid " +
             "order by cp_consumer.updated desc";
 

--- a/server/src/main/resources/db/changelog/20160714130753-add_lower_columns.xml
+++ b/server/src/main/resources/db/changelog/20160714130753-add_lower_columns.xml
@@ -21,21 +21,8 @@
          </column>      
         </addColumn>
                
-        <createTable tableName="cp_consumer_facts_lower">
-             <column name="cp_consumer_id" type="VARCHAR(32)">
-                 <constraints nullable="false"/>
-             </column>
-             <column name="element" type="VARCHAR(255)"/>
-             <column name="mapkey" type="VARCHAR(255)">
-                 <constraints nullable="false"/>
-             </column>
-        </createTable>
-
-        <addPrimaryKey columnNames="cp_consumer_id, mapkey" constraintName="cp_consumer_facts_lower_pkey" tableName="cp_consumer_facts_lower"/>
-
         <sql>UPDATE cp_consumer_guests SET guest_id_lower = lower(guest_id)</sql>
         <sql>UPDATE cp_pool_attribute SET value_lower = lower(value)</sql>
-        <sql>INSERT INTO cp_consumer_facts_lower(cp_consumer_id, element, mapkey) SELECT cp_consumer_id, lower(element), mapkey FROM cp_consumer_facts</sql>
         
         <createIndex indexName="cp_cnsmr_guests_lower_idx" tableName="cp_consumer_guests" unique="false">
             <column name="guest_id_lower"/>
@@ -43,14 +30,6 @@
 
         <createIndex indexName="cp_pool_attr_lower_idx" tableName="cp_pool_attribute" unique="false">
             <column name="value_lower"/>
-        </createIndex>
-
-        <createIndex indexName="fact_lower_consumer_id_idx" tableName="cp_consumer_facts_lower" unique="false">
-            <column name="cp_consumer_id"/>
-        </createIndex>
-
-        <createIndex indexName="fact_lower_element_idx" tableName="cp_consumer_facts_lower" unique="false">
-            <column name="element"/>
         </createIndex>
     </changeSet>
 


### PR DESCRIPTION
Intent of this PR is to revert part of #1300.

Initially in 62d36c29640c50ea14779d22f6b5559c6f78bfd9 I have changed
implementation of case insensitive search to improve performance while querying.
However cp_consumer_facts table usually contains a lot of data and the migration
step thus takes a lot of time. This commit reverts the changes for the
cp_consumer_facts_lower that were introduced in the above mentioned commit