### PR TITLE
Ensure debug symbols make it into compiled code.

### DIFF
--- a/buildfile
+++ b/buildfile
@@ -226,6 +226,7 @@ define "candlepin" do
   project.version = pom_version(path_to('pom.xml'))
   manifest["Copyright"] = "Red Hat, Inc. #{Date.today.strftime('%Y')}"
 
+  compile.using(:javac, :debug => true)
   compile.options.target = '1.6'
   compile.options.source = '1.6'
 

--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,8 @@
                     <configuration>
                         <source>1.6</source>
                         <target>1.6</target>
+                        <debug>true</debug>
+                        <debuglevel>lines,vars,source</debuglevel>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
It looks like the class files that our in our official builds do not
have debug symbols in them.  No debug symbols saves some space but also
means that Support can't install a Satellite instance and then attach to
a running Candlepin with jdwp.

I have a suspicion that MEAD sets debug=false in an environment
configuration somewhere because the debug symbols are added when I
compile locally.  Setting the values explicitly should ensure the
symbols are left in.