### PR TITLE
Disable autobind at Owner level (candlepin-0.9.54)

### DIFF
--- a/server/client/ruby/candlepin_api.rb
+++ b/server/client/ruby/candlepin_api.rb
@@ -275,6 +275,10 @@ class Candlepin
     end
   end
 
+  def heal_owner(owner_key)
+    post "owners/#{owner_key}/entitlements"
+  end
+
   def create_user(login, password, superadmin=false)
     user = {
       'username' => login,
@@ -895,12 +899,16 @@ class Candlepin
     return get("/owner/#{owner_key}/activation_keys")
   end
 
-  def create_activation_key(owner_key, name, service_level=nil)
+  def create_activation_key(owner_key, name, service_level=nil, autobind=false)
     key = {
       :name => name,
     }
     if service_level
       key['serviceLevel'] = service_level
+    end
+
+    if autobind
+      key['autoAttach'] = true
     end
     return post("/owners/#{owner_key}/activation_keys", key)
   end

--- a/server/spec/autobind_disabled_for_owner_spec.rb
+++ b/server/spec/autobind_disabled_for_owner_spec.rb
@@ -1,0 +1,89 @@
+require 'spec_helper'
+require 'candlepin_scenarios'
+require 'time'
+
+describe 'Autobind Disabled On Owner' do
+
+  include CandlepinMethods
+
+  before(:each) do
+    owner = create_owner random_string('test_owner1')
+    owner['autobindDisabled'] = true
+    @cp.update_owner(owner['key'], owner)
+
+    @owner = @cp.get_owner(owner['key'])
+    @owner.should_not be_nil
+
+    @activation_key = @cp.create_activation_key(@owner['key'], random_string('test_token'), nil, true)
+
+    @user_cp = user_client(@owner, random_string("test-user"))
+
+    @consumer = @user_cp.register("foofy", :system, nil, {'cpu.cpu_socket(s)' => '8'}, nil, @owner['key'], [], [])
+    @consumer_cp = Candlepin.new(nil, nil, @consumer.idCert.cert, @consumer.idCert['key'])
+  end
+
+  it 'autobind fails when autobind disabled on owner' do
+    exception_thrown = false
+    begin
+      @consumer_cp.consume_product()
+    rescue RestClient::BadRequest => e
+      exception_thrown = true
+      ex_message = "Autobind is not enabled for owner '#{@owner['key']}'."
+      data = JSON.parse(e.response)
+      data['displayMessage'].should == ex_message
+    end
+    exception_thrown.should be_true
+  end
+
+  it 'still allows dev consumer to autobind when disabled on owner' do
+    pending("candlepin running in standalone mode") if not is_hosted?
+    # active subscription to allow this all to work
+    active_prod = create_product()
+    active_sub = @cp.create_subscription(@owner['key'], active_prod.id, 10)
+    @cp.refresh_pools(@owner['key'])
+
+    dev_product = create_product("dev_product", "Dev Product", {:attributes => { :expires_after => "60"}})
+    dev_product_2 = create_product("2nd_dev_product", "Dev Product", {:attributes => { :expires_after => "60"}})
+    p_product1 = create_product("p_product_1", "Provided Product 1")
+    p_product2 = create_product("p_product", "Provided Product 2")
+
+    installed = [
+        {'productId' => p_product1.id, 'productName' => p_product1.name},
+        {'productId' => p_product2.id, 'productName' => p_product2.name}
+    ]
+    consumer = @user_cp.register("foofy_dev", :system, nil, {'dev_sku'=> "dev_product"}, nil, @owner['key'], installed, [])
+    consumer_cp = Candlepin.new(nil, nil, consumer.idCert.cert, consumer.idCert['key'])
+
+    consumer_cp.consume_product()
+    entitlements = consumer_cp.list_entitlements()
+    entitlements.length.should == 1
+    entitlements[0].id.should_not == old_ent_id unless old_ent_id == nil
+    new_pool = entitlements[0].pool
+    new_pool.type.should == "DEVELOPMENT"
+    new_pool.productId.should == expected_product_id
+    new_pool.providedProducts.length.should == 2
+  end
+
+  it 'fails registration when activation key has autobind enabled' do
+    exception_thrown = false
+    begin
+      ak_consumer = @user_cp.register("foofy", :system, nil, {'cpu.cpu_socket(s)' => '8'}, nil, @owner['key'], [@activation_key['name']], [])
+    rescue RestClient::BadRequest => e
+      exception_thrown = true
+      ex_message = "Could not register unit with key enabling autobind. Autobind is disabled for owner '#{@owner['key']}'."
+      data = JSON.parse(e.response)
+      data['displayMessage'].should == ex_message
+    end
+    exception_thrown.should be_true
+  end
+
+  it 'fails to heal entire org' do
+    job = @cp.heal_owner(@owner['key'])
+    wait_for_job(job['id'], 3)
+    job = @cp.get_job(job['id'])
+    job['state'].should == "FAILED"
+    job['result'].should == "Autobind is disabled for owner #{@owner['key']}"
+  end
+
+
+end

--- a/server/spec/healing_spec.rb
+++ b/server/spec/healing_spec.rb
@@ -171,4 +171,29 @@ describe 'Healing' do
     ents[0]['quantity'].should == 2
   end
 
+  it 'healing fails when autobind disabled on owner' do
+    owner = create_owner random_string('test_owner1')
+    owner['autobindDisabled'] = true
+    @cp.update_owner(owner['key'], owner)
+
+    owner = @cp.get_owner(owner['key'])
+    owner.should_not be_nil
+
+    user_cp = user_client(owner, random_string("test-user"))
+
+    consumer = user_cp.register("foofy", :system, nil, {'cpu.cpu_socket(s)' => '8'}, nil, owner['key'], [], [])
+    consumer_cp = Candlepin.new(nil, nil, consumer.idCert.cert, consumer.idCert['key'])
+
+    exception_thrown = false
+    begin
+      consumer_cp.consume_product()
+    rescue RestClient::BadRequest => e
+      exception_thrown = true
+      ex_message = "Autobind is not enabled for owner '#{owner['key']}'."
+      data = JSON.parse(e.response)
+      data['displayMessage'].should == ex_message
+    end
+    exception_thrown.should be_true
+  end
+
 end

--- a/server/spec/hypervisor_check_in_spec.rb
+++ b/server/spec/hypervisor_check_in_spec.rb
@@ -295,4 +295,19 @@ describe 'Hypervisor Resource', :type => :virt do
     consumer_client = Candlepin.new(nil, nil, consumer['idCert']['cert'], consumer['idCert']['key'])
     return consumer_client
   end
+
+  it 'should raise bad request exception if owner has autobind disabled' do
+    # Create a new owner and disable autobind.
+    owner = create_owner random_string('test_owner1')
+    owner['autobindDisabled'] = true
+    @cp.update_owner(owner['key'], owner)
+
+    # Attempt to check in.
+    user = user_client(owner, random_string("test-user"))
+    virtwho = create_virtwho_client(user)
+    host_guest_mapping = get_host_guest_mapping(random_string('my-host'), ['g1', 'g2'])
+    lambda do
+      virtwho.hypervisor_check_in(owner['key'], host_guest_mapping)
+    end.should raise_exception(RestClient::BadRequest)
+  end
 end

--- a/server/spec/owner_resource_spec.rb
+++ b/server/spec/owner_resource_spec.rb
@@ -380,6 +380,48 @@ describe 'Owner Resource' do
     found.delete("candlepin").should_not be_nil
   end
 
+  it 'allows updating autobindDisabled on an owner' do
+    owner = create_owner random_string("test_owner2")
+    owner_key = owner['key']
+    owner['autobindDisabled'].should be_nil
+
+    # disable autobind
+    owner['autobindDisabled'] = true
+    @cp.update_owner(owner_key, owner)
+
+    owner = @cp.get_owner(owner_key)
+    owner['autobindDisabled'].should == true
+
+    # re-enable autobind
+    owner['autobindDisabled'] = false
+    @cp.update_owner(owner_key, owner)
+
+    owner = @cp.get_owner(owner_key)
+    owner['autobindDisabled'].should == false
+  end
+
+  it 'ignores autobindDisabled when not set on incoming owner' do
+    owner = create_owner random_string("test_owner2")
+    owner_key = owner['key']
+    owner['autobindDisabled'].should be_nil
+
+    # disable autobind
+    owner['autobindDisabled'] = true
+    @cp.update_owner(owner_key, owner)
+
+    owner = @cp.get_owner(owner_key)
+    owner['autobindDisabled'].should == true
+
+    # Attempt to update owner display name
+    # and expect no update to the autobindDiabled
+    # field.
+    owner['autobindDisabled'] = nil
+    @cp.update_owner(owner_key, owner)
+
+    owner = @cp.get_owner(owner_key)
+    owner['autobindDisabled'].should == true
+  end
+
 end
 
 describe 'Owner Resource Pool Filter Tests' do

--- a/server/src/main/java/org/candlepin/controller/AutobindDisabledForOwnerException.java
+++ b/server/src/main/java/org/candlepin/controller/AutobindDisabledForOwnerException.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.controller;
+
+/**
+ * An exception that is thrown when an autobind attempt occurs
+ * for a consumer who's {@link Owner} was disabled.
+ */
+public class AutobindDisabledForOwnerException extends Exception {
+
+    public AutobindDisabledForOwnerException(String message) {
+        super(message);
+    }
+}

--- a/server/src/main/java/org/candlepin/model/Owner.java
+++ b/server/src/main/java/org/candlepin/model/Owner.java
@@ -105,6 +105,16 @@ public class Owner extends AbstractHibernateObject implements Serializable,
     private String logLevel;
 
     /**
+     * When set, autobind will be disabled no matter if it is set
+     * on the Consumer or not.
+     *
+     * NOTE: Need to allow null values here so that we can check
+     *       it on Owner update.
+     */
+    @Column(name = "autobind_disabled")
+    private Boolean autobindDisabled;
+
+    /**
      * Default constructor
      */
     public Owner() {
@@ -282,6 +292,10 @@ public class Owner extends AbstractHibernateObject implements Serializable,
             !this.contentPrefix.equals(other.contentPrefix)) {
             return false;
         }
+        if ((this.autobindDisabled == null) ? (other.autobindDisabled != null) :
+            !this.autobindDisabled.equals(other.autobindDisabled)) {
+            return false;
+        }
         return true;
     }
 
@@ -396,5 +410,31 @@ public class Owner extends AbstractHibernateObject implements Serializable,
     @XmlTransient
     public String getName() {
         return getDisplayName();
+    }
+
+    /**
+     * Utility method that checks null case for
+     * autobind setting since the getter can return null. If autobindDisabled is null,
+     * it is considered enabled.
+     *
+     * @return true if autobind is disabled, false otherwise.
+     */
+    @XmlTransient
+    public boolean autobindDisabled() {
+        return getAutobindDisabled() == null ? false : getAutobindDisabled();
+    }
+
+    /**
+     * Returns the true value of the autobindDisabled setting.
+     *
+     * @return True if autobind is disabled for this owner, False or null otherwise.
+     *         A value of null means that it is unset, and considered in code as False.
+     */
+    public Boolean getAutobindDisabled() {
+        return autobindDisabled;
+    }
+
+    public void setAutobindDisabled(Boolean autobindDisabled) {
+        this.autobindDisabled = autobindDisabled;
     }
 }

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/HealEntireOrgJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/HealEntireOrgJob.java
@@ -16,14 +16,17 @@ package org.candlepin.pinsetter.tasks;
 
 import static org.quartz.JobBuilder.*;
 
+import org.candlepin.controller.AutobindDisabledForOwnerException;
 import org.candlepin.controller.Entitler;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerCurator;
 import org.candlepin.model.Entitlement;
+import org.candlepin.model.Owner;
 import org.candlepin.model.OwnerCurator;
 import org.candlepin.pinsetter.core.model.JobStatus;
 import org.candlepin.resource.dto.AutobindData;
 import org.candlepin.util.Util;
+import org.jboss.resteasy.spi.BadRequestException;
 
 import com.google.inject.Inject;
 import com.google.inject.persist.Transactional;
@@ -61,6 +64,11 @@ public class HealEntireOrgJob extends UniqueByOwnerJob {
         try {
             JobDataMap map = ctx.getMergedJobDataMap();
             String ownerId = (String) map.get("ownerId");
+            Owner owner = ownerCurator.lookupByKey(ownerId);
+            if (owner.autobindDisabled()) {
+                throw new BadRequestException("Autobind is disabled for owner " + owner.getKey());
+            }
+
             Date entitleDate = (Date) map.get("entitle_date");
             List<String> uuids = ownerCurator.getConsumerUuids(ownerId);
             for (String uuid : uuids) {
@@ -89,7 +97,7 @@ public class HealEntireOrgJob extends UniqueByOwnerJob {
      * Each consumer heal should be a separate transaction
      */
     @Transactional
-    private void healSingleConsumer(Consumer consumer, Date date) {
+    private void healSingleConsumer(Consumer consumer, Date date) throws AutobindDisabledForOwnerException {
         List<Entitlement> ents = entitler.bindByProducts(AutobindData.create(consumer).on(date), true);
         entitler.sendEvents(ents);
     }

--- a/server/src/main/java/org/candlepin/resource/HypervisorResource.java
+++ b/server/src/main/java/org/candlepin/resource/HypervisorResource.java
@@ -120,6 +120,13 @@ public class HypervisorResource {
         }
 
         Owner owner = this.getOwner(ownerKey);
+        if (owner.autobindDisabled()) {
+            log.debug("Could not update host/guest mapping. Autobind is disabled for owner {}",
+                owner.getKey());
+            throw new BadRequestException(
+                i18n.tr("Could not update host/guest mapping. Autobind is disabled for owner {0}.",
+                    owner.getKey()));
+        }
 
         if (hostGuestMap.remove("") != null) {
             log.warn("Ignoring empty hypervisor id");

--- a/server/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -891,8 +891,7 @@ public class OwnerResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Path("{owner_key}")
     @Transactional
-    public Owner updateOwner(@PathParam("owner_key") @Verify(Owner.class) String key,
-        Owner owner) {
+    public Owner updateOwner(@PathParam("owner_key") @Verify(Owner.class) String key, Owner owner) {
         Owner toUpdate = findOwner(key);
         EventBuilder eventBuilder = eventFactory.getEventBuilder(Target.OWNER, Type.MODIFIED)
                 .setOldEntity(toUpdate);
@@ -917,6 +916,11 @@ public class OwnerResource {
                 serviceLevelValidator.validate(toUpdate, owner.getDefaultServiceLevel());
                 toUpdate.setDefaultServiceLevel(owner.getDefaultServiceLevel());
             }
+        }
+
+        // Update the autobindDisabled field if the incoming value is null.
+        if (owner.getAutobindDisabled() != null) {
+            toUpdate.setAutobindDisabled(owner.getAutobindDisabled());
         }
 
         ownerCurator.merge(toUpdate);

--- a/server/src/main/java/org/candlepin/resource/util/ConsumerBindUtil.java
+++ b/server/src/main/java/org/candlepin/resource/util/ConsumerBindUtil.java
@@ -16,6 +16,7 @@ package org.candlepin.resource.util;
 
 import org.candlepin.common.exceptions.BadRequestException;
 import org.candlepin.common.exceptions.ForbiddenException;
+import org.candlepin.controller.AutobindDisabledForOwnerException;
 import org.candlepin.controller.Entitler;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerContentOverride;
@@ -75,7 +76,8 @@ public class ConsumerBindUtil {
         this.serviceLevelValidator = serviceLevelValidator;
     }
 
-    public void handleActivationKeys(Consumer consumer, List<ActivationKey> keys) {
+    public void handleActivationKeys(Consumer consumer, List<ActivationKey> keys)
+        throws AutobindDisabledForOwnerException {
         // Process activation keys.
 
         boolean listSuccess = false;
@@ -127,7 +129,8 @@ public class ConsumerBindUtil {
         return onePassed;
     }
 
-    private void handleActivationKeyAutoBind(Consumer consumer, ActivationKey key) {
+    private void handleActivationKeyAutoBind(Consumer consumer, ActivationKey key)
+        throws AutobindDisabledForOwnerException {
         try {
             Set<String> productIds = new HashSet<String>();
             List<String> poolIds = new ArrayList<String>();

--- a/server/src/main/resources/db/changelog/20160907121757-add-autobind-disabled-column-to-owner.xml
+++ b/server/src/main/resources/db/changelog/20160907121757-add-autobind-disabled-column-to-owner.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+    <changeSet id="20160907121757-1" author="mstead">
+        <comment>Adds autobind_disabled column to cp_owners table.</comment>
+        <addColumn tableName="cp_owner">
+            <column name="autobind_disabled" type="BOOLEAN" />
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/server/src/main/resources/db/changelog/changelog-create.xml
+++ b/server/src/main/resources/db/changelog/changelog-create.xml
@@ -1179,4 +1179,5 @@
     <include file="db/changelog/20160614113932-add-owner-and-type-constraint-export-metadata.xml"/>
     <include file="db/changelog/20160720104426-remove-bad-ueber-cert-data.xml"/>
     <include file="db/changelog/20160819090519-delete-all-ueber-cert-data.xml"/>
+    <include file="db/changelog/20160907121757-add-autobind-disabled-column-to-owner.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-testing.xml
+++ b/server/src/main/resources/db/changelog/changelog-testing.xml
@@ -2269,4 +2269,5 @@
     <include file="db/changelog/20160614113932-add-owner-and-type-constraint-export-metadata.xml"/>
     <include file="db/changelog/20160720104426-remove-bad-ueber-cert-data.xml"/>
     <include file="db/changelog/20160819090519-delete-all-ueber-cert-data.xml"/>
+    <include file="db/changelog/20160907121757-add-autobind-disabled-column-to-owner.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-update.xml
+++ b/server/src/main/resources/db/changelog/changelog-update.xml
@@ -87,4 +87,5 @@
     <include file="db/changelog/20160614113932-add-owner-and-type-constraint-export-metadata.xml"/>
     <include file="db/changelog/20160720104426-remove-bad-ueber-cert-data.xml"/>
     <include file="db/changelog/20160819090519-delete-all-ueber-cert-data.xml"/>
+    <include file="db/changelog/20160907121757-add-autobind-disabled-column-to-owner.xml"/>
 </databaseChangeLog>

--- a/server/src/test/java/org/candlepin/controller/EntitlerTest.java
+++ b/server/src/test/java/org/candlepin/controller/EntitlerTest.java
@@ -66,6 +66,7 @@ public class EntitlerTest {
     private EventSink sink;
     private I18n i18n;
     private Entitler entitler;
+    private Owner owner;
     private Consumer consumer;
     private ConsumerCurator cc;
     private EntitlementRulesTranslator translator;
@@ -89,7 +90,9 @@ public class EntitlerTest {
         ef = mock(EventFactory.class);
         sink = mock(EventSink.class);
         cc = mock(ConsumerCurator.class);
+        owner = mock(Owner.class);
         consumer = mock(Consumer.class);
+        when(consumer.getOwner()).thenReturn(owner);
 
         entitlementCurator = mock(EntitlementCurator.class);
         i18n = I18nFactory.getI18n(
@@ -138,7 +141,7 @@ public class EntitlerTest {
     }
 
     @Test
-    public void bindByProductsString() throws EntitlementRefusedException {
+    public void bindByProductsString() throws Exception {
         String[] pids = {"prod1", "prod2", "prod3"};
         when(cc.findByUuid(eq("abcd1234"))).thenReturn(consumer);
         entitler.bindByProducts(pids, "abcd1234", null, null);
@@ -147,7 +150,7 @@ public class EntitlerTest {
     }
 
     @Test
-    public void bindByProducts() throws EntitlementRefusedException {
+    public void bindByProducts() throws Exception  {
         String[] pids = {"prod1", "prod2", "prod3"};
         AutobindData data = AutobindData.create(consumer).forProducts(pids);
         entitler.bindByProducts(data);
@@ -252,17 +255,17 @@ public class EntitlerTest {
     }
 
     @Test(expected = ForbiddenException.class)
-    public void alreadyHasProduct() {
+    public void alreadyHasProduct() throws Exception {
         bindByProductErrorTest("rulefailed.consumer.already.has.product");
     }
 
     @Test(expected = ForbiddenException.class)
-    public void noEntitlementsForProduct() {
+    public void noEntitlementsForProduct() throws Exception {
         bindByProductErrorTest("rulefailed.no.entitlements.available");
     }
 
     @Test(expected = ForbiddenException.class)
-    public void mismatchByProduct() {
+    public void mismatchByProduct() throws Exception {
         bindByProductErrorTest("rulefailed.consumer.type.mismatch");
     }
 
@@ -279,7 +282,7 @@ public class EntitlerTest {
     }
 
     @Test
-    public void physicalOnly() {
+    public void physicalOnly() throws Exception {
         String expected = "Pool is restricted to physical systems: 'pool10'.";
         try {
             bindByPoolErrorTest("rulefailed.physical.only");
@@ -291,11 +294,11 @@ public class EntitlerTest {
     }
 
     @Test(expected = ForbiddenException.class)
-    public void allOtherErrors() {
+    public void allOtherErrors() throws Exception {
         bindByProductErrorTest("generic.error");
     }
 
-    private void bindByProductErrorTest(String msg) {
+    private void bindByProductErrorTest(String msg) throws Exception {
         try {
             String[] pids = {"prod1", "prod2", "prod3"};
             EntitlementRefusedException ere = new EntitlementRefusedException(
@@ -424,7 +427,7 @@ public class EntitlerTest {
     }
 
     @Test
-    public void testDevPoolCreationAtBind() throws EntitlementRefusedException {
+    public void testDevPoolCreationAtBind() throws Exception {
         Owner owner = new Owner("o");
         List<Product> devProds = new ArrayList<Product>();
         Product p = new Product("test-product", "Test Product");
@@ -450,7 +453,7 @@ public class EntitlerTest {
     }
 
     @Test(expected = ForbiddenException.class)
-    public void testDevPoolCreationAtBindFailStandalone() throws EntitlementRefusedException {
+    public void testDevPoolCreationAtBindFailStandalone() throws Exception {
         Owner owner = new Owner("o");
         List<Product> devProds = new ArrayList<Product>();
         Product p = new Product("test-product", "Test Product");
@@ -472,7 +475,7 @@ public class EntitlerTest {
     }
 
     @Test(expected = ForbiddenException.class)
-    public void testDevPoolCreationAtBindFailNotActive() throws EntitlementRefusedException {
+    public void testDevPoolCreationAtBindFailNotActive() throws Exception {
         Owner owner = new Owner("o");
         List<Product> devProds = new ArrayList<Product>();
         Product p = new Product("test-product", "Test Product");
@@ -491,7 +494,7 @@ public class EntitlerTest {
     }
 
     @Test
-    public void testDevPoolCreationAtBindFailNoSkuProduct() throws EntitlementRefusedException {
+    public void testDevPoolCreationAtBindFailNoSkuProduct() throws Exception  {
         Owner owner = new Owner("o");
         List<Product> devProds = new ArrayList<Product>();
         Product p = new Product("test-product", "Test Product");
@@ -519,8 +522,7 @@ public class EntitlerTest {
     }
 
     @Test
-    public void testDevPoolCreationAtBindNoFailMissingInstalledProduct()
-        throws EntitlementRefusedException {
+    public void testDevPoolCreationAtBindNoFailMissingInstalledProduct() throws Exception {
         Owner owner = new Owner("o");
         List<Product> devProds = new ArrayList<Product>();
         Product p = new Product("test-product", "Test Product");

--- a/server/src/test/java/org/candlepin/model/OwnerTest.java
+++ b/server/src/test/java/org/candlepin/model/OwnerTest.java
@@ -14,8 +14,7 @@
  */
 package org.candlepin.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 
 import org.candlepin.test.DatabaseTestFixture;
 import org.candlepin.test.TestUtil;
@@ -141,6 +140,19 @@ public class OwnerTest extends DatabaseTestFixture {
         }
 
 
+    }
+
+    @Test
+    public void testAutobindDisabledUtilityMethod() {
+        Owner o = createOwner();
+        o.setAutobindDisabled(true);
+        assertTrue(o.autobindDisabled());
+
+        o.setAutobindDisabled(false);
+        assertFalse(o.autobindDisabled());
+
+        o.setAutobindDisabled(null);
+        assertFalse(o.autobindDisabled());
     }
 
     interface MixIn {

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/EntitleByProductsJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/EntitleByProductsJobTest.java
@@ -29,7 +29,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.quartz.JobDetail;
 import org.quartz.JobExecutionContext;
-import org.quartz.JobExecutionException;
 
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -71,7 +70,7 @@ public class EntitleByProductsJobTest {
     }
 
     @Test
-    public void bindByProductsExec() throws JobExecutionException {
+    public void bindByProductsExec() throws Exception  {
         String[] pids = {"pid1", "pid2", "pid3"};
 
         JobDetail detail = EntitleByProductsJob.bindByProducts(pids, consumer, null, null);

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceCreationTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceCreationTest.java
@@ -38,6 +38,7 @@ import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerContentOverrideCurator;
 import org.candlepin.model.ConsumerCurator;
 import org.candlepin.model.ConsumerType;
+import org.candlepin.model.ConsumerType.ConsumerTypeEnum;
 import org.candlepin.model.ConsumerTypeCurator;
 import org.candlepin.model.DeletedConsumerCurator;
 import org.candlepin.model.IdentityCertificate;
@@ -314,6 +315,26 @@ public class ConsumerResourceCreationTest {
             verify(activationKeyCurator).lookupForOwner(keyName, owner);
         }
     }
+
+    @Test
+    public void registerFailsWithKeyWhenAutobindOnKeyAndDisabledOnOwner() {
+        ConsumerType consumerType = new ConsumerType(ConsumerTypeEnum.SYSTEM);
+        when(consumerTypeCurator.lookupByLabel(consumerType.getLabel())).thenReturn(consumerType);
+
+        // Disable autobind for the owner.
+        owner.setAutobindDisabled(true);
+
+        // Create a key that has autobind disabled.
+        ActivationKey key = new ActivationKey("autobind-disabled-key", owner);
+        key.setAutoAttach(true);
+        when(activationKeyCurator.lookupForOwner(key.getName(), owner)).thenReturn(key);
+
+        // No auth should be required for registering with keys:
+        Principal p = new NoAuthPrincipal();
+        Consumer consumer = new Consumer("sys.example.com", null, null, consumerType);
+        resource.create(consumer, p, null, owner.getKey(), key.getName());
+    }
+
     @Test(expected = BadRequestException.class)
     public void orgRequiredWithActivationKeys() {
         Principal p = new NoAuthPrincipal();

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
@@ -350,7 +350,7 @@ public class ConsumerResourceTest {
     }
 
     @Test
-    public void testProductNoPool() {
+    public void testProductNoPool() throws Exception {
         Consumer c = mock(Consumer.class);
         Owner o = mock(Owner.class);
         SubscriptionServiceAdapter sa = mock(SubscriptionServiceAdapter.class);
@@ -372,7 +372,7 @@ public class ConsumerResourceTest {
     }
 
     @Test
-    public void futureHealing() {
+    public void futureHealing() throws Exception {
         Consumer c = mock(Consumer.class);
         Owner o = mock(Owner.class);
         SubscriptionServiceAdapter sa = mock(SubscriptionServiceAdapter.class);
@@ -553,6 +553,27 @@ public class ConsumerResourceTest {
             null, null, null, new CandlepinCommonTestConfig(),
             null, null, null, consumerBindUtil);
         cr.consumerExists("uuid");
+    }
+
+    @Test
+    public void testNoDryBindWhenAutobindDisabledForOwner() throws Exception {
+        Consumer consumer = createConsumer();
+        consumer.getOwner().setAutobindDisabled(true);
+        ConsumerCurator consumerCurator = mock(ConsumerCurator.class);
+        when(consumerCurator.verifyAndLookupConsumer(eq(consumer.getUuid()))).thenReturn(consumer);
+
+        ConsumerResource consumerResource = new ConsumerResource(consumerCurator, null,
+            null, null, null, null, null, i18n, null, null, null,
+            null, null, null, null, null, null, null, null, null, null, null,
+            null, new CandlepinCommonTestConfig(), null, null, null, consumerBindUtil);
+
+        try {
+            consumerResource.dryBind(consumer.getUuid(), "some-sla");
+            fail("Should have thrown a BadRequestException.");
+        }
+        catch (BadRequestException e) {
+            assertEquals("Autobind is not enabled for owner 'Test Owner'.", e.getMessage());
+        }
     }
 
 }

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
@@ -451,7 +451,7 @@ public class ConsumerResourceUpdateTest {
     // ignored out per mkhusid, see 768872 comment #41
     @Ignore
     @Test
-    public void ensureNewGuestIsHealedIfItWasMigratedFromAnotherHost() {
+    public void ensureNewGuestIsHealedIfItWasMigratedFromAnotherHost() throws Exception {
         String uuid = "TEST_CONSUMER";
         Consumer existingHost = createConsumerWithGuests("Guest 1", "Guest 2");
         existingHost.setUuid(uuid);

--- a/server/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
@@ -427,4 +427,24 @@ public class HypervisorResourceTest {
         List<GuestId> gids = created.get(0).getGuestIds();
         assertEquals(0, gids.size());
     }
+
+    @Test
+    public void ensureFailureWhenAutobindIsDisabledOnOwner() {
+        Owner owner = new Owner("test_admin");
+        owner.setAutobindDisabled(true);
+
+        Map<String, List<GuestId>> hostGuestMap = new HashMap<String, List<GuestId>>();
+        hostGuestMap.put("HYPERVISOR_A", new ArrayList());
+        when(ownerCurator.lookupByKey(eq(owner.getKey()))).thenReturn(owner);
+
+        try {
+            hypervisorResource.hypervisorCheckIn(
+                    hostGuestMap, principal, owner.getKey(), true);
+            fail("Exception should have been thrown since autobind was disabled for the owner.");
+        }
+        catch (BadRequestException bre) {
+            assertEquals("Could not update host/guest mapping. Autobind is disabled for owner test_admin.",
+                bre.getMessage());
+        }
+    }
 }

--- a/server/src/test/java/org/candlepin/resource/OwnerResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/OwnerResourceTest.java
@@ -991,6 +991,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         assertEquals("New Name", owner.getDisplayName());
         assertEquals(parentOwner1, owner.getParentOwner());
         assertEquals("premium", owner.getDefaultServiceLevel());
+        assertFalse(owner.getAutobindDisabled());
 
         // Update with Default Service Level only
         Owner upOwner2 = mock(Owner.class);
@@ -999,6 +1000,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         assertEquals("standard", owner.getDefaultServiceLevel());
         assertEquals("New Name", owner.getDisplayName());
         assertEquals(parentOwner1, owner.getParentOwner());
+        assertFalse(owner.getAutobindDisabled());
 
         // Update with Parent Owner only
         Owner upOwner3 = mock(Owner.class);
@@ -1007,6 +1009,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         assertEquals(parentOwner2, owner.getParentOwner());
         assertEquals("standard", owner.getDefaultServiceLevel());
         assertEquals("New Name", owner.getDisplayName());
+        assertFalse(owner.getAutobindDisabled());
 
         // Update with empty Service Level only
         Owner upOwner4 = mock(Owner.class);
@@ -1015,6 +1018,37 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         assertNull(owner.getDefaultServiceLevel());
         assertEquals("New Name", owner.getDisplayName());
         assertEquals(parentOwner2, owner.getParentOwner());
+        assertFalse(owner.getAutobindDisabled());
+
+        // Update autobind with disabled value.
+        Owner upOwner5 = mock(Owner.class);
+        when(upOwner5.getAutobindDisabled()).thenReturn(Boolean.TRUE);
+        ownerResource.updateOwner(owner.getKey(), upOwner5);
+        assertNull(owner.getDefaultServiceLevel());
+        assertEquals("New Name", owner.getDisplayName());
+        assertEquals(parentOwner2, owner.getParentOwner());
+        assertTrue(owner.getAutobindDisabled());
+        assertTrue(owner.autobindDisabled());
+
+        // Update autobind with enabled value.
+        Owner upOwner6 = mock(Owner.class);
+        when(upOwner6.getAutobindDisabled()).thenReturn(Boolean.FALSE);
+        ownerResource.updateOwner(owner.getKey(), upOwner6);
+        assertNull(owner.getDefaultServiceLevel());
+        assertEquals("New Name", owner.getDisplayName());
+        assertEquals(parentOwner2, owner.getParentOwner());
+        assertFalse(owner.getAutobindDisabled());
+        assertFalse(owner.autobindDisabled());
+
+        // Unset autobindDisabled results in no update.
+        Owner upOwner7 = mock(Owner.class);
+        when(upOwner7.getAutobindDisabled()).thenReturn(null);
+        ownerResource.updateOwner(owner.getKey(), upOwner7);
+        assertNull(owner.getDefaultServiceLevel());
+        assertEquals("New Name", owner.getDisplayName());
+        assertEquals(parentOwner2, owner.getParentOwner());
+        assertFalse(owner.getAutobindDisabled());
+        assertFalse(owner.autobindDisabled());
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/resource/PersonConsumerResourceCreationLiberalNameRules.java
+++ b/server/src/test/java/org/candlepin/resource/PersonConsumerResourceCreationLiberalNameRules.java
@@ -32,6 +32,8 @@ import org.junit.Test;
  */
 public class PersonConsumerResourceCreationLiberalNameRules extends
     ConsumerResourceCreationLiberalNameRules {
+
+    @Override
     public ConsumerType initSystem() {
         ConsumerType systemtype = new ConsumerType(
             ConsumerType.ConsumerTypeEnum.PERSON);

--- a/server/src/test/java/org/candlepin/resource/util/ConsumerBindUtilTest.java
+++ b/server/src/test/java/org/candlepin/resource/util/ConsumerBindUtilTest.java
@@ -92,7 +92,7 @@ public class ConsumerBindUtilTest {
     }
 
     @Test
-    public void registerWithKeyWithPoolAndInstalledProductsAutoAttach() {
+    public void registerWithKeyWithPoolAndInstalledProductsAutoAttach() throws Exception {
         Product prod = TestUtil.createProduct();
         String[] prodIds = new String[]{prod.getId()};
 
@@ -119,7 +119,7 @@ public class ConsumerBindUtilTest {
     }
 
     @Test
-    public void registerWithKeyWithInstalledProductsAutoAttach() {
+    public void registerWithKeyWithInstalledProductsAutoAttach() throws Exception {
         Product prod = TestUtil.createProduct();
         String[] prodIds = new String[]{prod.getId()};
 
@@ -140,7 +140,7 @@ public class ConsumerBindUtilTest {
     }
 
     @Test
-    public void registerWithKeyWithInstalledProductsPlusAutoAttach() {
+    public void registerWithKeyWithInstalledProductsPlusAutoAttach() throws Exception {
         // installed product
         Product prod1 = TestUtil.createProduct();
         // key product
@@ -165,7 +165,7 @@ public class ConsumerBindUtilTest {
     }
 
     @Test(expected = BadRequestException.class)
-    public void registerFailWithKeyServiceLevelNotExist() {
+    public void registerFailWithKeyServiceLevelNotExist() throws Exception {
         List<ActivationKey> keys = new ArrayList<ActivationKey>();
         ActivationKey key1 = new ActivationKey("key1", owner);
         keys.add(key1);
@@ -178,7 +178,7 @@ public class ConsumerBindUtilTest {
     }
 
     @Test
-    public void registerPassWithKeyServiceLevelNotExistOtherKeysSucceed() {
+    public void registerPassWithKeyServiceLevelNotExistOtherKeysSucceed() throws Exception {
         List<ActivationKey> keys = mockActivationKeys();
         ActivationKey key1 = new ActivationKey("key1", owner);
         keys.add(key1);
@@ -191,7 +191,7 @@ public class ConsumerBindUtilTest {
     }
 
     @Test(expected = BadRequestException.class)
-    public void registerFailWithNoGoodKeyPool() {
+    public void registerFailWithNoGoodKeyPool() throws Exception {
         List<ActivationKey> keys = new ArrayList<ActivationKey>();
         ActivationKey key1 = new ActivationKey("key1", owner);
         keys.add(key1);
@@ -208,7 +208,7 @@ public class ConsumerBindUtilTest {
     }
 
     @Test
-    public void registerPassWithOneGoodKeyPool() {
+    public void registerPassWithOneGoodKeyPool() throws Exception {
         List<ActivationKey> keys = new ArrayList<ActivationKey>();
         ActivationKey key1 = new ActivationKey("key1", owner);
         keys.add(key1);
@@ -235,7 +235,7 @@ public class ConsumerBindUtilTest {
     }
 
     @Test
-    public void registerPassWithOneGoodKey() {
+    public void registerPassWithOneGoodKey() throws Exception {
         List<ActivationKey> keys = new ArrayList<ActivationKey>();
         ActivationKey key1 = new ActivationKey("key1", owner);
         ActivationKey key2 = new ActivationKey("key2", owner);


### PR DESCRIPTION
**Reviewers please test the scenarios listed [here](https://docs.google.com/document/d/1i0SJB2zX6QWXXa_YMEC1AIktth_44Ml5tBYLykTQWnI/edit)!**

Added autobindDisabled field/column to Owner
* Added the field to the Owner object
* Added utility method to consider null value when
  asking if autobind is disabled for the Owner.
* Added a change set that adds the new column to
  the cp_owner table.

Add ability to update Owner.autobindDisable via API
* PUT owners/:key will now update the autobindDisable
  field on the targeted Owner.

Throw exception on autobind if disabled on owner
* Allows for determining precise impact points and
  allows for customizing the resulting behavior.
* In most cases this results in a BadRequestException
  thrown by the caller.

Block hypervisor checkins when autobind is disabled.
* Done so that migrations will not occur and entitlements
  will remain unchanged.
* One edge case here is when a migration happened before
  autobind was disabled. When a guest checks in in this
  state, all host related entitlements WILL be removed,
  but an attempt is not made to autoheal the guest.