### PR TITLE
Removed in-place updating for product and content

### DIFF
--- a/server/spec/owner_product_resource_spec.rb
+++ b/server/spec/owner_product_resource_spec.rb
@@ -45,7 +45,7 @@ describe 'Owner Product Resource' do
 
     # Delay here a moment to ensure an in-place update on the product doesn't trigger
     # attributes to be cloned/updated (as we're not updating attributes here)
-    sleep 1
+    # sleep 1
 
     prod = @cp.update_product(@owner['key'], prod.id, {:multiplier => prod2.multiplier, :attributes => nil})
 
@@ -251,7 +251,7 @@ describe 'Owner Product Resource' do
       lambda do
         @cp.delete_product(@owner['key'], @product.id)
       end.should raise_exception(RestClient::Forbidden)
-    else 
+    else
       lambda do
         @cp.delete_product(@owner['key'], @product.id)
       end.should raise_exception(RestClient::BadRequest)
@@ -263,7 +263,7 @@ describe 'Owner Product Resource' do
       lambda do
         @cp.delete_product(@owner['key'], @prov_product.id)
       end.should raise_exception(RestClient::Forbidden)
-    else 
+    else
       lambda do
         @cp.delete_product(@owner['key'], @prov_product.id)
       end.should raise_exception(RestClient::BadRequest)
@@ -275,7 +275,7 @@ describe 'Owner Product Resource' do
       lambda do
         @cp.delete_product(@owner['key'], @derived_product.id)
       end.should raise_exception(RestClient::Forbidden)
-    else 
+    else
       lambda do
         @cp.delete_product(@owner['key'], @derived_product.id)
       end.should raise_exception(RestClient::BadRequest)
@@ -287,7 +287,7 @@ describe 'Owner Product Resource' do
       lambda do
         @cp.delete_product(@owner['key'], @derived_prov_product.id)
       end.should raise_exception(RestClient::Forbidden)
-    else 
+    else
       lambda do
         @cp.delete_product(@owner['key'], @derived_prov_product.id)
       end.should raise_exception(RestClient::BadRequest)

--- a/server/spec/product_versioning_spec.rb
+++ b/server/spec/product_versioning_spec.rb
@@ -15,8 +15,6 @@ describe 'Product Versioning' do
     id = random_string("product")
     name = "shared_product"
 
-    updated_upstream = Date.today
-
     prod1 = @cp.create_product(owner1["key"], id, name)
     prod2 = @cp.create_product(owner2["key"], id, name)
 
@@ -30,12 +28,35 @@ describe 'Product Versioning' do
     id = random_string("product")
     name = "shared_product"
 
-    updated_upstream = Date.today
-
     prod1 = @cp.create_product(owner1["key"], id, name)
     prod2 = @cp.create_product(owner2["key"], id, name + "2")
 
     prod1["uuid"].should_not eq(prod2["uuid"])
+  end
+
+  it "creates a new instance when making changes to an existing instance" do
+    # If we enable clustered caching and re-enable the in-place content update branch, this
+    # test will need to be updated or removed.
+
+    owner1 = create_owner random_string('test_owner1')
+
+    id = random_string("product")
+    name = "shared_product"
+
+
+    prod1 = @cp.create_product(owner1["key"], id, name)
+    expect(prod1).to_not be_nil
+
+    prod2 = @cp.update_product(owner1["key"], id, { :name => "new product name" })
+    expect(prod2).to_not be_nil
+
+    expect(prod1["uuid"]).to_not eq(prod2["uuid"])
+
+    # content should now be different from both content1 and 2, and content2 should no longer exist
+    prods = @cp.list_products_by_owner(owner1["key"])
+    prods.size.should eq(1)
+    expect(prods[0]["uuid"]).to_not eq(prod1["uuid"])
+    expect(prods[0]["uuid"]).to eq(prod2["uuid"])
   end
 
   it "creates a new product instance when an org updates a shared instance" do
@@ -45,8 +66,6 @@ describe 'Product Versioning' do
 
     id = random_string("product")
     name = "shared_product"
-
-    updated_upstream = Date.today
 
     prod1 = @cp.create_product(owner1["key"], id, name)
     prod2 = @cp.create_product(owner2["key"], id, name)
@@ -80,8 +99,6 @@ describe 'Product Versioning' do
     id = random_string("product")
     name = "shared_product"
 
-    updated_upstream = Date.today
-
     prod1 = @cp.create_product(owner1["key"], id, name)
     prod2 = @cp.create_product(owner2["key"], id, name)
     prod3 = @cp.create_product(owner3["key"], id, "differing product name")
@@ -114,8 +131,6 @@ describe 'Product Versioning' do
     id = random_string("product")
     name = "shared_product"
 
-    updated_upstream = Date.today
-
     prod1 = @cp.create_product(owner1["key"], id, name)
     prod2 = @cp.create_product(owner2["key"], id, name)
 
@@ -141,8 +156,6 @@ describe 'Product Versioning' do
 
     id = random_string("product")
     name = "shared_product"
-
-    updated_upstream = Date.today
 
     prod1 = @cp.create_product(owner1["key"], id, name)
     prod2 = @cp.create_product(owner2["key"], id, name)
@@ -182,8 +195,6 @@ describe 'Product Versioning' do
 
     id = random_string("product")
     name = "shared_product"
-
-    updated_upstream = Date.today
 
     prod1 = @cp.create_product(owner1["key"], id, name)
     prod2 = @cp.create_product(owner2["key"], id, name)
@@ -251,8 +262,6 @@ describe 'Product Versioning' do
 
     id = random_string("product")
     name = "shared_product"
-
-    updated_upstream = Date.today
 
     prod1 = @cp.create_product(owner1["key"], id, name)
     prod2 = @cp.create_product(owner2["key"], id, name)
@@ -324,8 +333,6 @@ describe 'Product Versioning' do
     id = random_string("product")
     name = "shared_product"
 
-    updated_upstream = Date.today
-
     prod1 = @cp.create_product(owner1["key"], id, name)
     prod2 = @cp.create_product(owner2["key"], id, name)
 
@@ -355,8 +362,10 @@ describe 'Product Versioning' do
     # addition of the content to prod1 triggered the generation of a new product for org1 (prod3),
     # leaving org2 as the only owner for prod2. That being the case, prod2 was updated in-place,
     # allowing it to retain its UUID, and make this test look strange
-    prod4["uuid"].should eq(prod1["uuid"])
-    prod4["uuid"].should eq(prod2["uuid"])
+    # NOTE: The above will only be true when in-place updates are enabled. When they are disabled
+    # (as they are now), the UUIDs will not match, since we're always forking on any change.
+    prod4["uuid"].should_not eq(prod1["uuid"]) # ^
+    prod4["uuid"].should_not eq(prod2["uuid"]) # ^
     prod4["uuid"].should_not eq(prod3["uuid"])
 
     # Actual test starts here

--- a/server/src/main/java/org/candlepin/controller/ContentManager.java
+++ b/server/src/main/java/org/candlepin/controller/ContentManager.java
@@ -268,6 +268,9 @@ public class ContentManager {
             }
         }
 
+        // Temporarily (?) disabled. If we ever move to clustered caching (rather than per-instance
+        // caching, this branch should be re-enabled.
+        /*
         // No alternate versions with which to converge. Check if we can do an in-place update instead
         if (this.ownerContentCurator.getOwnerCount(updated) < 2) {
             log.debug("Applying in-place update to content: {}", updated);
@@ -287,7 +290,7 @@ public class ContentManager {
 
             return updated;
         }
-
+        */
 
         log.debug("Forking content and applying update: {}", updated);
 

--- a/server/src/main/java/org/candlepin/controller/ProductManager.java
+++ b/server/src/main/java/org/candlepin/controller/ProductManager.java
@@ -312,6 +312,9 @@ public class ProductManager {
             }
         }
 
+        // Temporarily (?) disabled. If we ever move to clustered caching (rather than per-instance
+        // caching, this branch should be re-enabled.
+        /*
         // No alternate versions with which to converge. Check if we can do an in-place update instead
         if (this.ownerProductCurator.getOwnerCount(updated) < 2) {
             log.debug("Applying in-place update to product: {}", updated);
@@ -326,6 +329,7 @@ public class ProductManager {
 
             return updated;
         }
+        */
 
         // Product is shared by multiple owners; we have to diverge here
         log.debug("Forking product and applying update: {}", updated);

--- a/server/src/test/java/org/candlepin/controller/ContentManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/ContentManagerTest.java
@@ -175,7 +175,7 @@ public class ContentManagerTest extends DatabaseTestFixture {
 
         Content output = this.contentManager.updateContent(content, update, owner, regenCerts);
 
-        assertEquals(output.getUuid(), content.getUuid());
+        assertNotEquals(output.getUuid(), content.getUuid());
         assertEquals(output.getName(), update.getName());
 
         if (regenCerts) {

--- a/server/src/test/java/org/candlepin/controller/ProductManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/ProductManagerTest.java
@@ -158,7 +158,7 @@ public class ProductManagerTest extends DatabaseTestFixture {
 
         Product output = this.productManager.updateProduct(product, update, owner, regenCerts);
 
-        assertEquals(output.getUuid(), product.getUuid());
+        assertNotEquals(output.getUuid(), product.getUuid());
         assertEquals(output.getName(), update.getName());
 
         if (regenCerts) {
@@ -395,8 +395,7 @@ public class ProductManagerTest extends DatabaseTestFixture {
             product, Arrays.asList(new ProductContent(null, content, true)), owner, false
         );
 
-        assertEquals(product, output);
-        assertTrue(product.hasContent(content.getId()));
+        assertNotEquals(product, output);
         assertTrue(output.hasContent(content.getId()));
 
         verifyZeroInteractions(this.mockEntCertGenerator);


### PR DESCRIPTION
- Product and Content entities are now treated as immutable objects
  by their respective managers. Every chage made to either of these
  types of entities will now result in new entities being created,
  even in instances when fewer than two owners are using the entity.
- Updated unit and spec tests accordingly, and added missing tests
  for verifying the new behavior