### PR TITLE
Added an argument for specifying the Java version in cp-test

### DIFF
--- a/docker/candlepin-base/cp-test
+++ b/docker/candlepin-base/cp-test
@@ -16,10 +16,6 @@ source /etc/profile
 
 export HOME=/root
 
-# Detect Java version and set JAVA_HOME accordingly
-export JAVA_VERSION=$(java -version 2>&1 | head -1 | sed -r 's/^(java|openjdk) version \"([0-9]+\.[0-9]+\.[0-9]+).*\"/\2/')
-export JAVA_HOME=/usr/lib/jvm/java-$JAVA_VERSION
-
 export SUPERVISOR=1
 export AUTOCONF=1
 export FORCECERT=1
@@ -116,12 +112,13 @@ OPTIONS:
   -b <task>        execute the specified buildr task
   -c <ref>         git reference to checkout
   -p <project>     subproject to build (defaults to "server")
+  -j <version>     use a specific Java version instead of the auto-detected default
   -v               enable verbose/debug output
 HELP
 }
 
 ARGV=("$@")
-while getopts ":dtrHulsb:c:p:v" opt; do
+while getopts ":dtrHulsb:c:p:vj:" opt; do
     case $opt in
         d  ) DEPLOY="1";;
         t  )
@@ -157,12 +154,33 @@ while getopts ":dtrHulsb:c:p:v" opt; do
         c  ) CHECKOUT="${OPTARG}";;
         p  ) PROJECT="${OPTARG}";;
         v  ) VERBOSE="1";;
+        j  ) JAVA_VERSION="${OPTARG}";;
         ?  ) usage; exit;;
     esac
 done
 
 shift $(($OPTIND - 1))
 
+
+# Auto-detect JAVA_VERSION if necessary and set JAVA_HOME and update executable links
+# Note that alternatives doesn't update the JDK binaries properly, and doesn't order
+# versions predictably, so we'll just explicitly make the links ourself.
+if [ -z "$JAVA_VERSION" ]; then
+    JAVA_VERSION=$(java -version 2>&1 | head -1 | sed -r 's/^(java|openjdk) version \"([0-9]+\.[0-9]+\.[0-9]+).*\"/\2/')
+fi
+
+export JAVA_VERSION
+export JAVA_HOME=/usr/lib/jvm/java-$JAVA_VERSION
+
+if [ -d "$JAVA_HOME" ]; then
+    ln -sf -t /usr/bin $JAVA_HOME/bin/*
+    echo "Using Java version: $JAVA_VERSION ($JAVA_HOME)"
+else
+    echo "Java home not found for version $JAVA_VERSION: $JAVA_HOME"
+    exit 1
+fi
+
+# Set our project to test
 PROJECT=${PROJECT:-server}
 
 # WARNING: control+c while this is running will take out supervisor as well.

--- a/docker/candlepin-base/setup-devel-env.sh
+++ b/docker/candlepin-base/setup-devel-env.sh
@@ -21,6 +21,9 @@ PACKAGES=(
     tig
     gcc
     tomcat
+    java-1.6.0-openjdk-devel
+    java-1.7.0-openjdk-devel
+    java-1.8.0-openjdk-devel
     java-$JAVA_VERSION-openjdk-devel
     liquibase
     libxml2-python


### PR DESCRIPTION
- Added the -j argument to cp-test for specifying a Java
  version to use for building and running Candlepin
- The candlepin-base container now automatically installs
  Java 1.6, 1.7 and 1.8, as well as the current version
  (which happens to be 1.8 at the moment)