### PR TITLE
Disable vagrant port forward

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ buildconf/scripts/import_products.json
 .rvmrc
 .ruby-version
 .ruby-gemset
+
+# Vagrant 
+.vagrant/

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,10 +18,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
  config.vm.define "dev" do |dev|
     dev.vm.host_name = "candlepin.example.com"
     # Tomcat remote debug
-    config.vm.network "forwarded_port", guest: 8000, host: 8000
+    # config.vm.network "forwarded_port", guest: 8000, host: 8000
     # Rest access for Candlepin
-    config.vm.network "forwarded_port", guest: 8080, host: 8080
-    config.vm.network "forwarded_port", guest: 8443, host: 8443
+    # config.vm.network "forwarded_port", guest: 8080, host: 8080
+    # config.vm.network "forwarded_port", guest: 8443, host: 8443
     config.ssh.forward_x11 = true
     dev.vm.provider :libvirt do |domain|
         domain.cpus = 1


### PR DESCRIPTION
Add the .vagrant directory to the .gitignore & disable the localhost port-forwarding now that the hostmanager plugin will automatically update your hosts file with candlepin.example.com