### PR TITLE
Add debug symbols to Java projects and not the top project.

### DIFF
--- a/buildfile
+++ b/buildfile
@@ -226,7 +226,7 @@ define "candlepin" do
   project.version = pom_version(path_to('pom.xml'))
   manifest["Copyright"] = "Red Hat, Inc. #{Date.today.strftime('%Y')}"
 
-  compile.using(:javac, :debug => true)
+  compile.using(:debug => true)
   compile.options.target = '1.6'
   compile.options.source = '1.6'
 
@@ -461,6 +461,7 @@ define "candlepin" do
       SUN_JAXB,
       SWAGGER,
     ]
+
     compile.with(compile_classpath)
     compile.with(project('common'))
     compile.with(LOGDRIVER, LOG4J_BRIDGE) if use_logdriver


### PR DESCRIPTION
Addresses issue with #1346 