### PR TITLE
Awood/new liquibase fix

### DIFF
--- a/server/src/main/resources/db/changelog/20130722140547-add-cdn-table.xml
+++ b/server/src/main/resources/db/changelog/20130722140547-add-cdn-table.xml
@@ -6,15 +6,8 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
 
-
-    <property name="date.type" value="TIMESTAMP WITHOUT TIME ZONE" dbms="postgresql,oracle"/>
-    <property name="date.type" value="DATETIME" dbms="mysql"/>
-
-    <property name="serial.type" value="BIGINT" dbms="oracle,mysql"/>
-    <property name="serial.type" value="int8" dbms="postgresql"/>
-
-    <property name="cert.type" value="BLOB" dbms="oracle,mysql"/>
-    <property name="cert.type" value="bytea" dbms="postgresql"/>
+    <!-- Include definitions for cert.type, timestamp.type, etc. -->
+    <include file="db/changelog/datatypes.xml"/>
 
     <changeSet id="20130722140547" author="wpoteat">
         <comment>CDN record</comment>

--- a/server/src/main/resources/db/changelog/20130912153356-create-import-upstream-consumer.xml
+++ b/server/src/main/resources/db/changelog/20130912153356-create-import-upstream-consumer.xml
@@ -6,9 +6,8 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
 
-    <property name="timestamp.type" value="TIMESTAMP WITHOUT TIME ZONE" dbms="oracle"/>
-    <property name="timestamp.type" value="TIMESTAMP WITHOUT TIME ZONE" dbms="postgresql"/>
-    <property name="timestamp.type" value="DATETIME" dbms="mysql"/>
+    <!-- Include definitions for cert.type, timestamp.type, etc. -->
+    <include file="db/changelog/datatypes.xml"/>
 
     <changeSet id="20130912153356" author="wpoteat">
         <validCheckSum>7:69e9ff14c6d2da8962d4870401700340</validCheckSum>

--- a/server/src/main/resources/db/changelog/20131002150608-consumer-content-override.xml
+++ b/server/src/main/resources/db/changelog/20131002150608-consumer-content-override.xml
@@ -6,10 +6,8 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
 
-
-    <property name="timestamp.type" value="TIMESTAMP WITHOUT TIME ZONE" dbms="oracle"/>
-    <property name="timestamp.type" value="TIMESTAMP WITHOUT TIME ZONE" dbms="postgresql"/>
-    <property name="timestamp.type" value="DATETIME" dbms="mysql"/>
+    <!-- Include definitions for cert.type, timestamp.type, etc. -->
+    <include file="db/changelog/datatypes.xml"/>
 
     <changeSet id="20131002150608" author="wpoteat">
         <validCheckSum>7:bef3100eb209f06cd08332a032e87c3f</validCheckSum>

--- a/server/src/main/resources/db/changelog/20140210083318-add-hypervisorid.xml
+++ b/server/src/main/resources/db/changelog/20140210083318-add-hypervisorid.xml
@@ -6,9 +6,8 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
 
-    <property name="timestamp.type" value="TIMESTAMP WITHOUT TIME ZONE" dbms="oracle"/>
-    <property name="timestamp.type" value="TIMESTAMP WITHOUT TIME ZONE" dbms="postgresql"/>
-    <property name="timestamp.type" value="DATETIME" dbms="mysql"/>
+    <!-- Include definitions for cert.type, timestamp.type, etc. -->
+    <include file="db/changelog/datatypes.xml"/>
 
     <changeSet id="20140210083318-0" author="ckozak">
         <comment>Add hypervisorId</comment>

--- a/server/src/main/resources/db/changelog/20140306150357-constrain-one-subpool-per-stack.xml
+++ b/server/src/main/resources/db/changelog/20140306150357-constrain-one-subpool-per-stack.xml
@@ -6,9 +6,8 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
 
-    <property name="timestamp.type" value="TIMESTAMP WITHOUT TIME ZONE" dbms="oracle"/>
-    <property name="timestamp.type" value="TIMESTAMP WITHOUT TIME ZONE" dbms="postgresql"/>
-    <property name="timestamp.type" value="DATETIME" dbms="mysql"/>
+    <!-- Include definitions for cert.type, timestamp.type, etc. -->
+    <include file="db/changelog/datatypes.xml"/>
 
     <changeSet id="20140306150357-0" author="ckozak">
         <comment>Constrain one subpool per stack to avoid concurrency problems</comment>

--- a/server/src/main/resources/db/changelog/20140313155734-create-branding.xml
+++ b/server/src/main/resources/db/changelog/20140313155734-create-branding.xml
@@ -6,9 +6,8 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
 
-    <property name="timestamp.type" value="TIMESTAMP WITHOUT TIME ZONE" dbms="oracle"/>
-    <property name="timestamp.type" value="TIMESTAMP WITHOUT TIME ZONE" dbms="postgresql"/>
-    <property name="timestamp.type" value="DATETIME" dbms="mysql"/>
+    <!-- Include definitions for cert.type, timestamp.type, etc. -->
+    <include file="db/changelog/datatypes.xml"/>
 
     <changeSet id="20140313155734-1" author="dgoodwin">
         <comment>Create the branding table.</comment>

--- a/server/src/main/resources/db/changelog/20140408160212-add-pool-source-sub-table.xml
+++ b/server/src/main/resources/db/changelog/20140408160212-add-pool-source-sub-table.xml
@@ -6,9 +6,8 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
 
-    <property name="timestamp.type" value="TIMESTAMP WITHOUT TIME ZONE" dbms="oracle"/>
-    <property name="timestamp.type" value="TIMESTAMP WITHOUT TIME ZONE" dbms="postgresql"/>
-    <property name="timestamp.type" value="DATETIME" dbms="mysql"/>
+    <!-- Include definitions for cert.type, timestamp.type, etc. -->
+    <include file="db/changelog/datatypes.xml"/>
 
     <changeSet id="20140408160212-0" author="ckozak">
         <comment>Create source subscription table</comment>

--- a/server/src/main/resources/db/changelog/20150123105016-add-consumer-checkin-table.xml
+++ b/server/src/main/resources/db/changelog/20150123105016-add-consumer-checkin-table.xml
@@ -6,8 +6,8 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
 
-    <property name="timestamp.type" value="TIMESTAMP WITH TIME ZONE" dbms="oracle,postgresql,hsqldb"/>
-    <property name="timestamp.type" value="DATETIME" dbms="mysql"/>
+    <!-- Include definitions for cert.type, timestamp.type, etc. -->
+    <include file="db/changelog/datatypes.xml"/>
 
     <changeSet id="20150123105016-1" author="dgoodwin">
         <comment>Add consumer checkin table.</comment>

--- a/server/src/main/resources/db/changelog/20150210094558-perorgproducts-phase-1.xml
+++ b/server/src/main/resources/db/changelog/20150210094558-perorgproducts-phase-1.xml
@@ -6,11 +6,8 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
 
-    <property name="timestamp.type" value="TIMESTAMP WITHOUT TIME ZONE" dbms="oracle,postgresql,hsqldb"/>
-    <property name="timestamp.type" value="DATETIME" dbms="mysql"/>
-
-    <property name="cert.type" value="BLOB" dbms="oracle,mysql"/>
-    <property name="cert.type" value="bytea" dbms="postgresql"/>
+    <!-- Include definitions for cert.type, timestamp.type, etc. -->
+    <include file="db/changelog/datatypes.xml"/>
 
     <!-- cp2_products -->
     <changeSet id="20150210094558-01" author="crog">

--- a/server/src/main/resources/db/changelog/20150210094558-perorgproducts-phase-1.xml
+++ b/server/src/main/resources/db/changelog/20150210094558-perorgproducts-phase-1.xml
@@ -9,7 +9,8 @@
     <property name="timestamp.type" value="TIMESTAMP WITHOUT TIME ZONE" dbms="oracle,postgresql,hsqldb"/>
     <property name="timestamp.type" value="DATETIME" dbms="mysql"/>
 
-
+    <property name="cert.type" value="BLOB" dbms="oracle,mysql"/>
+    <property name="cert.type" value="bytea" dbms="postgresql"/>
 
     <!-- cp2_products -->
     <changeSet id="20150210094558-01" author="crog">
@@ -313,10 +314,10 @@
             </column>
             <column name="created" type="${timestamp.type}"/>
             <column name="updated" type="${timestamp.type}"/>
-            <column name="cert" type="blob">
+            <column name="cert" type="${cert.type}">
                 <constraints nullable="false"/>
             </column>
-            <column name="privatekey" type="blob">
+            <column name="privatekey" type="${cert.type}">
                 <constraints nullable="false"/>
             </column>
             <column name="product_uuid" type="varchar(32)">

--- a/server/src/main/resources/db/changelog/20150211111319-add-last-guest-update-table.xml
+++ b/server/src/main/resources/db/changelog/20150211111319-add-last-guest-update-table.xml
@@ -6,8 +6,8 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
 
-    <property name="timestamp.type" value="TIMESTAMP WITH TIME ZONE" dbms="oracle,postgresql,hsqldb"/>
-    <property name="timestamp.type" value="DATETIME" dbms="mysql"/>
+    <!-- Include definitions for cert.type, timestamp.type, etc. -->
+    <include file="db/changelog/datatypes.xml"/>
 
     <changeSet id="20150211111319-1" author="dgoodwin">
         <comment>add last guest update table</comment>

--- a/server/src/main/resources/db/changelog/20150316122833-add-entitlement-end-date-override.xml
+++ b/server/src/main/resources/db/changelog/20150316122833-add-entitlement-end-date-override.xml
@@ -6,8 +6,8 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
 
-    <property name="timestamp.type" value="TIMESTAMP WITH TIME ZONE" dbms="oracle,postgresql,hsqldb"/>
-    <property name="timestamp.type" value="DATETIME" dbms="mysql"/>
+    <!-- Include definitions for cert.type, timestamp.type, etc. -->
+    <include file="db/changelog/datatypes.xml"/>
 
     <changeSet id="20150316122833-1" author="dgoodwin">
         <comment>add entitlement end date override</comment>

--- a/server/src/main/resources/db/changelog/20150820140403-revert-to-lastcheckin-column.xml
+++ b/server/src/main/resources/db/changelog/20150820140403-revert-to-lastcheckin-column.xml
@@ -6,9 +6,8 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
 
-    <property name="timestamp.type" value="TIMESTAMP WITHOUT TIME ZONE" dbms="oracle"/>
-    <property name="timestamp.type" value="TIMESTAMP WITHOUT TIME ZONE" dbms="postgresql"/>
-    <property name="timestamp.type" value="DATETIME" dbms="mysql"/>
+    <!-- Include definitions for cert.type, timestamp.type, etc. -->
+    <include file="db/changelog/datatypes.xml"/>
 
     <changeSet id="20150820140403-1" author="dgoodwin">
         <comment>revert to lastcheckin column</comment>

--- a/server/src/main/resources/db/changelog/datatypes.xml
+++ b/server/src/main/resources/db/changelog/datatypes.xml
@@ -1,0 +1,19 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+    <property name="timestamp.type" value="TIMESTAMP WITHOUT TIME ZONE" dbms="oracle,postgresql,hsqldb"/>
+    <property name="timestamp.type" value="DATETIME" dbms="mysql"/>
+
+    <property name="date.type" value="TIMESTAMP WITHOUT TIME ZONE" dbms="postgresql,oracle,hsqldb"/>
+    <property name="date.type" value="DATETIME" dbms="mysql"/>
+
+    <property name="serial.type" value="BIGINT" dbms="oracle,mysql,hsqldb"/>
+    <property name="serial.type" value="int8" dbms="postgresql"/>
+
+    <property name="cert.type" value="BLOB" dbms="oracle,mysql,hsqldb"/>
+    <property name="cert.type" value="bytea" dbms="postgresql"/>
+</databaseChangeLog>
+


### PR DESCRIPTION
The new version of Liquibase (3.5.3) that I'm building for Fedora failed when trying to deploy with the cert column as a blob instead of a bytea.  Other cert columns that we've had were bytea so this PR corrects the inconsistency.

When this gets merged, we need to send out a note to everyone informing them to drop and rebuild their database since the modification in the column element in the changeset alters the checksum on the changeset and makes Liquibase angry (since Liquibase now things alterations have occurred outside of its knowledge).
