### PR TITLE
Change mapping of NumericBooleanType to Integer

### DIFF
--- a/server/src/main/resources/db/changelog/20150210094558-perorgproducts-phase-1.xml
+++ b/server/src/main/resources/db/changelog/20150210094558-perorgproducts-phase-1.xml
@@ -28,7 +28,7 @@
                 <constraints nullable="false"/>
             </column>
             <column name="entity_version" type="int"/>
-            <column name="locked" type="smallint"/>
+            <column name="locked" type="int"/>
         </createTable>
     </changeSet>
 
@@ -118,7 +118,7 @@
             </column>
             <column name="arches" type="varchar(255)"/>
             <column name="entity_version" type="int"/>
-            <column name="locked" type="smallint"/>
+            <column name="locked" type="int"/>
         </createTable>
     </changeSet>
 


### PR DESCRIPTION
Candlepins with jpa.config.hibernate.hbm2ddl.auto=validate break when
NumericBooleanType is mapped to smallint.

Note that this change will require dropping your database and recreating it!
