### PR TITLE
Disable the Hibernate 2nd level cache and remove annotations

### DIFF
--- a/server/src/main/java/org/candlepin/model/Content.java
+++ b/server/src/main/java/org/candlepin/model/Content.java
@@ -23,8 +23,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.hibernate.annotations.BatchSize;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Type;
 
@@ -34,7 +32,6 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
 
-import javax.persistence.Cacheable;
 import javax.persistence.CollectionTable;
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
@@ -61,8 +58,6 @@ import javax.xml.bind.annotation.XmlTransient;
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @Entity
 @Table(name = "cp2_content")
-@Cacheable(true)
-@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 public class Content extends AbstractHibernateObject implements SharedEntity, Cloneable {
 
     public static final  String UEBER_CONTENT_NAME = "ueber_content";
@@ -126,7 +121,6 @@ public class Content extends AbstractHibernateObject implements SharedEntity, Cl
     @CollectionTable(name = "cp2_content_modified_products", joinColumns = @JoinColumn(name = "content_uuid"))
     @Column(name = "element")
     @Size(max = 255)
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private Set<String> modifiedProductIds;
 
     @Column(nullable = true)

--- a/server/src/main/java/org/candlepin/model/Product.java
+++ b/server/src/main/java/org/candlepin/model/Product.java
@@ -21,8 +21,6 @@ import org.candlepin.service.UniqueIdGenerator;
 import org.candlepin.util.Util;
 
 import org.hibernate.annotations.BatchSize;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.CascadeType;
 import org.hibernate.annotations.Fetch;
@@ -47,7 +45,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.StringTokenizer;
 
-import javax.persistence.Cacheable;
 import javax.persistence.CollectionTable;
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
@@ -78,8 +75,6 @@ import javax.xml.bind.annotation.XmlTransient;
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @Entity
 @Table(name = "cp2_products")
-@Cacheable(true)
-@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 public class Product extends AbstractHibernateObject implements SharedEntity, Linkable, Cloneable {
     /**
      * Commonly used/recognized product attributes
@@ -181,7 +176,6 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
     @BatchSize(size = 32)
     @Cascade({ CascadeType.ALL })
     @Fetch(FetchMode.SUBSELECT)
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private List<ProductAttribute> attributes;
 
     @ElementCollection
@@ -189,7 +183,6 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
     @CollectionTable(name = "cp2_product_content", joinColumns = @JoinColumn(name = "product_uuid"))
     @Column(name = "element")
     @LazyCollection(LazyCollectionOption.EXTRA) // allows .size() without loading all data
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private List<ProductContent> productContent;
 
     /*
@@ -203,7 +196,6 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
     @Column(name = "element")
     @BatchSize(size = 32)
     @LazyCollection(LazyCollectionOption.FALSE)
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private Set<String> dependentProductIds;
 
     @XmlTransient

--- a/server/src/main/java/org/candlepin/model/ProductAttribute.java
+++ b/server/src/main/java/org/candlepin/model/ProductAttribute.java
@@ -23,11 +23,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.GenericGenerator;
 
-import javax.persistence.Cacheable;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.persistence.Entity;
@@ -49,8 +46,6 @@ import javax.xml.bind.annotation.XmlTransient;
 @Table(name = "cp2_product_attributes")
 @Embeddable
 @JsonFilter("ProductAttributeFilter")
-@Cacheable(true)
-@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 public class ProductAttribute extends AbstractHibernateObject implements Attribute {
 
     @Id

--- a/server/src/main/resources/META-INF/persistence.xml
+++ b/server/src/main/resources/META-INF/persistence.xml
@@ -19,8 +19,6 @@
             <property name="hibernate.c3p0.min_size" value="5" />
             <property name="hibernate.c3p0.max_size" value="20" />
             <property name="hibernate.c3p0.timeout" value="300" />
-            <property name="hibernate.cache.use_second_level_cache" value="true" />
-            <property name="hibernate.cache.use_query_cache" value="true" />
             <property name="hibernate.cache.region.factory_class" value="org.hibernate.cache.ehcache.EhCacheRegionFactory" />
             <property name="net.sf.ehcache.configurationResourceName" value="ehcache.xml" />
             <!-- test period in seconds -->


### PR DESCRIPTION
Disable the hibernate 2nd level cache as it is competing for memory with the JSR-107 cache and does not appear to be providing significant speedup. 