### PR TITLE
Qpid Spec Test Support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'stringex'
 gem 'digest-murmurhash'
 gem 'httpclient'
 gem 'activesupport', '~> 4.2'
+gem 'qpid_proton'
 
 # Remove this once we are fully using the new Ruby bindings
 gem 'rest-client', '~> 1.6.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,8 @@ GEM
     pry-stack_explorer (0.4.9.2)
       binding_of_caller (>= 0.7)
       pry (>= 0.9.11)
+    qpid_proton (0.14.0)
+      json
     rainbow (2.1.0)
     rake (0.9.2.2)
     rest-client (1.6.9)
@@ -117,6 +119,7 @@ DEPENDENCIES
   pry
   pry-byebug
   pry-stack_explorer
+  qpid_proton
   rest-client (~> 1.6.0)
   rspec (~> 3.0)
   rubocop (= 0.36.0)
@@ -124,4 +127,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-   1.12.5
+   1.13.2

--- a/docker/candlepin-base/cp-test
+++ b/docker/candlepin-base/cp-test
@@ -118,7 +118,7 @@ HELP
 }
 
 ARGV=("$@")
-while getopts ":dtrHulsb:c:p:vj:" opt; do
+while getopts ":dtqrHulsb:c:p:vj:" opt; do
     case $opt in
         d  ) DEPLOY="1";;
         t  )
@@ -153,6 +153,7 @@ while getopts ":dtrHulsb:c:p:vj:" opt; do
         b  ) BUILDR_TASK="${OPTARG}";;
         c  ) CHECKOUT="${OPTARG}";;
         p  ) PROJECT="${OPTARG}";;
+        q  ) QPID="1";;
         v  ) VERBOSE="1";;
         j  ) JAVA_VERSION="${OPTARG}";;
         ?  ) usage; exit;;
@@ -254,6 +255,15 @@ if [ "$UNITTEST" -gt 0 ]; then
     done
 fi
 
+if [ "$QPID" == "1" ]; then
+    echo "Setting up Qpid"
+    pushd . 
+    cd ../gutterball/bin/qpid
+    ./configure-qpid.sh
+    popd 
+fi
+
+
 if [ "$DEPLOY" == "1" ]; then
     echo "Deploying candlepin..."
     CLEAN_CP=1
@@ -271,7 +281,11 @@ if [ "$DEPLOY" == "1" ]; then
     if [ "$VERBOSE" == "1" ]; then
         DEPLOY_FLAGS="$DEPLOY_FLAGS -v"
     fi
-
+    
+    if [ "$QPID" == "1" ]; then
+        DEPLOY_FLAGS="$DEPLOY_FLAGS -q"
+    fi
+    
     bin/deploy $DEPLOY_FLAGS
     sleep 7
 fi

--- a/docker/candlepin-base/setup-supervisord.sh
+++ b/docker/candlepin-base/setup-supervisord.sh
@@ -41,6 +41,20 @@ redirect_stderr=true
 TOMCAT_SUPERVISOR
 }
 
+setup_qpidd() {
+# qpid-proton-c-devel is dependency of qpid_proton ruby binding (needed for spec tests)
+yum install -y qpid-cpp-server qpid-cpp-client qpid-cpp-server-linearstore qpid-tools sudo qpid-proton-c-devel
+
+cat > /etc/supervisor/conf.d/qpid.conf <<  QPID_SUPERVISOR
+[program:qpidd]
+user=qpidd
+command=/usr/sbin/qpidd --config /etc/qpid/qpidd.conf --data-dir=/var/lib/qpidd
+stopsignal=INT
+redirect_stderr=true
+QPID_SUPERVISOR
+}
+
+
 setup_ssh() {
     yum install -y openssh-server
     echo 'root:redhat' |chpasswd
@@ -60,6 +74,7 @@ command=/usr/sbin/sshd -D
 SSH_SUPERVISOR
 }
 
+
 setup_candlepinrc() {
     cat > /root/.candlepinrc <<CANDLEPINRC
 SUPERVISOR=1
@@ -69,4 +84,5 @@ CANDLEPINRC
 setup_supervisor
 setup_ssh
 setup_tomcat
+setup_qpidd
 setup_candlepinrc

--- a/gutterball/bin/qpid/configure-qpid.sh
+++ b/gutterball/bin/qpid/configure-qpid.sh
@@ -302,7 +302,10 @@ if [ $IS_KATELLO -ne 0 ]; then
     setup_qpidd_config
 fi
 
-sudo service qpidd restart
+# In Docker image we use supervisord instead of systemd.
+# So the assumption of the following is that 'service' command 
+# fails, we try supervisord.
+sudo service qpidd restart || supervisorctl restart qpidd
 
 sleep 7
 create_exchange "event"

--- a/server/bin/deploy
+++ b/server/bin/deploy
@@ -133,6 +133,7 @@ usage: deploy [options]
 OPTIONS:
   -f          force cert regeneration
   -g          generate database
+  -q          Qpid enabled. Also deploys 'allmsg' queue used by spec tests
   -t          import test data
   -T          import minimal test data, some owners, users, and roles
   -H          include test resources for hosted mode
@@ -186,11 +187,12 @@ init
 
 DBUSER="candlepin"
 
-while getopts ":fgtTHolmavd:" opt; do
+while getopts ":fqgtTHolmavd:" opt; do
     case $opt in
         f  ) FORCECERT="1" ;;
         g  ) GENDB="1";;
         H  ) HOSTEDTEST="hostedtest";;
+        q  ) QPID="qpid";;
         t  ) TESTDATA="1";;
         T  ) TESTDATA="MIN";;
         o  ) USE_ORACLE="1";;
@@ -286,6 +288,26 @@ else
     HOSTEDTEST=""
 fi
 
+# Delete the allmsg Qpid queue. The error messages produced during
+# deletion are silenced
+# This deletion is attempted regardless of whether Qpid is enabled. We do that
+# to prevent the queue to grow indefinitely
+QPID_KEYS_DIR=$PROJECT_DIR/../gutterball/bin/qpid/keys
+
+qpid-config -b amqps://localhost:5671 --ssl-certificate $QPID_KEYS_DIR/qpid_ca.crt --ssl-key $QPID_KEYS_DIR/qpid_ca.key --force del queue allmsg 2 > /dev/null || true
+
+if [ "$QPID" == "qpid" ]; then
+    info_msg "Enable Qpid"
+    QPID="qpid=yes"
+
+    #Setup testing qpid queue allmsg, this will be needed by Qpid spec tests
+    qpid-config -b amqps://localhost:5671 --ssl-certificate $QPID_KEYS_DIR/qpid_ca.crt --ssl-key $QPID_KEYS_DIR/qpid_ca.key add queue allmsg --durable
+    qpid-config -b amqps://localhost:5671 --ssl-certificate $QPID_KEYS_DIR/qpid_ca.crt --ssl-key $QPID_KEYS_DIR/qpid_ca.key bind event allmsg "#"
+else
+    QPID=""
+fi
+
+
 if [ "$USE_ORACLE" == "1" ]; then
     info_msg "Building with Oracle JDBC jar"
     ENV_BUILDR="oracle"
@@ -324,7 +346,7 @@ create_var_log_candlepin
 create_var_cache_candlepin
 
 if [ "$AUTOCONF" == "1" ]; then
-  autoconf $ENV_BUILDR $LOGDRIVER $HOSTEDTEST
+  autoconf $ENV_BUILDR $LOGDRIVER $HOSTEDTEST $QPID
 fi
 
 # deploy the webapp

--- a/server/erb/candlepin.conf.erb
+++ b/server/erb/candlepin.conf.erb
@@ -34,6 +34,9 @@ candlepin.auth.oauth.consumer.thumbslug.secret=thumbslug-secret
 candlepin.importer.fail_on_unknown=<%= fail_on_unknown || false %>
 candlepin.pretty_print=<%= cp_pretty_print || true %>
 
+<%- if ENV['qpid'] 
+      amqp_enabled = true 
+    end -%>
 candlepin.amqp.enable=<%= amqp_enabled || false %>
 candlepin.amqp.connect=<%= amqp_server || "tcp://localhost:5671?ssl='true'&ssl_cert_alias='candlepin'" %>
 

--- a/server/spec/qpid_spec.rb
+++ b/server/spec/qpid_spec.rb
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+require 'spec_helper'
+require 'candlepin_scenarios'
+
+# To run this spec test it is necessary to have Qpid up and configured.
+#
+# In Jenkins environment, this should be a problem. The cp-test script 
+# has -q switch that will run configure-qpid.sh during candlepin server
+# deploy.
+#
+# Outside of Jenkins environment, you must install Qpid and run the 
+# configure-qpid.sh yourself. Also you must enable AMQP (Qpid) in your
+# candlepin config file. This can be done either manually or just by
+# using deploy.sh script with -q switch.
+describe 'Qpid Broker' do
+
+  include CandlepinMethods
+
+  before(:each) do
+     @cq = CandlepinQpid.new
+     skip("Qpid keys not found, skipping Qpid spec tests") if @cq.no_keys 
+     # Clean the qpid queue
+     @cq.receive
+  end
+
+  it 'should receive OWNER CREATED' do
+     create_owner random_string("test")
+     sleep 10
+     msgs = @cq.receive
+     msgs.length.should == 1
+     msgs[0].subject.should == 'owner.created'
+  end
+
+end


### PR DESCRIPTION
New -q switch for deploy script that will recreate queue 'allmsg' which is a
special queue for testing purposes. -a switch will also cause autoconf
to enable AMQP in candlepin config.

Docker image candlepin-base now installs qpid and starts it using supervisord.

cp-test script has new -q switch that uses guterrball configure-qpid.sh
script, to setup qpid (generate SSL keys, create event exchange) etc.

I also had to modify configure-qpid.sh to be aware of supervisorctl

You can now write spec tests that assert Qpid queue. There is a new
CandlepinQpid helper class.