### PR TITLE
Suspend mode

### DIFF
--- a/common/src/main/java/org/candlepin/common/exceptions/SuspendedException.java
+++ b/common/src/main/java/org/candlepin/common/exceptions/SuspendedException.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.common.exceptions;
+
+import javax.ws.rs.core.Response.Status;
+
+
+/**
+ * Thrown when Candlepin is unavailable, possibly due to Suspend Mode.
+ */
+public class SuspendedException extends CandlepinException {
+    public SuspendedException(String message) {
+        super(Status.SERVICE_UNAVAILABLE, message);
+    }
+
+    /**
+     * @param message
+     * @param e
+     */
+    public SuspendedException(String message, Throwable e) {
+        super(Status.SERVICE_UNAVAILABLE, message, e);
+    }
+
+
+}

--- a/server/spec/suspend_mode_spec.rb
+++ b/server/spec/suspend_mode_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+require 'candlepin_scenarios'
+
+describe 'Suspend mode' do
+  include CandlepinMethods
+
+  after(:each) do
+    resetMode
+  end
+
+  def resetMode
+    @cp.post('/status/mode?mode=NORMAL&reason=QPID_UP')
+  end
+
+  def changeMode(mode)
+    @cp.post("/status/mode?mode=#{mode}&reason=QPID_DOWN")
+  end
+
+  it 'should provide /status/mode endpoint' do
+    mode = @cp.get('/status/mode')
+    expect(mode).to have_key("mode")
+    expect(mode["mode"]).to eq("NORMAL")
+    changeMode("SUSPEND")
+
+    mode = @cp.get('/status/mode')
+    expect(mode).to have_key("mode")
+    expect(mode).to have_key("reason")
+ 
+    expect(mode["mode"]).to eq("SUSPEND")
+    expect(mode["reason"]).to eq("QPID_DOWN")
+  end
+
+  it 'should not accept requests when in SUSPEND mode' do
+    changeMode("SUSPEND")
+    begin
+      create_owner random_string('test_owner')
+    rescue RestClient::ServiceUnavailable => un
+      displayMessage = JSON.parse(un.response.body)["displayMessage"]
+      displayMessage.should == 'Candlepin is in Suspend mode, please check /status/mode resource to get more details'
+    end
+    expect(@cp.get_status).not_to be_empty
+  end
+
+  it 'should start receiving request when leaving SUSPEND mode' do
+    changeMode("SUSPEND")
+    expect { create_owner random_string('test_owner') }.to raise_error(RestClient::ServiceUnavailable)
+    expect(@cp.get_status).not_to be_empty
+
+    changeMode("NORMAL")
+    expect(create_owner random_string('test_owner')).to have_key("created")
+  end
+end

--- a/server/src/main/java/org/candlepin/audit/EventSinkImpl.java
+++ b/server/src/main/java/org/candlepin/audit/EventSinkImpl.java
@@ -16,6 +16,7 @@ package org.candlepin.audit;
 
 import org.candlepin.common.config.Configuration;
 import org.candlepin.config.ConfigProperties;
+import org.candlepin.controller.ModeManager;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.Entitlement;
 import org.candlepin.model.Owner;
@@ -61,6 +62,7 @@ public class EventSinkImpl implements EventSink {
     private ObjectMapper mapper;
     private EventFilter eventFilter;
     private int largeMsgSize;
+    private ModeManager modeManager;
 
     /*
      * Important use of ThreadLocal here, each Tomcat/Quartz thread gets it's own session
@@ -75,11 +77,12 @@ public class EventSinkImpl implements EventSink {
 
     @Inject
     public EventSinkImpl(EventFilter eventFilter, EventFactory eventFactory,
-        ObjectMapper mapper, Configuration config) {
+        ObjectMapper mapper, Configuration config, ModeManager modeManager) {
         this.eventFactory = eventFactory;
         this.mapper = mapper;
         this.config = config;
         this.eventFilter = eventFilter;
+        this.modeManager = modeManager;
         largeMsgSize = config.getInt(ConfigProperties.HORNETQ_LARGE_MSG_SIZE);
     }
 
@@ -172,6 +175,7 @@ public class EventSinkImpl implements EventSink {
             return;
         }
 
+        modeManager.throwRestEasyExceptionIfInSuspendMode();
         log.debug("Queuing event: {}", event);
 
         try {

--- a/server/src/main/java/org/candlepin/controller/ModeChangeListener.java
+++ b/server/src/main/java/org/candlepin/controller/ModeChangeListener.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.controller;
+
+import org.candlepin.model.CandlepinModeChange.Mode;
+
+/**
+ * Listener for Mode change events.
+ */
+public interface ModeChangeListener {
+    void modeChanged(Mode newMode);
+}

--- a/server/src/main/java/org/candlepin/controller/ModeManager.java
+++ b/server/src/main/java/org/candlepin/controller/ModeManager.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.controller;
+
+import org.candlepin.model.CandlepinModeChange;
+import org.candlepin.model.CandlepinModeChange.Mode;
+import org.candlepin.model.CandlepinModeChange.Reason;
+
+/**
+ * Class responsible for storing and managing the current Candlepin mode.
+ */
+public interface ModeManager {
+    /**
+     * Last mode change that happended. It is guaranteed that there
+     * will always be some last mode change (at least on startup the
+     * Candlepin is starting NORMAL mode)
+     * @return Information about the last mode transition
+     */
+    CandlepinModeChange getLastCandlepinModeChange();
+    /**
+     * Enters a mode m. Reason should be a machine readable enumeration
+     * @param m new Mode into which Candlepin should enter
+     * @param reason why is Candlepin entering this mode?
+     */
+    void enterMode(Mode m, Reason reason);
+    /**
+     * Checks if Candlepin is in suspend mode. In case it is, this method
+     * will throw an error. This method is useful to quickly fail requests
+     * that are running while Candlepin changes mode.
+     */
+    void throwRestEasyExceptionIfInSuspendMode();
+    /**
+     * Register a listener that will be notified when Candlepin mode changes
+     * @param list
+     */
+    void registerModeChangeListener(ModeChangeListener list);
+}

--- a/server/src/main/java/org/candlepin/controller/ModeManagerImpl.java
+++ b/server/src/main/java/org/candlepin/controller/ModeManagerImpl.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.controller;
+
+import com.google.inject.Singleton;
+import org.candlepin.common.exceptions.SuspendedException;
+import org.candlepin.model.CandlepinModeChange;
+import org.candlepin.model.CandlepinModeChange.Mode;
+import org.candlepin.model.CandlepinModeChange.Reason;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * This class drives Suspend Mode functionality. Suspend Mode is a
+ * mode where Candlepin stops serving requests and only responds to
+ * Status resource.
+ *
+ * @author fnguyen
+ */
+@Singleton
+public class ModeManagerImpl implements ModeManager {
+    private static Logger log = LoggerFactory.getLogger(ModeManagerImpl.class);
+    private CandlepinModeChange cpMode = new CandlepinModeChange(
+        new Date(), Mode.NORMAL, Reason.STARTUP);
+    private List<ModeChangeListener> listeners = new ArrayList<ModeChangeListener>();
+
+    @Override
+    public CandlepinModeChange getLastCandlepinModeChange() {
+        return cpMode;
+    }
+
+    @Override
+    public void enterMode(Mode m, Reason reason) {
+        if (reason == null) {
+            String noReasonErrorString = "No reason supplied when trying to change CandlepinModeChange.";
+            log.error(noReasonErrorString);
+            throw new IllegalArgumentException(noReasonErrorString);
+        }
+        log.info("Entering new mode {} for reason {}", m, reason);
+
+        Mode previousMode = cpMode.getMode();
+        if (previousMode != m) {
+            fireModeChangeEvent(m);
+        }
+        if (m.equals(Mode.SUSPEND)) {
+            log.warn("Candlepin is entering suspend mode for the following reason: {}", reason);
+        }
+
+        cpMode = new CandlepinModeChange(new Date(), m, reason);
+    }
+
+    @Override
+    public void throwRestEasyExceptionIfInSuspendMode() {
+        if (getLastCandlepinModeChange().getMode() == Mode.SUSPEND) {
+            log.debug("Mode manager detected SUSPEND mode and will throw SuspendException");
+            throw new SuspendedException("Candlepin is in Suspend Mode");
+        }
+    }
+
+    @Override
+    public void registerModeChangeListener(ModeChangeListener l) {
+        log.debug("Registering ModeChangeListener {} ", l.getClass().getSimpleName());
+        listeners.add(l);
+    }
+
+    private void fireModeChangeEvent(Mode newMode) {
+        log.debug("Mode changed event fired {}", newMode);
+        for (ModeChangeListener l : listeners) {
+            l.modeChanged(newMode);
+        }
+    }
+
+    private Integer getLastModeActiveTimeSeconds() {
+        return (int) ((new Date().getTime() - cpMode.getChangeTime().getTime()) / 1000);
+    }
+}

--- a/server/src/main/java/org/candlepin/model/CandlepinModeChange.java
+++ b/server/src/main/java/org/candlepin/model/CandlepinModeChange.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.model;
+
+import java.io.Serializable;
+import java.util.Date;
+
+/**
+ * Class representing candlepins mode, (NORMAL || SUSPEND),
+ * and the associated reason for this mode.
+ */
+public class CandlepinModeChange implements Serializable {
+    private static final long serialVersionUID = -7059065874812188168L;
+    private final Mode mode;
+    private final Reason reason;
+    private final Date changeTime;
+
+    /**
+     * Mode states enum.
+     */
+    public enum Mode {
+        SUSPEND,
+        NORMAL
+    }
+
+    /**
+     * Change reason
+     */
+    public enum Reason {
+        /**
+         * When Candlepin is starting up, it by default starts
+         * in NORMAL mode
+         */
+        STARTUP,
+        /**
+         * When Qpid broker isn't available, Candlepin must enter
+         * Suspend mode
+         */
+        QPID_DOWN,
+        /**
+         * Qpid comes back up
+         */
+        QPID_UP,
+        /**
+         * Qpid is overloaded to a point where its not possible to
+         * send messages to it
+         */
+        QPID_FLOW_STOPPED
+    }
+
+    public CandlepinModeChange(Date changeTime, Mode mode, Reason reason) {
+        this.mode = mode;
+        this.changeTime = changeTime;
+        this.reason = reason;
+    }
+
+    public Reason getReason() {
+        return reason;
+    }
+
+    public Mode getMode() {
+        return mode;
+    }
+
+    public Date getChangeTime() {
+        return changeTime;
+    }
+}

--- a/server/src/main/java/org/candlepin/pinsetter/core/PinsetterKernel.java
+++ b/server/src/main/java/org/candlepin/pinsetter/core/PinsetterKernel.java
@@ -25,6 +25,9 @@ import static org.quartz.impl.matchers.GroupMatcher.jobGroupEquals;
 import org.candlepin.auth.SystemPrincipal;
 import org.candlepin.common.config.Configuration;
 import org.candlepin.config.ConfigProperties;
+import org.candlepin.controller.ModeChangeListener;
+import org.candlepin.controller.ModeManager;
+import org.candlepin.model.CandlepinModeChange.Mode;
 import org.candlepin.model.JobCurator;
 import org.candlepin.pinsetter.core.model.JobStatus;
 import org.candlepin.pinsetter.tasks.CancelJobJob;
@@ -44,6 +47,7 @@ import org.quartz.JobListener;
 import org.quartz.Scheduler;
 import org.quartz.SchedulerException;
 import org.quartz.Trigger;
+import org.quartz.TriggerListener;
 import org.quartz.impl.JobDetailImpl;
 import org.quartz.impl.StdSchedulerFactory;
 import org.quartz.impl.matchers.GroupMatcher;
@@ -64,17 +68,16 @@ import java.util.Set;
  * @version $Rev$
  */
 @Singleton
-public class PinsetterKernel {
+public class PinsetterKernel implements ModeChangeListener {
 
     public static final String CRON_GROUP = "cron group";
     public static final String SINGLE_JOB_GROUP = "async group";
     public static final String[] DELETED_JOBS = new String[] { "StatisticHistoryTask" };
-
     private static Logger log = LoggerFactory.getLogger(PinsetterKernel.class);
-
     private Scheduler scheduler;
     private Configuration config;
     private JobCurator jobCurator;
+    private ModeManager modeManager;
 
     /**
      * Kernel main driver behind Pinsetter
@@ -85,11 +88,13 @@ public class PinsetterKernel {
     @Inject
     public PinsetterKernel(Configuration conf, JobFactory jobFactory,
         JobListener listener, JobCurator jobCurator,
-        StdSchedulerFactory fact) throws InstantiationException {
+        StdSchedulerFactory fact,
+        TriggerListener triggerListener,
+        ModeManager modeManager) throws InstantiationException {
 
         this.config = conf;
         this.jobCurator = jobCurator;
-
+        this.modeManager = modeManager;
         /*
          * Did your unit test get an NPE here?
          * this will help:
@@ -111,6 +116,9 @@ public class PinsetterKernel {
             if (listener != null) {
                 scheduler.getListenerManager().addJobListener(listener);
             }
+            if (triggerListener != null) {
+                scheduler.getListenerManager().addTriggerListener(triggerListener);
+            }
         }
         catch (SchedulerException e) {
             throw new InstantiationException("this.scheduler failed: " + e.getMessage());
@@ -126,6 +134,7 @@ public class PinsetterKernel {
     public void startup() throws PinsetterException {
         try {
             scheduler.start();
+            modeManager.registerModeChangeListener(this);
             configure();
         }
         catch (SchedulerException e) {
@@ -532,6 +541,36 @@ public class PinsetterKernel {
 
         public String getJobName() {
             return jobname;
+        }
+    }
+
+    private void pauseAll() {
+        try {
+            log.debug("Pinsetter Kernel is being paused");
+            scheduler.pauseAll();
+        }
+        catch (SchedulerException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void resumeAll() {
+        try {
+            log.debug("Pinsetter Kernel is being resumed");
+            scheduler.resumeAll();
+        }
+        catch (SchedulerException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void modeChanged(Mode newMode) {
+        if (newMode == Mode.SUSPEND) {
+            pauseAll();
+        }
+        else if (newMode == Mode.NORMAL) {
+            resumeAll();
         }
     }
 

--- a/server/src/main/java/org/candlepin/pinsetter/core/PinsetterTriggerListener.java
+++ b/server/src/main/java/org/candlepin/pinsetter/core/PinsetterTriggerListener.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.pinsetter.core;
+
+import com.google.inject.Inject;
+import org.candlepin.controller.ModeManager;
+import org.candlepin.model.CandlepinModeChange.Mode;
+import org.quartz.JobExecutionContext;
+import org.quartz.Trigger;
+import org.quartz.listeners.TriggerListenerSupport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This component receives events around job status and performs actions to
+ * allow for the job in question to run outside of a request scope, as well as
+ * record the status of the job for later retrieval.
+ */
+public class PinsetterTriggerListener extends TriggerListenerSupport {
+    private static Logger log = LoggerFactory.getLogger(PinsetterTriggerListener.class);
+    private ModeManager modeManager;
+
+    @Inject
+    public PinsetterTriggerListener(ModeManager modeManager) {
+        this.modeManager = modeManager;
+    }
+
+    @Override
+    public String getName() {
+        return "Suspend mode trigger listener";
+    }
+
+    @Override
+    public boolean vetoJobExecution(Trigger trigger, JobExecutionContext context) {
+        if (modeManager.getLastCandlepinModeChange().getMode() == Mode.SUSPEND) {
+            log.debug("Pinsetter trigger listener detected SUSPEND mode, " +
+                "vetoing job to be executed");
+            return true;
+        }
+        return false;
+    }
+}

--- a/server/src/main/java/org/candlepin/resteasy/filter/CandlepinSuspendModeFilter.java
+++ b/server/src/main/java/org/candlepin/resteasy/filter/CandlepinSuspendModeFilter.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.resteasy.filter;
+
+import org.candlepin.common.exceptions.SuspendedException;
+import org.candlepin.controller.ModeManager;
+import org.candlepin.model.CandlepinModeChange;
+import org.candlepin.model.CandlepinModeChange.Mode;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.Inject;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.PreMatching;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * Filter which check if Candlepin is currently in SUSPEND mode,
+ * and if so, returns appropriate error.
+ */
+@PreMatching
+@Provider
+public class CandlepinSuspendModeFilter implements ContainerRequestFilter{
+    private ModeManager modeManager;
+
+    @Inject
+    public CandlepinSuspendModeFilter(ModeManager modeManager, ObjectMapper mapper) {
+        this.modeManager = modeManager;
+    }
+
+    /**
+     * When Candlepin is in SuspendMode, this filter returns an error to the client.
+     * Status resource is still accessible, regardless of mode.
+     */
+    @Override
+    public void filter(ContainerRequestContext requestContext)
+        throws JsonProcessingException {
+
+        /**
+         * Allow status resource
+         */
+        if (requestContext.getUriInfo().getPath().startsWith("/status")) {
+            return;
+        }
+
+        CandlepinModeChange mode = modeManager.getLastCandlepinModeChange();
+        if (mode.getMode() == Mode.SUSPEND) {
+            throw new SuspendedException("Candlepin is in Suspend mode, " +
+                "please check /status/mode resource to get more details");
+        }
+    }
+
+}

--- a/server/src/test/java/org/candlepin/TestingModules.java
+++ b/server/src/test/java/org/candlepin/TestingModules.java
@@ -28,6 +28,8 @@ import org.candlepin.common.guice.JPAInitializer;
 import org.candlepin.common.validation.CandlepinMessageInterpolator;
 import org.candlepin.config.CandlepinCommonTestConfig;
 import org.candlepin.controller.CandlepinPoolManager;
+import org.candlepin.controller.ModeManager;
+import org.candlepin.controller.ModeManagerImpl;
 import org.candlepin.controller.PoolManager;
 import org.candlepin.guice.CandlepinRequestScope;
 import org.candlepin.guice.CandlepinRequestScoped;
@@ -41,6 +43,7 @@ import org.candlepin.model.Rules;
 import org.candlepin.model.RulesCurator;
 import org.candlepin.pinsetter.core.GuiceJobFactory;
 import org.candlepin.pinsetter.core.PinsetterJobListener;
+import org.candlepin.pinsetter.core.PinsetterTriggerListener;
 import org.candlepin.pinsetter.tasks.CertificateRevocationListTask;
 import org.candlepin.pki.PKIReader;
 import org.candlepin.pki.PKIUtility;
@@ -106,6 +109,7 @@ import org.jukito.TestSingleton;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.quartz.JobListener;
+import org.quartz.TriggerListener;
 import org.quartz.spi.JobFactory;
 import org.xnap.commons.i18n.I18n;
 
@@ -310,7 +314,8 @@ public class TestingModules {
 
             bind(Function.class).annotatedWith(Names.named("endDateGenerator"))
                 .to(ExpiryDateFunction.class).in(Singleton.class);
-
+            bind(ModeManager.class).to(ModeManagerImpl.class).asEagerSingleton();
+            bind(TriggerListener.class).to(PinsetterTriggerListener.class);
         }
     }
 }

--- a/server/src/test/java/org/candlepin/audit/EventSinkImplTest.java
+++ b/server/src/test/java/org/candlepin/audit/EventSinkImplTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.when;
 
 import org.candlepin.auth.Principal;
 import org.candlepin.config.CandlepinCommonTestConfig;
+import org.candlepin.controller.ModeManager;
 import org.candlepin.guice.PrincipalProvider;
 import org.candlepin.jackson.ProductCachedSerializationModule;
 import org.candlepin.model.Consumer;
@@ -72,6 +73,7 @@ public class EventSinkImplTest {
     @Mock private PrincipalProvider mockPrincipalProvider;
     @Mock private ServerLocator mockLocator;
     @Mock private ProductCurator mockProductCurator;
+    @Mock private ModeManager mockModeManager;
 
     private EventFactory factory;
     private EventFilter eventFilter;
@@ -104,7 +106,7 @@ public class EventSinkImplTest {
      */
     private EventSinkImpl createEventSink(final ClientSessionFactory sessionFactory) throws Exception {
         EventSinkImpl sink = new EventSinkImpl(eventFilter, factory, mapper,
-            new CandlepinCommonTestConfig()) {
+            new CandlepinCommonTestConfig(), mockModeManager) {
 
             @Override
             protected ClientSessionFactory createClientSessionFactory() {

--- a/server/src/test/java/org/candlepin/controller/ModeManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/ModeManagerTest.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.controller;
+
+import static java.lang.Thread.sleep;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.candlepin.common.exceptions.SuspendedException;
+import org.candlepin.model.CandlepinModeChange.Mode;
+import org.candlepin.model.CandlepinModeChange.Reason;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Date;
+
+
+public class ModeManagerTest {
+    private ModeManager modeManager;
+    private Reason testReason;
+    private boolean modeChanged;
+
+    @Before
+    public void setUp() {
+        modeManager = new ModeManagerImpl();
+        testReason = Reason.STARTUP;
+        modeChanged = false;
+    }
+
+    @Test
+    public void testInitialModeIsNormal() {
+        assertEquals(Mode.NORMAL, modeManager.getLastCandlepinModeChange().getMode());
+    }
+
+    @Test
+    public void testEnterMode() throws InterruptedException {
+        Date previousTime = modeManager.getLastCandlepinModeChange().getChangeTime();
+        Mode mode = Mode.SUSPEND;
+        sleep(1);
+        modeManager.enterMode(mode, testReason);
+        assertEquals(mode, modeManager.getLastCandlepinModeChange().getMode());
+        assertEquals(testReason, modeManager.getLastCandlepinModeChange().getReason());
+        assertTrue(previousTime.before(modeManager.getLastCandlepinModeChange().getChangeTime()));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testEnterModeNeedsReason() {
+        modeManager.enterMode(Mode.NORMAL, null);
+    }
+
+    @Test(expected = SuspendedException.class)
+    public void throwRestEasyExceptionIfInSuspendMode() {
+        modeManager.enterMode(Mode.SUSPEND, testReason);
+        modeManager.throwRestEasyExceptionIfInSuspendMode();
+    }
+
+    @Test
+    public void registerModeChangeListener() {
+        ModeChangeListener listener = new ModeChangeListener() {
+            @Override
+            public void modeChanged(Mode newMode) {
+                modeChanged = true;
+            }
+        };
+
+        modeManager.registerModeChangeListener(listener);
+        modeManager.enterMode(Mode.SUSPEND, testReason);
+        assertEquals(true, modeChanged);
+    }
+
+}

--- a/server/src/test/java/org/candlepin/resource/StatusResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/StatusResourceTest.java
@@ -27,6 +27,7 @@ import org.candlepin.audit.QpidConnection;
 import org.candlepin.audit.QpidQmf;
 import org.candlepin.cache.CandlepinCache;
 import org.candlepin.common.config.Configuration;
+import org.candlepin.controller.ModeManager;
 import org.candlepin.model.Rules;
 import org.candlepin.model.RulesCurator;
 import org.candlepin.model.Status;
@@ -65,6 +66,7 @@ public class StatusResourceTest {
     @Mock private Cache mockedStatusCache;
     @Mock private QpidConnection qpid;
     @Mock private QpidQmf qmf;
+    @Mock private ModeManager mockedModeManager;
 
     @Before
     public void setUp() {
@@ -82,7 +84,7 @@ public class StatusResourceTest {
         ps.println("version=${version}");
         ps.println("release=${release}");
         StatusResource sr = new StatusResource(rulesCurator, config, jsProvider, candlepinCache, qpid,
-            qmf);
+            qmf, mockedModeManager);
         Status s = sr.status();
         ps.close();
         assertNotNull(s);
@@ -97,7 +99,7 @@ public class StatusResourceTest {
             .getClassLoader().getResource("version.properties").toURI()));
         ps.println("foo");
         StatusResource sr = new StatusResource(rulesCurator, config, jsProvider, candlepinCache, qpid,
-            qmf);
+            qmf, mockedModeManager);
         Status s = sr.status();
         ps.close();
         assertNotNull(s);
@@ -114,7 +116,7 @@ public class StatusResourceTest {
         ps.println("release=${release}");
         when(rulesCurator.getUpdatedFromDB()).thenThrow(new RuntimeException());
         StatusResource sr = new StatusResource(rulesCurator, config, jsProvider, candlepinCache, qpid,
-            qmf);
+            qmf, mockedModeManager);
         Status s = sr.status();
         ps.close();
         assertNotNull(s);
@@ -137,8 +139,8 @@ public class StatusResourceTest {
             .getClassLoader().getResource("version.properties").toURI()));
         ps.println("version=${version}");
         ps.println("release=${release}");
-        StatusResource sr = new StatusResource(rulesCurator, null, jsProvider, candlepinCache, qpid,
-            qmf);
+        StatusResource sr = new StatusResource(rulesCurator, config, jsProvider, candlepinCache, qpid,
+            qmf, mockedModeManager);
         Status s = sr.status();
         ps.close();
 


### PR DESCRIPTION
Candlepin can enter Suspend Mode. In this mode Candlepin will only respond to Status Resource requests and pause all Pinsetter Jobs.
It is expected that as soon as Candlepin enters Suspend Mode, no more new requests or jobs are started.
It is still possible that some of the ongoing requests and jobs succeed.