### PR TITLE
1391922: Fixed concurrent ueber cert generation issues (0.9.54)

### DIFF
--- a/server/spec/ueber_cert_spec.rb
+++ b/server/spec/ueber_cert_spec.rb
@@ -119,4 +119,34 @@ describe 'Uebercert' do
     cert_content_suffix = cert_content.slice(-(exp_content_suffix.length()), exp_content_suffix.length())
     cert_content_suffix.should == exp_content_suffix
   end
+
+  it 'should handle concurrent requests to generate cert for an owner' do
+    owner = @cp.create_owner random_string("target_owner")
+    t1 = Thread.new{_generate_cert(owner)}
+    t2 = Thread.new{_generate_cert(owner)}
+    t1.join
+    t2.join
+
+    # Verify that the consumer has a single cert.
+    consumers = @cp.list_consumers({:owner => owner['key'], :type => "uebercert"})
+    consumers.should_not be_nil
+    consumers.length.should == 1
+
+    ueber_consumer = consumers[0]
+    ueber_consumer["uuid"].should_not be_nil
+    ueber_consumer["uuid"].should_not be_empty
+
+    entitlements = @cp.list_entitlements({:uuid => ueber_consumer["uuid"]})
+    entitlements.should_not be_nil
+    entitlements.length.should == 1
+    entitlements[0].should_not be_nil
+
+    # Verify that the cert can be generated again.
+    _generate_cert(owner)
+  end
+
+  def _generate_cert(owner)
+    ueber_cert = @cp.generate_ueber_cert(owner['key'])
+    ueber_cert.should_not be_nil
+  end
 end

--- a/server/src/main/java/org/candlepin/model/OwnerCurator.java
+++ b/server/src/main/java/org/candlepin/model/OwnerCurator.java
@@ -27,6 +27,8 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 
+import javax.persistence.LockModeType;
+
 /**
  * OwnerCurator
  */
@@ -47,6 +49,37 @@ public class OwnerCurator extends AbstractHibernateCurator<Owner> {
     @Override
     public Owner create(Owner entity) {
         return super.create(entity);
+    }
+
+    /**
+     * Find an owner by ownerKey and lock it.
+     *
+     * @param ownerKey the target Owner's key
+     * @return the Owner with the specified key, or null if not found.
+     */
+    @Transactional
+    public Owner findAndLock(String ownerKey) {
+        List<Owner> result = getEntityManager().createQuery("select o from Owner o where key = :ownerKey",
+                Owner.class)
+            .setParameter("ownerKey", ownerKey)
+            .setMaxResults(1)
+            .setLockMode(LockModeType.PESSIMISTIC_WRITE)
+            .getResultList();
+        if (result == null || result.isEmpty()) {
+            return null;
+        }
+        return result.get(0);
+    }
+
+    /**
+     * Refreshes the target Owner and locks it.
+     *
+     * @param owner the target owner.
+     * @return the refreshed and locked Owner.
+     */
+    public Owner lockAndLoad(Owner owner) {
+        getEntityManager().refresh(owner, LockModeType.PESSIMISTIC_WRITE);
+        return owner;
     }
 
     /**

--- a/server/src/main/java/org/candlepin/model/UeberCertificateGenerator.java
+++ b/server/src/main/java/org/candlepin/model/UeberCertificateGenerator.java
@@ -15,26 +15,34 @@
 package org.candlepin.model;
 
 import org.candlepin.auth.Principal;
+import org.candlepin.common.exceptions.BadRequestException;
+import org.candlepin.common.exceptions.NotFoundException;
 import org.candlepin.controller.PoolManager;
 import org.candlepin.model.ConsumerType.ConsumerTypeEnum;
 import org.candlepin.policy.EntitlementRefusedException;
 import org.candlepin.service.ProductServiceAdapter;
 import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.service.UniqueIdGenerator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.inject.Inject;
+import com.google.inject.persist.Transactional;
 
 import org.xnap.commons.i18n.I18n;
 
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashSet;
+import java.util.List;
 import java.util.TimeZone;
 
 /**
  * UeberCertificateGenerator
  */
 public class UeberCertificateGenerator {
+
+    private static Logger log = LoggerFactory.getLogger(UeberCertificateGenerator.class);
 
     private PoolManager poolManager;
     private PoolCurator poolCurator;
@@ -44,6 +52,9 @@ public class UeberCertificateGenerator {
     private SubscriptionServiceAdapter subService;
     private ConsumerTypeCurator consumerTypeCurator;
     private ConsumerCurator consumerCurator;
+    private EntitlementCurator entitlementCurator;
+    private EntitlementCertificateCurator entitlementCertCurator;
+    private OwnerCurator ownerCurator;
     private I18n i18n;
 
     @Inject
@@ -55,6 +66,9 @@ public class UeberCertificateGenerator {
         SubscriptionServiceAdapter subService,
         ConsumerTypeCurator consumerTypeCurator,
         ConsumerCurator consumerCurator,
+        EntitlementCurator entitlementCurator,
+        EntitlementCertificateCurator entitlementCertCurator,
+        OwnerCurator ownerCurator,
         I18n i18n) {
 
         this.poolManager = poolManager;
@@ -65,21 +79,65 @@ public class UeberCertificateGenerator {
         this.subService = subService;
         this.consumerTypeCurator = consumerTypeCurator;
         this.consumerCurator = consumerCurator;
+        this.entitlementCurator = entitlementCurator;
+        this.entitlementCertCurator = entitlementCertCurator;
+        this.ownerCurator = ownerCurator;
         this.i18n = i18n;
-
     }
 
-    public EntitlementCertificate generate(Owner o, Principal principal)
-        throws EntitlementRefusedException {
+    @Transactional
+    public EntitlementCertificate generate(String ownerKey, Principal principal) {
+        Owner o = ownerCurator.findAndLock(ownerKey);
+        if (o == null) {
+            throw new NotFoundException(i18n.tr("owner with key: {0} was not found.", ownerKey));
+        }
 
-        Product ueberProduct = createUeberProduct(o);
-        Subscription ueberSubscription = createUeberSubscription(o, ueberProduct);
-        poolManager.createPoolsForSubscription(ueberSubscription);
+        try {
+            Consumer ueberConsumer = consumerCurator.findByName(o, Consumer.UEBER_CERT_CONSUMER);
+
+            // ueber cert has already been generated - re-generate it now
+            if (ueberConsumer != null) {
+                List<Entitlement> ueberEntitlements = entitlementCurator.listByConsumer(ueberConsumer);
+
+                if (ueberEntitlements.size() > 0) {
+                    // Immediately revoke and regenerate ueber certificates:
+                    poolManager.regenerateCertificatesOf(ueberEntitlements.get(0), true, false);
+                    return entitlementCertCurator.listForConsumer(ueberConsumer).get(0);
+                }
+
+                // If there is a consumer without an entitlement, generate a new one. If an ueber pool
+                // does not exist, create it.
+                Pool ueberPool = poolCurator.findUeberPool(o);
+                if (ueberPool == null) {
+                    createSubscriptionAndPool(o);
+                    ueberPool = poolCurator.findUeberPool(o);
+                }
+                return generateUeberCertificate(ueberConsumer, ueberPool);
+            }
+
+            return this.generateCertificate(o, principal);
+        }
+        catch (Exception e) {
+            log.error("Problem generating ueber cert for owner: " + ownerKey, e);
+            throw new BadRequestException(i18n.tr("Problem generating ueber cert for owner {0}", ownerKey),
+                e);
+        }
+    }
+
+    private EntitlementCertificate generateCertificate(Owner o, Principal principal)
+        throws EntitlementRefusedException {
+        createSubscriptionAndPool(o);
         Consumer consumer = createUeberConsumer(principal, o);
 
         Pool ueberPool = poolCurator.findUeberPool(o);
         return generateUeberCertificate(consumer, ueberPool);
 
+    }
+
+    private void createSubscriptionAndPool(Owner o) {
+        Product ueberProduct = createUeberProduct(o);
+        Subscription ueberSubscription = createUeberSubscription(o, ueberProduct);
+        poolManager.createPoolsForSubscription(ueberSubscription);
     }
 
     public Product createUeberProduct(Owner o) {

--- a/server/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -1264,34 +1264,7 @@ public class OwnerResource {
     @Path("{owner_key}/uebercert")
     public EntitlementCertificate createUeberCertificate(@Context Principal principal,
         @Verify(Owner.class) @PathParam("owner_key") String ownerKey) {
-
-        Owner o = findOwner(ownerKey);
-
-        if (o == null) {
-            throw new NotFoundException(i18n.tr("owner with key: {0} was not found.", ownerKey));
-        }
-
-        try {
-            Consumer ueberConsumer = consumerCurator.findByName(o, Consumer.UEBER_CERT_CONSUMER);
-
-            // ueber cert has already been generated - re-generate it now
-            if (ueberConsumer != null) {
-                List<Entitlement> ueberEntitlements = entitlementCurator.listByConsumer(ueberConsumer);
-
-                if (ueberEntitlements.size() > 0) {
-                    // Immediately revoke and regenerate ueber certificates:
-                    poolManager.regenerateCertificatesOf(ueberEntitlements.get(0), true, false);
-                    return entitlementCertCurator.listForConsumer(ueberConsumer).get(0);
-                }
-            }
-
-            return ueberCertGenerator.generate(o, principal);
-        }
-        catch (Exception e) {
-            log.error("Problem generating ueber cert for owner: " + o.getKey(), e);
-            throw new BadRequestException(i18n.tr(
-                "Problem generating ueber cert for owner {0}", e));
-        }
+        return ueberCertGenerator.generate(ownerKey, principal);
     }
 
     /**

--- a/server/src/main/resources/db/changelog/20161025103454-cleanup-ueber-certs-round2.xml
+++ b/server/src/main/resources/db/changelog/20161025103454-cleanup-ueber-certs-round2.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+   <!-- POSTGRES, ORACLE, HSQLDB QUERIES -->
+   <property
+        dbms="postgresql,oracle,hsqldb"
+        name="delete_ueber_subs"
+        value="delete from cp_subscription
+               where id in (
+                 select s.id from cp_subscription s
+                   inner join cp_product p on s.product_id = p.id
+                   left outer join cp_pool pool on pool.productid = p.id
+                   where p.name LIKE '%_ueber_product'
+               );"/>
+
+    <property
+        dbms="postgresql,oracle,hsqldb"
+        name="delete_ueber_certs"
+        value="delete from cp_ent_certificate
+               where entitlement_id in (
+                 select e.id from cp_entitlement e
+                 inner join cp_pool p on e.pool_id = p.id
+                 inner join cp_product prod on prod.id = p.productid
+                 where prod.name like '%_ueber_product'
+               );"/>
+
+    <property
+        dbms="postgresql,oracle,hsqldb"
+        name="delete_ueber_ents"
+        value="delete from cp_entitlement
+               where pool_id in (
+                 select p.id from cp_pool p
+                 inner join cp_product prod on prod.id = p.productid
+                 where prod.name like '%_ueber_product');"/>
+
+    <property
+        dbms="postgresql,oracle,hsqldb"
+        name="delete_ueber_pools"
+        value="delete from cp_pool
+               where id in (
+                 select p.id from cp_pool p
+                 inner join cp_product prod on prod.id = p.productid
+                 where prod.name like '%_ueber_product');"/>
+
+    <property
+        dbms="postgresql,oracle,hsqldb"
+        name="delete_ueber_content"
+        value="delete from cp_content
+               where id in (
+                 select c.id from cp_content c
+                 inner join cp_product_content pc on pc.content_id = c.id
+                 inner join cp_product p on p.id = pc.product_id
+                 where p.name LIKE '%_ueber_product');"/>
+
+    <property
+        dbms="postgresql,oracle,hsqldb"
+        name="delete_ueber_products"
+        value="delete from cp_product where name like '%_ueber_product';"/>
+
+    <property
+        dbms="postgresql,oracle,hsqldb"
+        name="delete_ueber_consumers"
+        value="delete from cp_consumer where name = 'ueber_cert_consumer';"/>
+
+
+    <!-- MYSQL QUERIES -->
+
+    <property
+        dbms="mysql"
+        name="delete_ueber_subs"
+        value="delete s from cp_subscription s
+               inner join cp_product p on s.product_id = p.id
+               left outer join cp_pool pool on pool.productid = p.id
+               where p.name LIKE '%_ueber_product';"/>
+
+    <property
+        dbms="mysql"
+        name="delete_ueber_certs"
+        value="delete ec from cp_ent_certificate ec
+               inner join cp_entitlement e on ec.entitlement_id = e.id
+               inner join cp_pool p on e.pool_id = p.id
+               inner join cp_product prod on prod.id = p.productid
+               where prod.name like '%_ueber_product';"/>
+
+    <property
+        dbms="mysql"
+        name="delete_ueber_ents"
+        value="delete e from cp_entitlement e
+               inner join cp_pool p on e.pool_id = p.id
+               inner join cp_product prod on prod.id = p.productid
+               where prod.name like '%_ueber_product';"/>
+
+    <property
+        dbms="mysql"
+        name="delete_ueber_pools"
+        value="delete p from cp_pool p
+               inner join cp_product prod on prod.id = p.productid
+               where prod.name like '%_ueber_product';"/>
+
+    <property
+        dbms="mysql"
+        name="delete_ueber_content"
+        value="delete c from cp_content c
+               inner join cp_product_content pc on pc.content_id=c.id
+               inner join cp_product p on p.id=pc.product_id
+               where p.name LIKE '%_ueber_product';"/>
+
+    <property
+        dbms="mysql"
+        name="delete_ueber_products"
+        value="delete p from cp_product p where p.name LIKE '%_ueber_product';"/>
+
+    <property
+        dbms="mysql"
+        name="delete_ueber_consumers"
+        value="delete c from cp_consumer c where c.name = 'ueber_cert_consumer';"/>
+
+    <changeSet id="20161025103454-1" author="mstead">
+        <comment>Clean out all ueber cert (debug cert) data to avoid manual cleanup.
+                 We are required to do this a second time since anothe issue was
+                 found that would put the data in a strange state. In this case we fixed
+                 up transaction management when generating ueber certs and lock the owner
+                 when generating the cert.</comment>
+        <sql>${delete_ueber_subs}</sql>
+        <sql>${delete_ueber_certs}</sql>
+        <sql>${delete_ueber_ents}</sql>
+        <sql>${delete_ueber_pools}</sql>
+        <sql>${delete_ueber_content}</sql>
+        <sql>${delete_ueber_products}</sql>
+        <sql>${delete_ueber_consumers}</sql>
+    </changeSet>
+
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/server/src/main/resources/db/changelog/changelog-create.xml
+++ b/server/src/main/resources/db/changelog/changelog-create.xml
@@ -1181,4 +1181,5 @@
     <include file="db/changelog/20160819090519-delete-all-ueber-cert-data.xml"/>
     <include file="db/changelog/20160907121757-add-autobind-disabled-column-to-owner.xml"/>
     <include file="db/changelog/20161025100925-remove-unique-content-name-constraint.xml"/>
+    <include file="db/changelog/20161025103454-cleanup-ueber-certs-round2.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-testing.xml
+++ b/server/src/main/resources/db/changelog/changelog-testing.xml
@@ -2027,7 +2027,7 @@
     </changeSet>
     <changeSet author="awood" id="1413225753032-290">
         <comment>
-             Add the default quartz lock columns. 
+             Add the default quartz lock columns.
         </comment>
         <insert tableName="QRTZ_LOCKS">
             <column name="LOCK_NAME" value="TRIGGER_ACCESS"/>
@@ -2271,4 +2271,5 @@
     <include file="db/changelog/20160819090519-delete-all-ueber-cert-data.xml"/>
     <include file="db/changelog/20160907121757-add-autobind-disabled-column-to-owner.xml"/>
     <include file="db/changelog/20161025100925-remove-unique-content-name-constraint.xml"/>
+    <include file="db/changelog/20161025103454-cleanup-ueber-certs-round2.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-update.xml
+++ b/server/src/main/resources/db/changelog/changelog-update.xml
@@ -89,4 +89,5 @@
     <include file="db/changelog/20160819090519-delete-all-ueber-cert-data.xml"/>
     <include file="db/changelog/20160907121757-add-autobind-disabled-column-to-owner.xml"/>
     <include file="db/changelog/20161025100925-remove-unique-content-name-constraint.xml"/>
+    <include file="db/changelog/20161025103454-cleanup-ueber-certs-round2.xml"/>
 </databaseChangeLog>

--- a/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
@@ -114,7 +114,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
             TestUtil.createDate(2000, 3, 2), TestUtil.createDate(2005, 3, 2));
         poolCurator.create(pool);
 
-        ueberCertGenerator.generate(owner, new NoAuthPrincipal());
+        ueberCertGenerator.generate(owner.getKey(), new NoAuthPrincipal());
 
         List<Pool> results =
             poolCurator.listAvailableEntitlementPools(consumer, consumer.getOwner(),

--- a/server/src/test/java/org/candlepin/model/UeberCertGeneratorTest.java
+++ b/server/src/test/java/org/candlepin/model/UeberCertGeneratorTest.java
@@ -1,0 +1,158 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.model;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Locale;
+
+import org.candlepin.auth.Principal;
+import org.candlepin.common.exceptions.NotFoundException;
+import org.candlepin.controller.PoolManager;
+import org.candlepin.service.ProductServiceAdapter;
+import org.candlepin.service.SubscriptionServiceAdapter;
+import org.candlepin.service.UniqueIdGenerator;
+import org.candlepin.test.TestUtil;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.xnap.commons.i18n.I18n;
+import org.xnap.commons.i18n.I18nFactory;
+
+/**
+ * UeberCertGeneratorTest
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class UeberCertGeneratorTest {
+    @Mock private PoolManager poolManager;
+    @Mock private PoolCurator poolCurator;
+    @Mock private ProductServiceAdapter prodAdapter;
+    @Mock private ContentCurator contentCurator;
+    @Mock private UniqueIdGenerator idGenerator;
+    @Mock private SubscriptionServiceAdapter subService;
+    @Mock private ConsumerTypeCurator consumerTypeCurator;
+    @Mock private ConsumerCurator consumerCurator;
+    @Mock private EntitlementCurator entitlementCurator;
+    @Mock private EntitlementCertificateCurator entitlementCertCurator;
+    @Mock private OwnerCurator ownerCurator;
+    @Mock private Principal principal;
+
+    private I18n i18n;
+    private UeberCertificateGenerator ucg;
+    private Owner targetOwner;
+    private ConsumerType uConsumerType;
+
+    @Before
+    public void before() {
+        i18n = I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK);
+        ucg = new UeberCertificateGenerator(poolManager, poolCurator, prodAdapter, contentCurator,
+            idGenerator, subService, consumerTypeCurator, consumerCurator, entitlementCurator,
+            entitlementCertCurator, ownerCurator, i18n);
+        targetOwner = TestUtil.createOwner();
+
+        uConsumerType = new ConsumerType(ConsumerType.ConsumerTypeEnum.UEBER_CERT);
+        when(consumerTypeCurator.lookupByLabel(eq(ConsumerType.ConsumerTypeEnum.UEBER_CERT.toString())))
+            .thenReturn(uConsumerType);
+    }
+
+    @Test(expected = NotFoundException.class)
+    public void testGeneratorThrowsNotFoundExceptionWhenOwnerDoesNotExist() {
+        String ownerKey = "UNKNOWN";
+        when(ownerCurator.findAndLock(eq(ownerKey))).thenReturn(null);
+
+        ucg.generate(ownerKey, principal);
+    }
+
+    @Test
+    public void verifyUeberCertIsGeneratedWhenUeberConsumerIsNotFound() throws Exception {
+        when(ownerCurator.findAndLock(eq(targetOwner.getKey()))).thenReturn(targetOwner);
+        when(consumerCurator.findByName(eq(targetOwner), eq(Consumer.UEBER_CERT_CONSUMER))).thenReturn(null);
+        runGenerateTest();
+    }
+
+    @Test
+    public void verifyUeberCertIsRegeneratedWhenUeberConsumerIsFound() {
+        Consumer uConsumer = new Consumer(Consumer.UEBER_CERT_CONSUMER, principal.getUsername(), targetOwner,
+                uConsumerType);
+
+        when(ownerCurator.findAndLock(eq(targetOwner.getKey()))).thenReturn(targetOwner);
+        when(consumerCurator.findByName(eq(targetOwner), eq(Consumer.UEBER_CERT_CONSUMER)))
+            .thenReturn(uConsumer);
+
+        Product uProduct = Product.createUeberProductForOwner(targetOwner);
+        Pool uPool = TestUtil.createPool(targetOwner, uProduct);
+        EntitlementCertificate uCert = new EntitlementCertificate();
+        Entitlement uEnt = TestUtil.createEntitlement(targetOwner, uConsumer, uPool, uCert);
+        when(entitlementCurator.listByConsumer(eq(uConsumer))).thenReturn(Arrays.asList(uEnt));
+
+        EntitlementCertificate newGeneratedCert = new EntitlementCertificate();
+        when(entitlementCertCurator.listForConsumer(eq(uConsumer)))
+            .thenReturn(Arrays.asList(newGeneratedCert));
+
+        EntitlementCertificate cert = ucg.generate(targetOwner.getKey(), principal);
+        assertEquals(newGeneratedCert, cert);
+
+        // true, false
+        // Verify that the new cert was generated from the old ueber cert.
+        verify(poolManager).regenerateCertificatesOf(eq(uEnt), eq(true), eq(false));
+        verify(poolManager, never()).createPoolsForSubscription(any(Subscription.class));
+    }
+
+    private void runGenerateTest() throws Exception {
+        // Create Ueber Product
+        Product uProduct = Product.createUeberProductForOwner(targetOwner);
+        when(prodAdapter.createProduct(any(Product.class))).thenReturn(uProduct);
+
+        // Create Ueber Content
+        Content uContent = Content.createUeberContent(idGenerator, targetOwner, uProduct);
+        when(contentCurator.create(any(Content.class))).thenReturn(uContent);
+
+        // Create Ueber Subscription
+        Subscription uSub = new Subscription(targetOwner, uProduct, new HashSet<Product>(), 1L, new Date(),
+            new Date(), new Date());
+        when(subService.createSubscription(any(Subscription.class))).thenReturn(uSub);
+
+        // Create Ueber Consumer
+        Consumer uConsumer = new Consumer(Consumer.UEBER_CERT_CONSUMER, principal.getUsername(), targetOwner,
+            uConsumerType);
+        when(consumerCurator.create(any(Consumer.class))).thenReturn(uConsumer);
+
+        // Create Ueber Pool
+        Pool uPool = TestUtil.createPool(targetOwner, uProduct);
+        when(poolCurator.findUeberPool(eq(targetOwner))).thenReturn(uPool);
+
+        // Generate ueber entitlement
+        EntitlementCertificate uCert = new EntitlementCertificate();
+        Entitlement uEnt = TestUtil.createEntitlement(targetOwner, uConsumer, uPool, uCert);
+        when(poolManager.ueberCertEntitlement(eq(uConsumer), eq(uPool), eq(1))).thenReturn(uEnt);
+
+        EntitlementCertificate cert = ucg.generate(targetOwner.getKey(), principal);
+        assertNotNull(cert);
+        assertEquals(uCert, cert);
+
+        // Verify ProductContent is added to product.
+        assertFalse(uProduct.getProductContent().isEmpty());
+
+        verify(poolManager).createPoolsForSubscription(eq(uSub));
+        verify(poolManager, never()).regenerateCertificatesOf(any(Entitlement.class), any(Boolean.class),
+            any(Boolean.class));
+    }
+}


### PR DESCRIPTION
- Addressed transaction issues that would allow partial
  cert generation (combos of consumer, pool, prod, content).
- Lock the target Owner on cert generation so that checks
  for an existing cert will succeed and result in a single
  cert per owner.
- Added another changeset to delete all the ueber certificates
  since already affected candlepin instances may have invalid
  DB state due to this bug.

**Steps To Test This PR**
1. Deploy the latest version of candlepin 0954.
2. Follow steps to test in the BZ [1391922](https://bugzilla.redhat.com/show_bug.cgi?id=1391922) to reproduce.

**NOTE:** You may have to run the script a couple of times in order to get the bug to occur. See the BZ for more details. I had to run it twice, and counts are reflected in the DB query.

```bash
$ ./concurrent_ueber_cert.sh -o brewery
Creating owner brewery and generating certs...
{
  "parentOwner" : null,
  "id" : "402882e7582f5f6b01582f6180c8230d",
  "key" : "brewery",
  "displayName" : "brewery",
  "contentPrefix" : null,
  "defaultServiceLevel" : null,
  "upstreamConsumer" : null,
  "logLevel" : null,
  "autobindDisabled" : null,
  "href" : "/owners/brewery",
  "created" : "2016-11-04T12:47:48.936+0000",
  "updated" : "2016-11-04T12:47:48.936+0000"
}{
  "displayMessage" : "Problem generating ueber cert for owner org.hibernate.NonUniqueResultException: query did not return a unique result: 2",
  "requestUuid" : "1a1d52ad-7d91-4702-abc9-424a051c1646"
}{
  "displayMessage" : "Problem generating ueber cert for owner org.hibernate.NonUniqueResultException: query did not return a unique result: 2",
  "requestUuid" : "7ef66287-297b-47b0-ba35-7a707cc5d66d"
}
```

Here's the validation query. The counts should be the same across the board, but they are not.

```sql
candlepin=# SELECT (SELECT Count(*)
        FROM   cp_subscription s
               INNER JOIN cp_product p
                       ON s.product_id = p.id
               LEFT OUTER JOIN cp_pool pool
                            ON pool.productid = p.id
        WHERE  p.NAME LIKE '%_ueber_product')    AS UEBER_SUBS,
       (SELECT Count(*)
        FROM   cp_ent_certificate ec
               INNER JOIN cp_entitlement e
                       ON e.id = ec.entitlement_id
               INNER JOIN cp_pool p
                       ON e.pool_id = p.id
               INNER JOIN cp_product prod
                       ON prod.id = p.productid
        WHERE  prod.NAME LIKE '%_ueber_product') AS UEBER_ENT_CERTS,
       (SELECT Count(*)
        FROM   cp_entitlement e
               INNER JOIN cp_pool p
                       ON e.pool_id = p.id
               INNER JOIN cp_product prod
                       ON prod.id = p.productid
        WHERE  prod.NAME LIKE '%_ueber_product') AS UEBER_ENTS,
       (SELECT Count(*)
        FROM   cp_pool p
               INNER JOIN cp_product prod
                       ON prod.id = p.productid
        WHERE  prod.NAME LIKE '%_ueber_product') AS UEBER_POOLS, 
       (SELECT Count(*)
        FROM   cp_content c
               INNER JOIN cp_product_content pc
                       ON pc.content_id = c.id
               INNER JOIN cp_product p
                       ON p.id = pc.product_id
        WHERE  p.NAME LIKE '%_ueber_product')    AS UEBER_CONTENT,
       (SELECT Count(*)
        FROM   cp_product
        WHERE  NAME LIKE '%_ueber_product')      AS UEBER_PRODUCTS,
       (SELECT Count(*)
        FROM   cp_consumer
        WHERE  NAME = 'ueber_cert_consumer')     AS UEBER_CONSUMER;
  
 ueber_subs | ueber_ent_certs | ueber_ents | ueber_pools | ueber_content | ueber_products | ueber_consumer 
------------+-----------------+------------+-------------+---------------+----------------+----------------
          3 |               1 |          1 |           3 |             3 |              3 |              3
(1 row)
```
3. Getting the cert for the tartget owner will fail.

```bash
$ curl -k -u admin:admin https://localhost:8443/candlepin/owners/brewery/uebercert
{
  "displayMessage" : "Runtime Error query did not return a unique result: 2 at org.hibernate.internal.AbstractQueryImpl.uniqueElement:914",
  "requestUuid" : "dc9fdfbd-8707-4b53-ae51-d25952352d78"
}
```

4. A single regen request will fail.

```bash
$ curl -k -u admin:admin -X POST https://localhost:8443/candlepin/owners/brewery/uebercert
{
  "displayMessage" : "Problem generating ueber cert for owner org.hibernate.NonUniqueResultException: query did not return a unique result: 2",
  "requestUuid" : "bac32cb7-9497-4eb0-832d-775fd1b9efa9"
}
```

5. Deploy this patch WITHOUT regenerating the DB. The patch contains a liquibase change set to wipe out the ueber cert data. Verify with the following query. The results should show counts of 0 across the board.

```sql
candlepin=# SELECT (SELECT Count(*)
        FROM   cp_subscription s
               INNER JOIN cp_product p
                       ON s.product_id = p.id
               LEFT OUTER JOIN cp_pool pool
                            ON pool.productid = p.id
        WHERE  p.NAME LIKE '%_ueber_product')    AS UEBER_SUBS,
       (SELECT Count(*)
        FROM   cp_ent_certificate ec
               INNER JOIN cp_entitlement e
                       ON e.id = ec.entitlement_id
               INNER JOIN cp_pool p
                       ON e.pool_id = p.id
               INNER JOIN cp_product prod
                       ON prod.id = p.productid
        WHERE  prod.NAME LIKE '%_ueber_product') AS UEBER_ENT_CERTS,
       (SELECT Count(*)
        FROM   cp_entitlement e
               INNER JOIN cp_pool p
                       ON e.pool_id = p.id
               INNER JOIN cp_product prod
                       ON prod.id = p.productid
        WHERE  prod.NAME LIKE '%_ueber_product') AS UEBER_ENTS,
       (SELECT Count(*)
        FROM   cp_pool p
               INNER JOIN cp_product prod
                       ON prod.id = p.productid
        WHERE  prod.NAME LIKE '%_ueber_product') AS UEBER_POOLS, 
       (SELECT Count(*)
        FROM   cp_content c
               INNER JOIN cp_product_content pc
                       ON pc.content_id = c.id
               INNER JOIN cp_product p
                       ON p.id = pc.product_id
        WHERE  p.NAME LIKE '%_ueber_product')    AS UEBER_CONTENT,
       (SELECT Count(*)
        FROM   cp_product
        WHERE  NAME LIKE '%_ueber_product')      AS UEBER_PRODUCTS,
       (SELECT Count(*)
        FROM   cp_consumer
        WHERE  NAME = 'ueber_cert_consumer')     AS UEBER_CONSUMER;
  
 ueber_subs | ueber_ent_certs | ueber_ents | ueber_pools | ueber_content | ueber_products | ueber_consumer 
------------+-----------------+------------+-------------+---------------+----------------+----------------
          0 |               0 |          0 |           0 |             0 |              0 |              0
(1 row)
```

6. Re-run the script from the BZ again. Both cert generation requests should succeed, however, there should only be 1 set of ueber cert data in the DB. The counts from the query should increment for every owner that has an ueber cert generated, and every column should have the same count. For example, if 5 owners have a generated cert, the counts should be 5 across the board.

```bash
$ ./concurrent_ueber_cert.sh -o another_owner
Creating owner another_owner and generating certs...
{
  "parentOwner" : null,
  "id" : "402882e7582f67cc01582f89adbd0000",
  "key" : "another_owner",
  "displayName" : "another_owner",
  "contentPrefix" : null,
  "defaultServiceLevel" : null,
  "upstreamConsumer" : null,
  "logLevel" : null,
  "autobindDisabled" : null,
  "href" : "/owners/another_owner",
  "created" : "2016-11-04T13:31:41.885+0000",
  "updated" : "2016-11-04T13:31:41.885+0000"
}{
  "key" : "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEAqntFzRSj4Nj+p32CwVsBeAlE918ZhWKzWkpWXQlEoA0Kb2jN\nc8QXQnwgCUNHXSx3S6e3S4FDXsvMu/nBmoHRfCltUFumXM3LlD0OUnc5sfv23if5\nH3ykYUpazrSDrO0kRT02jVPJpOzcbA0yRrar7xyGuoQW/D5BGPlwNT3WunbFc3Hg\n28I7ebF0szYyzcnRypLMrl8Ux1n+/3tL+M2WFus8/xfEmJgAWtGh1BPg5SOqPEnH

----- SNIP -----

  "created" : "2016-11-04T13:31:43.015+0000",
  "updated" : "2016-11-04T13:31:43.015+0000"
}{
  "key" : "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEAqntFzRSj4Nj+p32CwVsBeAlE918ZhWKzWkpWXQlEoA0Kb2jN\nc8QXQnwgCUNHXSx3S6e3S4FDXsvMu/nBmoHRfCltUFumXM3LlD0OUnc5sfv23if5\nH3ykYUpazrSDrO0kRT02jVPJpOzcbA0yRrar7xyGuoQW/D5BGPlwNT3WunbFc3Hg\n28I7ebF0szYyzcnRypLMrl8Ux1n+/3tL+M2WFus8/xfEmJgAWtGh1BPg5SOqPEnH 

----- SNIP ---

  "created" : "2016-11-04T13:31:43.115+0000",
  "updated" : "2016-11-04T13:31:43.115+0000"
}
```

**NOTE:**  Both requests succeeded.

```sql
candlepin=# SELECT (SELECT Count(*)
        FROM   cp_subscription s
               INNER JOIN cp_product p
                       ON s.product_id = p.id
               LEFT OUTER JOIN cp_pool pool
                            ON pool.productid = p.id
        WHERE  p.NAME LIKE '%_ueber_product')    AS UEBER_SUBS,
       (SELECT Count(*)
        FROM   cp_ent_certificate ec
               INNER JOIN cp_entitlement e
                       ON e.id = ec.entitlement_id
               INNER JOIN cp_pool p
                       ON e.pool_id = p.id
               INNER JOIN cp_product prod
                       ON prod.id = p.productid
        WHERE  prod.NAME LIKE '%_ueber_product') AS UEBER_ENT_CERTS,
       (SELECT Count(*)
        FROM   cp_entitlement e
               INNER JOIN cp_pool p
                       ON e.pool_id = p.id
               INNER JOIN cp_product prod
                       ON prod.id = p.productid
        WHERE  prod.NAME LIKE '%_ueber_product') AS UEBER_ENTS,
       (SELECT Count(*)
        FROM   cp_pool p
               INNER JOIN cp_product prod
                       ON prod.id = p.productid
        WHERE  prod.NAME LIKE '%_ueber_product') AS UEBER_POOLS, 
       (SELECT Count(*)
        FROM   cp_content c
               INNER JOIN cp_product_content pc
                       ON pc.content_id = c.id
               INNER JOIN cp_product p
                       ON p.id = pc.product_id
        WHERE  p.NAME LIKE '%_ueber_product')    AS UEBER_CONTENT,
       (SELECT Count(*)
        FROM   cp_product
        WHERE  NAME LIKE '%_ueber_product')      AS UEBER_PRODUCTS,
       (SELECT Count(*)
        FROM   cp_consumer
        WHERE  NAME = 'ueber_cert_consumer')     AS UEBER_CONSUMER;
 
 ueber_subs | ueber_ent_certs | ueber_ents | ueber_pools | ueber
_content | ueber_products | ueber_consumer 
------------+-----------------+------------+-------------+------
---------+----------------+----------------
          1 |               1 |          1 |           1 |      
       1 |              1 |              1
(1 row)
```

7. You should be able to fetch the existing cert for the target owner.

```bash
$ curl -k -u admin:admin https://localhost:8443/candlepin/owners/another_owner/uebercert

{
  "key" : "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEAqntFzRSj4Nj+p32CwVsBeAlE918ZhWKzWkpWXQlEoA0Kb2jN\nc8QXQnwgCUNHXSx3S6e3S4FDXsvMu/nBmoHRfCltUFumXM3LlD0OUnc5sfv23if5

----- SNIP -----

  "created" : "2016-11-04T13:31:43.115+0000",
  "updated" : "2016-11-04T13:31:43.115+0000"
}
```

8. You should be able to regenerate the ueber cert.

```bash
$ curl -k -u admin:admin -X POST https://localhost:8443/candlepin/owners/another_owner/uebercert

{
  "key" : "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEAqntFzRSj4Nj+p32CwVsBeAlE918ZhWKzWkpWXQlEoA0Kb2jN\nc8QXQnwgCUNHXSx3S6e3S4FDXsvMu/nBmoHRfCltUFumXM3LlD0OUnc5sfv23if5

----- SNIP -----

  "created" : "2016-11-04T13:47:38.078+0000",
  "updated" : "2016-11-04T13:47:38.078+0000"
}
```

9. Verify the DB counts one last time.

```sql
candlepin=# SELECT (SELECT Count(*)
        FROM   cp_subscription s
               INNER JOIN cp_product p
                       ON s.product_id = p.id
               LEFT OUTER JOIN cp_pool pool
                            ON pool.productid = p.id
        WHERE  p.NAME LIKE '%_ueber_product')    AS UEBER_SUBS,
       (SELECT Count(*)
        FROM   cp_ent_certificate ec
               INNER JOIN cp_entitlement e
                       ON e.id = ec.entitlement_id
               INNER JOIN cp_pool p
                       ON e.pool_id = p.id
               INNER JOIN cp_product prod
                       ON prod.id = p.productid
        WHERE  prod.NAME LIKE '%_ueber_product') AS UEBER_ENT_CERTS,
       (SELECT Count(*)
        FROM   cp_entitlement e
               INNER JOIN cp_pool p
                       ON e.pool_id = p.id
               INNER JOIN cp_product prod
                       ON prod.id = p.productid
        WHERE  prod.NAME LIKE '%_ueber_product') AS UEBER_ENTS,
       (SELECT Count(*)
        FROM   cp_pool p
               INNER JOIN cp_product prod
                       ON prod.id = p.productid
        WHERE  prod.NAME LIKE '%_ueber_product') AS UEBER_POOLS, 
       (SELECT Count(*)
        FROM   cp_content c
               INNER JOIN cp_product_content pc
                       ON pc.content_id = c.id
               INNER JOIN cp_product p
                       ON p.id = pc.product_id
        WHERE  p.NAME LIKE '%_ueber_product')    AS UEBER_CONTENT,
       (SELECT Count(*)
        FROM   cp_product
        WHERE  NAME LIKE '%_ueber_product')      AS UEBER_PRODUCTS,
       (SELECT Count(*)
        FROM   cp_consumer
        WHERE  NAME = 'ueber_cert_consumer')     AS UEBER_CONSUMER;
 
 ueber_subs | ueber_ent_certs | ueber_ents | ueber_pools | ueber
_content | ueber_products | ueber_consumer 
------------+-----------------+------------+-------------+------
---------+----------------+----------------
          1 |               1 |          1 |           1 |      
       1 |              1 |              1
(1 row)
```