### PR TITLE
ProductManager now batches content fetching while updating products

### DIFF
--- a/server/spec/candlepin_scenarios.rb
+++ b/server/spec/candlepin_scenarios.rb
@@ -392,7 +392,7 @@ class StandardExporter < Exporter
         :attributes => { :arch => "x86_64", :virt_limit => "unlimited", 'stacking_id' => 'stack-vdc'}
     })
     @products[:product_dc] = create_product(random_string('prod-dc'), random_string(), {
-        :attributes => { :arch => "x86_64", 'stacking_id' => 'stack-dc', 'stacking_id' => 'stack-dc'}
+        :attributes => { :arch => "x86_64", 'stacking_id' => 'stack-dc'}
     })
 
     @products[:derived_product] = create_product(random_string('sub-prov-prod'), random_string(),

--- a/server/spec/import_update_single_pool_spec.rb
+++ b/server/spec/import_update_single_pool_spec.rb
@@ -11,7 +11,7 @@ describe 'Import Single Pool Update', :serial => true do
 
     def initialize
       super()
-      product = create_product(random_string(), random_string())
+      product = create_product(random_string("test_prod"), random_string())
       end_date = Date.new(2025, 5, 29)
       @pool = create_pool_and_subscription(@owner['key'], product.id, 200, [], '', '12345', '6789', nil, end_date)
       @entitlement1 = @candlepin_client.consume_pool(@pool.id, {:quantity => 15})[0]

--- a/server/src/main/java/org/candlepin/audit/Event.java
+++ b/server/src/main/java/org/candlepin/audit/Event.java
@@ -44,10 +44,13 @@ import javax.xml.bind.annotation.XmlTransient;
  * queue.
  */
 @Entity
-@Table(name = "cp_event")
+@Table(name = Event.DB_TABLE)
 @XmlRootElement(namespace = "http://fedorahosted.org/candlepin/Event")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 public class Event implements Persisted {
+
+    /** Name of the table backing this object in the database */
+    public static final String DB_TABLE = "cp_event";
 
     private static final long serialVersionUID = 1L;
 

--- a/server/src/main/java/org/candlepin/controller/ContentManager.java
+++ b/server/src/main/java/org/candlepin/controller/ContentManager.java
@@ -17,6 +17,7 @@ package org.candlepin.controller;
 import org.candlepin.model.Content;
 import org.candlepin.model.ContentCurator;
 import org.candlepin.model.Owner;
+import org.candlepin.model.OwnerContent;
 import org.candlepin.model.OwnerContentCurator;
 import org.candlepin.model.Product;
 import org.candlepin.model.ProductCurator;
@@ -31,8 +32,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 
 
@@ -78,6 +84,9 @@ public class ContentManager {
      * @throws IllegalArgumentException
      *  if contentData is null or incomplete, or owner is null
      *
+     * @throws IllegalStateException
+     *  if the contentData represents content that already exists
+     *
      * @return
      *  a new Content instance representing the specified content for the given owner
      */
@@ -88,69 +97,23 @@ public class ContentManager {
 
         if (contentData.getId() == null || contentData.getType() == null || contentData.getLabel() == null ||
             contentData.getName() == null || contentData.getVendor() == null) {
-
             throw new IllegalArgumentException("contentData is incomplete");
+        }
+
+        if (this.ownerContentCurator.contentExists(owner, contentData.getId())) {
+            throw new IllegalStateException("content has already been created: " + contentData.getId());
         }
 
         // TODO: more validation here...?
 
         Content entity = new Content(contentData.getId());
-        this.applyContentChanges(entity, contentData, owner);
-
-        return this.createContent(entity, owner);
-
-    }
-
-    /**
-     * Creates a new Content for the given owner, potentially using a different version than the
-     * entity provided if a matching entity has already been registered for another owner.
-     *
-     * @param entity
-     *  A Content instance representing the content to create
-     *
-     * @param owner
-     *  The owner for which to create the content
-     *
-     * @throws IllegalStateException
-     *  if this method is called with an entity that already exists in the backing database for the
-     *  given owner
-     *
-     * @throws NullPointerException
-     *  if entity or owner is null
-     *
-     * @return
-     *  a new Content instance representing the specified content for the given owner
-     */
-    @Transactional
-    public Content createContent(Content entity, Owner owner) {
-        if (entity == null) {
-            throw new IllegalArgumentException("entity is null");
-        }
-
-        if (owner == null) {
-            throw new IllegalArgumentException("owner is null");
-        }
+        this.applyContentChanges(entity, contentData);
 
         log.debug("Creating new content for org: {}, {}", entity, owner);
 
-        Content existing = this.ownerContentCurator.getContentById(owner, entity.getId());
-
-        // TODO: FIXME:
-        // There's a bug here where if changes are applied to an entity's collections, and then
-        // this method is called, the check below will trigger an illegal state exception, but
-        // Hibernate's helpful nature will have persisted the changes during the lookup above.
-        // This needs to be re-written to use DTOs as the primary source of entity creation, rather
-        // than a bolted-on utility method.
-
-        if (existing != null) {
-            // If we're doing an exclusive creation, this should be an error condition
-            throw new IllegalStateException("Content has already been created");
-        }
-
         // Check if we have an alternate version we can use instead.
         List<Content> alternateVersions = this.contentCurator
-            .getContentByVersion(entity.getId(), entity.getEntityVersion())
-            .list();
+            .getContentByVersion(entity.getId(), entity.getEntityVersion());
 
         log.debug("Checking {} alternate content versions", alternateVersions.size());
         for (Content alt : alternateVersions) {
@@ -174,9 +137,6 @@ public class ContentManager {
      * in. As such, once this method has been called, callers should only use the instance output by
      * this method.
      *
-     * @param entity
-     *  The content entity to update
-     *
      * @param owner
      *  The owner for which to update the content
      *
@@ -185,8 +145,7 @@ public class ContentManager {
      *  certificates for affected consumers
      *
      * @throws IllegalStateException
-     *  if this method is called with an entity does not exist in the backing database for the given
-     *  owner
+     *  if the given content update references a content that does not exist for the specified owner
      *
      * @throws IllegalArgumentException
      *  if either the provided content entity or owner are null
@@ -195,26 +154,30 @@ public class ContentManager {
      *  the updated content entity, or a new content entity
      */
     @Transactional
-    public Content updateContent(Content entity, ContentData update, Owner owner,
-        boolean regenerateEntitlementCerts) {
-
-        if (entity == null) {
-            throw new IllegalArgumentException("entity is null");
-        }
-
+    public Content updateContent(ContentData update, Owner owner, boolean regenerateEntitlementCerts) {
         if (update == null) {
             throw new IllegalArgumentException("update is null");
+        }
+
+        if (update.getId() == null) {
+            throw new IllegalArgumentException("update is incomplete");
         }
 
         if (owner == null) {
             throw new IllegalArgumentException("owner is null");
         }
 
-        log.debug("Applying content update for org: {}, {}", entity, owner);
-
         // Resolve the entity to ensure we're working with the merged entity, and to ensure it's
         // already been created.
-        entity = this.ownerContentCurator.getContentById(owner, entity.getId());
+
+        // TODO: FIXME:
+        // There's a bug here where if changes are applied to an entity's collections, and then
+        // this method is called, the check below will cause the changes to be persisted.
+        // This needs to be re-written to use DTOs as the primary source of entity creation, rather
+        // than a bolted-on utility method.
+        // If we never edit the entity directly, however, this is safe.
+
+        Content entity = this.ownerContentCurator.getContentById(owner, update.getId());
 
         if (entity == null) {
             // If we're doing an exclusive update, this should be an error condition
@@ -226,27 +189,25 @@ public class ContentManager {
             return entity;
         }
 
-        Content updated = this.applyContentChanges((Content) entity.clone(), update, owner);
+        log.debug("Applying content update for org: {}, {}", entity, owner);
+        Content updated = this.applyContentChanges((Content) entity.clone(), update);
 
         List<Content> alternateVersions = this.contentCurator
-            .getContentByVersion(update.getId(), updated.getEntityVersion())
-            .list();
+            .getContentByVersion(update.getId(), updated.getEntityVersion());
 
         log.debug("Checking {} alternate content versions", alternateVersions.size());
         for (Content alt : alternateVersions) {
             if (alt.equals(updated)) {
-                log.debug("Merging content with existing version: {} => {}", updated, alt);
+                log.debug("Converging product with existing: {} => {}", updated, alt);
 
                 // Make sure every product using the old version/entity are updated to use the new one
                 List<Product> affectedProducts = this.productCurator.getProductsWithContent(
                     owner, Arrays.asList(updated.getId())
                 );
 
-                List<Owner> owners = Arrays.asList(owner);
-                updated = this.ownerContentCurator.updateOwnerContentReferences(updated, alt, owners);
+                this.ownerContentCurator.updateOwnerContentReferences(owner,
+                    Collections.<String, String>singletonMap(entity.getUuid(), alt.getUuid()));
 
-                // Impl note:
-                // This block is a consequence of products and contents not being strongly related.
                 log.debug("Updating {} affected products", affectedProducts.size());
                 ContentData cdata = updated.toDTO();
                 for (Product product : affectedProducts) {
@@ -260,11 +221,11 @@ public class ContentManager {
                         pcd.setContent(cdata);
 
                         // Impl note: This should also take care of our entitlement cert regeneration
-                        this.productManager.updateProduct(product, pdata, owner, regenerateEntitlementCerts);
+                        this.productManager.updateProduct(pdata, owner, regenerateEntitlementCerts);
                     }
                 }
 
-                return updated;
+                return alt;
             }
         }
 
@@ -294,18 +255,17 @@ public class ContentManager {
 
         log.debug("Forking content and applying update: {}", updated);
 
-        // Clear the UUID so Hibernate doesn't think our copy is a detached entity
-        updated.setUuid(null);
-
         // Get products that currently use this content...
         List<Product> affectedProducts = this.productCurator.getProductsWithContent(
             owner, Arrays.asList(updated.getId())
         );
 
+        // Clear the UUID so Hibernate doesn't think our copy is a detached entity
+        updated.setUuid(null);
         updated = this.contentCurator.create(updated);
-        updated = this.ownerContentCurator.updateOwnerContentReferences(
-            entity, updated, Arrays.asList(owner)
-        );
+
+        this.ownerContentCurator.updateOwnerContentReferences(owner,
+            Collections.<String, String>singletonMap(entity.getUuid(), updated.getUuid()));
 
         log.debug("Updating {} affected products", affectedProducts.size());
         ContentData cdata = updated.toDTO();
@@ -313,16 +273,226 @@ public class ContentManager {
             log.debug("Updating affected product: {}", product);
             ProductData pdata = product.toDTO();
 
+            // We're taking advantage of the mutable nature of our joining objects.
+            // Probably not the best idea for long-term maintenance, but it works for now.
             ProductContentData pcd = pdata.getProductContent(updated.getId());
             if (pcd != null) {
                 pcd.setContent(cdata);
 
                 // Impl note: This should also take care of our entitlement cert regeneration
-                this.productManager.updateProduct(product, pdata, owner, regenerateEntitlementCerts);
+                this.productManager.updateProduct(pdata, owner, regenerateEntitlementCerts);
             }
         }
 
         return updated;
+    }
+
+    /**
+     * Creates or updates content from the given content DTOs, omitting product updates for the
+     * provided Red Hat product IDs.
+     * <p></p>
+     * The content DTOs provided in the given map should be mapped by the content's Red Hat ID. If
+     * the mappings are incorrect or inconsistent, the result of this method is undefined.
+     *
+     * @param owner
+     *  The owner for which to import the given content
+     *
+     * @param contentData
+     *  A mapping of Red Hat content ID to content DTOs to import
+     *
+     * @param importedProductIds
+     *  A set of Red Hat product IDs specifying products which are being imported and should not be
+     *  updated as part of this import operation
+     *
+     * @return
+     *  A mapping of Red Hat content ID to content entities representing the imported content
+     */
+    @SuppressWarnings("checkstyle:methodlength")
+    public Map<String, Content> importContent(Owner owner, Map<String, ContentData> contentData,
+        Set<String> importedProductIds) {
+
+        if (owner == null) {
+            throw new IllegalArgumentException("owner is null");
+        }
+
+        if (contentData == null || contentData.isEmpty()) {
+            // Nothing to import
+            return new HashMap<String, Content>();
+        }
+
+        Map<String, Content> importedContent = new HashMap<String, Content>();
+        Map<String, Content> createdContent = new HashMap<String, Content>();
+        Map<String, Content> updatedContent = new HashMap<String, Content>();
+
+        Map<String, Integer> contentVersions = new HashMap<String, Integer>();
+        Map<String, Content> sourceContent = new HashMap<String, Content>();
+        Map<String, List<Content>> existingVersions = new HashMap<String, List<Content>>();
+        List<OwnerContent> ownerContentBuffer = new LinkedList<OwnerContent>();
+
+        // - Divide imported products into sets of updates and creates
+        for (Content content : this.ownerContentCurator.getContentByIds(owner, contentData.keySet())) {
+            ContentData update = contentData.get(content.getId());
+
+            if (!content.isChangedBy(update)) {
+                // This content won't be changing, so we'll just pretend it's not being imported at all
+                importedContent.put(content.getId(), content);
+                continue;
+            }
+
+            // Content is coming from an upstream source; lock it so only upstream can make
+            // further changes to it. If we ever use this method for anything other than
+            // imports, we'll need to stop doing this.
+            sourceContent.put(content.getId(), content);
+            content = this.applyContentChanges((Content) content.clone(), update);
+
+            updatedContent.put(content.getId(), content);
+            contentVersions.put(content.getId(), content.getEntityVersion());
+        }
+
+        for (ContentData update : contentData.values()) {
+            if (!updatedContent.containsKey(update.getId()) && !importedContent.containsKey(update.getId())) {
+
+                // Ensure content is minimally populated
+                if (update.getId() == null || update.getType() == null || update.getLabel() == null ||
+                    update.getName() == null || update.getVendor() == null) {
+                    throw new IllegalStateException("Content data is incomplete: " + update);
+                }
+
+                // Content is coming from an upstream source; lock it so only upstream can make
+                // further changes to it. If we ever use this method for anything other than
+                // imports, we'll need to stop doing this.
+                Content content = this.applyContentChanges(new Content(update.getId()), update);
+
+                createdContent.put(content.getId(), content);
+                contentVersions.put(content.getId(), content.getEntityVersion());
+            }
+        }
+
+        for (Content alt : this.contentCurator.getContentByVersions(contentVersions)) {
+            List<Content> alternates = existingVersions.get(alt.getId());
+            if (alternates == null) {
+                alternates = new LinkedList<Content>();
+                existingVersions.put(alt.getId(), alternates);
+            }
+
+            alternates.add(alt);
+        }
+
+        contentVersions.clear();
+        contentVersions = null;
+
+        // Process the created group...
+        // Check our created set for existing versions:
+        //  - If there's an existing version, we'll remove the staged entity from the creation
+        //    set, and stage an owner-content mapping for the existing version
+        //  - Otherwise, we'll stage the new entity for persistence by leaving it in the created
+        //    set, and stage an owner-content mapping to the new entity
+        Iterator<Content> iterator = createdContent.values().iterator();
+        createdContentLoop: while (iterator.hasNext()) {
+            Content created = iterator.next();
+            List<Content> alternates = existingVersions.get(created.getId());
+
+            if (alternates != null) {
+                for (Content alt : alternates) {
+                    if (created.equals(alt)) {
+                        ownerContentBuffer.add(new OwnerContent(owner, alt));
+                        importedContent.put(alt.getId(), alt);
+                        iterator.remove();
+
+                        continue createdContentLoop;
+                    }
+                }
+            }
+
+            // TODO: If the saveAll below doesn't update these instances with a UUID, we'll have to
+            // do some work after the flush to ensure we use the instances with UUIDs.
+            ownerContentBuffer.add(new OwnerContent(owner, created));
+        }
+
+        // Process the updated group...
+        // Check our updated set for existing versions:
+        //  - If there's an existing versions, we'll update the update set to point to the existing
+        //    version
+        //  - Otherwise, we need to stage the updated entity for persistence
+        updatedContentLoop: for (Map.Entry<String, Content> entry : updatedContent.entrySet()) {
+            Content updated = entry.getValue();
+            List<Content> alternates = existingVersions.get(updated.getId());
+            if (alternates != null) {
+                for (Content alt : alternates) {
+                    if (updated.equals(alt)) {
+                        updated = alt;
+                        entry.setValue(alt);
+
+                        continue updatedContentLoop;
+                    }
+                }
+            }
+
+            // We need to stage the updated entity for persistence. We'll reuse the now-empty
+            // createdContent map for this.
+            updated.setUuid(null);
+            createdContent.put(updated.getId(), updated);
+        }
+
+        // Persist our staged entities
+        // We probably don't want to evict the content yet, as they'll appear as unmanaged if
+        // they're used later. However, the join objects can be evicted safely since they're only
+        // really used here.
+        this.contentCurator.saveAll(createdContent.values(), true, false);
+        this.ownerContentCurator.saveAll(ownerContentBuffer, true, true);
+
+        // Fetch collection of products affected by this import that aren't being imported themselves
+        List<Product> affectedProducts = this.productCurator.getProductsWithContent(
+            owner, sourceContent.keySet(), importedProductIds
+        );
+
+        if (affectedProducts != null && !affectedProducts.isEmpty()) {
+            // Get the collection of content those products use
+            Map<String, Content> affectedProductsContent = new HashMap<String, Content>();
+            for (Content content : this.contentCurator.getContentByProducts(affectedProducts)) {
+                affectedProductsContent.put(content.getId(), content);
+            }
+
+            // Update the content map so it references the updated content
+            affectedProductsContent.putAll(updatedContent);
+
+            Map<String, ProductData> affectedProductData = new HashMap<String, ProductData>();
+            for (Product product : affectedProducts) {
+                ProductData productData = product.toDTO();
+
+                for (ProductContentData pcd : productData.getProductContent()) {
+                    ContentData cdata = pcd.getContent();
+                    Content content = updatedContent.get(cdata.getId());
+
+                    if (content != null) {
+                        // We're taking advantage of the mutable nature of our joining objects.
+                        // Probably not the best idea for long-term maintenance, but it works for now.
+                        pcd.setContent(content.toDTO());
+                    }
+                }
+
+                affectedProductData.put(productData.getId(), productData);
+            }
+
+            // Perform a micro-import for these products using the content map we just built
+            this.productManager.importProducts(owner, affectedProductData, affectedProductsContent);
+        }
+
+        // Perform bulk reference update
+        Map<String, String> contentUuidMap = new HashMap<String, String>();
+        for (Content update : updatedContent.values()) {
+            Content source = sourceContent.get(update.getId());
+
+            contentUuidMap.put(source.getUuid(), update.getUuid());
+        }
+
+        this.ownerContentCurator.updateOwnerContentReferences(owner, contentUuidMap);
+
+        // Compile all our changes and return
+        importedContent.putAll(createdContent);
+        importedContent.putAll(updatedContent);
+
+        return importedContent;
     }
 
     /**
@@ -344,12 +514,9 @@ public class ContentManager {
      *
      * @throws IllegalArgumentException
      *  if entity or owner is null
-     *
-     * @return
-     *  a list of products affected by the removal of the given content
      */
     @Transactional
-    public List<Product> removeContent(Content entity, Owner owner, boolean regenerateEntitlementCerts) {
+    public void removeContent(Content entity, Owner owner, boolean regenerateEntitlementCerts) {
         if (entity == null) {
             throw new IllegalArgumentException("entity is null");
         }
@@ -372,30 +539,28 @@ public class ContentManager {
             this.productCurator.getProductsWithContent(owner, Arrays.asList(existing.getId()));
 
         // Update affected products and regenerate their certs
-        List<Product> updatedAffectedProducts = new LinkedList<Product>();
         List<Content> contentList = Arrays.asList(existing);
 
         log.debug("Updating {} affected products", affectedProducts.size());
         for (Product product : affectedProducts) {
             log.debug("Updating affected product: {}", product);
-            product = this.productManager.removeProductContent(
-                product, contentList, owner, regenerateEntitlementCerts
-            );
+            ProductData pdata = product.toDTO();
 
-            updatedAffectedProducts.add(product);
+            if (pdata.removeContent(existing.getId())) {
+                // Impl note: This should also take care of our entitlement cert regeneration
+                this.productManager.updateProduct(pdata, owner, regenerateEntitlementCerts);
+            }
         }
 
         this.ownerContentCurator.removeOwnerFromContent(existing, owner);
         if (this.ownerContentCurator.getOwnerCount(existing) == 0) {
-            // No one is using this product anymore; delete the entity
+            // No one is using this product anymore; delete the entity (should clean up everything)
             this.contentCurator.delete(existing);
         }
         else {
             // Clean up any dangling references to content
-            this.ownerContentCurator.removeOwnerContentReferences(existing, Arrays.asList(owner));
+            this.ownerContentCurator.removeOwnerContentReferences(existing, owner);
         }
-
-        return updatedAffectedProducts;
     }
 
     /**
@@ -407,26 +572,19 @@ public class ContentManager {
      * @param update
      *  The DTO containing the modifications to apply
      *
-     * @param owner
-     *  An owner to use for resolving entity references
-     *
      * @throws IllegalArgumentException
      *  if entity, update or owner is null
      *
      * @return
      *  The updated product entity
      */
-    private Content applyContentChanges(Content entity, ContentData update, Owner owner) {
+    private Content applyContentChanges(Content entity, ContentData update) {
         if (entity == null) {
             throw new IllegalArgumentException("entity is null");
         }
 
         if (update == null) {
             throw new IllegalArgumentException("update is null");
-        }
-
-        if (owner == null) {
-            throw new IllegalArgumentException("owner is null");
         }
 
         if (update.getType() != null) {

--- a/server/src/main/java/org/candlepin/hostedtest/HostedTestSubscriptionResource.java
+++ b/server/src/main/java/org/candlepin/hostedtest/HostedTestSubscriptionResource.java
@@ -257,7 +257,7 @@ public class HostedTestSubscriptionResource {
         Owner owner = this.getOwnerByKey(ownerKey);
         Product existing = this.fetchProduct(owner, productId);
 
-        Product updated = this.productManager.updateProduct(existing, update, owner, true);
+        Product updated = this.productManager.updateProduct(update, owner, true);
 
         return updated.toDTO();
 

--- a/server/src/main/java/org/candlepin/hostedtest/HostedTestSubscriptionServiceAdapter.java
+++ b/server/src/main/java/org/candlepin/hostedtest/HostedTestSubscriptionServiceAdapter.java
@@ -117,7 +117,6 @@ public class HostedTestSubscriptionServiceAdapter implements SubscriptionService
             productMap.put(s.getProduct().getId(), new ArrayList<Subscription>());
         }
 
-        log.debug("STORING PRODUCT: {} (name: {})", s.getProduct(), s.getProduct().getName());
         productMap.get(s.getProduct().getId()).add(s);
         return s;
     }

--- a/server/src/main/java/org/candlepin/model/Branding.java
+++ b/server/src/main/java/org/candlepin/model/Branding.java
@@ -38,8 +38,11 @@ import javax.xml.bind.annotation.XmlTransient;
  * See sub-classes for actual implementations tying this to a subscription or pool.
  */
 @Entity
-@Table(name = "cp_branding")
+@Table(name = Branding.DB_TABLE)
 public class Branding extends AbstractHibernateObject {
+
+    /** Name of the table backing this object in the database */
+    public static final String DB_TABLE = "cp_branding";
 
     @Id
     @GeneratedValue(generator = "system-uuid")

--- a/server/src/main/java/org/candlepin/model/Cdn.java
+++ b/server/src/main/java/org/candlepin/model/Cdn.java
@@ -37,8 +37,11 @@ import javax.xml.bind.annotation.XmlRootElement;
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @Entity
-@Table(name = "cp_cdn", uniqueConstraints = {@UniqueConstraint(columnNames = {"label"})})
+@Table(name = Cdn.DB_TABLE, uniqueConstraints = {@UniqueConstraint(columnNames = {"label"})})
 public class Cdn extends AbstractHibernateObject {
+
+    /** Name of the table backing this object in the database */
+    public static final String DB_TABLE = "cp_cdn";
 
     @Id
     @GeneratedValue(generator = "system-uuid")
@@ -126,4 +129,10 @@ public class Cdn extends AbstractHibernateObject {
         this.cert = cert;
     }
 
+    public String toString() {
+        return String.format(
+            "Cdn [id=%s, name=%s, label=%s, url=%s]",
+            this.getId(), this.getName(), this.getLabel(), this.getUrl()
+        );
+    }
 }

--- a/server/src/main/java/org/candlepin/model/CdnCertificate.java
+++ b/server/src/main/java/org/candlepin/model/CdnCertificate.java
@@ -37,8 +37,11 @@ import javax.xml.bind.annotation.XmlRootElement;
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @Entity
-@Table(name = "cp_cdn_certificate")
+@Table(name = CdnCertificate.DB_TABLE)
 public class CdnCertificate extends AbstractCertificate {
+
+    /** Name of the table backing this object in the database */
+    public static final String DB_TABLE = "cp_cdn_certificate";
 
     @Id
     @GeneratedValue(generator = "system-uuid")

--- a/server/src/main/java/org/candlepin/model/CertificateSerial.java
+++ b/server/src/main/java/org/candlepin/model/CertificateSerial.java
@@ -33,8 +33,11 @@ import javax.validation.constraints.NotNull;
  * unique serial numbers.
  */
 @Entity
-@Table(name = "cp_cert_serial")
+@Table(name = CertificateSerial.DB_TABLE)
 public class CertificateSerial extends AbstractHibernateObject {
+
+    /** Name of the table backing this object in the database */
+    public static final String DB_TABLE = "cp_cert_serial";
 
     @Id
     @GeneratedValue(generator = "serial-number")

--- a/server/src/main/java/org/candlepin/model/CertificateSerialCurator.java
+++ b/server/src/main/java/org/candlepin/model/CertificateSerialCurator.java
@@ -140,6 +140,6 @@ public class CertificateSerialCurator extends AbstractHibernateCurator<Certifica
      * unit test.
      */
     public Collection<CertificateSerial> saveOrUpdateAll(Map<String, CertificateSerial> serialMap) {
-        return this.saveOrUpdateAll(serialMap.values(), false);
+        return this.saveOrUpdateAll(serialMap.values(), false, false);
     }
 }

--- a/server/src/main/java/org/candlepin/model/Consumer.java
+++ b/server/src/main/java/org/candlepin/model/Consumer.java
@@ -74,10 +74,13 @@ import javax.xml.bind.annotation.XmlTransient;
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @Entity
-@Table(name = "cp_consumer")
+@Table(name = Consumer.DB_TABLE)
 @JsonFilter("ConsumerFilter")
 public class Consumer extends AbstractHibernateObject implements Linkable, Owned, Named, ConsumerProperty,
     Eventful {
+
+    /** Name of the table backing this object in the database */
+    public static final String DB_TABLE = "cp_consumer";
 
     public static final String UEBER_CERT_CONSUMER = "ueber_cert_consumer";
 
@@ -342,11 +345,11 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
 
     @Override
     public String toString() {
-        String consumerType = (getType() == null) ? "null" : getType().getLabel();
-        return "Consumer<id=" + getId() + ", uuid=" + getUuid() +
-                ", type=" + consumerType + ", name=" + getName() + ">";
-    }
+        String consumerType = (this.getType() != null) ? this.getType().getLabel() : "null";
 
+        return String.format("Consumer [id: %s, uuid: %s, consumerType: %s, name: %s] -- %s",
+            this.getId(), this.getUuid(), consumerType, this.getName(), super.toString());
+    }
 
     /**
      * @return all facts about this consumer.

--- a/server/src/main/java/org/candlepin/model/ConsumerCapability.java
+++ b/server/src/main/java/org/candlepin/model/ConsumerCapability.java
@@ -45,9 +45,12 @@ import javax.xml.bind.annotation.XmlRootElement;
 @XmlRootElement(name = "consumercapability")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @Entity
-@Table(name = "cp_consumer_capability")
+@Table(name = ConsumerCapability.DB_TABLE)
 
 public class ConsumerCapability implements Serializable {
+
+    /** Name of the table backing this object in the database */
+    public static final String DB_TABLE = "cp_consumer_capability";
 
     private static final long serialVersionUID = -7690166510977579116L;
 

--- a/server/src/main/java/org/candlepin/model/ConsumerCurator.java
+++ b/server/src/main/java/org/candlepin/model/ConsumerCurator.java
@@ -90,6 +90,8 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
 
     @Transactional
     public void delete(Consumer entity) {
+        log.debug("Deleting consumer: {}", entity);
+
         // save off the IDs before we delete
         DeletedConsumer dc = new DeletedConsumer(entity.getUuid(), entity.getOwner().getId(),
             entity.getOwner().getKey(), entity.getOwner().getDisplayName());

--- a/server/src/main/java/org/candlepin/model/ConsumerInstalledProduct.java
+++ b/server/src/main/java/org/candlepin/model/ConsumerInstalledProduct.java
@@ -45,8 +45,11 @@ import javax.xml.bind.annotation.XmlTransient;
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @Entity
-@Table(name = "cp_installed_products")
+@Table(name = ConsumerInstalledProduct.DB_TABLE)
 public class ConsumerInstalledProduct extends AbstractHibernateObject {
+
+    /** Name of the table backing this object in the database */
+    public static final String DB_TABLE = "cp_installed_products";
 
     @Id
     @GeneratedValue(generator = "system-uuid")

--- a/server/src/main/java/org/candlepin/model/ConsumerType.java
+++ b/server/src/main/java/org/candlepin/model/ConsumerType.java
@@ -34,8 +34,11 @@ import javax.xml.bind.annotation.XmlRootElement;
 @XmlRootElement(name = "consumertype")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @Entity
-@Table(name = "cp_consumer_type")
+@Table(name = ConsumerType.DB_TABLE)
 public class ConsumerType extends AbstractHibernateObject {
+
+    /** Name of the table backing this object in the database */
+    public static final String DB_TABLE = "cp_consumer_type";
 
     @Id
     @GeneratedValue(generator = "system-uuid")

--- a/server/src/main/java/org/candlepin/model/Content.java
+++ b/server/src/main/java/org/candlepin/model/Content.java
@@ -57,8 +57,11 @@ import javax.xml.bind.annotation.XmlTransient;
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @Entity
-@Table(name = "cp2_content")
+@Table(name = Content.DB_TABLE)
 public class Content extends AbstractHibernateObject implements SharedEntity, Cloneable {
+
+    /** Name of the table backing this object in the database */
+    public static final String DB_TABLE = "cp2_content";
 
     public static final  String UEBER_CONTENT_NAME = "ueber_content";
 

--- a/server/src/main/java/org/candlepin/model/ContentCurator.java
+++ b/server/src/main/java/org/candlepin/model/ContentCurator.java
@@ -17,11 +17,18 @@ package org.candlepin.model;
 import com.google.inject.Inject;
 import com.google.inject.persist.Transactional;
 
-import org.hibernate.criterion.DetachedCriteria;
+import org.hibernate.Criteria;
+import org.hibernate.criterion.Disjunction;
+import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 
 
 
@@ -81,17 +88,73 @@ public class ContentCurator extends AbstractHibernateCurator<Content> {
      *  a criteria for fetching content by version
      */
     @SuppressWarnings("checkstyle:indentation")
-    public CandlepinCriteria<Content> getContentByVersion(String contentId, int hashcode) {
-        DetachedCriteria criteria = this.createSecureDetachedCriteria()
+    public List<Content> getContentByVersion(String contentId, int hashcode) {
+        List<Content> result = this.createSecureCriteria()
             .add(Restrictions.eq("id", contentId))
             .add(Restrictions.or(
                 Restrictions.isNull("entityVersion"),
                 Restrictions.eq("entityVersion", hashcode)
-            ));
+            ))
+            .list();
 
-        return new CandlepinCriteria<Content>(criteria, this.currentSession());
+        return result != null ? result : new LinkedList<Content>();
     }
 
+    /**
+     * Retrieves a criteria which can be used to fetch a list of content with the specified Red Hat
+     * content ID and entity version. If no content were found matching the given criteria, this
+     * method returns an empty list.
+     *
+     * @param contentVersions
+     *  A mapping of Red Hat content IDs to content versions to fetch
+     *
+     * @return
+     *  a criteria for fetching content by version
+     */
+    @SuppressWarnings("checkstyle:indentation")
+    public List<Content> getContentByVersions(Map<String, Integer> contentVersions) {
+        List<Content> result = null;
 
+        if (contentVersions != null && !contentVersions.isEmpty()) {
+            Disjunction disjunction = Restrictions.disjunction();
+            Criteria criteria = this.createSecureCriteria().add(disjunction);
 
+            for (Map.Entry<String, Integer> entry : contentVersions.entrySet()) {
+                disjunction.add(Restrictions.and(
+                    Restrictions.eq("id", entry.getKey()),
+                    Restrictions.or(
+                        Restrictions.isNull("entityVersion"),
+                        Restrictions.eq("entityVersion", entry.getValue())
+                    )
+                ));
+            }
+
+            result = criteria.list();
+        }
+
+        return result != null ? result : new LinkedList<Content>();
+    }
+
+    /**
+     * Fetches a collection of content used by the given products
+     *
+     * @param products
+     *  The products for which to fetch content
+     *
+     * @return
+     *  A collection of content used by the specified products
+     */
+    @SuppressWarnings("unchecked")
+    public List<Content> getContentByProducts(Collection<Product> products) {
+        if (products == null || products.isEmpty()) {
+            return new LinkedList<Content>();
+        }
+
+        return this.createSecureCriteria(ProductContent.class, "productContent")
+                .createAlias("content", "content")
+                .add(this.unboundedInCriterion("product", products))
+                .setProjection(Projections.property("content"))
+                .setResultTransformer(Criteria.DISTINCT_ROOT_ENTITY)
+                .list();
+    }
 }

--- a/server/src/main/java/org/candlepin/model/ContentOverride.java
+++ b/server/src/main/java/org/candlepin/model/ContentOverride.java
@@ -33,10 +33,13 @@ import javax.xml.bind.annotation.XmlTransient;
  * different override types, consumer and activation key for now
  */
 @Entity
-@Table(name = "cp_content_override")
+@Table(name = ContentOverride.DB_TABLE)
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @DiscriminatorFormula("case when key_id is null then 'consumer' ELSE 'activation_key' end")
 public class ContentOverride extends AbstractHibernateObject {
+
+    /** Name of the table backing this object in the database */
+    public static final String DB_TABLE = "cp_content_override";
 
     @Id
     @GeneratedValue(generator = "system-uuid")

--- a/server/src/main/java/org/candlepin/model/DeletedConsumer.java
+++ b/server/src/main/java/org/candlepin/model/DeletedConsumer.java
@@ -33,8 +33,11 @@ import javax.xml.bind.annotation.XmlRootElement;
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @Entity
-@Table(name = "cp_deleted_consumers")
+@Table(name = DeletedConsumer.DB_TABLE)
 public class DeletedConsumer extends AbstractHibernateObject {
+
+    /** Name of the table backing this object in the database */
+    public static final String DB_TABLE = "cp_deleted_consumers";
 
     @Id
     @GeneratedValue(generator = "system-uuid")

--- a/server/src/main/java/org/candlepin/model/DistributorVersion.java
+++ b/server/src/main/java/org/candlepin/model/DistributorVersion.java
@@ -44,9 +44,12 @@ import javax.xml.bind.annotation.XmlRootElement;
 @XmlRootElement(name = "distributorversion")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @Entity
-@Table(name = "cp_dist_version")
+@Table(name = DistributorVersion.DB_TABLE)
 
 public class DistributorVersion extends AbstractHibernateObject {
+
+    /** Name of the table backing this object in the database */
+    public static final String DB_TABLE = "cp_dist_version";
 
     @Id
     @GeneratedValue(generator = "system-uuid")

--- a/server/src/main/java/org/candlepin/model/DistributorVersionCapability.java
+++ b/server/src/main/java/org/candlepin/model/DistributorVersionCapability.java
@@ -38,8 +38,11 @@ import javax.xml.bind.annotation.XmlTransient;
 @XmlRootElement(name = "distributorversioncapability")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @Entity
-@Table(name = "cp_dist_version_capability")
+@Table(name = DistributorVersionCapability.DB_TABLE)
 public class DistributorVersionCapability {
+
+    /** Name of the table backing this object in the database */
+    public static final String DB_TABLE = "cp_dist_version_capability";
 
     @Id
     @GeneratedValue(generator = "system-uuid")

--- a/server/src/main/java/org/candlepin/model/Entitlement.java
+++ b/server/src/main/java/org/candlepin/model/Entitlement.java
@@ -61,10 +61,13 @@ import javax.xml.bind.annotation.XmlTransient;
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @Entity
-@Table(name = "cp_entitlement")
+@Table(name = Entitlement.DB_TABLE)
 @JsonFilter("EntitlementFilter")
 public class Entitlement extends AbstractHibernateObject
     implements Linkable, Owned, Named, ConsumerProperty, Comparable<Entitlement>, Eventful {
+
+    /** Name of the table backing this object in the database */
+    public static final String DB_TABLE = "cp_entitlement";
 
     private static final long serialVersionUID = 1L;
 

--- a/server/src/main/java/org/candlepin/model/EntitlementCertificate.java
+++ b/server/src/main/java/org/candlepin/model/EntitlementCertificate.java
@@ -40,9 +40,12 @@ import javax.xml.bind.annotation.XmlTransient;
 @XmlRootElement(name = "cert")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @Entity
-@Table(name = "cp_ent_certificate")
+@Table(name = EntitlementCertificate.DB_TABLE)
 @JsonFilter("EntitlementCertificateFilter")
 public class EntitlementCertificate extends AbstractCertificate {
+
+    /** Name of the table backing this object in the database */
+    public static final String DB_TABLE = "cp_ent_certificate";
     @Id
     @GeneratedValue(generator = "system-uuid")
     @GenericGenerator(name = "system-uuid", strategy = "uuid")

--- a/server/src/main/java/org/candlepin/model/Environment.java
+++ b/server/src/main/java/org/candlepin/model/Environment.java
@@ -49,8 +49,11 @@ import javax.xml.bind.annotation.XmlTransient;
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @Entity
-@Table(name = "cp_environment")
+@Table(name = Environment.DB_TABLE)
 public class Environment extends AbstractHibernateObject implements Serializable, Owned {
+
+    /** Name of the table backing this object in the database */
+    public static final String DB_TABLE = "cp_environment";
     private static final long serialVersionUID = 4162471699021316341L;
 
     @ManyToOne

--- a/server/src/main/java/org/candlepin/model/EnvironmentContent.java
+++ b/server/src/main/java/org/candlepin/model/EnvironmentContent.java
@@ -35,8 +35,11 @@ import javax.xml.bind.annotation.XmlTransient;
  * been promoted to that environment.
  */
 @Entity
-@Table(name = "cp2_environment_content")
+@Table(name = EnvironmentContent.DB_TABLE)
 public class EnvironmentContent extends AbstractHibernateObject {
+
+    /** Name of the table backing this object in the database */
+    public static final String DB_TABLE = "cp2_environment_content";
 
     @Id
     @GeneratedValue(generator = "system-uuid")

--- a/server/src/main/java/org/candlepin/model/EnvironmentContentCurator.java
+++ b/server/src/main/java/org/candlepin/model/EnvironmentContentCurator.java
@@ -18,6 +18,8 @@ import org.hibernate.criterion.Restrictions;
 
 import java.util.List;
 
+
+
 /**
  * EnvironmentContentCurator
  */

--- a/server/src/main/java/org/candlepin/model/ExporterMetadata.java
+++ b/server/src/main/java/org/candlepin/model/ExporterMetadata.java
@@ -33,8 +33,11 @@ import javax.validation.constraints.Size;
  * ExporterMetadata
  */
 @Entity
-@Table(name = "cp_export_metadata")
+@Table(name = ExporterMetadata.DB_TABLE)
 public class ExporterMetadata extends AbstractHibernateObject {
+
+    /** Name of the table backing this object in the database */
+    public static final String DB_TABLE = "cp_export_metadata";
 
     public static final String TYPE_SYSTEM = "system";
     public static final String TYPE_PER_USER = "per_user";

--- a/server/src/main/java/org/candlepin/model/GuestId.java
+++ b/server/src/main/java/org/candlepin/model/GuestId.java
@@ -55,9 +55,12 @@ import javax.xml.bind.annotation.XmlTransient;
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @Entity
-@Table(name = "cp_consumer_guests")
+@Table(name = GuestId.DB_TABLE)
 @JsonFilter("GuestFilter")
 public class GuestId extends AbstractHibernateObject implements Owned, Named, ConsumerProperty, Eventful {
+
+    /** Name of the table backing this object in the database */
+    public static final String DB_TABLE = "cp_consumer_guests";
 
     @Id
     @GeneratedValue(generator = "system-uuid")

--- a/server/src/main/java/org/candlepin/model/HypervisorId.java
+++ b/server/src/main/java/org/candlepin/model/HypervisorId.java
@@ -51,9 +51,12 @@ import javax.xml.bind.annotation.XmlTransient;
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @Entity
-@Table(name = "cp_consumer_hypervisor", uniqueConstraints =
+@Table(name = HypervisorId.DB_TABLE, uniqueConstraints =
     @UniqueConstraint(name = "cp_consumer_hypervisor_ukey", columnNames = {"owner_id", "hypervisor_id"}))
 public class HypervisorId extends AbstractHibernateObject {
+
+    /** Name of the table backing this object in the database */
+    public static final String DB_TABLE = "cp_consumer_hypervisor";
 
     @Id
     @GeneratedValue(generator = "system-uuid")

--- a/server/src/main/java/org/candlepin/model/IdentityCertificate.java
+++ b/server/src/main/java/org/candlepin/model/IdentityCertificate.java
@@ -38,9 +38,12 @@ import javax.xml.bind.annotation.XmlTransient;
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @Entity
-@Table(name = "cp_id_cert")
+@Table(name = IdentityCertificate.DB_TABLE)
 @JsonFilter("IdentityCertificateFilter")
 public class IdentityCertificate extends AbstractCertificate {
+
+    /** Name of the table backing this object in the database */
+    public static final String DB_TABLE = "cp_id_cert";
 
     @Id
     @GeneratedValue(generator = "system-uuid")

--- a/server/src/main/java/org/candlepin/model/ImportRecord.java
+++ b/server/src/main/java/org/candlepin/model/ImportRecord.java
@@ -40,8 +40,11 @@ import javax.xml.bind.annotation.XmlTransient;
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @Entity
-@Table(name = "cp_import_record")
+@Table(name = ImportRecord.DB_TABLE)
 public class ImportRecord extends AbstractHibernateObject {
+
+    /** Name of the table backing this object in the database */
+    public static final String DB_TABLE = "cp_import_record";
 
     /**
      * The result status of an import.

--- a/server/src/main/java/org/candlepin/model/ImportUpstreamConsumer.java
+++ b/server/src/main/java/org/candlepin/model/ImportUpstreamConsumer.java
@@ -41,10 +41,13 @@ import javax.xml.bind.annotation.XmlRootElement;
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @Entity
-@Table(name = "cp_import_upstream_consumer")
+@Table(name = ImportUpstreamConsumer.DB_TABLE)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonFilter("ApiHateoas")
 public class ImportUpstreamConsumer extends AbstractHibernateObject {
+
+    /** Name of the table backing this object in the database */
+    public static final String DB_TABLE = "cp_import_upstream_consumer";
 
     @Id
     @GeneratedValue(generator = "system-uuid")

--- a/server/src/main/java/org/candlepin/model/KeyPair.java
+++ b/server/src/main/java/org/candlepin/model/KeyPair.java
@@ -31,8 +31,11 @@ import javax.validation.constraints.NotNull;
  * the database for re-use when generating entitlement and identity certificates.
  */
 @Entity
-@Table(name = "cp_key_pair")
+@Table(name = KeyPair.DB_TABLE)
 public class KeyPair extends AbstractHibernateObject{
+
+    /** Name of the table backing this object in the database */
+    public static final String DB_TABLE = "cp_key_pair";
 
     @Id
     @GeneratedValue(generator = "system-uuid")

--- a/server/src/main/java/org/candlepin/model/ManifestFileRecord.java
+++ b/server/src/main/java/org/candlepin/model/ManifestFileRecord.java
@@ -42,8 +42,11 @@ import org.hibernate.annotations.GenericGenerator;
  * the implemented {@link ManifestFileService}.
  */
 @Entity
-@Table(name = "cp_manifest_file_record")
+@Table(name = ManifestFileRecord.DB_TABLE)
 public class ManifestFileRecord extends AbstractHibernateObject implements ManifestFile {
+
+    /** Name of the table backing this object in the database */
+    public static final String DB_TABLE = "cp_manifest_file_record";
 
     @Id
     @GeneratedValue(generator = "system-uuid")

--- a/server/src/main/java/org/candlepin/model/Owner.java
+++ b/server/src/main/java/org/candlepin/model/Owner.java
@@ -53,10 +53,13 @@ import io.swagger.annotations.ApiModelProperty;
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @Entity
-@Table(name = "cp_owner")
+@Table(name = Owner.DB_TABLE)
 @JsonFilter("OwnerFilter")
 public class Owner extends AbstractHibernateObject implements Serializable,
     Linkable, Owned, Named, Eventful {
+
+    /** Name of the table backing this object in the database */
+    public static final String DB_TABLE = "cp_owner";
     private static final long serialVersionUID = -7059065874812188165L;
 
     @OneToOne

--- a/server/src/main/java/org/candlepin/model/OwnerProduct.java
+++ b/server/src/main/java/org/candlepin/model/OwnerProduct.java
@@ -22,6 +22,8 @@ import javax.persistence.Id;
 import javax.persistence.IdClass;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.PrePersist;
+import javax.persistence.PreUpdate;
 import javax.persistence.Table;
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -39,9 +41,12 @@ import javax.xml.bind.annotation.XmlRootElement;
  */
 @XmlRootElement
 @Entity
-@Table(name = "cp2_owner_products")
+@Table(name = OwnerProduct.DB_TABLE)
 @IdClass(OwnerProductKey.class)
 public class OwnerProduct implements Persisted, Serializable {
+
+    /** Name of the table backing this object in the database */
+    public static final String DB_TABLE = "cp2_owner_products";
     private static final long serialVersionUID = -7059065874812188165L;
 
     /**
@@ -77,6 +82,7 @@ public class OwnerProduct implements Persisted, Serializable {
 
     @Override
     public Serializable getId() {
+        this.applyObjectIds();
         return new OwnerProductKey(this.ownerId, this.productUuid);
     }
 
@@ -85,14 +91,7 @@ public class OwnerProduct implements Persisted, Serializable {
     }
 
     public void setOwner(Owner owner) {
-        if (owner.getId() == null) {
-            throw new IllegalStateException(
-                "Owner must be persisted before it can be linked to a product"
-            );
-        }
-
         this.owner = owner;
-        this.ownerId = owner.getId();
     }
 
     public Product getProduct() {
@@ -100,14 +99,49 @@ public class OwnerProduct implements Persisted, Serializable {
     }
 
     public void setProduct(Product product) {
-        if (product.getUuid() == null) {
+        this.product = product;
+    }
+
+    /**
+     * Sets the database object IDs this join object uses to link owners to content. If either the
+     * owner or content are not present or have not been persisted with a valid ID or UUID, this
+     * method will throw an IllegalStateException.
+     *
+     * @throws IllegalStateException
+     *  if either owner or content are null or unpersisted
+     */
+    protected void applyObjectIds() {
+        if (this.owner == null) {
+            throw new IllegalStateException("An owner must be specified to link products");
+        }
+
+        if (this.owner.getId() == null) {
+            throw new IllegalStateException(
+                "Owner must be persisted before it can be linked to products"
+            );
+        }
+
+        if (this.product == null) {
+            throw new IllegalStateException("A product must be specified to link an owner");
+        }
+
+        if (this.product.getUuid() == null) {
             throw new IllegalStateException(
                 "Product must be persisted before it can be linked to an owner"
             );
         }
 
-        this.product = product;
+        this.ownerId = owner.getId();
         this.productUuid = product.getUuid();
     }
 
+    @PrePersist
+    protected void onCreate() {
+        this.applyObjectIds();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.applyObjectIds();
+    }
 }

--- a/server/src/main/java/org/candlepin/model/PermissionBlueprint.java
+++ b/server/src/main/java/org/candlepin/model/PermissionBlueprint.java
@@ -42,8 +42,11 @@ import javax.xml.bind.annotation.XmlTransient;
  * the required permissions for the authenticating principal.
  */
 @Entity
-@Table(name = "cp_permission")
+@Table(name = PermissionBlueprint.DB_TABLE)
 public class PermissionBlueprint extends AbstractHibernateObject {
+
+    /** Name of the table backing this object in the database */
+    public static final String DB_TABLE = "cp_permission";
 
     @Id
     @GeneratedValue(generator = "system-uuid")

--- a/server/src/main/java/org/candlepin/model/Pool.java
+++ b/server/src/main/java/org/candlepin/model/Pool.java
@@ -66,10 +66,13 @@ import javax.xml.bind.annotation.XmlTransient;
 @XmlRootElement(name = "pool")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @Entity
-@Table(name = "cp_pool")
+@Table(name = Pool.DB_TABLE)
 @JsonFilter("PoolFilter")
 public class Pool extends AbstractHibernateObject implements Persisted, Owned, Named, Comparable<Pool>,
     Eventful {
+
+    /** Name of the table backing this object in the database */
+    public static final String DB_TABLE = "cp_pool";
 
     /**
      * Common pool attributes
@@ -741,11 +744,11 @@ public class Pool extends AbstractHibernateObject implements Persisted, Owned, N
 
     public String toString() {
         return String.format(
-            "Pool<type=%s, product=%s, productName=%s, id=%s, quantity=%s>",
+            "Pool [id=%s, type=%s, product=%s, productName=%s, quantity=%s]",
+            this.getId(),
             this.getType(),
             this.getProductId(),
             this.getProductName(),
-            this.getId(),
             this.getQuantity()
         );
     }

--- a/server/src/main/java/org/candlepin/model/PoolAttribute.java
+++ b/server/src/main/java/org/candlepin/model/PoolAttribute.java
@@ -40,10 +40,13 @@ import javax.xml.bind.annotation.XmlTransient;
  * An abstract base class for Pool attributes.
  */
 @Entity(name = "PoolAttribute")
-@Table(name = "cp_pool_attribute")
+@Table(name = PoolAttribute.DB_TABLE)
 @Embeddable
 @JsonFilter("PoolAttributeFilter")
 public class PoolAttribute extends AbstractHibernateObject implements Attribute {
+
+    /** Name of the table backing this object in the database */
+    public static final String DB_TABLE = "cp_pool_attribute";
 
     @Id
     @GeneratedValue(generator = "system-uuid")

--- a/server/src/main/java/org/candlepin/model/Product.java
+++ b/server/src/main/java/org/candlepin/model/Product.java
@@ -74,8 +74,11 @@ import javax.xml.bind.annotation.XmlTransient;
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @Entity
-@Table(name = "cp2_products")
+@Table(name = Product.DB_TABLE)
 public class Product extends AbstractHibernateObject implements SharedEntity, Linkable, Cloneable {
+
+    /** Name of the table backing this object in the database */
+    public static final String DB_TABLE = "cp2_products";
     /**
      * Commonly used/recognized product attributes
      */

--- a/server/src/main/java/org/candlepin/model/ProductAttribute.java
+++ b/server/src/main/java/org/candlepin/model/ProductAttribute.java
@@ -43,10 +43,13 @@ import javax.xml.bind.annotation.XmlTransient;
  * See Attributes interface for documentation.
  */
 @Entity
-@Table(name = "cp2_product_attributes")
+@Table(name = ProductAttribute.DB_TABLE)
 @Embeddable
 @JsonFilter("ProductAttributeFilter")
 public class ProductAttribute extends AbstractHibernateObject implements Attribute {
+
+    /** Name of the table backing this object in the database */
+    public static final String DB_TABLE = "cp2_product_attributes";
 
     @Id
     @GeneratedValue(generator = "system-uuid")

--- a/server/src/main/java/org/candlepin/model/ProductCertificate.java
+++ b/server/src/main/java/org/candlepin/model/ProductCertificate.java
@@ -34,9 +34,12 @@ import javax.xml.bind.annotation.XmlTransient;
  */
 @XmlRootElement(name = "cert")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@Table(name = "cp2_product_certificates")
+@Table(name = ProductCertificate.DB_TABLE)
 @Entity
 public class ProductCertificate extends AbstractCertificate {
+
+    /** Name of the table backing this object in the database */
+    public static final String DB_TABLE = "cp2_product_certificates";
 
     @Id
     @GeneratedValue(generator = "system-uuid")

--- a/server/src/main/java/org/candlepin/model/Role.java
+++ b/server/src/main/java/org/candlepin/model/Role.java
@@ -37,8 +37,11 @@ import javax.validation.constraints.Size;
  * Roles represent the relationship between users and the permissions they have.
  */
 @Entity
-@Table(name = "cp_role")
+@Table(name = Role.DB_TABLE)
 public class Role extends AbstractHibernateObject implements Linkable {
+
+    /** Name of the table backing this object in the database */
+    public static final String DB_TABLE = "cp_role";
 
     @Id
     @GeneratedValue(generator = "system-uuid")

--- a/server/src/main/java/org/candlepin/model/Rules.java
+++ b/server/src/main/java/org/candlepin/model/Rules.java
@@ -40,9 +40,12 @@ import javax.xml.bind.annotation.XmlTransient;
  * Rules
  */
 @Entity
-@Table(name = "cp_rules")
+@Table(name = Rules.DB_TABLE)
 @Embeddable
 public class Rules extends AbstractHibernateObject implements Named, Eventful {
+
+    /** Name of the table backing this object in the database */
+    public static final String DB_TABLE = "cp_rules";
 
     private static final Pattern VERSION_REGEX =
         Pattern.compile("[//|#]+ *[V|v]ersion: *([0-9]+(\\.[0-9]+)*) *");

--- a/server/src/main/java/org/candlepin/model/SourceStack.java
+++ b/server/src/main/java/org/candlepin/model/SourceStack.java
@@ -43,8 +43,11 @@ import javax.xml.bind.annotation.XmlTransient;
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @Entity
-@Table(name = "cp_pool_source_stack")
+@Table(name = SourceStack.DB_TABLE)
 public class SourceStack extends AbstractHibernateObject {
+
+    /** Name of the table backing this object in the database */
+    public static final String DB_TABLE = "cp_pool_source_stack";
 
     @Id
     @GeneratedValue(generator = "system-uuid")

--- a/server/src/main/java/org/candlepin/model/SourceSubscription.java
+++ b/server/src/main/java/org/candlepin/model/SourceSubscription.java
@@ -39,8 +39,11 @@ import javax.xml.bind.annotation.XmlTransient;
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @Entity
-@Table(name = "cp2_pool_source_sub")
+@Table(name = SourceSubscription.DB_TABLE)
 public class SourceSubscription extends AbstractHibernateObject {
+
+    /** Name of the table backing this object in the database */
+    public static final String DB_TABLE = "cp2_pool_source_sub";
 
     @Id
     @GeneratedValue(generator = "system-uuid")

--- a/server/src/main/java/org/candlepin/model/SubscriptionsCertificate.java
+++ b/server/src/main/java/org/candlepin/model/SubscriptionsCertificate.java
@@ -41,9 +41,12 @@ import javax.xml.bind.annotation.XmlRootElement;
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @Entity
-@Table(name = "cp_certificate")
+@Table(name = SubscriptionsCertificate.DB_TABLE)
 @JsonFilter("SubscriptionCertificateFilter")
 public class SubscriptionsCertificate extends AbstractCertificate {
+
+    /** Name of the table backing this object in the database */
+    public static final String DB_TABLE = "cp_certificate";
 
     @Id
     @GeneratedValue(generator = "system-uuid")
@@ -76,5 +79,15 @@ public class SubscriptionsCertificate extends AbstractCertificate {
      */
     public void setId(String id) {
         this.id = id;
+    }
+
+    public String toString() {
+        String serial = null;
+
+        if (this.serial != null) {
+            serial = String.format("Serial [id=%s]", this.serial.getId());
+        }
+
+        return String.format("Cert [id=%s, serial=%s]", this.id, serial);
     }
 }

--- a/server/src/main/java/org/candlepin/model/UpstreamConsumer.java
+++ b/server/src/main/java/org/candlepin/model/UpstreamConsumer.java
@@ -42,9 +42,12 @@ import javax.xml.bind.annotation.XmlRootElement;
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @Entity
-@Table(name = "cp_upstream_consumer")
+@Table(name = UpstreamConsumer.DB_TABLE)
 @JsonFilter("ApiHateoas")
 public class UpstreamConsumer extends AbstractHibernateObject {
+
+    /** Name of the table backing this object in the database */
+    public static final String DB_TABLE = "cp_upstream_consumer";
 
     @Id
     @GeneratedValue(generator = "system-uuid")

--- a/server/src/main/java/org/candlepin/model/User.java
+++ b/server/src/main/java/org/candlepin/model/User.java
@@ -48,8 +48,11 @@ import javax.xml.bind.annotation.XmlTransient;
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @Entity
-@Table(name = "cp_user")
+@Table(name = User.DB_TABLE)
 public class User extends AbstractHibernateObject {
+
+    /** Name of the table backing this object in the database */
+    public static final String DB_TABLE = "cp_user";
 
     @Id
     @GeneratedValue(generator = "system-uuid")

--- a/server/src/main/java/org/candlepin/model/activationkeys/ActivationKey.java
+++ b/server/src/main/java/org/candlepin/model/activationkeys/ActivationKey.java
@@ -53,9 +53,12 @@ import javax.xml.bind.annotation.XmlRootElement;
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @Entity
-@Table(name = "cp_activation_key",
+@Table(name = ActivationKey.DB_TABLE,
     uniqueConstraints = {@UniqueConstraint(columnNames = {"name", "owner_id"})})
 public class ActivationKey extends AbstractHibernateObject implements Owned, Named, Eventful {
+
+    /** Name of the table backing this object in the database */
+    public static final String DB_TABLE = "cp_activation_key";
 
     public static final int RELEASE_VERSION_LENGTH = 255;
 

--- a/server/src/main/java/org/candlepin/model/activationkeys/ActivationKeyPool.java
+++ b/server/src/main/java/org/candlepin/model/activationkeys/ActivationKeyPool.java
@@ -41,9 +41,12 @@ import javax.xml.bind.annotation.XmlTransient;
 @XmlRootElement
 @Entity
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@Table(name = "cp_activationkey_pool",
+@Table(name = ActivationKeyPool.DB_TABLE,
     uniqueConstraints = {@UniqueConstraint(columnNames = {"key_id", "pool_id"})})
 public class ActivationKeyPool extends AbstractHibernateObject implements Comparable<ActivationKeyPool> {
+
+    /** Name of the table backing this object in the database */
+    public static final String DB_TABLE = "cp_activationkey_pool";
 
     @Id
     @GeneratedValue(generator = "system-uuid")

--- a/server/src/main/java/org/candlepin/pinsetter/core/model/JobStatus.java
+++ b/server/src/main/java/org/candlepin/pinsetter/core/model/JobStatus.java
@@ -50,8 +50,11 @@ import javax.xml.bind.annotation.XmlTransient;
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @Entity
-@Table(name = "cp_job")
+@Table(name = JobStatus.DB_TABLE)
 public class JobStatus extends AbstractHibernateObject {
+
+    /** Name of the table backing this object in the database */
+    public static final String DB_TABLE = "cp_job";
 
     public static final String TARGET_TYPE = "target_type";
     public static final String TARGET_ID = "target_id";

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/RefreshPoolsJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/RefreshPoolsJob.java
@@ -91,24 +91,23 @@ public class RefreshPoolsJob extends UniqueByEntityJob {
             while (cause != null) {
                 if (SQLException.class.isAssignableFrom(cause.getClass())) {
                     log.warn("Caught a runtime exception wrapping an SQLException.");
-                    throw new RetryJobException("RefreshPoolsJob encountered a problem.",
-                            e);
+                    throw new RetryJobException("RefreshPoolsJob encountered a problem.", e);
                 }
                 cause = cause.getCause();
             }
 
             // Otherwise throw as we would normally for any generic Exception:
             log.error("RefreshPoolsJob encountered a problem.", e);
-            context.setResult(e.getMessage());
-            throw new JobExecutionException(e.getMessage(), e, false);
+            context.setResult(e.toString());
+            throw new JobExecutionException(e.toString(), e, false);
         }
         // Catch any other exception that is fired and re-throw as a
         // JobExecutionException so that the job will be properly
         // cleaned up on failure.
         catch (Exception e) {
             log.error("RefreshPoolsJob encountered a problem.", e);
-            context.setResult(e.getMessage());
-            throw new JobExecutionException(e.getMessage(), e, false);
+            context.setResult(e.toString());
+            throw new JobExecutionException(e.toString(), e, false);
         }
     }
 

--- a/server/src/main/java/org/candlepin/resource/DeletedConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/DeletedConsumerResource.java
@@ -55,8 +55,7 @@ public class DeletedConsumerResource {
     @Produces(MediaType.APPLICATION_JSON)
     public List<DeletedConsumer> listByDate(@QueryParam("date") String dateStr) {
         if (dateStr != null) {
-            return deletedConsumerCurator.findByDate(
-                    ResourceDateParser.parseDateString(dateStr));
+            return deletedConsumerCurator.findByDate(ResourceDateParser.parseDateString(dateStr));
         }
         else {
             return deletedConsumerCurator.listAll();

--- a/server/src/main/java/org/candlepin/resource/OwnerContentResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerContentResource.java
@@ -228,7 +228,7 @@ public class OwnerContentResource {
                     throw new ForbiddenException(i18n.tr("content \"{0}\" is locked", existing.getId()));
                 }
 
-                entity = this.contentManager.updateContent(existing, content, owner, true);
+                entity = this.contentManager.updateContent(content, owner, true);
             }
             else {
                 entity = this.contentManager.createContent(content, owner);
@@ -288,7 +288,7 @@ public class OwnerContentResource {
             throw new ForbiddenException(i18n.tr("content \"{0}\" is locked", existing.getId()));
         }
 
-        existing = this.contentManager.updateContent(existing, content, owner, true);
+        existing = this.contentManager.updateContent(content, owner, true);
         return existing.toDTO();
     }
 

--- a/server/src/main/java/org/candlepin/resource/OwnerProductResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerProductResource.java
@@ -243,8 +243,6 @@ public class OwnerProductResource {
         Owner owner = this.getOwnerByKey(ownerKey);
         Product product = this.fetchProduct(owner, productId);
 
-        log.debug("RETURNING PRODUCT WITH CONTENT: {}", product.getProductContent());
-
         return product.toDTO();
     }
 
@@ -279,8 +277,6 @@ public class OwnerProductResource {
         Owner owner = this.getOwnerByKey(ownerKey);
         Product entity = productManager.createProduct(product, owner);
 
-        log.debug("PRODUCT CREATED: {}", entity);
-
         return entity.toDTO();
     }
 
@@ -303,7 +299,7 @@ public class OwnerProductResource {
             throw new ForbiddenException(i18n.tr("product \"{0}\" is locked", existing.getId()));
         }
 
-        Product updated = this.productManager.updateProduct(existing, update, owner, true);
+        Product updated = this.productManager.updateProduct(update, owner, true);
 
         return updated.toDTO();
     }

--- a/server/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -875,7 +875,7 @@ public class OwnerResource {
         EventBuilder eventBuilder = eventFactory.getEventBuilder(Target.OWNER, Type.MODIFIED)
             .setOldEntity(toUpdate);
 
-        log.debug("Updating owner: " + key);
+        log.debug("Updating owner: {}", key);
 
         if (owner.getDisplayName() != null) {
             toUpdate.setDisplayName(owner.getDisplayName());
@@ -1212,7 +1212,6 @@ public class OwnerResource {
         MultipartInput input) {
 
         ConflictOverrides overrides = processConflictOverrideParams(overrideConflicts);
-
         UploadMetadata fileData = new UploadMetadata();
         Owner owner = findOwner(ownerKey);
         try {
@@ -1489,6 +1488,7 @@ public class OwnerResource {
         catch (IllegalArgumentException e) {
             throw new BadRequestException(i18n.tr("Unknown conflict to force"));
         }
+
         return overrides;
     }
 

--- a/server/src/main/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapter.java
+++ b/server/src/main/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapter.java
@@ -444,7 +444,7 @@ public class DefaultEntitlementCertServiceAdapter extends BaseEntitlementCertSer
         }
 
         log.info("Persisting certs.");
-        entCertCurator.saveOrUpdateAll(entitlementCerts.values(), false);
+        entCertCurator.saveOrUpdateAll(entitlementCerts.values(), false, false);
 
         return entitlementCerts;
     }

--- a/server/src/main/java/org/candlepin/sync/CdnImporter.java
+++ b/server/src/main/java/org/candlepin/sync/CdnImporter.java
@@ -38,10 +38,8 @@ public class CdnImporter {
         this.curator = curator;
     }
 
-    public Cdn createObject(ObjectMapper mapper, Reader reader)
-        throws IOException {
-        Cdn cdn = mapper.readValue(reader,
-            Cdn.class);
+    public Cdn createObject(ObjectMapper mapper, Reader reader) throws IOException {
+        Cdn cdn = mapper.readValue(reader, Cdn.class);
         cdn.setId(null);
         return cdn;
     }
@@ -54,14 +52,14 @@ public class CdnImporter {
         for (Cdn cdn : cdnSet) {
             Cdn existing = curator.lookupByLabel(cdn.getLabel());
             if (existing == null) {
+                log.debug("Creating CDN: {}", cdn);
                 curator.create(cdn);
-                log.debug("Created CDN: " + cdn.getName());
             }
             else {
+                log.debug("Updating CDN: {}", cdn);
                 existing.setName(cdn.getName());
                 existing.setUrl(cdn.getUrl());
                 curator.merge(existing);
-                log.debug("Updating CDN: " + cdn.getName());
             }
         }
     }

--- a/server/src/main/java/org/candlepin/sync/EntitlementImporter.java
+++ b/server/src/main/java/org/candlepin/sync/EntitlementImporter.java
@@ -96,8 +96,7 @@ public class EntitlementImporter {
         subscription.setQuantity(entitlement.getQuantity().longValue());
 
         for (Branding b : entitlement.getPool().getBranding()) {
-            subscription.getBranding().add(new Branding(b.getProductId(), b.getType(),
-                b.getName()));
+            subscription.getBranding().add(new Branding(b.getProductId(), b.getType(), b.getName()));
         }
 
         String cdnLabel = meta.getCdnLabel();
@@ -124,17 +123,20 @@ public class EntitlementImporter {
         // subscriptions have one cert
         int entcnt = 0;
         for (EntitlementCertificate cert : certs) {
-            entcnt++;
+            ++entcnt;
+
             CertificateSerial cs = new CertificateSerial();
             cs.setCollected(cert.getSerial().isCollected());
             cs.setExpiration(cert.getSerial().getExpiration());
             cs.setUpdated(cert.getSerial().getUpdated());
             cs.setCreated(cert.getSerial().getCreated());
             csCurator.create(cs);
+
             SubscriptionsCertificate sc = new SubscriptionsCertificate();
             sc.setKey(cert.getKey());
             sc.setCertAsBytes(cert.getCertAsBytes());
             sc.setSerial(cs);
+
             subscription.setCertificate(sc);
         }
 

--- a/server/src/main/java/org/candlepin/util/CrlFileUtil.java
+++ b/server/src/main/java/org/candlepin/util/CrlFileUtil.java
@@ -314,7 +314,7 @@ public class CrlFileUtil {
             this.updateCRLFile(file, revoke, unrevoke);
 
             // Store the state of the newly-revoked serials as "collected"
-            this.certificateSerialCurator.saveOrUpdateAll(serials, true);
+            this.certificateSerialCurator.saveOrUpdateAll(serials, true, true);
         }
 
         return true;

--- a/server/src/test/java/org/candlepin/TestingModules.java
+++ b/server/src/test/java/org/candlepin/TestingModules.java
@@ -265,21 +265,16 @@ public class TestingModules {
             bind(EnvironmentResource.class);
             bind(SubscriptionResource.class);
             bind(ActivationKeyResource.class);
-            bind(ProductServiceAdapter.class)
-                .to(DefaultProductServiceAdapter.class);
+            bind(ProductServiceAdapter.class).to(DefaultProductServiceAdapter.class);
             bind(ProductResource.class);
-            bind(DateSource.class).to(DateSourceForTesting.class)
-                .asEagerSingleton();
+            bind(DateSource.class).to(DateSourceForTesting.class).asEagerSingleton();
             bind(Enforcer.class).to(EnforcerForTesting.class); // .to(JavascriptEnforcer.class);
-            bind(SubjectKeyIdentifierWriter.class).to(
-                DefaultSubjectKeyIdentifierWriter.class);
+            bind(SubjectKeyIdentifierWriter.class).to(DefaultSubjectKeyIdentifierWriter.class);
             bind(PKIUtility.class).to(BouncyCastlePKIUtility.class);
             bind(PKIReader.class).to(PKIReaderForTesting.class).asEagerSingleton();
             bind(SubscriptionServiceAdapter.class).to(ImportSubscriptionServiceAdapter.class);
-            bind(OwnerServiceAdapter.class).to(
-                DefaultOwnerServiceAdapter.class);
-            bind(EntitlementCertServiceAdapter.class).to(
-                StubEntitlementCertServiceAdapter.class);
+            bind(OwnerServiceAdapter.class).to(DefaultOwnerServiceAdapter.class);
+            bind(EntitlementCertServiceAdapter.class).to(StubEntitlementCertServiceAdapter.class);
             bind(ManifestFileService.class).to(DBManifestService.class);
             bind(ScriptEngineProvider.class);
 
@@ -308,8 +303,7 @@ public class TestingModules {
 
             bind(CertificateRevocationListTask.class);
             // temporary
-            bind(IdentityCertServiceAdapter.class).to(
-                DefaultIdentityCertServiceAdapter.class);
+            bind(IdentityCertServiceAdapter.class).to(DefaultIdentityCertServiceAdapter.class);
             bind(PoolRules.class);
             bind(CriteriaRules.class);
             bind(PoolManager.class).to(CandlepinPoolManager.class);

--- a/server/src/test/java/org/candlepin/controller/ContentManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/ContentManagerTest.java
@@ -65,18 +65,6 @@ public class ContentManagerTest extends DatabaseTestFixture {
     @Test
     public void testCreateContent() {
         Owner owner = this.createOwner("test-owner", "Test Owner");
-        Content content = TestUtil.createContent("c1", "content-1");
-
-        assertNull(this.ownerContentCurator.getContentById(owner, content.getId()));
-
-        Content output = this.contentManager.createContent(content, owner);
-
-        assertEquals(output, this.ownerContentCurator.getContentById(owner, content.getId()));
-    }
-
-    @Test
-    public void testCreateContentWithDTO() {
-        Owner owner = this.createOwner("test-owner", "Test Owner");
         ContentData dto = TestUtil.createContentDTO("c1", "content-1");
         dto.setLabel("test-label");
         dto.setType("test-test");
@@ -93,46 +81,23 @@ public class ContentManagerTest extends DatabaseTestFixture {
     public void testCreateContentThatAlreadyExists() {
         Owner owner = this.createOwner("test-owner", "Test Owner");
 
-        Content content1 = TestUtil.createContent("c1", "content-1");
-        Content output = this.contentManager.createContent(content1, owner);
-
-        Content content2 = TestUtil.createContent("c1", "content-1");
-        this.contentManager.createContent(content2, owner);
-    }
-
-    @Test(expected = IllegalStateException.class)
-    public void testCreateContentThatAlreadyExistsWithDTO() {
-        Owner owner = this.createOwner("test-owner", "Test Owner");
-
-        Content content1 = TestUtil.createContent("c1", "content-1");
-        Content output = this.contentManager.createContent(content1, owner);
-
         ContentData dto = TestUtil.createContentDTO("c1", "content-1");
         dto.setLabel("test-label");
         dto.setType("test-test");
         dto.setVendor("test-vendor");
 
+        Content output = this.contentManager.createContent(dto, owner);
+
+        // Verify the creation worked
+        assertNotNull(output);
+        assertEquals(output, this.ownerContentCurator.getContentById(owner, dto.getId()));
+
+        // This should fail, since it already exists
         this.contentManager.createContent(dto, owner);
     }
 
     @Test
     public void testCreateContentMergeWithExisting() {
-        Owner owner1 = this.createOwner("test-owner-1", "Test Owner 1");
-        Owner owner2 = this.createOwner("test-owner-2", "Test Owner 2");
-
-        Content content1 = TestUtil.createContent("c1", "content-1");
-        Content content2 = this.createContent("c1", "content-1", owner2);
-
-        Content output = this.contentManager.createContent(content1, owner1);
-
-        assertEquals(output.getUuid(), content2.getUuid());
-        assertEquals(output, content2);
-        assertTrue(this.ownerContentCurator.isContentMappedToOwner(output, owner1));
-        assertTrue(this.ownerContentCurator.isContentMappedToOwner(output, owner2));
-    }
-
-    @Test
-    public void testCreateContentMergeWithExistingUsingDTO() {
         Owner owner1 = this.createOwner("test-owner-1", "Test Owner 1");
         Owner owner2 = this.createOwner("test-owner-2", "Test Owner 2");
 
@@ -155,7 +120,7 @@ public class ContentManagerTest extends DatabaseTestFixture {
         product.addContent(content, true);
         product = this.productCurator.merge(product);
 
-        Content output = this.contentManager.updateContent(content, content.toDTO(), owner, true);
+        Content output = this.contentManager.updateContent(content.toDTO(), owner, true);
 
         assertEquals(output.getUuid(), content.getUuid());
         assertEquals(output, content);
@@ -173,7 +138,7 @@ public class ContentManagerTest extends DatabaseTestFixture {
         product.addContent(content, true);
         product = this.productCurator.merge(product);
 
-        Content output = this.contentManager.updateContent(content, update, owner, regenCerts);
+        Content output = this.contentManager.updateContent(update, owner, regenCerts);
 
         assertNotEquals(output.getUuid(), content.getUuid());
         assertEquals(output.getName(), update.getName());
@@ -205,7 +170,7 @@ public class ContentManagerTest extends DatabaseTestFixture {
         assertFalse(this.ownerContentCurator.isContentMappedToOwner(content1, owner2));
         assertTrue(this.ownerContentCurator.isContentMappedToOwner(content2, owner2));
 
-        Content output = this.contentManager.updateContent(content1, update, owner1, regenCerts);
+        Content output = this.contentManager.updateContent(update, owner1, regenCerts);
 
         assertEquals(content2.getUuid(), output.getUuid());
         assertFalse(this.ownerContentCurator.isContentMappedToOwner(content1, owner1));
@@ -237,7 +202,7 @@ public class ContentManagerTest extends DatabaseTestFixture {
         assertTrue(this.ownerContentCurator.isContentMappedToOwner(content, owner1));
         assertTrue(this.ownerContentCurator.isContentMappedToOwner(content, owner2));
 
-        Content output = this.contentManager.updateContent(content, update, owner1, regenCerts);
+        Content output = this.contentManager.updateContent(update, owner1, regenCerts);
 
         assertNotEquals(output.getUuid(), content.getUuid());
         assertTrue(this.ownerContentCurator.isContentMappedToOwner(output, owner1));
@@ -263,7 +228,7 @@ public class ContentManagerTest extends DatabaseTestFixture {
 
         assertFalse(this.ownerContentCurator.isContentMappedToOwner(content, owner));
 
-        this.contentManager.updateContent(content, update, owner, false);
+        this.contentManager.updateContent(update, owner, false);
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/controller/PoolManagerFunctionalTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerFunctionalTest.java
@@ -320,8 +320,7 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
         this.ownerContentCurator.mapContentToOwner(content, this.o);
 
         List<Subscription> subscriptions = new LinkedList<Subscription>();
-        ImportSubscriptionServiceAdapter subAdapter
-            = new ImportSubscriptionServiceAdapter(subscriptions);
+        ImportSubscriptionServiceAdapter subAdapter = new ImportSubscriptionServiceAdapter(subscriptions);
 
         Subscription sub = TestUtil.createSubscription(o, modifier, new HashSet<Product>());
         sub.setQuantity(5L);
@@ -335,7 +334,6 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
 
         poolManager.getRefresher(subAdapter).add(o).run();
 
-
         // This test simulates https://bugzilla.redhat.com/show_bug.cgi?id=676870
         // where entitling first to the modifier then to the modifiee causes the modifier's
         // entitlement cert to get regenerated, but since it's all in the same http call,
@@ -344,11 +342,13 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
         // inside an entitleByProducts call, we do it in two singular calls here.
         AutobindData data = AutobindData.create(parentSystem).on(new Date())
             .forProducts(new String [] {"modifier"});
+
         poolManager.entitleByProducts(data);
 
         try {
             data = AutobindData.create(parentSystem).on(new Date())
-                    .forProducts(new String [] {PRODUCT_VIRT_HOST});
+                .forProducts(new String [] {PRODUCT_VIRT_HOST});
+
             poolManager.entitleByProducts(data);
         }
         catch (EntityNotFoundException e) {

--- a/server/src/test/java/org/candlepin/controller/ProductManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/ProductManagerTest.java
@@ -61,18 +61,6 @@ public class ProductManagerTest extends DatabaseTestFixture {
     @Test
     public void testCreateProduct() {
         Owner owner = this.createOwner("test-owner", "Test Owner");
-        Product product = TestUtil.createProduct("p1", "prod1");
-
-        assertNull(this.ownerProductCurator.getProductById(owner, "p1"));
-
-        Product output = this.productManager.createProduct(product, owner);
-
-        assertEquals(output, this.ownerProductCurator.getProductById(owner, "p1"));
-    }
-
-    @Test
-    public void testCreateProductWithDTO() {
-        Owner owner = this.createOwner("test-owner", "Test Owner");
         ProductData dto = TestUtil.createProductDTO("p1", "prod1");
 
         assertNull(this.ownerProductCurator.getProductById(owner, "p1"));
@@ -86,42 +74,17 @@ public class ProductManagerTest extends DatabaseTestFixture {
     public void testCreateProductThatAlreadyExists() {
         Owner owner = this.createOwner("test-owner", "Test Owner");
 
-        Product product1 = TestUtil.createProduct("p1", "prod1");
-        Product output = this.productManager.createProduct(product1, owner);
+        ProductData dto = TestUtil.createProductDTO("p1", "prod1");
+        Product output = this.productManager.createProduct(dto, owner);
 
-        Product product2 = TestUtil.createProduct("p1", "prod1");
-        this.productManager.createProduct(product2, owner);
-    }
+        assertNotNull(output);
+        assertEquals(output, this.ownerProductCurator.getProductById(owner, dto.getId()));
 
-    @Test(expected = IllegalStateException.class)
-    public void testCreateProductThatAlreadyExistsWithDTO() {
-        Owner owner = this.createOwner("test-owner", "Test Owner");
-
-        Product product1 = TestUtil.createProduct("p1", "prod1");
-        Product output = this.productManager.createProduct(product1, owner);
-
-        ProductData product2 = TestUtil.createProductDTO("p1", "prod1");
-        this.productManager.createProduct(product2, owner);
+        this.productManager.createProduct(dto, owner);
     }
 
     @Test
     public void testCreateProductMergeWithExisting() {
-        Owner owner1 = this.createOwner("test-owner-1", "Test Owner 1");
-        Owner owner2 = this.createOwner("test-owner-2", "Test Owner 2");
-
-        Product product1 = TestUtil.createProduct("p1", "prod1");
-        Product product2 = this.createProduct("p1", "prod1", owner2);
-
-        Product output = this.productManager.createProduct(product1, owner1);
-
-        assertEquals(output.getUuid(), product2.getUuid());
-        assertEquals(output, product2);
-        assertTrue(this.ownerProductCurator.isProductMappedToOwner(output, owner1));
-        assertTrue(this.ownerProductCurator.isProductMappedToOwner(output, owner2));
-    }
-
-    @Test
-    public void testCreateProductMergeWithExistingUsingDTO() {
         Owner owner1 = this.createOwner("test-owner-1", "Test Owner 1");
         Owner owner2 = this.createOwner("test-owner-2", "Test Owner 2");
 
@@ -141,7 +104,7 @@ public class ProductManagerTest extends DatabaseTestFixture {
         Owner owner = this.createOwner("test-owner", "Test Owner");
         Product product = this.createProduct("p1", "prod1", owner);
 
-        Product output = this.productManager.updateProduct(product, product.toDTO(), owner, true);
+        Product output = this.productManager.updateProduct(product.toDTO(), owner, true);
 
         assertEquals(output.getUuid(), product.getUuid());
         assertEquals(output, product);
@@ -156,7 +119,7 @@ public class ProductManagerTest extends DatabaseTestFixture {
         Product product = this.createProduct("p1", "prod1", owner);
         ProductData update = TestUtil.createProductDTO("p1", "new product name");
 
-        Product output = this.productManager.updateProduct(product, update, owner, regenCerts);
+        Product output = this.productManager.updateProduct(update, owner, regenCerts);
 
         assertNotEquals(output.getUuid(), product.getUuid());
         assertEquals(output.getName(), update.getName());
@@ -187,7 +150,7 @@ public class ProductManagerTest extends DatabaseTestFixture {
         assertFalse(this.ownerProductCurator.isProductMappedToOwner(product1, owner2));
         assertTrue(this.ownerProductCurator.isProductMappedToOwner(product2, owner2));
 
-        Product output = this.productManager.updateProduct(product1, update, owner1, regenCerts);
+        Product output = this.productManager.updateProduct(update, owner1, regenCerts);
 
         assertEquals(output.getUuid(), product2.getUuid());
         assertFalse(this.ownerProductCurator.isProductMappedToOwner(product1, owner1));
@@ -216,7 +179,7 @@ public class ProductManagerTest extends DatabaseTestFixture {
         assertTrue(this.ownerProductCurator.isProductMappedToOwner(product, owner1));
         assertTrue(this.ownerProductCurator.isProductMappedToOwner(product, owner2));
 
-        Product output = this.productManager.updateProduct(product, update, owner1, regenCerts);
+        Product output = this.productManager.updateProduct(update, owner1, regenCerts);
 
         assertNotEquals(output.getUuid(), product.getUuid());
         assertTrue(this.ownerProductCurator.isProductMappedToOwner(output, owner1));
@@ -237,12 +200,12 @@ public class ProductManagerTest extends DatabaseTestFixture {
     @Test(expected = IllegalStateException.class)
     public void testUpdateProductThatDoesntExist() {
         Owner owner = this.createOwner("test-owner", "Test Owner");
-        Product product = TestUtil.createProduct("p1", "prod1");
+        Product product = TestUtil.createProduct("p1", "new_name");
         ProductData update = TestUtil.createProductDTO("p1", "new_name");
 
         assertFalse(this.ownerProductCurator.isProductMappedToOwner(product, owner));
 
-        this.productManager.updateProduct(product, update, owner, false);
+        this.productManager.updateProduct(update, owner, false);
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/model/AbstractHibernateCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/AbstractHibernateCuratorTest.java
@@ -1,0 +1,343 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.model;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
+import static org.mockito.AdditionalAnswers.*;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+
+import org.candlepin.test.DatabaseTestFixture;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+
+
+/**
+ * AbstractHibernateCuratorTest
+ */
+@RunWith(JUnitParamsRunner.class)
+public class AbstractHibernateCuratorTest extends DatabaseTestFixture {
+
+    /**
+     * Test implementation that provides access to some protected methods
+     */
+    private static class TestHibernateCurator<E extends Persisted> extends AbstractHibernateCurator<E> {
+        public TestHibernateCurator(Class entityClass) {
+            super(entityClass);
+        }
+
+        @Override
+        public int bulkSQLUpdate(String table, String column, Map<Object, Object> values,
+            Map<String, Object> criteria) {
+
+            return super.bulkSQLUpdate(table, column, values, criteria);
+        }
+    }
+
+
+    AbstractHibernateCurator<Content> testContentCurator;
+
+    @Before
+    public void setup() {
+        this.testContentCurator = new TestHibernateCurator<Content>(Content.class);
+        this.injectMembers(this.testContentCurator);
+    }
+
+    @Test
+    public void testBulkSQLUpdate() throws Exception {
+        Owner owner = this.createOwner();
+
+        Content c1 = this.createContent("c1", "content 1", owner);
+        Content c2 = this.createContent("c2", "content 2", owner);
+        Content c3 = this.createContent("c3", "content 3", owner);
+
+        Map<Object, Object> values = new HashMap<Object, Object>();
+        values.put("content 1", "update 1");
+        values.put("content 2", "update 2");
+        values.put("content ?", "should not exist");
+
+        int result = this.testContentCurator.bulkSQLUpdate(Content.DB_TABLE, "name", values, null);
+
+        // Note:
+        // This looks like it should be 2, and technically that's what's happening here, but with
+        // the way the bulk updater works, even the non-matching columns are getting updated to
+        // themselves.
+        assertEquals(3, result);
+
+        testContentCurator.refresh(c1, c2, c3);
+
+        assertEquals("update 1", c1.getName());
+        assertEquals("update 2", c2.getName());
+        assertEquals("content 3", c3.getName());
+    }
+
+
+    @Test
+    public void testBulkSQLUpdateSingleUpdate() throws Exception {
+        Owner owner = this.createOwner();
+
+        Content c1 = this.createContent("c1", "content 1", owner);
+        Content c2 = this.createContent("c2", "content 2", owner);
+        Content c3 = this.createContent("c3", "content 3", owner);
+
+        Map<Object, Object> values = new HashMap<Object, Object>();
+        values.put("content 1", "update 1");
+
+        int result = this.testContentCurator.bulkSQLUpdate(Content.DB_TABLE, "name", values, null);
+
+        assertEquals(1, result);
+
+        testContentCurator.refresh(c1, c2, c3);
+
+        assertEquals("update 1", c1.getName());
+        assertEquals("content 2", c2.getName());
+        assertEquals("content 3", c3.getName());
+    }
+
+    @Test
+    public void testBulkSQLUpdateSingleUpdateNoChange() throws Exception {
+        Owner owner = this.createOwner();
+
+        Content c1 = this.createContent("c1", "content 1", owner);
+        Content c2 = this.createContent("c2", "content 2", owner);
+        Content c3 = this.createContent("c3", "content 3", owner);
+
+        Map<Object, Object> values = new HashMap<Object, Object>();
+        values.put("content B", "update 1");
+
+        int result = this.testContentCurator.bulkSQLUpdate(Content.DB_TABLE, "name", values, null);
+
+        assertEquals(0, result);
+
+        testContentCurator.refresh(c1, c2, c3);
+
+        assertEquals("content 1", c1.getName());
+        assertEquals("content 2", c2.getName());
+        assertEquals("content 3", c3.getName());
+    }
+
+    @Test
+    public void testBulkSQLUpdateWithEmptyValues() throws Exception {
+        Owner owner = this.createOwner();
+
+        Content c1 = this.createContent("c1", "content 1", owner);
+        Content c2 = this.createContent("c2", "content 2", owner);
+        Content c3 = this.createContent("c3", "content 3", owner);
+
+        Map<Object, Object> values = new HashMap<Object, Object>();
+
+        int result = this.testContentCurator.bulkSQLUpdate(Content.DB_TABLE, "name", values, null);
+
+        assertEquals(0, result);
+
+        testContentCurator.refresh(c1, c2, c3);
+
+        assertEquals("content 1", c1.getName());
+        assertEquals("content 2", c2.getName());
+        assertEquals("content 3", c3.getName());
+    }
+
+    @Test
+    public void testBulkSQLUpdateWithSingleCriteria() {
+        Owner owner = this.createOwner();
+
+        Content c1 = this.createContent("c1", "content 1", owner);
+        Content c2 = this.createContent("c2", "content 2", owner);
+        Content c3 = this.createContent("c3", "content 3", owner);
+
+        Map<Object, Object> values = new HashMap<Object, Object>();
+        values.put("content 1", "update 1");
+        values.put("content 2", "update 2");
+        values.put("content ?", "should not exist");
+
+        Map<String, Object> criteria = new HashMap<String, Object>();
+        criteria.put("name", values.keySet());
+
+        int result = this.testContentCurator.bulkSQLUpdate(Content.DB_TABLE, "name", values, criteria);
+
+        // Unlike the base test where the result count is 3, this filters by only the values we
+        // intend to update, so it should be 2.
+        assertEquals(2, result);
+
+        testContentCurator.refresh(c1, c2, c3);
+
+        assertEquals("update 1", c1.getName());
+        assertEquals("update 2", c2.getName());
+        assertEquals("content 3", c3.getName());
+    }
+
+    @Test
+    public void testBulkSQLUpdateWithMultipleCriteria() {
+        Owner owner = this.createOwner();
+
+        Content c1 = this.createContent("c1", "content 1", owner);
+        Content c2 = this.createContent("c2", "content 2", owner);
+        Content c3 = this.createContent("c3", "content 3", owner);
+
+        Map<Object, Object> values = new HashMap<Object, Object>();
+        values.put("content 1", "update 1");
+        values.put("content 2", "update 2");
+        values.put("content ?", "should not exist");
+
+        Map<String, Object> criteria = new HashMap<String, Object>();
+        criteria.put("name", values.keySet());
+        criteria.put("content_id", "c2");
+
+        int result = this.testContentCurator.bulkSQLUpdate(Content.DB_TABLE, "name", values, criteria);
+
+        // Unlike the base test where the result count is 3, this filters by only the values we
+        // intend to update, so it should be 1.
+        assertEquals(1, result);
+
+        testContentCurator.refresh(c1, c2, c3);
+
+        assertEquals("content 1", c1.getName());
+        assertEquals("update 2", c2.getName());
+        assertEquals("content 3", c3.getName());
+    }
+
+    protected Object[][] largeValueSetSizes() {
+        return new Object[][] {
+            new Object[] { (int) (AbstractHibernateCurator.CASE_OPERATOR_BLOCK_SIZE), 0 },
+            new Object[] { (int) (AbstractHibernateCurator.CASE_OPERATOR_BLOCK_SIZE + 1), 0 },
+            new Object[] { (int) (AbstractHibernateCurator.CASE_OPERATOR_BLOCK_SIZE * 1.5), 0 },
+            new Object[] { (int) (AbstractHibernateCurator.CASE_OPERATOR_BLOCK_SIZE * 1.5 + 1), 0 },
+            new Object[] { (int) (AbstractHibernateCurator.CASE_OPERATOR_BLOCK_SIZE * 2), 0 },
+            new Object[] { (int) (AbstractHibernateCurator.CASE_OPERATOR_BLOCK_SIZE * 2 + 1), 0 },
+            new Object[] { (int) (AbstractHibernateCurator.CASE_OPERATOR_BLOCK_SIZE * 2.5), 0 },
+            new Object[] { (int) (AbstractHibernateCurator.CASE_OPERATOR_BLOCK_SIZE * 2.5 + 1), 0 },
+            new Object[] { (int) (AbstractHibernateCurator.CASE_OPERATOR_BLOCK_SIZE * 3), 0 },
+            new Object[] { (int) (AbstractHibernateCurator.CASE_OPERATOR_BLOCK_SIZE * 3 + 1), 0 },
+            new Object[] { (int) (AbstractHibernateCurator.CASE_OPERATOR_BLOCK_SIZE * 3.5), 0 },
+            new Object[] { (int) (AbstractHibernateCurator.CASE_OPERATOR_BLOCK_SIZE * 3.5 + 1), 0 },
+
+            new Object[] { (int) (AbstractHibernateCurator.CASE_OPERATOR_BLOCK_SIZE), 1 },
+            new Object[] { (int) (AbstractHibernateCurator.CASE_OPERATOR_BLOCK_SIZE + 1), 1 },
+            new Object[] { (int) (AbstractHibernateCurator.CASE_OPERATOR_BLOCK_SIZE * 1.5), 1 },
+            new Object[] { (int) (AbstractHibernateCurator.CASE_OPERATOR_BLOCK_SIZE * 1.5 + 1), 1 },
+            new Object[] { (int) (AbstractHibernateCurator.CASE_OPERATOR_BLOCK_SIZE * 2), 1 },
+            new Object[] { (int) (AbstractHibernateCurator.CASE_OPERATOR_BLOCK_SIZE * 2 + 1), 1 },
+            new Object[] { (int) (AbstractHibernateCurator.CASE_OPERATOR_BLOCK_SIZE * 2.5), 1 },
+            new Object[] { (int) (AbstractHibernateCurator.CASE_OPERATOR_BLOCK_SIZE * 2.5 + 1), 1 },
+            new Object[] { (int) (AbstractHibernateCurator.CASE_OPERATOR_BLOCK_SIZE * 3), 1 },
+            new Object[] { (int) (AbstractHibernateCurator.CASE_OPERATOR_BLOCK_SIZE * 3 + 1), 1 },
+            new Object[] { (int) (AbstractHibernateCurator.CASE_OPERATOR_BLOCK_SIZE * 3.5), 1 },
+            new Object[] { (int) (AbstractHibernateCurator.CASE_OPERATOR_BLOCK_SIZE * 3.5 + 1), 1 },
+        };
+    }
+
+    @Test
+    @Parameters(method = "largeValueSetSizes")
+    public void testBulkSQLUpdateWithLargeValueSets(int count, int skip) {
+        Owner owner = this.createOwner();
+
+        for (int i = 1; i <= count; ++i) {
+            this.createContent("c" + i, "content-" + i, owner);
+        }
+
+        Map<Object, Object> values = new LinkedHashMap<Object, Object>();
+
+        for (int i = 1; i <= count; ++i) {
+            // We want every odd value to be unaffected, but we still want a fake update entry
+            // for the query
+            values.put("content-" + (i % 2 == skip ? i : "X" + i), "update-" + i);
+        }
+
+        int result = this.testContentCurator.bulkSQLUpdate(Content.DB_TABLE, "name", values, null);
+        assertEquals(count, result);
+
+        testContentCurator.clear();
+
+        for (int i = 1; i <= count; ++i) {
+            Content content = this.ownerContentCurator.getContentById(owner, "c" + i);
+
+            if (i % 2 == skip) {
+                assertEquals("update-" + i, content.getName());
+            }
+            else {
+                assertEquals("content-" + i, content.getName());
+            }
+        }
+    }
+
+    protected Object[] largeValueSetAndCriteriaSizes() {
+        List<Object[]> entries = new LinkedList<Object[]>();
+
+        // Declaring these as variables because the constant names are loooooooong
+        int caseBlockSize = AbstractHibernateCurator.CASE_OPERATOR_BLOCK_SIZE;
+        int inBlockSize = AbstractHibernateCurator.IN_OPERATOR_BLOCK_SIZE;
+
+        for (float multi = 1; multi < 4.0f; multi += 0.5) {
+            entries.add(new Object[] { (int) (caseBlockSize * multi), (int) (inBlockSize * multi) });
+            entries.add(new Object[] { (int) (caseBlockSize * multi + 1), (int) (inBlockSize * multi + 1) });
+        }
+
+        return entries.toArray();
+    }
+
+    @Test
+    @Parameters(method = "largeValueSetAndCriteriaSizes")
+    public void testBulkSQLUpdateWithLargeValueSetAndCriteriaList(int valueCount, int criteriaListSize) {
+        Owner owner = this.createOwner();
+
+        Map<Object, Object> values = new HashMap<Object, Object>();
+
+        for (int i = 1; i <= valueCount; ++i) {
+            this.createContent("c" + i, "content-" + i, owner);
+
+            // We want every odd value to be unaffected, but we still want a fake update entry
+            // for the query
+            values.put("content-" + (i % 2 == 0 ? i : "X" + i), "update-" + i);
+        }
+
+        Map<String, Object> criteria = new HashMap<String, Object>();
+        List<String> valueList = new LinkedList<String>();
+        criteria.put("name", valueList);
+
+        for (int i = 1; i <= criteriaListSize; ++i) {
+            valueList.add("content-" + (i % 2 == 0 ? i : "X" + i));
+        }
+
+        int result = this.testContentCurator.bulkSQLUpdate(Content.DB_TABLE, "name", values, criteria);
+        assertEquals(valueCount / 2, result);
+
+        testContentCurator.clear();
+
+        for (int i = 1; i <= valueCount; ++i) {
+            Content content = this.ownerContentCurator.getContentById(owner, "c" + i);
+
+            if (i % 2 == 0) {
+                assertEquals("update-" + i, content.getName());
+            }
+            else {
+                assertEquals("content-" + i, content.getName());
+            }
+        }
+    }
+
+
+}

--- a/server/src/test/java/org/candlepin/model/OwnerContentCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/OwnerContentCuratorTest.java
@@ -25,7 +25,9 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 
 
@@ -528,7 +530,10 @@ public class OwnerContentCuratorTest extends DatabaseTestFixture {
         assertFalse(this.isContentMappedToOwner(updated, owner1));
         assertTrue(this.isContentMappedToOwner(unmodified, owner2));
 
-        this.ownerContentCurator.updateOwnerContentReferences(original, updated, Arrays.asList(owner1));
+        Map<String, String> uuidMap = new HashMap<String, String>();
+        uuidMap.put(original.getUuid(), updated.getUuid());
+
+        this.ownerContentCurator.updateOwnerContentReferences(owner1, uuidMap);
 
         assertFalse(this.isContentMappedToOwner(original, owner1));
         assertTrue(this.isContentMappedToOwner(updated, owner1));
@@ -567,7 +572,7 @@ public class OwnerContentCuratorTest extends DatabaseTestFixture {
         assertTrue(this.isContentMappedToOwner(original, owner1));
         assertTrue(this.isContentMappedToOwner(unmodified, owner2));
 
-        this.ownerContentCurator.removeOwnerContentReferences(original, Arrays.asList(owner1));
+        this.ownerContentCurator.removeOwnerContentReferences(original, owner1);
 
         assertFalse(this.isContentMappedToOwner(original, owner1));
         assertTrue(this.isContentMappedToOwner(unmodified, owner2));

--- a/server/src/test/java/org/candlepin/model/OwnerProductCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/OwnerProductCuratorTest.java
@@ -28,7 +28,9 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 
 
@@ -537,7 +539,10 @@ public class OwnerProductCuratorTest extends DatabaseTestFixture {
         assertTrue(this.isProductMappedToOwner(original, owner));
         assertFalse(this.isProductMappedToOwner(updated, owner));
 
-        this.ownerProductCurator.updateOwnerProductReferences(original, updated, Arrays.asList(owner));
+        Map<String, String> uuidMap = new HashMap<String, String>();
+        uuidMap.put(original.getUuid(), updated.getUuid());
+
+        this.ownerProductCurator.updateOwnerProductReferences(owner, uuidMap);
 
         assertFalse(this.isProductMappedToOwner(original, owner));
         assertTrue(this.isProductMappedToOwner(updated, owner));
@@ -551,14 +556,17 @@ public class OwnerProductCuratorTest extends DatabaseTestFixture {
         assertEquals(updated.getUuid(), pool1.getProduct().getUuid());
 
         this.poolCurator.refresh(pool2);
+        assertNotEquals(updated.getUuid(), pool2.getProduct().getUuid());
         products = pool2.getProvidedProducts();
         assertEquals(1, products.size());
         assertEquals(updated.getUuid(), products.iterator().next().getUuid());
 
         this.poolCurator.refresh(pool3);
+        assertNotEquals(updated.getUuid(), pool3.getProduct().getUuid());
         assertEquals(updated.getUuid(), pool3.getDerivedProduct().getUuid());
 
         this.poolCurator.refresh(pool4);
+        assertNotEquals(updated.getUuid(), pool4.getProduct().getUuid());
         products = pool4.getDerivedProvidedProducts();
         assertEquals(1, products.size());
         assertEquals(updated.getUuid(), products.iterator().next().getUuid());
@@ -577,7 +585,7 @@ public class OwnerProductCuratorTest extends DatabaseTestFixture {
 
         assertTrue(this.isProductMappedToOwner(original, owner));
 
-        this.ownerProductCurator.removeOwnerProductReferences(original, Arrays.asList(owner));
+        this.ownerProductCurator.removeOwnerProductReferences(original, owner);
 
         assertFalse(this.isProductMappedToOwner(original, owner));
 

--- a/server/src/test/java/org/candlepin/model/dto/ProductDataTest.java
+++ b/server/src/test/java/org/candlepin/model/dto/ProductDataTest.java
@@ -31,6 +31,7 @@ import org.junit.runner.RunWith;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 
 
 
@@ -399,7 +400,7 @@ public class ProductDataTest {
         assertSame(dto, output2);
 
         output = dto.getProductContent();
-        assertEquals(input, output);
+        assertTrue(Util.collectionsAreEqual(input, output));
 
         // Second pass to ensure setProductContent is actually clearing existing content before
         // adding new ones
@@ -407,14 +408,14 @@ public class ProductDataTest {
         assertSame(dto, output2);
 
         output = dto.getProductContent();
-        assertEquals(input, output);
+        assertTrue(Util.collectionsAreEqual(input, output));
 
         // Third pass to ensure setting duplicates doesn't allow the dupes to be retained
         output2 = dto.setProductContent(input2);
         assertSame(dto, output2);
 
         output = dto.getProductContent();
-        assertEquals(input, output);
+        assertTrue(Util.collectionsAreEqual(input, output));
     }
 
     @Test
@@ -505,7 +506,7 @@ public class ProductDataTest {
         output = dto.addProductContent(pcdata3);
         output2 = dto.getProductContent();
         assertTrue(output);
-        assertEquals(Arrays.asList(pcdata1, pcdata3), output2);
+        assertTrue(Util.collectionsAreEqual(Arrays.asList(pcdata1, pcdata3), output2));
     }
 
     @Test
@@ -549,7 +550,7 @@ public class ProductDataTest {
         output = dto.addProductContent(pcentity3);
         output2 = dto.getProductContent();
         assertTrue(output);
-        assertEquals(Arrays.asList(pcdata1, pcdata3), output2);
+        assertTrue(Util.collectionsAreEqual(Arrays.asList(pcdata1, pcdata3), output2));
     }
 
     @Test
@@ -584,7 +585,7 @@ public class ProductDataTest {
         output = dto.addContent(pcdata3.getContent(), pcdata3.isEnabled());
         output2 = dto.getProductContent();
         assertTrue(output);
-        assertEquals(Arrays.asList(pcdata1, pcdata3), output2);
+        assertTrue(Util.collectionsAreEqual(Arrays.asList(pcdata1, pcdata3), output2));
     }
 
     @Test
@@ -629,7 +630,7 @@ public class ProductDataTest {
         output = dto.addContent(pcentity3.getContent(), pcentity3.isEnabled());
         output2 = dto.getProductContent();
         assertTrue(output);
-        assertEquals(Arrays.asList(pcdata1, pcdata3), output2);
+        assertTrue(Util.collectionsAreEqual(Arrays.asList(pcdata1, pcdata3), output2));
     }
 
     @Test
@@ -652,18 +653,18 @@ public class ProductDataTest {
         boolean output = dto.removeContent(content[0].getId());
         Collection<ProductContentData> output2 = dto.getProductContent();
         assertTrue(output);
-        assertEquals(Arrays.asList(pcdata2), output2);
+        assertTrue(Util.collectionsAreEqual(Arrays.asList(pcdata2), output2));
 
         output = dto.removeContent(content[0].getId());
         output2 = dto.getProductContent();
         assertFalse(output);
-        assertEquals(Arrays.asList(pcdata2), output2);
+        assertTrue(Util.collectionsAreEqual(Arrays.asList(pcdata2), output2));
 
         // Note that the collection should not be nulled by removing the final element
         output = dto.removeContent(content[1].getId());
         output2 = dto.getProductContent();
         assertTrue(output);
-        assertEquals(Arrays.asList(), output2);
+        assertTrue(Util.collectionsAreEqual(Collections.<ProductContentData>emptyList(), output2));
     }
 
     @Test
@@ -688,19 +689,19 @@ public class ProductDataTest {
         boolean output = dto.removeContent(content[0]);
         Collection<ProductContentData> output2 = dto.getProductContent();
         assertTrue(output);
-        assertEquals(Arrays.asList(pcdata2), output2);
+        assertTrue(Util.collectionsAreEqual(Arrays.asList(pcdata2), output2));
 
         output = dto.removeContent(content[0]);
         output2 = dto.getProductContent();
         assertFalse(output);
-        assertEquals(Arrays.asList(pcdata2), output2);
+        assertTrue(Util.collectionsAreEqual(Arrays.asList(pcdata2), output2));
 
         // This should work because we remove by content ID, not by exact element match
         // Note that the collection should not be nulled by removing the final element
         output = dto.removeContent(content[2]);
         output2 = dto.getProductContent();
         assertTrue(output);
-        assertEquals(Arrays.asList(), output2);
+        assertTrue(Util.collectionsAreEqual(Collections.<ProductContentData>emptyList(), output2));
     }
 
     @Test
@@ -730,19 +731,19 @@ public class ProductDataTest {
         boolean output = dto.removeContent(contentEntities[0]);
         Collection<ProductContentData> output2 = dto.getProductContent();
         assertTrue(output);
-        assertEquals(Arrays.asList(pcdata2), output2);
+        assertTrue(Util.collectionsAreEqual(Arrays.asList(pcdata2), output2));
 
         output = dto.removeContent(contentEntities[0]);
         output2 = dto.getProductContent();
         assertFalse(output);
-        assertEquals(Arrays.asList(pcdata2), output2);
+        assertTrue(Util.collectionsAreEqual(Arrays.asList(pcdata2), output2));
 
         // This should work because we remove by content ID, not by exact element match
         // Note that the collection should not be nulled by removing the final element
         output = dto.removeContent(contentEntities[2]);
         output2 = dto.getProductContent();
         assertTrue(output);
-        assertEquals(Arrays.asList(), output2);
+        assertTrue(Util.collectionsAreEqual(Collections.<ProductContentData>emptyList(), output2));
     }
 
     @Test
@@ -768,19 +769,19 @@ public class ProductDataTest {
         boolean output = dto.removeProductContent(pcdata1);
         Collection<ProductContentData> output2 = dto.getProductContent();
         assertTrue(output);
-        assertEquals(Arrays.asList(pcdata2), output2);
+        assertTrue(Util.collectionsAreEqual(Arrays.asList(pcdata2), output2));
 
         output = dto.removeProductContent(pcdata1);
         output2 = dto.getProductContent();
         assertFalse(output);
-        assertEquals(Arrays.asList(pcdata2), output2);
+        assertTrue(Util.collectionsAreEqual(Arrays.asList(pcdata2), output2));
 
         // This should work because we remove by content ID, not by exact element match
         // Note that the collection should not be nulled by removing the final element
         output = dto.removeProductContent(pcdata3);
         output2 = dto.getProductContent();
         assertTrue(output);
-        assertEquals(Arrays.asList(), output2);
+        assertTrue(Util.collectionsAreEqual(Collections.<ProductContentData>emptyList(), output2));
     }
 
     @Test
@@ -814,19 +815,19 @@ public class ProductDataTest {
         boolean output = dto.removeProductContent(pcentity1);
         Collection<ProductContentData> output2 = dto.getProductContent();
         assertTrue(output);
-        assertEquals(Arrays.asList(pcdata2), output2);
+        assertTrue(Util.collectionsAreEqual(Arrays.asList(pcdata2), output2));
 
         output = dto.removeProductContent(pcentity1);
         output2 = dto.getProductContent();
         assertFalse(output);
-        assertEquals(Arrays.asList(pcdata2), output2);
+        assertTrue(Util.collectionsAreEqual(Arrays.asList(pcdata2), output2));
 
         // This should work because we remove by content ID, not by exact element match
         // Note that the collection should not be nulled by removing the final element
         output = dto.removeProductContent(pcentity3);
         output2 = dto.getProductContent();
         assertTrue(output);
-        assertEquals(Arrays.asList(), output2);
+        assertTrue(Util.collectionsAreEqual(Collections.<ProductContentData>emptyList(), output2));
     }
 
     @Test
@@ -1044,7 +1045,15 @@ public class ProductDataTest {
         mutator.invoke(lhs, value1);
         mutator.invoke(rhs, value1);
 
-        assertEquals(accessor.invoke(lhs), accessor.invoke(rhs));
+        if (value1 instanceof Collection) {
+            assertTrue(Util.collectionsAreEqual(
+                (Collection) accessor.invoke(lhs), (Collection) accessor.invoke(rhs)
+            ));
+        }
+        else {
+            assertEquals(accessor.invoke(lhs), accessor.invoke(rhs));
+        }
+
         assertTrue(lhs.equals(rhs));
         assertTrue(rhs.equals(lhs));
         assertTrue(lhs.equals(lhs));
@@ -1053,7 +1062,15 @@ public class ProductDataTest {
 
         mutator.invoke(rhs, value2);
 
-        assertNotEquals(accessor.invoke(lhs), accessor.invoke(rhs));
+        if (value2 instanceof Collection) {
+            assertFalse(Util.collectionsAreEqual(
+                (Collection) accessor.invoke(lhs), (Collection) accessor.invoke(rhs)
+            ));
+        }
+        else {
+            assertNotEquals(accessor.invoke(lhs), accessor.invoke(rhs));
+        }
+
         assertFalse(lhs.equals(rhs));
         assertFalse(rhs.equals(lhs));
         assertTrue(lhs.equals(lhs));
@@ -1073,7 +1090,15 @@ public class ProductDataTest {
 
         ProductData clone = (ProductData) base.clone();
 
-        assertEquals(accessor.invoke(base, null), accessor.invoke(clone, null));
+        if (value1 instanceof Collection) {
+            assertTrue(Util.collectionsAreEqual(
+                (Collection) accessor.invoke(base, null), (Collection) accessor.invoke(clone, null)
+            ));
+        }
+        else {
+            assertEquals(accessor.invoke(base, null), accessor.invoke(clone, null));
+        }
+
         assertEquals(base, clone);
         assertEquals(base.hashCode(), clone.hashCode());
     }
@@ -1299,7 +1324,9 @@ public class ProductDataTest {
         assertTrue(base.getDependentProductIds().isEmpty());
 
         assertNotNull(base.getProductContent());
-        assertEquals(Arrays.asList(pcdata1, pcdata2, pcdata3), base.getProductContent());
+        assertTrue(Util.collectionsAreEqual(
+            Arrays.asList(pcdata1, pcdata2, pcdata3), base.getProductContent()
+        ));
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/test/DatabaseTestFixture.java
+++ b/server/src/test/java/org/candlepin/test/DatabaseTestFixture.java
@@ -173,12 +173,12 @@ public class DatabaseTestFixture {
     public void init() {
         this.config = new CandlepinCommonTestConfig();
         Module testingModule = new TestingModules.StandardTest(this.config);
-        injector = parentInjector.createChildInjector(
+        this.injector = parentInjector.createChildInjector(
             Modules.override(testingModule).with(getGuiceOverrideModule()));
 
-        locatorMap = injector.getInstance(ResourceLocatorMap.class);
+        locatorMap = this.injector.getInstance(ResourceLocatorMap.class);
         locatorMap.init();
-        securityInterceptor = injector.getInstance(TestingInterceptor.class);
+        securityInterceptor = this.injector.getInstance(TestingInterceptor.class);
 
         cpRequestScope = injector.getInstance(CandlepinRequestScope.class);
 
@@ -187,7 +187,7 @@ public class DatabaseTestFixture {
         // Exit the scope to make sure that it is clean before starting the test.
         cpRequestScope.exit();
         cpRequestScope.enter();
-        injector.injectMembers(this);
+        this.injector.injectMembers(this);
 
         dateSource = (DateSourceForTesting) injector.getInstance(DateSource.class);
         dateSource.currentDate(TestDateUtil.date(2010, 1, 1));
@@ -232,6 +232,17 @@ public class DatabaseTestFixture {
                 // NO OP
             }
         };
+    }
+
+    /**
+     * Populates the given object by injecting dependencies for its members tagged with the @Inject
+     * annotation.
+     *
+     * @param object
+     *  The object to populate
+     */
+    protected void injectMembers(Object object) {
+        this.injector.injectMembers(object);
     }
 
     protected EntityManager entityManager() {


### PR DESCRIPTION
- ProductManager.applyProductUpdates now fetches product content
  in batches, and no longer repeatedly iterates existing product
  content mapping while applying content changes
- Added commitProduct and commitContent to ProductManager and ContentManager
  respectively
- Refactored refreshPoolsWithRegeneration to minimize the number of times
  we hit the database for a given operation
- Reverted several changes in ProductManager and ContentManager
- Added importProduct and importContent to ProductManager and
  ContentManager respectively
- Changed the signatures of several methods according with
  optimizations made throughout the codebase
- AbstractHibernateCurator.saveAll, .updateAll, and .saveOrUpdateAll
  no longer use a universal session.clear, and instead evict the
  persisted elements
- Updated entitler to batch product and content lookups while doing
  dev pool resolution
- Updated tests accordingly