### PR TITLE
1391923: Fixed concurrent ueber cert generation issues (2.0)

### DIFF
--- a/server/src/main/java/org/candlepin/model/OwnerCurator.java
+++ b/server/src/main/java/org/candlepin/model/OwnerCurator.java
@@ -29,6 +29,8 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 
+import javax.persistence.LockModeType;
+
 /**
  * OwnerCurator
  */
@@ -49,6 +51,37 @@ public class OwnerCurator extends AbstractHibernateCurator<Owner> {
     @Override
     public Owner create(Owner entity) {
         return super.create(entity);
+    }
+
+    /**
+     * Find an owner by ownerKey and lock it.
+     *
+     * @param ownerKey the target Owner's key
+     * @return the Owner with the specified key, or null if not found.
+     */
+    @Transactional
+    public Owner findAndLock(String ownerKey) {
+        List<Owner> result = getEntityManager().createQuery("select o from Owner o where key = :ownerKey",
+            Owner.class)
+            .setParameter("ownerKey", ownerKey)
+            .setMaxResults(1)
+            .setLockMode(LockModeType.PESSIMISTIC_WRITE)
+            .getResultList();
+        if (result == null || result.isEmpty()) {
+            return null;
+        }
+        return result.get(0);
+    }
+
+    /**
+     * Refreshes the target Owner and locks it.
+     *
+     * @param owner the target owner.
+     * @return the refreshed and locked Owner.
+     */
+    public Owner lockAndLoad(Owner owner) {
+        getEntityManager().refresh(owner, LockModeType.PESSIMISTIC_WRITE);
+        return owner;
     }
 
     /**

--- a/server/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -1343,33 +1343,7 @@ public class OwnerResource {
         @ApiResponse(code = 400, message = "") })
     public EntitlementCertificate createUeberCertificate(@Context Principal principal,
         @Verify(Owner.class) @PathParam("owner_key") String ownerKey) {
-
-        Owner o = findOwner(ownerKey);
-
-        if (o == null) {
-            throw new NotFoundException(i18n.tr("owner with key: {0} was not found.", ownerKey));
-        }
-
-        try {
-            Consumer ueberConsumer = consumerCurator.findByName(o, Consumer.UEBER_CERT_CONSUMER);
-
-            // ueber cert has already been generated - re-generate it now
-            if (ueberConsumer != null) {
-                List<Entitlement> ueberEntitlements = entitlementCurator.listByConsumer(ueberConsumer);
-
-                if (ueberEntitlements.size() > 0) {
-                    // Immediately revoke and regenerate ueber certificates:
-                    poolManager.regenerateCertificatesOf(ueberEntitlements.get(0), true, false);
-                    return entitlementCertCurator.listForConsumer(ueberConsumer).get(0);
-                }
-            }
-
-            return ueberCertGenerator.generate(o, principal);
-        }
-        catch (Exception e) {
-            log.error("Problem generating uber cert for owner: " + o.getKey(), e);
-            throw new BadRequestException(i18n.tr("Problem generating uber cert for owner {0}", e), e);
-        }
+        return ueberCertGenerator.generate(ownerKey, principal);
     }
 
     /**

--- a/server/src/main/resources/db/changelog/20161025103454-cleanup-ueber-certs-round2.xml
+++ b/server/src/main/resources/db/changelog/20161025103454-cleanup-ueber-certs-round2.xml
@@ -1,0 +1,273 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+    <!-- POSTGRES/ORACLE QUERIES -->
+
+    <!-- Delete any ueber subscriptions that have been carried over from 0.9.54 -->
+    <property
+        dbms="postgresql,oracle,hsqldb"
+        name="delete_ueber_subs"
+        value="delete from cp_subscription
+               where id in (
+                 select s.id from cp_subscription s
+                   inner join cp_product p on s.product_id = p.id
+                   where p.name LIKE '%_ueber_product'
+               );" />
+
+    <!-- Delete ueber entitlement certificates -->
+    <property
+        dbms="postgresql,oracle,hsqldb"
+        name="delete_ueber_certs"
+        value="delete from cp_ent_certificate
+               where entitlement_id in (
+                 select e.id from cp_entitlement e
+                 inner join cp_pool p on e.pool_id = p.id
+                 inner join cp2_products prod ON prod.uuid = p.product_uuid
+                 where prod.name like '%_ueber_product'
+               );" />
+
+    <!-- Delete ueber entitlements -->
+    <property
+        dbms="postgresql,oracle,hsqldb"
+        name="delete_ueber_ents"
+        value="delete from cp_entitlement
+               where pool_id in (
+                 select p.id from cp_pool p
+                 inner join cp2_products prod ON prod.uuid = p.product_uuid
+                 where prod.name like '%_ueber_product');"/>
+
+    <!-- Delete any ueber pool source subscriptions (0.9.54 records) -->
+    <property
+        dbms="postgresql,oracle,hsqldb"
+        name="delete_cp_pool_source_sub"
+        value="delete from cp_pool_source_sub
+               where pool_id in (
+                 select p.id from cp_pool p
+                 inner join cp2_products prod on prod.uuid = p.product_uuid
+                 where prod.name like '%_ueber_product');" />
+
+    <!-- Delete any ueber pool source subscriptions (2.0 records) -->
+    <property
+        dbms="postgresql,oracle,hsqldb"
+        name="delete_cp2_pool_source_sub"
+        value="delete from cp2_pool_source_sub
+               where pool_id in (
+                 select p.id from cp_pool p
+                 inner join cp2_products prod on prod.uuid = p.product_uuid
+                 where prod.name like '%_ueber_product');" />
+
+    <!-- Delete any ueber pools -->
+    <property
+        dbms="postgresql,oracle,hsqldb"
+        name="delete_ueber_pools"
+        value="delete from cp_pool
+               where id in (
+                 select p.id from cp_pool p
+                 inner join cp2_products prod on prod.uuid = p.product_uuid
+                 where prod.name like '%_ueber_product');"/>
+
+    <!-- Delete any ueber content (0.9.54 records) -->
+    <property
+        dbms="postgresql,oracle,hsqldb"
+        name="delete_ueber_content"
+        value="delete from cp_content
+               where id in (
+                 select c.id from cp_content c
+                 inner join cp_product_content pc on pc.content_id = c.id
+                 inner join cp_product p on p.id = pc.product_id
+                 where p.name LIKE '%_ueber_product');"/>
+
+    <!-- Delete any ueber owner content (2.0 records) -->
+    <property
+        dbms="postgresql,oracle,hsqldb"
+        name="delete_cp2_owner_content"
+        value="delete from cp2_owner_content
+               where content_uuid in (
+                 select c.uuid from cp2_content c
+                   inner join cp2_product_content pc on pc.content_uuid=c.uuid
+                   inner join cp2_products p on p.uuid=pc.product_uuid
+                   where p.name LIKE '%ueber_product');"/>
+
+    <!-- Delete any ueber content (2.0 records) -->
+    <property
+        dbms="postgresql,oracle,hsqldb"
+        name="delete_cp2_ueber_content"
+        value="delete from cp2_content
+               where uuid in (
+                 select c.uuid from cp2_content c
+               inner join cp2_product_content pc on pc.content_uuid=c.uuid
+               inner join cp2_products p on p.uuid=pc.product_uuid
+               where p.name LIKE '%ueber_product');"/>
+
+    <!-- Delete any ueber products (0.9.54 records) -->
+    <property
+        dbms="postgresql,oracle,hsqldb"
+        name="delete_ueber_products"
+        value="delete from cp_product where name like '%_ueber_product';"/>
+
+    <!-- Delete any ueber owner products (2.0 records) -->
+    <property
+        dbms="postgresql,oracle,hsqldb"
+        name="delete_cp2_owner_products"
+        value="delete from cp2_owner_products
+               where product_uuid in (
+                    select uuid from cp2_products where name like '%ueber_product'
+               );"/>
+
+    <!-- Delete any ueber products (2.0 records) -->
+    <property
+        dbms="postgresql,oracle,hsqldb"
+        name="delete_cp2_ueber_products"
+        value="delete from cp2_products where name like '%_ueber_product';"/>
+
+    <!-- Delete any ueber consumers -->
+    <property
+        dbms="postgresql,oracle,hsqldb"
+        name="delete_ueber_consumers"
+        value="delete from cp_consumer where name like 'ueber_cert_consumer';"/>
+
+    <!-- MYSQL QUERIES -->
+
+    <!-- Delete any ueber subscriptions that have been carried over from 0.9.54 -->
+    <property
+        dbms="mysql"
+        name="delete_ueber_subs"
+        value="delete s from cp_subscription s
+               inner join cp_product p on s.product_id = p.id
+                   where p.name LIKE '%_ueber_product';"/>
+
+    <!-- Delete ueber entitlement certificates -->
+    <property
+        dbms="mysql"
+        name="delete_ueber_certs"
+        value="delete ec from cp_ent_certificate ec
+                   inner join cp_entitlement e on ec.entitlement_id = e.id
+                   inner join cp_pool p on e.pool_id = p.id
+                   inner join cp2_products prod ON prod.uuid = p.product_uuid
+               where prod.name like '%_ueber_product';"/>
+
+    <!-- Delete ueber entitlements -->
+    <property
+        dbms="mysql"
+        name="delete_ueber_ents"
+        value="delete e from cp_entitlement e
+                   inner join cp_pool p on e.pool_id = p.id
+                   inner join cp2_products prod ON prod.uuid = p.product_uuid
+               where prod.name like '%_ueber_product';" />
+
+    <!-- Delete any ueber pool source subscriptions (0.9.54 records) -->
+    <property
+        dbms="mysql"
+        name="delete_cp_pool_source_sub"
+        value="delete ss from cp_pool_source_sub ss
+                   inner join cp_pool p on ss.pool_id = p.id
+                   inner join cp2_products prod ON prod.uuid = p.product_uuid
+               where prod.name like '%_ueber_product';" />
+
+    <!-- Delete any ueber pool source subscriptions (2.0 records) -->
+    <property
+        dbms="mysql"
+        name="delete_cp2_pool_source_sub"
+        value="delete ss from cp2_pool_source_sub ss
+                   inner join cp_pool p on ss.pool_id = p.id
+                   inner join cp2_products prod ON prod.uuid = p.product_uuid
+               where prod.name like '%_ueber_product';" />
+
+    <!-- Delete any ueber pools -->
+    <property
+        dbms="mysql"
+        name="delete_ueber_pools"
+        value="delete p from cp_pool p
+                   inner join cp2_products prod ON prod.uuid = p.product_uuid
+                   where prod.name like '%_ueber_product';"/>
+
+    <!-- Delete any ueber content (0.9.54 records) -->
+    <property
+        dbms="mysql"
+        name="delete_ueber_content"
+        value="delete c from cp_content c
+                   inner join cp_product_content pc on pc.content_id = c.id
+                   inner join cp_product p on p.id = pc.product_id
+                   where p.name LIKE '%_ueber_product';"/>
+
+    <!-- Delete any ueber owner content (2.0 records) -->
+    <property
+        dbms="mysql"
+        name="delete_cp2_owner_content"
+        value="delete oc from cp2_owner_content oc
+                   inner join cp2_product_content pc on pc.content_uuid=oc.content_uuid
+                   inner join cp2_products p on p.uuid=pc.product_uuid
+                   where p.name LIKE '%ueber_product';"/>
+
+    <!-- Delete any ueber content (2.0 records) -->
+    <property
+        dbms="mysql"
+        name="delete_cp2_ueber_content"
+        value="delete c from cp2_content c
+                   inner join cp2_product_content pc on pc.content_uuid=c.uuid
+                   inner join cp2_products p on p.uuid=pc.product_uuid
+                   where p.name LIKE '%ueber_product';"/>
+
+
+
+
+
+
+
+
+
+    <!-- Delete any ueber products (0.9.54 records) -->
+    <property
+        dbms="mysql"
+        name="delete_ueber_products"
+        value="delete p from cp_product p where name like '%_ueber_product';"/>
+
+    <!-- Delete any ueber owner products (2.0 records) -->
+    <property
+        dbms="mysql"
+        name="delete_cp2_owner_products"
+        value="delete op from cp2_owner_products op
+                   inner join cp2_products p on op.product_uuid = p.uuid
+                   where name like '%ueber_product';"/>
+
+    <!-- Delete any ueber products (2.0 records) -->
+    <property
+        dbms="mysql"
+        name="delete_cp2_ueber_products"
+        value="delete p from cp2_products p where name like '%_ueber_product';"/>
+
+    <!-- Delete any ueber consumers -->
+    <property
+        dbms="mysql"
+        name="delete_ueber_consumers"
+        value="delete c from cp_consumer c where name like 'ueber_cert_consumer';"/>
+
+    <changeSet id="20161025103454-1" author="mstead">
+        <validCheckSum>7:9b3c3db544862eaa6e7ff0cb9f9ef4b5</validCheckSum>
+        <comment>Clean out all ueber cert (debug cert) data to avoid manual cleanup.
+                 This changeset will remove both the 0.9.54 (copied data) AND the
+                 2.0 ueber cert data. We are required to do this a second time since
+                 another issue was found that would put the data in a strange state.</comment>
+        <sql>${delete_ueber_subs}</sql>
+        <sql>${delete_ueber_certs}</sql>
+        <sql>${delete_cp_pool_source_sub}</sql>
+        <sql>${delete_cp2_pool_source_sub}</sql>
+        <sql>${delete_ueber_ents}</sql>
+        <sql>${delete_ueber_pools}</sql>
+        <sql>${delete_ueber_content}</sql>
+        <sql>${delete_cp2_owner_content}</sql>
+        <sql>${delete_cp2_ueber_content}</sql>
+        <sql>${delete_ueber_products}</sql>
+        <sql>${delete_cp2_owner_products}</sql>
+        <sql>${delete_cp2_ueber_products}</sql>
+        <sql>${delete_ueber_consumers}</sql>
+    </changeSet>
+
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->
+

--- a/server/src/main/resources/db/changelog/changelog-create.xml
+++ b/server/src/main/resources/db/changelog/changelog-create.xml
@@ -1192,4 +1192,5 @@
     <include file="db/changelog/20160907121757-add-autobind-disabled-column-to-owner.xml"/>
     <include file="db/changelog/20161025100925-remove-unique-content-name-constraint.xml"/>
     <include file="db/changelog/20160419092221-add-db-file-storage.xml"/>
+    <include file="db/changelog/20161025103454-cleanup-ueber-certs-round2.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-testing.xml
+++ b/server/src/main/resources/db/changelog/changelog-testing.xml
@@ -2282,4 +2282,5 @@
     <include file="db/changelog/20160907121757-add-autobind-disabled-column-to-owner.xml"/>
     <include file="db/changelog/20161025100925-remove-unique-content-name-constraint.xml"/>
     <include file="db/changelog/20160419092221-add-db-file-storage.xml"/>
+    <include file="db/changelog/20161025103454-cleanup-ueber-certs-round2.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-update.xml
+++ b/server/src/main/resources/db/changelog/changelog-update.xml
@@ -100,4 +100,5 @@
     <include file="db/changelog/20160907121757-add-autobind-disabled-column-to-owner.xml"/>
     <include file="db/changelog/20161025100925-remove-unique-content-name-constraint.xml"/>
     <include file="db/changelog/20160419092221-add-db-file-storage.xml"/>
+    <include file="db/changelog/20161025103454-cleanup-ueber-certs-round2.xml"/>
 </databaseChangeLog>

--- a/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
@@ -112,7 +112,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
             TestUtil.createDate(2000, 3, 2), TestUtil.createDate(2005, 3, 2));
         poolCurator.create(pool);
 
-        ueberCertGenerator.generate(owner, new NoAuthPrincipal());
+        ueberCertGenerator.generate(owner.getKey(), new NoAuthPrincipal());
 
         List<Pool> results = poolCurator.listAvailableEntitlementPools(
             consumer, consumer.getOwner(), (Collection<String>) null, null, true);

--- a/server/src/test/java/org/candlepin/resource/OwnerResourceUeberCertOperationsTest.java
+++ b/server/src/test/java/org/candlepin/resource/OwnerResourceUeberCertOperationsTest.java
@@ -24,6 +24,7 @@ import org.candlepin.common.exceptions.NotFoundException;
 import org.candlepin.controller.CandlepinPoolManager;
 import org.candlepin.controller.ContentManager;
 import org.candlepin.controller.ProductManager;
+import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerCurator;
 import org.candlepin.model.ConsumerType;
 import org.candlepin.model.ConsumerType.ConsumerTypeEnum;
@@ -33,6 +34,7 @@ import org.candlepin.model.EntitlementCertificateCurator;
 import org.candlepin.model.EntitlementCurator;
 import org.candlepin.model.Owner;
 import org.candlepin.model.OwnerCurator;
+import org.candlepin.model.Pool;
 import org.candlepin.model.PoolCurator;
 import org.candlepin.model.Product;
 import org.candlepin.model.ProductCurator;
@@ -164,5 +166,26 @@ public class OwnerResourceUeberCertOperationsTest extends DatabaseTestFixture {
     public void certificateRetrievalReturnsCert() {
         EntitlementCertificate cert = or.createUeberCertificate(principal, owner.getKey());
         assertNotNull(cert);
+    }
+
+    @Test
+    public void ueberPoolCreatedWhenMissing() throws Exception {
+        EntitlementCertificate firstCert = or.createUeberCertificate(principal, owner.getKey());
+        Pool firstPool = firstCert.getEntitlement().getPool();
+        poolManager.deletePool(firstPool);
+        EntitlementCertificate newCert = or.createUeberCertificate(principal, owner.getKey());
+        assertFalse(firstPool.equals(newCert.getEntitlement().getPool()));
+    }
+
+    @Test
+    public void ueberCertRegeneratedWhenNoUeberEntsExistForConsumer() throws Exception {
+        EntitlementCertificate firstCert = or.createUeberCertificate(principal, owner.getKey());
+        assertNotNull(firstCert);
+        Consumer ueberConsumer = consumerCurator.findByName(owner, Consumer.UEBER_CERT_CONSUMER);
+        assertNotNull(ueberConsumer);
+        assertEquals(1, poolManager.revokeAllEntitlements(ueberConsumer));
+        EntitlementCertificate newCert = or.createUeberCertificate(principal, owner.getKey());
+        assertNotNull(newCert);
+        assertFalse(newCert.equals(firstCert));
     }
 }


### PR DESCRIPTION
- Addressed transaction issues that would allow partial
  cert generation (combos of consumer, pool, prod, content).
- Lock the target Owner on cert generation so that checks
  for an existing cert will succeed and result in a single
  cert per owner.
- Added another changeset to delete all the ueber certificates
  since already affected candlepin instances may have invalid
  DB state due to this bug.

## Steps To Test This PR

1. Deploy the latest version of candlepin 2.0
2. Follow steps to test in the BZ [1391923](https://bugzilla.redhat.com/show_bug.cgi?id=1391923) to reproduce.

**NOTE:** You may have to run the script a couple of times in order to get the bug to occur. See the BZ for more details. I had to run it twice, and counts are reflected in the DB query.

```bash
$ ./concurrent_ueber_cert.sh -o brewery
Creating owner brewery and generating certs...
{
  "parentOwner" : null,
  "id" : "402882e7582f5f6b01582f6180c8230d",
  "key" : "brewery",
  "displayName" : "brewery",
  "contentPrefix" : null,
  "defaultServiceLevel" : null,
  "upstreamConsumer" : null,
  "logLevel" : null,
  "autobindDisabled" : null,
  "href" : "/owners/brewery",
  "created" : "2016-11-04T12:47:48.936+0000",
  "updated" : "2016-11-04T12:47:48.936+0000"
}{
  "displayMessage" : "Problem generating ueber cert for owner org.hibernate.NonUniqueResultException: query did not return a unique result: 2",
  "requestUuid" : "1a1d52ad-7d91-4702-abc9-424a051c1646"
}{
  "displayMessage" : "Problem generating ueber cert for owner org.hibernate.NonUniqueResultException: query did not return a unique result: 2",
  "requestUuid" : "7ef66287-297b-47b0-ba35-7a707cc5d66d"
}
```
Validate the bad data with the following query. The counts should be the same across the board, but they are not.

```sql
candlepin=# SELECT 
       -- NO SUBS FOR 2.0
       
       -- Certificates
       (SELECT Count(*)
        FROM   cp_ent_certificate ec
               INNER JOIN cp_entitlement e
                       ON e.id = ec.entitlement_id
               INNER JOIN cp_pool p
                       ON e.pool_id = p.id
               INNER JOIN cp2_products prod
                       ON prod.uuid = p.product_uuid
        WHERE  prod.NAME LIKE '%_ueber_product') AS UEBER_ENT_CERTS,
        
        -- Entitlements
       (SELECT Count(*)
        FROM   cp_entitlement e
               INNER JOIN cp_pool p
                       ON e.pool_id = p.id
               INNER JOIN cp2_products prod
                       ON prod.uuid = p.product_uuid
        WHERE  prod.NAME LIKE '%_ueber_product') AS UEBER_ENTS,
        
        -- Pools
       (SELECT Count(*)
        FROM   cp_pool p
               INNER JOIN cp2_products prod
                       ON prod.uuid = p.product_uuid
        WHERE  prod.NAME LIKE '%_ueber_product') AS UEBER_POOLS,
        
        -- Content
        (select count(*) from cp2_content c
               inner join cp2_product_content pc on pc.content_uuid=c.uuid
               inner join cp2_products p on p.uuid=pc.product_uuid
               where p.name LIKE '%ueber_product'
        ) AS CP2_UEBER_CONTENT,

        -- Owner Content
        (select count(*) from cp2_owner_content oc
               inner join cp2_content c on c.uuid=oc.content_uuid
               inner join cp2_product_content pc on pc.content_uuid=c.uuid
               inner join cp2_products p on p.uuid=pc.product_uuid
               where p.name LIKE '%ueber_product'
         ) as CP2_OWNER_CONTENT,

         -- Products
         (select count(*) from cp2_products p where p.name LIKE '%ueber_product') AS CP2_PRODUCTS,

         -- Owner Products
         (select count(*) from cp2_owner_products op
             INNER JOIN cp2_products prod on op.product_uuid = prod.uuid
             WHERE prod.name LIKE '%ueber_product'
         ) AS CP2_OWNER_PRODUCTS,

         -- Consumers
         (SELECT Count(*)
             FROM   cp_consumer
             WHERE  NAME = 'ueber_cert_consumer'
         ) AS UEBER_CONSUMER;
 ueber_ent_certs | ueber_ents | ueber_pools | cp2_ueber_content | cp2_owner_content | cp2_products | cp2_owner_products | ueber_consumer 
-----------------+------------+-------------+-------------------+-------------------+--------------+--------------------+----------------
               0 |          0 |          2 |                2 |                2 |           2 |                 2 |             2
(1 row)

```
3. Getting the cert for the target owner will fail.

```bash
$ curl -k -u admin:admin https://localhost:8443/candlepin/owners/brewery/uebercert
{
  "displayMessage" : "Runtime Error query did not return a unique result: 2 at org.hibernate.internal.AbstractQueryImpl.uniqueElement:914",
  "requestUuid" : "dc9fdfbd-8707-4b53-ae51-d25952352d78"
}
```

4. A single regen request will fail.

```bash
$ curl -k -u admin:admin -X POST https://localhost:8443/candlepin/owners/brewery/uebercert
{
  "displayMessage" : "Problem generating ueber cert for owner org.hibernate.NonUniqueResultException: query did not return a unique result: 2",
  "requestUuid" : "bac32cb7-9497-4eb0-832d-775fd1b9efa9"
}
```

5. Deploy this patch WITHOUT regenerating the DB. The patch contains a liquibase change set to wipe out the ueber cert data. Verify with the following query. The results should show counts of 0 across the board.

```sql
candlepin=# SELECT 
       -- NO SUBS FOR 2.0
       
       -- Certificates
       (SELECT Count(*)
        FROM   cp_ent_certificate ec
               INNER JOIN cp_entitlement e
                       ON e.id = ec.entitlement_id
               INNER JOIN cp_pool p
                       ON e.pool_id = p.id
               INNER JOIN cp2_products prod
                       ON prod.uuid = p.product_uuid
        WHERE  prod.NAME LIKE '%_ueber_product') AS UEBER_ENT_CERTS,
        
        -- Entitlements
       (SELECT Count(*)
        FROM   cp_entitlement e
               INNER JOIN cp_pool p
                       ON e.pool_id = p.id
               INNER JOIN cp2_products prod
                       ON prod.uuid = p.product_uuid
        WHERE  prod.NAME LIKE '%_ueber_product') AS UEBER_ENTS,
        
        -- Pools
       (SELECT Count(*)
        FROM   cp_pool p
               INNER JOIN cp2_products prod
                       ON prod.uuid = p.product_uuid
        WHERE  prod.NAME LIKE '%_ueber_product') AS UEBER_POOLS,
        
        -- Content
        (select count(*) from cp2_content c
               inner join cp2_product_content pc on pc.content_uuid=c.uuid
               inner join cp2_products p on p.uuid=pc.product_uuid
               where p.name LIKE '%ueber_product'
        ) AS CP2_UEBER_CONTENT,

        -- Owner Content
        (select count(*) from cp2_owner_content oc
               inner join cp2_content c on c.uuid=oc.content_uuid
               inner join cp2_product_content pc on pc.content_uuid=c.uuid
               inner join cp2_products p on p.uuid=pc.product_uuid
               where p.name LIKE '%ueber_product'
         ) as CP2_OWNER_CONTENT,

         -- Products
         (select count(*) from cp2_products p where p.name LIKE '%ueber_product') AS CP2_PRODUCTS,

         -- Owner Products
         (select count(*) from cp2_owner_products op
             INNER JOIN cp2_products prod on op.product_uuid = prod.uuid
             WHERE prod.name LIKE '%ueber_product'
         ) AS CP2_OWNER_PRODUCTS,

         -- Consumers
         (SELECT Count(*)
             FROM   cp_consumer
             WHERE  NAME = 'ueber_cert_consumer'
         ) AS UEBER_CONSUMER;
 ueber_ent_certs | ueber_ents | ueber_pools | cp2_ueber_content | cp2_owner_content | cp2_products | cp2_owner_products | ueber_consumer 
-----------------+------------+-------------+-------------------+-------------------+--------------+--------------------+----------------
               0 |          0 |          0 |                0 |                0 |           0 |                 0 |             0
(1 row)

```

6. Re-run the script from the BZ again. Both cert generation requests should succeed, however, there should only be 1 set of ueber cert data in the DB. The counts from the query should increment for every owner that has an ueber cert generated, and every column should have the same count. For example, if 5 owners have a generated cert, the counts should be 5 across the board.

```bash
$ ./concurrent_ueber_cert.sh -o another_owner
Creating owner another_owner and generating certs...
{
  "parentOwner" : null,
  "id" : "402882e7582f67cc01582f89adbd0000",
  "key" : "another_owner",
  "displayName" : "another_owner",
  "contentPrefix" : null,
  "defaultServiceLevel" : null,
  "upstreamConsumer" : null,
  "logLevel" : null,
  "autobindDisabled" : null,
  "href" : "/owners/another_owner",
  "created" : "2016-11-04T13:31:41.885+0000",
  "updated" : "2016-11-04T13:31:41.885+0000"
}{
  "key" : "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEAqntFzRSj4Nj+p32CwVsBeAlE918ZhWKzWkpWXQlEoA0Kb2jN\nc8QXQnwgCUNHXSx3S6e3S4FDXsvMu/nBmoHRfCltUFumXM3LlD0OUnc5sfv23if5\nH3ykYUpazrSDrO0kRT02jVPJpOzcbA0yRrar7xyGuoQW/D5BGPlwNT3WunbFc3Hg\n28I7ebF0szYyzcnRypLMrl8Ux1n+/3tL+M2WFus8/xfEmJgAWtGh1BPg5SOqPEnH

----- SNIP -----

  "created" : "2016-11-04T13:31:43.015+0000",
  "updated" : "2016-11-04T13:31:43.015+0000"
}{
  "key" : "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEAqntFzRSj4Nj+p32CwVsBeAlE918ZhWKzWkpWXQlEoA0Kb2jN\nc8QXQnwgCUNHXSx3S6e3S4FDXsvMu/nBmoHRfCltUFumXM3LlD0OUnc5sfv23if5\nH3ykYUpazrSDrO0kRT02jVPJpOzcbA0yRrar7xyGuoQW/D5BGPlwNT3WunbFc3Hg\n28I7ebF0szYyzcnRypLMrl8Ux1n+/3tL+M2WFus8/xfEmJgAWtGh1BPg5SOqPEnH 

----- SNIP ---

  "created" : "2016-11-04T13:31:43.115+0000",
  "updated" : "2016-11-04T13:31:43.115+0000"
}
```

**NOTE:**  Both requests succeeded.

```sql
candlepin=# SELECT 
       -- NO SUBS FOR 2.0
       
       -- Certificates
       (SELECT Count(*)
        FROM   cp_ent_certificate ec
               INNER JOIN cp_entitlement e
                       ON e.id = ec.entitlement_id
               INNER JOIN cp_pool p
                       ON e.pool_id = p.id
               INNER JOIN cp2_products prod
                       ON prod.uuid = p.product_uuid
        WHERE  prod.NAME LIKE '%_ueber_product') AS UEBER_ENT_CERTS,
        
        -- Entitlements
       (SELECT Count(*)
        FROM   cp_entitlement e
               INNER JOIN cp_pool p
                       ON e.pool_id = p.id
               INNER JOIN cp2_products prod
                       ON prod.uuid = p.product_uuid
        WHERE  prod.NAME LIKE '%_ueber_product') AS UEBER_ENTS,
        
        -- Pools
       (SELECT Count(*)
        FROM   cp_pool p
               INNER JOIN cp2_products prod
                       ON prod.uuid = p.product_uuid
        WHERE  prod.NAME LIKE '%_ueber_product') AS UEBER_POOLS,
        
        -- Content
        (select count(*) from cp2_content c
               inner join cp2_product_content pc on pc.content_uuid=c.uuid
               inner join cp2_products p on p.uuid=pc.product_uuid
               where p.name LIKE '%ueber_product'
        ) AS CP2_UEBER_CONTENT,

        -- Owner Content
        (select count(*) from cp2_owner_content oc
               inner join cp2_content c on c.uuid=oc.content_uuid
               inner join cp2_product_content pc on pc.content_uuid=c.uuid
               inner join cp2_products p on p.uuid=pc.product_uuid
               where p.name LIKE '%ueber_product'
         ) as CP2_OWNER_CONTENT,

         -- Products
         (select count(*) from cp2_products p where p.name LIKE '%ueber_product') AS CP2_PRODUCTS,

         -- Owner Products
         (select count(*) from cp2_owner_products op
             INNER JOIN cp2_products prod on op.product_uuid = prod.uuid
             WHERE prod.name LIKE '%ueber_product'
         ) AS CP2_OWNER_PRODUCTS,

         -- Consumers
         (SELECT Count(*)
             FROM   cp_consumer
             WHERE  NAME = 'ueber_cert_consumer'
         ) AS UEBER_CONSUMER;
 ueber_ent_certs | ueber_ents | ueber_pools | cp2_ueber_content | cp2_owner_content | cp2_products | cp2_owner_products | ueber_consumer 
-----------------+------------+-------------+-------------------+-------------------+--------------+--------------------+----------------
               1 |          1 |          1 |                1 |                1 |           1 |                 1 |             1
(1 row)

```

7. You should be able to fetch the existing cert for the target owner.

```bash
$ curl -k -u admin:admin https://localhost:8443/candlepin/owners/another_owner/uebercert

{
  "key" : "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEAqntFzRSj4Nj+p32CwVsBeAlE918ZhWKzWkpWXQlEoA0Kb2jN\nc8QXQnwgCUNHXSx3S6e3S4FDXsvMu/nBmoHRfCltUFumXM3LlD0OUnc5sfv23if5

----- SNIP -----

  "created" : "2016-11-04T13:31:43.115+0000",
  "updated" : "2016-11-04T13:31:43.115+0000"
}
```

8. You should be able to regenerate the ueber cert.

```bash
$ curl -k -u admin:admin -X POST https://localhost:8443/candlepin/owners/another_owner/uebercert

{
  "key" : "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEAqntFzRSj4Nj+p32CwVsBeAlE918ZhWKzWkpWXQlEoA0Kb2jN\nc8QXQnwgCUNHXSx3S6e3S4FDXsvMu/nBmoHRfCltUFumXM3LlD0OUnc5sfv23if5

----- SNIP -----

  "created" : "2016-11-04T13:47:38.078+0000",
  "updated" : "2016-11-04T13:47:38.078+0000"
}
```

9. Verify the DB counts one last time.

```sql
candlepin=# SELECT 
       -- NO SUBS FOR 2.0
       
       -- Certificates
       (SELECT Count(*)
        FROM   cp_ent_certificate ec
               INNER JOIN cp_entitlement e
                       ON e.id = ec.entitlement_id
               INNER JOIN cp_pool p
                       ON e.pool_id = p.id
               INNER JOIN cp2_products prod
                       ON prod.uuid = p.product_uuid
        WHERE  prod.NAME LIKE '%_ueber_product') AS UEBER_ENT_CERTS,
        
        -- Entitlements
       (SELECT Count(*)
        FROM   cp_entitlement e
               INNER JOIN cp_pool p
                       ON e.pool_id = p.id
               INNER JOIN cp2_products prod
                       ON prod.uuid = p.product_uuid
        WHERE  prod.NAME LIKE '%_ueber_product') AS UEBER_ENTS,
        
        -- Pools
       (SELECT Count(*)
        FROM   cp_pool p
               INNER JOIN cp2_products prod
                       ON prod.uuid = p.product_uuid
        WHERE  prod.NAME LIKE '%_ueber_product') AS UEBER_POOLS,
        
        -- Content
        (select count(*) from cp2_content c
               inner join cp2_product_content pc on pc.content_uuid=c.uuid
               inner join cp2_products p on p.uuid=pc.product_uuid
               where p.name LIKE '%ueber_product'
        ) AS CP2_UEBER_CONTENT,
        -- Owner Content
        (select count(*) from cp2_owner_content oc
               inner join cp2_content c on c.uuid=oc.content_uuid
               inner join cp2_product_content pc on pc.content_uuid=c.uuid
               inner join cp2_products p on p.uuid=pc.product_uuid
               where p.name LIKE '%ueber_product'
         ) as CP2_OWNER_CONTENT,
         -- Products
         (select count(*) from cp2_products p where p.name LIKE '%ueber_product') AS CP2_PRODUCTS,
         -- Owner Products
         (select count(*) from cp2_owner_products op
         ) AS UEBER_CONSUMER;
 ueber_ent_certs | ueber_ents | ueber_pools | cp2_ueber_content | cp2_owner_content | cp2_products | cp2_owner_products | ueber_consumer 
-----------------+------------+-------------+-------------------+-------------------+--------------+--------------------+----------------
               1 |          1 |          1 |                1 |                1 |           1 |                 1 |             1
(1 row)

```


## Bonus Points

Start with deploying an 0954 server before the equivalent bug fix was applied to it.

Try this commit: 

Then break the ueber cert data as above against 0954.

Once verified broken, deploy the master branch so that all the ueber data is migrated to the 2.0 version.

You can use the following queries to verify that the data is wrong in both cases. Remember that ueber cert data should have equal counts across the board.

**Old Data**
```sql
SELECT (SELECT Count(*)
        FROM   cp_subscription s
               INNER JOIN cp_product p
                       ON s.product_id = p.id
               LEFT OUTER JOIN cp_pool pool
                            ON pool.product_id_old = p.id
        WHERE  p.NAME LIKE '%_ueber_product')    AS UEBER_SUBS,
       (SELECT Count(*)
        FROM   cp_ent_certificate ec
               INNER JOIN cp_entitlement e
                       ON e.id = ec.entitlement_id
               INNER JOIN cp_pool p
                       ON e.pool_id = p.id
               INNER JOIN cp_product prod
                       ON prod.id = p.product_id_old
        WHERE  prod.NAME LIKE '%_ueber_product') AS UEBER_ENT_CERTS,
       (SELECT Count(*)
        FROM   cp_entitlement e
               INNER JOIN cp_pool p
                       ON e.pool_id = p.id
               INNER JOIN cp_product prod
                       ON prod.id = p.product_id_old
        WHERE  prod.NAME LIKE '%_ueber_product') AS UEBER_ENTS,
       (SELECT Count(*)
        FROM   cp_pool p
               INNER JOIN cp_product prod
                       ON prod.id = p.product_id_old
        WHERE  prod.NAME LIKE '%_ueber_product') AS UEBER_POOLS, 
       (SELECT Count(*)
        FROM   cp_content c
               INNER JOIN cp_product_content pc
                       ON pc.content_id = c.id
               INNER JOIN cp_product p
                       ON p.id = pc.product_id
        WHERE  p.NAME LIKE '%_ueber_product')    AS UEBER_CONTENT,
       (SELECT Count(*)
        FROM   cp_product
        WHERE  NAME LIKE '%_ueber_product')      AS UEBER_PRODUCTS,
       (SELECT Count(*)
        FROM   cp_consumer
        WHERE  NAME = 'ueber_cert_consumer')     AS UEBER_CONSUMER;
```

**2.0 Migrated data**
```sql
SELECT 
       -- NO SUBS FOR 2.0
       
       -- Certificates
       (SELECT Count(*)
        FROM   cp_ent_certificate ec
               INNER JOIN cp_entitlement e
                       ON e.id = ec.entitlement_id
               INNER JOIN cp_pool p
                       ON e.pool_id = p.id
               INNER JOIN cp2_products prod
                       ON prod.uuid = p.product_uuid
        WHERE  prod.NAME LIKE '%_ueber_product') AS UEBER_ENT_CERTS,
        
        -- Entitlements
       (SELECT Count(*)
        FROM   cp_entitlement e
               INNER JOIN cp_pool p
                       ON e.pool_id = p.id
               INNER JOIN cp2_products prod
                       ON prod.uuid = p.product_uuid
        WHERE  prod.NAME LIKE '%_ueber_product') AS UEBER_ENTS,
        
        -- Pools
       (SELECT Count(*)
        FROM   cp_pool p
               INNER JOIN cp2_products prod
                       ON prod.uuid = p.product_uuid
        WHERE  prod.NAME LIKE '%_ueber_product') AS UEBER_POOLS,
        
        -- Content
        (select count(*) from cp2_content c
               inner join cp2_product_content pc on pc.content_uuid=c.uuid
               inner join cp2_products p on p.uuid=pc.product_uuid
               where p.name LIKE '%ueber_product'
        ) AS CP2_UEBER_CONTENT,

        -- Owner Content
        (select count(*) from cp2_owner_content oc
               inner join cp2_content c on c.uuid=oc.content_uuid
               inner join cp2_product_content pc on pc.content_uuid=c.uuid
               inner join cp2_products p on p.uuid=pc.product_uuid
               where p.name LIKE '%ueber_product'
         ) as CP2_OWNER_CONTENT,

         -- Products
         (select count(*) from cp2_products p where p.name LIKE '%ueber_product') AS CP2_PRODUCTS,

         -- Owner Products
         (select count(*) from cp2_owner_products op
             INNER JOIN cp2_products prod on op.product_uuid = prod.uuid
             WHERE prod.name LIKE '%ueber_product'
         ) AS CP2_OWNER_PRODUCTS,

         -- Consumers
         (SELECT Count(*)
             FROM   cp_consumer
             WHERE  NAME = 'ueber_cert_consumer'
         ) AS UEBER_CONSUMER;
```

Next deploy this PR leaving the data in tact. After the deploy, running the queries should result in 0s across the board.