### PR TITLE
Fix issue locking Owner on Oracle

### DIFF
--- a/profiles.yaml
+++ b/profiles.yaml
@@ -36,7 +36,7 @@ development:
 oracle:
   static: &oracle_static
     driver_class: "oracle.jdbc.OracleDriver"
-    dialect: "org.hibernate.dialect.Oracle10gDialect"
+    dialect: "org.candlepin.hibernate.Oracle10gDialectFollowOnLockingOff"
     quartz_driver: "org.quartz.impl.jdbcjobstore.oracle.OracleDelegate"
   server:
     <<: *common_server

--- a/server/code/setup/cpsetup
+++ b/server/code/setup/cpsetup
@@ -161,7 +161,7 @@ class CertSetup(object):
 class OracleConf(object):
     def __init__(self, options):
         self.options = options
-        self.dialect = "org.hibernate.dialect.Oracle10gDialect"
+        self.dialect = "org.candlepin.hibernate.Oracle10gDialectFollowOnLockingOff"
         self.driver = "oracle.jdbc.OracleDriver"
         self.jdbc_url = "jdbc:oracle:thin:@//%s" % self.options.db
 

--- a/server/src/main/java/org/candlepin/hibernate/Oracle10gDialectFollowOnLockingOff.java
+++ b/server/src/main/java/org/candlepin/hibernate/Oracle10gDialectFollowOnLockingOff.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.hibernate;
+
+import org.hibernate.dialect.Oracle10gDialect;
+
+/**
+ * We make sure that our locking queries work on all supported database servers
+ * and thus don't need follow on locking. The feature caused us trouble. Queries
+ * that locked on other DBs were was not locking on Oracle.
+ *
+ * This dialect might cause some SQL syntax errors on Oracle. Some of the cases
+ * are covered here:
+ *
+ * - https://www.mail-archive.com/hibernate-dev@lists.jboss.org/msg14520.html
+ * - https://docs.oracle.com/database/121/SQLRF/statements_10002.htm#sthref7465
+ *
+ * I think its better to get SQL syntax error than silently fail to acquire
+ * a lock.
+ *
+ * @author fnguyen
+ *
+ */
+public class Oracle10gDialectFollowOnLockingOff extends Oracle10gDialect {
+
+    @Override
+    public boolean useFollowOnLocking() {
+        return false;
+    }
+}

--- a/server/src/main/java/org/candlepin/model/OwnerCurator.java
+++ b/server/src/main/java/org/candlepin/model/OwnerCurator.java
@@ -26,6 +26,8 @@ import org.hibernate.criterion.Property;
 import org.hibernate.criterion.Restrictions;
 import org.hibernate.criterion.Subqueries;
 import org.hibernate.sql.JoinType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.Date;
@@ -41,6 +43,7 @@ import javax.persistence.LockModeType;
 public class OwnerCurator extends AbstractHibernateCurator<Owner> {
 
     @Inject private CandlepinQueryFactory cpQueryFactory;
+    private static Logger log = LoggerFactory.getLogger(OwnerCurator.class);
 
     public OwnerCurator() {
         super(Owner.class);
@@ -67,22 +70,15 @@ public class OwnerCurator extends AbstractHibernateCurator<Owner> {
      */
     @Transactional
     public Owner findAndLock(String ownerKey) {
-        List<Owner> result = getEntityManager().createQuery("select o from Owner o where key = :ownerKey",
+        List<Owner> result = getEntityManager().createQuery("select o from Owner o where o.key = :ownerKey",
             Owner.class)
             .setParameter("ownerKey", ownerKey)
-            .setMaxResults(1)
             .setLockMode(LockModeType.PESSIMISTIC_WRITE)
             .getResultList();
         if (result == null || result.isEmpty()) {
             return null;
         }
-
-        // For some reason or other, setting LockMode on the initial query does
-        // not seem to lock the Owner on Oracle. Refreshing the entity after
-        // looking it up seems to do the trick.
-        Owner owner = result.get(0);
-        getEntityManager().refresh(owner, LockModeType.PESSIMISTIC_WRITE);
-        return owner;
+        return result.get(0);
     }
 
     /**

--- a/server/src/main/java/org/candlepin/model/OwnerCurator.java
+++ b/server/src/main/java/org/candlepin/model/OwnerCurator.java
@@ -76,16 +76,11 @@ public class OwnerCurator extends AbstractHibernateCurator<Owner> {
         if (result == null || result.isEmpty()) {
             return null;
         }
-        return result.get(0);
-    }
 
-    /**
-     * Refreshes the target Owner and locks it.
-     *
-     * @param owner the target owner.
-     * @return the refreshed and locked Owner.
-     */
-    public Owner lockAndLoad(Owner owner) {
+        // For some reason or other, setting LockMode on the initial query does
+        // not seem to lock the Owner on Oracle. Refreshing the entity after
+        // looking it up seems to do the trick.
+        Owner owner = result.get(0);
         getEntityManager().refresh(owner, LockModeType.PESSIMISTIC_WRITE);
         return owner;
     }


### PR DESCRIPTION
For some reason or other, against Oracle,
setting the LockMode on the query does not
seem to work.

As a workaround, look up the Owner by key,
and do a refresh with a LockMode.