### PR TITLE
Fixed a crash when paging certain requests

### DIFF
--- a/server/client/ruby/candlepin_api.rb
+++ b/server/client/ruby/candlepin_api.rb
@@ -536,24 +536,36 @@ class Candlepin
     post("/consumers/#{uuid}/entitlements")
   end
 
-  def list_products(product_ids=nil)
-    method = "/products?"
+  def list_products(product_ids=nil, params={})
+    path = "/products?"
     if product_ids
       product_ids.each { |id|
-        method << "&product=" << id
+        path << "product=#{id}&"
       }
     end
-    get(method)
+
+    # add paging params
+    path << "page=#{params[:page]}&" if params[:page]
+    path << "per_page=#{params[:per_page]}&" if params[:per_page]
+    path << "sort_by=#{params[:sort_by]}&" if params[:sort_by]
+
+    get(path)
   end
 
-  def list_products_by_owner(owner_key, product_ids=nil)
-    method = "/owners/#{owner_key}/products?"
+  def list_products_by_owner(owner_key, product_ids=nil, params={})
+    path = "/owners/#{owner_key}/products?"
     if product_ids
       product_ids.each { |id|
-        method << "&product=" << id
+        path << "product=#{id}&"
       }
     end
-    get(method)
+
+    # add paging params
+    path << "page=#{params[:page]}&" if params[:page]
+    path << "per_page=#{params[:per_page]}&" if params[:per_page]
+    path << "sort_by=#{params[:sort_by]}&" if params[:sort_by]
+
+    get(path)
   end
 
   def create_content(owner_key, name, id, label, type, vendor, params={}, post=true)
@@ -590,8 +602,15 @@ class Candlepin
     post("/owners/#{owner_key}/content/batch", contents)
   end
 
-  def list_content(owner_key)
-    get("/owners/#{owner_key}/content")
+  def list_content(owner_key, params={})
+    path = "/owners/#{owner_key}/content?"
+
+    # add paging params
+    path << "page=#{params[:page]}&" if params[:page]
+    path << "per_page=#{params[:per_page]}&" if params[:per_page]
+    path << "sort_by=#{params[:sort_by]}&" if params[:sort_by]
+
+    get(path)
   end
 
   def get_content(owner_key, content_id)

--- a/server/spec/owner_product_resource_spec.rb
+++ b/server/spec/owner_product_resource_spec.rb
@@ -219,7 +219,9 @@ describe 'Owner Product Resource' do
     prod2_id = random_string("test_id")
     prod3_id = random_string("test_id")
     prod1 = create_product(prod1_id, random_string("test_name"))
+    sleep 1
     prod2 = create_product(prod2_id, random_string("test_name"))
+    sleep 1
     prod3 = create_product(prod3_id, random_string("test_name"))
     all_products = @cp.list_products_by_owner(@owner['key'])
     all_products.size.should >= 3
@@ -238,6 +240,67 @@ describe 'Owner Product Resource' do
       bulk_get_products[0]['id'].should == prod3_id
       bulk_get_products[1]['id'].should == prod1_id
     end
+  end
+
+  it 'lists products in pages' do
+    @owner = create_owner random_string('test_owner')
+
+    prod1_id = "test_product-1"
+    prod2_id = "test_product-2"
+    prod3_id = "test_product-3"
+
+    # The creation order here is important. By default, Candlepin sorts in descending order of the
+    # entity's creation time, so we need to create them backward to let the default sorting order
+    # let us page through them in ascending order.
+    prod3 = create_product(prod3_id, random_string("test_name"))
+    sleep 1
+    prod2 = create_product(prod2_id, random_string("test_name"))
+    sleep 1
+    prod1 = create_product(prod1_id, random_string("test_name"))
+
+    p1set = @cp.list_products_by_owner(@owner['key'], nil, {:page=>1, :per_page=>1})
+    expect(p1set.size).to eq(1)
+    expect(p1set[0]['id']).to eq(prod1_id)
+
+    p2set = @cp.list_products_by_owner(@owner['key'], nil, {:page=>2, :per_page=>1})
+    expect(p2set.size).to eq(1)
+    expect(p2set[0]['id']).to eq(prod2_id)
+
+    p3set = @cp.list_products_by_owner(@owner['key'], nil, {:page=>3, :per_page=>1})
+    expect(p3set.size).to eq(1)
+    expect(p3set[0]['id']).to eq(prod3_id)
+
+    p4set = @cp.list_products_by_owner(@owner['key'], nil, {:page=>4, :per_page=>1})
+    expect(p4set.size).to eq(0)
+  end
+
+  it 'lists products in sorted pages' do
+    @owner = create_owner random_string('test_owner')
+
+    prod1_id = "test_product-1"
+    prod2_id = "test_product-2"
+    prod3_id = "test_product-3"
+
+    # The creation order here is important so we don't accidentally setup the correct ordering by
+    # default.
+    prod2 = create_product(prod2_id, random_string("test_name"))
+    prod1 = create_product(prod1_id, random_string("test_name"))
+    prod3 = create_product(prod3_id, random_string("test_name"))
+
+    p1set = @cp.list_products_by_owner(@owner['key'], nil, {:page=>1, :per_page=>1, :sort_by=>"id"})
+    expect(p1set.size).to eq(1)
+    expect(p1set[0]['id']).to eq(prod3_id)
+
+    p2set = @cp.list_products_by_owner(@owner['key'], nil, {:page=>2, :per_page=>1, :sort_by=>"id"})
+    expect(p2set.size).to eq(1)
+    expect(p2set[0]['id']).to eq(prod2_id)
+
+    p3set = @cp.list_products_by_owner(@owner['key'], nil, {:page=>3, :per_page=>1, :sort_by=>"id"})
+    expect(p3set.size).to eq(1)
+    expect(p3set[0]['id']).to eq(prod1_id)
+
+    p4set = @cp.list_products_by_owner(@owner['key'], nil, {:page=>4, :per_page=>1, :sort_by=>"id"})
+    expect(p4set.size).to eq(0)
   end
 
   it 'should return correct exception for contraint violations' do

--- a/server/src/main/java/org/candlepin/auth/permissions/OwnerPermission.java
+++ b/server/src/main/java/org/candlepin/auth/permissions/OwnerPermission.java
@@ -20,6 +20,7 @@ import org.candlepin.model.Consumer;
 import org.candlepin.model.Environment;
 import org.candlepin.model.Owned;
 import org.candlepin.model.Owner;
+import org.candlepin.model.OwnerContent;
 import org.candlepin.model.OwnerProduct;
 import org.candlepin.model.Pool;
 import org.candlepin.model.activationkeys.ActivationKey;
@@ -79,6 +80,9 @@ public class OwnerPermission implements Permission, Serializable {
             return Restrictions.eq("owner", owner);
         }
         else if (OwnerProduct.class.equals(entityClass)) {
+            return Restrictions.eq("owner", owner);
+        }
+        else if (OwnerContent.class.equals(entityClass)) {
             return Restrictions.eq("owner", owner);
         }
 

--- a/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
+++ b/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
@@ -274,6 +274,7 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
         else {
             resultsPage = listByCriteria(query, pageRequest);
         }
+
         return resultsPage;
     }
 

--- a/server/src/main/java/org/candlepin/model/ContentCurator.java
+++ b/server/src/main/java/org/candlepin/model/ContentCurator.java
@@ -112,27 +112,25 @@ public class ContentCurator extends AbstractHibernateCurator<Content> {
      *  a criteria for fetching content by version
      */
     @SuppressWarnings("checkstyle:indentation")
-    public List<Content> getContentByVersions(Map<String, Integer> contentVersions) {
-        List<Content> result = null;
-
+    public CandlepinQuery<Content> getContentByVersions(Map<String, Integer> contentVersions) {
         if (contentVersions != null && !contentVersions.isEmpty()) {
-            Disjunction disjunction = Restrictions.disjunction();
-            Criteria criteria = this.createSecureCriteria().add(disjunction);
-
-            for (Map.Entry<String, Integer> entry : contentVersions.entrySet()) {
-                disjunction.add(Restrictions.and(
-                    Restrictions.eq("id", entry.getKey()),
-                    Restrictions.or(
-                        Restrictions.isNull("entityVersion"),
-                        Restrictions.eq("entityVersion", entry.getValue())
-                    )
-                ));
-            }
-
-            result = criteria.list();
+            return this.cpQueryFactory.<Content>buildQuery();
         }
 
-        return result != null ? result : new LinkedList<Content>();
+        Disjunction disjunction = Restrictions.disjunction();
+        DetachedCriteria criteria = this.createSecureDetachedCriteria().add(disjunction);
+
+        for (Map.Entry<String, Integer> entry : contentVersions.entrySet()) {
+            disjunction.add(Restrictions.and(
+                Restrictions.eq("id", entry.getKey()),
+                Restrictions.or(
+                    Restrictions.isNull("entityVersion"),
+                    Restrictions.eq("entityVersion", entry.getValue())
+                )
+            ));
+        }
+
+        return this.cpQueryFactory.<Content>buildQuery(this.currentSession(), criteria);
     }
 
     /**

--- a/server/src/test/java/org/candlepin/model/OwnerContentCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/OwnerContentCuratorTest.java
@@ -118,8 +118,8 @@ public class OwnerContentCuratorTest extends DatabaseTestFixture {
         this.createOwnerContentMapping(owner1, content);
         this.createOwnerContentMapping(owner2, content);
 
-        Collection<Owner> ownersA = this.ownerContentCurator.getOwnersByContent(content);
-        Collection<Owner> ownersB = this.ownerContentCurator.getOwnersByContent(content.getId());
+        Collection<Owner> ownersA = this.ownerContentCurator.getOwnersByContent(content).list();
+        Collection<Owner> ownersB = this.ownerContentCurator.getOwnersByContent(content.getId()).list();
 
         assertTrue(ownersA.contains(owner1));
         assertTrue(ownersA.contains(owner2));
@@ -134,8 +134,8 @@ public class OwnerContentCuratorTest extends DatabaseTestFixture {
         Owner owner3 = this.createOwner();
         Content content = this.createContent();
 
-        Collection<Owner> ownersA = this.ownerContentCurator.getOwnersByContent(content);
-        Collection<Owner> ownersB = this.ownerContentCurator.getOwnersByContent(content.getId());
+        Collection<Owner> ownersA = this.ownerContentCurator.getOwnersByContent(content).list();
+        Collection<Owner> ownersB = this.ownerContentCurator.getOwnersByContent(content.getId()).list();
 
         assertTrue(ownersA.isEmpty());
         assertTrue(ownersB.isEmpty());
@@ -150,8 +150,8 @@ public class OwnerContentCuratorTest extends DatabaseTestFixture {
         this.createOwnerContentMapping(owner, content1);
         this.createOwnerContentMapping(owner, content2);
 
-        Collection<Content> contentA = this.ownerContentCurator.getContentByOwner(owner);
-        Collection<Content> contentB = this.ownerContentCurator.getContentByOwner(owner.getId());
+        Collection<Content> contentA = this.ownerContentCurator.getContentByOwner(owner).list();
+        Collection<Content> contentB = this.ownerContentCurator.getContentByOwner(owner.getId()).list();
 
         assertTrue(contentA.contains(content1));
         assertTrue(contentA.contains(content2));
@@ -166,8 +166,8 @@ public class OwnerContentCuratorTest extends DatabaseTestFixture {
         Content content2 = this.createContent();
         Content content3 = this.createContent();
 
-        Collection<Content> contentA = this.ownerContentCurator.getContentByOwner(owner);
-        Collection<Content> contentB = this.ownerContentCurator.getContentByOwner(owner.getId());
+        Collection<Content> contentA = this.ownerContentCurator.getContentByOwner(owner).list();
+        Collection<Content> contentB = this.ownerContentCurator.getContentByOwner(owner.getId()).list();
 
         assertTrue(contentA.isEmpty());
         assertTrue(contentB.isEmpty());
@@ -183,8 +183,8 @@ public class OwnerContentCuratorTest extends DatabaseTestFixture {
         this.createOwnerContentMapping(owner, content2);
 
         Collection<String> ids = Arrays.asList(content1.getId(), content2.getId(), content3.getId(), "dud");
-        Collection<Content> contentA = this.ownerContentCurator.getContentByIds(owner, ids);
-        Collection<Content> contentB = this.ownerContentCurator.getContentByIds(owner.getId(), ids);
+        Collection<Content> contentA = this.ownerContentCurator.getContentByIds(owner, ids).list();
+        Collection<Content> contentB = this.ownerContentCurator.getContentByIds(owner.getId(), ids).list();
 
         assertEquals(2, contentA.size());
         assertTrue(contentA.contains(content1));
@@ -203,8 +203,8 @@ public class OwnerContentCuratorTest extends DatabaseTestFixture {
         this.createOwnerContentMapping(owner, content2);
 
         Collection<String> ids = null;
-        Collection<Content> contentA = this.ownerContentCurator.getContentByIds(owner, ids);
-        Collection<Content> contentB = this.ownerContentCurator.getContentByIds(owner.getId(), ids);
+        Collection<Content> contentA = this.ownerContentCurator.getContentByIds(owner, ids).list();
+        Collection<Content> contentB = this.ownerContentCurator.getContentByIds(owner.getId(), ids).list();
 
         assertTrue(contentA.isEmpty());
         assertTrue(contentB.isEmpty());
@@ -220,8 +220,8 @@ public class OwnerContentCuratorTest extends DatabaseTestFixture {
         this.createOwnerContentMapping(owner, content2);
 
         Collection<String> ids = Collections.<String>emptyList();
-        Collection<Content> contentA = this.ownerContentCurator.getContentByIds(owner, ids);
-        Collection<Content> contentB = this.ownerContentCurator.getContentByIds(owner.getId(), ids);
+        Collection<Content> contentA = this.ownerContentCurator.getContentByIds(owner, ids).list();
+        Collection<Content> contentB = this.ownerContentCurator.getContentByIds(owner.getId(), ids).list();
 
         assertTrue(contentA.isEmpty());
         assertTrue(contentB.isEmpty());

--- a/server/src/test/java/org/candlepin/resource/OwnerContentResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/OwnerContentResourceTest.java
@@ -22,6 +22,7 @@ import org.candlepin.common.exceptions.NotFoundException;
 import org.candlepin.controller.ContentManager;
 import org.candlepin.controller.PoolManager;
 import org.candlepin.jackson.ProductCachedSerializationModule;
+import org.candlepin.model.CandlepinQuery;
 import org.candlepin.model.Content;
 import org.candlepin.model.Environment;
 import org.candlepin.model.Owner;
@@ -33,12 +34,10 @@ import org.candlepin.test.TestUtil;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
+import java.util.Collection;
 
 import javax.inject.Inject;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.StreamingOutput;
 
 
 
@@ -65,34 +64,27 @@ public class OwnerContentResourceTest extends DatabaseTestFixture {
         Owner owner = this.createOwner("test_owner");
         Content content = this.createContent("test_content", "test_content", owner);
 
-        Response response = this.ownerContentResource.list(owner.getKey());
+        CandlepinQuery<Content> response = this.ownerContentResource.list(owner.getKey());
 
         assertNotNull(response);
-        assertEquals(200, response.getStatus());
-        assertTrue(response.getEntity() instanceof StreamingOutput);
 
-        StreamingOutput output = (StreamingOutput) response.getEntity();
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        output.write(baos);
+        Collection<Content> received = response.list();
 
-        assertNotEquals(-1, baos.toString().indexOf("test_content"));
+        assertEquals(1, received.size());
+        assertTrue(received.contains(content));
     }
 
     @Test
     public void listContentNoContent() throws Exception {
         Owner owner = this.createOwner("test_owner");
 
-        Response response = this.ownerContentResource.list(owner.getKey());
+        CandlepinQuery<Content> response = this.ownerContentResource.list(owner.getKey());
 
         assertNotNull(response);
-        assertEquals(200, response.getStatus());
-        assertTrue(response.getEntity() instanceof StreamingOutput);
 
-        StreamingOutput output = (StreamingOutput) response.getEntity();
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        output.write(baos);
+        Collection<Content> received = response.list();
 
-        assertEquals("[]", baos.toString());
+        assertEquals(0, received.size());
     }
 
     @Test


### PR DESCRIPTION
- Fixed a crash that could occur when paging requests for products or content
  by owner while not sorting by a owner id or content/product uuid
- Updated OwnerContentCurator to use the CandlepinQuery for its collection-based
  queries