### PR TITLE
Fixed a bug that would treat unchanged entities as updated

### DIFF
--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -307,22 +307,16 @@ public class CandlepinPoolManager implements PoolManager {
         }
 
         Map<String, Content> importedContent = this.contentManager
-            .importContent(owner, contentMap, productMap.keySet());
-
-        // Determine which of our changes are net new
-        Set<Product> changedProducts = new HashSet<Product>();
-        Set<String> existingProductIds = this.ownerProductCurator
-            .filterUnknownProductIds(owner, productMap.keySet());
+            .importContent(owner, contentMap, productMap.keySet())
+            .getImportedEntities();
 
         log.debug("Importing {} product(s)...", productMap.size());
-        Map<String, Product> importedProducts = this.productManager
+        ImportResult<Product> importResult = this.productManager
             .importProducts(owner, productMap, importedContent);
 
-        for (String pid : existingProductIds) {
-            // FIXME: This is technically wrong, at the moment. Products which did not change will
-            // still be reported as changed if they existed in the DB prior to import.
-            changedProducts.add(importedProducts.get(pid));
-        }
+        Map<String, Product> importedProducts = importResult.getImportedEntities();
+        Set<Product> changedProducts = new HashSet<Product>();
+        changedProducts.addAll(importResult.getUpdatedEntities().values());
 
         log.debug("Refreshing {} pool(s)...", subscriptionMap.size());
         Iterator<Map.Entry<String, Subscription>> subsIterator = subscriptionMap.entrySet().iterator();

--- a/server/src/main/java/org/candlepin/controller/Entitler.java
+++ b/server/src/main/java/org/candlepin/controller/Entitler.java
@@ -428,11 +428,13 @@ public class Entitler {
         }
 
         Map<String, Content> importedContent = this.contentManager
-            .importContent(owner, contentMap, productMap.keySet());
+            .importContent(owner, contentMap, productMap.keySet())
+            .getImportedEntities();
 
         log.debug("Importing {} product(s)...", productMap.size());
         Map<String, Product> importedProducts = this.productManager
-            .importProducts(owner, productMap, importedContent);
+            .importProducts(owner, productMap, importedContent)
+            .getImportedEntities();
 
         log.debug("Resolved {} dev product(s) for sku: {}", productMap.size(), sku);
         return new DeveloperProducts(sku, importedProducts);

--- a/server/src/main/java/org/candlepin/controller/ImportResult.java
+++ b/server/src/main/java/org/candlepin/controller/ImportResult.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2009 - 2016 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.controller;
+
+import org.candlepin.model.Persisted;
+
+import java.util.HashMap;
+import java.util.Map;
+
+
+
+/**
+ * The ImportResult class contains references to the entities which were processed by a
+ * controller-level import operation.
+ *
+ * @param <E>
+ *  The entity class contained by a given import result instance
+ */
+public class ImportResult<E extends Persisted> {
+
+    private final Map<String, E> skippedEntities;
+    private final Map<String, E> createdEntities;
+    private final Map<String, E> updatedEntities;
+    private Map<String, E> importedEntities;
+
+    /**
+     * Instantiates a new, empty ImportResult instance.
+     */
+    public ImportResult() {
+        this.skippedEntities = new HashMap<String, E>();
+        this.createdEntities = new HashMap<String, E>();
+        this.updatedEntities = new HashMap<String, E>();
+        this.importedEntities = null;
+    }
+
+    /**
+     * Retrieves a map containing the skipped entities. The entities will be mapped by their Red
+     * Hat ID.
+     *
+     * @return
+     *  A map containing all skipped entities
+     */
+    public Map<String, E> getSkippedEntities() {
+        return this.skippedEntities;
+    }
+
+    /**
+     * Retrieves a map containing the created entities. The entities will be mapped by their Red
+     * Hat ID.
+     *
+     * @return
+     *  A map containing all created entities
+     */
+    public Map<String, E> getCreatedEntities() {
+        return this.createdEntities;
+    }
+
+    /**
+     * Retrieves a map containing the updated entities. The entities will be mapped by their Red
+     * Hat ID.
+     *
+     * @return
+     *  A map containing all updated entities
+     */
+    public Map<String, E> getUpdatedEntities() {
+        return this.updatedEntities;
+    }
+
+    /**
+     * Retrieves a map containing the imported entities. The entities will be mapped by their Red
+     * Hat ID.
+     *
+     * @return
+     *  A map containing all imported entities
+     */
+    public Map<String, E> getImportedEntities() {
+        if (this.importedEntities == null) {
+            this.importedEntities = new HashMap<String, E>();
+
+            this.importedEntities.putAll(this.skippedEntities);
+            this.importedEntities.putAll(this.createdEntities);
+            this.importedEntities.putAll(this.updatedEntities);
+        }
+
+        return this.importedEntities;
+    }
+}

--- a/server/src/main/java/org/candlepin/model/ProductCurator.java
+++ b/server/src/main/java/org/candlepin/model/ProductCurator.java
@@ -152,7 +152,7 @@ public class ProductCurator extends AbstractHibernateCurator<Product> {
     }
 
     public Set<Product> getPoolDerivedProvidedProductsCached(String poolId) {
-        Set<String> uuids = getDerivedPoolProvidedProducts(poolId);
+        Set<String> uuids = getDerivedPoolProvidedProductUuids(poolId);
         return getProductsByUuidCached(uuids);
     }
 
@@ -161,7 +161,7 @@ public class ProductCurator extends AbstractHibernateCurator<Product> {
     }
 
     public Set<Product> getPoolProvidedProductsCached(String poolId) {
-        Set<String> providedUuids = getPoolProvidedProducts(poolId);
+        Set<String> providedUuids = getPoolProvidedProductUuids(poolId);
         return getProductsByUuidCached(providedUuids);
     }
 
@@ -171,7 +171,7 @@ public class ProductCurator extends AbstractHibernateCurator<Product> {
      * @param poolId
      * @return Set of UUIDs
      */
-    public Set<String> getPoolProvidedProducts(String poolId) {
+    public Set<String> getPoolProvidedProductUuids(String poolId) {
         TypedQuery<String> query = getEntityManager().createQuery(
             "SELECT product.uuid FROM Pool p INNER JOIN p.providedProducts product where p.id = :poolid",
             String.class);
@@ -185,7 +185,7 @@ public class ProductCurator extends AbstractHibernateCurator<Product> {
      * @param poolId
      * @return Set of UUIDs
      */
-    public Set<String> getDerivedPoolProvidedProducts(String poolId) {
+    public Set<String> getDerivedPoolProvidedProductUuids(String poolId) {
         TypedQuery<String> query = getEntityManager().createQuery(
             "SELECT product.uuid FROM Pool p INNER JOIN p.derivedProvidedProducts product " +
             "WHERE p.id = :poolid",

--- a/server/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
@@ -544,11 +544,9 @@ public class PoolRules {
             !currentProvided.equals(incomingProvided);
 
         // Check if the existing product is in the set of changed products
-        if (!productsChanged && changedProducts != null && existingProduct.getId() != null) {
+        if (!productsChanged && changedProducts != null && pid != null) {
             for (Product product : changedProducts) {
                 if (pid.equals(product.getId())) {
-                    // TODO: Should we maybe check if the products have actually changed, or is it
-                    // safe to assume their presence is enough?
                     productsChanged = true;
                     break;
                 }

--- a/server/src/test/java/org/candlepin/model/ProductCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ProductCuratorTest.java
@@ -609,13 +609,13 @@ public class ProductCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void testPoolProvidedProducts() {
-        Set<String> uuids = productCurator.getPoolProvidedProducts(pool.getId());
+        Set<String> uuids = productCurator.getPoolProvidedProductUuids(pool.getId());
         assertEquals(new HashSet<String>(Arrays.asList(providedProduct.getUuid())), uuids);
     }
 
     @Test
     public void testDerivedPoolProvidedProducts() {
-        Set<String> uuids = productCurator.getDerivedPoolProvidedProducts(pool.getId());
+        Set<String> uuids = productCurator.getDerivedPoolProvidedProductUuids(pool.getId());
         assertEquals(new HashSet<String>(Arrays.asList(derivedProvidedProduct.getUuid())), uuids);
     }
 


### PR DESCRIPTION
- Fixed a bug that would count existing products or contents as
  updated during import or refresh, even if the operation did not
  result in a net change to the entity