### PR TITLE
Revoke performance fix

### DIFF
--- a/server/src/main/java/org/candlepin/audit/EventFactory.java
+++ b/server/src/main/java/org/candlepin/audit/EventFactory.java
@@ -18,7 +18,6 @@ import org.candlepin.audit.Event.Target;
 import org.candlepin.audit.Event.Type;
 import org.candlepin.common.jackson.HateoasBeanPropertyFilter;
 import org.candlepin.guice.PrincipalProvider;
-import org.candlepin.jackson.ProductCachedSerializationModule;
 import org.candlepin.jackson.PoolEventFilter;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.Entitlement;
@@ -55,8 +54,7 @@ public class EventFactory {
     private final ObjectMapper mapper;
 
     @Inject
-    public EventFactory(PrincipalProvider principalProvider,
-        ProductCachedSerializationModule productCachedModule) {
+    public EventFactory(PrincipalProvider principalProvider) {
         this.principalProvider = principalProvider;
 
         mapper = new ObjectMapper();
@@ -84,7 +82,6 @@ public class EventFactory {
         Hibernate4Module hbm = new Hibernate4Module();
         hbm.enable(Hibernate4Module.Feature.FORCE_LAZY_LOADING);
         mapper.registerModule(hbm);
-        mapper.registerModule(productCachedModule);
 
         AnnotationIntrospector primary = new JacksonAnnotationIntrospector();
         AnnotationIntrospector secondary = new JaxbAnnotationIntrospector(mapper.getTypeFactory());

--- a/server/src/main/java/org/candlepin/model/Pool.java
+++ b/server/src/main/java/org/candlepin/model/Pool.java
@@ -27,8 +27,6 @@ import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.Formula;
 import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.LazyCollection;
-import org.hibernate.annotations.LazyCollectionOption;
 
 import java.util.Collection;
 import java.util.Date;
@@ -305,7 +303,6 @@ public class Pool extends AbstractHibernateObject implements Persisted, Owned, N
     private Set<PoolAttribute> attributes = new HashSet<PoolAttribute>();
 
     @OneToMany(mappedBy = "pool", cascade = CascadeType.ALL)
-    @LazyCollection(LazyCollectionOption.EXTRA)
     private Set<Entitlement> entitlements = new HashSet<Entitlement>();
 
     @Size(max = 255)

--- a/server/src/test/java/org/candlepin/audit/AMQPBusPublisherTest.java
+++ b/server/src/test/java/org/candlepin/audit/AMQPBusPublisherTest.java
@@ -24,9 +24,7 @@ import static org.mockito.Mockito.when;
 import org.candlepin.audit.Event.Target;
 import org.candlepin.audit.Event.Type;
 import org.candlepin.guice.PrincipalProvider;
-import org.candlepin.jackson.ProductCachedSerializationModule;
 import org.candlepin.model.Consumer;
-import org.candlepin.model.ProductCurator;
 import org.candlepin.test.TestUtil;
 import org.candlepin.util.Util;
 
@@ -81,10 +79,9 @@ public class AMQPBusPublisherTest {
     @Test
     public void testApply() throws IOException {
         PrincipalProvider pp = mock(PrincipalProvider.class);
-        ProductCurator productCurator = mock(ProductCurator.class);
-
         when(pp.get()).thenReturn(TestUtil.createPrincipal("admin", null, null));
-        EventFactory factory = new EventFactory(pp, new ProductCachedSerializationModule(productCurator));
+
+        EventFactory factory = new EventFactory(pp);
         Consumer c = TestUtil.createConsumer();
         Event e = factory.consumerCreated(c);
 
@@ -98,10 +95,9 @@ public class AMQPBusPublisherTest {
     @Test
     public void onEvent() throws JMSException {
         PrincipalProvider pp = mock(PrincipalProvider.class);
-
-        ProductCurator productCurator = mock(ProductCurator.class);
         when(pp.get()).thenReturn(TestUtil.createPrincipal("admin", null, null));
-        EventFactory factory = new EventFactory(pp, new ProductCachedSerializationModule(productCurator));
+
+        EventFactory factory = new EventFactory(pp);
         Consumer c = TestUtil.createConsumer();
         Event e = factory.consumerCreated(c);
         TopicPublisher tp = publisherMap.get(Target.CONSUMER).get(Type.CREATED);

--- a/server/src/test/java/org/candlepin/audit/EventFactoryTest.java
+++ b/server/src/test/java/org/candlepin/audit/EventFactoryTest.java
@@ -20,11 +20,9 @@ import static org.mockito.Mockito.when;
 
 import org.candlepin.auth.Principal;
 import org.candlepin.guice.PrincipalProvider;
-import org.candlepin.jackson.ProductCachedSerializationModule;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.GuestId;
 import org.candlepin.model.Owner;
-import org.candlepin.model.ProductCurator;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -41,10 +39,8 @@ public class EventFactoryTest {
     public void init() throws Exception {
         principalProvider = mock(PrincipalProvider.class);
         Principal principal = mock(Principal.class);
-        ProductCurator productCurator = mock(ProductCurator.class);
         when(principalProvider.get()).thenReturn(principal);
-        eventFactory = new EventFactory(principalProvider,
-            new ProductCachedSerializationModule(productCurator));
+        eventFactory = new EventFactory(principalProvider);
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/audit/EventSinkImplTest.java
+++ b/server/src/test/java/org/candlepin/audit/EventSinkImplTest.java
@@ -31,7 +31,6 @@ import static org.mockito.Mockito.when;
 import org.candlepin.auth.Principal;
 import org.candlepin.config.CandlepinCommonTestConfig;
 import org.candlepin.guice.PrincipalProvider;
-import org.candlepin.jackson.ProductCachedSerializationModule;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.Owner;
 import org.candlepin.model.Pool;
@@ -82,8 +81,7 @@ public class EventSinkImplTest {
 
     @Before
     public void init() throws Exception {
-        this.factory = new EventFactory(mockPrincipalProvider,
-        new ProductCachedSerializationModule(mockProductCurator));
+        this.factory = new EventFactory(mockPrincipalProvider);
         this.principal = TestUtil.createOwnerPrincipal();
         eventFilter = new EventFilter(new CandlepinCommonTestConfig());
         when(mockPrincipalProvider.get()).thenReturn(this.principal);


### PR DESCRIPTION
Persistent collection Pool.entitlements has been set to EXTRA Lazy. That was
causing serious performance degradation when removing from that collection.
Specifically the removal from that collection in CandlepinPoolManager could take
as much as 8 seconds for big data sets.