### PR TITLE
1314042: bug caused by import and undo manifest run in parallel

### DIFF
--- a/server/spec/import_and_undo_exports_in_parallel_spec.rb
+++ b/server/spec/import_and_undo_exports_in_parallel_spec.rb
@@ -1,0 +1,118 @@
+#!/usr/bin/env ruby
+
+require 'spec_helper'
+require 'candlepin_scenarios'
+
+describe 'Import and Undo Manifest in parallel' do
+
+  include CandlepinMethods
+
+  before (:all) do	#exports generation
+    @iu_exporter = ImportUpdateBrandingExporter.new
+  end
+
+  after (:all) do
+    @iu_exporter.cleanup()
+  end
+
+  it 'should (sync) import and undo manifest in parallel successfully - import first' do
+    i = 0
+    count = 5
+    working = true
+    begin
+      import_owner = create_owner(random_string("import_branding_owner"))
+      begin
+        thr = concurrent_import_and_undo_manifest(import_owner, @iu_exporter)
+
+        if time_limit_on_thread_expired(thr)
+          puts "Replication No. #{i} - fail (time limit on thread expired)"
+          working = false
+          next
+        end
+      rescue Exception => e
+        puts "Replication No. #{i} - fail: #{e}"
+        puts e.backtrace
+        working = false
+        next
+      end
+      i += 1
+      delete_owner(import_owner)
+    end while (working && i < count)
+
+    working.should be true
+  end
+
+  it 'should (sync) import and undo manifest in parallel successfully - undo first' do
+    i = 0
+    count = 5
+    working = true
+    begin
+      import_owner = create_owner(random_string("import_branding_owner"))
+      begin
+        thr = concurrent_undo_and_import_manifest(import_owner, @iu_exporter)
+
+        if time_limit_on_thread_expired(thr)
+          puts "Replication No. #{i} - fail (time limit on thread expired)"
+          working = false
+          next
+        end
+      rescue Exception => e
+        puts "Replication No. #{i} - fail: #{e}"
+        puts e.backtrace
+        working = false
+        next
+      end
+      i += 1
+      delete_owner(import_owner)
+    end while (working && i < count)
+
+    working.should be true
+  end
+  # === Classes ====================================================
+  class UndoImportException < RuntimeError
+  end
+
+  # ===  Util Methods ==============================================
+
+  def concurrent_import_and_undo_manifest(import_owner, iu_exporter)
+    @cp.import(import_owner['key'], iu_exporter.export1_filename)
+    t1 = Thread.new do
+      @cp.import(import_owner['key'], iu_exporter.export2_filename)
+    end
+    undo_job = @cp.undo_import(import_owner['key'])
+
+    wait_for_undo_job(undo_job) #async job
+    thr = t1.join
+
+    return thr
+  end
+
+  def wait_for_undo_job(job)
+    r = wait_for_job(job['id'], 10) #undo_import can be still running becase is async,
+                                    #otherwise '409 Conflict - concurrent modification' can occur
+
+    status = @cp.get_job(job["id"])
+    if status["state"] != "FINISHED"
+      raise UndoImportException, "UndoImportsJob didn't finish, instead it has state = #{status['state']}"
+    end
+  end
+
+  def time_limit_on_thread_expired(thr)
+    return (thr == nil)
+  end
+
+  def concurrent_undo_and_import_manifest(import_owner, iu_exporter)
+    @cp.import(import_owner['key'], iu_exporter.export1_filename)
+    undo_job = nil
+    t1 = Thread.new do
+       undo_job = @cp.undo_import(import_owner['key'])
+    end
+    @cp.import(import_owner['key'], iu_exporter.export2_filename)
+
+    wait_for_undo_job(undo_job) #async job
+    thr = t1.join
+
+    return thr
+  end
+  # -----------------------------------------------------------
+end

--- a/server/spec/import_update_single_pool_spec.rb
+++ b/server/spec/import_update_single_pool_spec.rb
@@ -5,19 +5,6 @@ describe 'Import Single Pool Update', :serial => true do
 
   include CandlepinMethods
 
-  class ImportUpdateExporter < Exporter
-    attr_reader :pool
-    attr_reader :entitlement1
-
-    def initialize
-      super()
-      product = create_product(random_string("test_prod"), random_string())
-      end_date = Date.new(2025, 5, 29)
-      @pool = create_pool_and_subscription(@owner['key'], product.id, 200, [], '', '12345', '6789', nil, end_date)
-      @entitlement1 = @candlepin_client.consume_pool(@pool.id, {:quantity => 15})[0]
-    end
-  end
-
   before(:all) do
     @exporter = ImportUpdateExporter.new
   end

--- a/server/spec/spec_helper.rb
+++ b/server/spec/spec_helper.rb
@@ -25,6 +25,7 @@ module CleanupHooks
     if (@rules)
       @cp.delete_rules
     end
+
     if !@cp.get_status()['standalone']
       begin
         @cp.delete('/hostedtest/subscriptions/', nil, true)

--- a/server/src/main/java/org/candlepin/model/OwnerCurator.java
+++ b/server/src/main/java/org/candlepin/model/OwnerCurator.java
@@ -37,6 +37,8 @@ import javax.persistence.LockModeType;
 
 
 
+
+
 /**
  * OwnerCurator
  */
@@ -98,6 +100,14 @@ public class OwnerCurator extends AbstractHibernateCurator<Owner> {
             .add(CPRestrictions.in("key", keys));
 
         return this.cpQueryFactory.<Owner>buildQuery(this.currentSession(), criteria);
+    }
+
+    public Owner lookupByKeyAndLock(String key) {
+        return getEntityManager()
+            .createQuery("select o from Owner o WHERE o.key = :key", Owner.class)
+            .setParameter("key", key)
+            .setLockMode(LockModeType.PESSIMISTIC_WRITE)
+            .getSingleResult();
     }
 
     public Owner lookupWithUpstreamUuid(String upstreamUuid) {

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/UndoImportsJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/UndoImportsJob.java
@@ -33,6 +33,8 @@ import org.candlepin.pinsetter.core.model.JobStatus;
 import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.util.Util;
 
+import com.google.inject.persist.Transactional;
+
 import org.quartz.JobDataMap;
 import org.quartz.JobDetail;
 import org.quartz.JobExecutionContext;
@@ -92,13 +94,14 @@ public class UndoImportsJob extends UniqueByEntityJob {
      *
      * @param context the job's execution context
      */
+    @Transactional
     public void toExecute(JobExecutionContext context) throws JobExecutionException {
         try {
             JobDataMap map = context.getMergedJobDataMap();
             String ownerKey = map.getString(JobStatus.TARGET_ID);
+            Owner owner = this.ownerCurator.lookupByKeyAndLock(ownerKey);
             Boolean lazy = map.getBoolean(LAZY_REGEN);
             Principal principal = (Principal) map.get(PinsetterJobListener.PRINCIPAL_KEY);
-            Owner owner = this.ownerCurator.lookupByKey(ownerKey);
 
             // TODO: Should we check the principal again here?
 

--- a/server/src/main/java/org/candlepin/sync/Importer.java
+++ b/server/src/main/java/org/candlepin/sync/Importer.java
@@ -76,6 +76,7 @@ import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
+import javax.persistence.LockModeType;
 import javax.persistence.PersistenceException;
 
 
@@ -465,6 +466,7 @@ public class Importer {
     // WARNING: Keep this method public, otherwise @Transactional is ignored:
     public List<Subscription> importObjects(Owner owner, Map<String, File> importFiles,
         ConflictOverrides overrides) throws IOException, ImporterException {
+        ownerCurator.lock(owner, LockModeType.PESSIMISTIC_WRITE);
 
         log.debug("Importing objects for owner: {}", owner);
 


### PR DESCRIPTION
I wrote spec for this bug, which run (sync) importManifest (with updated manifest on brandings) and undoManifest in parralel.
    
When I experimented with mentioned spec I've never got same error like in bugzilla. It is becase we don't store subsrciption in DB anymore, but BZ should be covered by this fix.
I got different errors and deadlocks, so I locked owner at begining of both methods.
    
Fix's broken some unit tests so I changed those as well and made them little bit readable.

Note: For clarity, I moved ImportUpdateExporter from import_update_single_pool_spec to others exporters in candlepin_scenarios