### PR TITLE
Add API to clear productfullcache

### DIFF
--- a/server/src/test/java/org/candlepin/resource/AdminResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/AdminResourceTest.java
@@ -43,7 +43,7 @@ public class AdminResourceTest {
     public void init() {
         usa = mock(DefaultUserServiceAdapter.class);
         uc = mock(UserCurator.class);
-        ar = new AdminResource(usa, uc, null, config);
+        ar = new AdminResource(usa, uc, null, config, null);
     }
 
     @Test
@@ -55,7 +55,7 @@ public class AdminResourceTest {
 
     @Test
     public void initWithNonDefaultUserService() {
-        ar = new AdminResource(mock(UserServiceAdapter.class), uc, null, config);
+        ar = new AdminResource(mock(UserServiceAdapter.class), uc, null, config, null);
         assertEquals("Already initialized.", ar.initialize());
     }
 


### PR DESCRIPTION
In theory one should be able to see this api work by a curl something like the following:
`curl -ik -u admin:admin --request DELETE "https://localhost:8443/candlepin/admin/cache/product"`

You should be able to see the cache be cleared in jconsole by enabling statistics for ehcache by following the instructions found here: http://www.candlepinproject.org/docs/candlepin/caching.html