### PR TITLE
1399768: Make pool exported count calculation lazy

### DIFF
--- a/server/src/main/java/org/candlepin/model/Pool.java
+++ b/server/src/main/java/org/candlepin/model/Pool.java
@@ -36,10 +36,12 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import javax.persistence.Basic;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
 import javax.persistence.EnumType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
@@ -266,9 +268,13 @@ public class Pool extends AbstractHibernateObject implements Persisted, Owned, N
              "where ent.pool_id = id)")
     private Long consumed;
 
+    
     @Formula("(select sum(ent.quantity) from cp_entitlement ent, cp_consumer cons, " +
         "cp_consumer_type ctype where ent.pool_id = id and ent.consumer_id = cons.id " +
         "and cons.type_id = ctype.id and ctype.manifest = 'Y')")
+    // Only calculate exported lazily due to join fetches from entitlements taking extraordinary
+    // amounts of time
+    @Basic(fetch=FetchType.LAZY)
     private Long exported;
 
     // TODO: May not still be needed, IIRC a temporary hack for client.


### PR DESCRIPTION
Loading entitlements forces a pool load. Because this is done with a left join on pool which triggers the exported calculation an extraordinary amount of time is spent in the entitlement fetch (500ms for medium/large database). Under large amounts of load this is having a cascading effect of slowing down everything.  

The risk with this is that areas of code that rely on the exported count will trigger additional calls to the databse. Where pools are acted on in bulk there is additional risk (manifest import specifically). 