### PR TITLE
1399356: No transaction in syncCRLWithDB caused immediate rollback

### DIFF
--- a/server/src/main/java/org/candlepin/controller/ContentManager.java
+++ b/server/src/main/java/org/candlepin/controller/ContentManager.java
@@ -315,6 +315,7 @@ public class ContentManager {
      *  A mapping of Red Hat content ID to content entities representing the imported content
      */
     @SuppressWarnings("checkstyle:methodlength")
+    @Transactional
     public ImportResult<Content> importContent(Owner owner, Map<String, ContentData> contentData,
         Set<String> importedProductIds) {
 

--- a/server/src/main/java/org/candlepin/controller/Entitler.java
+++ b/server/src/main/java/org/candlepin/controller/Entitler.java
@@ -46,6 +46,7 @@ import org.candlepin.resource.dto.AutobindData;
 import org.candlepin.service.ProductServiceAdapter;
 
 import com.google.inject.Inject;
+import com.google.inject.persist.Transactional;
 
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
@@ -193,6 +194,7 @@ public class Entitler {
      * @throws AutobindDisabledForOwnerException when an autobind attempt is made and the owner
      *         has it disabled.
      */
+    @Transactional
     public List<Entitlement> bindByProducts(AutobindData data, boolean force)
         throws AutobindDisabledForOwnerException {
         Consumer consumer = data.getConsumer();

--- a/server/src/main/java/org/candlepin/controller/ProductManager.java
+++ b/server/src/main/java/org/candlepin/controller/ProductManager.java
@@ -273,6 +273,7 @@ public class ProductManager {
      * @return
      *  A mapping of Red Hat content ID to content entities representing the imported content
      */
+    @Transactional
     public ImportResult<Product> importProducts(Owner owner, Map<String, ProductData> productData,
         Map<String, Content> importedContent) {
 

--- a/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
+++ b/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
@@ -534,6 +534,7 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
         if (entities != null && !entities.isEmpty()) {
             try {
                 Session session = this.currentSession();
+                EntityManager em = this.getEntityManager();
                 Iterable<List<E>> blocks = Iterables.partition(entities, BATCH_BLOCK_SIZE);
 
                 for (List<E> block : blocks) {
@@ -542,7 +543,7 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
                     }
 
                     if (flush) {
-                        session.flush();
+                        em.flush();
 
                         if (evict) {
                             for (E entity : block) {
@@ -564,6 +565,7 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
         if (entities != null && !entities.isEmpty()) {
             try {
                 Session session = this.currentSession();
+                EntityManager em = this.getEntityManager();
                 Iterable<List<E>> blocks = Iterables.partition(entities, BATCH_BLOCK_SIZE);
 
                 for (List<E> block : blocks) {
@@ -572,7 +574,7 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
                     }
 
                     if (flush) {
-                        session.flush();
+                        em.flush();
 
                         if (evict) {
                             for (E entity : block) {
@@ -594,6 +596,7 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
         if (CollectionUtils.isNotEmpty(entities)) {
             try {
                 Session session = this.currentSession();
+                EntityManager em = this.getEntityManager();
                 Iterable<List<E>> blocks = Iterables.partition(entities, BATCH_BLOCK_SIZE);
 
                 for (List<E> block : blocks) {
@@ -602,7 +605,7 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
                     }
 
                     if (flush) {
-                        session.flush();
+                        em.flush();
 
                         if (evict) {
                             for (E entity : block) {
@@ -624,6 +627,7 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
         if (entities != null && !entities.isEmpty()) {
             try {
                 Session session = this.currentSession();
+                EntityManager em = this.getEntityManager();
 
                 if (flush) {
                     int i = 0;
@@ -631,13 +635,13 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
                         session.merge(entity);
 
                         if (++i % BATCH_BLOCK_SIZE == 0) {
-                            session.flush();
+                            em.flush();
                             session.clear();
                         }
                     }
 
                     if (i % BATCH_BLOCK_SIZE != 0) {
-                        session.flush();
+                        em.flush();
                         session.clear();
                     }
                 }

--- a/server/src/main/java/org/candlepin/util/CrlFileUtil.java
+++ b/server/src/main/java/org/candlepin/util/CrlFileUtil.java
@@ -22,6 +22,7 @@ import org.candlepin.pki.X509CRLEntryWrapper;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import com.google.inject.persist.Transactional;
 
 import org.apache.commons.codec.binary.Base64InputStream;
 import org.apache.commons.codec.binary.Base64OutputStream;
@@ -299,6 +300,7 @@ public class CrlFileUtil {
         }
     }
 
+    @Transactional
     public boolean syncCRLWithDB(File file) throws IOException {
         List<BigInteger> revoke = new LinkedList<BigInteger>();
         List<CertificateSerial> serials = this.certificateSerialCurator


### PR DESCRIPTION
Futhermore, use EntityManager's flush instead of Session's flush so that
a missing transaction will cause a TransactionRequiredException to be
thrown instead of Session's flush which just fails silently.