### PR TITLE
The Product and Content managers now clean up orphaned entities

### DIFF
--- a/server/client/ruby/candlepin_api.rb
+++ b/server/client/ruby/candlepin_api.rb
@@ -402,8 +402,10 @@ class Candlepin
     post("/jobs/scheduler", status)
   end
 
-  def trigger_job(job)
-    post("/jobs/schedule/#{job}")
+  def trigger_job(job, async=false)
+    return async_call(!async) do
+      post("/jobs/schedule/#{job}")
+    end
   end
 
   def create_consumer_type(type_label, manifest=false)
@@ -624,6 +626,10 @@ class Candlepin
     get("/owners/#{owner_key}/content/#{content_id}")
   end
 
+  def get_content_by_uuid(content_uuid)
+    get("/content/#{content_uuid}")
+  end
+
   def delete_content(owner_key, content_id)
     delete("/owners/#{owner_key}/content/#{content_id}")
   end
@@ -759,6 +765,10 @@ class Candlepin
 
   def get_product(owner_key, product_id)
     get("/owners/#{owner_key}/products/#{product_id}")
+  end
+
+  def get_product_by_uuid(product_uuid)
+    get("/products/#{product_uuid}")
   end
 
   def delete_product(owner_key, product_id)

--- a/server/client/ruby/candlepin_api.rb
+++ b/server/client/ruby/candlepin_api.rb
@@ -498,6 +498,7 @@ class Candlepin
       # POSTing here will delete the job once it has finished
       status = post(status['statusPath'])
     end
+
     return status['result']
   end
 

--- a/server/client/ruby/candlepin_api.rb
+++ b/server/client/ruby/candlepin_api.rb
@@ -1385,11 +1385,13 @@ class Candlepin
   end
 
   def post_file(uri, file=nil)
+    puts ("POST #{uri} #{file}") if @verbose
     response = get_client(uri, Net::HTTP::Post, :post)[URI.escape(uri)].post(:import => file)
     return JSON.parse(response.body) unless response.body.empty?
   end
 
   def post_text(uri, data=nil, accept='text/plain')
+    puts ("POST #{uri} #{data} #{accept}") if @verbose
     response = get_client(uri, Net::HTTP::Post, :post)[URI.escape(uri)].post(data, :content_type => 'text/plain', :accept => accept )
     return response.body
   end

--- a/server/spec/owner_product_resource_spec.rb
+++ b/server/spec/owner_product_resource_spec.rb
@@ -20,6 +20,12 @@ describe 'Owner Product Resource' do
       })
   end
 
+  it 'should fail when fetching non-existing products' do
+    lambda do
+      @cp.get_product(@owner['key'], "some bad product id")
+    end.should raise_exception(RestClient::ResourceNotFound)
+  end
+
   it 'updates individual product fields' do
     prod = create_product(nil, 'tacos', {:multiplier => 2, :dependentProductIds => [2, 4]})
     #Ensure the dates are at least one second different

--- a/server/spec/product_resource_spec.rb
+++ b/server/spec/product_resource_spec.rb
@@ -20,6 +20,12 @@ describe 'Product Resource' do
       })
   end
 
+  it 'should fail when fetching non-existing products' do
+    lambda do
+      @cp.get_product_by_uuid("some bad product uuid")
+    end.should raise_exception(RestClient::ResourceNotFound)
+  end
+
   it 'throws exception on write operations' do
     lambda do
       @cp.post("/products", {})

--- a/server/spec/product_versioning_spec.rb
+++ b/server/spec/product_versioning_spec.rb
@@ -391,4 +391,92 @@ describe 'Product Versioning' do
     prod6["uuid"].should eq(prod5["uuid"])
   end
 
+  it "should not converge with an orphaned product" do
+    # NOTE:
+    # This test should be removed/disabled if in-place updating/converging is reenabled, as orphans
+    # will not be created in such a case
+
+    owner1 = create_owner random_string('test_owner')
+    owner2 = create_owner random_string('test_owner')
+
+    id = random_string('test_product')
+
+    orphan = @cp.create_product(owner1["key"], id, id)
+    product1 = @cp.update_product(owner1["key"], id, { :name => "#{id}-update" })
+    product2 = @cp.create_product(owner2["key"], id, id)
+
+    expect(orphan['uuid']).to_not eq(product1['uuid'])
+    expect(orphan['uuid']).to_not eq(product2['uuid'])
+    expect(product1['uuid']).to_not eq(product2['uuid'])
+
+    expect(@cp.get_product_by_uuid(orphan['uuid'])).to_not be_nil
+    expect(@cp.get_product_by_uuid(product1['uuid'])).to_not be_nil
+    expect(@cp.get_product_by_uuid(product2['uuid'])).to_not be_nil
+  end
+
+  it 'should cleanup orphans without interfering with normal actions' do
+    # NOTE:
+    # This test takes advantage of the immutable nature of products with the in-place update branch
+    # disabled. If in-place updates are ever reenabled, we'll need a way to generate large numbers
+    # of orphaned products for this test.
+
+    owner1 = create_owner(random_string('test_owner-1'))
+    owner2 = create_owner(random_string('test_owner-2'))
+
+    prefix = "test-product-"
+    offset = 10000
+    length = 100
+
+    # Repeat this test a few(ish) times to hopefully catch any synchronization error
+    (1..5).each do
+      o1_uuids = []
+      o2_uuids = []
+
+      # Create a bunch of dummy products
+      (offset..(offset + length - 1)).each do |i|
+        id = "#{prefix}#{i}"
+
+        # create product and immediately update it to generate an orphaned product
+        @cp.create_product(owner1["key"], id, id)
+      end
+
+      # Attempt to update and create new products to get into some funky race conditions with
+      # convergence and orphanization
+      updater = Thread.new do
+        (offset..(offset + length - 1)).each do |i|
+          id = "#{prefix}#{i}"
+          product = @cp.update_product(owner1["key"], id, { :name => "#{id}-update" })
+          o1_uuids << product['uuid']
+        end
+      end
+
+      generator = Thread.new do
+        (offset..(offset + length - 1)).each do |i|
+          id = "#{prefix}#{i}"
+          product = @cp.create_product(owner2["key"], id, id)
+          o2_uuids << product['uuid']
+        end
+      end
+
+      sleep 1
+      @cp.trigger_job("OrphanCleanupJob");
+
+      updater.join
+      generator.join
+
+      # Verify the products created/updated still exist
+      o1_uuids.each do |uuid|
+        product = @cp.get_product_by_uuid(uuid)
+        expect(product).to_not be_nil
+      end
+
+      o2_uuids.each do |uuid|
+        product = @cp.get_product_by_uuid(uuid)
+        expect(product).to_not be_nil
+      end
+
+      offset += length
+    end
+  end
+
 end

--- a/server/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/server/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -25,6 +25,7 @@ import org.candlepin.pinsetter.tasks.ExpiredPoolsJob;
 import org.candlepin.pinsetter.tasks.ImportRecordJob;
 import org.candlepin.pinsetter.tasks.JobCleaner;
 import org.candlepin.pinsetter.tasks.ManifestCleanerJob;
+import org.candlepin.pinsetter.tasks.OrphanCleanupJob;
 import org.candlepin.pinsetter.tasks.SweepBarJob;
 import org.candlepin.pinsetter.tasks.UnmappedGuestEntitlementCleanerJob;
 import org.candlepin.pinsetter.tasks.UnpauseJob;
@@ -198,16 +199,17 @@ public class ConfigProperties {
     public static final int PINSETTER_MAX_RETRIES_DEFAULT = 10;
 
     public static final String[] DEFAULT_TASK_LIST = new String[] {
-        CertificateRevocationListTask.class.getName(),
-        JobCleaner.class.getName(),
-        ImportRecordJob.class.getName(),
-        CancelJobJob.class.getName(),
-        ExpiredPoolsJob.class.getName(),
-        UnpauseJob.class.getName(),
-        SweepBarJob.class.getName(),
-        ManifestCleanerJob.class.getName(),
         ActiveEntitlementJob.class.getName(),
+        CancelJobJob.class.getName(),
+        CertificateRevocationListTask.class.getName(),
+        ExpiredPoolsJob.class.getName(),
+        ImportRecordJob.class.getName(),
+        JobCleaner.class.getName(),
+        ManifestCleanerJob.class.getName(),
+        OrphanCleanupJob.class.getName(),
+        SweepBarJob.class.getName(),
         UnmappedGuestEntitlementCleanerJob.class.getName(),
+        UnpauseJob.class.getName(),
     };
 
     public static final String MANIFEST_CLEANER_JOB_MAX_AGE_IN_MINUTES =

--- a/server/src/main/java/org/candlepin/controller/ContentManager.java
+++ b/server/src/main/java/org/candlepin/controller/ContentManager.java
@@ -230,11 +230,6 @@ public class ContentManager {
                     }
                 }
 
-                // Clean up our content entity if it was orphaned
-                if (this.ownerContentCurator.getOwnerCount(entity) == 0) {
-                    this.contentCurator.delete(entity);
-                }
-
                 return alt;
             }
         }
@@ -296,11 +291,6 @@ public class ContentManager {
                 // Impl note: This should also take care of our entitlement cert regeneration
                 this.productManager.updateProduct(pdata, owner, regenerateEntitlementCerts);
             }
-        }
-
-        // Clean up our content entity if it was orphaned
-        if (this.ownerContentCurator.getOwnerCount(entity) == 0) {
-            this.contentCurator.delete(entity);
         }
 
         return updated;
@@ -512,20 +502,6 @@ public class ContentManager {
         }
 
         this.ownerContentCurator.updateOwnerContentReferences(owner, contentUuidMap);
-
-        // Kill any content objects we've orphaned as a result of this import
-        Map<String, Integer> ownerCounts = this.ownerContentCurator.getOwnerCounts(sourceContent.keySet());
-
-        for (iterator = sourceContent.values().iterator(); iterator.hasNext();) {
-            if (ownerCounts.containsKey(iterator.next().getUuid())) {
-                iterator.remove();
-            }
-        }
-
-        if (sourceContent.size() > 0) {
-            this.contentCurator.bulkDelete(sourceContent.values());
-            this.contentCurator.flush();
-        }
 
         // Return
         return importResult;

--- a/server/src/main/java/org/candlepin/controller/Entitler.java
+++ b/server/src/main/java/org/candlepin/controller/Entitler.java
@@ -375,8 +375,8 @@ public class Entitler {
 
             ProductData existingProduct = productMap.get(product.getId());
             if (existingProduct != null && !existingProduct.equals(product)) {
-                log.warn("WARNING: Multiple versions of the same product received during dev pool " +
-                    "resolution; discarding duplicate: {} => {}, {}",
+                log.warn("Multiple versions of the same product received during dev pool resolution; " +
+                    "discarding duplicate: {} => {}, {}",
                     product.getId(), existingProduct, product
                 );
             }
@@ -394,8 +394,7 @@ public class Entitler {
                         // check for, and throw out, such mappings
 
                         if (pcd == null) {
-                            log.error(
-                                "ERROR: product contains a null product-content mapping: {}", product);
+                            log.error("product contains a null product-content mapping: {}", product);
                             throw new IllegalStateException(
                                 "product contains a null product-content mapping: " + product);
                         }
@@ -405,8 +404,8 @@ public class Entitler {
                         // Do some simple mapping validation. Our import method will handle minimal
                         // population validation for us.
                         if (content == null || content.getId() == null) {
-                            log.error("ERROR: product contains a null or incomplete product-content " +
-                                "mapping: {}", product);
+                            log.error("product contains a null or incomplete product-content mapping: {}",
+                                product);
                             throw new IllegalStateException("product contains a null or incomplete " +
                                 "product-content mapping: " + product);
                         }
@@ -416,8 +415,8 @@ public class Entitler {
 
                         ContentData existingContent = contentMap.get(content.getId());
                         if (existingContent != null && !existingContent.equals(content)) {
-                            log.warn("WARNING: Multiple versions of the same content received during dev " +
-                                "pool resolution; discarding duplicate: {} => {}, {}",
+                            log.warn("Multiple versions of the same content received during dev pool " +
+                                "resolution; discarding duplicate: {} => {}, {}",
                                 content.getId(), existingContent, content
                             );
                         }

--- a/server/src/main/java/org/candlepin/controller/PoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/PoolManager.java
@@ -232,10 +232,11 @@ public interface PoolManager {
     /**
      * Updates the pool based on the entitlements in the specified stack.
      * @param pool
+     * @param changedProducts
      *
      * @return pool update specifics
      */
-    PoolUpdate updatePoolFromStack(Pool pool, Set<Product> changedProducts);
+    PoolUpdate updatePoolFromStack(Pool pool, Map<String, Product> changedProducts);
 
     /**
      * Updates the pools based on the entitlements in the specified stack.

--- a/server/src/main/java/org/candlepin/controller/ProductManager.java
+++ b/server/src/main/java/org/candlepin/controller/ProductManager.java
@@ -211,11 +211,6 @@ public class ProductManager {
                     );
                 }
 
-                // Clean up our product entity if it was orphaned
-                if (this.ownerProductCurator.getOwnerCount(entity) == 0) {
-                    this.productCurator.delete(entity);
-                }
-
                 return alt;
             }
         }
@@ -253,11 +248,6 @@ public class ProductManager {
             this.entitlementCertGenerator.regenerateCertificatesOf(
                 Arrays.asList(owner), Arrays.asList(updated), true
             );
-        }
-
-        // Clean up our product entity if it was orphaned
-        if (this.ownerProductCurator.getOwnerCount(entity) == 0) {
-            this.productCurator.delete(entity);
         }
 
         return updated;
@@ -426,20 +416,6 @@ public class ProductManager {
         }
 
         this.ownerProductCurator.updateOwnerProductReferences(owner, productUuidMap);
-
-        // Kill any product objects we've orphaned as a result of this import
-        Map<String, Integer> ownerCounts = this.ownerProductCurator.getOwnerCounts(productUuidMap.keySet());
-
-        for (iterator = sourceProducts.values().iterator(); iterator.hasNext();) {
-            if (ownerCounts.containsKey(iterator.next().getUuid())) {
-                iterator.remove();
-            }
-        }
-
-        if (sourceProducts.size() > 0) {
-            this.productCurator.bulkDelete(sourceProducts.values());
-            this.productCurator.flush();
-        }
 
         // Return
         return importResult;

--- a/server/src/main/java/org/candlepin/controller/Refresher.java
+++ b/server/src/main/java/org/candlepin/controller/Refresher.java
@@ -26,7 +26,7 @@ import com.google.inject.persist.UnitOfWork;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -147,7 +147,8 @@ public class Refresher {
              * dirty, they will never get regenerated
              */
             Pool masterPool = poolManager.convertToMasterPool(subscription);
-            poolManager.refreshPoolsForMasterPool(masterPool, true, lazy, new HashSet<Product>());
+            poolManager.refreshPoolsForMasterPool(masterPool, true, lazy,
+                Collections.<String, Product>emptyMap());
         }
 
         for (Owner owner : this.owners.values()) {

--- a/server/src/main/java/org/candlepin/model/CandlepinQuery.java
+++ b/server/src/main/java/org/candlepin/model/CandlepinQuery.java
@@ -22,6 +22,8 @@ import org.hibernate.criterion.Order;
 import java.util.List;
 import java.util.Iterator;
 
+import javax.persistence.LockModeType;
+
 
 
 /**
@@ -85,6 +87,18 @@ public interface CandlepinQuery<T> extends Iterable<T> {
      *  this query instance
      */
     CandlepinQuery<T> addOrder(Order order);
+
+    /**
+     * Sets the locking mode for the query. The lock mode will be applied to the database rows
+     * representing the entities returned by this query.
+     *
+     * @param lockMode
+     *  The lock mode to apply when executing this query
+     *
+     * @return
+     *  this query instance
+     */
+    CandlepinQuery<T> setLockMode(LockModeType lockMode);
 
     /**
      * Returns a CandlepinQuery instance that transforms the results using the given element

--- a/server/src/main/java/org/candlepin/model/Content.java
+++ b/server/src/main/java/org/candlepin/model/Content.java
@@ -656,7 +656,8 @@ public class Content extends AbstractHibernateObject implements SharedEntity, Cl
 
     @Override
     public String toString() {
-        return String.format("ContentData [id: %s, name: %s, label: %s]", this.id, this.name, this.label);
+        return String.format("ContentData [uuid: %s, id: %s, name: %s, label: %s]",
+            this.uuid, this.id, this.name, this.label);
     }
 
     @PrePersist

--- a/server/src/main/java/org/candlepin/model/ContentCurator.java
+++ b/server/src/main/java/org/candlepin/model/ContentCurator.java
@@ -19,7 +19,6 @@ import com.google.inject.persist.Transactional;
 
 import org.hibernate.Session;
 import org.hibernate.criterion.DetachedCriteria;
-import org.hibernate.criterion.Disjunction;
 import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
 

--- a/server/src/main/java/org/candlepin/model/ContentCurator.java
+++ b/server/src/main/java/org/candlepin/model/ContentCurator.java
@@ -28,7 +28,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 
 
 
@@ -71,65 +70,6 @@ public class ContentCurator extends AbstractHibernateCurator<Content> {
     public Content lookupByUuid(String uuid) {
         return (Content) currentSession().createCriteria(Content.class).setCacheable(true)
             .add(Restrictions.eq("uuid", uuid)).uniqueResult();
-    }
-
-    /**
-     * Retrieves a criteria which can be used to fetch a list of content with the specified Red Hat
-     * content ID and entity version. If no content were found matching the given criteria, this
-     * method returns an empty list.
-     *
-     * @param contentId
-     *  The Red Hat content ID
-     *
-     * @param hashcode
-     *  The hash code representing the content version
-     *
-     * @return
-     *  a criteria for fetching content by version
-     */
-    @SuppressWarnings("checkstyle:indentation")
-    public CandlepinQuery<Content> getContentByVersion(String contentId, int hashcode) {
-        DetachedCriteria criteria = this.createSecureDetachedCriteria()
-            .add(Restrictions.eq("id", contentId))
-            .add(Restrictions.or(
-                Restrictions.isNull("entityVersion"),
-                Restrictions.eq("entityVersion", hashcode)
-            ));
-
-        return this.cpQueryFactory.<Content>buildQuery(this.currentSession(), criteria);
-    }
-
-    /**
-     * Retrieves a criteria which can be used to fetch a list of content with the specified Red Hat
-     * content ID and entity version. If no content were found matching the given criteria, this
-     * method returns an empty list.
-     *
-     * @param contentVersions
-     *  A mapping of Red Hat content IDs to content versions to fetch
-     *
-     * @return
-     *  a criteria for fetching content by version
-     */
-    @SuppressWarnings("checkstyle:indentation")
-    public CandlepinQuery<Content> getContentByVersions(Map<String, Integer> contentVersions) {
-        if (contentVersions != null && !contentVersions.isEmpty()) {
-            return this.cpQueryFactory.<Content>buildQuery();
-        }
-
-        Disjunction disjunction = Restrictions.disjunction();
-        DetachedCriteria criteria = this.createSecureDetachedCriteria().add(disjunction);
-
-        for (Map.Entry<String, Integer> entry : contentVersions.entrySet()) {
-            disjunction.add(Restrictions.and(
-                Restrictions.eq("id", entry.getKey()),
-                Restrictions.or(
-                    Restrictions.isNull("entityVersion"),
-                    Restrictions.eq("entityVersion", entry.getValue())
-                )
-            ));
-        }
-
-        return this.cpQueryFactory.<Content>buildQuery(this.currentSession(), criteria);
     }
 
     /**

--- a/server/src/main/java/org/candlepin/model/DetachedCandlepinQuery.java
+++ b/server/src/main/java/org/candlepin/model/DetachedCandlepinQuery.java
@@ -42,6 +42,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.HashMap;
 
+import javax.persistence.LockModeType;
+
 
 
 /**
@@ -60,6 +62,7 @@ public class DetachedCandlepinQuery<T> implements CandlepinQuery<T> {
 
     protected int offset;
     protected int limit;
+    protected LockMode lockMode;
 
     /**
      * Creates a new DetachedCandlepinQuery instance using the specified criteria and session.
@@ -92,6 +95,7 @@ public class DetachedCandlepinQuery<T> implements CandlepinQuery<T> {
 
         this.offset = -1;
         this.limit = -1;
+        this.lockMode = null;
     }
 
     /**
@@ -165,6 +169,10 @@ public class DetachedCandlepinQuery<T> implements CandlepinQuery<T> {
             executable.setMaxResults(this.limit);
         }
 
+        if (this.lockMode != null) {
+            executable.setLockMode(this.lockMode);
+        }
+
         // TODO: Add read-only when we have a requirement to do so.
 
         return executable;
@@ -211,6 +219,22 @@ public class DetachedCandlepinQuery<T> implements CandlepinQuery<T> {
         }
 
         this.criteria.addOrder(order);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CandlepinQuery<T> setLockMode(LockModeType lockMode) {
+        // Translate the given lock mode to a Hibernate lock mode
+        if (lockMode != null) {
+            this.lockMode = LockMode.valueOf(lockMode.name());
+        }
+        else {
+            this.lockMode = null;
+        }
+
         return this;
     }
 

--- a/server/src/main/java/org/candlepin/model/DetachedCandlepinQuery.java
+++ b/server/src/main/java/org/candlepin/model/DetachedCandlepinQuery.java
@@ -20,6 +20,7 @@ import com.google.inject.persist.Transactional;
 
 import org.hibernate.CacheMode;
 import org.hibernate.Criteria;
+import org.hibernate.LockMode;
 import org.hibernate.ScrollMode;
 import org.hibernate.ScrollableResults;
 import org.hibernate.Session;

--- a/server/src/main/java/org/candlepin/model/EmptyCandlepinQuery.java
+++ b/server/src/main/java/org/candlepin/model/EmptyCandlepinQuery.java
@@ -23,6 +23,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.NoSuchElementException;
 
+import javax.persistence.LockModeType;
+
 
 
 /**
@@ -116,6 +118,19 @@ public class EmptyCandlepinQuery<T> implements CandlepinQuery<T> {
      */
     @Override
     public CandlepinQuery<T> addOrder(Order order) {
+        return this;
+    }
+
+    /**
+     * Returns a reference to this CandlepinQuery instance.
+     *
+     * @param lockMode
+     *
+     * @return
+     *  this query instance
+     */
+    @Override
+    public CandlepinQuery<T> setLockMode(LockModeType lockMode) {
         return this;
     }
 

--- a/server/src/main/java/org/candlepin/model/OwnerProductCurator.java
+++ b/server/src/main/java/org/candlepin/model/OwnerProductCurator.java
@@ -16,12 +16,10 @@ package org.candlepin.model;
 
 import org.candlepin.model.activationkeys.ActivationKey;
 
-import com.google.common.collect.Iterables;
 import com.google.inject.persist.Transactional;
 
 import org.hibernate.Criteria;
 import org.hibernate.Session;
-import org.hibernate.Query;
 import org.hibernate.criterion.DetachedCriteria;
 import org.hibernate.criterion.Disjunction;
 import org.hibernate.criterion.Projections;

--- a/server/src/main/java/org/candlepin/model/Product.java
+++ b/server/src/main/java/org/candlepin/model/Product.java
@@ -1140,7 +1140,7 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
 
     @Override
     public String toString() {
-        return String.format("Product [id = %s, name = %s]", this.id, this.name);
+        return String.format("Product [uuid: %s, id: %s, name: %s]", this.uuid, this.id, this.name);
     }
 
     @XmlTransient

--- a/server/src/main/java/org/candlepin/model/ProductCurator.java
+++ b/server/src/main/java/org/candlepin/model/ProductCurator.java
@@ -25,7 +25,6 @@ import com.google.inject.persist.Transactional;
 import org.apache.commons.lang.StringUtils;
 import org.hibernate.Criteria;
 import org.hibernate.criterion.DetachedCriteria;
-import org.hibernate.criterion.Disjunction;
 import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
 import org.hibernate.sql.JoinType;
@@ -256,65 +255,6 @@ public class ProductCurator extends AbstractHibernateCurator<Product> {
         }
 
         return productsByUuid;
-    }
-
-    /**
-     * Retrieves a criteria which can be used to fetch a list of products with the specified Red
-     * Hat product ID and entity version. If no products were found matching the given criteria,
-     * this method returns an empty list.
-     *
-     * @param productId
-     *  The Red Hat product ID
-     *
-     * @param hashcode
-     *  The hash code representing the product version
-     *
-     * @return
-     *  a criteria for fetching product by version
-     */
-    @SuppressWarnings("checkstyle:indentation")
-    public CandlepinQuery<Product> getProductsByVersion(String productId, int hashcode) {
-        DetachedCriteria criteria = this.createSecureDetachedCriteria()
-            .add(Restrictions.eq("id", productId))
-            .add(Restrictions.or(
-                Restrictions.isNull("entityVersion"),
-                Restrictions.eq("entityVersion", hashcode)
-            ));
-
-        return this.cpQueryFactory.<Product>buildQuery(this.currentSession(), criteria);
-    }
-
-    /**
-     * Retrieves a criteria which can be used to fetch a list of products with the specified Red Hat
-     * product ID and entity version. If no products were found matching the given criteria, this
-     * method returns an empty list.
-     *
-     * @param productVersions
-     *  A mapping of Red Hat product IDs to product versions to fetch
-     *
-     * @return
-     *  a criteria for fetching products by version
-     */
-    @SuppressWarnings("checkstyle:indentation")
-    public CandlepinQuery<Product> getProductByVersions(Map<String, Integer> productVersions) {
-        if (productVersions == null || productVersions.isEmpty()) {
-            return this.cpQueryFactory.<Product>buildQuery();
-        }
-
-        Disjunction disjunction = Restrictions.disjunction();
-        DetachedCriteria criteria = this.createSecureDetachedCriteria().add(disjunction);
-
-        for (Map.Entry<String, Integer> entry : productVersions.entrySet()) {
-            disjunction.add(Restrictions.and(
-                Restrictions.eq("id", entry.getKey()),
-                Restrictions.or(
-                    Restrictions.isNull("entityVersion"),
-                    Restrictions.eq("entityVersion", entry.getValue())
-                )
-            ));
-        }
-
-        return this.cpQueryFactory.<Product>buildQuery(this.currentSession(), criteria);
     }
 
     // TODO:

--- a/server/src/main/java/org/candlepin/model/RulesCurator.java
+++ b/server/src/main/java/org/candlepin/model/RulesCurator.java
@@ -108,11 +108,11 @@ public class RulesCurator extends AbstractHibernateCurator<Rules> {
 
     public Date getUpdatedFromDB() {
         return (Date) this.currentSession().createCriteria(Rules.class)
-                .setCacheable(true)
-                .setCacheRegion(CandlepinCacheRegions.FIVE_SECONDS_QUERY_CACHE)
-            .setProjection(Projections.projectionList()
-                .add(Projections.max("updated")))
-                .uniqueResult();
+            .setCacheable(true)
+            .setCacheRegion(CandlepinCacheRegions.FIVE_SECONDS_QUERY_CACHE)
+        .setProjection(Projections.projectionList()
+            .add(Projections.max("updated")))
+            .uniqueResult();
     }
 
     /**

--- a/server/src/main/java/org/candlepin/model/TransformedCandlepinQuery.java
+++ b/server/src/main/java/org/candlepin/model/TransformedCandlepinQuery.java
@@ -23,6 +23,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.LinkedList;
 
+import javax.persistence.LockModeType;
+
 
 
 /**
@@ -150,6 +152,15 @@ public class TransformedCandlepinQuery<I, O> implements CandlepinQuery<O> {
     @Override
     public CandlepinQuery<O> addOrder(Order order) {
         this.query.addOrder(order);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CandlepinQuery<O> setLockMode(LockModeType lockMode) {
+        this.query.setLockMode(lockMode);
         return this;
     }
 

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/OrphanCleanupJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/OrphanCleanupJob.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2009 - 2016 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.pinsetter.tasks;
+
+import org.candlepin.model.CandlepinQuery;
+import org.candlepin.model.Content;
+import org.candlepin.model.ContentCurator;
+import org.candlepin.model.OwnerContentCurator;
+import org.candlepin.model.Product;
+import org.candlepin.model.ProductCurator;
+import org.candlepin.model.OwnerProductCurator;
+
+import com.google.inject.Inject;
+import com.google.inject.persist.Transactional;
+
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.persistence.LockModeType;
+
+
+
+/**
+ * The OrphanCleanupJob searches for orphaned entities (products and content and the time of
+ * writing) and removes them.
+ */
+public class OrphanCleanupJob extends KingpinJob {
+    private static Logger log = LoggerFactory.getLogger(OrphanCleanupJob.class);
+
+    // Every Sunday at 3:00am
+    public static final String DEFAULT_SCHEDULE = "0 0 3 ? * 1";
+
+    private ContentCurator contentCurator;
+    private OwnerContentCurator ownerContentCurator;
+    private ProductCurator productCurator;
+    private OwnerProductCurator ownerProductCurator;
+
+    @Inject
+    public OrphanCleanupJob(ContentCurator contentCurator, OwnerContentCurator ownerContentCurator,
+        ProductCurator productCurator, OwnerProductCurator ownerProductCurator) {
+
+        this.ownerContentCurator = ownerContentCurator;
+        this.contentCurator = contentCurator;
+        this.ownerProductCurator = ownerProductCurator;
+        this.productCurator = productCurator;
+    }
+
+    @Override
+    @Transactional
+    public void toExecute(JobExecutionContext ctx) throws JobExecutionException {
+        log.debug("Deleting orphaned entities...");
+        int count;
+
+        // Content
+        count = 0;
+        CandlepinQuery<Content> contentQuery = this.ownerContentCurator.getOrphanedContent()
+            .setLockMode(LockModeType.PESSIMISTIC_WRITE);
+
+        for (Content content : contentQuery) {
+            this.contentCurator.delete(content);
+            ++count;
+        }
+
+        this.contentCurator.flush();
+        log.debug("{} orphaned content entities deleted", count);
+
+        // Products
+        count = 0;
+        CandlepinQuery<Product> productQuery = this.ownerProductCurator.getOrphanedProducts()
+            .setLockMode(LockModeType.PESSIMISTIC_WRITE);
+
+        for (Product product : productQuery) {
+            this.productCurator.delete(product);
+            ++count;
+        }
+
+        this.productCurator.flush();
+        log.debug("{} orphaned product entities deleted", count);
+    }
+}

--- a/server/src/main/java/org/candlepin/sync/Importer.java
+++ b/server/src/main/java/org/candlepin/sync/Importer.java
@@ -119,7 +119,6 @@ public class Importer {
         MANIFEST_OLD, MANIFEST_SAME, DISTRIBUTOR_CONFLICT, SIGNATURE_CONFLICT
     }
 
-
     private ConsumerTypeCurator consumerTypeCurator;
     private ProductCurator productCurator;
     private ObjectMapper mapper;
@@ -138,18 +137,15 @@ public class Importer {
     private DistributorVersionCurator distVerCurator;
     private SyncUtils syncUtils;
     private ImportRecordCurator importRecordCurator;
+    private SubscriptionReconciler subscriptionReconciler;
 
     @Inject
     public Importer(ConsumerTypeCurator consumerTypeCurator, ProductCurator productCurator,
-        RulesImporter rulesImporter, OwnerCurator ownerCurator,
-        IdentityCertificateCurator idCertCurator,
-        ContentCurator contentCurator, PoolManager pm,
-        PKIUtility pki, Configuration config, ExporterMetadataCurator emc,
-        CertificateSerialCurator csc, EventSink sink, I18n i18n,
-        DistributorVersionCurator distVerCurator,
-        CdnCurator cdnCurator,
-        SyncUtils syncUtils,
-        ImportRecordCurator importRecordCurator) {
+        RulesImporter rulesImporter, OwnerCurator ownerCurator, IdentityCertificateCurator idCertCurator,
+        ContentCurator contentCurator, PoolManager pm, PKIUtility pki, Configuration config,
+        ExporterMetadataCurator emc, CertificateSerialCurator csc, EventSink sink, I18n i18n,
+        DistributorVersionCurator distVerCurator, CdnCurator cdnCurator, SyncUtils syncUtils,
+        ImportRecordCurator importRecordCurator, SubscriptionReconciler subscriptionReconciler) {
 
         this.config = config;
         this.consumerTypeCurator = consumerTypeCurator;
@@ -169,6 +165,7 @@ public class Importer {
         this.distVerCurator = distVerCurator;
         this.cdnCurator = cdnCurator;
         this.importRecordCurator = importRecordCurator;
+        this.subscriptionReconciler = subscriptionReconciler;
     }
 
     public ImportRecord loadExport(Owner owner, File archive, ConflictOverrides overrides,
@@ -736,6 +733,9 @@ public class Importer {
                 }
             }
         }
+
+        // Reconcile the subscriptions so they line up with pools we're tracking
+        this.subscriptionReconciler.reconcile(owner, subscriptionsToImport);
 
         return subscriptionsToImport;
     }

--- a/server/src/main/java/org/candlepin/sync/SubscriptionReconciler.java
+++ b/server/src/main/java/org/candlepin/sync/SubscriptionReconciler.java
@@ -20,6 +20,8 @@ import org.candlepin.model.Pool.PoolType;
 import org.candlepin.model.PoolCurator;
 import org.candlepin.model.dto.Subscription;
 
+import com.google.inject.Inject;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,6 +49,13 @@ import java.util.Set;
 public class SubscriptionReconciler {
 
     private static Logger log = LoggerFactory.getLogger(SubscriptionReconciler.class);
+
+    private PoolCurator poolCurator;
+
+    @Inject
+    public SubscriptionReconciler(PoolCurator poolCurator) {
+        this.poolCurator = poolCurator;
+    }
 
     /**
      *  Reconciles incoming entitlements to existing pools to attempt to limit
@@ -77,17 +86,12 @@ public class SubscriptionReconciler {
      * @param subsToImport
      *  A collection of subscriptions which are being imported
      *
-     * @param poolCurator
-     *  The PoolCurator to use for pool lookup and resolution
-     *
      * @return
      *  The collection of reconciled subscriptions
      */
-    public Collection<Subscription> reconcile(Owner owner, Collection<Subscription> subsToImport,
-        PoolCurator poolCurator) {
+    public Collection<Subscription> reconcile(Owner owner, Collection<Subscription> subsToImport) {
 
-        Map<String, Map<String, Pool>> existingPoolsByUpstreamPool =
-            mapPoolsByUpstreamPool(owner, poolCurator);
+        Map<String, Map<String, Pool>> existingPoolsByUpstreamPool = this.mapPoolsByUpstreamPool(owner);
 
         // if we can match to the entitlement id do it.
         // we need a new list to hold the ones that are left
@@ -187,12 +191,12 @@ public class SubscriptionReconciler {
     /*
      * Maps upstream pool ID to a map of upstream entitlement ID to Subscription.
      */
-    private Map<String, Map<String, Pool>> mapPoolsByUpstreamPool(Owner owner, PoolCurator poolCurator) {
+    private Map<String, Map<String, Pool>> mapPoolsByUpstreamPool(Owner owner) {
         Map<String, Map<String, Pool>> existingSubsByUpstreamPool = new HashMap<String, Map<String, Pool>>();
 
         int idx = 0;
 
-        for (Pool p : poolCurator.listByOwnerAndType(owner, PoolType.NORMAL)) {
+        for (Pool p : this.poolCurator.listByOwnerAndType(owner, PoolType.NORMAL)) {
             // if the upstream pool id is null,
             // this must be a locally controlled sub.
             if (p.getUpstreamPoolId() == null) {

--- a/server/src/test/java/org/candlepin/controller/ContentManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/ContentManagerTest.java
@@ -143,6 +143,15 @@ public class ContentManagerTest extends DatabaseTestFixture {
         assertNotEquals(output.getUuid(), content.getUuid());
         assertEquals(output.getName(), update.getName());
 
+        // We shouldn't be able to find the original product via UUID (as we're currently treating
+        // products as immutable), but we should be able to find it via owner + RHID.
+        assertNull(this.contentCurator.find(content.getUuid()));
+        assertNotNull(this.ownerContentCurator.getContentById(owner, content.getId()));
+
+        // The product should have also changed in the same way as a result of the content change
+        assertNull(this.productCurator.find(product.getUuid()));
+        assertNotNull(this.ownerProductCurator.getProductById(owner, product.getId()));
+
         if (regenCerts) {
             verify(this.mockEntCertGenerator, times(1)).regenerateCertificatesOf(
                 eq(Arrays.asList(owner)), anyCollectionOf(Product.class), anyBoolean()

--- a/server/src/test/java/org/candlepin/controller/ContentManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/ContentManagerTest.java
@@ -143,13 +143,15 @@ public class ContentManagerTest extends DatabaseTestFixture {
         assertNotEquals(output.getUuid(), content.getUuid());
         assertEquals(output.getName(), update.getName());
 
-        // We shouldn't be able to find the original product via UUID (as we're currently treating
-        // products as immutable), but we should be able to find it via owner + RHID.
-        assertNull(this.contentCurator.find(content.getUuid()));
+        // We expect the original to be kept around as an orphan until the orphan removal job
+        // gets around to removing them
+        assertNotNull(this.contentCurator.find(content.getUuid()));
+        assertEquals(0, this.ownerContentCurator.getOwnerCount(content));
         assertNotNull(this.ownerContentCurator.getContentById(owner, content.getId()));
 
         // The product should have also changed in the same way as a result of the content change
-        assertNull(this.productCurator.find(product.getUuid()));
+        assertNotNull(this.productCurator.find(product.getUuid()));
+        assertEquals(0, this.ownerProductCurator.getOwnerCount(product));
         assertNotNull(this.ownerProductCurator.getProductById(owner, product.getId()));
 
         if (regenCerts) {

--- a/server/src/test/java/org/candlepin/controller/PoolManagerFunctionalTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerFunctionalTest.java
@@ -811,6 +811,7 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
         for (Entitlement entitlement : entitlements) {
             this.entitlementCurator.merge(entitlement);
         }
+        this.poolCurator.flush();
 
         this.poolManager.cleanupExpiredPools();
 

--- a/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -272,8 +272,7 @@ public class PoolManagerTest {
 
         // Make sure that only the floating pool was regenerated
         expectedFloating.add(floating);
-        verify(this.manager)
-            .updateFloatingPools(eq(expectedFloating), eq(true), any(Set.class));
+        verify(this.manager).updateFloatingPools(eq(expectedFloating), eq(true), any(Map.class));
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
@@ -315,11 +314,10 @@ public class PoolManagerTest {
 
         // Make sure that only the floating pool was regenerated
         expectedModified.add(p);
-        verify(this.manager)
-            .updateFloatingPools(eq(new LinkedList()), eq(true), any(Set.class));
+        verify(this.manager).updateFloatingPools(eq(new LinkedList()), eq(true), any(Map.class));
         ArgumentCaptor<Pool> argPool = ArgumentCaptor.forClass(Pool.class);
         verify(this.manager).updatePoolsForMasterPool(eq(expectedModified), argPool.capture(),
-            eq(sub.getQuantity()), eq(false), any(Set.class));
+            eq(sub.getQuantity()), eq(false), any(Map.class));
         TestUtil.assertPoolsAreEqual(TestUtil.copyFromSub(sub), argPool.getValue());
     }
 
@@ -742,7 +740,7 @@ public class PoolManagerTest {
 
         this.manager.getRefresher(mockSubAdapter).add(owner).run();
         ArgumentCaptor<List> poolCaptor = ArgumentCaptor.forClass(List.class);
-        verify(this.poolRulesMock).updatePools(poolCaptor.capture(), any(Set.class));
+        verify(this.poolRulesMock).updatePools(poolCaptor.capture(), any(Map.class));
         assertEquals(1, poolCaptor.getValue().size());
         assertEquals(p, poolCaptor.getValue().get(0));
     }
@@ -815,7 +813,7 @@ public class PoolManagerTest {
         u.setOrderChanged(true);
         updates.add(u);
         ArgumentCaptor<Pool> argPool = ArgumentCaptor.forClass(Pool.class);
-        when(poolRulesMock.updatePools(argPool.capture(), eq(pools), eq(s.getQuantity()), any(Set.class)))
+        when(poolRulesMock.updatePools(argPool.capture(), eq(pools), eq(s.getQuantity()), any(Map.class)))
             .thenReturn(updates);
 
         when(mockOwnerCurator.lookupByKey(owner.getKey())).thenReturn(owner);

--- a/server/src/test/java/org/candlepin/controller/ProductManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/ProductManagerTest.java
@@ -124,6 +124,11 @@ public class ProductManagerTest extends DatabaseTestFixture {
         assertNotEquals(output.getUuid(), product.getUuid());
         assertEquals(output.getName(), update.getName());
 
+        // We shouldn't be able to find the original product via UUID (as we're currently treating
+        // products as immutable), but we should be able to find it via owner + RHID.
+        assertNull(this.productCurator.find(product.getUuid()));
+        assertNotNull(this.ownerProductCurator.getProductById(owner, product.getId()));
+
         if (regenCerts) {
             // TODO: Is there a better way to do this? We won't know the exact product instance,
             // we just know that a product should be refreshed as a result of this operation.
@@ -281,7 +286,13 @@ public class ProductManagerTest extends DatabaseTestFixture {
             product, Arrays.asList(content), owner, regenCerts
         );
         assertFalse(output.hasContent(content.getId()));
-        assertNotNull(this.productCurator.find(product.getUuid()));
+
+        // Note: This bit may be temporary. At the time of writing, product reuse is disabled, so
+        // changing the product's content triggers the creation of a new product and the deletion
+        // of the old (as no other owners are using it). As such, we should not find the product
+        // by UUID, but should find it via owner + RHID.
+        assertNull(this.productCurator.find(product.getUuid()));
+        assertNotNull(this.ownerProductCurator.getProductById(owner, product.getId()));
         assertNotNull(this.contentCurator.find(content.getUuid()));
 
         if (regenCerts) {

--- a/server/src/test/java/org/candlepin/controller/RefresherTest.java
+++ b/server/src/test/java/org/candlepin/controller/RefresherTest.java
@@ -33,7 +33,9 @@ import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
+
+
 
 /**
  * RefresherTest
@@ -114,7 +116,7 @@ public class RefresherTest {
 
         verify(poolManager, times(1)).refreshPoolsWithRegeneration(eq(subAdapter), eq(owner), eq(false));
         verify(poolManager, times(0)).updatePoolsForMasterPool(any(List.class),
-            any(Pool.class), eq(pool.getQuantity()), eq(false), any(Set.class));
+            any(Pool.class), eq(pool.getQuantity()), eq(false), any(Map.class));
     }
 
     @Test
@@ -153,6 +155,6 @@ public class RefresherTest {
         refresher.run();
 
         verify(poolManager, times(1)).refreshPoolsForMasterPool(eq(mainPool), eq(true), eq(false),
-            any(Set.class));
+            any(Map.class));
     }
 }

--- a/server/src/test/java/org/candlepin/model/ColumnarResultIteratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ColumnarResultIteratorTest.java
@@ -38,7 +38,7 @@ public class ColumnarResultIteratorTest extends DatabaseTestFixture {
 
     @Before
     public void setup() {
-        this.session = (Session) this.entityManager().getDelegate();
+        this.session = (Session) this.getEntityManager().getDelegate();
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
@@ -74,8 +74,10 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
         Consumer consumer = new Consumer("testConsumer", "testUser", owner, ct);
         consumerCurator.create(consumer);
 
-        List<Consumer> results = entityManager().createQuery(
-            "select c from Consumer as c", Consumer.class).getResultList();
+        List<Consumer> results = this.getEntityManager()
+            .createQuery("select c from Consumer as c", Consumer.class)
+            .getResultList();
+
         assertEquals(1, results.size());
     }
 

--- a/server/src/test/java/org/candlepin/model/ConsumerTest.java
+++ b/server/src/test/java/org/candlepin/model/ConsumerTest.java
@@ -202,18 +202,18 @@ public class ConsumerTest extends DatabaseTestFixture {
         Owner o = createOwner();
         Product newProduct = this.createProduct(o);
 
-        Pool pool = createPool(o, newProduct,
-            1000L, TestUtil.createDate(2009, 11, 30),
+        Pool pool = createPool(o, newProduct, 1000L, TestUtil.createDate(2009, 11, 30),
             TestUtil.createDate(2015, 11, 30));
-        entityManager().persist(pool.getOwner());
-        entityManager().persist(pool);
+
+        this.getEntityManager().persist(pool.getOwner());
+        this.getEntityManager().persist(pool);
 
         Entitlement e1 = createEntitlement(pool, consumer);
         Entitlement e2 = createEntitlement(pool, consumer);
         Entitlement e3 = createEntitlement(pool, consumer);
-        entityManager().persist(e1);
-        entityManager().persist(e2);
-        entityManager().persist(e3);
+        this.getEntityManager().persist(e1);
+        this.getEntityManager().persist(e2);
+        this.getEntityManager().persist(e3);
 
         consumer.addEntitlement(e1);
         consumer.addEntitlement(e2);

--- a/server/src/test/java/org/candlepin/model/ConsumerTypeTest.java
+++ b/server/src/test/java/org/candlepin/model/ConsumerTypeTest.java
@@ -31,11 +31,13 @@ public class ConsumerTypeTest extends DatabaseTestFixture {
         beginTransaction();
 
         ConsumerType ct = new ConsumerType("standard-system");
-        entityManager().persist(ct);
+        this.getEntityManager().persist(ct);
 
         commitTransaction();
 
-        List<?> results = entityManager().createQuery("select ct from ConsumerType as ct").getResultList();
+        List<?> results = this.getEntityManager().createQuery("select ct from ConsumerType as ct")
+            .getResultList();
+
         assertEquals(1, results.size());
     }
 

--- a/server/src/test/java/org/candlepin/model/CuratorPaginationTest.java
+++ b/server/src/test/java/org/candlepin/model/CuratorPaginationTest.java
@@ -50,7 +50,10 @@ public class CuratorPaginationTest extends DatabaseTestFixture {
     private Session session;
 
     @Before
-    public void setUp() {
+    @Override
+    public void init() {
+        super.init();
+
         for (int i = 0; i < 10; i++) {
             Owner o = new Owner();
             o.setDisplayName(String.valueOf(i));
@@ -58,7 +61,7 @@ public class CuratorPaginationTest extends DatabaseTestFixture {
             ownerCurator.create(o);
         }
 
-        session = (Session) entityManager().getDelegate();
+        session = (Session) this.getEntityManager().getDelegate();
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/model/DeletedConsumerCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/DeletedConsumerCuratorTest.java
@@ -39,6 +39,7 @@ public class DeletedConsumerCuratorTest extends DatabaseTestFixture {
 
 
     @Before
+    @Override
     public void init() {
         super.init();
         DeletedConsumer dc = new DeletedConsumer("abcde", "10", "key", "name");

--- a/server/src/test/java/org/candlepin/model/EntitlementCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/EntitlementCuratorTest.java
@@ -96,7 +96,7 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
         Entitlement entitlement = createEntitlement(owner, c, p, cert);
         entitlementCurator.create(entitlement);
         commitTransaction();
-        entityManager().clear();
+        this.getEntityManager().clear();
 
         beginTransaction();
         c = consumerCurator.find(c.getId());

--- a/server/src/test/java/org/candlepin/model/OwnerContentCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/OwnerContentCuratorTest.java
@@ -46,8 +46,8 @@ public class OwnerContentCuratorTest extends DatabaseTestFixture {
      */
     private OwnerContent createOwnerContentMapping(Owner owner, Content content) {
         OwnerContent mapping = new OwnerContent(owner, content);
-        this.entityManager().persist(mapping);
-        this.entityManager().flush();
+        this.getEntityManager().persist(mapping);
+        this.getEntityManager().flush();
 
         return mapping;
     }
@@ -56,7 +56,7 @@ public class OwnerContentCuratorTest extends DatabaseTestFixture {
         String jpql = "SELECT count(op) FROM OwnerContent op " +
             "WHERE op.owner.id = :owner_id AND op.content.uuid = :content_uuid";
 
-        long count = (Long) this.entityManager()
+        long count = (Long) this.getEntityManager()
             .createQuery(jpql)
             .setParameter("owner_id", owner.getId())
             .setParameter("content_uuid", content.getUuid())

--- a/server/src/test/java/org/candlepin/model/OwnerContentCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/OwnerContentCuratorTest.java
@@ -586,60 +586,6 @@ public class OwnerContentCuratorTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void testGetOwnerCounts() {
-        Owner owner1 = this.createOwner();
-        Owner owner2 = this.createOwner();
-        Owner owner3 = this.createOwner();
-
-        Content content1 = this.createContent("p1", "p1");
-        Content content2 = this.createContent("p2", "p2", owner1);
-        Content content3 = this.createContent("p3", "p3", owner1, owner2);
-        Content content4 = this.createContent("p4", "p4", owner1, owner2, owner3);
-        Content content5 = this.createContent("p5", "p5", owner1, owner2, owner3);
-
-        this.ownerContentCurator.flush();
-
-        List<String> uuids = Arrays.asList(content1.getUuid(), content2.getUuid(), content3.getUuid(),
-            content4.getUuid(), "dummy uuid");
-
-        Map<String, Integer> result = this.ownerContentCurator.getOwnerCounts(uuids);
-
-        assertEquals(3, result.size());
-        assertEquals(1, result.get(content2.getUuid()).intValue());
-        assertEquals(2, result.get(content3.getUuid()).intValue());
-        assertEquals(3, result.get(content4.getUuid()).intValue());
-        assertFalse(result.containsKey(content1.getUuid()));
-        assertFalse(result.containsKey(content5.getUuid()));
-        assertFalse(result.containsKey("dummy uuid"));
-    }
-
-    @Test
-    public void testGetOwnerCountsNoUuids() {
-        Owner owner1 = this.createOwner();
-        Owner owner2 = this.createOwner();
-        Owner owner3 = this.createOwner();
-
-        Content content1 = this.createContent("p1", "p1");
-        Content content2 = this.createContent("p2", "p2", owner1);
-        Content content3 = this.createContent("p3", "p3", owner1, owner2);
-        Content content4 = this.createContent("p4", "p4", owner1, owner2, owner3);
-        Content content5 = this.createContent("p5", "p5", owner1, owner2, owner3);
-
-        this.ownerContentCurator.flush();
-
-        List<String> uuids = null;
-        Map<String, Integer> result = this.ownerContentCurator.getOwnerCounts(uuids);
-
-        assertEquals(4, result.size());
-        assertEquals(1, result.get(content2.getUuid()).intValue());
-        assertEquals(2, result.get(content3.getUuid()).intValue());
-        assertEquals(3, result.get(content4.getUuid()).intValue());
-        assertEquals(3, result.get(content5.getUuid()).intValue());
-        assertFalse(result.containsKey(content1.getUuid()));
-        assertFalse(result.containsKey("dummy uuid"));
-    }
-
-    @Test
     public void testGetContentByVersions() {
         Owner owner1 = this.createOwner();
         Owner owner2 = this.createOwner();

--- a/server/src/test/java/org/candlepin/model/OwnerCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/OwnerCuratorTest.java
@@ -58,6 +58,7 @@ public class OwnerCuratorTest extends DatabaseTestFixture {
         newOwner.setId(owner.getId());
 
         this.ownerCurator.replicate(newOwner);
+        this.commitTransaction();
     }
 
     @Test(expected = PersistenceException.class)

--- a/server/src/test/java/org/candlepin/model/OwnerProductCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/OwnerProductCuratorTest.java
@@ -49,8 +49,8 @@ public class OwnerProductCuratorTest extends DatabaseTestFixture {
      */
     private OwnerProduct createOwnerProductMapping(Owner owner, Product product) {
         OwnerProduct mapping = new OwnerProduct(owner, product);
-        this.entityManager().persist(mapping);
-        this.entityManager().flush();
+        this.getEntityManager().persist(mapping);
+        this.getEntityManager().flush();
 
         return mapping;
     }
@@ -59,7 +59,7 @@ public class OwnerProductCuratorTest extends DatabaseTestFixture {
         String jpql = "SELECT count(op) FROM OwnerProduct op " +
             "WHERE op.owner.id = :owner_id AND op.product.uuid = :product_uuid";
 
-        long count = (Long) this.entityManager()
+        long count = (Long) this.getEntityManager()
             .createQuery(jpql)
             .setParameter("owner_id", owner.getId())
             .setParameter("product_uuid", product.getUuid())

--- a/server/src/test/java/org/candlepin/model/OwnerProductCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/OwnerProductCuratorTest.java
@@ -592,60 +592,6 @@ public class OwnerProductCuratorTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void testGetOwnerCounts() {
-        Owner owner1 = this.createOwner();
-        Owner owner2 = this.createOwner();
-        Owner owner3 = this.createOwner();
-
-        Product product1 = this.createProduct("p1", "p1");
-        Product product2 = this.createProduct("p2", "p2", owner1);
-        Product product3 = this.createProduct("p3", "p3", owner1, owner2);
-        Product product4 = this.createProduct("p4", "p4", owner1, owner2, owner3);
-        Product product5 = this.createProduct("p5", "p5", owner1, owner2, owner3);
-
-        this.ownerProductCurator.flush();
-
-        List<String> uuids = Arrays.asList(product1.getUuid(), product2.getUuid(), product3.getUuid(),
-            product4.getUuid(), "dummy uuid");
-
-        Map<String, Integer> result = this.ownerProductCurator.getOwnerCounts(uuids);
-
-        assertEquals(3, result.size());
-        assertEquals(1, result.get(product2.getUuid()).intValue());
-        assertEquals(2, result.get(product3.getUuid()).intValue());
-        assertEquals(3, result.get(product4.getUuid()).intValue());
-        assertFalse(result.containsKey(product1.getUuid()));
-        assertFalse(result.containsKey(product5.getUuid()));
-        assertFalse(result.containsKey("dummy uuid"));
-    }
-
-    @Test
-    public void testGetOwnerCountsNoUuids() {
-        Owner owner1 = this.createOwner();
-        Owner owner2 = this.createOwner();
-        Owner owner3 = this.createOwner();
-
-        Product product1 = this.createProduct("p1", "p1");
-        Product product2 = this.createProduct("p2", "p2", owner1);
-        Product product3 = this.createProduct("p3", "p3", owner1, owner2);
-        Product product4 = this.createProduct("p4", "p4", owner1, owner2, owner3);
-        Product product5 = this.createProduct("p5", "p5", owner1, owner2, owner3);
-
-        this.ownerProductCurator.flush();
-
-        List<String> uuids = null;
-        Map<String, Integer> result = this.ownerProductCurator.getOwnerCounts(uuids);
-
-        assertEquals(4, result.size());
-        assertEquals(1, result.get(product2.getUuid()).intValue());
-        assertEquals(2, result.get(product3.getUuid()).intValue());
-        assertEquals(3, result.get(product4.getUuid()).intValue());
-        assertEquals(3, result.get(product5.getUuid()).intValue());
-        assertFalse(result.containsKey(product1.getUuid()));
-        assertFalse(result.containsKey("dummy uuid"));
-    }
-
-    @Test
     public void testGetProductsByVersions() {
         Owner owner1 = this.createOwner();
         Owner owner2 = this.createOwner();

--- a/server/src/test/java/org/candlepin/model/OwnerTest.java
+++ b/server/src/test/java/org/candlepin/model/OwnerTest.java
@@ -39,9 +39,9 @@ public class OwnerTest extends DatabaseTestFixture {
         o.setContentPrefix(prefix);
         ownerCurator.create(o);
 
-        Owner result = (Owner) entityManager().createQuery(
-            "select o from Owner o where o.key = :key").setParameter(
-            "key", ownerName).getSingleResult();
+        Owner result = (Owner) this.getEntityManager().createQuery("select o from Owner o where o.key = :key")
+            .setParameter("key", ownerName)
+            .getSingleResult();
 
         assertNotNull(result);
         assertEquals(ownerName, result.getKey());
@@ -53,14 +53,18 @@ public class OwnerTest extends DatabaseTestFixture {
 
     @Test
     public void testList() throws Exception {
-        int beforeCount = entityManager().createQuery(
-            "select o from Owner as o").getResultList().size();
+        int beforeCount = this.getEntityManager().createQuery("select o from Owner as o")
+            .getResultList()
+            .size();
 
         for (int i = 0; i < 10; i++) {
             this.createOwner("Corp " + i);
         }
 
-        int afterCount = entityManager().createQuery("select o from Owner as o").getResultList().size();
+        int afterCount = this.getEntityManager().createQuery("select o from Owner as o")
+            .getResultList()
+            .size();
+
         assertEquals(10, afterCount - beforeCount);
     }
 

--- a/server/src/test/java/org/candlepin/model/PoolTest.java
+++ b/server/src/test/java/org/candlepin/model/PoolTest.java
@@ -94,7 +94,7 @@ public class PoolTest extends DatabaseTestFixture {
 
     @Test
     public void testCreate() {
-        Pool lookedUp = entityManager().find(Pool.class, pool.getId());
+        Pool lookedUp = this.getEntityManager().find(Pool.class, pool.getId());
         assertNotNull(lookedUp);
         assertEquals(owner.getId(), lookedUp.getOwner().getId());
         assertEquals(prod1.getId(), lookedUp.getProductId());
@@ -112,7 +112,7 @@ public class PoolTest extends DatabaseTestFixture {
         p.setDerivedProvidedProducts(derivedProducts);
         poolCurator.create(p);
 
-        Pool lookedUp = entityManager().find(Pool.class, p.getId());
+        Pool lookedUp = this.getEntityManager().find(Pool.class, p.getId());
         assertEquals(1, lookedUp.getProvidedProducts().size());
         assertEquals(prod2.getId(), lookedUp.getProvidedProducts().iterator().next().getId());
         assertEquals(1, lookedUp.getDerivedProvidedProducts().size());

--- a/server/src/test/java/org/candlepin/model/ProductCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ProductCuratorTest.java
@@ -114,7 +114,9 @@ public class ProductCuratorTest extends DatabaseTestFixture {
         Product prod = new Product("cptest-label", "My Product");
         productCurator.create(prod);
 
-        List<Product> results = entityManager().createQuery("select p from Product as p").getResultList();
+        List<Product> results = this.getEntityManager().createQuery("select p from Product as p")
+            .getResultList();
+
         assertEquals(5, results.size());
     }
 

--- a/server/src/test/java/org/candlepin/model/ProductCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ProductCuratorTest.java
@@ -251,6 +251,8 @@ public class ProductCuratorTest extends DatabaseTestFixture {
 
         prod.setName("test-changed-name");
         prod = this.productCurator.merge(prod);
+        this.productCurator.flush();
+
         assertTrue(prod.getUpdated().getTime() > updated);
     }
 

--- a/server/src/test/java/org/candlepin/model/RoleTest.java
+++ b/server/src/test/java/org/candlepin/model/RoleTest.java
@@ -83,8 +83,9 @@ public class RoleTest extends DatabaseTestFixture {
     public void testAddPermission() {
         Role role = new Role("myrole");
         roleCurator.create(role);
-        role.addPermission(new PermissionBlueprint(PermissionType.OWNER, owner,
-            Access.ALL));
+        role.addPermission(new PermissionBlueprint(PermissionType.OWNER, owner, Access.ALL));
+        roleCurator.flush();
+
         role = roleCurator.find(role.getId());
         assertEquals(1, role.getPermissions().size());
         PermissionBlueprint perm = role.getPermissions().iterator().next();

--- a/server/src/test/java/org/candlepin/model/RowResultIteratorTest.java
+++ b/server/src/test/java/org/candlepin/model/RowResultIteratorTest.java
@@ -38,7 +38,7 @@ public class RowResultIteratorTest extends DatabaseTestFixture {
 
     @Before
     public void setup() {
-        this.session = (Session) this.entityManager().getDelegate();
+        this.session = (Session) this.getEntityManager().getDelegate();
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/model/UserTest.java
+++ b/server/src/test/java/org/candlepin/model/UserTest.java
@@ -36,10 +36,10 @@ public class UserTest extends DatabaseTestFixture {
         User user = new User(username, password);
 
         beginTransaction();
-        entityManager().persist(user);
+        this.getEntityManager().persist(user);
         commitTransaction();
 
-        User lookedUp = entityManager().find(User.class, user.getId());
+        User lookedUp = this.getEntityManager().find(User.class, user.getId());
         assertEquals(username, lookedUp.getUsername());
         assertEquals(hashedPassword, lookedUp.getHashedPassword());
     }

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/ActiveEntitlementJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/ActiveEntitlementJobTest.java
@@ -73,6 +73,7 @@ public class ActiveEntitlementJobTest extends DatabaseTestFixture {
         assertFalse("valid".equals(consumer.getEntitlementStatus()));
 
         job.toExecute(null);
+        consumerCurator.flush();
         consumerCurator.refresh(consumer);
         assertEquals("valid", consumer.getEntitlementStatus());
 

--- a/server/src/test/java/org/candlepin/policy/CriteriaRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/CriteriaRulesTest.java
@@ -62,6 +62,7 @@ public class CriteriaRulesTest extends DatabaseTestFixture {
         Pool virtPool = this.createPool(owner, targetProduct, 1L, new Date(), new Date());
         virtPool.setAttribute("virt_only", "true");
         poolCurator.merge(virtPool);
+        poolCurator.flush();
 
         List<Pool> results = poolCurator.listAvailableEntitlementPools(consumer, null,
             (Collection<String>) null, null, false);
@@ -123,6 +124,7 @@ public class CriteriaRulesTest extends DatabaseTestFixture {
         anotherVirtPool.setAttribute("virt_only", "true");
         anotherVirtPool.setAttribute("requires_host", "SOMEOTHERUUID");
         poolCurator.merge(anotherVirtPool);
+        poolCurator.flush();
 
         List<Pool> results = poolCurator.listAvailableEntitlementPools(consumer, null,
             (Collection<String>) null, null, false);
@@ -159,6 +161,7 @@ public class CriteriaRulesTest extends DatabaseTestFixture {
         virtPool.setAttribute("virt_only", "true");
         virtPool.setAttribute("requires_host", host.getUuid());
         poolCurator.merge(virtPool);
+        poolCurator.flush();
 
         List<Pool> results = poolCurator.listAvailableEntitlementPools(c, null, (Collection<String>) null,
             null, false);
@@ -182,6 +185,7 @@ public class CriteriaRulesTest extends DatabaseTestFixture {
         Pool virtPool = this.createPool(owner, targetProduct, 1L, new Date(), new Date());
         virtPool.setAttribute("virt_only", "true");
         poolCurator.merge(virtPool);
+        poolCurator.flush();
 
         List<Pool> results = poolCurator.listAvailableEntitlementPools(c, null, (Collection<String>) null,
             null, false);

--- a/server/src/test/java/org/candlepin/policy/PoolRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/PoolRulesTest.java
@@ -54,11 +54,13 @@ import org.mockito.runners.MockitoJUnitRunner;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+
 
 
 /**
@@ -145,7 +147,7 @@ public class PoolRulesTest {
         List<Pool> existingPools = new LinkedList<Pool>();
         existingPools.add(p1);
         List<PoolUpdate> updates = this.poolRules.updatePools(p, existingPools, p.getQuantity(),
-            new HashSet<Product>());
+            Collections.<String, Product>emptyMap());
         assertEquals(1, updates.size());
         PoolUpdate update = updates.get(0);
         assertTrue(update.getProductsChanged());
@@ -183,7 +185,7 @@ public class PoolRulesTest {
 
         List<Pool> existingPools = Arrays.asList(p1);
         List<PoolUpdate> updates = this.poolRules.updatePools(p, existingPools, p.getQuantity(),
-            new HashSet<Product>());
+            Collections.<String, Product>emptyMap());
 
         assertEquals(1, updates.size());
         PoolUpdate update = updates.get(0);
@@ -203,7 +205,7 @@ public class PoolRulesTest {
 
         List<Pool> existingPools = Arrays.asList(p1);
         List<PoolUpdate> updates = this.poolRules.updatePools(p, existingPools, p.getQuantity(),
-            new HashSet<Product>());
+            Collections.<String, Product>emptyMap());
 
         assertEquals(1, updates.size());
         PoolUpdate update = updates.get(0);
@@ -227,7 +229,7 @@ public class PoolRulesTest {
 
         List<Pool> existingPools = Arrays.asList(p1);
         List<PoolUpdate> updates = this.poolRules.updatePools(p, existingPools, p.getQuantity(),
-            new HashSet<Product>());
+            Collections.<String, Product>emptyMap());
 
         assertEquals(1, updates.size());
         PoolUpdate update = updates.get(0);
@@ -259,7 +261,7 @@ public class PoolRulesTest {
 
         List<Pool> existingPools = Arrays.asList(p1);
         List<PoolUpdate> updates = this.poolRules.updatePools(p, existingPools, p.getQuantity(),
-            new HashSet<Product>());
+            Collections.<String, Product>emptyMap());
 
         assertEquals(0, updates.size());
     }
@@ -306,9 +308,9 @@ public class PoolRulesTest {
         p1.getProvidedProducts().add(product3);
 
         List<Pool> existingPools = Arrays.asList(p1);
-
         List<PoolUpdate> updates = this.poolRules.updatePools(p, existingPools, p.getQuantity(),
-            new HashSet<Product>());
+            Collections.<String, Product>emptyMap());
+
         assertEquals(1, updates.size());
         assertEquals(2, updates.get(0).getPool().getDerivedProvidedProducts().size());
     }
@@ -639,7 +641,8 @@ public class PoolRulesTest {
 
         p = createVirtLimitPool("virtLimitProduct", 10, 10);
         p.setQuantity(50L);
-        List<PoolUpdate> updates = poolRules.updatePools(p, pools, p.getQuantity(), new HashSet<Product>());
+        List<PoolUpdate> updates = poolRules.updatePools(p, pools, p.getQuantity(),
+            Collections.<String, Product>emptyMap());
         assertEquals(2, updates.size());
         physicalPool = updates.get(0).getPool();
         assertEquals(new Long(50), physicalPool.getQuantity());
@@ -683,7 +686,8 @@ public class PoolRulesTest {
         assertEquals(1, pools.size());
 
         p = createVirtOnlyPool("virtOnlyProduct", 20);
-        List<PoolUpdate> updates = poolRules.updatePools(p, pools, p.getQuantity(), new HashSet<Product>());
+        List<PoolUpdate> updates = poolRules.updatePools(p, pools, p.getQuantity(),
+            Collections.<String, Product>emptyMap());
         assertEquals(1, updates.size());
         Pool updated = updates.get(0).getPool();
         assertEquals(new Long(20), updated.getQuantity());
@@ -708,7 +712,8 @@ public class PoolRulesTest {
         consumerSpecificPool.setSourceEntitlement(ent);
         pools.add(consumerSpecificPool);
 
-        List<PoolUpdate> updates = poolRules.updatePools(p, pools, p.getQuantity(), new HashSet<Product>());
+        List<PoolUpdate> updates = poolRules.updatePools(p, pools, p.getQuantity(),
+            Collections.<String, Product>emptyMap());
         assertEquals(0, updates.size());
     }
 
@@ -758,9 +763,9 @@ public class PoolRulesTest {
 
         List<Pool> existingPools = new LinkedList<Pool>();
         existingPools.add(p1);
-        List<PoolUpdate> updates = this.poolRules.updatePools(p, existingPools, p.getQuantity(),
-            new HashSet<Product>());
 
+        List<PoolUpdate> updates = this.poolRules.updatePools(p, existingPools, p.getQuantity(),
+            Collections.<String, Product>emptyMap());
         assertEquals(0, updates.size());
     }
 
@@ -779,7 +784,7 @@ public class PoolRulesTest {
         List<Pool> existingPools = new LinkedList<Pool>();
         existingPools.add(p1);
         List<PoolUpdate> updates = this.poolRules.updatePools(p, existingPools, p.getQuantity(),
-            new HashSet<Product>());
+            Collections.<String, Product>emptyMap());
 
         assertEquals(1, updates.size());
         PoolUpdate update = updates.get(0);
@@ -802,7 +807,7 @@ public class PoolRulesTest {
         List<Pool> existingPools = new LinkedList<Pool>();
         existingPools.add(p1);
         List<PoolUpdate> updates = this.poolRules.updatePools(p, existingPools, p.getQuantity(),
-            new HashSet<Product>());
+            Collections.<String, Product>emptyMap());
 
         assertEquals(1, updates.size());
         PoolUpdate update = updates.get(0);
@@ -823,7 +828,7 @@ public class PoolRulesTest {
         List<Pool> existingPools = new LinkedList<Pool>();
         existingPools.add(p1);
         List<PoolUpdate> updates = this.poolRules.updatePools(p, existingPools, p.getQuantity(),
-            new HashSet<Product>());
+            Collections.<String, Product>emptyMap());
 
         assertEquals(1, updates.size());
         PoolUpdate update = updates.get(0);
@@ -844,7 +849,7 @@ public class PoolRulesTest {
         List<Pool> existingPools = new LinkedList<Pool>();
         existingPools.add(p1);
         List<PoolUpdate> updates = this.poolRules.updatePools(p, existingPools, p.getQuantity(),
-            new HashSet<Product>());
+            Collections.<String, Product>emptyMap());
 
         assertEquals(1, updates.size());
         PoolUpdate update = updates.get(0);
@@ -862,10 +867,9 @@ public class PoolRulesTest {
 
         Product changed = p.getProduct();
         changed.setName("somethingelse");
-        Set<Product> changedProducts = new HashSet<Product>();
-        changedProducts.add(changed);
 
-        List<PoolUpdate> updates = this.poolRules.updatePools(floatingPools, changedProducts);
+        List<PoolUpdate> updates = this.poolRules.updatePools(floatingPools,
+            TestUtil.stubChangedProducts(changed));
         assertEquals(0, updates.size());
     }
 

--- a/server/src/test/java/org/candlepin/resource/OwnerResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/OwnerResourceTest.java
@@ -906,8 +906,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         createEntitlementWithQ(pool, retrieved, consumer, e1, "01/02/2010");
         createEntitlementWithQ(pool, retrieved, consumer1, e2, "01/01/2010");
         assertEquals(pool.getConsumed(), Long.valueOf(e1 + e2));
-        this.config.setProperty(
-            ConfigProperties.REVOKE_ENTITLEMENT_IN_FIFO_ORDER, fifo ? "true" : "false");
+        this.config.setProperty(ConfigProperties.REVOKE_ENTITLEMENT_IN_FIFO_ORDER, fifo ? "true" : "false");
 
         poolManager.getRefresher(subAdapter).add(retrieved).run();
         pool = poolCurator.find(pool.getId());

--- a/server/src/test/java/org/candlepin/resource/UserResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/UserResourceTest.java
@@ -163,12 +163,15 @@ public class UserResourceTest extends DatabaseTestFixture {
         User user = new User();
         user.setUsername("henri");
         user.setPassword("password");
+        userResource.createUser(user);
 
-        user = userResource.createUser(user);
-        user.setUsername("Luke");
-        user.setHashedPassword("Skywalker");
-        user.setSuperAdmin(true);
-        User updated = userResource.updateUser("henri", user);
+        User update = new User();
+        update.setUsername("Luke");
+        update.setHashedPassword("Skywalker");
+        update.setSuperAdmin(true);
+
+        User updated = userResource.updateUser("henri", update);
+
         assertEquals("Luke", updated.getUsername());
         assertEquals("Skywalker", updated.getHashedPassword());
         assertTrue(updated.isSuperAdmin());

--- a/server/src/test/java/org/candlepin/sync/ImporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/ImporterTest.java
@@ -118,6 +118,7 @@ public class ImporterTest {
     private ClassLoader classLoader = getClass().getClassLoader();
     private SyncUtils su;
     private ProductCurator pc;
+    private SubscriptionReconciler mockSubReconciler;
 
     @Before
     public void init() throws URISyntaxException, IOException {
@@ -134,12 +135,14 @@ public class ImporterTest {
         pc = Mockito.mock(ProductCurator.class);
         ProductCachedSerializationModule productCachedModule = new ProductCachedSerializationModule(pc);
         su = new SyncUtils(config, productCachedModule);
-        PrintStream ps = new PrintStream(new File(this.getClass()
-            .getClassLoader().getResource("version.properties").toURI()));
+        PrintStream ps = new PrintStream(
+            new File(this.getClass().getClassLoader().getResource("version.properties").toURI()));
         ps.println("version=0.0.3");
         ps.println("release=1");
         ps.close();
         mockJsPath = new File(folder.getRoot(), "empty.js").getPath();
+
+        this.mockSubReconciler = Mockito.mock(SubscriptionReconciler.class);
     }
 
     @After
@@ -172,7 +175,7 @@ public class ImporterTest {
         em.setType(ExporterMetadata.TYPE_SYSTEM);
         when(emc.lookupByType(ExporterMetadata.TYPE_SYSTEM)).thenReturn(em);
         Importer i = new Importer(null, null, null, null, null, null,
-            null, null, null, emc, null, null, i18n, null, null, su, null);
+            null, null, null, emc, null, null, i18n, null, null, su, null, this.mockSubReconciler);
         i.validateMetadata(ExporterMetadata.TYPE_SYSTEM, null, actual,
             new ConflictOverrides());
 
@@ -196,7 +199,7 @@ public class ImporterTest {
         ExporterMetadataCurator emc = mock(ExporterMetadataCurator.class);
         when(emc.lookupByType(ExporterMetadata.TYPE_SYSTEM)).thenReturn(null);
         Importer i = new Importer(null, null, null, null, null, null,
-            null, null, null, emc, null, null, i18n, null, null, su, null);
+            null, null, null, emc, null, null, i18n, null, null, su, null, this.mockSubReconciler);
         i.validateMetadata(ExporterMetadata.TYPE_SYSTEM, null, actualmeta,
             new ConflictOverrides());
         assertTrue(f.delete());
@@ -217,7 +220,7 @@ public class ImporterTest {
         em.setType(ExporterMetadata.TYPE_SYSTEM);
         when(emc.lookupByType(ExporterMetadata.TYPE_SYSTEM)).thenReturn(em);
         Importer i = new Importer(null, null, null, null, null, null,
-            null, null, null, emc, null, null, i18n, null, null, su, null);
+            null, null, null, emc, null, null, i18n, null, null, su, null, this.mockSubReconciler);
         try {
             i.validateMetadata(ExporterMetadata.TYPE_SYSTEM, null, actualmeta,
                 new ConflictOverrides());
@@ -245,7 +248,7 @@ public class ImporterTest {
         em.setType(ExporterMetadata.TYPE_SYSTEM);
         when(emc.lookupByType(ExporterMetadata.TYPE_SYSTEM)).thenReturn(em);
         Importer i = new Importer(null, null, null, null, null, null,
-            null, null, null, emc, null, null, i18n, null, null, su, null);
+            null, null, null, emc, null, null, i18n, null, null, su, null, this.mockSubReconciler);
         try {
             i.validateMetadata(ExporterMetadata.TYPE_SYSTEM, null, actualmeta,
                 new ConflictOverrides());
@@ -293,7 +296,7 @@ public class ImporterTest {
         em.setType(ExporterMetadata.TYPE_SYSTEM);
         when(emc.lookupByType(ExporterMetadata.TYPE_SYSTEM)).thenReturn(em);
         Importer i = new Importer(null, null, null, null, null, null,
-            null, null, null, emc, null, null, i18n, null, null, su, null);
+            null, null, null, emc, null, null, i18n, null, null, su, null, this.mockSubReconciler);
         i.validateMetadata(ExporterMetadata.TYPE_SYSTEM, null, actualmeta,
             new ConflictOverrides());
         assertEquals(importDate, em.getExported());
@@ -305,7 +308,7 @@ public class ImporterTest {
             "test_user", "prefix");
         try {
             Importer i = new Importer(null, null, null, null, null, null,
-                null, null, null, null, null, null, i18n, null, null, su, null);
+                null, null, null, null, null, null, i18n, null, null, su, null, this.mockSubReconciler);
 
             // null Type should cause exception
             i.validateMetadata(null, null, actualmeta, new ConflictOverrides());
@@ -323,7 +326,7 @@ public class ImporterTest {
         when(emc.lookupByTypeAndOwner(ExporterMetadata.TYPE_PER_USER, null))
             .thenReturn(null);
         Importer i = new Importer(null, null, null, null, null, null,
-            null, null, null, emc, null, null, i18n, null, null, su, null);
+            null, null, null, emc, null, null, i18n, null, null, su, null, this.mockSubReconciler);
 
         // null Type should cause exception
         i.validateMetadata(ExporterMetadata.TYPE_PER_USER, null, actualmeta,
@@ -335,7 +338,7 @@ public class ImporterTest {
     public void testImportWithNonZipArchive()
         throws IOException, ImporterException {
         Importer i = new Importer(null, null, null, null, null, null,
-            null, null, config, null, null, null, i18n, null, null, su, null);
+            null, null, config, null, null, null, i18n, null, null, su, null, this.mockSubReconciler);
         Owner owner = mock(Owner.class);
         ConflictOverrides co = mock(ConflictOverrides.class);
         File archive = new File(folder.getRoot(), "non_zip_file.zip");
@@ -354,7 +357,7 @@ public class ImporterTest {
     public void testImportZipArchiveNoContent()
         throws IOException, ImporterException {
         Importer i = new Importer(null, null, null, null, null, null,
-            null, null, config, null, null, null, i18n, null, null, su, null);
+            null, null, config, null, null, null, i18n, null, null, su, null, this.mockSubReconciler);
         Owner owner = mock(Owner.class);
         ConflictOverrides co = mock(ConflictOverrides.class);
 
@@ -374,7 +377,7 @@ public class ImporterTest {
         throws IOException, ImporterException {
         PKIUtility pki = mock(PKIUtility.class);
         Importer i = new Importer(null, null, null, null, null, null, null,
-            pki, config, null, null, null, i18n, null, null, su, null);
+            pki, config, null, null, null, i18n, null, null, su, null, this.mockSubReconciler);
         Owner owner = mock(Owner.class);
         ConflictOverrides co = mock(ConflictOverrides.class);
 
@@ -396,7 +399,7 @@ public class ImporterTest {
     public void testImportBadConsumerZip() throws Exception {
         PKIUtility pki = mock(PKIUtility.class);
         Importer i = new Importer(null, null, null, null, null, null, null,
-            pki, config, null, null, null, i18n, null, null, su, null);
+            pki, config, null, null, null, i18n, null, null, su, null, this.mockSubReconciler);
         Owner owner = mock(Owner.class);
         ConflictOverrides co = mock(ConflictOverrides.class);
 
@@ -425,7 +428,7 @@ public class ImporterTest {
         throws Exception {
         PKIUtility pki = mock(PKIUtility.class);
         Importer i = new Importer(null, null, null, null, null, null, null,
-            pki, config, null, null, null, i18n, null, null, su, null);
+            pki, config, null, null, null, i18n, null, null, su, null, this.mockSubReconciler);
         Owner owner = mock(Owner.class);
         ConflictOverrides co = mock(ConflictOverrides.class);
 
@@ -465,7 +468,7 @@ public class ImporterTest {
     public void testImportNoMeta() throws IOException, ImporterException {
         OwnerCurator oc = mock(OwnerCurator.class);
         Importer i = new Importer(null, null, null, oc, null, null, null,
-            null, config, null, null, null, i18n, null, null, su, null);
+            null, config, null, null, null, i18n, null, null, su, null, this.mockSubReconciler);
         Owner owner = mock(Owner.class);
         ConflictOverrides co = mock(ConflictOverrides.class);
 
@@ -483,7 +486,7 @@ public class ImporterTest {
     public void testImportNoConsumerTypesDir() throws IOException, ImporterException {
         OwnerCurator oc = mock(OwnerCurator.class);
         Importer i = new Importer(null, null, null, oc, null, null, null,
-            null, config, null, null, null, i18n, null, null, su, null);
+            null, config, null, null, null, i18n, null, null, su, null, this.mockSubReconciler);
         Owner owner = mock(Owner.class);
         ConflictOverrides co = mock(ConflictOverrides.class);
         Map<String, File> importFiles = getTestImportFiles();
@@ -501,7 +504,7 @@ public class ImporterTest {
     public void testImportNoConsumer() throws IOException, ImporterException {
         OwnerCurator oc = mock(OwnerCurator.class);
         Importer i = new Importer(null, null, null, oc, null, null, null,
-            null, config, null, null, null, i18n, null, null, su, null);
+            null, config, null, null, null, i18n, null, null, su, null, this.mockSubReconciler);
         Owner owner = mock(Owner.class);
         ConflictOverrides co = mock(ConflictOverrides.class);
         Map<String, File> importFiles = getTestImportFiles();
@@ -521,7 +524,7 @@ public class ImporterTest {
         RulesImporter ri = mock(RulesImporter.class);
         OwnerCurator oc = mock(OwnerCurator.class);
         Importer i = new Importer(null, null, ri, oc, null, null, null,
-            null, config, null, null, null, i18n, null, null, su, null);
+            null, config, null, null, null, i18n, null, null, su, null, this.mockSubReconciler);
         Owner owner = mock(Owner.class);
         ConflictOverrides co = mock(ConflictOverrides.class);
         Map<String, File> importFiles = getTestImportFiles();
@@ -611,7 +614,7 @@ public class ImporterTest {
         ConflictOverrides co = mock(ConflictOverrides.class);
 
         Importer i = new Importer(ctc, pc, ri, oc, null, null, pm,
-            null, config, emc, null, null, i18n, null, null, su, null);
+            null, config, emc, null, null, i18n, null, null, su, null, this.mockSubReconciler);
         List<Subscription> subscriptions = i.importObjects(owner, importFiles, co);
 
         assertEquals(1, subscriptions.size());
@@ -623,7 +626,7 @@ public class ImporterTest {
     public void testImportProductNoEntitlementDir() throws IOException, ImporterException {
         OwnerCurator oc = mock(OwnerCurator.class);
         Importer i = new Importer(null, null, null, oc, null, null, null,
-            null, config, null, null, null, i18n, null, null, su, null);
+            null, config, null, null, null, i18n, null, null, su, null, this.mockSubReconciler);
         Owner owner = mock(Owner.class);
         ConflictOverrides co = mock(ConflictOverrides.class);
         Map<String, File> importFiles = getTestImportFiles();
@@ -695,7 +698,7 @@ public class ImporterTest {
         Importer i = new Importer(ctc, null, null, oc,
             mock(IdentityCertificateCurator.class), null, null,
             pki, null, null, mock(CertificateSerialCurator.class), null, i18n, null,
-            null, su, null);
+            null, su, null, this.mockSubReconciler);
         File[] upstream = createUpstreamFiles();
         Owner owner = new Owner("admin", "Admin Owner");
         ConsumerDto consumer = new ConsumerDto("eb5e04bf-be27-44cf-abe3-0c0b1edd523e",
@@ -736,7 +739,7 @@ public class ImporterTest {
     public void importDistributorVersionCreate() throws Exception {
         DistributorVersionCurator dvc = mock(DistributorVersionCurator.class);
         Importer i = new Importer(null, null, null, null, null, null,
-            null, null, null, null, null, null, i18n, dvc, null, su, null);
+            null, null, null, null, null, null, i18n, dvc, null, su, null, this.mockSubReconciler);
         File[] distVer = new File[1];
         distVer[0] = new File(folder.getRoot(), "dist-ver.json");
         mapper.writeValue(distVer[0], createTestDistributerVersion());
@@ -751,7 +754,7 @@ public class ImporterTest {
     public void importDistributorVersionUpdate() throws Exception {
         DistributorVersionCurator dvc = mock(DistributorVersionCurator.class);
         Importer i = new Importer(null, null, null, null, null, null,
-            null, null, null, null, null, null, i18n, dvc, null, su, null);
+            null, null, null, null, null, null, i18n, dvc, null, su, null, this.mockSubReconciler);
         when(dvc.findByName("test-dist-ver")).thenReturn(
             new DistributorVersion("test-dist-ver"));
         File[] distVer = new File[1];
@@ -781,7 +784,7 @@ public class ImporterTest {
         ConflictOverrides co = mock(ConflictOverrides.class);
         Map<String, File> importFiles = createAndSetImportFiles();
         Importer i = new Importer(null, null, ri, oc, null, null,
-            null, null, config, emc, null, null, i18n, null, null, su, null);
+            null, null, config, emc, null, null, i18n, null, null, su, null, this.mockSubReconciler);
 
         ee.expect(RuntimeException.class);
         ee.expectMessage("Done with the test");
@@ -816,7 +819,7 @@ public class ImporterTest {
         EventSink eventSinkMock = mock(EventSink.class);
         ImportRecordCurator importRecordCurator = mock(ImportRecordCurator.class);
         Importer importer = new Importer(null, null, null, null, null, null, null, null, config, null,
-            null, eventSinkMock, i18n, null, null, su, importRecordCurator);
+            null, eventSinkMock, i18n, null, null, su, importRecordCurator, this.mockSubReconciler);
 
         Meta meta = new Meta("1.0", new Date(), "test-user", "candlepin", "testcdn");
 
@@ -851,7 +854,7 @@ public class ImporterTest {
         EventSink eventSinkMock = mock(EventSink.class);
         ImportRecordCurator importRecordCurator = mock(ImportRecordCurator.class);
         Importer importer = new Importer(null, null, null, null, null, null, null, null, config, null,
-            null, eventSinkMock, i18n, null, null, su, importRecordCurator);
+            null, eventSinkMock, i18n, null, null, su, importRecordCurator, this.mockSubReconciler);
 
         Meta meta = new Meta("1.0", new Date(), "test-user", "candlepin", "testcdn");
 
@@ -882,7 +885,7 @@ public class ImporterTest {
         EventSink eventSinkMock = mock(EventSink.class);
         ImportRecordCurator importRecordCurator = mock(ImportRecordCurator.class);
         Importer importer = new Importer(null, null, null, null, null, null, null, null, config, null,
-            null, eventSinkMock, i18n, null, null, su, importRecordCurator);
+            null, eventSinkMock, i18n, null, null, su, importRecordCurator, this.mockSubReconciler);
 
         Meta meta = new Meta("1.0", new Date(), "test-user", "candlepin", "testcdn");
 
@@ -903,7 +906,7 @@ public class ImporterTest {
         EventSink eventSinkMock = mock(EventSink.class);
         ImportRecordCurator importRecordCurator = mock(ImportRecordCurator.class);
         Importer importer = new Importer(null, null, null, null, null, null, null, null, config, null,
-            null, eventSinkMock, i18n, null, null, su, importRecordCurator);
+            null, eventSinkMock, i18n, null, null, su, importRecordCurator, this.mockSubReconciler);
 
         Map<String, Object> data = new HashMap<String, Object>();
         List<Subscription> subscriptions = new ArrayList<Subscription>();
@@ -935,7 +938,7 @@ public class ImporterTest {
         EventSink eventSinkMock = mock(EventSink.class);
         ImportRecordCurator importRecordCurator = mock(ImportRecordCurator.class);
         Importer importer = new Importer(null, null, null, null, null, null, null, null, config, null,
-            null, eventSinkMock, i18n, null, null, su, importRecordCurator);
+            null, eventSinkMock, i18n, null, null, su, importRecordCurator, this.mockSubReconciler);
 
         Map<String, Object> data = new HashMap<String, Object>();
         data.put("subscriptions", new ArrayList<Subscription>());

--- a/server/src/test/java/org/candlepin/sync/SubscriptionReconcilerTest.java
+++ b/server/src/test/java/org/candlepin/sync/SubscriptionReconcilerTest.java
@@ -70,7 +70,7 @@ public class SubscriptionReconcilerTest {
     @Before
     public void init() {
         this.owner = new Owner();
-        this.reconciler = new SubscriptionReconciler();
+        this.reconciler = new SubscriptionReconciler(this.poolCurator);
 
         i18n = I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK);
         this.importer = new EntitlementImporter(certSerialCurator, cdnCurator, i18n, pc);
@@ -112,7 +112,7 @@ public class SubscriptionReconcilerTest {
         Subscription testSub1 = createSubscription(owner, "test-prod-1", "up1", "ue1", "uc1", 25);
         createPoolsFor(testSub1);
 
-        reconciler.reconcile(owner, Arrays.asList(testSub1), poolCurator);
+        reconciler.reconcile(owner, Arrays.asList(testSub1));
 
         assertUpstream(testSub1, testSub1.getId());
     }
@@ -124,7 +124,7 @@ public class SubscriptionReconcilerTest {
 
         createPoolsFor(testSub2);
 
-        reconciler.reconcile(owner, Arrays.asList(testSub2, testSub3), poolCurator);
+        reconciler.reconcile(owner, Arrays.asList(testSub2, testSub3));
         assertUpstream(testSub2, testSub2.getId());
         assertUpstream(testSub3, testSub3.getId());
     }
@@ -136,7 +136,7 @@ public class SubscriptionReconcilerTest {
 
         createPoolsFor(testSub2, testSub3);
 
-        reconciler.reconcile(owner, Arrays.asList(testSub3), poolCurator);
+        reconciler.reconcile(owner, Arrays.asList(testSub3));
         assertUpstream(testSub3, testSub3.getId());
     }
 
@@ -149,7 +149,7 @@ public class SubscriptionReconcilerTest {
 
         createPoolsFor(testSub2, testSub3, testSub4);
 
-        reconciler.reconcile(owner, Arrays.asList(testSub2, testSub4, testSub5), poolCurator);
+        reconciler.reconcile(owner, Arrays.asList(testSub2, testSub4, testSub5));
         assertUpstream(testSub2, testSub2.getId());
         assertUpstream(testSub4, testSub4.getId());
         // Should assume subscription 3's ID:
@@ -168,7 +168,7 @@ public class SubscriptionReconcilerTest {
 
         createPoolsFor(testSub3, testSub4, testSub5);
 
-        reconciler.reconcile(owner, Arrays.asList(testSub6, testSub7, testSub8), poolCurator);
+        reconciler.reconcile(owner, Arrays.asList(testSub6, testSub7, testSub8));
         assertUpstream(testSub6, testSub3.getId());
         assertUpstream(testSub7, testSub4.getId());
         assertUpstream(testSub8, testSub5.getId());
@@ -184,7 +184,7 @@ public class SubscriptionReconcilerTest {
 
         createPoolsFor(testSub3, testSub4, testSub5);
 
-        reconciler.reconcile(owner, Arrays.asList(testSub6, testSub8), poolCurator);
+        reconciler.reconcile(owner, Arrays.asList(testSub6, testSub8));
         assertUpstream(testSub6, testSub3.getId());
         assertUpstream(testSub8, testSub5.getId());
     }
@@ -199,7 +199,7 @@ public class SubscriptionReconcilerTest {
 
         createPoolsFor(testSub3, testSub4);
 
-        reconciler.reconcile(owner, Arrays.asList(testSub6, testSub7, testSub8), poolCurator);
+        reconciler.reconcile(owner, Arrays.asList(testSub6, testSub7, testSub8));
         assertUpstream(testSub6, testSub3.getId());
         assertUpstream(testSub7, testSub4.getId());
         assertUpstream(testSub8, testSub8.getId());
@@ -216,7 +216,7 @@ public class SubscriptionReconcilerTest {
 
         createPoolsFor(testSub9, testSub10, testSub11);
 
-        reconciler.reconcile(owner, Arrays.asList(testSub3, testSub4, testSub5), poolCurator);
+        reconciler.reconcile(owner, Arrays.asList(testSub3, testSub4, testSub5));
         assertUpstream(testSub3, testSub9.getId());
         assertUpstream(testSub4, testSub10.getId());
         assertUpstream(testSub5, testSub11.getId());
@@ -233,7 +233,7 @@ public class SubscriptionReconcilerTest {
 
         createPoolsFor(testSub1, testSub2, testSub3);
 
-        reconciler.reconcile(owner, Arrays.asList(testSub12, testSub13, testSub14), poolCurator);
+        reconciler.reconcile(owner, Arrays.asList(testSub12, testSub13, testSub14));
 
         // Quantities 25, 20, 15 should be replaced by new pools with 23, 17, 10:
         assertUpstream(testSub12, testSub1.getId());
@@ -252,7 +252,7 @@ public class SubscriptionReconcilerTest {
 
         createPoolsFor(testSub2, testSub3, testSub4, testSub5);
 
-        reconciler.reconcile(owner, Arrays.asList(testSub12, testSub14), poolCurator);
+        reconciler.reconcile(owner, Arrays.asList(testSub12, testSub14));
 
         assertUpstream(testSub12, testSub2.getId());
         assertUpstream(testSub14, testSub4.getId());
@@ -266,7 +266,7 @@ public class SubscriptionReconcilerTest {
 
         createPoolsFor(testSub3, testSub15);
 
-        reconciler.reconcile(owner, Arrays.asList(testSub3, testSub16), poolCurator);
+        reconciler.reconcile(owner, Arrays.asList(testSub3, testSub16));
 
         // Quantities 25, 20, 15 should be replaced by new pools with 23, 17, 10:
         assertUpstream(testSub3, testSub3.getId());
@@ -294,7 +294,7 @@ public class SubscriptionReconcilerTest {
             testSub24);
 
         reconciler.reconcile(owner, Arrays.asList(testSub1, testSub2, testSub3, testSub4, testSub5, testSub30,
-            testSub31, testSub32, testSub33, testSub34), poolCurator);
+            testSub31, testSub32, testSub33, testSub34));
 
         // 20-24 have no matchup with 30-34 due to different upstream pool ID:
         assertUpstream(testSub1, testSub1.getId());

--- a/server/src/test/java/org/candlepin/test/SessionWrapper.java
+++ b/server/src/test/java/org/candlepin/test/SessionWrapper.java
@@ -1,0 +1,1235 @@
+/**
+ * Copyright (c) 2009 - 2017 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.test;
+
+import org.hibernate.CacheMode;
+import org.hibernate.Criteria;
+import org.hibernate.FlushMode;
+import org.hibernate.Filter;
+import org.hibernate.HibernateException;
+import org.hibernate.LobHelper;
+import org.hibernate.LockMode;
+import org.hibernate.LockOptions;
+import org.hibernate.MultiIdentifierLoadAccess;
+import org.hibernate.IdentifierLoadAccess;
+import org.hibernate.Interceptor;
+import org.hibernate.NaturalIdLoadAccess;
+import org.hibernate.Query;
+import org.hibernate.ReplicationMode;
+import org.hibernate.ScrollableResults;
+import org.hibernate.ScrollMode;
+import org.hibernate.Session;
+import org.hibernate.SessionEventListener;
+import org.hibernate.SessionFactory;
+import org.hibernate.SharedSessionBuilder;
+import org.hibernate.SimpleNaturalIdLoadAccess;
+import org.hibernate.SQLQuery;
+import org.hibernate.Transaction;
+import org.hibernate.TypeHelper;
+import org.hibernate.UnknownProfileException;
+import org.hibernate.collection.spi.PersistentCollection;
+import org.hibernate.loader.custom.CustomQuery;
+import org.hibernate.engine.jdbc.LobCreationContext;
+import org.hibernate.engine.jdbc.connections.spi.JdbcConnectionAccess;
+import org.hibernate.engine.jdbc.spi.JdbcCoordinator;
+import org.hibernate.engine.query.spi.sql.NativeSQLQuerySpecification;
+import org.hibernate.engine.spi.EntityKey;
+import org.hibernate.engine.spi.LoadQueryInfluencers;
+import org.hibernate.engine.spi.NamedQueryDefinition;
+import org.hibernate.engine.spi.NamedSQLQueryDefinition;
+import org.hibernate.engine.spi.PersistenceContext;
+import org.hibernate.engine.spi.QueryParameters;
+import org.hibernate.engine.spi.SessionEventListenerManager;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.jdbc.ReturningWork;
+import org.hibernate.jdbc.Work;
+import org.hibernate.persister.entity.EntityPersister;
+import org.hibernate.procedure.ProcedureCall;
+import org.hibernate.resource.transaction.TransactionCoordinator;
+import org.hibernate.stat.SessionStatistics;
+import org.hibernate.type.descriptor.WrapperOptions;
+
+import java.io.Serializable;
+import java.sql.Connection;
+import java.util.Iterator;
+import java.util.List;
+
+
+
+/**
+ * The SessionWrapper is a utility class intended to be used in places where we need to spy on an
+ * existing session instance, but are unable to due to the "final" nature of Hibernate's
+ * SessionImpl class.
+ */
+public class SessionWrapper implements Session, SessionImplementor {
+
+    protected final Session session;
+    protected final SessionImplementor sessionImpl;
+
+    public SessionWrapper(Session session) {
+        if (session == null) {
+            throw new IllegalArgumentException("session is null");
+        }
+
+        this.session = session;
+        this.sessionImpl = (SessionImplementor) session;
+    }
+
+    // Session methods
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SharedSessionBuilder sessionWithOptions() {
+        return this.session.sessionWithOptions();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void flush() throws HibernateException {
+        this.session.flush();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setFlushMode(FlushMode flushMode) {
+        this.session.setFlushMode(flushMode);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public FlushMode getFlushMode() {
+        return this.session.getFlushMode();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setCacheMode(CacheMode cacheMode) {
+        this.session.setCacheMode(cacheMode);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CacheMode getCacheMode() {
+        return this.session.getCacheMode();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SessionFactory getSessionFactory() {
+        return this.session.getSessionFactory();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void close() throws HibernateException {
+        this.session.close();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void cancelQuery() throws HibernateException {
+        this.session.cancelQuery();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isOpen() {
+        return this.session.isOpen();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isConnected() {
+        return this.session.isConnected();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isDirty() throws HibernateException {
+        return this.session.isDirty();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isDefaultReadOnly() {
+        return this.session.isDefaultReadOnly();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setDefaultReadOnly(boolean readOnly) {
+        this.session.setDefaultReadOnly(readOnly);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Serializable getIdentifier(Object object) {
+        return this.session.getIdentifier(object);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean contains(Object object) {
+        return this.session.contains(object);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void evict(Object object) {
+        this.session.evict(object);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T> T load(Class<T> theClass, Serializable id, LockMode lockMode) {
+        return this.session.load(theClass, id, lockMode);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T> T load(Class<T> theClass, Serializable id, LockOptions lockOptions) {
+        return this.session.load(theClass, id, lockOptions);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Object load(String entityName, Serializable id, LockMode lockMode) {
+        return this.session.load(entityName, id, lockMode);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Object load(String entityName, Serializable id, LockOptions lockOptions) {
+        return this.session.load(entityName, id, lockOptions);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T> T load(Class<T> theClass, Serializable id) {
+        return this.session.load(theClass, id);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Object load(String entityName, Serializable id) {
+        return this.session.load(entityName, id);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void load(Object object, Serializable id) {
+        this.session.load(object, id);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void replicate(Object object, ReplicationMode replicationMode) {
+        this.session.replicate(object, replicationMode);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void replicate(String entityName, Object object, ReplicationMode replicationMode)  {
+        this.session.replicate(entityName, object, replicationMode);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Serializable save(Object object) {
+        return this.session.save(object);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Serializable save(String entityName, Object object) {
+        return this.session.save(entityName, object);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void saveOrUpdate(Object object) {
+        this.session.saveOrUpdate(object);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void saveOrUpdate(String entityName, Object object) {
+        this.session.saveOrUpdate(entityName, object);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void update(Object object) {
+        this.session.update(object);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void update(String entityName, Object object) {
+        this.session.update(entityName, object);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Object merge(Object object) {
+        return this.session.merge(object);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Object merge(String entityName, Object object) {
+        return this.session.merge(entityName, object);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void persist(Object object) {
+        this.session.persist(object);
+    }
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void persist(String entityName, Object object) {
+        this.session.persist(entityName, object);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void delete(Object object) {
+        this.session.delete(object);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void delete(String entityName, Object object) {
+        this.session.delete(entityName, object);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void lock(Object object, LockMode lockMode) {
+        this.session.lock(object, lockMode);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void lock(String entityName, Object object, LockMode lockMode) {
+        this.session.lock(entityName, object, lockMode);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public LockRequest buildLockRequest(LockOptions lockOptions) {
+        return this.session.buildLockRequest(lockOptions);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void refresh(Object object) {
+        this.session.refresh(object);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void refresh(String entityName, Object object) {
+        this.session.refresh(entityName, object);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void refresh(Object object, LockMode lockMode) {
+        this.session.refresh(object, lockMode);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void refresh(Object object, LockOptions lockOptions) {
+        this.session.refresh(object, lockOptions);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void refresh(String entityName, Object object, LockOptions lockOptions) {
+        this.session.refresh(entityName, object, lockOptions);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public LockMode getCurrentLockMode(Object object) {
+        return this.session.getCurrentLockMode(object);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Query createFilter(Object collection, String queryString) {
+        return this.session.createFilter(collection, queryString);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void clear() {
+        this.session.clear();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T> T get(Class<T> entityType, Serializable id) {
+        return this.session.get(entityType, id);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T> T get(Class<T> entityType, Serializable id, LockMode lockMode) {
+        return this.session.get(entityType, id, lockMode);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T> T get(Class<T> entityType, Serializable id, LockOptions lockOptions) {
+        return this.session.get(entityType, id, lockOptions);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Object get(String entityName, Serializable id) {
+        return this.session.get(entityName, id);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Object get(String entityName, Serializable id, LockMode lockMode) {
+        return this.session.get(entityName, id, lockMode);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Object get(String entityName, Serializable id, LockOptions lockOptions) {
+        return this.session.get(entityName, id, lockOptions);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getEntityName(Object object) {
+        return this.session.getEntityName(object);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public IdentifierLoadAccess byId(String entityName) {
+        return this.session.byId(entityName);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T> IdentifierLoadAccess<T> byId(Class<T> entityClass) {
+        return this.session.byId(entityClass);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public MultiIdentifierLoadAccess byMultipleIds(String entityName) {
+        return this.session.byMultipleIds(entityName);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T> MultiIdentifierLoadAccess<T> byMultipleIds(Class<T> entityClass) {
+        return this.session.byMultipleIds(entityClass);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public NaturalIdLoadAccess byNaturalId(String entityName) {
+        return this.session.byNaturalId(entityName);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T> NaturalIdLoadAccess<T> byNaturalId(Class<T> entityClass) {
+        return this.session.byNaturalId(entityClass);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SimpleNaturalIdLoadAccess bySimpleNaturalId(String entityName) {
+        return this.session.bySimpleNaturalId(entityName);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T> SimpleNaturalIdLoadAccess<T> bySimpleNaturalId(Class<T> entityClass) {
+        return this.session.bySimpleNaturalId(entityClass);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Filter enableFilter(String filterName) {
+        return this.session.enableFilter(filterName);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Filter getEnabledFilter(String filterName) {
+        return this.session.getEnabledFilter(filterName);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void disableFilter(String filterName) {
+        this.session.disableFilter(filterName);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SessionStatistics getStatistics() {
+        return this.session.getStatistics();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isReadOnly(Object entityOrProxy) {
+        return this.session.isReadOnly(entityOrProxy);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setReadOnly(Object entityOrProxy, boolean readOnly) {
+        this.session.setReadOnly(entityOrProxy, readOnly);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void doWork(Work work) throws HibernateException {
+        this.session.doWork(work);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T> T doReturningWork(ReturningWork<T> work) throws HibernateException {
+        return this.session.doReturningWork(work);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Connection disconnect() {
+        return this.session.disconnect();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void reconnect(Connection connection) {
+        this.session.reconnect(connection);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isFetchProfileEnabled(String name) throws UnknownProfileException {
+        return this.session.isFetchProfileEnabled(name);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void enableFetchProfile(String name) throws UnknownProfileException {
+        this.session.enableFetchProfile(name);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void disableFetchProfile(String name) throws UnknownProfileException {
+        this.session.disableFetchProfile(name);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public TypeHelper getTypeHelper() {
+        return this.session.getTypeHelper();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public LobHelper getLobHelper() {
+        return this.session.getLobHelper();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void addEventListeners(SessionEventListener... listeners) {
+        this.session.addEventListeners(listeners);
+    }
+
+    // SharedSessionContract methods
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Transaction beginTransaction() {
+        return this.session.beginTransaction();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Criteria createCriteria(Class persistentClass) {
+        return this.session.createCriteria(persistentClass);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Criteria createCriteria(Class persistentClass, String alias) {
+        return this.session.createCriteria(persistentClass, alias);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Criteria createCriteria(String entityName) {
+        return this.session.createCriteria(entityName);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Criteria createCriteria(String entityName, String alias) {
+        return this.session.createCriteria(entityName, alias);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Query createQuery(String queryString) {
+        return this.session.createQuery(queryString);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SQLQuery createSQLQuery(String queryString) {
+        return this.session.createSQLQuery(queryString);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ProcedureCall createStoredProcedureCall(String procedureName) {
+        return this.session.createStoredProcedureCall(procedureName);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ProcedureCall createStoredProcedureCall(String procedureName, Class... resultClasses) {
+        return this.session.createStoredProcedureCall(procedureName, resultClasses);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ProcedureCall createStoredProcedureCall(String procedureName, String... resultSetMappings) {
+        return this.session.createStoredProcedureCall(procedureName, resultSetMappings);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ProcedureCall getNamedProcedureCall(String name) {
+        return this.session.getNamedProcedureCall(name);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Query getNamedQuery(String queryName) {
+        return this.session.getNamedQuery(queryName);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getTenantIdentifier() {
+        return this.session.getTenantIdentifier();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Transaction getTransaction() {
+        return this.session.getTransaction();
+    }
+
+    // SessionImplementor methods
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public JdbcConnectionAccess getJdbcConnectionAccess() {
+        return this.sessionImpl.getJdbcConnectionAccess();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public EntityKey generateEntityKey(Serializable id, EntityPersister persister) {
+        return this.sessionImpl.generateEntityKey(id, persister);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Interceptor getInterceptor() {
+        return this.sessionImpl.getInterceptor();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setAutoClear(boolean enabled) {
+        this.sessionImpl.setAutoClear(enabled);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void disableTransactionAutoJoin() {
+        this.sessionImpl.disableTransactionAutoJoin();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isTransactionInProgress() {
+        return this.sessionImpl.isTransactionInProgress();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void initializeCollection(PersistentCollection collection, boolean writing)
+        throws HibernateException {
+        this.sessionImpl.initializeCollection(collection, writing);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Object internalLoad(String entityName, Serializable id, boolean eager, boolean nullable)
+        throws HibernateException {
+        return this.sessionImpl.internalLoad(entityName, id, eager, nullable);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Object immediateLoad(String entityName, Serializable id) throws HibernateException {
+        return this.sessionImpl.immediateLoad(entityName, id);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public long getTimestamp() {
+        return this.sessionImpl.getTimestamp();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SessionFactoryImplementor getFactory() {
+        return this.sessionImpl.getFactory();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List list(String query, QueryParameters queryParameters) throws HibernateException {
+        return this.sessionImpl.list(query, queryParameters);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Iterator iterate(String query, QueryParameters queryParameters) throws HibernateException {
+        return this.sessionImpl.iterate(query, queryParameters);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ScrollableResults scroll(String query, QueryParameters queryParameters) throws HibernateException {
+        return this.sessionImpl.scroll(query, queryParameters);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ScrollableResults scroll(Criteria criteria, ScrollMode scrollMode) {
+        return this.sessionImpl.scroll(criteria, scrollMode);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List list(Criteria criteria) {
+        return this.sessionImpl.list(criteria);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List listFilter(Object collection, String filter, QueryParameters queryParameters)
+        throws HibernateException {
+        return this.sessionImpl.listFilter(collection, filter, queryParameters);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Iterator iterateFilter(Object collection, String filter, QueryParameters queryParameters)
+        throws HibernateException {
+        return this.sessionImpl.iterateFilter(collection, filter, queryParameters);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public EntityPersister getEntityPersister(String entityName, Object object) throws HibernateException {
+        return this.sessionImpl.getEntityPersister(entityName, object);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Object getEntityUsingInterceptor(EntityKey key) throws HibernateException {
+        return this.sessionImpl.getEntityUsingInterceptor(key);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Serializable getContextEntityIdentifier(Object object) {
+        return this.sessionImpl.getContextEntityIdentifier(object);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String bestGuessEntityName(Object object) {
+        return this.sessionImpl.bestGuessEntityName(object);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Connection connection() {
+        return this.sessionImpl.connection();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String guessEntityName(Object entity) throws HibernateException {
+        return this.sessionImpl.guessEntityName(entity);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Object instantiate(String entityName, Serializable id) throws HibernateException {
+        return this.sessionImpl.instantiate(entityName, id);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List listCustomQuery(CustomQuery customQuery, QueryParameters queryParameters)
+        throws HibernateException {
+        return this.sessionImpl.listCustomQuery(customQuery, queryParameters);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ScrollableResults scrollCustomQuery(CustomQuery customQuery, QueryParameters queryParameters)
+        throws HibernateException {
+        return this.sessionImpl.scrollCustomQuery(customQuery, queryParameters);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List list(NativeSQLQuerySpecification spec, QueryParameters queryParameters)
+        throws HibernateException {
+        return this.sessionImpl.list(spec, queryParameters);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ScrollableResults scroll(NativeSQLQuerySpecification spec, QueryParameters queryParameters) {
+        return this.sessionImpl.scroll(spec, queryParameters);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getDontFlushFromFind() {
+        return this.sessionImpl.getDontFlushFromFind();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public PersistenceContext getPersistenceContext() {
+        return this.sessionImpl.getPersistenceContext();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int executeUpdate(String query, QueryParameters queryParameters) throws HibernateException {
+        return this.sessionImpl.executeUpdate(query, queryParameters);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int executeNativeUpdate(NativeSQLQuerySpecification specification, QueryParameters queryParameters)
+        throws HibernateException {
+        return this.sessionImpl.executeNativeUpdate(specification, queryParameters);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Query getNamedSQLQuery(String name) {
+        return this.sessionImpl.getNamedSQLQuery(name);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isEventSource() {
+        return this.sessionImpl.isEventSource();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void afterScrollOperation() {
+        this.sessionImpl.afterScrollOperation();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public TransactionCoordinator getTransactionCoordinator() {
+        return this.sessionImpl.getTransactionCoordinator();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public JdbcCoordinator getJdbcCoordinator() {
+        return this.sessionImpl.getJdbcCoordinator();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isClosed() {
+        return this.sessionImpl.isClosed();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean shouldAutoClose() {
+        return this.sessionImpl.shouldAutoClose();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isAutoCloseSessionEnabled() {
+        return this.sessionImpl.isAutoCloseSessionEnabled();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public LoadQueryInfluencers getLoadQueryInfluencers() {
+        return this.sessionImpl.getLoadQueryInfluencers();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Query createQuery(NamedQueryDefinition namedQueryDefinition) {
+        return this.sessionImpl.createQuery(namedQueryDefinition);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SQLQuery createSQLQuery(NamedSQLQueryDefinition namedQueryDefinition) {
+        return this.sessionImpl.createSQLQuery(namedQueryDefinition);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SessionEventListenerManager getEventListenerManager() {
+        return this.sessionImpl.getEventListenerManager();
+    }
+
+    // LobCreationContext methods
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T> T execute(LobCreationContext.Callback<T> callback) {
+        return this.sessionImpl.execute(callback);
+    }
+
+    // WrapperOptionsContext methods
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public WrapperOptions getWrapperOptions() {
+        return this.sessionImpl.getWrapperOptions();
+    }
+}

--- a/server/src/test/java/org/candlepin/test/TestUtil.java
+++ b/server/src/test/java/org/candlepin/test/TestUtil.java
@@ -55,11 +55,15 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+
+
 
 /**
  * TestUtil for creating various testing objects. Objects backed by the database
@@ -629,10 +633,10 @@ public class TestUtil {
         }
     }
 
-    public static Set<Product> stubChangedProducts(Product ... products) {
-        Set<Product> result = new HashSet<Product>();
+    public static Map<String, Product> stubChangedProducts(Product ... products) {
+        Map<String, Product> result = new HashMap<String, Product>();
         for (Product p : products) {
-            result.add(p);
+            result.put(p.getId(), p);
         }
         return result;
     }


### PR DESCRIPTION
- Product and Content entities orphaned by update operations are now
  properly cleaned up at the end of the update operation
- Unit test within suites extending the DatabaseTestFixture are now automatically
  run within a transaction
- DatabaseTestFixture no longer throws IllegalStateExceptions if attempting
  to start a transaction when one is already active, or when committing or
  rolling back when a transaction is not active
- Some unit tests have been updated in accordance with the above changes
- Updated the async job call in candlepin_api to also abort on jobs in
  the "failed" state
- SubscriptionReconciler has been moved to the Importer, as it only needs
  to be performed during import
- Optimized product version lookups
- Added an additional spec test for verifying product retrevials