### PR TITLE
CandlepinQueryInterceptor now uses a separate session for cursors

### DIFF
--- a/server/client/ruby/candlepin_api.rb
+++ b/server/client/ruby/candlepin_api.rb
@@ -487,7 +487,8 @@ class Candlepin
 
     return status if immediate
     # otherwise poll the server to make this call synchronous
-    while status['state'].downcase != 'finished'
+    finished_states = ['FINISHED', 'CANCELED', 'FAILED']
+    while !finished_states.include? status['state'].upcase
       sleep 1
       # POSTing here will delete the job once it has finished
       status = post(status['statusPath'])

--- a/server/spec/owner_resource_spec.rb
+++ b/server/spec/owner_resource_spec.rb
@@ -541,6 +541,34 @@ describe 'Owner Resource' do
     owner['autobindDisabled'].should == true
   end
 
+  it 'lists owners with populated entity collections' do
+    owner1 = create_owner(random_string("owner1"))
+
+    owner2 = create_owner(random_string("owner2"))
+    @cp.create_activation_key(owner2['key'], random_string("actkey1"))
+    @cp.create_activation_key(owner2['key'], random_string("actkey2"))
+
+    owner3 = create_owner(random_string("owner3"))
+    @cp.create_activation_key(owner3['key'], random_string("actkey1"))
+    @cp.create_activation_key(owner3['key'], random_string("actkey2"))
+    @cp.register(random_string("consumer1"), :system, nil, {}, random_string("consumer1"), owner3['key'])
+    @cp.register(random_string("consumer2"), :system, nil, {}, random_string("consumer2"), owner3['key'])
+
+    owner4 = create_owner(random_string("owner4"))
+    @cp.create_activation_key(owner4['key'], random_string("actkey1"))
+    @cp.create_activation_key(owner4['key'], random_string("actkey2"))
+    @cp.register(random_string("consumer1"), :system, nil, {}, random_string("consumer1"), owner4['key'])
+    @cp.register(random_string("consumer2"), :system, nil, {}, random_string("consumer2"), owner4['key'])
+    @cp.create_environment(owner4['key'], random_string("env1"), random_string("env1"))
+    @cp.create_environment(owner4['key'], random_string("env2"), random_string("env2"))
+
+    owners = @cp.list_owners()
+    expect(owners.length).to be >= 4
+
+    # At the time of writing, we don't actually include any of the above objects in the serialized
+    # output for owners, so we don't need to verify their presence.
+  end
+
 end
 
 describe 'Owner Resource Pool Filter Tests' do
@@ -566,8 +594,7 @@ describe 'Owner Resource Pool Filter Tests' do
       }
     )
 
-    create_pool_and_subscription(@owner['key'], @product1.id, 10,
-				[], '', '', '', nil, nil, true)
+    create_pool_and_subscription(@owner['key'], @product1.id, 10, [], '', '', '', nil, nil, true)
     create_pool_and_subscription(@owner['key'], @product2.id, 10)
 
     pools = @cp.list_owner_pools(@owner['key'])

--- a/server/src/main/java/org/candlepin/resteasy/filter/CandlepinQueryInterceptor.java
+++ b/server/src/main/java/org/candlepin/resteasy/filter/CandlepinQueryInterceptor.java
@@ -22,10 +22,13 @@ import org.candlepin.model.ResultIterator;
 import org.candlepin.resteasy.JsonProvider;
 
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
 import org.hibernate.criterion.Order;
 
 import org.jboss.resteasy.annotations.interception.ServerInterceptor;
@@ -38,10 +41,10 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.OutputStream;
 
+import javax.persistence.EntityManager;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.StreamingOutput;
-import javax.ws.rs.ext.Provider;
 
 
 
@@ -49,16 +52,25 @@ import javax.ws.rs.ext.Provider;
  * The CandlepinQueryInterceptor handles the streaming of a query and applies any paging
  * configuration.
  */
-@Provider
+@javax.ws.rs.ext.Provider
 @ServerInterceptor
 public class CandlepinQueryInterceptor implements PostProcessInterceptor {
     private static Logger log = LoggerFactory.getLogger(CandlepinQueryInterceptor.class);
 
     protected JsonProvider jsonProvider;
+    protected Provider<EntityManager> emProvider;
 
     @Inject
-    public CandlepinQueryInterceptor(JsonProvider jsonProvider) {
+    public CandlepinQueryInterceptor(JsonProvider jsonProvider, Provider<EntityManager> emProvider) {
         this.jsonProvider = jsonProvider;
+        this.emProvider = emProvider;
+    }
+
+    protected Session openSession() {
+        Session currentSession = (Session) this.emProvider.get().getDelegate();
+        SessionFactory factory = currentSession.getSessionFactory();
+
+        return factory.openSession();
     }
 
     @Override
@@ -67,9 +79,14 @@ public class CandlepinQueryInterceptor implements PostProcessInterceptor {
 
         if (entity instanceof CandlepinQuery) {
             final PageRequest pageRequest = ResteasyProviderFactory.getContextData(PageRequest.class);
+            final Session session = this.openSession();
             final CandlepinQuery query = (CandlepinQuery) entity;
             final ObjectMapper mapper = this.jsonProvider
                 .locateMapper(Object.class, MediaType.APPLICATION_JSON_TYPE);
+
+            // Use a separate session so we aren't at risk of lazy loading or interceptors closing
+            // our cursor mid-stream.
+            // query.useSession(session);
 
             // Apply any paging config we may have
             if (pageRequest != null) {
@@ -121,6 +138,8 @@ public class CandlepinQueryInterceptor implements PostProcessInterceptor {
                     generator.close();
 
                     iterator.close();
+
+                    session.close();
                 }
             });
         }

--- a/server/src/main/java/org/candlepin/resteasy/filter/CandlepinQueryInterceptor.java
+++ b/server/src/main/java/org/candlepin/resteasy/filter/CandlepinQueryInterceptor.java
@@ -86,7 +86,7 @@ public class CandlepinQueryInterceptor implements PostProcessInterceptor {
 
             // Use a separate session so we aren't at risk of lazy loading or interceptors closing
             // our cursor mid-stream.
-            // query.useSession(session);
+            query.useSession(session);
 
             // Apply any paging config we may have
             if (pageRequest != null) {

--- a/server/src/test/java/org/candlepin/resteasy/filter/CandlepinQueryInterceptorTest.java
+++ b/server/src/test/java/org/candlepin/resteasy/filter/CandlepinQueryInterceptorTest.java
@@ -31,6 +31,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 
+import com.google.inject.Provider;
+
 import org.hibernate.criterion.Order;
 
 import org.jboss.resteasy.core.ServerResponse;
@@ -47,6 +49,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.List;
 
+import javax.persistence.EntityManager;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.StreamingOutput;
 
@@ -56,6 +59,7 @@ import javax.ws.rs.core.StreamingOutput;
 public class CandlepinQueryInterceptorTest extends DatabaseTestFixture {
     private static Logger log = LoggerFactory.getLogger(CandlepinQueryInterceptorTest.class);
 
+    protected Provider<EntityManager> emProvider;
     protected JsonProvider mockJsonProvider;
     protected JsonFactory mockJsonFactory;
     protected JsonGenerator mockJsonGenerator;
@@ -64,6 +68,8 @@ public class CandlepinQueryInterceptorTest extends DatabaseTestFixture {
 
     @Before
     public void setup() throws Exception {
+        this.emProvider = this.injector.getProvider(EntityManager.class);
+
         this.mockJsonProvider = mock(JsonProvider.class);
         this.mockJsonFactory = mock(JsonFactory.class);
         this.mockJsonGenerator = mock(JsonGenerator.class);
@@ -91,7 +97,7 @@ public class CandlepinQueryInterceptorTest extends DatabaseTestFixture {
     public void testWriteCandlepinQueryContents() throws IOException {
         List<Owner> owners = this.ownerCurator.listAll().list();
 
-        CandlepinQueryInterceptor cqi = new CandlepinQueryInterceptor(this.mockJsonProvider);
+        CandlepinQueryInterceptor cqi = new CandlepinQueryInterceptor(this.mockJsonProvider, this.emProvider);
         ServerResponse response = new ServerResponse();
         response.setEntity(this.ownerCurator.listAll());
 
@@ -139,7 +145,7 @@ public class CandlepinQueryInterceptorTest extends DatabaseTestFixture {
         pageRequest.setSortBy(sortBy);
         pageRequest.setOrder(order);
 
-        CandlepinQueryInterceptor cqi = new CandlepinQueryInterceptor(this.mockJsonProvider);
+        CandlepinQueryInterceptor cqi = new CandlepinQueryInterceptor(this.mockJsonProvider, this.emProvider);
         ServerResponse response = new ServerResponse();
         response.setEntity(this.ownerCurator.listAll());
 
@@ -171,7 +177,7 @@ public class CandlepinQueryInterceptorTest extends DatabaseTestFixture {
         // List of entities
         List<Owner> owners = this.ownerCurator.listAll().list();
 
-        CandlepinQueryInterceptor cqi = new CandlepinQueryInterceptor(this.mockJsonProvider);
+        CandlepinQueryInterceptor cqi = new CandlepinQueryInterceptor(this.mockJsonProvider, this.emProvider);
         ServerResponse response = new ServerResponse();
         response.setEntity(owners);
 


### PR DESCRIPTION
- CandlepinQueryInterceptor now uses its own session for streaming the
  query results
- Added additional spec tests for testing streaming certain entities