### PR TITLE
1394401: List of provided products empty on Bonus Pools

### DIFF
--- a/server/spec/consumer_bonus_pool_provided_spec.rb
+++ b/server/spec/consumer_bonus_pool_provided_spec.rb
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+require 'spec_helper'
+require 'candlepin_scenarios'
+require 'rexml/document'
+
+describe 'Consumer Resource Host/Guest' do
+
+  include CandlepinMethods
+
+  before(:each) do
+    @owner1 = create_owner random_string('test_owner1')
+    @username1 = random_string("user1")
+    @user1 = user_client(@owner1, @username1)
+  end
+
+  it 'bonus pool should have provided products' do
+    uuid1 = random_string('system.uuid')
+    guests = [{'guestId' => uuid1}]
+
+    std_product = create_product(random_string('product'),
+      random_string('product'),
+      {:attributes => {:virt_limit => "5",
+                       :host_limited => 'true'},
+      :owner => @owner1['key']})
+    provided_product = create_product(random_string('product'),
+      random_string('product'),
+      {:owner => @owner1['key']})
+
+    create_pool_and_subscription(@owner1['key'], std_product.id, 10, [provided_product.id])
+    all_pools =  @user1.list_owner_pools(@owner1['key'])
+    all_pools.size.should == 2
+    unmapped_pool = all_pools.find {|p| p['type'] == 'UNMAPPED_GUEST'} 
+    normal_pool = all_pools.find {|p| p['type'] == 'NORMAL'} 
+    
+    normal_pool['providedProducts'].size.should == 1
+    unmapped_pool['providedProducts'].size.should == 1
+  end
+
+end
+

--- a/server/src/main/java/org/candlepin/model/ProductCurator.java
+++ b/server/src/main/java/org/candlepin/model/ProductCurator.java
@@ -204,6 +204,10 @@ public class ProductCurator extends AbstractHibernateCurator<Product> {
      * @return Fully hydrated Product objects
      */
     public Set<Product> getProductsByUuidCached(Set<String> productUuids) {
+        if (productUuids.size() == 0) {
+            return new HashSet<Product>();
+        }
+
         Set<Product> products = new HashSet<Product>();
         Set<String> notInCache = new HashSet<String>();
         Cache<String, Product> productCache = candlepinCache.getProductCache();


### PR DESCRIPTION
The problem is in method PoolHelper.copyProvidedProducts. The method is used to
copy the original pool to a bonus pool. The method
expects the original pool (the one being copied) to be stored in the database.
It is trying to find its provided products in the database. That fails, because
the original pool is not yet there.

Adding more defensive code into that method. First I will check whether the
pool is already persisted (Pool.id != null). When it is not persisted, I will
copy the provided products directly from the original instance.