### PR TITLE
Reduce log level aquiring HornetQ session

### DIFF
--- a/server/src/main/java/org/candlepin/audit/EventSinkImpl.java
+++ b/server/src/main/java/org/candlepin/audit/EventSinkImpl.java
@@ -114,7 +114,7 @@ public class EventSinkImpl implements EventSink {
             catch (HornetQException e) {
                 throw new RuntimeException(e);
             }
-            log.info("Created new HornetQ session.");
+            log.debug("Created new HornetQ session.");
             sessions.set(session);
         }
         return session;


### PR DESCRIPTION
Every time the HornetQ session is aquired, EventSinkImpl
logs it. This can litter the logs which is unnecessary.
Reduced level to DEBUG so that the log info can still be
available.