### PR TITLE
Batch Revoke Performance Fix (v3)

### DIFF
--- a/server/src/main/java/org/candlepin/audit/EventFactory.java
+++ b/server/src/main/java/org/candlepin/audit/EventFactory.java
@@ -18,7 +18,6 @@ import org.candlepin.audit.Event.Target;
 import org.candlepin.audit.Event.Type;
 import org.candlepin.common.jackson.HateoasBeanPropertyFilter;
 import org.candlepin.guice.PrincipalProvider;
-import org.candlepin.jackson.ProductCachedSerializationModule;
 import org.candlepin.jackson.PoolEventFilter;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.Entitlement;
@@ -55,8 +54,7 @@ public class EventFactory {
     private final ObjectMapper mapper;
 
     @Inject
-    public EventFactory(PrincipalProvider principalProvider,
-        ProductCachedSerializationModule productCachedModule) {
+    public EventFactory(PrincipalProvider principalProvider) {
         this.principalProvider = principalProvider;
 
         mapper = new ObjectMapper();
@@ -84,7 +82,6 @@ public class EventFactory {
         Hibernate4Module hbm = new Hibernate4Module();
         hbm.enable(Hibernate4Module.Feature.FORCE_LAZY_LOADING);
         mapper.registerModule(hbm);
-        mapper.registerModule(productCachedModule);
 
         AnnotationIntrospector primary = new JacksonAnnotationIntrospector();
         AnnotationIntrospector secondary = new JaxbAnnotationIntrospector(mapper.getTypeFactory());

--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -1717,7 +1717,6 @@ public class CandlepinPoolManager implements PoolManager {
             int entQuantity = ent.getQuantity() != null ? ent.getQuantity() : 0;
 
             pool.setConsumed(pool.getConsumed() - entQuantity);
-            pool.getEntitlements().remove(ent);
             Consumer consumer = ent.getConsumer();
             if (consumer.getType().isManifest()) {
                 pool.setExported(pool.getExported() - entQuantity);

--- a/server/src/main/java/org/candlepin/model/Pool.java
+++ b/server/src/main/java/org/candlepin/model/Pool.java
@@ -304,7 +304,7 @@ public class Pool extends AbstractHibernateObject implements Persisted, Owned, N
     @BatchSize(size = 1000)
     private Set<PoolAttribute> attributes = new HashSet<PoolAttribute>();
 
-    @OneToMany(mappedBy = "pool", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "pool")
     @LazyCollection(LazyCollectionOption.EXTRA)
     private Set<Entitlement> entitlements = new HashSet<Entitlement>();
 

--- a/server/src/test/java/org/candlepin/audit/AMQPBusPublisherTest.java
+++ b/server/src/test/java/org/candlepin/audit/AMQPBusPublisherTest.java
@@ -24,9 +24,7 @@ import static org.mockito.Mockito.when;
 import org.candlepin.audit.Event.Target;
 import org.candlepin.audit.Event.Type;
 import org.candlepin.guice.PrincipalProvider;
-import org.candlepin.jackson.ProductCachedSerializationModule;
 import org.candlepin.model.Consumer;
-import org.candlepin.model.ProductCurator;
 import org.candlepin.test.TestUtil;
 import org.candlepin.util.Util;
 
@@ -81,10 +79,9 @@ public class AMQPBusPublisherTest {
     @Test
     public void testApply() throws IOException {
         PrincipalProvider pp = mock(PrincipalProvider.class);
-        ProductCurator productCurator = mock(ProductCurator.class);
-
         when(pp.get()).thenReturn(TestUtil.createPrincipal("admin", null, null));
-        EventFactory factory = new EventFactory(pp, new ProductCachedSerializationModule(productCurator));
+
+        EventFactory factory = new EventFactory(pp);
         Consumer c = TestUtil.createConsumer();
         Event e = factory.consumerCreated(c);
 
@@ -98,10 +95,9 @@ public class AMQPBusPublisherTest {
     @Test
     public void onEvent() throws JMSException {
         PrincipalProvider pp = mock(PrincipalProvider.class);
-
-        ProductCurator productCurator = mock(ProductCurator.class);
         when(pp.get()).thenReturn(TestUtil.createPrincipal("admin", null, null));
-        EventFactory factory = new EventFactory(pp, new ProductCachedSerializationModule(productCurator));
+
+        EventFactory factory = new EventFactory(pp);
         Consumer c = TestUtil.createConsumer();
         Event e = factory.consumerCreated(c);
         TopicPublisher tp = publisherMap.get(Target.CONSUMER).get(Type.CREATED);

--- a/server/src/test/java/org/candlepin/audit/EventFactoryTest.java
+++ b/server/src/test/java/org/candlepin/audit/EventFactoryTest.java
@@ -20,11 +20,9 @@ import static org.mockito.Mockito.when;
 
 import org.candlepin.auth.Principal;
 import org.candlepin.guice.PrincipalProvider;
-import org.candlepin.jackson.ProductCachedSerializationModule;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.GuestId;
 import org.candlepin.model.Owner;
-import org.candlepin.model.ProductCurator;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -41,10 +39,8 @@ public class EventFactoryTest {
     public void init() throws Exception {
         principalProvider = mock(PrincipalProvider.class);
         Principal principal = mock(Principal.class);
-        ProductCurator productCurator = mock(ProductCurator.class);
         when(principalProvider.get()).thenReturn(principal);
-        eventFactory = new EventFactory(principalProvider,
-            new ProductCachedSerializationModule(productCurator));
+        eventFactory = new EventFactory(principalProvider);
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/audit/EventSinkImplTest.java
+++ b/server/src/test/java/org/candlepin/audit/EventSinkImplTest.java
@@ -31,7 +31,6 @@ import static org.mockito.Mockito.when;
 import org.candlepin.auth.Principal;
 import org.candlepin.config.CandlepinCommonTestConfig;
 import org.candlepin.guice.PrincipalProvider;
-import org.candlepin.jackson.ProductCachedSerializationModule;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.Owner;
 import org.candlepin.model.Pool;
@@ -82,8 +81,7 @@ public class EventSinkImplTest {
 
     @Before
     public void init() throws Exception {
-        this.factory = new EventFactory(mockPrincipalProvider,
-        new ProductCachedSerializationModule(mockProductCurator));
+        this.factory = new EventFactory(mockPrincipalProvider);
         this.principal = TestUtil.createOwnerPrincipal();
         eventFilter = new EventFilter(new CandlepinCommonTestConfig());
         when(mockPrincipalProvider.get()).thenReturn(this.principal);

--- a/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -1717,7 +1717,6 @@ public class PoolManagerTest {
         List<Entitlement> entsDeleted = arg.getValue();
         assertThat(entsDeleted, hasItem(derivedEnt));
         assertEquals(2, derivedPool.getConsumed().intValue());
-        assertEquals(0, derivedPool.getEntitlements().size());
     }
 
     @Test
@@ -1763,9 +1762,7 @@ public class PoolManagerTest {
 
         // before
         assertEquals(3, derivedPool.getConsumed().intValue());
-        assertEquals(2, derivedPool.getEntitlements().size());
         assertEquals(2, derivedPool2.getConsumed().intValue());
-        assertEquals(1, derivedPool2.getEntitlements().size());
         assertEquals(2, derivedPool2.getConsumed().intValue());
 
         when(mockPoolCurator.lockAndLoadBatch(anyCollection())).thenReturn(Arrays.asList(pool));
@@ -1788,9 +1785,7 @@ public class PoolManagerTest {
         assertThat(entsDeleted, hasItems(derivedEnt, derivedEnt2, derivedEnt3));
 
         assertEquals(1, derivedPool.getConsumed().intValue());
-        assertEquals(0, derivedPool.getEntitlements().size());
         assertEquals(1, derivedPool2.getConsumed().intValue());
-        assertEquals(0, derivedPool2.getEntitlements().size());
         assertEquals(2, derivedPool3.getConsumed().intValue());
     }
 


### PR DESCRIPTION
Removed the useage of ProductCachedSerializationModule in
EventFactory while serializing pools since we use the
HATEOS JSON version of Pool when serializing for Events.

Removing this serializer produces the exact same JSON
data. No need to hydrate provided products as it is
never, and has never, been included.

On revoke entitlement, do not remove entitlements
from their pool's collection. Since the collection
is Extra lazy, hibernate will query the ents each
time an entitlement is removed from a Pool's collection.

By doing this, we are no longer maintaining runtime
consistency b/w Pools and Entitlements. The biggest
concern with doing this is that we may run into a
hibernate unscheduling problem. For example a missed
delete. To minimize this risk, this PR removes the cascades
on the Pool.entitlements collection.