### PR TITLE
1371009: clearer error message (for 0.9.54)

### DIFF
--- a/server/src/main/java/org/candlepin/model/Consumer.java
+++ b/server/src/main/java/org/candlepin/model/Consumer.java
@@ -75,7 +75,7 @@ import javax.xml.bind.annotation.XmlTransient;
 @Table(name = "cp_consumer")
 @JsonFilter("ConsumerFilter")
 public class Consumer extends AbstractHibernateObject implements Linkable, Owned, Named, ConsumerProperty {
-
+    public static final int MAX_LENGTH_OF_CONSUMER_NAME = 255;
     public static final String UEBER_CERT_CONSUMER = "ueber_cert_consumer";
 
     @Id
@@ -91,7 +91,7 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
     private String uuid;
 
     @Column(nullable = false)
-    @Size(max = 255)
+    @Size(max = MAX_LENGTH_OF_CONSUMER_NAME)
     @NotNull
     private String name;
 

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -602,11 +602,18 @@ public class ConsumerResource {
      */
     private void checkConsumerName(Consumer consumer) {
         // for now this applies to both types consumer
-        if (consumer.getName() != null &&
-            consumer.getName().indexOf('#') == 0) {
-            // this is a bouncycastle restriction
-            throw new BadRequestException(
-                i18n.tr("System name cannot begin with # character"));
+        if (consumer.getName() != null) {
+            if (consumer.getName().indexOf('#') == 0) {
+                // this is a bouncycastle restriction
+                throw new BadRequestException(
+                    i18n.tr("System name cannot begin with # character"));
+            }
+
+            int max = Consumer.MAX_LENGTH_OF_CONSUMER_NAME;
+            if (consumer.getName().length() > max) {
+                String m = "Name of the consumer should be shorter than {0} characters.";
+                throw new BadRequestException(i18n.tr(m, Integer.toString(max)));
+            }
         }
     }
 


### PR DESCRIPTION
1371009:Need clearer error message when register with system name exceeding max characters.

-throwing new exceptions with clear description + adding new constant to Consumer
-adding unit test

**Change from previous fix**: I cherry-picked commit from cp-0.9.23 and then changed generating of consumer name w.r.t @crog comment in /candlepin/candlepin/pull/1356. Another difference is that changing buildfile was not necessery, because buildfile has already corrected version of org.xnap.commons.i18n.