### PR TITLE
1371009:  clearer error message (for master)

### DIFF
--- a/server/src/main/java/org/candlepin/model/Consumer.java
+++ b/server/src/main/java/org/candlepin/model/Consumer.java
@@ -84,6 +84,8 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
 
     public static final String UEBER_CERT_CONSUMER = "ueber_cert_consumer";
 
+    public static final int MAX_LENGTH_OF_CONSUMER_NAME = 255;
+
     @Id
     @GeneratedValue(generator = "system-uuid")
     @GenericGenerator(name = "system-uuid", strategy = "uuid")
@@ -97,7 +99,7 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
     private String uuid;
 
     @Column(nullable = false)
-    @Size(max = 255)
+    @Size(max = MAX_LENGTH_OF_CONSUMER_NAME)
     @NotNull
     private String name;
 

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -596,11 +596,18 @@ public class ConsumerResource {
      */
     private void checkConsumerName(Consumer consumer) {
         // for now this applies to both types consumer
-        if (consumer.getName() != null &&
-            consumer.getName().indexOf('#') == 0) {
-            // this is a bouncycastle restriction
-            throw new BadRequestException(
-                i18n.tr("System name cannot begin with # character"));
+        if (consumer.getName() != null) {
+            if (consumer.getName().indexOf('#') == 0) {
+                // this is a bouncycastle restriction
+                throw new BadRequestException(
+                    i18n.tr("System name cannot begin with # character"));
+            }
+
+            int max = Consumer.MAX_LENGTH_OF_CONSUMER_NAME;
+            if (consumer.getName().length() > max) {
+                String m = "Name of the consumer should be shorter than {0} characters.";
+                throw new BadRequestException(i18n.tr(m, Integer.toString(max)));
+            }
         }
     }
 

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
@@ -80,8 +80,11 @@ import org.candlepin.test.TestUtil;
 import org.candlepin.util.ServiceLevelValidator;
 
 import org.hibernate.mapping.Collection;
+import org.apache.commons.lang.RandomStringUtils;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -110,6 +113,10 @@ import javax.ws.rs.core.Response;
  */
 @RunWith(MockitoJUnitRunner.class)
 public class ConsumerResourceTest {
+
+    @SuppressWarnings("checkstyle:visibilitymodifier")
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
     private I18n i18n;
 
@@ -612,6 +619,45 @@ public class ConsumerResourceTest {
             usa, null,  null, oc, null, null, null, null, null,
             null, new CandlepinCommonTestConfig(), null, null, null, consumerBindUtil, productCurator, null);
         cr.create(c, up, null, "testOwner", null, true);
+    }
+
+    @Test
+    public void testCreateConsumerShouldFailOnMaxLengthOfName() {
+        thrown.expect(BadRequestException.class);
+        int max = Consumer.MAX_LENGTH_OF_CONSUMER_NAME;
+        String m = String.format("Name of the consumer " +
+            "should be shorter than %d characters.", max);
+        thrown.expectMessage(m);
+
+        Consumer c = mock(Consumer.class);
+        Owner o = mock(Owner.class);
+        UserPrincipal up = mock(UserPrincipal.class);
+        OwnerCurator oc = mock(OwnerCurator.class);
+        ConsumerType cType = new ConsumerType(ConsumerTypeEnum.SYSTEM);
+        ConsumerResource consumerResource = createConsumerResource(oc);
+
+        String ownerKey = "testOwner";
+        when(oc.lookupByKey(eq(ownerKey))).thenReturn(o);
+        when(o.getKey()).thenReturn(ownerKey);
+        when(c.getType()).thenReturn(cType);
+        String s = RandomStringUtils.randomAlphanumeric(max + 1);
+        when(c.getName()).thenReturn(s);
+        when(up.canAccess(eq(o), eq(SubResource.CONSUMERS), eq(Access.CREATE))).
+            thenReturn(true);
+
+        consumerResource.create(c, up, null, ownerKey, null, false);
+    }
+
+    ConsumerResource createConsumerResource(OwnerCurator oc) {
+        ConsumerResource consumerResource = new ConsumerResource(
+            null, null, null, null, null, null, null,
+            i18n,
+            null, null, null, null, null, null, null,
+            oc,
+            null, null, null, null, null, null,
+            new CandlepinCommonTestConfig(),
+            null, null, null, null, null, null);
+        return consumerResource;
     }
 
     @Test


### PR DESCRIPTION
Need clearer error message when register with system name exceeding max characters.

-throwing new exceptions with clear description + adding new constant to Consumer
-adding unit test

**Change from previous fix:** I cherry-picked commit from cp-0.9.23 and then changed generating of consumer name w.r.t @crog comment in /candlepin/candlepin/pull/1356. Another difference is that changing buildfile was not necessery, because buildfile has already corrected version of org.xnap.commons.i18n.