### PR TITLE
1405125: Remove null byte from end of any fact value.

### DIFF
--- a/server/src/main/java/org/candlepin/jackson/StringTrimmingConverter.java
+++ b/server/src/main/java/org/candlepin/jackson/StringTrimmingConverter.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.jackson;
+
+import com.fasterxml.jackson.databind.util.StdConverter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class trims strings that are being deserialized by Jackson.  It is primarily
+ * necessitated by BZ 1405125 (ppc64 clients are reporting a virt uuid in the facts that
+ * ends in a null byte).
+ */
+public class StringTrimmingConverter extends StdConverter<String, String> {
+    private static final Logger log = LoggerFactory.getLogger(StringTrimmingConverter.class);
+
+    @Override
+    public String convert(String value) {
+        return (value == null) ? value : value.trim();
+    }
+}

--- a/server/src/main/java/org/candlepin/model/Consumer.java
+++ b/server/src/main/java/org/candlepin/model/Consumer.java
@@ -16,10 +16,12 @@ package org.candlepin.model;
 
 import org.candlepin.common.jackson.HateoasArrayExclude;
 import org.candlepin.common.jackson.HateoasInclude;
+import org.candlepin.jackson.StringTrimmingConverter;
 import org.candlepin.model.ConsumerType.ConsumerTypeEnum;
 import org.candlepin.util.Util;
 
 import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import org.apache.commons.lang.StringUtils;
 import org.hibernate.annotations.BatchSize;
@@ -173,6 +175,7 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
     //FIXME A cascade shouldn't be necessary here as ElementCollections cascade by default
     //See http://stackoverflow.com/a/7696147
     @Cascade({org.hibernate.annotations.CascadeType.ALL})
+    @JsonDeserialize(contentConverter = StringTrimmingConverter.class)
     private Map<String, String> facts;
 
     @OneToOne(cascade = CascadeType.ALL)

--- a/server/src/test/java/org/candlepin/jackson/StringTrimmingConverterTest.java
+++ b/server/src/test/java/org/candlepin/jackson/StringTrimmingConverterTest.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.jackson;
+
+import static org.junit.Assert.*;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class StringTrimmingConverterTest {
+    private StringTrimmingConverter converter;
+
+    @Before
+    public void setUp() {
+        converter = new StringTrimmingConverter();
+    }
+
+    @Test
+    public void testRemovesNullBytes() {
+        String in = "Hello world\0";
+        String out = converter.convert(in);
+        assertEquals("Hello world", out);
+    }
+
+    @Test
+    public void testLeavesOtherStringsAlone() {
+        String in = "Hello world";
+        String out = converter.convert(in);
+        assertEquals(in, out);
+    }
+
+    @Test
+    public void testStripsOtherWhiteSpace() {
+        String in = "Hello world   ";
+        String out = converter.convert(in);
+        assertEquals("Hello world", out);
+    }
+}


### PR DESCRIPTION
This is primarily intended to address ppc64 virt uuids that end with a
null byte, but in principle we do not want any facts to end in null
bytes or even whitespace.