### PR TITLE
Updated the environment setup to include qpid-proton

### DIFF
--- a/docker/candlepin-base/setup-devel-env.sh
+++ b/docker/candlepin-base/setup-devel-env.sh
@@ -30,6 +30,8 @@ PACKAGES=(
     openssl
     gettext
     tmux
+    qpid-proton-c
+    qpid-proton-c-devel
 )
 
 yum install -y ${PACKAGES[@]}


### PR DESCRIPTION
- The setup-devel-env script now installs qpid-proton-c and
  qpid-proton-c-devel, which are now used by some of the new qpid
  spec tests