### PR TITLE
1414426: Ability to get future pools by owner

### DIFF
--- a/server/client/ruby/candlepin_api.rb
+++ b/server/client/ruby/candlepin_api.rb
@@ -453,6 +453,8 @@ class Candlepin
     path << "order=#{params[:order]}&" if params[:order]
     path << "sort_by=#{params[:sort_by]}&" if params[:sort_by]
     path << "matches=#{params[:matches]}&" if params[:matches]
+    path << "add_future=#{params[:add_future]}&" if params[:add_future]
+    path << "only_future=#{params[:only_future]}&" if params[:only_future]
 
     # Attribute filters are specified in the following format:
     #    {attributeName}:{attributeValue}

--- a/server/spec/owner_resource_spec.rb
+++ b/server/spec/owner_resource_spec.rb
@@ -838,7 +838,6 @@ describe 'Owner Resource Future Pool Tests' do
     @future_pool2 = create_pool_and_subscription(@owner['key'], @product2.id, 10, [], '', '', '', start2)
   end
 
-  # active_only is true by default
   it 'can fetch current pools' do
     pools = @cp.list_owner_pools(@owner['key'])
     pools.length.should eq(1)

--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -1158,14 +1158,14 @@ public class CandlepinPoolManager implements PoolManager {
         PoolFilterBuilder poolFilter = new PoolFilterBuilder();
         poolFilter.addIdFilters(fromPools);
         List<Pool> allOwnerPools = this.listAvailableEntitlementPools(
-            host, null, owner, (String) null, null, activePoolDate, true, false,
+            host, null, owner, (String) null, null, activePoolDate, false,
             poolFilter, null, false, false).getPageData();
         log.debug("Found {} total pools in org.", allOwnerPools.size());
         logPools(allOwnerPools);
 
         List<Pool> allOwnerPoolsForGuest = this.listAvailableEntitlementPools(
             guest, null, owner, (String) null, null, activePoolDate,
-            true, false, poolFilter,
+            false, poolFilter,
             null, false, false).getPageData();
         log.debug("Found {} total pools already available for guest", allOwnerPoolsForGuest.size());
         logPools(allOwnerPoolsForGuest);
@@ -1302,7 +1302,7 @@ public class CandlepinPoolManager implements PoolManager {
         PoolFilterBuilder poolFilter = new PoolFilterBuilder();
         poolFilter.addIdFilters(fromPools);
         List<Pool> allOwnerPools = this.listAvailableEntitlementPools(
-            consumer, null, owner, (String) null, null, activePoolDate, true, false,
+            consumer, null, owner, (String) null, null, activePoolDate, false,
             poolFilter, null, false, false).getPageData();
         List<Pool> filteredPools = new LinkedList<Pool>();
 
@@ -2148,7 +2148,7 @@ public class CandlepinPoolManager implements PoolManager {
     @Override
     public Page<List<Pool>> listAvailableEntitlementPools(Consumer consumer,
         ActivationKey key, Owner owner, String productId, String subscriptionId, Date activeOn,
-        boolean activeOnly, boolean includeWarnings, PoolFilterBuilder filters,
+        boolean includeWarnings, PoolFilterBuilder filters,
         PageRequest pageRequest, boolean addFuture, boolean onlyFuture) {
 
         // Only postfilter if we have to
@@ -2158,7 +2158,7 @@ public class CandlepinPoolManager implements PoolManager {
         }
 
         Page<List<Pool>> page = this.poolCurator.listAvailableEntitlementPools(consumer,
-            owner, productId, subscriptionId, activeOn, activeOnly, filters, pageRequest, postFilter,
+            owner, productId, subscriptionId, activeOn, filters, pageRequest, postFilter,
             addFuture, onlyFuture);
 
         if (consumer == null && key == null) {

--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -1159,14 +1159,14 @@ public class CandlepinPoolManager implements PoolManager {
         poolFilter.addIdFilters(fromPools);
         List<Pool> allOwnerPools = this.listAvailableEntitlementPools(
             host, null, owner, (String) null, null, activePoolDate, true, false,
-            poolFilter, null).getPageData();
+            poolFilter, null, false, false).getPageData();
         log.debug("Found {} total pools in org.", allOwnerPools.size());
         logPools(allOwnerPools);
 
         List<Pool> allOwnerPoolsForGuest = this.listAvailableEntitlementPools(
             guest, null, owner, (String) null, null, activePoolDate,
             true, false, poolFilter,
-            null).getPageData();
+            null, false, false).getPageData();
         log.debug("Found {} total pools already available for guest", allOwnerPoolsForGuest.size());
         logPools(allOwnerPoolsForGuest);
 
@@ -1303,7 +1303,7 @@ public class CandlepinPoolManager implements PoolManager {
         poolFilter.addIdFilters(fromPools);
         List<Pool> allOwnerPools = this.listAvailableEntitlementPools(
             consumer, null, owner, (String) null, null, activePoolDate, true, false,
-            poolFilter, null).getPageData();
+            poolFilter, null, false, false).getPageData();
         List<Pool> filteredPools = new LinkedList<Pool>();
 
         // We have to check compliance status here so we can replace an empty
@@ -2149,7 +2149,7 @@ public class CandlepinPoolManager implements PoolManager {
     public Page<List<Pool>> listAvailableEntitlementPools(Consumer consumer,
         ActivationKey key, Owner owner, String productId, String subscriptionId, Date activeOn,
         boolean activeOnly, boolean includeWarnings, PoolFilterBuilder filters,
-        PageRequest pageRequest) {
+        PageRequest pageRequest, boolean addFuture, boolean onlyFuture) {
 
         // Only postfilter if we have to
         boolean postFilter = consumer != null || key != null;
@@ -2158,7 +2158,8 @@ public class CandlepinPoolManager implements PoolManager {
         }
 
         Page<List<Pool>> page = this.poolCurator.listAvailableEntitlementPools(consumer,
-            owner, productId, subscriptionId, activeOn, activeOnly, filters, pageRequest, postFilter);
+            owner, productId, subscriptionId, activeOn, activeOnly, filters, pageRequest, postFilter,
+            addFuture, onlyFuture);
 
         if (consumer == null && key == null) {
             return page;

--- a/server/src/main/java/org/candlepin/controller/EntitlementCertificateGenerator.java
+++ b/server/src/main/java/org/candlepin/controller/EntitlementCertificateGenerator.java
@@ -348,7 +348,7 @@ public class EntitlementCertificateGenerator {
     @Transactional
     public void regenerateCertificatesOf(Owner owner, String productId, boolean lazy) {
         List<Pool> pools = this.poolCurator.listAvailableEntitlementPools(
-            null, owner, productId, new Date(), false
+            null, owner, productId, new Date()
         );
 
         for (Pool pool : pools) {
@@ -408,7 +408,7 @@ public class EntitlementCertificateGenerator {
         // do this without hitting the DB several times over.
         for (Owner owner : owners) {
             pools.addAll(
-                this.poolCurator.listAvailableEntitlementPools(null, owner, productIds, now, false)
+                this.poolCurator.listAvailableEntitlementPools(null, owner, productIds, now)
             );
         }
 

--- a/server/src/main/java/org/candlepin/controller/PoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/PoolManager.java
@@ -181,7 +181,6 @@ public interface PoolManager {
      * @param productId only entitlements which provide this product are included.
      * @param activeOn Indicates to return only pools valid on this date.
      *        Set to null for no date filtering.
-     * @param activeOnly if true, only active entitlements are included.
      * @param includeWarnings When filtering by consumer, include pools that
      *        triggered a rule warning. (errors will still be excluded)
      * @param filterBuilder builds and applies all filters when looking up pools.
@@ -189,7 +188,7 @@ public interface PoolManager {
      * @return List of entitlement pools.
      */
     Page<List<Pool>> listAvailableEntitlementPools(Consumer consumer, ActivationKey key,
-        Owner owner, String productId, String subscriptionId, Date activeOn, boolean activeOnly,
+        Owner owner, String productId, String subscriptionId, Date activeOn,
         boolean includeWarnings, PoolFilterBuilder filterBuilder, PageRequest pageRequest,
         boolean addFuture, boolean onlyFuture);
 

--- a/server/src/main/java/org/candlepin/controller/PoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/PoolManager.java
@@ -190,7 +190,8 @@ public interface PoolManager {
      */
     Page<List<Pool>> listAvailableEntitlementPools(Consumer consumer, ActivationKey key,
         Owner owner, String productId, String subscriptionId, Date activeOn, boolean activeOnly,
-        boolean includeWarnings, PoolFilterBuilder filterBuilder, PageRequest pageRequest);
+        boolean includeWarnings, PoolFilterBuilder filterBuilder, PageRequest pageRequest,
+        boolean addFuture, boolean onlyFuture);
 
     /**
      *  Get the available service levels for consumers for this owner. Exempt

--- a/server/src/main/java/org/candlepin/model/PoolCurator.java
+++ b/server/src/main/java/org/candlepin/model/PoolCurator.java
@@ -186,7 +186,7 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
      */
     @Transactional
     public List<Pool> listByConsumer(Consumer c) {
-        return listAvailableEntitlementPools(c, c.getOwner(), (Set<String>) null, null, true);
+        return listAvailableEntitlementPools(c, c.getOwner(), (Set<String>) null, null);
     }
 
     /**
@@ -198,7 +198,7 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
      */
     @Transactional
     public List<Pool> listByOwnerAndProduct(Owner owner, String productId) {
-        return listAvailableEntitlementPools(null, owner, productId, null, false);
+        return listAvailableEntitlementPools(null, owner, productId, null);
     }
 
     /**
@@ -252,38 +252,37 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
 
     @SuppressWarnings("unchecked")
     @Transactional
-    public List<Pool> listAvailableEntitlementPools(Consumer c, Owner o, String productId, Date activeOn,
-        boolean activeOnly) {
+    public List<Pool> listAvailableEntitlementPools(Consumer c, Owner o, String productId, Date activeOn) {
 
         return listAvailableEntitlementPools(c, o,
             (productId != null ? Arrays.asList(productId) : (Collection<String>) null), null, activeOn,
-            activeOnly, new PoolFilterBuilder(), null, false, false, false).getPageData();
+            new PoolFilterBuilder(), null, false, false, false).getPageData();
     }
 
     @SuppressWarnings("unchecked")
     @Transactional
     public List<Pool> listAvailableEntitlementPools(Consumer c, Owner o, Collection<String> productIds,
-        Date activeOn, boolean activeOnly) {
+        Date activeOn) {
 
-        return listAvailableEntitlementPools(c, o, productIds, null, activeOn, activeOnly,
+        return listAvailableEntitlementPools(c, o, productIds, null, activeOn,
             new PoolFilterBuilder(), null, false, false, false).getPageData();
     }
 
     @Transactional
     public List<Pool> listByFilter(PoolFilterBuilder filters) {
         return listAvailableEntitlementPools(
-            null, null, (Set<String>) null, null, null, false, filters, null, false,
+            null, null, (Set<String>) null, null, null, filters, null, false,
             false, false).getPageData();
     }
 
     @Transactional
     public Page<List<Pool>> listAvailableEntitlementPools(Consumer c, Owner o, String productId,
-        String subscriptionId, Date activeOn, boolean activeOnly, PoolFilterBuilder filters,
+        String subscriptionId, Date activeOn, PoolFilterBuilder filters,
         PageRequest pageRequest, boolean postFilter, boolean addFuture, boolean onlyFuture) {
 
         return this.listAvailableEntitlementPools(c, o,
             (productId != null ? Arrays.asList(productId) : (Collection<String>) null), subscriptionId,
-            activeOn, activeOnly, filters, pageRequest, postFilter, addFuture, onlyFuture);
+            activeOn, filters, pageRequest, postFilter, addFuture, onlyFuture);
     }
 
     /**
@@ -296,7 +295,6 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
      * @param productIds only entitlements which provide these products are included.
      * @param activeOn Indicates to return only pools valid on this date.
      *        Set to null for no date filtering.
-     * @param activeOnly if true, only active entitlements are included.
      * @param filters filter builder with set filters to apply to the criteria.
      * @param pageRequest used to specify paging criteria.
      * @param postFilter if you plan on filtering the list in java
@@ -305,7 +303,7 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
     @SuppressWarnings("unchecked")
     @Transactional
     public Page<List<Pool>> listAvailableEntitlementPools(Consumer c, Owner o, Collection<String> productIds,
-        String subscriptionId, Date activeOn, boolean activeOnly, PoolFilterBuilder filters,
+        String subscriptionId, Date activeOn, PoolFilterBuilder filters,
         PageRequest pageRequest, boolean postFilter, boolean addFuture, boolean onlyFuture) {
 
         if (o == null && c != null) {
@@ -324,9 +322,6 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
             .createAlias("product", "product")
             .setResultTransformer(Criteria.DISTINCT_ROOT_ENTITY);
 
-        if (activeOnly) {
-            crit.add(Restrictions.eq("activeSubscription", Boolean.TRUE));
-        }
         if (c != null) {
             crit.add(Restrictions.eq("owner", c.getOwner()));
 

--- a/server/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -723,6 +723,8 @@ public class OwnerResource {
         @QueryParam("matches") String matches,
         @QueryParam("attribute") @CandlepinParam(type = KeyValueParameter.class)
             List<KeyValueParameter> attrFilters,
+        @QueryParam("add_future") @DefaultValue("false") boolean addFuture,
+        @QueryParam("only_future") @DefaultValue("false") boolean onlyFuture,
         @Context Principal principal,
         @Context PageRequest pageRequest) {
 
@@ -762,6 +764,10 @@ public class OwnerResource {
             }
         }
 
+        if (addFuture && onlyFuture) {
+            throw new BadRequestException(
+                i18n.tr("The flags add_future and only_future cannot be used at the same time."));
+        }
         // Process the filters passed for the attributes
         PoolFilterBuilder poolFilters = new PoolFilterBuilder();
         for (KeyValueParameter filterParam : attrFilters) {
@@ -772,8 +778,8 @@ public class OwnerResource {
         }
 
         Page<List<Pool>> page = poolManager.listAvailableEntitlementPools(
-            c, key, owner, productId, subscriptionId, activeOnDate, true, listAll, poolFilters, pageRequest
-        );
+            c, key, owner, productId, subscriptionId, activeOnDate, true, listAll, poolFilters, pageRequest,
+        addFuture, onlyFuture);
         List<Pool> poolList = page.getPageData();
         calculatedAttributesUtil.setCalculatedAttributes(poolList, activeOnDate);
         calculatedAttributesUtil.setQuantityAttributes(poolList, c, activeOnDate);

--- a/server/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -716,14 +716,22 @@ public class OwnerResource {
         @QueryParam("activation_key") String activationKeyName,
         @QueryParam("product") String productId,
         @QueryParam("subscription") String subscriptionId,
+        @ApiParam("Include pools that are not suited to the unit's facts.")
         @QueryParam("listall") @DefaultValue("false") boolean listAll,
+        @ApiParam("Date to use as current time for lookup criteria. Defaults" +
+                " to current date if not specified.")
         @QueryParam("activeon") String activeOn,
         @ApiParam("Find pools matching the given pattern in a variety of fields" +
                 " * and ? wildcards are supported.")
         @QueryParam("matches") String matches,
+        @ApiParam("The attributes to return based on the specified types.")
         @QueryParam("attribute") @CandlepinParam(type = KeyValueParameter.class)
             List<KeyValueParameter> attrFilters,
+        @ApiParam("When set to true, it will add future dated pools to the result, " +
+                "based on the activeon date.")
         @QueryParam("add_future") @DefaultValue("false") boolean addFuture,
+        @ApiParam("When set to true, it will return only future dated pools to the result, " +
+                "based on the activeon date.")
         @QueryParam("only_future") @DefaultValue("false") boolean onlyFuture,
         @Context Principal principal,
         @Context PageRequest pageRequest) {
@@ -778,7 +786,7 @@ public class OwnerResource {
         }
 
         Page<List<Pool>> page = poolManager.listAvailableEntitlementPools(
-            c, key, owner, productId, subscriptionId, activeOnDate, true, listAll, poolFilters, pageRequest,
+            c, key, owner, productId, subscriptionId, activeOnDate, listAll, poolFilters, pageRequest,
         addFuture, onlyFuture);
         List<Pool> poolList = page.getPageData();
         calculatedAttributesUtil.setCalculatedAttributes(poolList, activeOnDate);

--- a/server/src/main/java/org/candlepin/resource/PoolResource.java
+++ b/server/src/main/java/org/candlepin/resource/PoolResource.java
@@ -174,7 +174,7 @@ public class PoolResource {
         }
 
         Page<List<Pool>> page = poolManager.listAvailableEntitlementPools(c, null, o,
-            productId, null, activeOnDate, true, listAll, new PoolFilterBuilder(), pageRequest,
+            productId, null, activeOnDate, listAll, new PoolFilterBuilder(), pageRequest,
             false, false);
         List<Pool> poolList = page.getPageData();
 

--- a/server/src/main/java/org/candlepin/resource/PoolResource.java
+++ b/server/src/main/java/org/candlepin/resource/PoolResource.java
@@ -174,7 +174,8 @@ public class PoolResource {
         }
 
         Page<List<Pool>> page = poolManager.listAvailableEntitlementPools(c, null, o,
-            productId, null, activeOnDate, true, listAll, new PoolFilterBuilder(), pageRequest);
+            productId, null, activeOnDate, true, listAll, new PoolFilterBuilder(), pageRequest,
+            false, false);
         List<Pool> poolList = page.getPageData();
 
         calculatedAttributesUtil.setCalculatedAttributes(poolList, activeOnDate);

--- a/server/src/test/java/org/candlepin/controller/EntitlementCertificateGeneratorTest.java
+++ b/server/src/test/java/org/candlepin/controller/EntitlementCertificateGeneratorTest.java
@@ -18,7 +18,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyMapOf;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -286,7 +285,7 @@ public class EntitlementCertificateGeneratorTest {
         pool.setEntitlements(entitlements);
 
         when(this.mockPoolCurator.listAvailableEntitlementPools(any(Consumer.class), eq(owner),
-            eq(product.getId()), any(Date.class), anyBoolean())).thenReturn(Arrays.asList(pool));
+            eq(product.getId()), any(Date.class))).thenReturn(Arrays.asList(pool));
 
         this.ecGenerator.regenerateCertificatesOf(owner, product.getId(), true);
 
@@ -310,7 +309,7 @@ public class EntitlementCertificateGeneratorTest {
         ecMap.put(pool.getId(), new EntitlementCertificate());
 
         when(this.mockPoolCurator.listAvailableEntitlementPools(any(Consumer.class), eq(owner),
-            eq(product.getId()), any(Date.class), anyBoolean())).thenReturn(Arrays.asList(pool));
+            eq(product.getId()), any(Date.class))).thenReturn(Arrays.asList(pool));
         when(this.mockEntCertAdapter.generateEntitlementCerts(any(Consumer.class), any(Map.class),
             any(Map.class))).thenReturn(ecMap);
 

--- a/server/src/test/java/org/candlepin/controller/PoolManagerFunctionalTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerFunctionalTest.java
@@ -399,7 +399,7 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
     @Test
     public void testListAllForConsumerIncludesWarnings() {
         Page<List<Pool>> results = poolManager.listAvailableEntitlementPools(
-            parentSystem, null, parentSystem.getOwner(), null, null, null, true, true,
+            parentSystem, null, parentSystem.getOwner(), null, null, null, true,
             new PoolFilterBuilder(), new PageRequest(), false, false);
         assertEquals(4, results.getPageData().size());
 
@@ -409,7 +409,7 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
 
         parentSystem.setFact("cpu.sockets", "4");
         results = poolManager.listAvailableEntitlementPools(parentSystem, null,
-            parentSystem.getOwner(), null, null, null, true, true, new PoolFilterBuilder(),
+            parentSystem.getOwner(), null, null, null, true, new PoolFilterBuilder(),
             new PageRequest(), false, false);
         // Expect the warnings to be included. Should have one more pool available.
         assertEquals(5, results.getPageData().size());
@@ -421,7 +421,7 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
         productCurator.create(p);
 
         Page<List<Pool>> results = poolManager.listAvailableEntitlementPools(
-            parentSystem, null, parentSystem.getOwner(), null, null, null, true, true,
+            parentSystem, null, parentSystem.getOwner(), null, null, null, true,
             new PoolFilterBuilder(), new PageRequest(), false, false);
         assertEquals(4, results.getPageData().size());
 
@@ -432,7 +432,7 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
         poolCurator.create(pool);
 
         results = poolManager.listAvailableEntitlementPools(parentSystem, null,
-            parentSystem.getOwner(), null, null, null, true, true, new PoolFilterBuilder(),
+            parentSystem.getOwner(), null, null, null, true, new PoolFilterBuilder(),
             new PageRequest(), false, false);
         // Pool in error should not be included. Should have the same number of
         // initial pools.
@@ -449,7 +449,7 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
         akpool.setAttribute("physical_only", "true");
         ak.addPool(akpool, 1L);
         Page<List<Pool>> results = poolManager.listAvailableEntitlementPools(
-            null, ak, parentSystem.getOwner(), null, null, null, true, true,
+            null, ak, parentSystem.getOwner(), null, null, null, true,
             new PoolFilterBuilder(), new PageRequest(), false, false);
         assertEquals(4, results.getPageData().size());
 
@@ -460,7 +460,7 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
         poolCurator.create(pool);
 
         results = poolManager.listAvailableEntitlementPools(null, ak,
-            parentSystem.getOwner(), null, null, null, true, true, new PoolFilterBuilder(),
+            parentSystem.getOwner(), null, null, null, true, new PoolFilterBuilder(),
             new PageRequest(), false, false);
         // Pool in error should not be included. Should have the same number of
         // initial pools.
@@ -470,7 +470,7 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
     @Test
     public void testListForConsumerExcludesWarnings() {
         Page<List<Pool>> results = poolManager.listAvailableEntitlementPools(
-            parentSystem, null, parentSystem.getOwner(), (String) null, null, null, true, false,
+            parentSystem, null, parentSystem.getOwner(), (String) null, null, null, true,
             new PoolFilterBuilder(), new PageRequest(), false, false);
         assertEquals(4, results.getPageData().size());
 
@@ -481,7 +481,7 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
         parentSystem.setFact("cpu.cpu_socket(s)", "4");
 
         results = poolManager.listAvailableEntitlementPools(parentSystem, null,
-            parentSystem.getOwner(), (String) null, null, null, true, false,
+            parentSystem.getOwner(), (String) null, null, null, false,
             new PoolFilterBuilder(), new PageRequest(), false, false);
         // Pool in error should not be included. Should have the same number of
         // initial pools.
@@ -496,7 +496,7 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
         poolCurator.create(pool);
         Page<List<Pool>> results = poolManager.listAvailableEntitlementPools(
             childVirtSystem, null, o, virtGuest.getId(), null, null, true,
-            true, new PoolFilterBuilder(), new PageRequest(), false, false);
+            new PoolFilterBuilder(), new PageRequest(), false, false);
         int newbornPools = results.getPageData().size();
 
         childVirtSystem.setCreated(TestUtil.createDate(2000, 01, 01));
@@ -504,7 +504,7 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
 
         results = poolManager.listAvailableEntitlementPools(
             childVirtSystem, null, o, virtGuest.getId(), null, null, true,
-            true, new PoolFilterBuilder(), new PageRequest(), false, false);
+            new PoolFilterBuilder(), new PageRequest(), false, false);
 
         assertEquals(newbornPools - 1, results.getPageData().size());
     }
@@ -584,12 +584,12 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
         nonDevSystem.addInstalledProduct(new ConsumerInstalledProduct(p));
 
         Page<List<Pool>> results = poolManager.listAvailableEntitlementPools(devSystem, null,
-            owner, null, null, null, true, true, new PoolFilterBuilder(), new PageRequest(),
+            owner, null, null, null, true, new PoolFilterBuilder(), new PageRequest(),
             false, false);
         assertEquals(2, results.getPageData().size());
 
         results = poolManager.listAvailableEntitlementPools(nonDevSystem, null,
-                owner, null, null, null, true, true, new PoolFilterBuilder(), new PageRequest(),
+                owner, null, null, null, true, new PoolFilterBuilder(), new PageRequest(),
                 false, false);
         assertEquals(1, results.getPageData().size());
         Pool found2 = results.getPageData().get(0);

--- a/server/src/test/java/org/candlepin/controller/PoolManagerFunctionalTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerFunctionalTest.java
@@ -400,7 +400,7 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
     public void testListAllForConsumerIncludesWarnings() {
         Page<List<Pool>> results = poolManager.listAvailableEntitlementPools(
             parentSystem, null, parentSystem.getOwner(), null, null, null, true, true,
-            new PoolFilterBuilder(), new PageRequest());
+            new PoolFilterBuilder(), new PageRequest(), false, false);
         assertEquals(4, results.getPageData().size());
 
         Pool pool = createPool(o, socketLimitedProduct, 100L,
@@ -410,7 +410,7 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
         parentSystem.setFact("cpu.sockets", "4");
         results = poolManager.listAvailableEntitlementPools(parentSystem, null,
             parentSystem.getOwner(), null, null, null, true, true, new PoolFilterBuilder(),
-            new PageRequest());
+            new PageRequest(), false, false);
         // Expect the warnings to be included. Should have one more pool available.
         assertEquals(5, results.getPageData().size());
     }
@@ -422,7 +422,7 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
 
         Page<List<Pool>> results = poolManager.listAvailableEntitlementPools(
             parentSystem, null, parentSystem.getOwner(), null, null, null, true, true,
-            new PoolFilterBuilder(), new PageRequest());
+            new PoolFilterBuilder(), new PageRequest(), false, false);
         assertEquals(4, results.getPageData().size());
 
         // Creating a pool with no entitlements available, which will trigger
@@ -433,7 +433,7 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
 
         results = poolManager.listAvailableEntitlementPools(parentSystem, null,
             parentSystem.getOwner(), null, null, null, true, true, new PoolFilterBuilder(),
-            new PageRequest());
+            new PageRequest(), false, false);
         // Pool in error should not be included. Should have the same number of
         // initial pools.
         assertEquals(4, results.getPageData().size());
@@ -450,7 +450,7 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
         ak.addPool(akpool, 1L);
         Page<List<Pool>> results = poolManager.listAvailableEntitlementPools(
             null, ak, parentSystem.getOwner(), null, null, null, true, true,
-            new PoolFilterBuilder(), new PageRequest());
+            new PoolFilterBuilder(), new PageRequest(), false, false);
         assertEquals(4, results.getPageData().size());
 
         // Creating a pool with no entitlements available, which does not trigger
@@ -461,7 +461,7 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
 
         results = poolManager.listAvailableEntitlementPools(null, ak,
             parentSystem.getOwner(), null, null, null, true, true, new PoolFilterBuilder(),
-            new PageRequest());
+            new PageRequest(), false, false);
         // Pool in error should not be included. Should have the same number of
         // initial pools.
         assertEquals(5, results.getPageData().size());
@@ -471,7 +471,7 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
     public void testListForConsumerExcludesWarnings() {
         Page<List<Pool>> results = poolManager.listAvailableEntitlementPools(
             parentSystem, null, parentSystem.getOwner(), (String) null, null, null, true, false,
-            new PoolFilterBuilder(), new PageRequest());
+            new PoolFilterBuilder(), new PageRequest(), false, false);
         assertEquals(4, results.getPageData().size());
 
         Pool pool = createPool(o, socketLimitedProduct, 100L,
@@ -482,7 +482,7 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
 
         results = poolManager.listAvailableEntitlementPools(parentSystem, null,
             parentSystem.getOwner(), (String) null, null, null, true, false,
-            new PoolFilterBuilder(), new PageRequest());
+            new PoolFilterBuilder(), new PageRequest(), false, false);
         // Pool in error should not be included. Should have the same number of
         // initial pools.
         assertEquals(4, results.getPageData().size());
@@ -496,7 +496,7 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
         poolCurator.create(pool);
         Page<List<Pool>> results = poolManager.listAvailableEntitlementPools(
             childVirtSystem, null, o, virtGuest.getId(), null, null, true,
-            true, new PoolFilterBuilder(), new PageRequest());
+            true, new PoolFilterBuilder(), new PageRequest(), false, false);
         int newbornPools = results.getPageData().size();
 
         childVirtSystem.setCreated(TestUtil.createDate(2000, 01, 01));
@@ -504,7 +504,7 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
 
         results = poolManager.listAvailableEntitlementPools(
             childVirtSystem, null, o, virtGuest.getId(), null, null, true,
-            true, new PoolFilterBuilder(), new PageRequest());
+            true, new PoolFilterBuilder(), new PageRequest(), false, false);
 
         assertEquals(newbornPools - 1, results.getPageData().size());
     }
@@ -584,11 +584,13 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
         nonDevSystem.addInstalledProduct(new ConsumerInstalledProduct(p));
 
         Page<List<Pool>> results = poolManager.listAvailableEntitlementPools(devSystem, null,
-            owner, null, null, null, true, true, new PoolFilterBuilder(), new PageRequest());
+            owner, null, null, null, true, true, new PoolFilterBuilder(), new PageRequest(),
+            false, false);
         assertEquals(2, results.getPageData().size());
 
         results = poolManager.listAvailableEntitlementPools(nonDevSystem, null,
-                owner, null, null, null, true, true, new PoolFilterBuilder(), new PageRequest());
+                owner, null, null, null, true, true, new PoolFilterBuilder(), new PageRequest(),
+                false, false);
         assertEquals(1, results.getPageData().size());
         Pool found2 = results.getPageData().get(0);
         assertEquals(pool2, found2);

--- a/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -960,7 +960,7 @@ public class PoolManagerTest {
 
         when(page.getPageData()).thenReturn(pools);
         when(mockPoolCurator.listAvailableEntitlementPools(any(Consumer.class),
-            any(Owner.class), any(String.class), any(String.class), eq(now), anyBoolean(),
+            any(Owner.class), any(String.class), any(String.class), eq(now),
             any(PoolFilterBuilder.class), any(PageRequest.class), anyBoolean(), anyBoolean(), anyBoolean()))
             .thenReturn(page);
 
@@ -1008,7 +1008,7 @@ public class PoolManagerTest {
 
         when(page.getPageData()).thenReturn(pools);
         when(mockPoolCurator.listAvailableEntitlementPools(any(Consumer.class), any(Owner.class),
-            any(String.class), any(String.class), eq(now), anyBoolean(),
+            any(String.class), any(String.class), eq(now),
             any(PoolFilterBuilder.class), any(PageRequest.class), anyBoolean(), anyBoolean(), anyBoolean()))
             .thenReturn(page);
 
@@ -1218,7 +1218,7 @@ public class PoolManagerTest {
 
         when(mockPoolCurator.listAvailableEntitlementPools(any(Consumer.class),
             any(Owner.class), anyString(), anyString(), eq(now),
-            anyBoolean(), any(PoolFilterBuilder.class),
+            any(PoolFilterBuilder.class),
             any(PageRequest.class), anyBoolean(), anyBoolean(), anyBoolean()))
                 .thenReturn(page);
 

--- a/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -961,8 +961,8 @@ public class PoolManagerTest {
         when(page.getPageData()).thenReturn(pools);
         when(mockPoolCurator.listAvailableEntitlementPools(any(Consumer.class),
             any(Owner.class), any(String.class), any(String.class), eq(now), anyBoolean(),
-            any(PoolFilterBuilder.class), any(PageRequest.class),
-            anyBoolean())).thenReturn(page);
+            any(PoolFilterBuilder.class), any(PageRequest.class), anyBoolean(), anyBoolean(), anyBoolean()))
+            .thenReturn(page);
 
         when(mockPoolCurator.lockAndLoadBatch(any(List.class))).thenReturn(Arrays.asList(pool1));
         when(enforcerMock.preEntitlement(any(Consumer.class), any(Pool.class), anyInt(),
@@ -1009,7 +1009,8 @@ public class PoolManagerTest {
         when(page.getPageData()).thenReturn(pools);
         when(mockPoolCurator.listAvailableEntitlementPools(any(Consumer.class), any(Owner.class),
             any(String.class), any(String.class), eq(now), anyBoolean(),
-            any(PoolFilterBuilder.class), any(PageRequest.class), anyBoolean())).thenReturn(page);
+            any(PoolFilterBuilder.class), any(PageRequest.class), anyBoolean(), anyBoolean(), anyBoolean()))
+            .thenReturn(page);
 
         when(mockPoolCurator.lockAndLoad(any(Pool.class))).thenReturn(pool1);
         when(mockPoolCurator.lockAndLoadBatch(any(List.class))).thenReturn(Arrays.asList(pool1));
@@ -1218,7 +1219,7 @@ public class PoolManagerTest {
         when(mockPoolCurator.listAvailableEntitlementPools(any(Consumer.class),
             any(Owner.class), anyString(), anyString(), eq(now),
             anyBoolean(), any(PoolFilterBuilder.class),
-            any(PageRequest.class), anyBoolean()))
+            any(PageRequest.class), anyBoolean(), anyBoolean(), anyBoolean()))
                 .thenReturn(page);
 
         when(mockPoolCurator.lockAndLoadBatch(anyListOf(String.class))).thenReturn(pools);

--- a/server/src/test/java/org/candlepin/model/PoolCuratorFilterTest.java
+++ b/server/src/test/java/org/candlepin/model/PoolCuratorFilterTest.java
@@ -96,8 +96,8 @@ public class PoolCuratorFilterTest extends DatabaseTestFixture {
 
     private void searchTest(PoolFilterBuilder filters, int expectedResults, String ... expectedIds) {
         Page<List<Pool>> page = poolCurator.listAvailableEntitlementPools(
-            null, owner, (Collection<String>) null, null, null, false, filters, req, false
-        );
+            null, owner, (Collection<String>) null, null, null, false, filters, req, false,
+            false, false);
         List<Pool> results = page.getPageData();
 
         assertEquals(expectedResults, results.size());

--- a/server/src/test/java/org/candlepin/model/PoolCuratorFilterTest.java
+++ b/server/src/test/java/org/candlepin/model/PoolCuratorFilterTest.java
@@ -96,7 +96,7 @@ public class PoolCuratorFilterTest extends DatabaseTestFixture {
 
     private void searchTest(PoolFilterBuilder filters, int expectedResults, String ... expectedIds) {
         Page<List<Pool>> page = poolCurator.listAvailableEntitlementPools(
-            null, owner, (Collection<String>) null, null, null, false, filters, req, false,
+            null, owner, (Collection<String>) null, null, null, filters, req, false,
             false, false);
         List<Pool> results = page.getPageData();
 

--- a/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
@@ -82,7 +82,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         poolCurator.create(pool);
 
         List<Pool> results = poolCurator.listAvailableEntitlementPools(
-            consumer, consumer.getOwner(), (Collection<String>) null, TestUtil.createDate(20450, 3, 2), true);
+            consumer, consumer.getOwner(), (Collection<String>) null, TestUtil.createDate(20450, 3, 2));
         assertEquals(0, results.size());
     }
 
@@ -93,13 +93,13 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         poolCurator.create(pool);
 
         List<Pool> results = poolCurator.listAvailableEntitlementPools(
-            consumer, consumer.getOwner(), (Collection<String>) null, TestUtil.createDate(2005, 3, 3), true);
+            consumer, consumer.getOwner(), (Collection<String>) null, TestUtil.createDate(2005, 3, 3));
         assertEquals(0, results.size());
 
         // If we specify no date filtering, the expired pool should be returned:
         results =
             poolCurator.listAvailableEntitlementPools(consumer, consumer.getOwner(),
-                (String) null, null, true);
+                (String) null, null);
         assertEquals(1, results.size());
     }
 
@@ -112,7 +112,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         ueberCertGenerator.generate(owner.getKey(), new NoAuthPrincipal());
 
         List<Pool> results = poolCurator.listAvailableEntitlementPools(
-            consumer, consumer.getOwner(), (Collection<String>) null, null, true);
+            consumer, consumer.getOwner(), (Collection<String>) null, null);
         assertEquals(1, results.size());
     }
 
@@ -142,7 +142,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         filters.addAttributeFilter("cores", "8");
 
         Page<List<Pool>> page = poolCurator.listAvailableEntitlementPools(
-            null, owner, (Collection<String>) null, null, activeDate, false, filters,
+            null, owner, (Collection<String>) null, null, activeDate, filters,
             req, false, false, false);
         List<Pool> results = page.getPageData();
         assertEquals(1, results.size());
@@ -172,7 +172,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         filters.addAttributeFilter("virt_only", "true");
 
         Page<List<Pool>> page = poolCurator.listAvailableEntitlementPools(
-            null, owner, (Collection<String>) null, null, activeDate, false, filters,
+            null, owner, (Collection<String>) null, null, activeDate, filters,
             req, false, false, false);
         List<Pool> results = page.getPageData();
         assertEquals(1, results.size());
@@ -201,7 +201,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         filters.addIdFilter(pool2.getId());
 
         Page<List<Pool>> page = poolCurator.listAvailableEntitlementPools(
-            null, owner, (Collection<String>) null, null, activeDate, false, filters, req, false,
+            null, owner, (Collection<String>) null, null, activeDate, filters, req, false,
             false, false);
         List<Pool> results = page.getPageData();
         assertEquals(1, results.size());
@@ -212,7 +212,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         filters.addIdFilter(pool2.getId());
 
         page = poolCurator.listAvailableEntitlementPools(
-            null, owner, (Collection<String>) null, null, activeDate, false, filters, req, false,
+            null, owner, (Collection<String>) null, null, activeDate, filters, req, false,
             false, false);
         results = page.getPageData();
         assertEquals(2, results.size());
@@ -240,7 +240,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         filters.addAttributeFilter("virt_only", "true");
 
         Page<List<Pool>> page = poolCurator.listAvailableEntitlementPools(
-            null, owner, (Collection<String>) null, null, activeDate, false, filters, null, false,
+            null, owner, (Collection<String>) null, null, activeDate, filters, null, false,
             false, false);
         List<Pool> results = page.getPageData();
 
@@ -277,7 +277,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         filters.addAttributeFilter("cores", "4");
 
         Page<List<Pool>> page = poolCurator.listAvailableEntitlementPools(
-            null, owner, (Collection<String>) null, null, activeDate, false, filters, req, false,
+            null, owner, (Collection<String>) null, null, activeDate, filters, req, false,
             false, false);
         List<Pool> results = page.getPageData();
         assertEquals(1, results.size());
@@ -309,7 +309,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         filters.addAttributeFilter("empty-attr", "");
 
         Page<List<Pool>> page = poolCurator.listAvailableEntitlementPools(
-            null, owner, (Collection<String>) null, null, activeDate, false, filters, req, false,
+            null, owner, (Collection<String>) null, null, activeDate, filters, req, false,
             false, false);
         List<Pool> results = page.getPageData();
         assertEquals(1, results.size());
@@ -339,7 +339,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         filters.addAttributeFilter("A", "FOO");
 
         Page<List<Pool>> page = poolCurator.listAvailableEntitlementPools(
-            null, owner, (Collection<String>) null, null, activeDate, false, filters, req, false,
+            null, owner, (Collection<String>) null, null, activeDate, filters, req, false,
             false, false);
         List<Pool> results = page.getPageData();
         assertEquals(1, results.size());
@@ -386,7 +386,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         req.setSortBy("id");
 
         Page<List<Pool>> page = poolCurator.listAvailableEntitlementPools(
-            guestConsumer, owner, (Collection<String>) null, null, activeDate, false, null, req, false,
+            guestConsumer, owner, (Collection<String>) null, null, activeDate, null, req, false,
             false, false);
         List<Pool> results = page.getPageData();
         assertEquals(1, results.size());
@@ -449,7 +449,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         filters.addAttributeFilter("B", "zoo");
 
         Page<List<Pool>> page = poolCurator.listAvailableEntitlementPools(
-            null, owner, (Collection<String>) null, null, activeDate, false, filters, req, false,
+            null, owner, (Collection<String>) null, null, activeDate, filters, req, false,
             false, false);
         List<Pool> results = page.getPageData();
         assertEquals(2, results.size());
@@ -819,7 +819,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         poolCurator.create(pool);
 
         assertEquals(1, poolCurator.listAvailableEntitlementPools(null, owner, (Collection<String>) null,
-            activeOn, false).size());
+            activeOn).size());
     }
 
     @Test
@@ -831,7 +831,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         poolCurator.create(pool);
 
         assertEquals(1, poolCurator.listAvailableEntitlementPools(null, owner, (Collection<String>) null,
-            activeOn, false).size());
+            activeOn).size());
     }
 
     @Test
@@ -844,7 +844,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         poolCurator.create(pool);
 
         assertEquals(1, poolCurator.listAvailableEntitlementPools(null, owner, (Collection<String>) null,
-            activeOn, false).size());
+            activeOn).size());
     }
 
     @Test
@@ -873,7 +873,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
 
         Date activeOn = TestUtil.createDate(2011, 2, 2);
         Page<List<Pool>> page = poolCurator.listAvailableEntitlementPools(
-            null, owner, product.getId(), null, activeOn, false, new PoolFilterBuilder(),
+            null, owner, product.getId(), null, activeOn, new PoolFilterBuilder(),
             req, false, false, false);
         assertEquals(Integer.valueOf(50), page.getMaxRecords());
 
@@ -907,7 +907,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
 
         Date activeOn = TestUtil.createDate(2011, 2, 2);
         Page<List<Pool>> page = poolCurator.listAvailableEntitlementPools(
-            null, owner, product.getId(), null, activeOn, false, new PoolFilterBuilder(),
+            null, owner, product.getId(), null, activeOn, new PoolFilterBuilder(),
             req, false, false, false);
         assertEquals(Integer.valueOf(5), page.getMaxRecords());
         assertEquals(5, page.getPageData().size());
@@ -928,7 +928,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
 
         Date activeOn = TestUtil.createDate(2011, 2, 2);
         Page<List<Pool>> page = poolCurator.listAvailableEntitlementPools(
-            null, owner, product.getId(), null, activeOn, false, new PoolFilterBuilder(),
+            null, owner, product.getId(), null, activeOn, new PoolFilterBuilder(),
             req, false, false, false);
         assertEquals(Integer.valueOf(5), page.getMaxRecords());
         assertEquals(0, page.getPageData().size());
@@ -949,7 +949,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
 
         Date activeOn = TestUtil.createDate(2011, 2, 2);
         Page<List<Pool>> page = poolCurator.listAvailableEntitlementPools(
-            null, owner, product.getId(), null, activeOn, false, new PoolFilterBuilder(),
+            null, owner, product.getId(), null, activeOn, new PoolFilterBuilder(),
             req, false, false, false);
         assertEquals(Integer.valueOf(5), page.getMaxRecords());
         assertEquals(1, page.getPageData().size());
@@ -972,7 +972,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
 
         Date activeOn = TestUtil.createDate(2011, 2, 2);
         Page<List<Pool>> page = poolCurator.listAvailableEntitlementPools(
-            null, owner, product.getId(), null, activeOn, false, new PoolFilterBuilder(),
+            null, owner, product.getId(), null, activeOn, new PoolFilterBuilder(),
             req, false, false, false);
         assertEquals(Integer.valueOf(0), page.getMaxRecords());
         assertEquals(0, page.getPageData().size());
@@ -1427,7 +1427,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         this.poolCurator.create(p2);
 
         Page<List<Pool>> result = this.poolCurator.listAvailableEntitlementPools(null, owner1,
-            (Collection<String>) null, "subscriptionId-phil", new Date(), false, null, null, false,
+            (Collection<String>) null, "subscriptionId-phil", new Date(), null, null, false,
             false, false);
         assertEquals("subscriptionId-phil", result.getPageData().get(0).getSubscriptionId());
     }

--- a/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
@@ -143,7 +143,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
 
         Page<List<Pool>> page = poolCurator.listAvailableEntitlementPools(
             null, owner, (Collection<String>) null, null, activeDate, false, filters,
-            req, false);
+            req, false, false, false);
         List<Pool> results = page.getPageData();
         assertEquals(1, results.size());
         assertEquals(pool2.getId(), results.get(0).getId());
@@ -173,7 +173,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
 
         Page<List<Pool>> page = poolCurator.listAvailableEntitlementPools(
             null, owner, (Collection<String>) null, null, activeDate, false, filters,
-            req, false);
+            req, false, false, false);
         List<Pool> results = page.getPageData();
         assertEquals(1, results.size());
         assertEquals(pool2.getId(), results.get(0).getId());
@@ -201,7 +201,8 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         filters.addIdFilter(pool2.getId());
 
         Page<List<Pool>> page = poolCurator.listAvailableEntitlementPools(
-            null, owner, (Collection<String>) null, null, activeDate, false, filters, req, false);
+            null, owner, (Collection<String>) null, null, activeDate, false, filters, req, false,
+            false, false);
         List<Pool> results = page.getPageData();
         assertEquals(1, results.size());
         assertEquals(pool2.getId(), results.get(0).getId());
@@ -211,7 +212,8 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         filters.addIdFilter(pool2.getId());
 
         page = poolCurator.listAvailableEntitlementPools(
-            null, owner, (Collection<String>) null, null, activeDate, false, filters, req, false);
+            null, owner, (Collection<String>) null, null, activeDate, false, filters, req, false,
+            false, false);
         results = page.getPageData();
         assertEquals(2, results.size());
     }
@@ -238,7 +240,8 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         filters.addAttributeFilter("virt_only", "true");
 
         Page<List<Pool>> page = poolCurator.listAvailableEntitlementPools(
-            null, owner, (Collection<String>) null, null, activeDate, false, filters, null, false);
+            null, owner, (Collection<String>) null, null, activeDate, false, filters, null, false,
+            false, false);
         List<Pool> results = page.getPageData();
 
         assertEquals(1, results.size());
@@ -274,7 +277,8 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         filters.addAttributeFilter("cores", "4");
 
         Page<List<Pool>> page = poolCurator.listAvailableEntitlementPools(
-            null, owner, (Collection<String>) null, null, activeDate, false, filters, req, false);
+            null, owner, (Collection<String>) null, null, activeDate, false, filters, req, false,
+            false, false);
         List<Pool> results = page.getPageData();
         assertEquals(1, results.size());
         assertEquals(pool2.getId(), results.get(0).getId());
@@ -305,7 +309,8 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         filters.addAttributeFilter("empty-attr", "");
 
         Page<List<Pool>> page = poolCurator.listAvailableEntitlementPools(
-            null, owner, (Collection<String>) null, null, activeDate, false, filters, req, false);
+            null, owner, (Collection<String>) null, null, activeDate, false, filters, req, false,
+            false, false);
         List<Pool> results = page.getPageData();
         assertEquals(1, results.size());
         assertEquals(pool2.getId(), results.get(0).getId());
@@ -334,7 +339,8 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         filters.addAttributeFilter("A", "FOO");
 
         Page<List<Pool>> page = poolCurator.listAvailableEntitlementPools(
-            null, owner, (Collection<String>) null, null, activeDate, false, filters, req, false);
+            null, owner, (Collection<String>) null, null, activeDate, false, filters, req, false,
+            false, false);
         List<Pool> results = page.getPageData();
         assertEquals(1, results.size());
         assertEquals(pool, results.get(0));
@@ -380,7 +386,8 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         req.setSortBy("id");
 
         Page<List<Pool>> page = poolCurator.listAvailableEntitlementPools(
-            guestConsumer, owner, (Collection<String>) null, null, activeDate, false, null, req, false);
+            guestConsumer, owner, (Collection<String>) null, null, activeDate, false, null, req, false,
+            false, false);
         List<Pool> results = page.getPageData();
         assertEquals(1, results.size());
         assertEquals(pool, results.get(0));
@@ -442,7 +449,8 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         filters.addAttributeFilter("B", "zoo");
 
         Page<List<Pool>> page = poolCurator.listAvailableEntitlementPools(
-            null, owner, (Collection<String>) null, null, activeDate, false, filters, req, false);
+            null, owner, (Collection<String>) null, null, activeDate, false, filters, req, false,
+            false, false);
         List<Pool> results = page.getPageData();
         assertEquals(2, results.size());
 
@@ -866,7 +874,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         Date activeOn = TestUtil.createDate(2011, 2, 2);
         Page<List<Pool>> page = poolCurator.listAvailableEntitlementPools(
             null, owner, product.getId(), null, activeOn, false, new PoolFilterBuilder(),
-            req, false);
+            req, false, false, false);
         assertEquals(Integer.valueOf(50), page.getMaxRecords());
 
         List<Pool> pools = page.getPageData();
@@ -900,7 +908,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         Date activeOn = TestUtil.createDate(2011, 2, 2);
         Page<List<Pool>> page = poolCurator.listAvailableEntitlementPools(
             null, owner, product.getId(), null, activeOn, false, new PoolFilterBuilder(),
-            req, false);
+            req, false, false, false);
         assertEquals(Integer.valueOf(5), page.getMaxRecords());
         assertEquals(5, page.getPageData().size());
     }
@@ -921,7 +929,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         Date activeOn = TestUtil.createDate(2011, 2, 2);
         Page<List<Pool>> page = poolCurator.listAvailableEntitlementPools(
             null, owner, product.getId(), null, activeOn, false, new PoolFilterBuilder(),
-            req, false);
+            req, false, false, false);
         assertEquals(Integer.valueOf(5), page.getMaxRecords());
         assertEquals(0, page.getPageData().size());
     }
@@ -942,7 +950,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         Date activeOn = TestUtil.createDate(2011, 2, 2);
         Page<List<Pool>> page = poolCurator.listAvailableEntitlementPools(
             null, owner, product.getId(), null, activeOn, false, new PoolFilterBuilder(),
-            req, false);
+            req, false, false, false);
         assertEquals(Integer.valueOf(5), page.getMaxRecords());
         assertEquals(1, page.getPageData().size());
     }
@@ -965,7 +973,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         Date activeOn = TestUtil.createDate(2011, 2, 2);
         Page<List<Pool>> page = poolCurator.listAvailableEntitlementPools(
             null, owner, product.getId(), null, activeOn, false, new PoolFilterBuilder(),
-            req, false);
+            req, false, false, false);
         assertEquals(Integer.valueOf(0), page.getMaxRecords());
         assertEquals(0, page.getPageData().size());
     }
@@ -1419,7 +1427,8 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         this.poolCurator.create(p2);
 
         Page<List<Pool>> result = this.poolCurator.listAvailableEntitlementPools(null, owner1,
-            (Collection<String>) null, "subscriptionId-phil", new Date(), false, null, null, false);
+            (Collection<String>) null, "subscriptionId-phil", new Date(), false, null, null, false,
+            false, false);
         assertEquals("subscriptionId-phil", result.getPageData().get(0).getSubscriptionId());
     }
 

--- a/server/src/test/java/org/candlepin/model/PoolTest.java
+++ b/server/src/test/java/org/candlepin/model/PoolTest.java
@@ -208,7 +208,7 @@ public class PoolTest extends DatabaseTestFixture {
 
 
         List<Pool> results = poolCurator.listAvailableEntitlementPools(
-            null, owner, childProduct.getId(), null, false
+            null, owner, childProduct.getId(), null
         );
         assertEquals(1, results.size());
         assertEquals(pool.getId(), results.get(0).getId());

--- a/server/src/test/java/org/candlepin/policy/CriteriaRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/CriteriaRulesTest.java
@@ -64,7 +64,7 @@ public class CriteriaRulesTest extends DatabaseTestFixture {
         poolCurator.merge(virtPool);
 
         List<Pool> results = poolCurator.listAvailableEntitlementPools(consumer, null,
-            (Collection<String>) null, null, false);
+            (Collection<String>) null, null);
 
         assertEquals(1, results.size());
         assertEquals(physicalPool.getId(), results.get(0).getId());
@@ -72,7 +72,7 @@ public class CriteriaRulesTest extends DatabaseTestFixture {
         // Make the consumer a guest and try again:
         consumer.setFact("virt.is_guest", "true");
         results = poolCurator.listAvailableEntitlementPools(consumer, null,
-            (Collection<String>) null, null, false);
+            (Collection<String>) null, null);
 
         assertEquals(2, results.size());
 
@@ -91,13 +91,13 @@ public class CriteriaRulesTest extends DatabaseTestFixture {
         this.createPool(owner, targetProduct, 1L, new Date(), new Date());
 
         List<Pool> results = poolCurator.listAvailableEntitlementPools(consumer, null,
-            (Collection<String>) null, null, false);
+            (Collection<String>) null, null);
 
         assertEquals(0, results.size());
         // Make the consumer a guest and try again:
         consumer.setFact("virt.is_guest", "true");
         results = poolCurator.listAvailableEntitlementPools(consumer, null,
-            (Collection<String>) null, null, false);
+            (Collection<String>) null, null);
 
         assertEquals(2, results.size());
     }
@@ -125,7 +125,7 @@ public class CriteriaRulesTest extends DatabaseTestFixture {
         poolCurator.merge(anotherVirtPool);
 
         List<Pool> results = poolCurator.listAvailableEntitlementPools(consumer, null,
-            (Collection<String>) null, null, false);
+            (Collection<String>) null, null);
 
         assertEquals(0, results.size());
 
@@ -135,7 +135,7 @@ public class CriteriaRulesTest extends DatabaseTestFixture {
         consumerCurator.update(consumer);
         assertEquals(host.getUuid(), consumerCurator.getHost("GUESTUUID", owner).getUuid());
         results = poolCurator.listAvailableEntitlementPools(consumer, null,
-            (Collection<String>) null, null, false);
+            (Collection<String>) null, null);
 
         assertEquals(1, results.size());
         assertEquals(virtPool.getId(), results.get(0).getId());
@@ -161,7 +161,7 @@ public class CriteriaRulesTest extends DatabaseTestFixture {
         poolCurator.merge(virtPool);
 
         List<Pool> results = poolCurator.listAvailableEntitlementPools(c, null, (Collection<String>) null,
-            null, false);
+            null);
         assertEquals(0, results.size());
     }
 
@@ -184,7 +184,7 @@ public class CriteriaRulesTest extends DatabaseTestFixture {
         poolCurator.merge(virtPool);
 
         List<Pool> results = poolCurator.listAvailableEntitlementPools(c, null, (Collection<String>) null,
-            null, false);
+            null);
         assertEquals(1, results.size());
     }
 }

--- a/server/src/test/java/org/candlepin/resource/OwnerResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/OwnerResourceTest.java
@@ -445,7 +445,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         securityInterceptor.enable();
 
         ownerResource.listPools(owner.getKey(), null, null, null, null, false, null,
-            null, new ArrayList<KeyValueParameter>(), principal, null);
+            null, new ArrayList<KeyValueParameter>(), false, false, principal, null);
     }
 
     @Test
@@ -479,14 +479,15 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         poolCurator.create(pool2);
 
         List<Pool> nowList = ownerResource.listPools(owner.getKey(), c.getUuid(), null, null, null, false,
-            null, null, new ArrayList<KeyValueParameter>(), principal, null);
+            null, null, new ArrayList<KeyValueParameter>(), false, false, principal, null);
         assertEquals(1, nowList.size());
         assert (nowList.get(0).getId().equals(pool1.getId()));
 
         Date activeOn = new Date(pool2.getStartDate().getTime() + 1000L * 60 * 60 * 24);
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
         List<Pool> futureList = ownerResource.listPools(owner.getKey(), c.getUuid(), null, null, null,
-            false, sdf.format(activeOn), null, new ArrayList<KeyValueParameter>(), principal, null);
+            false, sdf.format(activeOn), null, new ArrayList<KeyValueParameter>(), false, false,
+            principal, null);
         assertEquals(1, futureList.size());
         assert (futureList.get(0).getId().equals(pool2.getId()));
     }
@@ -503,7 +504,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
 
         List<Pool> pools = ownerResource.listPools(owner.getKey(),
             null, null, null, null, true, null, null,
-            new ArrayList<KeyValueParameter>(), principal, null);
+            new ArrayList<KeyValueParameter>(), false, false, principal, null);
         assertEquals(2, pools.size());
     }
 
@@ -526,7 +527,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         params.add(createKeyValueParam("cores", "12"));
 
         List<Pool> pools = ownerResource.listPools(owner.getKey(), null,
-            null, null, null, true, null, null, params, principal, null);
+            null, null, null, true, null, null, params, false, false, principal, null);
         assertEquals(1, pools.size());
         assertEquals(pool2, pools.get(0));
 
@@ -534,7 +535,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         params.add(createKeyValueParam("virt_only", "true"));
 
         pools = ownerResource.listPools(owner.getKey(), null, null,
-            null, null, true, null, null, params, principal, null);
+            null, null, true, null, null, params, false, false, principal, null);
         assertEquals(1, pools.size());
         assertEquals(pool1, pools.get(0));
     }
@@ -556,13 +557,13 @@ public class OwnerResourceTest extends DatabaseTestFixture {
 
         List<KeyValueParameter> params = new ArrayList<KeyValueParameter>();
         List<Pool> pools = ownerResource.listPools(owner.getKey(), null,
-            null, null, null, true, null, null, params, principal, null);
+            null, null, null, true, null, null, params, false, false, principal, null);
         assertEquals(2, pools.size());
 
         params = new ArrayList<KeyValueParameter>();
         params.add(createKeyValueParam(Pool.Attributes.DEVELOPMENT_POOL, "!true"));
         pools = ownerResource.listPools(owner.getKey(), null,
-            null, null, null, true, null, null, params, principal, null);
+            null, null, null, true, null, null, params, false, false, principal, null);
         assertEquals(1, pools.size());
         assertEquals(pool2, pools.get(0));
     }
@@ -584,7 +585,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
 
         // Filtering should just cause this to return no results:
         ownerResource.listPools(owner.getKey(), null, null, null, null, true, null,
-            null, new ArrayList<KeyValueParameter>(), principal, null);
+            null, new ArrayList<KeyValueParameter>(), false, false, principal, null);
     }
 
     @Test(expected = ForbiddenException.class)
@@ -776,7 +777,8 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         securityInterceptor.enable();
 
         List<Pool> pools = ownerResource.listPools(owner.getKey(), c.getUuid(), null,
-            p.getId(), null, true, null, null, new ArrayList<KeyValueParameter>(), principal, null);
+            p.getId(), null, true, null, null, new ArrayList<KeyValueParameter>(), false, false,
+            principal, null);
         assertEquals(1, pools.size());
         Pool returnedPool = pools.get(0);
         assertNotNull(returnedPool.getCalculatedAttributes());
@@ -800,7 +802,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
 
         ownerResource.listPools(owner.getKey(), c.getUuid(), null,
             p.getUuid(),  null, true, null, null,
-            new ArrayList<KeyValueParameter>(), setupPrincipal(owner2, Access.NONE), null);
+            new ArrayList<KeyValueParameter>(), false, false, setupPrincipal(owner2, Access.NONE), null);
     }
 
     @Test


### PR DESCRIPTION
Either future only or active and future together.


To test this function you will need to use the two new query parameters 'add_future' and 'only_future' in conjunction with the 'activeon' parameter.

'activeon' determines what 'now' is for the other parameters. When not passed in, the current date will be used. If add_future is set to true, then you will get back any pool whose starting date is after the 'activeon' date in addition to those that the method previously returned. If only_future is set to true, then you will only get back the future date pools.

You may not use both add_future and only_future at the same time. It will return a bad request exception.   