### PR TITLE
Fixed a bug that broke CP2 migration with activation keys

### DIFF
--- a/server/src/main/java/org/candlepin/liquibase/PerOrgProductsMigrationTask.java
+++ b/server/src/main/java/org/candlepin/liquibase/PerOrgProductsMigrationTask.java
@@ -445,7 +445,7 @@ public class PerOrgProductsMigrationTask extends LiquibaseCustomTask {
 
         this.executeUpdate(
             "INSERT INTO cp2_activation_key_products(key_id, product_uuid) " +
-            "SELECT akp.id, p.uuid " +
+            "SELECT akp.key_id, p.uuid " +
             "FROM cp_activationkey_product akp " +
             "JOIN cp2_products p ON akp.product_id = p.product_id"
         );


### PR DESCRIPTION
- Fixed the query responsible for migrating activation keys to no
  longer reference a dummy ID on the join table for activation key
  products