### PR TITLE
1416825: Abstracted out property validation to new validator framework

### DIFF
--- a/server/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/server/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -223,6 +223,10 @@ public class ConfigProperties {
 
     public static final String SYNC_WORK_DIR = "candlepin.sync.work_dir";
 
+    /**
+     *  Controls which facts will be stored by Candlepin -- facts with keys that do not match this
+     *  value will be discarded.
+     */
     public static final String CONSUMER_FACTS_MATCHER = "candlepin.consumer.facts.match_regex";
 
     public static final String SHARD_USERNAME = "candlepin.shard.username";

--- a/server/src/main/java/org/candlepin/guice/CandlepinModule.java
+++ b/server/src/main/java/org/candlepin/guice/CandlepinModule.java
@@ -134,6 +134,8 @@ import org.candlepin.sync.EntitlementCertExporter;
 import org.candlepin.sync.Exporter;
 import org.candlepin.sync.MetaExporter;
 import org.candlepin.sync.RulesExporter;
+import org.candlepin.util.AttributeValidator;
+import org.candlepin.util.FactValidator;
 import org.candlepin.util.DateSource;
 import org.candlepin.util.DateSourceImpl;
 import org.candlepin.util.ExpiryDateFunction;
@@ -260,6 +262,8 @@ public class CandlepinModule extends AbstractModule {
         bind(DeletedConsumerResource.class);
         bind(CdnResource.class);
         bind(GuestIdResource.class);
+        bind(AttributeValidator.class);
+        bind(FactValidator.class);
 
         configureInterceptors();
         configureAuth();

--- a/server/src/main/java/org/candlepin/policy/js/compliance/ComplianceRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/compliance/ComplianceRules.java
@@ -162,7 +162,7 @@ public class ComplianceRules {
 
                 if (updateConsumer && (complianceChanged || entStatusChanged)) {
                     // Merge might work better here, but we use update in other places for this
-                    consumerCurator.updateWithOptionalFlush(c, false);
+                    consumerCurator.update(c, false);
                 }
             }
             return result;

--- a/server/src/main/java/org/candlepin/util/AttributeValidator.java
+++ b/server/src/main/java/org/candlepin/util/AttributeValidator.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2009 - 2016 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.util;
+
+import org.candlepin.common.config.Configuration;
+import org.candlepin.config.ConfigProperties;
+
+import com.google.inject.Inject;
+
+import org.xnap.commons.i18n.I18n;
+
+import java.util.Set;
+
+
+
+/**
+ * The AttributeValidator is a PropertyValidator implementation, configured to validate pool or
+ * product attributes.
+ */
+public class AttributeValidator extends PropertyValidator {
+    /** The maximum length of any fact key (name) or value */
+    public static final int ATTRIBUTE_MAX_LENGTH = 255;
+
+    @Inject
+    public AttributeValidator(Configuration config, I18n i18n) {
+        Set<String> attributes;
+
+        // Add integer attributes...
+        attributes = config.getSet(ConfigProperties.INTEGER_ATTRIBUTES, null);
+        if (attributes != null) {
+            for (String key : attributes) {
+                this.validators.put(key, new PropertyValidator.IntegerValidator(i18n, "attribute"));
+            }
+        }
+
+        // Add non-negative integer attributes...
+        attributes = config.getSet(ConfigProperties.NON_NEG_INTEGER_ATTRIBUTES, null);
+        if (attributes != null) {
+            for (String key : attributes) {
+                this.validators.put(key,
+                    new PropertyValidator.NonNegativeIntegerValidator(i18n, "attribute"));
+            }
+        }
+
+        // Add long attributes...
+        attributes = config.getSet(ConfigProperties.LONG_ATTRIBUTES, null);
+        if (attributes != null) {
+            for (String key : attributes) {
+                this.validators.put(key, new PropertyValidator.LongValidator(i18n, "attribute"));
+            }
+        }
+
+        // Add non-negative long attributes...
+        attributes = config.getSet(ConfigProperties.NON_NEG_LONG_ATTRIBUTES, null);
+        if (attributes != null) {
+            for (String key : attributes) {
+                this.validators.put(key, new PropertyValidator.NonNegativeLongValidator(i18n, "attribute"));
+            }
+        }
+
+        // Add boolean attributes...
+        attributes = config.getSet(ConfigProperties.BOOLEAN_ATTRIBUTES, null);
+        if (attributes != null) {
+            for (String key : attributes) {
+                this.validators.put(key, new PropertyValidator.BooleanValidator(i18n, "attribute"));
+            }
+        }
+
+        // Add global validators...
+        this.globalValidators.add(
+            new PropertyValidator.LengthValidator(i18n, "attribute", ATTRIBUTE_MAX_LENGTH));
+    }
+
+}

--- a/server/src/main/java/org/candlepin/util/FactValidator.java
+++ b/server/src/main/java/org/candlepin/util/FactValidator.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2009 - 2016 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.util;
+
+import org.candlepin.common.config.Configuration;
+import org.candlepin.config.ConfigProperties;
+
+import com.google.inject.Inject;
+
+import org.xnap.commons.i18n.I18n;
+
+import java.util.Set;
+
+
+
+/**
+ * The FactValidator is a PropertyValidator implementation, configured to validate consumer facts.
+ */
+public class FactValidator extends PropertyValidator {
+    /** The maximum length of any fact key (name) or value */
+    public static final int FACT_MAX_LENGTH = 255;
+
+    @Inject
+    public FactValidator(Configuration config, I18n i18n) {
+        Set<String> attributes;
+
+        // Add integer attributes...
+        attributes = config.getSet(ConfigProperties.INTEGER_FACTS, null);
+        if (attributes != null) {
+            for (String key : attributes) {
+                this.validators.put(key, new PropertyValidator.IntegerValidator(i18n, "fact"));
+            }
+        }
+
+        // Add non-negative integer attributes...
+        attributes = config.getSet(ConfigProperties.NON_NEG_INTEGER_FACTS, null);
+        if (attributes != null) {
+            for (String key : attributes) {
+                this.validators.put(key, new PropertyValidator.NonNegativeIntegerValidator(i18n, "fact"));
+            }
+        }
+
+        // Add global validators...
+        this.globalValidators.add(new PropertyValidator.LengthValidator(i18n, "fact", FACT_MAX_LENGTH));
+    }
+}

--- a/server/src/main/java/org/candlepin/util/PropertyValidationException.java
+++ b/server/src/main/java/org/candlepin/util/PropertyValidationException.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2009 - 2016 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.util;
+
+import org.candlepin.common.exceptions.CandlepinException;
+
+import javax.ws.rs.core.Response.Status;
+
+
+
+/**
+ * Represents an exception caused by a property (attribute, fact, etc.) containing an illegal
+ * key or value.
+ */
+public class PropertyValidationException extends CandlepinException {
+    private static final long serialVersionUID = 1L;
+
+    public PropertyValidationException(String message) {
+        super(Status.BAD_REQUEST, message);
+    }
+}

--- a/server/src/main/java/org/candlepin/util/PropertyValidator.java
+++ b/server/src/main/java/org/candlepin/util/PropertyValidator.java
@@ -1,0 +1,248 @@
+/**
+ * Copyright (c) 2009 - 2016 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.util;
+
+import org.xnap.commons.i18n.I18n;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+
+
+/**
+ * The PropertyValidator class provides a simple framework for determining whether or not a given
+ * value is valid for a specified property. The abstraction of this logic allows the logic to be
+ * reused for multiple classes of property (i.e. attributes, facts, etc.).
+ */
+public abstract class PropertyValidator {
+
+    /**
+     * Mini-class for performing validation of a class of values
+     */
+    protected abstract static class Validator {
+        protected I18n i18n;
+        protected String propertyType;
+
+        public Validator(I18n i18n, String propertyType) {
+            if (i18n == null) {
+                throw new IllegalArgumentException("i18n is null");
+            }
+
+            if (propertyType == null) {
+                throw new IllegalArgumentException("propertyType is null");
+            }
+
+            this.i18n = i18n;
+            this.propertyType = propertyType;
+        }
+
+        public abstract void validate(String key, String value);
+    }
+
+    /**
+     * Validator verifying the key or value are small enough to fit in the database
+     */
+    protected static class LengthValidator extends Validator {
+        private int length;
+
+        public LengthValidator(I18n i18n, String propertyType, int length) {
+            super(i18n, propertyType);
+
+            if (length < 0) {
+                throw new IllegalArgumentException("length is a non-positive value");
+            }
+
+            this.length = length;
+        }
+
+        public void validate(String key, String value) {
+            if (key.length() > this.length) {
+                throw new PropertyValidationException(this.i18n.tr(
+                    "The {0} name \"{1}\" must not exceed {2} characters in length",
+                    this.propertyType, key, this.length
+                ));
+            }
+
+            if (value != null && value.length() > this.length) {
+                throw new PropertyValidationException(this.i18n.tr(
+                    "The value for {0} \"{1}\" must not exceed {2} characters in length",
+                    this.propertyType, key, this.length
+                ));
+            }
+        }
+    }
+
+    /**
+     * Validator providing validation for integer properties
+     */
+    protected static class IntegerValidator extends Validator {
+        public IntegerValidator(I18n i18n, String propertyType) {
+            super(i18n, propertyType);
+        }
+
+        public void validate(String key, String value) {
+            try {
+                Integer.parseInt(value);
+            }
+            catch (NumberFormatException nfe) {
+                throw new PropertyValidationException(this.i18n.tr(
+                    "The {0} \"{1}\" must be an integer value", this.propertyType, key));
+            }
+        }
+    }
+
+    /**
+     * Validator providing validation for non-negative properties
+     */
+    protected static class NonNegativeIntegerValidator extends Validator {
+        public NonNegativeIntegerValidator(I18n i18n, String propertyType) {
+            super(i18n, propertyType);
+        }
+
+        public void validate(String key, String value) {
+            try {
+                int parsed = Integer.parseInt(value);
+
+                if (parsed < 0) {
+                    throw new PropertyValidationException(this.i18n.tr(
+                        "The {0} \"{1}\" must be a positive, integer value", this.propertyType, key));
+                }
+            }
+            catch (NumberFormatException nfe) {
+                throw new PropertyValidationException(this.i18n.tr(
+                    "The {0} \"{1}\" must be a positive, integer value", this.propertyType, key));
+            }
+        }
+    }
+
+    /**
+     * Validator providing validation for long-integer properties
+     */
+    protected static class LongValidator extends Validator {
+        public LongValidator(I18n i18n, String propertyType) {
+            super(i18n, propertyType);
+        }
+
+        public void validate(String key, String value) {
+            try {
+                Long.parseLong(value);
+            }
+            catch (NumberFormatException nfe) {
+                throw new PropertyValidationException(this.i18n.tr(
+                    "The {0} \"{1}\" must be a long-integer value", this.propertyType, key));
+            }
+        }
+    }
+
+    /**
+     * Validator providing validation for non-negative, long-integer properties
+     */
+    protected static class NonNegativeLongValidator extends Validator {
+        public NonNegativeLongValidator(I18n i18n, String propertyType) {
+            super(i18n, propertyType);
+        }
+
+        public void validate(String key, String value) {
+            try {
+                long parsed = Long.parseLong(value);
+
+                if (parsed < 0) {
+                    throw new PropertyValidationException(this.i18n.tr(
+                        "The {0} \"{1}\" must be a positive, long-integer value", this.propertyType, key));
+                }
+            }
+            catch (NumberFormatException nfe) {
+                throw new PropertyValidationException(this.i18n.tr(
+                    "The {0} \"{1}\" must be a positive, long-integer value", this.propertyType, key));
+            }
+        }
+    }
+
+    /**
+     * Validator providing validation for Boolean properties
+     */
+    protected static class BooleanValidator extends Validator {
+        private static final Set<String> BOOLEAN_VALUES = Collections.unmodifiableSet(new HashSet<String>(
+            Arrays.asList("true", "false", "1", "0")
+        ));
+
+        public BooleanValidator(I18n i18n, String propertyType) {
+            super(i18n, propertyType);
+        }
+
+        public void validate(String key, String value) {
+            if (!(BOOLEAN_VALUES.contains(value.trim().toLowerCase()))) {
+                throw new PropertyValidationException(this.i18n.tr(
+                    "The {0} \"{1}\" must be a Boolean value", this.propertyType, key));
+            }
+        }
+    }
+
+
+    protected Map<String, Validator> validators;
+    protected Set<Validator> globalValidators;
+
+    /**
+     * Creates a new PropertyValidator instance.
+     */
+    public PropertyValidator() {
+        this.validators = new HashMap<String, Validator>();
+        this.globalValidators = new HashSet<Validator>();
+
+        // Validators will be added by subclasses as necessary
+    }
+
+    /**
+     * Checks whether the value given for the specified key is valid.
+     *
+     * @param key
+     *  The key (property name) to validate
+     *
+     * @param value
+     *  The value to validate
+     *
+     * @throws IllegalArgumentException
+     *  if key is null
+     *
+     * #throws PropertyValidationException
+     *  if the given property has an illegal value
+     */
+    // TODO: Fix the Javadoc above once we can workaround/fix the checkstyle issue that prevents
+    // it from finding the PropertyValidationException.
+    public void validate(String key, String value) {
+        if (key == null) {
+            throw new IllegalArgumentException("key is null");
+        }
+
+        for (Validator validator : this.globalValidators) {
+            if (validator != null) {
+                validator.validate(key, value);
+            }
+        }
+
+        if (value != null && !value.isEmpty()) {
+            Validator validator = this.validators.get(key);
+
+            if (validator != null) {
+                validator.validate(key, value);
+            }
+        }
+    }
+
+}

--- a/server/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
@@ -22,6 +22,8 @@ import org.candlepin.config.ConfigProperties;
 import org.candlepin.model.ConsumerType.ConsumerTypeEnum;
 import org.candlepin.resource.util.ResourceDateParser;
 import org.candlepin.test.DatabaseTestFixture;
+import org.candlepin.util.FactValidator;
+import org.candlepin.util.PropertyValidationException;
 import org.candlepin.util.Util;
 
 import org.junit.Before;
@@ -30,6 +32,7 @@ import org.mockito.Mockito;
 import static org.mockito.Mockito.*;
 
 import java.math.BigInteger;
+import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
@@ -56,15 +59,19 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
     private Consumer factConsumer;
 
     @Before
-    public void setUp() {
+    public void setUp() throws Exception {
         owner = new Owner("test-owner", "Test Owner");
         owner = ownerCurator.create(owner);
         ct = new ConsumerType(ConsumerTypeEnum.SYSTEM);
         ct = consumerTypeCurator.create(ct);
 
-        config.setProperty(ConfigProperties.INTEGER_FACTS,
-            "system.count, system.multiplier");
+        config.setProperty(ConfigProperties.INTEGER_FACTS, "system.count, system.multiplier");
         config.setProperty(ConfigProperties.NON_NEG_INTEGER_FACTS, "system.count");
+
+        // Inject this factValidator into the curator
+        Field field = ConsumerCurator.class.getDeclaredField("factValidator");
+        field.setAccessible(true);
+        field.set(this.consumerCurator, new FactValidator(this.config, this.i18n));
 
         factConsumer = new Consumer("a consumer", "username", owner, ct);
     }
@@ -469,7 +476,7 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
         assertEquals(factConsumer.getFact("system.multiplier"), "-2");
     }
 
-    @Test
+    @Test(expected = PropertyValidationException.class)
     public void testConsumerFactsVerifyBadInt() {
         Map<String, String> facts = new HashMap<String, String>();
         facts.put("system.count", "zzz");
@@ -477,11 +484,9 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
 
         factConsumer.setFacts(facts);
         factConsumer = consumerCurator.create(factConsumer);
-        assertEquals(factConsumer.getFact("system.count"), null);
-        assertEquals(factConsumer.getFact("system.multiplier"), "-2");
     }
 
-    @Test
+    @Test(expected = PropertyValidationException.class)
     public void testConsumerFactsVerifyBadPositive() {
         Map<String, String> facts = new HashMap<String, String>();
         facts.put("system.count", "-2");
@@ -489,11 +494,9 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
 
         factConsumer.setFacts(facts);
         factConsumer = consumerCurator.create(factConsumer);
-        assertEquals(factConsumer.getFact("system.count"), null);
-        assertEquals(factConsumer.getFact("system.multiplier"), "-2");
     }
 
-    @Test
+    @Test(expected = PropertyValidationException.class)
     public void testConsumerFactsVerifyBadUpdateValue() {
         Map<String, String> facts = new HashMap<String, String>();
         facts.put("system.count", "3");
@@ -507,8 +510,6 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
 
         factConsumer.setFact("system.count", "sss");
         factConsumer = consumerCurator.update(factConsumer);
-        assertEquals(factConsumer.getFact("system.count"), null);
-        assertEquals(factConsumer.getFact("system.multiplier"), "-2");
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
@@ -45,6 +45,8 @@ import java.util.Set;
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
 
+
+
 /**
  * ConsumerCuratorTest JUnit tests for Consumer database code
  */

--- a/server/src/test/java/org/candlepin/model/ConsumerTest.java
+++ b/server/src/test/java/org/candlepin/model/ConsumerTest.java
@@ -414,33 +414,6 @@ public class ConsumerTest extends DatabaseTestFixture {
         assertEquals(consumer, consumerCurator.findByUser(user));
     }
 
-    // @Test
-    // public void testConsumerFactsFilter() {
-    //     String oldValue = config.getString(ConfigProperties.CONSUMER_FACTS_MATCHER);
-    //     config.setProperty(ConfigProperties.CONSUMER_FACTS_MATCHER, "^goodkey.*");
-
-    //     Consumer consumer = new Consumer("a consumer", "username", owner, consumerType);
-
-    //     Map<String, String> facts = new HashMap<String, String>();
-    //     facts.put("badkey.something", "zaz");
-    //     facts.put("goodkey.something", "foobar");
-
-    //     consumer.setFacts(facts);
-
-    //     consumer = consumerCurator.create(consumer);
-
-    //     assertNull(consumer.getFact("badkey.something"));
-    //     assertEquals("foobar", consumer.getFact("goodkey.something"));
-
-    //     consumer.setFact("anotherbadkey", "zippy");
-
-    //     consumer = consumerCurator.update(consumer);
-
-    //     assertNull(consumer.getFact("anotherbadkey"));
-
-    //     config.setProperty(ConfigProperties.CONSUMER_FACTS_MATCHER, oldValue);
-    // }
-
     @Test
     public void testInstalledProducts() throws Exception {
         Consumer lookedUp = consumerCurator.find(consumer.getId());

--- a/server/src/test/java/org/candlepin/model/ConsumerTest.java
+++ b/server/src/test/java/org/candlepin/model/ConsumerTest.java
@@ -18,7 +18,6 @@ import static org.junit.Assert.*;
 
 import org.candlepin.auth.ConsumerPrincipal;
 import org.candlepin.common.config.Configuration;
-import org.candlepin.config.ConfigProperties;
 import org.candlepin.model.ConsumerType.ConsumerTypeEnum;
 import org.candlepin.resource.ConsumerResource;
 import org.candlepin.test.DatabaseTestFixture;
@@ -28,11 +27,12 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Date;
-import java.util.HashMap;
 import java.util.Map;
 
 import javax.inject.Inject;
 import javax.persistence.PersistenceException;
+
+
 
 public class ConsumerTest extends DatabaseTestFixture {
 
@@ -414,32 +414,32 @@ public class ConsumerTest extends DatabaseTestFixture {
         assertEquals(consumer, consumerCurator.findByUser(user));
     }
 
-    @Test
-    public void testConsumerFactsFilter() {
-        String oldValue = config.getString(ConfigProperties.CONSUMER_FACTS_MATCHER);
-        config.setProperty(ConfigProperties.CONSUMER_FACTS_MATCHER, "^goodkey.*");
+    // @Test
+    // public void testConsumerFactsFilter() {
+    //     String oldValue = config.getString(ConfigProperties.CONSUMER_FACTS_MATCHER);
+    //     config.setProperty(ConfigProperties.CONSUMER_FACTS_MATCHER, "^goodkey.*");
 
-        Consumer consumer = new Consumer("a consumer", "username", owner, consumerType);
+    //     Consumer consumer = new Consumer("a consumer", "username", owner, consumerType);
 
-        Map<String, String> facts = new HashMap<String, String>();
-        facts.put("badkey.something", "zaz");
-        facts.put("goodkey.something", "foobar");
+    //     Map<String, String> facts = new HashMap<String, String>();
+    //     facts.put("badkey.something", "zaz");
+    //     facts.put("goodkey.something", "foobar");
 
-        consumer.setFacts(facts);
+    //     consumer.setFacts(facts);
 
-        consumer = consumerCurator.create(consumer);
+    //     consumer = consumerCurator.create(consumer);
 
-        assertNull(consumer.getFact("badkey.something"));
-        assertEquals("foobar", consumer.getFact("goodkey.something"));
+    //     assertNull(consumer.getFact("badkey.something"));
+    //     assertEquals("foobar", consumer.getFact("goodkey.something"));
 
-        consumer.setFact("anotherbadkey", "zippy");
+    //     consumer.setFact("anotherbadkey", "zippy");
 
-        consumer = consumerCurator.update(consumer);
+    //     consumer = consumerCurator.update(consumer);
 
-        assertNull(consumer.getFact("anotherbadkey"));
+    //     assertNull(consumer.getFact("anotherbadkey"));
 
-        config.setProperty(ConfigProperties.CONSUMER_FACTS_MATCHER, oldValue);
-    }
+    //     config.setProperty(ConfigProperties.CONSUMER_FACTS_MATCHER, oldValue);
+    // }
 
     @Test
     public void testInstalledProducts() throws Exception {

--- a/server/src/test/java/org/candlepin/model/ProductCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ProductCuratorTest.java
@@ -22,10 +22,11 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import org.candlepin.common.config.Configuration;
-import org.candlepin.common.exceptions.BadRequestException;
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.test.DatabaseTestFixture;
 import org.candlepin.test.TestUtil;
+import org.candlepin.util.AttributeValidator;
+import org.candlepin.util.PropertyValidationException;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -35,6 +36,7 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.HashMap;
@@ -60,16 +62,20 @@ public class ProductCuratorTest extends DatabaseTestFixture {
     private Product derivedProduct;
     private Product providedProduct;
     private Product derivedProvidedProduct;
-
     private Pool pool;
 
     @Before
-    public void setUp() {
+    public void setUp() throws Exception {
         config.setProperty(ConfigProperties.INTEGER_ATTRIBUTES, "product.count, product.multiplier");
         config.setProperty(ConfigProperties.NON_NEG_INTEGER_ATTRIBUTES, "product.pos_count");
         config.setProperty(ConfigProperties.LONG_ATTRIBUTES, "product.long_count, product.long_multiplier");
         config.setProperty(ConfigProperties.NON_NEG_LONG_ATTRIBUTES, "product.long_pos_count");
         config.setProperty(ConfigProperties.BOOLEAN_ATTRIBUTES, "product.bool_val_str, product.bool_val_num");
+
+        // Inject this attributeValidator into the curator
+        Field field = ProductCurator.class.getDeclaredField("attributeValidator");
+        field.setAccessible(true);
+        field.set(this.productCurator, new AttributeValidator(this.config, this.i18n));
 
         this.owner = this.createOwner();
 
@@ -372,7 +378,7 @@ public class ProductCuratorTest extends DatabaseTestFixture {
         productCurator.merge(original);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expected = PropertyValidationException.class)
     public void testProductAttributeCreationFailBadInt() {
         Product original = createTestProduct();
         original.addAttribute(new ProductAttribute("product.count", "1.0"));
@@ -386,21 +392,21 @@ public class ProductCuratorTest extends DatabaseTestFixture {
         productCurator.create(original);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expected = PropertyValidationException.class)
     public void testProductAttributeCreationFailBadPosInt() {
         Product original = createTestProduct();
         original.addAttribute(new ProductAttribute("product.pos_count", "-5"));
         productCurator.create(original);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expected = PropertyValidationException.class)
     public void testProductAttributeCreationFailBadLong() {
         Product original = createTestProduct();
         original.addAttribute(new ProductAttribute("product.long_multiplier", "ZZ"));
         productCurator.create(original);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expected = PropertyValidationException.class)
     public void testProductAttributeCreationFailBadPosLong() {
         Product original = createTestProduct();
         original.addAttribute(new ProductAttribute("product.long_pos_count",
@@ -408,21 +414,21 @@ public class ProductCuratorTest extends DatabaseTestFixture {
         productCurator.create(original);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expected = PropertyValidationException.class)
     public void testProductAttributeCreationFailBadStringBool() {
         Product original = createTestProduct();
         original.addAttribute(new ProductAttribute("product.bool_val_str", "yes"));
         productCurator.create(original);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expected = PropertyValidationException.class)
     public void testProductAttributeCreationFailNumberBool() {
         Product original = createTestProduct();
         original.addAttribute(new ProductAttribute("product.bool_val_num", "2"));
         productCurator.create(original);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expected = PropertyValidationException.class)
     public void testProductAttributeUpdateFailInt() {
         Product original = createTestProduct();
         productCurator.create(original);
@@ -431,7 +437,7 @@ public class ProductCuratorTest extends DatabaseTestFixture {
         productCurator.merge(original);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expected = PropertyValidationException.class)
     public void testProductAttributeUpdateFailPosInt() {
         Product original = createTestProduct();
         productCurator.create(original);
@@ -449,7 +455,7 @@ public class ProductCuratorTest extends DatabaseTestFixture {
         productCurator.merge(original);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expected = PropertyValidationException.class)
     public void testProductAttributeUpdateFailLong() {
         Product original = createTestProduct();
         productCurator.create(original);
@@ -458,7 +464,7 @@ public class ProductCuratorTest extends DatabaseTestFixture {
         productCurator.merge(original);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expected = PropertyValidationException.class)
     public void testProductAttributeUpdateFailPosLong() {
         Product original = createTestProduct();
         productCurator.create(original);
@@ -467,7 +473,7 @@ public class ProductCuratorTest extends DatabaseTestFixture {
         productCurator.merge(original);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expected = PropertyValidationException.class)
     public void testProductAttributeUpdateFailStringBool() {
         Product original = createTestProduct();
         productCurator.create(original);
@@ -476,7 +482,7 @@ public class ProductCuratorTest extends DatabaseTestFixture {
         productCurator.merge(original);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expected = PropertyValidationException.class)
     public void testProductAttributeUpdateFailNumberBool() {
         Product original = createTestProduct();
         productCurator.create(original);

--- a/server/src/test/java/org/candlepin/policy/js/compliance/ComplianceRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/compliance/ComplianceRulesTest.java
@@ -2034,7 +2034,7 @@ public class ComplianceRulesTest {
         ComplianceStatus originalStatus = compliance.getStatus(c);
         assertEquals("valid", originalStatus.getStatus());
 
-        verify(consumerCurator).updateWithOptionalFlush(eq(c), eq(false));
+        verify(consumerCurator).update(eq(c), eq(false));
         String pid = "testinstalledprod";
         c.addInstalledProduct(new ConsumerInstalledProduct(pid, pid));
         ComplianceStatus updated = compliance.getStatus(c);
@@ -2052,7 +2052,7 @@ public class ComplianceRulesTest {
         assertNotNull(initialHash);
         assertFalse(initialHash.isEmpty());
 
-        verify(consumerCurator).updateWithOptionalFlush(eq(c), eq(false));
+        verify(consumerCurator).update(eq(c), eq(false));
         String pid = "testinstalledprod";
         c.addInstalledProduct(new ConsumerInstalledProduct(pid, pid));
         ComplianceStatus updated = compliance.getStatus(c);

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceCreationTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceCreationTest.java
@@ -57,6 +57,7 @@ import org.candlepin.resource.util.ConsumerBindUtil;
 import org.candlepin.service.IdentityCertServiceAdapter;
 import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.service.UserServiceAdapter;
+import org.candlepin.util.FactValidator;
 import org.candlepin.util.ServiceLevelValidator;
 
 import org.apache.commons.lang.StringUtils;
@@ -128,10 +129,9 @@ public class ConsumerResourceCreationTest {
             this.consumerTypeCurator, null, this.subscriptionService, null,
             this.idCertService, null, this.i18n, this.sink, null, null, null,
             this.userService, null, null, this.ownerCurator,
-            this.activationKeyCurator,
-            null, this.complianceRules, this.deletedConsumerCurator,
+            this.activationKeyCurator, null, this.complianceRules, this.deletedConsumerCurator,
             null, null, this.config, null, null, null, this.consumerBindUtil,
-            productCurator, null, null);
+            productCurator, null, null, new FactValidator(this.config, this.i18n));
 
         this.system = initSystem();
 

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
@@ -575,10 +575,9 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
             null, null, this.entitlementCurator, null, null, null, null, null,
             null, null, null, this.poolManager, null, null, null,
             null, null, null, null, null, new CandlepinCommonTestConfig(), null,
-            null, null, mock(ConsumerBindUtil.class), productCurator, null, null);
+            null, null, mock(ConsumerBindUtil.class), productCurator, null, null, null);
 
-        Response rsp = consumerResource.bind(
-            consumer.getUuid(), pool.getId().toString(), null, 1, null,
+        Response rsp = consumerResource.bind(consumer.getUuid(), pool.getId().toString(), null, 1, null,
             null, false, null, null, null, null);
 
         List<Entitlement> resultList = (List<Entitlement>) rsp.getEntity();
@@ -586,8 +585,7 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
         assertEquals(1, ent.getCertificates().size());
         Certificate entCertBefore = ent.getCertificates().iterator().next();
 
-        cr.regenerateEntitlementCertificates(this.consumer.getUuid(),
-            ent.getId(), false);
+        cr.regenerateEntitlementCertificates(this.consumer.getUuid(), ent.getId(), false);
         assertEquals(1, ent.getCertificates().size());
         Certificate entCertAfter = ent.getCertificates().iterator().next();
 

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
@@ -30,6 +30,7 @@ import org.candlepin.auth.NoAuthPrincipal;
 import org.candlepin.auth.SubResource;
 import org.candlepin.auth.TrustedUserPrincipal;
 import org.candlepin.auth.UserPrincipal;
+import org.candlepin.common.config.Configuration;
 import org.candlepin.common.exceptions.BadRequestException;
 import org.candlepin.common.exceptions.NotFoundException;
 import org.candlepin.common.paging.Page;
@@ -77,6 +78,7 @@ import org.candlepin.service.IdentityCertServiceAdapter;
 import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.service.UserServiceAdapter;
 import org.candlepin.test.TestUtil;
+import org.candlepin.util.FactValidator;
 import org.candlepin.util.ServiceLevelValidator;
 
 import org.apache.commons.lang.RandomStringUtils;
@@ -119,6 +121,8 @@ public class ConsumerResourceTest {
     public ExpectedException thrown = ExpectedException.none();
 
     private I18n i18n;
+    private Configuration config;
+    private FactValidator factValidator;
 
     @Mock private ConsumerCurator mockedConsumerCurator;
     @Mock private OwnerCurator mockedOwnerCurator;
@@ -137,10 +141,14 @@ public class ConsumerResourceTest {
 
     @Before
     public void setUp() {
-        i18n = I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK);
+        this.config = new CandlepinCommonTestConfig();
+
+        this.i18n = I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK);
         when(eventBuilder.setOldEntity(any(Consumer.class))).thenReturn(eventBuilder);
         when(eventBuilder.setNewEntity(any(Consumer.class))).thenReturn(eventBuilder);
         when(eventFactory.getEventBuilder(any(Target.class), any(Type.class))).thenReturn(eventBuilder);
+
+        this.factValidator = new FactValidator(this.config, this.i18n);
     }
 
     @Test
@@ -160,8 +168,8 @@ public class ConsumerResourceTest {
             mockedConsumerCurator, null, null, null, mockedEntitlementCurator, null,
             mockedEntitlementCertServiceAdapter, null, null, null, null, null,
             null, mockedPoolManager, null, null, null, null, null,
-            null, null, null, new CandlepinCommonTestConfig(), null, null, null,
-            consumerBindUtil, productCurator, null, null);
+            null, null, null, this.config, null, null, null,
+            consumerBindUtil, productCurator, null, null, this.factValidator);
 
         List<CertificateSerialDto> serials = consumerResource
             .getEntitlementCertificateSerials(consumer.getUuid());
@@ -188,7 +196,7 @@ public class ConsumerResourceTest {
             .thenThrow(new IOException());
 
         CandlepinPoolManager poolManager = new CandlepinPoolManager(
-            null, null, null, new CandlepinCommonTestConfig(), null, null, mockedEntitlementCurator,
+            null, null, null, this.config, null, null, mockedEntitlementCurator,
             mockedConsumerCurator, null, null, null, null, mockedActivationKeyRules, null, null,
             null, null, null, null, null, null, null
         );
@@ -197,8 +205,8 @@ public class ConsumerResourceTest {
             mockedConsumerCurator, null, null, null, mockedEntitlementCurator, null,
             mockedEntitlementCertServiceAdapter, null, null, null, null, null, null,
             poolManager, null, null, null, null, null, null, null, null,
-            new CandlepinCommonTestConfig(), null, null, null, consumerBindUtil, productCurator,
-            null, null);
+            this.config, null, null, null, consumerBindUtil, productCurator,
+            null, null, this.factValidator);
 
         consumerResource.regenerateEntitlementCertificates(consumer.getUuid(), "9999", false);
     }
@@ -231,7 +239,7 @@ public class ConsumerResourceTest {
         ConsumerResource cr = new ConsumerResource(mockedConsumerCurator, null,
             null, mockedSubscriptionServiceAdapter, null, null, null, null, null, null, null, null, null,
             mgr, null, null, null, null, null, null, null, null,
-            new CandlepinCommonTestConfig(), null, null, null, consumerBindUtil, productCurator, null, null);
+            this.config, null, null, null, consumerBindUtil, productCurator, null, null, this.factValidator);
         cr.regenerateEntitlementCertificates(consumer.getUuid(), null, true);
         Mockito.verify(mgr, Mockito.times(1)).regenerateCertificatesOf(eq(consumer), eq(true));
     }
@@ -258,8 +266,8 @@ public class ConsumerResourceTest {
         ConsumerResource cr = new ConsumerResource(mockedConsumerCurator, null,
             null, null, null, mockedIdSvc, null, null, sink, eventFactory, null, null,
             null, null, null, mockedOwnerCurator, null, null, null, null,
-            null, null, new CandlepinCommonTestConfig(), null, null, null, consumerBindUtil, productCurator,
-            null, null);
+            null, null, this.config, null, null, null, consumerBindUtil, productCurator,
+            null, null, this.factValidator);
 
         Consumer fooc = cr.regenerateIdentityCertificates(consumer.getUuid());
 
@@ -293,8 +301,8 @@ public class ConsumerResourceTest {
         ConsumerResource cr = new ConsumerResource(mockedConsumerCurator, null,
             null, ssa, null, mockedIdSvc, null, null, sink, eventFactory, null, null,
             null, null, null, mockedOwnerCurator, null, null, rules, null,
-            null, null, new CandlepinCommonTestConfig(), null, null, null, consumerBindUtil, productCurator,
-            null, null);
+            null, null, this.config, null, null, null, consumerBindUtil, productCurator,
+            null, null, this.factValidator);
 
         Consumer c = cr.getConsumer(consumer.getUuid());
 
@@ -317,8 +325,8 @@ public class ConsumerResourceTest {
         ConsumerResource cr = new ConsumerResource(mockedConsumerCurator, null,
             null, ssa, null, null, null, null, null, null, null, null, null, null,
             null, mockedOwnerCurator, null, null, rules, null, null, null,
-            new CandlepinCommonTestConfig(), null, null, null, consumerBindUtil, productCurator,
-            null, null);
+            this.config, null, null, null, consumerBindUtil, productCurator,
+            null, null, this.factValidator);
 
         Consumer c = cr.getConsumer(consumer.getUuid());
 
@@ -348,8 +356,8 @@ public class ConsumerResourceTest {
         ConsumerResource cr = new ConsumerResource(null, ctc,
             null, null, null, null, null, i18n, null, null, null, null,
             null, null, null, oc, akc, null, null, null, null,
-            null, new CandlepinCommonTestConfig(), null, null, null, consumerBindUtil, productCurator,
-            null, null);
+            null, this.config, null, null, null, consumerBindUtil, productCurator,
+            null, null, this.factValidator);
         cr.create(c, nap, null, "testOwner", "testKey", true);
     }
 
@@ -370,8 +378,8 @@ public class ConsumerResourceTest {
         ConsumerResource cr = new ConsumerResource(cc, null,
             null, sa, null, null, null, i18n, null, null, null, null, null,
             null, null, null, null, e, null, null, null, null,
-            new CandlepinCommonTestConfig(), null, null, null, consumerBindUtil, productCurator,
-            null, null);
+            this.config, null, null, null, consumerBindUtil, productCurator,
+            null, null, this.factValidator);
         Response r = cr.bind(
             "fakeConsumer", null, prodIds, null, null, null, false, null, null, null, null);
         assertEquals(null, r.getEntity());
@@ -394,7 +402,7 @@ public class ConsumerResourceTest {
 
         ConsumerResource cr = new ConsumerResource(cc, null, null, sa, null, null, null, i18n, null,
             null, null, null, null, pm, null, null, null, null, null, null, null, null,
-            new CandlepinCommonTestConfig(), null, null, null, consumerBindUtil, productCurator, null, null);
+            this.config, null, null, null, consumerBindUtil, productCurator, null, null, this.factValidator);
 
         Response rsp = cr.bind("fakeConsumer", null, null, null, null, null, true, null,
             null, pools, new TrustedUserPrincipal("TaylorSwift"));
@@ -436,8 +444,8 @@ public class ConsumerResourceTest {
         ConsumerResource cr = new ConsumerResource(cc, null, null, sa,
             null, null, null, null, null, null, null, null, null, null,
             null, null, null, e, null, null, null, null,
-            new CandlepinCommonTestConfig(), null, null, null, consumerBindUtil, productCurator,
-            null, null);
+            this.config, null, null, null, consumerBindUtil, productCurator,
+            null, null, this.factValidator);
         String dtStr = "2011-09-26T18:10:50.184081+00:00";
         Date dt = ResourceDateParser.parseDateString(dtStr);
         cr.bind("fakeConsumer", null, null, null, null, null, false, dtStr, null, null, null);
@@ -457,8 +465,8 @@ public class ConsumerResourceTest {
         ConsumerResource consumerResource = new ConsumerResource(consumerCurator, null,
             null, null, entitlementCurator, null, null, i18n, null, null, null,
             null, null, null, null, null, null, null, null, null, null,
-            null, new CandlepinCommonTestConfig(), null, null, null, consumerBindUtil, productCurator,
-            null, null);
+            null, this.config, null, null, null, consumerBindUtil, productCurator,
+            null, null, this.factValidator);
 
         consumerResource.unbindBySerial("fake uuid",
             Long.valueOf(1234L));
@@ -481,8 +489,8 @@ public class ConsumerResourceTest {
         ConsumerResource consumerResource = new ConsumerResource(consumerCurator, null,
             null, null, entitlementCurator, null, null, i18n, null, null, null,
             null, null, null, null, null, null, null, null, null, null,
-            null, new CandlepinCommonTestConfig(), null, null, null, consumerBindUtil, productCurator,
-            null, null);
+            null, this.config, null, null, null, consumerBindUtil, productCurator,
+            null, null, this.factValidator);
         consumerResource.unbindByPool("fake-uuid", "Run Forest!");
     }
 
@@ -492,8 +500,8 @@ public class ConsumerResourceTest {
         ConsumerResource consumerResource = new ConsumerResource(consumerCurator, null,
             null, null, null, null, null, i18n, null, null, null,
             null, null, null, null, null, null, null, null, null, null,
-            null, new CandlepinCommonTestConfig(), null, null, null, consumerBindUtil, productCurator,
-            null, null);
+            null, this.config, null, null, null, consumerBindUtil, productCurator,
+            null, null, this.factValidator);
 
         consumerResource.bind("fake uuid", "fake pool uuid",
             new String[]{"12232"}, 1, null, null, false, null, null, null, null);
@@ -505,8 +513,8 @@ public class ConsumerResourceTest {
         ConsumerResource consumerResource = new ConsumerResource(consumerCurator, null,
             null, null, null, null, null, i18n, null, null, null,
             null, null, null, null, null, null, null, null, null, null,
-            null, new CandlepinCommonTestConfig(), null, null, null, consumerBindUtil, productCurator,
-            null, null);
+            null, this.config, null, null, null, consumerBindUtil, productCurator,
+            null, null, this.factValidator);
 
         PoolIdAndQuantity[] pools = new PoolIdAndQuantity[2];
         pools[0] = new PoolIdAndQuantity("first", 1);
@@ -522,8 +530,8 @@ public class ConsumerResourceTest {
         ConsumerResource consumerResource = new ConsumerResource(consumerCurator, null,
             null, null, null, null, null, i18n, null, null, null,
             null, null, null, null, null, null, null, null, null, null,
-            null, new CandlepinCommonTestConfig(), null, null, null, consumerBindUtil, productCurator,
-            null, null);
+            null, this.config, null, null, null, consumerBindUtil, productCurator,
+            null, null, this.factValidator);
 
         PoolIdAndQuantity[] pools = new PoolIdAndQuantity[2];
         pools[0] = new PoolIdAndQuantity("first", 1);
@@ -539,8 +547,8 @@ public class ConsumerResourceTest {
         ConsumerResource consumerResource = new ConsumerResource(consumerCurator, null,
             null, null, null, null, null, i18n, null, null, null,
             null, null, null, null, null, null, null, null, null, null,
-            null, new CandlepinCommonTestConfig(), null, null, null, consumerBindUtil, productCurator,
-            null, null);
+            null, this.config, null, null, null, consumerBindUtil, productCurator,
+            null, null, this.factValidator);
 
         PoolIdAndQuantity[] pools = new PoolIdAndQuantity[2];
         pools[0] = new PoolIdAndQuantity("first", 1);
@@ -556,8 +564,8 @@ public class ConsumerResourceTest {
         ConsumerResource consumerResource = new ConsumerResource(consumerCurator, null,
             null, null, null, null, null, i18n, null, null, null,
             null, null, null, null, null, null, null, null, null, null,
-            null, new CandlepinCommonTestConfig(), null, null, null, consumerBindUtil, productCurator,
-            null, null);
+            null, this.config, null, null, null, consumerBindUtil, productCurator,
+            null, null, this.factValidator);
 
         PoolIdAndQuantity[] pools = new PoolIdAndQuantity[2];
         pools[0] = new PoolIdAndQuantity("first", 1);
@@ -575,8 +583,8 @@ public class ConsumerResourceTest {
         ConsumerResource consumerResource = new ConsumerResource(consumerCurator, null,
             null, null, null, null, null, i18n, null, null, null,
             null, null, null, null, null, null, null, null, null, null,
-            null, new CandlepinCommonTestConfig(), null, null, null, consumerBindUtil, productCurator,
-            null, null);
+            null, this.config, null, null, null, consumerBindUtil, productCurator,
+            null, null, this.factValidator);
 
         consumerResource.bind("notarealuuid", "fake pool uuid", null, null, null,
             null, false, null, null, null, null);
@@ -594,8 +602,8 @@ public class ConsumerResourceTest {
         ConsumerResource consumerResource = new ConsumerResource(consumerCurator, null,
             null, null, null, null, null, i18n, null, null, null,
             null, null, null, null, null, null, null, null, null, null,
-            null, new CandlepinCommonTestConfig(), null, null, null, consumerBindUtil, productCurator,
-            null, null);
+            null, this.config, null, null, null, consumerBindUtil, productCurator,
+            null, null, this.factValidator);
 
         consumerResource.regenerateEntitlementCertificates("xyz", null, true);
     }
@@ -637,8 +645,8 @@ public class ConsumerResourceTest {
         ConsumerResource cr = new ConsumerResource(null, ctc,
             null, null, null, null, null, i18n, null, null, null, null,
             usa, null,  null, oc, null, null, null, null, null,
-            null, new CandlepinCommonTestConfig(), null, null, null, consumerBindUtil, productCurator,
-            null, null);
+            null, this.config, null, null, null, consumerBindUtil, productCurator,
+            null, null, this.factValidator);
         cr.create(c, up, null, "testOwner", null, true);
     }
 
@@ -669,13 +677,10 @@ public class ConsumerResourceTest {
 
     ConsumerResource createConsumerResource(OwnerCurator oc) {
         ConsumerResource consumerResource = new ConsumerResource(
-            null, null, null, null, null, null, null,
-            i18n,
-            null, null, null, null, null, null, null,
-            oc,
-            null, null, null, null, null, null,
-            new CandlepinCommonTestConfig(),
-            null, null, null, null, null, null, null);
+            null, null, null, null, null, null, null, i18n, null, null, null, null, null, null, null,
+            oc, null, null, null, null, null, null, this.config, null, null, null, null, null, null, null,
+            this.factValidator);
+
         return consumerResource;
     }
 
@@ -702,8 +707,8 @@ public class ConsumerResourceTest {
         ConsumerResource cr = new ConsumerResource(mockedConsumerCurator, null,
             null, null, null, null, null, i18n, null, null, null,
             null, null, null, null, null, null, null, mockedComplianceRules,
-            null, null, null, new CandlepinCommonTestConfig(), null, null, null,
-            consumerBindUtil, productCurator, null, null);
+            null, null, null, this.config, null, null, null,
+            consumerBindUtil, productCurator, null, null, this.factValidator);
 
         Map<String, ComplianceStatus> results = cr.getComplianceStatusList(uuids);
         assertEquals(2, results.size());
@@ -717,8 +722,8 @@ public class ConsumerResourceTest {
         ConsumerResource cr = new ConsumerResource(mockedConsumerCurator, null,
             null, null, null, null, null, i18n, null, null, null,
             null, null, null, null, null, null, null, mockedComplianceRules,
-            null, null, null, new CandlepinCommonTestConfig(),
-            null, null, null, consumerBindUtil, productCurator, null, null);
+            null, null, null, this.config, null, null, null, consumerBindUtil, productCurator,
+            null, null, this.factValidator);
         cr.consumerExists("uuid");
     }
 
@@ -728,8 +733,8 @@ public class ConsumerResourceTest {
         ConsumerResource cr = new ConsumerResource(mockedConsumerCurator, null,
             null, null, null, null, null, i18n, null, null, null,
             null, null, null, null, null, null, null, mockedComplianceRules,
-            null, null, null, new CandlepinCommonTestConfig(),
-            null, null, null, consumerBindUtil, productCurator, null, null);
+            null, null, null, this.config, null, null, null, consumerBindUtil,
+            productCurator, null, null, this.factValidator);
         cr.consumerExists("uuid");
     }
 
@@ -738,8 +743,8 @@ public class ConsumerResourceTest {
         ConsumerResource cr = new ConsumerResource(null, null,
             null, null, null, null, null, i18n, null, null, null,
             null, null, null, null, null, null, null, null,
-            null, null, null, new CandlepinCommonTestConfig(),
-            null, null, null, null, productCurator, null, null);
+            null, null, null, this.config, null, null, null, null,
+            productCurator, null, null, this.factValidator);
         cr.list(null, null, null, null, null, null, null);
     }
 
@@ -748,8 +753,8 @@ public class ConsumerResourceTest {
         ConsumerResource cr = new ConsumerResource(mockedConsumerCurator, null,
             null, null, null, null, null, i18n, null, null, null,
             null, null, null, null, null, null, null, null,
-            null, null, null, new CandlepinCommonTestConfig(),
-            null, null, null, null, productCurator, null, null);
+            null, null, null, this.config, null, null, null, null,
+            productCurator, null, null, this.factValidator);
         Page<List<Consumer>> page = new Page<List<Consumer>>();
         ArrayList<Consumer> consumers = new ArrayList<Consumer>();
         page.setPageData(consumers);
@@ -766,8 +771,8 @@ public class ConsumerResourceTest {
         ConsumerResource cr = new ConsumerResource(mockedConsumerCurator, null,
             null, null, null, null, null, i18n, null, null, null,
             null, null, null, null, mockedOwnerCurator, null, null, null,
-            null, null, null, new CandlepinCommonTestConfig(),
-            null, null, null, null, productCurator, null, null);
+            null, null, null, this.config, null, null, null, null,
+            productCurator, null, null, this.factValidator);
         Page<List<Consumer>> page = new Page<List<Consumer>>();
         ArrayList<Consumer> consumers = new ArrayList<Consumer>();
         page.setPageData(consumers);
@@ -786,8 +791,8 @@ public class ConsumerResourceTest {
         ConsumerResource cr = new ConsumerResource(mockedConsumerCurator, null,
             null, null, null, null, null, i18n, null, null, null,
             null, null, null, null, null, null, null, null,
-            null, null, null, new CandlepinCommonTestConfig(),
-            null, null, null, null, productCurator, null, null);
+            null, null, null, this.config, null, null, null, null,
+            productCurator, null, null, this.factValidator);
         List<Consumer> result = cr.list(null, null, null, new ArrayList<String>(), null, null, null);
     }
 
@@ -796,8 +801,8 @@ public class ConsumerResourceTest {
         ConsumerResource cr = new ConsumerResource(mockedConsumerCurator, null,
             null, null, null, null, null, i18n, null, null, null,
             null, null, null, null, null, null, null, null,
-            null, null, null, new CandlepinCommonTestConfig(),
-            null, null, null, null, productCurator, null, null);
+            null, null, null, this.config, null, null, null, null,
+            productCurator, null, null, this.factValidator);
         Page<List<Consumer>> page = new Page<List<Consumer>>();
         ArrayList<Consumer> consumers = new ArrayList<Consumer>();
         page.setPageData(consumers);
@@ -825,8 +830,8 @@ public class ConsumerResourceTest {
             mockedConsumerCurator, null, null, null, mockedEntitlementCurator, null,
             mockedEntitlementCertServiceAdapter, null, null, null, null, null,
             null, mockedPoolManager, null, null, null, null, null,
-            null, null, null, new CandlepinCommonTestConfig(), null, null, null,
-            consumerBindUtil, productCurator, null, null));
+            null, null, null, this.config, null, null, null, consumerBindUtil,
+            productCurator, null, null, this.factValidator));
 
         List<CertificateSerialDto> serials = consumerResource
             .getEntitlementCertificateSerials(consumer.getUuid());
@@ -846,8 +851,8 @@ public class ConsumerResourceTest {
             mockedConsumerCurator, null, null, null, mockedEntitlementCurator, null,
             mockedEntitlementCertServiceAdapter, null, null, null, null, null,
             null, mockedPoolManager, null, null, null, null, null,
-            null, null, null, new CandlepinCommonTestConfig(), null, null, null,
-            consumerBindUtil, productCurator, null, null));
+            null, null, null, this.config, null, null, null,
+            consumerBindUtil, productCurator, null, null, this.factValidator));
 
         Set<Long> serials = new HashSet<Long>();
         List<Certificate> certs = consumerResource
@@ -864,8 +869,8 @@ public class ConsumerResourceTest {
         ConsumerResource consumerResource = new ConsumerResource(mockedConsumerCurator, null,
             null, null, null, null, null, i18n, null, null, null,
             null, null, null, null, mockedOwnerCurator, null, null, null,
-            null, null, null, new CandlepinCommonTestConfig(),
-            null, null, null, null, productCurator, manifestManager, null);
+            null, null, null, this.config, null, null, null, null,
+            productCurator, manifestManager, null, this.factValidator);
 
         try {
             consumerResource.dryBind(consumer.getUuid(), "some-sla");
@@ -883,8 +888,8 @@ public class ConsumerResourceTest {
         ConsumerResource cr = new ConsumerResource(mockedConsumerCurator, null,
             null, null, null, null, null, i18n, null, null, null,
             null, null, null, null, mockedOwnerCurator, null, null, null,
-            null, null, null, new CandlepinCommonTestConfig(),
-            null, mockedCdnCurator, null, null, productCurator, manifestManager, null);
+            null, null, null, this.config, null, mockedCdnCurator, null, null,
+            productCurator, manifestManager, null, this.factValidator);
 
         List<KeyValueParameter> extParams = new ArrayList<KeyValueParameter>();
         Owner owner = TestUtil.createOwner();

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
@@ -24,6 +24,7 @@ import org.candlepin.audit.Event.Type;
 import org.candlepin.audit.EventBuilder;
 import org.candlepin.audit.EventFactory;
 import org.candlepin.audit.EventSink;
+import org.candlepin.common.config.Configuration;
 import org.candlepin.common.exceptions.BadRequestException;
 import org.candlepin.common.exceptions.NotFoundException;
 import org.candlepin.config.CandlepinCommonTestConfig;
@@ -56,6 +57,7 @@ import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.service.UserServiceAdapter;
 import org.candlepin.test.TestUtil;
 import org.candlepin.util.ServiceLevelValidator;
+import org.candlepin.util.FactValidator;
 
 import org.junit.Before;
 import org.junit.Ignore;
@@ -101,6 +103,8 @@ public class ConsumerResourceUpdateTest {
 
     @Before
     public void init() throws Exception {
+        Configuration config = new CandlepinCommonTestConfig();
+
         this.i18n = I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK);
 
         this.resource = new ConsumerResource(this.consumerCurator,
@@ -109,8 +113,9 @@ public class ConsumerResourceUpdateTest {
             this.userService, poolManager, null, null,
             this.activationKeyCurator, this.entitler, this.complianceRules,
             this.deletedConsumerCurator, this.environmentCurator, null,
-            new CandlepinCommonTestConfig(), null, null, null, this.consumerBindUtil, productCurator,
-            null, null);
+            config, null, null, null, this.consumerBindUtil, productCurator,
+            null, null, new FactValidator(config, this.i18n));
+
         when(complianceRules.getStatus(any(Consumer.class), any(Date.class),
                 any(Boolean.class), any(Boolean.class)))
             .thenReturn(new ComplianceStatus(new Date()));

--- a/server/src/test/java/org/candlepin/resource/GuestIdResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/GuestIdResourceTest.java
@@ -266,7 +266,7 @@ public class GuestIdResourceTest {
             super(null, null, null, null, null, null, null, null, null,
                   null, null, null, null, null, null, null, null,
                   null, null, null, null, null, null, null, null, null, null, productCurator,
-                  null, null);
+                  null, null, null);
         }
 
         public void checkForMigration(Consumer host, Consumer guest) {

--- a/server/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
@@ -26,6 +26,7 @@ import org.candlepin.audit.EventSink;
 import org.candlepin.auth.Access;
 import org.candlepin.auth.SubResource;
 import org.candlepin.auth.UserPrincipal;
+import org.candlepin.common.config.Configuration;
 import org.candlepin.common.exceptions.BadRequestException;
 import org.candlepin.config.CandlepinCommonTestConfig;
 import org.candlepin.model.Consumer;
@@ -49,6 +50,7 @@ import org.candlepin.resource.util.ConsumerBindUtil;
 import org.candlepin.service.IdentityCertServiceAdapter;
 import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.service.UserServiceAdapter;
+import org.candlepin.util.FactValidator;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -95,6 +97,8 @@ public class HypervisorResourceTest {
 
     @Before
     public void setupTest() {
+        Configuration config = new CandlepinCommonTestConfig();
+
         this.i18n = I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK);
         this.hypervisorType = new ConsumerType(ConsumerTypeEnum.HYPERVISOR);
         this.consumerResource = new ConsumerResource(this.consumerCurator,
@@ -102,8 +106,9 @@ public class HypervisorResourceTest {
             this.idCertService, null, this.i18n, this.sink, this.eventFactory, null, null,
             this.userService, null, null, this.ownerCurator,
             this.activationKeyCurator, null, this.complianceRules,
-            this.deletedConsumerCurator, null, null, new CandlepinCommonTestConfig(),
-            null, null, null, this.consumerBindUtil, productCurator, null, null);
+            this.deletedConsumerCurator, null, null, config,
+            null, null, null, this.consumerBindUtil, productCurator, null, null,
+            new FactValidator(config, this.i18n));
 
         hypervisorResource = new HypervisorResource(consumerResource,
             consumerCurator, i18n, ownerCurator);

--- a/server/src/test/java/org/candlepin/test/DatabaseTestFixture.java
+++ b/server/src/test/java/org/candlepin/test/DatabaseTestFixture.java
@@ -521,8 +521,7 @@ public class DatabaseTestFixture {
     }
 
     public Role createAdminRole(Owner owner) {
-        PermissionBlueprint p = new PermissionBlueprint(PermissionType.OWNER, owner,
-            Access.ALL);
+        PermissionBlueprint p = new PermissionBlueprint(PermissionType.OWNER, owner, Access.ALL);
         Role role = new Role("testrole" + TestUtil.randomInt());
         role.addPermission(p);
         return role;

--- a/server/src/test/java/org/candlepin/util/AttributeValidatorTest.java
+++ b/server/src/test/java/org/candlepin/util/AttributeValidatorTest.java
@@ -1,0 +1,200 @@
+/**
+ * Copyright (c) 2009 - 2017 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.util;
+
+import static org.junit.Assert.*;
+
+import org.candlepin.common.config.Configuration;
+import org.candlepin.config.CandlepinCommonTestConfig;
+import org.candlepin.config.ConfigProperties;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.xnap.commons.i18n.I18n;
+import org.xnap.commons.i18n.I18nFactory;
+
+import java.util.Locale;
+
+
+
+/**
+ * Test suite for the AttributeValidator class
+ */
+@RunWith(JUnitParamsRunner.class)
+public class AttributeValidatorTest {
+
+    private static I18n i18n = I18nFactory.getI18n(AttributeValidatorTest.class, Locale.US,
+        I18nFactory.FALLBACK);
+
+    private Configuration config;
+
+    @Before
+    public void init() {
+        this.config = new CandlepinCommonTestConfig();
+    }
+
+    @Test(expected = PropertyValidationException.class)
+    @Parameters({"true", "false", "1", "0", "-1", "string value"})
+    public void testLongAttributeKeyFailure(String value) {
+        StringBuilder builder = new StringBuilder(AttributeValidator.ATTRIBUTE_MAX_LENGTH + 2);
+        for (int i = 0; i < AttributeValidator.ATTRIBUTE_MAX_LENGTH + 1; ++i) {
+            builder.append(i % 10);
+        }
+
+        AttributeValidator validator = new AttributeValidator(this.config, i18n);
+        validator.validate(builder.toString(), value);
+    }
+
+    @Test(expected = PropertyValidationException.class)
+    public void testLongAttributeValueFailure() {
+        StringBuilder builder = new StringBuilder(AttributeValidator.ATTRIBUTE_MAX_LENGTH + 2);
+        for (int i = 0; i < AttributeValidator.ATTRIBUTE_MAX_LENGTH + 1; ++i) {
+            builder.append(i % 10);
+        }
+
+        AttributeValidator validator = new AttributeValidator(this.config, i18n);
+        validator.validate("key", builder.toString());
+    }
+
+    @Test
+    @Parameters({
+        "testattrib, testvalue, true",
+        "testattrib, yes, true",
+        "testattrib, no, true",
+        "testattrib, y, true",
+        "testattrib, n, true",
+        "testattrib, true, true",
+        "testattrib, false, true",
+        "testattrib, 1, true",
+        "testattrib, 0, true",
+        "testattrib, -1, true",
+        "testattrib, 2147483647, true",
+        "testattrib, -2147483648, true",
+        "testattrib, 9223372036854775807, true",
+        "testattrib, -9223372036854775808, true",
+        "testattrib, 3.14, true",
+        "testattrib, -2.72, true",
+
+        "intattrib, testvalue, false",
+        "intattrib, yes, false",
+        "intattrib, no, false",
+        "intattrib, y, false",
+        "intattrib, n, false",
+        "intattrib, true, false",
+        "intattrib, false, false",
+        "intattrib, 1, true",
+        "intattrib, 0, true",
+        "intattrib, -1, true",
+        "intattrib, 2147483647, true",
+        "intattrib, -2147483648, true",
+        "intattrib, 9223372036854775807, false",
+        "intattrib, -9223372036854775808, false",
+        "intattrib, 3.14, false",
+        "intattrib, -2.72, false",
+
+        "nnintattrib, testvalue, false",
+        "nnintattrib, yes, false",
+        "nnintattrib, no, false",
+        "nnintattrib, y, false",
+        "nnintattrib, n, false",
+        "nnintattrib, true, false",
+        "nnintattrib, false, false",
+        "nnintattrib, 1, true",
+        "nnintattrib, 0, true",
+        "nnintattrib, -1, false",
+        "nnintattrib, 2147483647, true",
+        "nnintattrib, -2147483648, false",
+        "nnintattrib, 9223372036854775807, false",
+        "nnintattrib, -9223372036854775808, false",
+        "nnintattrib, 3.14, false",
+        "nnintattrib, -2.72, false",
+
+        "longattrib, testvalue, false",
+        "longattrib, yes, false",
+        "longattrib, no, false",
+        "longattrib, y, false",
+        "longattrib, n, false",
+        "longattrib, true, false",
+        "longattrib, false, false",
+        "longattrib, 1, true",
+        "longattrib, 0, true",
+        "longattrib, -1, true",
+        "longattrib, 2147483647, true",
+        "longattrib, -2147483648, true",
+        "longattrib, 9223372036854775807, true",
+        "longattrib, -9223372036854775808, true",
+        "longattrib, 3.14, false",
+        "longattrib, -2.72, false",
+
+        "nnlongattrib, testvalue, false",
+        "nnlongattrib, yes, false",
+        "nnlongattrib, no, false",
+        "nnlongattrib, y, false",
+        "nnlongattrib, n, false",
+        "nnlongattrib, true, false",
+        "nnlongattrib, false, false",
+        "nnlongattrib, 1, true",
+        "nnlongattrib, 0, true",
+        "nnlongattrib, -1, false",
+        "nnlongattrib, 2147483647, true",
+        "nnlongattrib, -2147483648, false",
+        "nnlongattrib, 9223372036854775807, true",
+        "nnlongattrib, -9223372036854775808, false",
+        "nnlongattrib, 3.14, false",
+        "nnlongattrib, -2.72, false",
+
+        "boolattrib, testvalue, false",
+        "boolattrib, yes, false",
+        "boolattrib, no, false",
+        "boolattrib, y, false",
+        "boolattrib, n, false",
+        "boolattrib, true, true",
+        "boolattrib, false, true",
+        "boolattrib, 1, true",
+        "boolattrib, 0, true",
+        "boolattrib, -1, false",
+        "boolattrib, 2147483647, false",
+        "boolattrib, -2147483648, false",
+        "boolattrib, 9223372036854775807, false",
+        "boolattrib, -9223372036854775808, false",
+        "boolattrib, 3.14, false",
+        "boolattrib, -2.72, false"})
+    public void testFactValidation(String key, String value, boolean shouldValidate) {
+        this.config.setProperty(ConfigProperties.INTEGER_ATTRIBUTES, "intattrib");
+        this.config.setProperty(ConfigProperties.NON_NEG_INTEGER_ATTRIBUTES, "nnintattrib");
+        this.config.setProperty(ConfigProperties.LONG_ATTRIBUTES, "longattrib");
+        this.config.setProperty(ConfigProperties.NON_NEG_LONG_ATTRIBUTES, "nnlongattrib");
+        this.config.setProperty(ConfigProperties.BOOLEAN_ATTRIBUTES, "boolattrib");
+
+        AttributeValidator validator = new AttributeValidator(this.config, i18n);
+
+        boolean result;
+
+        try {
+            validator.validate(key, value);
+            result = true;
+        }
+        catch (PropertyValidationException e) {
+            result = false;
+        }
+
+        assertEquals(shouldValidate, result);
+    }
+
+}

--- a/server/src/test/java/org/candlepin/util/FactValidatorTest.java
+++ b/server/src/test/java/org/candlepin/util/FactValidatorTest.java
@@ -1,0 +1,144 @@
+/**
+ * Copyright (c) 2009 - 2017 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.util;
+
+import static org.junit.Assert.*;
+
+import org.candlepin.common.config.Configuration;
+import org.candlepin.config.CandlepinCommonTestConfig;
+import org.candlepin.config.ConfigProperties;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.xnap.commons.i18n.I18n;
+import org.xnap.commons.i18n.I18nFactory;
+
+import java.util.Locale;
+
+
+
+/**
+ * Test suite for the FactValidator class
+ */
+@RunWith(JUnitParamsRunner.class)
+public class FactValidatorTest {
+
+    private static I18n i18n = I18nFactory.getI18n(FactValidatorTest.class, Locale.US, I18nFactory.FALLBACK);
+    private Configuration config;
+
+    @Before
+    public void init() {
+        this.config = new CandlepinCommonTestConfig();
+    }
+
+    @Test(expected = PropertyValidationException.class)
+    @Parameters({"true", "false", "1", "0", "-1", "string value"})
+    public void testLongFactKeyFailure(String value) {
+        StringBuilder builder = new StringBuilder(FactValidator.FACT_MAX_LENGTH + 2);
+        for (int i = 0; i < FactValidator.FACT_MAX_LENGTH + 1; ++i) {
+            builder.append(i % 10);
+        }
+
+        FactValidator validator = new FactValidator(this.config, i18n);
+        validator.validate(builder.toString(), value);
+    }
+
+    @Test(expected = PropertyValidationException.class)
+    public void testLongFactValueFailure() {
+        StringBuilder builder = new StringBuilder(FactValidator.FACT_MAX_LENGTH + 2);
+        for (int i = 0; i < FactValidator.FACT_MAX_LENGTH + 1; ++i) {
+            builder.append(i % 10);
+        }
+
+        FactValidator validator = new FactValidator(this.config, i18n);
+        validator.validate("key", builder.toString());
+    }
+
+    @Test
+    @Parameters({
+        "testfact, testvalue, true",
+        "testfact, yes, true",
+        "testfact, no, true",
+        "testfact, y, true",
+        "testfact, n, true",
+        "testfact, true, true",
+        "testfact, false, true",
+        "testfact, 1, true",
+        "testfact, 0, true",
+        "testfact, -1, true",
+        "testfact, 2147483647, true",
+        "testfact, -2147483648, true",
+        "testfact, 9223372036854775807, true",
+        "testfact, -9223372036854775808, true",
+        "testfact, 3.14, true",
+        "testfact, -2.72, true",
+
+        "intfact, testvalue, false",
+        "intfact, yes, false",
+        "intfact, no, false",
+        "intfact, y, false",
+        "intfact, n, false",
+        "intfact, true, false",
+        "intfact, false, false",
+        "intfact, 1, true",
+        "intfact, 0, true",
+        "intfact, -1, true",
+        "intfact, 2147483647, true",
+        "intfact, -2147483648, true",
+        "intfact, 9223372036854775807, false",
+        "intfact, -9223372036854775808, false",
+        "intfact, 3.14, false",
+        "intfact, -2.72, false",
+
+        "nnintfact, testvalue, false",
+        "nnintfact, yes, false",
+        "nnintfact, no, false",
+        "nnintfact, y, false",
+        "nnintfact, n, false",
+        "nnintfact, true, false",
+        "nnintfact, false, false",
+        "nnintfact, 1, true",
+        "nnintfact, 0, true",
+        "nnintfact, -1, false",
+        "nnintfact, 2147483647, true",
+        "nnintfact, -2147483648, false",
+        "nnintfact, 9223372036854775807, false",
+        "nnintfact, -9223372036854775808, false",
+        "nnintfact, 3.14, false",
+        "nnintfact, -2.72, false"})
+    public void testFactValidation(String key, String value, boolean shouldValidate) {
+        this.config.setProperty(ConfigProperties.INTEGER_FACTS, "fact1,intfact,fact2");
+        this.config.setProperty(ConfigProperties.NON_NEG_INTEGER_FACTS, "nnintfact");
+
+        FactValidator validator = new FactValidator(this.config, i18n);
+
+        boolean result;
+
+        try {
+            validator.validate(key, value);
+            result = true;
+        }
+        catch (PropertyValidationException e) {
+            result = false;
+        }
+
+        assertEquals(shouldValidate, result);
+    }
+
+}

--- a/server/src/test/java/org/candlepin/util/PropertyValidatorTest.java
+++ b/server/src/test/java/org/candlepin/util/PropertyValidatorTest.java
@@ -1,0 +1,255 @@
+/**
+ * Copyright (c) 2009 - 2017 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.util;
+
+import static org.junit.Assert.*;
+
+import org.candlepin.util.PropertyValidator.Validator;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.xnap.commons.i18n.I18n;
+import org.xnap.commons.i18n.I18nFactory;
+
+import java.lang.reflect.Constructor;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+
+
+/**
+ * Test suite for the PropertyValidator class
+ */
+@RunWith(JUnitParamsRunner.class)
+public class PropertyValidatorTest {
+
+    private I18n i18n;
+
+    @Before
+    public void init() {
+        this.i18n = I18nFactory.getI18n(this.getClass(), Locale.US, I18nFactory.FALLBACK);
+    }
+
+    /**
+     * Utility method for fetching validators
+     */
+    private Validator getValidator(Class<? extends Validator> validatorClass, Object... args) {
+        Map<Class, Class> translator = new HashMap<Class, Class>();
+        translator.put(Boolean.class, Boolean.TYPE);
+        translator.put(Character.class, Character.TYPE);
+        translator.put(Byte.class, Byte.TYPE);
+        translator.put(Short.class, Short.TYPE);
+        translator.put(Integer.class, Integer.TYPE);
+        translator.put(Long.class, Long.TYPE);
+        translator.put(Float.class, Float.TYPE);
+        translator.put(Double.class, Double.TYPE);
+        translator.put(Void.class, Void.TYPE);
+
+        try {
+            if (args != null && args.length > 0) {
+                Class[] classes = new Class[args.length];
+
+                for (int i = 0; i < args.length; ++i) {
+                    Class base = args[i].getClass();
+                    classes[i] = translator.containsKey(base) ? translator.get(base) : base;
+                }
+
+                Constructor<? extends Validator> constructor = validatorClass.getConstructor(classes);
+                constructor.setAccessible(true);
+
+                return constructor.newInstance(args);
+            }
+            else {
+                Constructor<? extends Validator> constructor = validatorClass.getConstructor();
+                constructor.setAccessible(true);
+
+                return constructor.newInstance();
+            }
+        }
+        catch (Exception e) {
+            // Rethrow the exception as a RuntimeException so we don't need to pad all our
+            // tests with try/catch blocks or throws declarations.
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    @Parameters({
+        "5, key, value, true",
+        "3, key, value, false",
+        "5, longkey, value, false",
+        "0, key, value, false"})
+    public void testLengthValidator(int length, String key, String value, boolean shouldValidate) {
+        Validator validator = this.getValidator(PropertyValidator.LengthValidator.class,
+            this.i18n, "test", length);
+
+        boolean result;
+
+        try {
+            validator.validate(key, value);
+            result = true;
+        }
+        catch (PropertyValidationException e) {
+            result = false;
+        }
+
+        assertEquals(shouldValidate, result);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testLengthValidatorConfigurationFailure() {
+        Validator validator = this.getValidator(PropertyValidator.LengthValidator.class,
+            this.i18n, "test", -1);
+    }
+
+    @Test
+    @Parameters({
+        "key, 50, true",
+        "key, -50, true",
+        "key, 2147483647, true",
+        "key, -2147483648, true",
+        "key, string, false",
+        "key, two, false",
+        "key, 3.14, false",
+        "key, -2.72, false"})
+    public void testIntegerValidator(String key, String value, boolean shouldValidate) {
+        Validator validator = this.getValidator(PropertyValidator.IntegerValidator.class, this.i18n, "test");
+
+        boolean result;
+
+        try {
+            validator.validate(key, value);
+            result = true;
+        }
+        catch (PropertyValidationException e) {
+            result = false;
+        }
+
+        assertEquals(shouldValidate, result);
+    }
+
+    @Test
+    @Parameters({
+        "key, 50, true",
+        "key, -50, false",
+        "key, 2147483647, true",
+        "key, -2147483648, false",
+        "key, string, false",
+        "key, two, false",
+        "key, 3.14, false",
+        "key, -2.72, false"})
+    public void testNonNegativeIntegerValidator(String key, String value, boolean shouldValidate) {
+        Validator validator = this.getValidator(PropertyValidator.NonNegativeIntegerValidator.class,
+            this.i18n, "test");
+
+        boolean result;
+
+        try {
+            validator.validate(key, value);
+            result = true;
+        }
+        catch (PropertyValidationException e) {
+            result = false;
+        }
+
+        assertEquals(shouldValidate, result);
+    }
+
+    @Test
+    @Parameters({
+        "key, 50, true",
+        "key, -50, true",
+        "key, 9223372036854775807, true",
+        "key, -9223372036854775808, true",
+        "key, string, false",
+        "key, two, false",
+        "key, 3.14, false",
+        "key, -2.72, false"})
+    public void testLongValidator(String key, String value, boolean shouldValidate) {
+        Validator validator = this.getValidator(PropertyValidator.LongValidator.class, this.i18n, "test");
+
+        boolean result;
+
+        try {
+            validator.validate(key, value);
+            result = true;
+        }
+        catch (PropertyValidationException e) {
+            result = false;
+        }
+
+        assertEquals(shouldValidate, result);
+    }
+
+    @Test
+    @Parameters({
+        "key, 50, true",
+        "key, -50, false",
+        "key, 9223372036854775807, true",
+        "key, -9223372036854775808, false",
+        "key, string, false",
+        "key, two, false",
+        "key, 3.14, false",
+        "key, -2.72, false"})
+    public void testNonNegativeLongValidator(String key, String value, boolean shouldValidate) {
+        Validator validator = this.getValidator(PropertyValidator.NonNegativeLongValidator.class,
+            this.i18n, "test");
+
+        boolean result;
+
+        try {
+            validator.validate(key, value);
+            result = true;
+        }
+        catch (PropertyValidationException e) {
+            result = false;
+        }
+
+        assertEquals(shouldValidate, result);
+    }
+
+    @Test
+    @Parameters({
+        "key, true, true",
+        "key, false, true",
+        "key, 1, true",
+        "key, 0, true",
+        "key, yes, false",
+        "key, no, false",
+        "key, y, false",
+        "key, n, false"})
+    public void testBooleanValidator(String key, String value, boolean shouldValidate) {
+        Validator validator = this.getValidator(PropertyValidator.BooleanValidator.class,
+            this.i18n, "test");
+
+        boolean result;
+
+        try {
+            validator.validate(key, value);
+            result = true;
+        }
+        catch (PropertyValidationException e) {
+            result = false;
+        }
+
+        assertEquals(shouldValidate, result);
+    }
+
+}


### PR DESCRIPTION
- Added the new PropertyValidator class and its subclasses
  AttributeValidator and FactValidator, which provide implementations
  for validating attributes and facts, respectively
- Updated the ProductCurator and ConsumerCurator to use the new
  PropertyValidator instances in place of their old private validation
  methods
- ConsumerValidator no longer massages inbound fact data, but will
  now, instead, throw PropertyValidationExceptions when it encounters
  malformed or otherwise unmanagable data
- ConsumerResource now provides the massaging and filtering
  functionality previously performed in the ConsumerCurator