### PR TITLE
Pinhead counting feature

### DIFF
--- a/server/client/ruby/candlepin_api.rb
+++ b/server/client/ruby/candlepin_api.rb
@@ -782,11 +782,11 @@ class Candlepin
   end
 
   # TODO: Should we change these to bind to better match terminology?
-  def consume_pool(pool, params={})
+  def consume_pool(pool_id, params={})
     quantity = params[:quantity] || nil
     uuid = params[:uuid] || @uuid
     async = params[:async] || nil
-    path = "/consumers/#{uuid}/entitlements?pool=#{pool}"
+    path = "/consumers/#{uuid}/entitlements?pool=#{pool_id}"
     path << "&quantity=#{quantity}" if quantity
     path << "&async=#{async}" if async
 
@@ -913,7 +913,30 @@ class Candlepin
     facts.each do |fact|
       query << "&fact=%s" % [fact]
     end
+
     get(query)
+  end
+
+  def count_owner_consumers(owner_key, consumer_types=[], skus=[], subscription_ids=[], contracts=[])
+    query = "/owners/#{owner_key}/consumers/count?"
+
+    if !consumer_types.empty?
+      query += "&type=" + consumer_types.join("&type=")
+    end
+
+    if !skus.empty?
+      query += "&sku=" + skus.join("&sku=")
+    end
+
+    if !subscription_ids.empty?
+      query += "&subscription_id=" + subscription_ids.join("&subscription_id=")
+    end
+
+    if !contracts.empty?
+      query += "&contract=" + contracts.join("&contract=")
+    end
+
+    get(query,accept_header=:json, dont_parse=true)
   end
 
   def get_consumer(consumer_id=nil)

--- a/server/spec/owner_resource_spec.rb
+++ b/server/spec/owner_resource_spec.rb
@@ -870,3 +870,150 @@ describe 'Owner Resource Future Pool Tests' do
   end
 
 end
+
+describe 'Owner Resource counting feature' do
+
+  include CandlepinMethods
+
+  before(:each) do
+    @owner = create_owner(random_string("test_owner"))
+    @owner_cp = user_client(@owner, random_string('user_name'))
+  end
+
+  it 'should count all consumers of given owner' do
+    @owner_cp.register('consumer_name1')
+    @owner_cp.register('consumer_name2')
+
+    json_count = @owner_cp.count_owner_consumers(@owner['key'])
+    expect(Integer(json_count)).to be == 2
+
+    other_owner = create_owner(random_string("test_owner"))
+    other_cp = user_client(other_owner, random_string('bill'))
+    other_cp.register('consumer_name3')
+
+    json_count = @cp.count_owner_consumers(other_owner['key'])
+    expect(Integer(json_count)).to be == 1
+  end
+
+  it 'should count only consumers specified by type label' do
+    @owner_cp.register('consumer_name1', type=:system)
+    @owner_cp.register('consumer_name2', type=:hypervisor)
+
+    json_count = @owner_cp.count_owner_consumers(@owner['key'], type=[:system])
+    expect(Integer(json_count)).to be == 1
+
+    json_count = @owner_cp.count_owner_consumers(@owner['key'], type=[:system, :hypervisor])
+    expect(Integer(json_count)).to be == 2
+  end
+
+  it 'should count consumers only with specific skus' do
+    c = @owner_cp.register('consumer_name')
+    sku1 = create_product_and_bint_it_to_consumer_return_sku(c)
+    sku2 = create_product_and_bint_it_to_consumer_return_sku(c)
+    sku3 = create_consumer_with_binding_to_new_product_return_sku
+    expect(sku1).not_to be(sku2)
+    expect(sku2).not_to be(sku3)
+
+    json_count = @owner_cp.count_owner_consumers(@owner['key'], [], ["not-existing-sku"])
+    expect(Integer(json_count)).to be == 0
+
+    json_count = @owner_cp.count_owner_consumers(@owner['key'], [], [sku1])
+    expect(Integer(json_count)).to be == 1
+
+    json_count = @owner_cp.count_owner_consumers(@owner['key'], [], [sku1, sku2])
+    expect(Integer(json_count)).to be == 1
+
+    json_count = @owner_cp.count_owner_consumers(@owner['key'], [], [sku1, sku2, sku3])
+    expect(Integer(json_count)).to be == 2
+  end
+
+  it 'should count consumers only with specific subscriptionIds' do
+    c = @owner_cp.register('consumer_name')
+    subId1 = create_product_and_bint_it_to_consumer_return_subId(c)
+    subId2 = create_product_and_bint_it_to_consumer_return_subId(c)
+    subId3 = create_consumer_with_binding_to_new_product_return_subId
+    expect(subId1).not_to be(subId2)
+    expect(subId2).not_to be(subId3)
+
+    json_count = @owner_cp.count_owner_consumers(@owner['key'], [], [], ["not-existing-subId"])
+    expect(Integer(json_count)).to be == 0
+
+    json_count = @owner_cp.count_owner_consumers(@owner['key'], [], [], [subId1])
+    expect(Integer(json_count)).to be == 1
+
+    json_count = @owner_cp.count_owner_consumers(@owner['key'], [], [], [subId1, subId2])
+    expect(Integer(json_count)).to be == 1
+
+    json_count = @owner_cp.count_owner_consumers(@owner['key'], [], [], [subId1, subId2, subId3])
+    expect(Integer(json_count)).to be == 2
+  end
+
+  it 'should count consumer only with specific contract numbers' do
+    c = @owner_cp.register('consumer_name')
+    cn1 = create_product_and_bint_it_to_consumer_return_contractNr(c)
+    cn2 = create_product_and_bint_it_to_consumer_return_contractNr(c)
+    cn3 = create_consumer_with_binding_to_new_product_return_contractNr
+    expect(cn1).not_to be(cn2)
+    expect(cn2).not_to be(cn3)
+
+    json_count = @owner_cp.count_owner_consumers(@owner['key'], [], [], [], ["not-exisitng-cn"])
+    expect(Integer(json_count)).to be == 0
+
+    json_count = @owner_cp.count_owner_consumers(@owner['key'], [], [], [], [cn1])
+    expect(Integer(json_count)).to be == 1
+
+    json_count = @owner_cp.count_owner_consumers(@owner['key'], [], [], [], [cn1, cn2])
+    expect(Integer(json_count)).to be == 1
+
+    json_count = @owner_cp.count_owner_consumers(@owner['key'], [], [], [], [cn1, cn2, cn3])
+    expect(Integer(json_count)).to be == 2
+  end
+
+  def create_consumer_with_binding_to_new_product_return_sku(product_type='MKT')
+    c = @owner_cp.register('consumer_name')
+    create_product_and_bint_it_to_consumer_return_sku(c, product_type)
+  end
+
+  def create_product_and_bint_it_to_consumer_return_sku(consumer, product_type='MKT')
+    params = {:attributes => {'type' => product_type}}
+    p = create_product(@owner['key'], params)
+
+    pool = create_pool_and_subscription(@owner['key'], p.id, 1)
+    @owner_cp.consume_pool(pool.id, params={:uuid => consumer.uuid, :quantity => 1})
+    p.id #sku
+  end
+
+  def create_consumer_with_binding_to_new_product_return_subId
+    c = @owner_cp.register('consumer_name')
+
+    create_product_and_bint_it_to_consumer_return_subId(c)
+  end
+
+  def create_product_and_bint_it_to_consumer_return_subId(consumer)
+    p = create_product(@owner['key'])
+    pool = create_pool_and_subscription(@owner['key'], p.id, 1)
+    @owner_cp.consume_pool(pool.id, params={:uuid => consumer.uuid, :quantity => 1})
+    pool.subscriptionId
+  end
+
+  def create_consumer_with_binding_to_new_product_return_contractNr
+    c = @owner_cp.register('consumer_name')
+
+    create_product_and_bint_it_to_consumer_return_contractNr(c)
+  end
+
+  def create_product_and_bint_it_to_consumer_return_contractNr(consumer)
+    p = create_product(@owner['key'])
+    cn = random_string('contract_nr')
+    pool = create_pool_and_subscription(@owner['key'], p.id, 1, [], cn)
+    @owner_cp.consume_pool(pool.id, params={:uuid => consumer.uuid, :quantity => 1})
+    pool.contractNumber
+  end
+
+  def create_product(owner_key, params={})
+    id = random_string('sku')
+    name = 'prod_name-' + id
+    product = @cp.create_product(owner_key, id, name, params)
+  end
+
+end

--- a/server/src/main/java/org/candlepin/model/ConsumerTypeCurator.java
+++ b/server/src/main/java/org/candlepin/model/ConsumerTypeCurator.java
@@ -14,15 +14,10 @@
  */
 package org.candlepin.model;
 
-import org.candlepin.common.exceptions.BadRequestException;
-
-import org.apache.commons.lang.StringUtils;
 import org.hibernate.criterion.Restrictions;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 
 /**
  * ConsumerTypeCurator
@@ -55,22 +50,5 @@ public class ConsumerTypeCurator extends AbstractHibernateCurator<ConsumerType> 
     public List<ConsumerType> lookupByLabels(Collection<String> labels) {
         return (List<ConsumerType>) currentSession().createCriteria(ConsumerType.class)
             .add(Restrictions.in("label", labels)).list();
-    }
-
-    public List<ConsumerType> lookupConsumerTypes(Set<String> labels) {
-        List<ConsumerType> types = this.lookupByLabels(labels);
-        // Since the type labels are unique, our sizes must match.
-        if (labels.size() != types.size()) {
-            List<String> invalidLabels = new ArrayList<String>(labels);
-            for (ConsumerType type : types) {
-                String label = type.getLabel();
-                if (labels.contains(label)) {
-                    invalidLabels.remove(label);
-                }
-            }
-            throw new BadRequestException(i18n.tr("No such unit type(s): {0}",
-                StringUtils.join(invalidLabels, ", ")));
-        }
-        return types;
     }
 }

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -93,6 +93,7 @@ import org.candlepin.resource.dto.ContentAccessListing;
 import org.candlepin.resource.util.CalculatedAttributesUtil;
 import org.candlepin.resource.util.ConsumerBindUtil;
 import org.candlepin.resource.util.ConsumerInstalledProductEnricher;
+import org.candlepin.resource.util.ConsumerTypeValidator;
 import org.candlepin.resource.util.EntitlementFinderUtil;
 import org.candlepin.resource.util.ResourceDateParser;
 import org.candlepin.resteasy.DateFormat;
@@ -204,6 +205,7 @@ public class ConsumerResource {
     private ProductCurator productCurator;
     private ManifestManager manifestManager;
     private FactValidator factValidator;
+    private ConsumerTypeValidator consumerTypeValidator;
 
     @Inject
     @SuppressWarnings({"checkstyle:parameternumber"})
@@ -227,7 +229,8 @@ public class ConsumerResource {
         ProductCurator productCurator,
         ManifestManager manifestManager,
         ContentAccessCertServiceAdapter contentAccessCertService,
-        FactValidator factValidator) {
+        FactValidator factValidator,
+        ConsumerTypeValidator consumerTypeValidator) {
 
         this.consumerCurator = consumerCurator;
         this.consumerTypeCurator = consumerTypeCurator;
@@ -263,6 +266,7 @@ public class ConsumerResource {
         this.manifestManager = manifestManager;
         this.contentAccessCertService = contentAccessCertService;
         this.factValidator = factValidator;
+        this.consumerTypeValidator = consumerTypeValidator;
     }
 
     /**
@@ -358,10 +362,7 @@ public class ConsumerResource {
             }
         }
 
-        List<ConsumerType> types = null;
-        if (typeLabels != null && !typeLabels.isEmpty()) {
-            types = consumerTypeCurator.lookupConsumerTypes(typeLabels);
-        }
+        List<ConsumerType> types =  consumerTypeValidator.findAndValidateTypeLabels(typeLabels);
 
         Page<List<Consumer>> page = consumerCurator.searchOwnerConsumers(
             owner, userName, types, uuids, hypervisorIds, attrFilters,

--- a/server/src/main/java/org/candlepin/resource/util/ConsumerTypeValidator.java
+++ b/server/src/main/java/org/candlepin/resource/util/ConsumerTypeValidator.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2009 - 2017 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.resource.util;
+
+import org.candlepin.common.exceptions.BadRequestException;
+import org.candlepin.model.ConsumerType;
+import org.candlepin.model.ConsumerTypeCurator;
+
+import com.google.inject.Inject;
+
+import org.apache.commons.lang.StringUtils;
+import org.xnap.commons.i18n.I18n;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+/**
+ *
+ * ConsumerTypeValidator validate consumer type in REST API
+ */
+public class ConsumerTypeValidator {
+
+    private I18n i18n;
+    private ConsumerTypeCurator consumerTypeCurator;
+
+
+    @Inject
+    public ConsumerTypeValidator(ConsumerTypeCurator consumerTypeCurator, I18n i18n) {
+        super();
+        this.i18n = i18n;
+        this.consumerTypeCurator = consumerTypeCurator;
+    }
+
+    public List<ConsumerType> findAndValidateTypeLabels(Set<String> labels) {
+        if (labels != null && !labels.isEmpty()) {
+            List<ConsumerType> types = consumerTypeCurator.lookupByLabels(labels);
+            validate(types, labels);
+            return types;
+        }
+        return null;
+    }
+
+    private void validate(List<ConsumerType> types, Set<String> labels) {
+        // Since the type labels are unique, our sizes must match.
+        if (labels.size() != types.size()) {
+            List<String> invalidLabels = findInvalidLabels(labels, types);
+            throw new BadRequestException(i18n.tr("No such unit type(s): {0}",
+                StringUtils.join(invalidLabels, ", ")));
+        }
+    }
+
+    private List<String> findInvalidLabels(Set<String> labels,
+        List<ConsumerType> types) {
+        List<String> invalidLabels = new ArrayList<String>(labels);
+        for (ConsumerType type : types) {
+            String label = type.getLabel();
+            if (labels.contains(label)) {
+                invalidLabels.remove(label);
+            }
+        }
+        return invalidLabels;
+    }
+}

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceCreationTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceCreationTest.java
@@ -131,7 +131,7 @@ public class ConsumerResourceCreationTest {
             this.userService, null, null, this.ownerCurator,
             this.activationKeyCurator, null, this.complianceRules, this.deletedConsumerCurator,
             null, null, this.config, null, null, null, this.consumerBindUtil,
-            productCurator, null, null, new FactValidator(this.config, this.i18n));
+            productCurator, null, null, new FactValidator(this.config, this.i18n), null);
 
         this.system = initSystem();
 

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
@@ -575,7 +575,7 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
             null, null, this.entitlementCurator, null, null, null, null, null,
             null, null, null, this.poolManager, null, null, null,
             null, null, null, null, null, new CandlepinCommonTestConfig(), null,
-            null, null, mock(ConsumerBindUtil.class), productCurator, null, null, null);
+            null, null, mock(ConsumerBindUtil.class), productCurator, null, null, null, null);
 
         Response rsp = consumerResource.bind(consumer.getUuid(), pool.getId().toString(), null, 1, null,
             null, false, null, null, null, null);

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
@@ -14,9 +14,18 @@
  */
 package org.candlepin.resource;
 
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.atMost;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import org.candlepin.audit.Event;
 import org.candlepin.audit.Event.Target;
@@ -56,8 +65,8 @@ import org.candlepin.service.IdentityCertServiceAdapter;
 import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.service.UserServiceAdapter;
 import org.candlepin.test.TestUtil;
-import org.candlepin.util.ServiceLevelValidator;
 import org.candlepin.util.FactValidator;
+import org.candlepin.util.ServiceLevelValidator;
 
 import org.junit.Before;
 import org.junit.Ignore;
@@ -114,7 +123,7 @@ public class ConsumerResourceUpdateTest {
             this.activationKeyCurator, this.entitler, this.complianceRules,
             this.deletedConsumerCurator, this.environmentCurator, null,
             config, null, null, null, this.consumerBindUtil, productCurator,
-            null, null, new FactValidator(config, this.i18n));
+            null, null, new FactValidator(config, this.i18n), null);
 
         when(complianceRules.getStatus(any(Consumer.class), any(Date.class),
                 any(Boolean.class), any(Boolean.class)))

--- a/server/src/test/java/org/candlepin/resource/GuestIdResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/GuestIdResourceTest.java
@@ -14,8 +14,10 @@
  */
 package org.candlepin.resource;
 
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.when;
 
 import org.candlepin.audit.EventFactory;
@@ -266,7 +268,7 @@ public class GuestIdResourceTest {
             super(null, null, null, null, null, null, null, null, null,
                   null, null, null, null, null, null, null, null,
                   null, null, null, null, null, null, null, null, null, null, productCurator,
-                  null, null, null);
+                  null, null, null, null);
         }
 
         public void checkForMigration(Consumer host, Consumer guest) {

--- a/server/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
@@ -14,8 +14,12 @@
  */
 package org.candlepin.resource;
 
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.when;
 
 import org.candlepin.audit.Event.Target;
@@ -108,7 +112,7 @@ public class HypervisorResourceTest {
             this.activationKeyCurator, null, this.complianceRules,
             this.deletedConsumerCurator, null, null, config,
             null, null, null, this.consumerBindUtil, productCurator, null, null,
-            new FactValidator(config, this.i18n));
+            new FactValidator(config, this.i18n), null);
 
         hypervisorResource = new HypervisorResource(consumerResource,
             consumerCurator, i18n, ownerCurator);

--- a/server/src/test/java/org/candlepin/resource/OwnerResourceUeberCertOperationsTest.java
+++ b/server/src/test/java/org/candlepin/resource/OwnerResourceUeberCertOperationsTest.java
@@ -14,7 +14,10 @@
  */
 package org.candlepin.resource;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import org.candlepin.auth.Principal;
 import org.candlepin.auth.UserPrincipal;
@@ -103,7 +106,7 @@ public class OwnerResourceUeberCertOperationsTest extends DatabaseTestFixture {
             ownerCurator, null, consumerCurator, i18n, null, null, null, null, null, poolManager, null, null,
             null, null, consumerTypeCurator, entCertCurator, entitlementCurator, ueberCertGenerator, null,
             null, contentOverrideValidator, serviceLevelValidator, null, null, null, productManager,
-            contentManager
+            contentManager, null
         );
     }
 

--- a/server/src/test/java/org/candlepin/test/DatabaseTestFixture.java
+++ b/server/src/test/java/org/candlepin/test/DatabaseTestFixture.java
@@ -14,7 +14,8 @@
  */
 package org.candlepin.test;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
 
 import org.candlepin.TestingInterceptor;
 import org.candlepin.TestingModules;
@@ -83,7 +84,6 @@ import org.hibernate.ejb.HibernateEntityManagerFactory;
 import org.hibernate.event.service.spi.EventListenerRegistry;
 import org.hibernate.event.spi.EventType;
 import org.hibernate.internal.SessionFactoryImpl;
-
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -92,7 +92,6 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.xnap.commons.i18n.I18n;
 import org.xnap.commons.i18n.I18nFactory;
 
@@ -363,6 +362,20 @@ public class DatabaseTestFixture {
 
         pool.setSourceSubscription(new SourceSubscription(subscriptionId, subscriptionSubKey));
         return poolCurator.create(pool);
+    }
+
+    protected Pool createPool(Owner owner, Product product, Long quantity, Date startDate, Date endDate,
+        String contractNr) {
+        Pool pool = createPool(owner, product, quantity, startDate, endDate);
+        pool.setContractNumber(contractNr);
+        return poolCurator.merge(pool);
+    }
+
+    protected Pool createPool(Owner owner, Product product, Long quantity, Date startDate, Date endDate,
+        String contractNr, String subscriptionId) {
+        Pool pool = createPool(owner, product, quantity, subscriptionId, "master", startDate, endDate);
+        pool.setContractNumber(contractNr);
+        return poolCurator.merge(pool);
     }
 
     protected Owner createOwner() {


### PR DESCRIPTION
- This feature should be similar like listConsumer API, so it should return equal count of consumers.

- Feature was firstly implemented SQL, then with JPQL and at the end with hibernate criteria.
  Perfromance test didn't show significant difference between these implementation. Hibernate criteria
  was used because secureCriteria are used in listConsumer method and to use JPQL we would have to make more effort.

- Unit test added and refactored in ConsumerCuratorTest to test DB layer and OwnerResourceTest to test business layer.
  Some older portion of code in OwnerResourceTest was refactored as well.
  Notice methods which only passthrough collections.  These are only helpers for better readability and less verbosity.
      Consider these 2 approaches:

```java
        1)
            List<String> typeLabels = null;
            List<String> skus = null;
            List<String> ids = null;
            List<String> contracts = null;
            int count = consumerCurator.countConsumers(owner.getKey(), typeLabels, 
                                 skus, ids, contracts);
```
```java    
        2)
             int count = consumerCurator.countConsumers(owner.getKey(), typeLabels(null),
                                 skus(null), ids(null), contracts(null));
```
   
 - Spec test added. Refactored.
