### PR TITLE
1416823: Abstracted out property validation to new validator framework (0.9.49)

### DIFF
--- a/server/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/server/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -118,6 +118,11 @@ public class ConfigProperties {
     };
 
     public static final String SYNC_WORK_DIR = "candlepin.sync.work_dir";
+
+    /**
+     *  Controls which facts will be stored by Candlepin -- facts with keys that do not match this
+     *  value will be discarded.
+     */
     public static final String CONSUMER_FACTS_MATCHER = "candlepin.consumer.facts.match_regex";
 
     public static final String SHARD_USERNAME = "candlepin.shard.username";

--- a/server/src/main/java/org/candlepin/guice/CandlepinModule.java
+++ b/server/src/main/java/org/candlepin/guice/CandlepinModule.java
@@ -113,6 +113,8 @@ import org.candlepin.sync.EntitlementCertExporter;
 import org.candlepin.sync.Exporter;
 import org.candlepin.sync.MetaExporter;
 import org.candlepin.sync.RulesExporter;
+import org.candlepin.util.AttributeValidator;
+import org.candlepin.util.FactValidator;
 import org.candlepin.util.DateSource;
 import org.candlepin.util.DateSourceImpl;
 import org.candlepin.util.ExpiryDateFunction;
@@ -236,6 +238,8 @@ public class CandlepinModule extends AbstractModule {
         bind(DeletedConsumerResource.class);
         bind(CdnResource.class);
         bind(GuestIdResource.class);
+        bind(AttributeValidator.class);
+        bind(FactValidator.class);
 
         configureInterceptors();
         bind(JsonProvider.class);

--- a/server/src/main/java/org/candlepin/model/ConsumerCurator.java
+++ b/server/src/main/java/org/candlepin/model/ConsumerCurator.java
@@ -19,8 +19,8 @@ import org.candlepin.common.exceptions.BadRequestException;
 import org.candlepin.common.exceptions.NotFoundException;
 import org.candlepin.common.paging.Page;
 import org.candlepin.common.paging.PageRequest;
-import org.candlepin.config.ConfigProperties;
 import org.candlepin.resteasy.parameter.KeyValueParameter;
+import org.candlepin.util.FactValidator;
 import org.candlepin.util.Util;
 
 import com.google.inject.Inject;
@@ -48,7 +48,6 @@ import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -58,20 +57,21 @@ import java.util.Set;
 
 import javax.persistence.LockModeType;
 
+
+
 /**
  * ConsumerCurator
  */
 public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
+    private static Logger log = LoggerFactory.getLogger(ConsumerCurator.class);
+    private static final int MAX_IN_QUERY_LENGTH = 500;
 
     @Inject private EntitlementCurator entitlementCurator;
     @Inject private ConsumerTypeCurator consumerTypeCurator;
     @Inject private DeletedConsumerCurator deletedConsumerCurator;
     @Inject private Configuration config;
 
-    private static final int MAX_FACT_STR_LENGTH = 255;
-    private static final int NAME_LENGTH = 250;
-    private static final int MAX_IN_QUERY_LENGTH = 500;
-    private static Logger log = LoggerFactory.getLogger(ConsumerCurator.class);
+    @Inject private FactValidator factValidator;
 
     public ConsumerCurator() {
         super(Consumer.class);
@@ -81,9 +81,8 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
     @Override
     public Consumer create(Consumer entity) {
         entity.ensureUUID();
-        if (entity.getFacts() != null) {
-            entity.setFacts(filterAndVerifyFacts(entity));
-        }
+        this.validateFacts(entity);
+
         return super.create(entity);
     }
 
@@ -96,8 +95,7 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
 
         super.delete(entity);
 
-        DeletedConsumer existing = deletedConsumerCurator.
-                    findByConsumerUuid(dc.getConsumerUuid());
+        DeletedConsumer existing = deletedConsumerCurator.findByConsumerUuid(dc.getConsumerUuid());
         if (existing != null) {
             // update the owner ID in case the same UUID was specified by two owners
             existing.setOwnerId(dc.getOwnerId());
@@ -358,50 +356,58 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
      */
     @Transactional
     public Consumer update(Consumer updatedConsumer) {
-        Consumer existingConsumer = find(updatedConsumer.getId());
-        if (existingConsumer == null) {
-            return create(updatedConsumer);
-        }
-
-        // TODO: Are any of these read-only?
-        existingConsumer.setEntitlements(entitlementCurator
-            .bulkUpdate(updatedConsumer.getEntitlements()));
-        Map<String, String> newFacts = filterAndVerifyFacts(updatedConsumer);
-        if (factsChanged(newFacts, existingConsumer.getFacts())) {
-            existingConsumer.setFacts(newFacts);
-        }
-        existingConsumer.setName(updatedConsumer.getName());
-        existingConsumer.setOwner(updatedConsumer.getOwner());
-        existingConsumer.setType(updatedConsumer.getType());
-        existingConsumer.setUuid(updatedConsumer.getUuid());
-
-        save(existingConsumer);
-
-        return existingConsumer;
+        return update(updatedConsumer, true);
     }
 
     /**
-     * @param updatedConsumer updated Consumer values.
-     * @return Updated consumers
+     * Updates an existing consumer with the state specified by the given Consumer instance. If the
+     * consumer has not yet been created, it will be created.
+     * <p></p>
+     * <strong>Warning:</strong> Using an pre-existing and persisted Consumer entity as the update
+     * to apply may cause issues, as Hibernate may opt to save changes to nested collections
+     * (facts, guestIds, tags, etc.) when any other database operation is performed. To avoid this
+     * issue, it is advised to use only detached or otherwise unmanaged entities for the updated
+     * consumer to pass to this method.
+     *
+     * @param updatedConsumer
+     *  A Consumer instance representing the updated state of a consumer
+     *
+     * @param flush
+     *  Whether or not to flush pending database operations after creating or updating the given
+     *  consumer
+     *
+     * @return
+     *  The persisted, updated consumer
      */
     @Transactional
-    public Consumer updateNoFlush(Consumer updatedConsumer) {
+    public Consumer update(Consumer updatedConsumer, boolean flush) {
+        // TODO: FIXME:
+        // We really need to use a DTO here. Hibernate has so many pitfalls with this approach that
+        // can and will lead to odd, broken or out-of-order behavior.
+
+        // Validate inbound facts before even attempting to apply the update
+        this.validateFacts(updatedConsumer);
+
         Consumer existingConsumer = find(updatedConsumer.getId());
+
         if (existingConsumer == null) {
-            return create(updatedConsumer);
+            return this.create(updatedConsumer);
         }
 
         // TODO: Are any of these read-only?
-        existingConsumer.setEntitlements(entitlementCurator
-            .bulkUpdate(updatedConsumer.getEntitlements()));
-        Map<String, String> newFacts = filterAndVerifyFacts(updatedConsumer);
-        if (factsChanged(newFacts, existingConsumer.getFacts())) {
-            existingConsumer.setFacts(newFacts);
-        }
+        existingConsumer.setEntitlements(entitlementCurator.bulkUpdate(updatedConsumer.getEntitlements()));
+
+        // This set of updates is strange. We're ignoring the "null-as-no-change" semantics we use
+        // everywhere else, and just blindly copying everything over.
+        existingConsumer.setFacts(updatedConsumer.getFacts());
         existingConsumer.setName(updatedConsumer.getName());
         existingConsumer.setOwner(updatedConsumer.getOwner());
         existingConsumer.setType(updatedConsumer.getType());
         existingConsumer.setUuid(updatedConsumer.getUuid());
+
+        if (flush) {
+            save(existingConsumer);
+        }
 
         return existingConsumer;
     }
@@ -426,51 +432,27 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
     }
 
     /**
-     * @param facts
-     * @return the list of facts filtered by the fact filter regex config
+     * Validates the facts associated with the given consumer. If any fact fails validation a
+     * PropertyValidationException will be thrown.
+     *
+     * @param consumer
+     *  The consumer containing the facts to validate
      */
-    private Map<String, String> filterAndVerifyFacts(Consumer consumer) {
-        Map<String, String> factsIn = consumer.getFacts();
-        Map<String, String> facts = new HashMap<String, String>();
-        String factMatch = config.getString(ConfigProperties.CONSUMER_FACTS_MATCHER);
-        Set<String> intFacts = config.getSet(ConfigProperties.INTEGER_FACTS);
-        Set<String> posFacts = config.getSet(ConfigProperties.NON_NEG_INTEGER_FACTS);
+    private void validateFacts(Consumer consumer) {
+        // Impl note:
+        // Unlike the previous implementation, we are no longer attempting to "fix" anything here;
+        // if it's broken at this point, we're in trouble, so we're going to throw an exception
+        // instead of waiting for CP to die with a DB exception sometime in the very near future.
+        //
+        // Also, we're no longer using ConfigProperties.CONSUMER_FACTS_MATCHER at this point, as
+        // it's something that belongs with the other input validation and filtering.
 
-        for (Entry<String, String> entry : factsIn.entrySet()) {
-            if (entry.getKey().matches(factMatch)) {
-                if (intFacts != null && intFacts.contains(entry.getKey()) ||
-                    posFacts != null && posFacts.contains(entry.getKey())) {
-                    int value = -1;
-                    try {
-                        value = Integer.parseInt(entry.getValue());
-                    }
-                    catch (NumberFormatException nfe) {
-                        log.error("The fact " + entry.getKey() +
-                            " for consumer " + consumer.getUuid() +
-                            " must be an integer instead of " + entry.getValue() +
-                            ". " + "No value will exist for that fact.");
-                        continue;
-                    }
-                    if (posFacts != null && posFacts.contains(
-                        entry.getKey()) &&
-                        value < 0) {
-                        log.error("The fact " + entry.getKey() +
-                            " must have a positive integer value instead of " +
-                            entry.getValue() + ". No value will exist for that fact.");
-                        continue;
-                    }
-                }
-                facts.put(sanitizeFact(entry.getKey()), sanitizeFact(entry.getValue()));
+        Map<String, String> facts = consumer.getFacts();
+        if (facts != null) {
+            for (Entry<String, String> fact : facts.entrySet()) {
+                this.factValidator.validate(fact.getKey(), fact.getValue());
             }
         }
-        return facts;
-    }
-
-    private String sanitizeFact(String value) {
-        if (value != null && value.length() > MAX_FACT_STR_LENGTH) {
-            return value.substring(0, MAX_FACT_STR_LENGTH - 3) + "...";
-        }
-        return value;
     }
 
     /**

--- a/server/src/main/java/org/candlepin/policy/js/compliance/ComplianceRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/compliance/ComplianceRules.java
@@ -154,7 +154,7 @@ public class ComplianceRules {
 
                 if (updateConsumer && (complianceChanged || entStatusChanged)) {
                     // Merge might work better here, but we use update in other places for this
-                    consumerCurator.updateNoFlush(c);
+                    consumerCurator.update(c, false);
                 }
             }
             return result;

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -94,6 +94,8 @@ import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.service.UserServiceAdapter;
 import org.candlepin.sync.ExportCreationException;
 import org.candlepin.sync.Exporter;
+import org.candlepin.util.FactValidator;
+import org.candlepin.util.PropertyValidationException;
 import org.candlepin.util.Util;
 import org.candlepin.version.CertVersionConflictException;
 
@@ -139,6 +141,8 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+
+
 /**
  * API Gateway for Consumers
  */
@@ -176,8 +180,10 @@ public class ConsumerResource {
     private Configuration config;
     private CalculatedAttributesUtil calculatedAttributesUtil;
     private ConsumerBindUtil consumerBindUtil;
+    private FactValidator factValidator;
 
     @Inject
+    @SuppressWarnings({"checkstyle:parameternumber"})
     public ConsumerResource(ConsumerCurator consumerCurator,
         ConsumerTypeCurator consumerTypeCurator,
         ProductServiceAdapter productAdapter,
@@ -195,7 +201,7 @@ public class ConsumerResource {
         DistributorVersionCurator distributorVersionCurator,
         Configuration config, ContentCurator contentCurator,
         CdnCurator cdnCurator, CalculatedAttributesUtil calculatedAttributesUtil,
-        ConsumerBindUtil consumerBindUtil) {
+        ConsumerBindUtil consumerBindUtil, FactValidator factValidator) {
 
         this.consumerCurator = consumerCurator;
         this.consumerTypeCurator = consumerTypeCurator;
@@ -228,6 +234,69 @@ public class ConsumerResource {
         this.config = config;
         this.calculatedAttributesUtil = calculatedAttributesUtil;
         this.consumerBindUtil = consumerBindUtil;
+        this.factValidator = factValidator;
+    }
+
+    /**
+     * Sanitizes inbound consumer facts, truncating long facts and dropping invalid or untracked
+     * facts. The consumer will be updated in-place.
+     *
+     * @param consumer
+     *  The consumer containing the facts to sanitize
+     */
+    private void sanitizeConsumerFacts(Consumer consumer) {
+        if (consumer != null) {
+            Map<String, String> facts = consumer.getFacts();
+
+            if (facts != null && facts.size() > 0) {
+                log.info("Sanitizing facts for consumer {}", consumer.getName());
+                Map<String, String> sanitized = new HashMap<String, String>();
+
+                String factPattern = config.getString(ConfigProperties.CONSUMER_FACTS_MATCHER);
+                Pattern pattern = Pattern.compile(factPattern);
+
+                for (Map.Entry<String, String> fact : facts.entrySet()) {
+                    String key = fact.getKey();
+                    String value = fact.getValue();
+
+                    // Check for null fact keys (discard and continue)
+                    if (key == null) {
+                        log.warn("  Consumer contains a fact using a null key. Discarding fact...");
+                        continue;
+                    }
+
+                    // Check for fact match (discard and continue)
+                    if (!pattern.matcher(key).matches()) {
+                        log.warn("  Consumer fact \"{}\" does not match pattern \"{}\"", key, factPattern);
+                        log.warn("  Discarding fact \"{}\"...", key);
+                        continue;
+                    }
+
+                    // Check for long keys or values, truncating as necessary
+                    if (key.length() > FactValidator.FACT_MAX_LENGTH) {
+                        key = key.substring(0, FactValidator.FACT_MAX_LENGTH - 3) + "...";
+                    }
+
+                    if (value != null && value.length() > FactValidator.FACT_MAX_LENGTH) {
+                        value = value.substring(0, FactValidator.FACT_MAX_LENGTH - 3) + "...";
+                    }
+
+                    // Validate fact (discarding malformed facts) (discard and continue)
+                    try {
+                        this.factValidator.validate(key, value);
+                    }
+                    catch (PropertyValidationException e) {
+                        log.warn("  {}", e.getMessage());
+                        log.warn("  Discarding fact \"{}\"...", key);
+                        continue;
+                    }
+
+                    sanitized.put(key, value);
+                }
+
+                consumer.setFacts(sanitized);
+            }
+        }
     }
 
     /**
@@ -288,8 +357,7 @@ public class ConsumerResource {
     public void consumerExists(
         @PathParam("consumer_uuid") String uuid) {
         if (!consumerCurator.doesConsumerExist(uuid)) {
-            throw new NotFoundException(i18n.tr(
-                "Consumer with id {0} could not be found.", uuid));
+            throw new NotFoundException(i18n.tr("Consumer with id {0} could not be found.", uuid));
         }
     }
 
@@ -353,8 +421,7 @@ public class ConsumerResource {
             }
 
             // enrich with subscription data
-            consumer.setCanActivate(subAdapter
-                .canActivateSubscription(consumer));
+            consumer.setCanActivate(subAdapter.canActivateSubscription(consumer));
             // enrich with installed product data
             addDataToInstalledProducts(consumer);
         }
@@ -414,18 +481,17 @@ public class ConsumerResource {
         List<ActivationKey> keys = checkActivationKeys(principal, owner, keyStrings);
 
         userName = setUserName(consumer, principal, userName);
-
         checkConsumerName(consumer);
 
         ConsumerType type = lookupConsumerType(consumer.getType().getLabel());
         if (type.isType(ConsumerTypeEnum.PERSON)) {
             if (keys.size() > 0) {
-                throw new BadRequestException(i18n.tr(
-                        "A unit type of ''person'' cannot be used with activation keys"));
+                throw new BadRequestException(
+                    i18n.tr("A unit type of ''person'' cannot be used with activation keys"));
             }
+
             if (!isConsumerPersonNameValid(consumer.getName())) {
-                throw new BadRequestException(i18n.tr(
-                        "System name cannot contain most special characters."));
+                throw new BadRequestException(i18n.tr("System name cannot contain most special characters."));
             }
 
             verifyPersonConsumer(consumer, type, owner, userName, principal);
@@ -440,15 +506,20 @@ public class ConsumerResource {
         consumer.setType(type);
         consumer.setCanActivate(subAdapter.canActivateSubscription(consumer));
         consumer.setAutoheal(true); // this is the default
-        if (consumer.getServiceLevel() == null) { consumer.setServiceLevel(""); }
+
+        if (consumer.getServiceLevel() == null) {
+            consumer.setServiceLevel("");
+        }
+
+        // Sanitize the inbound facts
+        this.sanitizeConsumerFacts(consumer);
 
         // If no service level was specified, and the owner has a default set, use it:
-        if (consumer.getServiceLevel().equals("") &&
-            owner.getDefaultServiceLevel() != null) {
+        if (consumer.getServiceLevel().equals("") && owner.getDefaultServiceLevel() != null) {
             consumer.setServiceLevel(owner.getDefaultServiceLevel());
         }
-        updateCapabilities(consumer, null);
 
+        updateCapabilities(consumer, null);
         logNewConsumerDebugInfo(consumer, keys, type);
 
         if (consumer.getInstalledProducts() != null) {
@@ -456,6 +527,7 @@ public class ConsumerResource {
                 p.setConsumer(consumer);
             }
         }
+
         if (consumer.getGuestIds() != null) {
             for (GuestId g : consumer.getGuestIds()) {
                 g.setConsumer(consumer);
@@ -495,7 +567,7 @@ public class ConsumerResource {
             complianceRules.getStatus(consumer, null, false, false);
             consumerCurator.update(consumer);
 
-            log.info("Consumer " + consumer.getUuid() + " created in org " + consumer.getOwner().getKey());
+            log.info("Consumer {} created in org {}", consumer.getUuid(), consumer.getOwner().getKey());
 
             return consumer;
         }
@@ -505,8 +577,7 @@ public class ConsumerResource {
         }
         catch (Exception e) {
             log.error("Problem creating unit:", e);
-            throw new BadRequestException(i18n.tr(
-                "Problem creating unit {0}", consumer));
+            throw new BadRequestException(i18n.tr("Problem creating unit {0}", consumer));
         }
     }
 
@@ -524,8 +595,8 @@ public class ConsumerResource {
             }
         }
         if ((principal instanceof NoAuthPrincipal) && keys.isEmpty()) {
-            throw new BadRequestException(i18n.tr(
-                    "None of the activation keys specified exist for this org."));
+            throw new BadRequestException(
+                i18n.tr("None of the activation keys specified exist for this org."));
         }
         return keys;
     }
@@ -565,8 +636,7 @@ public class ConsumerResource {
                 if (capabilities != null) {
                     Set<ConsumerCapability> ccaps = new HashSet<ConsumerCapability>();
                     for (DistributorVersionCapability dvc : capabilities) {
-                        ConsumerCapability cc =
-                            new ConsumerCapability(existing, dvc.getName());
+                        ConsumerCapability cc = new ConsumerCapability(existing, dvc.getName());
                         ccaps.add(cc);
                     }
                     existing.setCapabilities(ccaps);
@@ -799,6 +869,7 @@ public class ConsumerResource {
     public void updateConsumer(
         @PathParam("consumer_uuid") @Verify(Consumer.class) String uuid,
         Consumer consumer) {
+
         Consumer toUpdate = consumerCurator.verifyAndLookupConsumer(uuid);
 
         VirtConsumerMap guestConsumerMap = new VirtConsumerMap();
@@ -808,15 +879,15 @@ public class ConsumerResource {
             for (GuestId gid : consumer.getGuestIds()) {
                 allGuestIds.add(gid.getGuestId());
             }
-            guestConsumerMap = consumerCurator.getGuestConsumersMap(
-                    toUpdate.getOwner(), allGuestIds);
 
-            guestsHostConsumerMap = consumerCurator.getGuestsHostMap(
-                    toUpdate.getOwner(), allGuestIds);
+            guestConsumerMap = consumerCurator.getGuestConsumersMap(toUpdate.getOwner(), allGuestIds);
+            guestsHostConsumerMap = consumerCurator.getGuestsHostMap(toUpdate.getOwner(), allGuestIds);
         }
 
-        if (performConsumerUpdates(consumer, toUpdate,
-                guestConsumerMap, guestsHostConsumerMap)) {
+        // Sanitize the inbound facts before applying the update
+        this.sanitizeConsumerFacts(consumer);
+
+        if (performConsumerUpdates(consumer, toUpdate, guestConsumerMap, guestsHostConsumerMap)) {
             try {
                 consumerCurator.update(toUpdate);
             }
@@ -826,19 +897,16 @@ public class ConsumerResource {
             }
             catch (Exception e) {
                 log.error("Problem updating unit:", e);
-                throw new BadRequestException(i18n.tr(
-                    "Problem updating unit {0}", consumer));
+                throw new BadRequestException(i18n.tr("Problem updating unit {0}", consumer));
             }
         }
     }
 
     @Transactional
     protected boolean performConsumerUpdates(Consumer updated, Consumer toUpdate,
-            VirtConsumerMap guestConsumerMap,
-            VirtConsumerMap guestHypervisorConsumers) {
-        if (log.isDebugEnabled()) {
-            log.debug("Updating consumer: {}", toUpdate.getUuid());
-        }
+        VirtConsumerMap guestConsumerMap, VirtConsumerMap guestHypervisorConsumers) {
+
+        log.debug("Updating consumer: {}", toUpdate.getUuid());
 
         // We need a representation of the consumer before making any modifications.
         // If nothing changes we won't send.  The new entity needs to be correct though,
@@ -889,8 +957,7 @@ public class ConsumerResource {
             changesMade = true;
         }
 
-        String environmentId =
-            updated.getEnvironment() == null ? null : updated.getEnvironment().getId();
+        String environmentId = updated.getEnvironment() == null ? null : updated.getEnvironment().getId();
         if (environmentId != null && (toUpdate.getEnvironment() == null ||
                     !toUpdate.getEnvironment().getId().equals(environmentId))) {
             Environment e = environmentCurator.find(environmentId);
@@ -898,7 +965,7 @@ public class ConsumerResource {
                 throw new NotFoundException(i18n.tr(
                     "Environment with ID ''{0}'' could not be found.", environmentId));
             }
-            log.info("Updating environment to: " + environmentId);
+            log.info("Updating environment to: {}", environmentId);
             toUpdate.setEnvironment(e);
 
             // lazily regenerate certs, so the client can still work
@@ -911,8 +978,7 @@ public class ConsumerResource {
         if (updated.getName() != null && !toUpdate.getName().equals(updated.getName())) {
             checkConsumerName(updated);
 
-            log.info("Updating consumer name: {} -> {}",
-                    toUpdate.getName(), updated.getName());
+            log.info("Updating consumer name: {} -> {}", toUpdate.getName(), updated.getName());
             toUpdate.setName(updated.getName());
 
             // get the new name into the id cert
@@ -940,6 +1006,7 @@ public class ConsumerResource {
             Event event = eventBuilder.setNewEntity(toUpdate).buildEvent();
             sink.queueEvent(event);
         }
+
         return changesMade;
     }
 
@@ -958,8 +1025,7 @@ public class ConsumerResource {
                 }
                 else {
                     // Safer to build a new clean HypervisorId object
-                    existing.setHypervisorId(
-                        new HypervisorId(incomingId.getHypervisorId()));
+                    existing.setHypervisorId(new HypervisorId(incomingId.getHypervisorId()));
                 }
             }
             return true;
@@ -992,7 +1058,7 @@ public class ConsumerResource {
     /**
      * Check if the consumers installed products have changed. If they do not appear to
      * have been specified in this PUT, skip updating installed products entirely.
-     * <p>
+     * <p></p>
      * It will return true if installed products were included in request and have changed.
      *
      * @param existing existing consumer
@@ -1032,8 +1098,7 @@ public class ConsumerResource {
      * @return a boolean
      */
     private boolean checkForGuestsUpdate(Consumer existing, Consumer incoming,
-            VirtConsumerMap guestConsumerMap,
-            VirtConsumerMap guestHypervisorConsumers) {
+        VirtConsumerMap guestConsumerMap, VirtConsumerMap guestHypervisorConsumers) {
 
         if (incoming.getGuestIds() == null) {
             log.debug("Guests not included in this consumer update, skipping update.");
@@ -1219,9 +1284,8 @@ public class ConsumerResource {
         }
         catch (ForbiddenException e) {
             String msg = e.message().getDisplayMessage();
-            throw new ForbiddenException(i18n.tr(
-                "Cannot unregister {0} {1} because: {2}", toDelete
-                    .getType().getLabel(), toDelete.getName(), msg), e);
+            throw new ForbiddenException(i18n.tr("Cannot unregister {0} {1} because: {2}",
+                toDelete.getType().getLabel(), toDelete.getName(), msg), e);
 
         }
         consumerRules.onConsumerDelete(toDelete);

--- a/server/src/main/java/org/candlepin/util/AttributeValidator.java
+++ b/server/src/main/java/org/candlepin/util/AttributeValidator.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.util;
+
+import org.candlepin.common.config.Configuration;
+import org.candlepin.config.ConfigProperties;
+
+import com.google.inject.Inject;
+
+import org.xnap.commons.i18n.I18n;
+
+import java.util.Set;
+
+
+
+/**
+ * The AttributeValidator is a PropertyValidator implementation, configured to validate pool or
+ * product attributes.
+ */
+public class AttributeValidator extends PropertyValidator {
+    /** The maximum length of any fact key (name) or value */
+    public static final int ATTRIBUTE_MAX_LENGTH = 255;
+
+    @Inject
+    public AttributeValidator(Configuration config, I18n i18n) {
+        Set<String> attributes;
+
+        // Add integer attributes...
+        attributes = config.getSet(ConfigProperties.INTEGER_ATTRIBUTES, null);
+        if (attributes != null) {
+            for (String key : attributes) {
+                this.validators.put(key, new PropertyValidator.IntegerValidator(i18n, "attribute"));
+            }
+        }
+
+        // Add non-negative integer attributes...
+        attributes = config.getSet(ConfigProperties.NON_NEG_INTEGER_ATTRIBUTES, null);
+        if (attributes != null) {
+            for (String key : attributes) {
+                this.validators.put(key,
+                    new PropertyValidator.NonNegativeIntegerValidator(i18n, "attribute"));
+            }
+        }
+
+        // Add long attributes...
+        attributes = config.getSet(ConfigProperties.LONG_ATTRIBUTES, null);
+        if (attributes != null) {
+            for (String key : attributes) {
+                this.validators.put(key, new PropertyValidator.LongValidator(i18n, "attribute"));
+            }
+        }
+
+        // Add non-negative long attributes...
+        attributes = config.getSet(ConfigProperties.NON_NEG_LONG_ATTRIBUTES, null);
+        if (attributes != null) {
+            for (String key : attributes) {
+                this.validators.put(key, new PropertyValidator.NonNegativeLongValidator(i18n, "attribute"));
+            }
+        }
+
+        // Add boolean attributes...
+        attributes = config.getSet(ConfigProperties.BOOLEAN_ATTRIBUTES, null);
+        if (attributes != null) {
+            for (String key : attributes) {
+                this.validators.put(key, new PropertyValidator.BooleanValidator(i18n, "attribute"));
+            }
+        }
+
+        // Add global validators...
+        this.globalValidators.add(
+            new PropertyValidator.LengthValidator(i18n, "attribute", ATTRIBUTE_MAX_LENGTH));
+    }
+
+}

--- a/server/src/main/java/org/candlepin/util/FactValidator.java
+++ b/server/src/main/java/org/candlepin/util/FactValidator.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.util;
+
+import org.candlepin.common.config.Configuration;
+import org.candlepin.config.ConfigProperties;
+
+import com.google.inject.Inject;
+
+import org.xnap.commons.i18n.I18n;
+
+import java.util.Set;
+
+
+
+/**
+ * The FactValidator is a PropertyValidator implementation, configured to validate consumer facts.
+ */
+public class FactValidator extends PropertyValidator {
+    /** The maximum length of any fact key (name) or value */
+    public static final int FACT_MAX_LENGTH = 255;
+
+    @Inject
+    public FactValidator(Configuration config, I18n i18n) {
+        Set<String> attributes;
+
+        // Add integer attributes...
+        attributes = config.getSet(ConfigProperties.INTEGER_FACTS, null);
+        if (attributes != null) {
+            for (String key : attributes) {
+                this.validators.put(key, new PropertyValidator.IntegerValidator(i18n, "fact"));
+            }
+        }
+
+        // Add non-negative integer attributes...
+        attributes = config.getSet(ConfigProperties.NON_NEG_INTEGER_FACTS, null);
+        if (attributes != null) {
+            for (String key : attributes) {
+                this.validators.put(key, new PropertyValidator.NonNegativeIntegerValidator(i18n, "fact"));
+            }
+        }
+
+        // Add global validators...
+        this.globalValidators.add(new PropertyValidator.LengthValidator(i18n, "fact", FACT_MAX_LENGTH));
+    }
+}

--- a/server/src/main/java/org/candlepin/util/PropertyValidationException.java
+++ b/server/src/main/java/org/candlepin/util/PropertyValidationException.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.util;
+
+import org.candlepin.common.exceptions.CandlepinException;
+
+import javax.ws.rs.core.Response.Status;
+
+
+
+/**
+ * Represents an exception caused by a property (attribute, fact, etc.) containing an illegal
+ * key or value.
+ */
+public class PropertyValidationException extends CandlepinException {
+    private static final long serialVersionUID = 1L;
+
+    public PropertyValidationException(String message) {
+        super(Status.BAD_REQUEST, message);
+    }
+}

--- a/server/src/main/java/org/candlepin/util/PropertyValidator.java
+++ b/server/src/main/java/org/candlepin/util/PropertyValidator.java
@@ -1,0 +1,248 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.util;
+
+import org.xnap.commons.i18n.I18n;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+
+
+/**
+ * The PropertyValidator class provides a simple framework for determining whether or not a given
+ * value is valid for a specified property. The abstraction of this logic allows the logic to be
+ * reused for multiple classes of property (i.e. attributes, facts, etc.).
+ */
+public abstract class PropertyValidator {
+
+    /**
+     * Mini-class for performing validation of a class of values
+     */
+    protected abstract static class Validator {
+        protected I18n i18n;
+        protected String propertyType;
+
+        public Validator(I18n i18n, String propertyType) {
+            if (i18n == null) {
+                throw new IllegalArgumentException("i18n is null");
+            }
+
+            if (propertyType == null) {
+                throw new IllegalArgumentException("propertyType is null");
+            }
+
+            this.i18n = i18n;
+            this.propertyType = propertyType;
+        }
+
+        public abstract void validate(String key, String value);
+    }
+
+    /**
+     * Validator verifying the key or value are small enough to fit in the database
+     */
+    protected static class LengthValidator extends Validator {
+        private int length;
+
+        public LengthValidator(I18n i18n, String propertyType, int length) {
+            super(i18n, propertyType);
+
+            if (length < 0) {
+                throw new IllegalArgumentException("length is a non-positive value");
+            }
+
+            this.length = length;
+        }
+
+        public void validate(String key, String value) {
+            if (key.length() > this.length) {
+                throw new PropertyValidationException(this.i18n.tr(
+                    "The {0} name \"{1}\" must not exceed {2} characters in length",
+                    this.propertyType, key, this.length
+                ));
+            }
+
+            if (value != null && value.length() > this.length) {
+                throw new PropertyValidationException(this.i18n.tr(
+                    "The value for {0} \"{1}\" must not exceed {2} characters in length",
+                    this.propertyType, key, this.length
+                ));
+            }
+        }
+    }
+
+    /**
+     * Validator providing validation for integer properties
+     */
+    protected static class IntegerValidator extends Validator {
+        public IntegerValidator(I18n i18n, String propertyType) {
+            super(i18n, propertyType);
+        }
+
+        public void validate(String key, String value) {
+            try {
+                Integer.parseInt(value);
+            }
+            catch (NumberFormatException nfe) {
+                throw new PropertyValidationException(this.i18n.tr(
+                    "The {0} \"{1}\" must be an integer value", this.propertyType, key));
+            }
+        }
+    }
+
+    /**
+     * Validator providing validation for non-negative properties
+     */
+    protected static class NonNegativeIntegerValidator extends Validator {
+        public NonNegativeIntegerValidator(I18n i18n, String propertyType) {
+            super(i18n, propertyType);
+        }
+
+        public void validate(String key, String value) {
+            try {
+                int parsed = Integer.parseInt(value);
+
+                if (parsed < 0) {
+                    throw new PropertyValidationException(this.i18n.tr(
+                        "The {0} \"{1}\" must be a positive, integer value", this.propertyType, key));
+                }
+            }
+            catch (NumberFormatException nfe) {
+                throw new PropertyValidationException(this.i18n.tr(
+                    "The {0} \"{1}\" must be a positive, integer value", this.propertyType, key));
+            }
+        }
+    }
+
+    /**
+     * Validator providing validation for long-integer properties
+     */
+    protected static class LongValidator extends Validator {
+        public LongValidator(I18n i18n, String propertyType) {
+            super(i18n, propertyType);
+        }
+
+        public void validate(String key, String value) {
+            try {
+                Long.parseLong(value);
+            }
+            catch (NumberFormatException nfe) {
+                throw new PropertyValidationException(this.i18n.tr(
+                    "The {0} \"{1}\" must be a long-integer value", this.propertyType, key));
+            }
+        }
+    }
+
+    /**
+     * Validator providing validation for non-negative, long-integer properties
+     */
+    protected static class NonNegativeLongValidator extends Validator {
+        public NonNegativeLongValidator(I18n i18n, String propertyType) {
+            super(i18n, propertyType);
+        }
+
+        public void validate(String key, String value) {
+            try {
+                long parsed = Long.parseLong(value);
+
+                if (parsed < 0) {
+                    throw new PropertyValidationException(this.i18n.tr(
+                        "The {0} \"{1}\" must be a positive, long-integer value", this.propertyType, key));
+                }
+            }
+            catch (NumberFormatException nfe) {
+                throw new PropertyValidationException(this.i18n.tr(
+                    "The {0} \"{1}\" must be a positive, long-integer value", this.propertyType, key));
+            }
+        }
+    }
+
+    /**
+     * Validator providing validation for Boolean properties
+     */
+    protected static class BooleanValidator extends Validator {
+        private static final Set<String> BOOLEAN_VALUES = Collections.unmodifiableSet(new HashSet<String>(
+            Arrays.asList("true", "false", "1", "0")
+        ));
+
+        public BooleanValidator(I18n i18n, String propertyType) {
+            super(i18n, propertyType);
+        }
+
+        public void validate(String key, String value) {
+            if (!(BOOLEAN_VALUES.contains(value.trim().toLowerCase()))) {
+                throw new PropertyValidationException(this.i18n.tr(
+                    "The {0} \"{1}\" must be a Boolean value", this.propertyType, key));
+            }
+        }
+    }
+
+
+    protected Map<String, Validator> validators;
+    protected Set<Validator> globalValidators;
+
+    /**
+     * Creates a new PropertyValidator instance.
+     */
+    public PropertyValidator() {
+        this.validators = new HashMap<String, Validator>();
+        this.globalValidators = new HashSet<Validator>();
+
+        // Validators will be added by subclasses as necessary
+    }
+
+    /**
+     * Checks whether the value given for the specified key is valid.
+     *
+     * @param key
+     *  The key (property name) to validate
+     *
+     * @param value
+     *  The value to validate
+     *
+     * @throws IllegalArgumentException
+     *  if key is null
+     *
+     * #throws PropertyValidationException
+     *  if the given property has an illegal value
+     */
+    // TODO: Fix the Javadoc above once we can workaround/fix the checkstyle issue that prevents
+    // it from finding the PropertyValidationException.
+    public void validate(String key, String value) {
+        if (key == null) {
+            throw new IllegalArgumentException("key is null");
+        }
+
+        for (Validator validator : this.globalValidators) {
+            if (validator != null) {
+                validator.validate(key, value);
+            }
+        }
+
+        if (value != null && !value.isEmpty()) {
+            Validator validator = this.validators.get(key);
+
+            if (validator != null) {
+                validator.validate(key, value);
+            }
+        }
+    }
+
+}

--- a/server/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
@@ -22,18 +22,24 @@ import org.candlepin.config.ConfigProperties;
 import org.candlepin.model.ConsumerType.ConsumerTypeEnum;
 import org.candlepin.resource.util.ResourceDateParser;
 import org.candlepin.test.DatabaseTestFixture;
+import org.candlepin.util.FactValidator;
+import org.candlepin.util.PropertyValidationException;
 import org.candlepin.util.Util;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.xnap.commons.i18n.I18n;
+import org.xnap.commons.i18n.I18nFactory;
 
 import java.math.BigInteger;
+import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -58,15 +64,21 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
     private Consumer factConsumer;
 
     @Before
-    public void setUp() {
+    public void setUp() throws Exception {
+        I18n i18n = I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK);
+
         owner = new Owner("test-owner", "Test Owner");
         owner = ownerCurator.create(owner);
         ct = new ConsumerType(ConsumerTypeEnum.SYSTEM);
         ct = consumerTypeCurator.create(ct);
 
-        config.setProperty(ConfigProperties.INTEGER_FACTS,
-            "system.count, system.multiplier");
+        config.setProperty(ConfigProperties.INTEGER_FACTS, "system.count, system.multiplier");
         config.setProperty(ConfigProperties.NON_NEG_INTEGER_FACTS, "system.count");
+
+        // Inject this factValidator into the curator
+        Field field = ConsumerCurator.class.getDeclaredField("factValidator");
+        field.setAccessible(true);
+        field.set(this.consumerCurator, new FactValidator(this.config, i18n));
 
         factConsumer = new Consumer("a consumer", "username", owner, ct);
     }
@@ -427,7 +439,7 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
         assertEquals(factConsumer.getFact("system.multiplier"), "-2");
     }
 
-    @Test
+    @Test(expected = PropertyValidationException.class)
     public void testConsumerFactsVerifyBadInt() {
         Map<String, String> facts = new HashMap<String, String>();
         facts.put("system.count", "zzz");
@@ -435,11 +447,9 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
 
         factConsumer.setFacts(facts);
         factConsumer = consumerCurator.create(factConsumer);
-        assertEquals(factConsumer.getFact("system.count"), null);
-        assertEquals(factConsumer.getFact("system.multiplier"), "-2");
     }
 
-    @Test
+    @Test(expected = PropertyValidationException.class)
     public void testConsumerFactsVerifyBadPositive() {
         Map<String, String> facts = new HashMap<String, String>();
         facts.put("system.count", "-2");
@@ -447,11 +457,9 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
 
         factConsumer.setFacts(facts);
         factConsumer = consumerCurator.create(factConsumer);
-        assertEquals(factConsumer.getFact("system.count"), null);
-        assertEquals(factConsumer.getFact("system.multiplier"), "-2");
     }
 
-    @Test
+    @Test(expected = PropertyValidationException.class)
     public void testConsumerFactsVerifyBadUpdateValue() {
         Map<String, String> facts = new HashMap<String, String>();
         facts.put("system.count", "3");
@@ -465,8 +473,6 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
 
         factConsumer.setFact("system.count", "sss");
         factConsumer = consumerCurator.update(factConsumer);
-        assertEquals(factConsumer.getFact("system.count"), null);
-        assertEquals(factConsumer.getFact("system.multiplier"), "-2");
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
@@ -46,6 +46,8 @@ import java.util.Set;
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
 
+
+
 /**
  * ConsumerCuratorTest JUnit tests for Consumer database code
  */

--- a/server/src/test/java/org/candlepin/model/ConsumerTest.java
+++ b/server/src/test/java/org/candlepin/model/ConsumerTest.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertTrue;
 
 import org.candlepin.auth.ConsumerPrincipal;
 import org.candlepin.common.config.Configuration;
-import org.candlepin.config.ConfigProperties;
 import org.candlepin.model.ConsumerType.ConsumerTypeEnum;
 import org.candlepin.resource.ConsumerResource;
 import org.candlepin.test.DatabaseTestFixture;
@@ -32,11 +31,12 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Date;
-import java.util.HashMap;
 import java.util.Map;
 
 import javax.inject.Inject;
 import javax.persistence.PersistenceException;
+
+
 
 public class ConsumerTest extends DatabaseTestFixture {
     @Inject private OwnerCurator ownerCurator;
@@ -426,32 +426,32 @@ public class ConsumerTest extends DatabaseTestFixture {
         assertEquals(consumer, consumerCurator.findByUser(user));
     }
 
-    @Test
-    public void testConsumerFactsFilter() {
-        String oldValue = config.getString(ConfigProperties.CONSUMER_FACTS_MATCHER);
-        config.setProperty(ConfigProperties.CONSUMER_FACTS_MATCHER, "^goodkey.*");
+    // @Test
+    // public void testConsumerFactsFilter() {
+    //     String oldValue = config.getString(ConfigProperties.CONSUMER_FACTS_MATCHER);
+    //     config.setProperty(ConfigProperties.CONSUMER_FACTS_MATCHER, "^goodkey.*");
 
-        Consumer consumer = new Consumer("a consumer", "username", owner, consumerType);
+    //     Consumer consumer = new Consumer("a consumer", "username", owner, consumerType);
 
-        Map<String, String> facts = new HashMap<String, String>();
-        facts.put("badkey.something", "zaz");
-        facts.put("goodkey.something", "foobar");
+    //     Map<String, String> facts = new HashMap<String, String>();
+    //     facts.put("badkey.something", "zaz");
+    //     facts.put("goodkey.something", "foobar");
 
-        consumer.setFacts(facts);
+    //     consumer.setFacts(facts);
 
-        consumer = consumerCurator.create(consumer);
+    //     consumer = consumerCurator.create(consumer);
 
-        assertNull(consumer.getFact("badkey.something"));
-        assertEquals("foobar", consumer.getFact("goodkey.something"));
+    //     assertNull(consumer.getFact("badkey.something"));
+    //     assertEquals("foobar", consumer.getFact("goodkey.something"));
 
-        consumer.setFact("anotherbadkey", "zippy");
+    //     consumer.setFact("anotherbadkey", "zippy");
 
-        consumer = consumerCurator.update(consumer);
+    //     consumer = consumerCurator.update(consumer);
 
-        assertNull(consumer.getFact("anotherbadkey"));
+    //     assertNull(consumer.getFact("anotherbadkey"));
 
-        config.setProperty(ConfigProperties.CONSUMER_FACTS_MATCHER, oldValue);
-    }
+    //     config.setProperty(ConfigProperties.CONSUMER_FACTS_MATCHER, oldValue);
+    // }
 
     @Test
     public void testInstalledProducts() throws Exception {

--- a/server/src/test/java/org/candlepin/policy/js/compliance/ComplianceRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/compliance/ComplianceRulesTest.java
@@ -1929,7 +1929,7 @@ public class ComplianceRulesTest {
         ComplianceStatus originalStatus = compliance.getStatus(c);
         assertEquals("valid", originalStatus.getStatus());
 
-        verify(consumerCurator).updateNoFlush(eq(c));
+        verify(consumerCurator).update(eq(c), eq(false));
         c.addInstalledProduct(new ConsumerInstalledProduct("tip", "Test Installed Procuct"));
         ComplianceStatus updated = compliance.getStatus(c);
         assertNotEquals(originalStatus.getStatus(), updated.getStatus());
@@ -1946,7 +1946,7 @@ public class ComplianceRulesTest {
         assertNotNull(initialHash);
         assertFalse(initialHash.isEmpty());
 
-        verify(consumerCurator).updateNoFlush(eq(c));
+        verify(consumerCurator).update(eq(c), eq(false));
         c.addInstalledProduct(new ConsumerInstalledProduct("tip", "Test Installed Procuct"));
         ComplianceStatus updated = compliance.getStatus(c);
         assertNotEquals(originalStatus.getStatus(), updated.getStatus());

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceCreationTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceCreationTest.java
@@ -55,6 +55,7 @@ import org.candlepin.resource.util.ConsumerBindUtil;
 import org.candlepin.service.IdentityCertServiceAdapter;
 import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.service.UserServiceAdapter;
+import org.candlepin.util.FactValidator;
 import org.candlepin.util.ServiceLevelValidator;
 
 import org.apache.commons.lang.StringUtils;
@@ -127,7 +128,8 @@ public class ConsumerResourceCreationTest {
             this.userService, null, null, null, this.ownerCurator,
             this.activationKeyCurator,
             null, this.complianceRules, this.deletedConsumerCurator,
-            null, null, this.config, null, null, null, this.consumerBindUtil);
+            null, null, this.config, null, null, null, this.consumerBindUtil,
+            new FactValidator(this.config, this.i18n));
 
         this.system = initSystem();
 

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
@@ -597,7 +597,7 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
                 null, null, this.entitlementCurator, null, null, null, null, null,
                 null, null, null, null, this.poolManager, null, null, null,
                 null, null, null, null, null, new CandlepinCommonTestConfig(), null,
-                null, null, mock(ConsumerBindUtil.class));
+                null, null, mock(ConsumerBindUtil.class), null);
 
         Response rsp = consumerResource.bind(
             consumer.getUuid(), pool.getId().toString(), null, 1, null,
@@ -607,8 +607,7 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
         Entitlement ent = resultList.get(0);
         Set<EntitlementCertificate> entCertsBefore = ent.getCertificates();
 
-        cr.regenerateEntitlementCertificates(this.consumer.getUuid(),
-            ent.getId(), true);
+        cr.regenerateEntitlementCertificates(this.consumer.getUuid(), ent.getId(), true);
         Set<EntitlementCertificate> entCertsAfter = ent.getCertificates();
 
         assertFalse(entCertsBefore.equals(entCertsAfter));

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
@@ -24,6 +24,7 @@ import org.candlepin.audit.Event.Type;
 import org.candlepin.audit.EventBuilder;
 import org.candlepin.audit.EventFactory;
 import org.candlepin.audit.EventSink;
+import org.candlepin.common.config.Configuration;
 import org.candlepin.common.exceptions.BadRequestException;
 import org.candlepin.common.exceptions.NotFoundException;
 import org.candlepin.config.CandlepinCommonTestConfig;
@@ -54,6 +55,7 @@ import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.service.UserServiceAdapter;
 import org.candlepin.test.TestUtil;
 import org.candlepin.util.ServiceLevelValidator;
+import org.candlepin.util.FactValidator;
 
 import org.junit.Before;
 import org.junit.Ignore;
@@ -98,6 +100,8 @@ public class ConsumerResourceUpdateTest {
 
     @Before
     public void init() throws Exception {
+        Configuration config = new CandlepinCommonTestConfig();
+
         this.i18n = I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK);
 
         this.resource = new ConsumerResource(this.consumerCurator,
@@ -106,7 +110,8 @@ public class ConsumerResourceUpdateTest {
             this.userService, null, poolManager, null, null,
             this.activationKeyCurator, this.entitler, this.complianceRules,
             this.deletedConsumerCurator, this.environmentCurator, null,
-            new CandlepinCommonTestConfig(), null, null, null, this.consumerBindUtil);
+            new CandlepinCommonTestConfig(), null, null, null, this.consumerBindUtil,
+            new FactValidator(config, this.i18n));
 
         when(complianceRules.getStatus(any(Consumer.class), any(Date.class),
                 any(Boolean.class), any(Boolean.class)))

--- a/server/src/test/java/org/candlepin/resource/GuestIdResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/GuestIdResourceTest.java
@@ -56,23 +56,12 @@ public class GuestIdResourceTest {
 
     private I18n i18n;
 
-    @Mock
-    private ConsumerCurator consumerCurator;
-
-    @Mock
-    private GuestIdCurator guestIdCurator;
-
-    @Mock
-    private ConsumerResourceForTesting consumerResource;
-
-    @Mock
-    private EventFactory eventFactory;
-
-    @Mock
-    private EventSink sink;
-
-    @Mock
-    private ServiceLevelValidator mockedServiceLevelValidator;
+    @Mock private ConsumerCurator consumerCurator;
+    @Mock private GuestIdCurator guestIdCurator;
+    @Mock private ConsumerResourceForTesting consumerResource;
+    @Mock private EventFactory eventFactory;
+    @Mock private EventSink sink;
+    @Mock private ServiceLevelValidator mockedServiceLevelValidator;
 
     private GuestIdResource guestIdResource;
 
@@ -275,7 +264,7 @@ public class GuestIdResourceTest {
         public ConsumerResourceForTesting() {
             super(null, null, null, null, null, null, null, null, null,
                   null, null, null, null, null, null, null, null, null,
-                  null, null, null, null, null, null, null, null, null, null);
+                  null, null, null, null, null, null, null, null, null, null, null);
         }
 
         public void revokeGuestEntitlementsNotMatchingHost(Consumer host, Consumer guest) {

--- a/server/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
@@ -26,6 +26,7 @@ import org.candlepin.audit.EventSink;
 import org.candlepin.auth.Access;
 import org.candlepin.auth.SubResource;
 import org.candlepin.auth.UserPrincipal;
+import org.candlepin.common.config.Configuration;
 import org.candlepin.common.exceptions.BadRequestException;
 import org.candlepin.config.CandlepinCommonTestConfig;
 import org.candlepin.model.Consumer;
@@ -47,6 +48,7 @@ import org.candlepin.resource.util.ConsumerBindUtil;
 import org.candlepin.service.IdentityCertServiceAdapter;
 import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.service.UserServiceAdapter;
+import org.candlepin.util.FactValidator;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -71,58 +73,30 @@ import java.util.Set;
 @RunWith(MockitoJUnitRunner.class)
 public class HypervisorResourceTest {
 
-    @Mock
-    private UserServiceAdapter userService;
-
-    @Mock
-    private IdentityCertServiceAdapter idCertService;
-
-    @Mock
-    private SubscriptionServiceAdapter subscriptionService;
-
-    @Mock
-    private ConsumerCurator consumerCurator;
-
-    @Mock
-    private ConsumerTypeCurator consumerTypeCurator;
-
-    @Mock
-    private OwnerCurator ownerCurator;
-
-    @Mock
-    private EventSink sink;
-
-    @Mock
-    private EventFactory eventFactory;
-
-    @Mock
-    private ActivationKeyCurator activationKeyCurator;
-
-    @Mock
-    private UserPrincipal principal;
-
-    @Mock
-    private ComplianceRules complianceRules;
-
-    @Mock
-    private DeletedConsumerCurator deletedConsumerCurator;
-
-    @Mock
-    private ConsumerBindUtil consumerBindUtil;
-
-    @Mock
-    private EventBuilder consumerEventBuilder;
+    @Mock private UserServiceAdapter userService;
+    @Mock private IdentityCertServiceAdapter idCertService;
+    @Mock private SubscriptionServiceAdapter subscriptionService;
+    @Mock private ConsumerCurator consumerCurator;
+    @Mock private ConsumerTypeCurator consumerTypeCurator;
+    @Mock private OwnerCurator ownerCurator;
+    @Mock private EventSink sink;
+    @Mock private EventFactory eventFactory;
+    @Mock private ActivationKeyCurator activationKeyCurator;
+    @Mock private UserPrincipal principal;
+    @Mock private ComplianceRules complianceRules;
+    @Mock private DeletedConsumerCurator deletedConsumerCurator;
+    @Mock private ConsumerBindUtil consumerBindUtil;
+    @Mock private EventBuilder consumerEventBuilder;
 
     private ConsumerResource consumerResource;
-
     private I18n i18n;
-
     private ConsumerType hypervisorType;
-
     private HypervisorResource hypervisorResource;
 
     @Before
     public void setupTest() {
+        Configuration config = new CandlepinCommonTestConfig();
+
         this.i18n = I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK);
         this.hypervisorType = new ConsumerType(ConsumerTypeEnum.HYPERVISOR);
         this.consumerResource = new ConsumerResource(this.consumerCurator,
@@ -131,7 +105,7 @@ public class HypervisorResourceTest {
             this.userService, null, null, null, this.ownerCurator,
             this.activationKeyCurator, null, this.complianceRules,
             this.deletedConsumerCurator, null, null, new CandlepinCommonTestConfig(),
-            null, null, null, this.consumerBindUtil);
+            null, null, null, this.consumerBindUtil, new FactValidator(config, this.i18n));
 
         hypervisorResource = new HypervisorResource(consumerResource,
             consumerCurator, i18n, ownerCurator);
@@ -149,10 +123,8 @@ public class HypervisorResourceTest {
         when(ownerCurator.lookupByKey(any(String.class))).thenReturn(new Owner());
         when(eventFactory.getEventBuilder(any(Target.class), any(Type.class)))
             .thenReturn(consumerEventBuilder);
-        when(consumerEventBuilder.setNewEntity(any(Consumer.class)))
-            .thenReturn(consumerEventBuilder);
-        when(consumerEventBuilder.setOldEntity(any(Consumer.class)))
-            .thenReturn(consumerEventBuilder);
+        when(consumerEventBuilder.setNewEntity(any(Consumer.class))).thenReturn(consumerEventBuilder);
+        when(consumerEventBuilder.setOldEntity(any(Consumer.class))).thenReturn(consumerEventBuilder);
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/test/DatabaseTestFixture.java
+++ b/server/src/test/java/org/candlepin/test/DatabaseTestFixture.java
@@ -305,8 +305,7 @@ public class DatabaseTestFixture {
     }
 
     public Role createAdminRole(Owner owner) {
-        PermissionBlueprint p = new PermissionBlueprint(PermissionType.OWNER, owner,
-            Access.ALL);
+        PermissionBlueprint p = new PermissionBlueprint(PermissionType.OWNER, owner, Access.ALL);
         Role role = new Role("testrole" + TestUtil.randomInt());
         role.addPermission(p);
         return role;

--- a/server/src/test/java/org/candlepin/util/AttributeValidatorTest.java
+++ b/server/src/test/java/org/candlepin/util/AttributeValidatorTest.java
@@ -1,0 +1,200 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.util;
+
+import static org.junit.Assert.*;
+
+import org.candlepin.common.config.Configuration;
+import org.candlepin.config.CandlepinCommonTestConfig;
+import org.candlepin.config.ConfigProperties;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.xnap.commons.i18n.I18n;
+import org.xnap.commons.i18n.I18nFactory;
+
+import java.util.Locale;
+
+
+
+/**
+ * Test suite for the AttributeValidator class
+ */
+@RunWith(JUnitParamsRunner.class)
+public class AttributeValidatorTest {
+
+    private static I18n i18n = I18nFactory.getI18n(AttributeValidatorTest.class, Locale.US,
+        I18nFactory.FALLBACK);
+
+    private Configuration config;
+
+    @Before
+    public void init() {
+        this.config = new CandlepinCommonTestConfig();
+    }
+
+    @Test(expected = PropertyValidationException.class)
+    @Parameters({"true", "false", "1", "0", "-1", "string value"})
+    public void testLongAttributeKeyFailure(String value) {
+        StringBuilder builder = new StringBuilder(AttributeValidator.ATTRIBUTE_MAX_LENGTH + 2);
+        for (int i = 0; i < AttributeValidator.ATTRIBUTE_MAX_LENGTH + 1; ++i) {
+            builder.append(i % 10);
+        }
+
+        AttributeValidator validator = new AttributeValidator(this.config, i18n);
+        validator.validate(builder.toString(), value);
+    }
+
+    @Test(expected = PropertyValidationException.class)
+    public void testLongAttributeValueFailure() {
+        StringBuilder builder = new StringBuilder(AttributeValidator.ATTRIBUTE_MAX_LENGTH + 2);
+        for (int i = 0; i < AttributeValidator.ATTRIBUTE_MAX_LENGTH + 1; ++i) {
+            builder.append(i % 10);
+        }
+
+        AttributeValidator validator = new AttributeValidator(this.config, i18n);
+        validator.validate("key", builder.toString());
+    }
+
+    @Test
+    @Parameters({
+        "testattrib, testvalue, true",
+        "testattrib, yes, true",
+        "testattrib, no, true",
+        "testattrib, y, true",
+        "testattrib, n, true",
+        "testattrib, true, true",
+        "testattrib, false, true",
+        "testattrib, 1, true",
+        "testattrib, 0, true",
+        "testattrib, -1, true",
+        "testattrib, 2147483647, true",
+        "testattrib, -2147483648, true",
+        "testattrib, 9223372036854775807, true",
+        "testattrib, -9223372036854775808, true",
+        "testattrib, 3.14, true",
+        "testattrib, -2.72, true",
+
+        "intattrib, testvalue, false",
+        "intattrib, yes, false",
+        "intattrib, no, false",
+        "intattrib, y, false",
+        "intattrib, n, false",
+        "intattrib, true, false",
+        "intattrib, false, false",
+        "intattrib, 1, true",
+        "intattrib, 0, true",
+        "intattrib, -1, true",
+        "intattrib, 2147483647, true",
+        "intattrib, -2147483648, true",
+        "intattrib, 9223372036854775807, false",
+        "intattrib, -9223372036854775808, false",
+        "intattrib, 3.14, false",
+        "intattrib, -2.72, false",
+
+        "nnintattrib, testvalue, false",
+        "nnintattrib, yes, false",
+        "nnintattrib, no, false",
+        "nnintattrib, y, false",
+        "nnintattrib, n, false",
+        "nnintattrib, true, false",
+        "nnintattrib, false, false",
+        "nnintattrib, 1, true",
+        "nnintattrib, 0, true",
+        "nnintattrib, -1, false",
+        "nnintattrib, 2147483647, true",
+        "nnintattrib, -2147483648, false",
+        "nnintattrib, 9223372036854775807, false",
+        "nnintattrib, -9223372036854775808, false",
+        "nnintattrib, 3.14, false",
+        "nnintattrib, -2.72, false",
+
+        "longattrib, testvalue, false",
+        "longattrib, yes, false",
+        "longattrib, no, false",
+        "longattrib, y, false",
+        "longattrib, n, false",
+        "longattrib, true, false",
+        "longattrib, false, false",
+        "longattrib, 1, true",
+        "longattrib, 0, true",
+        "longattrib, -1, true",
+        "longattrib, 2147483647, true",
+        "longattrib, -2147483648, true",
+        "longattrib, 9223372036854775807, true",
+        "longattrib, -9223372036854775808, true",
+        "longattrib, 3.14, false",
+        "longattrib, -2.72, false",
+
+        "nnlongattrib, testvalue, false",
+        "nnlongattrib, yes, false",
+        "nnlongattrib, no, false",
+        "nnlongattrib, y, false",
+        "nnlongattrib, n, false",
+        "nnlongattrib, true, false",
+        "nnlongattrib, false, false",
+        "nnlongattrib, 1, true",
+        "nnlongattrib, 0, true",
+        "nnlongattrib, -1, false",
+        "nnlongattrib, 2147483647, true",
+        "nnlongattrib, -2147483648, false",
+        "nnlongattrib, 9223372036854775807, true",
+        "nnlongattrib, -9223372036854775808, false",
+        "nnlongattrib, 3.14, false",
+        "nnlongattrib, -2.72, false",
+
+        "boolattrib, testvalue, false",
+        "boolattrib, yes, false",
+        "boolattrib, no, false",
+        "boolattrib, y, false",
+        "boolattrib, n, false",
+        "boolattrib, true, true",
+        "boolattrib, false, true",
+        "boolattrib, 1, true",
+        "boolattrib, 0, true",
+        "boolattrib, -1, false",
+        "boolattrib, 2147483647, false",
+        "boolattrib, -2147483648, false",
+        "boolattrib, 9223372036854775807, false",
+        "boolattrib, -9223372036854775808, false",
+        "boolattrib, 3.14, false",
+        "boolattrib, -2.72, false"})
+    public void testFactValidation(String key, String value, boolean shouldValidate) {
+        this.config.setProperty(ConfigProperties.INTEGER_ATTRIBUTES, "intattrib");
+        this.config.setProperty(ConfigProperties.NON_NEG_INTEGER_ATTRIBUTES, "nnintattrib");
+        this.config.setProperty(ConfigProperties.LONG_ATTRIBUTES, "longattrib");
+        this.config.setProperty(ConfigProperties.NON_NEG_LONG_ATTRIBUTES, "nnlongattrib");
+        this.config.setProperty(ConfigProperties.BOOLEAN_ATTRIBUTES, "boolattrib");
+
+        AttributeValidator validator = new AttributeValidator(this.config, i18n);
+
+        boolean result;
+
+        try {
+            validator.validate(key, value);
+            result = true;
+        }
+        catch (PropertyValidationException e) {
+            result = false;
+        }
+
+        assertEquals(shouldValidate, result);
+    }
+
+}

--- a/server/src/test/java/org/candlepin/util/FactValidatorTest.java
+++ b/server/src/test/java/org/candlepin/util/FactValidatorTest.java
@@ -1,0 +1,144 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.util;
+
+import static org.junit.Assert.*;
+
+import org.candlepin.common.config.Configuration;
+import org.candlepin.config.CandlepinCommonTestConfig;
+import org.candlepin.config.ConfigProperties;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.xnap.commons.i18n.I18n;
+import org.xnap.commons.i18n.I18nFactory;
+
+import java.util.Locale;
+
+
+
+/**
+ * Test suite for the FactValidator class
+ */
+@RunWith(JUnitParamsRunner.class)
+public class FactValidatorTest {
+
+    private static I18n i18n = I18nFactory.getI18n(FactValidatorTest.class, Locale.US, I18nFactory.FALLBACK);
+    private Configuration config;
+
+    @Before
+    public void init() {
+        this.config = new CandlepinCommonTestConfig();
+    }
+
+    @Test(expected = PropertyValidationException.class)
+    @Parameters({"true", "false", "1", "0", "-1", "string value"})
+    public void testLongFactKeyFailure(String value) {
+        StringBuilder builder = new StringBuilder(FactValidator.FACT_MAX_LENGTH + 2);
+        for (int i = 0; i < FactValidator.FACT_MAX_LENGTH + 1; ++i) {
+            builder.append(i % 10);
+        }
+
+        FactValidator validator = new FactValidator(this.config, i18n);
+        validator.validate(builder.toString(), value);
+    }
+
+    @Test(expected = PropertyValidationException.class)
+    public void testLongFactValueFailure() {
+        StringBuilder builder = new StringBuilder(FactValidator.FACT_MAX_LENGTH + 2);
+        for (int i = 0; i < FactValidator.FACT_MAX_LENGTH + 1; ++i) {
+            builder.append(i % 10);
+        }
+
+        FactValidator validator = new FactValidator(this.config, i18n);
+        validator.validate("key", builder.toString());
+    }
+
+    @Test
+    @Parameters({
+        "testfact, testvalue, true",
+        "testfact, yes, true",
+        "testfact, no, true",
+        "testfact, y, true",
+        "testfact, n, true",
+        "testfact, true, true",
+        "testfact, false, true",
+        "testfact, 1, true",
+        "testfact, 0, true",
+        "testfact, -1, true",
+        "testfact, 2147483647, true",
+        "testfact, -2147483648, true",
+        "testfact, 9223372036854775807, true",
+        "testfact, -9223372036854775808, true",
+        "testfact, 3.14, true",
+        "testfact, -2.72, true",
+
+        "intfact, testvalue, false",
+        "intfact, yes, false",
+        "intfact, no, false",
+        "intfact, y, false",
+        "intfact, n, false",
+        "intfact, true, false",
+        "intfact, false, false",
+        "intfact, 1, true",
+        "intfact, 0, true",
+        "intfact, -1, true",
+        "intfact, 2147483647, true",
+        "intfact, -2147483648, true",
+        "intfact, 9223372036854775807, false",
+        "intfact, -9223372036854775808, false",
+        "intfact, 3.14, false",
+        "intfact, -2.72, false",
+
+        "nnintfact, testvalue, false",
+        "nnintfact, yes, false",
+        "nnintfact, no, false",
+        "nnintfact, y, false",
+        "nnintfact, n, false",
+        "nnintfact, true, false",
+        "nnintfact, false, false",
+        "nnintfact, 1, true",
+        "nnintfact, 0, true",
+        "nnintfact, -1, false",
+        "nnintfact, 2147483647, true",
+        "nnintfact, -2147483648, false",
+        "nnintfact, 9223372036854775807, false",
+        "nnintfact, -9223372036854775808, false",
+        "nnintfact, 3.14, false",
+        "nnintfact, -2.72, false"})
+    public void testFactValidation(String key, String value, boolean shouldValidate) {
+        this.config.setProperty(ConfigProperties.INTEGER_FACTS, "fact1,intfact,fact2");
+        this.config.setProperty(ConfigProperties.NON_NEG_INTEGER_FACTS, "nnintfact");
+
+        FactValidator validator = new FactValidator(this.config, i18n);
+
+        boolean result;
+
+        try {
+            validator.validate(key, value);
+            result = true;
+        }
+        catch (PropertyValidationException e) {
+            result = false;
+        }
+
+        assertEquals(shouldValidate, result);
+    }
+
+}

--- a/server/src/test/java/org/candlepin/util/PropertyValidatorTest.java
+++ b/server/src/test/java/org/candlepin/util/PropertyValidatorTest.java
@@ -1,0 +1,255 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.util;
+
+import static org.junit.Assert.*;
+
+import org.candlepin.util.PropertyValidator.Validator;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.xnap.commons.i18n.I18n;
+import org.xnap.commons.i18n.I18nFactory;
+
+import java.lang.reflect.Constructor;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+
+
+/**
+ * Test suite for the PropertyValidator class
+ */
+@RunWith(JUnitParamsRunner.class)
+public class PropertyValidatorTest {
+
+    private I18n i18n;
+
+    @Before
+    public void init() {
+        this.i18n = I18nFactory.getI18n(this.getClass(), Locale.US, I18nFactory.FALLBACK);
+    }
+
+    /**
+     * Utility method for fetching validators
+     */
+    private Validator getValidator(Class<? extends Validator> validatorClass, Object... args) {
+        Map<Class, Class> translator = new HashMap<Class, Class>();
+        translator.put(Boolean.class, Boolean.TYPE);
+        translator.put(Character.class, Character.TYPE);
+        translator.put(Byte.class, Byte.TYPE);
+        translator.put(Short.class, Short.TYPE);
+        translator.put(Integer.class, Integer.TYPE);
+        translator.put(Long.class, Long.TYPE);
+        translator.put(Float.class, Float.TYPE);
+        translator.put(Double.class, Double.TYPE);
+        translator.put(Void.class, Void.TYPE);
+
+        try {
+            if (args != null && args.length > 0) {
+                Class[] classes = new Class[args.length];
+
+                for (int i = 0; i < args.length; ++i) {
+                    Class base = args[i].getClass();
+                    classes[i] = translator.containsKey(base) ? translator.get(base) : base;
+                }
+
+                Constructor<? extends Validator> constructor = validatorClass.getConstructor(classes);
+                constructor.setAccessible(true);
+
+                return constructor.newInstance(args);
+            }
+            else {
+                Constructor<? extends Validator> constructor = validatorClass.getConstructor();
+                constructor.setAccessible(true);
+
+                return constructor.newInstance();
+            }
+        }
+        catch (Exception e) {
+            // Rethrow the exception as a RuntimeException so we don't need to pad all our
+            // tests with try/catch blocks or throws declarations.
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    @Parameters({
+        "5, key, value, true",
+        "3, key, value, false",
+        "5, longkey, value, false",
+        "0, key, value, false"})
+    public void testLengthValidator(int length, String key, String value, boolean shouldValidate) {
+        Validator validator = this.getValidator(PropertyValidator.LengthValidator.class,
+            this.i18n, "test", length);
+
+        boolean result;
+
+        try {
+            validator.validate(key, value);
+            result = true;
+        }
+        catch (PropertyValidationException e) {
+            result = false;
+        }
+
+        assertEquals(shouldValidate, result);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testLengthValidatorConfigurationFailure() {
+        Validator validator = this.getValidator(PropertyValidator.LengthValidator.class,
+            this.i18n, "test", -1);
+    }
+
+    @Test
+    @Parameters({
+        "key, 50, true",
+        "key, -50, true",
+        "key, 2147483647, true",
+        "key, -2147483648, true",
+        "key, string, false",
+        "key, two, false",
+        "key, 3.14, false",
+        "key, -2.72, false"})
+    public void testIntegerValidator(String key, String value, boolean shouldValidate) {
+        Validator validator = this.getValidator(PropertyValidator.IntegerValidator.class, this.i18n, "test");
+
+        boolean result;
+
+        try {
+            validator.validate(key, value);
+            result = true;
+        }
+        catch (PropertyValidationException e) {
+            result = false;
+        }
+
+        assertEquals(shouldValidate, result);
+    }
+
+    @Test
+    @Parameters({
+        "key, 50, true",
+        "key, -50, false",
+        "key, 2147483647, true",
+        "key, -2147483648, false",
+        "key, string, false",
+        "key, two, false",
+        "key, 3.14, false",
+        "key, -2.72, false"})
+    public void testNonNegativeIntegerValidator(String key, String value, boolean shouldValidate) {
+        Validator validator = this.getValidator(PropertyValidator.NonNegativeIntegerValidator.class,
+            this.i18n, "test");
+
+        boolean result;
+
+        try {
+            validator.validate(key, value);
+            result = true;
+        }
+        catch (PropertyValidationException e) {
+            result = false;
+        }
+
+        assertEquals(shouldValidate, result);
+    }
+
+    @Test
+    @Parameters({
+        "key, 50, true",
+        "key, -50, true",
+        "key, 9223372036854775807, true",
+        "key, -9223372036854775808, true",
+        "key, string, false",
+        "key, two, false",
+        "key, 3.14, false",
+        "key, -2.72, false"})
+    public void testLongValidator(String key, String value, boolean shouldValidate) {
+        Validator validator = this.getValidator(PropertyValidator.LongValidator.class, this.i18n, "test");
+
+        boolean result;
+
+        try {
+            validator.validate(key, value);
+            result = true;
+        }
+        catch (PropertyValidationException e) {
+            result = false;
+        }
+
+        assertEquals(shouldValidate, result);
+    }
+
+    @Test
+    @Parameters({
+        "key, 50, true",
+        "key, -50, false",
+        "key, 9223372036854775807, true",
+        "key, -9223372036854775808, false",
+        "key, string, false",
+        "key, two, false",
+        "key, 3.14, false",
+        "key, -2.72, false"})
+    public void testNonNegativeLongValidator(String key, String value, boolean shouldValidate) {
+        Validator validator = this.getValidator(PropertyValidator.NonNegativeLongValidator.class,
+            this.i18n, "test");
+
+        boolean result;
+
+        try {
+            validator.validate(key, value);
+            result = true;
+        }
+        catch (PropertyValidationException e) {
+            result = false;
+        }
+
+        assertEquals(shouldValidate, result);
+    }
+
+    @Test
+    @Parameters({
+        "key, true, true",
+        "key, false, true",
+        "key, 1, true",
+        "key, 0, true",
+        "key, yes, false",
+        "key, no, false",
+        "key, y, false",
+        "key, n, false"})
+    public void testBooleanValidator(String key, String value, boolean shouldValidate) {
+        Validator validator = this.getValidator(PropertyValidator.BooleanValidator.class,
+            this.i18n, "test");
+
+        boolean result;
+
+        try {
+            validator.validate(key, value);
+            result = true;
+        }
+        catch (PropertyValidationException e) {
+            result = false;
+        }
+
+        assertEquals(shouldValidate, result);
+    }
+
+}


### PR DESCRIPTION
- Added the new PropertyValidator class and its subclasses
  AttributeValidator and FactValidator, which provide implementations
  for validating attributes and facts, respectively
- Updated the ProductCurator and ConsumerCurator to use the new
  PropertyValidator instances in place of their old private validation
  methods
- ConsumerValidator no longer massages inbound fact data, but will
  now, instead, throw PropertyValidationExceptions when it encounters
  malformed or otherwise unmanagable data
- ConsumerResource now provides the massaging and filtering
  functionality previously performed in the ConsumerCurator