### PR TITLE
Candlepin 2.0 ueber cert cleanup 3 + checksum fix

### DIFF
--- a/server/src/main/resources/db/changelog/20161025103454-cleanup-ueber-certs-round2.xml
+++ b/server/src/main/resources/db/changelog/20161025103454-cleanup-ueber-certs-round2.xml
@@ -248,7 +248,7 @@
         value="delete c from cp_consumer c where name like 'ueber_cert_consumer';"/>
 
     <changeSet id="20161025103454-1" author="mstead">
-        <validCheckSum>7:9b3c3db544862eaa6e7ff0cb9f9ef4b5</validCheckSum>
+        <validCheckSum>ALL</validCheckSum>
         <comment>Clean out all ueber cert (debug cert) data to avoid manual cleanup.
                  This changeset will remove both the 0.9.54 (copied data) AND the
                  2.0 ueber cert data. We are required to do this a second time since

--- a/server/src/main/resources/db/changelog/20170125112728-cleanup-uebercerts-round3-2-0.xml
+++ b/server/src/main/resources/db/changelog/20170125112728-cleanup-uebercerts-round3-2-0.xml
@@ -1,0 +1,187 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+    <!-- POSTGRES/ORACLE QUERIES -->
+
+    <!-- Delete ueber entitlement certificates -->
+    <property
+        dbms="postgresql,oracle,hsqldb"
+        name="delete_ueber_certs_round3"
+        value="delete from cp_ent_certificate
+               where entitlement_id in (
+                 select e.id from cp_entitlement e
+                 inner join cp_pool p on e.pool_id = p.id
+                 inner join cp2_products prod ON prod.uuid = p.product_uuid
+                 where prod.name like '%_ueber_product'
+               );" />
+
+    <!-- Delete ueber entitlements -->
+    <property
+        dbms="postgresql,oracle,hsqldb"
+        name="delete_ueber_ents_round3"
+        value="delete from cp_entitlement
+               where pool_id in (
+                 select p.id from cp_pool p
+                 inner join cp2_products prod ON prod.uuid = p.product_uuid
+                 where prod.name like '%_ueber_product');"/>
+
+    <!-- Delete any ueber pool source subscriptions -->
+    <property
+        dbms="postgresql,oracle,hsqldb"
+        name="delete_pool_source_sub_round3"
+        value="delete from cp2_pool_source_sub
+               where pool_id in (
+                 select p.id from cp_pool p
+                 inner join cp2_products prod on prod.uuid = p.product_uuid
+                 where prod.name like '%_ueber_product');" />
+
+    <!-- Delete any ueber pools -->
+    <property
+        dbms="postgresql,oracle,hsqldb"
+        name="delete_ueber_pools_round3"
+        value="delete from cp_pool
+               where id in (
+                 select p.id from cp_pool p
+                 inner join cp2_products prod on prod.uuid = p.product_uuid
+                 where prod.name like '%_ueber_product');"/>
+
+    <!-- Delete any ueber owner content (2.0 records) -->
+    <property
+        dbms="postgresql,oracle,hsqldb"
+        name="delete_owner_content_round3"
+        value="delete from cp2_owner_content
+               where content_uuid in (
+                 select c.uuid from cp2_content c
+                   inner join cp2_product_content pc on pc.content_uuid=c.uuid
+                   inner join cp2_products p on p.uuid=pc.product_uuid
+                   where p.name LIKE '%ueber_product');"/>
+
+    <!-- Delete any ueber content  -->
+    <property
+        dbms="postgresql,oracle,hsqldb"
+        name="delete_ueber_content_round3"
+        value="delete from cp2_content
+               where uuid in (
+                 select c.uuid from cp2_content c
+               inner join cp2_product_content pc on pc.content_uuid=c.uuid
+               inner join cp2_products p on p.uuid=pc.product_uuid
+               where p.name LIKE '%ueber_product');"/>
+
+    <!-- Delete any ueber owner products -->
+    <property
+        dbms="postgresql,oracle,hsqldb"
+        name="delete_owner_products_round3"
+        value="delete from cp2_owner_products
+               where product_uuid in (
+                    select uuid from cp2_products where name like '%ueber_product'
+               );"/>
+
+    <!-- Delete any ueber products  -->
+    <property
+        dbms="postgresql,oracle,hsqldb"
+        name="delete_ueber_products_round3"
+        value="delete from cp2_products where name like '%_ueber_product';"/>
+
+    <!-- Delete any ueber consumers -->
+    <property
+        dbms="postgresql,oracle,hsqldb"
+        name="delete_ueber_consumers_round3"
+        value="delete from cp_consumer where name like 'ueber_cert_consumer';"/>
+
+    <!-- MYSQL QUERIES -->
+
+    <!-- Delete ueber entitlement certificates -->
+    <property
+        dbms="mysql"
+        name="delete_ueber_certs_round3"
+        value="delete ec from cp_ent_certificate ec
+                   inner join cp_entitlement e on ec.entitlement_id = e.id
+                   inner join cp_pool p on e.pool_id = p.id
+                   inner join cp2_products prod ON prod.uuid = p.product_uuid
+               where prod.name like '%_ueber_product';"/>
+
+    <!-- Delete ueber entitlements -->
+    <property
+        dbms="mysql"
+        name="delete_ueber_ents_round3"
+        value="delete e from cp_entitlement e
+                   inner join cp_pool p on e.pool_id = p.id
+                   inner join cp2_products prod ON prod.uuid = p.product_uuid
+               where prod.name like '%_ueber_product';" />
+
+    <!-- Delete any ueber pool source subscriptions  -->
+    <property
+        dbms="mysql"
+        name="delete_pool_source_sub_round3"
+        value="delete ss from cp2_pool_source_sub ss
+                   inner join cp_pool p on ss.pool_id = p.id
+                   inner join cp2_products prod ON prod.uuid = p.product_uuid
+               where prod.name like '%_ueber_product';" />
+
+    <!-- Delete any ueber pools -->
+    <property
+        dbms="mysql"
+        name="delete_ueber_pools_round3"
+        value="delete p from cp_pool p
+                   inner join cp2_products prod ON prod.uuid = p.product_uuid
+                   where prod.name like '%_ueber_product';"/>
+
+    <!-- Delete any ueber owner content  -->
+    <property
+        dbms="mysql"
+        name="delete_owner_content_round3"
+        value="delete oc from cp2_owner_content oc
+                   inner join cp2_product_content pc on pc.content_uuid=oc.content_uuid
+                   inner join cp2_products p on p.uuid=pc.product_uuid
+                   where p.name LIKE '%ueber_product';"/>
+
+    <!-- Delete any ueber content  -->
+    <property
+        dbms="mysql"
+        name="delete_ueber_content_round3"
+        value="delete c from cp2_content c
+                   inner join cp2_product_content pc on pc.content_uuid=c.uuid
+                   inner join cp2_products p on p.uuid=pc.product_uuid
+                   where p.name LIKE '%ueber_product';"/>
+
+    <!-- Delete any ueber owner products  -->
+    <property
+        dbms="mysql"
+        name="delete_owner_products_round3"
+        value="delete op from cp2_owner_products op
+                   inner join cp2_products p on op.product_uuid = p.uuid
+                   where name like '%ueber_product';"/>
+
+    <!-- Delete any ueber products -->
+    <property
+        dbms="mysql"
+        name="delete_ueber_products_round3"
+        value="delete p from cp2_products p where name like '%_ueber_product';"/>
+
+    <!-- Delete any ueber consumers -->
+    <property
+        dbms="mysql"
+        name="delete_ueber_consumers_round3"
+        value="delete c from cp_consumer c where name like 'ueber_cert_consumer';"/>
+
+    <changeSet id="20170125112728-1" author="mstead">
+        <validCheckSum>ALL</validCheckSum>
+        <comment>Round 3 ueber cert data cleanup.</comment>
+        <sql>${delete_ueber_certs_round3}</sql>
+        <sql>${delete_pool_source_sub_round3}</sql>
+        <sql>${delete_ueber_ents_round3}</sql>
+        <sql>${delete_ueber_pools_round3}</sql>
+        <sql>${delete_owner_content_round3}</sql>
+        <sql>${delete_ueber_content_round3}</sql>
+        <sql>${delete_owner_products_round3}</sql>
+        <sql>${delete_ueber_products_round3}</sql>
+        <sql>${delete_ueber_consumers_round3}</sql>
+    </changeSet>
+
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/server/src/main/resources/db/changelog/changelog-create.xml
+++ b/server/src/main/resources/db/changelog/changelog-create.xml
@@ -1198,4 +1198,5 @@
     <include file="db/changelog/20161109145238-add-owner-environment-content-access.xml"/>
     <include file="db/changelog/20161129104417-add-content-access-mode-column-to-consumer.xml"/>
     <include file="db/changelog/20170130144529-perorgproducts-phase-2.xml"/>
+    <include file="db/changelog/20170125112728-cleanup-uebercerts-round3-2-0.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-testing.xml
+++ b/server/src/main/resources/db/changelog/changelog-testing.xml
@@ -2028,7 +2028,7 @@
     </changeSet>
     <changeSet author="awood" id="1413225753032-290">
         <comment>
-             Add the default quartz lock columns. 
+             Add the default quartz lock columns.
         </comment>
         <insert tableName="QRTZ_LOCKS">
             <column name="LOCK_NAME" value="TRIGGER_ACCESS"/>
@@ -2288,4 +2288,5 @@
     <include file="db/changelog/20161109145238-add-owner-environment-content-access.xml"/>
     <include file="db/changelog/20161129104417-add-content-access-mode-column-to-consumer.xml"/>
     <include file="db/changelog/20170130144529-perorgproducts-phase-2.xml"/>
+    <include file="db/changelog/20170125112728-cleanup-uebercerts-round3-2-0.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-update.xml
+++ b/server/src/main/resources/db/changelog/changelog-update.xml
@@ -106,4 +106,5 @@
     <include file="db/changelog/20161109145238-add-owner-environment-content-access.xml"/>
     <include file="db/changelog/20161129104417-add-content-access-mode-column-to-consumer.xml"/>
     <include file="db/changelog/20170130144529-perorgproducts-phase-2.xml"/>
+    <include file="db/changelog/20170125112728-cleanup-uebercerts-round3-2-0.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
This PR addresses 2 issues:

**1. When migrating the DB from 0.9.54 to 2.0 a checksum error occurs.**

The changeset causing the issue has been updated to validate all checksums that it encounters. It doesn't matter if the checksum is off here as it is only a cleanup task and contains no schema updates.

**2. Liquibase property definitions do not override existing ones that exist in a changelog.**

Re-run the cleanup as a precaution to make sure that the appropriate queries are run on migration.

**Testing Notes**
This PR will be tested in 2 stages -- checksum issue and the cleanup.

**Checksum Issue Testing**
1. Deploy candlepin 0.9.54 with test data
2. Deploy candlepin's current master branch (without recreating the DB) and the checksum issue should occur.
3. Apply this patch and redeploy without test data and the DB should get updated without error.

**Cleanup**
1. Deploy candlepin 0.9.54 with test data
2. Create an ueber cert for the 'admin' owner.
3. Verify all 1s in the verify query.
6. Deploy candlepin from this PRs branch.
7. Verify that the cleanup happened (all 0s).
8. Generate another ueber cert
9. Verify that there were no errors.

**Get past the checksum issue**
```bash
psql -U candlepin candlepin -c "UPDATE databasechangelog SET md5sum='7:67265f7bbe46b62a789d326361adee32' WHERE md5sum='7:db88449697deb0222cc22b9d0e30d614';"
```

**Generating an Ueber Cert**
```bash
$ curl -k -u admin:admin -X POST https://localhost:8443/candlepin/owners/admin/uebercert
```

**Verification Query**
```sql
-- all column counts should be equal if data is in a valid state.
-- all column counts should be equal and 0s if the ueber certs were cleaned up correctly.
SELECT 
       -- NO SUBS FOR 2.0
       
       -- Certificates
       (SELECT Count(*)
        FROM   cp_ent_certificate ec
               INNER JOIN cp_entitlement e
                       ON e.id = ec.entitlement_id
               INNER JOIN cp_pool p
                       ON e.pool_id = p.id
               INNER JOIN cp2_products prod
                       ON prod.uuid = p.product_uuid
        WHERE  prod.NAME LIKE '%_ueber_product') AS UEBER_ENT_CERTS,
        
        -- Entitlements
       (SELECT Count(*)
        FROM   cp_entitlement e
               INNER JOIN cp_pool p
                       ON e.pool_id = p.id
               INNER JOIN cp2_products prod
                       ON prod.uuid = p.product_uuid
        WHERE  prod.NAME LIKE '%_ueber_product') AS UEBER_ENTS,
        
        -- Pools
       (SELECT Count(*)
        FROM   cp_pool p
               INNER JOIN cp2_products prod
                       ON prod.uuid = p.product_uuid
        WHERE  prod.NAME LIKE '%_ueber_product') AS UEBER_POOLS,
        
        -- Content
        (select count(*) from cp2_content c
               inner join cp2_product_content pc on pc.content_uuid=c.uuid
               inner join cp2_products p on p.uuid=pc.product_uuid
               where p.name LIKE '%ueber_product'
        ) AS CP2_UEBER_CONTENT,

        -- Owner Content
        (select count(*) from cp2_owner_content oc
               inner join cp2_content c on c.uuid=oc.content_uuid
               inner join cp2_product_content pc on pc.content_uuid=c.uuid
               inner join cp2_products p on p.uuid=pc.product_uuid
               where p.name LIKE '%ueber_product'
         ) as CP2_OWNER_CONTENT,

         -- Products
         (select count(*) from cp2_products p where p.name LIKE '%ueber_product') AS CP2_PRODUCTS,

         -- Owner Products
         (select count(*) from cp2_owner_products op
             INNER JOIN cp2_products prod on op.product_uuid = prod.uuid
             WHERE prod.name LIKE '%ueber_product'
         ) AS CP2_OWNER_PRODUCTS,

         -- Consumers
         (SELECT Count(*)
             FROM   cp_consumer
             WHERE  NAME = 'ueber_cert_consumer'
         ) AS UEBER_CONSUMER;
```