### PR TITLE
Fix ProvidedProduct serialization

### DIFF
--- a/server/src/main/java/org/candlepin/model/ProvidedProduct.java
+++ b/server/src/main/java/org/candlepin/model/ProvidedProduct.java
@@ -18,6 +18,8 @@ import com.fasterxml.jackson.annotation.JsonFilter;
 
 import org.apache.commons.lang.builder.HashCodeBuilder;
 
+import java.io.Serializable;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
@@ -29,7 +31,9 @@ import javax.xml.bind.annotation.XmlRootElement;
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @JsonFilter("ProvidedProductFilter")
-public class ProvidedProduct {
+public class ProvidedProduct implements Serializable {
+
+    private static final long serialVersionUID = -6596019311091733072L;
 
     private String productId;
     private String productName;


### PR DESCRIPTION
Fixes a bug in async hypervisor checkin when the job requires a provided product to be serialized.

to test, deploy master, checkout this branch, and run:

buildr rspec:hypervisor_check_in_spec.rb:"Hypervisor Checkin should complete succesfully when a guest"