### PR TITLE
1420455: No ueber pool deletion on manifest cleanup

### DIFF
--- a/server/src/main/java/org/candlepin/model/Pool.java
+++ b/server/src/main/java/org/candlepin/model/Pool.java
@@ -1282,4 +1282,9 @@ public class Pool extends AbstractHibernateObject implements Persisted, Owned, N
         this.cert = cert;
     }
 
+    @JsonIgnore
+    public boolean isUeberPool() {
+        return product != null && Product.ueberProductNameForOwner(owner).equals(product.getName());
+    }
+
 }

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/UndoImportsJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/UndoImportsJob.java
@@ -126,7 +126,8 @@ public class UndoImportsJob extends UniqueByEntityJob {
 
             List<Pool> pools = this.poolManager.listPoolsByOwner(owner).list();
             for (Pool pool : pools) {
-                if (pool.getSourceSubscription() != null && !pool.getType().isDerivedType()) {
+                if (pool.getSourceSubscription() != null && !pool.getType().isDerivedType() &&
+                    !pool.isUeberPool()) {
                     this.poolManager.deletePool(pool);
                 }
             }


### PR DESCRIPTION
Ueber pools/entitlements should never get cleaned up unless the Owner is deleted.

### Testing
**Pre-req:** Grab a manifest you have lying around, or ask me and I'll get you one.

```bash
$ bin/deploy -g
$ ./cpc create_owner testorg
$ ./cpc generate_ueber_cert testorg
$ ./cpc import testorg <path_to_manifest_file>
```
Verify the uber cert data is correct:

```sql
SELECT 
       -- NO SUBS FOR 2.0
       
       -- Certificates
       (SELECT Count(*)
        FROM   cp_ent_certificate ec
               INNER JOIN cp_entitlement e
                       ON e.id = ec.entitlement_id
               INNER JOIN cp_pool p
                       ON e.pool_id = p.id
               INNER JOIN cp2_products prod
                       ON prod.uuid = p.product_uuid
        WHERE  prod.NAME LIKE '%_ueber_product') AS UEBER_ENT_CERTS,
        
        -- Entitlements
       (SELECT Count(*)
        FROM   cp_entitlement e
               INNER JOIN cp_pool p
                       ON e.pool_id = p.id
               INNER JOIN cp2_products prod
                       ON prod.uuid = p.product_uuid
        WHERE  prod.NAME LIKE '%_ueber_product') AS UEBER_ENTS,
        
        -- Pools
       (SELECT Count(*)
        FROM   cp_pool p
               INNER JOIN cp2_products prod
                       ON prod.uuid = p.product_uuid
        WHERE  prod.NAME LIKE '%_ueber_product') AS UEBER_POOLS,
        
        -- Content
        (select count(*) from cp2_content c
               inner join cp2_product_content pc on pc.content_uuid=c.uuid
               inner join cp2_products p on p.uuid=pc.product_uuid
               where p.name LIKE '%ueber_product'
        ) AS CP2_UEBER_CONTENT,

        -- Owner Content
        (select count(*) from cp2_owner_content oc
               inner join cp2_content c on c.uuid=oc.content_uuid
               inner join cp2_product_content pc on pc.content_uuid=c.uuid
               inner join cp2_products p on p.uuid=pc.product_uuid
               where p.name LIKE '%ueber_product'
         ) as CP2_OWNER_CONTENT,

         -- Products
         (select count(*) from cp2_products p where p.name LIKE '%ueber_product') AS CP2_PRODUCTS,

         -- Owner Products
         (select count(*) from cp2_owner_products op
             INNER JOIN cp2_products prod on op.product_uuid = prod.uuid
             WHERE prod.name LIKE '%ueber_product'
         ) AS CP2_OWNER_PRODUCTS,

         -- Consumers
         (SELECT Count(*)
             FROM   cp_consumer
             WHERE  NAME = 'ueber_cert_consumer'
         ) AS UEBER_CONSUMER;
```
**NOTE:** All columns should have counts == 1

```bash
$ ./cpc undo_import testorg

# The following should result in an error.
$ curl -k -u admin:admin https://localhost:8443/candlepin/owners/teestorg/uebercert
```
Check your ueber cert data counts with the query above. The counts should now show 0s for the pool and ent/ent certs.

Try the same steps with this patch applied. The curl for the ueber cert should succeed and all the counts should remain steady with 1s.
