### PR TITLE
Reverted the use of cursors in the heal entire org job

### DIFF
--- a/server/src/main/java/org/candlepin/pinsetter/tasks/HealEntireOrgJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/HealEntireOrgJob.java
@@ -75,9 +75,7 @@ public class HealEntireOrgJob extends UniqueByEntityJob {
 
             Date entitleDate = (Date) map.get("entitle_date");
 
-            // TODO:
-            // Make sure this doesn't choke on MySQL, since we're doing queries with the cursor open.
-            for (String uuid : ownerCurator.getConsumerUuids(ownerId)) {
+            for (String uuid : ownerCurator.getConsumerUuids(ownerId).list()) {
                 // Do not send in product IDs.  CandlepinPoolManager will take care
                 // of looking up the non or partially compliant products to bind.
                 try {


### PR DESCRIPTION
- Reverted the use of cursors in the heal entire org job when
  pulling consumers for a given org.