### PR TITLE
Moved transaction around autobind to after retry logic

### DIFF
--- a/server/src/test/java/org/candlepin/controller/PoolManagerFunctionalTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerFunctionalTest.java
@@ -101,7 +101,10 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
 
 
     @Before
-    public void setUp() throws Exception {
+    @Override
+    public void init() throws Exception {
+        super.init();
+
         o = createOwner();
         ownerCurator.create(o);
 

--- a/server/src/test/java/org/candlepin/model/CuratorPaginationTest.java
+++ b/server/src/test/java/org/candlepin/model/CuratorPaginationTest.java
@@ -51,7 +51,7 @@ public class CuratorPaginationTest extends DatabaseTestFixture {
 
     @Before
     @Override
-    public void init() {
+    public void init() throws Exception {
         super.init();
 
         for (int i = 0; i < 10; i++) {

--- a/server/src/test/java/org/candlepin/model/DeletedConsumerCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/DeletedConsumerCuratorTest.java
@@ -40,8 +40,9 @@ public class DeletedConsumerCuratorTest extends DatabaseTestFixture {
 
     @Before
     @Override
-    public void init() {
+    public void init() throws Exception {
         super.init();
+
         DeletedConsumer dc = new DeletedConsumer("abcde", "10", "key", "name");
         dcc.create(dc);
         try {

--- a/server/src/test/java/org/candlepin/model/GuestIdCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/GuestIdCuratorTest.java
@@ -42,8 +42,9 @@ public class GuestIdCuratorTest extends DatabaseTestFixture {
 
     @Before
     @Override
-    public void init() {
+    public void init() throws Exception {
         super.init();
+
         owner = new Owner("test-owner", "Test Owner");
         owner = ownerCurator.create(owner);
         ct = new ConsumerType(ConsumerTypeEnum.SYSTEM);

--- a/server/src/test/java/org/candlepin/model/OwnerAccessControlTest.java
+++ b/server/src/test/java/org/candlepin/model/OwnerAccessControlTest.java
@@ -38,7 +38,7 @@ public class OwnerAccessControlTest extends DatabaseTestFixture {
 
     @Before
     @Override
-    public void init() {
+    public void init() throws Exception {
         super.init();
         this.owner = createOwner();
     }

--- a/server/src/test/java/org/candlepin/model/ProductCertificateCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ProductCertificateCuratorTest.java
@@ -32,7 +32,7 @@ public class ProductCertificateCuratorTest extends DatabaseTestFixture {
 
     @Before
     @Override
-    public void init() {
+    public void init() throws Exception {
         super.init();
 
         Owner owner = this.createOwner("Test Corporation");

--- a/server/src/test/java/org/candlepin/resteasy/filter/CandlepinQueryInterceptorTest.java
+++ b/server/src/test/java/org/candlepin/resteasy/filter/CandlepinQueryInterceptorTest.java
@@ -69,7 +69,7 @@ public class CandlepinQueryInterceptorTest extends DatabaseTestFixture {
     protected Provider<EntityManager> emProvider;
 
     @Override
-    public void init() {
+    public void init() throws Exception {
         super.init();
 
         this.mockJsonProvider = mock(JsonProvider.class);

--- a/server/src/test/java/org/candlepin/service/impl/DefaultUserServiceAdapterTest.java
+++ b/server/src/test/java/org/candlepin/service/impl/DefaultUserServiceAdapterTest.java
@@ -57,7 +57,7 @@ public class DefaultUserServiceAdapterTest extends DatabaseTestFixture {
 
     @Before
     @Override
-    public void init() {
+    public void init() throws Exception {
         super.init();
         this.owner = ownerCurator.create(new Owner("default_owner"));
         this.service = new DefaultUserServiceAdapter(userCurator, roleCurator);

--- a/server/src/test/java/org/candlepin/test/CacheTestFixture.java
+++ b/server/src/test/java/org/candlepin/test/CacheTestFixture.java
@@ -47,7 +47,7 @@ public class CacheTestFixture extends DatabaseTestFixture {
     }
 
     @Override
-    public void init() {
+    public void init() throws Exception {
         super.init();
 
         CacheContextListener cacheListener = injector.getInstance(CacheContextListener.class);

--- a/server/src/test/java/org/candlepin/test/DatabaseTestFixture.java
+++ b/server/src/test/java/org/candlepin/test/DatabaseTestFixture.java
@@ -171,7 +171,11 @@ public class DatabaseTestFixture {
     }
 
     @Before
-    public void init() {
+    public void init() throws Exception {
+        this.init(true);
+    }
+
+    public void init(boolean beginTransaction) throws Exception {
         this.config = new CandlepinCommonTestConfig();
         Module testingModule = new TestingModules.StandardTest(this.config);
         this.injector = parentInjector.createChildInjector(
@@ -198,7 +202,9 @@ public class DatabaseTestFixture {
 
         this.i18n = I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK);
 
-        this.beginTransaction();
+        if (beginTransaction) {
+            this.beginTransaction();
+        }
     }
 
     @After


### PR DESCRIPTION
- Moved the transaction for CandlepinPoolManager.entitleByProducts
  to after the retry logic, which will allow many paths to release
  pool locks between attempts when retrying