### PR TITLE
Remove numeric limitation on engineering product IDs

### DIFF
--- a/server/src/main/java/org/candlepin/util/X509Util.java
+++ b/server/src/main/java/org/candlepin/util/X509Util.java
@@ -40,9 +40,19 @@ public abstract class X509Util {
     private static Logger log = LoggerFactory.getLogger(X509Util.class);
 
     public static final Predicate<Product> PROD_FILTER_PREDICATE = new Predicate<Product>() {
+        /**
+         * A filter to test if a product contains content that should be used
+         * for certificate generation. This effectively trims out marketing
+         * products & all other products that do not have any associated
+         * content sets.
+         *
+         * @param product The product to test.
+         * @return True if the supplied product contains content that should be included
+         *         in an entitlement certificate.
+         */
         @Override
         public boolean apply(Product product) {
-            return product != null && StringUtils.isNumeric(product.getId());
+            return product != null && product.getProductContent().size() > 0;
         }
     };
 


### PR DESCRIPTION
Remove the limitation that IDs for engineering products may only contain
numbers. This will allow any alphanumeric ID to be used for custom
product generation. In general this will allow someone to let Candlepin
generate the IDs for custom products during creation instead of having
to generate them externally and pass them in.