### PR TITLE
Uber certificate rewrite

### DIFF
--- a/server/client/ruby/candlepin_api.rb
+++ b/server/client/ruby/candlepin_api.rb
@@ -298,9 +298,14 @@ class Candlepin
     delete "/owners/#{owner_key}/log"
   end
 
-  def generate_ueber_cert(owner_key)
+  def generate_ueber_cert(owner_key, filename="")
     uri = "/owners/#{owner_key}/uebercert"
-    post uri
+    result_json = post uri
+    if !filename.empty?
+      File.open(filename, 'w') { |f| f.write("#{result_json['key']}\n\n#{result_json['cert']}") }
+      return filename
+    end
+    result_json
   end
 
   def delete_owner(owner_key, revoke=true)

--- a/server/src/main/java/org/candlepin/controller/PoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/PoolManager.java
@@ -103,8 +103,6 @@ public interface PoolManager {
     List<Entitlement> entitleByPools(Consumer consumer, Map<String, Integer> poolQuantities)
         throws EntitlementRefusedException;
 
-    Entitlement ueberCertEntitlement(Consumer consumer, Pool pool) throws EntitlementRefusedException;
-
     /**
      * Request an entitlement by product.
      *
@@ -134,11 +132,7 @@ public interface PoolManager {
     Refresher getRefresher(SubscriptionServiceAdapter subAdapter);
     Refresher getRefresher(SubscriptionServiceAdapter subAdapter, boolean lazy);
 
-    /**
-     * @param e
-     * @param ueberCertificate TODO
-     */
-    void regenerateCertificatesOf(Entitlement e, boolean ueberCertificate, boolean lazy);
+    void regenerateCertificatesOf(Entitlement e, boolean lazy);
 
     void regenerateCertificatesOf(Environment env, Set<String> contentIds, boolean lazy);
 
@@ -212,14 +206,6 @@ public interface PoolManager {
      * @return a list of entitlements
      */
     List<Entitlement> findEntitlements(Pool pool);
-
-    /**
-     * Find the Ueber pool for this owner
-     *
-     * @param owner the owner to fetch the pool from
-     * @return the Ueber pool
-     */
-    Pool findUeberPool(Owner owner);
 
     /**
      * Lists the pools for the specified Owner.

--- a/server/src/main/java/org/candlepin/model/CertificateSerialCurator.java
+++ b/server/src/main/java/org/candlepin/model/CertificateSerialCurator.java
@@ -44,7 +44,8 @@ public class CertificateSerialCurator extends AbstractHibernateCurator<Certifica
 
     @SuppressWarnings("rawtypes")
     private static final Class[] CERTCLASSES = {IdentityCertificate.class,
-        EntitlementCertificate.class, SubscriptionsCertificate.class, CdnCertificate.class};
+        EntitlementCertificate.class, SubscriptionsCertificate.class, CdnCertificate.class,
+        UeberCertificate.class};
 
     public CertificateSerialCurator() {
         super(CertificateSerial.class);

--- a/server/src/main/java/org/candlepin/model/Consumer.java
+++ b/server/src/main/java/org/candlepin/model/Consumer.java
@@ -86,8 +86,6 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
     /** Name of the table backing this object in the database */
     public static final String DB_TABLE = "cp_consumer";
 
-    public static final String UEBER_CERT_CONSUMER = "ueber_cert_consumer";
-
     public static final int MAX_LENGTH_OF_CONSUMER_NAME = 255;
 
     @Id

--- a/server/src/main/java/org/candlepin/model/ConsumerType.java
+++ b/server/src/main/java/org/candlepin/model/ConsumerType.java
@@ -62,8 +62,7 @@ public class ConsumerType extends AbstractHibernateObject {
      */
     public enum ConsumerTypeEnum {
         SYSTEM("system", false), PERSON("person", false), DOMAIN("domain",
-            false), CANDLEPIN("candlepin", true), HYPERVISOR("hypervisor", false),
-            UEBER_CERT("uebercert", false);
+            false), CANDLEPIN("candlepin", true), HYPERVISOR("hypervisor", false);
 
         private final String label;
         private final boolean manifest;

--- a/server/src/main/java/org/candlepin/model/Content.java
+++ b/server/src/main/java/org/candlepin/model/Content.java
@@ -15,7 +15,6 @@
 package org.candlepin.model;
 
 import org.candlepin.model.dto.ContentData;
-import org.candlepin.service.UniqueIdGenerator;
 import org.candlepin.util.SetView;
 import org.candlepin.util.Util;
 
@@ -62,8 +61,6 @@ public class Content extends AbstractHibernateObject implements SharedEntity, Cl
 
     /** Name of the table backing this object in the database */
     public static final String DB_TABLE = "cp2_content";
-
-    public static final  String UEBER_CONTENT_NAME = "ueber_content";
 
     // Object ID
     @Id
@@ -248,23 +245,6 @@ public class Content extends AbstractHibernateObject implements SharedEntity, Cl
      */
     public ContentData toDTO() {
         return new ContentData(this);
-    }
-
-    public static Content createUeberContent(UniqueIdGenerator idGenerator, Owner owner, Product product) {
-        Content ueberContent = new Content(idGenerator.generateId());
-        ueberContent.setName(UEBER_CONTENT_NAME);
-        ueberContent.setType("yum");
-        ueberContent.setLabel(ueberContentLabelForProduct(product));
-        ueberContent.setVendor("Custom");
-        ueberContent.setContentUrl("/" + owner.getKey());
-        ueberContent.setGpgUrl("");
-        ueberContent.setArches("");
-
-        return ueberContent;
-    }
-
-    public static String ueberContentLabelForProduct(Product p) {
-        return p.getUuid() + "_" + UEBER_CONTENT_NAME;
     }
 
     /**

--- a/server/src/main/java/org/candlepin/model/KeyPairCurator.java
+++ b/server/src/main/java/org/candlepin/model/KeyPairCurator.java
@@ -44,18 +44,35 @@ public class KeyPairCurator extends
         // if multiple exist.
         KeyPair cpKeyPair = c.getKeyPair();
         if (cpKeyPair == null) {
-            try {
-                java.security.KeyPair newPair = pki.generateNewKeyPair();
-                cpKeyPair = new KeyPair(newPair.getPrivate(), newPair.getPublic());
-                create(cpKeyPair);
-                c.setKeyPair(cpKeyPair);
-            }
-            catch (NoSuchAlgorithmException e) {
-                throw new RuntimeException(e);
-            }
+            cpKeyPair = generateKeyPair();
+            c.setKeyPair(cpKeyPair);
         }
         java.security.KeyPair returnMe = new java.security.KeyPair(
             cpKeyPair.getPublicKey(), cpKeyPair.getPrivateKey());
         return returnMe;
     }
+
+    /**
+     * Creates a key pair that is not associated with a known entity.
+     *
+     * @return the the generated key pair.
+     */
+    public java.security.KeyPair getKeyPair() {
+        KeyPair cpKeyPair = this.generateKeyPair();
+        java.security.KeyPair returnMe = new java.security.KeyPair(
+            cpKeyPair.getPublicKey(), cpKeyPair.getPrivateKey());
+        return returnMe;
+    }
+
+    private KeyPair generateKeyPair() {
+        try {
+            java.security.KeyPair newPair = pki.generateNewKeyPair();
+            KeyPair cpKeyPair = new KeyPair(newPair.getPrivate(), newPair.getPublic());
+            return create(cpKeyPair);
+        }
+        catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
 }

--- a/server/src/main/java/org/candlepin/model/Owner.java
+++ b/server/src/main/java/org/candlepin/model/Owner.java
@@ -48,7 +48,6 @@ import javax.xml.bind.annotation.XmlTransient;
 import io.swagger.annotations.ApiModelProperty;
 
 
-
 /**
  * Represents the owner of entitlements. This is akin to an organization,
  * whereas a User is an individual account within that organization.

--- a/server/src/main/java/org/candlepin/model/OwnerInfoCurator.java
+++ b/server/src/main/java/org/candlepin/model/OwnerInfoCurator.java
@@ -133,15 +133,10 @@ public class OwnerInfoCurator {
 
     @SuppressWarnings("checkstyle:indentation")
     private void setConsumerCountsByComplianceStatus(Owner owner, OwnerInfo info) {
-        // We exclude the following types since they are fake/transparent consumers
-        // and we do not want them included in the totals.
-        String[] typesToFilter = new String[]{"uebercert"};
-
         Criteria countCriteria = consumerCurator.createSecureCriteria()
             .createAlias("type", "t")
             .add(Restrictions.eq("owner", owner))
             .add(Restrictions.isNotNull("entitlementStatus"))
-            .add(Restrictions.not(Restrictions.in("t.label", typesToFilter)))
             .setProjection(Projections.projectionList()
                 .add(Projections.groupProperty("entitlementStatus"))
                 .add(Projections.count("id")));

--- a/server/src/main/java/org/candlepin/model/Pool.java
+++ b/server/src/main/java/org/candlepin/model/Pool.java
@@ -1282,9 +1282,4 @@ public class Pool extends AbstractHibernateObject implements Persisted, Owned, N
         this.cert = cert;
     }
 
-    @JsonIgnore
-    public boolean isUeberPool() {
-        return product != null && Product.ueberProductNameForOwner(owner).equals(product.getName());
-    }
-
 }

--- a/server/src/main/java/org/candlepin/model/PoolCurator.java
+++ b/server/src/main/java/org/candlepin/model/PoolCurator.java
@@ -339,7 +339,6 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
         }
         if (o != null) {
             crit.add(Restrictions.eq("owner", o));
-            crit.add(Restrictions.ne("product.name", Product.ueberProductNameForOwner(o)));
         }
 
         if (activeOn != null) {
@@ -410,15 +409,6 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
         return listByCriteria(
             currentSession().createCriteria(Pool.class)
                 .add(Restrictions.eq("restrictedToUsername", username)));
-    }
-
-    @Transactional
-    public Pool findUeberPool(Owner o) {
-        return (Pool) createSecureCriteria()
-            .createAlias("product", "product")
-            .add(Restrictions.eq("owner", o))
-            .add(Restrictions.eq("product.name", Product.ueberProductNameForOwner(o)))
-            .uniqueResult();
     }
 
     @SuppressWarnings("unchecked")

--- a/server/src/main/java/org/candlepin/model/Product.java
+++ b/server/src/main/java/org/candlepin/model/Product.java
@@ -17,7 +17,6 @@ package org.candlepin.model;
 import org.candlepin.model.dto.ProductAttributeData;
 import org.candlepin.model.dto.ProductContentData;
 import org.candlepin.model.dto.ProductData;
-import org.candlepin.service.UniqueIdGenerator;
 import org.candlepin.util.ListView;
 import org.candlepin.util.SetView;
 import org.candlepin.util.Util;
@@ -150,8 +149,6 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
          *  expiring subscription for a given product */
         public static final String WARNING_PERIOD = "warning_period";
     }
-
-    public static final String UEBER_PRODUCT_POSTFIX = "_ueber_product";
 
     // Object ID
     @Id
@@ -414,15 +411,6 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
      */
     public ProductData toDTO() {
         return new ProductData(this);
-    }
-
-    public static Product createUeberProductForOwner(UniqueIdGenerator idGenerator, Owner owner) {
-        return new Product(idGenerator.generateId(), ueberProductNameForOwner(owner), 1L);
-    }
-
-
-    public static String ueberProductNameForOwner(Owner owner) {
-        return owner.getKey() + UEBER_PRODUCT_POSTFIX;
     }
 
     /**

--- a/server/src/main/java/org/candlepin/model/UeberCertificate.java
+++ b/server/src/main/java/org/candlepin/model/UeberCertificate.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) 2009 - 2017 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.model;
+
+import org.hibernate.annotations.GenericGenerator;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+import javax.validation.constraints.NotNull;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * A debug certificate available for a particular owner. Ueber certificates are used by
+ * consumers of the candlepin API to browse content for a specific Owner.
+ *
+ */
+@XmlRootElement(name = "cert")
+@XmlAccessorType(XmlAccessType.PROPERTY)
+@Entity
+@Table(name = "cp_ueber_cert")
+public class UeberCertificate extends AbstractCertificate implements Certificate {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @GeneratedValue(generator = "system-uuid")
+    @GenericGenerator(name = "system-uuid", strategy = "uuid")
+    @Column(length = 32)
+    @NotNull
+    private String id;
+
+    @OneToOne
+    private CertificateSerial serial;
+
+    @OneToOne
+    private Owner owner;
+
+    @Override
+    public String getId() {
+        return this.id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CertificateSerial getSerial() {
+        return this.serial;
+    }
+
+    /**
+     * Sets the CertificateSerial for this certificate.
+     *
+     * @param certSerial the CertificateSerial for this certificate.
+     */
+    public void setSerial(CertificateSerial certSerial) {
+        this.serial = certSerial;
+    }
+
+    /**
+     * Returns the Owner of this certificate.
+     *
+     * @return the certificate's referenced Owner.
+     */
+    public Owner getOwner() {
+        return owner;
+    }
+
+    /**
+     * Sets the Owner of this certificate.
+     *
+     * @param owner the Owner of this certificate.
+     */
+    public void setOwner(Owner owner) {
+        this.owner = owner;
+    }
+
+}

--- a/server/src/main/java/org/candlepin/model/UeberCertificateCurator.java
+++ b/server/src/main/java/org/candlepin/model/UeberCertificateCurator.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2009 - 2017 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.model;
+
+import com.google.inject.Inject;
+
+import java.util.List;
+
+import javax.persistence.Query;
+
+/**
+ * UeberCertificateCurator
+ *
+ * Facilitates the creation and deletion of UeberCertificate objects in the database.
+ *
+ */
+public class UeberCertificateCurator extends AbstractHibernateCurator<UeberCertificate> {
+
+    @Inject
+    public UeberCertificateCurator() {
+        super(UeberCertificate.class);
+    }
+
+    /**
+     * Find the ueber certificate for the specified owner. Only one certificate should ever
+     * exist per owner.
+     *
+     * @param owner the target Owner
+     * @return the ueber certificate for this owner, null if one is not found.
+     */
+    @SuppressWarnings("unchecked")
+    public UeberCertificate findForOwner(Owner owner) {
+        String findByOwner = "select uc from UeberCertificate uc where uc.owner = :owner";
+        Query query = getEntityManager().createQuery(findByOwner);
+        query.setParameter("owner", owner);
+        List<UeberCertificate> certs = query.getResultList();
+        if (certs.isEmpty()) {
+            return null;
+        }
+        return certs.get(0);
+    }
+
+    /**
+     * Delete the UeberCertificate related to the specified owner.
+     *
+     * @param owner the target owner
+     * @return true if a certificate was deleted for the Owner, false otherwise.
+     */
+    public boolean deleteForOwner(Owner owner) {
+        String deleteForOwner = "delete from UeberCertificate uc where uc.owner = :owner";
+        Query query = getEntityManager().createQuery(deleteForOwner);
+        query.setParameter("owner", owner);
+        return query.executeUpdate() > 0;
+    }
+
+}

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/UndoImportsJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/UndoImportsJob.java
@@ -126,8 +126,7 @@ public class UndoImportsJob extends UniqueByEntityJob {
 
             List<Pool> pools = this.poolManager.listPoolsByOwner(owner).list();
             for (Pool pool : pools) {
-                if (pool.getSourceSubscription() != null && !pool.getType().isDerivedType() &&
-                    !pool.isUeberPool()) {
+                if (pool.getSourceSubscription() != null && !pool.getType().isDerivedType()) {
                     this.poolManager.deletePool(pool);
                 }
             }

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -1947,7 +1947,7 @@ public class ConsumerResource {
         @QueryParam("lazy_regen") @DefaultValue("true") Boolean lazyRegen) {
         if (entitlementId != null) {
             Entitlement e = verifyAndLookupEntitlement(entitlementId);
-            poolManager.regenerateCertificatesOf(e, false, lazyRegen);
+            poolManager.regenerateCertificatesOf(e, lazyRegen);
         }
         else {
             Consumer c = consumerCurator.verifyAndLookupConsumer(consumerUuid);

--- a/server/src/main/java/org/candlepin/service/EntitlementCertServiceAdapter.java
+++ b/server/src/main/java/org/candlepin/service/EntitlementCertServiceAdapter.java
@@ -44,20 +44,6 @@ public interface EntitlementCertServiceAdapter {
         throws GeneralSecurityException, IOException;
 
     /**
-     * Generate an ueber certificate, used to grant access to all content for
-     * the owner.
-     * End date specified explicitly to allow for flexible termination policies.
-     *
-     * @param entitlement entitlement which granted this cert.
-     * @param product product being consumed.
-     * @return Client entitlement certificate.
-     * @throws IOException thrown if there's a problem reading the cert.
-     * @throws GeneralSecurityException thrown security problem
-     */
-    EntitlementCertificate generateUeberCert(Entitlement entitlement, Product product)
-        throws GeneralSecurityException, IOException;
-
-    /**
      * Generate an entitlement certificate, used to grant access to some
      * content.
      * End date specified explicitly to allow for flexible termination policies.
@@ -73,25 +59,6 @@ public interface EntitlementCertServiceAdapter {
      * @throws GeneralSecurityException thrown security problem
      */
     Map<String, EntitlementCertificate> generateEntitlementCerts(Consumer consumer,
-        Map<String, Entitlement> entitlements, Map<String, Product> products)
-        throws GeneralSecurityException, IOException;
-
-    /**
-     * Generate an ueber certificate, used to grant access to all content for
-     * the owner.
-     * End date specified explicitly to allow for flexible termination policies.
-     * The Map keys are used to associate the entitlement with its product and
-     * cert generated. While they do not have to be pool ids, and can be any
-     * String, we use pool ids for consistency
-     *
-     * @param consumer
-     * @param entitlements entitlement which granted this cert.
-     * @param products Product being consumed.
-     * @return Client entitlement certificate.
-     * @throws IOException thrown if there's a problem reading the cert.
-     * @throws GeneralSecurityException thrown security problem
-     */
-    Map<String, EntitlementCertificate> generateUeberCerts(Consumer consumer,
         Map<String, Entitlement> entitlements, Map<String, Product> products)
         throws GeneralSecurityException, IOException;
 

--- a/server/src/main/resources/db/changelog/20170202093945-add-ueber-cert-to-owner.xml
+++ b/server/src/main/resources/db/changelog/20170202093945-add-ueber-cert-to-owner.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+    <property name="timestamp.type" value="TIMESTAMP WITHOUT TIME ZONE" dbms="oracle"/>
+    <property name="timestamp.type" value="TIMESTAMP WITHOUT TIME ZONE" dbms="postgresql"/>
+    <property name="timestamp.type" value="DATETIME" dbms="mysql"/>
+    <property name="cert.type" value="BLOB" dbms="oracle"/>
+    <property name="cert.type" value="bytea" dbms="postgresql"/>
+    <property name="cert.type" value="BLOB" dbms="mysql"/>
+
+    <changeSet id="20170202093945-1" author="mstead">
+        <comment>Create cp_ueber_cert table</comment>
+        <createTable tableName="cp_ueber_cert">
+            <column name="id" type="VARCHAR(32)">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="cp_ueber_cert_pkey"/>
+            </column>
+            <column name="created" type="${timestamp.type}"/>
+            <column name="updated" type="${timestamp.type}"/>
+            <column name="cert" type="${cert.type}">
+                <constraints nullable="false"/>
+            </column>
+            <column name="privatekey" type="${cert.type}">
+                <constraints nullable="false"/>
+            </column>
+            <column name="serial_id" type="BIGINT"/>
+            <column name="owner_id" type="varchar(32)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="20170202093945-2" author="mstead">
+        <comment>Create the foreign key constraints for the ueber cert relationships.</comment>
+        <!-- Owner relationship -->
+        <addForeignKeyConstraint
+            baseTableName="cp_ueber_cert"
+            baseColumnNames="owner_id"
+            constraintName="fk_owner"
+            deferrable="false"
+            initiallyDeferred="false"
+            onDelete="NO ACTION"
+            onUpdate="NO ACTION"
+            referencedColumnNames="id"
+            referencedTableName="cp_owner"
+            referencesUniqueColumn="true" />
+
+        <!-- CertificateSerial relationship -->
+        <addForeignKeyConstraint
+             baseColumnNames="serial_id"
+             baseTableName="cp_ueber_cert"
+             constraintName="ueber_cert_serial_fk"
+             deferrable="false"
+             initiallyDeferred="false"
+             onDelete="NO ACTION"
+             onUpdate="NO ACTION"
+             referencedColumnNames="id"
+             referencedTableName="cp_cert_serial" />
+
+    </changeSet>
+
+    <changeSet id="20170202093945-3" author="mstead" dbms="oracle">
+        <comment>Add indexes for the foreign keys in oracle.</comment>
+        <createIndex indexName="owner_fk" tableName="cp_ueber_cert" unique="true">
+            <column name="ueber_cert_id"/>
+        </createIndex>
+        <createIndex indexName="ueber_cert_serial_fk" tableName="cp_ueber_cert" unique="false">
+            <column name="serial_id"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/server/src/main/resources/db/changelog/20170214115606-uber-cert-rewrite.xml
+++ b/server/src/main/resources/db/changelog/20170214115606-uber-cert-rewrite.xml
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+    <!-- ********************************************************************* -->
+    <!-- *** Postgres/Oracle cleanup                                                                                                   ** -->
+    <!-- ********************************************************************* -->
+    <changeSet id="20170214115606-1" dbms="postgresql,oracle,hsqldb" author="mstead">
+        <comment>Cleanup all ueber data so that the new style ueber certs can be used.</comment>
+
+        <!-- Delete ueber entitlement certificates -->
+        <sql>delete from cp_ent_certificate
+                 where entitlement_id in (
+                     select e.id from cp_entitlement e
+                     inner join cp_pool p on e.pool_id = p.id
+                     inner join cp2_products prod ON prod.uuid = p.product_uuid
+                     where prod.name like '%_ueber_product'
+                 );
+        </sql>
+
+        <!-- Delete any ueber pool source subscriptions -->
+        <sql>delete from cp2_pool_source_sub
+               where pool_id in (
+                  select p.id from cp_pool p
+                  inner join cp2_products prod on prod.uuid = p.product_uuid
+                  where prod.name like '%_ueber_product'
+                );
+        </sql>
+
+        <!-- Delete ueber entitlements -->
+        <sql>delete from cp_entitlement
+                 where pool_id in (
+                     select p.id from cp_pool p
+                     inner join cp2_products prod ON prod.uuid = p.product_uuid
+                     where prod.name like '%_ueber_product'
+                 );
+        </sql>
+
+        <!-- Delete any ueber pools -->
+        <sql>delete from cp_pool
+                 where id in (
+                   select p.id from cp_pool p
+                   inner join cp2_products prod on prod.uuid = p.product_uuid
+                   where prod.name like '%_ueber_product'
+                 );
+        </sql>
+
+        <!-- Delete any ueber owner content -->
+        <sql>delete from cp2_owner_content
+               where content_uuid in (
+                  select c.uuid from cp2_content c
+                  inner join cp2_product_content pc on pc.content_uuid=c.uuid
+                  inner join cp2_products p on p.uuid=pc.product_uuid
+                  where p.name LIKE '%ueber_product'
+                );
+        </sql>
+
+        <!-- Delete any ueber content  -->
+        <sql>delete from cp2_content
+                 where uuid in (
+                   select c.uuid from cp2_content c
+                   inner join cp2_product_content pc on pc.content_uuid=c.uuid
+                   inner join cp2_products p on p.uuid=pc.product_uuid
+                   where p.name LIKE '%ueber_product'
+                 );
+        </sql>
+
+        <!-- Delete any ueber owner products -->
+        <sql>delete from cp2_owner_products
+                 where product_uuid in (
+                    select uuid from cp2_products where name like '%ueber_product'
+                 );
+        </sql>
+
+        <!-- Delete any ueber products  -->
+        <sql>delete from cp2_products where name like '%_ueber_product';</sql>
+
+        <!-- Delete any ueber consumers -->
+        <sql>delete from cp_consumer where name like 'ueber_cert_consumer';</sql>
+    </changeSet>
+
+    <changeSet id="20170214115606-2" dbms="postgresql,oracle,hsqldb" author="mstead">
+        <comment>Delete the UeberConsumer consumer type as it is no longer used.</comment>
+        <sql>delete from cp_consumer_type where label='uebercert';</sql>
+    </changeSet>
+
+    <!-- ********************************************************************* -->
+    <!-- *** MySQL cleanup                                                                                                                  ** -->
+    <!-- ********************************************************************* -->
+    <changeSet id="20170214115606-3" dbms="mysql" author="mstead">
+        <comment>Cleanup all ueber data so that the new style ueber certs can be used.</comment>
+
+        <!-- Delete ueber entitlement certificates -->
+        <sql>delete ec from cp_ent_certificate ec
+                 inner join cp_entitlement e on ec.entitlement_id = e.id
+                 inner join cp_pool p on e.pool_id = p.id
+                 inner join cp2_products prod ON prod.uuid = p.product_uuid
+                 where prod.name like '%_ueber_product';
+        </sql>
+
+        <!-- Delete any ueber pool source subscriptions -->
+        <sql>delete ss from cp2_pool_source_sub ss
+                 inner join cp_pool p on ss.pool_id = p.id
+                 inner join cp2_products prod ON prod.uuid = p.product_uuid
+                 where prod.name like '%_ueber_product';
+        </sql>
+
+        <!-- Delete ueber entitlements -->
+        <sql>delete e from cp_entitlement e
+                 inner join cp_pool p on e.pool_id = p.id
+                 inner join cp2_products prod ON prod.uuid = p.product_uuid
+                 where prod.name like '%_ueber_product';
+        </sql>
+
+        <!-- Delete any ueber pools -->
+        <sql>delete p from cp_pool p
+                 inner join cp2_products prod ON prod.uuid = p.product_uuid
+                 where prod.name like '%_ueber_product';
+        </sql>
+
+        <!-- Delete any ueber owner content -->
+        <sql>delete oc from cp2_owner_content oc
+                 inner join cp2_product_content pc on pc.content_uuid=oc.content_uuid
+                 inner join cp2_products p on p.uuid=pc.product_uuid
+                 where p.name LIKE '%ueber_product';
+        </sql>
+
+        <!-- Delete any ueber content  -->
+        <sql>delete c from cp2_content c
+                 inner join cp2_product_content pc on pc.content_uuid=c.uuid
+                 inner join cp2_products p on p.uuid=pc.product_uuid
+                 where p.name LIKE '%ueber_product';
+        </sql>
+
+        <!-- Delete any ueber owner products -->
+        <sql>delete op from cp2_owner_products op
+                 inner join cp2_products p on op.product_uuid = p.uuid
+                 where name like '%ueber_product';
+        </sql>
+
+        <!-- Delete any ueber products  -->
+        <sql>delete p from cp2_products p where name like '%_ueber_product';</sql>
+
+        <!-- Delete any ueber consumers -->
+        <sql>delete c from cp_consumer c where name like 'ueber_cert_consumer';</sql>
+    </changeSet>
+
+    <changeSet id="20170214115606-4" dbms="mysql" author="mstead">
+        <comment>Delete the UeberConsumer consumer type as it is no longer used.</comment>
+        <sql>delete t from cp_consumer_type t where t.label='uebercert';</sql>
+    </changeSet>
+
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/server/src/main/resources/db/changelog/changelog-create.xml
+++ b/server/src/main/resources/db/changelog/changelog-create.xml
@@ -1199,4 +1199,6 @@
     <include file="db/changelog/20161129104417-add-content-access-mode-column-to-consumer.xml"/>
     <include file="db/changelog/20170130144529-perorgproducts-phase-2.xml"/>
     <include file="db/changelog/20170125112728-cleanup-uebercerts-round3-2-0.xml"/>
+    <include file="db/changelog/20170202093945-add-ueber-cert-to-owner.xml"/>
+    <include file="db/changelog/20170214115606-uber-cert-rewrite.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-testing.xml
+++ b/server/src/main/resources/db/changelog/changelog-testing.xml
@@ -2028,7 +2028,7 @@
     </changeSet>
     <changeSet author="awood" id="1413225753032-290">
         <comment>
-             Add the default quartz lock columns.
+             Add the default quartz lock columns. 
         </comment>
         <insert tableName="QRTZ_LOCKS">
             <column name="LOCK_NAME" value="TRIGGER_ACCESS"/>
@@ -2289,4 +2289,6 @@
     <include file="db/changelog/20161129104417-add-content-access-mode-column-to-consumer.xml"/>
     <include file="db/changelog/20170130144529-perorgproducts-phase-2.xml"/>
     <include file="db/changelog/20170125112728-cleanup-uebercerts-round3-2-0.xml"/>
+    <include file="db/changelog/20170202093945-add-ueber-cert-to-owner.xml"/>
+    <include file="db/changelog/20170214115606-uber-cert-rewrite.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-update.xml
+++ b/server/src/main/resources/db/changelog/changelog-update.xml
@@ -107,4 +107,6 @@
     <include file="db/changelog/20161129104417-add-content-access-mode-column-to-consumer.xml"/>
     <include file="db/changelog/20170130144529-perorgproducts-phase-2.xml"/>
     <include file="db/changelog/20170125112728-cleanup-uebercerts-round3-2-0.xml"/>
+    <include file="db/changelog/20170202093945-add-ueber-cert-to-owner.xml"/>
+    <include file="db/changelog/20170214115606-uber-cert-rewrite.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/rules/rules.js
+++ b/server/src/main/resources/rules/rules.js
@@ -1,4 +1,4 @@
-// Version: 5.20
+// Version: 5.21
 
 /*
  * Default Candlepin rule set.
@@ -41,7 +41,6 @@ function pool_type_name_space() {
 // consumer types
 var SYSTEM_TYPE = "system";
 var HYPERVISOR_TYPE = "hypervisor";
-var UEBERCERT_TYPE = "uebercert";
 
 // Consumer fact names
 var SOCKET_FACT="cpu.cpu_socket(s)";
@@ -1515,9 +1514,8 @@ var Entitlement = {
         }
 
         var requiresConsumerType = context.getAttribute(context.pool, REQUIRES_CONSUMER_TYPE_ATTRIBUTE);
-        // skip if the attribtue is not defined, or if generating an uebercert.
-        if (requiresConsumerType != null &&
-            context.consumer.type.label != UEBERCERT_TYPE ) {
+        // skip if the attribtue is not defined.
+        if (requiresConsumerType != null) {
             // Consumer types need to match (except below)
             if (requiresConsumerType != context.consumer.type.label) {
                 // Allow hypervisors to be like systems
@@ -1764,10 +1762,9 @@ var Entitlement = {
             }
 
             // If the product has no required consumer type, assume it is restricted to "system".
-            // "hypervisor"/"uebercert" type are essentially the same as "system".
+            // "hypervisor" type are essentially the same as "system".
             if (!pool.getProductAttribute(REQUIRES_CONSUMER_TYPE_ATTRIBUTE)) {
-                if (consumer.type.label != SYSTEM_TYPE && consumer.type.label != HYPERVISOR_TYPE &&
-                        consumer.type.label != UEBERCERT_TYPE) {
+                if (consumer.type.label != SYSTEM_TYPE && consumer.type.label != HYPERVISOR_TYPE) {
                     result.addError("rulefailed.consumer.type.mismatch");
                 }
             }

--- a/server/src/test/java/org/candlepin/model/OwnerInfoCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/OwnerInfoCuratorTest.java
@@ -640,22 +640,6 @@ public class OwnerInfoCuratorTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void testConsumerCountsByEntitlementStatusExcludesUebercertConsumers() {
-        setupConsumerCountTest("test-user");
-
-        ConsumerType ueberType = consumerTypeCurator.lookupByLabel("uebercert");
-        Consumer ueberConsumer = new Consumer("test-ueber", "test-user", owner,
-            ueberType);
-        ueberConsumer.setEntitlementStatus(ComplianceStatus.GREEN);
-        consumerCurator.create(ueberConsumer);
-
-        // Even though we've added an ubercert consumer, the counts should remain
-        // as expected.
-        OwnerInfo info = ownerInfoCurator.lookupByOwner(owner);
-        assertConsumerCountsByEntitlementStatus(info);
-    }
-
-    @Test
     public void testPermissionsAppliedWhenDeterminingConsumerCountsByEntStatus() {
         User mySystemsUser = setupOnlyMyConsumersPrincipal();
         setupConsumerCountTest("test-user");

--- a/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
@@ -64,9 +64,6 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         ConsumerType systemType = new ConsumerType(ConsumerTypeEnum.SYSTEM);
         consumerTypeCurator.create(systemType);
 
-        ConsumerType ueberCertType = new ConsumerType(ConsumerTypeEnum.UEBER_CERT);
-        consumerTypeCurator.create(ueberCertType);
-
         product = this.createProduct(owner);
 
         consumer = TestUtil.createConsumer(owner);

--- a/server/src/test/java/org/candlepin/model/UeberCertificateCuratorTests.java
+++ b/server/src/test/java/org/candlepin/model/UeberCertificateCuratorTests.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2009 - 2017 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.model;
+
+import static org.junit.Assert.*;
+
+import org.candlepin.test.DatabaseTestFixture;
+
+import org.hibernate.exception.ConstraintViolationException;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.inject.Inject;
+import javax.persistence.PersistenceException;
+
+/**
+ * UeberCertificateCuratorTests
+ */
+public class UeberCertificateCuratorTests extends DatabaseTestFixture {
+
+    @Inject private UeberCertificateCurator ueberCertificateCurator;
+
+    private Owner owner;
+
+    @Before
+    public void setupTest() {
+        owner = this.createOwner("uebertest");
+    }
+
+    @Test
+    public void ensureCertificateCreationAndGet() {
+        UeberCertificate cert = this.createUeberCert(owner);
+        assertEquals(cert, ueberCertificateCurator.find(cert.getId()));
+        assertEquals(cert, ueberCertificateCurator.findForOwner(owner));
+    }
+
+    @Test
+    public void ensureCertificateDeletion() {
+        this.createUeberCert(owner);
+        this.ueberCertificateCurator.deleteForOwner(owner);
+        assertNull(this.ueberCertificateCurator.findForOwner(owner));
+    }
+
+    @Test
+    public void ensureDuplicateCertificateCreationFailsForAnOwner() {
+        // This should never happen in code, but adding a test to make
+        // sure that if there was ever an attempt to add more than one
+        // cert to an owner, the DB would block it.
+        //
+        // The second create should throw a constraint violation.
+        this.createUeberCert(owner);
+
+        try {
+            this.createUeberCert(owner);
+            fail("Expected an exception due to multiple certs for the owner.");
+        }
+        catch (PersistenceException e) {
+            assertTrue(e.getCause() != null && e.getCause() instanceof ConstraintViolationException);
+        }
+    }
+
+    private UeberCertificate createUeberCert(Owner owner) {
+        CertificateSerial serial = new CertificateSerial();
+        this.certSerialCurator.create(serial);
+
+        UeberCertificate uc = new UeberCertificate();
+        uc.setOwner(owner);
+        uc.setSerial(serial);
+        uc.setCert("A FAKE PEM STRING");
+        uc.setKey("A Fake Key");
+
+        return this.ueberCertificateCurator.create(uc);
+    }
+
+}

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/UndoImportsJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/UndoImportsJobTest.java
@@ -27,7 +27,6 @@ import org.candlepin.model.ConsumerType;
 import org.candlepin.model.ExporterMetadata;
 import org.candlepin.model.ExporterMetadataCurator;
 import org.candlepin.model.Entitlement;
-import org.candlepin.model.EntitlementCertificate;
 import org.candlepin.model.ImportRecord;
 import org.candlepin.model.ImportRecordCurator;
 import org.candlepin.model.Owner;
@@ -35,6 +34,7 @@ import org.candlepin.model.OwnerCurator;
 import org.candlepin.model.Pool;
 import org.candlepin.model.Pool.PoolType;
 import org.candlepin.model.Product;
+import org.candlepin.model.UeberCertificate;
 import org.candlepin.model.UeberCertificateGenerator;
 import org.candlepin.model.UpstreamConsumer;
 import org.candlepin.pinsetter.core.PinsetterJobListener;
@@ -113,7 +113,6 @@ public class UndoImportsJobTest extends DatabaseTestFixture {
             this.i18n, this.ownerCurator, this.poolManager, this.subAdapter,
             this.exportCurator, this.importRecordCurator
         );
-        this.consumerTypeCurator.create(new ConsumerType(ConsumerType.ConsumerTypeEnum.UEBER_CERT));
     }
 
     @Test
@@ -160,14 +159,13 @@ public class UndoImportsJobTest extends DatabaseTestFixture {
         Pool pool9 = this.createPool("pool9", owner2, true, PoolType.ENTITLEMENT_DERIVED);
 
         // Create an ueber certificate for the owner.
-        EntitlementCertificate uebercert = ueberCertGenerator.generate(owner1.getKey(),
+        UeberCertificate uebercert = ueberCertGenerator.generate(owner1.getKey(),
             this.setupAdminPrincipal("test_admin"));
         assertNotNull(uebercert);
-        Pool owner1UeberPool = uebercert.getEntitlement().getPool();
 
         // Verify initial state
         assertEquals(
-            Arrays.asList(pool1, pool2, pool3, pool4, pool5, pool6, owner1UeberPool),
+            Arrays.asList(pool1, pool2, pool3, pool4, pool5, pool6),
             this.poolManager.listPoolsByOwner(owner1).list()
         );
         assertEquals(Arrays.asList(pool7, pool8, pool9), this.poolManager.listPoolsByOwner(owner2).list());
@@ -188,7 +186,7 @@ public class UndoImportsJobTest extends DatabaseTestFixture {
         commitTransaction();
 
         // Verify deletions -- Ueber pools should not get deleted.
-        assertEquals(Arrays.asList(pool3, pool4, pool5, pool6, owner1UeberPool),
+        assertEquals(Arrays.asList(pool3, pool4, pool5, pool6),
             this.poolManager.listPoolsByOwner(owner1).list());
 
         assertEquals(Arrays.asList(pool7, pool8, pool9), this.poolManager.listPoolsByOwner(owner2).list());

--- a/server/src/test/java/org/candlepin/resource/OwnerResourceUeberCertOperationsTest.java
+++ b/server/src/test/java/org/candlepin/resource/OwnerResourceUeberCertOperationsTest.java
@@ -15,7 +15,6 @@
 package org.candlepin.resource;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -27,22 +26,16 @@ import org.candlepin.common.exceptions.NotFoundException;
 import org.candlepin.controller.CandlepinPoolManager;
 import org.candlepin.controller.ContentManager;
 import org.candlepin.controller.ProductManager;
-import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerCurator;
-import org.candlepin.model.ConsumerType;
-import org.candlepin.model.ConsumerType.ConsumerTypeEnum;
 import org.candlepin.model.ConsumerTypeCurator;
-import org.candlepin.model.EntitlementCertificate;
 import org.candlepin.model.EntitlementCertificateCurator;
 import org.candlepin.model.EntitlementCurator;
 import org.candlepin.model.Owner;
 import org.candlepin.model.OwnerCurator;
-import org.candlepin.model.Pool;
-import org.candlepin.model.PoolCurator;
-import org.candlepin.model.Product;
-import org.candlepin.model.ProductCurator;
 import org.candlepin.model.Role;
 import org.candlepin.model.RoleCurator;
+import org.candlepin.model.UeberCertificate;
+import org.candlepin.model.UeberCertificateCurator;
 import org.candlepin.model.UeberCertificateGenerator;
 import org.candlepin.model.User;
 import org.candlepin.test.DatabaseTestFixture;
@@ -61,12 +54,9 @@ import javax.inject.Inject;
  * OwnerResourceUeberCertOperationsTest
  */
 public class OwnerResourceUeberCertOperationsTest extends DatabaseTestFixture {
-    private static final String UEBER_PRODUCT = Product.UEBER_PRODUCT_POSTFIX;
     private static final String OWNER_NAME = "Jar_Jar_Binks";
 
     @Inject private OwnerCurator ownerCurator;
-    @Inject private ProductCurator productCurator;
-    @Inject private PoolCurator poolCurator;
     @Inject private ConsumerCurator consumerCurator;
     @Inject private ConsumerTypeCurator consumerTypeCurator;
     @Inject private EntitlementCurator entitlementCurator;
@@ -74,6 +64,7 @@ public class OwnerResourceUeberCertOperationsTest extends DatabaseTestFixture {
     @Inject private EntitlementCertificateCurator entCertCurator;
     @Inject private CandlepinPoolManager poolManager;
     @Inject private UeberCertificateGenerator ueberCertGenerator;
+    @Inject private UeberCertificateCurator ueberCertCurator;
     @Inject private PermissionFactory permFactory;
     @Inject private ServiceLevelValidator serviceLevelValidator;
     @Inject private I18n i18n;
@@ -99,49 +90,19 @@ public class OwnerResourceUeberCertOperationsTest extends DatabaseTestFixture {
                 ownerAdminRole.getPermissions())), false);
         setupPrincipal(principal);
 
-        ConsumerType ueberCertType = new ConsumerType(ConsumerTypeEnum.UEBER_CERT);
-        consumerTypeCurator.create(ueberCertType);
-
         or = new OwnerResource(
             ownerCurator, null, consumerCurator, i18n, null, null, null, null, null, poolManager, null, null,
-            null, null, consumerTypeCurator, entCertCurator, entitlementCurator, ueberCertGenerator, null,
-            null, contentOverrideValidator, serviceLevelValidator, null, null, null, productManager,
-            contentManager, null
+            null, null, consumerTypeCurator, entCertCurator, entitlementCurator, ueberCertCurator,
+            ueberCertGenerator, null,  null, contentOverrideValidator, serviceLevelValidator, null, null,
+            null, productManager, contentManager, null
         );
     }
 
     @Test
-    public void testUeberProductIsCreated() throws Exception {
-        or.createUeberCertificate(principal, owner.getKey());
-        assertNotNull(productCurator.lookupByName(owner, owner.getKey() + UEBER_PRODUCT));
-    }
-
-    @Test
-    public void testUeberConsumerIsCreated() throws Exception {
-        or.createUeberCertificate(principal, owner.getKey());
-        assertNotNull(consumerCurator.findByName(owner, "ueber_cert_consumer"));
-    }
-
-    @Test
-    public void testUeberEntitlementIsGenerated() throws Exception {
-        or.createUeberCertificate(principal, owner.getKey());
-        assertNotNull(poolCurator.findUeberPool(owner));
-    }
-
-    @Test
     public void testUeberCertIsRegeneratedOnNextInvocation() throws Exception {
-        EntitlementCertificate firstCert
-            = or.createUeberCertificate(principal, owner.getKey());
-        Product firstProduct = productCurator.lookupByName(owner, owner.getKey() + UEBER_PRODUCT);
-
-        EntitlementCertificate secondCert
-            = or.createUeberCertificate(principal, owner.getKey());
-        Product secondProduct = productCurator.lookupByName(owner, owner.getKey() + UEBER_PRODUCT);
-
-        //make sure we didn't regenerate the whole thing
-        assertTrue(firstProduct.getUuid() == secondProduct.getUuid());
-        // only the ueber cert
-        assertFalse(firstCert.getId() == secondCert.getId());
+        UeberCertificate firstCert = or.createUeberCertificate(principal, owner.getKey());
+        UeberCertificate secondCert = or.createUeberCertificate(principal, owner.getKey());
+        assertTrue(firstCert.getId() != secondCert.getId());
     }
 
     @Test(expected = NotFoundException.class)
@@ -157,9 +118,6 @@ public class OwnerResourceUeberCertOperationsTest extends DatabaseTestFixture {
     @Test(expected = NotFoundException.class)
     public void certificateRetrievalRaisesExceptionIfNoCertificateWasGenerated()
         throws Exception {
-        // generate certificate for one owner
-        or.createUeberCertificate(principal, owner.getKey());
-
         // verify that owner under test doesn't have a certificate
         Owner anotherOwner = ownerCurator.create(new Owner(OWNER_NAME + "1"));
         or.getUeberCertificate(principal, anotherOwner.getKey());
@@ -167,28 +125,13 @@ public class OwnerResourceUeberCertOperationsTest extends DatabaseTestFixture {
 
     @Test
     public void certificateRetrievalReturnsCert() {
-        EntitlementCertificate cert = or.createUeberCertificate(principal, owner.getKey());
-        assertNotNull(cert);
+        UeberCertificate generated = or.createUeberCertificate(principal, owner.getKey());
+        assertNotNull(generated);
+
+        UeberCertificate retrieved = or.getUeberCertificate(principal, owner.getKey());
+        assertNotNull(retrieved);
+
+        assertEquals(generated, retrieved);
     }
 
-    @Test
-    public void ueberPoolCreatedWhenMissing() throws Exception {
-        EntitlementCertificate firstCert = or.createUeberCertificate(principal, owner.getKey());
-        Pool firstPool = firstCert.getEntitlement().getPool();
-        poolManager.deletePool(firstPool);
-        EntitlementCertificate newCert = or.createUeberCertificate(principal, owner.getKey());
-        assertFalse(firstPool.equals(newCert.getEntitlement().getPool()));
-    }
-
-    @Test
-    public void ueberCertRegeneratedWhenNoUeberEntsExistForConsumer() throws Exception {
-        EntitlementCertificate firstCert = or.createUeberCertificate(principal, owner.getKey());
-        assertNotNull(firstCert);
-        Consumer ueberConsumer = consumerCurator.findByName(owner, Consumer.UEBER_CERT_CONSUMER);
-        assertNotNull(ueberConsumer);
-        assertEquals(1, poolManager.revokeAllEntitlements(ueberConsumer));
-        EntitlementCertificate newCert = or.createUeberCertificate(principal, owner.getKey());
-        assertNotNull(newCert);
-        assertFalse(newCert.equals(firstCert));
-    }
 }

--- a/server/src/test/java/org/candlepin/service/impl/stub/StubEntitlementCertServiceAdapter.java
+++ b/server/src/test/java/org/candlepin/service/impl/stub/StubEntitlementCertServiceAdapter.java
@@ -86,13 +86,6 @@ public class StubEntitlementCertServiceAdapter extends BaseEntitlementCertServic
     }
 
     @Override
-    public EntitlementCertificate generateUeberCert(Entitlement entitlement,
-        Product product) throws GeneralSecurityException,
-        IOException {
-        return generateEntitlementCert(entitlement, product);
-    }
-
-    @Override
     public Map<String, EntitlementCertificate> generateEntitlementCerts(Consumer consumer,
         Map<String, Entitlement> entitlements, Map<String, Product> products)
         throws GeneralSecurityException, IOException {
@@ -100,20 +93,6 @@ public class StubEntitlementCertServiceAdapter extends BaseEntitlementCertServic
         Map<String, EntitlementCertificate> result = new HashMap<String, EntitlementCertificate>();
         for (Entry<String, Entitlement> entry : entitlements.entrySet()) {
             EntitlementCertificate cert = generateEntitlementCert(entry.getValue(),
-                products.get(entry.getKey()));
-            result.put(entry.getKey(), cert);
-        }
-        return result;
-    }
-
-    @Override
-    public Map<String, EntitlementCertificate> generateUeberCerts(Consumer consumer,
-        Map<String, Entitlement> entitlements, Map<String, Product> products)
-        throws GeneralSecurityException, IOException {
-
-        Map<String, EntitlementCertificate> result = new HashMap<String, EntitlementCertificate>();
-        for (Entry<String, Entitlement> entry : entitlements.entrySet()) {
-            EntitlementCertificate cert = generateUeberCert(entry.getValue(),
                 products.get(entry.getKey()));
             result.put(entry.getKey(), cert);
         }


### PR DESCRIPTION
# Description
A rewrite of this functionality was done to
remove the complexity from the generation
process and supporting data model used to
create the certificate.

In the new approach, uber certificates are
stored in their own table, and no longer
require 'dummy' consumers/pools/constent/product
stored in the DB in order to get a certificate
for an Owner.

We still only allow one uber cert per owner
but the cert is now directly related to the
Owner record and has no ties to any other
entity.

As part of this patch, all legacy uber cert
functionality has been removed and replaced
with the new.

# Testing Basic Candlepin Uber Cert Functionality
**Candlepin Testing Notes**
- Exercise the GET /owners/:key/uebercert API
- Exercise the POST /owners/:key/uebercert API
  * Ensure that a new cert is generated each time.


# Testing The Basic Use Case On A Satellite Instance

**NOTES ON TESTING BASIC CASE FOR SATELLITE:**
We will be using the uber certificate to browse content of an owner with the browser. When testing this out, we will generate the uber certs on a local candlepin (we'll set up the same CA as a Satellite) and we'll test them out on a different instance of Satellite running 0.9.54. This is the easiest way to do this until Sat folk get a deployable version of Sat6 with CP 2.0
 
It took a bit of fiddling around to get this to work, so I hope I didn't miss anything. If something in these test steps does not work, let me know and I can help out.

**Setting Up Satellite**
- Stand up a satellite with forklift (doesn't matter what version)
- Create two Orgs (make note of the org/owner keys)
- For each Org
  - Select the org in the upper left dropdown
  - Generate a manifest using stage, and import it into the Org
  - Navigate to 'Content -> Red Hat Repositories' and enable one of the repos.
  - Navigate to 'Content -> Sync Plans' and create a new plan
    * Click the Add tab, select a product and click the 'Add Selected' button.
  - Click the 'Run Sync Plan' button to sync content to your satellite.
  - Navigate to 'Content -> Sync Status' and wait for the content to fully sync

**Setting up local candlepin**
- SSH into the satellite and SCP the CA and KEY used by candlepin over to your local candlepin server (same destination as the location on the satellite).
  * /etc/pki/katello/private/katello-default-ca.key
  * /etc/pki/katello/certs/katello-default-ca-stripped.crt
- Assign the 'tomcat' group to katello-default-ca.key
- Add the following to the candlepin conf and restart tomcat making sure that candlepin starts without error.
  * candlepin.ca_key=/etc/pki/katello/private/katello-default-ca.key
  * candlepin.ca_cert=/etc/pki/katello/certs/katello-default-ca-stripped.crt
- deploy candlepin with this patch
- Create two Owners in you local candlepin (ensure the owner_keys match those of the Orgs labels you created)

**Creating and Testing The Certs**
 - On your local CP, generate an uber cert for each owner:
  - ./client/ruby/cpc generate_ueber_cert <YOUR_OWNER_KEY> <FILE_NAME>
- Create a cert to be used in your browser for each uber cert:
  - Create a key.pem and cert.pem from the downloaded ueber certificate
  - Create a pfx file that can be imported to the browser. 
	openssl pkcs12 -keypbe PBE-SHA1-3DES -certpbe PBE-SHA1-3DES -export -in cert.pem -inkey key.pem -out [NAME].pfx -name [NAME]
- Browse to "https://192.168.121.8/pulp/repos/:YOUR_OWNER_KEY/" (You should get a security error)
- Import the cert (pfx file) (for the owner YOUR_OWNER_KEY) into your browser of choice.
- Try accessing the above URL again. This time you should see a dir listing for the repo.
- Try accessing the above URL but with the other owner key. You should get another security error.
- Import the key for the other owner, and try again. Make sure that you can see the content.