### PR TITLE
POC for making all certificate generation lazy

### DIFF
--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -2031,9 +2031,6 @@ public class CandlepinPoolManager implements PoolManager {
         void handlePostEntitlement(PoolManager manager, Consumer consumer,
             Map<String, Entitlement> entitlements);
 
-        void handleSelfCertificates(Consumer consumer, Map<String, PoolQuantity> pools,
-            Map<String, Entitlement> entitlements);
-
         void handleBonusPools(Owner owner, Map<String, PoolQuantity> pools,
             Map<String, Entitlement> entitlements);
     }
@@ -2054,7 +2051,8 @@ public class CandlepinPoolManager implements PoolManager {
                 Entitlement newEntitlement = new Entitlement(
                     entry.getValue().getPool(), consumer, entry.getValue().getQuantity()
                 );
-
+                //Set entitlement to dirty so it will generate certificates when they are first asked for
+                newEntitlement.setDirty(true);
                 entsToPersist.add(newEntitlement);
                 result.put(entry.getKey(), newEntitlement);
             }
@@ -2100,18 +2098,6 @@ public class CandlepinPoolManager implements PoolManager {
         }
 
         @Override
-        public void handleSelfCertificates(Consumer consumer, Map<String, PoolQuantity> poolQuantities,
-            Map<String, Entitlement> entitlements) {
-            Map<String, Product> products = new HashMap<String, Product>();
-            for (PoolQuantity poolQuantity : poolQuantities.values()) {
-                Pool pool = poolQuantity.getPool();
-                products.put(pool.getId(), pool.getProduct());
-            }
-
-            ecGenerator.generateEntitlementCertificates(consumer, products, entitlements);
-        }
-
-        @Override
         public void handleBonusPools(Owner owner, Map<String, PoolQuantity> pools,
             Map<String, Entitlement> entitlements) {
             checkBonusPoolQuantities(owner, pools, entitlements);
@@ -2140,13 +2126,6 @@ public class CandlepinPoolManager implements PoolManager {
             Map<String, Entitlement> entitlements) {
         }
 
-        @Override
-        public void handleSelfCertificates(Consumer consumer, Map<String, PoolQuantity> poolQuantities,
-            Map<String, Entitlement> entitlements) {
-            for (Entry<String, Entitlement> entry : entitlements.entrySet()) {
-                regenerateCertificatesOf(entry.getValue(), true);
-            }
-        }
         @Override
         public void handleBonusPools(Owner owner, Map<String, PoolQuantity> pools,
             Map<String, Entitlement> entitlements) {

--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -1567,7 +1567,6 @@ public class CandlepinPoolManager implements PoolManager {
         }
 
         handler.handlePostEntitlement(this, consumer, entitlements);
-        handler.handleSelfCertificates(consumer, poolQuantities, entitlements);
 
         this.ecGenerator.regenerateCertificatesByEntitlementIds(
             this.entitlementCurator.batchListModifying(entitlements.values()), true
@@ -1575,7 +1574,6 @@ public class CandlepinPoolManager implements PoolManager {
 
         // we might have changed the bonus pool quantities, lets find out.
         handler.handleBonusPools(consumer.getOwner(), poolQuantities, entitlements);
-
 
         /*
          * If the consumer is not a distributor, check consumer's new compliance

--- a/server/src/main/java/org/candlepin/model/Entitlement.java
+++ b/server/src/main/java/org/candlepin/model/Entitlement.java
@@ -256,6 +256,7 @@ public class Entitlement extends AbstractHibernateObject
         this.quantity = quantity;
     }
 
+    @XmlTransient
     public Set<EntitlementCertificate> getCertificates() {
         return certificates;
     }

--- a/server/src/test/java/org/candlepin/controller/PoolManagerFunctionalTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerFunctionalTest.java
@@ -260,7 +260,14 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
         throws Exception {
         AutobindData data = AutobindData.create(childVirtSystem).on(new Date())
             .forProducts(new String [] {provisioning.getId()});
-        this.entitlementCurator.refresh(poolManager.entitleByProducts(data).get(0));
+        //Entitle the system
+        Entitlement ent = poolManager.entitleByProducts(data).get(0);
+        //Regenerate dirty entitlements because certificates are created lazily
+        poolManager.regenerateDirtyEntitlements(childVirtSystem);
+        reset(this.eventSink);
+        //Refresh and assert new certs
+        this.entitlementCurator.refresh(ent);
+
         regenerateECAndAssertNotSameCertificates();
     }
 
@@ -295,8 +302,17 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
         throws EntitlementRefusedException {
         AutobindData data = AutobindData.create(childVirtSystem).on(new Date())
             .forProducts(new String [] {provisioning.getId()});
-        this.entitlementCurator.refresh(poolManager.entitleByProducts(data).get(0));
-        this.entitlementCurator.refresh(poolManager.entitleByProducts(data).get(0));
+
+        // Entitle the system
+        Entitlement ent1 = poolManager.entitleByProducts(data).get(0);
+        Entitlement ent2 = poolManager.entitleByProducts(data).get(0);
+        // Regenerate dirty entitlements because certificates are created lazily
+        poolManager.regenerateDirtyEntitlements(childVirtSystem);
+        // Reset the event sink for the above regenerate
+        reset(this.eventSink);
+        // Refresh and assert new certs
+        this.entitlementCurator.refresh(ent1);
+        this.entitlementCurator.refresh(ent2);
         regenerateECAndAssertNotSameCertificates();
     }
 


### PR DESCRIPTION
Make all entitlement certificate generation lazy and don't return the certificates as part of the entitlement object. 