### PR TITLE
Entering suspend mode on startup

### DIFF
--- a/server/spec/qpid_spec.rb
+++ b/server/spec/qpid_spec.rb
@@ -61,6 +61,14 @@ describe 'Qpid Broker' do
      expect(mode["mode"]).to eq(mode_name)
   end
 
+  def stop_tomcat()
+     `sudo systemctl stop tomcat || sudo supervisorctl stop tomcat`
+  end
+
+  def start_tomcat()
+     `sudo systemctl start tomcat || sudo supervisorctl start tomcat`
+  end
+
   it 'transition to SUSPEND mode' do
      assert_mode("NORMAL")
 
@@ -116,5 +124,16 @@ describe 'Qpid Broker' do
      msgs[0].subject.should == 'owner.created'
   end
 
+  it 'Candlepin startup without qpid ends in suspend mode' do
+     assert_mode("NORMAL")
+     stop_tomcat
+     @cq.stop
+     start_tomcat
+     sleep 10
+     assert_mode("SUSPEND")
+     @cq.start
+     sleep 12
+     assert_mode("NORMAL")
+  end
 
 end

--- a/server/src/main/java/org/candlepin/audit/HornetqContextListener.java
+++ b/server/src/main/java/org/candlepin/audit/HornetqContextListener.java
@@ -204,7 +204,6 @@ public class HornetqContextListener {
         }
         catch (Exception e) {
             log.error("Error starting AMQP client", e);
-            throw new RuntimeException(e);
         }
     }
 

--- a/server/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/server/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -153,11 +153,6 @@ public class ConfigProperties {
      */
     public static final String SUSPEND_MODE_ENABLED = "candlepin.suspend_mode_enabled";
     /**
-     * Candlepin will by default use QMF at startup to check if the Qpid is available. When it isn't its gonna
-     * fail fast.
-     */
-    public static final String QPID_STARTUP_CHECK_ENABLED = "candlepin.amqp.qmf.startup_check_enabled";
-    /**
      * Timeout that is used for QpidQmf while receiving messages. It shouldn't be necessary
      * to modify this unless the environment and Qpid Broker is so heavily utilized, that
      * reception takes longer.
@@ -378,7 +373,6 @@ public class ConfigProperties {
             this.put(AMQP_KEYSTORE_PASSWORD, "password");
             this.put(AMQP_TRUSTSTORE, "/etc/candlepin/certs/amqp/candlepin.truststore");
             this.put(AMQP_TRUSTSTORE_PASSWORD, "password");
-            this.put(QPID_STARTUP_CHECK_ENABLED, "true");
             this.put(SUSPEND_MODE_ENABLED, "true");
             this.put(QPID_QMF_RECEIVE_TIMEOUT, "5000");
             this.put(QPID_MODE_TANSITIONER_DELAY_GROWTH, "10");

--- a/server/src/main/java/org/candlepin/pinsetter/core/PinsetterKernel.java
+++ b/server/src/main/java/org/candlepin/pinsetter/core/PinsetterKernel.java
@@ -138,6 +138,9 @@ public class PinsetterKernel implements ModeChangeListener {
     public void startup() throws PinsetterException {
         try {
             scheduler.start();
+            if (modeManager.getLastCandlepinModeChange().getMode() != Mode.NORMAL) {
+                scheduler.pauseAll();
+            }
             modeManager.registerModeChangeListener(this);
             configure();
         }

--- a/server/src/test/java/org/candlepin/guice/CandlepinContextListenerTest.java
+++ b/server/src/test/java/org/candlepin/guice/CandlepinContextListenerTest.java
@@ -44,6 +44,7 @@ import org.junit.Test;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
 
 import javax.servlet.ServletContext;
 import javax.servlet.ServletContextEvent;
@@ -58,6 +59,7 @@ public class CandlepinContextListenerTest {
     private CacheContextListener cacheListener;
     private PinsetterContextListener pinlistener;
     private AMQPBusPublisher buspublisher;
+    private ScheduledExecutorService executorService;
     private ServletContextEvent evt;
     private ServletContext ctx;
     private VerifyConfigRead configRead;
@@ -78,6 +80,7 @@ public class CandlepinContextListenerTest {
         hqlistener = mock(HornetqContextListener.class);
         pinlistener = mock(PinsetterContextListener.class);
         buspublisher = mock(AMQPBusPublisher.class);
+        executorService = mock(ScheduledExecutorService.class);
         configRead = mock(VerifyConfigRead.class);
         cacheListener = mock(CacheContextListener.class);
 
@@ -154,6 +157,7 @@ public class CandlepinContextListenerTest {
     public void ensureAMQPClosedProperly() {
         when(config.getBoolean(
                 eq(ConfigProperties.AMQP_INTEGRATION_ENABLED))).thenReturn(true);
+        when(config.getBoolean(eq(ConfigProperties.SUSPEND_MODE_ENABLED))).thenReturn(true);
         when(config.getLong(ConfigProperties.QPID_MODE_TANSITIONER_DELAY_GROWTH)).thenReturn(100L);
         when(config.getLong(ConfigProperties.QPID_MODE_TRANSITIONER_INITIAL_DELAY)).thenReturn(100L);
         prepareForInitialization();
@@ -211,6 +215,7 @@ public class CandlepinContextListenerTest {
             bind(HornetqContextListener.class).toInstance(hqlistener);
             bind(AMQPBusPublisher.class).toInstance(buspublisher);
             bind(CacheContextListener.class).toInstance(cacheListener);
+            bind(ScheduledExecutorService.class).toInstance(executorService);
         }
     }
 

--- a/server/src/test/java/org/candlepin/pinsetter/core/PinsetterKernelTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/core/PinsetterKernelTest.java
@@ -27,6 +27,7 @@ import org.candlepin.auth.Principal;
 import org.candlepin.common.config.Configuration;
 import org.candlepin.common.config.MapConfiguration;
 import org.candlepin.config.ConfigProperties;
+import org.candlepin.model.CandlepinModeChange;
 import org.candlepin.model.CandlepinQuery;
 import org.candlepin.controller.ModeManager;
 import org.candlepin.model.JobCurator;
@@ -56,6 +57,7 @@ import org.quartz.impl.StdSchedulerFactory;
 import org.quartz.spi.JobFactory;
 
 import java.util.Arrays;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -107,6 +109,10 @@ public class PinsetterKernelTest {
             });
         when(sfactory.getScheduler()).thenReturn(sched);
         when(sched.getListenerManager()).thenReturn(lm);
+        when(modeManager.getLastCandlepinModeChange()).thenReturn(
+            new CandlepinModeChange(new Date(System.currentTimeMillis()),
+            CandlepinModeChange.Mode.NORMAL,
+            CandlepinModeChange.Reason.STARTUP));
     }
 
     @Test(expected = InstantiationException.class)


### PR DESCRIPTION
Candlepin will now enter suspend mode if Qpid is unavailable.
For this to occur the startup Qpid check must be disabled by setting `candlepin.amqp.qmf.startup_check_enabled` to `false`.