### PR TITLE
Certain queries now only pull distinct values

### DIFF
--- a/server/src/main/java/org/candlepin/model/OwnerContentCurator.java
+++ b/server/src/main/java/org/candlepin/model/OwnerContentCurator.java
@@ -358,7 +358,7 @@ public class OwnerContentCurator extends AbstractHibernateCurator<OwnerContent> 
         Criteria uuidCriteria = this.createSecureCriteria("oc")
             .createAlias("oc.content", "c")
             .add(disjunction)
-            .setProjection(Projections.property("c.uuid"));
+            .setProjection(Projections.distinct(Projections.property("c.uuid")));
 
         for (Map.Entry<String, Integer> entry : contentVersions.entrySet()) {
             disjunction.add(Restrictions.and(

--- a/server/src/main/java/org/candlepin/model/OwnerProductCurator.java
+++ b/server/src/main/java/org/candlepin/model/OwnerProductCurator.java
@@ -421,7 +421,7 @@ public class OwnerProductCurator extends AbstractHibernateCurator<OwnerProduct> 
         Criteria uuidCriteria = this.createSecureCriteria("op")
             .createAlias("op.product", "p")
             .add(disjunction)
-            .setProjection(Projections.property("p.uuid"));
+            .setProjection(Projections.distinct(Projections.property("p.uuid")));
 
         for (Map.Entry<String, Integer> entry : productVersions.entrySet()) {
             disjunction.add(Restrictions.and(


### PR DESCRIPTION
- Certain ID-fetching queries now only fetch distinct results, reducing
  the size of the following object-fetching queries and reducing the
  probability of hitting the packet size limit on some databases