### PR TITLE
1428827: Use batch delete when deleting expired pools

### DIFF
--- a/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -733,7 +733,7 @@ public class PoolManagerTest {
         manager.cleanupExpiredPools();
 
         // And the pool should be deleted:
-        verify(mockPoolCurator).delete(p);
+        verify(mockPoolCurator).batchDelete(pools);
         verify(mockSubAdapter).getSubscription(eq("subid"));
         verify(mockSubAdapter).deleteSubscription(eq(sub));
     }
@@ -760,7 +760,7 @@ public class PoolManagerTest {
         manager.cleanupExpiredPools();
 
         // And the pool should be deleted:
-        verify(mockPoolCurator).delete(p);
+        verify(mockPoolCurator).batchDelete(pools);
         verify(mockSubAdapter, never()).getSubscription(any(String.class));
         verify(mockSubAdapter, never()).deleteSubscription(any(Subscription.class));
     }
@@ -950,10 +950,10 @@ public class PoolManagerTest {
 
         assertEquals(newPools.size(), 2);
         assert (newPools.get(0).getSourceSubscription().getSubscriptionSubKey()
-            .equals("derived") || newPools.get(0).getSourceSubscription()
+            .equals("derived") || newPools.get(1).getSourceSubscription()
             .getSubscriptionSubKey().equals("derived"));
         assert (newPools.get(0).getSourceSubscription().getSubscriptionSubKey()
-            .equals("master") || newPools.get(0).getSourceSubscription()
+            .equals("master") || newPools.get(1).getSourceSubscription()
             .getSubscriptionSubKey().equals("master"));
     }
 


### PR DESCRIPTION
ExpiredPoolJob now batch deletes expired pools and
entitlements. This drastically reduces the time it
takes to delete large numbers of expired pools.

Also fixed a broken unit test that was pre-existing.

ExpiredPoolJob now batch deletes expired pools and
entitlements. This drastically reduces the time it
takes to delete large numbers of expired pools.

## Testing
Ping me for a test database with a lot of expired pools/ents and a git patch to apply over the top of this commit that provide a simple way to trigger the job.

Load the database by running:
```bash
$ ./restorecp-949.sh
```

Apply the support patch with:
```bash
# Run inside your checkout dir.
$ git apply 0001-Support-for-testing-expired-pool-job.patch
```

Deploy candlepin WITHOUT recreating the DB
```bash
$ bin/deploy
```

Validate the expired pools/entitlement counts with the following query:
```sql
candlepin=# select
    ( select count(*) from cp_entitlement e, cp_pool p where e.pool_id = p.id and p.enddate < NOW() ) as expired_ents,
    ( select count(*) from cp_pool p where enddate < NOW() ) as expired_pools,
    ( select count(*) from cp_pool where enddate < NOW() and sourceentitlement_id in (select e.id from cp_entitlement e, cp_pool p where p.enddate < NOW()) ) as expired_with_source, 
    ( select count(*) from cp_subscription where enddate < NOW() ) as expired_subs,
    ( select count(*) from cp_sub_branding where subscription_id in (select id from cp_subscription s where s.enddate < NOW()) ) as expired_sub_brand;
 expired_ents | expired_pools | expired_with_source | expired_subs | expired_sub_brand 
--------------+---------------+---------------------+--------------+-------------------
        21849 |          4184 |                4178 |            2 |                 2
(1 row)
```

With the support git patch applied, run the following to start the job.
```bash
$ curl -k -u admin:admin https://localhost:8443/candlepin/admin/clean
```

Monitor the job status until it completes. It should take around 10-20 minutes depending on the hardware. The speed of the cleanup still isn't the greatest, but it takes the time down from hours.