### PR TITLE
Vagrant: skip NFS if CANDLEPIN_VAGRANT_NO_NFS set

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "centos/7"
   # By default, Vagrant wants to mount the code in /vagrant with NFSv3, which will fail. Let's
   # explicitly mount the code using NFSv4.
-  config.vm.synced_folder ".", "/vagrant", type: "nfs", nfs_version: 4, nfs_udp: false
+  config.vm.synced_folder ".", "/vagrant", type: "nfs", nfs_version: 4, nfs_udp: false unless ENV['CANDLEPIN_VAGRANT_NO_NFS']
 
   # Set up the hostmanager plugin to automatically configure host & guest hostnames
   if Vagrant.has_plugin?("vagrant-hostmanager")


### PR DESCRIPTION
So, I'm not a huge fan of using NFS. So I'd like to be able to just use rsync. This PR allows me (and anyone else who'd rather just `vagrant rsync`) to do that without affecting everyone else.