### PR TITLE
1428145: Do not deadlock on simultaneous hypervisor checkin

### DIFF
--- a/server/src/main/java/org/candlepin/model/ConsumerCurator.java
+++ b/server/src/main/java/org/candlepin/model/ConsumerCurator.java
@@ -44,16 +44,8 @@ import org.hibernate.type.Type;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Arrays;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Set;
 
 import javax.persistence.LockModeType;
 
@@ -635,20 +627,41 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
         if (hypervisorIds == null || hypervisorIds.isEmpty()) {
             return new LinkedList<Consumer>();
         }
-        return currentSession().createCriteria(Consumer.class)
-            .createAlias("owner", "o")
-            .add(Restrictions.eq("o.key", ownerKey))
-            .createAlias("hypervisorId", "hvsr")
-            .add(getHypervisorIdRestriction(hypervisorIds))
-            .list();
-    }
-
-    private Criterion getHypervisorIdRestriction(Collection<String> hypervisorIds) {
-        List<Criterion> ors = new LinkedList<Criterion>();
+        LinkedList<String> hypervisorIdsUpper = new LinkedList<String>();
+        // Check for hypervisor ids case-insensitively
         for (String hypervisorId : hypervisorIds) {
-            ors.add(Restrictions.eq("hvsr.hypervisorId", hypervisorId).ignoreCase());
+            hypervisorIdsUpper.add(hypervisorId.toUpperCase());
         }
-        return Restrictions.or(ors.toArray(new Criterion[0]));
+        List<Consumer> consumers = new LinkedList<Consumer>();
+        /** The query below is done as it is to support locking on our various supported databases.
+         * When performing multiple simultaneous hypervisor checkins if both requests include at least two of the same
+         * hypervisorIds (and they do not occur in the same order in their respective lists), a deadlock can occur.
+         * By sorting the list of hypervisorIds as well as ordering the returned consumers by hypervisorId we can be
+         * sure that, should the above situation occur, the two hypervisorIds that are shared between checkins will be
+         * locked in the same order (meaning one transaction will wait for the lock first acquired by the other to be
+         * released before proceeding)
+         */
+        String query = "SELECT c FROM Consumer c WHERE " +
+                       "(c.owner.key = :ownerKey AND UPPER(c.hypervisorId.hypervisorId) IN (:hypervisorIds)) " +
+                       "ORDER BY c.hypervisorId.hypervisorId ASC";
+        javax.persistence.Query q = getEntityManager().createQuery(query);
+        java.util.Collections.sort(hypervisorIdsUpper);
+        int fromIndex = 0;
+        int toIndex = fromIndex + MAX_IN_QUERY_LENGTH;
+        // Do not exceed the MAX_IN_QUERY_LENGTH
+        while (fromIndex < hypervisorIdsUpper.size()) {
+            if (toIndex > hypervisorIdsUpper.size()) {
+                toIndex = hypervisorIdsUpper.size();
+            }
+            List<String> subList = hypervisorIdsUpper.subList(fromIndex, toIndex);
+            q.setLockMode(LockModeType.PESSIMISTIC_WRITE);
+            q.setParameter("ownerKey", ownerKey);
+            q.setParameter("hypervisorIds", subList);
+            consumers.addAll(q.getResultList());
+            fromIndex = toIndex;
+            toIndex += MAX_IN_QUERY_LENGTH;
+        }
+        return consumers;
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
The tests for this PR will fail until our docker mysql images are updated to set the transaction isolation level to READ-COMMITTED.

The PR from the branch docker-refactor includes those changes.