### PR TITLE
Remove null version inclusion on getProductsByVersions and getContentByVersions

### DIFF
--- a/server/src/main/java/org/candlepin/model/OwnerContentCurator.java
+++ b/server/src/main/java/org/candlepin/model/OwnerContentCurator.java
@@ -363,10 +363,7 @@ public class OwnerContentCurator extends AbstractHibernateCurator<OwnerContent> 
         for (Map.Entry<String, Integer> entry : contentVersions.entrySet()) {
             disjunction.add(Restrictions.and(
                 Restrictions.eq("c.id", entry.getKey()),
-                Restrictions.or(
-                    Restrictions.isNull("c.entityVersion"),
-                    Restrictions.eq("c.entityVersion", entry.getValue())
-                )
+                Restrictions.eq("c.entityVersion", entry.getValue())
             ));
         }
 

--- a/server/src/main/java/org/candlepin/model/OwnerProductCurator.java
+++ b/server/src/main/java/org/candlepin/model/OwnerProductCurator.java
@@ -426,10 +426,7 @@ public class OwnerProductCurator extends AbstractHibernateCurator<OwnerProduct> 
         for (Map.Entry<String, Integer> entry : productVersions.entrySet()) {
             disjunction.add(Restrictions.and(
                 Restrictions.eq("p.id", entry.getKey()),
-                Restrictions.or(
-                    Restrictions.isNull("p.entityVersion"),
-                    Restrictions.eq("p.entityVersion", entry.getValue())
-                )
+                Restrictions.eq("p.entityVersion", entry.getValue())
             ));
         }
 


### PR DESCRIPTION
This change removes the check to always include the version of a
given content or product that was created during the initial migration
to versioned products & content. This removal means that the
initial versions created during the migration will never be matched
for deduplication. The first refresh for a given product or content will
always create a new entity. The existing orphan cleanup job will
clean up the initially migrated data.

The plus side is that we are not performing the null check for every item in the SQL query
and that we do not always return 2 entities that must be field wise
compared for the existing entities once a new version has been imported.