### PR TITLE
Remove guestIds from the consumer json output

### DIFF
--- a/server/client/ruby/candlepin_api.rb
+++ b/server/client/ruby/candlepin_api.rb
@@ -185,8 +185,9 @@ class Candlepin
     delete(path)
   end
 
-  def get_guestids()
-    path = "/consumers/#{@uuid}/guestids"
+  def get_guestids(uuid = nil)
+    uuid = uuid || @uuid
+    path = "/consumers/#{uuid}/guestids"
     results = get(path)
     return results
   end

--- a/server/spec/consumer_resource_host_guest_spec.rb
+++ b/server/spec/consumer_resource_host_guest_spec.rb
@@ -32,9 +32,9 @@ describe 'Consumer Resource Host/Guest' do
     consumer_client = Candlepin.new(nil, nil, consumer['idCert']['cert'], consumer['idCert']['key'])
     consumer_client.update_consumer({:guestIds => guests})
 
-    consumer = @cp.get_consumer(consumer['uuid'])
-    consumer['guestIds'].length.should == 1
-    consumer['guestIds'][0]['guestId'].should == 'guest1'
+    guestIds = consumer_client.get_guestids()
+    guestIds.length.should == 1
+    guestIds[0]['guestId'].should == 'guest1'
   end
 
   it 'should allow updating guest ids from host consumer on update' do
@@ -48,13 +48,12 @@ describe 'Consumer Resource Host/Guest' do
     consumer_client = Candlepin.new(nil, nil, consumer['idCert']['cert'], consumer['idCert']['key'])
     consumer_client.update_consumer({:guestIds => guests})
 
-    consumer = @cp.get_consumer(consumer['uuid'])
-    consumer['guestIds'].length.should == 2
+    consumer_client.get_guestids().length.should == 2
 
     consumer_client.update_consumer({:guestIds => [guests[1]]})
-    consumer = @cp.get_consumer(consumer['uuid'])
-    consumer['guestIds'].length.should == 1
-    consumer['guestIds'][0]['guestId'].should == 'guest2'
+    guestIds = consumer_client.get_guestids()
+    guestIds.length.should == 1
+    guestIds[0]['guestId'].should == 'guest2'
   end
 
   it 'should not modify guest id list if guestIds list is null on update' do
@@ -66,15 +65,13 @@ describe 'Consumer Resource Host/Guest' do
 
     consumer_client = Candlepin.new(nil, nil, consumer['idCert']['cert'], consumer['idCert']['key'])
     consumer_client.update_consumer({:guestIds => guests})
-
-    consumer = @cp.get_consumer(consumer['uuid'])
-    consumer['guestIds'].length.should == 1
+    consumer_client.get_guestids().length.should == 1
 
     consumer_client.update_consumer({:guestIds => nil})
     consumer_client.update_consumer({})
-    consumer = @cp.get_consumer(consumer['uuid'])
-    consumer['guestIds'].length.should == 1
-    consumer['guestIds'][0]['guestId'].should == 'guest1'
+    guestIds = consumer_client.get_guestids()
+    guestIds.length.should == 1
+    guestIds[0]['guestId'].should == 'guest1'
   end
 
   it 'should clear guest ids when empty list is provided on update' do
@@ -86,13 +83,10 @@ describe 'Consumer Resource Host/Guest' do
 
     consumer_client = Candlepin.new(nil, nil, consumer['idCert']['cert'], consumer['idCert']['key'])
     consumer_client.update_consumer({:guestIds => guests})
-
-    consumer = @cp.get_consumer(consumer['uuid'])
-    consumer['guestIds'].length.should == 1
+    consumer_client.get_guestids().length.should == 1
 
     consumer_client.update_consumer({:guestIds => []})
-    consumer = @cp.get_consumer(consumer['uuid'])
-    consumer['guestIds'].length.should == 0
+    consumer_client.get_guestids().length.should == 0
   end
 
   it 'should allow host to list guests' do

--- a/server/spec/consumer_resource_spec.rb
+++ b/server/spec/consumer_resource_spec.rb
@@ -1005,9 +1005,9 @@ describe 'Consumer Resource' do
     consumer_client = Candlepin.new(nil, nil, consumer['idCert']['cert'], consumer['idCert']['key'])
     consumer_client.update_consumer({:guestIds => guests})
 
-    consumer = @cp.get_consumer(consumer['uuid'])
-    consumer['guestIds'].length.should == 1
-    consumer['guestIds'][0]['guestId'].should == 'guest1'
+    guestIds = consumer_client.get_guestids()
+    guestIds.length.should == 1
+    guestIds[0]['guestId'].should == 'guest1'
   end
 
   it 'should return correct exception for contraint violations' do

--- a/server/spec/hypervisor_check_in_spec.rb
+++ b/server/spec/hypervisor_check_in_spec.rb
@@ -353,7 +353,7 @@ describe 'Hypervisor Resource', :type => :virt do
     results = @consumer.hypervisor_check_in(@owner['key'], host_guest_mapping)
     # Host consumer should have been created.
     results.created.size.should == 1
-    results.created[0]['guestIds'].should_not == nil
+    @cp.get_guestids(results.created[0]['uuid']).should_not == nil
   end
 
   it 'should initialize guest ids to empty when creating new host - async' do
@@ -361,7 +361,7 @@ describe 'Hypervisor Resource', :type => :virt do
     result_data = job_detail['resultData']
     # Host consumer should have been created.
     result_data.created.size.should == 1
-    result_data.created[0]['guestIds'].should_not == nil
+    @cp.get_guestids(result_data.created[0]['uuid']).should_not == nil
   end
 
   it 'should support multiple orgs reporting the same cluster' do
@@ -549,8 +549,9 @@ describe 'Hypervisor Resource', :type => :virt do
     result.should_not be_nil
     expect(result['updated'].length).to eq(1)
     updated_consumer = result['updated'][0]
-    expect(updated_consumer['guestIds'].length).to eq(1)
-    guest_id = updated_consumer['guestIds'][0]['guestId']
+    guestIds = @cp.get_guestids(updated_consumer['uuid'])
+    expect(guestIds.length).to eq(1)
+    guest_id = guestIds[0]['guestId']
     expect(guest_id).to eq(expected_guest_id)
   end
 
@@ -564,8 +565,9 @@ describe 'Hypervisor Resource', :type => :virt do
     result.should_not be_nil
     expect(result['resultData']['updated'].length).to eq(1)
     updated_consumer = result['resultData']['updated'][0]
-    expect(updated_consumer['guestIds'].length).to eq(1)
-    guest_id = updated_consumer['guestIds'][0]['guestId']
+    guestIds = @cp.get_guestids(updated_consumer['uuid'])
+    expect(guestIds.length).to eq(1)
+    guest_id = guestIds[0]['guestId']
     expect(guest_id).to eq(expected_guest_id)
   end
 
@@ -617,7 +619,8 @@ describe 'Hypervisor Resource', :type => :virt do
   def check_hypervisor_consumer(consumer, expected_host_name, expected_guest_ids, reporter_id=nil)
     consumer['name'].should == expected_host_name
 
-    guest_ids = consumer['guestIds']
+    guest_ids = @cp.get_guestids(consumer['uuid'])
+    # guest_ids = consumer['guestIds']
     guest_ids.size.should == expected_guest_ids.size
 
     # sort the ids to make sure that we have the same list.

--- a/server/src/main/java/org/candlepin/model/Consumer.java
+++ b/server/src/main/java/org/candlepin/model/Consumer.java
@@ -14,6 +14,8 @@
  */
 package org.candlepin.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.candlepin.common.jackson.HateoasArrayExclude;
 import org.candlepin.common.jackson.HateoasInclude;
 import org.candlepin.jackson.StringTrimmingConverter;
@@ -585,6 +587,7 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
     /**
      * @param guests the GuestIds to set
      */
+    @JsonProperty
     public void setGuestIds(List<GuestId> guests) {
         this.guestIds = guests;
     }
@@ -592,6 +595,7 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
     /**
      * @return the guestIds
      */
+    @JsonIgnore
     public List<GuestId> getGuestIds() {
         return guestIds;
     }

--- a/server/src/main/java/org/candlepin/policy/js/autobind/AutobindRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/autobind/AutobindRules.java
@@ -103,6 +103,7 @@ public class AutobindRules {
         args.put("compliance", compliance);
         args.put("exemptList", exemptLevels);
         args.put("considerDerived", considerDerived);
+        args.put("guestIds", consumer.getGuestIds());
 
         // Convert the JSON returned into a Map object:
         Map<String, Integer> result = null;

--- a/server/src/main/java/org/candlepin/policy/js/compliance/ComplianceRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/compliance/ComplianceRules.java
@@ -138,6 +138,7 @@ public class ComplianceRules {
         args.put("ondate", date);
         args.put("calculateCompliantUntil", calculateCompliantUntil);
         args.put("log", log, false);
+        args.put("guestIds", c.getGuestIds());
 
         // Convert the JSON returned into a ComplianceStatus object:
         String json = jsRules.runJsFunction(String.class, "get_status", args);
@@ -178,6 +179,7 @@ public class ComplianceRules {
         args.put("consumer", consumer);
         args.put("entitlements", entsToConsider);
         args.put("log", log, false);
+        args.put("guestIds", consumer.getGuestIds());
 
         return jsRules.runJsFunction(Boolean.class, "is_stack_compliant", args);
     }
@@ -190,6 +192,7 @@ public class ComplianceRules {
         args.put("entitlement", ent);
         args.put("entitlements", ents);
         args.put("log", log, false);
+        args.put("guestIds", consumer.getGuestIds());
 
         return jsRules.runJsFunction(Boolean.class, "is_ent_compliant", args);
     }

--- a/server/src/main/java/org/candlepin/policy/js/quantity/QuantityRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/quantity/QuantityRules.java
@@ -65,6 +65,7 @@ public class QuantityRules {
         args.put("consumer", c);
         args.put("validEntitlements", validEntitlements);
         args.put("log", log, false);
+        args.put("guestIds", c.getGuestIds());
 
         String json = jsRules.runJsFunction(String.class, "get_suggested_quantity", args);
         SuggestedQuantity dto = mapper.toObject(json, SuggestedQuantity.class);
@@ -101,6 +102,7 @@ public class QuantityRules {
         args.put("consumer", c);
         args.put("validEntitlements", validEntitlements);
         args.put("log", log, false);
+        args.put("guestIds", c.getGuestIds());
 
         String json = jsRules.runJsFunction(String.class, "get_suggested_quantities", args);
         Map<String, SuggestedQuantity> resultMap;

--- a/server/src/main/resources/rules/rules.js
+++ b/server/src/main/resources/rules/rules.js
@@ -1,4 +1,4 @@
-// Version: 5.21
+// Version: 5.22
 
 /*
  * Default Candlepin rule set.
@@ -561,12 +561,13 @@ var FactValueCalculator = {
         },
 
         guest_limit: function (prodAttr, consumer) {
-            if (consumer.guestIds === null) {
+            var context = JSON.parse(json_context);
+            if (context.guestIds === null) {
                 return 0;
             }
             var activeGuestCount = 0;
-            for (var guestIdx = 0; guestIdx < consumer.guestIds.length; guestIdx++) {
-                var guest = consumer.guestIds[guestIdx];
+            for (var guestIdx = 0; guestIdx < context.guestIds.length; guestIdx++) {
+                var guest = context.guestIds[guestIdx];
                 if (Utils.isGuestActive(guest)) {
                     activeGuestCount++;
                 }


### PR DESCRIPTION
While maintaining the ability to use it as input when creating
and updating consumers.