### PR TITLE
Removed @Formula for  CertificateSerial.revoked

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@
 **/*.iws
 **/*.ipr
 .ideaDataSources
-.idea/*
+.idea
 !.idea/codeStyleSettings.xml
 !.idea/copyright
 dataSources/

--- a/server/spec/content_delivery_network_spec.rb
+++ b/server/spec/content_delivery_network_spec.rb
@@ -70,4 +70,84 @@ describe 'Content Delivery Network' do
     cdn.certificate['cert'].should == "test-cert"
   end
 
+  it 'should allow candlepin to create certificate serial' do
+    count = @cp.get_cdns.size
+    cdn_label = random_string("test-cdn")
+
+    serial = { 'expiration' => Date.today.next_year }
+
+    certificate = {
+        'key' => 'test-key',
+        'cert' => 'test-cert',
+        'serial' => serial
+    }
+    cdn = create_cdn(cdn_label,
+                     "Test CDN",
+                     "https://cdn.test.com",
+                     certificate)
+    cdn.id.should_not be nil
+    @cp.get_cdns.size.should == count+1
+    cdn.certificate['key'].should == "test-key"
+    cdn.certificate['cert'].should == "test-cert"
+    cdn.certificate['serial'].should_not be_nil
+  end
+
+  it 'should allow candlepin to update certificate serial' do
+    count = @cp.get_cdns.size
+    cdn_label = random_string("test-cdn")
+
+    serial = { 'expiration' => Date.today.next_year }
+
+    certificate = {
+        'key' => 'test-key',
+        'cert' => 'test-cert',
+        'serial' => serial
+    }
+    cdn = create_cdn(cdn_label,
+                     "Test CDN",
+                     "https://cdn.test.com",
+                     certificate)
+    cdn.id.should_not be nil
+
+    @cp.get_cdns.size.should == count+1
+    cdn.certificate['key'].should == "test-key"
+    cdn.certificate['cert'].should == "test-cert"
+    cdn.certificate['serial'].should_not be_nil
+
+    updated_key = 'm_test_key'
+    updated_cert = 'm_test_cert'
+    updated_expiration = Date.today.next_month.next_year
+    certificate['key'] = updated_key
+    certificate['cert'] = updated_cert
+    certificate['serial']['expiration'] = updated_expiration
+
+    cdn = update_cdn(cdn_label, nil, nil, certificate)
+    @cp.get_cdns.size.should == count+1
+    cdn.certificate['key'].should == updated_key
+    cdn.certificate['cert'].should == updated_cert
+    Date.parse(cdn.certificate['serial']['expiration']).should == updated_expiration
+  end
+
+  it 'should allow deletion with certificate' do
+    count = @cp.get_cdns.size
+    cdn_label = random_string("test-cdn")
+
+    serial = { 'expiration' => Date.today.next_year }
+
+    certificate = {
+        'key' => 'test-key',
+        'cert' => 'test-cert',
+        'serial' => serial
+    }
+    cdn = create_cdn(cdn_label,
+                     "Test CDN",
+                     "https://cdn.test.com",
+                     certificate)
+    cdn.id.should_not be nil
+    @cp.get_cdns.size.should == count+1
+
+    @cp.delete_cdn(cdn_label)
+    @cp.get_cdns.size.should == count
+  end
+
 end

--- a/server/src/main/java/org/candlepin/controller/CdnManager.java
+++ b/server/src/main/java/org/candlepin/controller/CdnManager.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2009 - 2017 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.controller;
+
+import com.google.inject.Inject;
+import com.google.inject.persist.Transactional;
+import org.candlepin.model.Cdn;
+import org.candlepin.model.CdnCertificate;
+import org.candlepin.model.CdnCurator;
+import org.candlepin.model.CertificateSerialCurator;
+
+import java.util.Arrays;
+
+/**
+ * Manages Cdn entity operations.
+ */
+public class CdnManager {
+
+    private CdnCurator cdnCurator;
+    private CertificateSerialCurator certSerialCurator;
+
+    @Inject
+    public CdnManager(CdnCurator cdnCurator, CertificateSerialCurator certSerialCurator) {
+        this.cdnCurator = cdnCurator;
+        this.certSerialCurator = certSerialCurator;
+    }
+
+    /**
+     * Creates and persists the specified Cdn.
+     *
+     * @param cdn the Cdn to create and persist.
+     * @return the managed Cdn object.
+     */
+    @Transactional
+    public Cdn createCdn(Cdn cdn) {
+        // Need to persist the certificate serial since by default
+        // we do not cascade persist.
+        CdnCertificate cert = cdn.getCertificate();
+        if (cert != null && cert.getSerial() != null) {
+            certSerialCurator.create(cert.getSerial());
+        }
+        return cdnCurator.create(cdn);
+    }
+
+    /**
+     * Updates the specified {@link Cdn}.
+     *
+     * @param cdn the {@link Cdn} to update.
+     */
+    @Transactional
+    public void updateCdn(Cdn cdn) {
+        CdnCertificate cert = cdn.getCertificate();
+        if (cert != null && cert.getSerial() != null) {
+            // No need to flush here since updating the Cdn will.
+            certSerialCurator.saveOrUpdateAll(Arrays.asList(cert.getSerial()), false, false);
+        }
+        cdnCurator.update(cdn);
+    }
+
+    /**
+     * Deletes the specified {@link Cdn}.
+     *
+     * @param cdn the cdn to delete.
+     */
+    @Transactional
+    public void deleteCdn(Cdn cdn) {
+        // FIXME When a Cdn is referenced by a Pool, and is deleted, an exception occurs.
+        //       We should handle this here.
+        cdnCurator.delete(cdn);
+    }
+}

--- a/server/src/main/java/org/candlepin/model/CdnCertificate.java
+++ b/server/src/main/java/org/candlepin/model/CdnCertificate.java
@@ -18,12 +18,10 @@ package org.candlepin.model;
 
 import org.hibernate.annotations.GenericGenerator;
 
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
-import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
 import javax.xml.bind.annotation.XmlAccessType;
@@ -38,7 +36,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @Entity
 @Table(name = CdnCertificate.DB_TABLE)
-public class CdnCertificate extends AbstractCertificate {
+public class CdnCertificate extends RevokableCertificate {
 
     /** Name of the table backing this object in the database */
     public static final String DB_TABLE = "cp_cdn_certificate";
@@ -49,9 +47,6 @@ public class CdnCertificate extends AbstractCertificate {
     @Column(length = 32)
     @NotNull
     private String id;
-
-    @OneToOne(cascade = CascadeType.ALL)
-    private CertificateSerial serial;
 
     /**
      * @return the id
@@ -67,11 +62,4 @@ public class CdnCertificate extends AbstractCertificate {
         this.id = id;
     }
 
-    public CertificateSerial getSerial() {
-        return serial;
-    }
-
-    public void setSerial(CertificateSerial serialNumber) {
-        this.serial = serialNumber;
-    }
 }

--- a/server/src/main/java/org/candlepin/model/CdnCurator.java
+++ b/server/src/main/java/org/candlepin/model/CdnCurator.java
@@ -14,6 +14,7 @@
  */
 package org.candlepin.model;
 
+import com.google.inject.Inject;
 import org.hibernate.criterion.Restrictions;
 
 
@@ -24,6 +25,7 @@ import org.hibernate.criterion.Restrictions;
 public class CdnCurator
     extends AbstractHibernateCurator<Cdn> {
 
+    @Inject
     public CdnCurator() {
         super(Cdn.class);
     }
@@ -39,4 +41,12 @@ public class CdnCurator
             .add(Restrictions.eq("label", label)).uniqueResult();
     }
 
+    /**
+     * Updates the specified {@link Cdn}.
+     *
+     * @param cdn the {@link Cdn} to update.
+     */
+    public void update(Cdn cdn) {
+        save(cdn);
+    }
 }

--- a/server/src/main/java/org/candlepin/model/CertificateSerial.java
+++ b/server/src/main/java/org/candlepin/model/CertificateSerial.java
@@ -16,12 +16,12 @@ package org.candlepin.model;
 
 import org.candlepin.util.Util;
 
-import org.hibernate.annotations.Formula;
 import org.hibernate.annotations.GenericGenerator;
 
 import java.math.BigInteger;
 import java.util.Date;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
@@ -49,20 +49,15 @@ public class CertificateSerial extends AbstractHibernateObject {
     /*
      * A CertificateSerial is considered revoked when no certificates reference it
      * TODO: put different kinds of serials into different tables.  More specifically,
-     * those that we own (can revoke) vs those that we don't
+     * those that we own (can revoke) vs those that we don't.
      */
-    @Formula("(CASE (" +
-        "(SELECT count(entcert.id) FROM cp_ent_certificate entcert where entcert.serial_id = id) + " +
-        "(SELECT count(cdncert.id) FROM cp_cdn_certificate cdncert where cdncert.serial_id = id) + " +
-        "(SELECT count(subcert.id) FROM cp_certificate subcert where subcert.serial_id = id) + " +
-        "(SELECT count(idcert.id) FROM cp_id_cert idcert where idcert.serial_id = id) + " +
-        "(SELECT count(contacccert.id) FROM cp_cont_access_cert contacccert where " +
-        "contacccert.serial_id = id)" +
-        ") WHEN 0 THEN 1 ELSE 0 END)")
+    @NotNull
+    @Column(nullable = false)
     private boolean revoked;
 
     // Set to true if this serial is already a part of the CRL
     @NotNull
+    @Column(nullable = false)
     private boolean collected;
 
     // The expiration.
@@ -101,6 +96,13 @@ public class CertificateSerial extends AbstractHibernateObject {
      */
     public boolean isRevoked() {
         return revoked;
+    }
+
+    /**
+     * @param isRevoked whether or not this serial is revoked.
+     */
+    public void setRevoked(boolean isRevoked) {
+        this.revoked = isRevoked;
     }
 
     /**

--- a/server/src/main/java/org/candlepin/model/CertificateSerialCurator.java
+++ b/server/src/main/java/org/candlepin/model/CertificateSerialCurator.java
@@ -20,13 +20,10 @@ import com.google.common.collect.Iterables;
 import com.google.inject.persist.Transactional;
 
 import org.hibernate.Query;
-import org.hibernate.criterion.Conjunction;
-import org.hibernate.criterion.Criterion;
 import org.hibernate.criterion.DetachedCriteria;
 import org.hibernate.criterion.Order;
 import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
-import org.hibernate.criterion.Subqueries;
 
 import java.util.Collection;
 import java.util.Date;
@@ -42,11 +39,6 @@ public class CertificateSerialCurator extends AbstractHibernateCurator<Certifica
 
     private static int inClauseLimit = 1000;
 
-    @SuppressWarnings("rawtypes")
-    private static final Class[] CERTCLASSES = {IdentityCertificate.class,
-        EntitlementCertificate.class, SubscriptionsCertificate.class, CdnCertificate.class,
-        UeberCertificate.class};
-
     public CertificateSerialCurator() {
         super(CertificateSerial.class);
     }
@@ -58,7 +50,7 @@ public class CertificateSerialCurator extends AbstractHibernateCurator<Certifica
     @SuppressWarnings("unchecked")
     public CandlepinQuery<CertificateSerial> retrieveTobeCollectedSerials() {
         DetachedCriteria criteria = DetachedCriteria.forClass(CertificateSerial.class)
-            .add(getRevokedCriteria())
+            .add(Restrictions.eq("revoked", true))
             .add(Restrictions.eq("collected", false));
 
         return this.cpQueryFactory.<CertificateSerial>buildQuery(this.currentSession(), criteria);
@@ -70,7 +62,7 @@ public class CertificateSerialCurator extends AbstractHibernateCurator<Certifica
 
         DetachedCriteria criteria = DetachedCriteria.forClass(CertificateSerial.class)
             .add(Restrictions.le("expiration", Util.yesterday()))
-            .add(getRevokedCriteria());
+            .add(Restrictions.eq("revoked", true));
 
         return this.cpQueryFactory.<CertificateSerial>buildQuery(this.currentSession(), criteria);
     }
@@ -88,7 +80,7 @@ public class CertificateSerialCurator extends AbstractHibernateCurator<Certifica
         List<String> ids = this.currentSession()
             .createCriteria(CertificateSerial.class)
             .add(Restrictions.le("expiration", Util.yesterday()))
-            .add(getRevokedCriteria())
+            .add(Restrictions.eq("revoked", true))
             .setProjection(Projections.id())
             .addOrder(Order.asc("id"))
             .list();
@@ -125,26 +117,6 @@ public class CertificateSerialCurator extends AbstractHibernateCurator<Certifica
             .add(CPRestrictions.in("id", lids));
 
         return this.cpQueryFactory.<CertificateSerial>buildQuery(this.currentSession(), criteria);
-    }
-
-    /*
-     * Generates criteria to check that no certificates (of any type in
-     * CertificateSerialCurator.CERTCLASSES) reference a serial so we can consider
-     * it revoked
-     */
-    @SuppressWarnings("rawtypes")
-    private Criterion getRevokedCriteria() {
-        Conjunction crit = Restrictions.conjunction();
-
-        for (Class clazz : CERTCLASSES) {
-            DetachedCriteria certSerialQuery = DetachedCriteria.forClass(clazz)
-                .createCriteria("serial")
-                .setProjection(Projections.property("id"));
-
-            crit.add(Subqueries.propertyNotIn("id", certSerialQuery));
-        }
-
-        return crit;
     }
 
     /*

--- a/server/src/main/java/org/candlepin/model/ContentAccessCertificate.java
+++ b/server/src/main/java/org/candlepin/model/ContentAccessCertificate.java
@@ -39,7 +39,8 @@ import javax.xml.bind.annotation.XmlTransient;
 @Entity
 @Table(name = "cp_cont_access_cert")
 @JsonFilter("ContentAccessCertificateFilter")
-public class ContentAccessCertificate extends AbstractCertificate implements Certificate {
+public class ContentAccessCertificate extends RevokableCertificate implements Certificate {
+
     @Id
     @GeneratedValue(generator = "system-uuid")
     @GenericGenerator(name = "system-uuid", strategy = "uuid")
@@ -47,19 +48,8 @@ public class ContentAccessCertificate extends AbstractCertificate implements Cer
     @NotNull
     private String id;
 
-    @OneToOne
-    private CertificateSerial serial;
-
     @OneToOne(mappedBy = "idCert", fetch = FetchType.LAZY)
     private Consumer consumer;
-
-    public CertificateSerial getSerial() {
-        return serial;
-    }
-
-    public void setSerial(CertificateSerial serialNumber) {
-        this.serial = serialNumber;
-    }
 
     @Override
     public String getId() {

--- a/server/src/main/java/org/candlepin/model/EntitlementCertificate.java
+++ b/server/src/main/java/org/candlepin/model/EntitlementCertificate.java
@@ -26,7 +26,6 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
-import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
 import javax.xml.bind.annotation.XmlAccessType;
@@ -43,7 +42,7 @@ import javax.xml.bind.annotation.XmlTransient;
 @Table(name = EntitlementCertificate.DB_TABLE)
 @JsonFilter("EntitlementCertificateFilter")
 
-public class EntitlementCertificate extends AbstractCertificate implements Certificate {
+public class EntitlementCertificate extends RevokableCertificate implements Certificate {
 
     /** Name of the table backing this object in the database */
     public static final String DB_TABLE = "cp_ent_certificate";
@@ -55,23 +54,12 @@ public class EntitlementCertificate extends AbstractCertificate implements Certi
     @NotNull
     private String id;
 
-    @OneToOne
-    private CertificateSerial serial;
-
     @ManyToOne
     @ForeignKey(name = "fk_cert_entitlement")
     @JoinColumn(nullable = false)
     @Index(name = "cp_cert_entitlement_fk_idx")
     @NotNull
     private Entitlement entitlement;
-
-    public CertificateSerial getSerial() {
-        return serial;
-    }
-
-    public void setSerial(CertificateSerial serialNumber) {
-        this.serial = serialNumber;
-    }
 
     @Override
     public String getId() {

--- a/server/src/main/java/org/candlepin/model/IdentityCertificate.java
+++ b/server/src/main/java/org/candlepin/model/IdentityCertificate.java
@@ -40,7 +40,7 @@ import javax.xml.bind.annotation.XmlTransient;
 @Entity
 @Table(name = IdentityCertificate.DB_TABLE)
 @JsonFilter("IdentityCertificateFilter")
-public class IdentityCertificate extends AbstractCertificate implements Certificate {
+public class IdentityCertificate extends RevokableCertificate implements Certificate {
 
     /** Name of the table backing this object in the database */
     public static final String DB_TABLE = "cp_id_cert";
@@ -52,19 +52,8 @@ public class IdentityCertificate extends AbstractCertificate implements Certific
     @NotNull
     private String id;
 
-    @OneToOne
-    private CertificateSerial serial;
-
     @OneToOne(mappedBy = "idCert", fetch = FetchType.LAZY)
     private Consumer consumer;
-
-    public CertificateSerial getSerial() {
-        return serial;
-    }
-
-    public void setSerial(CertificateSerial serialNumber) {
-        this.serial = serialNumber;
-    }
 
     public String getId() {
         return id;

--- a/server/src/main/java/org/candlepin/model/RevokableCertificate.java
+++ b/server/src/main/java/org/candlepin/model/RevokableCertificate.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2009 - 2016 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.model;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.persistence.MappedSuperclass;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
+import javax.persistence.PreRemove;
+import javax.persistence.Transient;
+
+
+/**
+ * A class that represents a revokable certificate. A revokable certificate should
+ * have an associated {@link CertificateSerial} that can be placed on the Certificate
+ * Revocation List.
+ */
+@MappedSuperclass
+public abstract class RevokableCertificate extends AbstractCertificate {
+    @Transient
+    private static Logger log = LoggerFactory.getLogger(RevokableCertificate.class);
+
+    @OneToOne
+    @JoinColumn(name = "serial_id")
+    protected CertificateSerial serial;
+
+    public RevokableCertificate() {
+
+    }
+
+    public RevokableCertificate(CertificateSerial serial) {
+        this.serial = serial;
+    }
+
+    public CertificateSerial getSerial() {
+        return serial;
+    }
+
+    public void setSerial(CertificateSerial serialNumber) {
+        this.serial = serialNumber;
+    }
+
+    /**
+     * When a certificate is deleted, it is considered revoked, and
+     * its {@link CertificateSerial} should be marked as such. This
+     * method is run before the certificate is deleted from the database and sets
+     * the revoked flag on the certificates serial to true.
+     *
+     * <strong>
+     *     NOTE: This callback is not fired when a certificate is deleted using
+     *     JPQL. The certificate has to be removed via EntityManager.remove or via
+     *     cascading.
+     * </strong>
+     */
+    @PreRemove
+    public void revokeCertificateSerial() {
+        CertificateSerial certSerial = getSerial();
+        if (certSerial != null) {
+            certSerial.setRevoked(true);
+        }
+    }
+}

--- a/server/src/main/java/org/candlepin/model/SubscriptionsCertificate.java
+++ b/server/src/main/java/org/candlepin/model/SubscriptionsCertificate.java
@@ -20,13 +20,10 @@ import com.fasterxml.jackson.annotation.JsonFilter;
 
 import org.hibernate.annotations.GenericGenerator;
 
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
 import javax.xml.bind.annotation.XmlAccessType;
@@ -43,7 +40,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 @Entity
 @Table(name = SubscriptionsCertificate.DB_TABLE)
 @JsonFilter("SubscriptionCertificateFilter")
-public class SubscriptionsCertificate extends AbstractCertificate {
+public class SubscriptionsCertificate extends RevokableCertificate {
 
     /** Name of the table backing this object in the database */
     public static final String DB_TABLE = "cp_certificate";
@@ -54,18 +51,6 @@ public class SubscriptionsCertificate extends AbstractCertificate {
     @Column(length = 32)
     @NotNull
     private String id;
-
-    @OneToOne(cascade = CascadeType.ALL)
-    @JoinColumn(name = "serial_id")
-    private CertificateSerial serial;
-
-    public CertificateSerial getSerial() {
-        return serial;
-    }
-
-    public void setSerial(CertificateSerial serialNumber) {
-        this.serial = serialNumber;
-    }
 
     /**
      * @return the id
@@ -84,8 +69,8 @@ public class SubscriptionsCertificate extends AbstractCertificate {
     public String toString() {
         String serial = null;
 
-        if (this.serial != null) {
-            serial = String.format("Serial [id=%s]", this.serial.getId());
+        if (super.serial != null) {
+            serial = String.format("Serial [id=%s]", super.serial.getId());
         }
 
         return String.format("Cert [id=%s, serial=%s]", this.id, serial);

--- a/server/src/main/java/org/candlepin/model/UeberCertificate.java
+++ b/server/src/main/java/org/candlepin/model/UeberCertificate.java
@@ -36,7 +36,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @Entity
 @Table(name = "cp_ueber_cert")
-public class UeberCertificate extends AbstractCertificate implements Certificate {
+public class UeberCertificate extends RevokableCertificate implements Certificate {
 
     private static final long serialVersionUID = 1L;
 
@@ -48,9 +48,6 @@ public class UeberCertificate extends AbstractCertificate implements Certificate
     private String id;
 
     @OneToOne
-    private CertificateSerial serial;
-
-    @OneToOne
     private Owner owner;
 
     @Override
@@ -60,23 +57,6 @@ public class UeberCertificate extends AbstractCertificate implements Certificate
 
     public void setId(String id) {
         this.id = id;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public CertificateSerial getSerial() {
-        return this.serial;
-    }
-
-    /**
-     * Sets the CertificateSerial for this certificate.
-     *
-     * @param certSerial the CertificateSerial for this certificate.
-     */
-    public void setSerial(CertificateSerial certSerial) {
-        this.serial = certSerial;
     }
 
     /**

--- a/server/src/main/java/org/candlepin/resource/CdnResource.java
+++ b/server/src/main/java/org/candlepin/resource/CdnResource.java
@@ -17,6 +17,7 @@ package org.candlepin.resource;
 import org.candlepin.auth.Principal;
 import org.candlepin.common.exceptions.BadRequestException;
 import org.candlepin.common.exceptions.NotFoundException;
+import org.candlepin.controller.CdnManager;
 import org.candlepin.model.CandlepinQuery;
 import org.candlepin.model.Cdn;
 import org.candlepin.model.CdnCurator;
@@ -53,12 +54,13 @@ public class CdnResource {
 
     private I18n i18n;
     private CdnCurator curator;
+    private CdnManager cdnManager;
 
     @Inject
-    public CdnResource(I18n i18n,
-        CdnCurator curator) {
+    public CdnResource(I18n i18n, CdnCurator curator, CdnManager manager) {
         this.i18n = i18n;
         this.curator = curator;
+        this.cdnManager = manager;
     }
 
     @ApiOperation(notes = "Retrieves a list of CDN's", value = "getContentDeliveryNetworks")
@@ -77,7 +79,7 @@ public class CdnResource {
         @Context Principal principal) {
         Cdn cdn = curator.lookupByLabel(label);
         if (cdn != null) {
-            curator.delete(cdn);
+            cdnManager.deleteCdn(cdn);
         }
     }
 
@@ -91,7 +93,7 @@ public class CdnResource {
         if (existing != null) {
             throw new BadRequestException(i18n.tr("A CDN with the label {0} already exists", cdn.getLabel()));
         }
-        return curator.create(cdn);
+        return cdnManager.createCdn(cdn);
     }
 
     @ApiOperation(notes = "Updates a CDN @return a Cdn object", value = "update")
@@ -112,7 +114,7 @@ public class CdnResource {
         if (cdn.getCertificate() != null) {
             existing.setCertificate(cdn.getCertificate());
         }
-        curator.merge(existing);
+        cdnManager.updateCdn(existing);
         return existing;
     }
 

--- a/server/src/main/resources/db/changelog/20170301083925-add-cert-serial-revoked-column.xml
+++ b/server/src/main/resources/db/changelog/20170301083925-add-cert-serial-revoked-column.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+    <changeSet id="20170301083925-1" author="mstead">
+        <comment>
+            Add cp_cert_serial.revoked column to support removing
+            the hibernate formula off of the CertificateSerial entity.
+        </comment>
+        <addColumn tableName="cp_cert_serial">
+            <column name="revoked" type="BOOLEAN" defaultValueBoolean="false">
+                <constraints nullable="false" />
+            </column>
+        </addColumn>
+    </changeSet>
+
+    <changeSet id="20170301083925-2" dbms="postgresql,oracle" author="mstead">
+        <comment>
+            [POSTGRESQL, ORACLE, HSQLDB]
+            Calculate the value of the field for all known serials
+            based on existence of entitlement certificates.
+        </comment>
+
+        <sql>
+            update cp_cert_serial cs
+            set revoked = true
+            from
+                (select cs.id from cp_cert_serial cs
+                 left outer join cp_ent_certificate ec on ec.serial_id = cs.id
+                 left outer join cp_cdn_certificate cdnc on cs.id = cdnc.serial_id
+                 left outer join cp_certificate subcert on cs.id = subcert.serial_id
+                 left outer join cp_id_cert idcert on cs.id = idcert.serial_id
+                 left outer join cp_cont_access_cert cacert on cs.id = cacert.serial_id
+                 left outer join cp_ueber_cert ueber on cs.id = ueber.serial_id
+                 where ec.id is null and cdnc.id is null and subcert.id is null and idcert.id is null and cacert.id is null and ueber.id is null
+                 ) revoked_cert
+            where cs.id = revoked_cert.id;
+        </sql>
+        <rollback>
+            alter table cp_cert_serial drop column if exists revoked;
+        </rollback>
+
+    </changeSet>
+
+    <changeSet id="20170301083925-3" dbms="mysql" author="mstead">
+        <comment>
+            [MySQL]
+            Calculate the value of the field for all known serials
+            based on existence of entitlement certificates.
+        </comment>
+
+        <sql>
+            update cp_cert_serial cs
+                left outer join cp_ent_certificate ec on ec.serial_id = cs.id
+                left outer join cp_cdn_certificate cdnc on cs.id = cdnc.serial_id
+                left outer join cp_certificate subcert on cs.id = subcert.serial_id
+                left outer join cp_id_cert idcert on cs.id = idcert.serial_id
+                left outer join cp_cont_access_cert cacert on cs.id = cacert.serial_id
+                left outer join cp_ueber_cert ueber on cs.id = ueber.serial_id
+            set revoked = true
+            where ec.id is null and cdnc.id is null and subcert.id is null and idcert.id is null and cacert.id is null and ueber.id is null;
+        </sql>
+        <rollback>
+            alter table cp_cert_serial drop column if exists revoked;
+        </rollback>
+
+    </changeSet>
+
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/server/src/main/resources/db/changelog/changelog-create.xml
+++ b/server/src/main/resources/db/changelog/changelog-create.xml
@@ -1205,4 +1205,5 @@
     <include file="db/changelog/20170214115606-uber-cert-rewrite.xml"/>
     <include file="db/changelog/20170220133446-add-correlation-id-to-job.xml"/>
     <include file="db/changelog/20170227140343-convert-consumer-entitlement-count-to-column.xml"/>
+    <include file="db/changelog/20170301083925-add-cert-serial-revoked-column.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-testing.xml
+++ b/server/src/main/resources/db/changelog/changelog-testing.xml
@@ -2295,4 +2295,5 @@
     <include file="db/changelog/20170214115606-uber-cert-rewrite.xml"/>
     <include file="db/changelog/20170220133446-add-correlation-id-to-job.xml"/>
     <include file="db/changelog/20170227140343-convert-consumer-entitlement-count-to-column.xml"/>
+    <include file="db/changelog/20170301083925-add-cert-serial-revoked-column.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-update.xml
+++ b/server/src/main/resources/db/changelog/changelog-update.xml
@@ -113,4 +113,5 @@
     <include file="db/changelog/20170214115606-uber-cert-rewrite.xml"/>
     <include file="db/changelog/20170220133446-add-correlation-id-to-job.xml"/>
     <include file="db/changelog/20170227140343-convert-consumer-entitlement-count-to-column.xml"/>
+    <include file="db/changelog/20170301083925-add-cert-serial-revoked-column.xml"/>
 </databaseChangeLog>

--- a/server/src/test/java/org/candlepin/controller/CdnManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/CdnManagerTest.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2009 - 2017 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.controller;
+
+import com.google.inject.Inject;
+import org.candlepin.model.Cdn;
+import org.candlepin.model.CdnCertificate;
+import org.candlepin.model.CdnCurator;
+import org.candlepin.model.CertificateSerial;
+import org.candlepin.test.DatabaseTestFixture;
+import org.junit.Test;
+
+import java.util.Date;
+
+import static org.junit.Assert.*;
+
+
+public class CdnManagerTest extends DatabaseTestFixture {
+    @Inject private CdnManager manager;
+    @Inject private CdnCurator curator;
+
+    @Test
+    public void createCdn() throws Exception {
+        Cdn cdn = createCdn("test_cdn");
+        Cdn fetched = curator.lookupByLabel(cdn.getLabel());
+        assertNotNull(fetched);
+        assertEquals("test_cdn", fetched.getLabel());
+    }
+
+    @Test
+    public void updateCdn() throws Exception {
+        Cdn cdn = createCdn("test_cdn");
+        assertEquals("Test CDN", cdn.getName());
+        cdn.setName("Updated CDN");
+        manager.updateCdn(cdn);
+
+        Cdn fetched = curator.lookupByLabel(cdn.getLabel());
+        assertNotNull(fetched);
+        assertEquals(cdn.getLabel(), fetched.getLabel());
+        assertEquals("Updated CDN", fetched.getName());
+    }
+
+    @Test
+    public void deleteCdn() throws Exception {
+        Cdn cdn = createCdn("test_cdn");
+        manager.deleteCdn(cdn);
+        assertNull(curator.lookupByLabel(cdn.getLabel()));
+    }
+
+    @Test
+    public void cdnCertSerialIsRevokedOnCdnDeletion() throws Exception {
+        Cdn cdn = createCdn("test_cdn");
+        CertificateSerial serial = cdn.getCertificate().getSerial();
+        assertNotNull(serial);
+        assertFalse(serial.isRevoked());
+        manager.deleteCdn(cdn);
+
+        CertificateSerial fetched = certSerialCurator.find(serial.getId());
+        assertNotNull(fetched);
+        assertTrue(fetched.isRevoked());
+    }
+
+    private Cdn createCdn(String label) {
+        CertificateSerial serial = certSerialCurator.create(new CertificateSerial(new Date()));
+        CdnCertificate cert = new CdnCertificate();
+        cert.setKey("key");
+        cert.setCert("cert");
+        cert.setSerial(serial);
+
+        Cdn cdn = new Cdn(label, "Test CDN", "test.url", cert);
+        manager.createCdn(cdn);
+        return cdn;
+    }
+
+}

--- a/server/src/test/java/org/candlepin/model/CertificateSerialCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/CertificateSerialCuratorTest.java
@@ -25,7 +25,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import org.candlepin.test.DatabaseTestFixture;
-import org.candlepin.test.TestUtil;
 
 import org.junit.Test;
 
@@ -75,10 +74,8 @@ public class CertificateSerialCuratorTest extends DatabaseTestFixture {
         public CertificateSerial save() {
             CertificateSerial serial = new CertificateSerial(dt);
             serial.setCollected(collected);
+            serial.setRevoked(revoked);
             serial = certSerialCurator.create(serial);
-            if (!this.revoked) {
-                serial = createEntitlementCertificate(serial).getSerial();
-            }
             return serial;
         }
     }
@@ -248,19 +245,4 @@ public class CertificateSerialCuratorTest extends DatabaseTestFixture {
         assertEquals(null, certSerialCurator.listBySerialIds(null));
     }
 
-    private EntitlementCertificate createEntitlementCertificate(CertificateSerial serial) {
-        Owner owner = this.createOwner();
-        Consumer c = this.createConsumer(owner);
-        Product prod = TestUtil.createProduct();
-        this.productCurator.create(prod);
-        Pool p = this.createPool(owner, prod, 10L, new Date(), new Date(new Date().getTime() + 100000L));
-
-        EntitlementCertificate toReturn = new EntitlementCertificate();
-        toReturn.setKeyAsBytes("key".getBytes());
-        toReturn.setCertAsBytes("cert".getBytes());
-        toReturn.setSerial(serial);
-        Entitlement e = this.createEntitlement(owner, c, p, toReturn);
-        this.entitlementCurator.create(e);
-        return toReturn;
-    }
 }

--- a/server/src/test/java/org/candlepin/model/UeberCertificateCuratorTests.java
+++ b/server/src/test/java/org/candlepin/model/UeberCertificateCuratorTests.java
@@ -71,6 +71,16 @@ public class UeberCertificateCuratorTests extends DatabaseTestFixture {
         }
     }
 
+    @Test
+    public void ensureCertificateDeletionRevokesCertSerial() {
+        UeberCertificate cert = this.createUeberCert(owner);
+        CertificateSerial serial = cert.getSerial();
+        this.ueberCertificateCurator.deleteForOwner(owner);
+        assertNull(this.ueberCertificateCurator.findForOwner(owner));
+        CertificateSerial fetchedSerial = certSerialCurator.find(serial.getId());
+        assertTrue("Serial should have been revoked", fetchedSerial.isRevoked());
+    }
+
     private UeberCertificate createUeberCert(Owner owner) {
         CertificateSerial serial = new CertificateSerial();
         this.certSerialCurator.create(serial);


### PR DESCRIPTION
No longer use @Formula to determine if a cert
serial is revoked or not. Instead, we store the
state on the object when the referencing certificate
is revoked.

The serial's revoked state is set to true on deletion
of the associated certificate via means of a @PreRemove
callback. Using the callback to update revoked comes
with a drawback. We can not delete the record via JPQL
or the callback will not be fired. It must be deleted
via cascade, or directly via the EntityManager.

Any certificate that wishes to make use of this functionality
must extend the RevokableCertificate base class, and should
follow the deletion process above.

A liquibase changeset is also included with this patch
and when applied, will add a new revoked column to
cp_certificate_serial and will update any serial with
no association to a certificate to be revoked.

## Testing Notes

It is a good idea to start testing this PR with a populated database so that you can verify that any existing cert serials get properly marked as revoked. Running the spec tests on the master branch will end up with some serials in the DB.

```sql
-- Check how many cert serials are not currently being referenced by a certificate
select count(*) from cp_cert_serial cs
                 left outer join cp_ent_certificate ec on ec.serial_id = cs.id
                 left outer join cp_cdn_certificate cdnc on cs.id = cdnc.serial_id
                 left outer join cp_certificate subcert on cs.id = subcert.serial_id
                 left outer join cp_id_cert idcert on cs.id = idcert.serial_id
                 left outer join cp_cont_access_cert cacert on cs.id = cacert.serial_id
                 left outer join cp_ueber_cert ueber on cs.id = ueber.serial_id
                 where ec.id is null and cdnc.id is null and subcert.id is null and idcert.id is null and cacert.id is null and ueber.id is null;

-- check how many cert serials are being referenced from a certificate
select count(*) from cp_cert_serial cs
                 left outer join cp_ent_certificate ec on ec.serial_id = cs.id
                 left outer join cp_cdn_certificate cdnc on cs.id = cdnc.serial_id
                 left outer join cp_certificate subcert on cs.id = subcert.serial_id
                 left outer join cp_id_cert idcert on cs.id = idcert.serial_id
                 left outer join cp_cont_access_cert cacert on cs.id = cacert.serial_id
                 left outer join cp_ueber_cert ueber on cs.id = ueber.serial_id
                 where ec.id is not null OR cdnc.id is not null OR subcert.id is not null OR idcert.id is not null OR cacert.id is not null OR ueber.id is not null;

-- After the changeset is applied, verify that the revoked count is the same as that
-- of the non-referenced query.
select count(*) from cp_cert_serial where revoked = true;

```