### PR TITLE
Add revoked column to cp_cert_serial table

### DIFF
--- a/server/src/main/resources/db/changelog/20170323142254-add-revoked-column-to-cert-serial.xml
+++ b/server/src/main/resources/db/changelog/20170323142254-add-revoked-column-to-cert-serial.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+    <changeSet id="20170323142254-1" author="mstead">
+        <comment>Add a revoked column to cert serial</comment>
+        <addColumn tableName="cp_cert_serial">
+            <column name="revoked" type="BOOLEAN" defaultValueBoolean="false">
+                <constraints nullable="false" />
+            </column>
+        </addColumn>
+        <rollback>
+            <dropColumn tableName="cp_cert_serial" columnName="revoked" />
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/server/src/main/resources/db/changelog/changelog-create.xml
+++ b/server/src/main/resources/db/changelog/changelog-create.xml
@@ -1205,4 +1205,5 @@
     <include file="db/changelog/20170214115606-uber-cert-rewrite.xml"/>
     <include file="db/changelog/20170220133446-add-correlation-id-to-job.xml"/>
     <include file="db/changelog/20170227140343-convert-consumer-entitlement-count-to-column.xml"/>
+    <include file="db/changelog/20170323142254-add-revoked-column-to-cert-serial.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-testing.xml
+++ b/server/src/main/resources/db/changelog/changelog-testing.xml
@@ -2295,4 +2295,5 @@
     <include file="db/changelog/20170214115606-uber-cert-rewrite.xml"/>
     <include file="db/changelog/20170220133446-add-correlation-id-to-job.xml"/>
     <include file="db/changelog/20170227140343-convert-consumer-entitlement-count-to-column.xml"/>
+    <include file="db/changelog/20170323142254-add-revoked-column-to-cert-serial.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-update.xml
+++ b/server/src/main/resources/db/changelog/changelog-update.xml
@@ -113,4 +113,5 @@
     <include file="db/changelog/20170214115606-uber-cert-rewrite.xml"/>
     <include file="db/changelog/20170220133446-add-correlation-id-to-job.xml"/>
     <include file="db/changelog/20170227140343-convert-consumer-entitlement-count-to-column.xml"/>
+    <include file="db/changelog/20170323142254-add-revoked-column-to-cert-serial.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
This PR simply adds the cp_cert_serial.revoked column and defaults the value to 'false'.

This is in prep for rolling out removing the @Formula currently on the field.
