### PR TITLE
Ensure product uuid does not change upon refresh with no actual changes

### DIFF
--- a/server/spec/product_versioning_spec.rb
+++ b/server/spec/product_versioning_spec.rb
@@ -21,6 +21,16 @@ describe 'Product Versioning' do
     prod1["uuid"].should eq(prod2["uuid"])
   end
 
+  it 'should not change uuid of a product after refresh' do
+    owner1 = create_owner random_string('test_owner')
+    prod = create_product(random_string('name'), random_string('id'), :owner => owner1['key'])
+    pool = create_pool_and_subscription(owner1['key'], prod['id'], 10,
+      [],'','','',nil,nil,true)
+    @cp.get_product(owner1['key'], prod['id'])['uuid'].should == prod['uuid']
+    @cp.refresh_pools(owner1['key'])
+    @cp.get_product(owner1['key'], prod['id'])['uuid'].should == prod['uuid']
+  end
+
   it "creates two distinct product instances when details differ" do
     owner1 = create_owner random_string('test_owner')
     owner2 = create_owner random_string('test_owner')

--- a/server/src/main/java/org/candlepin/model/Product.java
+++ b/server/src/main/java/org/candlepin/model/Product.java
@@ -1153,10 +1153,6 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
             return true;
         }
 
-        if (dto.isLocked() != null && !dto.isLocked().equals(this.locked)) {
-            return true;
-        }
-
         Collection<String> dependentProductIds = dto.getDependentProductIds();
         if (dependentProductIds != null &&
             !Util.collectionsAreEqual(this.dependentProductIds, dependentProductIds)) {


### PR DESCRIPTION
@awood found that upon refresh in hosted mode, the product UUID changes. To fix that issue, this PR:
1. instead of just validating, resolves all the products of a subscription in the default adapters.
2. when comparing products, does not look if both are locked.

to verify the PR:
1. deploy master in hosted mode.
2. checkout this branch
3.run :  buildr rspec:product_versioning_spec:"should not change uuid of a product after refresh"

the same test should pass when the current branch is deployed.