### PR TITLE
1435807: Optimize cert regen from content update

### DIFF
--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -1176,11 +1176,16 @@ public class CandlepinPoolManager implements PoolManager {
     @Override
     @Transactional
     public void regenerateCertificatesOf(String productId, boolean lazy) {
-        List<Pool> poolsForProduct = this.listAvailableEntitlementPools(null, null, null,
-            productId, new Date(), false, false, new PoolFilterBuilder(), null, false, false)
-            .getPageData();
-        for (Pool pool : poolsForProduct) {
-            regenerateCertificatesOf(pool.getEntitlements(), lazy);
+        if (lazy) {
+            poolCurator.markCertificatesDirtyForProductId(productId);
+        }
+        else {
+            List<Pool> poolsForProduct = this.listAvailableEntitlementPools(null, null, null,
+                productId, new Date(), false, false, new PoolFilterBuilder(), null, false, false)
+                .getPageData();
+            for (Pool pool : poolsForProduct) {
+                regenerateCertificatesOf(pool.getEntitlements(), false);
+            }
         }
     }
 

--- a/server/src/main/java/org/candlepin/model/PoolCurator.java
+++ b/server/src/main/java/org/candlepin/model/PoolCurator.java
@@ -830,4 +830,25 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
         q.setParameter("owner", owner);
         q.executeUpdate();
     }
+
+    public void markCertificatesDirtyForProductId(String productId) {
+        markCertificatesDirtyForProductIdForNormalProduct(productId);
+        markCertificatesDirtyForProductIdForProvidedProduct(productId);
+    }
+
+    private void markCertificatesDirtyForProductIdForNormalProduct(String productId) {
+        String statement = "update Entitlement e set e.dirty=true where e.pool.id in " +
+            "(select p.id from Pool p where p.productId = :productId)";
+        Query query = currentSession().createQuery(statement);
+        query.setParameter("productId", productId);
+        query.executeUpdate();
+    }
+
+    private void markCertificatesDirtyForProductIdForProvidedProduct(String productId) {
+        String statement = "update Entitlement e set e.dirty=true where e.pool.id in " +
+            "(select pp.pool.id from ProvidedProduct pp where pp.productId = :productId)";
+        Query query = currentSession().createQuery(statement);
+        query.setParameter("productId", productId);
+        query.executeUpdate();
+    }
 }

--- a/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
@@ -1149,6 +1149,45 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         assertNull(found);
     }
 
+    @Test
+    public void testMarkCertificatesDirtyForProductId() {
+
+        Pool pool = createPoolAndSub(owner, product, -1L, TestUtil.createDate(2017, 3, 27),
+            TestUtil.createDate(Calendar.getInstance().get(Calendar.YEAR) + 1, 3, 27));
+        EntitlementCertificate cert = createEntitlementCertificate("fake", "fake");
+        Entitlement entitlement = createEntitlement(owner, consumer, pool, cert);
+        assertFalse("entitlement should not be dirty initially", entitlement.getDirty());
+
+        poolCurator.create(pool);
+        entitlementCurator.create(entitlement);
+        poolCurator.markCertificatesDirtyForProductId(product.getId());
+        entitlementCurator.refresh(entitlement);
+
+        assertTrue("entitlement should be marked dirty", entitlement.getDirty());
+    }
+
+    @Test
+    public void testMarkCertificatesDirtyForProvidedProduct() {
+        Product parent = TestUtil.createProduct();
+        productCurator.create(parent);
+
+        Set<ProvidedProduct> providedProducts = new HashSet<ProvidedProduct>();
+        ProvidedProduct providedProduct = new ProvidedProduct(product.getId(), "Test Provided Product");
+        providedProducts.add(providedProduct);
+
+        Pool pool = TestUtil.createPool(owner, parent, providedProducts, 5);
+        EntitlementCertificate cert = createEntitlementCertificate("fake", "fake");
+        Entitlement entitlement = createEntitlement(owner, consumer, pool, cert);
+        assertFalse("entitlement should not be dirty initially", entitlement.getDirty());
+
+        poolCurator.create(pool);
+        entitlementCurator.create(entitlement);
+        poolCurator.markCertificatesDirtyForProductId(product.getId());
+        entitlementCurator.refresh(entitlement);
+        assertTrue("entitlement should be marked dirty", entitlement.getDirty());
+    }
+
+
     private Product generateProduct(String id, String name) {
         Product product = TestUtil.createProduct(id, name);
         this.productCurator.create(product);


### PR DESCRIPTION
Don't load pools into memory, instead, use a query to update the
affected entitlements DB-side.

One way to see the effects:
 - set `hibernate.show_sql` to `true` in `persistence.xml`.
 - observe queries made in `buildr rspec:content_resource_spec`