### PR TITLE
1436258: Optimize cert regen from content update

### DIFF
--- a/server/src/main/java/org/candlepin/controller/EntitlementCertificateGenerator.java
+++ b/server/src/main/java/org/candlepin/controller/EntitlementCertificateGenerator.java
@@ -377,7 +377,6 @@ public class EntitlementCertificateGenerator {
     @Transactional
     public void regenerateCertificatesOf(Collection<Owner> owners, Collection<Product> products,
         boolean lazy) {
-
         List<Pool> pools = new LinkedList<Pool>();
 
         Set<String> productIds = new HashSet<String>();
@@ -390,9 +389,14 @@ public class EntitlementCertificateGenerator {
         // TODO: This is a very expensive operation. Update pool curator with something to let us
         // do this without hitting the DB several times over.
         for (Owner owner : owners) {
-            pools.addAll(
-                this.poolCurator.listAvailableEntitlementPools(null, owner, productIds, now)
-            );
+            if (lazy) {
+                poolCurator.markCertificatesDirtyForPoolsWithProducts(owner, productIds);
+            }
+            else {
+                pools.addAll(
+                    this.poolCurator.listAvailableEntitlementPools(null, owner, productIds, now)
+                );
+            }
         }
 
         for (Pool pool : pools) {


### PR DESCRIPTION
Don't load pools into memory, instead, use a query to update the
affected entitlements DB-side.

Analogous to #1531 (this one targets 2.0).

One way to see the effects:
 - set `hibernate.show_sql` to `true` in `persistence.xml`
 - run `buildr rspec:owner_content_resource_spec`