### PR TITLE
Update required liquibase version

### DIFF
--- a/server/candlepin.spec.tmpl
+++ b/server/candlepin.spec.tmpl
@@ -46,7 +46,7 @@ BuildRequires: selinux-policy-doc
 Requires: java >= 0:1.6.0
 Requires: wget
 Requires: %{tomcat}
-Requires: liquibase >= 0:2.0.5
+Requires: liquibase >= 0:3.0.0
 # Need JDBC driver for cpdb
 Requires: postgresql-jdbc
 


### PR DESCRIPTION
Updating the liquibase version in the spec file as we are now using features from 3.0.0 in our changesets.