### PR TITLE
Updated spec tests to escape query params and use full date strings

### DIFF
--- a/common/src/main/java/org/candlepin/common/exceptions/mappers/BadRequestExceptionMapper.java
+++ b/common/src/main/java/org/candlepin/common/exceptions/mappers/BadRequestExceptionMapper.java
@@ -22,6 +22,8 @@ import com.google.inject.Inject;
 
 import org.jboss.resteasy.spi.BadRequestException;
 
+import org.xnap.commons.i18n.I18n;
+
 import java.util.Map;
 
 import javax.ws.rs.core.Response;
@@ -29,6 +31,8 @@ import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
+
+
 
 /**
  * BadRequestExceptionMapper maps the RESTEasy BadRequestException into JSON and
@@ -57,8 +61,19 @@ public class BadRequestExceptionMapper extends CandlepinExceptionMapper
             ResponseBuilder bldr = Response.status(Status.BAD_REQUEST)
                 .type(determineBestMediaType())
                 .header(VersionUtil.VERSION_HEADER, map.get("version") + "-" + map.get("release"));
-            bldr.entity(new ExceptionMessage(i18n.get().tr("Bad Request")));
-            return bldr.build();
+
+            // Use the message in the original exception if we have it
+            String message = null;
+            for (Throwable current = exception; current != null; current = current.getCause()) {
+                message = current.getMessage();
+            }
+
+            // Set default message if we didn't have anything...
+            if (message == null || message.isEmpty()) {
+                message = I18n.marktr("Bad Request");
+            }
+
+            return bldr.entity(new ExceptionMessage(i18n.get().tr(message))).build();
         }
     }
 }

--- a/common/src/main/java/org/candlepin/common/resteasy/filter/LinkHeaderResponseFilter.java
+++ b/common/src/main/java/org/candlepin/common/resteasy/filter/LinkHeaderResponseFilter.java
@@ -65,8 +65,8 @@ public class LinkHeaderResponseFilter implements ContainerResponseFilter {
     public void filter(ContainerRequestContext reqContext, ContainerResponseContext respContext) {
         Page page = ResteasyProviderFactory.getContextData(Page.class);
 
+        // Make sure we have page information in the context
         if (page == null) {
-            log.warn("Method marked for pagination, but no page exists in the context.");
             return;
         }
 

--- a/server/client/ruby/candlepin.rb
+++ b/server/client/ruby/candlepin.rb
@@ -529,7 +529,7 @@ module Candlepin
 
       def bind(opts = {})
         # Entitle dates are not allowed in bind by product.
-        default_date = Date.today
+        default_date = DateTime.now
         if opts.key?(:pool_id)
           default_date = nil
         end
@@ -1634,8 +1634,8 @@ module Candlepin
       def create_pool(opts = {})
         defaults = {
           :owner => key,
-          :start_date => Date.today,
-          :end_date => Date.today + 365,
+          :start_date => DateTime.now,
+          :end_date => DateTime.now + 365,
           :quantity => 1,
           :account_number => '',
           :order_number => '',

--- a/server/spec/activation_key_spec.rb
+++ b/server/spec/activation_key_spec.rb
@@ -21,8 +21,13 @@ describe 'Activation Keys' do
     @pool = @cp.list_pools(:owner => @owner.id, :product => @product['id']).first
     @pool2 = @cp.list_pools(:owner => @owner.id, :product => @product2['id']).first
 
+    expect(@pool).to_not be_nil
+    expect(@pool2).to_not be_nil
+
     @activation_key = @cp.create_activation_key(@owner['key'], random_string('test_token'))
-    @activation_key['id'].should_not be_nil
+
+    expect(@activation_key).to_not be_nil
+    expect(@activation_key['id']).to_not be_nil
   end
 
   it 'should allow owners to list existing activation keys' do

--- a/server/spec/candlepin_scenarios.rb
+++ b/server/spec/candlepin_scenarios.rb
@@ -314,8 +314,7 @@ class Exporter
 
     owner_client = Candlepin.new(user['username'], 'password')
 
-    @candlepin_client = consumer_client(owner_client, random_string('test_client'),
-        "candlepin", user['username'])
+    @candlepin_client = consumer_client(owner_client, random_string('test_client'), "candlepin", user['username'])
   end
 
   def do_export(client, dest_dir, opts={}, uuid=nil)
@@ -548,9 +547,7 @@ class StandardExporter < Exporter
     # pool3 is special
     @candlepin_client.consume_pool(@pool3.id, {:quantity => 1})
 
-    @cdn = create_cdn(@cdn_label,
-                "Test CDN",
-                "https://cdn.test.com")
+    @cdn = create_cdn(@cdn_label, "Test CDN", "https://cdn.test.com")
   end
 
   def create_candlepin_export_update
@@ -619,9 +616,7 @@ class VirtLimitExporter < Exporter
 
     @candlepin_client.consume_pool(@pool3.id, {:quantity => 2})
 
-    @cdn = create_cdn(@cdn_label,
-                "Test CDN",
-                "https://cdn.test.com")
+    @cdn = create_cdn(@cdn_label, "Test CDN", "https://cdn.test.com")
 
   end
 
@@ -653,45 +648,45 @@ end
 
 # We assume existence of queue allmsg that is bound to event exchange
 class CandlepinQpid
-  def initialize() 
+  def initialize()
     @address='amqps://localhost:5671/allmsg'
     @qpid_crt = "server/bin/qpid/keys/qpid_ca.crt"
     @qpid_key = "server/bin/qpid/keys/qpid_ca.key"
-   end 
+   end
 
-  def no_keys 
+  def no_keys
     !File.file?(@qpid_crt) or !File.file?(@qpid_key)
-  end 
+  end
 
   def stop
     `sudo systemctl stop qpidd || sudo supervisorctl stop qpidd`
-  end 
+  end
 
   def start
     `sudo systemctl start qpidd || sudo supervisorctl start qpidd`
-  end 
+  end
 
   #Create non-durable queue and bind it to an exchange
   def create_queue(qname, args, exchange)
     `sudo qpid-config -b amqps://localhost:5671 --ssl-certificate #{@qpid_crt} --ssl-key #{@qpid_key} add queue #{qname} #{args}`
     `sudo qpid-config -b amqps://localhost:5671 --ssl-certificate #{@qpid_crt} --ssl-key #{@qpid_key} bind #{exchange} #{qname} "#"`
-  end 
- 
+  end
+
   #Force removes the queue
   def delete_queue(qname)
     `sudo qpid-config -b amqps://localhost:5671 --ssl-certificate #{@qpid_crt} --ssl-key #{@qpid_key} del queue #{qname} --force`
-  end 
+  end
 
   def receive
     @messenger = Qpid::Proton::Messenger::Messenger.new
-   
+
     if (no_keys)
       raise "The Qpid keys doesnt exist on paths: #{File.absolute_path(@qpid_crt)}; #{File.absolute_path(@qpid_key)}"
     end
     @messenger.certificate = @qpid_crt
     @messenger.private_key = @qpid_key
     @messenger.blocking = false
- 
+
     msgs = []
     @messenger.start
     @messenger.subscribe(@address)
@@ -701,20 +696,20 @@ class CandlepinQpid
      # The receive method is non blocking but
      # it seems you need to call it several times to
      # establish connection to the broker
-     5.times do  
+     5.times do
        @messenger.receive
        sleep(0.3)
-     end 
+     end
 
-     break if @messenger.incoming.zero? 
+     break if @messenger.incoming.zero?
      while @messenger.incoming.nonzero?
       msg = Qpid::Proton::Message.new
       @messenger.get(msg)
-      msgs << msg 
-     end 
-    end 
+      msgs << msg
+     end
+    end
     @messenger.stop
 
    return msgs
-  end 
+  end
 end

--- a/server/spec/content_resource_spec.rb
+++ b/server/spec/content_resource_spec.rb
@@ -22,15 +22,15 @@ describe 'Content Resource' do
 
   it 'should throw exceptions on write operations' do
     lambda do
-      @cp.post("/content", {})
+      @cp.post("/content", {}, {})
     end.should raise_exception(RestClient::BadRequest)
 
     lambda do
-      @cp.put("/content/dummyid", {})
+      @cp.put("/content/dummyid", {}, {})
     end.should raise_exception(RestClient::BadRequest)
 
     lambda do
-      @cp.post("/content/batch", [])
+      @cp.post("/content/batch", {}, [])
     end.should raise_exception(RestClient::BadRequest)
 
     lambda do

--- a/server/spec/content_versioning_spec.rb
+++ b/server/spec/content_versioning_spec.rb
@@ -17,7 +17,7 @@ describe 'Content Versioning' do
     label = "shared content"
     type = "shared_content_type"
     vendor = "generous vendor"
-    updated_upstream = Date.today
+    updated_upstream = DateTime.now
 
     content1 = @cp.create_content(owner1["key"], name, id, label, type, vendor)
     content2 = @cp.create_content(owner2["key"], name, id, label, type, vendor)
@@ -34,7 +34,7 @@ describe 'Content Versioning' do
     label = "shared content"
     type = "shared_content_type"
     vendor = "generous vendor"
-    updated_upstream = Date.today
+    updated_upstream = DateTime.now
 
     content1 = @cp.create_content(owner1["key"], name, id, label, type, vendor)
     content2 = @cp.create_content(owner2["key"], name + "-2", id, label, type, vendor)
@@ -52,7 +52,7 @@ describe 'Content Versioning' do
     label = "shared content"
     type = "shared_content_type"
     vendor = "generous vendor"
-    updated_upstream = Date.today
+    updated_upstream = DateTime.now
 
     content1 = @cp.create_content(owner1["key"], name, id, label, type, vendor)
     content2 = @cp.create_content(owner2["key"], name, id, label, type, vendor)

--- a/server/spec/derived_product_import_spec.rb
+++ b/server/spec/derived_product_import_spec.rb
@@ -21,11 +21,16 @@ describe 'Import', :serial => true do
   end
 
   after(:all) do
-    @owners.each do |o|
-      @cp.delete_owner(o['key'])
+    if @owners
+      @owners.each do |o|
+        @cp.delete_owner(o['key'])
+      end
     end
-    @exporters.each do |e|
-      e.cleanup()
+
+    if @exporters
+      @exporters.each do |e|
+        e.cleanup()
+      end
     end
   end
 

--- a/server/spec/entitlement_certificate_v3_spec.rb
+++ b/server/spec/entitlement_certificate_v3_spec.rb
@@ -165,11 +165,9 @@ describe 'Entitlement Certificate V3' do
   it 'verify branding info is correct in json blob' do
     product = create_product(nil, nil)
 
-    branding = [{:productId => product['id'],
-        :type => 'Some Type', :name => 'Super Branded Name'}]
-    create_pool_and_subscription(@owner['key'], product.id, 10, [],
-        '12345', '6789', 'order1', Date.today - 10, Date.today + 365, false,
-        {:branding => branding})
+    now = DateTime.now
+    branding = [{:productId => product['id'], :type => 'Some Type', :name => 'Super Branded Name'}]
+    create_pool_and_subscription(@owner['key'], product.id, 10, [], '12345', '6789', 'order1', now - 10, now + 365, false, {:branding => branding})
     entitlement = @system.consume_product(product.id)[0]
     json_body = extract_payload(@system.list_certificates[0]['cert'])
 

--- a/server/spec/entitlement_migrate_spec.rb
+++ b/server/spec/entitlement_migrate_spec.rb
@@ -23,8 +23,8 @@ describe 'Entitlement Migrate' do
     pool = @dist1.list_pools(:owner => @owner['id'], :product => @product['id'])[0]
     entitlement = @dist1.consume_pool(pool.id, {:quantity => 25})[0]
     @cp.migrate_entitlement({:id => entitlement.id, :dest => @dist2.get_consumer()['uuid'], :quantity => 25})
-    @dist1.list_entitlements(:product_id => @product.id).length.should eq(0)
-    new_ent = @dist2.list_entitlements(:product_id => @product.id)[0]
+    @dist1.list_entitlements(:product => @product.id).length.should eq(0)
+    new_ent = @dist2.list_entitlements(:product => @product.id)[0]
     new_ent['quantity'].should == 25
     new_ent.id.should_not == entitlement.id
   end
@@ -33,10 +33,10 @@ describe 'Entitlement Migrate' do
     pool = @dist1.list_pools(:owner => @owner['id'], :product => @product['id'])[0]
     org_ent = @dist1.consume_pool(pool.id, {:quantity => 25})[0]
     @cp.migrate_entitlement({:id => org_ent.id, :dest => @dist2.get_consumer()['uuid'], :quantity => 15})
-    source_ent = @dist1.list_entitlements(:product_id => @product.id)[0]
+    source_ent = @dist1.list_entitlements(:product => @product.id)[0]
     source_ent['quantity'].should == 10
     source_ent.id.should == org_ent.id
-    dest_ent = @dist2.list_entitlements(:product_id => @product.id)[0]
+    dest_ent = @dist2.list_entitlements(:product => @product.id)[0]
     dest_ent['quantity'].should == 15
     dest_ent.id.should_not == org_ent.id
   end
@@ -54,8 +54,8 @@ describe 'Entitlement Migrate' do
     pool = @dist1.list_pools(:owner => @owner['id'], :product => @product['id'])[0]
     entitlement = @dist1.consume_pool(pool.id, {:quantity => 25})[0]
     @cp.migrate_entitlement({:id => entitlement.id, :dest => @dist2.get_consumer()['uuid']})
-    @dist1.list_entitlements(:product_id => @product.id).length.should eq(0)
-    new_ent = @dist2.list_entitlements(:product_id => @product.id)[0]
+    @dist1.list_entitlements(:product => @product.id).length.should eq(0)
+    new_ent = @dist2.list_entitlements(:product => @product.id)[0]
     new_ent['quantity'].should == 25
     new_ent.id.should_not == entitlement.id
   end

--- a/server/spec/entitlement_spec.rb
+++ b/server/spec/entitlement_spec.rb
@@ -60,7 +60,7 @@ describe 'Entitlements' do
 
   it 'should throw an error when filtering by a non-existant product ID' do
     lambda do
-      @system.list_entitlements(:product_id => 'non_existant')
+      @system.list_entitlements(:product => 'non_existant')
     end.should raise_exception(RestClient::BadRequest)
   end
 
@@ -93,14 +93,14 @@ describe 'Entitlements' do
   it 'should have the correct product ID when subscribing by product' do
     @system.consume_product @monitoring.id
 
-    entitlements = @system.list_entitlements(:product_id => @monitoring.id)
+    entitlements = @system.list_entitlements(:product => @monitoring.id)
     entitlements.length.should eq(1)
   end
 
   it 'should have the correct product ID when subscribing by pool' do
     @system.consume_pool find_pool_for_product(@monitoring).id
 
-    entitlements = @system.list_entitlements(:product_id => @monitoring.id)
+    entitlements = @system.list_entitlements(:product => @monitoring.id)
     entitlements.length.should eq(1)
   end
 

--- a/server/spec/healing_spec.rb
+++ b/server/spec/healing_spec.rb
@@ -7,6 +7,7 @@ describe 'Healing' do
   include CandlepinMethods
 
   before(:each) do
+    @now = DateTime.now
     @owner = create_owner random_string('test_owner1')
     @username = random_string("user1")
     consumername1 = random_string("consumer1")
@@ -19,8 +20,7 @@ describe 'Healing' do
         {'productId' => @product1['id'], 'productName' => @product1['name']},
         {'productId' => @product2['id'], 'productName' => @product2['name']}]
 
-    @consumer = @user_cp.register(consumername1, :system, nil,
-      {'cpu.cpu_socket(s)' => '8'}, nil, @owner['key'], [], installed)
+    @consumer = @user_cp.register(consumername1, :system, nil, {'cpu.cpu_socket(s)' => '8'}, nil, @owner['key'], [], installed)
     @consumer_cp = Candlepin.new(nil, nil, @consumer.idCert.cert, @consumer.idCert['key'])
   end
 
@@ -31,8 +31,8 @@ describe 'Healing' do
 
     # Create a future sub, the entitlement should not come from this one:
     future_pool = create_pool_and_subscription(@owner['key'], parent_prod['id'],
-      10, [@product1['id'], @product2['id']], '', '', Date.today + 30,
-        Date.today + 60)
+      10, [@product1['id'], @product2['id']], '', '', @now + 30,
+        @now + 60)
 
     ents = @consumer_cp.consume_product()
     ents.size.should == 1
@@ -46,8 +46,7 @@ describe 'Healing' do
 
     # Create a future sub, the entitlement should not come from this one:
     future_pool = create_pool_and_subscription(@owner['key'], parent_prod['id'],
-      10, [@product1['id'], @product2['id']], '', '', '', Date.today + 30,
-        Date.today + 60)
+      10, [@product1['id'], @product2['id']], '', '', '', @now + 30, @now + 60)
 
     # 35 days in future should land in our sub:
     future_iso8601 = (Time.now + (60 * 60 * 24 * 35)).utc.iso8601 # a string
@@ -68,8 +67,7 @@ describe 'Healing' do
 
     # Create a future sub, entitlement should end up coming from here:
     future_pool = create_pool_and_subscription(@owner['key'], parent_prod['id'],
-      10, [@product1['id'], @product2['id']], '', '', '', Date.today + 365 * 2,
-        Date.today + 365 * 4) # valid 2-4 years from now
+      10, [@product1['id'], @product2['id']], '', '', '', @now + 365 * 2, @now + 365 * 4) # valid 2-4 years from now
 
     future_iso8601 = (Time.now + (60 * 60 * 24 * 365 * 3)).utc.iso8601 # a string
 

--- a/server/spec/import_cleanup_spec.rb
+++ b/server/spec/import_cleanup_spec.rb
@@ -28,10 +28,13 @@ describe 'Import cleanup', :serial => true do
   end
 
   after(:all) do
-    @cp.delete_user(@import_username)
-    @cp.delete_owner(@import_owner['key'])
-    @exporters.each do |e|
-      e.cleanup()
+    @cp.delete_user(@import_username) if @import_username
+    @cp.delete_owner(@import_owner['key']) if @import_owner
+
+    if @exporters
+      @exporters.each do |e|
+        e.cleanup()
+      end
     end
   end
 

--- a/server/spec/import_excess_spec.rb
+++ b/server/spec/import_excess_spec.rb
@@ -19,9 +19,9 @@ describe 'Import Update', :serial => true do
   end
 
   after(:all) do
-    @cp.delete_user(@import_username)
-    @cp.delete_owner(@import_owner['key'])
-    @exporter.cleanup()
+    @cp.delete_user(@import_username) if @import_username
+    @cp.delete_owner(@import_owner['key']) if @import_owner
+    @exporter.cleanup() if @exporter
   end
 
   it 'should successfully update the import' do
@@ -31,12 +31,12 @@ describe 'Import Update', :serial => true do
     @host1_client = Candlepin.new(nil, nil, @host1['idCert']['cert'], @host1['idCert']['key'])
     all_pools = @user.list_pools :owner => @import_owner.id
     normal_pool = all_pools.select{|i| i['type']=='NORMAL'}[0]
-    all_pools.size.should == 2  
+    all_pools.size.should == 2
     @host1_client.consume_pool(normal_pool.id, {:quantity => 2})
     all_pools = @user.list_pools :owner => @import_owner.id
-    all_pools.size.should == 3  
-    
-    # Now lets import 
+    all_pools.size.should == 3
+
+    # Now lets import
     updated_export = @exporter.create_candlepin_export_update()
     @cp.import(@import_owner['key'], updated_export.export_filename)
 

--- a/server/spec/import_spec.rb
+++ b/server/spec/import_spec.rb
@@ -37,10 +37,13 @@ describe 'Import Test Group:', :serial => true do
     end
 
     after(:all) do
-      @cp.delete_user(@import_username)
-      @cp.delete_owner(@import_owner['key'])
-      @exporters.each do |e|
-        e.cleanup()
+      @cp.delete_user(@import_username) if @import_username
+      @cp.delete_owner(@import_owner['key']) if @import_owner
+
+      if @exporters
+        @exporters.each do |e|
+          e.cleanup()
+        end
       end
     end
 
@@ -52,8 +55,8 @@ describe 'Import Test Group:', :serial => true do
 
     def import_and_wait
       lambda { |owner_key, export_file, param_map={}|
-        param_map['correlation_id'] = @cp_correlation_id
-        job = @cp.import_async(owner_key, export_file, param_map)
+        headers = { :correlation_id => @cp_correlation_id }
+        job = @cp.import_async(owner_key, export_file, param_map, headers)
         # Wait a little longer here as import can take a bit of time
         wait_for_job(job["id"], 10)
         status = @cp.get_job(job["id"], true)

--- a/server/spec/import_warning_spec.rb
+++ b/server/spec/import_warning_spec.rb
@@ -23,9 +23,12 @@ describe 'Import Warning', :serial => true do
   end
 
   after(:all) do
-    @cp.delete_owner(@import_owner['key'])
-    @exporters.each do |e|
-      e.cleanup()
+    @cp.delete_owner(@import_owner['key']) if @import_owner
+
+    if @exporters
+      @exporters.each do |e|
+        e.cleanup()
+      end
     end
   end
 

--- a/server/spec/job_schedule_spec.rb
+++ b/server/spec/job_schedule_spec.rb
@@ -25,12 +25,13 @@ describe 'Scheduled Jobs' do
 
   it 'should purge expired pools' do
     @owner = create_owner random_string 'test_owner'
-    @monitoring_prod = create_product(nil, 'monitoring',
-      :attributes => { 'variant' => "Satellite Starter Pack" })
+    @monitoring_prod = create_product(nil, 'monitoring', :attributes => { 'variant' => "Satellite Starter Pack" })
+
+    now = DateTime.now
     pool = @cp.create_pool(@owner['key'], @monitoring_prod.id, {
       :quantity => 6,
-      :start_date => Date.today - 20,
-      :end_date => Date.today - 10
+      :start_date => now - 20,
+      :end_date => now - 10
     });
     #verify pool exists before
     @cp.get_pool(pool['id']).should_not be_nil

--- a/server/spec/one_sub_pool_per_stack_spec.rb
+++ b/server/spec/one_sub_pool_per_stack_spec.rb
@@ -10,7 +10,9 @@ describe 'One Sub Pool Per Stack' do
   include AttributeHelper
 
   before(:each) do
-    skip("candlepin not running in standalone mode") if is_hosted?
+    @now = DateTime.now
+
+    skip("candlepin running in standalone mode") if is_hosted?
     @owner = create_owner random_string('virt_owner')
     @user = user_client(@owner, random_string('virt_user'))
 
@@ -85,9 +87,9 @@ describe 'One Sub Pool Per Stack' do
       @virt_limit_product.id, 10, [@virt_limit_provided_product.id], "123", "321", "333",
       nil, nil, true)
     create_pool_and_subscription(@owner['key'],
-      @virt_limit_product.id, 10, [], "456", '', '', nil, Date.today + 380, true)
+      @virt_limit_product.id, 10, [], "456", '', '', nil, @now + 380, true)
     create_pool_and_subscription(@owner['key'],
-      @virt_limit_product2.id, 10, [], "444", '', '', nil, Date.today + 380, true)
+      @virt_limit_product2.id, 10, [], "444", '', '', nil, @now + 380, true)
     create_pool_and_subscription(@owner['key'],
       @regular_stacked_product.id, 4, [@regular_stacked_provided_product.id], "789",
       "","", nil, nil, true)

--- a/server/spec/pool_resource_spec.rb
+++ b/server/spec/pool_resource_spec.rb
@@ -69,11 +69,11 @@ describe 'Pool Resource' do
   end
 
   it 'should not return expired pools' do
+    now = DateTime.now
     owner = create_owner random_string('donaldduck')
     client = user_client(owner, random_string('testusr'))
     product = create_product(nil, nil, :owner => owner['key'])
-    create_pool_and_subscription(owner['key'], product.id, 5,
-      [], '', '', '', Date.today - 60, Date.today - 1)
+    create_pool_and_subscription(owner['key'], product.id, 5, [], '', '', '', now - 60, now - 1)
     (@cp.list_pools :owner => owner.id).size.should == 0
   end
 

--- a/server/spec/product_resource_spec.rb
+++ b/server/spec/product_resource_spec.rb
@@ -32,15 +32,15 @@ describe 'Product Resource' do
     end.should raise_exception(RestClient::BadRequest)
 
     lambda do
-      @cp.put("/products/#{@product.id}", {})
+      @cp.put("/products/#{@product.id}", {}, {})
     end.should raise_exception(RestClient::BadRequest)
 
     lambda do
-      @cp.post("/products/#{@product.id}/batch_content", {})
+      @cp.post("/products/#{@product.id}/batch_content", {}, {})
     end.should raise_exception(RestClient::BadRequest)
 
     lambda do
-      @cp.post("/products/#{@product.id}/content/contentid", {})
+      @cp.post("/products/#{@product.id}/content/contentid", {}, {})
     end.should raise_exception(RestClient::BadRequest)
 
     lambda do

--- a/server/spec/refresh_pools_spec.rb
+++ b/server/spec/refresh_pools_spec.rb
@@ -102,9 +102,10 @@ describe 'Refresh Pools' do
     consumer.consume_pool(pools.first.id, {:quantity => 1}).size.should == 1
 
     # Update the subscription to be expired so that pool, and entitlements are removed.
+    now = DateTime.now
     sub = get_hostedtest_subscription(pool.subscriptionId)
-    sub.startDate = Date.today - 20
-    sub.endDate = Date.today - 10
+    sub.startDate = now - 20
+    sub.endDate = now - 10
     update_hostedtest_subscription(sub)
     @cp.refresh_pools(owner['key'])
     @cp.list_pools({:owner => owner.id}).size.should == 0

--- a/server/spec/spec_helper.rb
+++ b/server/spec/spec_helper.rb
@@ -28,7 +28,7 @@ module CleanupHooks
 
     if !@cp.get_status()['standalone']
       begin
-        @cp.delete('/hostedtest/subscriptions/', nil, true)
+        @cp.delete('/hostedtest/subscriptions/', {}, nil, true)
       rescue RestClient::ResourceNotFound
         puts "skipping hostedtest cleanup"
       end

--- a/server/spec/unbind_spec.rb
+++ b/server/spec/unbind_spec.rb
@@ -67,7 +67,7 @@ describe 'Unbind' do
     ent = consumer.consume_pool(pool.id, {:quantity => 1}).first
 
     # Gather up the serials
-    serials = consumer.list_entitlements(:product_id => @monitoring.id).collect do |ent|
+    serials = consumer.list_entitlements(:product => @monitoring.id).collect do |ent|
       ent.certificates.collect { |cert| cert.serial.id }
     end.flatten
 
@@ -77,7 +77,7 @@ describe 'Unbind' do
     serials.each { |serial| @cp.get_serial(serial).revoked.should be true }
   end
 
-  it 'should leave other entitlements in tact' do
+  it 'should leave other entitlements intact' do
     virt_host = create_product(nil, random_string('virt_host'))
     pool = create_pool_and_subscription(@owner['key'], virt_host.id, 5)
 
@@ -93,7 +93,7 @@ describe 'Unbind' do
     virt_host_ent = consumer.consume_pool(pool.id, {:quantity => 1}).first
 
     # Gather up the serials
-    serials = consumer.list_entitlements(:product_id => @monitoring.id).collect do |ent|
+    serials = consumer.list_entitlements(:product => @monitoring.id).collect do |ent|
       ent.certificates.collect { |cert| cert.serial.id }
     end.flatten
 

--- a/server/spec/virt_spec.rb
+++ b/server/spec/virt_spec.rb
@@ -215,8 +215,8 @@ describe 'Standalone Virt-Limit Subscriptions', :type => :virt do
     # The old host-specific entitlement should not be on the guest anymore (see 768872 comment #41)
     # Instead the guest should be auto-healed for host2
     # second_product's entitlement should still be there, though.
-    @guest1_client.list_entitlements(:product_id => @second_product.id).length.should == 1
-    ents = @guest1_client.list_entitlements(:product_id => @virt_limit_product.id).first
+    @guest1_client.list_entitlements(:product => @second_product.id).length.should == 1
+    ents = @guest1_client.list_entitlements(:product => @virt_limit_product.id).first
 
     ents['pool']['id'].should_not == original_virt_limit_pool
 

--- a/server/src/main/java/org/candlepin/guice/CandlepinModule.java
+++ b/server/src/main/java/org/candlepin/guice/CandlepinModule.java
@@ -113,6 +113,7 @@ import org.candlepin.resource.StatusResource;
 import org.candlepin.resource.SubscriptionResource;
 import org.candlepin.resource.UserResource;
 import org.candlepin.resource.util.ResolverUtil;
+import org.candlepin.resteasy.DateFormatter;
 import org.candlepin.resteasy.JsonProvider;
 import org.candlepin.resteasy.ResourceLocatorMap;
 import org.candlepin.resteasy.filter.AuthenticationFilter;
@@ -266,6 +267,7 @@ public class CandlepinModule extends AbstractModule {
         bind(GuestIdResource.class);
         bind(AttributeValidator.class);
         bind(FactValidator.class);
+        bind(DateFormatter.class);
 
         configureInterceptors();
         configureAuth();

--- a/server/src/main/java/org/candlepin/guice/I18nProvider.java
+++ b/server/src/main/java/org/candlepin/guice/I18nProvider.java
@@ -36,12 +36,10 @@ import javax.servlet.http.HttpServletRequest;
  * I18nProvider
  */
 public class I18nProvider extends CommonI18nProvider implements Provider<I18n> {
-    private I18n i18n;
-
     private static Logger log = LoggerFactory.getLogger(I18nProvider.class);
+    private static Map<Locale, I18n> cache = new ConcurrentHashMap<Locale, I18n>();
 
-    private static Map<Locale, I18n>
-        cache = new ConcurrentHashMap<Locale, I18n>();
+    private I18n i18n;
 
     @Inject
     public I18nProvider(Injector injector) {
@@ -71,13 +69,9 @@ public class I18nProvider extends CommonI18nProvider implements Provider<I18n> {
         synchronized (cache) {
             i18n = cache.get(locale);
             if (i18n == null) {
-                i18n = I18nFactory.getI18n(getClass(), getBaseName(), locale,
-                    I18nFactory.FALLBACK);
+                log.debug("Getting i18n engine for locale {}", locale);
 
-                if (log.isDebugEnabled()) {
-                    log.debug("Getting i18n engine for locale " + locale);
-                }
-
+                i18n = I18nFactory.getI18n(getClass(), getBaseName(), locale, I18nFactory.FALLBACK);
                 cache.put(locale, i18n);
             }
         }

--- a/server/src/main/java/org/candlepin/model/PoolCurator.java
+++ b/server/src/main/java/org/candlepin/model/PoolCurator.java
@@ -314,6 +314,7 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
             log.debug("    owner: {}", owner);
             log.debug("    products: {}", productIds);
             log.debug("    subscription: {}", subscriptionId);
+            log.debug("    active on: {}", activeOn);
         }
 
         boolean joinedProvided = false;

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -1389,7 +1389,9 @@ public class ConsumerResource {
     @Produces(MediaType.APPLICATION_JSON)
     public Response getContentAccessBody(
         @PathParam("consumer_uuid") @Verify(Consumer.class) String consumerUuid,
-        @HeaderParam("If-Modified-Since") @DateFormat ("EEE, dd MMM yyyy HH:mm:ss z") Date since) {
+        @HeaderParam("If-Modified-Since") @DefaultValue("Thu, 01 Jan 1970 00:00:00 GMT")
+        @DateFormat({"EEE, dd MMM yyyy HH:mm:ss z"}) Date since) {
+
         log.debug("Getting content access certificate for consumer: {}", consumerUuid);
         Consumer consumer = consumerCurator.verifyAndLookupConsumer(consumerUuid);
         if (consumer.getOwner().contentAccessMode()

--- a/server/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -80,7 +80,7 @@ import org.candlepin.resource.util.CalculatedAttributesUtil;
 import org.candlepin.resource.util.ConsumerTypeValidator;
 import org.candlepin.resource.util.EntitlementFinderUtil;
 import org.candlepin.resource.util.ResolverUtil;
-import org.candlepin.resource.util.ResourceDateParser;
+import org.candlepin.resteasy.DateFormat;
 import org.candlepin.resteasy.parameter.CandlepinParam;
 import org.candlepin.resteasy.parameter.KeyValueParameter;
 import org.candlepin.service.ContentAccessCertServiceAdapter;
@@ -752,7 +752,7 @@ public class OwnerResource {
         @QueryParam("listall") @DefaultValue("false") boolean listAll,
         @ApiParam("Date to use as current time for lookup criteria. Defaults" +
                 " to current date if not specified.")
-        @QueryParam("activeon") String activeOn,
+        @QueryParam("activeon") @DefaultValue(DateFormat.NOW) @DateFormat Date activeOn,
         @ApiParam("Find pools matching the given pattern in a variety of fields" +
                 " * and ? wildcards are supported.")
         @QueryParam("matches") String matches,
@@ -769,11 +769,6 @@ public class OwnerResource {
         @Context PageRequest pageRequest) {
 
         Owner owner = findOwner(ownerKey);
-
-        Date activeOnDate = new Date();
-        if (activeOn != null) {
-            activeOnDate = ResourceDateParser.parseDateString(activeOn);
-        }
 
         Consumer c = null;
         if (consumerUuid != null) {
@@ -818,11 +813,11 @@ public class OwnerResource {
         }
 
         Page<List<Pool>> page = poolManager.listAvailableEntitlementPools(
-            c, key, owner, productId, subscriptionId, activeOnDate, listAll, poolFilters, pageRequest,
+            c, key, owner, productId, subscriptionId, activeOn, listAll, poolFilters, pageRequest,
         addFuture, onlyFuture);
         List<Pool> poolList = page.getPageData();
-        calculatedAttributesUtil.setCalculatedAttributes(poolList, activeOnDate);
-        calculatedAttributesUtil.setQuantityAttributes(poolList, c, activeOnDate);
+        calculatedAttributesUtil.setCalculatedAttributes(poolList, activeOn);
+        calculatedAttributesUtil.setQuantityAttributes(poolList, c, activeOn);
 
         // Store the page for the LinkHeaderResponseFilter
         ResteasyProviderFactory.pushContext(Page.class, page);

--- a/server/src/main/java/org/candlepin/resource/util/ResourceDateParser.java
+++ b/server/src/main/java/org/candlepin/resource/util/ResourceDateParser.java
@@ -33,11 +33,11 @@ public class ResourceDateParser {
 
     public static Date getFromDate(String from, String to, String days) {
         if (days != null && !days.trim().equals("") &&
-            (to != null && !to.trim().equals("") ||
-            from != null && !from.trim().equals(""))) {
-            throw new BadRequestException("You can use either the to/from " +
-                                           "date parameters or the number of " +
-                                           "days parameter, but not both");
+            (to != null && !to.trim().equals("") || from != null && !from.trim().equals(""))) {
+
+            throw new BadRequestException(
+                "You can use either the to/from date parameters or the number of days parameter, but not both"
+            );
         }
 
         Date daysDate = null;
@@ -63,13 +63,14 @@ public class ResourceDateParser {
         if (StringUtils.isBlank(activeOn)) {
             return null;
         }
+
         try {
             d = DatatypeConverter.parseDateTime(activeOn).getTime();
         }
         catch (IllegalArgumentException e) {
-            throw new BadRequestException(
-                "Invalid date, must use ISO 8601 format");
+            throw new BadRequestException("Invalid date, must use ISO 8601 format");
         }
+
         return d;
     }
 }

--- a/server/src/main/java/org/candlepin/resteasy/DateFormat.java
+++ b/server/src/main/java/org/candlepin/resteasy/DateFormat.java
@@ -19,11 +19,16 @@ import org.jboss.resteasy.annotations.StringParameterUnmarshallerBinder;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
+
+
 /**
  * Interface for dates on REST API parameters
  */
 @Retention(RetentionPolicy.RUNTIME)
 @StringParameterUnmarshallerBinder(DateFormatter.class)
 public @interface DateFormat {
-    String value();
+    /** Special value representing the current time when parsing */
+    String NOW = "now";
+
+    String[] value() default {};
 }

--- a/server/src/main/java/org/candlepin/resteasy/DateFormatter.java
+++ b/server/src/main/java/org/candlepin/resteasy/DateFormatter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ * Copyright (c) 2009 - 2017 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -15,34 +15,84 @@
 package org.candlepin.resteasy;
 
 import org.apache.commons.lang3.StringUtils;
+
 import org.jboss.resteasy.spi.StringParameterUnmarshaller;
 import org.jboss.resteasy.util.FindAnnotation;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.xnap.commons.i18n.I18n;
 
 import java.lang.annotation.Annotation;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
+import javax.xml.bind.DatatypeConverter;
+
+
+
 /**
- * Formatter for dates on REST API parameters
+ * Formatter for parsing dates for parameters annotated with the DateFormat annotation.
  */
 public class DateFormatter implements StringParameterUnmarshaller<Date> {
-    private SimpleDateFormat formatter;
+    private static Logger log = LoggerFactory.getLogger(DateFormatter.class);
+
+    private String[] formats;
 
     public void setAnnotations(Annotation[] annotations) {
-        DateFormat format = FindAnnotation.findAnnotation(annotations, DateFormat.class);
-        formatter = new SimpleDateFormat(format.value());
+        DateFormat annotation = FindAnnotation.findAnnotation(annotations, DateFormat.class);
+
+        this.formats = annotation.value();
     }
 
-    public Date fromString(String str) {
-        if (StringUtils.isBlank(str)) {
-            return new Date(0);
+    public Date fromString(String value) {
+        // If we're null/empty, we have nothing to parse, so return null
+        if (!StringUtils.isBlank(value)) {
+            // If the value is our special value for "now", return a new Date instance
+            if (DateFormat.NOW.equals(value)) {
+                return new Date();
+            }
+
+            // If we have any formats specified, use those...
+            if (this.formats != null && this.formats.length > 0) {
+                for (String format : this.formats) {
+                    log.debug("Attempting to parse date \"{}\" using format: {}", value, format);
+
+                    try {
+                        SimpleDateFormat formatter = new SimpleDateFormat(format);
+                        return formatter.parse(value);
+                    }
+                    catch (ParseException exception) {
+                        // Whoops. Hopefully we have more formats to try...
+                        log.debug("Unable to parse date \"{}\" with format {}", value, format, exception);
+                    }
+                }
+
+                // If we made it here, we're out of formats to use to parse the date
+                log.debug("Unable to parse date: {}", value);
+
+                // TODO: If we ever work around the difficulty of getting an I18n instance at this
+                // point, translate this directly with the value in the error message.
+                throw new RuntimeException(I18n.marktr("Unable to parse date parameter"));
+            }
+            else {
+                try {
+                    log.debug("Attempting to parse date \"{}\" using ISO8601 date converter", value);
+
+                    // Use the DatatypeConverter to parse the date, as it accepts dates in ISO8601
+                    return DatatypeConverter.parseDateTime(value).getTime();
+                }
+                catch (IllegalArgumentException exception) {
+                    log.debug("Unable to parse date \"{}\" using ISO8601 date converter", value, exception);
+
+                    // TODO: Need more translation stuff here
+                    throw new RuntimeException(I18n.marktr("Unable to parse date parameter"));
+                }
+            }
         }
-        try {
-            return formatter.parse(str);
-        }
-        catch (ParseException e) {
-            throw new RuntimeException(e);
-        }
+
+        return null;
     }
 }

--- a/server/src/main/java/org/candlepin/resteasy/filter/AbstractAuthorizationFilter.java
+++ b/server/src/main/java/org/candlepin/resteasy/filter/AbstractAuthorizationFilter.java
@@ -51,8 +51,7 @@ public abstract class AbstractAuthorizationFilter
     private Marker duplicate = MarkerFactory.getMarker("DUPLICATE");
 
     @Override
-    public void filter(ContainerRequestContext requestContext)
-        throws IOException {
+    public void filter(ContainerRequestContext requestContext) throws IOException {
         try {
             runFilter(requestContext);
         }

--- a/server/src/test/java/org/candlepin/resource/OwnerResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/OwnerResourceTest.java
@@ -498,14 +498,14 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         poolCurator.create(pool2);
 
         List<Pool> nowList = ownerResource.listPools(owner.getKey(), c.getUuid(), null, null, null, false,
-            null, null, new ArrayList<KeyValueParameter>(), false, false, principal, null);
+            new Date(), null, new ArrayList<KeyValueParameter>(), false, false, principal, null);
+
         assertEquals(1, nowList.size());
         assert (nowList.get(0).getId().equals(pool1.getId()));
 
         Date activeOn = new Date(pool2.getStartDate().getTime() + 1000L * 60 * 60 * 24);
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
         List<Pool> futureList = ownerResource.listPools(owner.getKey(), c.getUuid(), null, null, null,
-            false, sdf.format(activeOn), null, new ArrayList<KeyValueParameter>(), false, false,
+            false, activeOn, null, new ArrayList<KeyValueParameter>(), false, false,
             principal, null);
         assertEquals(1, futureList.size());
         assert (futureList.get(0).getId().equals(pool2.getId()));

--- a/server/src/test/java/org/candlepin/resource/util/ResourceDateParserTest.java
+++ b/server/src/test/java/org/candlepin/resource/util/ResourceDateParserTest.java
@@ -95,8 +95,7 @@ public class ResourceDateParserTest {
 
     @Test
     public void parseDateTime() {
-        Date parsed = ResourceDateParser.parseDateString(
-            "1997-07-16T19:20:30-00:00");
+        Date parsed = ResourceDateParser.parseDateString("1997-07-16T19:20:30-00:00");
 
         Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
         cal.setTime(parsed);


### PR DESCRIPTION
- Updated several spec tests to use complete dates that include
  time zones to address an issue with pool visibility when created
  on a system with a time zone using a positive offset
- Updated candlepin_api to escape URIs and query parameters
  separately and more completely
- Updated several rspec tests and helper methods to no longer
  include query parameters when building request URIs
- Updated the DateFormat annotation and DateFormatter handler to
  process either ISO8601 date strings or lists of specifically
  supported formats
- Updated ConsumerResource and OwnerResource to use the changes
  made to the DateFormat annotation