### PR TITLE
Database failfast

### DIFF
--- a/server/spec/candlepin_scenarios.rb
+++ b/server/spec/candlepin_scenarios.rb
@@ -246,6 +246,29 @@ module CandlepinMethods
     asn1_body
   end
 
+  def assert_broker_state(mode_name, state)
+    mode = get_mode
+    expect(mode["mode"]).to eq(mode_name)
+    expect(mode["brokerState"]).to eq(state)
+  end
+
+  def assert_db_state(mode_name, state)
+    mode = get_mode
+    expect(mode["mode"]).to eq(mode_name)
+    expect(mode["dbState"]).to eq(state)
+  end
+
+  def assert_mode(mode_name)
+    mode = get_mode
+    expect(mode["mode"]).to eq(mode_name)
+  end
+
+  def get_mode
+    mode = @cp.get('/status')
+    expect(mode).to have_key("mode")
+    return mode
+  end
+
 end
 
 class Export

--- a/server/spec/db_failfast_spec.rb
+++ b/server/spec/db_failfast_spec.rb
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+require 'spec_helper'
+require 'candlepin_scenarios'
+
+
+describe 'DB failfast' do
+
+  include CandlepinMethods
+
+  after(:each) do
+    mode = get_mode
+    if mode["mode"] == "SUSPEND"
+      start_db
+      sleep(20)
+    end
+  end
+
+  def stop_db
+    `sudo systemctl stop postgresql || sudo supervisorctl stop postgresql`
+  end
+
+  def start_db
+    `sudo systemctl start postgresql || sudo supervisorctl start postgresql`
+  end
+
+  it 'DB down is detected' do
+    assert_mode('NORMAL')
+
+    stop_db
+    sleep(11)
+    assert_db_state('SUSPEND', 'DOWN')
+  end
+
+  it 'DB up is detected' do
+    assert_mode('NORMAL')
+
+    stop_db
+    sleep(11)
+    assert_db_state("SUSPEND", "DOWN")
+
+    start_db
+    sleep(20)
+    assert_db_state("NORMAL", "UP")
+  end
+
+  it 'old DB connections are closed after reconnect' do
+    assert_mode('NORMAL')
+
+    stop_db
+    sleep(11)
+    assert_db_state("SUSPEND", "DOWN")
+
+    start_db
+    sleep(20)
+    assert_db_state("NORMAL", "UP")
+    30.times do
+      create_owner random_string("test")
+    end
+  end
+
+end

--- a/server/src/main/java/org/candlepin/controller/ModeManager.java
+++ b/server/src/main/java/org/candlepin/controller/ModeManager.java
@@ -16,7 +16,8 @@ package org.candlepin.controller;
 
 import org.candlepin.model.CandlepinModeChange;
 import org.candlepin.model.CandlepinModeChange.Mode;
-import org.candlepin.model.CandlepinModeChange.Reason;
+import org.candlepin.model.CandlepinModeChange.BrokerState;
+import org.candlepin.model.CandlepinModeChange.DbState;
 
 /**
  * Class responsible for storing and managing the current Candlepin mode.
@@ -30,11 +31,21 @@ public interface ModeManager {
      */
     CandlepinModeChange getLastCandlepinModeChange();
     /**
-     * Enters a mode m. Reason should be a machine readable enumeration
+     * Enters a mode m.
      * @param m new Mode into which Candlepin should enter
-     * @param reason why is Candlepin entering this mode?
+     * @param brokerState State of Qpid when entering mode m.
+     * @param dbState State of Database when entering mode m.
      */
-    void enterMode(Mode m, Reason reason);
+    void enterMode(Mode m, BrokerState brokerState, DbState dbState);
+
+    /**
+     * Checks if given Qpid or DB state differ from the ones in modeChange
+     * @param modeChange Old mode and states
+     * @param brokerState New broker state
+     * @param dbState New DB state
+     * @return true if one of the new states differ from old, false otherwise.
+     */
+    boolean stateChanged(CandlepinModeChange modeChange, BrokerState brokerState, DbState dbState);
     /**
      * Checks if Candlepin is in suspend mode. In case it is, this method
      * will throw an error. This method is useful to quickly fail requests

--- a/server/src/main/java/org/candlepin/model/CandlepinModeChange.java
+++ b/server/src/main/java/org/candlepin/model/CandlepinModeChange.java
@@ -24,7 +24,8 @@ import java.util.Date;
 public class CandlepinModeChange implements Serializable {
     private static final long serialVersionUID = -7059065874812188168L;
     private final Mode mode;
-    private final Reason reason;
+    private final BrokerState brokerState;
+    private final DbState dbState;
     private final Date changeTime;
 
     /**
@@ -36,38 +37,56 @@ public class CandlepinModeChange implements Serializable {
     }
 
     /**
-     * Change reason
+     * Qpid broker state
      */
-    public enum Reason {
-        /**
-         * When Candlepin is starting up, it by default starts
-         * in NORMAL mode
-         */
-        STARTUP,
+    public enum BrokerState {
         /**
          * When Qpid broker isn't available, Candlepin must enter
          * Suspend mode
          */
-        QPID_DOWN,
+        DOWN,
         /**
          * Qpid comes back up
          */
-        QPID_UP,
+        UP,
         /**
          * Qpid is overloaded to a point where its not possible to
          * send messages to it
          */
-        QPID_FLOW_STOPPED
+        FLOW_STOPPED,
+        /**
+         * AMQP integration is turned off
+         */
+        OFF
     }
 
-    public CandlepinModeChange(Date changeTime, Mode mode, Reason reason) {
+    /**
+     * Database state
+     */
+    public enum DbState {
+        /**
+         * Database is not available, Candlepin must enter Suspend mode
+         */
+        DOWN,
+        /**
+         * Database connection is back up
+         */
+        UP
+    }
+
+    public CandlepinModeChange(Date changeTime, Mode mode, BrokerState brokerState, DbState dbState) {
         this.mode = mode;
         this.changeTime = changeTime;
-        this.reason = reason;
+        this.brokerState = brokerState;
+        this.dbState = dbState;
     }
 
-    public Reason getReason() {
-        return reason;
+    public BrokerState getBrokerState() {
+        return brokerState;
+    }
+
+    public DbState getDbState() {
+        return dbState;
     }
 
     public Mode getMode() {
@@ -80,8 +99,8 @@ public class CandlepinModeChange implements Serializable {
 
     @Override
     public String toString() {
-        return "CandlepinModeChange [mode=" + mode + ", reason=" + reason + ", changeTime=" +
-            changeTime + "]";
+        return "CandlepinModeChange [mode=" + mode + ", brokerState=" + brokerState + ", dbState=" + dbState +
+                ", changeTime=" + changeTime + "]";
     }
 
 

--- a/server/src/main/java/org/candlepin/model/Status.java
+++ b/server/src/main/java/org/candlepin/model/Status.java
@@ -16,7 +16,8 @@
 package org.candlepin.model;
 
 import org.candlepin.model.CandlepinModeChange.Mode;
-import org.candlepin.model.CandlepinModeChange.Reason;
+import org.candlepin.model.CandlepinModeChange.BrokerState;
+import org.candlepin.model.CandlepinModeChange.DbState;
 import org.candlepin.model.Rules.RulesSourceEnum;
 
 import java.util.Date;
@@ -39,10 +40,16 @@ public class Status {
      * The current Suspend Mode of Candlepin
      */
     private Mode mode;
+
     /**
-     * The reason for the last Suspend Mode change
+     * The current state of Qpid broker
      */
-    private Reason modeReason;
+    private BrokerState brokerState;
+
+    /**
+     * The current state of database
+     */
+    private DbState dbState;
 
     /**
      * Last time the mode was changed
@@ -81,8 +88,8 @@ public class Status {
     }
 
     public Status(Boolean result, String version, String release, Boolean standalone,
-        String rulesVersion, Rules.RulesSourceEnum rulesSource, Mode mode, Reason reason
-        , Date modeChangeTime) {
+        String rulesVersion, Rules.RulesSourceEnum rulesSource, Mode mode, BrokerState brokerState,
+        DbState dbState, Date modeChangeTime) {
         this.result = result;
         this.version = version;
         this.release = release;
@@ -90,7 +97,8 @@ public class Status {
         this.timeUTC = new Date();
         this.rulesVersion = rulesVersion;
         this.mode = mode;
-        this.modeReason = reason;
+        this.brokerState = brokerState;
+        this.dbState = dbState;
         this.modeChangeTime = modeChangeTime;
         this.setRulesSource(rulesSource);
     }
@@ -164,8 +172,12 @@ public class Status {
         return mode;
     }
 
-    public Reason getModeReason() {
-        return modeReason;
+    public BrokerState getBrokerState() {
+        return brokerState;
+    }
+
+    public DbState getDbState() {
+        return dbState;
     }
 
     public Date getModeChangeTime() {

--- a/server/src/main/resources/META-INF/persistence.xml
+++ b/server/src/main/resources/META-INF/persistence.xml
@@ -25,6 +25,7 @@
             <property name="hibernate.c3p0.idle_test_period" value="300" />
             <!-- max_statements should always be 0 -->
             <property name="hibernate.c3p0.max_statements" value="0" />
+            <property name="hibernate.c3p0.dataSourceName" value="hibernateDataSource" />
         </properties>
     </persistence-unit>
 

--- a/server/src/test/java/org/candlepin/cache/StatusCacheTest.java
+++ b/server/src/test/java/org/candlepin/cache/StatusCacheTest.java
@@ -46,7 +46,7 @@ public class StatusCacheTest {
         StatusCache cache = new StatusCache();
         Status status = new Status(true, "2.0", "2.0", false, "4.2",
             Rules.RulesSourceEnum.DATABASE, CandlepinModeChange.Mode.NORMAL,
-            CandlepinModeChange.Reason.STARTUP, new Date());
+            CandlepinModeChange.BrokerState.UP, CandlepinModeChange.DbState.UP, new Date());
         cache.setStatus(status);
         assertEquals(status, cache.getStatus());
     }
@@ -56,7 +56,7 @@ public class StatusCacheTest {
         StatusCache cache = new StatusCache();
         Status status = new Status(true, "2.0", "2.0", false, "4.2",
             Rules.RulesSourceEnum.DATABASE, CandlepinModeChange.Mode.NORMAL,
-            CandlepinModeChange.Reason.STARTUP, new Date());
+            CandlepinModeChange.BrokerState.UP, CandlepinModeChange.DbState.UP, new Date());
         cache.setStatus(status);
         assertEquals(status, cache.getStatus());
         Thread.sleep(6000L);
@@ -68,7 +68,7 @@ public class StatusCacheTest {
         StatusCache cache1 = new StatusCache();
         Status status = new Status(true, "2.0", "2.0", false, "4.2",
             Rules.RulesSourceEnum.DATABASE, CandlepinModeChange.Mode.NORMAL,
-            CandlepinModeChange.Reason.STARTUP, new Date());
+            CandlepinModeChange.BrokerState.UP, CandlepinModeChange.DbState.UP, new Date());
         cache1.setStatus(status);
 
         StatusCache cache2 = new StatusCache();

--- a/server/src/test/java/org/candlepin/model/StatusTest.java
+++ b/server/src/test/java/org/candlepin/model/StatusTest.java
@@ -20,7 +20,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import org.candlepin.model.CandlepinModeChange.Mode;
-import org.candlepin.model.CandlepinModeChange.Reason;
+import org.candlepin.model.CandlepinModeChange.BrokerState;
+import org.candlepin.model.CandlepinModeChange.DbState;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -40,13 +41,13 @@ public class StatusTest {
     public void init() {
         status = new Status(Boolean.TRUE, "1.0", "2",
             Boolean.TRUE, "2.0", Rules.RulesSourceEnum.DEFAULT,
-            Mode.NORMAL, Reason.QPID_UP, new Date());
+            Mode.NORMAL, BrokerState.UP, DbState.UP, new Date());
         statusUndef = new Status(Boolean.TRUE, "1.0", "2",
             Boolean.TRUE, "2.0", Rules.RulesSourceEnum.UNDEFINED,
-            Mode.NORMAL, Reason.QPID_UP, new Date());
+            Mode.NORMAL, BrokerState.UP, DbState.UP, new Date());
         statusDb = new Status(Boolean.TRUE, "1.0", "2",
             Boolean.TRUE, "2.0", Rules.RulesSourceEnum.DATABASE,
-            Mode.NORMAL, Reason.QPID_UP, new Date());
+            Mode.NORMAL, BrokerState.UP, DbState.UP, new Date());
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/pinsetter/core/PinsetterKernelTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/core/PinsetterKernelTest.java
@@ -112,7 +112,8 @@ public class PinsetterKernelTest {
         when(modeManager.getLastCandlepinModeChange()).thenReturn(
             new CandlepinModeChange(new Date(System.currentTimeMillis()),
             CandlepinModeChange.Mode.NORMAL,
-            CandlepinModeChange.Reason.STARTUP));
+            CandlepinModeChange.BrokerState.UP,
+            CandlepinModeChange.DbState.UP));
     }
 
     @Test(expected = InstantiationException.class)

--- a/server/src/test/java/org/candlepin/resource/StatusResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/StatusResourceTest.java
@@ -33,7 +33,8 @@ import org.candlepin.model.Rules;
 import org.candlepin.model.RulesCurator;
 import org.candlepin.model.Status;
 import org.candlepin.model.CandlepinModeChange.Mode;
-import org.candlepin.model.CandlepinModeChange.Reason;
+import org.candlepin.model.CandlepinModeChange.BrokerState;
+import org.candlepin.model.CandlepinModeChange.DbState;
 import org.candlepin.policy.js.JsRunnerProvider;
 
 import org.junit.Before;
@@ -72,7 +73,7 @@ public class StatusResourceTest {
         MockitoAnnotations.initMocks(this);
 
         CandlepinModeChange mockModeChange =
-            new CandlepinModeChange(new Date(), Mode.NORMAL, Reason.STARTUP);
+            new CandlepinModeChange(new Date(), Mode.NORMAL, BrokerState.UP, DbState.UP);
         CandlepinQuery mockCPQuery = mock(CandlepinQuery.class);
         when(mockCPQuery.list()).thenReturn(new ArrayList<Rules>());
 


### PR DESCRIPTION
This extends the current failfast check that runs every 10 secs and uses it to check if the connection to database is ok.
If it is not, SUSPEND mode is entered and vice versa.
Before the transition from SUSPEND to NORMAL mode due to DB recovery all database connection in the pool will be closed.