### PR TITLE
1440945: Support manifest ext params in deprecated API

### DIFF
--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -1996,11 +1996,15 @@ public class ConsumerResource {
         @PathParam("consumer_uuid") @Verify(Consumer.class) String consumerUuid,
         @QueryParam("cdn_label") String cdnLabel,
         @QueryParam("webapp_prefix") String webAppPrefix,
-        @QueryParam("api_url") String apiUrl) {
+        @QueryParam("api_url") String apiUrl,
+        @QueryParam("ext") @CandlepinParam(type = KeyValueParameter.class)
+        @ApiParam(value = "Key/Value pairs to be passed to the extension adapter when generating a manifest",
+        required = false, example = "ext=version:1.2.3&ext=extension_key:EXT1")
+        List<KeyValueParameter> extensionArgs) {
 
         try {
             File archive = manifestManager.generateManifest(consumerUuid, cdnLabel, webAppPrefix, apiUrl,
-                new HashMap<String, String>());
+                getExtensionParamMap(extensionArgs));
             response.addHeader("Content-Disposition", "attachment; filename=" + archive.getName());
             return archive;
         }

--- a/server/src/test/java/org/candlepin/controller/ManifestManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/ManifestManagerTest.java
@@ -113,6 +113,7 @@ public class ManifestManagerTest {
         String webAppPrefix = "webapp-prefix";
         String apiUrl = "api-url";
         Map<String, String> extData = new HashMap<String, String>();
+        extData.put("version", "1.0");
 
         List<Entitlement> ents = new ArrayList<Entitlement>();
         when(entitlementCurator.listByConsumer(eq(consumer))).thenReturn(ents);

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
@@ -276,7 +276,8 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
         consumerCurator.update(consumer);
         setupPrincipal(owner, Access.READ_ONLY);
         securityInterceptor.enable();
-        consumerResource.exportData(mock(HttpServletResponse.class), consumer.getUuid(), null, null, null);
+        consumerResource.exportData(mock(HttpServletResponse.class), consumer.getUuid(), null, null, null,
+            new ArrayList<KeyValueParameter>());
         // if no exception, we're good
     }
 


### PR DESCRIPTION
Added the manifest extension params to the synchronous
export API.

### Testing Notes

Testing this is a little hackish since the default implementation of the ExportExtensionAdapter does nothing. After checking out this PR's branch, modify the DefaultExportExtensionAdapter.java to look like below. During an export, any provided ext params will be put in a file in the 'extensions' dir of the manifest zip.

```java
/**
 * Copyright (c) 2009 - 2016 Red Hat, Inc.
 *
 * This software is licensed to you under the GNU General Public License,
 * version 2 (GPLv2). There is NO WARRANTY for this software, express or
 * implied, including the implied warranties of MERCHANTABILITY or FITNESS
 * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
 * along with this software; if not, see
 * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 *
 * Red Hat trademarks are not licensed under GPLv2. No permission is
 * granted to use or replicate Red Hat trademarks that are incorporated
 * in this software or its documentation.
 */
package org.candlepin.service.impl;

import java.io.File;
import java.io.FileWriter;
import java.io.IOException;
import java.util.Map;
import java.util.Map.Entry;

import org.candlepin.model.Consumer;
import org.candlepin.service.ExportExtensionAdapter;
import org.slf4j.Logger;
import org.slf4j.LoggerFactory;

/**
 * The default implementation of the {@link ExportExtensionAdapter}. This adapter adds
 * nothing to the manifest.
 *
 */
public class DefaultExportExtensionAdapter implements ExportExtensionAdapter {

    private static Logger log =
            LoggerFactory.getLogger(DefaultExportExtensionAdapter.class);

    @Override
    public void extendManifest(File extensionDir, Consumer targetConsumer, Map<String, String> extensionData)
        throws IOException {
        // The default implementation does nothing.
        File target = new File(extensionDir, "ext.txt");
        FileWriter w = new FileWriter(target);
        try {
            log.info("###### EXPORTING WITH EXTENSIONS:");
            for (Entry<String, String> next : extensionData.entrySet()) {
                log.info("-- {}: {}", next.getKey(), next.getValue());
                w.append(next.getKey() + ": " + next.getValue());
            }
        }
        finally {
            w.close();
        }

    }

}
```

Make sure you redeploy!!!!!! Then follow the steps below to create a distributor and to download a manifest.

```bash
# Register a distributor consumer
$ sudo subscription-manager register --org admin --user admin --pass admin --type candlepin

# List available pools and attach a subscription to that consumer
$ sudo subscription-manager list --available  --pool-only
$ sudo subscription-manager attach --pool POOL_ID

# Find the identity of your consumer and download the manifest with the **synchronous** API.
$ sudo subscription-manager identity
$ wget --no-check-certificate --content-disposition --user admin --password admin "https://localhost:8443/candlepin/consumers/YOUR_CONSUMER_UUID/export?ext=version:1.2.3&ext=username:test_user"
```

Check that the manifest has an extension dir containing a file with the ext params and values in it. The export dir is inside the manifest.zip --> consumer_export.zip --> export/extensions