### PR TITLE
Update Pool.cdn reference on Cdn deletion

### DIFF
--- a/server/src/main/java/org/candlepin/controller/CdnManager.java
+++ b/server/src/main/java/org/candlepin/controller/CdnManager.java
@@ -20,6 +20,7 @@ import org.candlepin.model.Cdn;
 import org.candlepin.model.CdnCertificate;
 import org.candlepin.model.CdnCurator;
 import org.candlepin.model.CertificateSerialCurator;
+import org.candlepin.model.PoolCurator;
 
 import java.util.Arrays;
 
@@ -30,11 +31,14 @@ public class CdnManager {
 
     private CdnCurator cdnCurator;
     private CertificateSerialCurator certSerialCurator;
+    private PoolCurator poolCurator;
 
     @Inject
-    public CdnManager(CdnCurator cdnCurator, CertificateSerialCurator certSerialCurator) {
+    public CdnManager(CdnCurator cdnCurator, PoolCurator poolCurator,
+        CertificateSerialCurator certSerialCurator) {
         this.cdnCurator = cdnCurator;
         this.certSerialCurator = certSerialCurator;
+        this.poolCurator = poolCurator;
     }
 
     /**
@@ -76,8 +80,7 @@ public class CdnManager {
      */
     @Transactional
     public void deleteCdn(Cdn cdn) {
-        // FIXME When a Cdn is referenced by a Pool, and is deleted, an exception occurs.
-        //       We should handle this here.
+        poolCurator.removeCdn(cdn);
         cdnCurator.delete(cdn);
     }
 }

--- a/server/src/main/java/org/candlepin/model/CdnCurator.java
+++ b/server/src/main/java/org/candlepin/model/CdnCurator.java
@@ -15,8 +15,8 @@
 package org.candlepin.model;
 
 import com.google.inject.Inject;
+import com.google.inject.persist.Transactional;
 import org.hibernate.criterion.Restrictions;
-
 
 
 /**
@@ -48,5 +48,10 @@ public class CdnCurator
      */
     public void update(Cdn cdn) {
         save(cdn);
+    }
+
+    @Transactional
+    public void delete(Cdn toDelete) {
+        getEntityManager().remove(toDelete);
     }
 }

--- a/server/src/main/java/org/candlepin/model/PoolCurator.java
+++ b/server/src/main/java/org/candlepin/model/PoolCurator.java
@@ -1394,4 +1394,19 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
         query.setParameterList("productIds", productIds);
         query.executeUpdate();
     }
+
+    @Transactional
+    public void removeCdn(Cdn cdn) {
+        if (cdn == null) {
+            throw new IllegalArgumentException("Attempt to remove pool's cdn with null cdn value.");
+        }
+        List<Pool> pools = getEntityManager()
+            .createQuery("select p from Pool p where p.cdn = :cdn")
+            .setParameter("cdn", cdn)
+            .getResultList();
+        if (pools.isEmpty()) {
+            return;
+        }
+        pools.get(0).setCdn(null);
+    }
 }


### PR DESCRIPTION
When a Cdn is deleted and is associated with a pool,
we need to update the pool reference. Otherwise, hibernate
will throw an exception.