### PR TITLE
Mark modifying ents as dirty if not already

### DIFF
--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -1553,10 +1553,7 @@ public class CandlepinPoolManager implements PoolManager {
         }
         else {
             regenerateCertificatesOf(consumer, true);
-            this.ecGenerator.regenerateCertificatesByEntitlementIds(
-                this.entitlementCurator.batchListModifying(Collections.singleton(entitlement)),
-                true
-            );
+            this.entitlementCurator.markModifyingEntsDirty(Collections.singleton(entitlement));
         }
 
         /*
@@ -1767,11 +1764,8 @@ public class CandlepinPoolManager implements PoolManager {
          * modifier entitlements that need to have their certificates regenerated
          */
         if (regenCertsAndStatuses) {
-            Collection<String> modifiedEntIds = this.entitlementCurator.batchListModifying(entsToRevoke);
-            log.debug("Regenerating certificates for modifying entitlements: {}", modifiedEntIds);
-
-            this.ecGenerator.regenerateCertificatesByEntitlementIds(modifiedEntIds,  true);
-            log.debug("Modifier entitlements done.");
+            int update = this.entitlementCurator.markModifyingEntsDirty(entsToRevoke);
+            log.debug("Marked {} modifying entitlements as dirty.", update);
         }
 
         log.info("Starting batch delete of pools");

--- a/server/src/main/java/org/candlepin/resource/OwnerProductResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerProductResource.java
@@ -177,6 +177,7 @@ public class OwnerProductResource {
      * @return
      *  the Content instance for the content with the specified id
      */
+
     protected Content fetchContent(Owner owner, String contentId) {
         Content content = this.ownerContentCurator.getContentById(owner, contentId);
 

--- a/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -958,7 +958,7 @@ public class PoolManagerTest {
         int total = manager.revokeAllEntitlements(c);
 
         assertEquals(2, total);
-        verify(entitlementCurator, never()).listModifying(any(Entitlement.class));
+        verify(entitlementCurator, times(1)).markModifyingEntsDirty(any(List.class));
         //TODO assert batch revokes have been called
     }
 


### PR DESCRIPTION
HQL didnt help here, there was a bug that always resulted in a weird error "References to collections must be define a SQL alias" 
This happens due to the left outer join with products in the inner class fwiw.
resorting to native query here.

There was also a unit test in PoolManagerTest that did not make sense to me, please take a second look, I think what I did makes sense. we were ensuring a method isnt called before, but that method is only used in tests a.t.m.