### PR TITLE
Added indexes to various tables (CP 2.0)

### DIFF
--- a/server/src/main/resources/db/changelog/20150210094558-perorgproducts-phase-1.xml
+++ b/server/src/main/resources/db/changelog/20150210094558-perorgproducts-phase-1.xml
@@ -30,6 +30,12 @@
         </createTable>
     </changeSet>
 
+    <changeSet id="20150210094558-01b" author="crog">
+        <createIndex indexName="cp2_products_idx2" tableName="cp2_products" unique="false">
+            <column name="product_id"/>
+        </createIndex>
+    </changeSet>
+
 
 
     <!-- cp2_owner_products -->
@@ -120,6 +126,15 @@
         </createTable>
     </changeSet>
 
+    <changeSet id="20150210094558-06b" author="crog">
+        <createIndex indexName="cp2_content_idx2" tableName="cp2_content" unique="false">
+            <column name="content_id"/>
+        </createIndex>
+    </changeSet>
+
+
+
+    <!-- cp2_owner_content -->
     <changeSet id="20150210094558-07" author="crog">
         <createTable tableName="cp2_owner_content">
             <column name="owner_id" type="varchar(32)">
@@ -493,6 +508,19 @@
             columnNames="pool_id, subscription_id, subscription_sub_key"
             constraintName="cp2_pool_source_sub_unq1"
         />
+    </changeSet>
+
+    <changeSet id="20150210094558-34b" author="crog">
+        <!-- Since this is a retroactive addition to a table that we delete in a future changeset, we need
+             to ensure that the table still exists before we go attempting to add an index to it. -->
+        <preConditions onFail="MARK_RAN" onError="HALT">
+            <tableExists tableName="cp_pool_products"/>
+        </preConditions>
+
+        <!-- This table won't last after the migration, but this index drastically reduces migration time -->
+        <createIndex indexName="cp_pool_products_idx1" tableName="cp_pool_products" unique="false">
+            <column name="product_id"/>
+        </createIndex>
     </changeSet>
 
 

--- a/server/src/main/resources/db/changelog/20170214115606-uber-cert-rewrite.xml
+++ b/server/src/main/resources/db/changelog/20170214115606-uber-cert-rewrite.xml
@@ -7,7 +7,7 @@
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
 
     <!-- ********************************************************************* -->
-    <!-- *** Postgres/Oracle cleanup                                                                                                   ** -->
+    <!-- *** Postgres/Oracle cleanup                                        ** -->
     <!-- ********************************************************************* -->
     <changeSet id="20170214115606-1" dbms="postgresql,oracle,hsqldb" author="mstead">
         <comment>Cleanup all ueber data so that the new style ueber certs can be used.</comment>
@@ -89,7 +89,7 @@
     </changeSet>
 
     <!-- ********************************************************************* -->
-    <!-- *** MySQL cleanup                                                                                                                  ** -->
+    <!-- *** MySQL cleanup                                                  ** -->
     <!-- ********************************************************************* -->
     <changeSet id="20170214115606-3" dbms="mysql" author="mstead">
         <comment>Cleanup all ueber data so that the new style ueber certs can be used.</comment>


### PR DESCRIPTION
- Added an index to cp2_products.product_id and cp2_content.content_id.
  These should help improve overall performance, as many of our queries
  still do RHID-oriented lookups rather than using the UUID.
- Added an index to cp_pool_products.product_id, which should
  significantly improve migration times