### PR TITLE
1445010: Fix permission issue on getting pools for an AK

### DIFF
--- a/server/src/main/java/org/candlepin/resource/ActivationKeyResource.java
+++ b/server/src/main/java/org/candlepin/resource/ActivationKeyResource.java
@@ -109,7 +109,7 @@ public class ActivationKeyResource {
     @Path("{activation_key_id}/pools")
     @Produces(MediaType.APPLICATION_JSON)
     public Iterator<Pool> getActivationKeyPools(
-        @PathParam("activation_key_id") String activationKeyId) {
+        @PathParam("activation_key_id") @Verify(ActivationKey.class) String activationKeyId) {
 
         ActivationKey key = activationKeyCurator.verifyAndLookupKey(activationKeyId);
 


### PR DESCRIPTION
Fetching the pools for an activation key was
being scoped to a Super Admin. Loosened this
permission to anyone with access to the AK.