### PR TITLE
Added the skip_existing option to the populate hosted DB task

### DIFF
--- a/server/src/main/java/org/candlepin/model/ProductCurator.java
+++ b/server/src/main/java/org/candlepin/model/ProductCurator.java
@@ -27,6 +27,7 @@ import org.hibernate.sql.JoinType;
 import org.xnap.commons.i18n.I18n;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -174,4 +175,23 @@ public class ProductCurator extends AbstractHibernateCurator<Product> {
             .setProjection(Projections.id())
             .list();
     }
+
+    /**
+     * Fetches the list of existing product IDs currently available in the Candlepin database. If
+     * there are no existing products, this method returns an empty list.
+     *
+     * @return
+     *  The list of currently existing product IDs
+     */
+    public List<String> getExistingProductIds() {
+        // Impl notes:
+        // - At this point in CP, id is the primary key for Product, so we don't need to explicitly
+        //   request distinct IDs.
+        List<String> ids = this.getEntityManager()
+            .createQuery("SELECT id FROM Product", String.class)
+            .getResultList();
+
+        return ids != null ? ids : Collections.<String>emptyList();
+    }
+
 }

--- a/server/src/main/java/org/candlepin/resource/AdminResource.java
+++ b/server/src/main/java/org/candlepin/resource/AdminResource.java
@@ -36,9 +36,11 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
 /**
@@ -121,16 +123,18 @@ public class AdminResource {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Path("pophosteddb")
-    public JobDetail populatedHostedDB() {
+    public JobDetail populatedHostedDB(
+        @QueryParam("skip_existing") @DefaultValue("false") boolean skipExisting) {
+
         // TODO: Remove this method once we no longer need the task.
 
-        // Impl note: We don't need to bother doing this
+        // Impl note: We don't need to bother doing this task in standalone mode
         if (config.getBoolean(ConfigProperties.STANDALONE)) {
             log.warn("Ignoring populate DB request in standalone environment");
             return null;
         }
 
-        return PopulateHostedDBTask.createAsyncTask();
+        return PopulateHostedDBTask.createAsyncTask(skipExisting);
     }
 
 }


### PR DESCRIPTION
- Added support for a skip_existing query parameter/option for
  the populate hosted DB task which will skip fetching and updating
  product information for products which already exist in the local
  database
- When the hosted DB population job runs, it will now verify that the
  products it requested were fetched; for each product it determines
  was omitted, a warning will be printed. Additionally, the final
  job status now includes the number of "unresolved references" hit.