### PR TITLE
1395747: Fix incorrect semantics in entitlement certificate SANs.

### DIFF
--- a/server/spec/identity_spec.rb
+++ b/server/spec/identity_spec.rb
@@ -45,4 +45,14 @@ describe 'Identity Certificate' do
     cert_time = @identity_cert.not_before
     cert_time.should < before
   end
+
+  it 'contains the consumer name and uuid in subject alternative names' do
+    e = @identity_cert.extensions.select { |e| e.oid == 'subjectAltName' }.first
+    expect(e).to_not be_nil
+    name = @consumer['name']
+    uuid = @consumer['uuid']
+
+    expect(e.value).to match(/CN=#{name}/)
+    expect(e.value).to match(/CN=#{uuid}/)
+  end
 end


### PR DESCRIPTION
Prior to this patch, identity certificates were adding a distinguished name with the consumer name (generally the hostname) as a URI.  This behavior is obviously incorrect, but the question of what the correct behavior should be isn't immediately obvious.

I discuss my reasoning in the [bug](https://bugzilla.redhat.com/show_bug.cgi?id=1395747), but in short, I elected to add both the subject field as a distinguished name and the consumer name as a distinguished name to the subject alternative names extension.  An identity certificate's subject alternative name extension will now look something like this:

```
X509v3 Subject Alternative Name: 
    DirName:/CN=048d9b62-7665-4878-966b-6434d6b80a67, DirName:/CN=consumer-Fo7o5y9a
```

when viewed with `openssl x509 -in CERT_FILE -noout -text`.

This change should correct the erroneous semantics we were using before as well as preserve the consumer name information in the identity certificate.