### PR TITLE
Consolidated and refactored the database locking methods

### DIFF
--- a/server/spec/consumer_resource_host_guest_spec.rb
+++ b/server/spec/consumer_resource_host_guest_spec.rb
@@ -195,7 +195,7 @@ describe 'Consumer Resource Host/Guest' do
     host2['uuid'].should == host_consumer2['uuid']
   end
 
-  it 'guest should impose SLA on host auto-attach' do
+  it 'guest should not impose SLA on host auto-attach' do
     uuid1 = random_string('system.uuid')
     uuid2 = random_string('system.uuid')
     uuid3 = random_string('system.uuid')

--- a/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
+++ b/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
@@ -21,12 +21,13 @@ import org.candlepin.common.paging.Page;
 import org.candlepin.common.paging.PageRequest;
 import org.candlepin.guice.PrincipalProvider;
 
+import org.apache.commons.collections.CollectionUtils;
+
 import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.persist.Transactional;
 
-import org.apache.commons.collections.CollectionUtils;
 import org.hibernate.Criteria;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
@@ -37,7 +38,13 @@ import org.hibernate.criterion.Order;
 import org.hibernate.criterion.Projection;
 import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
+import org.hibernate.engine.spi.EntityKey;
+import org.hibernate.engine.spi.PersistenceContext;
 import org.hibernate.internal.CriteriaImpl;
+import org.hibernate.internal.SessionImpl;
+import org.hibernate.jpa.AvailableSettings;
+import org.hibernate.metadata.ClassMetadata;
+import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.transform.ResultTransformer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,15 +53,31 @@ import org.xnap.commons.i18n.I18n;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
+import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import java.util.TreeMap;
+import java.util.TreeSet;
 
+import javax.persistence.CacheRetrieveMode;
+import javax.persistence.CacheStoreMode;
 import javax.persistence.EntityManager;
+import javax.persistence.FlushModeType;
 import javax.persistence.LockModeType;
 import javax.persistence.NonUniqueResultException;
+import javax.persistence.NoResultException;
 import javax.persistence.OptimisticLockException;
 import javax.persistence.TypedQuery;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Root;
+import javax.persistence.criteria.ParameterExpression;
+import javax.persistence.criteria.Path;
+
+
 
 /**
  * AbstractHibernateCurator base class for all Candlepin curators. Curators are
@@ -66,6 +89,7 @@ import javax.persistence.TypedQuery;
 public abstract class AbstractHibernateCurator<E extends Persisted> {
     // Oracle has a limit of 1000
     public static final int IN_OPERATOR_BLOCK_SIZE = 999;
+
     // Oracle has a limit of 255 arguments per CASE, which caps us around 100 entries.
     public static final int CASE_OPERATOR_BLOCK_SIZE = 100;
     public static final int BATCH_BLOCK_SIZE = 500;
@@ -687,10 +711,6 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
         }
     }
 
-    public void lock(E object, LockModeType lmt) {
-        this.getEntityManager().lock(object, lmt);
-    }
-
     public E evict(E entity) {
         this.currentSession().evict(entity);
         return entity;
@@ -767,47 +787,386 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
         return count;
     }
 
-    public List<E> lockAndLoadBatch(Iterable<String> ids, String entityName, String keyName) {
-        List<E> result = new LinkedList<E>();
-
-        if (ids != null && ids.iterator().hasNext()) {
-            StringBuilder hql = new StringBuilder("SELECT obj FROM ")
-                .append(entityName)
-                .append(" obj WHERE ")
-                .append(keyName)
-                .append(" IN (:ids)");
-
-            javax.persistence.Query query = this.getEntityManager()
-                .createQuery(hql.toString())
-                .setLockMode(LockModeType.PESSIMISTIC_WRITE);
-
-            for (List<String> block : Iterables.partition(ids, IN_OPERATOR_BLOCK_SIZE)) {
-                query.setParameter("ids", block);
-                result.addAll((List<E>) query.getResultList());
-            }
-
-            //In some situations, even after locking the entity we
-            //got stale in the entity e.g. Pool.consumed
-            //This refresh reloads the entity after the lock has
-            //been issued.
-            for (E e : result) {
-                getEntityManager().refresh(e);
-            }
-        }
-
-        return result;
+    /**
+     * Locks the specified entity with a pessimistic write lock. Note that the entity will not be
+     * refreshed as a result of a call to this method. If the entity needs to be locked and
+     * refreshed, use the lockAndLoad method family instead.
+     *
+     * @param entity
+     *  The entity to lock
+     *
+     * @throws IllegalArgumentException
+     *  if entity is null
+     *
+     * @return
+     *  The locked entity
+     */
+    public E lock(E entity) {
+        return this.lock(entity, LockModeType.PESSIMISTIC_WRITE);
     }
 
-    public List<E> lockAndLoadBatchById(Iterable<String> ids) {
-        List<E> result = new LinkedList<E>();
-        for (String id : ids) {
-            // Load at the current lock level so an existing object in the session will be loaded
-            // if it already exists.
-            E entity = getEntityManager().find(this.entityType(), id);
-            // Use refresh in order to upgrade the lock level & return the new version of the entity
-            getEntityManager().refresh(entity, LockModeType.PESSIMISTIC_WRITE);
-            result.add(entity);
+    /**
+     * Locks the specified entity using the given lock mode. Note that the entity will not be
+     * refreshed as a result of a call to this method. If the entity needs to be locked and
+     * refreshed, use the lockAndLoad method family instead.
+     *
+     * @param entity
+     *  The entity to lock
+     *
+     * @param lockMode
+     *  The lock mode to apply to the entity
+     *
+     * @throws IllegalArgumentException
+     *  if either entity or lockMode are null
+     *
+     * @return
+     *  The locked entity
+     */
+    public E lock(E entity, LockModeType lockMode) {
+        if (entity == null) {
+            throw new IllegalArgumentException("entity is null");
         }
+
+        if (lockMode == null) {
+            throw new IllegalArgumentException("lockMode is null");
+        }
+
+        this.getEntityManager().lock(entity, lockMode);
+        return entity;
+    }
+
+    /**
+     * Refreshes/reloads the given entity and locks it using a pessimistic write lock.
+     *
+     * @param entity
+     *  The entity to lock and load
+     *
+     * @return
+     *  The locked entity
+     */
+    public E lockAndLoad(E entity) {
+        if (entity == null) {
+            throw new IllegalArgumentException("entity is null");
+        }
+
+        // Pull the entity's metadata and identifier, just in case we were passed a detached
+        // entity or some such.
+        SessionImpl session = (SessionImpl) this.currentSession();
+        ClassMetadata metadata = session.getSessionFactory().getClassMetadata(this.entityType);
+
+        if (metadata == null || !metadata.hasIdentifierProperty()) {
+            throw new UnsupportedOperationException(
+                "lockAndLoad only supports entities with database identifiers");
+        }
+
+        return this.lockAndLoadById(this.entityType, metadata.getIdentifier(entity, session));
+    }
+
+    /**
+     * Locks the given collection of entities, reloading them as necessary.
+     *
+     * @param entities
+     *  A collection of entities to lock
+     *
+     * @throws RuntimeException
+     *  If this method is called for a curator handling an entity type that is not a subclass of
+     *  the AbstractHibernateObject class.
+     *
+     * @return
+     *  The collection of locked entities
+     */
+    public Collection<E> lockAndLoad(Iterable<E> entities) {
+        // Impl note:
+        // We're going to take advantage of some blackbox knowledge of how LockAndLoadByIds works to
+        // minimize the amount of extra loops we need to do. We can pass a custom iterable which
+        // fetches the entity's ID on the call to "next" and pass that through to LockAndLoadByIds.
+
+        if (entities == null) {
+            return Collections.<E>emptyList();
+        }
+
+        // We redeclare the collection here so we don't require the final modifier in subclass
+        // definitions
+        final Iterable<E> entityCollection = entities;
+        final SessionImpl session = (SessionImpl) this.currentSession();
+        final ClassMetadata metadata = session.getSessionFactory().getClassMetadata(this.entityType);
+
+        if (metadata == null || !metadata.hasIdentifierProperty()) {
+            throw new UnsupportedOperationException(
+                "lockAndLoad only supports entities with database identifiers");
+        }
+
+        Iterable<Serializable> iterable = new Iterable<Serializable>() {
+            @Override
+            public Iterator<Serializable> iterator() {
+                return new Iterator<Serializable>() {
+                    private Iterator<E> entityIterator;
+
+                    /* initializer */ {
+                        this.entityIterator = entityCollection.iterator();
+                    }
+
+                    @Override
+                    public boolean hasNext() {
+                        return this.entityIterator.hasNext();
+                    }
+
+                    @Override
+                    public Serializable next() {
+                        E next = this.entityIterator.next();
+                        return next != null ? metadata.getIdentifier(next, session) : null;
+                    }
+
+                    @Override
+                    public void remove() {
+                        this.entityIterator.remove();
+                    }
+                };
+            }
+        };
+
+        return this.lockAndLoadByIds(this.entityType, iterable);
+    }
+
+    /**
+     * Loads an entity with a pessimistic lock using the specified ID. If the entity has already
+     * been loaded, it will be refreshed with the lock instead. If a  matching entity could not be
+     * found, this method returns null.
+     *
+     * @param id
+     *  The id of the entity to load/refresh and lock
+     *
+     * @return
+     *  A locked entity instance, or null if a matching entity could not be found
+     */
+    public E lockAndLoadById(Serializable id) {
+        return this.lockAndLoadById(this.entityType, id);
+    }
+
+    /**
+     * Loads an entity with a pessimistic lock using the specified entity class and ID. If the
+     * entity has already been loaded, it will be refreshed with the lock instead. If a  matching
+     * entity could not be found, this method returns null.
+     *
+     * @param entityClass
+     *  The class representing the type of entity to fetch (i.e. Pool.class or Product.class)
+     *
+     * @param id
+     *  The id of the entity to load/refresh and lock
+     *
+     * @return
+     *  A locked entity instance, or null if a matching entity could not be found
+     */
+    protected E lockAndLoadById(Class<E> entityClass, Serializable id) {
+        EntityManager entityManager = this.getEntityManager();
+        SessionImpl session = (SessionImpl) this.currentSession();
+        ClassMetadata metadata = session.getFactory().getClassMetadata(entityClass);
+
+        // Get the entity's metadata so we can ask Hibernate for the name of its identifier
+        // and check if it's already in the session cache without doing a database lookup
+        if (metadata == null || !metadata.hasIdentifierProperty()) {
+            throw new UnsupportedOperationException(
+                "lockAndLoad only supports entities with database identifiers");
+        }
+
+        // Fetch the entity persister and session context so we can check the session cache for an
+        // entity before hitting the database.
+        EntityPersister persister = session.getFactory().getEntityPersister(metadata.getEntityName());
+        PersistenceContext context = session.getPersistenceContext();
+
+        // Lookup whether or not we have an entity with a given ID in the current session's cache.
+        // See the notes in lockAndLoadByIds for details as to why we're going about it this way.
+        EntityKey key = session.generateEntityKey(id, persister);
+        E entity = (E) context.getEntity(key);
+
+        if (entity == null) {
+            // The entity isn't in the local session, we'll need to query for it
+
+            String idName = metadata.getIdentifierPropertyName();
+            if (idName == null) {
+                // This shouldn't happen.
+                throw new RuntimeException("Unable to fetch identifier property name");
+            }
+
+            // Impl note:
+            // We're building the query here using JPA Criteria to avoid fiddling with string
+            // building and, potentially, erroneously using the class name as the entity name.
+            // Additionally, using a query (as opposed to the .find and .load methods) lets us set
+            // the flush, cache and lock modes for the entity we're attempting to fetch.
+            CriteriaBuilder builder = entityManager.getCriteriaBuilder();
+            CriteriaQuery<E> query = builder.createQuery(entityClass);
+            Root<E> root = query.from(entityClass);
+            Path<Serializable> target = root.<Serializable>get(idName);
+            ParameterExpression<Serializable> param = builder.parameter(Serializable.class);
+
+            query.select(root).where(builder.equal(target, param));
+
+            // Note that it's critical here to set both modes, as Hibernate is wildly inconsistent
+            // (and non-standard) in which properties it actually accepts when processing its own
+            // config objects. The cache mode combination specified below ends up being evaluated
+            // by Hibernate down to a CacheMode.REFRESH.
+            try {
+                entity = entityManager.createQuery(query)
+                    .setFlushMode(FlushModeType.COMMIT)
+                    .setHint(AvailableSettings.SHARED_CACHE_RETRIEVE_MODE, CacheRetrieveMode.BYPASS)
+                    .setHint(AvailableSettings.SHARED_CACHE_STORE_MODE, CacheStoreMode.REFRESH)
+                    .setLockMode(LockModeType.PESSIMISTIC_WRITE)
+                    .setParameter(param, id)
+                    .getSingleResult();
+            }
+            catch (NoResultException exception) {
+                // No entity found matching the ID. We don't define this as an error case, so we're
+                // going to silently discard the exception.
+            }
+        }
+        else {
+            // It's already available locally. Issue a refresh with a lock.
+            entityManager.refresh(entity, LockModeType.PESSIMISTIC_WRITE);
+        }
+
+        return entity;
+    }
+
+    /**
+     * Loads the entities represented by the given IDs with a pessimistic write lock. If no
+     * entities were found with the given IDs, this method returns an empty collection.
+     *
+     * @param ids
+     *  A collection of entity IDs to use to load and lock the represented entities
+     *
+     * @return
+     *  A collection of locked entities represented by the given IDs
+     */
+    public Collection<E> lockAndLoadByIds(Iterable<? extends Serializable> ids) {
+        return this.lockAndLoadByIds(this.entityType, ids);
+    }
+
+    /**
+     * Loads a collection of entities with a pessimistic lock using the specified entity class
+     * and collection of IDs. If no entities could be found matching the given IDs, this method
+     * returns an empty collection. Note that this method makes no attempt to ensure that an entity
+     * is loaded for every ID provided. It is possible for the output collection to be smaller than
+     * the provided set of IDs.
+     * <p></p>
+     * Depending on the session state when this method is called, this method may perform a refresh
+     * on each entity individually rather than performing a bulk lookup. This is due to a current
+     * limitation in Hibernate that forces use of the L1 cache when executing a query. To avoid
+     * this bottleneck, before calling this method, the caller should either evict the target
+     * entities from the session -- using session.evict or session.clear -- or use this method to
+     * perform the initial lookup straight away. Entities which are not already in the session
+     * cache will be fetched and locked in bulk, rather than refreshed and locked individually.
+     *
+     * @param entityClass
+     *  The class representing the type of the entity to load (i.e. Pool.class or Product.class)
+     *
+     * @param ids
+     *  A collection of IDs to use to load
+     *
+     * @return
+     *  A collection of locked entities matching the given values
+     */
+    protected Collection<E> lockAndLoadByIds(Class<E> entityClass, Iterable<? extends Serializable> ids) {
+        // The lockAndLoadById(s) methods work in two separate stages. The first stage determines
+        // whether or not an entity associated with a given ID is present in Hibernate's L1 cache.
+        // If it is, we need to fetch it from the cache and perform an explicit refresh operation
+        // for that entity. Otherwise, if it is not present, we can do a normal(ish) query to fetch
+        // it, and any other non-present entities.
+        //
+        // Unfortunately, there isn't a single, concise method for performing such a lookup.
+        // Instead, we need to check with the persistence context and determine whether or not it
+        // has an entity associated with a given entity key, which we generate using the session
+        // and entity persister. It's convoluted, but necessary to get consistently correct
+        // behavior from these methods.
+        List<E> result = new ArrayList<E>();
+
+        if (ids != null && ids.iterator().hasNext()) {
+            EntityManager entityManager = this.getEntityManager();
+            SessionImpl session = (SessionImpl) this.currentSession();
+            ClassMetadata metadata = session.getFactory().getClassMetadata(entityClass);
+
+            if (metadata == null || !metadata.hasIdentifierProperty()) {
+                throw new UnsupportedOperationException(
+                    "lockAndLoad only supports entities with database identifiers");
+            }
+
+            EntityPersister persister = session.getFactory().getEntityPersister(metadata.getEntityName());
+            PersistenceContext context = session.getPersistenceContext();
+
+            SortedSet<Serializable> idSet = new TreeSet<Serializable>();
+            SortedMap<Serializable, E> entitySet = new TreeMap<Serializable, E>();
+
+            // Step through the collection of IDs and figure out which entities we have to refresh,
+            // and which we need to lookup.
+            for (Serializable id : ids) {
+                // Make sure we don't doubly load/lock anything
+                if (id != null && !idSet.contains(id) && !entitySet.containsKey(id)) {
+                    EntityKey key = session.generateEntityKey(id, persister);
+                    E entity = (E) context.getEntity(key);
+
+                    if (entity != null) {
+                        entitySet.put(id, entity);
+                    }
+                    else {
+                        idSet.add(id);
+                    }
+                }
+            }
+
+            // First address the slow (and hopefully smaller) part of the lookup and refresh the
+            // entities that exist
+
+            // TODO: Maybe add a debug warning here to call out situations where our existing
+            // entity size is larger than our absent entity size. Those are areas where we may be
+            // reloading entities unnecessarily and could be optimized to avoid doing extraneous
+            // work.
+            if (entitySet.size() > 0) {
+                for (E entity : entitySet.values()) {
+                    entityManager.refresh(entity, LockModeType.PESSIMISTIC_WRITE);
+                    result.add(entity);
+                }
+            }
+
+            // Build a query to fetch the remaining entities
+            if (idSet.size() > 0) {
+                // Get the entity's metadata so we can ask Hibernate for the name of its identifier
+                String idName = metadata.getIdentifierPropertyName();
+                if (idName == null) {
+                    // This shouldn't happen.
+                    throw new RuntimeException("Unable to fetch identifier property name");
+                }
+
+                // Impl note:
+                // We're building the query here using JPA Criteria to avoid fiddling with string
+                // building and, potentially, erroneously using the class name as the entity name.
+                // Additionally, using a query (as opposed to the .find and .load methods) lets us set
+                // the flush, cache and lock modes for the entity we're attempting to fetch.
+                CriteriaBuilder builder = entityManager.getCriteriaBuilder();
+                CriteriaQuery<E> query = builder.createQuery(entityClass);
+                Root<E> root = query.from(entityClass);
+                Path<Serializable> target = root.<Serializable>get(idName);
+                ParameterExpression<List> param = builder.parameter(List.class);
+
+                query.select(root).where(target.in(param));
+
+                // Note that it's critical here to set both modes, as Hibernate is wildly inconsistent
+                // (and non-standard) in which properties it actually accepts when processing its own
+                // config objects. The cache mode combination specified below ends up being evaluated
+                // by Hibernate down to a CacheMode.REFRESH.
+                TypedQuery<E> executable = entityManager.createQuery(query)
+                    .setFlushMode(FlushModeType.COMMIT)
+                    .setHint(AvailableSettings.SHARED_CACHE_RETRIEVE_MODE, CacheRetrieveMode.BYPASS)
+                    .setHint(AvailableSettings.SHARED_CACHE_STORE_MODE, CacheStoreMode.REFRESH)
+                    .setLockMode(LockModeType.PESSIMISTIC_WRITE);
+
+                // Step through the query in blocks
+                for (List<Serializable> block : Iterables.partition(idSet, IN_OPERATOR_BLOCK_SIZE)) {
+                    executable.setParameter(param, block);
+                    result.addAll(executable.getResultList());
+                }
+            }
+        }
+
+        // Should we be returning a view of the list, rather than the fully mutable list here?
         return result;
     }
 

--- a/server/src/main/java/org/candlepin/model/Consumer.java
+++ b/server/src/main/java/org/candlepin/model/Consumer.java
@@ -379,8 +379,8 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
     public String toString() {
         String consumerType = (this.getType() != null) ? this.getType().getLabel() : "null";
 
-        return String.format("Consumer [id: %s, uuid: %s, consumerType: %s, name: %s] -- %s",
-            this.getId(), this.getUuid(), consumerType, this.getName(), super.toString());
+        return String.format("Consumer [id: %s, uuid: %s, consumerType: %s, name: %s]",
+            this.getId(), this.getUuid(), consumerType, this.getName());
     }
 
     /**

--- a/server/src/main/java/org/candlepin/model/ConsumerCurator.java
+++ b/server/src/main/java/org/candlepin/model/ConsumerCurator.java
@@ -41,7 +41,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
@@ -270,36 +269,6 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
     @Transactional
     public Consumer findByUuid(String uuid) {
         return getConsumer(uuid);
-    }
-
-    /**
-     * Apply a SELECT FOR UPDATE on a consumer.
-     *
-     * Note this method is not transactional.  It is meant to be used within
-     * a larger transaction.  Starting a transaction, running a select for update,
-     * and then ending the transaction is pointless.
-     *
-     * @return A consumer locked in the database
-     */
-    public Consumer lockAndLoad(Consumer c) {
-        getEntityManager().lock(c, LockModeType.PESSIMISTIC_WRITE);
-        return c;
-    }
-
-    /**
-     * Find a consumer by uuid and immediately lock it.
-     *
-     * @param consumerUuid the uuid of the target consumer.
-     *
-     * @return the Consumer matching the given uuid, null if the consumer was not found.
-     */
-    public Consumer lockAndLoadByUuid(String consumerUuid) {
-        List<Consumer> consumerList = lockAndLoadBatch(Arrays.asList(consumerUuid));
-        return (CollectionUtils.isEmpty(consumerList)) ? null : consumerList.get(0);
-    }
-
-    public List<Consumer> lockAndLoadBatch(Collection<String> uuids) {
-        return lockAndLoadBatch(uuids, "Consumer", "uuid");
     }
 
     @Transactional

--- a/server/src/main/java/org/candlepin/model/EntitlementCurator.java
+++ b/server/src/main/java/org/candlepin/model/EntitlementCurator.java
@@ -369,7 +369,6 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
     public List<Entitlement> listByConsumer(Consumer consumer, EntitlementFilterBuilder filters) {
         Criteria criteria = this.createCriteriaFromFilters(filters)
             .add(Restrictions.eq("consumer", consumer));
-            // .addOrder(Order.asc("Pool.id")); // Why do we care about the order?
 
         List<String> entitlementIds = criteria.list();
 

--- a/server/src/main/java/org/candlepin/model/OwnerContentCurator.java
+++ b/server/src/main/java/org/candlepin/model/OwnerContentCurator.java
@@ -20,6 +20,7 @@ import org.hibernate.Criteria;
 import org.hibernate.Session;
 import org.hibernate.criterion.DetachedCriteria;
 import org.hibernate.criterion.Disjunction;
+import org.hibernate.criterion.Order;
 import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
 
@@ -406,7 +407,8 @@ public class OwnerContentCurator extends AbstractHibernateCurator<OwnerContent> 
 
         if (uuids != null && !uuids.isEmpty()) {
             DetachedCriteria criteria = DetachedCriteria.forClass(Content.class)
-                .add(CPRestrictions.in("uuid", uuids));
+                .add(CPRestrictions.in("uuid", uuids))
+                .addOrder(Order.asc("uuid"));
 
             return this.cpQueryFactory.<Content>buildQuery(this.currentSession(), criteria);
         }

--- a/server/src/main/java/org/candlepin/model/OwnerProductCurator.java
+++ b/server/src/main/java/org/candlepin/model/OwnerProductCurator.java
@@ -22,6 +22,7 @@ import org.hibernate.Criteria;
 import org.hibernate.Session;
 import org.hibernate.criterion.DetachedCriteria;
 import org.hibernate.criterion.Disjunction;
+import org.hibernate.criterion.Order;
 import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
 import org.hibernate.sql.JoinType;
@@ -378,7 +379,8 @@ public class OwnerProductCurator extends AbstractHibernateCurator<OwnerProduct> 
 
         if (uuids != null && !uuids.isEmpty()) {
             DetachedCriteria criteria = DetachedCriteria.forClass(Product.class)
-                .add(CPRestrictions.in("uuid", uuids));
+                .add(CPRestrictions.in("uuid", uuids))
+                .addOrder(Order.asc("uuid"));
 
             return this.cpQueryFactory.<Product>buildQuery(this.currentSession(), criteria);
         }

--- a/server/src/main/java/org/candlepin/model/PoolCurator.java
+++ b/server/src/main/java/org/candlepin/model/PoolCurator.java
@@ -29,7 +29,6 @@ import org.hibernate.Criteria;
 import org.hibernate.FetchMode;
 import org.hibernate.Filter;
 import org.hibernate.Hibernate;
-import org.hibernate.LockOptions;
 import org.hibernate.Query;
 import org.hibernate.ReplicationMode;
 import org.hibernate.criterion.Criterion;
@@ -910,29 +909,6 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
         Filter consumerFilter = currentSession().getEnabledFilter(CONSUMER_FILTER);
         currentSession().disableFilter(CONSUMER_FILTER);
         return consumerFilter;
-    }
-
-    public Pool lockAndLoad(Pool pool) {
-        currentSession().refresh(pool, LockOptions.UPGRADE);
-        getEntityManager().refresh(pool);
-        return pool;
-    }
-
-    public List<Pool> lockAndLoadBatch(Collection<String> ids) {
-        return lockAndLoadBatch(ids, "Pool", "id");
-    }
-
-    public void lock(List<Pool> poolsToLock) {
-        if (poolsToLock.isEmpty()) {
-            log.debug("Nothing to lock");
-            return;
-        }
-        List<String> ids = new ArrayList<String>();
-        for (Pool p : poolsToLock) {
-            ids.add(p.getId());
-        }
-        lockAndLoadBatchById(ids);
-        log.debug("Done locking pools");
     }
 
     public List<ActivationKey> getActivationKeysForPool(Pool p) {

--- a/server/src/main/java/org/candlepin/model/UeberCertificateGenerator.java
+++ b/server/src/main/java/org/candlepin/model/UeberCertificateGenerator.java
@@ -86,18 +86,20 @@ public class UeberCertificateGenerator {
 
     @Transactional
     public UeberCertificate generate(String ownerKey, Principal principal) {
-        Owner o = ownerCurator.findAndLock(ownerKey);
-        if (o == null) {
-            throw new NotFoundException(i18n.tr("owner with key: {0} was not found.", ownerKey));
+        Owner owner = this.ownerCurator.lookupByKey(ownerKey);
+        if (owner == null) {
+            throw new NotFoundException(i18n.tr("Unable to find an owner with key: {0}", ownerKey));
         }
+
+        this.ownerCurator.lock(owner);
 
         try {
             // There can only be one ueber certificate per owner, so delete the existing and regenerate it.
-            this.ueberCertCurator.deleteForOwner(o);
-            return  this.generateUeberCert(o, principal.getUsername());
+            this.ueberCertCurator.deleteForOwner(owner);
+            return  this.generateUeberCert(owner, principal.getUsername());
         }
         catch (Exception e) {
-            log.error("Problem generating ueber cert for owner: " + ownerKey, e);
+            log.error("Problem generating ueber cert for owner: {}", ownerKey, e);
             throw new BadRequestException(i18n.tr("Problem generating ueber cert for owner {0}", ownerKey),
                 e);
         }

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/HealEntireOrgJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/HealEntireOrgJob.java
@@ -68,6 +68,8 @@ public class HealEntireOrgJob extends UniqueByEntityJob {
     @Override
     public void toExecute(JobExecutionContext ctx) throws JobExecutionException {
         try {
+            // NOTE: ownerId is actually the owner key here.
+
             JobDataMap map = ctx.getMergedJobDataMap();
             String ownerId = (String) map.get("ownerId");
             Owner owner = ownerCurator.lookupByKey(ownerId);
@@ -78,7 +80,7 @@ public class HealEntireOrgJob extends UniqueByEntityJob {
 
             Date entitleDate = (Date) map.get("entitle_date");
 
-            for (String uuid : ownerCurator.getConsumerUuids(ownerId).list()) {
+            for (String uuid : ownerCurator.getConsumerUuids(owner).list()) {
                 // Do not send in product IDs.  CandlepinPoolManager will take care
                 // of looking up the non or partially compliant products to bind.
                 try {

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -412,8 +412,7 @@ public class ConsumerResource {
                 int days = config.getInt(ConfigProperties.IDENTITY_CERT_EXPIRY_THRESHOLD, 90);
                 Date futureExpire = Util.addDaysToDt(days);
                 // if expiration is within 90 days, regenerate it
-                log.debug("Threshold [{}] expires on [{}] futureExpire [{}]",
-                    days, expire, futureExpire);
+                log.debug("Threshold [{}] expires on [{}] futureExpire [{}]", days, expire, futureExpire);
 
                 if (expire.before(futureExpire)) {
                     log.info("Regenerating identity certificate for consumer: {}, expiry: {}", uuid, expire);
@@ -1428,7 +1427,10 @@ public class ConsumerResource {
         @PathParam("consumer_uuid") @Verify(Consumer.class) String uuid,
         @Context Principal principal) {
         log.debug("Deleting consumer_uuid {}", uuid);
-        Consumer toDelete = consumerCurator.lockAndLoadByUuid(uuid);
+
+        Consumer toDelete = consumerCurator.findByUuid(uuid);
+        this.consumerCurator.lock(toDelete);
+
         try {
             this.poolManager.revokeAllEntitlements(toDelete);
         }
@@ -1486,6 +1488,7 @@ public class ConsumerResource {
         // we want to insert the content access cert to this list
         if (!consumer.getOwner().contentAccessMode()
             .equals(ContentAccessCertServiceAdapter.DEFAULT_CONTENT_ACCESS_MODE)) {
+
             try {
                 Certificate cert = contentAccessCertService.getCertificate(consumer);
                 if (cert != null) {

--- a/server/src/main/java/org/candlepin/resource/HypervisorResource.java
+++ b/server/src/main/java/org/candlepin/resource/HypervisorResource.java
@@ -117,7 +117,7 @@ public class HypervisorResource {
             "Default is true.  If false is specified, hypervisorIds that are not found" +
             "will result in failed entries in the resulting HypervisorCheckInResult")
         @QueryParam("create_missing") @DefaultValue("true") boolean createMissing) {
-        log.debug("Hypervisor check-in by principal: " + principal);
+        log.debug("Hypervisor check-in by principal: {}", principal);
 
         if (hostGuestMap == null) {
             log.debug("Host/Guest mapping provided during hypervisor checkin was null.");

--- a/server/src/main/java/org/candlepin/resource/OwnerProductResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerProductResource.java
@@ -53,7 +53,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import javax.persistence.LockModeType;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
@@ -313,8 +312,7 @@ public class OwnerProductResource {
             throw new ForbiddenException(i18n.tr("product \"{0}\" is locked", product.getId()));
         }
 
-        this.productCurator.lock(product, LockModeType.PESSIMISTIC_WRITE);
-        boolean change = false;
+        this.productCurator.lock(product);
 
         for (Entry<String, Boolean> entry : contentMap.entrySet()) {
             Content content = this.fetchContent(owner, entry.getKey());
@@ -346,7 +344,7 @@ public class OwnerProductResource {
             throw new ForbiddenException(i18n.tr("product \"{0}\" is locked", product.getId()));
         }
 
-        this.productCurator.lock(product, LockModeType.PESSIMISTIC_WRITE);
+        this.productCurator.lock(product);
 
         product = this.productManager.addContentToProduct(
             product, Arrays.asList(new ProductContent(product, content, enabled)), owner, true

--- a/server/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -965,6 +965,7 @@ public class OwnerResource {
         }
 
         ownerCurator.merge(toUpdate);
+        ownerCurator.flush();
 
         if (toUpdate.isContentAccessModeDirty()) {
             ownerManager.refreshOwnerForContentAccess(toUpdate);

--- a/server/src/main/java/org/candlepin/sync/Importer.java
+++ b/server/src/main/java/org/candlepin/sync/Importer.java
@@ -76,7 +76,6 @@ import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
-import javax.persistence.LockModeType;
 import javax.persistence.PersistenceException;
 
 
@@ -459,7 +458,7 @@ public class Importer {
     // WARNING: Keep this method public, otherwise @Transactional is ignored:
     public List<Subscription> importObjects(Owner owner, Map<String, File> importFiles,
         ConflictOverrides overrides) throws IOException, ImporterException {
-        ownerCurator.lock(owner, LockModeType.PESSIMISTIC_WRITE);
+        ownerCurator.lock(owner);
 
         log.debug("Importing objects for owner: {}", owner);
 

--- a/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -961,7 +961,7 @@ public class PoolManagerTest {
             any(PoolFilterBuilder.class), any(PageRequest.class), anyBoolean(), anyBoolean(), anyBoolean()))
             .thenReturn(page);
 
-        when(mockPoolCurator.lockAndLoadBatchById(any(List.class))).thenReturn(Arrays.asList(pool1));
+        when(mockPoolCurator.lockAndLoadByIds(any(List.class))).thenReturn(Arrays.asList(pool1));
         when(enforcerMock.preEntitlement(any(Consumer.class), any(Pool.class), anyInt(),
             any(CallerType.class))).thenReturn(result);
 
@@ -1010,7 +1010,7 @@ public class PoolManagerTest {
             .thenReturn(page);
 
         when(mockPoolCurator.lockAndLoad(any(Pool.class))).thenReturn(pool1);
-        when(mockPoolCurator.lockAndLoadBatchById(any(List.class))).thenReturn(Arrays.asList(pool1));
+        when(mockPoolCurator.lockAndLoadByIds(any(List.class))).thenReturn(Arrays.asList(pool1));
         when(enforcerMock.preEntitlement(any(Consumer.class), anyCollectionOf(PoolQuantity.class),
             any(CallerType.class))).thenReturn(resultMap);
 
@@ -1219,7 +1219,7 @@ public class PoolManagerTest {
             any(PageRequest.class), anyBoolean(), anyBoolean(), anyBoolean()))
                 .thenReturn(page);
 
-        when(mockPoolCurator.lockAndLoadBatchById(anyListOf(String.class))).thenReturn(pools);
+        when(mockPoolCurator.lockAndLoadByIds(anyListOf(String.class))).thenReturn(pools);
         when(enforcerMock.preEntitlement(any(Consumer.class), any(Pool.class), anyInt(),
             any(CallerType.class))).thenReturn(result);
 

--- a/server/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
@@ -16,7 +16,6 @@ package org.candlepin.model;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.times;
@@ -945,35 +944,6 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
         consumerCurator.delete(c);
         i = (BigInteger) em.createNativeQuery(countQuery).getSingleResult();
         assertEquals(new BigInteger("0"), i);
-    }
-
-    @Test
-    public void lockAndLoadByUuidReturnsFindsConsumer() {
-        Consumer consumer = new Consumer("testConsumer", "testUser", owner, ct);
-        consumerCurator.create(consumer);
-        assertTrue(consumer.getUuid() != null && !consumer.getUuid().isEmpty());
-
-        beginTransaction();
-        try {
-            Consumer found = consumerCurator.lockAndLoadByUuid(consumer.getUuid());
-            assertNotNull(found);
-            assertEquals(consumer.getUuid(), found.getUuid());
-        }
-        finally {
-            rollbackTransaction();
-        }
-    }
-
-    @Test
-    public void lockAndLoadByUuidReturnsNullWhenConsumerIsNotFound() {
-        beginTransaction();
-        try {
-            Consumer found = consumerCurator.lockAndLoadByUuid("an_unknown_uuid");
-            assertNull(found);
-        }
-        finally {
-            rollbackTransaction();
-        }
     }
 
     // select by owner

--- a/server/src/test/java/org/candlepin/model/OwnerCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/OwnerCuratorTest.java
@@ -201,7 +201,7 @@ public class OwnerCuratorTest extends DatabaseTestFixture {
         consumerCurator.create(c2);
         consumerCurator.create(c3);
 
-        List<String> result = ownerCurator.getConsumerUuids(owner.getKey()).list();
+        List<String> result = ownerCurator.getConsumerUuids(owner).list();
         assertEquals(2, result.size());
         assertTrue(result.contains(c1.getUuid()));
         assertTrue(result.contains(c2.getUuid()));

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/UndoImportsJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/UndoImportsJobTest.java
@@ -178,7 +178,8 @@ public class UndoImportsJobTest extends DatabaseTestFixture {
         Principal principal = new UserPrincipal("JarJarBinks", null, true);
 
         this.jobDataMap.put(JobStatus.TARGET_TYPE, JobStatus.TargetType.OWNER);
-        this.jobDataMap.put(JobStatus.TARGET_ID, owner1.getKey());
+        this.jobDataMap.put(JobStatus.TARGET_ID, owner1.getId());
+        this.jobDataMap.put(UndoImportsJob.OWNER_KEY, owner1.getKey());
         this.jobDataMap.put(PinsetterJobListener.PRINCIPAL_KEY, principal);
 
         beginTransaction(); //since we locking owner we need start transaction
@@ -245,7 +246,7 @@ public class UndoImportsJobTest extends DatabaseTestFixture {
     @Test
     public void handleException() throws JobExecutionException {
         // the real thing we want to handle
-        doThrow(new NullPointerException()).when(this.ownerCurator).lookupByKeyAndLock(anyString());
+        doThrow(new NullPointerException()).when(this.ownerCurator).lockAndLoadById(anyString());
 
         try {
             this.undoImportsJob.execute(this.jobContext);
@@ -261,7 +262,7 @@ public class UndoImportsJobTest extends DatabaseTestFixture {
     @Test
     public void refireOnWrappedSQLException() throws JobExecutionException {
         RuntimeException e = new RuntimeException("uh oh", new SQLException("not good"));
-        doThrow(e).when(this.ownerCurator).lookupByKeyAndLock(anyString());
+        doThrow(e).when(this.ownerCurator).lockAndLoadById(anyString());
 
         try {
             this.undoImportsJob.execute(this.jobContext);
@@ -278,7 +279,7 @@ public class UndoImportsJobTest extends DatabaseTestFixture {
     public void refireOnMultiLayerWrappedSQLException() throws JobExecutionException {
         RuntimeException e = new RuntimeException("uh oh", new SQLException("not good"));
         RuntimeException e2 = new RuntimeException("trouble!", e);
-        doThrow(e2).when(this.ownerCurator).lookupByKeyAndLock(anyString());
+        doThrow(e2).when(this.ownerCurator).lockAndLoadById(anyString());
 
         try {
             this.undoImportsJob.execute(this.jobContext);
@@ -292,7 +293,7 @@ public class UndoImportsJobTest extends DatabaseTestFixture {
     @Test
     public void noRefireOnRegularRuntimeException() throws JobExecutionException {
         RuntimeException e = new RuntimeException("uh oh", new NullPointerException());
-        doThrow(e).when(this.ownerCurator).lookupByKeyAndLock(anyString());
+        doThrow(e).when(this.ownerCurator).lockAndLoadById(anyString());
 
         try {
             this.undoImportsJob.execute(this.jobContext);

--- a/server/src/test/java/org/candlepin/resource/OwnerResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/OwnerResourceTest.java
@@ -431,8 +431,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
 
         // Generate an ueber certificate for the Owner. This will need to
         // be cleaned up along with the owner deletion.
-        UeberCertificate uCert = ueberCertGenerator.generate(
-            owner.getKey(), setupAdminPrincipal("test"));
+        UeberCertificate uCert = ueberCertGenerator.generate(owner.getKey(), setupAdminPrincipal("test"));
         assertNotNull(uCert);
 
         ownerResource.deleteOwner(owner.getKey(), true);


### PR DESCRIPTION
- Several methods used for applying database/entity locks have been
  generalized and refactored; extraneous methods have been removed
- Fixed a bug that could allow a temporary service level change to
  be permanently applied
- Fixed a bug that prevented consumers from being refreshed when
  the lockAndLoad method was called