### PR TITLE
Added the skip_existing option to the populate hosted DB task (0.9.51)

### DIFF
--- a/server/src/main/java/org/candlepin/model/ProductCurator.java
+++ b/server/src/main/java/org/candlepin/model/ProductCurator.java
@@ -29,6 +29,7 @@ import org.hibernate.sql.JoinType;
 import org.xnap.commons.i18n.I18n;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
@@ -221,4 +222,23 @@ public class ProductCurator extends AbstractHibernateCurator<Product> {
             .setProjection(Projections.id())
             .list();
     }
+
+    /**
+     * Fetches the list of existing product IDs currently available in the Candlepin database. If
+     * there are no existing products, this method returns an empty list.
+     *
+     * @return
+     *  The list of currently existing product IDs
+     */
+    public List<String> getExistingProductIds() {
+        // Impl notes:
+        // - At this point in CP, id is the primary key for Product, so we don't need to explicitly
+        //   request distinct IDs.
+        List<String> ids = this.getEntityManager()
+            .createQuery("SELECT id FROM Product", String.class)
+            .getResultList();
+
+        return ids != null ? ids : Collections.<String>emptyList();
+    }
+
 }

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/PopulateHostedDBTask.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/PopulateHostedDBTask.java
@@ -27,12 +27,14 @@ import org.candlepin.util.Util;
 import com.google.inject.Inject;
 
 import org.quartz.JobBuilder;
+import org.quartz.JobDataMap;
 import org.quartz.JobDetail;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -45,6 +47,9 @@ import java.util.Set;
  */
 public class PopulateHostedDBTask extends KingpinJob {
     private static Logger log = LoggerFactory.getLogger(PopulateHostedDBTask.class);
+
+    /** Constant config name used to store the "skip_existing" variable in the JobDataMap */
+    public static final String SKIP_EXISTING = "skip_existing";
 
     private ProductServiceAdapter productService;
     private ProductCurator productCurator;
@@ -72,42 +77,76 @@ public class PopulateHostedDBTask extends KingpinJob {
             return;
         }
 
+        JobDataMap map = context.getMergedJobDataMap();
+        Boolean skipExisting = map.getBoolean(SKIP_EXISTING);
+
         int pcount = 0;
         int ccount = 0;
+        int ecount = 0;
         log.info("Populating Hosted DB");
 
         Set<String> productCache = new HashSet<String>();
         Set<String> productIds = this.poolCurator.getAllKnownProductIds();
-        log.info("Importing data for known products...");
+        Set<String> dependentProducts = new HashSet<String>();
 
-        do {
-            Set<String> dependentProducts = new HashSet<String>();
+        if (Boolean.TRUE.equals(skipExisting)) {
+            log.info("Checking known new products...");
 
+            Collection<String> existingProductIds = this.productCurator.getExistingProductIds();
+            log.info("Skipping {} existing products...", existingProductIds.size());
+
+            productIds.removeAll(existingProductIds);
+            log.info("Importing data for {} known new products...", productIds.size());
+        }
+        else {
+            log.info("Importing data for all {} known products...", productIds.size());
+        }
+
+        while (productIds.size() > 0) {
             for (Product product : this.productService.getProductsByIds(productIds)) {
-                log.info("Storing product: {}", product);
+                if (product != null) {
+                    log.info("Storing product: {}", product);
 
-                dependentProducts.addAll(product.getDependentProductIds());
+                    dependentProducts.addAll(product.getDependentProductIds());
 
-                for (ProductContent pcontent : product.getProductContent()) {
-                    log.info("  Storing product content: {}", pcontent.getContent());
-                    this.contentCurator.createOrUpdate(pcontent.getContent());
-                    ++ccount;
+                    for (ProductContent pcontent : product.getProductContent()) {
+                        log.info("  Storing product content: {}", pcontent.getContent());
+                        this.contentCurator.createOrUpdate(pcontent.getContent());
+                        ++ccount;
+                    }
+
+                    this.productCurator.createOrUpdate(product);
+                    productCache.add(product.getId());
+                    ++pcount;
                 }
-
-                this.productCurator.createOrUpdate(product);
-                ++pcount;
             }
 
+            // Verify that we received the products we expected to receive...
+            productIds.removeAll(productCache);
+            if (productIds.size() > 0) {
+                ecount += productIds.size();
+
+                for (String productId : productIds) {
+                    log.warn("Unable to find product for referenced product ID: {}", productId);
+                }
+            }
+
+            // Process dependent products
             log.info("Importing data for dependent products...");
-            productCache.addAll(productIds);
             dependentProducts.removeAll(productCache);
+
+            // Clear the product ID set and swap with the dependent products set
+            productIds.clear();
+            Set<String> temp = productIds;
             productIds = dependentProducts;
-        } while (productIds.size() > 0);
+            dependentProducts = temp;
+        }
 
         // TODO: Should this be translated?
         String result = String.format(
-            "Finished populating Hosted DB. Received %d product(s) and %d content",
-            pcount, ccount
+            "Finished populating hosted DB. Received %d product(s) and %d content " +
+            "with %d unresolved reference(s)",
+            pcount, ccount, ecount
         );
 
         log.info(result);
@@ -116,9 +155,13 @@ public class PopulateHostedDBTask extends KingpinJob {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-    public static JobDetail createAsyncTask() {
+    public static JobDetail createAsyncTask(boolean skipExisting) {
+        JobDataMap map = new JobDataMap();
+        map.put(SKIP_EXISTING, skipExisting);
+
         JobDetail detail = JobBuilder.newJob(PopulateHostedDBTask.class)
             .withIdentity("populated_hosted_db-" + Util.generateUUID())
+            .usingJobData(map)
             .requestRecovery(true)
             .build();
 

--- a/server/src/main/java/org/candlepin/resource/AdminResource.java
+++ b/server/src/main/java/org/candlepin/resource/AdminResource.java
@@ -36,10 +36,14 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
+
+
 
 /**
  * Candlepin server administration REST calls.
@@ -121,16 +125,17 @@ public class AdminResource {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Path("pophosteddb")
-    public JobDetail populatedHostedDB() {
+    public JobDetail populatedHostedDB(
+        @QueryParam("skip_existing") @DefaultValue("false") boolean skipExisting) {
         // TODO: Remove this method once we no longer need the task.
 
-        // Impl note: We don't need to bother doing this
+        // Impl note: We don't need to bother doing this task in standalone mode
         if (config.getBoolean(ConfigProperties.STANDALONE)) {
             log.warn("Ignoring populate DB request in standalone environment");
             return null;
         }
 
-        return PopulateHostedDBTask.createAsyncTask();
+        return PopulateHostedDBTask.createAsyncTask(skipExisting);
     }
 
 }


### PR DESCRIPTION
- Added support for a skip_existing query parameter/option for
  the populate hosted DB task which will skip fetching and updating
  product information for products which already exist in the local
  database
- When the hosted DB population job runs, it will now verify that the
  products it requested were fetched; for each product it determines
  was omitted, a warning will be printed. Additionally, the final
  job status now includes the number of "unresolved references" hit.