### PR TITLE
1440909: Prioritize host based pools over regular ones for guests

### DIFF
--- a/server/spec/virt_spec.rb
+++ b/server/spec/virt_spec.rb
@@ -43,7 +43,7 @@ describe 'Standalone Virt-Limit Subscriptions', :type => :virt do
     @guest_pool = pools.find_all { |i| !i['sourceEntitlement'].nil? }[0]
 
   end
-  
+
   it 'should remove excess entitlements' do
    prod = create_product(nil, nil,{:attributes => {"multi-entitlement" => "yes", "virt_limit" => 1}})
    sub = @cp.create_subscription(@owner['key'], prod.id, 2)
@@ -56,12 +56,12 @@ describe 'Standalone Virt-Limit Subscriptions', :type => :virt do
    pools = @cp.list_pools({:owner => @owner['id'], :product => prod['id']})
    #New entitlement pool has been created
    pools.size.should == 3
- 
+
    #Change subscription quantity and the name of the product
    sub.quantity = 1
    @cp.update_subscription(sub)
    @cp.update_product(sub['product'].id, :name=>'newrandomname')
-   
+
    #Refresh pools and make sure it succeeds
    status = @cp.refresh_pools(@owner['key'], true)
    # The job is being retried several times anyway. We need to sleep it out
@@ -71,8 +71,8 @@ describe 'Standalone Virt-Limit Subscriptions', :type => :virt do
 
    #The entitlement derived pool has been removed by refresh pools
    pools = @cp.list_pools({:owner => @owner['id'], :product => prod['id']})
-   pools.size.should == 2   
-  end 
+   pools.size.should == 2
+  end
 
   it 'should create a virt_only pool for hosts guests' do
     # Get the attribute that indicates which host:
@@ -144,8 +144,8 @@ describe 'Standalone Virt-Limit Subscriptions', :type => :virt do
     host3 = @user.register(random_string('host'), :system, nil,
       {}, nil, nil, [], [])
     host3_client = Candlepin.new(nil, nil, host3['idCert']['cert'], host3['idCert']['key'])
-     # Adding a product to consumer that cannot be covered 
-    @guest1_client.update_consumer({:installedProducts => 
+     # Adding a product to consumer that cannot be covered
+    @guest1_client.update_consumer({:installedProducts =>
        [{'productId' => 'someNonExistentProduct', 'productName' => 'nonExistentProduct'}]
     })
 
@@ -154,7 +154,7 @@ describe 'Standalone Virt-Limit Subscriptions', :type => :virt do
     @guest1_client.list_entitlements.length.should == 1
 
     #Guest changes the hypervisor. This will trigger revocation of
-    #the entitlement to guest_pool (because it requires_host) and 
+    #the entitlement to guest_pool (because it requires_host) and
     #it will also trigger unsuccessfull autobind (because the
     #someNonExistentProduct cannot be covered)
     host3_client.update_consumer({:guestIds => [{'guestId' => @uuid1}]})
@@ -276,6 +276,93 @@ describe 'Standalone Virt-Limit Subscriptions', :type => :virt do
     # Entitlements should have remained the same for guest 2 and its host
     # is the same.
     @guest2_client.list_entitlements.length.should == 1
+  end
+
+  it 'should attach host provided pools before other available pools' do
+    @both_products = create_product(nil, nil, {
+        :attributes => {
+            :type => 'MKT'
+        }})
+    datacenter_product_1 = create_product(nil, nil, {
+        :attributes => {
+            :virt_limit => "unlimited",
+            :stacking_id => "stackme1",
+            :sockets => "2",
+            'multi-entitlement' => "yes"
+        }
+    })
+    derived_product_1 = create_product(nil, nil, {
+        :attributes => {
+            :cores => 2,
+            :stacking_id => "stackme1-derived",
+            :sockets=>4
+        }
+    })
+    datacenter_product_2 = create_product(nil, nil, {
+        :attributes => {
+            :virt_limit => "unlimited",
+            :stacking_id => "stackme2",
+            :sockets => "2",
+            'multi-entitlement' => "yes"
+        }
+    })
+    derived_product_2 = create_product(nil, nil, {
+        :attributes => {
+            :cores => 2,
+            :stacking_id => "stackme2-derived",
+            :sockets=>4
+        }
+    })
+    # We'd like there two be three subs, two that require a specific host and one that provides both required products
+    # in one. These first two are similar to VDC subscriptions, hence the name datacenter.
+    @cp.create_subscription(@owner['key'], datacenter_product_1.id, 10, [], '', '', '', nil, nil,
+                             {
+                                 'derived_product_id' => derived_product_1['id']
+                             })
+    @cp.create_subscription(@owner['key'], datacenter_product_2.id, 10, [], '', '', '', nil, nil,
+                             {
+                                 'derived_product_id' => derived_product_2['id']
+                             })
+    @cp.create_subscription(@owner['key'], @both_products.id, 1, provided_products=[derived_product_1.id, derived_product_2.id])
+
+    @cp.refresh_pools(@owner['key'])
+
+    @installed_product_list = [
+        {'productId' => derived_product_1.id, 'productName' => derived_product_1.name},
+        {'productId' => derived_product_2.id, 'productName' => derived_product_2.name}]
+    @guest2_client.update_consumer({:installedProducts => @installed_product_list})
+    @host1_client.consume_product(product=datacenter_product_1.id)
+    @host1_client.consume_product(product=datacenter_product_2.id)
+
+    @host2_client.consume_product(product=datacenter_product_1.id)
+    @host2_client.consume_product(product=datacenter_product_2.id)
+
+    @host1_client.update_consumer({:guestIds => [{'guestId' => @uuid2}]})
+
+    @guest2_client.list_entitlements.length.should == 0
+
+    @guest2_client.consume_product()
+    @guest2_client.list_entitlements.length.should == 2
+
+    @guest2_client.list_entitlements.each { |ent|
+      [derived_product_1.id, derived_product_2.id].should include(ent['pool']['productId'])
+      ent['pool']['attributes'].each { |attribute|
+        attribute['value'].should == @host1['uuid'] if attribute['name'] == 'requires_host'
+      }
+    }
+    # A similar set of pools should be chosen during guest migration
+    # So remove the guest from the first host and add the guest to the second host
+    @host1_client.update_consumer({:guestIds => []})
+    @host2_client.update_consumer({:guestIds => [{'guestId' => @uuid2}]})
+
+    @guest2_client.list_entitlements.length.should == 2
+
+    @guest2_client.list_entitlements.each { |ent|
+      [derived_product_1.id, derived_product_2.id].should include(ent['pool']['productId'])
+      ent['pool']['attributes'].each { |attribute|
+        attribute['value'].should == @host2['uuid'] if attribute['name'] == 'requires_host'
+      }
+    }
   end
 
   it 'should heal the host before healing itself' do

--- a/server/src/main/java/org/candlepin/model/PoolCurator.java
+++ b/server/src/main/java/org/candlepin/model/PoolCurator.java
@@ -53,6 +53,7 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import javax.persistence.LockModeType;
+import javax.persistence.TypedQuery;
 
 /**
  * EntitlementPoolCurator
@@ -810,6 +811,23 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
                 .createQuery("SELECT COUNT(p) FROM Pool p WHERE p=:pool", Long.class)
                 .setParameter("pool", pool)
                 .getSingleResult() > 0;
+    }
+
+    /**
+     * Uses a database query to list pool ids of pools that require the given host for the given owner
+     * @param host the host consumer that is required
+     * @param owner the owner of the desired pools
+     * @return A list of pool ids that require the given host owned by the given owner
+     */
+    public List<String> getPoolsProvidedByHost(Consumer host) {
+        Owner owner = host.getOwner();
+        String stmt = "SELECT p.id FROM Pool p INNER JOIN p.attributes AS attr WHERE attr.name='requires_host' AND attr.value=:hostUuid AND p.owner=:owner";
+        Query q = currentSession().createQuery(stmt);
+        q.setParameter("hostUuid", host.getUuid());
+        q.setParameter("owner", owner);
+        List<String> pools = new ArrayList<String>();
+        pools.addAll(q.list());
+        return pools;
     }
 
     public void calculateConsumedForOwnersPools(Owner owner) {


### PR DESCRIPTION
This PR implements the following design[1] for candlepin 0.9.54.
In short, this PR causes candlepin to perform an auto attach against just the pools provided by the host the guest is currently known to be on before performing a normal auto attach (for any products non-compliant or partially compliant post the first auto attach).

[1]: https://docs.google.com/document/d/1fM19-FFxUAkt3T2kf_g1ZbjFUZBl5oA_LzlrN5WZtLs/edit#