### PR TITLE
Updates for owner delete

### DIFF
--- a/server/client/ruby/candlepin_api.rb
+++ b/server/client/ruby/candlepin_api.rb
@@ -323,11 +323,12 @@ class Candlepin
     result_json
   end
 
-  def delete_owner(owner_key, revoke=true)
+  def delete_owner(owner_key, revoke=true, force=false)
     uri = "/owners/#{owner_key}"
 
     params = {}
     params[:revoke] = false if !revoke
+    params[:force] = force if force
 
     delete(uri, params)
   end

--- a/server/spec/candlepin_scenarios.rb
+++ b/server/spec/candlepin_scenarios.rb
@@ -22,8 +22,8 @@ module CandlepinMethods
     return owner
   end
 
-  def delete_owner(owner, revoke=true)
-    @cp.delete_owner(owner['key'], revoke)
+  def delete_owner(owner, revoke=true, force=false)
+    @cp.delete_owner(owner['key'], revoke, force)
     @owners.delete owner
   end
 

--- a/server/spec/multi_org_spec.rb
+++ b/server/spec/multi_org_spec.rb
@@ -475,4 +475,75 @@ describe "Multi Org Shares" do
     expect(pools_length).to eq 0
   end
 
+  it 'share consumer gets removed when recipient org is removed' do
+    @user_client.register(
+      random_string('orgBShare'),
+      :share,
+      nil,
+      {},
+      nil,
+      @owner1['key'],
+      [],
+      [],
+      nil,
+      [],
+      nil,
+      [],
+      nil,
+      nil,
+      nil,
+      @owner2['key']
+    )
+
+    share = @cp.list_consumers(:owner => @owner1['key']).first
+    delete_owner(@owner2)
+    @cp.list_consumers(:owner => @owner1['key']).size.should == 0
+  end
+
+  it 'cannot delete org when share consumer exists' do
+    @user_client.register(
+      random_string('orgBShare'),
+      :share,
+      nil,
+      {},
+      nil,
+      @owner1['key'],
+      [],
+      [],
+      nil,
+      [],
+      nil,
+      [],
+      nil,
+      nil,
+      nil,
+      @owner2['key']
+    )
+
+    expect do
+      delete_owner(@owner1)
+    end.to raise_error(RestClient::BadRequest)
+  end
+
+  it 'can delete org when share consumer exists with force' do
+    @user_client.register(
+      random_string('orgBShare'),
+      :share,
+      nil,
+      {},
+      nil,
+      @owner1['key'],
+      [],
+      [],
+      nil,
+      [],
+      nil,
+      [],
+      nil,
+      nil,
+      nil,
+      @owner2['key']
+    )
+    delete_owner(@owner1, true, true)
+  end
 end

--- a/server/spec/spec_helper.rb
+++ b/server/spec/spec_helper.rb
@@ -16,7 +16,7 @@ module CleanupHooks
 
   def cleanup_after
     @roles.reverse_each { |r| @cp.delete_role r['id'] }
-    @owners.reverse_each { |owner| @cp.delete_owner owner['key'] }
+    @owners.reverse_each { |owner| @cp.delete_owner(owner['key'], true, true) }
     @users.reverse_each { |user| @cp.delete_user user['username'] }
     @dist_versions.reverse_each { |dist_version| @cp.delete_distributor_version dist_version['id'] }
     @cdns.reverse_each { |cdn| @cp.delete_cdn cdn['label'] }

--- a/server/src/main/java/org/candlepin/controller/OwnerManager.java
+++ b/server/src/main/java/org/candlepin/controller/OwnerManager.java
@@ -75,6 +75,7 @@ public class OwnerManager {
 
         Collection<String> consumerIds = this.ownerCurator.getConsumerIds(owner).list();
         Collection<Consumer> consumers = this.consumerCurator.lockAndLoadByIds(consumerIds);
+        consumers.addAll(consumerCurator.listByRecipientOwner(owner).list());
 
         for (Consumer consumer : consumers) {
             log.info("Removing all entitlements for consumer: {}", consumer);

--- a/server/src/main/java/org/candlepin/model/ConsumerCurator.java
+++ b/server/src/main/java/org/candlepin/model/ConsumerCurator.java
@@ -305,6 +305,25 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
         return this.cpQueryFactory.<Consumer>buildQuery(this.currentSession(), criteria);
     }
 
+    @SuppressWarnings("unchecked")
+    @Transactional
+    public CandlepinQuery<Consumer> listByRecipientOwner(Owner owner) {
+        DetachedCriteria criteria = this.createSecureDetachedCriteria()
+            .add(Restrictions.eq("recipientOwnerKey", owner.getKey()));
+
+        return this.cpQueryFactory.<Consumer>buildQuery(this.currentSession(), criteria);
+    }
+
+    public boolean doesShareConsumerExist(Owner owner) {
+        long result = (Long) createSecureCriteria()
+            .add(Restrictions.eq("owner", owner))
+            .add(Restrictions.isNotNull("recipientOwnerKey"))
+            .setProjection(Projections.count("id"))
+            .uniqueResult();
+
+        return result != 0;
+    }
+
     /**
      * Search for Consumers with fields matching those provided.
      *

--- a/server/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -360,9 +360,16 @@ public class OwnerResource {
     @ApiOperation(notes = "Removes an Owner", value = "Delete Owner")
     @ApiResponses({ @ApiResponse(code = 404, message = "Owner not found") })
     public void deleteOwner(@PathParam("owner_key") String ownerKey,
-        @QueryParam("revoke") @DefaultValue("true") boolean revoke) {
+        @QueryParam("revoke") @DefaultValue("true") boolean revoke,
+        @QueryParam("force") @DefaultValue("false") boolean force) {
         Owner owner = findOwner(ownerKey);
         Event event = eventFactory.ownerDeleted(owner);
+
+        if (!force && consumerCurator.doesShareConsumerExist(owner)) {
+            throw new BadRequestException(
+                i18n.tr("owner ''{0}'' cannot be deleted while there is a share consumer. " +
+                    "You may use 'force' to bypass.", owner.getKey()));
+        }
 
         try {
             ownerManager.cleanupAndDelete(owner, revoke);
@@ -1061,7 +1068,7 @@ public class OwnerResource {
         Pool existingPool = this.poolManager.getMasterPoolBySubscriptionId(subscription.getId());
         if (existingPool == null) {
             throw new NotFoundException(i18n.tr(
-                "Unable to find a subscription with the ID \"{0}\".", subscription.getId()
+                "Unable to find a subscription with the ID ''{0}''.", subscription.getId()
             ));
         }
         Pool updatedPool = this.poolManager.convertToMasterPool(subscription);

--- a/server/src/test/java/org/candlepin/resource/OwnerResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/OwnerResourceTest.java
@@ -175,7 +175,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
     @Test
     public void testSimpleDeleteOwner() {
         String id = owner.getId();
-        ownerResource.deleteOwner(owner.getKey(), true);
+        ownerResource.deleteOwner(owner.getKey(), true, false);
         owner = ownerCurator.find(id);
         assertNull(owner);
     }
@@ -434,7 +434,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         UeberCertificate uCert = ueberCertGenerator.generate(owner.getKey(), setupAdminPrincipal("test"));
         assertNotNull(uCert);
 
-        ownerResource.deleteOwner(owner.getKey(), true);
+        ownerResource.deleteOwner(owner.getKey(), true, false);
 
         assertEquals(0, consumerCurator.listByOwner(owner).list().size());
         assertNull(consumerCurator.findByUuid(c1.getUuid()));
@@ -619,7 +619,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
     public void testOwnerAdminCannotDelete() {
         setupPrincipal(owner, Access.ALL);
         securityInterceptor.enable();
-        ownerResource.deleteOwner(owner.getKey(), true);
+        ownerResource.deleteOwner(owner.getKey(), true, false);
     }
 
     private Event createConsumerCreatedEvent(Owner o) {
@@ -1018,7 +1018,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         Role r = new Role("rolename");
         r.addPermission(p);
         roleCurator.create(r);
-        ownerResource.deleteOwner(owner.getKey(), false);
+        ownerResource.deleteOwner(owner.getKey(), false, false);
     }
 
     @Test(expected = NotFoundException.class)
@@ -1045,7 +1045,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         ConstraintViolationException ce = new ConstraintViolationException(null, null, null);
         PersistenceException pe = new PersistenceException(ce);
         Mockito.doThrow(pe).when(ownerManager).cleanupAndDelete(eq(o), eq(true));
-        or.deleteOwner("testOwner", true);
+        or.deleteOwner("testOwner", true, true);
     }
 
     @Test(expected = BadRequestException.class)


### PR DESCRIPTION
If share org is deleted, then the share consumer is removed from master org
If REST call comes to delete master org while there is a share, then it will
 fail with a message unless the force query parameter is used.