### PR TITLE
Added content access list refreshing to the refresh process

### DIFF
--- a/server/spec/candlepin_scenarios.rb
+++ b/server/spec/candlepin_scenarios.rb
@@ -14,8 +14,11 @@ module CandlepinMethods
   # most other objects can be created using the ruby API.
   def create_owner(owner_name, parent=nil, params={})
     params[:parent] = parent
-    # this will only affect the ability to set the mode on the owner
+
+    # Set the content access mode list for new owners. We do this here instead of doing it explicitly
+    # in each test due to some test objects creating owners internally which need this list.
     params['contentAccessModeList'] = 'org_environment,test_access_mode,entitlement'
+
     owner = @cp.create_owner(owner_name, params)
     @owners << owner
 

--- a/server/spec/content_access_spec.rb
+++ b/server/spec/content_access_spec.rb
@@ -11,7 +11,11 @@ describe 'Content Access' do
   include Unpack
 
   before(:each) do
-      @owner = create_owner(random_string("test_owner"), nil,{'contentAccessMode' => "org_environment"})
+      @owner = create_owner(random_string("test_owner"), nil, {
+        'contentAccessModeList' => 'org_environment,test_access_mode,entitlement',
+        'contentAccessMode' => "org_environment"
+      })
+
       @username = random_string("user")
       @consumername = random_string("consumer")
       @consumername2 = random_string("consumer")
@@ -237,6 +241,7 @@ describe 'Content Access' do
       @cp = Candlepin.new('admin', 'admin')
       @cp_export = StandardExporter.new
       owner = @cp_export.owner
+
       @cp.update_owner(owner['key'],{'contentAccessMode' => "test_access_mode"})
       candlepin_client = @cp_export.candlepin_client
       candlepin_client.update_consumer({'contentAccessMode' => "test_access_mode"})

--- a/server/src/main/java/org/candlepin/controller/OwnerManager.java
+++ b/server/src/main/java/org/candlepin/controller/OwnerManager.java
@@ -34,9 +34,13 @@ import org.candlepin.model.UeberCertificateCurator;
 import org.candlepin.model.activationkeys.ActivationKey;
 import org.candlepin.model.activationkeys.ActivationKeyCurator;
 import org.candlepin.service.ContentAccessCertServiceAdapter;
+import org.candlepin.service.OwnerServiceAdapter;
 
 import com.google.inject.Inject;
 import com.google.inject.persist.Transactional;
+
+import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,7 +55,8 @@ import java.util.Collection;
  */
 public class OwnerManager {
 
-    @Inject private static Logger log = LoggerFactory.getLogger(OwnerManager.class);
+    private static Logger log = LoggerFactory.getLogger(OwnerManager.class);
+
     @Inject private ConsumerCurator consumerCurator;
     @Inject private PoolManager poolManager;
     @Inject private ActivationKeyCurator activationKeyCurator;
@@ -68,6 +73,7 @@ public class OwnerManager {
     @Inject private ContentAccessCertificateCurator contentAccessCertCurator;
     @Inject private OwnerEnvContentAccessCurator ownerEnvContentAccessCurator;
     @Inject private UeberCertificateCurator uberCertificateCurator;
+    @Inject private OwnerServiceAdapter ownerServiceAdapter;
 
     @Transactional
     public void cleanupAndDelete(Owner owner, boolean revokeCerts) {
@@ -144,24 +150,96 @@ public class OwnerManager {
         ownerCurator.flush();
     }
 
-    public void determineContentAccessCertState(Owner owner) {
-        if (!owner.isContentAccessModeDirty()) {
-            return;
-        }
-        if (owner.contentAccessMode()
-            .equals(ContentAccessCertServiceAdapter.DEFAULT_CONTENT_ACCESS_MODE)) {
-            contentAccessCertCurator.deleteForOwner(owner);
-        }
-        owner.setContentAccessModeDirty(false);
-        ownerCurator.merge(owner);
+    /**
+     * Refreshes the content access mode and content access mode list for the given owner using the
+     * default owner service adapter.
+     *
+     * @param owner
+     *  The owner to refresh
+     *
+     * @throws IllegalArgumentException
+     *  if adapter is null or owner is null or invalid
+     */
+    public void refreshContentAccessMode(Owner owner) {
+        this.refreshContentAccessMode(this.ownerServiceAdapter, owner);
     }
 
+    /**
+     * Refreshes the content access mode and content access mode list for the given owner using the
+     * specified owner service adapter.
+     *
+     * @param adapter
+     *  The OwnerServiceAdapter instance to use for refreshing the owner's content access
+     *
+     * @param owner
+     *  The owner to refresh
+     *
+     * @throws IllegalArgumentException
+     *  if adapter is null or owner is null or invalid
+     */
+    @Transactional
+    public void refreshContentAccessMode(OwnerServiceAdapter adapter, Owner owner) {
+        if (adapter == null) {
+            throw new IllegalArgumentException("adapter is null");
+        }
+
+        if (owner == null) {
+            throw new IllegalArgumentException("owner is null");
+        }
+
+        // Lock the owner
+        owner = ownerCurator.lockAndLoad(owner);
+
+        // Fetch the upstream list and mode
+        String upstreamList = adapter.getContentAccessModeList(owner.getKey());
+        String upstreamMode = adapter.getContentAccessMode(owner.getKey());
+        String currentMode = owner.getContentAccessMode();
+
+        // This shouldn't happen, but in the event our upstream source is having issues, let's
+        // not put ourselves in a bad state as well.
+        if (upstreamList != null && !upstreamList.isEmpty()) {
+            // Not empty list. Verify that the upstream mode is present.
+            String[] list = upstreamList.split(",");
+
+            if (!StringUtils.isEmpty(upstreamMode) && !ArrayUtils.contains(list, upstreamMode)) {
+                throw new IllegalStateException("Upstream access mode is not present in access mode list");
+            }
+        }
+        else {
+            // Empty list. Verify the upstream mode is also empty.
+            if (!StringUtils.isEmpty(upstreamMode)) {
+                throw new IllegalStateException("Upstream access mode is not present in access mode list");
+            }
+        }
+
+        // Set new values
+        owner.setContentAccessModeList(upstreamList);
+
+        // If the content access mode changed, we'll need to update it and refresh the access certs
+        if (currentMode != null ? !currentMode.equals(upstreamMode) : upstreamMode != null) {
+            owner.setContentAccessMode(upstreamMode);
+
+            ownerCurator.merge(owner);
+            ownerCurator.flush();
+
+            this.refreshOwnerForContentAccess(owner);
+        }
+    }
+
+    /**
+     * Refreshes the content access certificates for the given owner.
+     *
+     * @param owner
+     *  The owner for which to refresh content access
+     */
     @Transactional
     public void refreshOwnerForContentAccess(Owner owner) {
         // we need to update the owner's consumers if the content access mode has changed
         owner = ownerCurator.lockAndLoad(owner);
 
-        this.determineContentAccessCertState(owner);
+        if (owner.contentAccessMode().equals(ContentAccessCertServiceAdapter.DEFAULT_CONTENT_ACCESS_MODE)) {
+            contentAccessCertCurator.deleteForOwner(owner);
+        }
 
         // removed cached versions of content access cert data
         ownerEnvContentAccessCurator.removeAllForOwner(owner.getId());

--- a/server/src/main/java/org/candlepin/controller/PoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/PoolManager.java
@@ -30,6 +30,7 @@ import org.candlepin.model.dto.Subscription;
 import org.candlepin.policy.EntitlementRefusedException;
 import org.candlepin.policy.js.pool.PoolUpdate;
 import org.candlepin.resource.dto.AutobindData;
+import org.candlepin.service.OwnerServiceAdapter;
 import org.candlepin.service.SubscriptionServiceAdapter;
 
 import java.util.Collection;
@@ -129,8 +130,9 @@ public interface PoolManager {
 
     List<Pool> lookupBySubscriptionIds(Owner owner, Collection<String> id);
 
-    Refresher getRefresher(SubscriptionServiceAdapter subAdapter);
-    Refresher getRefresher(SubscriptionServiceAdapter subAdapter, boolean lazy);
+    Refresher getRefresher(SubscriptionServiceAdapter subAdapter, OwnerServiceAdapter ownerAdapter);
+    Refresher getRefresher(SubscriptionServiceAdapter subAdapter, OwnerServiceAdapter ownerAdapter,
+        boolean lazy);
 
     void regenerateCertificatesOf(Entitlement e, boolean lazy);
 

--- a/server/src/main/java/org/candlepin/controller/Refresher.java
+++ b/server/src/main/java/org/candlepin/controller/Refresher.java
@@ -18,6 +18,7 @@ import org.candlepin.model.Owner;
 import org.candlepin.model.Pool;
 import org.candlepin.model.Product;
 import org.candlepin.model.dto.Subscription;
+import org.candlepin.service.OwnerServiceAdapter;
 import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.util.Util;
 
@@ -40,6 +41,7 @@ public class Refresher {
 
     private CandlepinPoolManager poolManager;
     private SubscriptionServiceAdapter subAdapter;
+    private OwnerServiceAdapter ownerAdapter;
     private OwnerManager ownerManager;
     private boolean lazy;
     private UnitOfWork uow;
@@ -49,9 +51,11 @@ public class Refresher {
     private Set<Product> products = Util.newSet();
 
     Refresher(CandlepinPoolManager poolManager, SubscriptionServiceAdapter subAdapter,
-        OwnerManager ownerManager, boolean lazy) {
+        OwnerServiceAdapter ownerAdapter, OwnerManager ownerManager, boolean lazy) {
+
         this.poolManager = poolManager;
         this.subAdapter = subAdapter;
+        this.ownerAdapter = ownerAdapter;
         this.ownerManager = ownerManager;
         this.lazy = lazy;
     }
@@ -152,9 +156,10 @@ public class Refresher {
         }
 
         for (Owner owner : this.owners.values()) {
-            poolManager.refreshPoolsWithRegeneration(subAdapter, owner, lazy);
+            poolManager.refreshPoolsWithRegeneration(this.subAdapter, owner, this.lazy);
             poolManager.recalculatePoolQuantitiesForOwner(owner);
-            ownerManager.refreshOwnerForContentAccess(owner);
+
+            ownerManager.refreshContentAccessMode(this.ownerAdapter, owner);
         }
     }
 

--- a/server/src/main/java/org/candlepin/model/Entitlement.java
+++ b/server/src/main/java/org/candlepin/model/Entitlement.java
@@ -153,8 +153,7 @@ public class Entitlement extends AbstractHibernateObject
         pool = poolIn;
         owner = consumerIn.getOwner();
         consumer = consumerIn;
-        quantity = quantityIn == null || quantityIn.intValue() < 1 ?
-            1 : quantityIn;
+        quantity = quantityIn == null || quantityIn.intValue() < 1 ? 1 : quantityIn;
         updatedOnStart = poolIn.getStartDate().after(new Date());
         deletedFromPool = false;
     }

--- a/server/src/main/java/org/candlepin/model/Owner.java
+++ b/server/src/main/java/org/candlepin/model/Owner.java
@@ -48,6 +48,7 @@ import javax.xml.bind.annotation.XmlTransient;
 import io.swagger.annotations.ApiModelProperty;
 
 
+
 /**
  * Represents the owner of entitlements. This is akin to an organization,
  * whereas a User is an individual account within that organization.
@@ -127,24 +128,15 @@ public class Owner extends AbstractHibernateObject implements Serializable,
 
     /**
      * Determines the behavior of the content access.
-     *
      */
     @Column(name = "content_access_mode")
     private String contentAccessMode;
 
     /**
      * Determines the allowable modes of the content access.
-     *
      */
     @Column(name = "content_access_mode_list")
     private String contentAccessModeList;
-
-    /**
-     * Has the content access mode changed on owner update.
-     *
-     */
-    @Column(name = "content_access_mode_dirty")
-    private boolean contentAccessModeDirty;
 
     /**
      * Default constructor
@@ -505,7 +497,9 @@ public class Owner extends AbstractHibernateObject implements Serializable,
     }
 
     public void setContentAccessModeList(String contentAccessModeList) {
-        this.contentAccessModeList = contentAccessModeList;
+        this.contentAccessModeList = !StringUtils.isEmpty(contentAccessModeList) ?
+            contentAccessModeList :
+            null;
     }
 
     @XmlTransient
@@ -513,28 +507,17 @@ public class Owner extends AbstractHibernateObject implements Serializable,
         if (StringUtils.isEmpty(mode)) {
             return true;
         }
+
         if (mode.equals(ContentAccessCertServiceAdapter.DEFAULT_CONTENT_ACCESS_MODE)) {
             return true;
         }
+
         if (StringUtils.isEmpty(contentAccessModeList)) {
             return false;
         }
+
         String[] list = contentAccessModeList.split(",");
         return ArrayUtils.contains(list, mode);
-    }
-
-    /**
-     * Returns the value of the contentAccessMode setting.
-     *
-     * @return String the value
-     */
-    @XmlTransient
-    public boolean isContentAccessModeDirty() {
-        return contentAccessModeDirty;
-    }
-
-    public void setContentAccessModeDirty(boolean contentAccessModeDirty) {
-        this.contentAccessModeDirty = contentAccessModeDirty;
     }
 
 }

--- a/server/src/main/java/org/candlepin/model/OwnerEnvContentAccessCurator.java
+++ b/server/src/main/java/org/candlepin/model/OwnerEnvContentAccessCurator.java
@@ -19,9 +19,7 @@ import com.google.inject.persist.Transactional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import javax.persistence.Query;
 
@@ -44,11 +42,10 @@ public class OwnerEnvContentAccessCurator extends AbstractHibernateCurator<Owner
     @SuppressWarnings("unchecked")
     @Transactional
     public OwnerEnvContentAccess getContentAccess(String ownerId, String environmentId) {
-        OwnerEnvContentAccess result = null;
-        String hql = "";
-        List<OwnerEnvContentAccess> resultList = null;
+        List<OwnerEnvContentAccess> resultList;
+
         if (environmentId != null) {
-            hql = "SELECT oeca" +
+            String hql = "SELECT oeca" +
                 "    FROM OwnerEnvContentAccess oeca" +
                 "     JOIN oeca.owner o" +
                 "     JOIN oeca.environment e" +
@@ -62,10 +59,9 @@ public class OwnerEnvContentAccessCurator extends AbstractHibernateCurator<Owner
                 .setParameter("ownerId", ownerId)
                 .setParameter("enviromentId",  environmentId)
                 .getResultList();
-
         }
         else {
-            hql = "SELECT oeca" +
+            String hql = "SELECT oeca" +
                 "    FROM OwnerEnvContentAccess oeca" +
                 "     JOIN oeca.owner o" +
                 "    WHERE" +
@@ -77,32 +73,18 @@ public class OwnerEnvContentAccessCurator extends AbstractHibernateCurator<Owner
             resultList = (List<OwnerEnvContentAccess>) query
                 .setParameter("ownerId", ownerId)
                 .getResultList();
-            if (resultList.isEmpty()) {
-                result = null;
-            }
-            else {
-                result = resultList.get(0);
-            }
         }
-        if (resultList.isEmpty()) {
-            result = null;
-        }
-        else {
-            result = resultList.get(0);
-        }
-        return result;
+
+        return (resultList == null || resultList.isEmpty()) ? null : resultList.get(0);
     }
 
     public void removeAllForOwner(String ownerId) {
-        this.currentSession().createQuery(
-            "delete from OwnerEnvContentAccess where owner_id = :ownerId")
-                .setParameter("ownerId", ownerId)
-                .executeUpdate();
+        this.currentSession().createQuery("delete from OwnerEnvContentAccess where owner_id = :ownerId")
+            .setParameter("ownerId", ownerId)
+            .executeUpdate();
     }
 
     public void saveOrUpdate(OwnerEnvContentAccess ownerEnvContentAccess) {
-        Set<OwnerEnvContentAccess> entities = new HashSet<OwnerEnvContentAccess>();
-        entities.add(ownerEnvContentAccess);
-        saveOrUpdateAll(entities, false, false);
+        this.currentSession().saveOrUpdate(ownerEnvContentAccess);
     }
 }

--- a/server/src/main/java/org/candlepin/model/Pool.java
+++ b/server/src/main/java/org/candlepin/model/Pool.java
@@ -343,8 +343,7 @@ public class Pool extends AbstractHibernateObject implements Persisted, Owned, N
     @JoinTable(name = "cp_pool_branding",
         joinColumns = @JoinColumn(name = "pool_id"),
         inverseJoinColumns = @JoinColumn(name = "branding_id"))
-    @Cascade({org.hibernate.annotations.CascadeType.ALL,
-        org.hibernate.annotations.CascadeType.DELETE_ORPHAN})
+    @Cascade({org.hibernate.annotations.CascadeType.ALL, org.hibernate.annotations.CascadeType.DELETE_ORPHAN})
     @BatchSize(size = 1000)
     private Set<Branding> branding;
 

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/RefreshPoolsForProductJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/RefreshPoolsForProductJob.java
@@ -23,6 +23,7 @@ import org.candlepin.model.OwnerProductCurator;
 import org.candlepin.model.Product;
 import org.candlepin.model.ProductCurator;
 import org.candlepin.pinsetter.core.model.JobStatus;
+import org.candlepin.service.OwnerServiceAdapter;
 import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.util.Util;
 
@@ -45,17 +46,19 @@ public class RefreshPoolsForProductJob extends KingpinJob {
     private PoolManager poolManager;
     private ProductCurator productCurator;
     private SubscriptionServiceAdapter subAdapter;
+    private OwnerServiceAdapter ownerAdapter;
 
     public static final String LAZY_REGEN = "lazy_regen";
 
     @Inject
     public RefreshPoolsForProductJob(OwnerProductCurator ownerProductCurator, ProductCurator productCurator,
-        PoolManager poolManager, SubscriptionServiceAdapter subAdapter) {
+        PoolManager poolManager, SubscriptionServiceAdapter subAdapter, OwnerServiceAdapter ownerAdapter) {
 
         this.ownerProductCurator = ownerProductCurator;
         this.poolManager = poolManager;
         this.productCurator = productCurator;
         this.subAdapter = subAdapter;
+        this.ownerAdapter = ownerAdapter;
     }
 
     @Override
@@ -67,7 +70,7 @@ public class RefreshPoolsForProductJob extends KingpinJob {
         Product product = this.productCurator.find(productUuid);
 
         if (product != null) {
-            Refresher refresher = poolManager.getRefresher(subAdapter, lazy);
+            Refresher refresher = poolManager.getRefresher(this.subAdapter, this.ownerAdapter, lazy);
 
             refresher.add(product);
             refresher.run();

--- a/server/src/main/java/org/candlepin/resource/OwnerContentResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerContentResource.java
@@ -214,6 +214,7 @@ public class OwnerContentResource {
                 entity = this.contentManager.createContent(content, owner);
             }
         }
+
         return entity;
     }
 
@@ -248,6 +249,7 @@ public class OwnerContentResource {
 
             result.add(entity.toDTO());
         }
+
         ownerManager.refreshOwnerForContentAccess(owner);
         return result;
     }
@@ -269,8 +271,8 @@ public class OwnerContentResource {
         }
 
         existing = this.contentManager.updateContent(content, owner, true);
-
         ownerManager.refreshOwnerForContentAccess(owner);
+
         return existing.toDTO();
     }
 

--- a/server/src/main/java/org/candlepin/service/OwnerServiceAdapter.java
+++ b/server/src/main/java/org/candlepin/service/OwnerServiceAdapter.java
@@ -15,17 +15,58 @@
 package org.candlepin.service;
 
 
+
 /**
- * Owner key may originate from a separate service outside Candlepin
- * in some configurations. This service allows the key to be confirmed
- * against that outside source.
+ * The OwnerServiceAdapter defines an interface for hooking into some owner/org-specific operations
+ * for additional or external verification of values, or for providing data from alternate sources.
  */
 public interface OwnerServiceAdapter {
 
     /**
-     * Confirms that the key can be created in the system.
-     * @param ownerKey key for owner to be created.
-     * @return boolean true if the owner key is allowed.
+     * Checks that the given key is a valid key to be used during owner creation. The owner key may
+     * originate from a separate service outside of Candlepin in some configurations.
+     *
+     * @param ownerKey
+     *  The potential key to be used for a new owner
+     *
+     * @return
+     *  true if the key is valid for a new owner, false otherwise
      */
     boolean isOwnerKeyValidForCreation(String ownerKey);
+
+    /**
+     * Retrieves the current content access mode for the owner represented by the given key. If the
+     * owner should not be using. The value returned by this method should always be present in the
+     * list returned by getContentAccessModeList, or null to represent the owner isn't using any
+     * special content access modes.
+     *
+     * @param ownerKey
+     *  A key representing the owner for which to fetch the content access mode
+     *
+     * @throws IllegalArgumentException
+     *  if ownerKey is null, empty or otherwise does not represent a valid owner
+     *
+     * @return
+     *  A string representing the content access mode for the specified owner, or null if the owner
+     *  should not be using any special content access mode
+     */
+    String getContentAccessMode(String ownerKey);
+
+    /**
+     * Retrieves a comma-delimited string representing the content access mode list for the owner
+     * represented by the given key. This method may return a null or empty string, indicating the
+     * owner does not have any special content access modes.
+     *
+     * @param ownerKey
+     *  A key representing the owner for which to fetch the content access mode
+     *
+     * @throws IllegalArgumentException
+     *  if ownerKey is null, empty or otherwise does not represent a valid owner
+     *
+     * @return
+     *  A comma-delimited string representing the content access mode list for the specified owner,
+     *  or null if the owner does not have any special content access modes
+     */
+    String getContentAccessModeList(String ownerKey);
+
 }

--- a/server/src/main/java/org/candlepin/service/impl/DefaultOwnerServiceAdapter.java
+++ b/server/src/main/java/org/candlepin/service/impl/DefaultOwnerServiceAdapter.java
@@ -14,6 +14,7 @@
  */
 package org.candlepin.service.impl;
 
+import org.candlepin.model.Owner;
 import org.candlepin.model.OwnerCurator;
 import org.candlepin.service.OwnerServiceAdapter;
 
@@ -21,15 +22,17 @@ import com.google.inject.Inject;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import org.xnap.commons.i18n.I18n;
+
+
 
 /**
  * default SubscriptionAdapter implementation
  */
 public class DefaultOwnerServiceAdapter implements OwnerServiceAdapter {
+    private static Logger log = LoggerFactory.getLogger(DefaultOwnerServiceAdapter.class);
 
-    private static Logger log =
-        LoggerFactory.getLogger(DefaultOwnerServiceAdapter.class);
     private OwnerCurator ownerCurator;
     private I18n i18n;
 
@@ -40,12 +43,38 @@ public class DefaultOwnerServiceAdapter implements OwnerServiceAdapter {
     }
 
     /**
-     * Confirms that the key can be created in the system.
-     * @param ownerKey key for owner to be created.
-     * @return boolean true if the owner key is allowed.
+     * @{inheritDocs}
      */
     @Override
     public boolean isOwnerKeyValidForCreation(String ownerKey) {
         return true;
+    }
+
+    /**
+     * @{inheritDocs}
+     */
+    @Override
+    public String getContentAccessMode(String ownerKey) {
+        // Since we're acting as the upstream source, we'll just pass-through any existing value.
+        Owner owner = ownerKey != null ? this.ownerCurator.lookupByKey(ownerKey) : null;
+        if (owner == null) {
+            throw new IllegalArgumentException("ownerKey does not represent a valid owner: " + ownerKey);
+        }
+
+        return owner.getContentAccessMode();
+    }
+
+    /**
+     * @{inheritDocs}
+     */
+    @Override
+    public String getContentAccessModeList(String ownerKey) {
+        // Since we're acting as the upstream source, we'll just pass-through any existing value.
+        Owner owner = ownerKey != null ? this.ownerCurator.lookupByKey(ownerKey) : null;
+        if (owner == null) {
+            throw new IllegalArgumentException("ownerKey does not represent a valid owner: " + ownerKey);
+        }
+
+        return owner.getContentAccessModeList();
     }
 }

--- a/server/src/main/java/org/candlepin/service/impl/ImportSubscriptionServiceAdapter.java
+++ b/server/src/main/java/org/candlepin/service/impl/ImportSubscriptionServiceAdapter.java
@@ -35,7 +35,6 @@ import java.util.Map;
 
 /**
  * @author mstead
- *
  */
 public class ImportSubscriptionServiceAdapter implements SubscriptionServiceAdapter {
 

--- a/server/src/main/resources/db/changelog/20170518143217-remove-obsoleted-dirty-column.xml
+++ b/server/src/main/resources/db/changelog/20170518143217-remove-obsoleted-dirty-column.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+    <changeSet id="20170518143217-1" author="crog">
+        <comment>remove obsoleted dirty column</comment>
+        <dropColumn tableName="cp_owner" columnName="content_access_mode_dirty"/>
+    </changeSet>
+
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/server/src/main/resources/db/changelog/changelog-create.xml
+++ b/server/src/main/resources/db/changelog/changelog-create.xml
@@ -1211,4 +1211,5 @@
     <include file="db/changelog/20170224113816-add-productshare-table.xml"/>
     <include file="db/changelog/20170404164458-add-share-quantity-column-to-pools.xml"/>
     <include file="db/changelog/20170421055601-add-recipient-owner-to-consumer.xml"/>
+    <include file="db/changelog/20170518143217-remove-obsoleted-dirty-column.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-testing.xml
+++ b/server/src/main/resources/db/changelog/changelog-testing.xml
@@ -2302,4 +2302,5 @@
     <include file="db/changelog/20170224113816-add-productshare-table.xml"/>
     <include file="db/changelog/20170404164458-add-share-quantity-column-to-pools.xml"/>
     <include file="db/changelog/20170421055601-add-recipient-owner-to-consumer.xml"/>
+    <include file="db/changelog/20170518143217-remove-obsoleted-dirty-column.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-update.xml
+++ b/server/src/main/resources/db/changelog/changelog-update.xml
@@ -119,4 +119,5 @@
     <include file="db/changelog/20170224113816-add-productshare-table.xml"/>
     <include file="db/changelog/20170404164458-add-share-quantity-column-to-pools.xml"/>
     <include file="db/changelog/20170421055601-add-recipient-owner-to-consumer.xml"/>
+    <include file="db/changelog/20170518143217-remove-obsoleted-dirty-column.xml"/>
 </databaseChangeLog>

--- a/server/src/test/java/org/candlepin/controller/PoolManagerFunctionalTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerFunctionalTest.java
@@ -43,6 +43,8 @@ import org.candlepin.policy.EntitlementRefusedException;
 import org.candlepin.policy.js.entitlement.Enforcer;
 import org.candlepin.policy.js.entitlement.EntitlementRules;
 import org.candlepin.resource.dto.AutobindData;
+import org.candlepin.service.OwnerServiceAdapter;
+import org.candlepin.service.impl.DefaultOwnerServiceAdapter;
 import org.candlepin.service.impl.ImportSubscriptionServiceAdapter;
 import org.candlepin.test.DatabaseTestFixture;
 import org.candlepin.test.TestUtil;
@@ -82,6 +84,8 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
 
     @Inject private CandlepinPoolManager poolManager;
 
+    private OwnerServiceAdapter ownerAdapter;
+
     private Product virtHost;
     private Product virtHostPlatform;
     private Product virtGuest;
@@ -105,6 +109,8 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
 
         o = createOwner();
         ownerCurator.create(o);
+
+        this.ownerAdapter = new DefaultOwnerServiceAdapter(this.ownerCurator, this.i18n);
 
         virtHost = TestUtil.createProduct(PRODUCT_VIRT_HOST, PRODUCT_VIRT_HOST);
         virtHostPlatform = TestUtil.createProduct(PRODUCT_VIRT_HOST_PLATFORM, PRODUCT_VIRT_HOST_PLATFORM);
@@ -172,7 +178,7 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
         subscriptions.add(sub3);
         subscriptions.add(sub4);
 
-        poolManager.getRefresher(subAdapter).add(o).run();
+        poolManager.getRefresher(subAdapter, ownerAdapter).add(o).run();
 
         this.systemType = new ConsumerType(ConsumerTypeEnum.SYSTEM);
         consumerTypeCurator.create(systemType);
@@ -337,7 +343,7 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
 
         subscriptions.add(sub);
 
-        poolManager.getRefresher(subAdapter).add(o).run();
+        poolManager.getRefresher(subAdapter, ownerAdapter).add(o).run();
 
         // This test simulates https://bugzilla.redhat.com/show_bug.cgi?id=676870
         // where entitling first to the modifier then to the modifiee causes the modifier's
@@ -386,7 +392,7 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
         subscriptions.add(subscription);
 
         // set up initial pool
-        poolManager.getRefresher(subAdapter).add(o).run();
+        poolManager.getRefresher(subAdapter, ownerAdapter).add(o).run();
 
         List<Pool> pools = poolCurator.listByOwnerAndProduct(o, product1.getId());
         assertEquals(1, pools.size());
@@ -395,7 +401,7 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
         subscription.setProduct(product2.toDTO());
 
         // set up initial pool
-        poolManager.getRefresher(subAdapter).add(o).run();
+        poolManager.getRefresher(subAdapter, ownerAdapter).add(o).run();
 
         pools = poolCurator.listByOwnerAndProduct(o, product2.getId());
         assertEquals(1, pools.size());

--- a/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -73,6 +73,7 @@ import org.candlepin.policy.js.entitlement.PreUnbindHelper;
 import org.candlepin.policy.js.pool.PoolRules;
 import org.candlepin.policy.js.pool.PoolUpdate;
 import org.candlepin.resource.dto.AutobindData;
+import org.candlepin.service.OwnerServiceAdapter;
 import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.test.MockResultIterator;
 import org.candlepin.test.TestUtil;
@@ -118,6 +119,7 @@ public class PoolManagerTest {
     private I18n i18n;
 
     @Mock private PoolCurator mockPoolCurator;
+    @Mock private OwnerServiceAdapter mockOwnerAdapter;
     @Mock private SubscriptionServiceAdapter mockSubAdapter;
     @Mock private ProductCurator mockProductCurator;
     @Mock private ProductManager mockProductManager;
@@ -266,7 +268,7 @@ public class PoolManagerTest {
         when(cqmock.iterator()).thenReturn(pools.iterator());
         when(mockPoolCurator.listByOwnerAndType(eq(owner), any(PoolType.class))).thenReturn(cqmock);
 
-        this.manager.getRefresher(mockSubAdapter).add(owner).run();
+        this.manager.getRefresher(mockSubAdapter, mockOwnerAdapter).add(owner).run();
         List<Pool> expectedFloating = new LinkedList();
 
         // Make sure that only the floating pool was regenerated
@@ -308,7 +310,7 @@ public class PoolManagerTest {
         when(cqmock.iterator()).thenReturn(pools.iterator());
         when(mockPoolCurator.listByOwnerAndType(eq(owner), any(PoolType.class))).thenReturn(cqmock);
 
-        this.manager.getRefresher(mockSubAdapter).add(owner).run();
+        this.manager.getRefresher(mockSubAdapter, mockOwnerAdapter).add(owner).run();
         List<Pool> expectedModified = new LinkedList();
 
         // Make sure that only the floating pool was regenerated
@@ -580,7 +582,7 @@ public class PoolManagerTest {
 
         Owner owner = getOwner();
         when(mockOwnerCurator.lookupByKey(owner.getKey())).thenReturn(owner);
-        this.manager.getRefresher(mockSubAdapter).add(owner).run();
+        this.manager.getRefresher(mockSubAdapter, mockOwnerAdapter).add(owner).run();
         List<Pool> poolsToDelete = Arrays.asList(p);
         verify(this.manager).deletePools(eq(poolsToDelete));
     }
@@ -613,7 +615,7 @@ public class PoolManagerTest {
         when(cqmock.iterator()).thenReturn(pools.iterator());
         when(mockPoolCurator.listByOwnerAndType(eq(owner), any(PoolType.class))).thenReturn(cqmock);
 
-        this.manager.getRefresher(mockSubAdapter).add(owner).run();
+        this.manager.getRefresher(mockSubAdapter, mockOwnerAdapter).add(owner).run();
         List<Pool> delPools = Arrays.asList(p);
         verify(this.manager).deletePools(eq(delPools));
     }
@@ -646,7 +648,7 @@ public class PoolManagerTest {
         when(cqmock.iterator()).thenReturn(pools.iterator());
         when(mockPoolCurator.listByOwnerAndType(eq(owner), any(PoolType.class))).thenReturn(cqmock);
 
-        this.manager.getRefresher(mockSubAdapter).add(owner).run();
+        this.manager.getRefresher(mockSubAdapter, mockOwnerAdapter).add(owner).run();
         verify(this.manager, never()).deletePool(same(p));
     }
 
@@ -677,7 +679,7 @@ public class PoolManagerTest {
 
         Owner owner = getOwner();
         when(mockOwnerCurator.lookupByKey(owner.getKey())).thenReturn(owner);
-        this.manager.getRefresher(mockSubAdapter).add(owner).run();
+        this.manager.getRefresher(mockSubAdapter, mockOwnerAdapter).add(owner).run();
         verify(this.manager, never()).deletePool(same(p));
     }
 
@@ -707,7 +709,7 @@ public class PoolManagerTest {
         Owner owner = getOwner();
         when(mockOwnerCurator.lookupByKey(owner.getKey())).thenReturn(owner);
 
-        this.manager.getRefresher(mockSubAdapter).add(owner).run();
+        this.manager.getRefresher(mockSubAdapter, mockOwnerAdapter).add(owner).run();
         verify(this.manager, never()).deletePool(same(p));
     }
 
@@ -737,7 +739,7 @@ public class PoolManagerTest {
         when(cqmock.iterator()).thenReturn(pools.iterator());
         when(mockPoolCurator.listByOwnerAndType(eq(owner), any(PoolType.class))).thenReturn(cqmock);
 
-        this.manager.getRefresher(mockSubAdapter).add(owner).run();
+        this.manager.getRefresher(mockSubAdapter, mockOwnerAdapter).add(owner).run();
         ArgumentCaptor<List> poolCaptor = ArgumentCaptor.forClass(List.class);
         verify(this.poolRulesMock).updatePools(poolCaptor.capture(), any(Map.class));
         assertEquals(1, poolCaptor.getValue().size());
@@ -777,7 +779,7 @@ public class PoolManagerTest {
         when(cqmock.iterator()).thenReturn(pools.iterator());
         when(mockPoolCurator.listByOwnerAndType(eq(owner), any(PoolType.class))).thenReturn(cqmock);
 
-        this.manager.getRefresher(mockSubAdapter).add(owner).run();
+        this.manager.getRefresher(mockSubAdapter, mockOwnerAdapter).add(owner).run();
 
         TestUtil.assertPoolsAreEqual(TestUtil.copyFromSub(s), argPool.getValue());
         verify(this.mockPoolCurator, times(1)).create(any(Pool.class));
@@ -825,7 +827,7 @@ public class PoolManagerTest {
         when(cqmock.iterator()).thenReturn(pools.iterator());
         when(mockPoolCurator.listByOwnerAndType(eq(owner), any(PoolType.class))).thenReturn(cqmock);
 
-        this.manager.getRefresher(mockSubAdapter).add(owner).run();
+        this.manager.getRefresher(mockSubAdapter, mockOwnerAdapter).add(owner).run();
         verify(poolRulesMock).createAndEnrichPools(argPool.capture(), any(List.class));
         TestUtil.assertPoolsAreEqual(TestUtil.copyFromSub(s), argPool.getValue());
     }
@@ -1091,7 +1093,7 @@ public class PoolManagerTest {
         when(cqmock.iterator()).thenReturn(pools.iterator());
         when(mockPoolCurator.listByOwnerAndType(eq(owner), any(PoolType.class))).thenReturn(cqmock);
 
-        this.manager.getRefresher(mockSubAdapter).add(owner).run();
+        this.manager.getRefresher(mockSubAdapter, mockOwnerAdapter).add(owner).run();
 
         List<Entitlement> entsToDelete = Arrays.asList(ent);
         List<Pool> poolsToDelete = Arrays.asList(p);
@@ -1289,7 +1291,7 @@ public class PoolManagerTest {
         when(cqmock.iterator()).thenReturn(pools.iterator());
         when(mockPoolCurator.listByOwnerAndType(eq(owner), any(PoolType.class))).thenReturn(cqmock);
 
-        this.manager.getRefresher(mockSubAdapter).add(owner).run();
+        this.manager.getRefresher(mockSubAdapter, mockOwnerAdapter).add(owner).run();
 
         // The pool left over from the pre-migrated subscription should be deleted
         // and granted entitlements should be revoked

--- a/server/src/test/java/org/candlepin/controller/RefresherTest.java
+++ b/server/src/test/java/org/candlepin/controller/RefresherTest.java
@@ -23,6 +23,7 @@ import org.candlepin.model.Product;
 import org.candlepin.model.SourceSubscription;
 import org.candlepin.model.dto.ProductData;
 import org.candlepin.model.dto.Subscription;
+import org.candlepin.service.OwnerServiceAdapter;
 import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.util.Util;
 import org.candlepin.test.TestUtil;
@@ -44,6 +45,7 @@ import java.util.Map;
 public class RefresherTest {
 
     private CandlepinPoolManager poolManager;
+    private OwnerServiceAdapter ownerAdapter;
     private SubscriptionServiceAdapter subAdapter;
     private OwnerManager ownerManager;
 
@@ -55,7 +57,7 @@ public class RefresherTest {
         subAdapter = mock(SubscriptionServiceAdapter.class);
         ownerManager = mock(OwnerManager.class);
 
-        refresher = new Refresher(poolManager, subAdapter, ownerManager, false);
+        refresher = new Refresher(poolManager, subAdapter, ownerAdapter, ownerManager, false);
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/UndoImportsJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/UndoImportsJobTest.java
@@ -39,6 +39,7 @@ import org.candlepin.model.UeberCertificateGenerator;
 import org.candlepin.model.UpstreamConsumer;
 import org.candlepin.pinsetter.core.PinsetterJobListener;
 import org.candlepin.pinsetter.core.model.JobStatus;
+import org.candlepin.service.OwnerServiceAdapter;
 import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.sync.ImporterException;
 import org.candlepin.test.DatabaseTestFixture;
@@ -105,7 +106,8 @@ public class UndoImportsJobTest extends DatabaseTestFixture {
 
         // Setup common behavior
         when(this.jobContext.getMergedJobDataMap()).thenReturn(this.jobDataMap);
-        when(this.poolManager.getRefresher(eq(this.subAdapter), anyBoolean())).thenReturn(this.refresher);
+        when(this.poolManager.getRefresher(eq(this.subAdapter), any(OwnerServiceAdapter.class), anyBoolean()))
+            .thenReturn(this.refresher);
         when(this.refresher.setUnitOfWork(any(UnitOfWork.class))).thenReturn(this.refresher);
         when(this.refresher.add(any(Owner.class))).thenReturn(this.refresher);
 

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceCreationTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceCreationTest.java
@@ -55,6 +55,7 @@ import org.candlepin.policy.js.compliance.ComplianceStatus;
 import org.candlepin.resource.util.ConsumerBindUtil;
 import org.candlepin.resource.util.ConsumerEnricher;
 import org.candlepin.service.IdentityCertServiceAdapter;
+import org.candlepin.service.OwnerServiceAdapter;
 import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.service.UserServiceAdapter;
 import org.candlepin.util.FactValidator;
@@ -98,6 +99,7 @@ public class ConsumerResourceCreationTest {
     @Mock protected UserServiceAdapter userService;
     @Mock private IdentityCertServiceAdapter idCertService;
     @Mock private SubscriptionServiceAdapter subscriptionService;
+    @Mock private OwnerServiceAdapter ownerService;
     @Mock private ConsumerCurator consumerCurator;
     @Mock private ConsumerTypeCurator consumerTypeCurator;
     @Mock private OwnerCurator ownerCurator;
@@ -126,9 +128,9 @@ public class ConsumerResourceCreationTest {
 
         this.config = initConfig();
         this.resource = new ConsumerResource(
-            this.consumerCurator, this.consumerTypeCurator, null, this.subscriptionService, null,
-            this.idCertService, null, this.i18n, this.sink, null, null, null, this.userService, null, null,
-            this.ownerCurator, this.activationKeyCurator, null, this.complianceRules,
+            this.consumerCurator, this.consumerTypeCurator, null, this.subscriptionService, this.ownerService,
+            null, this.idCertService, null, this.i18n, this.sink, null, null, null, this.userService, null,
+            null, this.ownerCurator, this.activationKeyCurator, null, this.complianceRules,
             this.deletedConsumerCurator, null, null, this.config, null, null, null, this.consumerBindUtil,
             null, null, new FactValidator(this.config, this.i18n), null, consumerEnricher);
 

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
@@ -553,8 +553,8 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
     @Test
     public void testRegenerateEntitlementCertificateWithValidConsumerByEntitlement() {
         ConsumerResource cr = new ConsumerResource(
-            this.consumerCurator, null, null, null, this.entitlementCurator, null, null, null, null, null,
-            null, null, null, this.poolManager, null, null, null, null, null, null, null, null,
+            this.consumerCurator, null, null, null, null, this.entitlementCurator, null, null, null, null,
+            null, null, null, null, this.poolManager, null, null, null, null, null, null, null, null,
             new CandlepinCommonTestConfig(), null, null, null, mock(ConsumerBindUtil.class),
             null, null, null, null, consumerEnricher);
 

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
@@ -75,6 +75,7 @@ import org.candlepin.resource.util.ResourceDateParser;
 import org.candlepin.resteasy.parameter.KeyValueParameter;
 import org.candlepin.service.EntitlementCertServiceAdapter;
 import org.candlepin.service.IdentityCertServiceAdapter;
+import org.candlepin.service.OwnerServiceAdapter;
 import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.service.UserServiceAdapter;
 import org.candlepin.test.TestUtil;
@@ -127,6 +128,7 @@ public class ConsumerResourceTest {
     @Mock private ConsumerCurator mockedConsumerCurator;
     @Mock private OwnerCurator mockedOwnerCurator;
     @Mock private EntitlementCertServiceAdapter mockedEntitlementCertServiceAdapter;
+    @Mock private OwnerServiceAdapter mockedOwnerServiceAdapter;
     @Mock private SubscriptionServiceAdapter mockedSubscriptionServiceAdapter;
     @Mock private PoolManager mockedPoolManager;
     @Mock private EntitlementCurator mockedEntitlementCurator;
@@ -159,7 +161,7 @@ public class ConsumerResourceTest {
             "Test Owner"), share);
 
         ConsumerResource consumerResource = new ConsumerResource(
-            mockedConsumerCurator, mockConsumerTypeCurator, null, null, mockedEntitlementCurator, null,
+            mockedConsumerCurator, mockConsumerTypeCurator, null, null, null, mockedEntitlementCurator, null,
             mockedEntitlementCertServiceAdapter, i18n, null, null, null, null,
             null, mockedPoolManager, null, mockedOwnerCurator, null, null, null,
             null, null, null, new CandlepinCommonTestConfig(), null, null, null,
@@ -187,7 +189,7 @@ public class ConsumerResourceTest {
             "Test Owner"), share);
 
         ConsumerResource consumerResource = new ConsumerResource(
-            mockedConsumerCurator, mockConsumerTypeCurator, null, null, mockedEntitlementCurator, null,
+            mockedConsumerCurator, mockConsumerTypeCurator, null, null, null, mockedEntitlementCurator, null,
             mockedEntitlementCertServiceAdapter, i18n, null, null, null, null,
             null, mockedPoolManager, null, mockedOwnerCurator, null, null, null,
             null, null, null, new CandlepinCommonTestConfig(), null, null, null,
@@ -226,7 +228,7 @@ public class ConsumerResourceTest {
         when(mockedEntitlementCurator.listByConsumer(consumer)).thenReturn(new ArrayList<Entitlement>());
 
         ConsumerResource consumerResource = new ConsumerResource(
-            mockedConsumerCurator, null, null, null, mockedEntitlementCurator, null,
+            mockedConsumerCurator, null, null, null, null, mockedEntitlementCurator, null,
             mockedEntitlementCertServiceAdapter, null, null, null, null, null, null, mockedPoolManager, null,
             null, null, null, null, null, null, null, this.config, null, null, null, consumerBindUtil,
             null, null, this.factValidator, null, consumerEnricher);
@@ -262,7 +264,7 @@ public class ConsumerResourceTest {
         );
 
         ConsumerResource consumerResource = new ConsumerResource(
-            mockedConsumerCurator, null, null, null, mockedEntitlementCurator, null,
+            mockedConsumerCurator, null, null, null, null, mockedEntitlementCurator, null,
             mockedEntitlementCertServiceAdapter, null, null, null, null, null, null,
             poolManager, null, null, null, null, null, null, null, null,
             this.config, null, null, null, consumerBindUtil,
@@ -297,8 +299,8 @@ public class ConsumerResourceTest {
 
         CandlepinPoolManager mgr = mock(CandlepinPoolManager.class);
         ConsumerResource cr = new ConsumerResource(mockedConsumerCurator, null,
-            null, mockedSubscriptionServiceAdapter, null, null, null, null, null, null, null, null, null,
-            mgr, null, null, null, null, null, null, null, null,
+            null, mockedSubscriptionServiceAdapter, this.mockedOwnerServiceAdapter, null, null, null, null,
+            null, null, null, null, null, mgr, null, null, null, null, null, null, null, null,
             this.config, null, null, null, consumerBindUtil, null, null, this.factValidator,
             null, consumerEnricher);
 
@@ -325,7 +327,7 @@ public class ConsumerResourceTest {
         when(mockedConsumerCurator.verifyAndLookupConsumer(consumer.getUuid())).thenReturn(consumer);
         when(mockedIdSvc.regenerateIdentityCert(consumer)).thenReturn(createIdCert());
 
-        ConsumerResource cr = new ConsumerResource(mockedConsumerCurator, null,
+        ConsumerResource cr = new ConsumerResource(mockedConsumerCurator, null, null,
             null, null, null, mockedIdSvc, null, null, sink, eventFactory, null, null,
             null, null, null, mockedOwnerCurator, null, null, null, null,
             null, null, this.config, null, null, null, consumerBindUtil,
@@ -361,8 +363,8 @@ public class ConsumerResourceTest {
         when(mockedIdSvc.regenerateIdentityCert(consumer)).thenReturn(createIdCert());
 
         ConsumerResource cr = new ConsumerResource(mockedConsumerCurator, null,
-            null, ssa, null, mockedIdSvc, null, null, sink, eventFactory, null, null,
-            null, null, null, mockedOwnerCurator, null, null, rules, null,
+            null, ssa, this.mockedOwnerServiceAdapter, null, mockedIdSvc, null, null, sink, eventFactory,
+            null, null, null, null, null, mockedOwnerCurator, null, null, rules, null,
             null, null, this.config, null, null, null, consumerBindUtil,
             null, null, this.factValidator, null, consumerEnricher);
 
@@ -385,8 +387,8 @@ public class ConsumerResourceTest {
         when(mockedConsumerCurator.verifyAndLookupConsumer(consumer.getUuid())).thenReturn(consumer);
 
         ConsumerResource cr = new ConsumerResource(mockedConsumerCurator, null,
-            null, ssa, null, null, null, null, null, null, null, null, null, null,
-            null, mockedOwnerCurator, null, null, rules, null, null, null,
+            null, ssa, this.mockedOwnerServiceAdapter, null, null, null, null, null, null, null, null, null,
+            null, null, mockedOwnerCurator, null, null, rules, null, null, null,
             this.config, null, null, null, consumerBindUtil,
             null, null, this.factValidator, null, consumerEnricher);
 
@@ -415,7 +417,7 @@ public class ConsumerResourceTest {
         when(c.getName()).thenReturn("testConsumer");
         when(ctc.lookupByLabel(eq("person"))).thenReturn(cType);
 
-        ConsumerResource cr = new ConsumerResource(null, ctc,
+        ConsumerResource cr = new ConsumerResource(null, ctc, null,
             null, null, null, null, null, i18n, null, null, null, null,
             null, null, null, oc, akc, null, null, null, null,
             null, this.config, null, null, null, consumerBindUtil,
@@ -437,7 +439,7 @@ public class ConsumerResourceTest {
         when(e.bindByProducts(any(AutobindData.class))).thenReturn(null);
 
         ConsumerResource cr = new ConsumerResource(cc, null,
-            null, sa, null, null, null, i18n, null, null, null, null, null,
+            null, sa, this.mockedOwnerServiceAdapter, null, null, null, i18n, null, null, null, null, null,
             null, null, null, null, e, null, null, null, null,
             this.config, null, null, null, consumerBindUtil,
             null, null, this.factValidator, null, consumerEnricher);
@@ -463,9 +465,9 @@ public class ConsumerResourceTest {
         when(cc.verifyAndLookupConsumerWithEntitlements(eq("fakeConsumer"))).thenReturn(consumer);
         when(sa.hasUnacceptedSubscriptionTerms(any(Owner.class))).thenReturn(false);
 
-        ConsumerResource cr = new ConsumerResource(cc, null, null, sa, null, null, null, i18n, null,
-            null, null, null, null, pm, null, null, null, null, null, null, null, null,
-            this.config, null, null, null, consumerBindUtil, null, null, this.factValidator,
+        ConsumerResource cr = new ConsumerResource(cc, null, null, sa, this.mockedOwnerServiceAdapter, null,
+            null, null, i18n, null, null, null, null, null, pm, null, null, null, null, null, null, null,
+            null, this.config, null, null, null, consumerBindUtil, null, null, this.factValidator,
             null, consumerEnricher);
 
         Response rsp = cr.bind("fakeConsumer", null, null, null, null, null, true, null,
@@ -503,7 +505,7 @@ public class ConsumerResourceTest {
         when(sa.hasUnacceptedSubscriptionTerms(eq(c.getOwner()))).thenReturn(false);
         when(cc.verifyAndLookupConsumerWithEntitlements(eq(c.getUuid()))).thenReturn(c);
 
-        ConsumerResource cr = new ConsumerResource(cc, null, null, sa,
+        ConsumerResource cr = new ConsumerResource(cc, null, null, sa, this.mockedOwnerServiceAdapter,
             null, null, null, null, null, null, null, null, null, null,
             null, null, null, e, null, null, null, null,
             this.config, null, null, null, consumerBindUtil,
@@ -528,7 +530,7 @@ public class ConsumerResourceTest {
         when(entitlementCurator.find(any(Serializable.class))).thenReturn(null);
 
         ConsumerResource consumerResource = new ConsumerResource(consumerCurator, null,
-            null, null, entitlementCurator, null, null, i18n, null, null, null,
+            null, null, null, entitlementCurator, null, null, i18n, null, null, null,
             null, null, null, null, null, null, null, null, null, null,
             null, this.config, null, null, null, consumerBindUtil,
             null, null, this.factValidator, null, consumerEnricher);
@@ -552,7 +554,7 @@ public class ConsumerResourceTest {
             .thenReturn(new ArrayList<Entitlement>());
 
         ConsumerResource consumerResource = new ConsumerResource(consumerCurator, null,
-            null, null, entitlementCurator, null, null, i18n, null, null, null,
+            null, null, null, entitlementCurator, null, null, i18n, null, null, null,
             null, null, null, null, null, null, null, null, null, null,
             null, this.config, null, null, null, consumerBindUtil,
             null, null, this.factValidator, null, consumerEnricher);
@@ -564,7 +566,7 @@ public class ConsumerResourceTest {
     public void testBindMultipleParams() throws Exception {
         ConsumerCurator consumerCurator = mock(ConsumerCurator.class);
         ConsumerResource consumerResource = new ConsumerResource(consumerCurator, null,
-            null, null, null, null, null, i18n, null, null, null,
+            null, null, null, null, null, null, i18n, null, null, null,
             null, null, null, null, null, null, null, null, null, null,
             null, this.config, null, null, null, consumerBindUtil,
             null, null, this.factValidator, null, consumerEnricher);
@@ -579,7 +581,7 @@ public class ConsumerResourceTest {
     public void testBindMultipleParamsBodyAndProducts() throws Exception {
         ConsumerCurator consumerCurator = mock(ConsumerCurator.class);
         ConsumerResource consumerResource = new ConsumerResource(consumerCurator, null,
-            null, null, null, null, null, i18n, null, null, null,
+            null, null, null, null, null, null, i18n, null, null, null,
             null, null, null, null, null, null, null, null, null, null,
             null, this.config, null, null, null, consumerBindUtil,
             null, null, this.factValidator, null, consumerEnricher);
@@ -598,7 +600,7 @@ public class ConsumerResourceTest {
     public void testBindMultipleParamsBodyAndPoolString() throws Exception {
         ConsumerCurator consumerCurator = mock(ConsumerCurator.class);
         ConsumerResource consumerResource = new ConsumerResource(consumerCurator, null,
-            null, null, null, null, null, i18n, null, null, null,
+            null, null, null, null, null, null, i18n, null, null, null,
             null, null, null, null, null, null, null, null, null, null,
             null, this.config, null, null, null, consumerBindUtil,
             null, null, this.factValidator, null, consumerEnricher);
@@ -617,7 +619,7 @@ public class ConsumerResourceTest {
     public void testBindMultipleParamsBodyAndAsync() throws Exception {
         ConsumerCurator consumerCurator = mock(ConsumerCurator.class);
         ConsumerResource consumerResource = new ConsumerResource(consumerCurator, null,
-            null, null, null, null, null, i18n, null, null, null,
+            null, null, null, null, null, null, i18n, null, null, null,
             null, null, null, null, null, null, null, null, null, null,
             null, this.config, null, null, null, consumerBindUtil,
             null, null, this.factValidator, null, consumerEnricher);
@@ -635,7 +637,7 @@ public class ConsumerResourceTest {
     public void testBindMultipleParamsBodyAndQuantity() throws Exception {
         ConsumerCurator consumerCurator = mock(ConsumerCurator.class);
         ConsumerResource consumerResource = new ConsumerResource(consumerCurator, null,
-            null, null, null, null, null, i18n, null, null, null,
+            null, null, null, null, null, null, i18n, null, null, null,
             null, null, null, null, null, null, null, null, null, null,
             null, this.config, null, null, null, consumerBindUtil,
             null, null, this.factValidator, null, consumerEnricher);
@@ -656,7 +658,7 @@ public class ConsumerResourceTest {
         when(consumerCurator.verifyAndLookupConsumerWithEntitlements(any(String.class)))
             .thenThrow(new NotFoundException(""));
         ConsumerResource consumerResource = new ConsumerResource(consumerCurator, null,
-            null, null, null, null, null, i18n, null, null, null,
+            null, null, null, null, null, null, i18n, null, null, null,
             null, null, null, null, null, null, null, null, null, null,
             null, this.config, null, null, null, consumerBindUtil,
             null, null, this.factValidator, null, consumerEnricher);
@@ -677,7 +679,7 @@ public class ConsumerResourceTest {
         when(consumerCurator.verifyAndLookupConsumer(any(String.class)))
             .thenThrow(new NotFoundException(""));
         ConsumerResource consumerResource = new ConsumerResource(consumerCurator, null,
-            null, null, null, null, null, i18n, null, null, null,
+            null, null, null, null, null, null, i18n, null, null, null,
             null, null, null, null, null, null, null, null, null, null,
             null, this.config, null, null, null, consumerBindUtil,
             null, null, this.factValidator, null, consumerEnricher);
@@ -719,7 +721,7 @@ public class ConsumerResourceTest {
             thenReturn(true);
         // usa.findByLogin() will return null by default no need for a when
 
-        ConsumerResource cr = new ConsumerResource(null, ctc,
+        ConsumerResource cr = new ConsumerResource(null, ctc, null,
             null, null, null, null, null, i18n, null, null, null, null,
             usa, null,  null, oc, null, null, null, null, null,
             null, this.config, null, null, null, consumerBindUtil,
@@ -755,7 +757,7 @@ public class ConsumerResourceTest {
 
     ConsumerResource createConsumerResource(OwnerCurator oc) {
         ConsumerResource consumerResource = new ConsumerResource(
-            null, null, null, null, null, null, null, i18n, null, null, null, null, null, null, null,
+            null, null, null, null, null, null, null, null, i18n, null, null, null, null, null, null, null,
             oc, null, null, null, null, null, null, this.config, null, null, null, null, null, null,
             this.factValidator, null, consumerEnricher);
 
@@ -787,8 +789,8 @@ public class ConsumerResourceTest {
             .thenReturn(status);
 
         ConsumerResource cr = new ConsumerResource(mockedConsumerCurator, null, null, null, null, null, null,
-            i18n, null, null, null, null, null, null, null, null, null, null, mockedComplianceRules, null,
-            null, null, this.config, null, null, null, consumerBindUtil, null, null,
+            null, i18n, null, null, null, null, null, null, null, null, null, null, mockedComplianceRules,
+            null, null, null, this.config, null, null, null, consumerBindUtil, null, null,
             this.factValidator, null, consumerEnricher);
 
         Map<String, ComplianceStatus> results = cr.getComplianceStatusList(uuids);
@@ -801,7 +803,7 @@ public class ConsumerResourceTest {
     public void testConsumerExistsYes() {
         when(mockedConsumerCurator.doesConsumerExist(any(String.class))).thenReturn(true);
         ConsumerResource cr = new ConsumerResource(mockedConsumerCurator, null,
-            null, null, null, null, null, i18n, null, null, null,
+            null, null, null, null, null, null, i18n, null, null, null,
             null, null, null, null, null, null, null, mockedComplianceRules,
             null, null, null, this.config, null, null, null, consumerBindUtil,
             null, null, this.factValidator, null, consumerEnricher);
@@ -813,8 +815,8 @@ public class ConsumerResourceTest {
     public void testConsumerExistsNo() {
         when(mockedConsumerCurator.doesConsumerExist(any(String.class))).thenReturn(false);
         ConsumerResource cr = new ConsumerResource(mockedConsumerCurator, null, null, null, null, null, null,
-            i18n, null, null, null, null, null, null, null, null, null, null, mockedComplianceRules, null,
-            null, null, this.config, null, null, null, consumerBindUtil, null, null,
+            null, i18n, null, null, null, null, null, null, null, null, null, null, mockedComplianceRules,
+            null, null, null, this.config, null, null, null, consumerBindUtil, null, null,
             this.factValidator, null, consumerEnricher);
 
         cr.consumerExists("uuid");
@@ -823,8 +825,8 @@ public class ConsumerResourceTest {
     @Test(expected = BadRequestException.class)
     public void testFetchAllConsumers() {
         ConsumerResource cr = new ConsumerResource(
-            null, null, null, null, null, null, null, i18n, null, null, null, null, null, null, null, null,
-            null, null, null, null, null, null, this.config, null, null, null, null, null,
+            null, null, null, null, null, null, null, null, i18n, null, null, null, null, null, null, null,
+            null, null, null, null, null, null, null, this.config, null, null, null, null, null,
             null, this.factValidator, null, consumerEnricher);
 
         cr.list(null, null, null, null, null, null, null);
@@ -833,8 +835,8 @@ public class ConsumerResourceTest {
     @Test
     public void testFetchAllConsumersForUser() {
         ConsumerResource cr = new ConsumerResource(
-            mockedConsumerCurator, null, null, null, null, null, null, i18n, null, null, null, null, null,
-            null, null, null, null, null, null, null, null, null, this.config, null, null, null, null,
+            mockedConsumerCurator, null, null, null, null, null, null, null, i18n, null, null, null, null,
+            null, null, null, null, null, null, null, null, null, null, this.config, null, null, null, null,
             null, null, this.factValidator, new ConsumerTypeValidator(null, null),
             consumerEnricher);
 
@@ -854,9 +856,9 @@ public class ConsumerResourceTest {
 
     public void testFetchAllConsumersForOwner() {
         ConsumerResource cr = new ConsumerResource(
-            mockedConsumerCurator, null, null, null, null, null, null, i18n, null, null, null, null, null,
-            null, null, mockedOwnerCurator, null, null, null, null, null, null, this.config, null, null, null,
-            null, null, null, this.factValidator, null, consumerEnricher);
+            mockedConsumerCurator, null, null, null, null, null, null, null, i18n, null, null, null, null,
+            null, null, null, mockedOwnerCurator, null, null, null, null, null, null, this.config, null, null,
+            null, null, null, null, this.factValidator, null, consumerEnricher);
 
         ArrayList<Consumer> consumers = new ArrayList<Consumer>();
         CandlepinQuery cqmock = mock(CandlepinQuery.class);
@@ -876,8 +878,8 @@ public class ConsumerResourceTest {
     @Test(expected = BadRequestException.class)
     public void testFetchAllConsumersForEmptyUUIDs() {
         ConsumerResource cr = new ConsumerResource(
-            mockedConsumerCurator, null, null, null, null, null, null, i18n, null, null, null, null, null,
-            null, null, null, null, null, null, null, null, null, this.config, null, null, null, null,
+            mockedConsumerCurator, null, null, null, null, null, null, null, i18n, null, null, null, null,
+            null, null, null, null, null, null, null, null, null, null, this.config, null, null, null, null,
             null, null, this.factValidator, null, consumerEnricher);
 
         cr.list(null, null, null, new ArrayList<String>(), null, null, null);
@@ -886,8 +888,8 @@ public class ConsumerResourceTest {
     @Test
     public void testFetchAllConsumersForSomeUUIDs() {
         ConsumerResource cr = new ConsumerResource(
-            mockedConsumerCurator, null, null, null, null, null, null, i18n, null, null, null, null, null,
-            null, null, null, null, null, null, null, null, null, this.config, null, null, null, null,
+            mockedConsumerCurator, null, null, null, null, null, null, null, i18n, null, null, null, null,
+            null, null, null, null, null, null, null, null, null, null, this.config, null, null, null, null,
             null, null, this.factValidator, new ConsumerTypeValidator(null, null),
             consumerEnricher);
 
@@ -917,7 +919,7 @@ public class ConsumerResourceTest {
         when(mockedEntitlementCurator.listByConsumer(consumer)).thenReturn(new ArrayList<Entitlement>());
 
         ConsumerResource consumerResource = Mockito.spy(new ConsumerResource(
-            mockedConsumerCurator, null, null, null, mockedEntitlementCurator, null,
+            mockedConsumerCurator, null, null, null, null, mockedEntitlementCurator, null,
             mockedEntitlementCertServiceAdapter, null, null, null, null, null, null, mockedPoolManager, null,
             null, null, null, null, null, null, null, this.config, null, null, null, consumerBindUtil,
             null, null, this.factValidator, null, consumerEnricher));
@@ -937,7 +939,7 @@ public class ConsumerResourceTest {
         when(mockedEntitlementCurator.listByConsumer(consumer)).thenReturn(new ArrayList<Entitlement>());
 
         ConsumerResource consumerResource = Mockito.spy(new ConsumerResource(
-            mockedConsumerCurator, null, null, null, mockedEntitlementCurator, null,
+            mockedConsumerCurator, null, null, null, null, mockedEntitlementCurator, null,
             mockedEntitlementCertServiceAdapter, null, null, null, null, null, null, mockedPoolManager, null,
             null, null, null, null, null, null, null, this.config, null, null, null, consumerBindUtil,
             null, null, this.factValidator, null, consumerEnricher));
@@ -955,9 +957,9 @@ public class ConsumerResourceTest {
         when(mockedConsumerCurator.verifyAndLookupConsumer(eq(consumer.getUuid()))).thenReturn(consumer);
         ManifestManager manifestManager = mock(ManifestManager.class);
         ConsumerResource consumerResource = new ConsumerResource(
-            mockedConsumerCurator, null, null, null, null, null, null, i18n, null, null, null, null, null,
-            null, null, mockedOwnerCurator, null, null, null, null, null, null, this.config, null, null, null,
-            null, manifestManager, null, this.factValidator, null, consumerEnricher);
+            mockedConsumerCurator, null, null, null, null, null, null, null, i18n, null, null, null, null,
+            null, null, null, mockedOwnerCurator, null, null, null, null, null, null, this.config, null, null,
+            null, null, manifestManager, null, this.factValidator, null, consumerEnricher);
 
         try {
             consumerResource.dryBind(consumer.getUuid(), "some-sla");
@@ -973,8 +975,8 @@ public class ConsumerResourceTest {
         CdnCurator mockedCdnCurator = mock(CdnCurator.class);
         ManifestManager manifestManager = mock(ManifestManager.class);
         ConsumerResource cr = new ConsumerResource(
-            mockedConsumerCurator, null, null, null, null, null, null, i18n, null, null, null, null, null,
-            null, null, mockedOwnerCurator, null, null, null, null, null, null, this.config, null,
+            mockedConsumerCurator, null, null, null, null, null, null, null, i18n, null, null, null, null,
+            null, null, null, mockedOwnerCurator, null, null, null, null, null, null, this.config, null,
             mockedCdnCurator, null, null, manifestManager, null, this.factValidator, null,
             consumerEnricher);
 

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
@@ -56,6 +56,7 @@ import org.candlepin.resource.dto.AutobindData;
 import org.candlepin.resource.util.ConsumerBindUtil;
 import org.candlepin.resource.util.ConsumerEnricher;
 import org.candlepin.service.IdentityCertServiceAdapter;
+import org.candlepin.service.OwnerServiceAdapter;
 import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.service.UserServiceAdapter;
 import org.candlepin.test.TestUtil;
@@ -84,6 +85,7 @@ public class ConsumerResourceUpdateTest {
 
     @Mock private UserServiceAdapter userService;
     @Mock private IdentityCertServiceAdapter idCertService;
+    @Mock private OwnerServiceAdapter ownerService;
     @Mock private SubscriptionServiceAdapter subscriptionService;
     @Mock private ConsumerCurator consumerCurator;
     @Mock private ConsumerTypeCurator consumerTypeCurator;
@@ -112,7 +114,7 @@ public class ConsumerResourceUpdateTest {
         this.i18n = I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK);
 
         this.resource = new ConsumerResource(this.consumerCurator,
-            this.consumerTypeCurator, null, this.subscriptionService, null,
+            this.consumerTypeCurator, null, this.subscriptionService, this.ownerService, null,
             this.idCertService, null, this.i18n, this.sink, this.eventFactory, null, null,
             this.userService, poolManager, null, null,
             this.activationKeyCurator, this.entitler, this.complianceRules,

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceVirtEntitlementTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceVirtEntitlementTest.java
@@ -28,6 +28,7 @@ import org.candlepin.model.Product;
 import org.candlepin.model.dto.Subscription;
 import org.candlepin.policy.js.entitlement.Enforcer;
 import org.candlepin.policy.js.entitlement.EntitlementRules;
+import org.candlepin.service.OwnerServiceAdapter;
 import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.service.impl.ImportSubscriptionServiceAdapter;
 import org.candlepin.test.DatabaseTestFixture;
@@ -53,6 +54,7 @@ public class ConsumerResourceVirtEntitlementTest extends DatabaseTestFixture {
 
     @Inject private ConsumerResource consumerResource;
     @Inject private PoolManager poolManager;
+    @Inject private OwnerServiceAdapter ownerAdapter;
     @Inject private SubscriptionServiceAdapter subAdapter;
 
     private ConsumerType manifestType;
@@ -203,7 +205,7 @@ public class ConsumerResourceVirtEntitlementTest extends DatabaseTestFixture {
                 p = poolManager.find(p.getId());
                 assertTrue(p.getConsumed() == 20);
                 assertTrue(p.getQuantity() == -1);
-                poolManager.getRefresher(subAdapter).add(owner).run();
+                poolManager.getRefresher(subAdapter, ownerAdapter).add(owner).run();
                 // double check after pools refresh
                 assertTrue(p.getConsumed() == 20);
                 assertTrue(p.getQuantity() == -1);

--- a/server/src/test/java/org/candlepin/resource/GuestIdResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/GuestIdResourceTest.java
@@ -268,7 +268,7 @@ public class GuestIdResourceTest {
     private class ConsumerResourceForTesting extends ConsumerResource {
         public ConsumerResourceForTesting() {
             super(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null,
-                null, null, null, null, null, null, null, null, null, null, null, null,
+                null, null, null, null, null, null, null, null, null, null, null, null, null,
                 null, null, null, null, consumerEnricher);
         }
 

--- a/server/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
@@ -52,6 +52,7 @@ import org.candlepin.resource.dto.HypervisorCheckInResult;
 import org.candlepin.resource.util.ConsumerBindUtil;
 import org.candlepin.resource.util.ConsumerEnricher;
 import org.candlepin.service.IdentityCertServiceAdapter;
+import org.candlepin.service.OwnerServiceAdapter;
 import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.service.UserServiceAdapter;
 import org.candlepin.util.FactValidator;
@@ -80,6 +81,7 @@ public class HypervisorResourceTest {
     @Mock private UserServiceAdapter userService;
     @Mock private IdentityCertServiceAdapter idCertService;
     @Mock private SubscriptionServiceAdapter subscriptionService;
+    @Mock private OwnerServiceAdapter ownerService;
     @Mock private ConsumerCurator consumerCurator;
     @Mock private ConsumerTypeCurator consumerTypeCurator;
     @Mock private OwnerCurator ownerCurator;
@@ -106,7 +108,7 @@ public class HypervisorResourceTest {
         this.i18n = I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK);
         this.hypervisorType = new ConsumerType(ConsumerTypeEnum.HYPERVISOR);
         this.consumerResource = new ConsumerResource(this.consumerCurator,
-            this.consumerTypeCurator, null, this.subscriptionService, null,
+            this.consumerTypeCurator, null, this.subscriptionService, this.ownerService, null,
             this.idCertService, null, this.i18n, this.sink, this.eventFactory, null, null,
             this.userService, null, null, this.ownerCurator,
             this.activationKeyCurator, null, this.complianceRules,

--- a/server/src/test/java/org/candlepin/resource/OwnerResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/OwnerResourceTest.java
@@ -77,6 +77,8 @@ import org.candlepin.model.dto.Subscription;
 import org.candlepin.resteasy.parameter.CandlepinParam;
 import org.candlepin.resteasy.parameter.CandlepinParameterUnmarshaller;
 import org.candlepin.resteasy.parameter.KeyValueParameter;
+import org.candlepin.service.OwnerServiceAdapter;
+import org.candlepin.service.impl.DefaultOwnerServiceAdapter;
 import org.candlepin.service.impl.ImportSubscriptionServiceAdapter;
 import org.candlepin.sync.ConflictOverrides;
 import org.candlepin.sync.ImporterException;
@@ -186,6 +188,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
 
         List<Subscription> subscriptions = new LinkedList<Subscription>();
         ImportSubscriptionServiceAdapter subAdapter = new ImportSubscriptionServiceAdapter(subscriptions);
+        OwnerServiceAdapter ownerAdapter = new DefaultOwnerServiceAdapter(this.ownerCurator, this.i18n);
 
         Subscription sub = TestUtil.createSubscription(owner, prod, new HashSet<Product>());
         sub.setId(Util.generateDbUUID());
@@ -196,7 +199,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         subscriptions.add(sub);
 
         // Trigger the refresh:
-        poolManager.getRefresher(subAdapter).add(owner).run();
+        poolManager.getRefresher(subAdapter, ownerAdapter).add(owner).run();
         List<Pool> pools = poolCurator.listByOwnerAndProduct(owner, prod.getId());
         assertEquals(1, pools.size());
         Pool newPool = pools.get(0);
@@ -216,6 +219,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
 
         List<Subscription> subscriptions = new LinkedList<Subscription>();
         ImportSubscriptionServiceAdapter subAdapter = new ImportSubscriptionServiceAdapter(subscriptions);
+        OwnerServiceAdapter ownerAdapter = new DefaultOwnerServiceAdapter(this.ownerCurator, this.i18n);
 
         Subscription sub = TestUtil.createSubscription(owner, prod, new HashSet<Product>());
         sub.setId(Util.generateDbUUID());
@@ -232,7 +236,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         pool.getSourceSubscription().setSubscriptionId(sub.getId());
         poolCurator.merge(pool);
 
-        poolManager.getRefresher(subAdapter).add(owner).run();
+        poolManager.getRefresher(subAdapter, ownerAdapter).add(owner).run();
 
         pool = poolCurator.find(pool.getId());
         assertEquals(sub.getId(), pool.getSubscriptionId());
@@ -247,6 +251,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
 
         List<Subscription> subscriptions = new LinkedList<Subscription>();
         ImportSubscriptionServiceAdapter subAdapter = new ImportSubscriptionServiceAdapter(subscriptions);
+        OwnerServiceAdapter ownerAdapter = new DefaultOwnerServiceAdapter(this.ownerCurator, this.i18n);
 
         Subscription sub = TestUtil.createSubscription(owner, prod, new HashSet<Product>());
         sub.setId(Util.generateDbUUID());
@@ -257,7 +262,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         subscriptions.add(sub);
 
         // Trigger the refresh:
-        poolManager.getRefresher(subAdapter).add(owner).run();
+        poolManager.getRefresher(subAdapter, ownerAdapter).add(owner).run();
 
         List<Pool> pools = poolCurator.listByOwnerAndProduct(owner, prod.getId());
         assertEquals(1, pools.size());
@@ -268,7 +273,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         subscriptions.remove(sub);
 
         // Trigger the refresh:
-        poolManager.getRefresher(subAdapter).add(owner).run();
+        poolManager.getRefresher(subAdapter, ownerAdapter).add(owner).run();
         assertNull("Pool not having subscription should have been deleted", poolCurator.find(poolId));
     }
 
@@ -279,6 +284,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
 
         List<Subscription> subscriptions = new LinkedList<Subscription>();
         ImportSubscriptionServiceAdapter subAdapter = new ImportSubscriptionServiceAdapter(subscriptions);
+        OwnerServiceAdapter ownerAdapter = new DefaultOwnerServiceAdapter(this.ownerCurator, this.i18n);
 
         Subscription sub = TestUtil.createSubscription(owner, prod, new HashSet<Product>());
         sub.setId(Util.generateDbUUID());
@@ -297,7 +303,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         subscriptions.add(sub2);
 
         // Trigger the refresh:
-        poolManager.getRefresher(subAdapter).add(owner).run();
+        poolManager.getRefresher(subAdapter, ownerAdapter).add(owner).run();
 
         List<Pool> pools = poolCurator.listByOwner(owner).list();
         assertEquals(2, pools.size());
@@ -313,6 +319,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
 
         List<Subscription> subscriptions = new LinkedList<Subscription>();
         ImportSubscriptionServiceAdapter subAdapter = new ImportSubscriptionServiceAdapter(subscriptions);
+        OwnerServiceAdapter ownerAdapter = new DefaultOwnerServiceAdapter(this.ownerCurator, this.i18n);
 
         Subscription sub = TestUtil.createSubscription(owner, prod, new HashSet<Product>());
         sub.setId(Util.generateDbUUID());
@@ -323,7 +330,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         subscriptions.add(sub);
 
         // Trigger the refresh:
-        poolManager.getRefresher(subAdapter).add(owner).run();
+        poolManager.getRefresher(subAdapter, ownerAdapter).add(owner).run();
 
         List<Pool> pools = poolCurator.lookupBySubscriptionId(owner, sub.getId());
         assertEquals(2, pools.size());
@@ -341,7 +348,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         }
 
         // Trigger the refresh:
-        poolManager.getRefresher(subAdapter).add(owner).run();
+        poolManager.getRefresher(subAdapter, ownerAdapter).add(owner).run();
 
         assertNull("Original Master Pool should be gone", poolCurator.find(masterId));
         assertNotNull("Bonus Pool should be the same", poolCurator.find(bonusId));
@@ -367,6 +374,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
 
         List<Subscription> subscriptions = new LinkedList<Subscription>();
         ImportSubscriptionServiceAdapter subAdapter = new ImportSubscriptionServiceAdapter(subscriptions);
+        OwnerServiceAdapter ownerAdapter = new DefaultOwnerServiceAdapter(this.ownerCurator, this.i18n);
 
         Subscription sub = TestUtil.createSubscription(owner, prod, new HashSet<Product>());
         sub.setId(Util.generateDbUUID());
@@ -377,7 +385,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         subscriptions.add(sub);
 
         // Trigger the refresh:
-        poolManager.getRefresher(subAdapter).add(owner).run();
+        poolManager.getRefresher(subAdapter, ownerAdapter).add(owner).run();
 
         List<Pool> pools = poolCurator.lookupBySubscriptionId(owner, sub.getId());
         assertEquals(2, pools.size());
@@ -395,7 +403,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         }
 
         // Trigger the refresh:
-        poolManager.getRefresher(subAdapter).add(owner).run();
+        poolManager.getRefresher(subAdapter, ownerAdapter).add(owner).run();
 
         assertNull("Original bonus pool should be gone", poolCurator.find(bonusId));
         assertNotNull("Master pool should be the same", poolCurator.find(masterId));
@@ -843,8 +851,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         Owner owner2 = createOwner();
         ownerCurator.create(owner2);
 
-        ownerResource.listPools(owner.getKey(), c.getUuid(), null,
-            p.getUuid(),  null, true, null, null,
+        ownerResource.listPools(owner.getKey(), c.getUuid(), null, p.getUuid(),  null, true, null, null,
             new ArrayList<KeyValueParameter>(), false, false, setupPrincipal(owner2, Access.NONE), null);
     }
 
@@ -928,6 +935,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
 
         List<Subscription> subscriptions = new LinkedList<Subscription>();
         ImportSubscriptionServiceAdapter subAdapter = new ImportSubscriptionServiceAdapter(subscriptions);
+        OwnerServiceAdapter ownerAdapter = new DefaultOwnerServiceAdapter(this.ownerCurator, this.i18n);
 
         Subscription sub = TestUtil.createSubscription(owner, prod, new HashSet<Product>());
         sub.setId(Util.generateDbUUID());
@@ -953,7 +961,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         assertEquals(pool.getConsumed(), Long.valueOf(e1 + e2));
         this.config.setProperty(ConfigProperties.REVOKE_ENTITLEMENT_IN_FIFO_ORDER, fifo ? "true" : "false");
 
-        poolManager.getRefresher(subAdapter).add(retrieved).run();
+        poolManager.getRefresher(subAdapter, ownerAdapter).add(retrieved).run();
         pool = poolCurator.find(pool.getId());
         return pool;
     }
@@ -1083,6 +1091,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
 
         List<Subscription> subscriptions = new LinkedList<Subscription>();
         ImportSubscriptionServiceAdapter subAdapter = new ImportSubscriptionServiceAdapter(subscriptions);
+        OwnerServiceAdapter ownerAdapter = new DefaultOwnerServiceAdapter(this.ownerCurator, this.i18n);
 
         Subscription sub1 = TestUtil.createSubscription(owner, prod1, new HashSet<Product>());
         sub1.setId(Util.generateDbUUID());
@@ -1101,7 +1110,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         subscriptions.add(sub2);
 
         // Trigger the refresh:
-        poolManager.getRefresher(subAdapter).add(owner).run();
+        poolManager.getRefresher(subAdapter, ownerAdapter).add(owner).run();
 
         owner.setDefaultServiceLevel("premium");
         Owner parentOwner1 = new Owner("Paren Owner 1", "parentTest1");

--- a/server/src/test/java/org/candlepin/sync/ImporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/ImporterTest.java
@@ -60,6 +60,7 @@ import org.candlepin.model.dto.Subscription;
 import org.candlepin.pki.PKIUtility;
 import org.candlepin.pki.impl.BouncyCastlePKIUtility;
 import org.candlepin.pki.impl.DefaultSubjectKeyIdentifierWriter;
+import org.candlepin.service.OwnerServiceAdapter;
 import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.sync.Importer.ImportFile;
 
@@ -567,15 +568,15 @@ public class ImporterTest {
 
         PoolManager pm = mock(PoolManager.class);
         Refresher refresher = mock(Refresher.class);
-        when(pm.getRefresher(any(SubscriptionServiceAdapter.class))).thenReturn(refresher);
+        when(pm.getRefresher(any(SubscriptionServiceAdapter.class), any(OwnerServiceAdapter.class)))
+            .thenReturn(refresher);
 
         Map<String, File> importFiles = new HashMap<String, File>();
         File ruleDir = mock(File.class);
         File[] rulesFiles = createMockJsFile(mockJsPath);
         when(ruleDir.listFiles()).thenReturn(rulesFiles);
 
-        File actualmeta = createFile("meta.json", "0.0.3", new Date(),
-            "test_user", "prefix");
+        File actualmeta = createFile("meta.json", "0.0.3", new Date(), "test_user", "prefix");
         importFiles.put(ImportFile.META.fileName(), actualmeta);
 
         ConsumerDto consumer = new ConsumerDto("eb5e04bf-be27-44cf-abe3-0c0b1edd523e", "mymachine",


### PR DESCRIPTION
- The refresher will now refresh an owner's content access mode
  and content access mode list during the refresh process. This
  also takes over refreshing content access mode list duties from
  the importer as well.
- Fixed an issue where changing the content access mode or content
  access mode list during import would not cause certificates to be
  properly regenerated.
- Fixed an issue that would cause events to be generated for owner
  creation, even if the owner was not created due to an internal
  error.