### PR TITLE
[0.9.51] Batch product fetching from adapters when populating hosted db.

### DIFF
--- a/server/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/server/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -168,6 +168,9 @@ public class ConfigProperties {
         "management_enabled," +
         "virt_only";
 
+    public static final String POPULATE_HOSTED_DB_JOB_PROD_LOOKUP_BATCH_SIZE =
+        "candlepin.pophosted.prod_id_batch_size";
+
     public static final Map<String, String> DEFAULT_PROPERTIES =
         new HashMap<String, String>() {
 
@@ -273,6 +276,9 @@ public class ConfigProperties {
                 // Default 20 minutes
                 this.put(PINSETTER_ASYNC_JOB_TIMEOUT, Integer.toString(1200));
                 this.put(PINSETTER_MAX_RETRIES, Integer.toString(PINSETTER_MAX_RETRIES_DEFAULT));
+
+                // Populate hosted DB product adapter lookup batch size.
+                this.put(POPULATE_HOSTED_DB_JOB_PROD_LOOKUP_BATCH_SIZE, Integer.toString(250));
             }
         };
     public static final String CRL_FILE_PATH = "candlepin.crl.file";

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/PopulateHostedDBTaskTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/PopulateHostedDBTaskTest.java
@@ -299,4 +299,19 @@ public class PopulateHostedDBTaskTest extends DatabaseTestFixture {
         assertEquals(5, this.productCurator.listAll().size());
         assertEquals(6, this.contentCurator.listAll().size());
     }
+
+    @Test
+    public void ensureFailureOnInvalidProductAdapterBatchConfig() throws Exception {
+        JobExecutionContext jec = mock(JobExecutionContext.class);
+        CandlepinCommonTestConfig config = new CandlepinCommonTestConfig();
+        config.setProperty(ConfigProperties.STANDALONE, "false");
+        config.setProperty(ConfigProperties.POPULATE_HOSTED_DB_JOB_PROD_LOOKUP_BATCH_SIZE, "-1");
+
+        // Test
+        PopulateHostedDBTask task = new PopulateHostedDBTask(null, null, null, null, config);
+        task.toExecute(jec);
+
+        verify(jec).setResult(eq(String.format("Aborting populate DB task. Invalid configuration setting for {0}.",
+            ConfigProperties.POPULATE_HOSTED_DB_JOB_PROD_LOOKUP_BATCH_SIZE)));
+    }
 }


### PR DESCRIPTION
Product lookups via the adapter take a long time on hosted,
and seems to cause c3p0 to close the DB connection due to
an idle connection timeout. This patch performs batch product
adapter lookups in order to shorten the idle time while
updating the product records.