### PR TITLE
1452330: Added refresh behavior from Candlepin 0.9.x (2.0)

### DIFF
--- a/server/client/ruby/hostedtest_api.rb
+++ b/server/client/ruby/hostedtest_api.rb
@@ -6,7 +6,7 @@ module HostedTest
   def is_hostedtest_alive?
     if @@hostedtest_alive.nil?
       begin
-        @@hostedtest_alive = @cp.get('/hostedtest/subscriptions/is_alive', {}, 'json', true)
+        @@hostedtest_alive = @cp.get('/hostedtest/subscriptions/is_alive','json', true)
       rescue RestClient::ResourceNotFound
         @@hostedttest_alive = false
       end
@@ -15,9 +15,8 @@ module HostedTest
   end
 
   def create_hostedtest_subscription(owner_key, product_id, quantity=1, params={})
-
     provided_products = params[:provided_products] || []
-    start_date = params[:start_date] || DateTime.now
+    start_date = params[:start_date] || Date.today
     end_date = params[:end_date] || start_date + 365
 
     subscription = {
@@ -59,11 +58,11 @@ module HostedTest
     if params[:derived_provided_products]
       subscription['derivedProvidedProducts'] = params[:derived_provided_products].collect { |pid| {'id' => pid} }
     end
-    return @cp.post("/hostedtest/subscriptions", {}, subscription)
+    return @cp.post("/hostedtest/subscriptions", subscription)
   end
 
   def update_hostedtest_subscription(subscription)
-    return @cp.put("/hostedtest/subscriptions", {}, subscription)
+    return @cp.put("/hostedtest/subscriptions", subscription)
   end
 
   def get_all_hostedtest_subscriptions()
@@ -75,11 +74,11 @@ module HostedTest
   end
 
   def delete_hostedtest_subscription(id)
-    return @cp.delete("/hostedtest/subscriptions/#{id}", {}, nil, true)
+    return @cp.delete("/hostedtest/subscriptions/#{id}", nil, true)
   end
 
   def delete_all_hostedtest_subscriptions()
-    @cp.delete('/hostedtest/subscriptions/', {}, nil, true)
+    @cp.delete('/hostedtest/subscriptions/', nil, true)
   end
 
   def is_hosted?
@@ -109,7 +108,7 @@ module HostedTest
       content_ids.each do |id|
         data[id] = enabled
       end
-      @cp.post("/hostedtest/subscriptions/owners/#{owner_key}/products/#{product_id}/batch_content", {}, data)
+      @cp.post("/hostedtest/subscriptions/owners/#{owner_key}/products/#{product_id}/batch_content", data)
     else
       @cp.add_batch_content_to_product(owner_key, product_id, content_ids, true)
     end
@@ -117,7 +116,7 @@ module HostedTest
 
   def add_content_to_product(owner_key, product_id, content_id, enabled=true)
     if is_hosted?
-      @cp.post("/hostedtest/subscriptions/owners/#{owner_key}/products/#{product_id}/content/#{content_id}", {:enabled => enabled})
+      @cp.post("/hostedtest/subscriptions/owners/#{owner_key}/products/#{product_id}/content/#{content_id}?enabled=#{enabled}")
     else
       @cp.add_content_to_product(owner_key, product_id, content_id, true)
     end
@@ -134,7 +133,7 @@ module HostedTest
       product[:dependentProductIds] = params[:dependentProductIds] if params[:dependentProductIds]
       product[:relies_on] = params[:relies_on] if params[:relies_on]
 
-      @cp.put("/hostedtest/subscriptions/owners/#{owner_key}/products/#{product_id}", {}, product)
+      @cp.put("/hostedtest/subscriptions/owners/#{owner_key}/products/#{product_id}", product)
     else
       @cp.update_product(owner_key, product_id, params)
     end

--- a/server/spec/candlepin_scenarios.rb
+++ b/server/spec/candlepin_scenarios.rb
@@ -548,9 +548,7 @@ class StandardExporter < Exporter
     # pool3 is special
     @candlepin_client.consume_pool(@pool3.id, {:quantity => 1})
 
-    @cdn = create_cdn(@cdn_label,
-                "Test CDN",
-                "https://cdn.test.com")
+    @cdn = create_cdn(@cdn_label, "Test CDN", "https://cdn.test.com")
   end
 
   def create_candlepin_export_update
@@ -585,7 +583,7 @@ class StandardExporter < Exporter
   end
 
   def create_candlepin_export_update_no_ent
-    ## We need to test the behavoir of the manifest update when no entitlements
+    ## We need to test the behavior of the manifest update when no entitlements
     ## are included
     ents = @candlepin_client.list_entitlements()
     # remove all entitlements
@@ -653,45 +651,45 @@ end
 
 # We assume existence of queue allmsg that is bound to event exchange
 class CandlepinQpid
-  def initialize() 
+  def initialize()
     @address='amqps://localhost:5671/allmsg'
     @qpid_crt = "server/bin/qpid/keys/qpid_ca.crt"
     @qpid_key = "server/bin/qpid/keys/qpid_ca.key"
-   end 
+   end
 
-  def no_keys 
+  def no_keys
     !File.file?(@qpid_crt) or !File.file?(@qpid_key)
-  end 
+  end
 
   def stop
     `sudo systemctl stop qpidd || sudo supervisorctl stop qpidd`
-  end 
+  end
 
   def start
     `sudo systemctl start qpidd || sudo supervisorctl start qpidd`
-  end 
+  end
 
   #Create non-durable queue and bind it to an exchange
   def create_queue(qname, args, exchange)
     `sudo qpid-config -b amqps://localhost:5671 --ssl-certificate #{@qpid_crt} --ssl-key #{@qpid_key} add queue #{qname} #{args}`
     `sudo qpid-config -b amqps://localhost:5671 --ssl-certificate #{@qpid_crt} --ssl-key #{@qpid_key} bind #{exchange} #{qname} "#"`
-  end 
- 
+  end
+
   #Force removes the queue
   def delete_queue(qname)
     `sudo qpid-config -b amqps://localhost:5671 --ssl-certificate #{@qpid_crt} --ssl-key #{@qpid_key} del queue #{qname} --force`
-  end 
+  end
 
   def receive
     @messenger = Qpid::Proton::Messenger::Messenger.new
-   
+
     if (no_keys)
       raise "The Qpid keys doesnt exist on paths: #{File.absolute_path(@qpid_crt)}; #{File.absolute_path(@qpid_key)}"
     end
     @messenger.certificate = @qpid_crt
     @messenger.private_key = @qpid_key
     @messenger.blocking = false
- 
+
     msgs = []
     @messenger.start
     @messenger.subscribe(@address)
@@ -701,20 +699,20 @@ class CandlepinQpid
      # The receive method is non blocking but
      # it seems you need to call it several times to
      # establish connection to the broker
-     5.times do  
+     5.times do
        @messenger.receive
        sleep(0.3)
-     end 
+     end
 
-     break if @messenger.incoming.zero? 
+     break if @messenger.incoming.zero?
      while @messenger.incoming.nonzero?
       msg = Qpid::Proton::Message.new
       @messenger.get(msg)
-      msgs << msg 
-     end 
-    end 
+      msgs << msg
+     end
+    end
     @messenger.stop
 
    return msgs
-  end 
+  end
 end

--- a/server/spec/import_cleanup_spec.rb
+++ b/server/spec/import_cleanup_spec.rb
@@ -65,8 +65,7 @@ describe 'Import cleanup', :serial => true do
     @cp.import(@import_owner['key'], updated_export.export_filename)
 
     # All the pools for that owner should be removed
-    normal = @import_owner_client.list_pools({
-           :owner => @import_owner['id']} )
+    normal = @import_owner_client.list_pools({:owner => @import_owner['id']} )
     normal.length.should == 0
   end
 

--- a/server/spec/import_environment_spec.rb
+++ b/server/spec/import_environment_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+require 'candlepin_scenarios'
+
+describe 'Import Into Environment', :serial => true do
+
+  include CandlepinMethods
+
+  before(:all) do
+    @exporters = []
+
+    @cp = Candlepin.new('admin', 'admin')
+    skip("candlepin running in hosted mode") if is_hosted?
+  end
+
+  after(:all) do
+    @exporters.each do |e|
+      e.cleanup()
+    end
+  end
+
+  it 'should not remove pools for custom products during import' do
+    cp_export = StandardExporter.new
+    cp_export.create_candlepin_export()
+    cp_export_file = cp_export.export_filename
+    @cp_correlation_id = "a7b79f6d-63ca-40d8-8bfb-f255041f4e3b"
+
+    candlepin_consumer = cp_export.candlepin_client.get_consumer()
+    candlepin_consumer.unregister candlepin_consumer['uuid']
+
+    @exporters << cp_export
+
+    import_owner = create_owner(random_string("test_owner"))
+    import_username = random_string("import-user")
+    import_owner_client = user_client(import_owner, import_username)
+
+    product1 = create_product('custom_prod-1', 'custom_prod-1', :owner => import_owner['key'])
+    product2 = create_product('custom_prod-2', 'custom_prod-2', :owner => import_owner['key'])
+    custom_prod_pool_1 = @cp.create_pool(import_owner['key'], product1.id, { :quantity => 10 })
+    custom_prod_pool_2 = @cp.create_pool(import_owner['key'], product2.id, { :quantity => 10 })
+
+    expect(custom_prod_pool_1).to_not be_nil
+    expect(custom_prod_pool_2).to_not be_nil
+
+    import_record = @cp.import(import_owner['key'], cp_export_file)
+    import_record.status.should == 'SUCCESS'
+    import_record.statusMessage.should == "#{import_owner['key']} file imported successfully."
+
+    # The custom pools should *not* have been deleted during the import
+    pool1 = @cp.get_pool(custom_prod_pool_1['id'])
+    pool2 = @cp.get_pool(custom_prod_pool_2['id'])
+
+    expect(pool1).to_not be_nil
+    expect(pool2).to_not be_nil
+  end
+
+end

--- a/server/spec/import_environment_spec.rb
+++ b/server/spec/import_environment_spec.rb
@@ -18,7 +18,7 @@ describe 'Import Into Environment', :serial => true do
     end
   end
 
-  it 'should not remove pools for custom products during import' do
+  it 'should not remove custom pools during import' do
     cp_export = StandardExporter.new
     cp_export.create_candlepin_export()
     cp_export_file = cp_export.export_filename
@@ -48,6 +48,41 @@ describe 'Import Into Environment', :serial => true do
     # The custom pools should *not* have been deleted during the import
     pool1 = @cp.get_pool(custom_prod_pool_1['id'])
     pool2 = @cp.get_pool(custom_prod_pool_2['id'])
+
+    expect(pool1).to_not be_nil
+    expect(pool2).to_not be_nil
+  end
+
+  it 'should not remove pools for custom subscriptions during import' do
+    cp_export = StandardExporter.new
+    cp_export.create_candlepin_export()
+    cp_export_file = cp_export.export_filename
+    @cp_correlation_id = "a7b79f6d-63ca-40d8-8bfb-f255041f4e3b"
+
+    candlepin_consumer = cp_export.candlepin_client.get_consumer()
+    candlepin_consumer.unregister candlepin_consumer['uuid']
+
+    @exporters << cp_export
+
+    import_owner = create_owner(random_string("test_owner"))
+    import_username = random_string("import-user")
+    import_owner_client = user_client(import_owner, import_username)
+
+    product1 = create_product('custom_prod-1', 'custom_prod-1', :owner => import_owner['key'])
+    product2 = create_product('custom_prod-2', 'custom_prod-2', :owner => import_owner['key'])
+    custom_sub_pool_1 = create_pool_and_subscription(import_owner['key'], product1.id, 10)
+    custom_sub_pool_2 = create_pool_and_subscription(import_owner['key'], product2.id, 10)
+
+    expect(custom_sub_pool_1).to_not be_nil
+    expect(custom_sub_pool_2).to_not be_nil
+
+    import_record = @cp.import(import_owner['key'], cp_export_file)
+    import_record.status.should == 'SUCCESS'
+    import_record.statusMessage.should == "#{import_owner['key']} file imported successfully."
+
+    # The custom pools should *not* have been deleted during the import
+    pool1 = @cp.get_pool(custom_sub_pool_1['id'])
+    pool2 = @cp.get_pool(custom_sub_pool_2['id'])
 
     expect(pool1).to_not be_nil
     expect(pool2).to_not be_nil

--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -1636,6 +1636,7 @@ public class CandlepinPoolManager implements PoolManager {
                 derivedPools.add(pool);
             }
         }
+
         deleteExcessEntitlements(derivedPools);
     }
 

--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -188,7 +188,7 @@ public class CandlepinPoolManager implements PoolManager {
     @Transactional
     @SuppressWarnings("checkstyle:methodlength")
     void refreshPoolsWithRegeneration(SubscriptionServiceAdapter subAdapter, Owner owner, boolean lazy) {
-        long start = System.currentTimeMillis();
+        Date now = new Date();
         owner = this.refreshOwner(owner);
         log.info("Refreshing pools for owner: {}", owner);
 
@@ -280,7 +280,6 @@ public class CandlepinPoolManager implements PoolManager {
 
                             // We need to lock the incoming content here, but doing so will affect
                             // the equality comparison for products. We'll correct them later.
-
                             ContentData existingContent = contentMap.get(content.getId());
                             if (existingContent != null && !existingContent.equals(content)) {
                                 log.warn("Multiple versions of the same content received during refresh; " +
@@ -323,7 +322,7 @@ public class CandlepinPoolManager implements PoolManager {
             Map.Entry<String, Subscription> entry = subsIterator.next();
             Subscription sub = entry.getValue();
 
-            if (this.isExpired(sub)) {
+            if (now.after(sub.getEndDate())) {
                 log.info("Skipping expired subscription: {}", sub);
 
                 subsIterator.remove();
@@ -331,7 +330,6 @@ public class CandlepinPoolManager implements PoolManager {
             }
 
             log.debug("Processing subscription: {}", sub);
-
             Pool pool = this.convertToMasterPoolImpl(sub, owner, importedProducts);
             this.refreshPoolsForMasterPool(pool, false, lazy, updatedProducts);
         }
@@ -339,8 +337,24 @@ public class CandlepinPoolManager implements PoolManager {
         // delete pools whose subscription disappeared:
         log.debug("Deleting pools for absent subscriptions...");
         List<Pool> poolsToDelete = new ArrayList<Pool>();
+
+        // BZ 1452694: Don't delete pools for custom subscriptions
+        // We need to verify that we aren't deleting pools that are created via the API.
+        // Unfortunately, we don't have a 100% reliable way of detecting such pools at this point,
+        // so we'll do the next best thing: In standalone, pools with an upstream pool ID are those
+        // we've received from an import (and, thus, are eligible for deletion). In hosted,
+        // however, we *are* the upstream source, so everything is eligible for removal.
+        // This is pretty hacky, so the way we go about doing this check should eventually be
+        // replaced with something more generic and reliable, and not dependent on the config.
+
+        // TODO:
+        // Remove the standalone config check and replace it with a check for whether or not the
+        // pool is "managed"  -- however we decide to implement that in the future.
+        boolean standalone = config.getBoolean(ConfigProperties.STANDALONE, true);
         for (Pool pool : poolCurator.getPoolsFromBadSubs(owner, subscriptionMap.keySet())) {
-            if (pool.getSourceSubscription() != null && !pool.getType().isDerivedType()) {
+            if ((!standalone || pool.getUpstreamPoolId() != null) && pool.getSourceSubscription() != null &&
+                !pool.getType().isDerivedType()) {
+
                 poolsToDelete.add(pool);
             }
         }
@@ -353,7 +367,7 @@ public class CandlepinPoolManager implements PoolManager {
         updateFloatingPools(floatingPools, lazy, updatedProducts);
 
         log.info("Refresh pools for owner: {} completed in: {}ms", owner.getKey(),
-            System.currentTimeMillis() - start);
+            System.currentTimeMillis() - now.getTime());
     }
 
     private Owner refreshOwner(Owner owner) {
@@ -484,11 +498,6 @@ public class CandlepinPoolManager implements PoolManager {
         this.poolCurator.flush();
 
         return pools.size();
-    }
-
-    private boolean isExpired(Subscription subscription) {
-        Date now = new Date();
-        return now.after(subscription.getEndDate());
     }
 
     @Transactional
@@ -841,7 +850,6 @@ public class CandlepinPoolManager implements PoolManager {
         pool.setOrderNumber(sub.getOrderNumber());
 
         // Copy over subscription details
-        pool.setSubscriptionId(sub.getId());
         pool.setSourceSubscription(new SourceSubscription(sub.getId(), "master"));
 
         // Copy over upstream details
@@ -1946,13 +1954,13 @@ public class CandlepinPoolManager implements PoolManager {
     }
 
     @Override
-    public void deletePools(List<Pool> pools) {
+    public void deletePools(Collection<Pool> pools) {
         deletePools(pools, null);
     }
 
     @Override
     @Transactional
-    public void deletePools(List<Pool> pools, Set<String> alreadyDeletedPools) {
+    public void deletePools(Collection<Pool> pools, Set<String> alreadyDeletedPools) {
         if (pools == null || pools.isEmpty()) {
             return;
         }
@@ -1966,22 +1974,40 @@ public class CandlepinPoolManager implements PoolManager {
         }
 
         List<Entitlement> entitlementsToRevoke = new LinkedList<Entitlement>();
-
-        for (Pool p : pools) {
-            if (log.isDebugEnabled()) {
-                log.debug("Deletion of pool {} will revoke the following entitlements: {}",
-                    p.getId(), getEntIds(p.getEntitlements()));
-            }
-            entitlementsToRevoke.addAll(p.getEntitlements());
-        }
-
-        if (!pools.isEmpty()) {
-            revokeEntitlements(entitlementsToRevoke, alreadyDeletedPools);
-            log.debug("Batch deleting pools after successful revocation");
-            poolCurator.batchDelete(pools, alreadyDeletedPools);
-        }
+        Set<String> subscriptionIds = new HashSet<String>();
+        Set<Pool> poolsToDelete = new HashSet<Pool>();
 
         for (Pool pool : pools) {
+            if (log.isDebugEnabled()) {
+                log.debug("Deletion of pool {} will revoke the following entitlements: {}",
+                    pool.getId(), getEntIds(pool.getEntitlements()));
+            }
+
+            // If this is a master pool, we should also be deleting any derived/bonus pools
+            // as well...
+            SourceSubscription srcSub = pool.getSourceSubscription();
+            if (srcSub != null && srcSub.getSubscriptionId() != null &&
+                "master".equals(srcSub.getSubscriptionSubKey())) {
+
+                subscriptionIds.add(srcSub.getSubscriptionId());
+            }
+
+            poolsToDelete.add(pool);
+            entitlementsToRevoke.addAll(pool.getEntitlements());
+        }
+
+        // Look up the related pools for these subscription IDs.
+        if (!subscriptionIds.isEmpty()) {
+            poolsToDelete.addAll(this.poolCurator.getPoolsBySubscriptionIds(subscriptionIds));
+        }
+
+        if (!poolsToDelete.isEmpty()) {
+            revokeEntitlements(entitlementsToRevoke, alreadyDeletedPools);
+            log.debug("Batch deleting pools after successful revocation");
+            poolCurator.batchDelete(poolsToDelete, alreadyDeletedPools);
+        }
+
+        for (Pool pool : poolsToDelete) {
             Event event = eventFactory.poolDeleted(pool);
             sink.queueEvent(event);
         }
@@ -2185,6 +2211,7 @@ public class CandlepinPoolManager implements PoolManager {
                 regenerateCertificatesOf(entry.getValue(), true);
             }
         }
+
         @Override
         public void handleBonusPools(Owner owner, Map<String, PoolQuantity> pools,
             Map<String, Entitlement> entitlements) {
@@ -2259,83 +2286,7 @@ public class CandlepinPoolManager implements PoolManager {
             throw new IllegalArgumentException("pool is null");
         }
 
-        Long poolQuantity = pool.getQuantity();
-        Long multiplier = 1L;
-
-        if (pool.getProduct() != null) {
-            multiplier = pool.getProduct().getMultiplier();
-        }
-        else {
-            log.error("Master product for the pool {} is null", pool.getId());
-        }
-
-
-        /**
-         * The following code reconstructs Subscription quantity from the Pool quantity.
-         * To understand it, it is important to understand how pool (the parameter)
-         * is created in candlepin from a source subscription.
-         * The pool has quantity was computed from
-         * source subscription quantity and was multiplied by product.multiplier.
-         * To reconstruct subscription, we must therefore divide the quantity of the pool
-         * by the product.multiplier.
-         * It's not easy to find COMPLETE code related to the conversion of
-         * subscription to the pool. There is a method convertToMasterPool in this class,
-         * that should do part of that (multiplication is not there).
-         * But looking at its javadoc, it directly instructs callers of the
-         * convertToMasterPool method to override quantity with method
-         * PoolRules.calculateQuantity (when browsing the code that calls convertToMasterPool,
-         * the calculateQuantity is usually called after convertToMasterPool).
-         * The method PoolRules.calculateQuantity does the actual
-         * multiplication of pool.quantity by pool.product.multiplier.
-         * It seems that we also need to account account for
-         * instance_multiplier (again logic is in calculateQuantity). If the attribute
-         * is present, we must further divide the poolQuantity by
-         * product.getAttributeValue(Product.Attributes.INSTANCE_MULTIPLIER).
-         */
-        Product sku = pool.getProduct();
-
-        if (poolQuantity != null && multiplier != null && multiplier != 0 && sku != null) {
-            if (poolQuantity % multiplier != 0) {
-                log.error("Pool {} from which we fabricate subscription has quantity {} that " +
-                    "is not divisable by its product's multiplier {}! Division wont be made.",
-                    pool.getId(), poolQuantity, multiplier);
-            }
-            else {
-                poolQuantity /= multiplier;
-            }
-
-            //This is reverse of what part of PooRules.calculateQuantity does. See that method
-            //to understand why we check that upstreamPoolId must be null.
-            if (sku.hasAttribute(Product.Attributes.INSTANCE_MULTIPLIER) &&
-                pool.getUpstreamPoolId() == null) {
-
-                Integer instMult = null;
-                String stringInstmult = sku.getAttributeValue(Product.Attributes.INSTANCE_MULTIPLIER);
-                try {
-                    instMult = Integer.parseInt(stringInstmult);
-                }
-                catch (NumberFormatException nfe) {
-                    log.error("Instance multilier couldn't be parsed: {} ", stringInstmult);
-                }
-                if (instMult != null && instMult != 0 && poolQuantity % instMult == 0) {
-                    poolQuantity /=  instMult;
-                }
-                else {
-                    log.error("Cannot divide pool quantity by instance multiplier. Won't touch the " +
-                        "current value {} instance multiplier: {}, pool quantity: {}",
-                        poolQuantity, instMult, poolQuantity);
-                }
-            }
-        }
-        else {
-            log.warn("Either quantity or multiplier or product is null: {}, {}, productInstance={}",
-                poolQuantity, multiplier, sku);
-        }
-
-        Subscription subscription = new Subscription(pool, productCurator);
-        subscription.setQuantity(poolQuantity);
-
-        return subscription;
+        return new Subscription(pool, productCurator);
     }
 
     @Override
@@ -2348,9 +2299,30 @@ public class CandlepinPoolManager implements PoolManager {
         return this.poolCurator.getMasterPoolBySubscriptionId(subscriptionId);
     }
 
+    /**
+     * @{inheritDoc}
+     */
     @Override
-    public List<Pool> listMasterPools() {
-        return this.poolCurator.listMasterPools();
+    public CandlepinQuery<Pool> getMasterPools() {
+        return this.poolCurator.getMasterPools();
+    }
+
+    /**
+     * @{inheritDoc}
+     */
+    @Override
+    public CandlepinQuery<Pool> getMasterPoolsForOwner(Owner owner) {
+        return this.poolCurator.getMasterPoolsForOwner(owner);
+    }
+
+    /**
+     * @{inheritDoc}
+     */
+    @Override
+    public CandlepinQuery<Pool> getMasterPoolsForOwnerExcludingSubs(Owner owner,
+        Collection<String> excludedSubs) {
+
+        return this.poolCurator.getMasterPoolsForOwnerExcludingSubs(owner, excludedSubs);
     }
 
     @Override

--- a/server/src/main/java/org/candlepin/controller/PoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/PoolManager.java
@@ -300,9 +300,35 @@ public interface PoolManager {
      * @return
      *  a list of known master pools
      */
-    List<Pool> listMasterPools();
+    CandlepinQuery<Pool> getMasterPools();
 
-    void deletePools(List<Pool> pools);
+    /**
+     * Retrieves a list consisting of all known master pools for the given owner
+     *
+     * @param owner
+     *  The owner for which to retrieve master pools
+     *
+     * @return
+     *  a list of known master pools for the given owner
+     */
+    CandlepinQuery<Pool> getMasterPoolsForOwner(Owner owner);
 
-    void deletePools(List<Pool> pools, Set<String> alreadyDeletedPools);
+    /**
+     * Retrieves a list consisting of all known master pools for the given owner, excluding those
+     * for the specified subscriptions.
+     *
+     * @param owner
+     *  The owner for which to retrieve master pools
+     *
+     * @param excludedSubs
+     *  A collection of subscription IDs to exclude from the retrieved master pools
+     *
+     * @return
+     *  a list of known master pools for the given owner
+     */
+    CandlepinQuery<Pool> getMasterPoolsForOwnerExcludingSubs(Owner owner, Collection<String> excludedSubs);
+
+    void deletePools(Collection<Pool> pools);
+
+    void deletePools(Collection<Pool> pools, Set<String> alreadyDeletedPools);
 }

--- a/server/src/main/java/org/candlepin/model/Pool.java
+++ b/server/src/main/java/org/candlepin/model/Pool.java
@@ -809,6 +809,7 @@ public class Pool extends AbstractHibernateObject implements Persisted, Owned, N
         }
         return false;
     }
+
     /**
      * @return True if entitlement pool is unlimited.
      */
@@ -839,6 +840,7 @@ public class Pool extends AbstractHibernateObject implements Persisted, Owned, N
         if (this.getSourceSubscription() != null) {
             return this.getSourceSubscription().getSubscriptionId();
         }
+
         return null;
     }
 

--- a/server/src/main/java/org/candlepin/policy/js/autobind/AutobindRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/autobind/AutobindRules.java
@@ -195,8 +195,7 @@ public class AutobindRules {
                 // skip the pool:
 
                 for (Product product : productCurator.getPoolProvidedProductsCached(p.getId())) {
-                    if (product.getProductContent().size() >
-                        X509ExtensionUtil.V1_CONTENT_LIMIT) {
+                    if (product.getProductContent().size() > X509ExtensionUtil.V1_CONTENT_LIMIT) {
                         contentOk = false;
                         break;
                     }

--- a/server/src/main/java/org/candlepin/policy/js/pool/PoolHelper.java
+++ b/server/src/main/java/org/candlepin/policy/js/pool/PoolHelper.java
@@ -29,6 +29,9 @@ import org.candlepin.model.SourceSubscription;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -44,8 +47,10 @@ import java.util.Set;
  * Post Entitlement Helper, and some attribute utility methods.
  */
 public class PoolHelper {
+    private static Logger log = LoggerFactory.getLogger(PoolHelper.class);
 
     private PoolHelper() {
+        // Intentionally left empty
     }
 
     /**
@@ -220,7 +225,10 @@ public class PoolHelper {
             sourcePool.getContractNumber(), sourcePool.getAccountNumber(),
             sourcePool.getOrderNumber(), new HashSet<Product>(), sourceEntitlement);
 
-        pool.setSourceSubscription(new SourceSubscription(sourcePool.getSubscriptionId(), subKey));
+        SourceSubscription srcSub = sourcePool.getSourceSubscription();
+        if (srcSub != null && srcSub.getSubscriptionId() != null) {
+            pool.setSourceSubscription(new SourceSubscription(srcSub.getSubscriptionId(), subKey));
+        }
 
         copyProvidedProducts(sourcePool, pool, curator, productCurator);
 
@@ -229,9 +237,10 @@ public class PoolHelper {
             pool.setAttribute(entry.getKey(), entry.getValue());
         }
 
-        for (Branding b : sourcePool.getBranding()) {
-            pool.getBranding().add(new Branding(b.getProductId(), b.getType(), b.getName()));
+        for (Branding brand : sourcePool.getBranding()) {
+            pool.getBranding().add(new Branding(brand.getProductId(), brand.getType(), brand.getName()));
         }
+
         return pool;
     }
 

--- a/server/src/main/java/org/candlepin/resource/PoolResource.java
+++ b/server/src/main/java/org/candlepin/resource/PoolResource.java
@@ -41,6 +41,8 @@ import com.google.inject.Inject;
 
 import org.jboss.resteasy.annotations.providers.jaxb.Wrapped;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xnap.commons.i18n.I18n;
 
 import java.util.ArrayList;
@@ -71,6 +73,7 @@ import io.swagger.annotations.Authorization;
 @Path("/pools")
 @Api(value = "pools", authorizations = { @Authorization("basic") })
 public class PoolResource {
+    private static Logger log = LoggerFactory.getLogger(PoolResource.class);
 
     private ConsumerCurator consumerCurator;
     private OwnerCurator ownerCurator;

--- a/server/src/main/java/org/candlepin/resource/SubscriptionResource.java
+++ b/server/src/main/java/org/candlepin/resource/SubscriptionResource.java
@@ -137,7 +137,7 @@ public class SubscriptionResource {
     public List<Subscription> getSubscriptions() {
         List<Subscription> subscriptions = new LinkedList<Subscription>();
 
-        for (Pool pool : this.poolManager.listMasterPools()) {
+        for (Pool pool : this.poolManager.getMasterPools()) {
             subscriptions.add(this.poolManager.fabricateSubscriptionFromPool(pool));
         }
 

--- a/server/src/main/java/org/candlepin/resource/util/ResolverUtil.java
+++ b/server/src/main/java/org/candlepin/resource/util/ResolverUtil.java
@@ -111,10 +111,8 @@ public class ResolverUtil {
 
     public Pool resolvePool(Pool pool) {
         // Impl note:
-        // We don't check that the subscription exists here, because it's
-        // entirely possible that it
-        // doesn't (i.e. during creation). We just need to make sure it's not
-        // null.
+        // We don't check that the subscription exists here, because it's entirely possible that it
+        // doesn't (i.e. during creation). We just need to make sure it's not null.
         if (pool == null) {
             throw new BadRequestException(i18n.tr("No subscription specified"));
         }

--- a/server/src/main/java/org/candlepin/sync/Importer.java
+++ b/server/src/main/java/org/candlepin/sync/Importer.java
@@ -550,7 +550,7 @@ public class Importer {
         // If the consumer has no entitlements, this products directory will end up empty.
         // This also implies there will be no entitlements to import.
         Meta meta = mapper.readValue(metadata, Meta.class);
-        List<Subscription> importSubs = new ArrayList<Subscription>();
+        List<Subscription> importSubs;
         if (importFiles.get(ImportFile.PRODUCTS.fileName()) != null) {
             ProductImporter importer = new ProductImporter();
 
@@ -564,7 +564,7 @@ public class Importer {
         else {
             log.warn("No products found to import, skipping product import.");
             log.warn("No entitlements in manifest, removing all subscriptions for owner.");
-            importEntitlements(owner, new HashSet<Product>(), new File[]{}, consumer, meta);
+            importSubs = importEntitlements(owner, new HashSet<Product>(), new File[]{}, consumer, meta);
         }
 
         // Setup our import subscription adapter with the subscriptions imported:

--- a/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -223,7 +223,7 @@ public class PoolManagerTest {
 
     @Test
     public void deletePoolsTest() {
-        List<Pool> pools = new ArrayList<Pool>();
+        Set<Pool> pools = new HashSet<Pool>();
         pools.add(TestUtil.createPool(TestUtil.createProduct()));
         doNothing().when(mockPoolCurator).batchDelete(eq(pools), anySetOf(String.class));
         manager.deletePools(pools);
@@ -1094,7 +1094,7 @@ public class PoolManagerTest {
         this.manager.getRefresher(mockSubAdapter).add(owner).run();
 
         List<Entitlement> entsToDelete = Arrays.asList(ent);
-        List<Pool> poolsToDelete = Arrays.asList(p);
+        Set<Pool> poolsToDelete = new HashSet<Pool>(Arrays.asList(p));
         verify(mockPoolCurator).batchDelete(eq(poolsToDelete), anySetOf(String.class));
         verify(entitlementCurator).batchDelete(eq(entsToDelete));
     }
@@ -1149,7 +1149,8 @@ public class PoolManagerTest {
         manager.cleanupExpiredPools();
 
         // And the pool should be deleted:
-        verify(mockPoolCurator).batchDelete(eq(pools), anySetOf(String.class));
+        Set<Pool> expectedPools = new HashSet<Pool>(pools);
+        verify(mockPoolCurator).batchDelete(eq(expectedPools), anySetOf(String.class));
     }
 
     @Test
@@ -1173,7 +1174,8 @@ public class PoolManagerTest {
         manager.cleanupExpiredPools();
 
         // And the pool should be deleted:
-        verify(mockPoolCurator).batchDelete(eq(pools), anySetOf(String.class));
+        Set<Pool> expectedPools = new HashSet<Pool>(pools);
+        verify(mockPoolCurator).batchDelete(eq(expectedPools), anySetOf(String.class));
         verify(mockSubAdapter, never()).getSubscription(any(String.class));
         verify(mockSubAdapter, never()).deleteSubscription(any(Subscription.class));
     }

--- a/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
@@ -1477,6 +1477,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         Product prod3 = this.createProduct(owner1);
         Product prod4 = this.createProduct(owner2);
         Product prod5 = this.createProduct(owner1);
+        Product prod6 = this.createProduct(owner2);
 
         Pool p1 = TestUtil.createPool(owner1, prod1);
         p1.setSourceSubscription(new SourceSubscription("sub1", "master"));
@@ -1495,14 +1496,19 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         list.add(p4);
 
         Pool p5 = TestUtil.createPool(owner1, prod5);
-        p5.setSourceSubscription(new SourceSubscription("sub3", "asd"));
+        p5.setSourceSubscription(new SourceSubscription("sub3", "master"));
         list.add(p5);
+
+        Pool p6 = TestUtil.createPool(owner2, prod6);
+        p6.setSourceSubscription(new SourceSubscription("sub3", "asd"));
+        list.add(p6);
 
         this.poolCurator.create(p1);
         this.poolCurator.create(p2);
         this.poolCurator.create(p3);
         this.poolCurator.create(p4);
         this.poolCurator.create(p5);
+        this.poolCurator.create(p6);
 
         return list;
     }
@@ -1516,20 +1522,50 @@ public class PoolCuratorTest extends DatabaseTestFixture {
 
         actual = this.poolCurator.getMasterPoolBySubscriptionId("sub2");
         assertEquals(pools.get(1), actual);
-
-        actual = this.poolCurator.getMasterPoolBySubscriptionId("sub3");
+        actual = this.poolCurator.getMasterPoolBySubscriptionId("sub5");
         assertEquals(null, actual);
     }
 
     @Test
-    public void testListMasterPools() {
+    public void testGetMasterPools() {
         List<Pool> pools = this.setupMasterPoolsTests();
         List<Pool> expected = new LinkedList<Pool>();
 
         expected.add(pools.get(0));
         expected.add(pools.get(1));
+        expected.add(pools.get(4));
 
-        List<Pool> actual = this.poolCurator.listMasterPools();
+        List<Pool> actual = this.poolCurator.getMasterPools().list();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testGetMasterPoolsForOwner() {
+        List<Pool> pools = this.setupMasterPoolsTests();
+        List<Pool> expected = new LinkedList<Pool>();
+
+        Owner owner = pools.get(0).getOwner();
+
+        expected.add(pools.get(0));
+        expected.add(pools.get(4));
+
+        List<Pool> actual = this.poolCurator.getMasterPoolsForOwner(owner).list();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testGetMasterPoolsForOwnerExcludingSubs() {
+        List<Pool> pools = this.setupMasterPoolsTests();
+        List<Pool> expected = new LinkedList<Pool>();
+
+        Owner owner = pools.get(0).getOwner();
+        expected.add(pools.get(0));
+
+        Collection<String> excludedSubIds = Arrays.asList(pools.get(4).getSubscriptionId());
+
+        List<Pool> actual = this.poolCurator.getMasterPoolsForOwnerExcludingSubs(owner, excludedSubIds)
+            .list();
+
         assertEquals(expected, actual);
     }
 

--- a/server/src/test/java/org/candlepin/resource/OwnerResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/OwnerResourceTest.java
@@ -254,6 +254,11 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         sub.setStartDate(TestUtil.createDate(2010, 2, 9));
         sub.setEndDate(TestUtil.createDate(3000, 2, 9));
         sub.setModified(TestUtil.createDate(2010, 2, 12));
+
+        // This line is only present as a result of a (temporary?) fix for BZ 1452694. Once a
+        // better fix has been implemented, the upstream pool ID can be removed.
+        sub.setUpstreamPoolId("upstream_pool_id");
+
         subscriptions.add(sub);
 
         // Trigger the refresh:


### PR DESCRIPTION
- Fixed a crash that could occur when creating a custom pool without
  a source subscription that would require creation of derived pools
- Derived or bonus pools are no longer created for custom pools
  without source subscription IDs
- Added a spec test for verifying that custom pools are not removed
  during an import or refresh, so long as they were not created with
  a source subscription
- Added a check to refresh to not remove pools that lack an upstream
  pool ID in standalone mode. This temporary fix should avoid an issue
  where pools created through the API were getting deleted during
  refresh.
- Derived/children pools are now properly cleaned up during batch
  deletion.