### PR TITLE
1448897: Include default content access mode when showing org list

### DIFF
--- a/server/spec/cert_revocation_spec.rb
+++ b/server/spec/cert_revocation_spec.rb
@@ -140,7 +140,8 @@ describe 'Certificate Revocation List', :serial => true do
   end
 
   it 'should put revoked content access cert on CRL' do
-    cam_owner = create_owner(random_string("test_owner"), nil,{'contentAccessMode' => "org_environment"})
+    skip("candlepin running in standalone mode") unless is_hosted?
+    cam_owner = create_owner(random_string("test_owner"), nil,{'contentAccessMode' => "org_environment", 'contentAccessModeList' => "org_environment, entitlement"})
 
     username = random_string('bob')
     user = create_user(cam_owner, username, 'password')

--- a/server/spec/content_access_spec.rb
+++ b/server/spec/content_access_spec.rb
@@ -12,7 +12,7 @@ describe 'Content Access' do
 
   before(:each) do
       @owner = create_owner(random_string("test_owner"), nil, {
-        'contentAccessModeList' => 'org_environment,test_access_mode,entitlement',
+        'contentAccessModeList' => 'org_environment,test_access_mode',
         'contentAccessMode' => "org_environment"
       })
 
@@ -35,6 +35,7 @@ describe 'Content Access' do
       skip("candlepin running in standalone mode") unless is_hosted?
       @cp.update_owner(@owner['key'], {'contentAccessMode' => "test_access_mode"})
       @owner = @cp.get_owner(@owner['key'])
+      @owner['contentAccessModeList'].should == "org_environment,test_access_mode,entitlement"
       @owner['contentAccessMode'].should == "test_access_mode"
   end
 
@@ -260,7 +261,7 @@ describe 'Content Access' do
 
       owner = @cp.get_owner(@import_owner['key'])
       owner['contentAccessMode'].should == 'test_access_mode'
-      owner['contentAccessModeList'].should == 'test_access_mode'
+      owner['contentAccessModeList'].should == 'test_access_mode,entitlement'
 
       uc = owner.upstreamConsumer['contentAccessMode'].should == 'test_access_mode'
 

--- a/server/src/main/java/org/candlepin/controller/OwnerManager.java
+++ b/server/src/main/java/org/candlepin/controller/OwnerManager.java
@@ -42,6 +42,7 @@ import com.google.inject.persist.Transactional;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 
+import org.candlepin.service.impl.DefaultContentAccessCertServiceAdapter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,26 +58,54 @@ public class OwnerManager {
 
     private static Logger log = LoggerFactory.getLogger(OwnerManager.class);
 
-    @Inject private ConsumerCurator consumerCurator;
-    @Inject private PoolManager poolManager;
-    @Inject private ActivationKeyCurator activationKeyCurator;
-    @Inject private EnvironmentCurator envCurator;
-    @Inject private ExporterMetadataCurator exportCurator;
-    @Inject private ImportRecordCurator importRecordCurator;
-    @Inject private PermissionBlueprintCurator permissionCurator;
-    @Inject private OwnerProductCurator ownerProductCurator;
-    @Inject private ProductManager productManager;
-    @Inject private OwnerContentCurator ownerContentCurator;
-    @Inject private ContentManager contentManager;
-    @Inject private OwnerCurator ownerCurator;
-    @Inject private ContentAccessCertServiceAdapter contentAccessCertService;
-    @Inject private ContentAccessCertificateCurator contentAccessCertCurator;
-    @Inject private OwnerEnvContentAccessCurator ownerEnvContentAccessCurator;
-    @Inject private UeberCertificateCurator uberCertificateCurator;
-    @Inject private OwnerServiceAdapter ownerServiceAdapter;
+    private ConsumerCurator consumerCurator;
+    private ActivationKeyCurator activationKeyCurator;
+    private EnvironmentCurator envCurator;
+    private ExporterMetadataCurator exportCurator;
+    private ImportRecordCurator importRecordCurator;
+    private PermissionBlueprintCurator permissionCurator;
+    private OwnerProductCurator ownerProductCurator;
+    private ProductManager productManager;
+    private OwnerContentCurator ownerContentCurator;
+    private ContentManager contentManager;
+    private OwnerCurator ownerCurator;
+    private ContentAccessCertServiceAdapter contentAccessCertService;
+    private ContentAccessCertificateCurator contentAccessCertCurator;
+    private OwnerEnvContentAccessCurator ownerEnvContentAccessCurator;
+    private UeberCertificateCurator uberCertificateCurator;
+    private OwnerServiceAdapter ownerServiceAdapter;
 
+    @Inject
+    public OwnerManager(ConsumerCurator consumerCurator,
+        ActivationKeyCurator activationKeyCurator, EnvironmentCurator envCurator,
+        ExporterMetadataCurator exportCurator, ImportRecordCurator importRecordCurator,
+        PermissionBlueprintCurator permissionCurator, OwnerProductCurator ownerProductCurator,
+        ProductManager productManager, OwnerContentCurator ownerContentCurator,
+        ContentManager contentManager, OwnerCurator ownerCurator,
+        ContentAccessCertServiceAdapter contentAccessCertService,
+        ContentAccessCertificateCurator contentAccessCertCurator,
+        OwnerEnvContentAccessCurator ownerEnvContentAccessCurator,
+        UeberCertificateCurator uberCertificateCurator, OwnerServiceAdapter ownerServiceAdapter) {
+
+        this.consumerCurator = consumerCurator;
+        this.activationKeyCurator = activationKeyCurator;
+        this.envCurator = envCurator;
+        this.exportCurator = exportCurator;
+        this.importRecordCurator = importRecordCurator;
+        this.permissionCurator = permissionCurator;
+        this.ownerProductCurator = ownerProductCurator;
+        this.productManager = productManager;
+        this.ownerContentCurator = ownerContentCurator;
+        this.contentManager = contentManager;
+        this.ownerCurator = ownerCurator;
+        this.contentAccessCertService = contentAccessCertService;
+        this.contentAccessCertCurator = contentAccessCertCurator;
+        this.ownerEnvContentAccessCurator = ownerEnvContentAccessCurator;
+        this.uberCertificateCurator = uberCertificateCurator;
+        this.ownerServiceAdapter = ownerServiceAdapter;
+    }
     @Transactional
-    public void cleanupAndDelete(Owner owner, boolean revokeCerts) {
+    public void cleanupAndDelete(Owner owner, PoolManager poolManager, boolean revokeCerts) {
         log.info("Cleaning up owner: {}", owner);
 
         Collection<String> consumerIds = this.ownerCurator.getConsumerIds(owner).list();
@@ -198,19 +227,18 @@ public class OwnerManager {
 
         // This shouldn't happen, but in the event our upstream source is having issues, let's
         // not put ourselves in a bad state as well.
-        if (upstreamList != null && !upstreamList.isEmpty()) {
+        if (!StringUtils.isBlank(upstreamList)) {
             // Not empty list. Verify that the upstream mode is present.
             String[] list = upstreamList.split(",");
-
-            if (!StringUtils.isEmpty(upstreamMode) && !ArrayUtils.contains(list, upstreamMode)) {
-                throw new IllegalStateException("Upstream access mode is not present in access mode list");
+            if (upstreamMode == null || !ArrayUtils.contains(list, upstreamMode)) {
+                throw new IllegalStateException("Upstream access mode is not present in access mode list. " +
+                    "The mode must be set to one in the list.");
             }
         }
         else {
-            // Empty list. Verify the upstream mode is also empty.
-            if (!StringUtils.isEmpty(upstreamMode)) {
-                throw new IllegalStateException("Upstream access mode is not present in access mode list");
-            }
+            // Empty list. Will be forced to default along with mode.
+            upstreamList = DefaultContentAccessCertServiceAdapter.DEFAULT_CONTENT_ACCESS_MODE;
+            upstreamMode = DefaultContentAccessCertServiceAdapter.DEFAULT_CONTENT_ACCESS_MODE;
         }
 
         // Set new values
@@ -238,7 +266,7 @@ public class OwnerManager {
         // we need to update the owner's consumers if the content access mode has changed
         owner = ownerCurator.lockAndLoad(owner);
 
-        if (owner.contentAccessMode().equals(ContentAccessCertServiceAdapter.DEFAULT_CONTENT_ACCESS_MODE)) {
+        if (!ContentAccessCertServiceAdapter.ORG_ENV_ACCESS_MODE.equals(owner.getContentAccessMode())) {
             contentAccessCertCurator.deleteForOwner(owner);
         }
 

--- a/server/src/main/java/org/candlepin/model/Owner.java
+++ b/server/src/main/java/org/candlepin/model/Owner.java
@@ -493,7 +493,13 @@ public class Owner extends AbstractHibernateObject implements Serializable,
      * @return String the value
      */
     public String getContentAccessModeList() {
-        return this.contentAccessModeList;
+        String[] modeList = contentAccessModeList == null ? new String[0] : contentAccessModeList.split(",");
+        String ammend = "";
+        if (!ArrayUtils.contains(modeList, ContentAccessCertServiceAdapter.DEFAULT_CONTENT_ACCESS_MODE)) {
+            ammend = modeList.length > 0 ? "," : "";
+            ammend += ContentAccessCertServiceAdapter.DEFAULT_CONTENT_ACCESS_MODE;
+        }
+        return modeList.length > 0 ? this.contentAccessModeList + ammend : ammend;
     }
 
     public void setContentAccessModeList(String contentAccessModeList) {

--- a/server/src/main/java/org/candlepin/model/Owner.java
+++ b/server/src/main/java/org/candlepin/model/Owner.java
@@ -17,12 +17,10 @@ package org.candlepin.model;
 import org.candlepin.common.jackson.HateoasInclude;
 import org.candlepin.model.activationkeys.ActivationKey;
 import org.candlepin.resteasy.InfoProperty;
-import org.candlepin.service.ContentAccessCertServiceAdapter;
 
 import com.fasterxml.jackson.annotation.JsonFilter;
 
 import org.apache.commons.lang.ArrayUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.hibernate.annotations.GenericGenerator;
 
 import java.io.Serializable;
@@ -463,18 +461,6 @@ public class Owner extends AbstractHibernateObject implements Serializable,
     }
 
     /**
-     * Utility method that defaults to 'entitlement'.
-     *  This covers legacy owners
-     *
-     * @return access mode.
-     */
-    @XmlTransient
-    public String contentAccessMode() {
-        return StringUtils.isEmpty(getContentAccessMode()) ?
-            ContentAccessCertServiceAdapter.DEFAULT_CONTENT_ACCESS_MODE : getContentAccessMode();
-    }
-
-    /**
      * Returns the value of the contentAccessMode setting.
      *
      * @return String the value
@@ -493,35 +479,15 @@ public class Owner extends AbstractHibernateObject implements Serializable,
      * @return String the value
      */
     public String getContentAccessModeList() {
-        String[] modeList = contentAccessModeList == null ? new String[0] : contentAccessModeList.split(",");
-        String ammend = "";
-        if (!ArrayUtils.contains(modeList, ContentAccessCertServiceAdapter.DEFAULT_CONTENT_ACCESS_MODE)) {
-            ammend = modeList.length > 0 ? "," : "";
-            ammend += ContentAccessCertServiceAdapter.DEFAULT_CONTENT_ACCESS_MODE;
-        }
-        return modeList.length > 0 ? this.contentAccessModeList + ammend : ammend;
+        return this.contentAccessModeList;
     }
 
     public void setContentAccessModeList(String contentAccessModeList) {
-        this.contentAccessModeList = !StringUtils.isEmpty(contentAccessModeList) ?
-            contentAccessModeList :
-            null;
+        this.contentAccessModeList = contentAccessModeList;
     }
 
     @XmlTransient
     public boolean isAllowedContentAccessMode(String mode) {
-        if (StringUtils.isEmpty(mode)) {
-            return true;
-        }
-
-        if (mode.equals(ContentAccessCertServiceAdapter.DEFAULT_CONTENT_ACCESS_MODE)) {
-            return true;
-        }
-
-        if (StringUtils.isEmpty(contentAccessModeList)) {
-            return false;
-        }
-
         String[] list = contentAccessModeList.split(",");
         return ArrayUtils.contains(list, mode);
     }

--- a/server/src/main/java/org/candlepin/service/impl/DefaultContentAccessCertServiceAdapter.java
+++ b/server/src/main/java/org/candlepin/service/impl/DefaultContentAccessCertServiceAdapter.java
@@ -105,7 +105,7 @@ public class DefaultContentAccessCertServiceAdapter implements ContentAccessCert
         Owner owner = consumer.getOwner();
         // we only know about one mode right now. If add any, we will need to add the
         // appropriate cert generation
-        if (!ORG_ENV_ACCESS_MODE.equals(owner.contentAccessMode()) || !consumer.isCertV3Capable()) {
+        if (!ORG_ENV_ACCESS_MODE.equals(owner.getContentAccessMode()) || !consumer.isCertV3Capable()) {
             return null;
         }
 

--- a/server/src/test/java/org/candlepin/controller/OwnerManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/OwnerManagerTest.java
@@ -1,0 +1,159 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.controller;
+
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
+
+import org.candlepin.model.ConsumerCurator;
+import org.candlepin.model.ContentAccessCertificateCurator;
+import org.candlepin.model.EnvironmentCurator;
+import org.candlepin.model.ExporterMetadataCurator;
+import org.candlepin.model.ImportRecordCurator;
+import org.candlepin.model.Owner;
+import org.candlepin.model.OwnerContentCurator;
+import org.candlepin.model.OwnerCurator;
+import org.candlepin.model.OwnerEnvContentAccessCurator;
+import org.candlepin.model.OwnerProductCurator;
+import org.candlepin.model.PermissionBlueprintCurator;
+import org.candlepin.model.UeberCertificateCurator;
+import org.candlepin.model.activationkeys.ActivationKeyCurator;
+
+import org.candlepin.service.ContentAccessCertServiceAdapter;
+import org.candlepin.service.OwnerServiceAdapter;
+import org.candlepin.service.impl.DefaultContentAccessCertServiceAdapter;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.Assert;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+
+/**
+ * RefresherTest
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class OwnerManagerTest {
+    private OwnerManager ownerManager;
+    @Mock
+    private ConsumerCurator consumerCurator;
+    @Mock
+    private ActivationKeyCurator activationKeyCurator;
+    @Mock
+    private EnvironmentCurator envCurator;
+    @Mock
+    private ExporterMetadataCurator exportCurator;
+    @Mock
+    private ImportRecordCurator importRecordCurator;
+    @Mock
+    private PermissionBlueprintCurator permissionCurator;
+    @Mock
+    private OwnerProductCurator ownerProductCurator;
+    @Mock
+    private ProductManager productManager;
+    @Mock
+    private OwnerContentCurator ownerContentCurator;
+    @Mock
+    private ContentManager contentManager;
+    @Mock
+    private OwnerCurator ownerCurator;
+    @Mock
+    private ContentAccessCertServiceAdapter contentAccessCertService;
+    @Mock
+    private ContentAccessCertificateCurator contentAccessCertCurator;
+    @Mock
+    private OwnerEnvContentAccessCurator ownerEnvContentAccessCurator;
+    @Mock
+    private UeberCertificateCurator uberCertificateCurator;
+    @Mock
+    private OwnerServiceAdapter ownerServiceAdapter;
+
+    @Before
+    public void setUp() {
+        ownerManager = new OwnerManager(consumerCurator, activationKeyCurator, envCurator,
+            exportCurator, importRecordCurator, permissionCurator, ownerProductCurator, productManager,
+            ownerContentCurator, contentManager, ownerCurator, contentAccessCertService,
+            contentAccessCertCurator, ownerEnvContentAccessCurator, uberCertificateCurator,
+            ownerServiceAdapter);
+    }
+
+    @Test
+    public void testContentAccessSetEmpty() {
+        Owner owner = new Owner();
+        when(ownerCurator.lockAndLoad(eq(owner))).thenReturn(owner);
+        when(ownerServiceAdapter.getContentAccessModeList(eq(owner.getKey()))).thenReturn("");
+        when(ownerServiceAdapter.getContentAccessMode(eq(owner.getKey()))).thenReturn("");
+        ownerManager.refreshContentAccessMode(ownerServiceAdapter, owner);
+        Assert.assertEquals(owner.getContentAccessModeList(),
+            DefaultContentAccessCertServiceAdapter.DEFAULT_CONTENT_ACCESS_MODE);
+        Assert.assertEquals(owner.getContentAccessMode(),
+            DefaultContentAccessCertServiceAdapter.DEFAULT_CONTENT_ACCESS_MODE);
+    }
+
+    @Test
+    public void testContentAccessSetNull() {
+        Owner owner = new Owner();
+        when(ownerCurator.lockAndLoad(eq(owner))).thenReturn(owner);
+        when(ownerServiceAdapter.getContentAccessModeList(eq(owner.getKey()))).thenReturn(null);
+        when(ownerServiceAdapter.getContentAccessMode(eq(owner.getKey()))).thenReturn(null);
+        ownerManager.refreshContentAccessMode(ownerServiceAdapter, owner);
+        Assert.assertEquals(owner.getContentAccessModeList(),
+            DefaultContentAccessCertServiceAdapter.DEFAULT_CONTENT_ACCESS_MODE);
+        Assert.assertEquals(owner.getContentAccessMode(),
+            DefaultContentAccessCertServiceAdapter.DEFAULT_CONTENT_ACCESS_MODE);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testContentAccessModeNotOnList() {
+        Owner owner = new Owner();
+        when(ownerCurator.lockAndLoad(eq(owner))).thenReturn(owner);
+        when(ownerServiceAdapter.getContentAccessModeList(eq(owner.getKey()))).thenReturn("one,two");
+        when(ownerServiceAdapter.getContentAccessMode(eq(owner.getKey()))).thenReturn("three");
+        ownerManager.refreshContentAccessMode(ownerServiceAdapter, owner);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testContentAccessModeBlankSelection() {
+        Owner owner = new Owner();
+        when(ownerCurator.lockAndLoad(eq(owner))).thenReturn(owner);
+        when(ownerServiceAdapter.getContentAccessModeList(eq(owner.getKey()))).thenReturn("one,two");
+        when(ownerServiceAdapter.getContentAccessMode(eq(owner.getKey()))).thenReturn("");
+        ownerManager.refreshContentAccessMode(ownerServiceAdapter, owner);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testContentAccessModeNullSelection() {
+        Owner owner = new Owner();
+        when(ownerCurator.lockAndLoad(eq(owner))).thenReturn(owner);
+        when(ownerServiceAdapter.getContentAccessModeList(eq(owner.getKey()))).thenReturn("one,two");
+        when(ownerServiceAdapter.getContentAccessMode(eq(owner.getKey()))).thenReturn(null);
+        ownerManager.refreshContentAccessMode(ownerServiceAdapter, owner);
+    }
+
+    @Test
+    public void testContentAccessModeNoList() {
+        Owner owner = new Owner();
+        when(ownerCurator.lockAndLoad(eq(owner))).thenReturn(owner);
+        when(ownerServiceAdapter.getContentAccessModeList(eq(owner.getKey()))).thenReturn("");
+        when(ownerServiceAdapter.getContentAccessMode(eq(owner.getKey()))).thenReturn("three");
+        ownerManager.refreshContentAccessMode(ownerServiceAdapter, owner);
+        Assert.assertEquals(owner.getContentAccessModeList(),
+            DefaultContentAccessCertServiceAdapter.DEFAULT_CONTENT_ACCESS_MODE);
+        Assert.assertEquals(owner.getContentAccessMode(),
+            DefaultContentAccessCertServiceAdapter.DEFAULT_CONTENT_ACCESS_MODE);
+    }
+}

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
@@ -78,6 +78,7 @@ import org.candlepin.service.IdentityCertServiceAdapter;
 import org.candlepin.service.OwnerServiceAdapter;
 import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.service.UserServiceAdapter;
+import org.candlepin.service.impl.DefaultContentAccessCertServiceAdapter;
 import org.candlepin.test.TestUtil;
 import org.candlepin.util.FactValidator;
 import org.candlepin.util.ServiceLevelValidator;
@@ -141,6 +142,7 @@ public class ConsumerResourceTest {
     @Mock private OwnerManager mockOwnerManager;
     @Mock private ConsumerEnricher consumerEnricher;
     @Mock private ConsumerTypeCurator mockConsumerTypeCurator;
+    @Mock private DefaultContentAccessCertServiceAdapter mockContentAccessCertService;
 
     @Before
     public void setUp() {
@@ -231,7 +233,7 @@ public class ConsumerResourceTest {
             mockedConsumerCurator, null, null, null, null, mockedEntitlementCurator, null,
             mockedEntitlementCertServiceAdapter, null, null, null, null, null, null, mockedPoolManager, null,
             null, null, null, null, null, null, null, this.config, null, null, null, consumerBindUtil,
-            null, null, this.factValidator, null, consumerEnricher);
+            null, mockContentAccessCertService, this.factValidator, null, consumerEnricher);
 
         List<CertificateSerialDto> serials = consumerResource
             .getEntitlementCertificateSerials(consumer.getUuid());
@@ -922,7 +924,7 @@ public class ConsumerResourceTest {
             mockedConsumerCurator, null, null, null, null, mockedEntitlementCurator, null,
             mockedEntitlementCertServiceAdapter, null, null, null, null, null, null, mockedPoolManager, null,
             null, null, null, null, null, null, null, this.config, null, null, null, consumerBindUtil,
-            null, null, this.factValidator, null, consumerEnricher));
+            null, mockContentAccessCertService, this.factValidator, null, consumerEnricher));
 
         List<CertificateSerialDto> serials = consumerResource
             .getEntitlementCertificateSerials(consumer.getUuid());
@@ -942,7 +944,7 @@ public class ConsumerResourceTest {
             mockedConsumerCurator, null, null, null, null, mockedEntitlementCurator, null,
             mockedEntitlementCertServiceAdapter, null, null, null, null, null, null, mockedPoolManager, null,
             null, null, null, null, null, null, null, this.config, null, null, null, consumerBindUtil,
-            null, null, this.factValidator, null, consumerEnricher));
+            null, mockContentAccessCertService, this.factValidator, null, consumerEnricher));
 
         Set<Long> serials = new HashSet<Long>();
         List<Certificate> certs = consumerResource

--- a/server/src/test/java/org/candlepin/resource/OwnerResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/OwnerResourceTest.java
@@ -1042,15 +1042,15 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         OwnerManager ownerManager = mock(OwnerManager.class);
         EventFactory eventFactory = mock(EventFactory.class);
         OwnerResource or = new OwnerResource(
-            oc, null, null, i18n, null, eventFactory, null, null, null, null, ownerManager,  null, null,
-            null, null, null, null, null, null, null, null, contentOverrideValidator, serviceLevelValidator,
-            null, null, null, productManager, contentManager, null
+            oc, null, null, i18n, null, eventFactory, null, null, null, poolManager, ownerManager,  null,
+            null, null, null, null, null, null, null, null, null, contentOverrideValidator,
+            serviceLevelValidator, null, null, null, productManager, contentManager, null
         );
 
         when(oc.lookupByKey(eq("testOwner"))).thenReturn(o);
         ConstraintViolationException ce = new ConstraintViolationException(null, null, null);
         PersistenceException pe = new PersistenceException(ce);
-        Mockito.doThrow(pe).when(ownerManager).cleanupAndDelete(eq(o), eq(true));
+        Mockito.doThrow(pe).when(ownerManager).cleanupAndDelete(eq(o), eq(poolManager), eq(true));
         or.deleteOwner("testOwner", true, true);
     }
 


### PR DESCRIPTION
If the default mode is not included in the mode list, then the list is
appended with the default mode. This is so that the user will see
the default mode as a selection.