### PR TITLE
Undo excessive regen added by mistake in 731188f

### DIFF
--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -79,6 +79,7 @@ import org.slf4j.LoggerFactory;
 import org.xnap.commons.i18n.I18n;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -1552,7 +1553,7 @@ public class CandlepinPoolManager implements PoolManager {
             }
         }
         else {
-            regenerateCertificatesOf(consumer, true);
+            this.entitlementCurator.markEntitlementsDirty(Arrays.asList(entitlement.getId()));
             this.entitlementCurator.markModifyingEntsDirty(Collections.singleton(entitlement));
         }
 


### PR DESCRIPTION
in 731188f, when I split addOrUpdateEntitlements , I mistakingly coded to regenerate *all* the entitlements of a consumer, instead of just the one that we are now updating. this commit undoes that mistake.