### PR TITLE
1448897: Enforce default content access mode list

### DIFF
--- a/server/bin/test_data.json
+++ b/server/bin/test_data.json
@@ -388,7 +388,8 @@
         {
             "name": "snowwhite",
             "displayName": "Snow White",
-            "contentAccessModeList": "org_environment",
+            "contentAccessModeList": "entitlement,org_environment",
+            "contentAccessMode": "entitlement",
             "content": [
                 {
                     "name": "snowy-content",

--- a/server/spec/candlepin_scenarios.rb
+++ b/server/spec/candlepin_scenarios.rb
@@ -17,7 +17,10 @@ module CandlepinMethods
 
     # Set the content access mode list for new owners. We do this here instead of doing it explicitly
     # in each test due to some test objects creating owners internally which need this list.
-    params['contentAccessModeList'] = 'org_environment,test_access_mode,entitlement'
+    if not params['contentAccessModeList']
+      params['contentAccessModeList']= 'org_environment,test_access_mode,entitlement'
+      params['contentAccessMode'] = 'entitlement'
+    end
 
     owner = @cp.create_owner(owner_name, params)
     @owners << owner

--- a/server/spec/cert_revocation_spec.rb
+++ b/server/spec/cert_revocation_spec.rb
@@ -140,7 +140,8 @@ describe 'Certificate Revocation List', :serial => true do
   end
 
   it 'should put revoked content access cert on CRL' do
-    cam_owner = create_owner(random_string("test_owner"), nil,{'contentAccessMode' => "org_environment"})
+    skip("candlepin running in standalone mode") unless is_hosted?
+    cam_owner = create_owner(random_string("test_owner"), nil,{'contentAccessMode' => "org_environment", 'contentAccessModeList' => "org_environment,entitlement"})
 
     username = random_string('bob')
     user = create_user(cam_owner, username, 'password')

--- a/server/spec/content_access_spec.rb
+++ b/server/spec/content_access_spec.rb
@@ -35,13 +35,31 @@ describe 'Content Access' do
       skip("candlepin running in standalone mode") unless is_hosted?
       @cp.update_owner(@owner['key'], {'contentAccessMode' => "test_access_mode"})
       @owner = @cp.get_owner(@owner['key'])
+      @owner['contentAccessModeList'].should == "org_environment,test_access_mode,entitlement"
       @owner['contentAccessMode'].should == "test_access_mode"
   end
 
-  it "does not allow assignment of incorrect content access mode" do
+  it "will assign the default mode and list when none is specified" do
+      owner = @cp.create_owner random_string("test_owner")
+      owner['contentAccessModeList'].should == "entitlement"
+      owner['contentAccessMode'].should == "entitlement"
+  end
+
+  it "must assign a mode from the list" do
+    lambda do
+      owner = create_owner(random_string("test_owner"), nil, {
+        'contentAccessModeList' => 'org_environment,test_access_mode'
+      })
+    end.should raise_exception(RestClient::BadRequest)
+  end
+
+  it "does not allow assignment of incorrect content access mode or blank" do
       skip("candlepin running in standalone mode") unless is_hosted?
       lambda do
-          @cp.update_owner(@owner['key'], {'contentAccessMode' => "super_mode"})
+        @cp.update_owner(@owner['key'], {'contentAccessMode' => "super_mode"})
+      end.should raise_exception(RestClient::BadRequest)
+      lambda do
+        @cp.update_owner(@owner['key'], {'contentAccessMode' => ""})
       end.should raise_exception(RestClient::BadRequest)
   end
 
@@ -111,14 +129,14 @@ describe 'Content Access' do
       certs = @consumer.list_certificates
       certs.length.should == 1
 
-      @cp.update_owner(@owner['key'], {'contentAccessMode' => ""})
+      @cp.update_owner(@owner['key'], {'contentAccessMode' => "entitlement"})
       certs = @consumer.list_certificates
       certs.length.should == 0
   end
 
   it "can create the content access certificate for the consumer when org content access mode added" do
       skip("candlepin running in standalone mode") unless is_hosted?
-      @cp.update_owner(@owner['key'], {'contentAccessMode' => ""})
+      @cp.update_owner(@owner['key'], {'contentAccessMode' => "entitlement"})
       @consumer = consumer_client(@user, @consumername, type=:system, username=nil, facts= {'system.certificate_version' => '3.3'})
 
       certs = @consumer.list_certificates

--- a/server/src/main/java/org/candlepin/model/Owner.java
+++ b/server/src/main/java/org/candlepin/model/Owner.java
@@ -17,12 +17,11 @@ package org.candlepin.model;
 import org.candlepin.common.jackson.HateoasInclude;
 import org.candlepin.model.activationkeys.ActivationKey;
 import org.candlepin.resteasy.InfoProperty;
-import org.candlepin.service.ContentAccessCertServiceAdapter;
 
 import com.fasterxml.jackson.annotation.JsonFilter;
 
 import org.apache.commons.lang.ArrayUtils;
-import org.apache.commons.lang3.StringUtils;
+import org.candlepin.service.ContentAccessCertServiceAdapter;
 import org.hibernate.annotations.GenericGenerator;
 
 import java.io.Serializable;
@@ -129,14 +128,14 @@ public class Owner extends AbstractHibernateObject implements Serializable,
     /**
      * Determines the behavior of the content access.
      */
-    @Column(name = "content_access_mode")
-    private String contentAccessMode;
+    @Column(name = "content_access_mode", nullable = false)
+    private String contentAccessMode = ContentAccessCertServiceAdapter.DEFAULT_CONTENT_ACCESS_MODE;
 
     /**
      * Determines the allowable modes of the content access.
      */
-    @Column(name = "content_access_mode_list")
-    private String contentAccessModeList;
+    @Column(name = "content_access_mode_list", nullable = false)
+    private String contentAccessModeList = ContentAccessCertServiceAdapter.DEFAULT_CONTENT_ACCESS_MODE;
 
     /**
      * Default constructor
@@ -463,18 +462,6 @@ public class Owner extends AbstractHibernateObject implements Serializable,
     }
 
     /**
-     * Utility method that defaults to 'entitlement'.
-     *  This covers legacy owners
-     *
-     * @return access mode.
-     */
-    @XmlTransient
-    public String contentAccessMode() {
-        return StringUtils.isEmpty(getContentAccessMode()) ?
-            ContentAccessCertServiceAdapter.DEFAULT_CONTENT_ACCESS_MODE : getContentAccessMode();
-    }
-
-    /**
      * Returns the value of the contentAccessMode setting.
      *
      * @return String the value
@@ -493,29 +480,15 @@ public class Owner extends AbstractHibernateObject implements Serializable,
      * @return String the value
      */
     public String getContentAccessModeList() {
-        return this.contentAccessModeList;
+        return contentAccessModeList;
     }
 
     public void setContentAccessModeList(String contentAccessModeList) {
-        this.contentAccessModeList = !StringUtils.isEmpty(contentAccessModeList) ?
-            contentAccessModeList :
-            null;
+        this.contentAccessModeList = contentAccessModeList;
     }
 
     @XmlTransient
     public boolean isAllowedContentAccessMode(String mode) {
-        if (StringUtils.isEmpty(mode)) {
-            return true;
-        }
-
-        if (mode.equals(ContentAccessCertServiceAdapter.DEFAULT_CONTENT_ACCESS_MODE)) {
-            return true;
-        }
-
-        if (StringUtils.isEmpty(contentAccessModeList)) {
-            return false;
-        }
-
         String[] list = contentAccessModeList.split(",");
         return ArrayUtils.contains(list, mode);
     }

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -658,7 +658,8 @@ public class ConsumerResource {
     }
 
     private void validateContentAccessMode(Consumer consumer) throws BadRequestException {
-        if (!consumer.getOwner().isAllowedContentAccessMode(consumer.getContentAccessMode())) {
+        if (consumer.getContentAccessMode() != null &&
+            !consumer.getOwner().isAllowedContentAccessMode(consumer.getContentAccessMode())) {
             throw new BadRequestException(i18n.tr(
                 "The consumer cannot use the supplied content access mode."));
         }
@@ -1481,22 +1482,18 @@ public class ConsumerResource {
                 returnCerts.add(cert);
             }
         }
-        // we want to insert the content access cert to this list
-        if (!consumer.getOwner().contentAccessMode()
-            .equals(ContentAccessCertServiceAdapter.DEFAULT_CONTENT_ACCESS_MODE)) {
-
-            try {
-                Certificate cert = contentAccessCertService.getCertificate(consumer);
-                if (cert != null) {
-                    returnCerts.add(cert);
-                }
+        // we want to insert the content access cert to this list if appropriate
+        try {
+            Certificate cert = contentAccessCertService.getCertificate(consumer);
+            if (cert != null) {
+                returnCerts.add(cert);
             }
-            catch (IOException ioe) {
-                throw new BadRequestException(i18n.tr("Cannot retrieve content access certificate"), ioe);
-            }
-            catch (GeneralSecurityException gse) {
-                throw new BadRequestException(i18n.tr("Cannot retrieve content access certificate"), gse);
-            }
+        }
+        catch (IOException ioe) {
+            throw new BadRequestException(i18n.tr("Cannot retrieve content access certificate"), ioe);
+        }
+        catch (GeneralSecurityException gse) {
+            throw new BadRequestException(i18n.tr("Cannot retrieve content access certificate"), gse);
         }
         return returnCerts;
     }
@@ -1518,9 +1515,10 @@ public class ConsumerResource {
             throw new BadRequestException(i18n.tr("Content access body " +
                "can not be requested for a share consumer"));
         }
-        if (consumer.getOwner().contentAccessMode()
-            .equals(ContentAccessCertServiceAdapter.DEFAULT_CONTENT_ACCESS_MODE)) {
-            throw new BadRequestException(i18n.tr("No content access mode assigned"));
+        if (consumer.getOwner().getContentAccessMode() != null &&
+            !consumer.getOwner().getContentAccessMode()
+            .equals(ContentAccessCertServiceAdapter.ORG_ENV_ACCESS_MODE)) {
+            throw new BadRequestException(i18n.tr("Content access mode does not allow this request."));
         }
         if (!contentAccessCertService.hasCertChangedSince(consumer, since)) {
             return Response.status(Response.Status.NOT_MODIFIED)
@@ -1645,20 +1643,17 @@ public class ConsumerResource {
             allCerts.add(new CertificateSerialDto(id));
         }
         // add content access cert if needed
-        if (!consumer.getOwner().contentAccessMode()
-            .equals(ContentAccessCertServiceAdapter.DEFAULT_CONTENT_ACCESS_MODE)) {
-            try {
-                ContentAccessCertificate cac = contentAccessCertService.getCertificate(consumer);
-                if (cac != null) {
-                    allCerts.add(new CertificateSerialDto(cac.getSerial().getId()));
-                }
+        try {
+            ContentAccessCertificate cac = contentAccessCertService.getCertificate(consumer);
+            if (cac != null) {
+                allCerts.add(new CertificateSerialDto(cac.getSerial().getId()));
             }
-            catch (IOException ioe) {
-                throw new BadRequestException(i18n.tr("Cannot retrieve content access certificate"), ioe);
-            }
-            catch (GeneralSecurityException gse) {
-                throw new BadRequestException(i18n.tr("Cannot retrieve content access certificate", gse));
-            }
+        }
+        catch (IOException ioe) {
+            throw new BadRequestException(i18n.tr("Cannot retrieve content access certificate"), ioe);
+        }
+        catch (GeneralSecurityException gse) {
+            throw new BadRequestException(i18n.tr("Cannot retrieve content access certificate", gse));
         }
         return allCerts;
     }

--- a/server/src/main/java/org/candlepin/service/impl/DefaultContentAccessCertServiceAdapter.java
+++ b/server/src/main/java/org/candlepin/service/impl/DefaultContentAccessCertServiceAdapter.java
@@ -105,7 +105,7 @@ public class DefaultContentAccessCertServiceAdapter implements ContentAccessCert
         Owner owner = consumer.getOwner();
         // we only know about one mode right now. If add any, we will need to add the
         // appropriate cert generation
-        if (!ORG_ENV_ACCESS_MODE.equals(owner.contentAccessMode()) || !consumer.isCertV3Capable()) {
+        if (!ORG_ENV_ACCESS_MODE.equals(owner.getContentAccessMode()) || !consumer.isCertV3Capable()) {
             return null;
         }
 

--- a/server/src/main/java/org/candlepin/sync/Importer.java
+++ b/server/src/main/java/org/candlepin/sync/Importer.java
@@ -40,6 +40,7 @@ import org.candlepin.model.ProductCurator;
 import org.candlepin.model.UpstreamConsumer;
 import org.candlepin.model.dto.Subscription;
 import org.candlepin.pki.PKIUtility;
+import org.candlepin.service.ContentAccessCertServiceAdapter;
 import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.service.OwnerServiceAdapter;
 import org.candlepin.service.impl.ImportSubscriptionServiceAdapter;
@@ -568,7 +569,9 @@ public class Importer {
         }
 
         // Setup our import subscription adapter with the subscriptions imported:
-        final String contentAccessMode = consumer.getContentAccessMode();
+        final String contentAccessMode = StringUtils.isEmpty(consumer.getContentAccessMode()) ?
+            ContentAccessCertServiceAdapter.DEFAULT_CONTENT_ACCESS_MODE :
+            consumer.getContentAccessMode();
         SubscriptionServiceAdapter subAdapter = new ImportSubscriptionServiceAdapter(importSubs);
         OwnerServiceAdapter ownerAdapter = new OwnerServiceAdapter() {
             @Override

--- a/server/src/main/resources/db/changelog/20170612091842-default-content-access-list.xml
+++ b/server/src/main/resources/db/changelog/20170612091842-default-content-access-list.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+    <changeSet id="20170612091842-1" author="wpoteat">
+        <sql>
+            update cp_owner set content_access_mode_list = 'entitlement' where content_access_mode_list is null;
+            update cp_owner set content_access_mode_list = concat(content_access_mode_list,',entitlement') where content_access_mode_list not like '%entitlement%';
+            update cp_owner set content_access_mode = 'entitlement' where content_access_mode is null;
+        </sql>
+        <addNotNullConstraint tableName="cp_owner"
+                              columnName="content_access_mode_list"
+                              columnDataType="varchar(255)"
+        />
+        <addNotNullConstraint tableName="cp_owner"
+                              columnName="content_access_mode"
+                              columnDataType="varchar(255)"
+        />
+    </changeSet>
+
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/server/src/main/resources/db/changelog/changelog-create.xml
+++ b/server/src/main/resources/db/changelog/changelog-create.xml
@@ -1214,4 +1214,5 @@
     <include file="db/changelog/20170421055601-add-recipient-owner-to-consumer.xml"/>
     <include file="db/changelog/20170518143217-remove-obsoleted-dirty-column.xml"/>
     <include file="db/changelog/20170510130908-remove-pool-version.xml"/>
+    <include file="db/changelog/20170612091842-default-content-access-list.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-testing.xml
+++ b/server/src/main/resources/db/changelog/changelog-testing.xml
@@ -2305,4 +2305,5 @@
     <include file="db/changelog/20170421055601-add-recipient-owner-to-consumer.xml"/>
     <include file="db/changelog/20170518143217-remove-obsoleted-dirty-column.xml"/>
     <include file="db/changelog/20170510130908-remove-pool-version.xml"/>
+    <include file="db/changelog/20170612091842-default-content-access-list.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-update.xml
+++ b/server/src/main/resources/db/changelog/changelog-update.xml
@@ -122,4 +122,5 @@
     <include file="db/changelog/20170421055601-add-recipient-owner-to-consumer.xml"/>
     <include file="db/changelog/20170518143217-remove-obsoleted-dirty-column.xml"/>
     <include file="db/changelog/20170510130908-remove-pool-version.xml"/>
+    <include file="db/changelog/20170612091842-default-content-access-list.xml"/>
 </databaseChangeLog>

--- a/server/src/test/java/org/candlepin/controller/OwnerManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/OwnerManagerTest.java
@@ -1,0 +1,158 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.controller;
+
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
+
+import org.candlepin.model.ConsumerCurator;
+import org.candlepin.model.ContentAccessCertificateCurator;
+import org.candlepin.model.EnvironmentCurator;
+import org.candlepin.model.ExporterMetadataCurator;
+import org.candlepin.model.ImportRecordCurator;
+import org.candlepin.model.Owner;
+import org.candlepin.model.OwnerContentCurator;
+import org.candlepin.model.OwnerCurator;
+import org.candlepin.model.OwnerEnvContentAccessCurator;
+import org.candlepin.model.OwnerProductCurator;
+import org.candlepin.model.PermissionBlueprintCurator;
+import org.candlepin.model.UeberCertificateCurator;
+import org.candlepin.model.activationkeys.ActivationKeyCurator;
+
+import org.candlepin.service.ContentAccessCertServiceAdapter;
+import org.candlepin.service.OwnerServiceAdapter;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.Assert;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+
+/**
+ * RefresherTest
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class OwnerManagerTest {
+    private OwnerManager ownerManager;
+    @Mock
+    private ConsumerCurator consumerCurator;
+    @Mock
+    private ActivationKeyCurator activationKeyCurator;
+    @Mock
+    private EnvironmentCurator envCurator;
+    @Mock
+    private ExporterMetadataCurator exportCurator;
+    @Mock
+    private ImportRecordCurator importRecordCurator;
+    @Mock
+    private PermissionBlueprintCurator permissionCurator;
+    @Mock
+    private OwnerProductCurator ownerProductCurator;
+    @Mock
+    private ProductManager productManager;
+    @Mock
+    private OwnerContentCurator ownerContentCurator;
+    @Mock
+    private ContentManager contentManager;
+    @Mock
+    private OwnerCurator ownerCurator;
+    @Mock
+    private ContentAccessCertServiceAdapter contentAccessCertService;
+    @Mock
+    private ContentAccessCertificateCurator contentAccessCertCurator;
+    @Mock
+    private OwnerEnvContentAccessCurator ownerEnvContentAccessCurator;
+    @Mock
+    private UeberCertificateCurator uberCertificateCurator;
+    @Mock
+    private OwnerServiceAdapter ownerServiceAdapter;
+
+    @Before
+    public void setUp() {
+        ownerManager = new OwnerManager(consumerCurator, activationKeyCurator, envCurator,
+            exportCurator, importRecordCurator, permissionCurator, ownerProductCurator, productManager,
+            ownerContentCurator, contentManager, ownerCurator, contentAccessCertService,
+            contentAccessCertCurator, ownerEnvContentAccessCurator, uberCertificateCurator,
+            ownerServiceAdapter);
+    }
+
+    @Test
+    public void testContentAccessSetEmpty() {
+        Owner owner = new Owner();
+        when(ownerCurator.lockAndLoad(eq(owner))).thenReturn(owner);
+        when(ownerServiceAdapter.getContentAccessModeList(eq(owner.getKey()))).thenReturn("");
+        when(ownerServiceAdapter.getContentAccessMode(eq(owner.getKey()))).thenReturn("");
+        ownerManager.refreshContentAccessMode(ownerServiceAdapter, owner);
+        Assert.assertEquals(owner.getContentAccessModeList(),
+            ContentAccessCertServiceAdapter.DEFAULT_CONTENT_ACCESS_MODE);
+        Assert.assertEquals(owner.getContentAccessMode(),
+            ContentAccessCertServiceAdapter.DEFAULT_CONTENT_ACCESS_MODE);
+    }
+
+    @Test
+    public void testContentAccessSetNull() {
+        Owner owner = new Owner();
+        when(ownerCurator.lockAndLoad(eq(owner))).thenReturn(owner);
+        when(ownerServiceAdapter.getContentAccessModeList(eq(owner.getKey()))).thenReturn(null);
+        when(ownerServiceAdapter.getContentAccessMode(eq(owner.getKey()))).thenReturn(null);
+        ownerManager.refreshContentAccessMode(ownerServiceAdapter, owner);
+        Assert.assertEquals(owner.getContentAccessModeList(),
+            ContentAccessCertServiceAdapter.DEFAULT_CONTENT_ACCESS_MODE);
+        Assert.assertEquals(owner.getContentAccessMode(),
+            ContentAccessCertServiceAdapter.DEFAULT_CONTENT_ACCESS_MODE);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testContentAccessModeNotOnList() {
+        Owner owner = new Owner();
+        when(ownerCurator.lockAndLoad(eq(owner))).thenReturn(owner);
+        when(ownerServiceAdapter.getContentAccessModeList(eq(owner.getKey()))).thenReturn("one,two");
+        when(ownerServiceAdapter.getContentAccessMode(eq(owner.getKey()))).thenReturn("three");
+        ownerManager.refreshContentAccessMode(ownerServiceAdapter, owner);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testContentAccessModeBlankSelection() {
+        Owner owner = new Owner();
+        when(ownerCurator.lockAndLoad(eq(owner))).thenReturn(owner);
+        when(ownerServiceAdapter.getContentAccessModeList(eq(owner.getKey()))).thenReturn("one,two");
+        when(ownerServiceAdapter.getContentAccessMode(eq(owner.getKey()))).thenReturn("");
+        ownerManager.refreshContentAccessMode(ownerServiceAdapter, owner);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testContentAccessModeNullSelection() {
+        Owner owner = new Owner();
+        when(ownerCurator.lockAndLoad(eq(owner))).thenReturn(owner);
+        when(ownerServiceAdapter.getContentAccessModeList(eq(owner.getKey()))).thenReturn("one,two");
+        when(ownerServiceAdapter.getContentAccessMode(eq(owner.getKey()))).thenReturn(null);
+        ownerManager.refreshContentAccessMode(ownerServiceAdapter, owner);
+    }
+
+    @Test
+    public void testContentAccessModeNoList() {
+        Owner owner = new Owner();
+        when(ownerCurator.lockAndLoad(eq(owner))).thenReturn(owner);
+        when(ownerServiceAdapter.getContentAccessModeList(eq(owner.getKey()))).thenReturn("");
+        when(ownerServiceAdapter.getContentAccessMode(eq(owner.getKey()))).thenReturn("three");
+        ownerManager.refreshContentAccessMode(ownerServiceAdapter, owner);
+        Assert.assertEquals(owner.getContentAccessModeList(),
+            ContentAccessCertServiceAdapter.DEFAULT_CONTENT_ACCESS_MODE);
+        Assert.assertEquals(owner.getContentAccessMode(),
+            ContentAccessCertServiceAdapter.DEFAULT_CONTENT_ACCESS_MODE);
+    }
+}

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
@@ -78,6 +78,7 @@ import org.candlepin.service.IdentityCertServiceAdapter;
 import org.candlepin.service.OwnerServiceAdapter;
 import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.service.UserServiceAdapter;
+import org.candlepin.service.impl.DefaultContentAccessCertServiceAdapter;
 import org.candlepin.test.TestUtil;
 import org.candlepin.util.FactValidator;
 import org.candlepin.util.ServiceLevelValidator;
@@ -141,6 +142,7 @@ public class ConsumerResourceTest {
     @Mock private OwnerManager mockOwnerManager;
     @Mock private ConsumerEnricher consumerEnricher;
     @Mock private ConsumerTypeCurator mockConsumerTypeCurator;
+    @Mock private DefaultContentAccessCertServiceAdapter mockContentAccessCertService;
 
     @Before
     public void setUp() {
@@ -231,7 +233,7 @@ public class ConsumerResourceTest {
             mockedConsumerCurator, null, null, null, null, mockedEntitlementCurator, null,
             mockedEntitlementCertServiceAdapter, null, null, null, null, null, null, mockedPoolManager, null,
             null, null, null, null, null, null, null, this.config, null, null, null, consumerBindUtil,
-            null, null, this.factValidator, null, consumerEnricher);
+            null, mockContentAccessCertService, this.factValidator, null, consumerEnricher);
 
         List<CertificateSerialDto> serials = consumerResource
             .getEntitlementCertificateSerials(consumer.getUuid());
@@ -922,7 +924,7 @@ public class ConsumerResourceTest {
             mockedConsumerCurator, null, null, null, null, mockedEntitlementCurator, null,
             mockedEntitlementCertServiceAdapter, null, null, null, null, null, null, mockedPoolManager, null,
             null, null, null, null, null, null, null, this.config, null, null, null, consumerBindUtil,
-            null, null, this.factValidator, null, consumerEnricher));
+            null, mockContentAccessCertService, this.factValidator, null, consumerEnricher));
 
         List<CertificateSerialDto> serials = consumerResource
             .getEntitlementCertificateSerials(consumer.getUuid());
@@ -942,7 +944,7 @@ public class ConsumerResourceTest {
             mockedConsumerCurator, null, null, null, null, mockedEntitlementCurator, null,
             mockedEntitlementCertServiceAdapter, null, null, null, null, null, null, mockedPoolManager, null,
             null, null, null, null, null, null, null, this.config, null, null, null, consumerBindUtil,
-            null, null, this.factValidator, null, consumerEnricher));
+            null, mockContentAccessCertService, this.factValidator, null, consumerEnricher));
 
         Set<Long> serials = new HashSet<Long>();
         List<Certificate> certs = consumerResource

--- a/server/src/test/java/org/candlepin/resource/OwnerResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/OwnerResourceTest.java
@@ -1042,9 +1042,9 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         OwnerManager ownerManager = mock(OwnerManager.class);
         EventFactory eventFactory = mock(EventFactory.class);
         OwnerResource or = new OwnerResource(
-            oc, null, null, i18n, null, eventFactory, null, null, null, null, ownerManager,  null, null,
-            null, null, null, null, null, null, null, null, contentOverrideValidator, serviceLevelValidator,
-            null, null, null, productManager, contentManager, null
+            oc, null, null, i18n, null, eventFactory, null, null, null, poolManager, ownerManager,  null,
+            null, null, null, null, null, null, null, null, null, contentOverrideValidator,
+            serviceLevelValidator, null, null, null, productManager, contentManager, null
         );
 
         when(oc.lookupByKey(eq("testOwner"))).thenReturn(o);


### PR DESCRIPTION
If no list exists, then it is set to the default list and
 the mode is also set to the default value ['entitlement']
Ensure that the org's content access mode is defined when the
 org is created or updated
Update the mode list and mode columns to not null and default.