### PR TITLE
Fixed an issue with migrating a database with product content

### DIFF
--- a/server/src/main/resources/db/changelog/20161025103454-cleanup-ueber-certs-round2.xml
+++ b/server/src/main/resources/db/changelog/20161025103454-cleanup-ueber-certs-round2.xml
@@ -249,6 +249,8 @@
 
     <changeSet id="20161025103454-1" author="mstead">
         <validCheckSum>7:67265f7bbe46b62a789d326361adee32</validCheckSum>
+        <validCheckSum>7:9b3c3db544862eaa6e7ff0cb9f9ef4b5</validCheckSum>
+
         <comment>Clean out all ueber cert (debug cert) data to avoid manual cleanup.
                  This changeset will remove both the 0.9.54 (copied data) AND the
                  2.0 ueber cert data. We are required to do this a second time since

--- a/server/src/main/resources/db/changelog/20170220102027-add-id-column-for-productcontent.xml
+++ b/server/src/main/resources/db/changelog/20170220102027-add-id-column-for-productcontent.xml
@@ -4,19 +4,38 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+
 
     <changeSet id="20170220102027-1" author="crog">
+        <!-- Original checksum of this changeset prior to adding the populating SQL -->
+        <validCheckSum>7:bb7e778ce1c3821e649eaa7699c51f8e</validCheckSum>
+
         <!-- On MySQL/MariaDB, we need to drop *all* foreign keys before we can drop our primary key -->
         <dropAllForeignKeyConstraints baseTableName="cp2_product_content"/>
 
         <dropPrimaryKey tableName="cp2_product_content" constraintName="cp2_product_content_pk"/>
 
-        <!-- Liquibase won't let us specify the positional offset, despite the docs saying we can. -->
         <addColumn tableName="cp2_product_content">
-            <column name="id" type="varchar(32)"/>
+            <column name="id" type="varchar(32)" position="1"/>
         </addColumn>
 
+        <!-- We need to populate the ID column before we designate it as a primary key -->
+        <sql dbms="mysql">
+            UPDATE cp2_product_content SET id=REPLACE(UUID(), '-', '')
+        </sql>
+
+        <sql dbms="postgresql">
+            <!-- Unfortunately, postgres doesn't provide a standard UUID-like function, so we hack it here -->
+            UPDATE cp2_product_content SET id=md5(product_uuid || content_uuid || random()::text || clock_timestamp()::text)
+        </sql>
+
+        <sql dbms="oracle">
+            UPDATE cp2_product_content SET id=SYS_GUID()
+        </sql>
+
+        <!-- Add the primary key -->
         <addPrimaryKey tableName="cp2_product_content"
             columnNames="id"
             constraintName="cp2_product_content_pk"

--- a/tasks/liquibase.rake
+++ b/tasks/liquibase.rake
@@ -62,7 +62,7 @@ module Liquibase
                 xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                 xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-                http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+                http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
 
             <changeSet id="<%= id%>" author="<%= author%>">
                 <comment><%= description %></comment>


### PR DESCRIPTION
- Fixed a Liquibase migration task that would fail when attempting
  to update a database that already contained product content
  when run against MySQL
- Updated the Liquibase buildr task to use a newer version of the
  XML validator
- Added a valid checksum to the ueber cert cleanup task to avoid
  issues with certain migrations