### PR TITLE
(2.1) Added logging for quartz job misfires

### DIFF
--- a/server/src/main/java/org/candlepin/pinsetter/core/PinsetterTriggerListener.java
+++ b/server/src/main/java/org/candlepin/pinsetter/core/PinsetterTriggerListener.java
@@ -51,4 +51,18 @@ public class PinsetterTriggerListener extends TriggerListenerSupport {
         }
         return false;
     }
+
+    @Override
+    public void triggerMisfired(Trigger trigger) {
+        log.warn("Trigger misfired for for Job: \nKey: {}\nJob Key: {}\nStart: {}\nEnd: {}\n" +
+            "Final Fire Time: {}\nNext Fire Time: {}\nMisfire Instruction: {}\nPriority: {}",
+            trigger.getKey(),
+            trigger.getJobKey(),
+            trigger.getStartTime(),
+            trigger.getEndTime(),
+            trigger.getFinalFireTime(),
+            trigger.getNextFireTime(),
+            trigger.getMisfireInstruction(),
+            trigger.getPriority());
+    }
 }


### PR DESCRIPTION
Adds some debug logging showing trigger information for the misfired quartz job.

Honestly, there isn't an easy way to test this. I had to hack some candlepin code to make it happen on my dev box. I don't think it is worth spending the time to verify this PR and a code review is enough.