### PR TITLE
(2.1) 1457902: Fix failure listing Jobs when class not found

### DIFF
--- a/server/src/main/java/org/candlepin/model/JobCurator.java
+++ b/server/src/main/java/org/candlepin/model/JobCurator.java
@@ -157,11 +157,15 @@ public class JobCurator extends AbstractHibernateCurator<JobStatus> {
     }
 
     public long findNumRunningByClassAndTarget(String target, Class<? extends KingpinJob> jobClass) {
+        if (jobClass == null) {
+            throw new IllegalArgumentException("jobClass can not be null");
+        }
+
         return (Long) this.currentSession().createCriteria(JobStatus.class)
             .add(Restrictions.ge("updated", getBlockingCutoff()))
             .add(Restrictions.eq("state", JobState.RUNNING))
             .add(Restrictions.eq("targetId", target))
-            .add(Restrictions.eq("jobClass", jobClass))
+            .add(Restrictions.eq("jobClass", jobClass.getCanonicalName()))
             .setProjection(Projections.count("id"))
             .uniqueResult();
     }
@@ -171,6 +175,10 @@ public class JobCurator extends AbstractHibernateCurator<JobStatus> {
         // This is not guaranteed to find the intended target if more than one job in the DB
         // matches the input criteria
 
+        if (jobClass == null) {
+            throw new IllegalArgumentException("jobClass can not be null");
+        }
+
         return (JobStatus) this.currentSession().createCriteria(JobStatus.class)
             .addOrder(Order.desc("created"))
             .add(Restrictions.ge("updated", getBlockingCutoff()))
@@ -178,7 +186,7 @@ public class JobCurator extends AbstractHibernateCurator<JobStatus> {
             .add(Restrictions.ne("state", JobState.FAILED))
             .add(Restrictions.ne("state", JobState.CANCELED))
             .add(Restrictions.eq("targetId", target))
-            .add(Restrictions.eq("jobClass", jobClass))
+            .add(Restrictions.eq("jobClass", jobClass.getCanonicalName()))
             .setMaxResults(1)
             .uniqueResult();
     }

--- a/server/src/main/java/org/candlepin/pinsetter/core/model/JobStatus.java
+++ b/server/src/main/java/org/candlepin/pinsetter/core/model/JobStatus.java
@@ -17,7 +17,6 @@ package org.candlepin.pinsetter.core.model;
 import org.candlepin.auth.Principal;
 import org.candlepin.model.AbstractHibernateObject;
 import org.candlepin.pinsetter.core.PinsetterJobListener;
-import org.candlepin.pinsetter.tasks.KingpinJob;
 
 import org.quartz.JobDetail;
 import org.quartz.JobExecutionContext;
@@ -116,7 +115,7 @@ public class JobStatus extends AbstractHibernateObject {
     private String correlationId;
 
     @Column(length = 255)
-    private Class<? extends KingpinJob> jobClass;
+    private String jobClass;
 
     private byte[] resultData;
 
@@ -164,8 +163,8 @@ public class JobStatus extends AbstractHibernateObject {
     }
 
     @SuppressWarnings("unchecked")
-    private Class<? extends KingpinJob> getJobClass(JobDetail jobDetail) {
-        return (Class<? extends KingpinJob>) jobDetail.getJobClass();
+    private String getJobClass(JobDetail jobDetail) {
+        return  jobDetail.getJobClass() != null ? jobDetail.getJobClass().getCanonicalName() : null;
     }
 
     public void update(JobExecutionContext context) {
@@ -263,7 +262,7 @@ public class JobStatus extends AbstractHibernateObject {
     }
 
     @XmlTransient
-    public Class<? extends KingpinJob> getJobClass() {
+    public String getJobClass() {
         return jobClass;
     }
 
@@ -352,7 +351,7 @@ public class JobStatus extends AbstractHibernateObject {
     public String toString() {
         return String.format("JobStatus [id: %s, type: %s, owner: %s, target: %s (%s), state: %s]",
             this.id,
-            this.jobClass != null ? this.jobClass.getSimpleName() : null,
+            this.jobClass != null ? this.jobClass : null,
             this.ownerId,
             this.targetId,
             this.targetType,

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/EntitlerJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/EntitlerJob.java
@@ -145,8 +145,17 @@ public class EntitlerJob extends KingpinJob {
     }
 
     public static boolean isSchedulable(JobCurator jobCurator, JobStatus status) {
-        long running = jobCurator.findNumRunningByClassAndTarget(
-            status.getTargetId(), status.getJobClass());
+
+        Class<? extends KingpinJob> jobClass;
+        try {
+            jobClass = (Class<? extends KingpinJob>) Class.forName(status.getJobClass());
+        }
+        catch (ClassNotFoundException cnfe) {
+            log.warn("Could not schedule job of class {}. The class was not found.", status.getJobClass());
+            return false;
+        }
+
+        long running = jobCurator.findNumRunningByClassAndTarget(status.getTargetId(), jobClass);
         // We can start the job if there are less than N others running
         int throttle = conf.getInt(ConfigProperties.ENTITLER_JOB_THROTTLE);
         return running < throttle;

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/UniqueByEntityJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/UniqueByEntityJob.java
@@ -57,8 +57,17 @@ public abstract class UniqueByEntityJob extends KingpinJob {
     }
 
     public static boolean isSchedulable(JobCurator jobCurator, JobStatus status) {
+        Class<? extends KingpinJob> jobClass;
+        try {
+            jobClass = (Class<? extends KingpinJob>) Class.forName(status.getJobClass());
+        }
+        catch (ClassNotFoundException cnfe) {
+            log.warn("Could not schedule job of class {}. The class was not found.", status.getJobClass());
+            return false;
+        }
+
         long running = jobCurator.findNumRunningByClassAndTarget(
-            status.getTargetId(), status.getJobClass());
+            status.getTargetId(), jobClass);
         return running == 0;  // We can start the job if there are 0 like it running
     }
 }

--- a/server/src/test/java/org/candlepin/model/JobCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/JobCuratorTest.java
@@ -409,6 +409,16 @@ public class JobCuratorTest extends DatabaseTestFixture {
         assertEquals(job, jobs.get(0));
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void findNumRunningByClassAndTargetThrowsIllegalArguementExceptionWithNullJobClass() {
+        curator.findNumRunningByClassAndTarget("TEST", null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void getByClassAndTargetThrowsIllegalArguementExceptionWithNullJobClass() {
+        curator.getByClassAndTarget("TEST", null);
+    }
+
     private JobStatusBuilder newJobStatus() {
         return new JobStatusBuilder();
     }

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/HypervisorUpdateJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/HypervisorUpdateJobTest.java
@@ -288,4 +288,5 @@ public class HypervisorUpdateJobTest {
                 "Could not update host/guest mapping. Auto-attach is disabled for owner joe.");
         }
     }
+
 }


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1457902


When listing jobs, if the job class was deleted and is not
found, hibernate would through an exception when building
up the JobStatus object.

This was addressed by changing the JobStatus.jobClass field
to be a String instead of a class. This way hibernate will
not try and create a Class object from the class string.

Callers of JobStatus.getJobClass will now have to instantiate
the Class directly and handle cases where the class is not found.


## Testing

1. Deploy 0.9.54 in **hosted** mode with test data.
2. Run the populate hosted DB Job
```bash
$ curl -k -u admin:admin https://localhost:8443/candlepin/admin/pophosteddb
{
  "id" : "populated_hosted_db-9baf8b43-a96e-449b-a32d-7fbd909c7dd9",
  "state" : "CREATED",
  "startTime" : null,
  "finishTime" : null,
  "result" : null,
  "principalName" : "admin",
  "targetType" : null,
  "targetId" : null,
  "ownerId" : null,
  "statusPath" : "/jobs/populated_hosted_db-9baf8b43-a96e-449b-a32d-7fbd909c7dd9",
  "done" : false,
  "group" : "async group",
  "created" : "2017-06-23T12:19:43.140+0000",
  "updated" : "2017-06-23T12:19:43.140+0000"
}

$ curl -k -u admin:admin https://localhost:8443/candlepin/jobs?principal=admin
[ {
  "id" : "populated_hosted_db-9baf8b43-a96e-449b-a32d-7fbd909c7dd9",
  "state" : "FINISHED",
  "startTime" : "2017-06-23T12:19:43.157+0000",
  "finishTime" : "2017-06-23T12:19:43.631+0000",
  "result" : "Finished populating hosted DB. Received 84 product(s) and 78 content with 0 unresolved reference(s)",
  "principalName" : "admin",
  "targetType" : null,
  "targetId" : null,
  "ownerId" : null,
  "statusPath" : "/jobs/populated_hosted_db-9baf8b43-a96e-449b-a32d-7fbd909c7dd9",
  "done" : true,
  "group" : "async group",
  "created" : "2017-06-23T12:19:43.140+0000",
  "updated" : "2017-06-23T12:19:43.648+0000"
} ]
```
3. Check out master and redeploy **without** resetting the DB.
4. Try to get the jobs for the admin principal. It should fail.
```bash
$ curl -k -u admin:admin https://localhost:8443/candlepin/jobs?principal=admin
{
  "displayMessage" : "Runtime Error Unable to locate named class org.candlepin.pinsetter.tasks.PopulateHostedDBTask at org.hibernate.type.descriptor.java.ClassTypeDescriptor.fromString:37",
  "requestUuid" : "c124355a-8e74-4fd5-9bee-aeea20387aa9"
}
```
5. Deploy this patch **without** recreating the DB.
6. Try to get the jobs again. Should now display the job data.
```bash
$ curl -k -u admin:admin https://localhost:8443/candlepin/jobs?principal=admin
[ {
  "id" : "populated_hosted_db-9baf8b43-a96e-449b-a32d-7fbd909c7dd9",
  "state" : "FINISHED",
  "startTime" : "2017-06-23T12:19:43+0000",
  "finishTime" : "2017-06-23T12:19:43+0000",
  "result" : "Finished populating hosted DB. Received 84 product(s) and 78 content with 0 unresolved reference(s)",
  "principalName" : "admin",
  "targetType" : null,
  "targetId" : null,
  "ownerId" : null,
  "correlationId" : null,
  "resultData" : null,
  "statusPath" : "/jobs/populated_hosted_db-9baf8b43-a96e-449b-a32d-7fbd909c7dd9",
  "done" : true,
  "group" : "async group",
  "created" : "2017-06-23T12:19:43+0000",
  "updated" : "2017-06-23T12:19:43+0000"
} ]
```