### PR TITLE
(2.0) Re-enable JobCleaner logging

### DIFF
--- a/server/src/main/java/org/candlepin/pinsetter/tasks/JobCleaner.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/JobCleaner.java
@@ -49,9 +49,4 @@ public class JobCleaner extends KingpinJob {
         this.jobCurator.cleanupAllOldJobs(failedJobDeadLineDt);
     }
 
-    @Override
-    protected boolean logExecutionTime() {
-        return false;
-    }
-
 }


### PR DESCRIPTION
Since JobCleaner runs every 12h by default and
nothing is currently overriding it, there is no
reason not to log it.