### PR TITLE
1461472: Update rules to run against 0.9 versions

### DIFF
--- a/server/src/main/resources/rules/rules.js
+++ b/server/src/main/resources/rules/rules.js
@@ -1,4 +1,4 @@
-// Version: 5.23
+// Version: 5.24
 
 /*
  * Default Candlepin rule set.
@@ -568,7 +568,7 @@ var FactValueCalculator = {
 
         guest_limit: function (prodAttr, consumer) {
             var context = JSON.parse(json_context);
-            if (context.guestIds === null) {
+            if (!context.hasOwnProperty('guestIds') || context.guestIds === null) {
                 return 0;
             }
             var activeGuestCount = 0;


### PR DESCRIPTION
Detects guestIds as non-existent in the context. This condition
 occurs when newer rules versions are run in 0.9.54 because of
 inclusion in manifests. This will delay the need to make a
 major revision bump.