### PR TITLE
Consolidated and refactored the database locking methods (2.0)

### DIFF
--- a/server/spec/consumer_resource_host_guest_spec.rb
+++ b/server/spec/consumer_resource_host_guest_spec.rb
@@ -195,7 +195,7 @@ describe 'Consumer Resource Host/Guest' do
     host2['uuid'].should == host_consumer2['uuid']
   end
 
-  it 'guest should impose SLA on host auto-attach' do
+  it 'guest should not impose SLA on host auto-attach' do
     uuid1 = random_string('system.uuid')
     uuid2 = random_string('system.uuid')
     uuid3 = random_string('system.uuid')

--- a/server/src/main/java/org/candlepin/model/Consumer.java
+++ b/server/src/main/java/org/candlepin/model/Consumer.java
@@ -373,8 +373,8 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
     public String toString() {
         String consumerType = (this.getType() != null) ? this.getType().getLabel() : "null";
 
-        return String.format("Consumer [id: %s, uuid: %s, consumerType: %s, name: %s] -- %s",
-            this.getId(), this.getUuid(), consumerType, this.getName(), super.toString());
+        return String.format("Consumer [id: %s, uuid: %s, consumerType: %s, name: %s]",
+            this.getId(), this.getUuid(), consumerType, this.getName());
     }
 
     /**

--- a/server/src/main/java/org/candlepin/model/ConsumerCurator.java
+++ b/server/src/main/java/org/candlepin/model/ConsumerCurator.java
@@ -41,7 +41,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
@@ -51,8 +50,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-
-import javax.persistence.LockModeType;
 
 
 
@@ -270,36 +267,6 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
     @Transactional
     public Consumer findByUuid(String uuid) {
         return getConsumer(uuid);
-    }
-
-    /**
-     * Apply a SELECT FOR UPDATE on a consumer.
-     *
-     * Note this method is not transactional.  It is meant to be used within
-     * a larger transaction.  Starting a transaction, running a select for update,
-     * and then ending the transaction is pointless.
-     *
-     * @return A consumer locked in the database
-     */
-    public Consumer lockAndLoad(Consumer c) {
-        getEntityManager().lock(c, LockModeType.PESSIMISTIC_WRITE);
-        return c;
-    }
-
-    /**
-     * Find a consumer by uuid and immediately lock it.
-     *
-     * @param consumerUuid the uuid of the target consumer.
-     *
-     * @return the Consumer matching the given uuid, null if the consumer was not found.
-     */
-    public Consumer lockAndLoadByUuid(String consumerUuid) {
-        List<Consumer> consumerList = lockAndLoadBatch(Arrays.asList(consumerUuid));
-        return (CollectionUtils.isEmpty(consumerList)) ? null : consumerList.get(0);
-    }
-
-    public List<Consumer> lockAndLoadBatch(Collection<String> uuids) {
-        return lockAndLoadBatch(uuids, "Consumer", "uuid");
     }
 
     @Transactional

--- a/server/src/main/java/org/candlepin/model/EntitlementCurator.java
+++ b/server/src/main/java/org/candlepin/model/EntitlementCurator.java
@@ -369,7 +369,6 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
     public List<Entitlement> listByConsumer(Consumer consumer, EntitlementFilterBuilder filters) {
         Criteria criteria = this.createCriteriaFromFilters(filters)
             .add(Restrictions.eq("consumer", consumer));
-            // .addOrder(Order.asc("Pool.id")); // Why do we care about the order?
 
         List<String> entitlementIds = criteria.list();
 

--- a/server/src/main/java/org/candlepin/model/OwnerContentCurator.java
+++ b/server/src/main/java/org/candlepin/model/OwnerContentCurator.java
@@ -20,6 +20,7 @@ import org.hibernate.Criteria;
 import org.hibernate.Session;
 import org.hibernate.criterion.DetachedCriteria;
 import org.hibernate.criterion.Disjunction;
+import org.hibernate.criterion.Order;
 import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
 
@@ -411,7 +412,8 @@ public class OwnerContentCurator extends AbstractHibernateCurator<OwnerContent> 
 
         if (uuids != null && !uuids.isEmpty()) {
             DetachedCriteria criteria = DetachedCriteria.forClass(Content.class)
-                .add(CPRestrictions.in("uuid", uuids));
+                .add(CPRestrictions.in("uuid", uuids))
+                .addOrder(Order.asc("uuid"));
 
             return this.cpQueryFactory.<Content>buildQuery(this.currentSession(), criteria);
         }

--- a/server/src/main/java/org/candlepin/model/OwnerProductCurator.java
+++ b/server/src/main/java/org/candlepin/model/OwnerProductCurator.java
@@ -22,6 +22,7 @@ import org.hibernate.Criteria;
 import org.hibernate.Session;
 import org.hibernate.criterion.DetachedCriteria;
 import org.hibernate.criterion.Disjunction;
+import org.hibernate.criterion.Order;
 import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
 import org.hibernate.sql.JoinType;
@@ -380,7 +381,8 @@ public class OwnerProductCurator extends AbstractHibernateCurator<OwnerProduct> 
 
         if (uuids != null && !uuids.isEmpty()) {
             DetachedCriteria criteria = DetachedCriteria.forClass(Product.class)
-                .add(CPRestrictions.in("uuid", uuids));
+                .add(CPRestrictions.in("uuid", uuids))
+                .addOrder(Order.asc("uuid"));
 
             return this.cpQueryFactory.<Product>buildQuery(this.currentSession(), criteria);
         }

--- a/server/src/main/java/org/candlepin/model/PoolCurator.java
+++ b/server/src/main/java/org/candlepin/model/PoolCurator.java
@@ -28,7 +28,6 @@ import org.hibernate.Criteria;
 import org.hibernate.FetchMode;
 import org.hibernate.Filter;
 import org.hibernate.Hibernate;
-import org.hibernate.LockOptions;
 import org.hibernate.Query;
 import org.hibernate.ReplicationMode;
 import org.hibernate.criterion.Criterion;
@@ -903,29 +902,6 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
         Filter consumerFilter = currentSession().getEnabledFilter(CONSUMER_FILTER);
         currentSession().disableFilter(CONSUMER_FILTER);
         return consumerFilter;
-    }
-
-    public Pool lockAndLoad(Pool pool) {
-        currentSession().refresh(pool, LockOptions.UPGRADE);
-        getEntityManager().refresh(pool);
-        return pool;
-    }
-
-    public List<Pool> lockAndLoadBatch(Collection<String> ids) {
-        return lockAndLoadBatch(ids, "Pool", "id");
-    }
-
-    public void lock(List<Pool> poolsToLock) {
-        if (poolsToLock.isEmpty()) {
-            log.debug("Nothing to lock");
-            return;
-        }
-        List<String> ids = new ArrayList<String>();
-        for (Pool p : poolsToLock) {
-            ids.add(p.getId());
-        }
-        lockAndLoadBatchById(ids);
-        log.debug("Done locking pools");
     }
 
     public List<ActivationKey> getActivationKeysForPool(Pool p) {

--- a/server/src/main/java/org/candlepin/model/UeberCertificateGenerator.java
+++ b/server/src/main/java/org/candlepin/model/UeberCertificateGenerator.java
@@ -86,18 +86,20 @@ public class UeberCertificateGenerator {
 
     @Transactional
     public UeberCertificate generate(String ownerKey, Principal principal) {
-        Owner o = ownerCurator.findAndLock(ownerKey);
-        if (o == null) {
-            throw new NotFoundException(i18n.tr("owner with key: {0} was not found.", ownerKey));
+        Owner owner = this.ownerCurator.lookupByKey(ownerKey);
+        if (owner == null) {
+            throw new NotFoundException(i18n.tr("Unable to find an owner with key: {0}", ownerKey));
         }
+
+        this.ownerCurator.lock(owner);
 
         try {
             // There can only be one ueber certificate per owner, so delete the existing and regenerate it.
-            this.ueberCertCurator.deleteForOwner(o);
-            return  this.generateUeberCert(o, principal.getUsername());
+            this.ueberCertCurator.deleteForOwner(owner);
+            return  this.generateUeberCert(owner, principal.getUsername());
         }
         catch (Exception e) {
-            log.error("Problem generating ueber cert for owner: " + ownerKey, e);
+            log.error("Problem generating ueber cert for owner: {}", ownerKey, e);
             throw new BadRequestException(i18n.tr("Problem generating ueber cert for owner {0}", ownerKey),
                 e);
         }

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/HealEntireOrgJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/HealEntireOrgJob.java
@@ -68,6 +68,8 @@ public class HealEntireOrgJob extends UniqueByEntityJob {
     @Override
     public void toExecute(JobExecutionContext ctx) throws JobExecutionException {
         try {
+            // NOTE: ownerId is actually the owner key here.
+
             JobDataMap map = ctx.getMergedJobDataMap();
             String ownerId = (String) map.get("ownerId");
             Owner owner = ownerCurator.lookupByKey(ownerId);
@@ -78,7 +80,7 @@ public class HealEntireOrgJob extends UniqueByEntityJob {
 
             Date entitleDate = (Date) map.get("entitle_date");
 
-            for (String uuid : ownerCurator.getConsumerUuids(ownerId).list()) {
+            for (String uuid : ownerCurator.getConsumerUuids(owner).list()) {
                 // Do not send in product IDs.  CandlepinPoolManager will take care
                 // of looking up the non or partially compliant products to bind.
                 try {

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -416,8 +416,7 @@ public class ConsumerResource {
                 int days = config.getInt(ConfigProperties.IDENTITY_CERT_EXPIRY_THRESHOLD, 90);
                 Date futureExpire = Util.addDaysToDt(days);
                 // if expiration is within 90 days, regenerate it
-                log.debug("Threshold [{}] expires on [{}] futureExpire [{}]",
-                    days, expire, futureExpire);
+                log.debug("Threshold [{}] expires on [{}] futureExpire [{}]", days, expire, futureExpire);
 
                 if (expire.before(futureExpire)) {
                     log.info("Regenerating identity certificate for consumer: {}, expiry: {}", uuid, expire);
@@ -1318,7 +1317,10 @@ public class ConsumerResource {
         @PathParam("consumer_uuid") @Verify(Consumer.class) String uuid,
         @Context Principal principal) {
         log.debug("Deleting consumer_uuid {}", uuid);
-        Consumer toDelete = consumerCurator.lockAndLoadByUuid(uuid);
+
+        Consumer toDelete = consumerCurator.findByUuid(uuid);
+        this.consumerCurator.lock(toDelete);
+
         try {
             this.poolManager.revokeAllEntitlements(toDelete);
         }
@@ -1365,6 +1367,7 @@ public class ConsumerResource {
         // we want to insert the content access cert to this list
         if (!consumer.getOwner().contentAccessMode()
             .equals(ContentAccessCertServiceAdapter.DEFAULT_CONTENT_ACCESS_MODE)) {
+
             try {
                 Certificate cert = contentAccessCertService.getCertificate(consumer);
                 if (cert != null) {

--- a/server/src/main/java/org/candlepin/resource/HypervisorResource.java
+++ b/server/src/main/java/org/candlepin/resource/HypervisorResource.java
@@ -117,7 +117,7 @@ public class HypervisorResource {
             "Default is true.  If false is specified, hypervisorIds that are not found" +
             "will result in failed entries in the resulting HypervisorCheckInResult")
         @QueryParam("create_missing") @DefaultValue("true") boolean createMissing) {
-        log.debug("Hypervisor check-in by principal: " + principal);
+        log.debug("Hypervisor check-in by principal: {}", principal);
 
         if (hostGuestMap == null) {
             log.debug("Host/Guest mapping provided during hypervisor checkin was null.");

--- a/server/src/main/java/org/candlepin/resource/OwnerProductResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerProductResource.java
@@ -53,7 +53,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import javax.persistence.LockModeType;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
@@ -313,8 +312,7 @@ public class OwnerProductResource {
             throw new ForbiddenException(i18n.tr("product \"{0}\" is locked", product.getId()));
         }
 
-        this.productCurator.lock(product, LockModeType.PESSIMISTIC_WRITE);
-        boolean change = false;
+        this.productCurator.lock(product);
 
         for (Entry<String, Boolean> entry : contentMap.entrySet()) {
             Content content = this.fetchContent(owner, entry.getKey());
@@ -346,7 +344,7 @@ public class OwnerProductResource {
             throw new ForbiddenException(i18n.tr("product \"{0}\" is locked", product.getId()));
         }
 
-        this.productCurator.lock(product, LockModeType.PESSIMISTIC_WRITE);
+        this.productCurator.lock(product);
 
         product = this.productManager.addContentToProduct(
             product, Arrays.asList(new ProductContent(product, content, enabled)), owner, true

--- a/server/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -970,6 +970,7 @@ public class OwnerResource {
         }
 
         ownerCurator.merge(toUpdate);
+        ownerCurator.flush();
 
         if (toUpdate.isContentAccessModeDirty()) {
             ownerManager.refreshOwnerForContentAccess(toUpdate);

--- a/server/src/main/java/org/candlepin/sync/Importer.java
+++ b/server/src/main/java/org/candlepin/sync/Importer.java
@@ -76,7 +76,6 @@ import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
-import javax.persistence.LockModeType;
 import javax.persistence.PersistenceException;
 
 
@@ -459,7 +458,7 @@ public class Importer {
     // WARNING: Keep this method public, otherwise @Transactional is ignored:
     public List<Subscription> importObjects(Owner owner, Map<String, File> importFiles,
         ConflictOverrides overrides) throws IOException, ImporterException {
-        ownerCurator.lock(owner, LockModeType.PESSIMISTIC_WRITE);
+        ownerCurator.lock(owner);
 
         log.debug("Importing objects for owner: {}", owner);
 

--- a/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -961,7 +961,7 @@ public class PoolManagerTest {
             any(PoolFilterBuilder.class), any(PageRequest.class), anyBoolean(), anyBoolean(), anyBoolean()))
             .thenReturn(page);
 
-        when(mockPoolCurator.lockAndLoadBatchById(any(List.class))).thenReturn(Arrays.asList(pool1));
+        when(mockPoolCurator.lockAndLoadByIds(any(List.class))).thenReturn(Arrays.asList(pool1));
         when(enforcerMock.preEntitlement(any(Consumer.class), any(Pool.class), anyInt(),
             any(CallerType.class))).thenReturn(result);
 
@@ -1010,7 +1010,7 @@ public class PoolManagerTest {
             .thenReturn(page);
 
         when(mockPoolCurator.lockAndLoad(any(Pool.class))).thenReturn(pool1);
-        when(mockPoolCurator.lockAndLoadBatchById(any(List.class))).thenReturn(Arrays.asList(pool1));
+        when(mockPoolCurator.lockAndLoadByIds(any(List.class))).thenReturn(Arrays.asList(pool1));
         when(enforcerMock.preEntitlement(any(Consumer.class), anyCollectionOf(PoolQuantity.class),
             any(CallerType.class))).thenReturn(resultMap);
 
@@ -1221,7 +1221,7 @@ public class PoolManagerTest {
             any(PageRequest.class), anyBoolean(), anyBoolean(), anyBoolean()))
                 .thenReturn(page);
 
-        when(mockPoolCurator.lockAndLoadBatchById(anyListOf(String.class))).thenReturn(pools);
+        when(mockPoolCurator.lockAndLoadByIds(anyListOf(String.class))).thenReturn(pools);
         when(enforcerMock.preEntitlement(any(Consumer.class), any(Pool.class), anyInt(),
             any(CallerType.class))).thenReturn(result);
 
@@ -1700,7 +1700,7 @@ public class PoolManagerTest {
         assertEquals(3, derivedPool.getConsumed().intValue());
         assertEquals(1, derivedPool.getEntitlements().size());
 
-        when(mockPoolCurator.lockAndLoadBatchById(anyCollection())).thenReturn(Arrays.asList(pool));
+        when(mockPoolCurator.lockAndLoadByIds(anyCollection())).thenReturn(Arrays.asList(pool));
 
         when(mockPoolCurator.lookupOversubscribedBySubscriptionIds(any(Owner.class), anyMap()))
             .thenReturn(Arrays.asList(derivedPool));
@@ -1766,7 +1766,7 @@ public class PoolManagerTest {
         assertEquals(2, derivedPool2.getConsumed().intValue());
         assertEquals(2, derivedPool2.getConsumed().intValue());
 
-        when(mockPoolCurator.lockAndLoadBatchById(anyCollection())).thenReturn(Arrays.asList(pool));
+        when(mockPoolCurator.lockAndLoadByIds(anyCollection())).thenReturn(Arrays.asList(pool));
 
         when(mockPoolCurator.lookupOversubscribedBySubscriptionIds(any(Owner.class), anyMap())).thenReturn(
             Arrays.asList(derivedPool, derivedPool2, derivedPool3));

--- a/server/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
@@ -16,7 +16,6 @@ package org.candlepin.model;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.times;
@@ -945,35 +944,6 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
         consumerCurator.delete(c);
         i = (BigInteger) em.createNativeQuery(countQuery).getSingleResult();
         assertEquals(new BigInteger("0"), i);
-    }
-
-    @Test
-    public void lockAndLoadByUuidReturnsFindsConsumer() {
-        Consumer consumer = new Consumer("testConsumer", "testUser", owner, ct);
-        consumerCurator.create(consumer);
-        assertTrue(consumer.getUuid() != null && !consumer.getUuid().isEmpty());
-
-        beginTransaction();
-        try {
-            Consumer found = consumerCurator.lockAndLoadByUuid(consumer.getUuid());
-            assertNotNull(found);
-            assertEquals(consumer.getUuid(), found.getUuid());
-        }
-        finally {
-            rollbackTransaction();
-        }
-    }
-
-    @Test
-    public void lockAndLoadByUuidReturnsNullWhenConsumerIsNotFound() {
-        beginTransaction();
-        try {
-            Consumer found = consumerCurator.lockAndLoadByUuid("an_unknown_uuid");
-            assertNull(found);
-        }
-        finally {
-            rollbackTransaction();
-        }
     }
 
     // select by owner

--- a/server/src/test/java/org/candlepin/model/OwnerCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/OwnerCuratorTest.java
@@ -201,7 +201,7 @@ public class OwnerCuratorTest extends DatabaseTestFixture {
         consumerCurator.create(c2);
         consumerCurator.create(c3);
 
-        List<String> result = ownerCurator.getConsumerUuids(owner.getKey()).list();
+        List<String> result = ownerCurator.getConsumerUuids(owner).list();
         assertEquals(2, result.size());
         assertTrue(result.contains(c1.getUuid()));
         assertTrue(result.contains(c2.getUuid()));

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/UndoImportsJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/UndoImportsJobTest.java
@@ -178,7 +178,8 @@ public class UndoImportsJobTest extends DatabaseTestFixture {
         Principal principal = new UserPrincipal("JarJarBinks", null, true);
 
         this.jobDataMap.put(JobStatus.TARGET_TYPE, JobStatus.TargetType.OWNER);
-        this.jobDataMap.put(JobStatus.TARGET_ID, owner1.getKey());
+        this.jobDataMap.put(JobStatus.TARGET_ID, owner1.getId());
+        this.jobDataMap.put(UndoImportsJob.OWNER_KEY, owner1.getKey());
         this.jobDataMap.put(PinsetterJobListener.PRINCIPAL_KEY, principal);
 
         beginTransaction(); //since we locking owner we need start transaction
@@ -245,7 +246,7 @@ public class UndoImportsJobTest extends DatabaseTestFixture {
     @Test
     public void handleException() throws JobExecutionException {
         // the real thing we want to handle
-        doThrow(new NullPointerException()).when(this.ownerCurator).lookupByKeyAndLock(anyString());
+        doThrow(new NullPointerException()).when(this.ownerCurator).lockAndLoadById(anyString());
 
         try {
             this.undoImportsJob.execute(this.jobContext);
@@ -261,7 +262,7 @@ public class UndoImportsJobTest extends DatabaseTestFixture {
     @Test
     public void refireOnWrappedSQLException() throws JobExecutionException {
         RuntimeException e = new RuntimeException("uh oh", new SQLException("not good"));
-        doThrow(e).when(this.ownerCurator).lookupByKeyAndLock(anyString());
+        doThrow(e).when(this.ownerCurator).lockAndLoadById(anyString());
 
         try {
             this.undoImportsJob.execute(this.jobContext);
@@ -278,7 +279,7 @@ public class UndoImportsJobTest extends DatabaseTestFixture {
     public void refireOnMultiLayerWrappedSQLException() throws JobExecutionException {
         RuntimeException e = new RuntimeException("uh oh", new SQLException("not good"));
         RuntimeException e2 = new RuntimeException("trouble!", e);
-        doThrow(e2).when(this.ownerCurator).lookupByKeyAndLock(anyString());
+        doThrow(e2).when(this.ownerCurator).lockAndLoadById(anyString());
 
         try {
             this.undoImportsJob.execute(this.jobContext);
@@ -292,7 +293,7 @@ public class UndoImportsJobTest extends DatabaseTestFixture {
     @Test
     public void noRefireOnRegularRuntimeException() throws JobExecutionException {
         RuntimeException e = new RuntimeException("uh oh", new NullPointerException());
-        doThrow(e).when(this.ownerCurator).lookupByKeyAndLock(anyString());
+        doThrow(e).when(this.ownerCurator).lockAndLoadById(anyString());
 
         try {
             this.undoImportsJob.execute(this.jobContext);

--- a/server/src/test/java/org/candlepin/resource/OwnerResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/OwnerResourceTest.java
@@ -436,8 +436,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
 
         // Generate an ueber certificate for the Owner. This will need to
         // be cleaned up along with the owner deletion.
-        UeberCertificate uCert = ueberCertGenerator.generate(
-            owner.getKey(), setupAdminPrincipal("test"));
+        UeberCertificate uCert = ueberCertGenerator.generate(owner.getKey(), setupAdminPrincipal("test"));
         assertNotNull(uCert);
 
         ownerResource.deleteOwner(owner.getKey(), true);


### PR DESCRIPTION
- Several methods used for applying database/entity locks have been
  generalized and refactored; extraneous methods have been removed
- Fixed a bug that could allow a temporary service level change to
  be permanently applied
- Fixed a bug that prevented consumers from being refreshed when
  the lockAndLoad method was called