### PR TITLE
1467888: Fixed broken rules when importing into old candlepin (2.1)

### DIFF
--- a/server/src/main/resources/rules/rules.js
+++ b/server/src/main/resources/rules/rules.js
@@ -1,4 +1,4 @@
-// Version: 5.24
+// Version: 5.25
 
 /*
  * Default Candlepin rule set.
@@ -41,6 +41,7 @@ function pool_type_name_space() {
 // consumer types
 var SYSTEM_TYPE = "system";
 var HYPERVISOR_TYPE = "hypervisor";
+var UEBERCERT_TYPE = "uebercert";
 
 // Consumer fact names
 var SOCKET_FACT="cpu.cpu_socket(s)";
@@ -1522,7 +1523,8 @@ var Entitlement = {
 
         var requiresConsumerType = context.getAttribute(context.pool, REQUIRES_CONSUMER_TYPE_ATTRIBUTE);
         // skip if the attribtue is not defined.
-        if (requiresConsumerType != null) {
+        log.debug("Checking consumerType:" + context.consumer.type.label);
+        if (requiresConsumerType != null && context.consumer.type.label != UEBERCERT_TYPE) {
             // Consumer types need to match (except below)
             if (requiresConsumerType != context.consumer.type.label) {
                 // Allow hypervisors to be like systems
@@ -1771,7 +1773,8 @@ var Entitlement = {
             // If the product has no required consumer type, assume it is restricted to "system".
             // "hypervisor" type are essentially the same as "system".
             if (!pool.getProductAttribute(REQUIRES_CONSUMER_TYPE_ATTRIBUTE)) {
-                if (consumer.type.label != SYSTEM_TYPE && consumer.type.label != HYPERVISOR_TYPE) {
+                if (consumer.type.label != SYSTEM_TYPE && consumer.type.label != HYPERVISOR_TYPE &&
+                    consumer.type.label != UEBERCERT_TYPE ) {
                     result.addError("rulefailed.consumer.type.mismatch");
                 }
             }


### PR DESCRIPTION
Rules changes during the Uber Cert re-write broke ueber cert
generation after the rules were imported into an older candlepin.
This patch reverts those changes to maintain backwards compatibility.


# Testing
1. Deploy candlepin from master - clean database with test data.
2. Create a distributor -- no need to attach any subs, we only need the rules.
```bash
# Create the distributor -- make sure to grab the uuid.
$ curl -k -u admin:admin -X POST -H "Content-Type: application/json" -d '{"type":{"label":"candlepin"}, "name":"my_distributor", "facts":{}, "installedProducts":[], "contentTags":[]}' https://localhost:8443/candlepin/consumers?owner=admin
```
3. Export a manifest using the distributor you just created.
```bash
$ curl -k -u admin:admin https://localhost:8443/candlepin/consumers/:uuid/export > manifest1.zip
```
4. Deploy this patch (without cleaning the DB)
5. Export another manifest using the distributor created in Step 2.
```bash
$ curl -k -u admin:admin https://localhost:8443/candlepin/consumers/:uuid/export > manifest2.zip
```
6. Deploy candlepin-0.9.54.XX - clean database with test data.
7. Import the first manifest that you created.
```bash
$ curl -k -X POST -F "application/zip=@manifest1.zip" -u admin:admin https://localhost:8443/candlepin/owners/admin/imports
```
8. Attempt to generate an ueber certificate for the owner and it will fail.
```bash
curl -k -u admin:admin -X POST https://localhost:8443/candlepin/owners/admin/uebercert
```
9. Undo the manifest import.
10. Import the second manifest
```bash
$ curl -k -X POST -F "application/zip=@manifest2.zip" -u admin:admin https://localhost:8443/candlepin/owners/admin/imports
```
11. Attempt to generate an ueber certificate again and it should succeed.
```bash
curl -k -u admin:admin -X POST https://localhost:8443/candlepin/owners/admin/uebercert
```