### PR TITLE
1452694: Candlepin no longer deletes pools for custom subscriptions (2.0)

### DIFF
--- a/server/spec/import_spec.rb
+++ b/server/spec/import_spec.rb
@@ -120,7 +120,8 @@ describe 'Import Test Group:', :serial => true do
     it 'can be undone' do
       # Make a custom pool so we can be sure it does not get wiped
       # out during either the undo or a subsequent re-import:
-      prod = create_product(random_string(), random_string(), {:owner => @import_owner['key']})
+      prod_name = random_string("custom_pool_prod-")
+      prod = create_product(prod_name, prod_name, {:owner => @import_owner['key']})
       custom_pool = @cp.create_pool(@import_owner['key'], prod['id'])
 
       job = @import_owner_client.undo_import(@import_owner['key'])

--- a/server/spec/rules_import_spec.rb
+++ b/server/spec/rules_import_spec.rb
@@ -11,7 +11,7 @@ describe 'Rules Import', :serial => true do
     # ones that may have been left in the database:
     @cp.delete_rules
 
-    sleep 6 #The status resource response is being cached for 5 seconds
+    sleep 7 # The status resource response is being cached for 5 seconds
     @orig_ver = @cp.get_status()['rulesVersion']
 
     rules_version_parts = @orig_ver.split(".")
@@ -44,7 +44,7 @@ describe 'Rules Import', :serial => true do
     fetched_rules = @cp.list_rules
     decoded_fetched_rules = Base64.decode64(fetched_rules)
     (decoded_fetched_rules == @rules).should be true
-    sleep 6 #The status resource response is being cached for 5 seconds
+    sleep 7 # The status resource response is being cached for 5 seconds
 
     @cp.get_status()['rulesVersion'].should == @new_ver
   end
@@ -60,7 +60,7 @@ describe 'Rules Import', :serial => true do
     rules = @cp.list_rules
 
     # Version should be back to original:
-    sleep 6 #The status resource response is being cached for 5 seconds
+    sleep 7 # The status resource response is being cached for 5 seconds
 
     @cp.get_status()['rulesVersion'].should == @orig_ver
 

--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -342,23 +342,8 @@ public class CandlepinPoolManager implements PoolManager {
         log.debug("Deleting pools for absent subscriptions...");
         List<Pool> poolsToDelete = new ArrayList<Pool>();
 
-        // BZ 1452694: Don't delete pools for custom subscriptions
-        // We need to verify that we aren't deleting pools that are created via the API.
-        // Unfortunately, we don't have a 100% reliable way of detecting such pools at this point,
-        // so we'll do the next best thing: In standalone, pools with an upstream pool ID are those
-        // we've received from an import (and, thus, are eligible for deletion). In hosted,
-        // however, we *are* the upstream source, so everything is eligible for removal.
-        // This is pretty hacky, so the way we go about doing this check should eventually be
-        // replaced with something more generic and reliable, and not dependent on the config.
-
-        // TODO:
-        // Remove the standalone config check and replace it with a check for whether or not the
-        // pool is "managed"  -- however we decide to implement that in the future.
-        boolean standalone = config.getBoolean(ConfigProperties.STANDALONE, true);
         for (Pool pool : poolCurator.getPoolsFromBadSubs(owner, subscriptionMap.keySet())) {
-            if ((!standalone || pool.getUpstreamPoolId() != null) && pool.getSourceSubscription() != null &&
-                !pool.getType().isDerivedType()) {
-
+            if (this.isManaged(pool)) {
                 poolsToDelete.add(pool);
             }
         }
@@ -2388,5 +2373,27 @@ public class CandlepinPoolManager implements PoolManager {
     public void recalculatePoolQuantitiesForOwner(Owner owner) {
         poolCurator.calculateConsumedForOwnersPools(owner);
         poolCurator.calculateExportedForOwnersPools(owner);
+    }
+
+    /**
+     * @{inheritDocs}
+     */
+    @Override
+    public boolean isManaged(Pool pool) {
+        // BZ 1452694: Don't delete pools for custom subscriptions
+        // We need to verify that we aren't deleting pools that are created via the API.
+        // Unfortunately, we don't have a 100% reliable way of detecting such pools at this point,
+        // so we'll do the next best thing: In standalone, pools with an upstream pool ID are those
+        // we've received from an import (and, thus, are eligible for deletion). In hosted,
+        // however, we *are* the upstream source, so everything is eligible for removal.
+        // This is pretty hacky, so the way we go about doing this check should eventually be
+        // replaced with something more generic and reliable, and not dependent on the config.
+
+        // TODO:
+        // Remove the standalone config check and replace it with a check for whether or not the
+        // pool is non-custom  -- however we decide to implement that in the future.
+
+        return pool != null && pool.getSourceSubscription() != null && !pool.getType().isDerivedType() &&
+            (pool.getUpstreamPoolId() != null || !this.config.getBoolean(ConfigProperties.STANDALONE, true));
     }
 }

--- a/server/src/main/java/org/candlepin/controller/PoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/PoolManager.java
@@ -331,4 +331,15 @@ public interface PoolManager {
     void deletePools(Collection<Pool> pools);
 
     void deletePools(Collection<Pool> pools, Set<String> alreadyDeletedPools);
+
+    /**
+     * Checks whether or not the given pool is a managed (that is, non-custom) pool.
+     *
+     * @param pool
+     *  The pool to check
+     *
+     * @return
+     *  true if the pool is a managed pool; false otherwise
+     */
+    boolean isManaged(Pool pool);
 }

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/UndoImportsJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/UndoImportsJob.java
@@ -131,7 +131,7 @@ public class UndoImportsJob extends UniqueByEntityJob {
 
             List<Pool> pools = this.poolManager.listPoolsByOwner(owner).list();
             for (Pool pool : pools) {
-                if (pool.getSourceSubscription() != null && !pool.getType().isDerivedType()) {
+                if (this.poolManager.isManaged(pool)) {
                     this.poolManager.deletePool(pool);
                 }
             }

--- a/server/src/main/java/org/candlepin/policy/js/JsRunnerProvider.java
+++ b/server/src/main/java/org/candlepin/policy/js/JsRunnerProvider.java
@@ -112,7 +112,7 @@ public class JsRunnerProvider implements Provider<JsRunner> {
                 return;
             }
 
-            log.info("Recompiling rules with timestamp: " + newUpdated);
+            log.info("Recompiling rules with timestamp: {}", newUpdated);
 
             Context context = Context.enter();
             context.setOptimizationLevel(9);

--- a/server/src/main/java/org/candlepin/policy/js/pool/PoolHelper.java
+++ b/server/src/main/java/org/candlepin/policy/js/pool/PoolHelper.java
@@ -241,6 +241,15 @@ public class PoolHelper {
             pool.getBranding().add(new Branding(brand.getProductId(), brand.getType(), brand.getName()));
         }
 
+        // Copy upstream fields
+        // Impl note/TODO:
+        // We are only doing this to facilitate marking pools derived from an upstream source/manifest
+        // as also from that same upstream source. A proper pool hierarchy would be a better solution
+        // here, but this will work for the interim.
+        pool.setUpstreamPoolId(sourcePool.getUpstreamPoolId());
+        pool.setUpstreamEntitlementId(sourcePool.getUpstreamEntitlementId());
+        pool.setUpstreamConsumerId(sourcePool.getUpstreamConsumerId());
+
         return pool;
     }
 

--- a/server/src/main/java/org/candlepin/sync/Exporter.java
+++ b/server/src/main/java/org/candlepin/sync/Exporter.java
@@ -213,8 +213,7 @@ public class Exporter {
         log.info("Creating archive of " + exportDir.getAbsolutePath() + " in: " +
             exportFileName);
 
-        File archive = createZipArchiveWithDir(
-            tempDir, exportDir, "consumer_export.zip",
+        File archive = createZipArchiveWithDir(tempDir, exportDir, "consumer_export.zip",
             "Candlepin export for " + consumer.getUuid());
 
         InputStream archiveInputStream = null;

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/UndoImportsJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/UndoImportsJobTest.java
@@ -209,6 +209,9 @@ public class UndoImportsJobTest extends DatabaseTestFixture {
         if (!keepSourceSub) {
             pool.setSourceSubscription(null);
         }
+        else {
+            pool.setUpstreamPoolId("upstream_pool_id");
+        }
 
         this.poolCurator.create(pool);
 


### PR DESCRIPTION
- Pools for custom subscriptions will no longer be deleted on manifest
  delete/undo import
- The Per-org products migration has been updated/fixed to also migrate
  subscription information from the subscription table to the pool table
- Bonus pools now inherit upstream pool and customer data from their
  source pool