### PR TITLE
1452694: Candlepin no longer deletes pools for custom subscriptions (2.1/master)

### DIFF
--- a/server/spec/import_spec.rb
+++ b/server/spec/import_spec.rb
@@ -123,7 +123,8 @@ describe 'Import Test Group:', :serial => true do
     it 'can be undone' do
       # Make a custom pool so we can be sure it does not get wiped
       # out during either the undo or a subsequent re-import:
-      prod = create_product(random_string(), random_string(), {:owner => @import_owner['key']})
+      prod_name = random_string("custom_pool_prod-")
+      prod = create_product(prod_name, prod_name, {:owner => @import_owner['key']})
       custom_pool = @cp.create_pool(@import_owner['key'], prod['id'])
 
       job = @import_owner_client.undo_import(@import_owner['key'])

--- a/server/spec/rules_import_spec.rb
+++ b/server/spec/rules_import_spec.rb
@@ -11,7 +11,7 @@ describe 'Rules Import', :serial => true do
     # ones that may have been left in the database:
     @cp.delete_rules
 
-    sleep 6 #The status resource response is being cached for 5 seconds
+    sleep 7 # The status resource response is being cached for 5 seconds
     @orig_ver = @cp.get_status()['rulesVersion']
 
     rules_version_parts = @orig_ver.split(".")
@@ -44,7 +44,7 @@ describe 'Rules Import', :serial => true do
     fetched_rules = @cp.list_rules
     decoded_fetched_rules = Base64.decode64(fetched_rules)
     (decoded_fetched_rules == @rules).should be true
-    sleep 6 #The status resource response is being cached for 5 seconds
+    sleep 7 # The status resource response is being cached for 5 seconds
 
     @cp.get_status()['rulesVersion'].should == @new_ver
   end
@@ -60,7 +60,7 @@ describe 'Rules Import', :serial => true do
     rules = @cp.list_rules
 
     # Version should be back to original:
-    sleep 6 #The status resource response is being cached for 5 seconds
+    sleep 7 # The status resource response is being cached for 5 seconds
 
     @cp.get_status()['rulesVersion'].should == @orig_ver
 

--- a/server/src/main/java/org/candlepin/controller/PoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/PoolManager.java
@@ -339,4 +339,15 @@ public interface PoolManager {
 
     void checkBonusPoolQuantities(Owner owner,
         Map<String, Entitlement> entitlements);
+
+    /**
+     * Checks whether or not the given pool is a managed (that is, non-custom) pool.
+     *
+     * @param pool
+     *  The pool to check
+     *
+     * @return
+     *  true if the pool is a managed pool; false otherwise
+     */
+    boolean isManaged(Pool pool);
 }

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/UndoImportsJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/UndoImportsJob.java
@@ -131,7 +131,7 @@ public class UndoImportsJob extends UniqueByEntityJob {
 
             List<Pool> pools = this.poolManager.listPoolsByOwner(owner).list();
             for (Pool pool : pools) {
-                if (pool.getSourceSubscription() != null && !pool.getType().isDerivedType()) {
+                if (this.poolManager.isManaged(pool)) {
                     this.poolManager.deletePool(pool);
                 }
             }

--- a/server/src/main/java/org/candlepin/policy/js/JsRunnerProvider.java
+++ b/server/src/main/java/org/candlepin/policy/js/JsRunnerProvider.java
@@ -112,7 +112,7 @@ public class JsRunnerProvider implements Provider<JsRunner> {
                 return;
             }
 
-            log.info("Recompiling rules with timestamp: " + newUpdated);
+            log.info("Recompiling rules with timestamp: {}", newUpdated);
 
             Context context = Context.enter();
             context.setOptimizationLevel(9);

--- a/server/src/main/java/org/candlepin/policy/js/pool/PoolHelper.java
+++ b/server/src/main/java/org/candlepin/policy/js/pool/PoolHelper.java
@@ -241,6 +241,15 @@ public class PoolHelper {
             pool.getBranding().add(new Branding(brand.getProductId(), brand.getType(), brand.getName()));
         }
 
+        // Copy upstream fields
+        // Impl note/TODO:
+        // We are only doing this to facilitate marking pools derived from an upstream source/manifest
+        // as also from that same upstream source. A proper pool hierarchy would be a better solution
+        // here, but this will work for the interim.
+        pool.setUpstreamPoolId(sourcePool.getUpstreamPoolId());
+        pool.setUpstreamEntitlementId(sourcePool.getUpstreamEntitlementId());
+        pool.setUpstreamConsumerId(sourcePool.getUpstreamConsumerId());
+
         return pool;
     }
 

--- a/server/src/main/java/org/candlepin/sync/Exporter.java
+++ b/server/src/main/java/org/candlepin/sync/Exporter.java
@@ -213,8 +213,7 @@ public class Exporter {
         log.info("Creating archive of " + exportDir.getAbsolutePath() + " in: " +
             exportFileName);
 
-        File archive = createZipArchiveWithDir(
-            tempDir, exportDir, "consumer_export.zip",
+        File archive = createZipArchiveWithDir(tempDir, exportDir, "consumer_export.zip",
             "Candlepin export for " + consumer.getUuid());
 
         InputStream archiveInputStream = null;

--- a/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -88,14 +88,17 @@ import org.candlepin.test.MockResultIterator;
 import org.candlepin.test.TestUtil;
 import org.candlepin.util.Util;
 
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.runners.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -120,7 +123,7 @@ import java.util.Set;
 /**
  * PoolManagerTest
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(JUnitParamsRunner.class)
 public class PoolManagerTest {
     private static Logger log = LoggerFactory.getLogger(PoolManagerTest.class);
 
@@ -166,6 +169,7 @@ public class PoolManagerTest {
 
     @Before
     public void init() throws Exception {
+        MockitoAnnotations.initMocks(this);
 
         i18n = I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK);
 
@@ -1961,6 +1965,122 @@ public class PoolManagerTest {
         if (owner.getKey() != null) {
             when(this.mockOwnerCurator.lookupByKey(eq(owner.getKey()))).thenReturn(owner);
         }
+    }
+
+    // TODO:
+    // Refactor these tests when isManaged is refactored to not be reliant upon the config
+    public Object[][] getParametersForIsManagedTests() {
+        SourceSubscription srcSub = new SourceSubscription("test_sub_id", "test_sub_key");
+
+        return new Object[][] {
+            // Standalone tests
+            new Object[] { PoolType.NORMAL, null, null, false, false },
+            new Object[] { PoolType.ENTITLEMENT_DERIVED, null, null, false, false },
+            new Object[] { PoolType.STACK_DERIVED, null, null, false, false },
+            new Object[] { PoolType.BONUS, null, null, false, false },
+            new Object[] { PoolType.UNMAPPED_GUEST, null, null, false, false },
+            new Object[] { PoolType.DEVELOPMENT, null, null, false, false },
+
+            new Object[] { PoolType.NORMAL, srcSub, null, false, false },
+            new Object[] { PoolType.ENTITLEMENT_DERIVED, srcSub, null, false, false },
+            new Object[] { PoolType.STACK_DERIVED, srcSub, null, false, false },
+            new Object[] { PoolType.BONUS, srcSub, null, false, false },
+            new Object[] { PoolType.UNMAPPED_GUEST, srcSub, null, false, false },
+            new Object[] { PoolType.DEVELOPMENT, srcSub, null, false, false },
+
+            new Object[] { PoolType.NORMAL, null, "upstream_pool_id", false, false },
+            new Object[] { PoolType.ENTITLEMENT_DERIVED, null, "upstream_pool_id", false, false },
+            new Object[] { PoolType.STACK_DERIVED, null, "upstream_pool_id", false, false },
+            new Object[] { PoolType.BONUS, null, "upstream_pool_id", false, false },
+            new Object[] { PoolType.UNMAPPED_GUEST, null, "upstream_pool_id", false, false },
+            new Object[] { PoolType.DEVELOPMENT, null, "upstream_pool_id", false, false },
+
+            new Object[] { PoolType.NORMAL, srcSub, "upstream_pool_id", false, true },
+            new Object[] { PoolType.ENTITLEMENT_DERIVED, srcSub, "upstream_pool_id", false, false },
+            new Object[] { PoolType.STACK_DERIVED, srcSub, "upstream_pool_id", false, false },
+            new Object[] { PoolType.BONUS, srcSub, "upstream_pool_id", false, true },
+            new Object[] { PoolType.UNMAPPED_GUEST, srcSub, "upstream_pool_id", false, true },
+            new Object[] { PoolType.DEVELOPMENT, srcSub, "upstream_pool_id", false, true },
+
+            // Hosted tests
+            new Object[] { PoolType.NORMAL, null, null, true, false },
+            new Object[] { PoolType.ENTITLEMENT_DERIVED, null, null, true, false },
+            new Object[] { PoolType.STACK_DERIVED, null, null, true, false },
+            new Object[] { PoolType.BONUS, null, null, true, false },
+            new Object[] { PoolType.UNMAPPED_GUEST, null, null, true, false },
+            new Object[] { PoolType.DEVELOPMENT, null, null, true, false },
+
+            new Object[] { PoolType.NORMAL, srcSub, null, true, true },
+            new Object[] { PoolType.ENTITLEMENT_DERIVED, srcSub, null, true, false },
+            new Object[] { PoolType.STACK_DERIVED, srcSub, null, true, false },
+            new Object[] { PoolType.BONUS, srcSub, null, true, true },
+            new Object[] { PoolType.UNMAPPED_GUEST, srcSub, null, true, true },
+            new Object[] { PoolType.DEVELOPMENT, srcSub, null, true, true },
+
+            new Object[] { PoolType.NORMAL, null, "upstream_pool_id", true, false },
+            new Object[] { PoolType.ENTITLEMENT_DERIVED, null, "upstream_pool_id", true, false },
+            new Object[] { PoolType.STACK_DERIVED, null, "upstream_pool_id", true, false },
+            new Object[] { PoolType.BONUS, null, "upstream_pool_id", true, false },
+            new Object[] { PoolType.UNMAPPED_GUEST, null, "upstream_pool_id", true, false },
+            new Object[] { PoolType.DEVELOPMENT, null, "upstream_pool_id", true, false },
+
+            new Object[] { PoolType.NORMAL, srcSub, "upstream_pool_id", true, true },
+            new Object[] { PoolType.ENTITLEMENT_DERIVED, srcSub, "upstream_pool_id", true, false },
+            new Object[] { PoolType.STACK_DERIVED, srcSub, "upstream_pool_id", true, false },
+            new Object[] { PoolType.BONUS, srcSub, "upstream_pool_id", true, true },
+            new Object[] { PoolType.UNMAPPED_GUEST, srcSub, "upstream_pool_id", true, true },
+            new Object[] { PoolType.DEVELOPMENT, srcSub, "upstream_pool_id", true, true },
+        };
+    }
+
+    @Test
+    public void testIsManagedWithNullPool() {
+        assertFalse(manager.isManaged(null));
+    }
+
+    @Test
+    @Parameters(method = "getParametersForIsManagedTests")
+    public void testIsManaged(PoolType type, SourceSubscription srcSub, String upstreamPoolId, boolean hosted,
+        boolean expected) {
+
+        Pool pool = TestUtil.createPool(owner, product);
+        when(mockConfig.getBoolean(eq(ConfigProperties.STANDALONE))).thenReturn(!hosted);
+        when(mockConfig.getBoolean(eq(ConfigProperties.STANDALONE), anyBoolean())).thenReturn(!hosted);
+
+        pool.setSourceSubscription(srcSub);
+        pool.setUpstreamPoolId(upstreamPoolId);
+
+        switch (type) {
+            case UNMAPPED_GUEST:
+                pool.setAttribute(Pool.Attributes.DERIVED_POOL, "true");
+                pool.setAttribute(Pool.Attributes.UNMAPPED_GUESTS_ONLY, "true");
+                break;
+
+            case ENTITLEMENT_DERIVED:
+                pool.setAttribute(Pool.Attributes.DERIVED_POOL, "true");
+                pool.setSourceEntitlement(new Entitlement());
+                break;
+
+            case STACK_DERIVED:
+                pool.setAttribute(Pool.Attributes.DERIVED_POOL, "true");
+                pool.setSourceStack(new SourceStack());
+                break;
+
+            case BONUS:
+                pool.setAttribute(Pool.Attributes.DERIVED_POOL, "true");
+                break;
+
+            case DEVELOPMENT:
+                pool.setAttribute(Pool.Attributes.DEVELOPMENT_POOL, "true");
+                break;
+
+            case NORMAL:
+            default:
+                // Nothing to do here
+        }
+
+        boolean output = manager.isManaged(pool);
+        assertEquals(expected, output);
     }
 
 }

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/UndoImportsJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/UndoImportsJobTest.java
@@ -211,6 +211,9 @@ public class UndoImportsJobTest extends DatabaseTestFixture {
         if (!keepSourceSub) {
             pool.setSourceSubscription(null);
         }
+        else {
+            pool.setUpstreamPoolId("upstream_pool_id");
+        }
 
         this.poolCurator.create(pool);
 


### PR DESCRIPTION
- Pools for custom subscriptions will no longer be deleted on manifest
  delete/undo import
- The Per-org products migration has been updated/fixed to also migrate
  subscription information from the subscription table to the pool table
- Bonus pools now inherit upstream pool and customer data from their
  source pool