### PR TITLE
Updated CMV to store and verify activation keys (0.9.51)

### DIFF
--- a/server/bin/cmv
+++ b/server/bin/cmv
@@ -95,7 +95,7 @@ class CMVCommand
             yield "orgs[#{org}]", "orgs/#{org}/org_info.json", org_data
 
             # list consumers and store in orgs/<org>/consumers/<consumer>.json
-            print "  Retrieving consumers...      "
+            print "  Retrieving consumers...          "
             consumers = candlepin.list_consumers({:owner => org})
             consumers.each do |consumer|
                 yield "orgs[#{org}].consumers[#{consumer['uuid']}]", "orgs/#{org}/consumers/#{consumer['uuid']}.json", consumer
@@ -103,7 +103,7 @@ class CMVCommand
             puts "done."
 
             # list pools and store in orgs/<org>/pools/<pool>.json
-            print "  Retrieving pools...          "
+            print "  Retrieving pools...              "
             pools = candlepin.list_pools({:owner => org_data['id']})
             pools.each do |pool|
                 yield "orgs[#{org}].pools[#{pool['id']}]", "orgs/#{org}/pools/#{pool['id']}.json", pool
@@ -126,7 +126,7 @@ class CMVCommand
             puts "done."
 
             # list subscriptions and store in orgs/<org>/subscriptions/<subscription>.json
-            print "  Retrieving subscriptions...  "
+            print "  Retrieving subscriptions...      "
             subscriptions = candlepin.list_subscriptions(org)
             subscriptions.each do |subscription|
                 yield "orgs[#{org}].subscriptions[#{subscription['id']}]", "orgs/#{org}/subscriptions/#{subscription['id']}.json", subscription
@@ -149,11 +149,19 @@ class CMVCommand
             puts "done."
 
             # list products and store in orgs/<org>/products/<product>.json
-            print "  Retrieving products...       "
+            print "  Retrieving products...           "
             product_ids.each do |pid|
                 product = candlepin.get_product(pid)
 
                 yield "orgs[#{org}].products[#{product['id']}]", "orgs/#{org}/products/#{product['id']}.json", product
+            end
+            puts "done."
+
+            # list activation keys and store in orgs/<org>/activation_keys/<key>.json
+            print "  Retrieving activation_keys...    "
+            act_keys = candlepin.list_activation_keys(org)
+            act_keys.each do |act_key|
+                yield "orgs[#{org}].activation_keys[#{act_key['id']}]", "orgs/#{org}/activation_keys/#{act_key['id']}.json", act_key
             end
             puts "done."
         end
@@ -193,6 +201,7 @@ class VerifyCommand < CMVCommand
             'orgs' => 'id',
 
             'orgs.consumers' => 'uuid',
+            'orgs.consumers.capabilities' => 'id',
 
             'orgs.pools' => 'id',
             'orgs.pools.attributes' => 'name',
@@ -212,15 +221,27 @@ class VerifyCommand < CMVCommand
             'orgs.subscriptions.derivedProduct.attributes' => 'name',
             'orgs.subscriptions.derivedProvidedProducts' => 'id',
             'orgs.subscriptions.derivedProvidedProducts.attributes' => 'name',
-            'orgs.subscriptions.derivedProvidedProducts.attributes' => 'name',
             'orgs.subscriptions.derivedProvidedProducts.productContent' => 'content.id',
             'orgs.subscriptions.derivedProvidedProducts.productContent.content' => 'id',
             'orgs.subscriptions.product.attributes' => 'name',
             'orgs.subscriptions.providedProducts' => 'id',
             'orgs.subscriptions.providedProducts.attributes' => 'name',
-            'orgs.subscriptions.providedProducts.attributes' => 'name',
             'orgs.subscriptions.providedProducts.productContent' => 'content.id',
             'orgs.subscriptions.providedProducts.productContent.content' => 'id',
+
+            'orgs.activation_keys' => 'id',
+            'orgs.activation_keys.owner' => 'id',
+            'orgs.activation_keys.pools' => 'id',
+            'orgs.activation_keys.pools.pool' => 'id',
+            'orgs.activation_keys.pools.pool.attributes' => 'name',
+            'orgs.activation_keys.pools.pool.branding' => 'productId',
+            'orgs.activation_keys.pools.pool.derivedProvidedProducts' => 'productId',
+            'orgs.activation_keys.pools.pool.derivedProductAttributes' => 'name',
+            'orgs.activation_keys.pools.pool.productAttributes' => 'name',
+            'orgs.activation_keys.products' => 'id',
+            'orgs.activation_keys.products.attributes' => 'name',
+            'orgs.activation_keys.products.productContent' => 'content.id',
+            'orgs.activation_keys.products.productContent.content' => 'id',
         }
 
         # Common paths we should expect to exclude
@@ -366,12 +387,19 @@ class VerifyCommand < CMVCommand
                         exp_id = self.get_obj_id(path, exp_obj)
                         act_id = self.get_obj_id(path, act_obj)
 
-                        if key and exp_id == act_id then
-                            expected -= [exp_obj]
-                            actual -= [act_obj]
+                        if key then
+                            if exp_id == act_id then
+                                expected -= [exp_obj]
+                                actual -= [act_obj]
 
-                            result = self.compare_objects("#{path}[#{exp_id}]", exp_obj, act_obj)
-                            messages.insert(messages.length, *result)
+                                result = self.compare_objects("#{path}[#{exp_id}]", exp_obj, act_obj)
+                                messages.insert(messages.length, *result)
+                            end
+                        else
+                            if exp_obj.eql?(act_obj) then
+                                expected -= [exp_obj]
+                                actual -= [act_obj]
+                            end
                         end
                     elsif exp_obj == act_obj then
                         expected -= [exp_obj]

--- a/server/client/ruby/candlepin_api.rb
+++ b/server/client/ruby/candlepin_api.rb
@@ -913,7 +913,7 @@ class Candlepin
     if owner_key.nil?
       return get("/activation_keys")
     end
-    return get("/owner/#{owner_key}/activation_keys")
+    return get("/owners/#{owner_key}/activation_keys")
   end
 
   def create_activation_key(owner_key, name, service_level=nil)

--- a/server/spec/spec_helper.rb
+++ b/server/spec/spec_helper.rb
@@ -102,7 +102,7 @@ module VirtHelper
     return pools.find_all { |i| !i['sourceEntitlement'].nil? }[0]
   end
 
-  def filter_unmapped_guest_pools(pools)  
+  def filter_unmapped_guest_pools(pools)
     # need to ignore the unmapped guest pools
     pools.select! do |p|
       unmapped = p['attributes'].select {|i| i['name'] == 'unmapped_guests_only' }[0]


### PR DESCRIPTION
- CMV will now pull and verify activation keys
- Fixed a bug in candlepin_api which was sending activation key
  requests to the wrong URL