### PR TITLE
Account for misfires in job status

### DIFF
--- a/server/src/main/java/org/candlepin/pinsetter/core/model/JobStatus.java
+++ b/server/src/main/java/org/candlepin/pinsetter/core/model/JobStatus.java
@@ -177,6 +177,9 @@ public class JobStatus extends AbstractHibernateObject {
             if (runTime > -1) {
                 setState(JobState.FINISHED);
                 this.finishTime = new Date(startTime.getTime() + runTime);
+                // Note that the result string is set off the jobResult later.
+                // The result will only be blank if the jobResult has no value.
+                setResult("");
             }
         }
         else {

--- a/server/src/test/java/org/candlepin/pinsetter/core/PinsetterTriggerListenerTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/core/PinsetterTriggerListenerTest.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.pinsetter.core;
+
+import org.candlepin.controller.ModeManager;
+import org.candlepin.model.JobCurator;
+import org.candlepin.pinsetter.core.model.JobStatus;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Matchers;
+import org.quartz.JobKey;
+import org.quartz.SchedulerException;
+import org.quartz.Trigger;
+
+import java.util.Date;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Created by wpoteat on 7/13/17.
+ */
+public class PinsetterTriggerListenerTest {
+
+    private ModeManager modeManager;
+    private JobCurator jobCurator;
+
+    @Before
+    public void init() throws SchedulerException {
+        modeManager = mock(ModeManager.class);
+        jobCurator = mock(JobCurator.class);
+    }
+
+    @Test
+    public void triggerMisfireRunAgain() {
+        PinsetterTriggerListener ptl = new PinsetterTriggerListener(modeManager, jobCurator);
+        Trigger trigger = mock(Trigger.class);
+        JobStatus jobStatus = new JobStatus();
+        JobKey jobKey = new JobKey("mockName");
+        when(trigger.mayFireAgain()).thenReturn(true);
+        when(trigger.getJobKey()).thenReturn(jobKey);
+        when(trigger.getNextFireTime()).thenReturn(new Date());
+        when(jobCurator.find(Matchers.anyString())).thenReturn(jobStatus);
+
+        ptl.triggerMisfired(trigger);
+        assert (jobStatus.getResult().startsWith("Will reattempt job at or after"));
+        assert (jobStatus.getState().equals(JobStatus.JobState.PENDING));
+
+    }
+
+    @Test
+    public void triggerMisfireDontRunAgain() {
+        PinsetterTriggerListener ptl = new PinsetterTriggerListener(modeManager, jobCurator);
+        Trigger trigger = mock(Trigger.class);
+        JobStatus jobStatus = new JobStatus();
+        JobKey jobKey = new JobKey("mockName");
+        when(trigger.mayFireAgain()).thenReturn(false);
+        when(trigger.getJobKey()).thenReturn(jobKey);
+        when(jobCurator.find(Matchers.anyString())).thenReturn(jobStatus);
+
+        ptl.triggerMisfired(trigger);
+        assert (jobStatus.getResult().startsWith("Failed run. Will not attempt again."));
+        assert (jobStatus.getState().equals(JobStatus.JobState.FAILED));
+    }
+}


### PR DESCRIPTION
If you want to see the misfire happen do the following:

Alter ConfigProperties.java such that org.quartz.threadPool.threadCount = 1

Then add a sleep to the job you want to try out. I did ManifestCleanerJob.java
```
     public void toExecute(JobExecutionContext arg0) throws JobExecutionException {
         File baseDir = new File(config.getString(ConfigProperties.SYNC_WORK_DIR));
        int maxAgeInMinutes = config.getInt(ConfigProperties.MANIFEST_CLEANER_JOB_MAX_AGE_IN_MINUTES);
        try { Thread.sleep(10000); } catch (InterruptedException ie) { };
```

You will need to flood the API with requests to run the job. Here is a the bash I used:

```
#!/bin/bash
for it in `seq 1 150`;
do
    curl -k -u admin:admin -X POST https://localhost:8443/candlepin/jobs/schedule/ManifestCleanerJob
done
```

About 30 seconds after the script finishes running, you will see in the DB jobs that have the "mayFireAgain" message in the result as well as a pending state. Eventually, the jobs will all get picked up again and run [about 10 minutes].

I was not able to get it to hit the "!mayFireAgain" path except by unit test.  I tried setting the default number of retries down to 0. I tried setting the end time on the trigger to only a minute later. I simply got the same retry scenario as when those were not set.

If you have a !mayFireAgain condition, I'd love to see it. 






