### PR TITLE
Fix custom pom plugin to be compatible with new Buildr version.

### DIFF
--- a/buildfile
+++ b/buildfile
@@ -233,6 +233,8 @@ define "candlepin" do
 
   desc "Custom Checkstyle checks for candlepin"
   define "checks" do
+    pom.name = "Candlepin Style Checks"
+    pom.description = "Custom Checkstyle checks for Candlepin"
     project.version = '0.1'
     eclipse.natures :java
     package(:jar)
@@ -264,6 +266,9 @@ define "candlepin" do
 
   desc "Common Candlepin Code"
   define "common" do
+    pom.name = "Candlepin Common"
+    pom.description = "Common code for Candlepin"
+
     project.version = spec_version('candlepin-common.spec.tmpl')
 
     eclipse.natures :java
@@ -316,6 +321,9 @@ define "candlepin" do
 
   desc "The Candlepin Server"
   define "server" do
+    pom.name = "Candlepin"
+    pom.description = "The Candlepin Entitlement Engine"
+
     spec_file = "candlepin.spec.tmpl"
     project.version = spec_version(spec_file)
     release_number = spec_release(spec_file)

--- a/checks/pom.xml
+++ b/checks/pom.xml
@@ -13,6 +13,8 @@
   <artifactId>candlepin-checks</artifactId>
   <version>0.1</version>
   <packaging>jar</packaging>
+  <name>Candlepin Style Checks</name>
+  <description>Custom Checkstyle checks for Candlepin</description>
   <properties>
     <com.puppycrawl.tools-checkstyle.version>7.0</com.puppycrawl.tools-checkstyle.version>
     <org.antlr-antlr4-runtime.version>4.5.3</org.antlr-antlr4-runtime.version>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -13,6 +13,8 @@
   <artifactId>candlepin-common</artifactId>
   <version>2.0.3</version>
   <packaging>jar</packaging>
+  <name>Candlepin Common</name>
+  <description>Common code for Candlepin</description>
   <properties>
     <commons-codec-commons-codec.version>1.4</commons-codec-commons-codec.version>
     <commons-collections-commons-collections.version>3.2</commons-collections-commons-collections.version>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -13,6 +13,8 @@
   <artifactId>candlepin</artifactId>
   <version>2.1.1</version>
   <packaging>war</packaging>
+  <name>Candlepin</name>
+  <description>The Candlepin Entitlement Engine</description>
   <properties>
     <release>1</release>
     <org.apache.qpid-qpid-common.version>0.32</org.apache.qpid-qpid-common.version>


### PR DESCRIPTION
The new version of Buildr added attributes to its POM plugin that we did
not have in our POM plugin.  When the IDEA plugin attempted to access
these attributes, an exception was thrown.  This patch adds in those
attributes and writes them, if defined, into the POM file the same way
that Buildr would itself.