### PR TITLE
1473255: Fix SELinux error when logrotate runs on candlepin logs

### DIFF
--- a/server/selinux/candlepin.te
+++ b/server/selinux/candlepin.te
@@ -27,7 +27,7 @@ type candlepin_var_lib_t;
 files_type(candlepin_var_lib_t)
 
 type candlepin_var_log_t;
-files_type(candlepin_var_log_t)
+logging_log_type(candlepin_var_log_t)
 
 
 ########################################


### PR DESCRIPTION
I have had no luck reproducing the actual SELinux denial, but you can test that the module works like so:

* `cd server/selinux`
* `dnf install selinux-policy-devel`
* `make NAME=targeted -f /usr/share/selinux/devel/Makefile` will build `candlepin.pp`
* `sudo semodule -s targeted -i candlepin.pp` which will install the module
* `ls -Z /var/log/candlepin` if you don't have a Candlepin policy already installed will likely show the context as `var_log_t`
* `sudo restorecon -R /var/log/candlepin`
* `ls -Z /var/log/candlepin` will show the new context
* `sudo semodule -r candlepin` will remove the module

You can find more information on the `logging_log_file` directive [here](https://debian-handbook.info/browse/stable/sect.selinux.html#example.te.interface).