### PR TITLE
updating docker registry to new engineering host

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -1,1 +1,1 @@
-REGISTRY=docker-registry.usersys.redhat.com/jmolet
+REGISTRY=docker-registry.engineering.redhat.com/candlepin


### PR DESCRIPTION
Jenkins slaves have been updated (that work is in the rhsm-ansible repo), this should be all that is needed candlepin side.  This probably needs to be cherrypicked into the HOTFIX and other (?) branches, which @kahowell has written a nice script to do that.