### PR TITLE
Fix custom pool lookup for bonus pool - 2.0

### DIFF
--- a/server/client/ruby/candlepin_api.rb
+++ b/server/client/ruby/candlepin_api.rb
@@ -1075,6 +1075,10 @@ class Candlepin
       pool['derivedProvidedProducts'] = params[:derived_provided_products].collect { |pid| {'productId' => pid} }
     end
 
+    if params[:upstream_pool_id]
+      pool['upstreamPoolId'] = params[:upstream_pool_id]
+    end
+
     return post("/owners/#{owner_key}/pools", pool)
   end
 

--- a/server/client/ruby/hostedtest_api.rb
+++ b/server/client/ruby/hostedtest_api.rb
@@ -141,6 +141,7 @@ module HostedTest
 
   # Lets users be agnostic of what mode we are in, standalone or hosted.
   # Always returns the main pool that was created ( unless running in hosted mode and refresh is skipped )
+  # not to be used to create custom pool
   def create_pool_and_subscription(owner_key, product_id, quantity=1,
                           provided_products=[], contract_number='',
                           account_number='', order_number='',
@@ -164,6 +165,7 @@ module HostedTest
       end
     else
       params[:source_subscription] = { 'id' => random_str('source_sub_') }
+      params[:upstream_pool_id] = random_str('upstream_')
       pool = @cp.create_pool(owner_key, product_id, params)
     end
     return pool

--- a/server/spec/autobind_spec.rb
+++ b/server/spec/autobind_spec.rb
@@ -101,4 +101,165 @@ describe 'Autobind On Owner' do
 
   end
 
+  it 'succeeds when requesting bind of multiple pools with same stack id' do
+    # create 4 products with the same stack id and sockets.
+    prod = create_product('taylorid', 'taylor swift', {
+      :owner => owner_key,
+      :version => "6.1",
+      :attributes => {
+        :stacking_id => "ouch",
+        "sockets" => "2",
+        "vcpu" => "4",
+        "warning_period" => "30",
+        "brand_type" => "OS",
+      }
+    })
+
+    prod1 = create_product(nil, nil, {
+      :owner => owner_key,
+      :attributes => {
+        :stacking_id => "ouch",
+        "virt_limit" => 1,
+        "sockets" => 1,
+        "instance_multiplier" => 1,
+        "multi-entitlement" => "yes",
+        "host_limited" => "true"
+      }
+    })
+
+    prod2 = create_product(nil, nil, {
+      :owner => owner_key,
+      :attributes => {
+        :stacking_id => "ouch",
+        "virt_limit" => 1,
+        "sockets" => 1,
+        "instance_multiplier" => 1,
+        "multi-entitlement" => "yes",
+        "host_limited" => "true"
+      }
+    })
+
+    prod3 = create_product(nil, nil, {
+      :owner => owner_key,
+      :attributes => {
+        :stacking_id => "ouch",
+        "virt_limit" => 1,
+        "sockets" => 1,
+        "instance_multiplier" => 1,
+        "multi-entitlement" => "yes",
+        "host_limited" => "true"
+      }
+    })
+
+    # create 4 pools, all must provide product "prod" . none of them
+    # should provide enough sockets to heal the host on it's own
+    create_pool_and_subscription(owner['key'], prod['id'], 10)['id']
+    create_pool_and_subscription(owner['key'], prod1['id'], 30, [prod['id']])['id']
+    create_pool_and_subscription(owner['key'], prod2['id'], 30, [prod['id']])['id']
+    create_pool_and_subscription(owner['key'], prod3['id'], 30, [prod['id']])['id']
+
+    # create a guest with "prod" as an installed product
+    guest_uuid =  random_string('guest')
+    guest_facts = {
+      "virt.is_guest"=>"true",
+      "virt.uuid"=>"myGuestId",
+      "cpu.cpu_socket(s)"=>"1",
+      "virt.host_type"=>"kvm",
+      "system.certificate_version"=>"3.2"
+    }
+
+    guest = @cp.register('guest.bind.com',:system, guest_uuid, guest_facts, 'admin',
+      owner_key, [], [{"productId" => prod.id, "productName" => "taylor swift"}])
+
+    # create a hypervisor that needs 40 sockets and report the guest with it
+    hypervisor_facts = {
+      "virt.is_guest"=>"false",
+      "cpu.cpu(s)"=>"4",
+      "cpu.cpu_socket(s)"=>"40"
+    }
+
+    hypervisor_guests = [{"guestId"=>"myGuestId"}]
+    hypervisor_uuid = random_string("hypervisor")
+    hypervisor = @cp.register('hypervisor.bind.com',:system, hypervisor_uuid, hypervisor_facts, 'admin',
+      owner_key, [], [], nil, [], random_string('hypervisorid'))
+    hypervisor = @cp.update_consumer({:uuid => hypervisor.uuid, :guestIds => hypervisor_guests})
+
+    @cp.list_owner_pools(owner_key).length.should == 7
+
+    @cp.consume_product(nil, {:uuid => guest_uuid})
+
+    @cp.list_owner_pools(owner_key).length.should == 8
+
+    # heal should succeed, and hypervisor should consume 2 pools of 30 sockets each
+    @cp.list_entitlements({:uuid => hypervisor_uuid}).length.should == 2
+    @cp.list_entitlements({:uuid => guest_uuid}).length.should == 1
+
+    @cp.revoke_all_entitlements(hypervisor_uuid)
+    @cp.revoke_all_entitlements(guest_uuid)
+
+    # change the hypervisor to 70 sockets
+    hypervisor_facts = {
+      "virt.is_guest"=>"false",
+      "cpu.cpu(s)"=>"4",
+      "cpu.cpu_socket(s)"=>"70"
+    }
+
+    # heal should succeed, and hypervisor should consume 3 pools of 30 sockets each
+    @cp.update_consumer({:uuid => hypervisor_uuid, :facts => hypervisor_facts})
+
+    @cp.consume_product(nil, {:uuid => guest_uuid})
+
+    @cp.list_entitlements({:uuid => hypervisor_uuid}).length.should == 3
+    @cp.list_entitlements({:uuid => guest_uuid}).length.should == 1
+    @cp.list_owner_pools(owner_key).length.should == 8
+  end
+
+  it 'favors non-shared pools' do
+    prod = create_product(random_string('prod'), random_string('prod'), {
+      :owner => owner_key,
+      :attributes => {}
+    })
+
+    orgB = random_string('orgB')
+    create_owner(orgB)
+
+    shared_pool = create_pool_and_subscription(owner_key, prod['id'])
+    share_consumer = @cp.register(
+      random_string('orgBShare'),
+      :share,
+      nil,
+      {},
+      nil,
+      owner_key,
+      [],
+      [],
+      nil,
+      [],
+      nil,
+      [],
+      nil,
+      nil,
+      nil,
+      orgB
+    )
+
+    # Create the shared pool in Org B first since all else being equal Candlepin
+    # will pick an earlier expiring pool in autobind.
+    @cp.consume_pool(shared_pool['id'], :uuid => share_consumer['uuid'])
+
+    orgBconsumer = @cp.register(
+      random_string('orgBConsumer'),
+      :system,
+      nil,
+      {},
+      'admin',
+      orgB
+    )
+
+    # OrgB now has a shared pool and an unshared pool for prod
+    pool = create_pool_and_subscription(orgB, prod['id'])
+    ent = @cp.consume_product(prod['id'], :uuid => orgBconsumer['uuid'])
+
+    expect(ent.first['pool']['id']).to eq(pool['id'])
+  end
 end

--- a/server/spec/import_environment_spec.rb
+++ b/server/spec/import_environment_spec.rb
@@ -70,8 +70,8 @@ describe 'Import Into Environment', :serial => true do
 
     product1 = create_product('custom_prod-1', 'custom_prod-1', :owner => import_owner['key'])
     product2 = create_product('custom_prod-2', 'custom_prod-2', :owner => import_owner['key'])
-    custom_sub_pool_1 = create_pool_and_subscription(import_owner['key'], product1.id, 10)
-    custom_sub_pool_2 = create_pool_and_subscription(import_owner['key'], product2.id, 10)
+    custom_sub_pool_1 = @cp.create_pool(import_owner['key'], product1.id, {:quantity => 10})
+    custom_sub_pool_2 = @cp.create_pool(import_owner['key'], product2.id, {:quantity => 10})
 
     expect(custom_sub_pool_1).to_not be_nil
     expect(custom_sub_pool_2).to_not be_nil

--- a/server/spec/instance_spec.rb
+++ b/server/spec/instance_spec.rb
@@ -47,8 +47,15 @@ describe 'Instance Based Subscriptions' do
       has_attribute(p['attributes'], 'unmapped_guests_only')
     end
     instance_pools.size.should == 1
+    # In hosted, we increase the quantity on the subscription. However in standalone,
+    # we assume this already has happened in hosted and the accurate quantity was
+    # exported
     @instance_pool = instance_pools.first
-    @instance_pool.quantity.should == 20
+    if is_hosted?
+      @instance_pool.quantity.should == 20
+    else
+      @instance_pool.quantity.should == 10
+    end
   end
 
   it 'should auto-subscribe physical systems with quantity 2 per socket pair' do

--- a/server/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
@@ -162,7 +162,7 @@ public class PoolRules {
         // we have no way of linking the bonus/derived pools to the master pool (at the time of
         // writing), and we'd end up with orphaned pools. If/when this issue is resolved, the check
         // for a source subscription should be removed.
-        if (masterPool.getSourceSubscription() != null && virtQuantity != null &&
+        if (poolManager.isManaged(masterPool) && virtQuantity != null &&
             !hasBonusPool(existingPools)) {
 
             boolean hostLimited = "true".equals(attributes.get(Product.Attributes.HOST_LIMITED));

--- a/server/src/test/java/org/candlepin/policy/PoolRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/PoolRulesTest.java
@@ -62,8 +62,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-
-
 /**
  * JsPoolRulesTest: Tests for the default rules.
  */
@@ -320,6 +318,7 @@ public class PoolRulesTest {
         Product product = TestUtil.createProduct(productId, productId);
         product.setAttribute(Product.Attributes.VIRT_LIMIT, Integer.toString(virtLimit));
         Pool p = TestUtil.createPool(owner, product);
+        p.setUpstreamPoolId("upstreamId-" + p.getId());
         p.setQuantity(new Long(quantity));
         return p;
     }
@@ -333,6 +332,7 @@ public class PoolRulesTest {
     @Test
     public void virtLimitWithHostLimitedCreatesTaggedBonusPool() {
         Pool p1 = createVirtLimitPool("virtLimitProduct", 10, 10);
+        when(poolManagerMock.isManaged(eq(p1))).thenReturn(true);
         p1.getProduct().setAttribute(Product.Attributes.HOST_LIMITED, "true");
         this.mockProducts(owner, p1.getProduct());
         List<Pool> pools = poolRules.createAndEnrichPools(p1, new LinkedList<Pool>());
@@ -350,6 +350,7 @@ public class PoolRulesTest {
     public void hostedVirtLimitWithHostLimitedFalseCreatesBonusPools() {
         when(configMock.getBoolean(ConfigProperties.STANDALONE)).thenReturn(false);
         Pool p = createVirtLimitPool("virtLimitProduct", 10, 10);
+        when(poolManagerMock.isManaged(eq(p))).thenReturn(true);
         p.getProduct().setAttribute(Product.Attributes.HOST_LIMITED, "false");
         this.mockProducts(owner, p.getProduct());
         List<Pool> pools = poolRules.createAndEnrichPools(p, new LinkedList<Pool>());
@@ -361,6 +362,7 @@ public class PoolRulesTest {
         when(configMock.getBoolean(ConfigProperties.STANDALONE)).thenReturn(false);
         Pool p = createVirtLimitPool("virtLimitProduct", 10, 10);
         this.mockProducts(owner, p.getProduct());
+        when(poolManagerMock.isManaged(eq(p))).thenReturn(true);
         List<Pool> pools = poolRules.createAndEnrichPools(p, new LinkedList<Pool>());
         assertEquals(2, pools.size());
 
@@ -380,6 +382,7 @@ public class PoolRulesTest {
     public void hostedVirtLimitSubCreatesUnlimitedBonusVirtOnlyPool() {
         when(configMock.getBoolean(ConfigProperties.STANDALONE)).thenReturn(false);
         Pool p = createVirtLimitPool("virtLimitProduct", 10, 10);
+        when(poolManagerMock.isManaged(eq(p))).thenReturn(true);
         p.getProduct().setAttribute(Product.Attributes.VIRT_LIMIT, "unlimited");
         this.mockProducts(owner, p.getProduct());
         List<Pool> pools = poolRules.createAndEnrichPools(p, new LinkedList<Pool>());
@@ -395,6 +398,7 @@ public class PoolRulesTest {
     public void hostedVirtLimitSubUpdatesUnlimitedBonusVirtOnlyPool() {
         when(configMock.getBoolean(ConfigProperties.STANDALONE)).thenReturn(false);
         Pool p = createVirtLimitPool("virtLimitProduct", 10, 10);
+        when(poolManagerMock.isManaged(eq(p))).thenReturn(true);
         p.getProduct().setAttribute(Product.Attributes.VIRT_LIMIT, "unlimited");
         this.mockProducts(owner, p.getProduct());
         List<Pool> pools = poolRules.createAndEnrichPools(p, new LinkedList<Pool>());
@@ -421,6 +425,7 @@ public class PoolRulesTest {
     public void hostedVirtLimitRemoved() {
         when(configMock.getBoolean(ConfigProperties.STANDALONE)).thenReturn(false);
         Pool p = createVirtLimitPool("virtLimitProduct", 10, 10);
+        when(poolManagerMock.isManaged(eq(p))).thenReturn(true);
         p.getProduct().setAttribute(Product.Attributes.VIRT_LIMIT, "4");
         this.mockProducts(owner, p.getProduct());
         List<Pool> pools = poolRules.createAndEnrichPools(p, new LinkedList<Pool>());
@@ -450,6 +455,7 @@ public class PoolRulesTest {
     public void hostedVirtLimitSubWithMultiplierCreatesUnlimitedBonusVirtOnlyPool() {
         when(configMock.getBoolean(ConfigProperties.STANDALONE)).thenReturn(false);
         Pool p = createVirtLimitPool("virtLimitProduct", 10, 10);
+        when(poolManagerMock.isManaged(eq(p))).thenReturn(true);
         p.getProduct().setAttribute(Product.Attributes.VIRT_LIMIT, "unlimited");
         p.getProduct().setMultiplier(5L);
         this.mockProducts(owner, p.getProduct());
@@ -467,6 +473,7 @@ public class PoolRulesTest {
     public void hostedVirtLimitSubCreateAttributesTest() {
         when(configMock.getBoolean(ConfigProperties.STANDALONE)).thenReturn(false);
         Pool p = createVirtLimitPool("virtLimitProduct", 10, 10);
+        when(poolManagerMock.isManaged(eq(p))).thenReturn(true);
         p.getProduct().setAttribute(Pool.Attributes.PHYSICAL_ONLY, "true");
         this.mockProducts(owner, p.getProduct());
 
@@ -493,6 +500,7 @@ public class PoolRulesTest {
         when(configMock.getBoolean(ConfigProperties.STANDALONE)).thenReturn(true);
         Pool p = createVirtLimitPool("virtLimitProduct", 10, 10);
 
+        when(poolManagerMock.isManaged(eq(p))).thenReturn(true);
         Product provided1 = TestUtil.createProduct();
         Product provided2 = TestUtil.createProduct();
         Product derivedProd = TestUtil.createProduct();
@@ -546,6 +554,7 @@ public class PoolRulesTest {
         Subscription s = createVirtLimitSubWithDerivedProducts("virtLimitProduct",
             "derivedProd", 10, 10);
         Pool p = TestUtil.copyFromSub(s);
+        when(poolManagerMock.isManaged(eq(p))).thenReturn(true);
         p.setId("mockVirtLimitSubCreateDerived");
         when(productCurator.getPoolDerivedProvidedProductsCached(p))
             .thenReturn(p.getDerivedProvidedProducts());
@@ -652,6 +661,7 @@ public class PoolRulesTest {
         when(configMock.getBoolean(ConfigProperties.STANDALONE)).thenReturn(true);
         Pool p = createVirtLimitPool("virtLimitProduct", 10, 10);
         this.mockProducts(owner, p.getProduct());
+        when(poolManagerMock.isManaged(eq(p))).thenReturn(true);
         List<Pool> pools = poolRules.createAndEnrichPools(p, new LinkedList<Pool>());
 
         // Should be unmapped virt_only pool:
@@ -719,6 +729,7 @@ public class PoolRulesTest {
         when(configMock.getBoolean(ConfigProperties.STANDALONE)).thenReturn(true);
         Pool p = createVirtLimitPool("virtLimitProduct", 10, 10);
         this.mockProducts(owner, p.getProduct());
+        when(poolManagerMock.isManaged(eq(p))).thenReturn(true);
         List<Pool> pools = poolRules.createAndEnrichPools(p, new LinkedList<Pool>());
         assertEquals(2, pools.size());
         Entitlement ent = mock(Entitlement.class);
@@ -746,6 +757,7 @@ public class PoolRulesTest {
         when(configMock.getBoolean(ConfigProperties.STANDALONE)).thenReturn(true);
         Pool p = createVirtLimitPool("virtLimitProduct", 10, 10);
         this.mockProducts(owner, p.getProduct());
+        when(poolManagerMock.isManaged(eq(p))).thenReturn(true);
         List<Pool> pools = poolRules.createAndEnrichPools(p, new LinkedList<Pool>());
         assertEquals(2, pools.size());
         p.setQuantity(new Long(20));
@@ -920,6 +932,7 @@ public class PoolRulesTest {
         product.setAttribute(Product.Attributes.VIRT_LIMIT, "4");
         List<Pool> existingPools = new ArrayList<Pool>();
         Pool masterPool = TestUtil.createPool(owner, product);
+        when(poolManagerMock.isManaged(eq(masterPool))).thenReturn(true);
         masterPool.setSubscriptionSubKey("master");
         existingPools.add(masterPool);
         this.mockProducts(owner, product);

--- a/server/src/test/java/org/candlepin/policy/js/entitlement/HostedVirtLimitEntitlementRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/entitlement/HostedVirtLimitEntitlementRulesTest.java
@@ -72,7 +72,9 @@ public class HostedVirtLimitEntitlementRulesTest extends EntitlementRulesTestFix
         when(config.getBoolean(ConfigProperties.STANDALONE)).thenReturn(false);
         Subscription s = createVirtLimitSub("virtLimitProduct", 10, "10");
         consumer.setType(new ConsumerType(ConsumerTypeEnum.CANDLEPIN));
-        List<Pool> pools = poolRules.createAndEnrichPools(TestUtil.copyFromSub(s), new LinkedList<Pool>());
+        Pool p = TestUtil.copyFromSub(s);
+        when(poolManagerMock.isManaged(eq(p))).thenReturn(true);
+        List<Pool> pools = poolRules.createAndEnrichPools(p, new LinkedList<Pool>());
         assertEquals(2, pools.size());
 
         Pool physicalPool = pools.get(0);
@@ -122,7 +124,9 @@ public class HostedVirtLimitEntitlementRulesTest extends EntitlementRulesTestFix
 
         consumer.setType(new ConsumerType(ConsumerTypeEnum.CANDLEPIN));
         Subscription s = createVirtLimitSub("virtLimitProduct", 10, "10");
-        List<Pool> pools = poolRules.createAndEnrichPools(TestUtil.copyFromSub(s), new LinkedList<Pool>());
+        Pool p = TestUtil.copyFromSub(s);
+        when(poolManagerMock.isManaged(eq(p))).thenReturn(true);
+        List<Pool> pools = poolRules.createAndEnrichPools(p, new LinkedList<Pool>());
         assertEquals(2, pools.size());
 
         Pool physicalPool = pools.get(0);
@@ -141,7 +145,9 @@ public class HostedVirtLimitEntitlementRulesTest extends EntitlementRulesTestFix
 
         Subscription s2 = createVirtLimitSub("virtLimitProduct2", 10, "10");
         s2.setId("subId2");
-        List<Pool> pools2 = poolRules.createAndEnrichPools(TestUtil.copyFromSub(s2), new LinkedList<Pool>());
+        Pool p2 = TestUtil.copyFromSub(s2);
+        when(poolManagerMock.isManaged(eq(p2))).thenReturn(true);
+        List<Pool> pools2 = poolRules.createAndEnrichPools(p2, new LinkedList<Pool>());
         assertEquals(2, pools.size());
 
         Pool physicalPool2 = pools2.get(0);
@@ -205,7 +211,9 @@ public class HostedVirtLimitEntitlementRulesTest extends EntitlementRulesTestFix
         when(config.getBoolean(ConfigProperties.STANDALONE)).thenReturn(false);
         Subscription s = createVirtLimitSub("virtLimitProduct", 10, "unlimited");
         s.getProduct().setAttribute(Product.Attributes.HOST_LIMITED, "true");
-        List<Pool> pools = poolRules.createAndEnrichPools(TestUtil.copyFromSub(s), new LinkedList<Pool>());
+        Pool p = TestUtil.copyFromSub(s);
+        when(poolManagerMock.isManaged(eq(p))).thenReturn(true);
+        List<Pool> pools = poolRules.createAndEnrichPools(p, new LinkedList<Pool>());
         assertEquals(2, pools.size());
 
         Pool physicalPool = pools.get(0);
@@ -227,7 +235,9 @@ public class HostedVirtLimitEntitlementRulesTest extends EntitlementRulesTestFix
     public void hostedVirtLimitUnlimitedBonusPoolQuantity() {
         when(config.getBoolean(ConfigProperties.STANDALONE)).thenReturn(false);
         Subscription s = createVirtLimitSub("virtLimitProduct", 10, "unlimited");
-        List<Pool> pools = poolRules.createAndEnrichPools(TestUtil.copyFromSub(s), new LinkedList<Pool>());
+        Pool p = TestUtil.copyFromSub(s);
+        when(poolManagerMock.isManaged(eq(p))).thenReturn(true);
+        List<Pool> pools = poolRules.createAndEnrichPools(p, new LinkedList<Pool>());
         assertEquals(2, pools.size());
 
         Pool physicalPool = pools.get(0);
@@ -270,7 +280,9 @@ public class HostedVirtLimitEntitlementRulesTest extends EntitlementRulesTestFix
     public void noBonusPoolsForHostedNonDistributorBinds() {
         when(config.getBoolean(ConfigProperties.STANDALONE)).thenReturn(false);
         Subscription s = createVirtLimitSub("virtLimitProduct", 10, "unlimited");
-        List<Pool> pools = poolRules.createAndEnrichPools(TestUtil.copyFromSub(s), new LinkedList<Pool>());
+        Pool p = TestUtil.copyFromSub(s);
+        when(poolManagerMock.isManaged(eq(p))).thenReturn(true);
+        List<Pool> pools = poolRules.createAndEnrichPools(p, new LinkedList<Pool>());
         assertEquals(2, pools.size());
 
         Pool physicalPool = pools.get(0);
@@ -307,7 +319,9 @@ public class HostedVirtLimitEntitlementRulesTest extends EntitlementRulesTestFix
         when(config.getBoolean(ConfigProperties.STANDALONE)).thenReturn(false);
         consumer.setType(new ConsumerType(ConsumerTypeEnum.CANDLEPIN));
         Subscription s = createVirtLimitSub("virtLimitProduct", 10, "unlimited");
-        List<Pool> pools = poolRules.createAndEnrichPools(TestUtil.copyFromSub(s), new LinkedList<Pool>());
+        Pool p = TestUtil.copyFromSub(s);
+        when(poolManagerMock.isManaged(eq(p))).thenReturn(true);
+        List<Pool> pools = poolRules.createAndEnrichPools(p, new LinkedList<Pool>());
         assertEquals(2, pools.size());
 
         Pool physicalPool = pools.get(0);

--- a/server/src/test/java/org/candlepin/resource/OwnerResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/OwnerResourceTest.java
@@ -1388,6 +1388,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         prod.setAttribute(Product.Attributes.VIRT_LIMIT, "2");
         productCurator.merge(prod);
         Pool pool = TestUtil.createPool(owner, prod);
+        pool.setUpstreamPoolId("upstream-" + pool.getId());
         assertEquals(0, poolCurator.listByOwner(owner).list().size());
         ownerResource.createPool(owner.getKey(), pool);
         List<Pool> pools = poolCurator.listByOwner(owner).list();
@@ -1404,6 +1405,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         prod.setAttribute(Product.Attributes.VIRT_LIMIT, "3");
         productCurator.merge(prod);
         Pool pool = TestUtil.createPool(owner, prod);
+        pool.setUpstreamPoolId("upstream-" + pool.getId());
         pool.setSubscriptionSubKey("master");
         ownerResource.createPool(owner.getKey(), pool);
         pool.setQuantity(100L);
@@ -1424,6 +1426,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         prod.setAttribute(Product.Attributes.VIRT_LIMIT, "3");
         productCurator.merge(prod);
         Pool pool = TestUtil.createPool(owner, prod);
+        pool.setUpstreamPoolId("upstream-" + pool.getId());
         pool.setSubscriptionSubKey("master");
         ownerResource.createPool(owner.getKey(), pool);
         List<Pool> pools = poolCurator.listByOwner(owner).list();
@@ -1441,6 +1444,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         prod.setAttribute(Product.Attributes.VIRT_LIMIT, "3");
         productCurator.merge(prod);
         Pool pool = TestUtil.createPool(owner, prod);
+        pool.setUpstreamPoolId("upstream-" + pool.getId());
         pool.setSubscriptionSubKey("master");
         ownerResource.createPool(owner.getKey(), pool);
         List<Pool> pools = poolCurator.listByOwner(owner).list();


### PR DESCRIPTION
Fix custom pool lookup for bonus pool

the absence of source subscription is not a reliable way to determine if a pool is a custom pool,
since that behaviour varies with the candlepin verion. More reliable is the presence or absence of
an upstream pool id.

CandlepinPoolManager.isManaged is now the single method to determine if a pool is custom, and checks
both source subscription and upstream pool id.

This is ready for a merge, but would like @mstead to confirm if this fix should be pushed in this branch.