### PR TITLE
Fix custom pool lookup for bonus pool - 2.1

### DIFF
--- a/server/client/ruby/candlepin_api.rb
+++ b/server/client/ruby/candlepin_api.rb
@@ -1046,6 +1046,10 @@ class Candlepin
       pool['derivedProvidedProducts'] = params[:derived_provided_products].collect { |pid| {'productId' => pid} }
     end
 
+    if params[:upstream_pool_id]
+      pool['upstreamPoolId'] = params[:upstream_pool_id]
+    end
+
     return post("/owners/#{owner_key}/pools", {}, pool)
   end
 

--- a/server/client/ruby/hostedtest_api.rb
+++ b/server/client/ruby/hostedtest_api.rb
@@ -142,6 +142,7 @@ module HostedTest
 
   # Lets users be agnostic of what mode we are in, standalone or hosted.
   # Always returns the main pool that was created ( unless running in hosted mode and refresh is skipped )
+  # not to be used to create custom pool
   def create_pool_and_subscription(owner_key, product_id, quantity=1,
                           provided_products=[], contract_number='',
                           account_number='', order_number='',
@@ -165,6 +166,7 @@ module HostedTest
       end
     else
       params[:source_subscription] = { 'id' => random_str('source_sub_') }
+      params[:upstream_pool_id] = random_str('upstream_')
       pool = @cp.create_pool(owner_key, product_id, params)
     end
     return pool

--- a/server/spec/autobind_spec.rb
+++ b/server/spec/autobind_spec.rb
@@ -32,7 +32,7 @@ describe 'Autobind On Owner' do
         :stacking_id => "ouch",
         "virt_limit" => 1,
         "sockets" => 1,
-        "instance_multiplier" => 2,
+        "instance_multiplier" => 1,
         "multi-entitlement" => "yes",
         "host_limited" => "true"
       }
@@ -44,7 +44,7 @@ describe 'Autobind On Owner' do
         :stacking_id => "ouch",
         "virt_limit" => 1,
         "sockets" => 1,
-        "instance_multiplier" => 2,
+        "instance_multiplier" => 1,
         "multi-entitlement" => "yes",
         "host_limited" => "true"
       }
@@ -56,7 +56,7 @@ describe 'Autobind On Owner' do
         :stacking_id => "ouch",
         "virt_limit" => 1,
         "sockets" => 1,
-        "instance_multiplier" => 2,
+        "instance_multiplier" => 1,
         "multi-entitlement" => "yes",
         "host_limited" => "true"
       }
@@ -64,10 +64,10 @@ describe 'Autobind On Owner' do
 
     # create 4 pools, all must provide product "prod" . none of them
     # should provide enough sockets to heal the host on it's own
-    create_pool_and_subscription(owner['key'], prod['id'], 10)
-    create_pool_and_subscription(owner['key'], prod1['id'], 20, [prod['id']])
-    create_pool_and_subscription(owner['key'], prod2['id'], 20, [prod['id']])
-    create_pool_and_subscription(owner['key'], prod3['id'], 20, [prod['id']])
+    create_pool_and_subscription(owner['key'], prod['id'], 10)['id']
+    create_pool_and_subscription(owner['key'], prod1['id'], 30, [prod['id']])['id']
+    create_pool_and_subscription(owner['key'], prod2['id'], 30, [prod['id']])['id']
+    create_pool_and_subscription(owner['key'], prod3['id'], 30, [prod['id']])['id']
 
     # create a guest with "prod" as an installed product
     guest_uuid =  random_string('guest')
@@ -101,24 +101,25 @@ describe 'Autobind On Owner' do
 
     @cp.list_owner_pools(owner_key).length.should == 8
 
-    # heal should succeed, and hypervisor should consume 2 pools of 20 sockets each
+    # heal should succeed, and hypervisor should consume 2 pools of 30 sockets each
     @cp.list_entitlements({:uuid => hypervisor_uuid}).length.should == 2
     @cp.list_entitlements({:uuid => guest_uuid}).length.should == 1
 
     @cp.revoke_all_entitlements(hypervisor_uuid)
     @cp.revoke_all_entitlements(guest_uuid)
 
-    # change the hypervisor to 50 sockets
+    # change the hypervisor to 70 sockets
     hypervisor_facts = {
       "virt.is_guest"=>"false",
       "cpu.cpu(s)"=>"4",
-      "cpu.cpu_socket(s)"=>"50"
+      "cpu.cpu_socket(s)"=>"70"
     }
 
-    # heal should succeed, and hypervisor should consume 3 pools of 20 sockets each
+    # heal should succeed, and hypervisor should consume 3 pools of 30 sockets each
     @cp.update_consumer({:uuid => hypervisor_uuid, :facts => hypervisor_facts})
 
     @cp.consume_product(nil, {:uuid => guest_uuid})
+
     @cp.list_entitlements({:uuid => hypervisor_uuid}).length.should == 3
     @cp.list_entitlements({:uuid => guest_uuid}).length.should == 1
     @cp.list_owner_pools(owner_key).length.should == 8

--- a/server/spec/import_environment_spec.rb
+++ b/server/spec/import_environment_spec.rb
@@ -70,8 +70,8 @@ describe 'Import Into Environment', :serial => true do
 
     product1 = create_product('custom_prod-1', 'custom_prod-1', :owner => import_owner['key'])
     product2 = create_product('custom_prod-2', 'custom_prod-2', :owner => import_owner['key'])
-    custom_sub_pool_1 = create_pool_and_subscription(import_owner['key'], product1.id, 10)
-    custom_sub_pool_2 = create_pool_and_subscription(import_owner['key'], product2.id, 10)
+    custom_sub_pool_1 = @cp.create_pool(import_owner['key'], product1.id, {:quantity => 10})
+    custom_sub_pool_2 = @cp.create_pool(import_owner['key'], product2.id, {:quantity => 10})
 
     expect(custom_sub_pool_1).to_not be_nil
     expect(custom_sub_pool_2).to_not be_nil

--- a/server/spec/instance_spec.rb
+++ b/server/spec/instance_spec.rb
@@ -47,8 +47,15 @@ describe 'Instance Based Subscriptions' do
       has_attribute(p['attributes'], 'unmapped_guests_only')
     end
     instance_pools.size.should == 1
+    # In hosted, we increase the quantity on the subscription. However in standalone,
+    # we assume this already has happened in hosted and the accurate quantity was
+    # exported
     @instance_pool = instance_pools.first
-    @instance_pool.quantity.should == 20
+    if is_hosted?
+      @instance_pool.quantity.should == 20
+    else
+      @instance_pool.quantity.should == 10
+    end
   end
 
   it 'should auto-subscribe physical systems with quantity 2 per socket pair' do

--- a/server/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
@@ -162,7 +162,7 @@ public class PoolRules {
         // we have no way of linking the bonus/derived pools to the master pool (at the time of
         // writing), and we'd end up with orphaned pools. If/when this issue is resolved, the check
         // for a source subscription should be removed.
-        if (masterPool.getSourceSubscription() != null && virtQuantity != null &&
+        if (poolManager.isManaged(masterPool) && virtQuantity != null &&
             !hasBonusPool(existingPools)) {
 
             boolean hostLimited = "true".equals(attributes.get(Product.Attributes.HOST_LIMITED));

--- a/server/src/test/java/org/candlepin/policy/PoolRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/PoolRulesTest.java
@@ -317,6 +317,7 @@ public class PoolRulesTest {
         Product product = TestUtil.createProduct(productId, productId);
         product.setAttribute(Product.Attributes.VIRT_LIMIT, Integer.toString(virtLimit));
         Pool p = TestUtil.createPool(owner, product);
+        p.setUpstreamPoolId("upstreamId-" + p.getId());
         p.setQuantity(new Long(quantity));
         return p;
     }
@@ -330,6 +331,7 @@ public class PoolRulesTest {
     @Test
     public void virtLimitWithHostLimitedCreatesTaggedBonusPool() {
         Pool p1 = createVirtLimitPool("virtLimitProduct", 10, 10);
+        when(poolManagerMock.isManaged(eq(p1))).thenReturn(true);
         p1.getProduct().setAttribute(Product.Attributes.HOST_LIMITED, "true");
         List<Pool> pools = poolRules.createAndEnrichPools(p1, new LinkedList<Pool>());
         assertEquals(2, pools.size());
@@ -346,6 +348,7 @@ public class PoolRulesTest {
     public void hostedVirtLimitWithHostLimitedFalseCreatesBonusPools() {
         when(configMock.getBoolean(ConfigProperties.STANDALONE)).thenReturn(false);
         Pool p = createVirtLimitPool("virtLimitProduct", 10, 10);
+        when(poolManagerMock.isManaged(eq(p))).thenReturn(true);
         p.getProduct().setAttribute(Product.Attributes.HOST_LIMITED, "false");
         List<Pool> pools = poolRules.createAndEnrichPools(p, new LinkedList<Pool>());
         assertEquals(2, pools.size());
@@ -355,6 +358,7 @@ public class PoolRulesTest {
     public void hostedVirtLimitSubCreatesBonusVirtOnlyPool() {
         when(configMock.getBoolean(ConfigProperties.STANDALONE)).thenReturn(false);
         Pool p = createVirtLimitPool("virtLimitProduct", 10, 10);
+        when(poolManagerMock.isManaged(eq(p))).thenReturn(true);
         List<Pool> pools = poolRules.createAndEnrichPools(p, new LinkedList<Pool>());
         assertEquals(2, pools.size());
 
@@ -374,6 +378,7 @@ public class PoolRulesTest {
     public void hostedVirtLimitSubCreatesUnlimitedBonusVirtOnlyPool() {
         when(configMock.getBoolean(ConfigProperties.STANDALONE)).thenReturn(false);
         Pool p = createVirtLimitPool("virtLimitProduct", 10, 10);
+        when(poolManagerMock.isManaged(eq(p))).thenReturn(true);
         p.getProduct().setAttribute(Product.Attributes.VIRT_LIMIT, "unlimited");
         List<Pool> pools = poolRules.createAndEnrichPools(p, new LinkedList<Pool>());
         assertEquals(2, pools.size());
@@ -388,6 +393,7 @@ public class PoolRulesTest {
     public void hostedVirtLimitSubUpdatesUnlimitedBonusVirtOnlyPool() {
         when(configMock.getBoolean(ConfigProperties.STANDALONE)).thenReturn(false);
         Pool p = createVirtLimitPool("virtLimitProduct", 10, 10);
+        when(poolManagerMock.isManaged(eq(p))).thenReturn(true);
         p.getProduct().setAttribute(Product.Attributes.VIRT_LIMIT, "unlimited");
         List<Pool> pools = poolRules.createAndEnrichPools(p, new LinkedList<Pool>());
         assertEquals(2, pools.size());
@@ -411,6 +417,7 @@ public class PoolRulesTest {
     public void hostedVirtLimitRemoved() {
         when(configMock.getBoolean(ConfigProperties.STANDALONE)).thenReturn(false);
         Pool p = createVirtLimitPool("virtLimitProduct", 10, 10);
+        when(poolManagerMock.isManaged(eq(p))).thenReturn(true);
         p.getProduct().setAttribute(Product.Attributes.VIRT_LIMIT, "4");
         List<Pool> pools = poolRules.createAndEnrichPools(p, new LinkedList<Pool>());
         assertEquals(2, pools.size());
@@ -437,6 +444,7 @@ public class PoolRulesTest {
     public void hostedVirtLimitSubWithMultiplierCreatesUnlimitedBonusVirtOnlyPool() {
         when(configMock.getBoolean(ConfigProperties.STANDALONE)).thenReturn(false);
         Pool p = createVirtLimitPool("virtLimitProduct", 10, 10);
+        when(poolManagerMock.isManaged(eq(p))).thenReturn(true);
         p.getProduct().setAttribute(Product.Attributes.VIRT_LIMIT, "unlimited");
         p.getProduct().setMultiplier(5L);
         List<Pool> pools = poolRules.createAndEnrichPools(p, new LinkedList<Pool>());
@@ -452,6 +460,7 @@ public class PoolRulesTest {
     public void hostedVirtLimitSubCreateAttributesTest() {
         when(configMock.getBoolean(ConfigProperties.STANDALONE)).thenReturn(false);
         Pool p = createVirtLimitPool("virtLimitProduct", 10, 10);
+        when(poolManagerMock.isManaged(eq(p))).thenReturn(true);
         p.getProduct().setAttribute(Pool.Attributes.PHYSICAL_ONLY, "true");
         List<Pool> pools = poolRules.createAndEnrichPools(p, new LinkedList<Pool>());
 
@@ -476,6 +485,7 @@ public class PoolRulesTest {
         when(configMock.getBoolean(ConfigProperties.STANDALONE)).thenReturn(true);
         Pool p = createVirtLimitPool("virtLimitProduct", 10, 10);
 
+        when(poolManagerMock.isManaged(eq(p))).thenReturn(true);
         Product provided1 = TestUtil.createProduct();
         Product provided2 = TestUtil.createProduct();
         Product derivedProd = TestUtil.createProduct();
@@ -533,6 +543,7 @@ public class PoolRulesTest {
         Subscription s = createVirtLimitSubWithDerivedProducts("virtLimitProduct",
             "derivedProd", 10, 10);
         Pool p = TestUtil.copyFromSub(s);
+        when(poolManagerMock.isManaged(eq(p))).thenReturn(true);
         p.setId("mockVirtLimitSubCreateDerived");
         when(productCurator.getPoolDerivedProvidedProductsCached(p))
             .thenReturn(p.getDerivedProvidedProducts());
@@ -632,6 +643,7 @@ public class PoolRulesTest {
     public void standaloneVirtLimitSubUpdate() {
         when(configMock.getBoolean(ConfigProperties.STANDALONE)).thenReturn(true);
         Pool p = createVirtLimitPool("virtLimitProduct", 10, 10);
+        when(poolManagerMock.isManaged(eq(p))).thenReturn(true);
         List<Pool> pools = poolRules.createAndEnrichPools(p, new LinkedList<Pool>());
 
         // Should be unmapped virt_only pool:
@@ -698,6 +710,7 @@ public class PoolRulesTest {
     public void standaloneVirtSubPoolUpdateNoChanges() {
         when(configMock.getBoolean(ConfigProperties.STANDALONE)).thenReturn(true);
         Pool p = createVirtLimitPool("virtLimitProduct", 10, 10);
+        when(poolManagerMock.isManaged(eq(p))).thenReturn(true);
         List<Pool> pools = poolRules.createAndEnrichPools(p, new LinkedList<Pool>());
         assertEquals(2, pools.size());
         Entitlement ent = mock(Entitlement.class);
@@ -722,6 +735,7 @@ public class PoolRulesTest {
     public void standaloneVirtSubPoolUpdateVirtLimitChanged() {
         when(configMock.getBoolean(ConfigProperties.STANDALONE)).thenReturn(true);
         Pool p = createVirtLimitPool("virtLimitProduct", 10, 10);
+        when(poolManagerMock.isManaged(eq(p))).thenReturn(true);
         List<Pool> pools = poolRules.createAndEnrichPools(p, new LinkedList<Pool>());
         assertEquals(2, pools.size());
         p.setQuantity(new Long(20));
@@ -894,6 +908,7 @@ public class PoolRulesTest {
         product.setAttribute(Product.Attributes.VIRT_LIMIT, "4");
         List<Pool> existingPools = new ArrayList<Pool>();
         Pool masterPool = TestUtil.createPool(product);
+        when(poolManagerMock.isManaged(eq(masterPool))).thenReturn(true);
         masterPool.setSubscriptionSubKey("master");
         existingPools.add(masterPool);
         List<Pool> pools = this.poolRules.createAndEnrichPools(masterPool, existingPools);

--- a/server/src/test/java/org/candlepin/policy/js/entitlement/HostedVirtLimitEntitlementRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/entitlement/HostedVirtLimitEntitlementRulesTest.java
@@ -72,7 +72,9 @@ public class HostedVirtLimitEntitlementRulesTest extends EntitlementRulesTestFix
         when(config.getBoolean(ConfigProperties.STANDALONE)).thenReturn(false);
         Subscription s = createVirtLimitSub("virtLimitProduct", 10, "10");
         consumer.setType(new ConsumerType(ConsumerTypeEnum.CANDLEPIN));
-        List<Pool> pools = poolRules.createAndEnrichPools(TestUtil.copyFromSub(s), new LinkedList<Pool>());
+        Pool p = TestUtil.copyFromSub(s);
+        when(poolManagerMock.isManaged(eq(p))).thenReturn(true);
+        List<Pool> pools = poolRules.createAndEnrichPools(p, new LinkedList<Pool>());
         assertEquals(2, pools.size());
 
         Pool physicalPool = pools.get(0);
@@ -122,7 +124,9 @@ public class HostedVirtLimitEntitlementRulesTest extends EntitlementRulesTestFix
 
         consumer.setType(new ConsumerType(ConsumerTypeEnum.CANDLEPIN));
         Subscription s = createVirtLimitSub("virtLimitProduct", 10, "10");
-        List<Pool> pools = poolRules.createAndEnrichPools(TestUtil.copyFromSub(s), new LinkedList<Pool>());
+        Pool p = TestUtil.copyFromSub(s);
+        when(poolManagerMock.isManaged(eq(p))).thenReturn(true);
+        List<Pool> pools = poolRules.createAndEnrichPools(p, new LinkedList<Pool>());
         assertEquals(2, pools.size());
 
         Pool physicalPool = pools.get(0);
@@ -141,7 +145,9 @@ public class HostedVirtLimitEntitlementRulesTest extends EntitlementRulesTestFix
 
         Subscription s2 = createVirtLimitSub("virtLimitProduct2", 10, "10");
         s2.setId("subId2");
-        List<Pool> pools2 = poolRules.createAndEnrichPools(TestUtil.copyFromSub(s2), new LinkedList<Pool>());
+        Pool p2 = TestUtil.copyFromSub(s2);
+        when(poolManagerMock.isManaged(eq(p2))).thenReturn(true);
+        List<Pool> pools2 = poolRules.createAndEnrichPools(p2, new LinkedList<Pool>());
         assertEquals(2, pools.size());
 
         Pool physicalPool2 = pools2.get(0);
@@ -205,7 +211,9 @@ public class HostedVirtLimitEntitlementRulesTest extends EntitlementRulesTestFix
         when(config.getBoolean(ConfigProperties.STANDALONE)).thenReturn(false);
         Subscription s = createVirtLimitSub("virtLimitProduct", 10, "unlimited");
         s.getProduct().setAttribute(Product.Attributes.HOST_LIMITED, "true");
-        List<Pool> pools = poolRules.createAndEnrichPools(TestUtil.copyFromSub(s), new LinkedList<Pool>());
+        Pool p = TestUtil.copyFromSub(s);
+        when(poolManagerMock.isManaged(eq(p))).thenReturn(true);
+        List<Pool> pools = poolRules.createAndEnrichPools(p, new LinkedList<Pool>());
         assertEquals(2, pools.size());
 
         Pool physicalPool = pools.get(0);
@@ -227,7 +235,9 @@ public class HostedVirtLimitEntitlementRulesTest extends EntitlementRulesTestFix
     public void hostedVirtLimitUnlimitedBonusPoolQuantity() {
         when(config.getBoolean(ConfigProperties.STANDALONE)).thenReturn(false);
         Subscription s = createVirtLimitSub("virtLimitProduct", 10, "unlimited");
-        List<Pool> pools = poolRules.createAndEnrichPools(TestUtil.copyFromSub(s), new LinkedList<Pool>());
+        Pool p = TestUtil.copyFromSub(s);
+        when(poolManagerMock.isManaged(eq(p))).thenReturn(true);
+        List<Pool> pools = poolRules.createAndEnrichPools(p, new LinkedList<Pool>());
         assertEquals(2, pools.size());
 
         Pool physicalPool = pools.get(0);
@@ -270,7 +280,9 @@ public class HostedVirtLimitEntitlementRulesTest extends EntitlementRulesTestFix
     public void noBonusPoolsForHostedNonDistributorBinds() {
         when(config.getBoolean(ConfigProperties.STANDALONE)).thenReturn(false);
         Subscription s = createVirtLimitSub("virtLimitProduct", 10, "unlimited");
-        List<Pool> pools = poolRules.createAndEnrichPools(TestUtil.copyFromSub(s), new LinkedList<Pool>());
+        Pool p = TestUtil.copyFromSub(s);
+        when(poolManagerMock.isManaged(eq(p))).thenReturn(true);
+        List<Pool> pools = poolRules.createAndEnrichPools(p, new LinkedList<Pool>());
         assertEquals(2, pools.size());
 
         Pool physicalPool = pools.get(0);
@@ -307,7 +319,9 @@ public class HostedVirtLimitEntitlementRulesTest extends EntitlementRulesTestFix
         when(config.getBoolean(ConfigProperties.STANDALONE)).thenReturn(false);
         consumer.setType(new ConsumerType(ConsumerTypeEnum.CANDLEPIN));
         Subscription s = createVirtLimitSub("virtLimitProduct", 10, "unlimited");
-        List<Pool> pools = poolRules.createAndEnrichPools(TestUtil.copyFromSub(s), new LinkedList<Pool>());
+        Pool p = TestUtil.copyFromSub(s);
+        when(poolManagerMock.isManaged(eq(p))).thenReturn(true);
+        List<Pool> pools = poolRules.createAndEnrichPools(p, new LinkedList<Pool>());
         assertEquals(2, pools.size());
 
         Pool physicalPool = pools.get(0);

--- a/server/src/test/java/org/candlepin/resource/OwnerResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/OwnerResourceTest.java
@@ -1390,6 +1390,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         prod.setAttribute(Product.Attributes.VIRT_LIMIT, "2");
         productCurator.merge(prod);
         Pool pool = TestUtil.createPool(owner, prod);
+        pool.setUpstreamPoolId("upstream-" + pool.getId());
         assertEquals(0, poolCurator.listByOwner(owner).list().size());
         ownerResource.createPool(owner.getKey(), pool);
         List<Pool> pools = poolCurator.listByOwner(owner).list();
@@ -1406,6 +1407,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         prod.setAttribute(Product.Attributes.VIRT_LIMIT, "3");
         productCurator.merge(prod);
         Pool pool = TestUtil.createPool(owner, prod);
+        pool.setUpstreamPoolId("upstream-" + pool.getId());
         pool.setSubscriptionSubKey("master");
         ownerResource.createPool(owner.getKey(), pool);
         pool.setQuantity(100L);
@@ -1426,6 +1428,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         prod.setAttribute(Product.Attributes.VIRT_LIMIT, "3");
         productCurator.merge(prod);
         Pool pool = TestUtil.createPool(owner, prod);
+        pool.setUpstreamPoolId("upstream-" + pool.getId());
         pool.setSubscriptionSubKey("master");
         ownerResource.createPool(owner.getKey(), pool);
         List<Pool> pools = poolCurator.listByOwner(owner).list();
@@ -1443,6 +1446,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         prod.setAttribute(Product.Attributes.VIRT_LIMIT, "3");
         productCurator.merge(prod);
         Pool pool = TestUtil.createPool(owner, prod);
+        pool.setUpstreamPoolId("upstream-" + pool.getId());
         pool.setSubscriptionSubKey("master");
         ownerResource.createPool(owner.getKey(), pool);
         List<Pool> pools = poolCurator.listByOwner(owner).list();


### PR DESCRIPTION
Fix custom pool lookup for bonus pool

the absence of source subscription is not a reliable way to determine if a pool is a custom pool,
since that behaviour varies with the candlepin verion. More reliable is the presence or absence of
an upstream pool id.

CandlepinPoolManager.isManaged is now the single method to determine if a pool is custom, and checks
both source subscription and upstream pool id.