### PR TITLE
ambiguous subscription resources

### DIFF
--- a/common/src/main/java/org/candlepin/common/exceptions/ResourceMovedException.java
+++ b/common/src/main/java/org/candlepin/common/exceptions/ResourceMovedException.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.common.exceptions;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.ws.rs.core.Response.Status;
+
+/**
+ * Represents a See Other (HTTP 303) error.
+ */
+public class ResourceMovedException extends CandlepinException {
+    String location = null;
+
+    public ResourceMovedException(String argLocation) {
+        super(Status.SEE_OTHER, "The resource has moved to the location: " + argLocation);
+        location = argLocation;
+    }
+
+    @Override
+    public Map<String, String> headers() {
+        HashMap<String, String> negHeaders = new HashMap<String, String>();
+        negHeaders.put("Location", location);
+        return  negHeaders;
+    }
+}

--- a/server/client/ruby/candlepin_api.rb
+++ b/server/client/ruby/candlepin_api.rb
@@ -982,6 +982,10 @@ class Candlepin
     return get_text("/subscriptions/#{sub_id}/cert", {}, 'text/plain')
   end
 
+  def get_pool_cert(id)
+    return get_text("/pools/#{id}/cert", {}, 'text/plain')
+  end
+
   def get_subscription_cert_by_ent_id(ent_id)
     return get_text("/entitlements/#{ent_id}/upstream_cert", {}, 'text/plain')
   end

--- a/server/spec/import_spec.rb
+++ b/server/spec/import_spec.rb
@@ -394,15 +394,15 @@ describe 'Import Test Group:', :serial => true do
       # use sub.first.id because find_all returns an array, but there
       # can only be one, HIGHLANDER!
       sub.length.should == 1
-      cert = @cp.get_subscription_cert sub.first.id
-      cert[0..26].should == "-----BEGIN CERTIFICATE-----"
-      cert.include?("-----BEGIN RSA PRIVATE KEY-----").should == true
-
-      # while were here, lets access the upstream cert via entitlement id
       pools =  @import_owner_client.list_pools({:owner => @import_owner['id']})
       pool = pools.find_all {
         |p| p.subscriptionId == sub.first.id && p.subscriptionSubKey == "master"
       }[0]
+      cert = @cp.get_pool_cert pool.id
+      cert[0..26].should == "-----BEGIN CERTIFICATE-----"
+      cert.include?("-----BEGIN RSA PRIVATE KEY-----").should == true
+
+      # while were here, lets access the upstream cert via entitlement id
       consumer = consumer_client(@import_owner_client, 'system6')
       entitlement = consumer.consume_pool(pool.id, {:quantity => 1})[0]
       ent =  @cp.get_subscription_cert_by_ent_id entitlement.id

--- a/server/spec/owner_resource_spec.rb
+++ b/server/spec/owner_resource_spec.rb
@@ -101,10 +101,10 @@ describe 'Owner Resource' do
     tomorrow = (DateTime.now + 1)
     poolOrSub.startDate = tomorrow
     update_pool_or_subscription(poolOrSub)
-    updatedSub = @cp.get_subscription(pool.subscriptionId)
+    updatedPool = @cp.get_pool(pool.id)
 
     # parse the received start date and convert it back to our local time zone
-    startDate = DateTime.strptime(updatedSub.startDate).new_offset(tomorrow.offset)
+    startDate = DateTime.strptime(updatedPool.startDate).new_offset(tomorrow.offset)
 
     expect(startDate.to_s).to eq(tomorrow.to_s)
   end

--- a/server/spec/subscription_resource_spec.rb
+++ b/server/spec/subscription_resource_spec.rb
@@ -29,15 +29,23 @@ describe 'Subscription Resource' do
       @cp.list_subscriptions(@owner['key']).size.should == 0
   end
 
-  it 'should fabricate subscriptions originating from multiplier products correctly and with branding' do
-      b1 = {:productId => 'prodid1',
-        :type => 'type1', :name => 'branding1'}
-      b2 = {:productId => 'prodid2',
-        :type => 'type2', :name => 'branding2'}
-      created = create_pool_and_subscription(@owner['key'], @some_product.id, 11,
-        [], '', '', '', nil, nil, false, :branding => [b1,b2])
-      sub = @cp.get_subscription(created['subscriptionId'])
-      sub.quantity.should == 11
-      sub.branding.size.should == 2
+  it 'should not allow clients to fetch subscriptions using id' do
+      pool = create_pool_and_subscription(@owner['key'], @one_more_product.id, 2)
+      begin
+          @cp.get_subscription(pool['subscriptionId'])
+          fail("Should not allow to fetch subscription")
+      rescue URI::InvalidURIError => e
+          e.to_s.eql? "bad URI(is not URI?): pools/{pool_id}"
+      end
+  end
+
+  it 'should not allow clients to fetch subscription cert using subscription id' do
+      pool = create_pool_and_subscription(@owner['key'], @one_more_product.id, 2)
+      begin
+          @cp.get_subscription_cert(pool['subscriptionId'])
+          fail("Should not allow to fetch subscription")
+      rescue URI::InvalidURIError => e
+          e.to_s.eql? "bad URI(is not URI?): pools/{pool_id}/cert"
+      end
   end
 end

--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -1967,7 +1967,10 @@ public class CandlepinPoolManager implements PoolManager {
             }
 
             poolsToDelete.add(pool);
-            entitlementsToRevoke.addAll(pool.getEntitlements());
+            for (Entitlement e: pool.getEntitlements()) {
+                e.setDeletedFromPool(true);
+                entitlementsToRevoke.add(e);
+            }
         }
 
         // Look up the related pools for these subscription IDs.
@@ -2184,11 +2187,6 @@ public class CandlepinPoolManager implements PoolManager {
         return this.poolCurator.getPoolsBySubscriptionId(subscriptionId);
     }
 
-    @Override
-    public Pool getMasterPoolBySubscriptionId(String subscriptionId) {
-        return this.poolCurator.getMasterPoolBySubscriptionId(subscriptionId);
-    }
-
     /**
      * @{inheritDoc}
      */
@@ -2288,7 +2286,10 @@ public class CandlepinPoolManager implements PoolManager {
         // Remove the standalone config check and replace it with a check for whether or not the
         // pool is non-custom  -- however we decide to implement that in the future.
 
-        return pool != null && pool.getSourceSubscription() != null && !pool.getType().isDerivedType() &&
+        return pool != null &&
+            pool.getSourceSubscription() != null &&
+            !pool.getType().isDerivedType() &&
+            !pool.isCreatedByShare() &&
             (pool.getUpstreamPoolId() != null || !this.config.getBoolean(ConfigProperties.STANDALONE, true));
     }
 }

--- a/server/src/main/java/org/candlepin/controller/PoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/PoolManager.java
@@ -285,18 +285,6 @@ public interface PoolManager {
     List<Pool> getPoolsBySubscriptionId(String subscriptionId);
 
     /**
-     * Retrieves the master pool associated with the specified subscription ID. If there is not a
-     * master pool asscoated with the given subscription, this method should return null.
-     *
-     * @param subscriptionId
-     *  The subscription ID to use to lookup a master pool
-     *
-     * @return
-     *  the master pool associated with the specified subscription.
-     */
-    Pool getMasterPoolBySubscriptionId(String subscriptionId);
-
-    /**
      * Retrieves a list consisting of all known master pools.
      *
      * @return

--- a/server/src/main/java/org/candlepin/controller/RevocationOp.java
+++ b/server/src/main/java/org/candlepin/controller/RevocationOp.java
@@ -167,7 +167,7 @@ public class RevocationOp {
         for (Entitlement ent : entitlements) {
             if (newConsumed > existing) {
                 if (!ent.getConsumer().isShare()) {
-                    if (ent.getPool().getType().equals(Pool.PoolType.SHARE_DERIVED)) {
+                    if (ent.getPool().isCreatedByShare()) {
                         Entitlement source = ent.getPool().getSourceEntitlement();
                         // the source entitlement may have already been adjusted in the shared pool reduction
                         if (shareEntitlementsToAdjust.get(source) == null) {

--- a/server/src/main/java/org/candlepin/model/PoolCurator.java
+++ b/server/src/main/java/org/candlepin/model/PoolCurator.java
@@ -1126,6 +1126,7 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
         return currentSession().createCriteria(Pool.class)
             .createAlias("sourceSubscription", "sourceSub", JoinType.LEFT_OUTER_JOIN)
             .add(Restrictions.eq("sourceSub.subscriptionId", subId))
+            .add(Restrictions.eq("hasSharedAncestor", Boolean.FALSE))
             .addOrder(Order.asc("id"))
             .list();
     }
@@ -1135,17 +1136,9 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
         return currentSession().createCriteria(Pool.class)
             .createAlias("sourceSubscription", "sourceSub", JoinType.LEFT_OUTER_JOIN)
             .add(CPRestrictions.in("sourceSub.subscriptionId", subIds))
+            .add(Restrictions.eq("hasSharedAncestor", Boolean.FALSE))
             .addOrder(Order.asc("id"))
             .list();
-    }
-
-    @SuppressWarnings("unchecked")
-    public Pool getMasterPoolBySubscriptionId(String subscriptionId) {
-        return (Pool) currentSession().createCriteria(Pool.class)
-            .createAlias("sourceSubscription", "srcsub", JoinType.LEFT_OUTER_JOIN)
-            .add(Restrictions.eq("srcsub.subscriptionId", subscriptionId))
-            .add(Restrictions.eq("srcsub.subscriptionSubKey", "master"))
-            .uniqueResult();
     }
 
     @SuppressWarnings("unchecked")
@@ -1684,7 +1677,7 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
                 currentSession().createCriteria(Pool.class)
                     .createAlias("sourceEntitlement", "se")
                     .createAlias("se.pool", "sep")
-                    .add(Restrictions.and(Restrictions.eq("type", PoolType.SHARE_DERIVED)))
+                    .add(Restrictions.and(Restrictions.eq("createdByShare", Boolean.TRUE)))
                     .add(Restrictions.and(Restrictions.eq("se.pool", pool)))
                     .addOrder(Order.desc("created")));
     }

--- a/server/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRules.java
@@ -275,7 +275,7 @@ public class EntitlementRules implements Enforcer {
         }
         List<Owner> potentialOwners = new ArrayList<Owner>(Arrays.asList(consumer.getOwner()));
         for (Pool p : pools) {
-            if (p.getType() == Pool.PoolType.SHARE_DERIVED) {
+            if (p.isCreatedByShare()) {
                 potentialOwners.add(p.getSourceEntitlement().getOwner());
             }
         }
@@ -421,7 +421,7 @@ public class EntitlementRules implements Enforcer {
         else if (pool.getType() == Pool.PoolType.DEVELOPMENT) {
             result.addError(EntitlementRulesTranslator.PoolErrorKeys.SHARING_DEVELOPMENT_POOL);
         }
-        else if (pool.getType() == Pool.PoolType.SHARE_DERIVED) {
+        else if (pool.isCreatedByShare()) {
             result.addError(EntitlementRulesTranslator.PoolErrorKeys.SHARING_A_SHARE);
         }
     }
@@ -680,7 +680,8 @@ public class EntitlementRules implements Enforcer {
                 sharedPool.setAttribute(entry.getKey(), entry.getValue());
             }
             sharedPool.setAttribute(Pool.Attributes.DERIVED_POOL, "true");
-            sharedPool.setAttribute(Pool.Attributes.SHARE, "true");
+            sharedPool.setCreatedByShare(Boolean.TRUE);
+            sharedPool.setHasSharedAncestor(Boolean.TRUE);
 
             for (Branding b : sourcePool.getBranding()) {
                 sharedPool.getBranding().add(new Branding(b.getProductId(), b.getType(),

--- a/server/src/main/java/org/candlepin/policy/js/pool/PoolHelper.java
+++ b/server/src/main/java/org/candlepin/policy/js/pool/PoolHelper.java
@@ -102,7 +102,8 @@ public class PoolHelper {
                     pool.getAccountNumber(),
                     pool.getOrderNumber(),
                     productCurator.getPoolProvidedProductsCached(pool),
-                    sourceEntitlements.get(pool.getId()));
+                    sourceEntitlements.get(pool.getId()),
+                    pool.getHasSharedAncestor());
             }
             else {
                 // If a derived product is on the pool, we want to define the
@@ -121,7 +122,8 @@ public class PoolHelper {
                     pool.getAccountNumber(),
                     pool.getOrderNumber(),
                     productCurator.getPoolDerivedProvidedProductsCached(pool),
-                    sourceEntitlements.get(pool.getId()));
+                    sourceEntitlements.get(pool.getId()),
+                    pool.getHasSharedAncestor());
             }
 
             consumerSpecificPool.setAttribute(Pool.Attributes.REQUIRES_HOST, consumer.getUuid());
@@ -223,7 +225,8 @@ public class PoolHelper {
         Pool pool = createPool(product, sourcePool.getOwner(), quantity,
             sourcePool.getStartDate(), sourcePool.getEndDate(),
             sourcePool.getContractNumber(), sourcePool.getAccountNumber(),
-            sourcePool.getOrderNumber(), new HashSet<Product>(), sourceEntitlement);
+            sourcePool.getOrderNumber(), new HashSet<Product>(), sourceEntitlement,
+            sourcePool.getHasSharedAncestor());
 
         SourceSubscription srcSub = sourcePool.getSourceSubscription();
         if (srcSub != null && srcSub.getSubscriptionId() != null) {
@@ -255,7 +258,7 @@ public class PoolHelper {
 
     private static Pool createPool(Product product, Owner owner, String quantity, Date startDate,
         Date endDate, String contractNumber, String accountNumber, String orderNumber,
-        Set<Product> providedProducts, Entitlement sourceEntitlement) {
+        Set<Product> providedProducts, Entitlement sourceEntitlement, Boolean hasSharedAncestor) {
 
         Long q = Pool.parseQuantity(quantity);
 
@@ -286,6 +289,7 @@ public class PoolHelper {
 
         // temp - we need a way to specify this on the product
         pool.setAttribute(Pool.Attributes.REQUIRES_CONSUMER_TYPE, "system");
+        pool.setHasSharedAncestor(hasSharedAncestor);
 
         return pool;
     }

--- a/server/src/main/java/org/candlepin/resource/SubscriptionResource.java
+++ b/server/src/main/java/org/candlepin/resource/SubscriptionResource.java
@@ -17,6 +17,7 @@ package org.candlepin.resource;
 import org.candlepin.auth.Verify;
 import org.candlepin.common.exceptions.BadRequestException;
 import org.candlepin.common.exceptions.NotFoundException;
+import org.candlepin.common.exceptions.ResourceMovedException;
 import org.candlepin.controller.PoolManager;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerCurator;
@@ -81,56 +82,6 @@ public class SubscriptionResource {
         this.i18n = i18n;
     }
 
-    /**
-     * Retrieves the master pool generated from the specified subscription. If an appropriate master
-     * pool cannot be found, this method throws a NotFoundException.
-     *
-     * @param subscriptionId
-     *  The subscription ID for which to retrieve the master pool
-     *
-     * @throws NotFoundException
-     *  if an appropriate master pool cannot be found.
-     *
-     * @return
-     *  the master pool for the given subscription
-     */
-    protected Pool getMasterPoolForSubscription(String subscriptionId) {
-        Pool pool = this.poolManager.getMasterPoolBySubscriptionId(subscriptionId);
-
-        if (pool == null) {
-            throw new NotFoundException(
-                i18n.tr("A subscription with the ID \"{0}\" could not be found.", subscriptionId)
-            );
-        }
-
-        return pool;
-    }
-
-    /**
-     * Retrieves the subscription certificate for the given subscription ID. If the subscription
-     * cannot be found or does not have a certificate, this method throws a NotFoundException.
-     *
-     * @param subscriptionId
-     *  The subscription ID for which to retrieve a subscription certificate
-     *
-     * @throws NotFoundException
-     *  if the subscription cannot be found or the subscription does not have a certificate
-     *
-     * @return
-     *  the certificate associated with the specified subscription
-     */
-    protected SubscriptionsCertificate getSubscriptionCertificate(String subscriptionId) {
-        Pool pool = this.getMasterPoolForSubscription(subscriptionId);
-
-        if (pool.getCertificate() == null) {
-            throw new NotFoundException(
-                i18n.tr("A certificate was not found for subscription \"{0}\"", subscriptionId)
-            );
-        }
-
-        return pool.getCertificate();
-    }
-
     @ApiOperation(notes = "Retrieves a list of Subscriptions", value = "getSubscriptions")
     @GET
     @Produces(MediaType.APPLICATION_JSON)
@@ -150,9 +101,8 @@ public class SubscriptionResource {
     @Path("/{subscription_id}")
     @Produces(MediaType.APPLICATION_JSON)
     public Subscription getSubscription(@PathParam("subscription_id") String subscriptionId) {
-        Pool pool = this.getMasterPoolForSubscription(subscriptionId);
 
-        return this.poolManager.fabricateSubscriptionFromPool(pool);
+        throw new ResourceMovedException("pools/{pool_id}");
     }
 
     @ApiOperation(notes = "Retrieves a Subscription Certificate As a PEM", value = "getSubCertAsPem")
@@ -165,8 +115,7 @@ public class SubscriptionResource {
     public String getSubCertAsPem(
         @PathParam("subscription_id") String subscriptionId) {
 
-        SubscriptionsCertificate cert = this.getSubscriptionCertificate(subscriptionId);
-        return cert.getCert() + cert.getKey();
+        throw new ResourceMovedException("pools/{pool_id}/cert");
     }
 
     @ApiOperation(notes = "Retrieves a Subscription Certificate", value = "getSubCert")
@@ -177,7 +126,7 @@ public class SubscriptionResource {
     public SubscriptionsCertificate getSubCert(
         @PathParam("subscription_id") String subscriptionId) {
 
-        return this.getSubscriptionCertificate(subscriptionId);
+        throw new ResourceMovedException("pools/{pool_id}/cert");
     }
 
     @ApiOperation(notes = "Activates a Subscription", value = "activateSubscription")

--- a/server/src/main/resources/db/changelog/20170816084513-add-createdByShare-and-hasSharedAncestor.xml
+++ b/server/src/main/resources/db/changelog/20170816084513-add-createdByShare-and-hasSharedAncestor.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <changeSet id="20170816084513-1" author="vrjain">
+        <comment> add-createdByShare-and-hasSharedAncestor</comment>
+        <addColumn tableName="cp_pool">
+            <column name="created_by_share" type="BOOLEAN" defaultValueBoolean="false"/>
+        </addColumn>
+        <addColumn tableName="cp_pool">
+            <column name="has_shared_ancestor" type="BOOLEAN" defaultValueBoolean="false"/>
+        </addColumn>
+        <!-- See http://www.liquibase.org/documentation/changes/index.html -->
+    </changeSet>
+
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/server/src/main/resources/db/changelog/changelog-create.xml
+++ b/server/src/main/resources/db/changelog/changelog-create.xml
@@ -1215,4 +1215,5 @@
     <include file="db/changelog/20170518143217-remove-obsoleted-dirty-column.xml"/>
     <include file="db/changelog/20170510130908-remove-pool-version.xml"/>
     <include file="db/changelog/20170612091842-default-content-access-list.xml"/>
+    <include file="db/changelog/20170816084513-add-createdByShare-and-hasSharedAncestor.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-testing.xml
+++ b/server/src/main/resources/db/changelog/changelog-testing.xml
@@ -2306,4 +2306,5 @@
     <include file="db/changelog/20170518143217-remove-obsoleted-dirty-column.xml"/>
     <include file="db/changelog/20170510130908-remove-pool-version.xml"/>
     <include file="db/changelog/20170612091842-default-content-access-list.xml"/>
+    <include file="db/changelog/20170816084513-add-createdByShare-and-hasSharedAncestor.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-update.xml
+++ b/server/src/main/resources/db/changelog/changelog-update.xml
@@ -123,4 +123,5 @@
     <include file="db/changelog/20170518143217-remove-obsoleted-dirty-column.xml"/>
     <include file="db/changelog/20170510130908-remove-pool-version.xml"/>
     <include file="db/changelog/20170612091842-default-content-access-list.xml"/>
+    <include file="db/changelog/20170816084513-add-createdByShare-and-hasSharedAncestor.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/rules/rules.js
+++ b/server/src/main/resources/rules/rules.js
@@ -1,4 +1,4 @@
-// Version: 5.25
+// Version: 5.26
 
 /*
  * Default Candlepin rule set.
@@ -64,7 +64,6 @@ var REQUIRES_CONSUMER_TYPE_ATTRIBUTE = "requires_consumer_type";
 var VIRT_ONLY = "virt_only";
 var PHYSICAL_ONLY = "physical_only";
 var POOL_DERIVED = "pool_derived";
-var SHARE_DERIVED = "share_derived";
 var UNMAPPED_GUESTS_ONLY = "unmapped_guests_only";
 var GUEST_LIMIT_ATTRIBUTE = "guest_limit";
 var VCPU_ATTRIBUTE = "vcpu";
@@ -338,7 +337,7 @@ function get_pool_priority(pool, consumer) {
     }
 
     // Decrease the priority of shared pools slightly so that non-shared pools will get consumed first.
-    if (Utils.equalsIgnoreCase('true', pool.getAttribute(SHARE_DERIVED))) {
+    if (pool.hasSharedAncestor) {
         priority -= 10;
     }
     /*

--- a/server/src/test/java/org/candlepin/controller/PoolManagerFunctionalTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerFunctionalTest.java
@@ -275,7 +275,13 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
     @Test
     public void testFabricateWithBranding()
         throws Exception {
-        Pool masterPool = poolManager.getMasterPoolBySubscriptionId(sub4.getId());
+        List<Pool> masterPools = poolManager.getPoolsBySubscriptionId(sub4.getId());
+        Pool masterPool = null;
+        for (Pool pool: masterPools) {
+            if (pool.getType() == Pool.PoolType.NORMAL) {
+                masterPool = pool;
+            }
+        }
         Set<Branding> brandingSet = poolManager.fabricateSubscriptionFromPool(masterPool).getBranding();
 
         Assert.assertNotNull(brandingSet);

--- a/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
@@ -1606,16 +1606,24 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         return list;
     }
 
+    private Pool getMasterPoolBySubscriptionId(String subscriptionId) {
+        for (Pool pool: this.poolCurator.getPoolsBySubscriptionId(subscriptionId)) {
+            if (pool.getType() == Pool.PoolType.NORMAL) {
+                return pool;
+            }
+        }
+        return null;
+    }
     @Test
     public void testGetMasterPoolBySubscriptionId() {
         List<Pool> pools = this.setupMasterPoolsTests();
 
-        Pool actual = this.poolCurator.getMasterPoolBySubscriptionId("sub1");
+        Pool actual = getMasterPoolBySubscriptionId("sub1");
         assertEquals(pools.get(0), actual);
 
-        actual = this.poolCurator.getMasterPoolBySubscriptionId("sub2");
+        actual = getMasterPoolBySubscriptionId("sub2");
         assertEquals(pools.get(1), actual);
-        actual = this.poolCurator.getMasterPoolBySubscriptionId("sub5");
+        actual = getMasterPoolBySubscriptionId("sub5");
         assertEquals(null, actual);
     }
 

--- a/server/src/test/java/org/candlepin/resource/SubscriptionResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/SubscriptionResourceTest.java
@@ -73,11 +73,6 @@ public class SubscriptionResourceTest  {
         subResource.activateSubscription("random", null, "en_us");
     }
 
-    @Test(expected = NotFoundException.class)
-    public void noSubForCert() {
-        subResource.getSubCert("philadelphia-experiment");
-    }
-
     @Test(expected = BadRequestException.class)
     public void activateNoEmailLocale() {
         subResource.activateSubscription("random", "random@somthing.com", null);


### PR DESCRIPTION
I'd like to call out the following items this PR does, one should consider before merging:
* discontinues the following APIs and provides replacements if they did not exist already
  * PUT owner/subscriptions
  * GET subscriptions/{id}
  * GET subscriptions/{id}/cert
* SHARED is no longer a pool type, instead we have two new fields 
  * createdByShare ( to identify a pool that was created because of a share)
  * hasSharedAncestor ( to identify shared pools and their descendants )
* The rest API "DELETE pool/{id}" now deletes child pools of the pool id provided.
  * This is necessary if it is to replace "DELETE subscription/{id}"
 * CPM.deletePools no longer  sends out events for revoking entitlements when the pool is deleted.
   * This was already the implementation in CPM.deletePool, and I think we should keep that behavior consistent across candlepin, irrespective of the method.
* PoolCurator method that fetched pools for a subscription id not scoped by owner id were either removed OR are now filtering out shared pools and their descendants.
* Henceforth, not only do we de-priortize shared pools during autobind, we do the same for their descendants as well.