### PR TITLE
Made several optimizations to PoolManager.deletePools

### DIFF
--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -1590,8 +1590,7 @@ public class CandlepinPoolManager implements PoolManager {
         handler.handleSelfCertificates(consumer, poolQuantities, entitlements);
 
         this.ecGenerator.regenerateCertificatesByEntitlementIds(
-            this.entitlementCurator.batchListModifying(entitlements.values()), true
-        );
+            this.entitlementCurator.getModifiedEntitlementIds(entitlements.values()), true);
 
         // we might have changed the bonus pool quantities, lets find out.
         handler.handleBonusPools(consumer.getOwner(), poolQuantities, entitlements);
@@ -1771,7 +1770,9 @@ public class CandlepinPoolManager implements PoolManager {
          * modifier entitlements that need to have their certificates regenerated
          */
         if (regenCertsAndStatuses) {
-            Collection<String> modifiedEntIds = this.entitlementCurator.batchListModifying(entsToRevoke);
+            Collection<String> modifiedEntIds = this.entitlementCurator
+                .getModifiedEntitlementIds(entsToRevoke);
+
             log.debug("Regenerating certificates for modifying entitlements: {}", modifiedEntIds);
 
             this.ecGenerator.regenerateCertificatesByEntitlementIds(modifiedEntIds,  true);
@@ -1950,62 +1951,240 @@ public class CandlepinPoolManager implements PoolManager {
     }
 
     @Override
+    @Transactional
     public void deletePools(Collection<Pool> pools) {
-        deletePools(pools, null);
+        this.deletePools(pools, null);
     }
 
     @Override
     @Transactional
-    public void deletePools(Collection<Pool> pools, Set<String> alreadyDeletedPools) {
+    @SuppressWarnings("checkstyle:methodlength")
+    public void deletePools(Collection<Pool> pools, Collection<String> alreadyDeletedPoolIds) {
         if (pools == null || pools.isEmpty()) {
             return;
         }
 
-        if (alreadyDeletedPools == null) {
-            alreadyDeletedPools = new HashSet<String>();
+        log.info("Attempting to delete {} pools...", pools.size());
+
+        // TODO: Remove this and fix the bugs it works around. We absolutely should not be
+        // passing state through the various codepaths like this. It makes things far messier
+        // than they need to be and is resulting in running slow calculations multiple times.
+        if (alreadyDeletedPoolIds == null) {
+            alreadyDeletedPoolIds = new HashSet<String>();
         }
 
-        if (log.isDebugEnabled()) {
-            log.debug("Delete pools: {}", getPoolIds(pools));
-        }
+        Set<String> poolIds = new HashSet<String>();
+        Set<String> entitlementIds = new HashSet<String>();
+        Owner owner = null;
 
-        List<Entitlement> entitlementsToRevoke = new LinkedList<Entitlement>();
-        Set<String> subscriptionIds = new HashSet<String>();
-        Set<Pool> poolsToDelete = new HashSet<Pool>();
-
+        // Convert pools to pool IDs.
+        log.info("Fetching related pools and entitlements...");
         for (Pool pool : pools) {
-            if (log.isDebugEnabled()) {
-                log.debug("Deletion of pool {} will revoke the following entitlements: {}",
-                    pool.getId(), getEntIds(pool.getEntitlements()));
+            if (owner == null) {
+                owner = pool.getOwner();
             }
 
-            // If this is a master pool, we should also be deleting any derived/bonus pools
-            // as well...
-            SourceSubscription srcSub = pool.getSourceSubscription();
-            if (srcSub != null && srcSub.getSubscriptionId() != null &&
-                "master".equals(srcSub.getSubscriptionSubKey())) {
+            poolIds.add(pool.getId());
+        }
 
-                subscriptionIds.add(srcSub.getSubscriptionId());
+        // Fetch pools which are derived from the pools we're going to delete...
+        poolIds.addAll(this.poolCurator.getDerivedPoolIdsForPools(poolIds));
+
+        // Fetch related pools and entitlements (recursively)
+        Collection<String> pids = poolIds;
+        int cachedSize;
+        do {
+            // Fetch entitlement IDs for our set of pools
+            Collection<String> eids = this.poolCurator.getEntitlementIdsForPools(pids);
+
+            // Fetch pools which are derived from these entitlements...
+            pids = this.poolCurator.getPoolIdsForSourceEntitlements(eids);
+
+            // Fetch pools which are derived from the pools we're going to delete...
+            pids.addAll(this.poolCurator.getDerivedPoolIdsForPools(poolIds));
+
+            // Add the new entitlement and pool IDs to our list of things to delete
+            cachedSize = poolIds.size();
+            entitlementIds.addAll(eids);
+            poolIds.addAll(pids);
+        }
+        while (poolIds.size() != cachedSize);
+
+        // If we've been provided a collection of already-deleted pool IDs, remove those from
+        // the list so we don't pull entitlements for them.
+        if (alreadyDeletedPoolIds != null) {
+            poolIds.removeAll(alreadyDeletedPoolIds);
+        }
+
+        // Lock pools we're going to delete (also, fetch them for event generation/slow deletes)
+        pools = this.poolCurator.lockAndLoadByIds(poolIds);
+
+        if (!pools.isEmpty()) {
+            log.info("Locked {} pools for deletion...", pools.size());
+
+            // Impl note:
+            // There is a fair bit of duplicated work between the actions below this block and
+            // methods like revokeEntitlements. However, the decision was made to decouple these
+            // methods explicitly to avoid situations such as fetching collections of pools, getting
+            // entitlements from them (a slow process in itself) and then passing it off to another
+            // standalone method which repeats the process of fetching pools and related entitlements.
+            //
+            // More work can be done in revokeEntitlements to optimize that method and maybe make it
+            // slightly more generic so that this work can be offloaded to it again. Though, at the time
+            // of writing, that's no small undertaking. Even changing this method has far-reaching
+            // consequences when trying to remove direct uses of entities as far as interoperability is
+            // concerned. Going forward we need to be more aware of the amount of duplication we're
+            // adding to our code when writing standlone/generic utility methods and linking them
+            // together, and perhaps take steps to avoid getting into situations like these two methods.
+
+
+            // Fetch our collection of entitlements which are modified by the entitlements we're going
+            // to be revoking...
+            Set<String> modifiedEntitlementIds = this.entitlementCurator
+                .getModifiedEntitlementIds(owner, entitlementIds);
+
+            // Regen certs for modified entitlements (lazily)
+            this.ecGenerator.regenerateCertificatesByEntitlementIds(modifiedEntitlementIds,  true);
+
+            // Fetch the list of pools which are related to the entitlements but are *not* being
+            // deleted. We'll need to update the quantities on these.
+            Collection<String> affectedPoolIds = this.poolCurator.getPoolIdsForEntitlements(entitlementIds);
+            affectedPoolIds.removeAll(poolIds);
+
+            // Fetch entitlements (uggh).
+            // TODO: Stop doing this. Update the bits below to not use the entities directly and
+            // do the updates via queries.
+            Collection<Entitlement> entitlements = !entitlementIds.isEmpty() ?
+                this.entitlementCurator.listAllByIds(entitlementIds).list() :
+                Collections.<Entitlement>emptySet();
+
+            // Revoke/delete entitlements
+            if (!entitlements.isEmpty()) {
+                log.info("Revoking {} entitlements...", entitlements.size());
+                this.entitlementCurator.batchDelete(entitlements);
+                this.entitlementCurator.flush();
+                log.info("Entitlements successfully revoked");
+            }
+            else {
+                log.info("Skipping entitlement revocation; no entitlements to revoke");
             }
 
-            poolsToDelete.add(pool);
-            entitlementsToRevoke.addAll(pool.getEntitlements());
-        }
+            // Delete pools
+            log.info("Deleting {} pools...", pools.size());
+            this.poolCurator.batchDelete(pools, alreadyDeletedPoolIds);
+            this.poolCurator.flush();
+            log.info("Pools successfully deleted");
 
-        // Look up the related pools for these subscription IDs.
-        if (!subscriptionIds.isEmpty()) {
-            poolsToDelete.addAll(this.poolCurator.getPoolsBySubscriptionIds(subscriptionIds));
-        }
+            if (!entitlements.isEmpty()) {
+                // Update entitlement counts on affected, non-deleted pools
+                log.info("Updating entitlement counts on remaining, affected pools...");
+                Map<Consumer, List<Entitlement>> consumerEntitlements =
+                    new HashMap<Consumer, List<Entitlement>>();
+                List<Pool> poolsToSave = new LinkedList<Pool>();
 
-        if (!poolsToDelete.isEmpty()) {
-            revokeEntitlements(entitlementsToRevoke, alreadyDeletedPools);
-            log.debug("Batch deleting pools after successful revocation");
-            poolCurator.batchDelete(poolsToDelete, alreadyDeletedPools);
-        }
+                for (Entitlement entitlement : entitlements) {
+                    // Since we're sifting through these already, let's also sort them into consumer lists
+                    // for some of the other methods we'll be calling later
+                    Consumer consumer = entitlement.getConsumer();
+                    Pool pool = entitlement.getPool();
 
-        for (Pool pool : poolsToDelete) {
-            Event event = eventFactory.poolDeleted(pool);
-            sink.queueEvent(event);
+                    List<Entitlement> stackedEntitlements = consumerEntitlements.get(consumer);
+                    if (stackedEntitlements == null) {
+                        stackedEntitlements = new LinkedList<Entitlement>();
+                        consumerEntitlements.put(consumer, stackedEntitlements);
+                    }
+
+                    if (!"true".equals(pool.getAttributeValue(Pool.Attributes.DERIVED_POOL)) &&
+                        pool.hasProductAttribute(Product.Attributes.STACKING_ID)) {
+
+                        stackedEntitlements.add(entitlement);
+                    }
+
+                    // Update quantities if the entitlement quantity is non-zero
+                    int quantity = entitlement.getQuantity() != null ? entitlement.getQuantity() : 0;
+                    if (quantity != 0) {
+                        // Update the pool quantities if we didn't delete it
+                        if (affectedPoolIds.contains(pool.getId())) {
+                            pool.setConsumed(pool.getConsumed() - quantity);
+                            poolsToSave.add(pool);
+                        }
+
+                        // Update entitlement counts for affected consumers...
+                        consumer.setEntitlementCount(consumer.getEntitlementCount() - quantity);
+                        if (consumer.getType().isManifest()) {
+                            pool.setExported(pool.getExported() - quantity);
+                        }
+                    }
+                }
+
+                this.poolCurator.updateAll(poolsToSave, false, false);
+                this.consumerCurator.updateAll(consumerEntitlements.keySet(), false, false);
+                this.consumerCurator.flush();
+                log.info("Entitlement counts successfully updated for {} pools and {} consumers",
+                    poolsToSave.size(), consumerEntitlements.size());
+
+                // Update stacked entitlements for affected consumers(???)
+                log.info("Updating stacked entitlements for {} consumers...", consumerEntitlements.size());
+                for (Entry<Consumer, List<Entitlement>> entry : consumerEntitlements.entrySet()) {
+                    Consumer consumer = entry.getKey();
+                    List<Entitlement> stackedEntitlements = entry.getValue();
+
+                    log.debug("Updating {} stacking entitlements for consumer: {}",
+                        stackedEntitlements.size(), consumer);
+
+                    Set<String> stackIds = new HashSet<String>();
+                    for (Entitlement entitlement : stackedEntitlements) {
+                        stackIds.add(entitlement.getPool().getStackId());
+                    }
+
+                    if (!stackIds.isEmpty()) {
+                        Collection<Pool> subPools = this.poolCurator
+                            .getSubPoolForStackIds(consumer, stackIds);
+
+                        if (subPools != null && !subPools.isEmpty()) {
+                            this.poolRules.updatePoolsFromStack(
+                                consumer, subPools, alreadyDeletedPoolIds, true);
+                        }
+                    }
+                }
+
+                this.consumerCurator.flush();
+
+                // Fire post-unbind events for revoked entitlements
+                log.info("Firing post-unbind events for {} entitlements...", entitlements.size());
+                for (Entitlement entitlement : entitlements) {
+                    this.enforcer.postUnbind(entitlement.getConsumer(), this, entitlement);
+                }
+
+                // Recalculate status for affected consumers
+                log.info("Recomputing status for {} consumers", consumerEntitlements.size());
+                int i = 0;
+                for (Consumer consumer : consumerEntitlements.keySet()) {
+                    this.complianceRules.getStatus(consumer);
+
+                    if (++i % 1000 == 0) {
+                        this.consumerCurator.flush();
+                    }
+                }
+                this.consumerCurator.flush();
+
+                log.info("All statuses recomputed");
+            }
+
+            // Impl note:
+            // We don't need to fire entitlement revocation events, since they're all being revoked as
+            // a consequence of the pools being deleted.
+
+            // Fire pool deletion events
+            // This part hurts so much. Because we output the whole entity, we have to fetch the bloody
+            // things before we delete them.
+            log.info("Firing pool deletion events for {} pools...", pools.size());
+            for (Pool pool : pools) {
+                this.sink.queueEvent(this.eventFactory.poolDeleted(pool));
+            }
+        }
+        else {
+            log.info("Skipping pool deletion; no pools to delete");
         }
     }
 

--- a/server/src/main/java/org/candlepin/controller/PoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/PoolManager.java
@@ -330,7 +330,7 @@ public interface PoolManager {
 
     void deletePools(Collection<Pool> pools);
 
-    void deletePools(Collection<Pool> pools, Set<String> alreadyDeletedPools);
+    void deletePools(Collection<Pool> pools, Collection<String> alreadyDeletedPools);
 
     /**
      * Checks whether or not the given pool is a managed (that is, non-custom) pool.

--- a/server/src/main/java/org/candlepin/model/Pool.java
+++ b/server/src/main/java/org/candlepin/model/Pool.java
@@ -657,6 +657,44 @@ public class Pool extends AbstractHibernateObject implements Persisted, Owned, N
     }
 
     /**
+     * Checks if the given attribute has been defined on this pool's product. If this pool does not
+     * have a product, any present imported product attributes will be checked instead. If the pool
+     * has neither a product nor any imported product attributes, this method returns false.
+     * <p></p>
+     * The imported product attributes is a legacy feature from when product attributes were copied
+     * from products to any pools using it. The product attributes would then be present on the
+     * pool's JSON, leading to two places for such attributes to exist. As this secondary attribute
+     * store will eventually be dropped, clients/callers should refrain from making use of the
+     * imported product attributes where possible.
+     *
+     * @param key
+     *  The key (name) of the attribute to lookup
+     *
+     * @throws IllegalArgumentException
+     *  if key is null
+     *
+     * @return
+     *  true if the attribute is defined for this pool's product; false otherwise
+     */
+    @XmlTransient
+    public boolean hasProductAttribute(String key) {
+        if (key == null) {
+            throw new IllegalArgumentException("key is null");
+        }
+
+        Product product = this.getProduct();
+        if (product != null) {
+            return product.hasAttribute(key);
+        }
+
+        if (this.importedProductAttributes != null) {
+            return this.importedProductAttributes.containsKey(key);
+        }
+
+        return false;
+    }
+
+    /**
      * Sets the specified attribute for this pool. If the attribute has already been set for
      * this pool, the existing value will be overwritten. If the given attribute value is null
      * or empty, the attribute will be removed.

--- a/server/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
@@ -37,6 +37,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -365,7 +366,7 @@ public class PoolRules {
      * @param consumer
      * @return updates
      */
-    public List<PoolUpdate> updatePoolsFromStack(Consumer consumer, List<Pool> pools,
+    public List<PoolUpdate> updatePoolsFromStack(Consumer consumer, Collection<Pool> pools,
         boolean deleteIfNoStackedEnts) {
         return updatePoolsFromStack(consumer, pools, null, deleteIfNoStackedEnts);
     }
@@ -377,8 +378,9 @@ public class PoolRules {
      * @param consumer
      * @return updates
      */
-    public List<PoolUpdate> updatePoolsFromStack(Consumer consumer, List<Pool> pools,
-        Set<String> alreadyDeletedPools, boolean deleteIfNoStackedEnts) {
+    public List<PoolUpdate> updatePoolsFromStack(Consumer consumer, Collection<Pool> pools,
+        Collection<String> alreadyDeletedPools, boolean deleteIfNoStackedEnts) {
+
         Map<String, List<Entitlement>> entitlementMap = new HashMap<String, List<Entitlement>>();
         Set<String> sourceStackIds = new HashSet<String>();
         List<PoolUpdate> result = new ArrayList<PoolUpdate>();
@@ -416,7 +418,7 @@ public class PoolRules {
         return result;
     }
 
-    public PoolUpdate updatePoolFromStackedEntitlements(Pool pool, List<Entitlement> stackedEnts,
+    public PoolUpdate updatePoolFromStackedEntitlements(Pool pool, Collection<Entitlement> stackedEnts,
         Map<String, Product> changedProducts) {
         PoolUpdate update = new PoolUpdate(pool);
 

--- a/server/src/main/java/org/candlepin/policy/js/pool/StackedSubPoolValueAccumulator.java
+++ b/server/src/main/java/org/candlepin/policy/js/pool/StackedSubPoolValueAccumulator.java
@@ -20,8 +20,8 @@ import org.candlepin.model.Product;
 import org.candlepin.model.ProductCurator;
 
 import java.util.Date;
+import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 
@@ -41,8 +41,9 @@ public class StackedSubPoolValueAccumulator {
     private Set<Product> expectedProvidedProds = new HashSet<Product>();
     private ProductCurator productCurator;
 
-    public StackedSubPoolValueAccumulator(Pool stackedSubPool, List<Entitlement> stackedEnts,
+    public StackedSubPoolValueAccumulator(Pool stackedSubPool, Collection<Entitlement> stackedEnts,
         ProductCurator productCurator) {
+
         this.productCurator = productCurator;
         for (Entitlement nextStacked : stackedEnts) {
             Pool nextStackedPool = nextStacked.getPool();

--- a/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -229,7 +229,14 @@ public class PoolManagerTest {
     @Test
     public void deletePoolsTest() {
         Set<Pool> pools = new HashSet<Pool>();
-        pools.add(TestUtil.createPool(TestUtil.createProduct()));
+
+        Product prod = TestUtil.createProduct();
+        Pool pool = TestUtil.createPool(prod);
+        pool.setId("test-id");
+        pools.add(pool);
+
+        when(mockPoolCurator.lockAndLoadByIds(any(Iterable.class))).thenReturn(pools);
+
         doNothing().when(mockPoolCurator).batchDelete(eq(pools), anySetOf(String.class));
         manager.deletePools(pools);
         verify(mockPoolCurator).batchDelete(eq(pools), anySetOf(String.class));
@@ -1067,22 +1074,31 @@ public class PoolManagerTest {
 
         List<Pool> pools = Util.newList();
         Pool p = TestUtil.createPool(owner, product);
+        p.setId("test-pool");
         p.setSourceSubscription(new SourceSubscription(sub.getId(), "master"));
         p.setStartDate(expiredStart);
         p.setEndDate(expiredDate);
         p.setConsumed(1L);
         pools.add(p);
 
-        when(mockPoolCurator.lockAndLoad(any(Pool.class))).thenReturn(p);
-
+        when(mockPoolCurator.lockAndLoadByIds(anyCollection())).thenReturn(pools);
         mockPoolsList(pools);
 
         List<Entitlement> poolEntitlements = Util.newList();
         Entitlement ent = TestUtil.createEntitlement();
+        ent.setId("test-ent");
         ent.setPool(p);
         ent.setQuantity(1);
         poolEntitlements.add(ent);
         p.getEntitlements().addAll(poolEntitlements);
+
+        when(mockPoolCurator.getEntitlementIdsForPools(anyCollection()))
+            .thenReturn(Arrays.asList(ent.getId()));
+
+        CandlepinQuery<Entitlement> cqmockEnt = mock(CandlepinQuery.class);
+        when(cqmockEnt.list()).thenReturn(poolEntitlements);
+        when(cqmockEnt.iterator()).thenReturn(poolEntitlements.iterator());
+        when(entitlementCurator.listAllByIds(anyCollection())).thenReturn(cqmockEnt);
 
         ValidationResult result = new ValidationResult();
         when(preHelper.getResult()).thenReturn(result);
@@ -1091,17 +1107,15 @@ public class PoolManagerTest {
         this.mockProductImport(owner, product);
         this.mockContentImport(owner, new Content[] {});
 
-        CandlepinQuery<Pool> cqmock = mock(CandlepinQuery.class);
-        when(cqmock.list()).thenReturn(pools);
-        when(cqmock.iterator()).thenReturn(pools.iterator());
-        when(mockPoolCurator.listByOwnerAndType(eq(owner), any(PoolType.class))).thenReturn(cqmock);
+        CandlepinQuery<Pool> cqmockPool = mock(CandlepinQuery.class);
+        when(cqmockPool.list()).thenReturn(pools);
+        when(cqmockPool.iterator()).thenReturn(pools.iterator());
+        when(mockPoolCurator.listByOwnerAndType(eq(owner), any(PoolType.class))).thenReturn(cqmockPool);
 
         this.manager.getRefresher(mockSubAdapter).add(owner).run();
 
-        List<Entitlement> entsToDelete = Arrays.asList(ent);
-        Set<Pool> poolsToDelete = new HashSet<Pool>(Arrays.asList(p));
-        verify(mockPoolCurator).batchDelete(eq(poolsToDelete), anySetOf(String.class));
-        verify(entitlementCurator).batchDelete(eq(entsToDelete));
+        verify(mockPoolCurator).batchDelete(eq(pools), anyCollectionOf(String.class));
+        verify(entitlementCurator).batchDelete(eq(poolEntitlements));
     }
 
     private List<Pool> createPoolsWithSourceEntitlement(Entitlement e, Product p) {
@@ -1137,10 +1151,9 @@ public class PoolManagerTest {
     public void testCleanupExpiredPools() {
         Pool p = createPoolWithEntitlements();
         p.setSubscriptionId("subid");
-        List<Pool> pools = new LinkedList<Pool>();
-        pools.add(p);
+        List<Pool> pools = Arrays.asList(p);
 
-        when(mockPoolCurator.lockAndLoad(any(Pool.class))).thenReturn(p);
+        when(mockPoolCurator.lockAndLoadByIds(anyCollection())).thenReturn(pools);
         when(mockPoolCurator.listExpiredPools(anyInt())).thenReturn(pools);
         when(mockPoolCurator.entitlementsIn(p)).thenReturn(new ArrayList<Entitlement>(p.getEntitlements()));
         Subscription sub = new Subscription();
@@ -1154,18 +1167,16 @@ public class PoolManagerTest {
         manager.cleanupExpiredPools();
 
         // And the pool should be deleted:
-        Set<Pool> expectedPools = new HashSet<Pool>(pools);
-        verify(mockPoolCurator).batchDelete(eq(expectedPools), anySetOf(String.class));
+        verify(mockPoolCurator).batchDelete(eq(pools), anySetOf(String.class));
     }
 
     @Test
     public void testCleanupExpiredPoolsReadOnlySubscriptions() {
         Pool p = createPoolWithEntitlements();
         p.setSubscriptionId("subid");
-        List<Pool> pools = new LinkedList<Pool>();
-        pools.add(p);
+        List<Pool> pools = Arrays.asList(p);
 
-        when(mockPoolCurator.lockAndLoad(any(Pool.class))).thenReturn(p);
+        when(mockPoolCurator.lockAndLoadByIds(anyCollection())).thenReturn(pools);
         when(mockPoolCurator.listExpiredPools(anyInt())).thenReturn(pools);
         when(mockPoolCurator.entitlementsIn(p)).thenReturn(new ArrayList<Entitlement>(p.getEntitlements()));
         Subscription sub = new Subscription();
@@ -1179,8 +1190,7 @@ public class PoolManagerTest {
         manager.cleanupExpiredPools();
 
         // And the pool should be deleted:
-        Set<Pool> expectedPools = new HashSet<Pool>(pools);
-        verify(mockPoolCurator).batchDelete(eq(expectedPools), anySetOf(String.class));
+        verify(mockPoolCurator).batchDelete(eq(pools), anySetOf(String.class));
         verify(mockSubAdapter, never()).getSubscription(any(String.class));
         verify(mockSubAdapter, never()).deleteSubscription(any(Subscription.class));
     }

--- a/server/src/test/java/org/candlepin/model/EntitlementCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/EntitlementCuratorTest.java
@@ -442,7 +442,9 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
      */
     @Test
     public void testModifyMarketingProduct() {
-        Collection<String> result = entitlementCurator.batchListModifying(modifierData.getEntitlements(2));
+        Collection<String> result = entitlementCurator
+            .getModifiedEntitlementIds(modifierData.getEntitlements(2));
+
         assertEquals("Entitlement 2 should be modified  by exactly one entitlement", 1, result.size());
         String e6Id = modifierData.getEntitlementId(6);
         assertEquals("Entitlement 6 should modify entitlement 2", e6Id, result.iterator().next());
@@ -454,7 +456,9 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
      */
     @Test
     public void testModifyShouldntIncludeInput() {
-        Collection<String> result = entitlementCurator.batchListModifying(modifierData.getEntitlements(2, 6));
+        Collection<String> result = entitlementCurator
+            .getModifiedEntitlementIds(modifierData.getEntitlements(2, 6));
+
         assertEquals(0, result.size());
     }
 
@@ -469,8 +473,9 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
      */
     @Test
     public void testOutNonExpired() {
-        Collection<String> result = entitlementCurator.
-            batchListModifying(modifierData.getEntitlements(3, 13));
+        Collection<String> result = entitlementCurator
+            .getModifiedEntitlementIds(modifierData.getEntitlements(3, 13));
+
         assertEquals("Entitlements 3 and 13 are modified by entitlements 1,6, 11, 16. 1 and 11 is expired!",
             2, result.size());
         String e6Id = modifierData.getEntitlementId(6);
@@ -488,9 +493,11 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
      */
     @Test
     public void testEntitlementThatDoesntOverlap() {
-        Collection<String> result = entitlementCurator.batchListModifying(modifierData.getEntitlements(17));
+        Collection<String> result = entitlementCurator
+            .getModifiedEntitlementIds(modifierData.getEntitlements(17));
+
         assertEquals("Entitlement 17 shouldn't overlap with any entitlements.", 0, result.size());
-        result = entitlementCurator.batchListModifying(modifierData.getEntitlements(19));
+        result = entitlementCurator.getModifiedEntitlementIds(modifierData.getEntitlements(19));
         assertEquals("Entitlement 19 should overlap with 15", 1, result.size());
     }
 
@@ -500,7 +507,9 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
      */
     @Test
     public void testModifyOnlyConsumers() {
-        Collection<String> result = entitlementCurator.batchListModifying(modifierData.getEntitlements(3, 8));
+        Collection<String> result = entitlementCurator
+            .getModifiedEntitlementIds(modifierData.getEntitlements(3, 8));
+
         assertEquals("Entitlements 3, 8 are modified by entitlements 6, 4 and 5", 3, result.size());
         String e6Id = modifierData.getEntitlementId(6);
         String e4Id = modifierData.getEntitlementId(4);
@@ -520,7 +529,8 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
     @Test
     public void testModifyConsumerDoesntHaveEntitlement() {
         Collection<String> result = entitlementCurator
-            .batchListModifying(modifierData.getEntitlements(18, 19));
+            .getModifiedEntitlementIds(modifierData.getEntitlements(18, 19));
+
         assertEquals(1, result.size());
         String e15id = modifierData.getEntitlementId(15);
         assertEquals("Expected entitlement is E15", e15id, result.iterator().next());
@@ -530,9 +540,8 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
     public void batchListModifying() {
         prepareEntitlementsForModifying();
 
-        Collection<String> entIds = entitlementCurator.batchListModifying(
-            Arrays.asList(ent1modif, ent2modif)
-        );
+        Collection<String> entIds = entitlementCurator.getModifiedEntitlementIds(
+            Arrays.asList(ent1modif, ent2modif));
 
         assertEquals(2, entIds.size());
 


### PR DESCRIPTION
- PoolManager.deletePools no longer calls out to revokeEntitlements
  as part of its operation
- Several optimizations were made to deletePools to minimize the
  number of queries peformed and the number of entities it fetches
- Added new ID-based query methods to PoolCurator and EntitlementCurator
- Added a new utility method for partitioning blocks by the in-operator
  block size to AbstractHibernateCurator
- Added a new utility method to Pool for properly checking if a pool
  has a product attribute