### PR TITLE
Make UpstreamConsumer lazy load

### DIFF
--- a/server/src/main/java/org/candlepin/model/Owner.java
+++ b/server/src/main/java/org/candlepin/model/Owner.java
@@ -31,6 +31,7 @@ import java.util.Set;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
@@ -107,7 +108,7 @@ public class Owner extends AbstractHibernateObject implements Serializable,
     @OneToMany(mappedBy = "owner", targetEntity = Pool.class)
     private Set<Pool> pools;
 
-    @OneToOne(cascade = CascadeType.ALL)
+    @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @JoinColumn(name = "upstream_id")
     private UpstreamConsumer upstreamConsumer;
 


### PR DESCRIPTION
In order to prevent unnecessary queries for upstream consumer ever time an organization is loaded mark the relationship as lazy.

Back port of https://github.com/candlepin/candlepin/pull/1697