### PR TITLE
1482937: Fix regression in scoping of JsRunnerRequestCache

### DIFF
--- a/server/src/main/java/org/candlepin/pinsetter/tasks/KingpinJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/KingpinJob.java
@@ -19,6 +19,7 @@ import static org.quartz.impl.matchers.NameMatcher.jobNameEquals;
 import org.candlepin.audit.EventSink;
 import org.candlepin.common.config.Configuration;
 import org.candlepin.config.ConfigProperties;
+import org.candlepin.guice.CandlepinRequestScope;
 import org.candlepin.model.JobCurator;
 import org.candlepin.pinsetter.core.PinsetterJobListener;
 import org.candlepin.pinsetter.core.RetryJobException;
@@ -53,6 +54,7 @@ public abstract class KingpinJob implements Job {
     @Inject protected UnitOfWork unitOfWork;
     @Inject protected Configuration config;
     @Inject private EventSink eventSink;
+    @Inject private CandlepinRequestScope candlepinRequestScope;
 
     protected static String prefix = "job";
 
@@ -60,6 +62,7 @@ public abstract class KingpinJob implements Job {
     public void execute(JobExecutionContext context) throws JobExecutionException {
 
         long startTime = System.currentTimeMillis();
+        candlepinRequestScope.enter();
 
         // Store the job's unique ID in log4j's thread local MDC, which will automatically
         // add it to all log entries executed for this job.
@@ -113,6 +116,7 @@ public abstract class KingpinJob implements Job {
             }
         }
         finally {
+            candlepinRequestScope.exit();
             if (startedUow) {
                 endUnitOfWork();
             }

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/BaseJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/BaseJobTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ * Copyright (c) 2009 - 2017 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,29 +12,24 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.policy.js;
+package org.candlepin.pinsetter.tasks;
 
-import org.candlepin.guice.CandlepinRequestScoped;
-
-import java.util.Date;
-
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.candlepin.TestingModules;
 
 /**
- * A request scoped cache that is used to mitigate repeated
- * DB requests for cp_rules.updated column.
- * @author fnguyen
- *
+ * Base class for tests of jobs that need Guice injection
  */
-@CandlepinRequestScoped
-public class JsRunnerRequestCache {
+public class BaseJobTest {
 
-    private Date updated = null;
+    protected Injector injector;
 
-    public void setUpdated(Date updated) {
-        this.updated = updated;
-    }
-
-    public Date getUpdated() {
-        return updated;
+    public void init() {
+        injector = Guice.createInjector(
+                new TestingModules.MockJpaModule(),
+                new TestingModules.ServletEnvironmentModule(),
+                new TestingModules.StandardTest()
+        );
     }
 }

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/CancelJobJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/CancelJobJobTest.java
@@ -43,7 +43,7 @@ import java.util.Set;
 /**
  * CancelJobJobTest
  */
-public class CancelJobJobTest {
+public class CancelJobJobTest extends BaseJobTest{
     private CancelJobJob cancelJobJob;
     @Mock private JobCurator j;
     @Mock private PinsetterKernel pk;
@@ -52,8 +52,10 @@ public class CancelJobJobTest {
 
     @Before
     public void init() {
+        super.init();
         MockitoAnnotations.initMocks(this);
         cancelJobJob = new CancelJobJob(j, pk);
+        injector.injectMembers(cancelJobJob);
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/CertificateRevocationListTaskTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/CertificateRevocationListTaskTest.java
@@ -37,7 +37,7 @@ import java.io.File;
  * CertificateRevocationListTaskTest
  */
 @RunWith(MockitoJUnitRunner.class)
-public class CertificateRevocationListTaskTest {
+public class CertificateRevocationListTaskTest extends BaseJobTest {
     private CertificateRevocationListTask task;
 
     @Mock private Configuration config;
@@ -45,7 +45,9 @@ public class CertificateRevocationListTaskTest {
 
     @Before
     public void init() {
+        super.init();
         this.task = new CertificateRevocationListTask(config, crlFileUtil);
+        injector.injectMembers(task);
     }
 
     @Test(expected = JobExecutionException.class)

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/EntitleByProductsJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/EntitleByProductsJobTest.java
@@ -42,7 +42,7 @@ import java.util.List;
 /**
  * EntitleByProductsJobTest
  */
-public class EntitleByProductsJobTest {
+public class EntitleByProductsJobTest extends BaseJobTest {
 
     private Consumer consumer;
     private String consumerUuid;
@@ -50,9 +50,10 @@ public class EntitleByProductsJobTest {
 
     @Before
     public void init() {
+        super.init();
         consumerUuid = "49bd6a8f-e9f8-40cc-b8d7-86cafd687a0e";
         consumer = new Consumer("Test Consumer", "test-consumer", new Owner("test-owner"),
-            new ConsumerType("system"));
+                new ConsumerType("system"));
         consumer.setUuid(consumerUuid);
         e = mock(Entitler.class);
     }
@@ -82,6 +83,7 @@ public class EntitleByProductsJobTest {
             eq((Date) null), eq((Collection<String>) null))).thenReturn(ents);
 
         EntitleByProductsJob job = new EntitleByProductsJob(e, null);
+        injector.injectMembers(job);
         job.execute(ctx);
         verify(e).bindByProducts(eq(pids), eq(consumerUuid), eq((Date) null),
             eq((Collection<String>) null));

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/EntitlerJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/EntitlerJobTest.java
@@ -58,7 +58,7 @@ import java.util.Locale;
 /**
  * EntitlerJobTest
  */
-public class EntitlerJobTest {
+public class EntitlerJobTest extends BaseJobTest{
 
     private String consumerUuid;
     private Consumer consumer;
@@ -68,6 +68,7 @@ public class EntitlerJobTest {
 
     @Before
     public void init() {
+        super.init();
         consumerUuid = "49bd6a8f-e9f8-40cc-b8d7-86cafd687a0e";
         consumer = new Consumer("Test Consumer", "test-consumer", new Owner("test-owner"),
             new ConsumerType("system"));
@@ -114,6 +115,7 @@ public class EntitlerJobTest {
             .thenReturn(ents);
 
         EntitlerJob job = new EntitlerJob(e, null, pC, null);
+        injector.injectMembers(job);
         job.execute(ctx);
         verify(e).bindByPoolQuantities(eq(consumerUuid), anyMapOf(String.class, Integer.class));
         verify(e).sendEvents(eq(ents));
@@ -169,6 +171,7 @@ public class EntitlerJobTest {
             .thenThrow(new ForbiddenException("job should fail"));
 
         EntitlerJob job = new EntitlerJob(e, null, null, null);
+        injector.injectMembers(job);
         job.execute(ctx);
     }
 
@@ -188,6 +191,7 @@ public class EntitlerJobTest {
             .thenThrow(new EntitlementRefusedException(mapResult));
 
         EntitlerJob job = new EntitlerJob(e, null, pC, i18n);
+        injector.injectMembers(job);
         Pool p = new Pool();
         p.setId("hello");
 

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/ExportJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/ExportJobTest.java
@@ -36,15 +36,19 @@ import org.quartz.JobExecutionContext;
 
 
 @RunWith(MockitoJUnitRunner.class)
-public class ExportJobTest {
+public class ExportJobTest extends BaseJobTest {
 
     @Mock private ManifestManager manifestManager;
     @Mock private JobExecutionContext ctx;
     private ExportJob job;
 
+
+
     @Before
     public void setupTest() {
+        super.init();
         job = new ExportJob(manifestManager);
+        injector.injectMembers(job);
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/HypervisorUpdateJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/HypervisorUpdateJobTest.java
@@ -49,7 +49,7 @@ import java.util.Set;
 /**
  * HypervisorUpdateJobTest
  */
-public class HypervisorUpdateJobTest {
+public class HypervisorUpdateJobTest extends BaseJobTest{
 
     private Owner owner;
     private Principal principal;
@@ -63,6 +63,7 @@ public class HypervisorUpdateJobTest {
 
     @Before
     public void init() {
+        super.init();
         i18n = I18nFactory.getI18n(
             getClass(),
             Locale.US,
@@ -106,6 +107,7 @@ public class HypervisorUpdateJobTest {
 
         HypervisorUpdateJob job = new HypervisorUpdateJob(ownerCurator, consumerCurator, consumerResource,
             i18n);
+        injector.injectMembers(job);
         job.execute(ctx);
         verify(consumerResource).create(any(Consumer.class), eq(principal), anyString(), eq("joe"),
             anyString(), eq(false));
@@ -124,6 +126,7 @@ public class HypervisorUpdateJobTest {
 
         HypervisorUpdateJob job = new HypervisorUpdateJob(ownerCurator, consumerCurator, consumerResource,
             i18n);
+        injector.injectMembers(job);
         job.execute(ctx);
         ArgumentCaptor<Consumer> argument = ArgumentCaptor.forClass(Consumer.class);
         verify(consumerResource).create(argument.capture(), eq(principal), anyString(), eq("joe"),
@@ -147,6 +150,7 @@ public class HypervisorUpdateJobTest {
 
         HypervisorUpdateJob job = new HypervisorUpdateJob(ownerCurator, consumerCurator, consumerResource,
             i18n);
+        injector.injectMembers(job);
         job.execute(ctx);
         verify(consumerResource).performConsumerUpdates(any(Consumer.class), eq(hypervisor),
             any(VirtConsumerMap.class), eq(false));
@@ -169,6 +173,7 @@ public class HypervisorUpdateJobTest {
 
         HypervisorUpdateJob job = new HypervisorUpdateJob(ownerCurator, consumerCurator, consumerResource,
             i18n);
+        injector.injectMembers(job);
         job.execute(ctx);
         assertEquals("updateReporterId", hypervisor.getHypervisorId().getReporterId());
     }
@@ -190,6 +195,7 @@ public class HypervisorUpdateJobTest {
 
         HypervisorUpdateJob job = new HypervisorUpdateJob(ownerCurator, consumerCurator, consumerResource,
             i18n);
+        injector.injectMembers(job);
         job.execute(ctx);
         verify(consumerResource, never()).create(any(Consumer.class), any(Principal.class),
             anyString(), anyString(), anyString(), eq(false));
@@ -218,6 +224,7 @@ public class HypervisorUpdateJobTest {
 
         HypervisorUpdateJob job = new HypervisorUpdateJob(ownerCurator, consumerCurator, consumerResource,
             i18n);
+        injector.injectMembers(job);
         job.execute(ctx);
 
         Set<String> expectedSet = new HashSet<String>();
@@ -278,6 +285,7 @@ public class HypervisorUpdateJobTest {
 
         HypervisorUpdateJob job = new HypervisorUpdateJob(ownerCurator, consumerCurator, consumerResource,
             i18n);
+        injector.injectMembers(job);
 
         try {
             job.execute(ctx);

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/ImportJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/ImportJobTest.java
@@ -39,7 +39,7 @@ import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 
 @RunWith(MockitoJUnitRunner.class)
-public class ImportJobTest {
+public class ImportJobTest extends BaseJobTest{
 
     @Mock private OwnerCurator ownerCurator;
     @Mock private JobExecutionContext ctx;
@@ -50,8 +50,10 @@ public class ImportJobTest {
 
     @Before
     public void setup() {
+        super.init();
         owner = new Owner("my-test-owner");
         job = new ImportJob(ownerCurator, manifestManager);
+        injector.injectMembers(job);
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/JobCleanerTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/JobCleanerTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.*;
 
 import org.candlepin.model.JobCurator;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Date;
@@ -26,12 +27,18 @@ import java.util.Date;
 /**
  * JobCleanerTest
  */
-public class JobCleanerTest {
+public class JobCleanerTest extends BaseJobTest{
+
+    @Before
+    public void init() {
+        super.init();
+    }
 
     @Test
     public void execute() throws Exception {
         JobCurator curator = mock(JobCurator.class);
         JobCleaner cleaner = new JobCleaner(curator);
+        injector.injectMembers(cleaner);
         cleaner.execute(null);
         verify(curator).cleanUpOldCompletedJobs(any(Date.class));
         verify(curator).cleanupAllOldJobs(any(Date.class));

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/RefreshPoolsJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/RefreshPoolsJobTest.java
@@ -39,7 +39,7 @@ import java.sql.SQLException;
 /**
  * RefreshPoolsJobTest
  */
-public class RefreshPoolsJobTest {
+public class RefreshPoolsJobTest extends BaseJobTest{
 
     private CandlepinPoolManager pm;
     private OwnerCurator oc;
@@ -52,6 +52,7 @@ public class RefreshPoolsJobTest {
 
     @Before
     public void setUp() {
+        super.init();
         pm = mock(CandlepinPoolManager.class);
         oc = mock(OwnerCurator.class);
         owner = mock(Owner.class);
@@ -75,6 +76,7 @@ public class RefreshPoolsJobTest {
     public void execute() throws Exception {
         // test
         RefreshPoolsJob rpj = new RefreshPoolsJob(oc, pm, subAdapter, ownerAdapter);
+        injector.injectMembers(rpj);
         rpj.execute(ctx);
 
         // verification
@@ -102,6 +104,7 @@ public class RefreshPoolsJobTest {
         doThrow(new NullPointerException()).when(refresher).run();
 
         RefreshPoolsJob rpj = new RefreshPoolsJob(oc, pm, subAdapter, ownerAdapter);
+        injector.injectMembers(rpj);
         try {
             rpj.execute(ctx);
             fail("Expected exception not thrown");
@@ -119,6 +122,7 @@ public class RefreshPoolsJobTest {
         doThrow(e).when(refresher).run();
 
         RefreshPoolsJob rpj = new RefreshPoolsJob(oc, pm, subAdapter, ownerAdapter);
+        injector.injectMembers(rpj);
         try {
             rpj.execute(ctx);
             fail("Expected exception not thrown");
@@ -137,6 +141,7 @@ public class RefreshPoolsJobTest {
         doThrow(e2).when(refresher).run();
 
         RefreshPoolsJob rpj = new RefreshPoolsJob(oc, pm, subAdapter, ownerAdapter);
+        injector.injectMembers(rpj);
         try {
             rpj.execute(ctx);
             fail("Expected exception not thrown");
@@ -152,6 +157,7 @@ public class RefreshPoolsJobTest {
         doThrow(e).when(refresher).run();
 
         RefreshPoolsJob rpj = new RefreshPoolsJob(oc, pm, subAdapter, ownerAdapter);
+        injector.injectMembers(rpj);
         try {
             rpj.execute(ctx);
             fail("Expected exception not thrown");

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/RegenEntitlementCertsJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/RegenEntitlementCertsJobTest.java
@@ -22,6 +22,7 @@ import org.candlepin.model.CandlepinQuery;
 import org.candlepin.model.Owner;
 import org.candlepin.model.OwnerCurator;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.quartz.JobDataMap;
 import org.quartz.JobDetail;
@@ -34,7 +35,12 @@ import java.util.Arrays;
 /**
  * RegenEntitlementCertsJobTest
  */
-public class RegenEntitlementCertsJobTest {
+public class RegenEntitlementCertsJobTest extends BaseJobTest{
+
+    @Before
+    public void init() {
+        super.init();
+    }
 
     @Test
     public void execute() throws Exception {
@@ -62,6 +68,7 @@ public class RegenEntitlementCertsJobTest {
 
         // test
         RegenProductEntitlementCertsJob recj = new RegenProductEntitlementCertsJob(pm, oc);
+        injector.injectMembers(recj);
         recj.execute(jec);
 
         // verification

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/SweepBarJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/SweepBarJobTest.java
@@ -33,16 +33,18 @@ import java.util.HashSet;
 /**
  * SweepBarJobTest
  */
-public class SweepBarJobTest {
+public class SweepBarJobTest extends BaseJobTest {
     private SweepBarJob sweepBarJob;
     @Mock private JobCurator j;
     @Mock private PinsetterKernel pk;
     @Mock private JobExecutionContext ctx;
 
     @Before
-    public void init() throws SchedulerException {
+    public void startup() throws SchedulerException {
+        super.init();
         MockitoAnnotations.initMocks(this);
         sweepBarJob = new SweepBarJob(j, pk);
+        injector.injectMembers(sweepBarJob);
         when(pk.getSingleJobKeys()).thenReturn((new HashSet<JobKey>()));
     }
 

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/UndoImportsJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/UndoImportsJobTest.java
@@ -115,6 +115,7 @@ public class UndoImportsJobTest extends DatabaseTestFixture {
             this.i18n, this.ownerCurator, this.poolManager, this.subAdapter,
             this.exportCurator, this.importRecordCurator
         );
+        injector.injectMembers(undoImportsJob);
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/UnpauseJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/UnpauseJobTest.java
@@ -44,7 +44,7 @@ import java.util.List;
 /**
  * UnpauseJobTest
  */
-public class UnpauseJobTest {
+public class UnpauseJobTest extends BaseJobTest{
     private UnpauseJob unpauseJob;
     @Mock private JobCurator jobCurator;
     @Mock private PinsetterKernel pk;
@@ -53,8 +53,10 @@ public class UnpauseJobTest {
 
     @Before
     public void init() {
+        super.init();
         MockitoAnnotations.initMocks(this);
         unpauseJob = new UnpauseJob(jobCurator, pk);
+        injector.injectMembers(unpauseJob);
     }
 
     @Test


### PR DESCRIPTION
When the @CandlepinScopedRequest annotation was removed from the cache it
caused the JsRunnerRequestCacheProvider to always return a new instance.
This meant that the rules version was queried many times instead of once in a given request.

In the KingPinJob was updated to properly enter & exit the scope CandlepinRequestScope