### PR TITLE
1419016: Fix registration issue when owner's autobind is disabled.

### DIFF
--- a/server/spec/autobind_disabled_for_owner_spec.rb
+++ b/server/spec/autobind_disabled_for_owner_spec.rb
@@ -59,17 +59,8 @@ describe 'Autobind Disabled On Owner' do
     new_pool.providedProducts.length.should == 2
   end
 
-  it 'fails registration when activation key has autobind enabled' do
-    exception_thrown = false
-    begin
-      ak_consumer = @user_cp.register("foofy", :system, nil, {'cpu.cpu_socket(s)' => '8'}, nil, @owner['key'], [@activation_key['name']], [])
-    rescue RestClient::BadRequest => e
-      exception_thrown = true
-      ex_message = "Could not register unit with key enabling auto-attach. Auto-attach is disabled for org '#{@owner['key']}'."
-      data = JSON.parse(e.response)
-      data['displayMessage'].should == ex_message
-    end
-    exception_thrown.should be true
+  it 'will still register when activation key has autobind enabled' do
+      @user_cp.register("foofy", :system, nil, {'cpu.cpu_socket(s)' => '8'}, nil, @owner['key'], [@activation_key['name']], [])
   end
 
   it 'fails to heal entire org' do

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -552,7 +552,7 @@ public class ConsumerResource {
             sink.emitConsumerCreated(consumer);
 
             if (keys.size() > 0) {
-                consumerBindUtil.handleActivationKeys(consumer, keys);
+                consumerBindUtil.handleActivationKeys(consumer, keys, owner.autobindDisabled());
             }
 
             // Don't allow complianceRules to update entitlementStatus, because we're about to perform
@@ -567,11 +567,6 @@ public class ConsumerResource {
         catch (CandlepinException ce) {
             // If it is one of ours, rethrow it.
             throw ce;
-        }
-        catch (AutobindDisabledForOwnerException e) {
-            throw new BadRequestException(i18n.tr(
-                "Could not register unit with key enabling auto-attach. " +
-                "Auto-attach is disabled for org ''{0}''.", consumer.getOwner().getKey()));
         }
         catch (Exception e) {
             log.error("Problem creating unit:", e);

--- a/server/src/main/java/org/candlepin/resource/util/ConsumerBindUtil.java
+++ b/server/src/main/java/org/candlepin/resource/util/ConsumerBindUtil.java
@@ -74,8 +74,8 @@ public class ConsumerBindUtil {
         this.serviceLevelValidator = serviceLevelValidator;
     }
 
-    public void handleActivationKeys(Consumer consumer, List<ActivationKey> keys)
-        throws AutobindDisabledForOwnerException {
+    public void handleActivationKeys(Consumer consumer, List<ActivationKey> keys,
+        boolean autoattachDisabledForOwner) throws AutobindDisabledForOwnerException {
         // Process activation keys.
 
         boolean listSuccess = false;
@@ -85,7 +85,14 @@ public class ConsumerBindUtil {
             handleActivationKeyRelease(consumer, key.getReleaseVer());
             keySuccess &= handleActivationKeyServiceLevel(consumer, key.getServiceLevel(), key.getOwner());
             if (key.isAutoAttach() != null && key.isAutoAttach()) {
-                handleActivationKeyAutoBind(consumer, key);
+                if (autoattachDisabledForOwner) {
+                    log.warn(
+                        "Auto-attach is disabled for owner. Skipping auto-attach for consumer/key: {}/{}",
+                        consumer.getUuid(), key.getName());
+                }
+                else {
+                    handleActivationKeyAutoBind(consumer, key);
+                }
             }
             else {
                 keySuccess &= handleActivationKeyPools(consumer, key);

--- a/server/src/test/java/org/candlepin/resource/util/ConsumerBindUtilTest.java
+++ b/server/src/test/java/org/candlepin/resource/util/ConsumerBindUtilTest.java
@@ -119,7 +119,7 @@ public class ConsumerBindUtilTest {
         consumer.setInstalledProducts(cips);
 
         AutobindData ad = new AutobindData(consumer).withPools(poolIds).forProducts(prodIds);
-        consumerBindUtil.handleActivationKeys(consumer, keys);
+        consumerBindUtil.handleActivationKeys(consumer, keys, false);
         verify(entitler).bindByProducts(eq(ad));
     }
 
@@ -140,7 +140,7 @@ public class ConsumerBindUtilTest {
         consumer.setInstalledProducts(cips);
 
         AutobindData ad = new AutobindData(consumer).forProducts(prodIds);
-        consumerBindUtil.handleActivationKeys(consumer, keys);
+        consumerBindUtil.handleActivationKeys(consumer, keys, false);
         verify(entitler).bindByProducts(eq(ad));
     }
 
@@ -165,7 +165,7 @@ public class ConsumerBindUtilTest {
         consumer.setInstalledProducts(cips);
 
         AutobindData ad = new AutobindData(consumer).forProducts(prodIds);
-        consumerBindUtil.handleActivationKeys(consumer, keys);
+        consumerBindUtil.handleActivationKeys(consumer, keys, false);
         verify(entitler).bindByProducts(eq(ad));
     }
 
@@ -179,7 +179,7 @@ public class ConsumerBindUtilTest {
         Consumer consumer = new Consumer("sys.example.com", null, null, system);
         doThrow(new BadRequestException("exception")).when(serviceLevelValidator)
             .validate(eq(owner), eq(key1.getServiceLevel()));
-        consumerBindUtil.handleActivationKeys(consumer, keys);
+        consumerBindUtil.handleActivationKeys(consumer, keys, false);
     }
 
     @Test
@@ -192,7 +192,7 @@ public class ConsumerBindUtilTest {
         Consumer consumer = new Consumer("sys.example.com", null, null, system);
         doThrow(new BadRequestException("exception")).when(serviceLevelValidator)
             .validate(eq(owner), eq(key1.getServiceLevel()));
-        consumerBindUtil.handleActivationKeys(consumer, keys);
+        consumerBindUtil.handleActivationKeys(consumer, keys, false);
     }
 
     @Test(expected = BadRequestException.class)
@@ -209,7 +209,7 @@ public class ConsumerBindUtilTest {
         Consumer consumer = new Consumer("sys.example.com", null, null, system);
         when(entitler.bindByPoolQuantity(eq(consumer), eq(ghost.getId()), eq(10)))
             .thenThrow(new ForbiddenException("fail"));
-        consumerBindUtil.handleActivationKeys(consumer, keys);
+        consumerBindUtil.handleActivationKeys(consumer, keys, false);
     }
 
     @Test
@@ -236,7 +236,7 @@ public class ConsumerBindUtilTest {
             .thenThrow(new ForbiddenException("fail"));
         when(entitler.bindByPoolQuantity(eq(consumer), eq(pool2.getId()), eq(10)))
             .thenThrow(new ForbiddenException("fail"));
-        consumerBindUtil.handleActivationKeys(consumer, keys);
+        consumerBindUtil.handleActivationKeys(consumer, keys, false);
     }
 
     @Test
@@ -265,7 +265,25 @@ public class ConsumerBindUtilTest {
             .thenThrow(new ForbiddenException("fail"));
         when(entitler.bindByPoolQuantity(eq(consumer), eq(pool2.getId()), eq(10)))
             .thenThrow(new ForbiddenException("fail"));
-        consumerBindUtil.handleActivationKeys(consumer, keys);
+        consumerBindUtil.handleActivationKeys(consumer, keys, false);
+    }
+
+    @Test
+    public void registerPassWhenAutobindDisabledForOwnerAndKeyHasAutobindEnabled() throws Exception {
+        List<ActivationKey> keys = new ArrayList<ActivationKey>();
+        ActivationKey key1 = new ActivationKey("key1", owner);
+        key1.setAutoAttach(true);
+        keys.add(key1);
+
+        Product prod1 = TestUtil.createProduct();
+        Pool pool1 = TestUtil.createPool(owner, prod1, 5);
+        pool1.setId("pool1");
+        key1.addPool(pool1, 10L);
+
+        Consumer consumer = new Consumer("sys.example.com", null, null, system);
+        when(entitler.bindByPoolQuantity(eq(consumer), eq(pool1.getId()), eq(10)))
+                .thenThrow(new ForbiddenException("fail"));
+        consumerBindUtil.handleActivationKeys(consumer, keys, true);
     }
 
 }


### PR DESCRIPTION
Allow registration with autobind enabled key when owner
has disabled autobind.

When the disable owner's autobind feature was implemented
we blocked registration in this case, but this was in the end
not desirable.