### PR TITLE
[2.0] Added a valid checksum to a problematic Liquibase changeset

### DIFF
--- a/server/src/main/resources/db/changelog/20140317115036-index-facts-consumerid.xml
+++ b/server/src/main/resources/db/changelog/20140317115036-index-facts-consumerid.xml
@@ -8,6 +8,9 @@
 
 
     <changeSet id="20140317115036" author="ckozak">
+        <!-- This a valid state for this changeset; often appears this way in dumps from Satellite -->
+        <validCheckSum>7:ceb9b38d059a57332a2b9799299663fe</validCheckSum>
+
         <comment>Index cp_consumer_facts on cp_consumer_id</comment>
         <createIndex indexName="consumer_fact_consumer_id_idx"
             tableName="cp_consumer_facts"


### PR DESCRIPTION
- Added a valid checksum to the consumer ID fact index changeset
  to fix an issue where Liquibase would detect an a mismatch when
  the changeset was actually valid