### PR TITLE
[2.0] 1488508: Restricted upstream info migration to master pools

### DIFF
--- a/server/src/main/java/org/candlepin/liquibase/PerOrgProductsMigrationTask.java
+++ b/server/src/main/java/org/candlepin/liquibase/PerOrgProductsMigrationTask.java
@@ -806,12 +806,13 @@ public class PerOrgProductsMigrationTask extends LiquibaseCustomTask {
             "FROM cp_pool_source_sub "
         );
 
-        // Migrate upstream tracking columns from subscription to pool
+        // Migrate upstream tracking columns from subscription to master pool
         ResultSet subscriptionInfo = this.executeQuery(
             "SELECT ss.pool_id, s.cdn_id, s.certificate_id, s.upstream_entitlement_id, " +
             "  s.upstream_consumer_id, s.upstream_pool_id " +
             "FROM cp_subscription s " +
-            "JOIN cp2_pool_source_sub ss ON s.id = ss.subscription_id"
+            "JOIN cp2_pool_source_sub ss ON s.id = ss.subscription_id " +
+            "WHERE ss.subscription_sub_key = 'master'"
         );
 
         // Update any pool referencing this subscription...

--- a/server/src/main/resources/db/changelog/20170919110500-fixupstreampoolmigration.xml
+++ b/server/src/main/resources/db/changelog/20170919110500-fixupstreampoolmigration.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <changeSet id="20170919110500-1" author="crog">
+        <!--
+        Unfortunately we don't have a reliable, efficient way of avoiding this task if it doesn't need
+        to be run. At the time of writing, changesets themselves can't set properties, and doing a limited
+        lookup would still require performing the joins and much of the work of the update query such
+        that it's overall quicker to just do the update rather than looking for data to fix first.
+        -->
+
+        <comment>Removes extraneous upstream pool info from non-master pools</comment>
+
+        <sql>
+            <!--
+            Impl note:
+            We can't safely use an IN statement here, since it's reasonable/expected for there to be
+            more pools than the IN-clause size limit would allow
+            -->
+
+            UPDATE cp_pool p
+            SET cdn_id=NULL, certificate_id=NULL, upstream_entitlement_id=NULL, upstream_consumer_id=NULL,
+                upstream_pool_id=NULL
+            WHERE (SELECT ss.subscription_sub_key FROM cp2_pool_source_sub ss WHERE ss.pool_id = p.id) != 'master'
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/server/src/main/resources/db/changelog/changelog-create.xml
+++ b/server/src/main/resources/db/changelog/changelog-create.xml
@@ -1207,4 +1207,5 @@
     <include file="db/changelog/20170227140343-convert-consumer-entitlement-count-to-column.xml"/>
     <include file="db/changelog/20170323142254-add-revoked-column-to-cert-serial.xml"/>
     <include file="db/changelog/20170301083925-update-revoked-cert-serial-data.xml"/>
+    <include file="db/changelog/20170919110500-fixupstreampoolmigration.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-testing.xml
+++ b/server/src/main/resources/db/changelog/changelog-testing.xml
@@ -2297,4 +2297,5 @@
     <include file="db/changelog/20170227140343-convert-consumer-entitlement-count-to-column.xml"/>
     <include file="db/changelog/20170323142254-add-revoked-column-to-cert-serial.xml"/>
     <include file="db/changelog/20170301083925-update-revoked-cert-serial-data.xml"/>
+    <include file="db/changelog/20170919110500-fixupstreampoolmigration.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-update.xml
+++ b/server/src/main/resources/db/changelog/changelog-update.xml
@@ -115,4 +115,5 @@
     <include file="db/changelog/20170227140343-convert-consumer-entitlement-count-to-column.xml"/>
     <include file="db/changelog/20170323142254-add-revoked-column-to-cert-serial.xml"/>
     <include file="db/changelog/20170301083925-update-revoked-cert-serial-data.xml"/>
+    <include file="db/changelog/20170919110500-fixupstreampoolmigration.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
- The per-org migration task no longer migrates upstream subscription
  info to all related pools, but instead only updates the master pool
  for a given subscription