### PR TITLE
adding tomcat logs to the artifacts saved during cp-test

### DIFF
--- a/docker/candlepin-base/cp-test
+++ b/docker/candlepin-base/cp-test
@@ -44,19 +44,34 @@ move_artifact() {
 collect_artifacts() {
     # If the caller mounted a volume at /artifacts, copy server logs out:
     ARTIFACT_DIR="/candlepin-dev/artifacts/"
+
+    # We only want these from /var/log/candlepin
+    CANDLEPIN_LOGS=(
+        access.log
+        audit.log
+        candlepin.log
+        error.log
+        lint.log
+        buildr.log
+        unit_tests.log
+        rspec.log
+    )
+    # prepend full file path for maximum lazy typers
+    for ((i=0; i<${#CANDLEPIN_LOGS[*]}; i++)); do
+        CANDLEPIN_LOGS[${i}]="/var/log/candlepin/${CANDLEPIN_LOGS[${i}]}"
+    done
+
+    TOMCAT_LOGS=$(find /var/log/tomcat/ -maxdepth 1 -type f)
+    ARCHIVE_LOGS=("${CANDLEPIN_LOGS[@]}" "${TOMCAT_LOGS[@]}")
+
     if [ -d "${ARTIFACT_DIR}" ]; then
         echo "Collecting artifacts..."
 
         # It's entirely possible for these to not exist, so we'll copy them if we can, but if we
         # fail, we shouldn't abort
-        move_artifact '/var/log/candlepin/access.log' "${ARTIFACT_DIR}"
-        move_artifact '/var/log/candlepin/audit.log' "${ARTIFACT_DIR}"
-        move_artifact '/var/log/candlepin/candlepin.log' "${ARTIFACT_DIR}"
-        move_artifact '/var/log/candlepin/error.log' "${ARTIFACT_DIR}"
-        move_artifact '/var/log/candlepin/lint.log' "${ARTIFACT_DIR}"
-        move_artifact '/var/log/candlepin/buildr.log' "${ARTIFACT_DIR}"
-        move_artifact '/var/log/candlepin/unit_tests.log' "${ARTIFACT_DIR}"
-        move_artifact '/var/log/candlepin/rspec.log' "${ARTIFACT_DIR}"
+        for i in ${ARCHIVE_LOGS[@]}; do
+            move_artifact "${i}" "${ARTIFACT_DIR}"
+        done
     fi
 }
 


### PR DESCRIPTION
beefing up the artifact saving for the Jenkins jobs to help with debugging errors.