### PR TITLE
[2.1] Added the new Traceable and TraceableParam annotations

### DIFF
--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -67,6 +67,8 @@ import org.candlepin.resource.dto.AutobindData;
 import org.candlepin.service.OwnerServiceAdapter;
 import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.util.Util;
+import org.candlepin.util.Traceable;
+import org.candlepin.util.TraceableParam;
 
 import com.google.inject.Inject;
 import com.google.inject.persist.Transactional;
@@ -191,7 +193,10 @@ public class CandlepinPoolManager implements PoolManager {
      */
     @Transactional
     @SuppressWarnings("checkstyle:methodlength")
-    void refreshPoolsWithRegeneration(SubscriptionServiceAdapter subAdapter, Owner owner, boolean lazy) {
+    @Traceable
+    void refreshPoolsWithRegeneration(SubscriptionServiceAdapter subAdapter,
+        @TraceableParam("owner") Owner owner, boolean lazy) {
+
         Date now = new Date();
         owner = this.resolveOwner(owner);
         log.info("Refreshing pools for owner: {}", owner);
@@ -1685,6 +1690,7 @@ public class CandlepinPoolManager implements PoolManager {
      * choose to set this to false.
      */
     @Transactional
+    @Traceable
     public void revokeEntitlements(List<Entitlement> entsToRevoke, Set<String> alreadyDeletedPools,
         boolean regenCertsAndStatuses) {
         if (log.isDebugEnabled()) {
@@ -1934,6 +1940,7 @@ public class CandlepinPoolManager implements PoolManager {
 
     @Override
     @Transactional
+    @Traceable
     public void deletePools(Collection<Pool> pools, Set<String> alreadyDeletedPools) {
         if (pools == null || pools.isEmpty()) {
             return;

--- a/server/src/main/java/org/candlepin/controller/ContentManager.java
+++ b/server/src/main/java/org/candlepin/controller/ContentManager.java
@@ -24,6 +24,8 @@ import org.candlepin.model.ProductCurator;
 import org.candlepin.model.dto.ContentData;
 import org.candlepin.model.dto.ProductData;
 import org.candlepin.model.dto.ProductContentData;
+import org.candlepin.util.Traceable;
+import org.candlepin.util.TraceableParam;
 
 import com.google.inject.Inject;
 import com.google.inject.persist.Transactional;
@@ -318,8 +320,9 @@ public class ContentManager {
      */
     @SuppressWarnings("checkstyle:methodlength")
     @Transactional
-    public ImportResult<Content> importContent(Owner owner, Map<String, ContentData> contentData,
-        Set<String> importedProductIds) {
+    @Traceable
+    public ImportResult<Content> importContent(@TraceableParam("owner") Owner owner,
+        Map<String, ContentData> contentData, Set<String> importedProductIds) {
 
         if (owner == null) {
             throw new IllegalArgumentException("owner is null");

--- a/server/src/main/java/org/candlepin/controller/ProductManager.java
+++ b/server/src/main/java/org/candlepin/controller/ProductManager.java
@@ -25,6 +25,8 @@ import org.candlepin.model.ProductCurator;
 import org.candlepin.model.dto.ContentData;
 import org.candlepin.model.dto.ProductContentData;
 import org.candlepin.model.dto.ProductData;
+import org.candlepin.util.Traceable;
+import org.candlepin.util.TraceableParam;
 
 import com.google.inject.Inject;
 import com.google.inject.persist.Transactional;
@@ -272,8 +274,9 @@ public class ProductManager {
      *  A mapping of Red Hat content ID to content entities representing the imported content
      */
     @Transactional
-    public ImportResult<Product> importProducts(Owner owner, Map<String, ProductData> productData,
-        Map<String, Content> importedContent) {
+    @Traceable
+    public ImportResult<Product> importProducts(@TraceableParam("owner") Owner owner,
+        Map<String, ProductData> productData, Map<String, Content> importedContent) {
 
         if (owner == null) {
             throw new IllegalArgumentException("owner is null");

--- a/server/src/main/java/org/candlepin/model/PoolCurator.java
+++ b/server/src/main/java/org/candlepin/model/PoolCurator.java
@@ -1680,12 +1680,11 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
 
     @Transactional
     public List<Pool> listSharedPoolsOf(Pool pool) {
-        return listByCriteria(
-                currentSession().createCriteria(Pool.class)
-                    .createAlias("sourceEntitlement", "se")
-                    .createAlias("se.pool", "sep")
-                    .add(Restrictions.and(Restrictions.eq("type", PoolType.SHARE_DERIVED)))
-                    .add(Restrictions.and(Restrictions.eq("se.pool", pool)))
-                    .addOrder(Order.desc("created")));
+        return listByCriteria(currentSession().createCriteria(Pool.class)
+            .createAlias("sourceEntitlement", "se")
+            .createAlias("se.pool", "sep")
+            .add(Restrictions.and(Restrictions.eq("type", PoolType.SHARE_DERIVED)))
+            .add(Restrictions.and(Restrictions.eq("se.pool", pool)))
+            .addOrder(Order.desc("created")));
     }
 }

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/KingpinJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/KingpinJob.java
@@ -24,6 +24,7 @@ import org.candlepin.model.JobCurator;
 import org.candlepin.pinsetter.core.PinsetterJobListener;
 import org.candlepin.pinsetter.core.RetryJobException;
 import org.candlepin.pinsetter.core.model.JobStatus;
+import org.candlepin.util.Traceable;
 
 import com.google.inject.Inject;
 import com.google.inject.persist.UnitOfWork;
@@ -59,6 +60,7 @@ public abstract class KingpinJob implements Job {
     protected static String prefix = "job";
 
     @Override
+    @Traceable(startable = true)
     public void execute(JobExecutionContext context) throws JobExecutionException {
 
         long startTime = System.currentTimeMillis();

--- a/server/src/main/java/org/candlepin/util/Traceable.java
+++ b/server/src/main/java/org/candlepin/util/Traceable.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2009 - 2017 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.util;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+
+/**
+ * Indicates to any application performance managers that this method should be recorded as part of a trace.
+ * By default it will only include itself into an already-in-progress trace. However it can be made to start
+ * a new trace if one isn't already in progress by specifying {@code @Traceable(startable = true)}.
+ */
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.METHOD})
+public @interface Traceable {
+
+    /**
+     * Indicates if the method should be allowed to start a new trace if a trace isn't already in progress.
+     *
+     * @return
+     *  true if a new trace is allowed to start if needed, false otherwise
+     */
+    boolean startable() default false;
+}

--- a/server/src/main/java/org/candlepin/util/TraceableParam.java
+++ b/server/src/main/java/org/candlepin/util/TraceableParam.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2009 - 2017 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.util;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+
+/**
+ * Marks a parameter as traceable. Only applies when used on method parameters for methods
+ * annotated with the @Traceable annotation.
+ */
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.PARAMETER})
+public @interface TraceableParam {
+
+    /**
+     * Specifies the name/alias of the parameter to use in the tracing framework. This value
+     * may be different than actual parameter name.
+     *
+     * @return
+     *  the name or alias of the parameter
+     */
+    String value();
+}


### PR DESCRIPTION
- Added the new Traceable and TraceableParam annotations, to denote
  large, complex or messy methods likely to be hotspots to be
  explicitly measured in profiling tools
- Tagged a handful of methods with the new annotations:
  - CandlepinPoolManager.refreshWithRegeneration
  - CandlepinPoolManager.deletePools
  - CandlepinPoolManager.revokeEntitlements
  - ContentManager.importContent
  - KingpinJob.execute
  - ProductManager.importProducts