### PR TITLE
[M] Test Failure Fixes

### DIFF
--- a/server/spec/autobind_disabled_for_owner_spec.rb
+++ b/server/spec/autobind_disabled_for_owner_spec.rb
@@ -32,7 +32,8 @@ describe 'Autobind Disabled On Owner' do
   end
 
   it 'still allows dev consumer to autobind when disabled on owner' do
-    pending("candlepin running in standalone mode") if not is_hosted?
+    skip("candlepin running in standalone mode") if not is_hosted?
+
     # active subscription to allow this all to work
     active_prod = create_product()
     active_sub = create_pool_and_subscription(@owner['key'], active_prod.id, 10)

--- a/server/spec/owner_product_resource_spec.rb
+++ b/server/spec/owner_product_resource_spec.rb
@@ -185,7 +185,7 @@ describe 'Owner Product Resource' do
   end
 
   it "refreshes pools for orgs owning products" do
-    pending("candlepin running in standalone mode") if not is_hosted?
+    skip("candlepin running in standalone mode") if not is_hosted?
 
     owners = setupOrgProductsAndPools()
     owner1 = owners[0]

--- a/server/spec/product_resource_spec.rb
+++ b/server/spec/product_resource_spec.rb
@@ -167,7 +167,7 @@ describe 'Product Resource' do
   end
 
   it "refreshes pools for orgs owning products" do
-    pending("candlepin running in standalone mode") if not is_hosted?
+    skip("candlepin running in standalone mode") if not is_hosted?
 
     owners = setupOrgProductsAndPools()
     owner1 = owners[0]

--- a/server/src/main/java/org/candlepin/model/PoolCurator.java
+++ b/server/src/main/java/org/candlepin/model/PoolCurator.java
@@ -1673,12 +1673,11 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
 
     @Transactional
     public List<Pool> listSharedPoolsOf(Pool pool) {
-        return listByCriteria(
-                currentSession().createCriteria(Pool.class)
-                    .createAlias("sourceEntitlement", "se")
-                    .createAlias("se.pool", "sep")
-                    .add(Restrictions.and(Restrictions.eq("createdByShare", Boolean.TRUE)))
-                    .add(Restrictions.and(Restrictions.eq("se.pool", pool)))
-                    .addOrder(Order.desc("created")));
+        return listByCriteria(currentSession().createCriteria(Pool.class)
+            .createAlias("sourceEntitlement", "se")
+            .createAlias("se.pool", "sep")
+            .add(Restrictions.eq("createdByShare", Boolean.TRUE))
+            .add(Restrictions.eq("se.pool", pool))
+            .addOrder(Order.desc("created")));
     }
 }

--- a/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
@@ -2270,17 +2270,25 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         sourceEnt.setId(Util.generateDbUUID());
         entitlementCurator.create(sourceEnt);
 
-        pool.getEntitlements().add(sourceEnt);
+        Set<Entitlement> entitlements = new HashSet<Entitlement>();
+        entitlements.add(sourceEnt);
+
+        pool.setEntitlements(entitlements);
         poolCurator.merge(pool);
 
         Pool sharedPool = createPool(owner, product, 1L,
             TestUtil.createDate(2011, 3, 2), TestUtil.createDate(2055, 3, 2));
-        sharedPool.setAttribute(Pool.Attributes.SHARE, "true");
+        sharedPool.setCreatedByShare(true);
         sharedPool.setAttribute(Pool.Attributes.DERIVED_POOL, "true");
         sharedPool.setSourceEntitlement(sourceEnt);
         poolCurator.create(sharedPool);
 
-        Pool result = poolCurator.listSharedPoolsOf(pool).get(0);
+        List<Pool> sharedPools = poolCurator.listSharedPoolsOf(pool);
+
+        assertNotNull(sharedPools);
+        assertTrue(sharedPools.size() > 0);
+
+        Pool result = sharedPools.get(0);
         assertEquals(sharedPool, result);
     }
 }


### PR DESCRIPTION
Updated select rspec tests to use "skip" over "pending"
    
    - Updated a few rspec tests to use "skip" instead of "pending" when
      Candlepin is running in standalone mode

Fixed an issue with some PoolCurator tests and functionality
    
    - Fixed a compilation error and failure in PoolCuratorTest
