### PR TITLE
1482949: Limit consumer check-in time updates to specific calls

### DIFF
--- a/server/client/ruby/candlepin_api.rb
+++ b/server/client/ruby/candlepin_api.rb
@@ -919,6 +919,11 @@ class Candlepin
     get("/consumers/#{consumer_id}")
   end
 
+  def get_consumer_release(consumer_id=nil)
+    consumer_id ||= @uuid
+    get("/consumers/#{consumer_id}/release")
+  end
+
   def get_compliance(consumer_id=nil, on_date=nil)
     consumer_id ||= @uuid
     query = "/consumers/#{consumer_id}/compliance"
@@ -1199,8 +1204,9 @@ class Candlepin
     end
   end
 
-  def regenerate_entitlement_certificates(lazy_regen=true)
-    url = "/consumers/#{@uuid}/certificates"
+  def regenerate_entitlement_certificates(lazy_regen=true, consumer_uuid=nil)
+    consumer_uuid ||= @uuid
+    url = "/consumers/#{consumer_uuid}/certificates"
     params = {}
     params[:lazy_regen] = false if !lazy_regen
 
@@ -1233,8 +1239,9 @@ class Candlepin
     return get("/status/")
   end
 
-  def list_certificate_serials
-    return get("/consumers/#{@uuid}/certificates/serials")
+  def list_certificate_serials(consumer_uuid=nil)
+    consumer_uuid ||= @uuid
+    return get("/consumers/#{consumer_uuid}/certificates/serials")
   end
 
   def get_serial(serial_id)

--- a/server/spec/authorization_spec.rb
+++ b/server/spec/authorization_spec.rb
@@ -22,23 +22,6 @@ describe 'Authorization' do
       raise_error
   end
 
-  it 'updates consumer\'s last checkin time' do
-    consumer_cp = consumer_client(@user, random_string('test'))
-    consumer_cp.list_entitlements()
-    consumer = @cp.get_consumer(consumer_cp.uuid)
-    last_checkin1 = consumer['lastCheckin']
-
-    # MySQL before 5.6.4 doesn't store fractional seconds on timestamps.
-    sleep 1
-
-    # Do something as the consumer, should cause last checkin time to be updated:
-    consumer_cp.list_entitlements()
-    consumer = @cp.get_consumer(consumer_cp.uuid)
-    last_checkin2 = consumer['lastCheckin']
-
-    (last_checkin2 > last_checkin1).should be true
-  end
-
   it 'allows trusted consumer clients' do
     consumer_cp = consumer_client(@user, random_string('test'))
     trusted_cp = trusted_consumer_client(consumer_cp.uuid)

--- a/server/spec/consumer_checkin_spec.rb
+++ b/server/spec/consumer_checkin_spec.rb
@@ -1,0 +1,119 @@
+require 'spec_helper'
+require 'candlepin_scenarios'
+require 'time'
+
+describe 'Consumer Checkin Spec' do
+
+  include CandlepinMethods
+
+
+  before(:each) do
+    @owner = create_owner(random_string('test_owner'))
+    @username = random_string("user")
+    @user = user_client(@owner, @username)
+    @consumer_name = random_string("consumer")
+
+    @consumer = @user.register(@consumer_name, :system, nil, {}, nil, nil)
+    @ccp = Candlepin.new(nil, nil, @consumer['idCert']['cert'], @consumer['idCert']['key'])
+  end
+
+  it 'Updates last checkin time on consumer update' do
+    # Delay a second or two so we don't accidentally updated to the identical timestamp on MySQL
+    last_checkin = @consumer['lastCheckin']
+    sleep 1
+
+    @ccp.update_consumer(@consumer)
+    updated = @ccp.get_consumer(@consumer['uuid'])
+
+    expect(updated['lastCheckin']).to_not eq(last_checkin)
+  end
+
+  it 'Updates last checkin time on entitlement regeneration' do
+    # Delay a second or two so we don't accidentally updated to the identical timestamp on MySQL
+    last_checkin = @consumer['lastCheckin']
+    sleep 1
+
+    @ccp.regenerate_entitlement_certificates(consumer_uuid=@consumer['uuid'])
+    updated = @ccp.get_consumer(@consumer['uuid'])
+
+    expect(updated['lastCheckin']).to_not eq(last_checkin)
+  end
+
+  it 'Updates last checkin time when fetching entitlement certs' do
+    # Delay a second or two so we don't accidentally updated to the identical timestamp on MySQL
+    last_checkin = @consumer['lastCheckin']
+    sleep 1
+
+    @ccp.list_certificates(['123'], {:uuid => @consumer['uuid']})
+    updated = @ccp.get_consumer(@consumer['uuid'])
+
+    expect(updated['lastCheckin']).to_not eq(last_checkin)
+  end
+
+  it 'Updates last checkin time when fetching entitlement cert serials' do
+    # Delay a second or two so we don't accidentally updated to the identical timestamp on MySQL
+    last_checkin = @consumer['lastCheckin']
+    sleep 1
+
+    @ccp.list_certificate_serials(@consumer['uuid'])
+    updated = @ccp.get_consumer(@consumer['uuid'])
+
+    expect(updated['lastCheckin']).to_not eq(last_checkin)
+  end
+
+  it 'Updates last checkin time on hypervisor checkin' do
+    # Delay a second or two so we don't accidentally updated to the identical timestamp on MySQL
+    last_checkin = @consumer['lastCheckin']
+    sleep 1
+
+    @ccp.hypervisor_check_in(@owner['key'], {}, false)
+    updated = @ccp.get_consumer(@consumer['uuid'])
+
+    expect(updated['lastCheckin']).to_not eq(last_checkin)
+  end
+
+  it 'Updates last checkin time on async hypervisor checkin' do
+    # Delay a second or two so we don't accidentally updated to the identical timestamp on MySQL
+    last_checkin = @consumer['lastCheckin']
+    sleep 1
+
+    def build_checkin_data(name, hypervisor_id, guest_id_list)
+        guestIds = []
+
+        guest_id_list.each do |guest|
+            guestIds << {'guestId' => guest}
+        end
+
+        json = {"hypervisors" => [
+            "name" => name,
+            "hypervisorId" => {"hypervisorId" => hypervisor_id},
+            "guestIds" => guestIds,
+            "facts" => {"test_fact" => "fact_value"}
+        ]}
+
+        return json.to_json
+    end
+
+    hypervisor_data = build_checkin_data('test_hv', 'test_hv', ['guest-1', 'guest-2', 'guest-3'])
+
+    @ccp.hypervisor_update(@owner['key'], hypervisor_data, false)
+    updated = @ccp.get_consumer(@consumer['uuid'])
+
+    expect(updated['lastCheckin']).to_not eq(last_checkin)
+  end
+
+  # TODO:
+  # Add more checks for high-traffic or high-impact endpoints to verify we're not updating
+  # the last checkin time in those.
+
+  it 'Does not update last checkin when fetching releases' do
+    # Delay a second or two so we don't accidentally updated to the identical timestamp on MySQL
+    last_checkin = @consumer['lastCheckin']
+    sleep 1
+
+    @ccp.get_consumer_release(@consumer['uuid'])
+    updated = @ccp.get_consumer(@consumer['uuid'])
+
+    expect(updated['lastCheckin']).to eq(last_checkin)
+  end
+end

--- a/server/spec/consumer_resource_spec.rb
+++ b/server/spec/consumer_resource_spec.rb
@@ -193,13 +193,11 @@ describe 'Consumer Resource' do
   end
 
   it 'lets a super admin see a peson consumer with a given username' do
-
     username = random_string("user1")
     user1 = user_client(@owner1, username)
     consumer_client(user1, random_string("consumer1"), 'person')
 
-    @cp.list_consumers({:type => 'person',
-                       :username => username}).length.should == 1
+    @cp.list_consumers({:type => 'person', :username => username}).length.should == 1
   end
 
   it 'lets a super admin create person consumer for another user' do
@@ -436,8 +434,7 @@ describe 'Consumer Resource' do
   it 'should allow consumer to bind to products based on product socket quantity across pools' do
     owner = create_owner random_string('owner')
     owner_client = user_client(owner, random_string('testowner'))
-    cp_client = consumer_client(owner_client, random_string('consumer123'), :system,
-                                nil, 'cpu.cpu_socket(s)' => '4')
+    cp_client = consumer_client(owner_client, random_string('consumer123'), :system, nil, 'cpu.cpu_socket(s)' => '4')
     prod1 = create_product(random_string('product'), random_string('product-stackable'),
       {:attributes => { :sockets => '2', :'multi-entitlement' => 'yes', :stacking_id => '8888'}, :owner => owner['key']})
     prod2 = create_product(random_string('product'), random_string('product-stackable'),
@@ -551,8 +548,7 @@ describe 'Consumer Resource' do
 
   it 'should allow a consumer to update their autoheal flag' do
     user_cp = user_client(@owner1, random_string('billy'))
-    consumer = user_cp.register(random_string('system'), :system, nil,
-      {}, nil, nil, [], [])
+    consumer = user_cp.register(random_string('system'), :system, nil, {}, nil, nil, [], [])
     consumer_client = Candlepin.new(nil, nil, consumer['idCert']['cert'], consumer['idCert']['key'])
     consumer = @cp.get_consumer(consumer['uuid'])
     consumer['autoheal'].should == true
@@ -569,8 +565,7 @@ describe 'Consumer Resource' do
 
   it 'should allow a consumer to update their hypervisorId' do
     user_cp = user_client(@owner1, random_string('billy'))
-    consumer = user_cp.register(random_string('system'), :system, nil,
-      {}, nil, nil, [], [])
+    consumer = user_cp.register(random_string('system'), :system, nil, {}, nil, nil, [], [])
     consumer_client = Candlepin.new(nil, nil, consumer['idCert']['cert'], consumer['idCert']['key'])
 
     consumer = @cp.get_consumer(consumer['uuid'])
@@ -588,10 +583,8 @@ describe 'Consumer Resource' do
 
   it 'should not allow a consumer to update their hypervisorId to one in use by owner' do
     user_cp = user_client(@owner1, random_string('billy'))
-    consumer = user_cp.register(random_string('system'), :system, nil,
-      {}, nil, nil, [], [])
-    consumer1 = user_cp.register(random_string('system'), :system, nil,
-      {}, nil, nil, [], [], nil, [], "hYpervisor")
+    consumer = user_cp.register(random_string('system'), :system, nil, {}, nil, nil, [], [])
+    consumer1 = user_cp.register(random_string('system'), :system, nil, {}, nil, nil, [], [], nil, [], "hYpervisor")
     consumer_client = Candlepin.new(nil, nil, consumer['idCert']['cert'], consumer['idCert']['key'])
     consumer1 =  @cp.get_consumer(consumer1['uuid'])
     consumer1['hypervisorId']['hypervisorId'].should == "hypervisor"
@@ -606,8 +599,7 @@ describe 'Consumer Resource' do
 
   it 'should allow a consumer to unset their hypervisorId' do
     user_cp = user_client(@owner1, random_string('billy'))
-    consumer = user_cp.register(random_string('system'), :system, nil,
-      {}, nil, nil, [], [])
+    consumer = user_cp.register(random_string('system'), :system, nil, {}, nil, nil, [], [])
     consumer_client = Candlepin.new(nil, nil, consumer['idCert']['cert'], consumer['idCert']['key'])
 
     consumer = @cp.get_consumer(consumer['uuid'])

--- a/server/src/main/java/org/candlepin/auth/UpdateConsumerCheckIn.java
+++ b/server/src/main/java/org/candlepin/auth/UpdateConsumerCheckIn.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.auth;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to mark a method that should trigger an update in the consumer last update time.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface UpdateConsumerCheckIn {
+}

--- a/server/src/main/java/org/candlepin/guice/CandlepinModule.java
+++ b/server/src/main/java/org/candlepin/guice/CandlepinModule.java
@@ -124,6 +124,7 @@ import org.candlepin.resteasy.filter.AuthenticationFilter;
 import org.candlepin.resteasy.filter.AuthorizationFeature;
 import org.candlepin.resteasy.filter.CandlepinQueryInterceptor;
 import org.candlepin.resteasy.filter.CandlepinSuspendModeFilter;
+import org.candlepin.resteasy.filter.ConsumerCheckInFilter;
 import org.candlepin.resteasy.filter.PinsetterAsyncFilter;
 import org.candlepin.resteasy.filter.SecurityHoleAuthorizationFilter;
 import org.candlepin.resteasy.filter.StoreFactory;
@@ -347,6 +348,7 @@ public class CandlepinModule extends AbstractModule {
     }
 
     private void configureInterceptors() {
+        bind(ConsumerCheckInFilter.class);
         bind(CandlepinSuspendModeFilter.class);
         bind(PageRequestFilter.class);
         bind(PinsetterAsyncFilter.class);

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -25,6 +25,7 @@ import org.candlepin.auth.Access;
 import org.candlepin.auth.NoAuthPrincipal;
 import org.candlepin.auth.Principal;
 import org.candlepin.auth.SubResource;
+import org.candlepin.auth.UpdateConsumerCheckIn;
 import org.candlepin.auth.UserPrincipal;
 import org.candlepin.auth.Verify;
 import org.candlepin.common.auth.SecurityHole;
@@ -998,6 +999,7 @@ public class ConsumerResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Path("{consumer_uuid}")
     @Transactional
+    @UpdateConsumerCheckIn
     public void updateConsumer(
         @PathParam("consumer_uuid") @Verify(Consumer.class) String uuid,
         @ApiParam(name = "consumer", required = true) Consumer consumer,
@@ -1447,6 +1449,7 @@ public class ConsumerResource {
     @GET
     @Path("{consumer_uuid}/certificates")
     @Produces(MediaType.APPLICATION_JSON)
+    @UpdateConsumerCheckIn
     public List<Certificate> getEntitlementCertificates(
         @PathParam("consumer_uuid") @Verify(Consumer.class) String consumerUuid,
         @QueryParam("serials") String serials) {
@@ -1465,11 +1468,9 @@ public class ConsumerResource {
         Set<Long> serialSet = this.extractSerials(serials);
 
         List<Certificate> returnCerts = new LinkedList<Certificate>();
-        List<EntitlementCertificate> allCerts = entCertService
-            .listForConsumer(consumer);
+        List<EntitlementCertificate> allCerts = entCertService.listForConsumer(consumer);
         for (EntitlementCertificate cert : allCerts) {
-            if (serialSet.isEmpty() ||
-                serialSet.contains(cert.getSerial().getId())) {
+            if (serialSet.isEmpty() || serialSet.contains(cert.getSerial().getId())) {
                 returnCerts.add(cert);
             }
         }
@@ -1583,7 +1584,7 @@ public class ConsumerResource {
 
     private Set<Long> extractSerials(String serials) {
         Set<Long> serialSet = new HashSet<Long>();
-        if (serials != null) {
+        if (serials != null && !serials.isEmpty()) {
             log.debug("Requested serials: {}", serials);
             for (String s : serials.split(",")) {
                 log.debug("   {}", s);
@@ -1615,6 +1616,7 @@ public class ConsumerResource {
     @Path("{consumer_uuid}/certificates/serials")
     @Produces(MediaType.APPLICATION_JSON)
     @Wrapped(element = "serials")
+    @UpdateConsumerCheckIn
     public List<CertificateSerialDto> getEntitlementCertificateSerials(
         @PathParam("consumer_uuid") @Verify(Consumer.class) String consumerUuid) {
 
@@ -2082,6 +2084,7 @@ public class ConsumerResource {
     @Produces(MediaType.WILDCARD)
     @Consumes(MediaType.WILDCARD)
     @Path("/{consumer_uuid}/certificates")
+    @UpdateConsumerCheckIn
     public void regenerateEntitlementCertificates(
         @PathParam("consumer_uuid") @Verify(Consumer.class) String consumerUuid,
         @QueryParam("entitlement") String entitlementId,

--- a/server/src/main/java/org/candlepin/resource/HypervisorResource.java
+++ b/server/src/main/java/org/candlepin/resource/HypervisorResource.java
@@ -18,6 +18,7 @@ import org.candlepin.auth.Access;
 import org.candlepin.auth.Principal;
 import org.candlepin.auth.SubResource;
 import org.candlepin.auth.Verify;
+import org.candlepin.auth.UpdateConsumerCheckIn;
 import org.candlepin.common.exceptions.BadRequestException;
 import org.candlepin.common.exceptions.NotFoundException;
 import org.candlepin.model.Consumer;
@@ -107,6 +108,7 @@ public class HypervisorResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Deprecated
     @Transactional
+    @UpdateConsumerCheckIn
     @SuppressWarnings("checkstyle:indentation")
     public HypervisorCheckInResult hypervisorUpdate(
         Map<String, List<GuestId>> hostGuestMap, @Context Principal principal,
@@ -243,6 +245,7 @@ public class HypervisorResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Transactional
     @Path("/{owner}")
+    @UpdateConsumerCheckIn
     @SuppressWarnings("checkstyle:indentation")
     public JobDetail hypervisorUpdateAsync(
         String hypervisorJson, @Context Principal principal,

--- a/server/src/main/java/org/candlepin/resteasy/filter/AuthenticationFilter.java
+++ b/server/src/main/java/org/candlepin/resteasy/filter/AuthenticationFilter.java
@@ -16,7 +16,6 @@ package org.candlepin.resteasy.filter;
 
 import org.candlepin.auth.AuthProvider;
 import org.candlepin.auth.BasicAuth;
-import org.candlepin.auth.ConsumerPrincipal;
 import org.candlepin.auth.NoAuthPrincipal;
 import org.candlepin.auth.OAuth;
 import org.candlepin.auth.Principal;
@@ -154,14 +153,6 @@ public class AuthenticationFilter implements ContainerRequestFilter {
             else {
                 throw new NotAuthorizedException("Invalid credentials.");
             }
-        }
-
-        if (principal instanceof ConsumerPrincipal) {
-            // HACK: We need to do this after the principal has been pushed,
-            // lest our security settings start getting upset when we try to
-            // update a consumer without any roles:
-            ConsumerPrincipal p = (ConsumerPrincipal) principal;
-            consumerCurator.updateLastCheckin(p.getConsumer());
         }
 
         SecurityContext securityContext = new CandlepinSecurityContext(principal);

--- a/server/src/main/java/org/candlepin/resteasy/filter/ConsumerCheckInFilter.java
+++ b/server/src/main/java/org/candlepin/resteasy/filter/ConsumerCheckInFilter.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2009 - 2017 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.resteasy.filter;
+
+import org.candlepin.auth.ConsumerPrincipal;
+import org.candlepin.auth.Principal;
+import org.candlepin.auth.UpdateConsumerCheckIn;
+import org.candlepin.model.ConsumerCurator;
+
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+
+import javax.annotation.Priority;
+import javax.inject.Inject;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.ext.Provider;
+
+/** This filter is applied to resource methods annotated with @UpdateConsumerCheckIn.  It
+ * will inspect the principal and if the principal is a ConsumerPrincipal, it will update
+ * the consumer's check-in time.
+ */
+@Priority(Priorities.USER)
+@Provider
+public class ConsumerCheckInFilter implements ContainerRequestFilter {
+    private final ConsumerCurator consumerCurator;
+
+    @Inject
+    public ConsumerCheckInFilter(ConsumerCurator consumerCurator) {
+        this.consumerCurator = consumerCurator;
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        ResourceInfo resourceInfo = ResteasyProviderFactory.getContextData(ResourceInfo.class);
+        Method method = resourceInfo.getResourceMethod();
+
+        Principal principal = ResteasyProviderFactory.getContextData(Principal.class);
+        if (principal instanceof ConsumerPrincipal &&
+            method.getAnnotation(UpdateConsumerCheckIn.class) != null) {
+            ConsumerPrincipal p = (ConsumerPrincipal) principal;
+            consumerCurator.updateLastCheckin(p.getConsumer());
+        }
+    }
+}

--- a/server/src/test/java/org/candlepin/resteasy/filter/ConsumerCheckInFilterTest.java
+++ b/server/src/test/java/org/candlepin/resteasy/filter/ConsumerCheckInFilterTest.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.resteasy.filter;
+
+import static org.mockito.Mockito.*;
+
+import org.candlepin.auth.ConsumerPrincipal;
+import org.candlepin.auth.Principal;
+import org.candlepin.auth.UpdateConsumerCheckIn;
+import org.candlepin.model.Consumer;
+import org.candlepin.model.ConsumerCurator;
+import org.candlepin.test.DatabaseTestFixture;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+
+import org.jboss.resteasy.core.interception.PostMatchContainerRequestContext;
+import org.jboss.resteasy.mock.MockHttpRequest;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.jukito.JukitoRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.lang.reflect.Method;
+
+import javax.inject.Inject;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ResourceInfo;
+
+/**
+ * AuthInterceptorTest
+ */
+@RunWith(JukitoRunner.class)
+public class ConsumerCheckInFilterTest extends DatabaseTestFixture {
+    @Inject private Injector injector;
+
+    @Mock private ContainerRequestContext mockRequestContext;
+    @Mock private CandlepinSecurityContext mockSecurityContext;
+    @Mock private ResourceInfo mockInfo;
+
+    private ConsumerCheckInFilter interceptor;
+    private MockHttpRequest mockReq;
+
+    protected Module getGuiceOverrideModule() {
+        return new ConsumerCheckInFilterModule();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+
+        Class clazz = FakeResource.class;
+        when(mockInfo.getResourceClass()).thenReturn(clazz);
+
+        mockReq = MockHttpRequest.create("GET", "http://localhost/candlepin/status");
+
+        Consumer consumer = createConsumer(createOwner());
+        ConsumerPrincipal principal = new ConsumerPrincipal(consumer);
+
+        ResteasyProviderFactory.pushContext(ResourceInfo.class, mockInfo);
+        ResteasyProviderFactory.pushContext(Principal.class, principal);
+
+        interceptor = new ConsumerCheckInFilter(consumerCurator);
+    }
+
+    private void mockResourceMethod(Method method) {
+        when(mockInfo.getResourceMethod()).thenReturn(method);
+    }
+
+    private ContainerRequestContext getContext() {
+        return new PostMatchContainerRequestContext(mockReq, null);
+    }
+
+    @Test
+    public void testUpdatesCheckinWithAnnotation() throws Exception {
+        Method method = FakeResource.class.getMethod("checkinMethod", String.class);
+        mockResourceMethod(method);
+
+        interceptor.filter(getContext());
+
+        ConsumerPrincipal p = (ConsumerPrincipal) ResteasyProviderFactory.getContextData(Principal.class);
+        doNothing().when(consumerCurator).updateLastCheckin(p.getConsumer());
+        verify(consumerCurator).updateLastCheckin(p.getConsumer());
+    }
+
+    @Test
+    public void testNoCheckinWithoutAnnotation() throws Exception {
+        Method method = FakeResource.class.getMethod("someMethod", String.class);
+        mockResourceMethod(method);
+
+        interceptor.filter(getContext());
+
+        ConsumerPrincipal p = (ConsumerPrincipal) ResteasyProviderFactory.getContextData(Principal.class);
+        verify(consumerCurator, never()).updateLastCheckin(p.getConsumer());
+    }
+
+    /**
+     * FakeResource simply to create a Method object to pass down into
+     * the interceptor.
+     */
+    public static class FakeResource {
+        public String someMethod(String str) {
+            return str;
+        }
+
+        @UpdateConsumerCheckIn
+        public String checkinMethod(String str) {
+            return str;
+        }
+    }
+
+    private static class ConsumerCheckInFilterModule extends AbstractModule {
+        @Override
+        protected void configure() {
+            bind(ConsumerCurator.class).toInstance(mock(ConsumerCurator.class));
+        }
+    }
+}


### PR DESCRIPTION
This patch adds a ConsumerCheckInFilter that updates a consumer's
check-in time only if the REST resource called has the
UpdateConsumerCheckIn annotation.

The following methods have been annotated:
* ConsumerResource.updateConsumer (PUT /consumers/{uuid})
* ConsumerResource.regenerateEntitlementCertificates (PUT
  /consumers/{uuid}/certificates)
* ConsumerResource.getEntitlementCertificates (GET
  /consumers/{uuid}/certificates)
* ConsumerResource.getEntitlementCertificateSerials (GET
  /consumers/{uuid}/certificates/serials)
* HypervisorResource.hypervisorUpdate (POST /hypervisors)
* HypervisorResource.hypervisorUpdateAsync (POST /hypervisors/{owner})

which should cover the cases of rhsmcertd check-ins, consumer refreshes,
and hypervisor check-ins.