### PR TITLE
[M] Pool deleted events no longer contain old pool entities

### DIFF
--- a/server/spec/pool_resource_spec.rb
+++ b/server/spec/pool_resource_spec.rb
@@ -244,13 +244,13 @@ describe 'Pool Resource' do
     pools = @cp.list_pools
 
     events = @cp.list_owner_events(owner['key'])
-    pool_created_events = events.find_all { |event| event['target'] == 'POOL' && event['type'] == 'CREATED'}
+    pool_created_events = events.find_all { |event| event['target'] == 'POOL' && event['type'] == 'CREATED' }
     pool_created_events.size.should eq(6)
-    pool_deleted_events = events.find_all { |event| event['target'] == 'POOL' && event['type'] == 'DELETED'}
+    pool_deleted_events = events.find_all { |event| event['target'] == 'POOL' && event['type'] == 'DELETED' }
     pool_deleted_events.size.should eq(6)
-    ent_created_events = events.find_all { |event| event['target'] == 'ENTITLEMENT' && event['type'] == 'CREATED'}
+    ent_created_events = events.find_all { |event| event['target'] == 'ENTITLEMENT' && event['type'] == 'CREATED' }
     ent_created_events.size.should eq(6)
-    ent_deleted_events = events.find_all { |event| event['target'] == 'ENTITLEMENT' && event['type'] == 'DELETED'}
+    ent_deleted_events = events.find_all { |event| event['target'] == 'ENTITLEMENT' && event['type'] == 'DELETED' }
     ent_deleted_events.size.should eq(0)
   end
 

--- a/server/src/main/java/org/candlepin/audit/EventFactory.java
+++ b/server/src/main/java/org/candlepin/audit/EventFactory.java
@@ -185,9 +185,19 @@ public class EventFactory {
     }
 
     public Event poolDeleted(Pool pool) {
-        return getEventBuilder(Target.POOL, Type.DELETED)
-            .setOldEntity(pool)
+        // Impl note:
+        // As of 2017-09-28, no one consumes the old/deleted entity on this event, and
+        // it's incredibly expensive to serialize. As such, we're not going to set/output
+        // the old entity until we have an explicit need to do so. This means we need to
+        // manually set the entity and owner IDs.
+
+        Event event = getEventBuilder(Target.POOL, Type.DELETED)
             .buildEvent();
+
+        event.setEntityId(pool.getId());
+        event.setOwnerId(pool.getOwner().getId());
+
+        return event;
     }
 
     public Event exportCreated(Consumer consumer) {

--- a/server/src/main/java/org/candlepin/audit/EventFilter.java
+++ b/server/src/main/java/org/candlepin/audit/EventFilter.java
@@ -139,8 +139,7 @@ public class EventFilter {
             return false;
         }
         else {
-            throw new IllegalArgumentException("Unknown default filtering policy: " +
-        defaultFilterPolicy);
+            throw new IllegalArgumentException("Unknown default filtering policy: " + defaultFilterPolicy);
         }
     }
 


### PR DESCRIPTION
- Removed the old/previous pool from pool deleted events, as they
  were unused by event consumers and very expensive to serialize