### PR TITLE
1497248: Execute HypervisorUpdateJobs in the order they were received

### DIFF
--- a/server/src/main/java/org/candlepin/pinsetter/tasks/HypervisorUpdateJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/HypervisorUpdateJob.java
@@ -63,6 +63,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 import java.util.zip.DeflaterOutputStream;
 import java.util.zip.InflaterInputStream;
 
@@ -109,9 +110,9 @@ public class HypervisorUpdateJob extends KingpinJob {
     }
 
     public static boolean isSchedulable(JobCurator jobCurator, JobStatus status) {
-        long running = jobCurator.findNumRunningByClassAndTarget(
-            status.getTargetId(), HypervisorUpdateJob.class);
-        return running == 0;  // We can start the job if there are 0 like it running
+        JobStatus nextJob = jobCurator.getNextByClassAndTarget(status.getTargetId(),
+            HypervisorUpdateJob.class);
+        return nextJob != null && nextJob.getId().equals(status.getId());
     }
 
     private void parseHypervisorList(HypervisorList hypervisorList, Set<String> hosts,


### PR DESCRIPTION
This patch ensures that for a given owner only one HypervisorUpdateJob
will be run at a time. The next job (for the given owner) to execute will
be the job with oldest created date that is not in a Failed, Cancelled, or
Finished state.


You can test this PR by adding a sleep and some logging to the HypervisorUpdateJob.toExecute method as follows:

```java
log.debug("BEGINNING SLEEPING FOR 2 min");
Thread.sleep(120000);
log.debug("DONE SLEEPING EXECUTING");
```

After that change, you need only deploy CP and submit a bunch of async hypervisor check ins (such as repeatedly executing the following):

```shell
curl -ik -u admin:admin --request POST "https://localhost:8443/candlepin/hypervisors/admin" -d @async_hypervisor_report.json --header "Content-type: text/plain"
```

The file referenced above as "async_hypervisor_report.json" looks as follows:

```json
{"hypervisors": [{"hypervisorId": {"hypervisorId": "d722aaaf-011b-4154-ba50-fc79de2e8c82"}, "guestIds": [{"guestId": "c63cfe79-2227-474c-9531-3bf1d09e77b9", "state": 2}, {"guestId": "fae70640-8a17-4079-9f30-7ded0ec30184", "state": 2}]}, {"hypervisorId": {"hypervisorId": "02d9d132-63c7-4a02-8dd7-d6adf0bebee8"}, "guestIds": [{"guestId": "59240b70-3deb-4def-b79b-d09ea883abcc", "state": 4}, {"guestId": "038a0fc8-ba8d-4022-bdae-ce8794f64b69", "state": 5}]}, {"hypervisorId": {"hypervisorId": "a4c1f7c4-1b55-4657-9945-ddb58dde896e"}, "guestIds": [{"guestId": "4276bf67-a32d-430a-99d9-c7ca4214ba06", "state": 5}, {"guestId": "922145af-7529-4305-8958-b40d9e20d0fd", "state": 4}]}, {"hypervisorId": {"hypervisorId": "88ed17e9-1391-4cb5-8cc7-e49dad4d23a5"}, "guestIds": [{"guestId": "87e87a4a-aaf5-4b90-8677-cc2a1416050b", "state": 5}, {"guestId": "c3e14019-8925-426a-b4fc-7f76d3b8e127", "state": 5}]}]}
```

Should this PR work as intended, you should only see one job begin sleeping at a time.

Cheers