### PR TITLE
[2.1] Updated qpid rspec tests

### DIFF
--- a/server/bin/qpid/README.md
+++ b/server/bin/qpid/README.md
@@ -22,3 +22,6 @@ Here's how:
 3. `rm /etc/qpid/brokerdb/*`
 4. `rm keys/*` if the `keys` directory is already present from a previous run
    of the script.
+
+
+When starting Candlepin, remember to use the -q flag with the deploy script.

--- a/server/bin/qpid/configure-qpid.sh
+++ b/server/bin/qpid/configure-qpid.sh
@@ -258,7 +258,7 @@ done
 
 if ! is_rpm_installed qpid-cpp-server qpid-tools qpid-cpp-server; then
     echo "installing Qpid"
-    sudo yum -y install qpid-cpp-server qpid-tools qpid-cpp-server 
+    sudo yum -y install qpid-cpp-server qpid-tools qpid-cpp-server
 fi
 
 # QPid needs a package to provide persistent storage or else everything
@@ -301,9 +301,9 @@ if [ $IS_KATELLO -ne 0 ]; then
 fi
 
 # In Docker image we use supervisord instead of systemd.
-# So the assumption of the following is that 'service' command 
+# So the assumption of the following is that 'service' command
 # fails, we try supervisord.
-sudo service qpidd restart || supervisorctl restart qpidd
+if which supervisorctl > /dev/null 2>&1; then sudo supervisorctl restart qpidd; else sudo systemctl restart qpidd; fi
 
 sleep 7
 create_exchange "event"

--- a/server/spec/qpid_spec.rb
+++ b/server/spec/qpid_spec.rb
@@ -4,11 +4,11 @@ require 'candlepin_scenarios'
 
 # To run this spec test it is necessary to have Qpid up and configured.
 #
-# In Jenkins environment, this shouldn't be a problem. The cp-test script 
+# In Jenkins environment, this shouldn't be a problem. The cp-test script
 # has -q switch that will run configure-qpid.sh during candlepin server
 # deploy.
 #
-# Outside of Jenkins environment, you must install Qpid and run the 
+# Outside of Jenkins environment, you must install Qpid and run the
 # configure-qpid.sh yourself. Also you must enable AMQP (Qpid) in your
 # candlepin config file. This can be done either manually or just by
 # using deploy.sh script with -q switch.
@@ -16,124 +16,224 @@ describe 'Qpid Broker' do
 
   include CandlepinMethods
 
+
+  def assert_mode(mode, status = nil)
+    if status == nil
+      status = @cp.get('/status')
+    end
+
+    expect(status).to have_key("mode")
+    expect(status["mode"]).to eq(mode)
+  end
+
+  def assert_mode_and_reason(mode, reason, status = nil)
+    if status == nil
+      status = @cp.get('/status')
+    end
+
+    expect(status).to have_key("mode")
+    expect(status).to have_key("modeReason")
+    expect(status["mode"]).to eq(mode)
+    expect(status["modeReason"]).to eq(reason)
+  end
+
+  def wait_for_mode(mode, max_wait_time = 90, poll_delay = 3)
+    ellapsed = 0
+    last_status = nil
+
+    loop do
+      begin
+        last_status = @cp.get('/status')
+        expect(last_status).to have_key("mode")
+
+        if last_status['mode'] == mode
+          break
+        end
+      rescue
+        # Likely connection refused or timed out waiting on candlepin. Just ignore it and we'll try
+        # again in a few seconds
+        last_status = nil
+      end
+
+      break if ellapsed >= max_wait_time
+
+      sleep poll_delay
+      ellapsed += poll_delay
+    end
+
+    return last_status
+  end
+
+  def wait_for_event(subject, max_wait_time = 90)
+    start_time = Time.now
+
+    loop do
+      begin
+        timeout = max_wait_time - (Time.now - start_time)
+        break if timeout <= 0
+
+        msgs = @cq.receive(1, true, timeout)
+
+        msgs.each do |msg|
+          if msg.subject == subject
+            return msg
+          end
+        end
+      rescue Qpid::Proton::TimeoutError
+        # Return nil since we didn't receive the message in time.
+        break
+      end
+    end
+
+    return nil
+  end
+
   before(:each) do
-     @cq = CandlepinQpid.new
-     skip("Qpid keys not found, skipping Qpid spec tests") if @cq.no_keys 
-     # Clean the qpid queue
-     @cq.receive
+    @cq = CandlepinQpid.new('amqps://localhost:5671/allmsg', 'server/bin/qpid/keys/qpid_ca.crt', 'server/bin/qpid/keys/qpid_ca.key')
+    skip("Qpid keys not found, skipping Qpid spec tests") if @cq.no_keys?
+
+    # Create an owner to guarantee we have an event to consume.
+    expect(create_owner(random_string('test_owner'))).to have_key("created")
+
+    # Consume any existing messages that may be in the queue already, blocking until we receive
+    # at least one.
+    msgs = @cq.receive
+    expect(msgs.length).to be > 0
   end
 
-  it 'flow stop is detected' do
-     assert_mode("NORMAL")
-     # Create a queue that will initiate flow control after
-     # 3 messages
-     test_q = "flowStopQueue"
-     @cq.create_queue(test_q, '--flow-stop-count=3', 'event') 
-     puts "#{test_q} queue created"
-     2.times do 
-       create_owner random_string("test")
-     end
-     puts "2 owners should be successfully created now"
-     assert_mode("NORMAL")
-     puts "Creating additional owners which will FLOW_STOP #{test_q}"
-     3.times do 
-       create_owner random_string("test")
-     end
-     sleep 10
-     assert_mode_reason("SUSPEND", "QPID_FLOW_STOPPED")
+  it 'should detect FLOW_STOP' do
+    assert_mode("NORMAL")
 
-     puts "Removing queue #{test_q}, this should unblock again"
-     @cq.delete_queue(test_q) 
-     sleep 20
-     assert_mode_reason("NORMAL", "QPID_UP")
-  end 
-  
-  def assert_mode_reason(mode_name, reason)
-     mode = @cp.get('/status')
-     expect(mode).to have_key("mode")
-     expect(mode["mode"]).to eq(mode_name)
-     expect(mode["modeReason"]).to eq(reason)
+    # Create a queue that will initiate flow control after 3 messages
+    queue = "flowStopQueue"
+    @cq.create_queue(queue, 'event', '--flow-stop-count=3')
+    # puts "Queue created: #{queue}"
+
+    # Create two users to generate two messages
+    owners = 0
+
+    # puts "Creating first block of owners..."
+    2.times do
+      owners += 1
+      create_owner(random_string("test-owner_#{owners}"))
+    end
+
+    # We should still be in a good state here
+    assert_mode("NORMAL")
+
+    # Create additional owners, which should fill our queue and cause a FLOW_STOP
+    # puts "Creating second block of owners..."
+    3.times do
+      owners += 1
+      create_owner(random_string("test-owner_#{owners}"))
+    end
+
+    # We should eventually be suspended with a FLOW_STOPPED error
+    status = wait_for_mode("SUSPEND")
+    assert_mode_and_reason("SUSPEND", "QPID_FLOW_STOPPED", status)
+
+    # Removing the queue should restore normal operations...
+    # puts "Removing queue: #{queue}"
+    @cq.delete_queue(queue)
+
+    status = wait_for_mode("NORMAL")
+    assert_mode_and_reason("NORMAL", "QPID_UP", status)
   end
 
-  def assert_mode(mode_name)
-     mode = @cp.get('/status')
-     expect(mode).to have_key("mode")
-     expect(mode["mode"]).to eq(mode_name)
+  it 'should transition to SUSPEND mode' do
+    assert_mode("NORMAL")
+
+    # puts "Candlepin is in Normal mode. Stopping Qpid"
+    @cq.stop
+
+    status = wait_for_mode("SUSPEND")
+    assert_mode_and_reason("SUSPEND", "QPID_DOWN", status)
+
+    # puts "Candlepin is in Suspend mode. Creating owner"
+
+    begin
+      create_owner random_string('test_owner')
+      fail("Expected error did not occur")
+    rescue RestClient::ServiceUnavailable => un
+      displayMessage = JSON.parse(un.response.body)["displayMessage"]
+      displayMessage.should == 'Candlepin is in Suspend mode, please check /status resource to get more details'
+    end
+
+    # puts "Starting Qpid"
+    @cq.start
+
+    status = wait_for_mode("NORMAL")
+    assert_mode_and_reason("NORMAL", "QPID_UP", status)
+
+    # puts "Candlepin in Normal mode. Creating owner"
+    owner = create_owner(random_string('test_owner'))
+    expect(owner).to have_key("created")
+
+    start_time = Time.now
+    loop do
+      event = wait_for_event('owner.created', 90 - (Time.now - start_time))
+      expect(event).to_not be_nil
+      expect(event.body).to_not be_nil
+
+      body = JSON.parse(event.body)
+      break if body['targetName'] == owner['key']
+    end
   end
 
-  def stop_tomcat()
-     `sudo systemctl stop tomcat || sudo supervisorctl stop tomcat`
+  it 'should transition to NORMAL mode' do
+    assert_mode("NORMAL")
+
+    # puts "Stopping Qpid and creating owner..."
+    @cq.stop
+    expect(create_owner(random_string('test_owner'))).to have_key("created")
+
+    status = wait_for_mode("SUSPEND")
+    assert_mode_and_reason("SUSPEND", "QPID_DOWN", status)
+
+    # puts "Restarting Qpid and querying queues..."
+    @cq.start
+
+    # puts "Waiting for Candlepin to reconnect to Qpid..."
+    status = wait_for_mode("NORMAL")
+    assert_mode("NORMAL", status)
+
+    # puts "Reconnected. Creating owner and waiting for the message..."
+    owner = create_owner(random_string('test_owner'))
+    expect(owner).to have_key("created")
+
+    start_time = Time.now
+    loop do
+      event = wait_for_event('owner.created', 90 - (Time.now - start_time))
+      expect(event).to_not be_nil
+      expect(event.body).to_not be_nil
+
+      body = JSON.parse(event.body)
+      break if body['targetName'] == owner['key']
+    end
   end
 
-  def start_tomcat()
-     `sudo systemctl start tomcat || sudo supervisorctl start tomcat`
-  end
+  it 'should start in SUSPEND mode without Qpid' do
+    def start_tomcat()
+      `if which supervisorctl > /dev/null 2>&1; then sudo supervisorctl start tomcat; else sudo systemctl start tomcat; fi`
+    end
 
-  it 'transition to SUSPEND mode' do
-     assert_mode("NORMAL")
+    def stop_tomcat()
+      `if which supervisorctl > /dev/null 2>&1; then sudo supervisorctl stop tomcat; else sudo systemctl stop tomcat; fi`
+    end
 
-     puts "Candlepin is in Normal mode. Stopping Qpid"
-     @cq.stop
-     sleep 40
-     
-     assert_mode_reason("SUSPEND", "QPID_DOWN")
+    assert_mode("NORMAL")
+    stop_tomcat
 
-     puts "Candlepin is in Suspend mode. Creating owner"
+    @cq.stop
+    start_tomcat
 
-     begin
-       create_owner random_string('test_owner')
-     rescue RestClient::ServiceUnavailable => un
-       displayMessage = JSON.parse(un.response.body)["displayMessage"]
-       displayMessage.should == 'Candlepin is in Suspend mode, please check /status resource to get more details'
-     end 
+    status = wait_for_mode("SUSPEND")
+    assert_mode("SUSPEND", status)
 
-     puts "Starting Qpid"
-     @cq.start
-     sleep 40
+    @cq.start
 
-     assert_mode_reason("NORMAL", "QPID_UP")
-     
-     puts "Candlepin in Normal mode. Creating owner"
-     expect(create_owner random_string('test_owner')).to have_key("created")
-     sleep 15
-     msgs = @cq.receive
-     msgs.length.should == 1
-     msgs[0].subject.should == 'owner.created'
-  end
-
-
-  it 'reconnect should work' do
-     @cq.stop
-     puts "Qpid stopped, creating owner"
-     create_owner random_string("test")
-     sleep 10
-     
-     @cq.start 
-     puts "Qpid restarted, querying queues"
-     sleep 1
-     msgs = @cq.receive
-     msgs.length.should == 0
-    
-     puts "Nothing found in the queues. Waiting for reconnect"
-     
-     sleep 20 
-     create_owner random_string("test")
-     sleep 3
-     msgs = @cq.receive
-     msgs.length.should == 1
-     msgs[0].subject.should == 'owner.created'
-  end
-
-  it 'Candlepin startup without qpid ends in suspend mode' do
-     assert_mode("NORMAL")
-     stop_tomcat
-     @cq.stop
-     start_tomcat
-     sleep 10
-     assert_mode("SUSPEND")
-     @cq.start
-     sleep 12
-     assert_mode("NORMAL")
+    status = wait_for_mode("NORMAL")
+    assert_mode("NORMAL", status)
   end
 
 end


### PR DESCRIPTION
- Updated the qpid rspec tests to wait for messages and status
  changes rather than using static sleep timers
- Updated the CandlepinQpid wrapper object to make use of
  blocking calls, timeout configuration and configurable addresses
  and cert/key files