### PR TITLE
1497707: Execute HypervisorUpdateJobs in the order they were received

### DIFF
--- a/server/src/main/java/org/candlepin/pinsetter/tasks/HypervisorUpdateJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/HypervisorUpdateJob.java
@@ -63,6 +63,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 import java.util.zip.DeflaterOutputStream;
 import java.util.zip.InflaterInputStream;
 
@@ -109,9 +110,9 @@ public class HypervisorUpdateJob extends KingpinJob {
     }
 
     public static boolean isSchedulable(JobCurator jobCurator, JobStatus status) {
-        long running = jobCurator.findNumRunningByClassAndTarget(
-            status.getTargetId(), HypervisorUpdateJob.class);
-        return running == 0;  // We can start the job if there are 0 like it running
+        JobStatus nextJob = jobCurator.getNextByClassAndTarget(status.getTargetId(),
+            HypervisorUpdateJob.class);
+        return nextJob != null && nextJob.getId().equals(status.getId());
     }
 
     private void parseHypervisorList(HypervisorList hypervisorList, Set<String> hosts,


### PR DESCRIPTION
This patch ensures that for a given owner only one HypervisorUpdateJob
will be run at a time. The next job (for the given owner) to execute will
be the job with oldest created date that is not in a Failed, Cancelled, or
Finished state.

see #1728 for testing instructions