### PR TITLE
1497288: Mark jobs canceled when shutting down

### DIFF
--- a/server/src/main/java/org/candlepin/pinsetter/core/PinsetterKernel.java
+++ b/server/src/main/java/org/candlepin/pinsetter/core/PinsetterKernel.java
@@ -57,6 +57,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -138,6 +139,7 @@ public class PinsetterKernel implements ModeChangeListener {
     public void startup() throws PinsetterException {
         try {
             scheduler.start();
+            jobCurator.cancelOrphanedJobs(Collections.EMPTY_LIST);
             if (modeManager.getLastCandlepinModeChange().getMode() != Mode.NORMAL) {
                 scheduler.pauseAll();
             }
@@ -496,6 +498,7 @@ public class PinsetterKernel implements ModeChangeListener {
             Set<JobKey> jobs = this.scheduler.getJobKeys(jobGroupEquals(groupName));
 
             for (JobKey jobKey : jobs) {
+                this.jobCurator.cancel(jobKey.getName());
                 this.scheduler.deleteJob(jobKey);
             }
         }


### PR DESCRIPTION
Jobs are tracked in both cp_job and in the Quartz tables.  Prior to this
patch, when Pinsetter shutdown, it deleted job detail information from
the Quartz tables but did not alter the job in cp_job.  Upon startup,
the UnpauseJob would attempt to restart the job found in cp_job but no
correlating record would be found in the Quartz tables.

This patch adds a line to mark a job as canceled in the cp_job table as
the job is purged from the Quartz tables.  It also invokes a JobCurator
method that removes orphaned jobs on start up although this measure is
primarily preventative.