### PR TITLE
1498215: Use the environment name in the certificate

### DIFF
--- a/server/spec/content_access_spec.rb
+++ b/server/spec/content_access_spec.rb
@@ -114,12 +114,12 @@ describe 'Content Access' do
       # puts ("json_body:%s" % json_body)
 
       content = json_body['products'][0]['content'][0]
-      content['path'].should == '/' + @owner['key'] + '/' + @env['id'] + '/this/is/the/path'
+      content['path'].should == '/' + @owner['key'] + '/' + @env['name'] + '/this/is/the/path'
       content['enabled'].should == false
 
       value = extension_from_cert(certs[0]['cert'], "1.3.6.1.4.1.2312.9.7")
       urls = []
-      urls[0] = '/' + @owner['key'] + '/' + @env['id']
+      urls[0] = '/' + @owner['key'] + '/' + @env['name']
       are_content_urls_present(value, urls).should == true
   end
 

--- a/server/src/main/java/org/candlepin/service/impl/DefaultContentAccessCertServiceAdapter.java
+++ b/server/src/main/java/org/candlepin/service/impl/DefaultContentAccessCertServiceAdapter.java
@@ -246,7 +246,7 @@ public class DefaultContentAccessCertServiceAdapter implements ContentAccessCert
         contentPrefix.append(owner.getKey());
         if (environment != null) {
             contentPrefix.append("/");
-            contentPrefix.append(environment.getId());
+            contentPrefix.append(environment.getName());
         }
         return contentPrefix.toString();
     }
@@ -258,7 +258,7 @@ public class DefaultContentAccessCertServiceAdapter implements ContentAccessCert
         sb.append(consumer.getOwner().getKey());
         if (consumer.getEnvironment() != null) {
             sb.append(", OU=");
-            sb.append(consumer.getEnvironment().getId());
+            sb.append(consumer.getEnvironment().getName());
         }
         return sb.toString();
     }


### PR DESCRIPTION
The URLs that are contructed at the CDN use the environment name instead
of the environment id.