### PR TITLE
[2.1] Updated an autobind test to use "skip" instead of "pending"

### DIFF
--- a/server/spec/autobind_disabled_for_owner_spec.rb
+++ b/server/spec/autobind_disabled_for_owner_spec.rb
@@ -32,7 +32,8 @@ describe 'Autobind Disabled On Owner' do
   end
 
   it 'still allows dev consumer to autobind when disabled on owner' do
-    pending("candlepin running in standalone mode") if not is_hosted?
+    skip("candlepin running in standalone mode") if not is_hosted?
+
     # active subscription to allow this all to work
     active_prod = create_product()
     active_sub = create_pool_and_subscription(@owner['key'], active_prod.id, 10)


### PR DESCRIPTION
- Updated an autobind spec test to use use "skip" rather than "pending"
  when checking if the test is running in hosted mode. This will
  prevent the test from still running and failing with an error when
  running in standalone mode.