### PR TITLE
[2.1] Optimized fetching/deleting pools by subscription IDs

### DIFF
--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -400,7 +400,7 @@ public class CandlepinPoolManager implements PoolManager {
         Map<String, Product> changedProducts) {
 
         // These don't all necessarily belong to this owner
-        List<Pool> subscriptionPools = poolCurator.getPoolsBySubscriptionId(pool.getSubscriptionId());
+        List<Pool> subscriptionPools = poolCurator.getPoolsBySubscriptionId(pool.getSubscriptionId()).list();
         log.debug("Found {} pools for subscription {}", subscriptionPools.size(), pool.getSubscriptionId());
         if (log.isDebugEnabled()) {
             for (Pool p : subscriptionPools) {
@@ -445,6 +445,22 @@ public class CandlepinPoolManager implements PoolManager {
             subscriptionPools, pool, originalQuantity, updateStackDerived, changedProducts);
 
         regenerateCertificatesByEntIds(updatedMasterPools, lazy);
+    }
+
+    private void removeAndDeletePoolsOnOtherOwners(List<Pool> existingPools, Pool pool) {
+        List<Pool> toRemove = new LinkedList<Pool>();
+
+        for (Pool existing : existingPools) {
+            if (!existing.getOwner().equals(pool.getOwner())) {
+                toRemove.add(existing);
+                log.warn("Removing {} because it exists in the wrong org", existing);
+                if (existing.getType() == PoolType.NORMAL || existing.getType() == PoolType.BONUS) {
+                    deletePool(existing);
+                }
+            }
+        }
+
+        existingPools.removeAll(toRemove);
     }
 
     /**
@@ -494,26 +510,6 @@ public class CandlepinPoolManager implements PoolManager {
         this.poolCurator.flush();
 
         return pools.size();
-    }
-
-    private boolean isExpired(Subscription subscription) {
-        Date now = new Date();
-        return now.after(subscription.getEndDate());
-    }
-
-    void removeAndDeletePoolsOnOtherOwners(List<Pool> existingPools, Pool pool) {
-        List<Pool> toRemove = new LinkedList<Pool>();
-        for (Pool existing : existingPools) {
-            if (!existing.getOwner().equals(pool.getOwner())) {
-                toRemove.add(existing);
-                log.warn("Removing {} because it exists in the wrong org", existing);
-                if (existing.getType() == PoolType.NORMAL ||
-                    existing.getType() == PoolType.BONUS) {
-                    deletePool(existing);
-                }
-            }
-        }
-        existingPools.removeAll(toRemove);
     }
 
     /**
@@ -1979,7 +1975,7 @@ public class CandlepinPoolManager implements PoolManager {
 
         // Look up the related pools for these subscription IDs.
         if (!subscriptionIds.isEmpty()) {
-            poolsToDelete.addAll(this.poolCurator.getPoolsBySubscriptionIds(subscriptionIds));
+            poolsToDelete.addAll(this.poolCurator.getPoolsBySubscriptionIds(subscriptionIds).list());
         }
 
         if (!poolsToDelete.isEmpty()) {
@@ -2187,7 +2183,7 @@ public class CandlepinPoolManager implements PoolManager {
     }
 
     @Override
-    public List<Pool> getPoolsBySubscriptionId(String subscriptionId) {
+    public CandlepinQuery<Pool> getPoolsBySubscriptionId(String subscriptionId) {
         return this.poolCurator.getPoolsBySubscriptionId(subscriptionId);
     }
 

--- a/server/src/main/java/org/candlepin/controller/OwnerManager.java
+++ b/server/src/main/java/org/candlepin/controller/OwnerManager.java
@@ -118,7 +118,10 @@ public class OwnerManager {
 
         for (Consumer consumer : consumers) {
             log.info("Removing all entitlements for consumer: {}", consumer);
-            poolManager.revokeAllEntitlements(consumer, revokeCerts);
+
+            // We're about to delete these consumers; no need to regen/dirty their dependent
+            // entitlements or recalculate status.
+            poolManager.revokeAllEntitlements(consumer, false);
         }
 
         // Actual consumer deletion is done out of the loop above since all

--- a/server/src/main/java/org/candlepin/controller/PoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/PoolManager.java
@@ -282,7 +282,7 @@ public interface PoolManager {
      * @return
      *  a list of pools associated with the specified subscription.
      */
-    List<Pool> getPoolsBySubscriptionId(String subscriptionId);
+    CandlepinQuery<Pool> getPoolsBySubscriptionId(String subscriptionId);
 
     /**
      * Retrieves the master pool associated with the specified subscription ID. If there is not a

--- a/server/src/main/java/org/candlepin/liquibase/FixDuplicatePoolsLiquibaseWrapper.java
+++ b/server/src/main/java/org/candlepin/liquibase/FixDuplicatePoolsLiquibaseWrapper.java
@@ -49,8 +49,7 @@ public class FixDuplicatePoolsLiquibaseWrapper implements CustomTaskChange {
     @Override
     public void execute(Database db) throws CustomChangeException {
         JdbcConnection conn = (JdbcConnection) db.getConnection();
-        FixDuplicatePools fixer = new FixDuplicatePools(conn,
-            new LiquibaseCustomTaskLogger());
+        FixDuplicatePools fixer = new FixDuplicatePools(conn, new LiquibaseCustomTaskLogger());
 
         try {
             fixer.execute();

--- a/server/src/main/java/org/candlepin/model/PoolCurator.java
+++ b/server/src/main/java/org/candlepin/model/PoolCurator.java
@@ -31,6 +31,7 @@ import org.hibernate.Filter;
 import org.hibernate.Hibernate;
 import org.hibernate.Query;
 import org.hibernate.ReplicationMode;
+import org.hibernate.Session;
 import org.hibernate.criterion.Criterion;
 import org.hibernate.criterion.DetachedCriteria;
 import org.hibernate.criterion.Disjunction;
@@ -1122,27 +1123,51 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
     }
 
     @SuppressWarnings("unchecked")
-    public List<Pool> getPoolsBySubscriptionId(String subId) {
-        return currentSession().createCriteria(Pool.class)
-            .createAlias("sourceSubscription", "sourceSub", JoinType.LEFT_OUTER_JOIN)
-            .add(Restrictions.eq("sourceSub.subscriptionId", subId))
-            .addOrder(Order.asc("id"))
-            .list();
+    public CandlepinQuery<Pool> getPoolsBySubscriptionId(String subId) {
+        String jpql = "SELECT DISTINCT ss.pool.id FROM SourceSubscription ss WHERE ss.subscriptionId = :sid";
+
+        List<String> ids = this.getEntityManager()
+            .createQuery(jpql, String.class)
+            .setParameter("sid", subId)
+            .getResultList();
+
+        if (ids != null && !ids.isEmpty()) {
+            DetachedCriteria criteria = this.createSecureDetachedCriteria(Pool.class, null)
+                .add(CPRestrictions.in("id", ids))
+                .addOrder(Order.asc("id"));
+
+            return this.cpQueryFactory.<Pool>buildQuery(this.currentSession(), criteria);
+        }
+
+        return this.cpQueryFactory.<Pool>buildQuery();
     }
 
     @SuppressWarnings("unchecked")
-    public List<Pool> getPoolsBySubscriptionIds(Collection<String> subIds) {
-        return currentSession().createCriteria(Pool.class)
-            .createAlias("sourceSubscription", "sourceSub", JoinType.LEFT_OUTER_JOIN)
-            .add(CPRestrictions.in("sourceSub.subscriptionId", subIds))
-            .addOrder(Order.asc("id"))
-            .list();
+    public CandlepinQuery<Pool> getPoolsBySubscriptionIds(Collection<String> subIds) {
+        if (subIds != null && !subIds.isEmpty()) {
+            Session session = this.currentSession();
+
+            List<String> ids = session.createCriteria(SourceSubscription.class)
+                .add(CPRestrictions.in("subscriptionId", subIds))
+                .setProjection(Projections.distinct(Projections.property("pool.id")))
+                .list();
+
+            if (ids != null && !ids.isEmpty()) {
+                DetachedCriteria criteria = this.createSecureDetachedCriteria(Pool.class, null)
+                    .add(CPRestrictions.in("id", ids))
+                    .addOrder(Order.asc("id"));
+
+                return this.cpQueryFactory.<Pool>buildQuery(session, criteria);
+            }
+        }
+
+        return this.cpQueryFactory.<Pool>buildQuery();
     }
 
     @SuppressWarnings("unchecked")
     public Pool getMasterPoolBySubscriptionId(String subscriptionId) {
         return (Pool) currentSession().createCriteria(Pool.class)
-            .createAlias("sourceSubscription", "srcsub", JoinType.LEFT_OUTER_JOIN)
+            .createAlias("sourceSubscription", "srcsub")
             .add(Restrictions.eq("srcsub.subscriptionId", subscriptionId))
             .add(Restrictions.eq("srcsub.subscriptionSubKey", "master"))
             .uniqueResult();

--- a/server/src/main/java/org/candlepin/model/SourceSubscription.java
+++ b/server/src/main/java/org/candlepin/model/SourceSubscription.java
@@ -144,8 +144,8 @@ public class SourceSubscription extends AbstractHibernateObject {
 
     @Override
     public String toString() {
-        return "SourceSubscription [subscriptionId=" + subscriptionId +
-                ", subscriptionSubKey=" + subscriptionSubKey + "]";
+        return String.format("SourceSubscription [subscriptionId: %s, subscriptionSubKey: %s]",
+            this.getSubscriptionId(), this.getSubscriptionSubKey());
     }
 
 

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -1423,7 +1423,9 @@ public class ConsumerResource {
         this.consumerCurator.lock(toDelete);
 
         try {
-            this.poolManager.revokeAllEntitlements(toDelete);
+            // We're about to delete this consumer; no need to regen/dirty its dependent
+            // entitlements or recalculate status.
+            this.poolManager.revokeAllEntitlements(toDelete, false);
         }
         catch (ForbiddenException e) {
             String msg = e.message().getDisplayMessage();
@@ -1969,7 +1971,7 @@ public class ConsumerResource {
         // CertificateCurator) to lookup by serialNumber
         Consumer consumer = consumerCurator.verifyAndLookupConsumer(consumerUuid);
 
-        int total = poolManager.revokeAllEntitlements(consumer);
+        int total = poolManager.revokeAllEntitlements(consumer, true);
         log.debug("Revoked {} entitlements from {}", total, consumerUuid);
         return new DeleteResult(total);
 

--- a/server/src/main/java/org/candlepin/resource/EnvironmentResource.java
+++ b/server/src/main/java/org/candlepin/resource/EnvironmentResource.java
@@ -140,7 +140,9 @@ public class EnvironmentResource {
         for (Consumer c : e.getConsumers()) {
             log.info("Deleting consumer: {}", c);
 
-            poolManager.revokeAllEntitlements(c);
+            // We're about to delete these consumers; no need to regen/dirty their dependent
+            // entitlements or recalculate status.
+            poolManager.revokeAllEntitlements(c, false);
             consumerCurator.delete(c);
         }
 

--- a/server/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -1086,9 +1086,8 @@ public class OwnerResource {
         @ApiParam(name = "subscription", required = true) Subscription subscription) {
         Pool existingPool = this.poolManager.getMasterPoolBySubscriptionId(subscription.getId());
         if (existingPool == null) {
-            throw new NotFoundException(i18n.tr(
-                "Unable to find a subscription with the ID ''{0}''.", subscription.getId()
-            ));
+            throw new NotFoundException(
+                i18n.tr("Unable to find a subscription with the ID ''{0}''.", subscription.getId()));
         }
         Pool updatedPool = this.poolManager.convertToMasterPool(subscription);
         updatedPool.setId(existingPool.getId());
@@ -1198,7 +1197,8 @@ public class OwnerResource {
         notes = "Updates a pool for an Owner. assumes this is a normal pool, and " +
         "errors out otherwise cause we cannot create master pools from bonus pools " +
         "TODO: while this method replaces the now deprecated updateSubsciption, it " +
-        "still uses it underneath. We need to re-implement the wheel like we did in " + "createPool ",
+        "still uses it underneath. We need to re-implement the wheel like we did in " +
+        "createPool ",
         value = "Update Pool")
     @ApiResponses({ @ApiResponse(code = 404, message = "Owner not found") })
     public void updatePool(@PathParam("owner_key") @Verify(Owner.class) String ownerKey,
@@ -1206,13 +1206,11 @@ public class OwnerResource {
 
         Pool currentPool = this.poolManager.find(newPool.getId());
         if (currentPool == null) {
-            throw new NotFoundException(i18n.tr(
-                "Unable to find a pool with the ID \"{0}\".", newPool.getId()
-            ));
+            throw new NotFoundException(
+                i18n.tr("Unable to find a pool with the ID \"{0}\".", newPool.getId()));
         }
 
-        if (currentPool.getType() != PoolType.NORMAL ||
-            newPool.getType() != PoolType.NORMAL) {
+        if (currentPool.getType() != PoolType.NORMAL || newPool.getType() != PoolType.NORMAL) {
             throw new BadRequestException(i18n.tr("Cannot update bonus pools, as they are auto generated"));
         }
 

--- a/server/src/main/java/org/candlepin/resource/SubscriptionResource.java
+++ b/server/src/main/java/org/candlepin/resource/SubscriptionResource.java
@@ -54,10 +54,11 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 
+
+
 /**
  * SubscriptionResource
  */
-
 @Path("/subscriptions")
 @Api(value = "subscriptions", authorizations = { @Authorization("basic") })
 @Consumes(MediaType.APPLICATION_JSON)
@@ -220,16 +221,16 @@ public class SubscriptionResource {
     public void deleteSubscription(@PathParam("subscription_id") String subscriptionId) {
 
         // Lookup pools from subscription ID
-        List<Pool> pools = this.poolManager.getPoolsBySubscriptionId(subscriptionId);
+        int count = 0;
 
-        if (pools.isEmpty()) {
-            throw new NotFoundException(
-                i18n.tr("A subscription with the ID \"{0}\" could not be found.", subscriptionId)
-            );
+        for (Pool pool : this.poolManager.getPoolsBySubscriptionId(subscriptionId)) {
+            this.poolManager.deletePool(pool);
+            ++count;
         }
 
-        for (Pool pool : pools) {
-            this.poolManager.deletePool(pool);
+        if (count == 0) {
+            throw new NotFoundException(
+                i18n.tr("A subscription with the ID \"{0}\" could not be found.", subscriptionId));
         }
     }
 

--- a/server/src/main/resources/db/changelog/20171011093538-add-sourcesub-id-index.xml
+++ b/server/src/main/resources/db/changelog/20171011093538-add-sourcesub-id-index.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <changeSet id="20171011093538-1" author="crog">
+        <comment>Add SourceSub ID Index</comment>
+
+        <createIndex indexName="cp2_pool_source_sub_idx2" tableName="cp2_pool_source_sub" unique="false">
+            <column name="subscription_id"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/server/src/main/resources/db/changelog/changelog-create.xml
+++ b/server/src/main/resources/db/changelog/changelog-create.xml
@@ -1217,4 +1217,5 @@
     <include file="db/changelog/20170612091842-default-content-access-list.xml"/>
     <include file="db/changelog/20170919110500-fixupstreampoolmigration.xml"/>
     <include file="db/changelog/20170718095058-purge-orphaned-pools.xml"/>
+    <include file="db/changelog/20171011093538-add-sourcesub-id-index.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-testing.xml
+++ b/server/src/main/resources/db/changelog/changelog-testing.xml
@@ -2308,4 +2308,5 @@
     <include file="db/changelog/20170612091842-default-content-access-list.xml"/>
     <include file="db/changelog/20170919110500-fixupstreampoolmigration.xml"/>
     <include file="db/changelog/20170718095058-purge-orphaned-pools.xml"/>
+    <include file="db/changelog/20171011093538-add-sourcesub-id-index.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-update.xml
+++ b/server/src/main/resources/db/changelog/changelog-update.xml
@@ -125,4 +125,5 @@
     <include file="db/changelog/20170612091842-default-content-access-list.xml"/>
     <include file="db/changelog/20170919110500-fixupstreampoolmigration.xml"/>
     <include file="db/changelog/20170718095058-purge-orphaned-pools.xml"/>
+    <include file="db/changelog/20171011093538-add-sourcesub-id-index.xml"/>
 </databaseChangeLog>

--- a/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -653,6 +653,10 @@ public class PoolManagerTest {
         when(cqmock.iterator()).thenReturn(pools.iterator());
         when(mockPoolCurator.listByOwnerAndType(eq(owner), any(PoolType.class))).thenReturn(cqmock);
 
+        cqmock = mock(CandlepinQuery.class);
+        when(cqmock.list()).thenReturn(Collections.<Pool>emptyList());
+        when(mockPoolCurator.getPoolsBySubscriptionIds(anyList())).thenReturn(cqmock);
+
         this.mockProductImport(owner, product);
         this.mockContentImport(owner, new Content[] {});
 
@@ -690,6 +694,10 @@ public class PoolManagerTest {
         when(cqmock.list()).thenReturn(pools);
         when(cqmock.iterator()).thenReturn(pools.iterator());
         when(mockPoolCurator.listByOwnerAndType(eq(owner), any(PoolType.class))).thenReturn(cqmock);
+
+        cqmock = mock(CandlepinQuery.class);
+        when(cqmock.list()).thenReturn(Collections.<Pool>emptyList());
+        when(mockPoolCurator.getPoolsBySubscriptionIds(anyList())).thenReturn(cqmock);
 
         this.manager.getRefresher(mockSubAdapter, mockOwnerAdapter).add(owner).run();
         List<Pool> delPools = Arrays.asList(p);
@@ -854,6 +862,14 @@ public class PoolManagerTest {
         when(cqmock.list()).thenReturn(pools);
         when(cqmock.iterator()).thenReturn(pools.iterator());
         when(mockPoolCurator.listByOwnerAndType(eq(owner), any(PoolType.class))).thenReturn(cqmock);
+
+        cqmock = mock(CandlepinQuery.class);
+        when(cqmock.list()).thenReturn(Collections.<Pool>emptyList());
+        when(mockPoolCurator.getPoolsBySubscriptionIds(anyList())).thenReturn(cqmock);
+
+        cqmock = mock(CandlepinQuery.class);
+        when(cqmock.list()).thenReturn(Collections.<Pool>emptyList());
+        when(mockPoolCurator.getPoolsBySubscriptionId(anyString())).thenReturn(cqmock);
 
         this.manager.getRefresher(mockSubAdapter, mockOwnerAdapter).add(owner).run();
 
@@ -1178,6 +1194,10 @@ public class PoolManagerTest {
         when(cqmock.iterator()).thenReturn(pools.iterator());
         when(mockPoolCurator.listByOwnerAndType(eq(owner), any(PoolType.class))).thenReturn(cqmock);
 
+        cqmock = mock(CandlepinQuery.class);
+        when(cqmock.list()).thenReturn(Collections.<Pool>emptyList());
+        when(mockPoolCurator.getPoolsBySubscriptionIds(anyList())).thenReturn(cqmock);
+
         this.manager.getRefresher(mockSubAdapter, mockOwnerAdapter).add(owner).run();
 
         List<Entitlement> entsToDelete = Arrays.asList(ent);
@@ -1409,6 +1429,7 @@ public class PoolManagerTest {
     private void mockPoolsList(List<Pool> pools) {
         List<Pool> floating = new LinkedList<Pool>();
         subToPools = new HashMap<String, List<Pool>>();
+
         for (Pool pool : pools) {
             String subid = pool.getSubscriptionId();
             if (subid != null) {
@@ -1421,9 +1442,13 @@ public class PoolManagerTest {
                 floating.add(pool);
             }
         }
+
         for (String subid : subToPools.keySet()) {
-            when(mockPoolCurator.getPoolsBySubscriptionId(eq(subid))).thenReturn(subToPools.get(subid));
+            CandlepinQuery cqmock = mock(CandlepinQuery.class);
+            when(cqmock.list()).thenReturn(subToPools.get(subid));
+            when(mockPoolCurator.getPoolsBySubscriptionId(eq(subid))).thenReturn(cqmock);
         }
+
         when(mockPoolCurator.getOwnersFloatingPools(any(Owner.class))).thenReturn(floating);
         when(mockPoolCurator.getPoolsFromBadSubs(any(Owner.class), any(Collection.class)))
             .thenAnswer(new Answer<List<Pool>>() {

--- a/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
@@ -1383,7 +1383,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
 
         Pool pool = createPool(owner2, "id123");
 
-        List<Pool> result = poolCurator.getPoolsBySubscriptionId(pool.getSubscriptionId());
+        List<Pool> result = poolCurator.getPoolsBySubscriptionId(pool.getSubscriptionId()).list();
         assertEquals(1, result.size());
         assertEquals(pool, result.get(0));
     }
@@ -1395,7 +1395,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
 
         createPool(owner2, "id123");
 
-        List<Pool> result = poolCurator.getPoolsBySubscriptionId(null);
+        List<Pool> result = poolCurator.getPoolsBySubscriptionId(null).list();
         assertTrue(result.isEmpty());
     }
 

--- a/server/src/test/java/org/candlepin/resource/SubscriptionResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/SubscriptionResourceTest.java
@@ -14,10 +14,11 @@
  */
 package org.candlepin.resource;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
 
+import java.util.Collections;
 import java.util.Locale;
 
 import javax.servlet.http.HttpServletResponse;
@@ -26,8 +27,10 @@ import javax.ws.rs.core.Response;
 import org.candlepin.common.exceptions.BadRequestException;
 import org.candlepin.common.exceptions.NotFoundException;
 import org.candlepin.controller.PoolManager;
+import org.candlepin.model.CandlepinQuery;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerCurator;
+import org.candlepin.model.Pool;
 import org.candlepin.service.SubscriptionServiceAdapter;
 import org.junit.Before;
 import org.junit.Test;
@@ -36,6 +39,8 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.xnap.commons.i18n.I18n;
 import org.xnap.commons.i18n.I18nFactory;
+
+
 
 /**
  * SubscriptionResourceTest
@@ -65,6 +70,11 @@ public class SubscriptionResourceTest  {
 
     @Test(expected = NotFoundException.class)
     public void testInvalidIdOnDelete() throws Exception {
+        CandlepinQuery<Pool> cqmock = mock(CandlepinQuery.class);
+        when(cqmock.list()).thenReturn(Collections.<Pool>emptyList());
+        when(cqmock.iterator()).thenReturn(Collections.<Pool>emptyList().iterator());
+        when(poolManager.getPoolsBySubscriptionId(anyString())).thenReturn(cqmock);
+
         subResource.deleteSubscription("JarJarBinks");
     }
 


### PR DESCRIPTION
- Updated getPoolsBySubscriptionIds to pull pool IDs directly from
  the cp2_pool_source_sub table, then lookup pools from there
- Deleting consumers no longer triggers consumer status recalcuation
  nor dependent entitlement regeneration
- Added an index on the cp2_pool_source_sub.subscription_id column
  to help speed up subscription ID based lookups