### PR TITLE
1487758 Added index on cp_consumer.username field

### DIFF
--- a/server/src/main/java/org/candlepin/model/Consumer.java
+++ b/server/src/main/java/org/candlepin/model/Consumer.java
@@ -28,9 +28,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.apache.commons.lang.StringUtils;
 import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Cascade;
-import org.hibernate.annotations.ForeignKey;
 import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Index;
 import org.hibernate.annotations.Type;
 
 import java.util.ArrayList;
@@ -150,19 +148,14 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
 
     @ManyToOne
     @JoinColumn(nullable = false)
-    @ForeignKey(name = "fk_consumer_consumer_type")
     private ConsumerType type;
 
     @ManyToOne
-    @ForeignKey(name = "fk_consumer_owner")
     @JoinColumn(nullable = false)
-    @Index(name = "cp_consumer_owner_fk_idx")
     private Owner owner;
 
     @ManyToOne
-    @ForeignKey(name = "fk_consumer_env")
     @JoinColumn(nullable = true)
-    @Index(name = "cp_consumer_env_fk_idx")
     private Environment environment;
 
     @Column(name = "entitlement_count")

--- a/server/src/main/resources/db/changelog/20171010164730-add-cp-consumer-username-index.xml
+++ b/server/src/main/resources/db/changelog/20171010164730-add-cp-consumer-username-index.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <changeSet id="20171010164730" author="nmoumoul">
+        <comment>Add index on username to cp_consumer</comment>
+        <createIndex indexName="cp_consumer_username_idx"
+                    tableName="cp_consumer"
+                    unique="false">
+            <column name="username"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-create.xml
+++ b/server/src/main/resources/db/changelog/changelog-create.xml
@@ -1218,5 +1218,6 @@
     <include file="db/changelog/20170816084513-add-createdByShare-and-hasSharedAncestor.xml"/>
     <include file="db/changelog/20170919110500-fixupstreampoolmigration.xml"/>
     <include file="db/changelog/20170718095058-purge-orphaned-pools.xml"/>
+    <include file="db/changelog/20171010164730-add-cp-consumer-username-index.xml"/>
     <include file="db/changelog/20171011093538-add-sourcesub-id-index.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-testing.xml
+++ b/server/src/main/resources/db/changelog/changelog-testing.xml
@@ -2309,5 +2309,6 @@
     <include file="db/changelog/20170816084513-add-createdByShare-and-hasSharedAncestor.xml"/>
     <include file="db/changelog/20170919110500-fixupstreampoolmigration.xml"/>
     <include file="db/changelog/20170718095058-purge-orphaned-pools.xml"/>
+    <include file="db/changelog/20171010164730-add-cp-consumer-username-index.xml"/>
     <include file="db/changelog/20171011093538-add-sourcesub-id-index.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-update.xml
+++ b/server/src/main/resources/db/changelog/changelog-update.xml
@@ -126,5 +126,6 @@
     <include file="db/changelog/20170816084513-add-createdByShare-and-hasSharedAncestor.xml"/>
     <include file="db/changelog/20170919110500-fixupstreampoolmigration.xml"/>
     <include file="db/changelog/20170718095058-purge-orphaned-pools.xml"/>
+    <include file="db/changelog/20171010164730-add-cp-consumer-username-index.xml"/>
     <include file="db/changelog/20171011093538-add-sourcesub-id-index.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
In addition to liquibase changes to add the index I have
deleted useless and deprecated @Index and @ForeignKey hibernate
annotations from Consumer since they are DDL specific.