### PR TITLE
Event Simplification: Removed oldEntity from Events

### DIFF
--- a/server/src/main/java/org/candlepin/audit/Event.java
+++ b/server/src/main/java/org/candlepin/audit/Event.java
@@ -137,14 +137,6 @@ public class Event implements Persisted {
     @Enumerated(EnumType.STRING)
     private ReferenceType referenceType;
 
-    // Both old/new may be null for creation/deletion events. These are marked
-    // Transient as we decided we do not necessarily want to store the object
-    // state
-    // in our Events table. The Event passing through the message queue will
-    // still
-    // carry them.
-    @Transient
-    private String oldEntity;
     @Transient
     private String newEntity;
 
@@ -156,7 +148,7 @@ public class Event implements Persisted {
 
     public Event(Type type, Target target, String targetName,
         Principal principal, String ownerId, String consumerId,
-        String entityId, String oldEntity, String newEntity,
+        String entityId, String newEntity,
         String referenceId, ReferenceType referenceType) {
         this.type = type;
         this.target = target;
@@ -167,7 +159,6 @@ public class Event implements Persisted {
         this.ownerId = ownerId;
 
         this.entityId = entityId;
-        this.oldEntity = oldEntity;
         this.newEntity = newEntity;
         this.consumerId = consumerId;
         this.referenceId = referenceId;
@@ -258,15 +249,6 @@ public class Event implements Persisted {
 
     public void setEntityId(String entityId) {
         this.entityId = entityId;
-    }
-
-    @XmlTransient
-    public String getOldEntity() {
-        return oldEntity;
-    }
-
-    public void setOldEntity(String oldEntity) {
-        this.oldEntity = oldEntity;
     }
 
     @XmlTransient

--- a/server/src/main/java/org/candlepin/audit/EventBuilder.java
+++ b/server/src/main/java/org/candlepin/audit/EventBuilder.java
@@ -40,47 +40,42 @@ public class EventBuilder {
         this.factory = factory;
 
         event = new Event(type, target, null, factory.principalProvider.get(),
-                null, null, null, null, null, null, null);
+                null, null, null, null, null, null);
     }
 
-    private void setEventData(Eventful entity) {
-        // Be careful to check for null before setting so we don't overwrite anything useful
-        if (entity instanceof Named && ((Named) entity).getName() != null) {
-            event.setTargetName(((Named) entity).getName());
-        }
-        if (entity instanceof Owned) {
-            Owner entityOwner = ((Owned) entity).getOwner();
-            if (entityOwner != null && entityOwner.getId() != null) {
-                event.setOwnerId(entityOwner.getId());
+    /*  Implementation note (2017/10/16):
+        This method is currently used instead of setOldEntity, since oldEntity was removed,
+        and it will also be used in the future instead of setNewEntity once newEntity is removed.
+        This is part of simplifying the data Events hold.
+     */
+    public EventBuilder setEventData(Eventful entity) {
+        if (entity != null) {
+            // Be careful to check for null before setting so we don't overwrite anything useful
+            if (entity instanceof Named && ((Named) entity).getName() != null) {
+                event.setTargetName(((Named) entity).getName());
             }
-        }
-        if (entity instanceof Entitlement) {
-            event.setReferenceType(Event.ReferenceType.POOL);
-            Pool referencedPool = ((Entitlement) entity).getPool();
-            if (referencedPool != null && referencedPool.getId() != null) {
-                event.setReferenceId(referencedPool.getId());
-            }
-        }
-        if ((String) entity.getId() != null) {
-            event.setEntityId((String) entity.getId());
-            if (entity instanceof ConsumerProperty) {
-                Consumer owningConsumer = ((ConsumerProperty) entity).getConsumer();
-                if (owningConsumer != null && owningConsumer.getId() != null) {
-                    event.setConsumerId(owningConsumer.getId());
+            if (entity instanceof Owned) {
+                Owner entityOwner = ((Owned) entity).getOwner();
+                if (entityOwner != null && entityOwner.getId() != null) {
+                    event.setOwnerId(entityOwner.getId());
                 }
             }
-        }
-    }
-
-    public EventBuilder setOldEntity(Eventful old) {
-        // Allow null, but don't do anything
-        if (old != null) {
-            // If the value is non-null and a value is set, we shouldn't allow it to continue
-            if (event.getType() == Type.CREATED) {
-                throw new IllegalArgumentException("You cannot set the old entity for a creation event");
+            if (entity instanceof Entitlement) {
+                event.setReferenceType(Event.ReferenceType.POOL);
+                Pool referencedPool = ((Entitlement) entity).getPool();
+                if (referencedPool != null && referencedPool.getId() != null) {
+                    event.setReferenceId(referencedPool.getId());
+                }
             }
-            setEventData(old);
-            event.setOldEntity(factory.entityToJson(old));
+            if ((String) entity.getId() != null) {
+                event.setEntityId((String) entity.getId());
+                if (entity instanceof ConsumerProperty) {
+                    Consumer owningConsumer = ((ConsumerProperty) entity).getConsumer();
+                    if (owningConsumer != null && owningConsumer.getId() != null) {
+                        event.setConsumerId(owningConsumer.getId());
+                    }
+                }
+            }
         }
         return this;
     }

--- a/server/src/main/java/org/candlepin/audit/EventFactory.java
+++ b/server/src/main/java/org/candlepin/audit/EventFactory.java
@@ -101,14 +101,14 @@ public class EventFactory {
 
     public Event rulesUpdated(Rules oldRules, Rules newRules) {
         return getEventBuilder(Target.RULES, Type.MODIFIED)
-            .setOldEntity(oldRules)
+            .setEventData(oldRules)
             .setNewEntity(newRules)
             .buildEvent();
     }
 
     public Event rulesDeleted(Rules deletedRules) {
         return getEventBuilder(Target.RULES, Type.DELETED)
-            .setOldEntity(deletedRules)
+            .setEventData(deletedRules)
             .buildEvent();
     }
 
@@ -118,16 +118,9 @@ public class EventFactory {
             .buildEvent();
     }
 
-    public Event consumerModified(Consumer oldConsumer, Consumer newConsumer) {
-        return getEventBuilder(Target.CONSUMER, Type.MODIFIED)
-            .setOldEntity(oldConsumer)
-            .setNewEntity(newConsumer)
-            .buildEvent();
-    }
-
     public Event consumerDeleted(Consumer oldConsumer) {
         return getEventBuilder(Target.CONSUMER, Type.DELETED)
-            .setOldEntity(oldConsumer)
+            .setEventData(oldConsumer)
             .buildEvent();
     }
 
@@ -139,13 +132,13 @@ public class EventFactory {
 
     public Event entitlementDeleted(Entitlement e) {
         return getEventBuilder(Target.ENTITLEMENT, Type.DELETED)
-            .setOldEntity(e)
+            .setEventData(e)
             .buildEvent();
     }
 
     public Event entitlementExpired(Entitlement e) {
         return getEventBuilder(Target.ENTITLEMENT, Type.EXPIRED)
-            .setOldEntity(e)
+            .setEventData(e)
             .buildEvent();
     }
 
@@ -169,13 +162,8 @@ public class EventFactory {
 
     public Event ownerDeleted(Owner owner) {
         return getEventBuilder(Target.OWNER, Type.DELETED)
-            .setOldEntity(owner)
+            .setEventData(owner)
             .buildEvent();
-    }
-
-    // FIXME: Why do we need this?
-    public Event ownerMigrated(Owner owner) {
-        return ownerModified(owner);
     }
 
     public Event poolCreated(Pool newPool) {
@@ -185,19 +173,9 @@ public class EventFactory {
     }
 
     public Event poolDeleted(Pool pool) {
-        // Impl note:
-        // As of 2017-09-28, no one consumes the old/deleted entity on this event, and
-        // it's incredibly expensive to serialize. As such, we're not going to set/output
-        // the old entity until we have an explicit need to do so. This means we need to
-        // manually set the entity and owner IDs.
-
-        Event event = getEventBuilder(Target.POOL, Type.DELETED)
+        return getEventBuilder(Target.POOL, Type.DELETED)
+            .setEventData(pool)
             .buildEvent();
-
-        event.setEntityId(pool.getId());
-        event.setOwnerId(pool.getOwner().getId());
-
-        return event;
     }
 
     public Event exportCreated(Consumer consumer) {
@@ -220,13 +198,13 @@ public class EventFactory {
 
     public Event guestIdDeleted(GuestId guestId) {
         return getEventBuilder(Target.GUESTID, Type.DELETED)
-            .setOldEntity(guestId)
+            .setEventData(guestId)
             .buildEvent();
     }
 
     public Event subscriptionExpired(Subscription subscription) {
         return getEventBuilder(Target.SUBSCRIPTION, Type.EXPIRED)
-             .setOldEntity(subscription)
+             .setEventData(subscription)
              .buildEvent();
     }
 
@@ -238,7 +216,7 @@ public class EventFactory {
         // part of a larger piece of work to simplify Event consumption.
         return new Event(Event.Type.CREATED, Event.Target.COMPLIANCE,
             consumer.getName(), principalProvider.get(), consumer.getOwner().getId(), consumer.getUuid(),
-            consumer.getUuid(), null, buildComplianceDataJson(consumer, entitlements, compliance), null,
+            consumer.getUuid(), buildComplianceDataJson(consumer, entitlements, compliance), null,
             null);
     }
 

--- a/server/src/main/java/org/candlepin/audit/EventSinkImpl.java
+++ b/server/src/main/java/org/candlepin/audit/EventSinkImpl.java
@@ -233,7 +233,7 @@ public class EventSinkImpl implements EventSink {
     }
 
     public void emitOwnerMigrated(Owner owner) {
-        Event e = eventFactory.ownerMigrated(owner);
+        Event e = eventFactory.ownerModified(owner);
         queueEvent(e);
     }
 

--- a/server/src/main/java/org/candlepin/audit/LoggingListener.java
+++ b/server/src/main/java/org/candlepin/audit/LoggingListener.java
@@ -89,8 +89,7 @@ public class LoggingListener implements EventListener {
                 e.getOwnerId()}
         );
         if (verbose) {
-            auditLog.info(String.format("==OLD==\n%s\n==NEW==\n%s\n\n", e.getOldEntity(),
-                e.getNewEntity()));
+            auditLog.info(String.format("==NEW==\n%s\n\n", e.getNewEntity()));
         }
     }
 

--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -539,7 +539,7 @@ public class CandlepinPoolManager implements PoolManager {
         for (Pool existing : existingPools) {
             EventBuilder eventBuilder = eventFactory
                 .getEventBuilder(Target.POOL, Type.MODIFIED)
-                .setOldEntity(existing);
+                .setEventData(existing);
             poolEvents.put(existing.getId(), eventBuilder);
         }
 
@@ -565,7 +565,7 @@ public class CandlepinPoolManager implements PoolManager {
 
                     EventBuilder eventBuilder = eventFactory
                         .getEventBuilder(Target.POOL, Type.MODIFIED)
-                        .setOldEntity(subPool);
+                        .setEventData(subPool);
 
                     poolEvents.put(subPool.getId(), eventBuilder);
                 }
@@ -647,7 +647,7 @@ public class CandlepinPoolManager implements PoolManager {
         Map<String, EventBuilder> poolEvents = new HashMap<String, EventBuilder>();
         for (Pool existing : floatingPools) {
             EventBuilder eventBuilder = eventFactory.getEventBuilder(Target.POOL, Type.MODIFIED)
-                .setOldEntity(existing);
+                .setEventData(existing);
             poolEvents.put(existing.getId(), eventBuilder);
         }
 

--- a/server/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRules.java
@@ -767,7 +767,7 @@ public class EntitlementRules implements Enforcer {
 
                     EventBuilder builder = eventFactory.getEventBuilder(
                         Event.Target.PRODUCT, Event.Type.MODIFIED);
-                    builder.setOldEntity(existingProduct);
+                    builder.setEventData(existingProduct);
                     sharesToDelete.add(existingShare);
                     sharesToCreate.add(new ProductShare(sharingOwner, sharingOwnerProduct, recipient));
                     // Now we need to reconcile all of recipient's pools that were using the old product.

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -1055,7 +1055,7 @@ public class ConsumerResource {
         // If nothing changes we won't send.  The new entity needs to be correct though,
         // so we should get a Jsonstring now, and finish it off if we're going to send
         EventBuilder eventBuilder = eventFactory.getEventBuilder(Target.CONSUMER, Type.MODIFIED)
-            .setOldEntity(toUpdate);
+            .setEventData(toUpdate);
 
         // version changed on non-checked in consumer, or list of capabilities
         // changed on checked in consumer
@@ -2312,7 +2312,7 @@ public class ConsumerResource {
     private Consumer regenerateIdentityCertificate(Consumer consumer) {
         EventBuilder eventBuilder = eventFactory
             .getEventBuilder(Target.CONSUMER, Type.MODIFIED)
-            .setOldEntity(consumer);
+            .setEventData(consumer);
 
         IdentityCertificate ic = generateIdCert(consumer, true);
         consumer.setIdCert(ic);

--- a/server/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -934,7 +934,7 @@ public class OwnerResource {
         @ApiParam(name = "owner", required = true) Owner owner) {
         Owner toUpdate = findOwner(key);
         EventBuilder eventBuilder = eventFactory.getEventBuilder(Target.OWNER, Type.MODIFIED)
-            .setOldEntity(toUpdate);
+            .setEventData(toUpdate);
 
         log.debug("Updating owner: {}", key);
 

--- a/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -183,7 +183,7 @@ public class PoolManagerTest {
         when(eventFactory.getEventBuilder(any(Target.class), any(Type.class))).thenReturn(eventBuilder);
 
         when(eventBuilder.setNewEntity(any(Eventful.class))).thenReturn(eventBuilder);
-        when(eventBuilder.setOldEntity(any(Eventful.class))).thenReturn(eventBuilder);
+        when(eventBuilder.setEventData(any(Eventful.class))).thenReturn(eventBuilder);
 
         this.principal = TestUtil.createOwnerPrincipal(owner);
 
@@ -1776,7 +1776,6 @@ public class PoolManagerTest {
 
         Event event = new Event();
         event.setConsumerId(guest.getUuid());
-        event.setOldEntity(ent.getId());
         event.setOwnerId(owner.getId());
         event.setTarget(Target.ENTITLEMENT);
         event.setType(Type.EXPIRED);

--- a/server/src/test/java/org/candlepin/model/EventCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/EventCuratorTest.java
@@ -16,7 +16,6 @@ package org.candlepin.model;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 
 import org.candlepin.audit.Event;
 import org.candlepin.audit.Event.Type;
@@ -61,7 +60,6 @@ public class EventCuratorTest extends DatabaseTestFixture {
         eventCurator.create(event);
 
         Event lookedUp = eventCurator.find(event.getId());
-        assertNull(lookedUp.getOldEntity());
         assertEquals(Type.CREATED, lookedUp.getType());
         assertNotNull(lookedUp.getId());
     }
@@ -81,7 +79,7 @@ public class EventCuratorTest extends DatabaseTestFixture {
 
         EventBuilder builder = eventFactory.getEventBuilder(Event.Target.RULES,
             Event.Type.DELETED);
-        Event rulesDeletedEvent = builder.setOldEntity(new Rules()).buildEvent();
+        Event rulesDeletedEvent = builder.setEventData(new Rules()).buildEvent();
         rulesDeletedEvent.setTimestamp(forcedDate);
 
         builder = eventFactory.getEventBuilder(Event.Target.CONSUMER,
@@ -92,7 +90,7 @@ public class EventCuratorTest extends DatabaseTestFixture {
         builder = eventFactory.getEventBuilder(Event.Target.CONSUMER,
                 Event.Type.MODIFIED);
         Event consumerModifiedEvent = builder.setNewEntity(newConsumer).
-            setOldEntity(newConsumer).buildEvent();
+            setEventData(newConsumer).buildEvent();
         consumerModifiedEvent.setTimestamp(forcedDate);
 
         eventCurator.create(rulesDeletedEvent);

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
@@ -149,7 +149,7 @@ public class ConsumerResourceTest {
         this.config = new CandlepinCommonTestConfig();
 
         this.i18n = I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK);
-        when(eventBuilder.setOldEntity(any(Consumer.class))).thenReturn(eventBuilder);
+        when(eventBuilder.setEventData(any(Consumer.class))).thenReturn(eventBuilder);
         when(eventBuilder.setNewEntity(any(Consumer.class))).thenReturn(eventBuilder);
         when(eventFactory.getEventBuilder(any(Target.class), any(Type.class))).thenReturn(eventBuilder);
 

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
@@ -130,7 +130,7 @@ public class ConsumerResourceUpdateTest {
 
         when(consumerEventBuilder.setNewEntity(any(Consumer.class)))
             .thenReturn(consumerEventBuilder);
-        when(consumerEventBuilder.setOldEntity(any(Consumer.class)))
+        when(consumerEventBuilder.setEventData(any(Consumer.class)))
             .thenReturn(consumerEventBuilder);
         when(eventFactory.getEventBuilder(any(Target.class), any(Type.class)))
             .thenReturn(consumerEventBuilder);
@@ -424,10 +424,6 @@ public class ConsumerResourceUpdateTest {
         Consumer updated = createConsumerWithGuests("Guest 1", "Guest 2");
         updated.setUuid(uuid);
 
-        // Has to be mocked even though we don't intend to send:
-        Event event = new Event();
-        when(this.eventFactory.consumerModified(existing, updated)).thenReturn(event);
-
         when(this.consumerCurator.getGuestConsumersMap(any(Owner.class), any(Set.class))).
             thenReturn(new VirtConsumerMap());
 
@@ -446,10 +442,6 @@ public class ConsumerResourceUpdateTest {
         // flip case on one ID, should be treated as no change
         Consumer updated = createConsumerWithGuests("aaa123", "BBB123");
         updated.setUuid(uuid);
-
-        // Has to be mocked even though we don't intend to send:
-        Event event = new Event();
-        when(this.eventFactory.consumerModified(existing, updated)).thenReturn(event);
 
         when(this.consumerCurator.getGuestConsumersMap(any(Owner.class), any(Set.class))).
             thenReturn(new VirtConsumerMap());

--- a/server/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
@@ -134,7 +134,7 @@ public class HypervisorResourceTest {
             .thenReturn(consumerEventBuilder);
         when(consumerEventBuilder.setNewEntity(any(Consumer.class)))
             .thenReturn(consumerEventBuilder);
-        when(consumerEventBuilder.setOldEntity(any(Consumer.class)))
+        when(consumerEventBuilder.setEventData(any(Consumer.class)))
             .thenReturn(consumerEventBuilder);
     }
 


### PR DESCRIPTION
- Removed the oldEntity field from the Event class, also
removed setOldEntity/getOldEntity from EventBuilder and EventFactory.
- Made setEventData on EventBuilder public to be used instead
of setOldEntity when building Events. This method will probably be
re-used similarly when newEntity will be removed in the future and
will be used when creating CREATED/DELETED events. It will be
overloaded for creating MODIFIED events (which currently need both
old/new entity).
- Removed a couple of unused methods (consumerModified, ownerMigrated)