### PR TITLE
[M] Made several optimizations to PoolManager.deletePools

### DIFF
--- a/server/src/main/java/org/candlepin/bind/HandleCertificatesOp.java
+++ b/server/src/main/java/org/candlepin/bind/HandleCertificatesOp.java
@@ -66,6 +66,7 @@ public class HandleCertificatesOp implements BindOperation {
             List<Pool> pools = new LinkedList<Pool>();
             Map<String, Product> products = new HashMap<String, Product>();
             Map<String, PoolQuantity> poolQuantities = context.getPoolQuantities();
+
             for (PoolQuantity poolQuantity : poolQuantities.values()) {
                 Pool pool = poolQuantity.getPool();
                 products.put(pool.getId(), pool.getProduct());
@@ -78,8 +79,9 @@ public class HandleCertificatesOp implements BindOperation {
                 context.getEntitlementMap(),
                 false);
 
-            modifyingEnts = this.eCurator.getDependentEntitlementIds(context.getConsumer(), pools);
+            modifyingEnts = this.eCurator.getDependentEntitlementIdsForPools(context.getConsumer(), pools);
         }
+
         return true;
     }
 

--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -1009,6 +1009,7 @@ public class CandlepinPoolManager implements PoolManager {
                         }
                     }
                 }
+
                 if (retry) {
                     log.info("Entitlements exhausted between select best pools and bind operations;" +
                         " retrying");
@@ -1585,9 +1586,9 @@ public class CandlepinPoolManager implements PoolManager {
         Map<String, Integer> poolQuantityMap, CallerType caller)
         throws EntitlementRefusedException {
 
-        Collection<Entitlement> ents = bindChainFactory.
-            create(consumer, poolQuantityMap, caller).
-            run();
+        Collection<Entitlement> ents = bindChainFactory
+            .create(consumer, poolQuantityMap, caller)
+            .run();
 
         poolCurator.flush();
 
@@ -1621,6 +1622,7 @@ public class CandlepinPoolManager implements PoolManager {
                 derivedPools.add(pool);
             }
         }
+
         RevocationOp rp = new RevocationOp(poolCurator, derivedPools);
         rp.execute(this);
     }
@@ -1691,9 +1693,11 @@ public class CandlepinPoolManager implements PoolManager {
         if (log.isDebugEnabled()) {
             log.debug("Starting batch revoke of entitlements: {}", getEntIds(entsToRevoke));
         }
+
         if (CollectionUtils.isEmpty(entsToRevoke)) {
             return;
         }
+
         List<Pool> poolsToDelete = poolCurator.listBySourceEntitlements(entsToRevoke);
         if (log.isDebugEnabled()) {
             log.debug("Found additional pools to delete by source entitlements: {}",
@@ -1734,16 +1738,19 @@ public class CandlepinPoolManager implements PoolManager {
 
             pool.setConsumed(pool.getConsumed() - entQuantity);
             Consumer consumer = ent.getConsumer();
+
             if (consumer.isManifestDistributor()) {
                 pool.setExported(pool.getExported() - entQuantity);
             }
             else if (consumer.isShare()) {
                 pool.setShared(pool.getShared() - entQuantity);
             }
+
             consumer.setEntitlementCount(consumer.getEntitlementCount() - entQuantity);
             consumerCurator.update(consumer);
             poolsToSave.add(pool);
         }
+
         poolCurator.updateAll(poolsToSave, false, false);
 
         /*
@@ -1787,8 +1794,10 @@ public class CandlepinPoolManager implements PoolManager {
             if (i++ % 1000 == 0) {
                 consumerCurator.flush();
             }
+
             complianceRules.getStatus(consumer);
         }
+
         consumerCurator.flush();
 
         log.info("All statuses recomputed.");
@@ -1802,14 +1811,17 @@ public class CandlepinPoolManager implements PoolManager {
             if (entitlement.deletedFromPool()) {
                 continue;
             }
+
             Consumer consumer = entitlement.getConsumer();
             Event event = eventFactory.entitlementDeleted(entitlement);
+
             if (!entitlement.isValid() && entitlement.getPool().isUnmappedGuestPool() &&
                 consumerCurator.getHost(consumer) == null) {
                 event = eventFactory.entitlementExpired(entitlement);
                 event.setMessageText(event.getMessageText() + ": " +
                     i18n.tr("Unmapped guest entitlement expired without establishing a host/guest mapping."));
             }
+
             sink.queueEvent(event);
         }
     }
@@ -1821,9 +1833,11 @@ public class CandlepinPoolManager implements PoolManager {
      */
     private List<String> getEntIds(Collection<Entitlement> entitlements) {
         List<String> ids = new ArrayList<String>();
+
         for (Entitlement e : entitlements) {
             ids.add(e.getId());
         }
+
         return ids;
     }
 
@@ -1834,9 +1848,11 @@ public class CandlepinPoolManager implements PoolManager {
      */
     private List<String> getPoolIds(Collection<Pool> pools) {
         List<String> ids = new ArrayList<String>();
+
         for (Pool e : pools) {
             ids.add(e.getId());
         }
+
         return ids;
     }
 
@@ -1882,6 +1898,7 @@ public class CandlepinPoolManager implements PoolManager {
             for (Entitlement ent : entry.getValue()) {
                 stackIds.add(ent.getPool().getStackId());
             }
+
             List<Pool> subPools = poolCurator.getSubPoolForStackIds(entry.getKey(), stackIds);
             if (CollectionUtils.isNotEmpty(subPools)) {
                 poolRules.updatePoolsFromStack(entry.getKey(), subPools, alreadyDeletedPools, true);
@@ -1931,65 +1948,237 @@ public class CandlepinPoolManager implements PoolManager {
 
     @Override
     public void deletePools(Collection<Pool> pools) {
-        deletePools(pools, null);
+        this.deletePools(pools, null);
     }
 
     @Override
     @Transactional
     @Traceable
-    public void deletePools(Collection<Pool> pools, Set<String> alreadyDeletedPools) {
+    @SuppressWarnings("checkstyle:methodlength")
+    public void deletePools(Collection<Pool> pools, Collection<String> alreadyDeletedPoolIds) {
         if (pools == null || pools.isEmpty()) {
             return;
         }
 
-        if (alreadyDeletedPools == null) {
-            alreadyDeletedPools = new HashSet<String>();
+        log.info("Attempting to delete {} pools...", pools.size());
+
+        // TODO: Remove this and fix the bugs it works around. We absolutely should not be
+        // passing state through the various codepaths like this. It makes things far messier
+        // than they need to be and is resulting in running slow calculations multiple times.
+        if (alreadyDeletedPoolIds == null) {
+            alreadyDeletedPoolIds = new HashSet<String>();
         }
 
-        if (log.isDebugEnabled()) {
-            log.debug("Delete pools: {}", getPoolIds(pools));
-        }
+        Set<String> poolIds = new HashSet<String>();
+        Set<String> entitlementIds = new HashSet<String>();
+        Owner owner = null;
 
-        List<Entitlement> entitlementsToRevoke = new LinkedList<Entitlement>();
-        Set<String> subscriptionIds = new HashSet<String>();
-        Set<Pool> poolsToDelete = new HashSet<Pool>();
-
+        // Convert pools to pool IDs.
+        log.info("Fetching related pools and entitlements...");
         for (Pool pool : pools) {
-            if (log.isDebugEnabled()) {
-                log.debug("Deletion of pool {} will revoke the following entitlements: {}",
-                    pool.getId(), getEntIds(pool.getEntitlements()));
+            if (owner == null) {
+                owner = pool.getOwner();
             }
 
-            // If this is a master pool, we should also be deleting any derived/bonus pools
-            // as well...
-            SourceSubscription srcSub = pool.getSourceSubscription();
-            if (srcSub != null && srcSub.getSubscriptionId() != null &&
-                "master".equals(srcSub.getSubscriptionSubKey())) {
+            poolIds.add(pool.getId());
+        }
 
-                subscriptionIds.add(srcSub.getSubscriptionId());
+        // Fetch pools which are derived from the pools we're going to delete...
+        poolIds.addAll(this.poolCurator.getDerivedPoolIdsForPools(poolIds));
+
+        // Fetch related pools and entitlements (recursively)
+        Collection<String> pids = poolIds;
+        int cachedSize;
+        do {
+            // Fetch entitlement IDs for our set of pools
+            Collection<String> eids = this.poolCurator.getEntitlementIdsForPools(pids);
+
+            // Fetch pools which are derived from these entitlements...
+            pids = this.poolCurator.getPoolIdsForSourceEntitlements(eids);
+
+            // Fetch pools which are derived from the pools we're going to delete...
+            pids.addAll(this.poolCurator.getDerivedPoolIdsForPools(pids));
+
+            // Add the new entitlement and pool IDs to our list of things to delete
+            cachedSize = poolIds.size();
+            entitlementIds.addAll(eids);
+            poolIds.addAll(pids);
+        }
+        while (poolIds.size() != cachedSize);
+
+        // If we've been provided a collection of already-deleted pool IDs, remove those from
+        // the list so we don't pull entitlements for them.
+        if (alreadyDeletedPoolIds != null) {
+            poolIds.removeAll(alreadyDeletedPoolIds);
+        }
+
+        // Lock pools we're going to delete (also, fetch them for event generation/slow deletes)
+        pools = this.poolCurator.lockAndLoadByIds(poolIds);
+
+        if (!pools.isEmpty()) {
+            log.info("Locked {} pools for deletion...", pools.size());
+
+            // Impl note:
+            // There is a fair bit of duplicated work between the actions below this block and
+            // methods like revokeEntitlements. However, the decision was made to decouple these
+            // methods explicitly to avoid situations such as fetching collections of pools, getting
+            // entitlements from them (a slow process in itself) and then passing it off to another
+            // standalone method which repeats the process of fetching pools and related entitlements.
+            //
+            // More work can be done in revokeEntitlements to optimize that method and maybe make it
+            // slightly more generic so that this work can be offloaded to it again. Though, at the time
+            // of writing, that's no small undertaking. Even changing this method has far-reaching
+            // consequences when trying to remove direct uses of entities as far as interoperability is
+            // concerned. Going forward we need to be more aware of the amount of duplication we're
+            // adding to our code when writing standlone/generic utility methods and linking them
+            // together, and perhaps take steps to avoid getting into situations like these two methods.
+
+            // Fetch the list of pools which are related to the entitlements but are *not* being
+            // deleted. We'll need to update the quantities on these.
+            Collection<String> affectedPoolIds = this.poolCurator.getPoolIdsForEntitlements(entitlementIds);
+            affectedPoolIds.removeAll(poolIds);
+
+            // Fetch entitlements (uggh).
+            // TODO: Stop doing this. Update the bits below to not use the entities directly and
+            // do the updates via queries.
+            Collection<Entitlement> entitlements = !entitlementIds.isEmpty() ?
+                this.entitlementCurator.listAllByIds(entitlementIds).list() :
+                Collections.<Entitlement>emptySet();
+
+            // Mark remaining dependent entitlements dirty for this consumer
+            this.entitlementCurator.markDependentEntitlementsDirty(entitlements, true);
+
+            // Unlink the pools and entitlements we're about to delete so we don't error out while
+            // trying to delete entitlements.
+            this.poolCurator.clearPoolSourceEntitlementRefs(poolIds);
+
+            // Revoke/delete entitlements
+            if (!entitlements.isEmpty()) {
+                log.info("Revoking {} entitlements...", entitlements.size());
+                this.entitlementCurator.batchDelete(entitlements);
+                this.entitlementCurator.flush();
+                log.info("Entitlements successfully revoked");
+            }
+            else {
+                log.info("Skipping entitlement revocation; no entitlements to revoke");
             }
 
-            poolsToDelete.add(pool);
-            for (Entitlement e: pool.getEntitlements()) {
-                e.setDeletedFromPool(true);
-                entitlementsToRevoke.add(e);
+            // Delete pools
+            log.info("Deleting {} pools...", pools.size());
+            this.poolCurator.batchDelete(pools, alreadyDeletedPoolIds);
+            this.poolCurator.flush();
+            log.info("Pools successfully deleted");
+
+            if (!entitlements.isEmpty()) {
+                // Update entitlement counts on affected, non-deleted pools
+                log.info("Updating entitlement counts on remaining, affected pools...");
+                Map<Consumer, List<Entitlement>> consumerEntitlements =
+                    new HashMap<Consumer, List<Entitlement>>();
+                List<Pool> poolsToSave = new LinkedList<Pool>();
+
+                for (Entitlement entitlement : entitlements) {
+                    // Since we're sifting through these already, let's also sort them into consumer lists
+                    // for some of the other methods we'll be calling later
+                    Consumer consumer = entitlement.getConsumer();
+                    Pool pool = entitlement.getPool();
+
+                    List<Entitlement> stackedEntitlements = consumerEntitlements.get(consumer);
+                    if (stackedEntitlements == null) {
+                        stackedEntitlements = new LinkedList<Entitlement>();
+                        consumerEntitlements.put(consumer, stackedEntitlements);
+                    }
+
+                    if (!"true".equals(pool.getAttributeValue(Pool.Attributes.DERIVED_POOL)) &&
+                        pool.hasProductAttribute(Product.Attributes.STACKING_ID)) {
+
+                        stackedEntitlements.add(entitlement);
+                    }
+
+                    // Update quantities if the entitlement quantity is non-zero
+                    int quantity = entitlement.getQuantity() != null ? entitlement.getQuantity() : 0;
+                    if (quantity != 0) {
+                        // Update the pool quantities if we didn't delete it
+                        if (affectedPoolIds.contains(pool.getId())) {
+                            pool.setConsumed(pool.getConsumed() - quantity);
+                            poolsToSave.add(pool);
+                        }
+
+                        // Update entitlement counts for affected consumers...
+                        consumer.setEntitlementCount(consumer.getEntitlementCount() - quantity);
+                        if (consumer.getType().isManifest()) {
+                            pool.setExported(pool.getExported() - quantity);
+                        }
+                    }
+                }
+
+                this.poolCurator.updateAll(poolsToSave, false, false);
+                this.consumerCurator.updateAll(consumerEntitlements.keySet(), false, false);
+                this.consumerCurator.flush();
+                log.info("Entitlement counts successfully updated for {} pools and {} consumers",
+                    poolsToSave.size(), consumerEntitlements.size());
+
+                // Update stacked entitlements for affected consumers(???)
+                log.info("Updating stacked entitlements for {} consumers...", consumerEntitlements.size());
+                for (Entry<Consumer, List<Entitlement>> entry : consumerEntitlements.entrySet()) {
+                    Consumer consumer = entry.getKey();
+                    List<Entitlement> stackedEntitlements = entry.getValue();
+
+                    log.debug("Updating {} stacking entitlements for consumer: {}",
+                        stackedEntitlements.size(), consumer);
+
+                    Set<String> stackIds = new HashSet<String>();
+                    for (Entitlement entitlement : stackedEntitlements) {
+                        stackIds.add(entitlement.getPool().getStackId());
+                    }
+
+                    if (!stackIds.isEmpty()) {
+                        Collection<Pool> subPools = this.poolCurator
+                            .getSubPoolForStackIds(consumer, stackIds);
+
+                        if (subPools != null && !subPools.isEmpty()) {
+                            this.poolRules.updatePoolsFromStack(
+                                consumer, subPools, alreadyDeletedPoolIds, true);
+                        }
+                    }
+                }
+
+                this.consumerCurator.flush();
+
+                // Fire post-unbind events for revoked entitlements
+                log.info("Firing post-unbind events for {} entitlements...", entitlements.size());
+                for (Entitlement entitlement : entitlements) {
+                    this.enforcer.postUnbind(entitlement.getConsumer(), this, entitlement);
+                }
+
+                // Recalculate status for affected consumers
+                log.info("Recomputing status for {} consumers", consumerEntitlements.size());
+                int i = 0;
+                for (Consumer consumer : consumerEntitlements.keySet()) {
+                    this.complianceRules.getStatus(consumer);
+
+                    if (++i % 1000 == 0) {
+                        this.consumerCurator.flush();
+                    }
+                }
+                this.consumerCurator.flush();
+
+                log.info("All statuses recomputed");
+            }
+
+            // Impl note:
+            // We don't need to fire entitlement revocation events, since they're all being revoked as
+            // a consequence of the pools being deleted.
+
+            // Fire pool deletion events
+            // This part hurts so much. Because we output the whole entity, we have to fetch the bloody
+            // things before we delete them.
+            log.info("Firing pool deletion events for {} pools...", pools.size());
+            for (Pool pool : pools) {
+                this.sink.queueEvent(this.eventFactory.poolDeleted(pool));
             }
         }
-
-        // Look up the related pools for these subscription IDs.
-        if (!subscriptionIds.isEmpty()) {
-            poolsToDelete.addAll(this.poolCurator.getPoolsBySubscriptionIds(subscriptionIds).list());
-        }
-
-        if (!poolsToDelete.isEmpty()) {
-            revokeEntitlements(entitlementsToRevoke, alreadyDeletedPools);
-            log.debug("Batch deleting pools after successful revocation");
-            poolCurator.batchDelete(poolsToDelete, alreadyDeletedPools);
-        }
-
-        for (Pool pool : poolsToDelete) {
-            Event event = eventFactory.poolDeleted(pool);
-            sink.queueEvent(event);
+        else {
+            log.info("Skipping pool deletion; no pools to delete");
         }
     }
 
@@ -2254,14 +2443,17 @@ public class CandlepinPoolManager implements PoolManager {
             }
             else if (log.isDebugEnabled()) {
                 log.debug("Omitting pool due to failed rules: {}", p.getId());
+
                 if (result.hasErrors()) {
                     log.debug("\tErrors: {}", result.getErrors());
                 }
+
                 if (result.hasWarnings()) {
                     log.debug("\tWarnings: {}", result.getWarnings());
                 }
             }
         }
+
         return filteredPools;
     }
 

--- a/server/src/main/java/org/candlepin/controller/PoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/PoolManager.java
@@ -320,7 +320,7 @@ public interface PoolManager {
 
     void deletePools(Collection<Pool> pools);
 
-    void deletePools(Collection<Pool> pools, Set<String> alreadyDeletedPools);
+    void deletePools(Collection<Pool> pools, Collection<String> alreadyDeletedPools);
 
     void handlePostEntitlement(PoolManager manager, Consumer consumer,
         Map<String, Entitlement> entitlements, Map<String, PoolQuantity> poolQuantityMap);

--- a/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
+++ b/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
@@ -780,7 +780,7 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
         Session session = this.currentSession();
         SQLQuery query = session.createSQLQuery(sql);
 
-        for (List<?> block : Iterables.partition(collection, getInBlockSize())) {
+        for (List<?> block : this.partition(collection)) {
             int index = 1;
 
             if (params != null) {
@@ -1310,8 +1310,7 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
             if (block.size() != lastBlock && criteria != null && !criteria.isEmpty()) {
                 for (Object criterion : criteria.values()) {
                     if (criterion instanceof Collection) {
-                        Iterable<List> inBlocks = Iterables.partition((Collection) criterion,
-                            getInBlockSize());
+                        Iterable<List> inBlocks = this.partition((Collection) criterion);
 
                         for (List inBlock : inBlocks) {
                             query.setParameterList(String.valueOf(++param), inBlock);
@@ -1406,7 +1405,7 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
 
             for (Object criterion : criteria.values()) {
                 if (criterion instanceof Collection) {
-                    Iterable<List> inBlocks = Iterables.partition((Collection) criterion, getInBlockSize());
+                    Iterable<List> inBlocks = this.partition((Collection) criterion);
 
                     for (List inBlock : inBlocks) {
                         query.setParameterList(String.valueOf(++param), inBlock);
@@ -1419,5 +1418,24 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
         }
 
         return query.executeUpdate();
+    }
+
+    /**
+     * Partitions the given collection using the value returned by the getInBlockSize() method as
+     * the partition size. This method is provided as a utility method to avoid referencing a very
+     * long constant name used in many curators. Callers which need this behavior with a custom
+     * size can simulate the behavior by using the <tt>Iterables.partition</tt> method directly:
+     * <pre>
+     *  Iterable<List<String>> blocks = ', 'entityIds, blockSize);
+     * </pre>
+     *
+     * @param collection
+     *  The collection to partition
+     *
+     * @return
+     *  An iterable collection of lists containing the partitioned data in the provided collection
+     */
+    protected <T> Iterable<List<T>> partition(Iterable<T> collection) {
+        return Iterables.partition(collection, this.getInBlockSize());
     }
 }

--- a/server/src/main/java/org/candlepin/model/EntitlementCurator.java
+++ b/server/src/main/java/org/candlepin/model/EntitlementCurator.java
@@ -22,7 +22,6 @@ import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
 import com.google.inject.persist.Transactional;
 
-import org.apache.commons.collections.CollectionUtils;
 import org.hibernate.Criteria;
 import org.hibernate.Hibernate;
 import org.hibernate.ReplicationMode;
@@ -634,19 +633,19 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
             // CriteriaBuilder.
             String querySql = "SELECT DISTINCT e2.id " +
                 // Required entitlement
-                "FROM cp_entitlement e1                                                       " +
+                "FROM cp_entitlement e1 " +
                 // Required entitlement => required pool
-                "JOIN cp2_pool_provided_products ppp1 ON ppp1.pool_id = e1.pool_id            " +
+                "JOIN cp2_pool_provided_products ppp1 ON ppp1.pool_id = e1.pool_id " +
                 // Required pool => required product
-                "JOIN cp2_products p ON p.uuid = ppp1.product_uuid                            " +
+                "JOIN cp2_products p ON p.uuid = ppp1.product_uuid " +
                 // Required product => conditional content
-                "JOIN cp2_content_modified_products cmp ON cmp.element = p.product_id         " +
+                "JOIN cp2_content_modified_products cmp ON cmp.element = p.product_id " +
                 // Conditional content => dependent product
-                "JOIN cp2_product_content pc ON pc.content_uuid = cmp.content_uuid            " +
+                "JOIN cp2_product_content pc ON pc.content_uuid = cmp.content_uuid " +
                 // Dependent product => dependent pool
-                "JOIN cp2_pool_provided_products ppp2 ON ppp2.product_uuid = pc.product_uuid  " +
+                "JOIN cp2_pool_provided_products ppp2 ON ppp2.product_uuid = pc.product_uuid " +
                 // Dependent pool => dependent entitlement
-                "JOIN cp_entitlement e2 ON e2.pool_id = ppp2.pool_id                          " +
+                "JOIN cp_entitlement e2 ON e2.pool_id = ppp2.pool_id " +
                 "WHERE e1.consumer_id = e2.consumer_id " +
                 "  AND e1.consumer_id = :consumer_id " +
                 "  AND e1.id != e2.id " +
@@ -701,12 +700,10 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
         int count = 0;
 
         if (entitlementIds != null && entitlementIds.iterator().hasNext()) {
-            Iterable<List<String>> blocks = Iterables.partition(entitlementIds, getInBlockSize());
-
             String hql = "UPDATE Entitlement SET dirty = true WHERE id IN (:entIds)";
             Query query = this.getEntityManager().createQuery(hql);
 
-            for (List<String> block : blocks) {
+            for (List<String> block : this.partition(entitlementIds)) {
                 count += query.setParameter("entIds", block).executeUpdate();
             }
         }
@@ -715,60 +712,96 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
     }
 
     /**
-     * A version of list Modifying that finds Entitlements  of a consumer that modify
-     * input pools .
-     * When dealing with creating entitlements for which it is necessary
-     * to determine their modifier products. We fetch the modifying ents outside the lock,
-     * and once the pool is locked we simply mark the modifying ents as dirty.
-     * @param consumer
-     * @param pools
+     * Fetches dependent entitlement IDs for the specified collection of pools, belonging to the
+     * given consumer.
      *
-     * @return Entitlements that are being modified by the input entitlements
+     * @param consumer
+     *  The consumer for which to find dependent entitlement IDs
+     *
+     * @param pools
+     *  A collection of pools which the fetched entitlements depend upon
+     *
+     * @return
+     *  a collection of entitlement IDs for the entitlements dependent upon the provided pools
+     *  belonging to the given consumer
      */
-    public Collection<String> getDependentEntitlementIds(Consumer consumer, Collection<Pool> pools) {
-        List<String> eids = new LinkedList<String>();
+    public Collection<String> getDependentEntitlementIdsForPools(Consumer consumer,
+        Iterable<Pool> pools) {
 
-        if (CollectionUtils.isNotEmpty(pools)) {
+        Set<String> poolIds = new HashSet<String>();
 
-            String hql =
-                "SELECT DISTINCT eOut.id" +
-                "    FROM Entitlement eOut" +
-                "        JOIN eOut.pool outPool" +
-                "        JOIN outPool.providedProducts outProvided" +
-                "        JOIN outProvided.productContent outProvContent" +
-                "        JOIN outProvContent.content outContent" +
-                "        JOIN outContent.modifiedProductIds outModProdId" +
-                "    WHERE" +
-                "        outPool.endDate >= current_date AND" +
-                "        eOut.owner = :owner AND" +
-                "        eOut.consumer = :consumer AND " +
-                "        EXISTS (" +
-                "            SELECT pIn" +
-                "            FROM Pool pIn" +
-                "                JOIN pIn.product inMktProd" +
-                "                LEFT JOIN pIn.providedProducts inProvidedProd" +
-                "            WHERE pIn in (:pin) AND" +
-                "                  pIn.endDate >= outPool.startDate AND" +
-                "                  pIn.startDate <= outPool.endDate AND" +
-                "                  (inProvidedProd.id = outModProdId OR inMktProd.id = outModProdId))";
-
-            Query query = this.getEntityManager().createQuery(hql);
-
-            Iterable<List<Pool>> blocks = Iterables.partition(pools, getInBlockSize());
-            Owner owner = consumer.getOwner();
-            for (List<Pool> block : blocks) {
-
-                query.setParameter("pin", block)
-                     .setParameter("consumer", consumer)
-                     .setParameter("owner", owner);
-
-                eids.addAll(query.getResultList());
+        if (consumer != null && pools != null && pools.iterator().hasNext()) {
+            for (Pool pool : pools) {
+                if (pool != null && pool.getId() != null) {
+                    poolIds.add(pool.getId());
+                }
             }
         }
 
-        return eids;
+        return this.getDependentEntitlementIdsForPoolIds(consumer, poolIds);
     }
 
+    /**
+     * Fetches dependent entitlement IDs for the specified collection of pools, belonging to the
+     * given consumer.
+     *
+     * @param consumer
+     *  The consumer for which to find dependent entitlement IDs
+     *
+     * @param poolIds
+     *  A collection of IDs of pools, which the fetched entitlements depend upon
+     *
+     * @return
+     *  a collection of entitlement IDs for the entitlements dependent upon the provided pools
+     *  belonging to the given consumer
+     */
+    public Collection<String> getDependentEntitlementIdsForPoolIds(Consumer consumer,
+        Iterable<String> poolIds) {
+
+        Set<String> entitlementIds = new HashSet<String>();
+
+        if (consumer != null && poolIds != null && poolIds.iterator().hasNext()) {
+            // Impl note:
+            // We do this in direct SQL, as it lets us take a sane path from base to dependent
+            // entitlements, rather than the lunacy that would be required with HQL, JPQL or
+            // CriteriaBuilder.
+            String querySql = "SELECT DISTINCT e.id " +
+                // Required pool
+                "FROM cp2_pool_provided_products ppp1 " +
+                // Required pool => required product
+                "JOIN cp2_products p ON p.uuid = ppp1.product_uuid " +
+                // Required product => conditional content
+                "JOIN cp2_content_modified_products cmp ON cmp.element = p.product_id " +
+                // Conditional content => dependent product
+                "JOIN cp2_product_content pc ON pc.content_uuid = cmp.content_uuid " +
+                // Dependent product => dependent pool
+                "JOIN cp2_pool_provided_products ppp2 ON ppp2.product_uuid = pc.product_uuid " +
+                // Dependent pool => dependent entitlement
+                "JOIN cp_entitlement e ON e.pool_id = ppp2.pool_id " +
+                "WHERE e.consumer_id = :consumer_id " +
+                "  AND ppp1.pool_id IN (:pool_ids) ";
+
+
+            Query query = this.getEntityManager().createNativeQuery(querySql)
+                .setParameter("consumer_id", consumer.getId());
+
+            for (List<String> block : this.partition(poolIds)) {
+                query.setParameter("pool_ids", block);
+                entitlementIds.addAll(query.getResultList());
+            }
+        }
+
+        return entitlementIds;
+    }
+
+    /**
+     * @deprecated
+     *  This method is a utility method for revokeEntitlements and, as it has no communication with
+     *  the database, does not belong in this curator
+     *
+     * @return a map of consumers to their entitlements
+     */
+    @Deprecated
     public Map<Consumer, List<Entitlement>> getDistinctConsumers(List<Entitlement> entsToRevoke) {
         Map<Consumer, List<Entitlement>> result = new HashMap<Consumer, List<Entitlement>>();
         for (Entitlement ent : entsToRevoke) {

--- a/server/src/main/java/org/candlepin/model/JobCurator.java
+++ b/server/src/main/java/org/candlepin/model/JobCurator.java
@@ -227,27 +227,30 @@ public class JobCurator extends AbstractHibernateCurator<JobStatus> {
             "j.state != :finished and " +
             "j.state != :failed and " +
             "j.updated <= :date";
+
         // Must trim out activeIds if the list is empty, otherwise the
         // statement will fail.
         if (!activeIds.isEmpty()) {
             hql += " and j.id not in (:activeIds)";
         }
+
         Query query = this.currentSession().createQuery(hql)
             .setTimestamp("date", before)
             .setParameter("async", PinsetterKernel.SINGLE_JOB_GROUP)
             .setInteger("finished", JobState.FINISHED.ordinal())
             .setInteger("failed", JobState.FAILED.ordinal())
             .setInteger("canceled", JobState.CANCELED.ordinal());
+
         if (!activeIds.isEmpty()) {
             query.setParameterList("activeIds", activeIds);
         }
+
         return query.executeUpdate();
     }
 
     private Date getBlockingCutoff() {
         Calendar calendar = Calendar.getInstance();
-        calendar.add(Calendar.SECOND, -1 * config.getInt(
-            ConfigProperties.PINSETTER_ASYNC_JOB_TIMEOUT));
+        calendar.add(Calendar.SECOND, -1 * config.getInt(ConfigProperties.PINSETTER_ASYNC_JOB_TIMEOUT));
         return calendar.getTime();
     }
 }

--- a/server/src/main/java/org/candlepin/model/Pool.java
+++ b/server/src/main/java/org/candlepin/model/Pool.java
@@ -681,6 +681,44 @@ public class Pool extends AbstractHibernateObject implements Persisted, Owned, N
     }
 
     /**
+     * Checks if the given attribute has been defined on this pool's product. If this pool does not
+     * have a product, any present imported product attributes will be checked instead. If the pool
+     * has neither a product nor any imported product attributes, this method returns false.
+     * <p></p>
+     * The imported product attributes is a legacy feature from when product attributes were copied
+     * from products to any pools using it. The product attributes would then be present on the
+     * pool's JSON, leading to two places for such attributes to exist. As this secondary attribute
+     * store will eventually be dropped, clients/callers should refrain from making use of the
+     * imported product attributes where possible.
+     *
+     * @param key
+     *  The key (name) of the attribute to lookup
+     *
+     * @throws IllegalArgumentException
+     *  if key is null
+     *
+     * @return
+     *  true if the attribute is defined for this pool's product; false otherwise
+     */
+    @XmlTransient
+    public boolean hasProductAttribute(String key) {
+        if (key == null) {
+            throw new IllegalArgumentException("key is null");
+        }
+
+        Product product = this.getProduct();
+        if (product != null) {
+            return product.hasAttribute(key);
+        }
+
+        if (this.importedProductAttributes != null) {
+            return this.importedProductAttributes.containsKey(key);
+        }
+
+        return false;
+    }
+
+    /**
      * Sets the specified attribute for this pool. If the attribute has already been set for
      * this pool, the existing value will be overwritten. If the given attribute value is null
      * or empty, the attribute will be removed.

--- a/server/src/main/java/org/candlepin/model/PoolCurator.java
+++ b/server/src/main/java/org/candlepin/model/PoolCurator.java
@@ -1051,7 +1051,7 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
      * @param pools pools to delete
      * @param alreadyDeletedPools pools to skip, they have already been deleted.
      */
-    public void batchDelete(Collection<Pool> pools, Set<String> alreadyDeletedPools) {
+    public void batchDelete(Collection<Pool> pools, Collection<String> alreadyDeletedPools) {
         if (alreadyDeletedPools == null) {
             alreadyDeletedPools = new HashSet<String>();
         }
@@ -1120,6 +1120,109 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
 
         crit.addOrder(Order.asc("id"));
         return crit.list();
+    }
+
+    /**
+     * Fetches the IDs of the derived pools for the given pool IDs. If the provided pool IDs do not
+     * have any derived pools, this method returns an empty collection.
+     *
+     * @param poolIds
+     *  A collection of pool IDs for which to retrieve derived pool IDs
+     *
+     * @return
+     *  A collection of pool IDs for pools derived from the given pool IDs
+     */
+    @SuppressWarnings("unchecked")
+    public Set<String> getDerivedPoolIdsForPools(Iterable<String> poolIds) {
+        Set<String> output = new HashSet<String>();
+
+        if (poolIds != null && poolIds.iterator().hasNext()) {
+            // TODO: Update this method to use the pool hierarchy columns when they're available
+            String sql = "SELECT DISTINCT ss2.pool_id " +
+                "FROM cp2_pool_source_sub ss1 " +
+                "JOIN cp2_pool_source_sub ss2 ON ss2.subscription_id = ss1.subscription_id " +
+                "WHERE ss1.subscription_sub_key = 'master' " +
+                "  AND ss2.subscription_sub_key != 'master' " +
+                "  AND ss1.pool_id IN (:pool_ids)";
+
+            javax.persistence.Query query = this.getEntityManager().createNativeQuery(sql);
+
+            for (List<String> block : this.partition(poolIds)) {
+                query.setParameter("pool_ids", block);
+                output.addAll(query.getResultList());
+            }
+        }
+
+        return output;
+    }
+
+    /**
+     * Fetches the entitlement IDs for the pools specified by the given pool IDs. If there are no
+     * entitlements linked to the given pool IDs, this method returns an empty collection.
+     *
+     * @param poolIds
+     *  A collection of pool IDs for which to retrieve entitlement IDs
+     *
+     * @return
+     *  A collection of entitlement IDs for the pools specified for the given pool IDs
+     */
+    @SuppressWarnings("unchecked")
+    public Collection<String> getEntitlementIdsForPools(Collection<String> poolIds) {
+        if (poolIds != null && !poolIds.isEmpty()) {
+            return this.currentSession().createCriteria(Pool.class, "p")
+                .createAlias("p.entitlements", "e")
+                .add(CPRestrictions.in("p.id", poolIds))
+                .setProjection(Projections.distinct(Projections.property("e.id")))
+                .list();
+        }
+
+        return new LinkedList<String>();
+    }
+
+    /**
+     * Fetches the pool IDs for the pools derived from any of the entitlements specified by the
+     * provided entitlement IDs. If there are no pools derived from the given entitlements, this
+     * method returns an empty collection.
+     *
+     * @param entIds
+     *  A collection of entitlement IDs for which to fetch derived pools
+     *
+     * @return
+     *  A collection of pool IDs for pools derived from the given entitlement IDs
+     */
+    @SuppressWarnings("unchecked")
+    public Collection<String> getPoolIdsForSourceEntitlements(Collection<String> entIds) {
+        if (entIds != null && !entIds.isEmpty()) {
+            return this.currentSession().createCriteria(Pool.class, "p")
+                .createAlias("p.sourceEntitlement", "e")
+                .add(CPRestrictions.in("e.id", entIds))
+                .setProjection(Projections.distinct(Projections.property("p.id")))
+                .list();
+        }
+
+        return new LinkedList<String>();
+    }
+
+    /**
+     * Fetches the IDs of the pools to which these entitlements provide access.
+     *
+     * @param entIds
+     *  A collection of entitlement IDs for which to fetch pool IDs
+     *
+     * @return
+     *  A collection of IDs of the pools for the given entitlement IDs
+     */
+    @SuppressWarnings("unchecked")
+    public Collection<String> getPoolIdsForEntitlements(Collection<String> entIds) {
+        if (entIds != null && !entIds.isEmpty()) {
+            return this.currentSession().createCriteria(Entitlement.class, "e")
+                .createAlias("e.pool", "p")
+                .add(CPRestrictions.in("e.id", entIds))
+                .setProjection(Projections.distinct(Projections.property("p.id")))
+                .list();
+        }
+
+        return new LinkedList<String>();
     }
 
     @SuppressWarnings("unchecked")
@@ -1704,5 +1807,25 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
             .add(Restrictions.eq("createdByShare", Boolean.TRUE))
             .add(Restrictions.eq("se.pool", pool))
             .addOrder(Order.desc("created")));
+    }
+
+    /**
+     * Removes source entitlements for the pools represented by the given collection of pool IDs.
+     * Note that this operation does not update any fetched or cached Pool objects, and will be
+     * reverted should a pool's state be persisted after this method has returned.
+     *
+     * @param poolIds
+     *  A collection of pool IDs for which to clear source entitlement references
+     */
+    public void clearPoolSourceEntitlementRefs(Iterable<String> poolIds) {
+        if (poolIds != null && poolIds.iterator().hasNext()) {
+            String hql = "UPDATE Pool SET sourceEntitlement = null WHERE id IN (:pids)";
+            Query query = this.currentSession().createQuery(hql);
+
+            for (List<String> block : this.partition(poolIds)) {
+                query.setParameterList("pids", block);
+                query.executeUpdate();
+            }
+        }
     }
 }

--- a/server/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
@@ -37,6 +37,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -365,7 +366,7 @@ public class PoolRules {
      * @param consumer
      * @return updates
      */
-    public List<PoolUpdate> updatePoolsFromStack(Consumer consumer, List<Pool> pools,
+    public List<PoolUpdate> updatePoolsFromStack(Consumer consumer, Collection<Pool> pools,
         boolean deleteIfNoStackedEnts) {
         return updatePoolsFromStack(consumer, pools, null, deleteIfNoStackedEnts);
     }
@@ -377,8 +378,9 @@ public class PoolRules {
      * @param consumer
      * @return updates
      */
-    public List<PoolUpdate> updatePoolsFromStack(Consumer consumer, List<Pool> pools,
-        Set<String> alreadyDeletedPools, boolean deleteIfNoStackedEnts) {
+    public List<PoolUpdate> updatePoolsFromStack(Consumer consumer, Collection<Pool> pools,
+        Collection<String> alreadyDeletedPools, boolean deleteIfNoStackedEnts) {
+
         Map<String, List<Entitlement>> entitlementMap = new HashMap<String, List<Entitlement>>();
         Set<String> sourceStackIds = new HashSet<String>();
         List<PoolUpdate> result = new ArrayList<PoolUpdate>();
@@ -416,7 +418,7 @@ public class PoolRules {
         return result;
     }
 
-    public PoolUpdate updatePoolFromStackedEntitlements(Pool pool, List<Entitlement> stackedEnts,
+    public PoolUpdate updatePoolFromStackedEntitlements(Pool pool, Collection<Entitlement> stackedEnts,
         Map<String, Product> changedProducts) {
         PoolUpdate update = new PoolUpdate(pool);
 

--- a/server/src/main/java/org/candlepin/policy/js/pool/StackedSubPoolValueAccumulator.java
+++ b/server/src/main/java/org/candlepin/policy/js/pool/StackedSubPoolValueAccumulator.java
@@ -20,8 +20,8 @@ import org.candlepin.model.Product;
 import org.candlepin.model.ProductCurator;
 
 import java.util.Date;
+import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 
@@ -41,8 +41,9 @@ public class StackedSubPoolValueAccumulator {
     private Set<Product> expectedProvidedProds = new HashSet<Product>();
     private ProductCurator productCurator;
 
-    public StackedSubPoolValueAccumulator(Pool stackedSubPool, List<Entitlement> stackedEnts,
+    public StackedSubPoolValueAccumulator(Pool stackedSubPool, Collection<Entitlement> stackedEnts,
         ProductCurator productCurator) {
+
         this.productCurator = productCurator;
         for (Entitlement nextStacked : stackedEnts) {
             Pool nextStackedPool = nextStacked.getPool();

--- a/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
@@ -2291,4 +2291,85 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         Pool result = sharedPools.get(0);
         assertEquals(sharedPool, result);
     }
+
+    @Test
+    public void testClearPoolSourceEntitlementRefs() {
+        Date startDate = TestUtil.createDate(2010, 3, 2);
+        Date endDate = TestUtil.createDate(Calendar.getInstance().get(Calendar.YEAR) + 1, 3, 2);
+
+        Pool pool1 = createPool(owner, product, 20L, startDate, endDate);
+        poolCurator.create(pool1);
+
+        Entitlement e = new Entitlement(pool1, consumer, 5);
+        e.setId("test-entitlement-id-1");
+        entitlementCurator.create(e);
+
+        Pool pool2 = createPool(owner, product, 20L, startDate, endDate);
+        pool2.setSourceEntitlement(e);
+        poolCurator.create(pool2);
+
+        this.poolCurator.clearPoolSourceEntitlementRefs(Arrays.asList(pool2.getId()));
+
+        this.poolCurator.refresh(pool2);
+        assertNull(pool2.getSourceEntitlement());
+    }
+
+    @Test
+    public void testClearPoolSourceEntitlementRefsDoesntAffectUnspecifiedPools() {
+        Date startDate = TestUtil.createDate(2010, 3, 2);
+        Date endDate = TestUtil.createDate(Calendar.getInstance().get(Calendar.YEAR) + 1, 3, 2);
+
+        Pool pool1 = createPool(owner, product, 20L, startDate, endDate);
+        poolCurator.create(pool1);
+
+        Entitlement e = new Entitlement(pool1, consumer, 5);
+        e.setId("test-entitlement-id-1");
+        entitlementCurator.create(e);
+
+        Pool pool2 = createPool(owner, product, 20L, startDate, endDate);
+        pool2.setSourceEntitlement(e);
+        poolCurator.create(pool2);
+
+        this.poolCurator.clearPoolSourceEntitlementRefs(Arrays.asList(pool1.getId()));
+
+        this.poolCurator.refresh(pool2);
+        assertSame(e, pool2.getSourceEntitlement());
+    }
+
+
+    @Test
+    public void testClearPoolSourceEntitlementRefsWorksOnMultiplePools() {
+        Date startDate = TestUtil.createDate(2010, 3, 2);
+        Date endDate = TestUtil.createDate(Calendar.getInstance().get(Calendar.YEAR) + 1, 3, 2);
+
+        Pool pool1 = createPool(owner, product, 20L, startDate, endDate);
+        poolCurator.create(pool1);
+
+        Entitlement e = new Entitlement(pool1, consumer, 5);
+        e.setId("test-entitlement-id-1");
+        entitlementCurator.create(e);
+
+        Pool pool2 = createPool(owner, product, 20L, startDate, endDate);
+        pool2.setSourceEntitlement(e);
+        poolCurator.create(pool2);
+
+        Pool pool3 = createPool(owner, product, 20L, startDate, endDate);
+        pool3.setSourceEntitlement(e);
+        poolCurator.create(pool3);
+
+        Pool pool4 = createPool(owner, product, 20L, startDate, endDate);
+        pool4.setSourceEntitlement(e);
+        poolCurator.create(pool4);
+
+
+        this.poolCurator.clearPoolSourceEntitlementRefs(Arrays.asList(pool2.getId(), pool3.getId()));
+
+        this.poolCurator.refresh(pool2);
+        this.poolCurator.refresh(pool3);
+        this.poolCurator.refresh(pool4);
+
+        assertNull(pool2.getSourceEntitlement());
+        assertNull(pool3.getSourceEntitlement());
+        assertSame(e, pool4.getSourceEntitlement());
+    }
 }


### PR DESCRIPTION
- PoolManager.deletePools no longer calls out to revokeEntitlements
  as part of its operation
- Several optimizations were made to deletePools to minimize the
  number of queries peformed and the number of entities it fetches
- Added new ID-based query methods to PoolCurator and EntitlementCurator
- Added a new utility method for partitioning blocks by the in-operator
  block size to AbstractHibernateCurator
- Added a new utility method to Pool for properly checking if a pool
  has a product attribute