### PR TITLE
[2.0] 1502807: bind with an empty string as POST body

### DIFF
--- a/server/client/ruby/candlepin_api.rb
+++ b/server/client/ruby/candlepin_api.rb
@@ -800,11 +800,10 @@ class Candlepin
     post(path)
   end
 
-  def consume_pools(poolAndQuantities, params={})
+  def consume_pool_empty_body(pool_id, params={})
     uuid = params[:uuid] || @uuid
-    path = "/consumers/#{uuid}/entitlements?async=true"
-
-    return post(path, poolAndQuantities)
+    path = "/consumers/#{uuid}/entitlements?pool=#{pool_id}&quantity=1"
+    return post(path, " ")
   end
 
   def consume_product(product=nil, params={})

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -82,7 +82,6 @@ import org.candlepin.model.User;
 import org.candlepin.model.VirtConsumerMap;
 import org.candlepin.model.activationkeys.ActivationKey;
 import org.candlepin.model.activationkeys.ActivationKeyCurator;
-import org.candlepin.model.dto.PoolIdAndQuantity;
 import org.candlepin.pinsetter.tasks.EntitleByProductsJob;
 import org.candlepin.pinsetter.tasks.EntitlerJob;
 import org.candlepin.policy.js.compliance.ComplianceRules;
@@ -1525,13 +1524,10 @@ public class ConsumerResource {
         return allCerts;
     }
 
-    private void validateBindArguments(boolean hasPoolQuantities, String poolIdString, Integer quantity,
+    private void validateBindArguments(String poolIdString, Integer quantity,
         String[] productIds, List<String> fromPools, Date entitleDate, boolean async) {
         short parameters = 0;
 
-        if (hasPoolQuantities) {
-            parameters++;
-        }
         if (poolIdString != null) {
             parameters++;
         }
@@ -1541,17 +1537,6 @@ public class ConsumerResource {
         }
         if (parameters > 1) {
             throw new BadRequestException(i18n.tr("Cannot bind by multiple parameters."));
-        }
-
-        if (hasPoolQuantities) {
-            if (quantity != null) {
-                throw new BadRequestException(
-                        i18n.tr("Cannot specify a single quantity when binding a batch of " +
-                                " exact pools. Please specify a quantity for each pool"));
-            }
-            else if (!async) {
-                throw new BadRequestException(i18n.tr("Batch bind can only be performed asynchronously"));
-            }
         }
 
         if (poolIdString == null && quantity != null) {
@@ -1589,47 +1574,26 @@ public class ConsumerResource {
         @QueryParam("email_locale") String emailLocale,
         @QueryParam("async") @DefaultValue("false") boolean async,
         @QueryParam("entitle_date") String entitleDateStr,
-        @QueryParam("from_pool") List<String> fromPools,
-        PoolIdAndQuantity[] poolQuantities,
-        @Context Principal principal) {
-        boolean hasPoolQuantities = (poolQuantities != null && poolQuantities.length > 0);
+        @QueryParam("from_pool") List<String> fromPools) {
+        /* NOTE: This method should NEVER be provided with a POST body.
+           While technically that change would be backwards compatible,
+           there are older clients which erroneously provide an empty string
+           as a post body and hence result in a serialization error.
+           ref: BZ: 1502807
+         */
+
         // TODO: really should do this in a before we get to this call
         // so the method takes in a real Date object and not just a String.
         Date entitleDate = ResourceDateParser.parseDateString(entitleDateStr);
 
         // Check that only one query param was set, and some other validations
-        validateBindArguments(hasPoolQuantities, poolIdString, quantity, productIds, fromPools,
+        validateBindArguments(poolIdString, quantity, productIds, fromPools,
             entitleDate, async);
 
         // Verify consumer exists:
         Consumer consumer = consumerCurator.verifyAndLookupConsumerWithEntitlements(consumerUuid);
 
         log.debug("Consumer (post verify): {}", consumer);
-
-        if (hasPoolQuantities) {
-            Map<String, PoolIdAndQuantity> pqMap = new HashMap<String, PoolIdAndQuantity>();
-            for (PoolIdAndQuantity poolQuantity : poolQuantities) {
-                if (pqMap.containsKey(poolQuantity.getPoolId())) {
-                    pqMap.get(poolQuantity.getPoolId()).addQuantity(poolQuantity.getQuantity());
-                }
-                else {
-                    pqMap.put(poolQuantity.getPoolId(), poolQuantity);
-                }
-            }
-            int batchBindLimit = config.getInt(ConfigProperties.BATCH_BIND_NUMBER_OF_POOLS_LIMIT);
-            if (pqMap.keySet().size() > batchBindLimit) {
-                throw new BadRequestException(i18n.tr(
-                    "Cannot bind more than {0} pools per request, found: {1}",
-                    batchBindLimit, pqMap.keySet().size()
-                ));
-            }
-
-            List<Pool> pools = poolManager.secureFind(pqMap.keySet());
-            if (!principal.canAccessAll(pools, SubResource.ENTITLEMENTS, Access.CREATE)) {
-                throw new NotFoundException(i18n.tr("Pools with ids {0} could not be found.",
-                    pqMap.keySet()));
-            }
-        }
 
         try {
             // I hate double negatives, but if they have accepted all
@@ -1664,9 +1628,6 @@ public class ConsumerResource {
 
             if (poolIdString != null) {
                 detail = EntitlerJob.bindByPool(poolIdString, consumer, quantity);
-            }
-            else if (hasPoolQuantities) {
-                detail = EntitlerJob.bindByPoolAndQuantities(consumer, poolQuantities);
             }
             else {
                 detail = EntitleByProductsJob.bindByProducts(productIds,

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceEntitlementRulesTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceEntitlementRulesTest.java
@@ -83,21 +83,21 @@ public class ConsumerResourceEntitlementRulesTest extends DatabaseTestFixture {
             Consumer c = TestUtil.createConsumer(consumer.getType(), owner);
             consumerCurator.create(c);
             consumerResource.bind(c.getUuid(), pool.getId(),
-                null, 1, null, null, false, null, null, null, null);
+                null, 1, null, null, false, null, null);
         }
 
         // Now for the 11th:
         Consumer c = TestUtil.createConsumer(consumer.getType(), owner);
         consumerCurator.create(c);
         consumerResource.bind(c.getUuid(), pool.getId(), null, 1, null, null,
-            false, null, null, null, null);
+            false, null, null);
     }
 
     @Test(expected = RuntimeException.class)
     public void testEntitlementsHaveExpired() {
         dateSource.currentDate(TestDateUtil.date(2030, 1, 13));
         consumerResource.bind(consumer.getUuid(), pool.getId(), null,
-            null, null, null, false, null, null, null, null);
+            null, null, null, false, null, null);
     }
 
     @Override

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
@@ -153,7 +153,7 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
     @Test
     public void testGetCerts() {
         consumerResource.bind(consumer.getUuid(), pool.getId().toString(),
-            null, 1, null, null, false, null, null, null, null);
+            null, 1, null, null, false, null, null);
         List<Certificate> serials = consumerResource
             .getEntitlementCertificates(consumer.getUuid(), null);
         assertEquals(1, serials.size());
@@ -162,13 +162,13 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
     @Test
     public void testGetSerialFiltering() {
         consumerResource.bind(consumer.getUuid(), pool.getId().toString(),
-            null, 1, null, null, false, null, null, null, null);
+            null, 1, null, null, false, null, null);
         consumerResource.bind(consumer.getUuid(), pool.getId().toString(),
-            null, 1, null, null, false, null, null, null, null);
+            null, 1, null, null, false, null, null);
         consumerResource.bind(consumer.getUuid(), pool.getId().toString(),
-            null, 1, null, null, false, null, null, null, null);
+            null, 1, null, null, false, null, null);
         consumerResource.bind(consumer.getUuid(), pool.getId().toString(),
-            null, 1, null, null, false, null, null, null, null);
+            null, 1, null, null, false, null, null);
         List<Certificate> certificates = consumerResource
             .getEntitlementCertificates(consumer.getUuid(), null);
         assertEquals(4, certificates.size());
@@ -286,7 +286,7 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
     public void testBindByPool() throws Exception {
         Response rsp = consumerResource.bind(
             consumer.getUuid(), pool.getId().toString(), null, 1, null,
-            null, false, null, null, null, null);
+            null, false, null, null);
 
         List<Entitlement> resultList = (List<Entitlement>) rsp.getEntity();
 
@@ -331,7 +331,7 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
     @Test
     public void unbindBySerialWithExistingCertificateShouldPass() {
         consumerResource.bind(consumer.getUuid(), pool.getId().toString(),
-            null, 1, null, null, false, null, null, null, null);
+            null, 1, null, null, false, null, null);
         List<Certificate> serials = consumerResource
             .getEntitlementCertificates(consumer.getUuid(), null);
         assertEquals(1, serials.size());
@@ -344,11 +344,11 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
     @Test(expected = NotFoundException.class)
     public void testCannotGetAnotherConsumersCerts() {
         consumerResource.bind(consumer.getUuid(), pool.getId().toString(),
-            null, 1, null, null, false, null, null, null, null);
+            null, 1, null, null, false, null, null);
         consumerResource.bind(consumer.getUuid(), pool.getId().toString(),
-            null, 1, null, null, false, null, null, null, null);
+            null, 1, null, null, false, null, null);
         consumerResource.bind(consumer.getUuid(), pool.getId().toString(),
-            null, 1, null, null, false, null, null, null, null);
+            null, 1, null, null, false, null, null);
 
         Consumer evilConsumer = TestUtil.createConsumer(standardSystemType, owner);
         consumerCurator.create(evilConsumer);
@@ -362,11 +362,11 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
     @Test
     public void testCanGetOwnedConsumersCerts() {
         consumerResource.bind(consumer.getUuid(), pool.getId().toString(),
-            null, 1, null, null, false, null, null, null, null);
+            null, 1, null, null, false, null, null);
         consumerResource.bind(consumer.getUuid(), pool.getId().toString(),
-            null, 1, null, null, false, null, null, null, null);
+            null, 1, null, null, false, null, null);
         consumerResource.bind(consumer.getUuid(), pool.getId().toString(),
-            null, 1, null, null, false, null, null, null, null);
+            null, 1, null, null, false, null, null);
 
         setupPrincipal(new ConsumerPrincipal(consumer));
 
@@ -444,11 +444,11 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
     @Test
     public void consumerShouldSeeOwnEntitlements() {
         consumerResource.bind(consumer.getUuid(), pool.getId().toString(),
-            null, 1, null, null, false, null, null, null, null);
+            null, 1, null, null, false, null, null);
         consumerResource.bind(consumer.getUuid(), pool.getId().toString(),
-            null, 1, null, null, false, null, null, null, null);
+            null, 1, null, null, false, null, null);
         consumerResource.bind(consumer.getUuid(), pool.getId().toString(),
-            null, 1, null, null, false, null, null, null, null);
+            null, 1, null, null, false, null, null);
 
         setupPrincipal(new ConsumerPrincipal(consumer));
         securityInterceptor.enable();
@@ -463,11 +463,11 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
         consumerCurator.create(evilConsumer);
 
         consumerResource.bind(consumer.getUuid(), pool.getId().toString(),
-            null, 1, null, null, false, null, null, null, null);
+            null, 1, null, null, false, null, null);
         consumerResource.bind(consumer.getUuid(), pool.getId().toString(),
-            null, 1, null, null, false, null, null, null, null);
+            null, 1, null, null, false, null, null);
         consumerResource.bind(evilConsumer.getUuid(), pool.getId().toString(),
-            null, 1, null, null, false, null, null, null, null);
+            null, 1, null, null, false, null, null);
 
         setupPrincipal(new ConsumerPrincipal(evilConsumer));
         securityInterceptor.enable();
@@ -479,11 +479,11 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
     @Test(expected = NotFoundException.class)
     public void ownerShouldNotSeeOtherOwnerEntitlements() {
         consumerResource.bind(consumer.getUuid(), pool.getId().toString(),
-            null, 1, null, null, false, null, null, null, null);
+            null, 1, null, null, false, null, null);
         consumerResource.bind(consumer.getUuid(), pool.getId().toString(),
-            null, 1, null, null, false, null, null, null, null);
+            null, 1, null, null, false, null, null);
         consumerResource.bind(consumer.getUuid(), pool.getId().toString(),
-            null, 1, null, null, false, null, null, null, null);
+            null, 1, null, null, false, null, null);
 
         Owner evilOwner = ownerCurator.create(new Owner("another-owner"));
         ownerCurator.create(evilOwner);
@@ -498,11 +498,11 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
     @Test
     public void ownerShouldSeeOwnEntitlements() {
         consumerResource.bind(consumer.getUuid(), pool.getId().toString(),
-            null, 1, null, null, false, null, null, null, null);
+            null, 1, null, null, false, null, null);
         consumerResource.bind(consumer.getUuid(), pool.getId().toString(),
-            null, 1, null, null, false, null, null, null, null);
+            null, 1, null, null, false, null, null);
         consumerResource.bind(consumer.getUuid(), pool.getId().toString(),
-            null, 1, null, null, false, null, null, null, null);
+            null, 1, null, null, false, null, null);
 
         securityInterceptor.enable();
 
@@ -561,7 +561,7 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
             null, null, null, null, consumerEnricher);
 
         Response rsp = consumerResource.bind(consumer.getUuid(), pool.getId().toString(), null, 1, null,
-            null, false, null, null, null, null);
+            null, false, null, null);
 
         List<Entitlement> resultList = (List<Entitlement>) rsp.getEntity();
         Entitlement ent = resultList.get(0);
@@ -577,8 +577,7 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
 
     @Test(expected = BadRequestException.class)
     public void testInvalidProductId() {
-        consumerResource.bind(consumer.getUuid(), "JarjarBinks", null, null, null, null, false, null, null,
-            null, null);
+        consumerResource.bind(consumer.getUuid(), "JarjarBinks", null, null, null, null, false, null, null);
     }
 
     private static class ProductCertCreationModule extends AbstractModule {

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
@@ -37,7 +37,6 @@ import org.candlepin.audit.EventSinkImpl;
 import org.candlepin.auth.Access;
 import org.candlepin.auth.NoAuthPrincipal;
 import org.candlepin.auth.SubResource;
-import org.candlepin.auth.TrustedUserPrincipal;
 import org.candlepin.auth.UserPrincipal;
 import org.candlepin.common.config.Configuration;
 import org.candlepin.common.exceptions.BadRequestException;
@@ -72,7 +71,6 @@ import org.candlepin.model.Product;
 import org.candlepin.model.ProductCurator;
 import org.candlepin.model.activationkeys.ActivationKey;
 import org.candlepin.model.activationkeys.ActivationKeyCurator;
-import org.candlepin.model.dto.PoolIdAndQuantity;
 import org.candlepin.model.dto.Subscription;
 import org.candlepin.policy.js.activationkey.ActivationKeyRules;
 import org.candlepin.policy.js.compliance.ComplianceRules;
@@ -101,7 +99,6 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
-import org.quartz.JobDetail;
 import org.xnap.commons.i18n.I18n;
 import org.xnap.commons.i18n.I18nFactory;
 
@@ -395,49 +392,8 @@ public class ConsumerResourceTest {
             null, null, this.factValidator, null, consumerEnricher);
 
         Response r = cr.bind(
-            "fakeConsumer", null, prodIds, null, null, null, false, null, null, null, null);
+            "fakeConsumer", null, prodIds, null, null, null, false, null, null);
         assertEquals(null, r.getEntity());
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    public void testBindByPools() throws Exception {
-        PoolIdAndQuantity[] pools = new PoolIdAndQuantity[2];
-        pools[0] = new PoolIdAndQuantity("first", 1);
-        pools[1] = new PoolIdAndQuantity("second", 2);
-        ConsumerCurator cc = mock(ConsumerCurator.class);
-        SubscriptionServiceAdapter sa = mock(SubscriptionServiceAdapter.class);
-        PoolManager pm = mock(PoolManager.class);
-        Owner owner = TestUtil.createOwner();
-        Consumer consumer = TestUtil.createConsumer(owner);
-
-        when(cc.verifyAndLookupConsumerWithEntitlements(eq("fakeConsumer"))).thenReturn(consumer);
-        when(sa.hasUnacceptedSubscriptionTerms(any(Owner.class))).thenReturn(false);
-
-        ConsumerResource cr = new ConsumerResource(cc, null, null, sa, null, null, null, i18n, null,
-            null, null, null, null, pm, null, null, null, null, null, null, null, null,
-            this.config, null, null, null, consumerBindUtil, productCurator, null, null, this.factValidator,
-            null, consumerEnricher);
-
-        Response rsp = cr.bind("fakeConsumer", null, null, null, null, null, true, null,
-            null, pools, new TrustedUserPrincipal("TaylorSwift"));
-
-        JobDetail detail = (JobDetail) rsp.getEntity();
-        PoolIdAndQuantity[] pQs = (PoolIdAndQuantity[]) detail.getJobDataMap().get("pool_and_quantities");
-        boolean firstFound = false;
-        boolean secondFound = false;
-        for (PoolIdAndQuantity pq : pQs) {
-            if (pq.getPoolId().contentEquals("first")) {
-                firstFound = true;
-                assertEquals(1, pq.getQuantity().intValue());
-            }
-            if (pq.getPoolId().contentEquals("second")) {
-                secondFound = true;
-                assertEquals(2, pq.getQuantity().intValue());
-            }
-        }
-        assertTrue(firstFound);
-        assertTrue(secondFound);
     }
 
     @Test
@@ -463,7 +419,7 @@ public class ConsumerResourceTest {
             null, null, this.factValidator, null, consumerEnricher);
         String dtStr = "2011-09-26T18:10:50.184081+00:00";
         Date dt = ResourceDateParser.parseDateString(dtStr);
-        cr.bind("fakeConsumer", null, null, null, null, null, false, dtStr, null, null, null);
+        cr.bind("fakeConsumer", null, null, null, null, null, false, dtStr, null);
         AutobindData data = AutobindData.create(c).on(dt);
         verify(e).bindByProducts(eq(data));
     }
@@ -520,75 +476,7 @@ public class ConsumerResourceTest {
             null, null, this.factValidator, null, consumerEnricher);
 
         consumerResource.bind("fake uuid", "fake pool uuid",
-            new String[]{"12232"}, 1, null, null, false, null, null, null, null);
-    }
-
-    @Test(expected = BadRequestException.class)
-    public void testBindMultipleParamsBodyAndProducts() throws Exception {
-        ConsumerCurator consumerCurator = mock(ConsumerCurator.class);
-        ConsumerResource consumerResource = new ConsumerResource(consumerCurator, null,
-            null, null, null, null, null, i18n, null, null, null,
-            null, null, null, null, null, null, null, null, null, null,
-            null, this.config, null, null, null, consumerBindUtil, productCurator,
-            null, null, this.factValidator, null, consumerEnricher);
-
-        PoolIdAndQuantity[] pools = new PoolIdAndQuantity[2];
-        pools[0] = new PoolIdAndQuantity("first", 1);
-        pools[1] = new PoolIdAndQuantity("second", 2);
-
-        consumerResource.bind("fake uuid", null,
-            new String[]{"12232"}, null, null, null, false, null, null, pools, null);
-    }
-
-    @Test(expected = BadRequestException.class)
-    public void testBindMultipleParamsBodyAndPoolString() throws Exception {
-        ConsumerCurator consumerCurator = mock(ConsumerCurator.class);
-        ConsumerResource consumerResource = new ConsumerResource(consumerCurator, null,
-            null, null, null, null, null, i18n, null, null, null,
-            null, null, null, null, null, null, null, null, null, null,
-            null, this.config, null, null, null, consumerBindUtil, productCurator,
-            null, null, this.factValidator, null, consumerEnricher);
-
-        PoolIdAndQuantity[] pools = new PoolIdAndQuantity[2];
-        pools[0] = new PoolIdAndQuantity("first", 1);
-        pools[1] = new PoolIdAndQuantity("second", 2);
-
-        consumerResource.bind("fake uuid", "assad",
-            null, null, null, null, false, null, null, pools, null);
-    }
-
-    @Test(expected = BadRequestException.class)
-    public void testBindMultipleParamsBodyAndAsync() throws Exception {
-        ConsumerCurator consumerCurator = mock(ConsumerCurator.class);
-        ConsumerResource consumerResource = new ConsumerResource(consumerCurator, null,
-            null, null, null, null, null, i18n, null, null, null,
-            null, null, null, null, null, null, null, null, null, null,
-            null, this.config, null, null, null, consumerBindUtil, productCurator,
-            null, null, this.factValidator, null, consumerEnricher);
-
-        PoolIdAndQuantity[] pools = new PoolIdAndQuantity[2];
-        pools[0] = new PoolIdAndQuantity("first", 1);
-        pools[1] = new PoolIdAndQuantity("second", 2);
-
-        consumerResource.bind("fake uuid", null,
-            null, null, null, null, false, null, null, pools, null);
-    }
-
-    @Test(expected = BadRequestException.class)
-    public void testBindMultipleParamsBodyAndQuantity() throws Exception {
-        ConsumerCurator consumerCurator = mock(ConsumerCurator.class);
-        ConsumerResource consumerResource = new ConsumerResource(consumerCurator, null,
-            null, null, null, null, null, i18n, null, null, null,
-            null, null, null, null, null, null, null, null, null, null,
-            null, this.config, null, null, null, consumerBindUtil, productCurator,
-            null, null, this.factValidator, null, consumerEnricher);
-
-        PoolIdAndQuantity[] pools = new PoolIdAndQuantity[2];
-        pools[0] = new PoolIdAndQuantity("first", 1);
-        pools[1] = new PoolIdAndQuantity("second", 2);
-
-        consumerResource.bind("fake uuid", null,
-            null, 1, null, null, false, null, null, pools, null);
+            new String[]{"12232"}, 1, null, null, false, null, null);
     }
 
     @Test(expected = NotFoundException.class)
@@ -603,7 +491,7 @@ public class ConsumerResourceTest {
             null, null, this.factValidator, null, consumerEnricher);
 
         consumerResource.bind("notarealuuid", "fake pool uuid", null, null, null,
-            null, false, null, null, null, null);
+            null, false, null, null);
     }
 
     /**

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceVirtEntitlementTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceVirtEntitlementTest.java
@@ -142,9 +142,9 @@ public class ConsumerResourceVirtEntitlementTest extends DatabaseTestFixture {
             if (null != p.getAttributeValue(Pool.Attributes.DERIVED_POOL)) {
                 // consume 2 times so one can get revoked later.
                 consumerResource.bind(guestConsumer.getUuid(), p.getId(), null,
-                    10, null, null, false, null, null, null, null);
+                    10, null, null, false, null, null);
                 consumerResource.bind(guestConsumer.getUuid(), p.getId(), null,
-                    10, null, null, false, null, null, null, null);
+                    10, null, null, false, null, null);
                 p = poolManager.find(p.getId());
                 // ensure the correct # consumed from the bonus pool
                 assertTrue(p.getConsumed() == 20);
@@ -158,7 +158,7 @@ public class ConsumerResourceVirtEntitlementTest extends DatabaseTestFixture {
         }
         // manifest consume from the physical pool and then check bonus pool quantities
         consumerResource.bind(manifestConsumer.getUuid(), parentPool.getId(), null, 7, null,
-            null, false, null, null, null, null);
+            null, false, null, null);
         for (Pool p : subscribedTo) {
             p = poolManager.find(p.getId());
             assertTrue(p.getConsumed() == 20);
@@ -167,7 +167,7 @@ public class ConsumerResourceVirtEntitlementTest extends DatabaseTestFixture {
         // manifest consume from the physical pool and then check bonus pool quantities.
         //   Should result in a revocation of one of the 10 count entitlements.
         consumerResource.bind(manifestConsumer.getUuid(), parentPool.getId(), null, 2, null,
-            null, false, null, null, null, null);
+            null, false, null, null);
         for (Pool p : subscribedTo) {
             p = poolManager.find(p.getId());
             assertTrue(p.getConsumed() == 10);
@@ -176,7 +176,7 @@ public class ConsumerResourceVirtEntitlementTest extends DatabaseTestFixture {
         // system consume from the physical pool and then check bonus pool quantities.
         //   Should result in no change in the entitlements for the guest.
         consumerResource.bind(systemConsumer.getUuid(), parentPool.getId(), null, 1, null,
-            null, false, null, null, null, null);
+            null, false, null, null);
         for (Pool p : subscribedTo) {
             p = poolManager.find(p.getId());
             assertTrue(p.getConsumed() == 10);
@@ -199,9 +199,9 @@ public class ConsumerResourceVirtEntitlementTest extends DatabaseTestFixture {
             if (null != p.getAttributeValue(Pool.Attributes.DERIVED_POOL)) {
                 // consume 2 times so they can get revoked separately.
                 consumerResource.bind(guestConsumer.getUuid(), p.getId(), null,
-                    10, null, null, false, null, null, null, null);
+                    10, null, null, false, null, null);
                 consumerResource.bind(guestConsumer.getUuid(), p.getId(), null,
-                    10, null, null, false, null, null, null, null);
+                    10, null, null, false, null, null);
                 p = poolManager.find(p.getId());
                 assertTrue(p.getConsumed() == 20);
                 assertTrue(p.getQuantity() == -1);
@@ -217,7 +217,7 @@ public class ConsumerResourceVirtEntitlementTest extends DatabaseTestFixture {
         }
         // Incomplete consumption of physical pool leaves unlimited pool unchanged.
         consumerResource.bind(manifestConsumer.getUuid(), parentPool.getId(), null, 7, null,
-            null, false, null, null, null, null);
+            null, false, null, null);
         for (Pool p : subscribedTo) {
             assertTrue(p.getConsumed() == 20);
             assertTrue(p.getQuantity() == -1);
@@ -225,7 +225,7 @@ public class ConsumerResourceVirtEntitlementTest extends DatabaseTestFixture {
         // Full consumption of physical pool causes revocation of bonus pool entitlements
         //   and quantity change to 0
         consumerResource.bind(manifestConsumer.getUuid(), parentPool.getId(), null, 3, null,
-            null, false, null, null, null, null);
+            null, false, null, null);
         for (Pool p : subscribedTo) {
             p = poolManager.find(p.getId());
             assertEquals(new Long(0), p.getConsumed());


### PR DESCRIPTION
ConsumerResource.bind should NEVER be provided with a POST body. While technically that change would be backwards compatible,  there are older clients which erroneously provide an empty string  as a post body and hence result in a serialization error.
 ref: BZ: 1502807