### PR TITLE
[M] 1503299: bind with an empty string as POST body

### DIFF
--- a/server/client/ruby/candlepin_api.rb
+++ b/server/client/ruby/candlepin_api.rb
@@ -802,14 +802,10 @@ class Candlepin
     return post(path, qparams)
   end
 
-  def consume_pools(poolAndQuantities, params={})
+  def consume_pool_empty_body(pool_id, params={})
     uuid = params[:uuid] || @uuid
-    path = "/consumers/#{uuid}/entitlements"
-    params = {
-      :async => true
-    }
-
-    return post(path, params, poolAndQuantities)
+    path = "/consumers/#{uuid}/entitlements?pool=#{pool_id}&quantity=1"
+    return post(path, {}," ")
   end
 
   def consume_product(product=nil, params={})

--- a/server/spec/consumer_resource_spec.rb
+++ b/server/spec/consumer_resource_spec.rb
@@ -70,16 +70,6 @@ describe 'Consumer Resource' do
     lambda {
       @consumer2.consume_pool(pool.id, {:quantity => 1}).size.should == 1
     }.should raise_exception(RestClient::ResourceNotFound)
-
-    another_pool = create_pool_and_subscription(@owner1['key'], product.id)
-    poolAndQuantities = []
-    poolAndQuantity = { 'poolId' => pool.id, 'quantity' => 1}
-    poolAndQuantities.push(poolAndQuantity)
-    poolAndQuantity = { 'poolId' => another_pool.id, 'quantity' => 1}
-    poolAndQuantities.push(poolAndQuantity)
-    lambda {
-      status = @consumer2.consume_pools(poolAndQuantities)
-    }.should raise_exception(RestClient::ResourceNotFound)
   end
 
   it "should expose a consumer's event atom feed" do
@@ -396,20 +386,6 @@ describe 'Consumer Resource' do
     consumer_client.consume_pool(pool['id'], {:quantity => 1})
     new_updated = @cp.get_consumer(consumer['uuid'])['updated']
     new_updated.should_not == old_updated
-
-    sleep 1
-
-    pool1 = create_pool_and_subscription(@owner1['key'], prod.id)
-    pool2 = create_pool_and_subscription(@owner1['key'], prod.id)
-    poolAndQuantities = []
-    poolAndQuantity = { 'poolId' => pool1.id, 'quantity' => 1}
-    poolAndQuantities.push(poolAndQuantity)
-    poolAndQuantity = { 'poolId' => pool2.id, 'quantity' => 1}
-    poolAndQuantities.push(poolAndQuantity)
-    status = consumer_client.consume_pools(poolAndQuantities)
-    # wait for job to complete, or test clean up will conflict with the asynchronous job.
-    wait_for_job(status['id'], 15)
-    @cp.get_consumer(consumer['uuid'])['updated'].should_not == new_updated
   end
 
   it 'consumer can async bind by product id' do
@@ -863,6 +839,19 @@ describe 'Consumer Resource' do
     @cp.get_pool(pool.id).consumed.should == 0
   end
 
+  it 'should allow a consumer to bind when the POST body is empty string' do
+    owner = create_owner(random_string('zowner'))
+    user = user_client(owner, random_string('cukebuster'))
+    # performs the register for us
+    consumer = consumer_client(user, random_string('machine1'))
+    product = create_product(nil, nil, {:owner => owner['key']})
+    create_pool_and_subscription(owner['key'], product.id, 2)
+    pool = consumer.list_pools(:consumer => consumer.uuid)[0]
+    pool.consumed.should == 0
+    consumer.consume_pool_empty_body(pool.id)
+    @cp.get_pool(pool.id).consumed.should == 1
+  end
+
   it 'should allow a consumer to unregister and free up the pools consumed in a batch' do
     owner = create_owner(random_string('zowner'))
     user = user_client(owner, random_string('cukebuster'))
@@ -876,18 +865,7 @@ describe 'Consumer Resource' do
     pools.length.should == 3
     poolAndQuantities = []
     pools.each do |pool|
-      pool.consumed.should == 0
-      poolAndQuantity = {}
-      poolAndQuantity.poolId = pool.id
-      poolAndQuantity.quantity = 1
-      poolAndQuantities.push(poolAndQuantity)
-    end
-    status = consumer.consume_pools(poolAndQuantities)
-    wait_for_job(status.id, 10)
-    status = @cp.get_job(status.id, true)
-    status.resultData.length.should == 3
-    status.resultData.each do |consumed|
-      consumed.quantity.should == 1
+      consumer.consume_pool(pool['id'])
     end
 
     pools.each do |pool|

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceEntitlementRulesTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceEntitlementRulesTest.java
@@ -83,21 +83,21 @@ public class ConsumerResourceEntitlementRulesTest extends DatabaseTestFixture {
             Consumer c = TestUtil.createConsumer(consumer.getType(), owner);
             consumerCurator.create(c);
             consumerResource.bind(c.getUuid(), pool.getId(),
-                null, 1, null, null, false, null, null, null, null);
+                null, 1, null, null, false, null, null);
         }
 
         // Now for the 11th:
         Consumer c = TestUtil.createConsumer(consumer.getType(), owner);
         consumerCurator.create(c);
         consumerResource.bind(c.getUuid(), pool.getId(), null, 1, null, null,
-            false, null, null, null, null);
+            false, null, null);
     }
 
     @Test(expected = RuntimeException.class)
     public void testEntitlementsHaveExpired() {
         dateSource.currentDate(TestDateUtil.date(2030, 1, 13));
         consumerResource.bind(consumer.getUuid(), pool.getId(), null,
-            null, null, null, false, null, null, null, null);
+            null, null, null, false, null, null);
     }
 
     @Override

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
@@ -151,7 +151,7 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
     @Test
     public void testGetCerts() {
         consumerResource.bind(consumer.getUuid(), pool.getId().toString(),
-            null, 1, null, null, false, null, null, null, null);
+            null, 1, null, null, false, null, null);
         List<Certificate> serials = consumerResource
             .getEntitlementCertificates(consumer.getUuid(), null);
         assertEquals(1, serials.size());
@@ -160,13 +160,13 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
     @Test
     public void testGetSerialFiltering() {
         consumerResource.bind(consumer.getUuid(), pool.getId().toString(),
-            null, 1, null, null, false, null, null, null, null);
+            null, 1, null, null, false, null, null);
         consumerResource.bind(consumer.getUuid(), pool.getId().toString(),
-            null, 1, null, null, false, null, null, null, null);
+            null, 1, null, null, false, null, null);
         consumerResource.bind(consumer.getUuid(), pool.getId().toString(),
-            null, 1, null, null, false, null, null, null, null);
+            null, 1, null, null, false, null, null);
         consumerResource.bind(consumer.getUuid(), pool.getId().toString(),
-            null, 1, null, null, false, null, null, null, null);
+            null, 1, null, null, false, null, null);
         List<Certificate> certificates = consumerResource
             .getEntitlementCertificates(consumer.getUuid(), null);
         assertEquals(4, certificates.size());
@@ -284,7 +284,7 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
     public void testBindByPool() throws Exception {
         Response rsp = consumerResource.bind(
             consumer.getUuid(), pool.getId().toString(), null, 1, null,
-            null, false, null, null, null, null);
+            null, false, null, null);
 
         List<Entitlement> resultList = (List<Entitlement>) rsp.getEntity();
 
@@ -329,7 +329,7 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
     @Test
     public void unbindBySerialWithExistingCertificateShouldPass() {
         consumerResource.bind(consumer.getUuid(), pool.getId().toString(),
-            null, 1, null, null, false, null, null, null, null);
+            null, 1, null, null, false, null, null);
         List<Certificate> serials = consumerResource
             .getEntitlementCertificates(consumer.getUuid(), null);
         assertEquals(1, serials.size());
@@ -342,11 +342,11 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
     @Test(expected = NotFoundException.class)
     public void testCannotGetAnotherConsumersCerts() {
         consumerResource.bind(consumer.getUuid(), pool.getId().toString(),
-            null, 1, null, null, false, null, null, null, null);
+            null, 1, null, null, false, null, null);
         consumerResource.bind(consumer.getUuid(), pool.getId().toString(),
-            null, 1, null, null, false, null, null, null, null);
+            null, 1, null, null, false, null, null);
         consumerResource.bind(consumer.getUuid(), pool.getId().toString(),
-            null, 1, null, null, false, null, null, null, null);
+            null, 1, null, null, false, null, null);
 
         Consumer evilConsumer = TestUtil.createConsumer(standardSystemType, owner);
         consumerCurator.create(evilConsumer);
@@ -360,11 +360,11 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
     @Test
     public void testCanGetOwnedConsumersCerts() {
         consumerResource.bind(consumer.getUuid(), pool.getId().toString(),
-            null, 1, null, null, false, null, null, null, null);
+            null, 1, null, null, false, null, null);
         consumerResource.bind(consumer.getUuid(), pool.getId().toString(),
-            null, 1, null, null, false, null, null, null, null);
+            null, 1, null, null, false, null, null);
         consumerResource.bind(consumer.getUuid(), pool.getId().toString(),
-            null, 1, null, null, false, null, null, null, null);
+            null, 1, null, null, false, null, null);
 
         setupPrincipal(new ConsumerPrincipal(consumer));
 
@@ -442,11 +442,11 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
     @Test
     public void consumerShouldSeeOwnEntitlements() {
         consumerResource.bind(consumer.getUuid(), pool.getId().toString(),
-            null, 1, null, null, false, null, null, null, null);
+            null, 1, null, null, false, null, null);
         consumerResource.bind(consumer.getUuid(), pool.getId().toString(),
-            null, 1, null, null, false, null, null, null, null);
+            null, 1, null, null, false, null, null);
         consumerResource.bind(consumer.getUuid(), pool.getId().toString(),
-            null, 1, null, null, false, null, null, null, null);
+            null, 1, null, null, false, null, null);
 
         setupPrincipal(new ConsumerPrincipal(consumer));
         securityInterceptor.enable();
@@ -461,11 +461,11 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
         consumerCurator.create(evilConsumer);
 
         consumerResource.bind(consumer.getUuid(), pool.getId().toString(),
-            null, 1, null, null, false, null, null, null, null);
+            null, 1, null, null, false, null, null);
         consumerResource.bind(consumer.getUuid(), pool.getId().toString(),
-            null, 1, null, null, false, null, null, null, null);
+            null, 1, null, null, false, null, null);
         consumerResource.bind(evilConsumer.getUuid(), pool.getId().toString(),
-            null, 1, null, null, false, null, null, null, null);
+            null, 1, null, null, false, null, null);
 
         setupPrincipal(new ConsumerPrincipal(evilConsumer));
         securityInterceptor.enable();
@@ -477,11 +477,11 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
     @Test(expected = NotFoundException.class)
     public void ownerShouldNotSeeOtherOwnerEntitlements() {
         consumerResource.bind(consumer.getUuid(), pool.getId().toString(),
-            null, 1, null, null, false, null, null, null, null);
+            null, 1, null, null, false, null, null);
         consumerResource.bind(consumer.getUuid(), pool.getId().toString(),
-            null, 1, null, null, false, null, null, null, null);
+            null, 1, null, null, false, null, null);
         consumerResource.bind(consumer.getUuid(), pool.getId().toString(),
-            null, 1, null, null, false, null, null, null, null);
+            null, 1, null, null, false, null, null);
 
         Owner evilOwner = ownerCurator.create(new Owner("another-owner"));
         ownerCurator.create(evilOwner);
@@ -496,11 +496,11 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
     @Test
     public void ownerShouldSeeOwnEntitlements() {
         consumerResource.bind(consumer.getUuid(), pool.getId().toString(),
-            null, 1, null, null, false, null, null, null, null);
+            null, 1, null, null, false, null, null);
         consumerResource.bind(consumer.getUuid(), pool.getId().toString(),
-            null, 1, null, null, false, null, null, null, null);
+            null, 1, null, null, false, null, null);
         consumerResource.bind(consumer.getUuid(), pool.getId().toString(),
-            null, 1, null, null, false, null, null, null, null);
+            null, 1, null, null, false, null, null);
 
         securityInterceptor.enable();
 
@@ -559,7 +559,7 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
             null, null, null, null, consumerEnricher);
 
         Response rsp = consumerResource.bind(consumer.getUuid(), pool.getId().toString(), null, 1, null,
-            null, false, null, null, null, null);
+            null, false, null, null);
 
         List<Entitlement> resultList = (List<Entitlement>) rsp.getEntity();
         Entitlement ent = resultList.get(0);
@@ -575,8 +575,7 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
 
     @Test(expected = BadRequestException.class)
     public void testInvalidProductId() {
-        consumerResource.bind(consumer.getUuid(), "JarjarBinks", null, null, null, null, false, null, null,
-            null, null);
+        consumerResource.bind(consumer.getUuid(), "JarjarBinks", null, null, null, null, false, null, null);
     }
 
     private static class ProductCertCreationModule extends AbstractModule {

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
@@ -28,7 +28,6 @@ import org.candlepin.audit.EventSinkImpl;
 import org.candlepin.auth.Access;
 import org.candlepin.auth.NoAuthPrincipal;
 import org.candlepin.auth.SubResource;
-import org.candlepin.auth.TrustedUserPrincipal;
 import org.candlepin.auth.UserPrincipal;
 import org.candlepin.common.config.Configuration;
 import org.candlepin.common.exceptions.BadRequestException;
@@ -62,7 +61,6 @@ import org.candlepin.model.Pool;
 import org.candlepin.model.Product;
 import org.candlepin.model.activationkeys.ActivationKey;
 import org.candlepin.model.activationkeys.ActivationKeyCurator;
-import org.candlepin.model.dto.PoolIdAndQuantity;
 import org.candlepin.model.dto.Subscription;
 import org.candlepin.policy.js.activationkey.ActivationKeyRules;
 import org.candlepin.policy.js.compliance.ComplianceRules;
@@ -93,7 +91,6 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
-import org.quartz.JobDetail;
 import org.xnap.commons.i18n.I18n;
 import org.xnap.commons.i18n.I18nFactory;
 
@@ -448,49 +445,8 @@ public class ConsumerResourceTest {
 
 
         Response r = cr.bind(
-            "fakeConsumer", null, prodIds, null, null, null, false, null, null, null, null);
+            "fakeConsumer", null, prodIds, null, null, null, false, null, null);
         assertEquals(null, r.getEntity());
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    public void testBindByPools() throws Exception {
-        PoolIdAndQuantity[] pools = new PoolIdAndQuantity[2];
-        pools[0] = new PoolIdAndQuantity("first", 1);
-        pools[1] = new PoolIdAndQuantity("second", 2);
-        ConsumerCurator cc = mock(ConsumerCurator.class);
-        SubscriptionServiceAdapter sa = mock(SubscriptionServiceAdapter.class);
-        PoolManager pm = mock(PoolManager.class);
-        Owner owner = TestUtil.createOwner();
-        Consumer consumer = TestUtil.createConsumer(owner);
-
-        when(cc.verifyAndLookupConsumerWithEntitlements(eq("fakeConsumer"))).thenReturn(consumer);
-        when(sa.hasUnacceptedSubscriptionTerms(any(Owner.class))).thenReturn(false);
-
-        ConsumerResource cr = new ConsumerResource(cc, null, null, sa, this.mockedOwnerServiceAdapter, null,
-            null, null, i18n, null, null, null, null, null, pm, null, null, null, null, null, null, null,
-            null, this.config, null, null, null, consumerBindUtil, null, null, this.factValidator,
-            null, consumerEnricher);
-
-        Response rsp = cr.bind("fakeConsumer", null, null, null, null, null, true, null,
-            null, pools, new TrustedUserPrincipal("TaylorSwift"));
-
-        JobDetail detail = (JobDetail) rsp.getEntity();
-        PoolIdAndQuantity[] pQs = (PoolIdAndQuantity[]) detail.getJobDataMap().get("pool_and_quantities");
-        boolean firstFound = false;
-        boolean secondFound = false;
-        for (PoolIdAndQuantity pq : pQs) {
-            if (pq.getPoolId().contentEquals("first")) {
-                firstFound = true;
-                assertEquals(1, pq.getQuantity().intValue());
-            }
-            if (pq.getPoolId().contentEquals("second")) {
-                secondFound = true;
-                assertEquals(2, pq.getQuantity().intValue());
-            }
-        }
-        assertTrue(firstFound);
-        assertTrue(secondFound);
     }
 
     @Test
@@ -516,8 +472,7 @@ public class ConsumerResourceTest {
         String dtStr = "2011-09-26T18:10:50.184081+00:00";
         Date dt = ResourceDateParser.parseDateString(dtStr);
 
-        cr.bind(c.getUuid(), null, null, null, null, null, false, dtStr, null, null, null);
-
+        cr.bind(c.getUuid(), null, null, null, null, null, false, dtStr, null);
         AutobindData data = AutobindData.create(c).on(dt);
         verify(e).bindByProducts(eq(data));
     }
@@ -576,82 +531,7 @@ public class ConsumerResourceTest {
         Consumer c = createConsumer();
         when(consumerCurator.verifyAndLookupConsumerWithEntitlements(eq(c.getUuid()))).thenReturn(c);
         consumerResource.bind(c.getUuid(), "fake pool uuid",
-            new String[]{"12232"}, 1, null, null, false, null, null, null, null);
-    }
-
-    @Test(expected = BadRequestException.class)
-    public void testBindMultipleParamsBodyAndProducts() throws Exception {
-        ConsumerCurator consumerCurator = mock(ConsumerCurator.class);
-        ConsumerResource consumerResource = new ConsumerResource(consumerCurator, null,
-            null, null, null, null, null, null, i18n, null, null, null,
-            null, null, null, null, null, null, null, null, null, null,
-            null, this.config, null, null, null, consumerBindUtil,
-            null, null, this.factValidator, null, consumerEnricher);
-
-        PoolIdAndQuantity[] pools = new PoolIdAndQuantity[2];
-        pools[0] = new PoolIdAndQuantity("first", 1);
-        pools[1] = new PoolIdAndQuantity("second", 2);
-
-        Consumer c = createConsumer();
-        when(consumerCurator.verifyAndLookupConsumerWithEntitlements(eq(c.getUuid()))).thenReturn(c);
-        consumerResource.bind(c.getUuid(), null,
-            new String[]{"12232"}, null, null, null, false, null, null, pools, null);
-    }
-
-    @Test(expected = BadRequestException.class)
-    public void testBindMultipleParamsBodyAndPoolString() throws Exception {
-        ConsumerCurator consumerCurator = mock(ConsumerCurator.class);
-        ConsumerResource consumerResource = new ConsumerResource(consumerCurator, null,
-            null, null, null, null, null, null, i18n, null, null, null,
-            null, null, null, null, null, null, null, null, null, null,
-            null, this.config, null, null, null, consumerBindUtil,
-            null, null, this.factValidator, null, consumerEnricher);
-
-        PoolIdAndQuantity[] pools = new PoolIdAndQuantity[2];
-        pools[0] = new PoolIdAndQuantity("first", 1);
-        pools[1] = new PoolIdAndQuantity("second", 2);
-
-        Consumer c = createConsumer();
-        when(consumerCurator.verifyAndLookupConsumerWithEntitlements(eq(c.getUuid()))).thenReturn(c);
-        consumerResource.bind(c.getUuid(), "assad",
-            null, null, null, null, false, null, null, pools, null);
-    }
-
-    @Test(expected = BadRequestException.class)
-    public void testBindMultipleParamsBodyAndAsync() throws Exception {
-        ConsumerCurator consumerCurator = mock(ConsumerCurator.class);
-        ConsumerResource consumerResource = new ConsumerResource(consumerCurator, null,
-            null, null, null, null, null, null, i18n, null, null, null,
-            null, null, null, null, null, null, null, null, null, null,
-            null, this.config, null, null, null, consumerBindUtil,
-            null, null, this.factValidator, null, consumerEnricher);
-
-        PoolIdAndQuantity[] pools = new PoolIdAndQuantity[2];
-        pools[0] = new PoolIdAndQuantity("first", 1);
-        pools[1] = new PoolIdAndQuantity("second", 2);
-        Consumer c = createConsumer();
-        when(consumerCurator.verifyAndLookupConsumerWithEntitlements(eq(c.getUuid()))).thenReturn(c);
-        consumerResource.bind(c.getUuid(), null,
-            null, null, null, null, false, null, null, pools, null);
-    }
-
-    @Test(expected = BadRequestException.class)
-    public void testBindMultipleParamsBodyAndQuantity() throws Exception {
-        ConsumerCurator consumerCurator = mock(ConsumerCurator.class);
-        ConsumerResource consumerResource = new ConsumerResource(consumerCurator, null,
-            null, null, null, null, null, null, i18n, null, null, null,
-            null, null, null, null, null, null, null, null, null, null,
-            null, this.config, null, null, null, consumerBindUtil,
-            null, null, this.factValidator, null, consumerEnricher);
-
-        PoolIdAndQuantity[] pools = new PoolIdAndQuantity[2];
-        pools[0] = new PoolIdAndQuantity("first", 1);
-        pools[1] = new PoolIdAndQuantity("second", 2);
-
-        Consumer c = createConsumer();
-        when(consumerCurator.verifyAndLookupConsumerWithEntitlements(eq(c.getUuid()))).thenReturn(c);
-        consumerResource.bind(c.getUuid(), null,
-            null, 1, null, null, false, null, null, pools, null);
+            new String[]{"12232"}, 1, null, null, false, null, null);
     }
 
     @Test(expected = NotFoundException.class)
@@ -668,7 +548,7 @@ public class ConsumerResourceTest {
         Consumer c = createConsumer();
         when(consumerCurator.verifyAndLookupConsumerWithEntitlements(eq(c.getUuid()))).thenReturn(c);
         consumerResource.bind(c.getUuid(), "fake pool uuid", null, null, null,
-            null, false, null, null, null, null);
+            null, false, null, null);
     }
 
     /**

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceVirtEntitlementTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceVirtEntitlementTest.java
@@ -142,9 +142,9 @@ public class ConsumerResourceVirtEntitlementTest extends DatabaseTestFixture {
             if (null != p.getAttributeValue(Pool.Attributes.DERIVED_POOL)) {
                 // consume 2 times so one can get revoked later.
                 consumerResource.bind(guestConsumer.getUuid(), p.getId(), null,
-                    10, null, null, false, null, null, null, null);
+                    10, null, null, false, null, null);
                 consumerResource.bind(guestConsumer.getUuid(), p.getId(), null,
-                    10, null, null, false, null, null, null, null);
+                    10, null, null, false, null, null);
                 p = poolManager.find(p.getId());
                 // ensure the correct # consumed from the bonus pool
                 assertTrue(p.getConsumed() == 20);
@@ -158,7 +158,7 @@ public class ConsumerResourceVirtEntitlementTest extends DatabaseTestFixture {
         }
         // manifest consume from the physical pool and then check bonus pool quantities
         consumerResource.bind(manifestConsumer.getUuid(), parentPool.getId(), null, 7, null,
-            null, false, null, null, null, null);
+            null, false, null, null);
         for (Pool p : subscribedTo) {
             p = poolManager.find(p.getId());
             assertTrue(p.getConsumed() == 20);
@@ -167,7 +167,7 @@ public class ConsumerResourceVirtEntitlementTest extends DatabaseTestFixture {
         // manifest consume from the physical pool and then check bonus pool quantities.
         //   Should result in a revocation of one of the 10 count entitlements.
         consumerResource.bind(manifestConsumer.getUuid(), parentPool.getId(), null, 2, null,
-            null, false, null, null, null, null);
+            null, false, null, null);
         for (Pool p : subscribedTo) {
             p = poolManager.find(p.getId());
             assertTrue(p.getConsumed() == 10);
@@ -176,7 +176,7 @@ public class ConsumerResourceVirtEntitlementTest extends DatabaseTestFixture {
         // system consume from the physical pool and then check bonus pool quantities.
         //   Should result in no change in the entitlements for the guest.
         consumerResource.bind(systemConsumer.getUuid(), parentPool.getId(), null, 1, null,
-            null, false, null, null, null, null);
+            null, false, null, null);
         for (Pool p : subscribedTo) {
             p = poolManager.find(p.getId());
             assertTrue(p.getConsumed() == 10);
@@ -199,9 +199,9 @@ public class ConsumerResourceVirtEntitlementTest extends DatabaseTestFixture {
             if (null != p.getAttributeValue(Pool.Attributes.DERIVED_POOL)) {
                 // consume 2 times so they can get revoked separately.
                 consumerResource.bind(guestConsumer.getUuid(), p.getId(), null,
-                    10, null, null, false, null, null, null, null);
+                    10, null, null, false, null, null);
                 consumerResource.bind(guestConsumer.getUuid(), p.getId(), null,
-                    10, null, null, false, null, null, null, null);
+                    10, null, null, false, null, null);
                 p = poolManager.find(p.getId());
                 assertTrue(p.getConsumed() == 20);
                 assertTrue(p.getQuantity() == -1);
@@ -217,7 +217,7 @@ public class ConsumerResourceVirtEntitlementTest extends DatabaseTestFixture {
         }
         // Incomplete consumption of physical pool leaves unlimited pool unchanged.
         consumerResource.bind(manifestConsumer.getUuid(), parentPool.getId(), null, 7, null,
-            null, false, null, null, null, null);
+            null, false, null, null);
         for (Pool p : subscribedTo) {
             assertTrue(p.getConsumed() == 20);
             assertTrue(p.getQuantity() == -1);
@@ -225,7 +225,7 @@ public class ConsumerResourceVirtEntitlementTest extends DatabaseTestFixture {
         // Full consumption of physical pool causes revocation of bonus pool entitlements
         //   and quantity change to 0
         consumerResource.bind(manifestConsumer.getUuid(), parentPool.getId(), null, 3, null,
-            null, false, null, null, null, null);
+            null, false, null, null);
         for (Pool p : subscribedTo) {
             p = poolManager.find(p.getId());
             assertEquals(new Long(0), p.getConsumed());


### PR DESCRIPTION
ConsumerResource.bind should NEVER be provided with a POST body. While technically that change would be backwards compatible,  there are older clients which erroneously provide an empty string  as a post body and hence result in a serialization error.
 ref: BZ: 1502807