### PR TITLE
Override docker network MTU

### DIFF
--- a/docker/docker-compose-build.yml
+++ b/docker/docker-compose-build.yml
@@ -18,3 +18,8 @@ services:
   candlepin-rhel7:
     build: candlepin-rhel7/
     image: ${REGISTRY}/candlepin-rhel7
+networks:
+  default:
+    driver: bridge
+    driver_opts:
+      com.docker.network.driver.mtu: 1400

--- a/docker/docker-compose-mysql.yml
+++ b/docker/docker-compose-mysql.yml
@@ -17,3 +17,8 @@ services:
       - ../:/candlepin-dev
     depends_on:
       - db
+networks:
+  default:
+    driver: bridge
+    driver_opts:
+      com.docker.network.driver.mtu: 1400

--- a/docker/docker-compose-oracle.yml
+++ b/docker/docker-compose-oracle.yml
@@ -18,3 +18,8 @@ services:
       - ../:/candlepin-dev
     depends_on:
       - db
+networks:
+  default:
+    driver: bridge
+    driver_opts:
+      com.docker.network.driver.mtu: 1400

--- a/docker/docker-compose-postgres.yml
+++ b/docker/docker-compose-postgres.yml
@@ -19,3 +19,8 @@ services:
       - ../:/candlepin-dev
     depends_on:
       - db
+networks:
+  default:
+    driver: bridge
+    driver_opts:
+      com.docker.network.driver.mtu: 1400


### PR DESCRIPTION
If this makes the tests pass, we should do this for the other HOTFIX
branches as well. Our test infrastructure uses an MTU lower than 1500,
but when docker-compose creates networks they get an MTU of 1500, thus
problems.