### PR TITLE
[2.1] 1503164: Do not use schema version past what is available in RHEL 7.

### DIFF
--- a/server/src/main/resources/db/changelog/20170220102027-add-id-column-for-productcontent.xml
+++ b/server/src/main/resources/db/changelog/20170220102027-add-id-column-for-productcontent.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
 
 

--- a/server/src/main/resources/db/changelog/20170718095058-purge-orphaned-pools.xml
+++ b/server/src/main/resources/db/changelog/20170718095058-purge-orphaned-pools.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="20170718095058-1" author="vrjain">
         <comment> purge orphaned stack derived pools.

--- a/server/src/main/resources/db/changelog/20170919110500-fixupstreampoolmigration.xml
+++ b/server/src/main/resources/db/changelog/20170919110500-fixupstreampoolmigration.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="20170919110500-1" author="crog">
         <!--

--- a/server/src/main/resources/db/changelog/20171011093538-add-sourcesub-id-index.xml
+++ b/server/src/main/resources/db/changelog/20171011093538-add-sourcesub-id-index.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="20171011093538-1" author="crog">
         <comment>Add SourceSub ID Index</comment>

--- a/tasks/liquibase.rake
+++ b/tasks/liquibase.rake
@@ -55,6 +55,9 @@ module Liquibase
 
     attr_writer :template
     def template
+      # Do not change the schemaLocation unless you know what you are doing.  As of October 2017, RHEL 7 only
+      # supports Liquibase 3.1 and moving the schemaLocation to 3.5 will cause the JVM to attempt to fetch the
+      # schema over http which breaks in disconnected installations.  See BZ #1503164.
       @template || <<-LIQUIBASE
         <?xml version="1.0" encoding="UTF-8"?>
 
@@ -62,7 +65,7 @@ module Liquibase
                 xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                 xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-                http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+                http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
             <changeSet id="<%= id%>" author="<%= author%>">
                 <comment><%= description %></comment>


### PR DESCRIPTION
Using a schema version newer than what is packaged in the Liquibase jar
file will cause Liquibase to attempt to access the new schema over http.
In disconnected installations, the lack of network connectivity will
cause the request to fail and Liquibase will fail to run in turn.

Notes on testing:

1. To test this item, you will need to be running Liquibase 3.1 and not 3.5 (which is the current version in Fedora).  You can grab the old Liquibase RPM from the Satellite 6 repository and downgrade.
2. You will need to turn off your machine's network connectivity.
3. Run a `bin/deploy -g`.  Liquibase will run and will fail because some of the changeset files are referencing the 3.5 schema.  The failure occurs when trying to run the `20170220102027-add-id-column-for-productcontent.xml` changeset.

@Ceiu Would you mind checking your editor?  Some of the files were originally using the 2.0 xsd and were then upgraded to 3.5 when you modified them last.  I'm wondering if your editor is trying to be "helpful".