### PR TITLE
1504710: Do not use schema version past what is available in RHEL 7.

### DIFF
--- a/server/src/main/resources/db/changelog/20170220102027-add-id-column-for-productcontent.xml
+++ b/server/src/main/resources/db/changelog/20170220102027-add-id-column-for-productcontent.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
 
 

--- a/server/src/main/resources/db/changelog/20170718095058-purge-orphaned-pools.xml
+++ b/server/src/main/resources/db/changelog/20170718095058-purge-orphaned-pools.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="20170718095058-1" author="vrjain">
         <comment> purge orphaned stack derived pools.
@@ -13,7 +13,7 @@
             1. delete stack derived pools with no source stacks
             2. delete bonus pools with no source subscription
             3. delete stack derived pools with no source ents
-                
+
             we are trying to purge orphaned pools, but we need to ensure the dependency chain
             of the pools is purged too. Thus, for each use case we delete the following:
             1.delete provided products of the pools whose source entitlements are going
@@ -28,8 +28,8 @@
             7.delete provided products of the pools in the use case
             8.delete source subs of the pools in the use case
             9.delete derived provided products of the pools in the use case
-            10.delete pools in the use case  
-                
+            10.delete pools in the use case
+
             </comment>
         <sql>
 DELETE

--- a/server/src/main/resources/db/changelog/20170816084513-add-createdByShare-and-hasSharedAncestor.xml
+++ b/server/src/main/resources/db/changelog/20170816084513-add-createdByShare-and-hasSharedAncestor.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="20170816084513-1" author="vrjain">
         <comment> add-createdByShare-and-hasSharedAncestor</comment>

--- a/server/src/main/resources/db/changelog/20170919110500-fixupstreampoolmigration.xml
+++ b/server/src/main/resources/db/changelog/20170919110500-fixupstreampoolmigration.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="20170919110500-1" author="crog">
         <!--

--- a/server/src/main/resources/db/changelog/20171010164730-add-cp-consumer-username-index.xml
+++ b/server/src/main/resources/db/changelog/20171010164730-add-cp-consumer-username-index.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="20171010164730" author="nmoumoul">
         <comment>Add index on username to cp_consumer</comment>

--- a/server/src/main/resources/db/changelog/20171011093538-add-sourcesub-id-index.xml
+++ b/server/src/main/resources/db/changelog/20171011093538-add-sourcesub-id-index.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="20171011093538-1" author="crog">
         <comment>Add SourceSub ID Index</comment>

--- a/tasks/liquibase.rake
+++ b/tasks/liquibase.rake
@@ -55,6 +55,9 @@ module Liquibase
 
     attr_writer :template
     def template
+      # Do not change the schemaLocation unless you know what you are doing.  As of October 2017, RHEL 7 only
+      # supports Liquibase 3.1 and moving the schemaLocation to 3.5 will cause the JVM to attempt to fetch the
+      # schema over http which breaks in disconnected installations.  See BZ #1503164.
       @template || <<-LIQUIBASE
         <?xml version="1.0" encoding="UTF-8"?>
 
@@ -62,7 +65,7 @@ module Liquibase
                 xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                 xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-                http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+                http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
             <changeSet id="<%= id%>" author="<%= author%>">
                 <comment><%= description %></comment>


### PR DESCRIPTION
Using a schema version newer than what is packaged in the Liquibase jar
file will cause Liquibase to attempt to access the new schema over http.
In disconnected installations, the lack of network connectivity will
cause the request to fail and Liquibase will fail to run in turn.



Notes on testing:

1.  To test this item, you will need to be running Liquibase 3.1 and not 3.5 (which is the current version in Fedora). You can grab the old Liquibase RPM from the Satellite 6 repository and downgrade.
1.  You will need to turn off your machine's network connectivity.
1.  Run a bin/deploy -g. Liquibase will run and will fail because some of the changeset files are referencing the 3.5 schema. The failure occurs when trying to run the 20170220102027-add-id-column-for-productcontent.xml changeset.
