### PR TITLE
[M] Add a setting to allow users to mask capabilities.

### DIFF
--- a/common/src/main/java/org/candlepin/common/config/PropertyConverter.java
+++ b/common/src/main/java/org/candlepin/common/config/PropertyConverter.java
@@ -142,7 +142,7 @@ public class PropertyConverter {
 
     public static List<String> toList(Object value) {
         if (value instanceof String) {
-            String[] parts = ((String) value).split("\\s*,\\s*");
+            String[] parts = ((String) value).trim().split("\\s*,\\s*");
             return Arrays.asList(parts);
         }
         else {
@@ -154,7 +154,7 @@ public class PropertyConverter {
 
     public static Set<String> toSet(Object value) {
         if (value instanceof String) {
-            String[] parts = ((String) value).split("\\s*,\\s*");
+            String[] parts = ((String) value).trim().split("\\s*,\\s*");
             return new HashSet<String>(Arrays.asList(parts));
         }
         else {

--- a/common/src/test/java/org/candlepin/common/config/MapConfigurationTest.java
+++ b/common/src/test/java/org/candlepin/common/config/MapConfigurationTest.java
@@ -290,6 +290,13 @@ public class MapConfigurationTest {
     }
 
     @Test
+    public void testGetSet() {
+        config.setProperty("x", "  a  , b  ,  c  ");
+        Set<String> expected = new HashSet<String>(Arrays.asList("a", "b", "c"));
+        assertEquals(expected, config.getSet("x"));
+    }
+
+    @Test
     public void testGetPropertyWithDefault() {
         assertEquals("z", config.getProperty("x", "z"));
     }

--- a/server/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/server/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -131,6 +131,9 @@ public class ConfigProperties {
     // Space separated list of resources to hide in the GET / list:
     public static final String HIDDEN_RESOURCES = "candlepin.hidden_resources";
 
+    // Space separated list of resources to hide in GET /status
+    public static final String HIDDEN_CAPABILITIES = "candlepin.hidden_capabilities";
+
     // Authentication
     public static final String TRUSTED_AUTHENTICATION = "candlepin.auth.trusted.enable";
     public static final String SSL_AUTHENTICATION = "candlepin.auth.ssl.enable";
@@ -349,6 +352,7 @@ public class ConfigProperties {
             // By default, environments should be hidden so clients do not need to
             // submit one when registering.
             this.put(HIDDEN_RESOURCES, "environments");
+            this.put(HIDDEN_CAPABILITIES, "");
 
             this.put(FAIL_ON_UNKNOWN_IMPORT_PROPERTIES, "false");
 

--- a/server/src/main/java/org/candlepin/guice/CandlepinContextListener.java
+++ b/server/src/main/java/org/candlepin/guice/CandlepinContextListener.java
@@ -31,6 +31,7 @@ import org.candlepin.config.ConfigProperties;
 import org.candlepin.config.DatabaseConfigFactory;
 import org.candlepin.controller.SuspendModeTransitioner;
 import org.candlepin.logging.LoggerContextListener;
+import org.candlepin.model.Status;
 import org.candlepin.pinsetter.core.PinsetterContextListener;
 import org.candlepin.resteasy.ResourceLocatorMap;
 import org.candlepin.swagger.CandlepinSwaggerModelConverter;
@@ -60,9 +61,13 @@ import net.sf.ehcache.management.ManagementService;
 import java.io.File;
 import java.lang.management.ManagementFactory;
 import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 
 import javax.management.MBeanServer;
 import javax.persistence.EntityManagerFactory;
@@ -126,6 +131,7 @@ public class CandlepinContextListener extends GuiceResteasyBootstrapServletConte
         LoggingConfigurator.init(config);
 
         servletContext.setAttribute(CONFIGURATION_NAME, config);
+        setCapabilities(config);
         log.debug("Candlepin stored config on context.");
 
         // set things up BEFORE calling the super class' initialize method.
@@ -203,6 +209,16 @@ public class CandlepinContextListener extends GuiceResteasyBootstrapServletConte
             Util.closeSafely(injector.getInstance(AMQPBusPublisher.class),
                 "AMQPBusPublisher");
         }
+    }
+
+    protected void setCapabilities(Configuration config) {
+        Set<String> blacklistedSet = config.getSet(ConfigProperties.HIDDEN_CAPABILITIES,
+            Collections.<String>emptySet());
+        Set<String> exposedSet = new HashSet<String>(Arrays.asList(Status.DEFAULT_CAPABILITIES));
+        exposedSet.removeAll(blacklistedSet);
+
+        Status.setAvailableCapabilities(exposedSet.toArray(new String[exposedSet.size()]));
+        log.info("Candlepin will show support for {}", Status.getAvailableCapabilities());
     }
 
     protected Configuration readConfiguration(ServletContext context)

--- a/server/src/main/java/org/candlepin/model/Status.java
+++ b/server/src/main/java/org/candlepin/model/Status.java
@@ -19,14 +19,14 @@ import org.candlepin.model.CandlepinModeChange.Mode;
 import org.candlepin.model.CandlepinModeChange.Reason;
 import org.candlepin.model.Rules.RulesSourceEnum;
 
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
 import java.util.Date;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
-
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
 
 /**
  * Status
@@ -35,6 +35,12 @@ import io.swagger.annotations.ApiModelProperty;
 @XmlRootElement(name = "status")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 public class Status {
+    public static final String[] DEFAULT_CAPABILITIES = { "cores", "ram", "instance_multiplier",
+        "derived_product", "cert_v3", "guest_limit", "vcpu", "hypervisors_async", "storage_band",
+        "remove_by_pool_id", "batch_bind", "org_level_content_access" };
+
+    private static String[] availableCapabilities = DEFAULT_CAPABILITIES;
+
     /**
      * The current Suspend Mode of Candlepin
      */
@@ -65,11 +71,6 @@ public class Status {
 
     private Date timeUTC;
 
-    @ApiModelProperty(example = "[ \"cores\", \"ram\", \"instance_multiplier\" ]")
-    private String[] managerCapabilities = {"cores", "ram", "instance_multiplier",
-        "derived_product", "cert_v3", "guest_limit", "vcpu", "hypervisors_async",
-        "storage_band", "remove_by_pool_id", "batch_bind", "org_level_content_access"};
-
     private RulesSourceEnum rulesSource;
 
 
@@ -93,6 +94,14 @@ public class Status {
         this.modeReason = reason;
         this.modeChangeTime = modeChangeTime;
         this.setRulesSource(rulesSource);
+    }
+
+    public static void setAvailableCapabilities(String[] availableCapabilities) {
+        Status.availableCapabilities = availableCapabilities;
+    }
+
+    public static String[] getAvailableCapabilities() {
+        return Status.availableCapabilities;
     }
 
     public boolean getResult() {
@@ -156,8 +165,9 @@ public class Status {
         this.rulesSource = rulesSource;
     }
 
+    @ApiModelProperty(example = "[ \"cores\", \"ram\", \"instance_multiplier\" ]")
     public String[] getManagerCapabilities() {
-        return managerCapabilities;
+        return Status.availableCapabilities;
     }
 
     public Mode getMode() {

--- a/server/src/main/java/org/candlepin/resource/StatusResource.java
+++ b/server/src/main/java/org/candlepin/resource/StatusResource.java
@@ -32,15 +32,15 @@ import com.google.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+
 import java.util.Map;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
 
 /**
  * Status Resource

--- a/server/src/test/java/org/candlepin/guice/CandlepinContextListenerTest.java
+++ b/server/src/test/java/org/candlepin/guice/CandlepinContextListenerTest.java
@@ -15,7 +15,8 @@
 package org.candlepin.guice;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 
 import org.candlepin.TestingModules;
@@ -27,6 +28,7 @@ import org.candlepin.common.config.ConfigurationPrefixes;
 import org.candlepin.common.config.MapConfiguration;
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.junit.CandlepinLiquibaseResource;
+import org.candlepin.model.Status;
 import org.candlepin.pinsetter.core.PinsetterContextListener;
 
 import com.google.inject.AbstractModule;
@@ -41,8 +43,11 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 
 import javax.servlet.ServletContext;
@@ -119,6 +124,30 @@ public class CandlepinContextListenerTest {
         verify(ctx).setAttribute(
             eq(CandlepinContextListener.CONFIGURATION_NAME), eq(config));
         verify(configRead).verify(eq(ctx));
+
+        Set<String> displayedCapabilities = new HashSet<String>(
+            Arrays.asList(Status.getAvailableCapabilities()));
+        Set<String> expectedCapabilities = new HashSet<String>(Arrays.asList(Status.DEFAULT_CAPABILITIES));
+        assertEquals(expectedCapabilities, displayedCapabilities);
+    }
+
+    @Test
+    public void blackListsCapabilities() {
+        Set<String> testSet = new HashSet<String>();
+        testSet.add("cores");
+        testSet.add("ram");
+
+        when(config.getSet(eq(ConfigProperties.HIDDEN_CAPABILITIES), any(Set.class))).thenReturn(testSet);
+        prepareForInitialization();
+        listener.contextInitialized(evt);
+
+        Set<String> expectedCapabilities = new HashSet<String>(Arrays.asList(Status.DEFAULT_CAPABILITIES));
+        expectedCapabilities.remove("cores");
+        expectedCapabilities.remove("ram");
+
+        Set<String> displayedCapabilities = new HashSet<String>(
+            Arrays.asList(Status.getAvailableCapabilities()));
+        assertEquals(expectedCapabilities, displayedCapabilities);
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/resource/StatusResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/StatusResourceTest.java
@@ -14,26 +14,20 @@
  */
 package org.candlepin.resource;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 import org.candlepin.cache.CandlepinCache;
 import org.candlepin.cache.StatusCache;
 import org.candlepin.common.config.Configuration;
 import org.candlepin.controller.ModeManager;
 import org.candlepin.model.CandlepinModeChange;
+import org.candlepin.model.CandlepinModeChange.Mode;
+import org.candlepin.model.CandlepinModeChange.Reason;
 import org.candlepin.model.CandlepinQuery;
 import org.candlepin.model.Rules;
 import org.candlepin.model.RulesCurator;
 import org.candlepin.model.Status;
-import org.candlepin.model.CandlepinModeChange.Mode;
-import org.candlepin.model.CandlepinModeChange.Reason;
 import org.candlepin.policy.js.JsRunnerProvider;
 
 import org.junit.Before;


### PR DESCRIPTION
Using the key "candlepin.hidden_capabilities", users can set a
comma-delimited list of capabilities that will *not* be shown in the
response to /status call.