### PR TITLE
[2.0] Add a setting to allow users to mask capabilities.

### DIFF
--- a/common/src/main/java/org/candlepin/common/config/PropertyConverter.java
+++ b/common/src/main/java/org/candlepin/common/config/PropertyConverter.java
@@ -142,7 +142,7 @@ public class PropertyConverter {
 
     public static List<String> toList(Object value) {
         if (value instanceof String) {
-            String[] parts = ((String) value).split("\\s*,\\s*");
+            String[] parts = ((String) value).trim().split("\\s*,\\s*");
             return Arrays.asList(parts);
         }
         else {
@@ -154,7 +154,7 @@ public class PropertyConverter {
 
     public static Set<String> toSet(Object value) {
         if (value instanceof String) {
-            String[] parts = ((String) value).split("\\s*,\\s*");
+            String[] parts = ((String) value).trim().split("\\s*,\\s*");
             return new HashSet<String>(Arrays.asList(parts));
         }
         else {

--- a/common/src/test/java/org/candlepin/common/config/MapConfigurationTest.java
+++ b/common/src/test/java/org/candlepin/common/config/MapConfigurationTest.java
@@ -290,6 +290,13 @@ public class MapConfigurationTest {
     }
 
     @Test
+    public void testGetSet() {
+        config.setProperty("x", "  a  , b  ,  c  ");
+        Set<String> expected = new HashSet<String>(Arrays.asList("a", "b", "c"));
+        assertEquals(expected, config.getSet("x"));
+    }
+
+    @Test
     public void testGetPropertyWithDefault() {
         assertEquals("z", config.getProperty("x", "z"));
     }

--- a/server/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/server/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -132,6 +132,9 @@ public class ConfigProperties {
     // Space separated list of resources to hide in the GET / list:
     public static final String HIDDEN_RESOURCES = "candlepin.hidden_resources";
 
+    // Space separated list of resources to hide in GET /status
+    public static final String HIDDEN_CAPABILITIES = "candlepin.hidden_capabilities";
+
     // Authentication
     public static final String TRUSTED_AUTHENTICATION = "candlepin.auth.trusted.enable";
     public static final String SSL_AUTHENTICATION = "candlepin.auth.ssl.enable";
@@ -351,6 +354,7 @@ public class ConfigProperties {
             // By default, environments should be hidden so clients do not need to
             // submit one when registering.
             this.put(HIDDEN_RESOURCES, "environments");
+            this.put(HIDDEN_CAPABILITIES, "");
 
             this.put(FAIL_ON_UNKNOWN_IMPORT_PROPERTIES, "false");
 

--- a/server/src/main/java/org/candlepin/model/Status.java
+++ b/server/src/main/java/org/candlepin/model/Status.java
@@ -19,14 +19,14 @@ import org.candlepin.model.CandlepinModeChange.Mode;
 import org.candlepin.model.CandlepinModeChange.Reason;
 import org.candlepin.model.Rules.RulesSourceEnum;
 
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
 import java.util.Date;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
-
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
 
 /**
  * Status
@@ -35,6 +35,12 @@ import io.swagger.annotations.ApiModelProperty;
 @XmlRootElement(name = "status")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 public class Status {
+    public static final String[] DEFAULT_CAPABILITIES = { "cores", "ram", "instance_multiplier",
+        "derived_product", "cert_v3", "guest_limit", "vcpu", "hypervisors_async", "storage_band",
+        "remove_by_pool_id", "batch_bind", "org_level_content_access" };
+
+    private static String[] availableCapabilities = DEFAULT_CAPABILITIES;
+
     /**
      * The current Suspend Mode of Candlepin
      */
@@ -65,11 +71,6 @@ public class Status {
 
     private Date timeUTC;
 
-    @ApiModelProperty(example = "[ \"cores\", \"ram\", \"instance_multiplier\" ]")
-    private String[] managerCapabilities = {"cores", "ram", "instance_multiplier",
-        "derived_product", "cert_v3", "guest_limit", "vcpu", "hypervisors_async",
-        "storage_band", "remove_by_pool_id", "batch_bind", "org_level_content_access"};
-
     private RulesSourceEnum rulesSource;
 
 
@@ -93,6 +94,14 @@ public class Status {
         this.modeReason = reason;
         this.modeChangeTime = modeChangeTime;
         this.setRulesSource(rulesSource);
+    }
+
+    public static void setAvailableCapabilities(String[] availableCapabilities) {
+        Status.availableCapabilities = availableCapabilities;
+    }
+
+    public static String[] getAvailableCapabilities() {
+        return Status.availableCapabilities;
     }
 
     public boolean getResult() {
@@ -156,8 +165,9 @@ public class Status {
         this.rulesSource = rulesSource;
     }
 
+    @ApiModelProperty(example = "[ \"cores\", \"ram\", \"instance_multiplier\" ]")
     public String[] getManagerCapabilities() {
-        return managerCapabilities;
+        return Status.availableCapabilities;
     }
 
     public Mode getMode() {

--- a/server/src/main/java/org/candlepin/resource/StatusResource.java
+++ b/server/src/main/java/org/candlepin/resource/StatusResource.java
@@ -31,6 +31,9 @@ import com.google.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+
 import java.util.Map;
 
 import javax.cache.Cache;
@@ -38,9 +41,6 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
 
 /**
  * Status Resource

--- a/server/src/test/java/org/candlepin/resource/StatusResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/StatusResourceTest.java
@@ -14,25 +14,19 @@
  */
 package org.candlepin.resource;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 import org.candlepin.cache.CandlepinCache;
 import org.candlepin.common.config.Configuration;
 import org.candlepin.controller.ModeManager;
 import org.candlepin.model.CandlepinModeChange;
+import org.candlepin.model.CandlepinModeChange.Mode;
+import org.candlepin.model.CandlepinModeChange.Reason;
 import org.candlepin.model.CandlepinQuery;
 import org.candlepin.model.Rules;
 import org.candlepin.model.RulesCurator;
 import org.candlepin.model.Status;
-import org.candlepin.model.CandlepinModeChange.Mode;
-import org.candlepin.model.CandlepinModeChange.Reason;
 import org.candlepin.policy.js.JsRunnerProvider;
 
 import org.junit.Before;


### PR DESCRIPTION
Using the key "candlepin.hidden_capabilities", users can set a
comma-delimited list of capabilities that will *not* be shown in the
response to /status call.