### PR TITLE
[2.1] Job Cleaner

### DIFF
--- a/server/src/main/java/org/candlepin/model/JobCurator.java
+++ b/server/src/main/java/org/candlepin/model/JobCurator.java
@@ -76,6 +76,7 @@ public class JobCurator extends AbstractHibernateCurator<JobStatus> {
         }
     }
 
+    @Transactional
     public int deleteJobNoStatusReturn(String jobId) {
         return this.currentSession().createQuery(
             "delete from JobStatus where id = :jobid")
@@ -83,6 +84,7 @@ public class JobCurator extends AbstractHibernateCurator<JobStatus> {
                 .executeUpdate();
     }
 
+    @Transactional
     public int cleanupAllOldJobs(Date deadline) {
         return this.currentSession().createQuery(
             "delete from JobStatus where updated <= :date")
@@ -90,6 +92,7 @@ public class JobCurator extends AbstractHibernateCurator<JobStatus> {
                .executeUpdate();
     }
 
+    @Transactional
     public int cleanUpOldCompletedJobs(Date deadLineDt) {
         return this.currentSession().createQuery(
             "delete from JobStatus where updated <= :date and " +
@@ -218,6 +221,7 @@ public class JobCurator extends AbstractHibernateCurator<JobStatus> {
         return cancelOrphanedJobs(activeIds, 1000L * 60L * 2L); //2 minutes
     }
 
+    @Transactional
     public int cancelOrphanedJobs(List<String> activeIds, Long millis) {
         Date before = new Date(new Date().getTime() - millis);
         String hql = "update JobStatus j " +

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/KingpinJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/KingpinJob.java
@@ -16,6 +16,7 @@ package org.candlepin.pinsetter.tasks;
 
 import static org.quartz.impl.matchers.NameMatcher.jobNameEquals;
 
+import com.google.common.collect.Iterables;
 import org.candlepin.audit.EventSink;
 import org.candlepin.common.config.Configuration;
 import org.candlepin.config.ConfigProperties;
@@ -42,6 +43,7 @@ import org.slf4j.MDC;
 
 import javax.persistence.EntityExistsException;
 import javax.persistence.PersistenceException;
+import java.util.List;
 
 /**
  * KingpinJob replaces TransactionalPinsetterJob, which encapsulated
@@ -57,6 +59,7 @@ public abstract class KingpinJob implements Job {
     @Inject private EventSink eventSink;
     @Inject private CandlepinRequestScope candlepinRequestScope;
 
+    public static final int IN_OPERATOR_BLOCK_SIZE = 2048;
     protected static String prefix = "job";
 
     @Override
@@ -237,5 +240,9 @@ public abstract class KingpinJob implements Job {
     // Override in jobs to disable execution time logging.
     protected boolean logExecutionTime() {
         return true;
+    }
+
+    protected <T> Iterable<List<T>> partition(Iterable<T> collection) {
+        return Iterables.partition(collection, IN_OPERATOR_BLOCK_SIZE);
     }
 }

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/SweepBarJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/SweepBarJob.java
@@ -72,9 +72,12 @@ public class SweepBarJob extends KingpinJob {
             for (JobKey key : keys) {
                 statusIds.add(key.getName());
             }
-            int canceled = jobCurator.cancelOrphanedJobs(statusIds);
-            if (canceled > 0) {
-                log.info("Canceled " + canceled + " orphaned jobs");
+            int cancelled = 0;
+            for (List<String> block : this.partition(statusIds)) {
+                cancelled += jobCurator.cancelOrphanedJobs(block);
+            }
+            if (cancelled > 0) {
+                log.info("Cancelled " + cancelled + " orphaned jobs");
             }
         }
         catch (Exception e) {

--- a/server/src/test/java/org/candlepin/pinsetter/core/PinsetterKernelTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/core/PinsetterKernelTest.java
@@ -454,6 +454,11 @@ public class PinsetterKernelTest {
         pk = new PinsetterKernel(config, jfactory, jlistener, jcurator,
             sfactory, triggerListener, modeManager);
 
+        Set<JobKey> mockJK = new HashSet<JobKey>();
+        JobKey jk = new JobKey("test key");
+        mockJK.add(jk);
+        when(pk.getSingleJobKeys()).thenReturn(mockJK);
+
         pk.unpauseScheduler();
         verify(jcurator).findCanceledJobs(any(Set.class));
         verify(sched).start();

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/CancelJobJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/CancelJobJobTest.java
@@ -34,9 +34,12 @@ import org.quartz.Job;
 import org.quartz.JobDetail;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
+import org.quartz.JobKey;
+import org.quartz.SchedulerException;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -71,7 +74,7 @@ public class CancelJobJobTest extends BaseJobTest{
     }
 
     @Test
-    public void cancelTest() throws JobExecutionException, PinsetterException {
+    public void cancelTest() throws JobExecutionException, PinsetterException, SchedulerException {
         JobDetail jd = newJob(Job.class)
             .withIdentity("Kayfabe", "Deluxe")
             .build();
@@ -80,6 +83,9 @@ public class CancelJobJobTest extends BaseJobTest{
         List<JobStatus> jl = new ArrayList<JobStatus>();
         jl.add(js);
 
+        Set<JobKey> jobKeys = new HashSet<JobKey>();
+        jobKeys.add(new JobKey("Kayfabe"));
+        when(pk.getSingleJobKeys()).thenReturn(jobKeys);
         CandlepinQuery query = mock(CandlepinQuery.class);
         when(query.list()).thenReturn(jl);
         when(j.findCanceledJobs(any(Set.class))).thenReturn(query);

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/SweepBarJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/SweepBarJobTest.java
@@ -29,6 +29,7 @@ import org.quartz.JobKey;
 import org.quartz.SchedulerException;
 
 import java.util.HashSet;
+import java.util.Set;
 
 /**
  * SweepBarJobTest
@@ -45,8 +46,10 @@ public class SweepBarJobTest extends BaseJobTest {
         MockitoAnnotations.initMocks(this);
         sweepBarJob = new SweepBarJob(j, pk);
         injector.injectMembers(sweepBarJob);
-        when(pk.getSingleJobKeys()).thenReturn((new HashSet<JobKey>()));
-    }
+        Set<JobKey> mockJK = new HashSet<JobKey>();
+        JobKey jk = new JobKey("test key");
+        mockJK.add(jk);
+        when(pk.getSingleJobKeys()).thenReturn(mockJK);    }
 
     @Test
     public void testSweepBarJob() throws Exception {


### PR DESCRIPTION
Transactionalize delete jobs - Missing annotations were causing deletes not to occur
Batch lookups by id - List exceeding the limit