### PR TITLE
[M] 1506014: Optimized pool serialization and dependent entitlement lookup

### DIFF
--- a/server/src/main/java/org/candlepin/model/Pool.java
+++ b/server/src/main/java/org/candlepin/model/Pool.java
@@ -27,6 +27,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.apache.commons.lang.StringUtils;
+
+import org.hibernate.Hibernate;
 import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.Fetch;
@@ -363,13 +365,6 @@ public class Pool extends AbstractHibernateObject implements Persisted, Owned, N
     @Transient
     private Set<ProvidedProduct> derivedProvidedProductDtos;
 
-    /**
-     * Transient property that holds derived provided products from database. It is
-     * populated before serialization happens.
-     */
-    @Transient
-    private Set<ProvidedProduct> derivedProvidedProductDtosCached;
-
     @Transient
     @JsonSerialize(using = CandlepinLegacyAttributeSerializer.class)
     @JsonDeserialize(using = CandlepinAttributeDeserializer.class)
@@ -434,7 +429,6 @@ public class Pool extends AbstractHibernateObject implements Persisted, Owned, N
         this.importedDerivedProductAttributes = null;
         this.providedProductDtos = null;
         this.derivedProvidedProductDtos = null;
-        this.derivedProvidedProductDtosCached = null;
 
         this.markedForDelete = false;
 
@@ -973,11 +967,15 @@ public class Pool extends AbstractHibernateObject implements Persisted, Owned, N
     }
 
     public void addProvidedProduct(Product provided) {
-        this.providedProducts.add(provided);
+        if (provided != null) {
+            this.providedProducts.add(provided);
+            this.providedProductDtos = null;
+        }
     }
 
     public void setProvidedProducts(Collection<Product> providedProducts) {
         this.providedProducts.clear();
+        this.providedProductDtos = null;
 
         if (providedProducts != null) {
             this.providedProducts.addAll(providedProducts);
@@ -992,9 +990,52 @@ public class Pool extends AbstractHibernateObject implements Persisted, Owned, N
         return providedProductDtos;
     }
 
+    /*
+     * Used temporarily while importing a manifest.
+     */
+    public void setProvidedProductDtos(Set<ProvidedProduct> dtos) {
+        providedProductDtos = dtos;
+    }
+
+    @JsonIgnore
+    public Set<Product> getDerivedProvidedProducts() {
+        return derivedProvidedProducts;
+    }
+
+    public void addDerivedProvidedProduct(Product provided) {
+        if (provided != null) {
+            this.derivedProvidedProducts.add(provided);
+            this.derivedProvidedProductDtos = null;
+        }
+    }
+
+    public void setDerivedProvidedProducts(Collection<Product> derivedProvidedProducts) {
+        this.derivedProvidedProducts.clear();
+        this.derivedProvidedProductDtos = null;
+
+        if (derivedProvidedProducts != null) {
+            this.derivedProvidedProducts.addAll(derivedProvidedProducts);
+        }
+    }
+
+    /*
+     * Always exported as a DTO for API/import backward compatibility.
+     */
+    @JsonProperty("derivedProvidedProducts")
+    public Set<ProvidedProduct> getDerivedProvidedProductDtos() {
+        return this.derivedProvidedProductDtos;
+    }
+
+    /*
+     * Used temporarily while importing a manifest.
+     */
+    public void setDerivedProvidedProductDtos(Set<ProvidedProduct> dtos) {
+        derivedProvidedProductDtos = dtos;
+    }
+
     /**
      * This is a helper method to fill in transient fields in this class.
-     * The transient fields are providedProductDtos, derivedProvidedProductDtosCached
+     * The transient fields are providedProductDtos, derivedProvidedProductDtos
      *
      * The reason we need to fill transient properties is, that various parts of code
      * that rely on serialization expect Pool object.
@@ -1006,31 +1047,31 @@ public class Pool extends AbstractHibernateObject implements Persisted, Owned, N
      * @param productCurator
      */
     public void populateAllTransientProvidedProducts(ProductCurator productCurator) {
-        Set<ProvidedProduct> prods = new HashSet<ProvidedProduct>();
+        // If we've already populated this field, assume it's correctly populated
+        if (this.providedProductDtos == null) {
+            Collection<Product> products = Hibernate.isInitialized(this.providedProducts) ?
+                this.providedProducts :
+                productCurator.getPoolProvidedProductsCached(this.getId());
 
-        if (this.providedProductDtos != null) {
-            prods.addAll(this.providedProductDtos);
+            this.providedProductDtos = new HashSet<ProvidedProduct>();
+
+            for (Product product : products) {
+                this.providedProductDtos.add(new ProvidedProduct(product));
+            }
         }
 
-        for (Product p : productCurator.getPoolProvidedProductsCached(id)) {
-            prods.add(new ProvidedProduct(p));
+        // If we've already populated this field, assume it's correctly populated
+        if (this.derivedProvidedProductDtos == null) {
+            Collection<Product> products = Hibernate.isInitialized(this.derivedProvidedProducts) ?
+                this.derivedProvidedProducts :
+                productCurator.getPoolDerivedProvidedProductsCached(this.getId());
+
+            this.derivedProvidedProductDtos = new HashSet<ProvidedProduct>();
+
+            for (Product product : products) {
+                this.derivedProvidedProductDtos.add(new ProvidedProduct(product));
+            }
         }
-
-        providedProductDtos = prods;
-
-        derivedProvidedProductDtosCached = new HashSet<ProvidedProduct>();
-
-        for (Product p : productCurator.getPoolDerivedProvidedProductsCached(id)) {
-            ProvidedProduct product = new ProvidedProduct(p);
-            derivedProvidedProductDtosCached.add(product);
-        }
-    }
-
-    /*
-     * Used temporarily while importing a manifest.
-     */
-    public void setProvidedProductDtos(Set<ProvidedProduct> dtos) {
-        providedProductDtos = dtos;
     }
 
     /**
@@ -1249,57 +1290,6 @@ public class Pool extends AbstractHibernateObject implements Persisted, Owned, N
             this.importedDerivedProductId = null;
             this.importedDerivedProductAttributes = null;
         }
-    }
-
-    @JsonIgnore
-    public Set<Product> getDerivedProvidedProducts() {
-        return derivedProvidedProducts;
-    }
-
-    public void addDerivedProvidedProduct(Product provided) {
-        this.derivedProvidedProducts.add(provided);
-    }
-
-    public void setDerivedProvidedProducts(Collection<Product> derivedProvidedProducts) {
-        this.derivedProvidedProducts.clear();
-
-        if (derivedProvidedProducts != null) {
-            this.derivedProvidedProducts.addAll(derivedProvidedProducts);
-        }
-    }
-
-    /*
-     * Always exported as a DTO for API/import backward compatibility.
-     */
-    @JsonProperty("derivedProvidedProducts")
-    public Set<ProvidedProduct> getDerivedProvidedProductDtos() {
-        Set<ProvidedProduct> pp = new HashSet<ProvidedProduct>();
-        Set<String> added = new HashSet<String>();
-
-        if (this.derivedProvidedProductDtosCached != null) {
-            for (ProvidedProduct p : this.derivedProvidedProductDtosCached) {
-                pp.add(p);
-                added.add(p.getProductId());
-            }
-        }
-
-        if (this.derivedProvidedProductDtos != null) {
-            for (ProvidedProduct p : this.derivedProvidedProductDtos) {
-                if (!added.contains(p.getProductId())) {
-                    pp.add(p);
-                }
-            }
-        }
-
-        return pp;
-    }
-
-
-    /*
-     * Used temporarily while importing a manifest.
-     */
-    public void setDerivedProvidedProductDtos(Set<ProvidedProduct> dtos) {
-        derivedProvidedProductDtos = dtos;
     }
 
     /*

--- a/server/src/main/java/org/candlepin/model/PoolCurator.java
+++ b/server/src/main/java/org/candlepin/model/PoolCurator.java
@@ -722,15 +722,15 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
     }
 
     @SuppressWarnings("unchecked")
-    public List<Entitlement> retrieveOrderedEntitlementsOf(List<Pool> existingPools) {
+    public List<Entitlement> retrieveOrderedEntitlementsOf(Collection<Pool> existingPools) {
         return criteriaToSelectEntitlementForPools(existingPools)
             .addOrder(Order.desc("created"))
             .list();
     }
 
     @SuppressWarnings("unchecked")
-    public List<String> retrieveOrderedEntitlementIdsOf(Pool existingPool) {
-        return criteriaToSelectEntitlementForPool(existingPool)
+    public List<String> retrieveOrderedEntitlementIdsOf(Collection<Pool> pools) {
+        return this.criteriaToSelectEntitlementForPools(pools)
             .addOrder(Order.desc("created"))
             .setProjection(Projections.id())
             .list();
@@ -749,7 +749,7 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
             .add(Restrictions.eq("pool", entitlementPool));
     }
 
-    private Criteria criteriaToSelectEntitlementForPools(List<Pool> entitlementPools) {
+    private Criteria criteriaToSelectEntitlementForPools(Collection<Pool> entitlementPools) {
         return this.currentSession().createCriteria(Entitlement.class)
                 .add(CPRestrictions.in("pool", entitlementPools));
     }
@@ -1827,5 +1827,138 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
                 query.executeUpdate();
             }
         }
+    }
+
+    /**
+     * Fetches a set of pool IDs which represent the set of provided pool IDs that currently exist
+     * in the database
+     *
+     * @param poolIds
+     *  A collection of pool IDs to use to fetch existing pool IDs
+     *
+     * @return
+     *  a set of pool IDs representing existing pools in the given collection of pool IDs
+     */
+    public Set<String> getExistingPoolIdsByIds(Iterable<String> poolIds) {
+        Set<String> existing = new HashSet<String>();
+
+        if (poolIds != null && poolIds.iterator().hasNext()) {
+            String jpql = "SELECT DISTINCT p.id FROM Pool p WHERE p.id IN (:pids)";
+            TypedQuery<String> query = this.getEntityManager()
+                .createQuery(jpql, String.class);
+
+            for (List<String> block : this.partition(poolIds)) {
+                query.setParameter("pids", block);
+                existing.addAll(query.getResultList());
+            }
+        }
+
+        return existing;
+    }
+
+    /**
+     * Fetches a map of consumer IDs to pool IDs of stack derived pools for the given stack IDs. If
+     * no such pools can be found, an empty map is returned.
+     *
+     * @param stackIds
+     *  A collection of stack IDs to use to fetch consumer pool IDs
+     *
+     * @return
+     *  a map of consumer IDs to pool IDs of stack derived pools fro the given stack IDs
+     */
+    public Map<String, Set<String>> getConsumerStackDerivedPoolIdMap(Iterable<String> stackIds) {
+        Map<String, Set<String>> consumerPoolMap = new HashMap<String, Set<String>>();
+
+        if (stackIds != null && stackIds.iterator().hasNext()) {
+            // We do this in native SQL to avoid some unnecessary joins
+            String jpql = "SELECT DISTINCT ss.sourceConsumer.id, ss.derivedPool.id FROM SourceStack ss " +
+                "WHERE ss.sourceStackId IN (:stackids)";
+
+            TypedQuery<Object[]> query = this.getEntityManager().createQuery(jpql, Object[].class);
+
+            for (List<String> block : this.partition(stackIds)) {
+                query.setParameter("stackids", block);
+
+                for (Object[] row : query.getResultList()) {
+                    String consumerId = (String) row[0];
+                    String poolId = (String) row[1];
+
+                    Set<String> poolIds = consumerPoolMap.get(consumerId);
+                    if (poolIds == null) {
+                        poolIds = new HashSet<String>();
+                        consumerPoolMap.put(consumerId, poolIds);
+                    }
+
+                    poolIds.add(poolId);
+                }
+            }
+        }
+
+        return consumerPoolMap;
+    }
+
+    /**
+     * Fetches a list of pool IDs for stack derived pools that will be unentitled with the deletion
+     * of the specified entitlement IDs.
+     * <p></p>
+     * <strong>WARNING</strong>: This method can miss stack derived pools in cases where the number
+     * of provided entitlement IDs exceeds the size limitations for the SQL IN operator and
+     * entitlements for a given stack end up in multiple blocks.
+     * <p></p>
+     * To work around this issue, the entitlement list needs to be manually partitioned into blocks
+     * either by consumer or stack ID, such that the partitions are smaller than the IN operator
+     * limit returned by getInBlockSize().
+     *
+     * @param entitlementIds
+     *  A collection of entitlement IDs for entitlements that are being deleted
+     *
+     * @return
+     *  a collection of pool IDs representing unentitled stack derived pools with the deletion of
+     *  the specified entitlements
+     */
+    public Set<String> getUnentitledStackDerivedPoolIds(Iterable<String> entitlementIds) {
+        Set<String> output = new HashSet<String>();
+
+        String sql = "SELECT ss.derivedpool_id " +
+            "FROM cp_pool_source_stack ss " +
+            "LEFT JOIN (SELECT e.consumer_id, ppa.value AS stack_id, e.id AS entitlement_id " +
+            "    FROM cp_entitlement e " +
+            "    JOIN cp_pool p ON p.id = e.pool_id " +
+            "    JOIN cp2_product_attributes ppa ON ppa.product_uuid = p.product_uuid " +
+            "    LEFT JOIN cp_pool_source_stack ss ON ss.derivedpool_id = p.id " +
+            "    WHERE ss.id IS NULL " +
+            "        AND p.sourceentitlement_id IS NULL " +
+            "        AND ppa.name = :stackid_attrib_name ";
+
+        if (entitlementIds != null && entitlementIds.iterator().hasNext()) {
+            // Impl note:
+            // We do this in raw SQL as HQL/JPQL does not allow joining on a query/temp table, and
+            // it allows us to skip a few joins to get directly to the data we need.
+            sql += " AND e.id NOT IN (:eids) " +
+                ") ec ON ec.consumer_id = ss.sourceconsumer_id AND ec.stack_id = ss.sourcestackid " +
+                "WHERE ec.entitlement_id IS NULL";
+
+            javax.persistence.Query query = this.getEntityManager()
+                .createNativeQuery(sql)
+                .setParameter("stackid_attrib_name", Product.Attributes.STACKING_ID);
+
+            int blockSize = Math.min(this.getQueryParameterLimit() - 1, this.getInBlockSize());
+            for (List<String> block : Iterables.partition(entitlementIds, blockSize)) {
+                query.setParameter("eids", block);
+                output.addAll(query.getResultList());
+            }
+        }
+        else {
+            sql += ") ec ON ec.consumer_id = ss.sourceconsumer_id AND ec.stack_id = ss.sourcestackid " +
+                "WHERE ec.entitlement_id IS NULL";
+
+            javax.persistence.Query query = this.getEntityManager()
+                .createNativeQuery(sql)
+                .setParameter("stackid_attrib_name", Product.Attributes.STACKING_ID);
+
+            output.addAll(query.getResultList());
+        }
+
+        return output;
     }
 }

--- a/server/src/main/java/org/candlepin/policy/js/compliance/ComplianceRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/compliance/ComplianceRules.java
@@ -43,26 +43,27 @@ import java.util.List;
  * A class used to check consumer compliance status.
  */
 public class ComplianceRules {
-
-    private EntitlementCurator entCurator;
-    private JsRunner jsRules;
-    private RulesObjectMapper mapper;
     private static Logger log = LoggerFactory.getLogger(ComplianceRules.class);
+
+    private JsRunner jsRules;
+    private EntitlementCurator entCurator;
     private StatusReasonMessageGenerator generator;
     private EventSink eventSink;
-    // Use the curator to update consumer entitlement status every time we run compliance (with null date)
     private ConsumerCurator consumerCurator;
+    private RulesObjectMapper mapper;
 
     @Inject
     public ComplianceRules(JsRunner jsRules, EntitlementCurator entCurator,
-        StatusReasonMessageGenerator generator, EventSink eventSink,
-        ConsumerCurator consumerCurator, RulesObjectMapper mapper) {
-        this.entCurator = entCurator;
+        StatusReasonMessageGenerator generator, EventSink eventSink, ConsumerCurator consumerCurator,
+        RulesObjectMapper mapper) {
+
         this.jsRules = jsRules;
+        this.entCurator = entCurator;
         this.generator = generator;
         this.eventSink = eventSink;
         this.consumerCurator = consumerCurator;
         this.mapper = mapper;
+
         jsRules.init("compliance_name_space");
     }
 
@@ -147,10 +148,8 @@ public class ComplianceRules {
             allEnts.addAll(newEntitlements);
         }
 
-        /*
-         * Do not calculate compliance status for distributors and shares. It is prohibitively
-         * expensive and meaningless
-         */
+        // Do not calculate compliance status for distributors and shares. It is prohibitively
+        // expensive and meaningless
         if (c.isManifestDistributor() || c.isShare()) {
             return new ComplianceStatus(new Date());
         }
@@ -168,12 +167,15 @@ public class ComplianceRules {
         String json = jsRules.runJsFunction(String.class, "get_status", args);
         try {
             ComplianceStatus status = mapper.toObject(json, ComplianceStatus.class);
+
             for (ComplianceReason reason : status.getReasons()) {
                 generator.setMessage(c, reason, status.getDate());
             }
+
             if (currentCompliance) {
                 applyStatus(c, status, updateConsumer);
             }
+
             return status;
         }
         catch (Exception e) {

--- a/server/src/main/java/org/candlepin/policy/js/pool/StackedSubPoolValueAccumulator.java
+++ b/server/src/main/java/org/candlepin/policy/js/pool/StackedSubPoolValueAccumulator.java
@@ -119,8 +119,7 @@ public class StackedSubPoolValueAccumulator {
             }
         }
         else {
-            for (Product provided : productCurator
-                .getPoolDerivedProvidedProductsCached(nextStackedPool)) {
+            for (Product provided : productCurator.getPoolDerivedProvidedProductsCached(nextStackedPool)) {
                 this.expectedProvidedProds.add(provided);
             }
         }

--- a/server/src/main/resources/db/changelog/20171023140857-add-modified-prods-index.xml
+++ b/server/src/main/resources/db/changelog/20171023140857-add-modified-prods-index.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="20171023140857-1" author="crog">
+        <comment>add_modified_prods_index</comment>
+
+        <createIndex indexName="cp2_cmp_idx1" tableName="cp2_content_modified_products" unique="false">
+            <column name="element"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="20171023140857-2" author="crog">
+        <addForeignKeyConstraint constraintName="cp2_cmp_fk1"
+            baseTableName="cp2_content_modified_products" baseColumnNames="content_uuid"
+            referencedTableName="cp2_content" referencedColumnNames="uuid"
+            onDelete="NO ACTION" onUpdate="NO ACTION"
+            deferrable="false" initiallyDeferred="false"/>
+    </changeSet>
+
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/server/src/main/resources/db/changelog/changelog-create.xml
+++ b/server/src/main/resources/db/changelog/changelog-create.xml
@@ -1221,4 +1221,5 @@
     <include file="db/changelog/20171010164730-add-cp-consumer-username-index.xml"/>
     <include file="db/changelog/20171011093538-add-sourcesub-id-index.xml"/>
     <include file="db/changelog/20171020150559-add-index-to-cp-consumer-content-tags.xml"/>
+    <include file="db/changelog/20171023140857-add-modified-prods-index.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-testing.xml
+++ b/server/src/main/resources/db/changelog/changelog-testing.xml
@@ -2028,7 +2028,7 @@
     </changeSet>
     <changeSet author="awood" id="1413225753032-290">
         <comment>
-             Add the default quartz lock columns. 
+             Add the default quartz lock columns.
         </comment>
         <insert tableName="QRTZ_LOCKS">
             <column name="LOCK_NAME" value="TRIGGER_ACCESS"/>
@@ -2312,4 +2312,5 @@
     <include file="db/changelog/20171010164730-add-cp-consumer-username-index.xml"/>
     <include file="db/changelog/20171011093538-add-sourcesub-id-index.xml"/>
     <include file="db/changelog/20171020150559-add-index-to-cp-consumer-content-tags.xml"/>
+    <include file="db/changelog/20171023140857-add-modified-prods-index.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-update.xml
+++ b/server/src/main/resources/db/changelog/changelog-update.xml
@@ -129,4 +129,5 @@
     <include file="db/changelog/20171010164730-add-cp-consumer-username-index.xml"/>
     <include file="db/changelog/20171011093538-add-sourcesub-id-index.xml"/>
     <include file="db/changelog/20171020150559-add-index-to-cp-consumer-content-tags.xml"/>
+    <include file="db/changelog/20171023140857-add-modified-prods-index.xml"/>
 </databaseChangeLog>

--- a/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -282,6 +282,13 @@ public class PoolManagerTest {
         List<PoolUpdate> updatedPools = new ArrayList<PoolUpdate>();
         Pool deletedPool = Mockito.mock(Pool.class);
         Pool normalPool = Mockito.mock(Pool.class);
+
+        when(normalPool.getId()).thenReturn("normal-pool-id");
+
+        Set<String> existingPoolIds = new HashSet<String>();
+        existingPoolIds.add("normal-pool-id");
+
+        when(mockPoolCurator.getExistingPoolIdsByIds(any(Iterable.class))).thenReturn(existingPoolIds);
         when(mockPoolCurator.exists(deletedPool)).thenReturn(false);
         when(mockPoolCurator.exists(normalPool)).thenReturn(true);
 

--- a/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
@@ -2372,4 +2372,336 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         assertNull(pool3.getSourceEntitlement());
         assertSame(e, pool4.getSourceEntitlement());
     }
+
+    @Test
+    public void testGetExistingPoolIdsByIds() {
+        Date startDate = TestUtil.createDate(2010, 3, 2);
+        Date endDate = TestUtil.createDate(Calendar.getInstance().get(Calendar.YEAR) + 1, 3, 2);
+
+        Pool pool1 = createPool(owner, product, 20L, startDate, endDate);
+        poolCurator.create(pool1);
+
+        Pool pool2 = createPool(owner, product, 20L, startDate, endDate);
+        poolCurator.create(pool2);
+
+        Pool pool3 = createPool(owner, product, 20L, startDate, endDate);
+        poolCurator.create(pool3);
+
+        Pool pool4 = createPool(owner, product, 20L, startDate, endDate);
+        poolCurator.create(pool4);
+
+        Set<String> output;
+        output = this.poolCurator.getExistingPoolIdsByIds(Arrays.asList(pool2.getId(), pool3.getId()));
+
+        assertFalse(output.contains(pool1.getId()));
+        assertTrue(output.contains(pool2.getId()));
+        assertTrue(output.contains(pool3.getId()));
+        assertFalse(output.contains(pool4.getId()));
+        assertFalse(output.contains("banana"));
+
+        output = this.poolCurator.getExistingPoolIdsByIds(
+            Arrays.asList(pool1.getId(), pool3.getId(), "banana"));
+
+        assertTrue(output.contains(pool1.getId()));
+        assertFalse(output.contains(pool2.getId()));
+        assertTrue(output.contains(pool3.getId()));
+        assertFalse(output.contains(pool4.getId()));
+        assertFalse(output.contains("banana"));
+    }
+
+    @Test
+    public void testGetConsumerStackDerivedPoolIdMap() {
+        Owner owner1 = this.createOwner("owner-1");
+        Owner owner2 = this.createOwner("owner-2");
+
+        Consumer consumer1 = this.createConsumer(owner1);
+        Consumer consumer2 = this.createConsumer(owner1);
+        Consumer consumer3 = this.createConsumer(owner2);
+
+        Date startDate = TestUtil.createDate(2010, 3, 2);
+        Date endDate = TestUtil.createDate(Calendar.getInstance().get(Calendar.YEAR) + 1, 3, 2);
+
+        String stackId1 = "123";
+        Product stackingProduct1 = TestUtil.createProduct();
+        stackingProduct1.setAttribute(Product.Attributes.VIRT_LIMIT, "3");
+        stackingProduct1.setAttribute(Product.Attributes.STACKING_ID, stackId1);
+        stackingProduct1 = this.createProduct(stackingProduct1, owner);
+
+        String stackId2 = "456";
+        Product stackingProduct2 = TestUtil.createProduct();
+        stackingProduct2.setAttribute(Product.Attributes.VIRT_LIMIT, "3");
+        stackingProduct2.setAttribute(Product.Attributes.STACKING_ID, stackId2);
+        stackingProduct2 = this.createProduct(stackingProduct2, owner);
+
+        String stackId3 = "789";
+        Product stackingProduct3 = TestUtil.createProduct();
+        stackingProduct3.setAttribute(Product.Attributes.VIRT_LIMIT, "3");
+        stackingProduct3.setAttribute(Product.Attributes.STACKING_ID, stackId3);
+        stackingProduct3 = this.createProduct(stackingProduct3, owner);
+
+        Pool pool1 = createPool(owner, stackingProduct1, 20L, startDate, endDate);
+        pool1.setSourceStack(new SourceStack(consumer1, stackId1));
+        pool1.setAttribute(Pool.Attributes.REQUIRES_HOST, consumer1.getUuid());
+        poolCurator.create(pool1);
+
+        Pool pool2 = createPool(owner, stackingProduct2, 20L, startDate, endDate);
+        pool2.setSourceStack(new SourceStack(consumer1, stackId2));
+        pool2.setAttribute(Pool.Attributes.REQUIRES_HOST, consumer1.getUuid());
+        poolCurator.create(pool2);
+
+        Pool pool3 = createPool(owner, stackingProduct3, 20L, startDate, endDate);
+        pool3.setSourceStack(new SourceStack(consumer2, stackId3));
+        pool3.setAttribute(Pool.Attributes.REQUIRES_HOST, consumer2.getUuid());
+        poolCurator.create(pool3);
+
+        Pool pool4 = createPool(owner, stackingProduct1, 20L, startDate, endDate);
+        pool4.setSourceStack(new SourceStack(consumer2, stackId1));
+        pool4.setAttribute(Pool.Attributes.REQUIRES_HOST, consumer2.getUuid());
+        poolCurator.create(pool4);
+
+        Pool pool5 = createPool(owner, stackingProduct2, 20L, startDate, endDate);
+        pool5.setSourceStack(new SourceStack(consumer2, stackId2));
+        pool5.setAttribute(Pool.Attributes.REQUIRES_HOST, consumer2.getUuid());
+        poolCurator.create(pool5);
+
+        Pool pool6 = createPool(owner, stackingProduct3, 20L, startDate, endDate);
+        pool6.setSourceStack(new SourceStack(consumer3, stackId3));
+        pool6.setAttribute(Pool.Attributes.REQUIRES_HOST, consumer3.getUuid());
+        poolCurator.create(pool6);
+
+
+        Map<String, Set<String>> output;
+
+        output = this.poolCurator.getConsumerStackDerivedPoolIdMap(
+            Arrays.asList(stackId1, stackId2, stackId3));
+
+        assertNotNull(output);
+        assertEquals(3, output.size());
+        assertTrue(output.containsKey(consumer1.getId()));
+        assertTrue(output.containsKey(consumer2.getId()));
+        assertTrue(output.containsKey(consumer3.getId()));
+        assertEquals(output.get(consumer1.getId()), Util.asSet(pool1.getId(), pool2.getId()));
+        assertEquals(output.get(consumer2.getId()), Util.asSet(pool3.getId(), pool4.getId(), pool5.getId()));
+        assertEquals(output.get(consumer3.getId()), Util.asSet(pool6.getId()));
+
+        output = this.poolCurator.getConsumerStackDerivedPoolIdMap(Arrays.asList(stackId1, stackId2));
+
+        assertNotNull(output);
+        assertEquals(2, output.size());
+        assertTrue(output.containsKey(consumer1.getId()));
+        assertTrue(output.containsKey(consumer2.getId()));
+        assertFalse(output.containsKey(consumer3.getId()));
+        assertEquals(output.get(consumer1.getId()), Util.asSet(pool1.getId(), pool2.getId()));
+        assertEquals(output.get(consumer2.getId()), Util.asSet(pool4.getId(), pool5.getId()));
+
+        output = this.poolCurator.getConsumerStackDerivedPoolIdMap(Arrays.asList(stackId1));
+
+        assertNotNull(output);
+        assertEquals(2, output.size());
+        assertTrue(output.containsKey(consumer1.getId()));
+        assertTrue(output.containsKey(consumer2.getId()));
+        assertFalse(output.containsKey(consumer3.getId()));
+        assertEquals(output.get(consumer1.getId()), Util.asSet(pool1.getId()));
+        assertEquals(output.get(consumer2.getId()), Util.asSet(pool4.getId()));
+
+        output = this.poolCurator.getConsumerStackDerivedPoolIdMap(Collections.<String>emptyList());
+
+        assertNotNull(output);
+        assertEquals(0, output.size());
+
+        output = this.poolCurator.getConsumerStackDerivedPoolIdMap(null);
+
+        assertNotNull(output);
+        assertEquals(0, output.size());
+    }
+
+    @Test
+    @SuppressWarnings("checkstyle:methodlength")
+    public void testGetUnentitledStackDerivedPoolIds() {
+        Owner owner1 = this.createOwner("owner-1");
+        Owner owner2 = this.createOwner("owner-2");
+
+        Consumer consumer1 = this.createConsumer(owner1);
+        Consumer consumer2 = this.createConsumer(owner1);
+        Consumer consumer3 = this.createConsumer(owner2);
+
+        Date startDate = TestUtil.createDate(2010, 3, 2);
+        Date endDate = TestUtil.createDate(Calendar.getInstance().get(Calendar.YEAR) + 1, 3, 2);
+
+        String stackId1 = "123";
+        Product stackingProduct1 = TestUtil.createProduct();
+        stackingProduct1.setAttribute(Product.Attributes.VIRT_LIMIT, "3");
+        stackingProduct1.setAttribute(Product.Attributes.STACKING_ID, stackId1);
+        stackingProduct1 = this.createProduct(stackingProduct1, owner1);
+
+        Product stackingProduct1b = TestUtil.createProduct();
+        stackingProduct1b.setAttribute(Product.Attributes.VIRT_LIMIT, "3");
+        stackingProduct1b.setAttribute(Product.Attributes.STACKING_ID, stackId1);
+        stackingProduct1b = this.createProduct(stackingProduct1b, owner2);
+
+        String stackId2 = "456";
+        Product stackingProduct2 = TestUtil.createProduct();
+        stackingProduct2.setAttribute(Product.Attributes.VIRT_LIMIT, "3");
+        stackingProduct2.setAttribute(Product.Attributes.STACKING_ID, stackId2);
+        stackingProduct2 = this.createProduct(stackingProduct2, owner1);
+
+        Product stackingProduct2b = TestUtil.createProduct();
+        stackingProduct2b.setAttribute(Product.Attributes.VIRT_LIMIT, "3");
+        stackingProduct2b.setAttribute(Product.Attributes.STACKING_ID, stackId2);
+        stackingProduct2b = this.createProduct(stackingProduct2b, owner2);
+
+        String stackId3 = "789";
+        Product stackingProduct3 = TestUtil.createProduct();
+        stackingProduct3.setAttribute(Product.Attributes.VIRT_LIMIT, "3");
+        stackingProduct3.setAttribute(Product.Attributes.STACKING_ID, stackId3);
+        stackingProduct3 = this.createProduct(stackingProduct3, owner1);
+
+        Product stackingProduct3b = TestUtil.createProduct();
+        stackingProduct3b.setAttribute(Product.Attributes.VIRT_LIMIT, "3");
+        stackingProduct3b.setAttribute(Product.Attributes.STACKING_ID, stackId3);
+        stackingProduct3b = this.createProduct(stackingProduct3b, owner2);
+
+        Pool pool1 = createPool(owner1, stackingProduct1, 20L, startDate, endDate);
+        pool1.setSourceStack(new SourceStack(consumer1, stackId1));
+        pool1.setAttribute(Pool.Attributes.REQUIRES_HOST, consumer1.getUuid());
+        poolCurator.create(pool1);
+
+        Pool pool1a = createPool(owner1, stackingProduct1, 20L, startDate, endDate);
+        poolCurator.create(pool1a);
+
+        Entitlement ent1a = new Entitlement(pool1a, consumer1, 5);
+        ent1a.setId("test-entitlement-id-1a");
+        entitlementCurator.create(ent1a);
+
+        Pool pool1b = createPool(owner1, stackingProduct1, 20L, startDate, endDate);
+        poolCurator.create(pool1b);
+
+        Entitlement ent1b = new Entitlement(pool1b, consumer1, 5);
+        ent1b.setId("test-entitlement-id-1b");
+        entitlementCurator.create(ent1b);
+
+        Pool pool2 = createPool(owner1, stackingProduct2, 20L, startDate, endDate);
+        pool2.setSourceStack(new SourceStack(consumer1, stackId2));
+        pool2.setAttribute(Pool.Attributes.REQUIRES_HOST, consumer1.getUuid());
+        poolCurator.create(pool2);
+
+        Pool pool2a = createPool(owner1, stackingProduct2, 20L, startDate, endDate);
+        poolCurator.create(pool2a);
+
+        Entitlement ent2a = new Entitlement(pool2a, consumer1, 5);
+        ent2a.setId("test-entitlement-id-2a");
+        entitlementCurator.create(ent2a);
+
+        Pool pool3 = createPool(owner1, stackingProduct3, 20L, startDate, endDate);
+        pool3.setSourceStack(new SourceStack(consumer2, stackId3));
+        pool3.setAttribute(Pool.Attributes.REQUIRES_HOST, consumer2.getUuid());
+        poolCurator.create(pool3);
+
+        Pool pool3a = createPool(owner1, stackingProduct3, 20L, startDate, endDate);
+        poolCurator.create(pool3a);
+
+        Entitlement ent3a = new Entitlement(pool3a, consumer2, 5);
+        ent3a.setId("test-entitlement-id-3a");
+        entitlementCurator.create(ent3a);
+
+        Pool pool4 = createPool(owner1, stackingProduct1, 20L, startDate, endDate);
+        pool4.setSourceStack(new SourceStack(consumer2, stackId1));
+        pool4.setAttribute(Pool.Attributes.REQUIRES_HOST, consumer2.getUuid());
+        poolCurator.create(pool4);
+
+        Pool pool4a = createPool(owner1, stackingProduct1, 20L, startDate, endDate);
+        poolCurator.create(pool4a);
+
+        Entitlement ent4a = new Entitlement(pool4a, consumer2, 5);
+        ent4a.setId("test-entitlement-id-4a");
+        entitlementCurator.create(ent4a);
+
+        Pool pool5 = createPool(owner1, stackingProduct2, 20L, startDate, endDate);
+        pool5.setSourceStack(new SourceStack(consumer2, stackId2));
+        pool5.setAttribute(Pool.Attributes.REQUIRES_HOST, consumer2.getUuid());
+        poolCurator.create(pool5);
+
+        Pool pool5a = createPool(owner1, stackingProduct2, 20L, startDate, endDate);
+        poolCurator.create(pool5a);
+
+        Entitlement ent5a = new Entitlement(pool5a, consumer2, 5);
+        ent5a.setId("test-entitlement-id-5a");
+        entitlementCurator.create(ent5a);
+
+        Pool pool6 = createPool(owner2, stackingProduct3b, 20L, startDate, endDate);
+        pool6.setSourceStack(new SourceStack(consumer3, stackId3));
+        pool6.setAttribute(Pool.Attributes.REQUIRES_HOST, consumer3.getUuid());
+        poolCurator.create(pool6);
+
+        Pool pool6a = createPool(owner2, stackingProduct3b, 20L, startDate, endDate);
+        poolCurator.create(pool6a);
+
+        Entitlement ent6a = new Entitlement(pool6a, consumer3, 5);
+        ent6a.setId("test-entitlement-id-6a");
+        entitlementCurator.create(ent6a);
+
+        Pool pool7 = createPool(owner2, stackingProduct1b, 20L, startDate, endDate);
+        pool7.setSourceStack(new SourceStack(consumer3, stackId1));
+        pool7.setAttribute(Pool.Attributes.REQUIRES_HOST, consumer3.getUuid());
+        poolCurator.create(pool7);
+
+        Pool pool8 = createPool(owner2, stackingProduct2b, 20L, startDate, endDate);
+        poolCurator.create(pool8);
+
+        Entitlement ent8 = new Entitlement(pool8, consumer3, 5);
+        ent8.setId("test-entitlement-id-8");
+        entitlementCurator.create(ent8);
+
+        Set<String> output;
+
+        // No entitlements should find existing unentitled stack derived pools
+        output = this.poolCurator.getUnentitledStackDerivedPoolIds(null);
+
+        assertNotNull(output);
+        assertEquals(1, output.size());
+        assertEquals(output, Util.asSet(pool7.getId()));
+
+        output = this.poolCurator.getUnentitledStackDerivedPoolIds(Collections.<String>emptyList());
+
+        assertNotNull(output);
+        assertEquals(1, output.size());
+        assertEquals(output, Util.asSet(pool7.getId()));
+
+        // Providing entitlements should simulate deleted entitlements
+        output = this.poolCurator.getUnentitledStackDerivedPoolIds(
+            Arrays.asList(ent1a.getId(), ent1b.getId(), ent2a.getId(), ent3a.getId()));
+
+        assertNotNull(output);
+        assertEquals(4, output.size());
+        assertEquals(output, Util.asSet(pool1.getId(), pool2.getId(), pool3.getId(), pool7.getId()));
+
+        // Filtering entitlements should not pull pools if more entitlements remain
+        output = this.poolCurator.getUnentitledStackDerivedPoolIds(Arrays.asList(ent1a.getId()));
+
+        assertNotNull(output);
+        assertEquals(1, output.size());
+        assertEquals(output, Util.asSet(pool7.getId()));
+
+        // Filtering entitlements should not pull pools if more entitlements remain
+        output = this.poolCurator.getUnentitledStackDerivedPoolIds(Arrays.asList(ent1b.getId()));
+
+        assertNotNull(output);
+        assertEquals(1, output.size());
+        assertEquals(output, Util.asSet(pool7.getId()));
+
+        // Bad entitlement IDs shouldn't impact output...
+        output = this.poolCurator.getUnentitledStackDerivedPoolIds(
+            Arrays.asList(ent1a.getId(), ent1b.getId(), ent2a.getId(), ent3a.getId(), "bad_ent_id"));
+
+        assertNotNull(output);
+        assertEquals(4, output.size());
+        assertEquals(output, Util.asSet(pool1.getId(), pool2.getId(), pool3.getId(), pool7.getId()));
+
+        output = this.poolCurator.getUnentitledStackDerivedPoolIds(Arrays.asList("bad_ent_id"));
+
+        assertNotNull(output);
+        assertEquals(1, output.size());
+        assertEquals(output, Util.asSet(pool7.getId()));
+    }
+
 }

--- a/server/src/test/java/org/candlepin/policy/AutobindRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/AutobindRulesTest.java
@@ -93,13 +93,11 @@ public class AutobindRulesTest {
 
         when(config.getInt(eq(ConfigProperties.PRODUCT_CACHE_MAX))).thenReturn(100);
 
-        InputStream is = this.getClass().getResourceAsStream(
-            RulesCurator.DEFAULT_RULES_FILE);
+        InputStream is = this.getClass().getResourceAsStream(RulesCurator.DEFAULT_RULES_FILE);
         Rules rules = new Rules(Util.readFile(is));
 
         when(rulesCurator.getRules()).thenReturn(rules);
-        when(rulesCurator.getUpdated()).thenReturn(
-            TestDateUtil.date(2010, 1, 1));
+        when(rulesCurator.getUpdated()).thenReturn(TestDateUtil.date(2010, 1, 1));
         when(cacheProvider.get()).thenReturn(cache);
         JsRunner jsRules = new JsRunnerProvider(rulesCurator, cacheProvider).get();
         autobindRules = new AutobindRules(jsRules, mockProductCurator,
@@ -338,6 +336,7 @@ public class AutobindRulesTest {
     private Pool createPool(String poolId, Owner owner, Product sku, Product provided) {
         Pool pool = TestUtil.createPool(owner, sku);
         pool.setId(poolId);
+        pool.addProvidedProduct(provided);
         when(mockProductCurator.getPoolProvidedProductsCached(poolId))
             .thenReturn(Collections.singleton(provided));
         return pool;

--- a/server/src/test/java/org/candlepin/policy/js/compliance/ComplianceRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/compliance/ComplianceRulesTest.java
@@ -113,9 +113,10 @@ public class ComplianceRulesTest {
         when(rulesCuratorMock.getRules()).thenReturn(rules);
         when(cacheProvider.get()).thenReturn(cache);
         provider = new JsRunnerProvider(rulesCuratorMock, cacheProvider);
-        compliance = new ComplianceRules(provider.get(),
-            entCurator, new StatusReasonMessageGenerator(i18n), eventSink,
-            consumerCurator, new RulesObjectMapper(new ProductCachedSerializationModule(productCurator)));
+        compliance = new ComplianceRules(provider.get(), entCurator, new StatusReasonMessageGenerator(i18n),
+            eventSink, consumerCurator,
+            new RulesObjectMapper(new ProductCachedSerializationModule(productCurator)));
+
         owner = new Owner("test");
         activeGuestAttrs = new HashMap<String, String>();
         activeGuestAttrs.put("virtWhoType", "libvirt");
@@ -129,9 +130,10 @@ public class ComplianceRulesTest {
     @Test
     public void additivePropertiesCanStillDeserialize() {
         JsRunner mockRunner = mock(JsRunner.class);
-        compliance = new ComplianceRules(mockRunner,
-            entCurator, new StatusReasonMessageGenerator(i18n), eventSink,
-            consumerCurator, new RulesObjectMapper(new ProductCachedSerializationModule(productCurator)));
+        compliance = new ComplianceRules(mockRunner, entCurator, new StatusReasonMessageGenerator(i18n),
+            eventSink, consumerCurator,
+            new RulesObjectMapper(new ProductCachedSerializationModule(productCurator)));
+
         when(mockRunner.runJsFunction(any(Class.class), eq("get_status"),
             any(JsContext.class))).thenReturn("{\"unknown\": \"thing\"}");
         Consumer c = mockConsumerWithTwoProductsAndNoEntitlements();


### PR DESCRIPTION
- Made additional optimizations to how marking dependent entitlements
  is performed, significantly reducing execution time in cases where
  many entitlements owned by many different consumers are updated
- Added the ProductCurator.hydratePoolProvidedProducts method, which
  hydrates a pool's provided and derived provided products and the
  product cache
- Updated CandlepinPoolManager.deletePools to use the new bulk pool
  hydration method to substantially reduce serialization time while
  passing pools and entitlements to the rules engine
- Modified CandlepinPoolManager.processPoolUpdates to bulk its
  merge and flush operations, entitlement fetching and pool
  existence checking
- Added a check to skip stacked pool updating for a consumer
  when there are no stacked pools to update
- Added a method for fetching unentitled stack derived pools to
  avoid recursive calls into deletePools
- Added a method for fetching maps of consumer IDs to stacked pool
  IDs to avoid repeatedly hitting the DB per consumer