### PR TITLE
[M] Moved job ID partitioning to the curators

### DIFF
--- a/server/src/main/java/org/candlepin/model/JobCurator.java
+++ b/server/src/main/java/org/candlepin/model/JobCurator.java
@@ -23,6 +23,7 @@ import org.candlepin.pinsetter.core.model.JobStatus.JobState;
 import org.candlepin.pinsetter.core.model.JobStatus.TargetType;
 import org.candlepin.pinsetter.tasks.KingpinJob;
 
+import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
 import com.google.inject.persist.Transactional;
 
@@ -33,9 +34,13 @@ import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
 
 import java.util.Calendar;
+import java.util.Collection;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
+import javax.persistence.TypedQuery;
 
 
 
@@ -133,20 +138,32 @@ public class JobCurator extends AbstractHibernateCurator<JobStatus> {
      * Finds all jobs marked as CANCELED which have an ID in the input list
      * so we can remove the scheduled job.
      *
-     * @param activeJobs Names of jobs that are currently active
-     * @return JobStatus list to have quartz job canceled
+     * @param jobIds
+     *  A collection of IDs representing the jobs to check
+     *
+     * @return
+     *  A set of JobStatus objects representing canceled jobs from the provided job ID collection
      */
     @SuppressWarnings("unchecked")
-    public CandlepinQuery<JobStatus> findCanceledJobs(Set<String> activeJobs) {
-        if (activeJobs == null || activeJobs.isEmpty()) {
-            return this.cpQueryFactory.<JobStatus>buildQuery();
+    public Set<JobStatus> findCanceledJobs(Iterable<String> jobIds) {
+        Set<JobStatus> statuses = new HashSet<JobStatus>();
+
+        if (jobIds != null && jobIds.iterator().hasNext()) {
+            String jpql = "SELECT js FROM JobStatus js WHERE js.state = :state AND js.id IN (:job_ids)";
+
+            TypedQuery<JobStatus> query = this.getEntityManager()
+                .createQuery(jpql, JobStatus.class)
+                .setParameter("state", JobState.CANCELED);
+
+            int blockSize = Math.min(this.getQueryParameterLimit() - 1, this.getInBlockSize());
+
+            for (List<String> block : Iterables.partition(jobIds, blockSize)) {
+                query.setParameter("job_ids", block);
+                statuses.addAll(query.getResultList());
+            }
         }
 
-        DetachedCriteria criteria = DetachedCriteria.forClass(JobStatus.class)
-            .add(Restrictions.eq("state", JobState.CANCELED))
-            .add(Restrictions.in("id", activeJobs));
-
-        return this.cpQueryFactory.<JobStatus>buildQuery(this.currentSession(), criteria);
+        return statuses;
     }
 
     @SuppressWarnings("unchecked")
@@ -217,12 +234,14 @@ public class JobCurator extends AbstractHibernateCurator<JobStatus> {
      * Cancel jobs that should have a quartz job (but don't),
      * and have not been updated within the last 2 minutes.
      */
-    public int cancelOrphanedJobs(List<String> activeIds) {
+    public int cancelOrphanedJobs(Collection<String> activeIds) {
         return cancelOrphanedJobs(activeIds, 1000L * 60L * 2L); //2 minutes
     }
 
     @Transactional
-    public int cancelOrphanedJobs(List<String> activeIds, Long millis) {
+    public int cancelOrphanedJobs(Collection<String> activeIds, Long millis) {
+        int count = 0;
+
         Date before = new Date(new Date().getTime() - millis);
         String hql = "update JobStatus j " +
             "set j.state = :canceled " +
@@ -246,10 +265,16 @@ public class JobCurator extends AbstractHibernateCurator<JobStatus> {
             .setInteger("canceled", JobState.CANCELED.ordinal());
 
         if (!activeIds.isEmpty()) {
-            query.setParameterList("activeIds", activeIds);
+            for (List<String> block : this.partition(activeIds)) {
+                count += query.setParameterList("activeIds", block)
+                    .executeUpdate();
+            }
+        }
+        else {
+            count = query.executeUpdate();
         }
 
-        return query.executeUpdate();
+        return count;
     }
 
     private Date getBlockingCutoff() {

--- a/server/src/main/java/org/candlepin/pinsetter/core/PinsetterKernel.java
+++ b/server/src/main/java/org/candlepin/pinsetter/core/PinsetterKernel.java
@@ -406,7 +406,7 @@ public class PinsetterKernel implements ModeChangeListener {
             // this deletes from the scheduler, it's already marked as
             // canceled in the JobStatus table
             if (scheduler.deleteJob(jobKey((String) id, group))) {
-                log.info("canceled job " + group + ":" + id + " in scheduler");
+                log.info("Canceled job in scheduler: {}:{} ", group, id);
             }
         }
         catch (SchedulerException e) {

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/KingpinJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/KingpinJob.java
@@ -16,7 +16,6 @@ package org.candlepin.pinsetter.tasks;
 
 import static org.quartz.impl.matchers.NameMatcher.jobNameEquals;
 
-import com.google.common.collect.Iterables;
 import org.candlepin.audit.EventSink;
 import org.candlepin.common.config.Configuration;
 import org.candlepin.config.ConfigProperties;
@@ -43,7 +42,8 @@ import org.slf4j.MDC;
 
 import javax.persistence.EntityExistsException;
 import javax.persistence.PersistenceException;
-import java.util.List;
+
+
 
 /**
  * KingpinJob replaces TransactionalPinsetterJob, which encapsulated
@@ -59,7 +59,6 @@ public abstract class KingpinJob implements Job {
     @Inject private EventSink eventSink;
     @Inject private CandlepinRequestScope candlepinRequestScope;
 
-    public static final int IN_OPERATOR_BLOCK_SIZE = 2048;
     protected static String prefix = "job";
 
     @Override
@@ -138,8 +137,9 @@ public abstract class KingpinJob implements Job {
         int maxRefires = getMaxRetries();
         // If the maximum is sub-zero, do not enforce any limit
         boolean refire = maxRefires < 0 || context.getRefireCount() < maxRefires;
-        log.error("Persistence exception caught running pinsetter task. Attempt: " +
-            context.getRefireCount() + ", Refire: " + refire, e);
+        log.error("Persistence exception caught running pinsetter task. Attempt: {}, Refire: {}",
+            context.getRefireCount(), refire, e);
+
         throw new JobExecutionException(e, refire);
     }
 
@@ -240,9 +240,5 @@ public abstract class KingpinJob implements Job {
     // Override in jobs to disable execution time logging.
     protected boolean logExecutionTime() {
         return true;
-    }
-
-    protected <T> Iterable<List<T>> partition(Iterable<T> collection) {
-        return Iterables.partition(collection, IN_OPERATOR_BLOCK_SIZE);
     }
 }

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/SweepBarJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/SweepBarJob.java
@@ -26,8 +26,7 @@ import org.quartz.JobKey;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.LinkedList;
-import java.util.List;
+import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -68,16 +67,15 @@ public class SweepBarJob extends KingpinJob {
     public void toExecute(JobExecutionContext ctx) throws JobExecutionException {
         try {
             Set<JobKey> keys = pinsetterKernel.getSingleJobKeys();
-            List<String> statusIds = new LinkedList<String>();
+            Set<String> statusIds = new HashSet<String>();
+
             for (JobKey key : keys) {
                 statusIds.add(key.getName());
             }
-            int cancelled = 0;
-            for (List<String> block : this.partition(statusIds)) {
-                cancelled += jobCurator.cancelOrphanedJobs(block);
-            }
+
+            int cancelled = jobCurator.cancelOrphanedJobs(statusIds);
             if (cancelled > 0) {
-                log.info("Cancelled " + cancelled + " orphaned jobs");
+                log.info("Cancelled {} orphaned jobs", cancelled);
             }
         }
         catch (Exception e) {

--- a/server/src/test/java/org/candlepin/pinsetter/core/PinsetterKernelTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/core/PinsetterKernelTest.java
@@ -28,7 +28,6 @@ import org.candlepin.common.config.Configuration;
 import org.candlepin.common.config.MapConfiguration;
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.model.CandlepinModeChange;
-import org.candlepin.model.CandlepinQuery;
 import org.candlepin.controller.ModeManager;
 import org.candlepin.model.JobCurator;
 import org.candlepin.pinsetter.core.model.JobStatus;
@@ -56,11 +55,10 @@ import org.quartz.impl.JobDetailImpl;
 import org.quartz.impl.StdSchedulerFactory;
 import org.quartz.spi.JobFactory;
 
-import java.util.Arrays;
+import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -436,20 +434,16 @@ public class PinsetterKernelTest {
 
     @Test
     public void unpauseScheduler() throws Exception {
-        CandlepinQuery cqmock = mock(CandlepinQuery.class);
-
         JobStatus mockStatus1 = mock(JobStatus.class);
         JobStatus mockStatus2 = mock(JobStatus.class);
 
-        List<JobStatus> statuses = Arrays.asList(mockStatus1, mockStatus2);
+        Set<JobStatus> statuses = Util.asSet(mockStatus1, mockStatus2);
 
         when(mockStatus1.getId()).thenReturn("group1");
         when(mockStatus1.getGroup()).thenReturn("group1");
         when(mockStatus2.getId()).thenReturn("group2");
         when(mockStatus2.getGroup()).thenReturn("group2");
-        when(cqmock.list()).thenReturn(statuses);
-        when(cqmock.iterator()).thenReturn(statuses.iterator());
-        when(jcurator.findCanceledJobs(any(Set.class))).thenReturn(cqmock);
+        when(jcurator.findCanceledJobs(any(Collection.class))).thenReturn(statuses);
 
         pk = new PinsetterKernel(config, jfactory, jlistener, jcurator,
             sfactory, triggerListener, modeManager);

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/CancelJobJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/CancelJobJobTest.java
@@ -19,8 +19,6 @@ import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 import static org.quartz.JobBuilder.*;
 
-import org.candlepin.model.CandlepinQuery;
-import org.candlepin.model.EmptyCandlepinQuery;
 import org.candlepin.model.JobCurator;
 import org.candlepin.pinsetter.core.PinsetterException;
 import org.candlepin.pinsetter.core.PinsetterKernel;
@@ -38,9 +36,9 @@ import org.quartz.JobKey;
 import org.quartz.SchedulerException;
 
 import java.io.Serializable;
-import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 /**
@@ -63,8 +61,9 @@ public class CancelJobJobTest extends BaseJobTest{
 
     @Test
     public void noCancellationsTest() throws JobExecutionException {
-        when(j.findCanceledJobs(any(Set.class))).thenReturn(new EmptyCandlepinQuery<JobStatus>());
+        when(j.findCanceledJobs(any(Collection.class))).thenReturn(Collections.<JobStatus>emptySet());
         cancelJobJob.execute(ctx);
+
         try {
             verify(pk, never()).cancelJob(any(Serializable.class), any(String.class));
         }
@@ -80,15 +79,14 @@ public class CancelJobJobTest extends BaseJobTest{
             .build();
 
         JobStatus js = new JobStatus(jd);
-        List<JobStatus> jl = new ArrayList<JobStatus>();
+        Set<JobStatus> jl = new HashSet<JobStatus>();
         jl.add(js);
 
         Set<JobKey> jobKeys = new HashSet<JobKey>();
         jobKeys.add(new JobKey("Kayfabe"));
+
         when(pk.getSingleJobKeys()).thenReturn(jobKeys);
-        CandlepinQuery query = mock(CandlepinQuery.class);
-        when(query.list()).thenReturn(jl);
-        when(j.findCanceledJobs(any(Set.class))).thenReturn(query);
+        when(j.findCanceledJobs(any(Collection.class))).thenReturn(jl);
 
         cancelJobJob.execute(ctx);
         verify(pk, atLeastOnce()).cancelJob((Serializable) "Kayfabe", "Deluxe");


### PR DESCRIPTION
- Moved job ID partitioning to the curators, as the jobs themselves
  should not be concerned with partitioning a collection due to
  query/database limitations