### PR TITLE
[M] Fixed an issue with shared pools not being deprioritized

### DIFF
--- a/server/spec/autobind_spec.rb
+++ b/server/spec/autobind_spec.rb
@@ -9,7 +9,7 @@ describe 'Autobind On Owner' do
   end
 
   let!(:owner) do
-    create_owner( owner_key)
+    create_owner(owner_key)
   end
 
   it 'succeeds when requesting bind of multiple pools with same stack id' do
@@ -157,6 +157,11 @@ describe 'Autobind On Owner' do
     # Create the shared pool in Org B first since all else being equal Candlepin
     # will pick an earlier expiring pool in autobind.
     @cp.consume_pool(shared_pool['id'], :uuid => share_consumer['uuid'])
+    sleep 1
+
+    pools = @cp.list_owner_pools(orgB)
+    expect(pools.size).to eq(1)
+    orgBshared_pool = pools.first
 
     orgBconsumer = @cp.register(
       random_string('orgBConsumer'),
@@ -171,6 +176,7 @@ describe 'Autobind On Owner' do
     pool = create_pool_and_subscription(orgB, prod['id'])
     ent = @cp.consume_product(prod['id'], :uuid => orgBconsumer['uuid'])
 
+    expect(ent.first['pool']['id']).to_not eq(orgBshared_pool['id'])
     expect(ent.first['pool']['id']).to eq(pool['id'])
   end
 end

--- a/server/src/main/java/org/candlepin/model/Pool.java
+++ b/server/src/main/java/org/candlepin/model/Pool.java
@@ -949,14 +949,21 @@ public class Pool extends AbstractHibernateObject implements Persisted, Owned, N
     }
 
     /**
-     * @return true if this pool or it's parent was created because of a share.
+     * Checks if this pool or its ancestors were created as a result of a share.
+     *
+     * @return true if this pool or its parent was created because of a share.
      */
+    @JsonProperty
     public Boolean hasSharedAncestor() {
         return hasSharedAncestor;
     }
 
     /**
+     * Sets whether or not this pool or any of its ancestors were created as a result of
+     * a share.
+     *
      * @param hasSharedAncestor
+     *  true if this pool or any of its ancestors were created as a result of a share
      */
     public void setHasSharedAncestor(Boolean hasSharedAncestor) {
         this.hasSharedAncestor = hasSharedAncestor;

--- a/server/src/main/resources/rules/rules.js
+++ b/server/src/main/resources/rules/rules.js
@@ -326,11 +326,13 @@ function get_mock_ent_for_pool(pool, consumer) {
 
 function get_pool_priority(pool, consumer) {
     var priority = 100;
+
     // use virt only if possible
     // if the consumer is not virt, the pool will have been filtered out
     if (Utils.equalsIgnoreCase(pool.getProductAttribute(VIRT_ONLY), "true")) {
         priority += 100;
     }
+
     // better still if host_specific
     if (pool.getAttribute(REQUIRES_HOST_ATTRIBUTE) !== null) {
         priority += 150;
@@ -340,22 +342,27 @@ function get_pool_priority(pool, consumer) {
     if (pool.hasSharedAncestor) {
         priority -= 10;
     }
+
     /*
      * Special case to match socket counts exactly if possible.  We don't want to waste a pair
      * of two socket subscriptions when we have a 4 socket sub.
      */
     var attrsToCheck = [SOCKETS_ATTRIBUTE, CORES_ATTRIBUTE, RAM_ATTRIBUTE, VCPU_ATTRIBUTE];
     var complianceAttrs = getComplianceAttributes(consumer);
-    for (var i=0; i<attrsToCheck.length; i++) {
+    for (var i=0; i < attrsToCheck.length; i++) {
         var attribute = attrsToCheck[i];
+
         if (contains(complianceAttrs, attribute)) {
             var consumerVal = FactValueCalculator.getFact(attribute, consumer);
             var poolVal = parseInt(pool.getProductAttribute(attribute));
+
             if (consumerVal !== null && poolVal !== null && consumerVal > 0 && poolVal > 0) {
                 var required = Math.ceil(consumerVal/poolVal);
+
                 // Don't count pools INSTANCE_MULTIPLIER times for "required", however let's be sure there
                 // are enough available if we give it preference.
                 var multi = (attribute == SOCKETS_ATTRIBUTE) ? pool.getInstanceMulti() : 1;
+
                 if (pool.getAvailable()/multi >= required) {
                     poolVal *= required;
                     // Maximum of 10 with an exact match.  We prefer the closest match possible.
@@ -369,6 +376,7 @@ function get_pool_priority(pool, consumer) {
             }
         }
     }
+
     return priority;
 }
 


### PR DESCRIPTION
- Fixed an issue with the hasSharedAncestor property not being
  serialized, preventing the rules from deprioritizing shared
  pools during pool selection