### PR TITLE
Event Simplification: Added eventData to Events

### DIFF
--- a/server/src/main/java/org/candlepin/audit/ActivationListener.java
+++ b/server/src/main/java/org/candlepin/audit/ActivationListener.java
@@ -14,7 +14,6 @@
  */
 package org.candlepin.audit;
 
-import org.candlepin.model.Pool;
 import org.candlepin.service.SubscriptionServiceAdapter;
 
 import com.fasterxml.jackson.core.JsonParseException;
@@ -30,8 +29,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.io.Reader;
-import java.io.StringReader;
 
 /**
  * ActivationListener
@@ -55,11 +52,9 @@ public class ActivationListener implements EventListener {
     public void onEvent(Event e) {
         if (e.getType().equals(Event.Type.CREATED) &&
             e.getTarget().equals(Event.Target.POOL)) {
-            String poolJson = e.getNewEntity();
-            Reader reader = new StringReader(poolJson);
             try {
-                Pool pool = mapper.readValue(reader, Pool.class);
-                subscriptionService.sendActivationEmail(pool.getSubscriptionId());
+                String subscriptionId = mapper.readTree(e.getEventData()).get("subscriptionId").asText();
+                subscriptionService.sendActivationEmail(subscriptionId);
             }
             catch (JsonMappingException ex) {
                 logError(e);

--- a/server/src/main/java/org/candlepin/audit/Event.java
+++ b/server/src/main/java/org/candlepin/audit/Event.java
@@ -138,6 +138,9 @@ public class Event implements Persisted {
     private ReferenceType referenceType;
 
     @Transient
+    private String eventData;
+
+    @Transient
     private String newEntity;
 
     @Transient
@@ -148,7 +151,7 @@ public class Event implements Persisted {
 
     public Event(Type type, Target target, String targetName,
         Principal principal, String ownerId, String consumerId,
-        String entityId, String newEntity,
+        String entityId, String eventData, String newEntity,
         String referenceId, ReferenceType referenceType) {
         this.type = type;
         this.target = target;
@@ -159,6 +162,7 @@ public class Event implements Persisted {
         this.ownerId = ownerId;
 
         this.entityId = entityId;
+        this.eventData = eventData;
         this.newEntity = newEntity;
         this.consumerId = consumerId;
         this.referenceId = referenceId;
@@ -249,6 +253,15 @@ public class Event implements Persisted {
 
     public void setEntityId(String entityId) {
         this.entityId = entityId;
+    }
+
+    @XmlTransient
+    public String getEventData() {
+        return eventData;
+    }
+
+    public void setEventData(String eventData) {
+        this.eventData = eventData;
     }
 
     @XmlTransient

--- a/server/src/main/java/org/candlepin/audit/EventBuilder.java
+++ b/server/src/main/java/org/candlepin/audit/EventBuilder.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.candlepin.audit.Event.Target;
 import org.candlepin.audit.Event.Type;
+import org.candlepin.common.exceptions.IseException;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerProperty;
 import org.candlepin.model.Entitlement;
@@ -26,6 +27,8 @@ import org.candlepin.model.Named;
 import org.candlepin.model.Owned;
 import org.candlepin.model.Owner;
 import org.candlepin.model.Pool;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -36,6 +39,8 @@ import java.util.Map;
  *
  */
 public class EventBuilder {
+
+    private static final Logger log = LoggerFactory.getLogger(EventBuilder.class);
 
     private final EventFactory factory;
     private final ObjectMapper mapper;
@@ -90,7 +95,8 @@ public class EventBuilder {
                     event.setEventData(mapper.writeValueAsString(eventData));
                 }
                 catch (JsonProcessingException e) {
-                    e.printStackTrace();
+                    log.error("Error while building JSON for pool.created event.");
+                    throw new IseException("Error while building JSON for pool.created event.");
                 }
             }
         }

--- a/server/src/main/java/org/candlepin/audit/EventBuilder.java
+++ b/server/src/main/java/org/candlepin/audit/EventBuilder.java
@@ -40,7 +40,7 @@ public class EventBuilder {
         this.factory = factory;
 
         event = new Event(type, target, null, factory.principalProvider.get(),
-                null, null, null, null, null, null);
+                null, null, null, null, null, null, null);
     }
 
     /*  Implementation note (2017/10/16):
@@ -75,6 +75,14 @@ public class EventBuilder {
                         event.setConsumerId(owningConsumer.getId());
                     }
                 }
+            }
+            if (event.getTarget().equals(Target.POOL) && event.getType().equals(Type.CREATED)) {
+                StringBuilder eventDataBuilder = new StringBuilder()
+                    .append("{\"subscriptionId\": \"")
+                    .append(((Pool) entity).getSubscriptionId())
+                    .append("\"")
+                    .append("}");
+                event.setEventData(eventDataBuilder.toString());
             }
         }
         return this;

--- a/server/src/main/java/org/candlepin/audit/EventBuilder.java
+++ b/server/src/main/java/org/candlepin/audit/EventBuilder.java
@@ -95,7 +95,7 @@ public class EventBuilder {
                     event.setEventData(mapper.writeValueAsString(eventData));
                 }
                 catch (JsonProcessingException e) {
-                    log.error("Error while building JSON for pool.created event.");
+                    log.error("Error while building JSON for pool.created event.", e);
                     throw new IseException("Error while building JSON for pool.created event.");
                 }
             }

--- a/server/src/main/java/org/candlepin/audit/EventFactory.java
+++ b/server/src/main/java/org/candlepin/audit/EventFactory.java
@@ -17,6 +17,7 @@ package org.candlepin.audit;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.candlepin.audit.Event.Target;
 import org.candlepin.audit.Event.Type;
+import org.candlepin.common.exceptions.IseException;
 import org.candlepin.common.jackson.HateoasBeanPropertyFilter;
 import org.candlepin.guice.PrincipalProvider;
 import org.candlepin.jackson.PoolEventFilter;
@@ -221,7 +222,8 @@ public class EventFactory {
             eventDataJson = mapper.writeValueAsString(eventData);
         }
         catch (JsonProcessingException e) {
-            e.printStackTrace();
+            log.error("Error while building JSON for compliance.created event.");
+            throw new IseException("Error while building JSON for compliance.created event.");
         }
         // Instead of an internal db id, compliance.created events now use
         // UUID for the 'consumerId' and 'entityId' fields, since Katello

--- a/server/src/main/java/org/candlepin/audit/EventFactory.java
+++ b/server/src/main/java/org/candlepin/audit/EventFactory.java
@@ -217,22 +217,21 @@ public class EventFactory {
         Map<String, String> eventData = new HashMap<String, String>();
         eventData.put("consumer_uuid", consumer.getUuid());
         eventData.put("status", compliance.getStatus());
-        String eventDataJson = "";
         try {
-            eventDataJson = mapper.writeValueAsString(eventData);
+            String eventDataJson = mapper.writeValueAsString(eventData);
+            // Instead of an internal db id, compliance.created events now use
+            // UUID for the 'consumerId' and 'entityId' fields, since Katello
+            // is concerned only with the consumer UUID field. This is the first
+            // part of a larger piece of work to simplify Event consumption.
+            return new Event(Event.Type.CREATED, Event.Target.COMPLIANCE,
+                consumer.getName(), principalProvider.get(), consumer.getOwner().getId(), consumer.getUuid(),
+                consumer.getUuid(), eventDataJson,
+                    buildComplianceDataJson(consumer, entitlements, compliance), null, null);
         }
         catch (JsonProcessingException e) {
-            log.error("Error while building JSON for compliance.created event.");
+            log.error("Error while building JSON for compliance.created event.", e);
             throw new IseException("Error while building JSON for compliance.created event.");
         }
-        // Instead of an internal db id, compliance.created events now use
-        // UUID for the 'consumerId' and 'entityId' fields, since Katello
-        // is concerned only with the consumer UUID field. This is the first
-        // part of a larger piece of work to simplify Event consumption.
-        return new Event(Event.Type.CREATED, Event.Target.COMPLIANCE,
-            consumer.getName(), principalProvider.get(), consumer.getOwner().getId(), consumer.getUuid(),
-            consumer.getUuid(), eventDataJson,
-                buildComplianceDataJson(consumer, entitlements, compliance), null, null);
     }
 
     // Jackson should think all 3 are root entities so hateoas doesn't bite us

--- a/server/src/main/java/org/candlepin/audit/EventFactory.java
+++ b/server/src/main/java/org/candlepin/audit/EventFactory.java
@@ -210,14 +210,23 @@ public class EventFactory {
 
     public Event complianceCreated(Consumer consumer,
         Set<Entitlement> entitlements, ComplianceStatus compliance) {
+        StringBuilder eventDataBuilder = new StringBuilder()
+            .append("{\"consumer\": ")
+            .append("{\"uuid\": \"")
+            .append(consumer.getUuid())
+            .append("\"}")
+            .append(", \"status\": \"")
+            .append(compliance.getStatus())
+            .append("\"")
+            .append("}");
         // Instead of an internal db id, compliance.created events now use
         // UUID for the 'consumerId' and 'entityId' fields, since Katello
         // is concerned only with the consumer UUID field. This is the first
         // part of a larger piece of work to simplify Event consumption.
         return new Event(Event.Type.CREATED, Event.Target.COMPLIANCE,
             consumer.getName(), principalProvider.get(), consumer.getOwner().getId(), consumer.getUuid(),
-            consumer.getUuid(), buildComplianceDataJson(consumer, entitlements, compliance), null,
-            null);
+            consumer.getUuid(), eventDataBuilder.toString(),
+                buildComplianceDataJson(consumer, entitlements, compliance), null, null);
     }
 
     // Jackson should think all 3 are root entities so hateoas doesn't bite us

--- a/server/src/test/java/org/candlepin/audit/ActivationListenerTest.java
+++ b/server/src/test/java/org/candlepin/audit/ActivationListenerTest.java
@@ -37,7 +37,7 @@ public class ActivationListenerTest {
         Event event = mock(Event.class);
         when(event.getTarget()).thenReturn(Event.Target.POOL);
         when(event.getType()).thenReturn(Event.Type.CREATED);
-        when(event.getEventData()).thenReturn("{\"subscriptionId\": \"sub-id-1\"}");
+        when(event.getEventData()).thenReturn("{\"subscriptionId\":\"sub-id-1\"}");
         listener.onEvent(event);
         verify(subscriptionService, times(1)).sendActivationEmail("sub-id-1");
     }

--- a/server/src/test/java/org/candlepin/audit/ActivationListenerTest.java
+++ b/server/src/test/java/org/candlepin/audit/ActivationListenerTest.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2009 - 2017 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.audit;
+
+import org.candlepin.service.SubscriptionServiceAdapter;
+import org.candlepin.service.impl.ImportSubscriptionServiceAdapter;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.*;
+
+public class ActivationListenerTest {
+
+    private ActivationListener listener;
+    private SubscriptionServiceAdapter subscriptionService;
+
+    @Before
+    public void init() {
+        subscriptionService = mock(ImportSubscriptionServiceAdapter.class);
+        listener = new ActivationListener(subscriptionService);
+    }
+
+    @Test
+    public void testActivationEmailIsSentWithCorrectSubscriptionId() {
+        Event event = mock(Event.class);
+        when(event.getTarget()).thenReturn(Event.Target.POOL);
+        when(event.getType()).thenReturn(Event.Type.CREATED);
+        when(event.getEventData()).thenReturn("{\"subscriptionId\": \"sub-id-1\"}");
+        listener.onEvent(event);
+        verify(subscriptionService, times(1)).sendActivationEmail("sub-id-1");
+    }
+}

--- a/server/src/test/java/org/candlepin/audit/EventBuilderTest.java
+++ b/server/src/test/java/org/candlepin/audit/EventBuilderTest.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2009 - 2017 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.audit;
+
+import org.candlepin.auth.Principal;
+import org.candlepin.guice.PrincipalProvider;
+import org.candlepin.model.Pool;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class EventBuilderTest {
+
+    private EventFactory factory;
+    private EventBuilder eventBuilder;
+    private PrincipalProvider principalProvider;
+
+    @Before
+    public void init() throws Exception {
+        principalProvider = mock(PrincipalProvider.class);
+        Principal principal = mock(Principal.class);
+        factory = new EventFactory(principalProvider);
+        when(principalProvider.get()).thenReturn(principal);
+    }
+
+    @Test
+    public void testSetEventDataForPoolSetsEventDataJson() {
+        Pool pool = mock(Pool.class);
+        eventBuilder = new EventBuilder(factory, Event.Target.POOL, Event.Type.CREATED);
+
+        when(pool.getSubscriptionId()).thenReturn("test-subscription-id");
+
+        String expectedEventData = "{\"subscriptionId\": \"test-subscription-id\"}";
+        Event event = eventBuilder.setEventData(pool).buildEvent();
+        assertEquals("The expected event data should have been" +
+            expectedEventData + ", but they weren't", expectedEventData, event.getEventData());
+    }
+}

--- a/server/src/test/java/org/candlepin/audit/EventBuilderTest.java
+++ b/server/src/test/java/org/candlepin/audit/EventBuilderTest.java
@@ -45,9 +45,8 @@ public class EventBuilderTest {
 
         when(pool.getSubscriptionId()).thenReturn("test-subscription-id");
 
-        String expectedEventData = "{\"subscriptionId\": \"test-subscription-id\"}";
+        String expectedEventData = "{\"subscriptionId\":\"test-subscription-id\"}";
         Event event = eventBuilder.setEventData(pool).buildEvent();
-        assertEquals("The expected event data should have been" +
-            expectedEventData + ", but they weren't", expectedEventData, event.getEventData());
+        assertEquals(expectedEventData, event.getEventData());
     }
 }

--- a/server/src/test/java/org/candlepin/audit/EventFactoryTest.java
+++ b/server/src/test/java/org/candlepin/audit/EventFactoryTest.java
@@ -80,8 +80,8 @@ public class EventFactoryTest {
         when(consumer.getUuid()).thenReturn("48b09f4e-f18c-4765-9c41-9aed6f122739");
         when(status.getStatus()).thenReturn("valid");
 
-        String expectedEventData = "{\"consumer\": {\"uuid\": \"48b09f4e-f18c-4765-9c41-9aed6f122739\"}," +
-            " \"status\": \"valid\"}";
+        String expectedEventData = "{\"consumer_uuid\":\"48b09f4e-f18c-4765-9c41-9aed6f122739\"," +
+            "\"status\":\"valid\"}";
         Event event = eventFactory.complianceCreated(consumer, entitlementSet, status);
         assertEquals(expectedEventData, event.getEventData());
     }

--- a/server/src/test/java/org/candlepin/audit/EventFactoryTest.java
+++ b/server/src/test/java/org/candlepin/audit/EventFactoryTest.java
@@ -14,17 +14,23 @@
  */
 package org.candlepin.audit;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.google.common.collect.Sets;
 import org.candlepin.auth.Principal;
 import org.candlepin.guice.PrincipalProvider;
 import org.candlepin.model.Consumer;
+import org.candlepin.model.Entitlement;
 import org.candlepin.model.GuestId;
 import org.candlepin.model.Owner;
+import org.candlepin.policy.js.compliance.ComplianceStatus;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.Set;
 
 /**
  * EventFactoryTest
@@ -62,4 +68,21 @@ public class EventFactoryTest {
         assertNotNull(event.getEntityId());
     }
 
+    @Test
+    public void testComplianceCreatedSetsEventData() {
+        Consumer consumer = mock(Consumer.class);
+        Owner owner = mock(Owner.class);
+        ComplianceStatus status = mock(ComplianceStatus.class);
+        Set<Entitlement> entitlementSet = Sets.newHashSet();
+
+        when(consumer.getName()).thenReturn("consumer-name");
+        when(consumer.getOwner()).thenReturn(owner);
+        when(consumer.getUuid()).thenReturn("48b09f4e-f18c-4765-9c41-9aed6f122739");
+        when(status.getStatus()).thenReturn("valid");
+
+        String expectedEventData = "{\"consumer\": {\"uuid\": \"48b09f4e-f18c-4765-9c41-9aed6f122739\"}," +
+            " \"status\": \"valid\"}";
+        Event event = eventFactory.complianceCreated(consumer, entitlementSet, status);
+        assertEquals(expectedEventData, event.getEventData());
+    }
 }


### PR DESCRIPTION
This change is a precursor to removing newEntity.
- Added json blob field 'eventData' to Events which
holds a minimal dictionary of data, specific to events
'pool.created' and 'compliance.created', which are
the only data consumed currently from those on newEntity.
- ActivationListener now uses the new eventData field to
retrieve the subscriptionId for 'pool.created' events.