### PR TITLE
[M] 1500843: Fixed several issues with OwnerResource.updatePool

### DIFF
--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -695,6 +695,7 @@ public class CandlepinPoolManager implements PoolManager {
     public List<Pool> createAndEnrichPools(Subscription sub, List<Pool> existingPools) {
         List<Pool> pools = poolRules.createAndEnrichPools(sub, existingPools);
         log.debug("Creating {} pools for subscription: {}", pools.size(), sub);
+
         for (Pool pool : pools) {
             createPool(pool);
         }
@@ -711,9 +712,11 @@ public class CandlepinPoolManager implements PoolManager {
     public Pool createAndEnrichPools(Pool pool, List<Pool> existingPools) {
         List<Pool> pools = poolRules.createAndEnrichPools(pool, existingPools);
         log.debug("Creating {} pools: ", pools.size());
+
         for (Pool p : pools) {
             createPool(p);
         }
+
         return pool;
     }
 

--- a/server/src/main/java/org/candlepin/controller/PoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/PoolManager.java
@@ -67,12 +67,11 @@ public interface PoolManager {
     Pool convertToMasterPool(Subscription subscription);
 
     /**
-     * Updates the pools using the information stored in the given pool. Because
-     * the input subscription is used to lookup pools, the ID field must be set
-     * for this method to operate properly.
+     * Applies changes to the given pool to itself and any of its derived pools. This may result in
+     * a deletion of the pool if it has been expired as a result of the changes.
      *
      * @param pool
-     *        The pool to use for updating the associated pools
+     *  The pool to update
      */
     void updateMasterPool(Pool pool);
 

--- a/server/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
@@ -87,6 +87,7 @@ public class PoolRules {
             log.debug("Increasing pool quantity for instance multiplier: {}", instanceMultiplier);
             result = result * instanceMultiplier;
         }
+
         return result;
     }
 
@@ -114,15 +115,19 @@ public class PoolRules {
      */
     public List<Pool> createAndEnrichPools(Pool masterPool, List<Pool> existingPools) {
         List<Pool> pools = new LinkedList<Pool>();
-        masterPool.setQuantity(calculateQuantity(masterPool.getQuantity(),
-            masterPool.getProduct(), masterPool.getUpstreamPoolId()));
 
-        String virtOnly = masterPool.getProductAttributeValue(Product.Attributes.VIRT_ONLY);
+        masterPool.setQuantity(calculateQuantity(masterPool.getQuantity(), masterPool.getProduct(),
+            masterPool.getUpstreamPoolId()));
+
         // The following will make virt_only a pool attribute. That makes the
         // pool explicitly virt_only to subscription manager and any other
         // downstream consumer.
+        String virtOnly = masterPool.getProductAttributeValue(Product.Attributes.VIRT_ONLY);
         if (virtOnly != null && !virtOnly.isEmpty()) {
             masterPool.setAttribute(Pool.Attributes.VIRT_ONLY, virtOnly);
+        }
+        else {
+            masterPool.removeAttribute(Pool.Attributes.VIRT_ONLY);
         }
 
         log.info("Checking if pools need to be created for: {}", masterPool);
@@ -133,13 +138,16 @@ public class PoolRules {
                 // is not possible without the subscription itself
                 throw new IllegalStateException("Cannot create master pool from bonus pool");
             }
+
             pools.add(masterPool);
             log.info("Creating new master pool: {}", masterPool);
         }
+
         Pool bonusPool = createBonusPool(masterPool, existingPools);
         if (bonusPool != null) {
             pools.add(bonusPool);
         }
+
         return pools;
     }
 

--- a/server/src/main/java/org/candlepin/resource/util/ResolverUtil.java
+++ b/server/src/main/java/org/candlepin/resource/util/ResolverUtil.java
@@ -55,7 +55,7 @@ public class ResolverUtil {
     public Owner resolveOwner(Owner owner) {
         if (owner == null || (owner.getKey() == null && owner.getId() == null)) {
             throw new BadRequestException(
-                    i18n.tr("No owner specified, or owner lacks identifying information"));
+                i18n.tr("No owner specified, or owner lacks identifying information"));
         }
 
         if (owner.getKey() != null) {


### PR DESCRIPTION
- OwnerResource.updatePool now properly completes/merges the inbound
  pool object using data from the existing pool before passing it
  to the rules or refresh operations
- PoolRules now removes the VIRT_ONLY attribute from a pool if its
  product no longer carries the restriction during enrichment