### PR TITLE
Event Simplification: Removed newEntity field

### DIFF
--- a/server/src/main/java/org/candlepin/audit/Event.java
+++ b/server/src/main/java/org/candlepin/audit/Event.java
@@ -141,9 +141,6 @@ public class Event implements Persisted {
     private String eventData;
 
     @Transient
-    private String newEntity;
-
-    @Transient
     private String messageText;
 
     public Event() {
@@ -151,7 +148,7 @@ public class Event implements Persisted {
 
     public Event(Type type, Target target, String targetName,
         Principal principal, String ownerId, String consumerId,
-        String entityId, String eventData, String newEntity,
+        String entityId, String eventData,
         String referenceId, ReferenceType referenceType) {
         this.type = type;
         this.target = target;
@@ -163,7 +160,6 @@ public class Event implements Persisted {
 
         this.entityId = entityId;
         this.eventData = eventData;
-        this.newEntity = newEntity;
         this.consumerId = consumerId;
         this.referenceId = referenceId;
         this.referenceType = referenceType;
@@ -262,15 +258,6 @@ public class Event implements Persisted {
 
     public void setEventData(String eventData) {
         this.eventData = eventData;
-    }
-
-    @XmlTransient
-    public String getNewEntity() {
-        return newEntity;
-    }
-
-    public void setNewEntity(String newEntity) {
-        this.newEntity = newEntity;
     }
 
     @Override

--- a/server/src/main/java/org/candlepin/audit/LoggingListener.java
+++ b/server/src/main/java/org/candlepin/audit/LoggingListener.java
@@ -42,8 +42,6 @@ import java.util.TimeZone;
 public class LoggingListener implements EventListener {
     private static Logger auditLog;
 
-    private boolean verbose;
-
     private final DateFormat df;
 
     @Inject
@@ -67,7 +65,6 @@ public class LoggingListener implements EventListener {
         // Keep these messages in audit.log only
         auditLog.setAdditive(false);
 
-        verbose = config.getBoolean(ConfigProperties.AUDIT_LOG_VERBOSE);
         TimeZone tz = TimeZone.getDefault();
         // Format for ISO8601 to match our other logging:
         df = new SimpleDateFormat("yyyy-MM-dd' 'HH:mm:ssZ");
@@ -78,7 +75,7 @@ public class LoggingListener implements EventListener {
     @SuppressWarnings("checkstyle:indentation")
     public void onEvent(Event e) {
         auditLog.info(
-            "{} principalType={} principal={} target={} entityId={} type={} owner={}\n",
+            "{} principalType={} principal={} target={} entityId={} type={} owner={} eventData={}\n",
             new Object[] {
                 df.format(e.getTimestamp()),
                 e.getPrincipal().getType(),
@@ -86,11 +83,9 @@ public class LoggingListener implements EventListener {
                 e.getTarget(),
                 e.getEntityId(),
                 e.getType(),
-                e.getOwnerId()}
+                e.getOwnerId(),
+                e.getEventData()}
         );
-        if (verbose) {
-            auditLog.info(String.format("==NEW==\n%s\n\n", e.getNewEntity()));
-        }
     }
 
 }

--- a/server/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/server/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -123,7 +123,6 @@ public class ConfigProperties {
      * will be filtered, meaning they will not enter HORNETQ.
      */
     public static final String AUDIT_FILTER_DEFAULT_POLICY = "candlepin.audit.filter.policy";
-    public static final String AUDIT_LOG_VERBOSE = "candlepin.audit.log_verbose";
 
     public static final String PRETTY_PRINT = "candlepin.pretty_print";
     public static final String ACTIVATION_DEBUG_PREFIX = "candlepin.subscription.activation.debug_prefix";
@@ -318,7 +317,6 @@ public class ConfigProperties {
                 "org.candlepin.audit.LoggingListener," +
                 "org.candlepin.audit.ActivationListener");
             this.put(AUDIT_LOG_FILE, "/var/log/candlepin/audit.log");
-            this.put(AUDIT_LOG_VERBOSE, "false");
             this.put(AUDIT_FILTER_ENABLED, "false");
 
             /**

--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -631,7 +631,7 @@ public class CandlepinPoolManager implements PoolManager {
             // Build event for this update...
             EventBuilder builder = poolEvents.get(existingPool.getId());
             if (builder != null) {
-                Event event = builder.setNewEntity(existingPool).buildEvent();
+                Event event = builder.setEventData(existingPool).buildEvent();
                 sink.queueEvent(event);
             }
             else {

--- a/server/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRules.java
@@ -773,7 +773,7 @@ public class EntitlementRules implements Enforcer {
                     // Now we need to reconcile all of recipient's pools that were using the old product.
                     Product resolvedProduct = productManager.updateProduct(
                         sharingOwnerProduct.toDTO(), recipient, true);
-                    builder.setNewEntity(resolvedProduct);
+                    builder.setEventData(resolvedProduct);
                     resolvedProducts.put(resolvedProduct.getId(), resolvedProduct);
                     events.add(builder.buildEvent());
                 }

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -1157,7 +1157,7 @@ public class ConsumerResource {
             // this should update compliance on toUpdate, but not call the curator
             complianceRules.getStatus(toUpdate, null, false, false);
 
-            Event event = eventBuilder.setNewEntity(toUpdate).buildEvent();
+            Event event = eventBuilder.setEventData(toUpdate).buildEvent();
             sink.queueEvent(event);
         }
 
@@ -2274,7 +2274,7 @@ public class ConsumerResource {
         IdentityCertificate ic = generateIdCert(consumer, true);
         consumer.setIdCert(ic);
         consumerCurator.update(consumer);
-        sink.queueEvent(eventBuilder.setNewEntity(consumer).buildEvent());
+        sink.queueEvent(eventBuilder.setEventData(consumer).buildEvent());
         return consumer;
     }
 

--- a/server/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -993,7 +993,7 @@ public class OwnerResource {
             ownerManager.refreshOwnerForContentAccess(toUpdate);
         }
 
-        Event e = eventBuilder.setNewEntity(toUpdate).buildEvent();
+        Event e = eventBuilder.setEventData(toUpdate).buildEvent();
         sink.queueEvent(e);
         return toUpdate;
     }

--- a/server/src/test/java/org/candlepin/audit/EventBuilderTest.java
+++ b/server/src/test/java/org/candlepin/audit/EventBuilderTest.java
@@ -15,10 +15,13 @@
 package org.candlepin.audit;
 
 import org.candlepin.auth.Principal;
+import org.candlepin.common.exceptions.IseException;
 import org.candlepin.guice.PrincipalProvider;
 import org.candlepin.model.Pool;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -29,6 +32,9 @@ public class EventBuilderTest {
     private EventFactory factory;
     private EventBuilder eventBuilder;
     private PrincipalProvider principalProvider;
+
+    @Rule
+    public ExpectedException exceptions = ExpectedException.none();
 
     @Before
     public void init() throws Exception {
@@ -48,5 +54,15 @@ public class EventBuilderTest {
         String expectedEventData = "{\"subscriptionId\":\"test-subscription-id\"}";
         Event event = eventBuilder.setEventData(pool).buildEvent();
         assertEquals(expectedEventData, event.getEventData());
+    }
+
+    @Test
+    public void testSetEventDataForNonModifiedEventsThrowsIesException() {
+        Pool pool = mock(Pool.class);
+        eventBuilder = new EventBuilder(factory, Event.Target.POOL, Event.Type.CREATED);
+
+        exceptions.expect(IseException.class);
+        exceptions.expectMessage("This method is only for type MODIFIED Events.");
+        eventBuilder.setEventData(pool, pool);
     }
 }

--- a/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -182,7 +182,6 @@ public class PoolManagerTest {
         when(mockConfig.getInt(eq(ConfigProperties.PRODUCT_CACHE_MAX))).thenReturn(100);
         when(eventFactory.getEventBuilder(any(Target.class), any(Type.class))).thenReturn(eventBuilder);
 
-        when(eventBuilder.setNewEntity(any(Eventful.class))).thenReturn(eventBuilder);
         when(eventBuilder.setEventData(any(Eventful.class))).thenReturn(eventBuilder);
 
         this.principal = TestUtil.createOwnerPrincipal(owner);

--- a/server/src/test/java/org/candlepin/model/EventCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/EventCuratorTest.java
@@ -84,13 +84,12 @@ public class EventCuratorTest extends DatabaseTestFixture {
 
         builder = eventFactory.getEventBuilder(Event.Target.CONSUMER,
                 Event.Type.CREATED);
-        Event consumerCreatedEvent = builder.setNewEntity(newConsumer).buildEvent();
+        Event consumerCreatedEvent = builder.setEventData(newConsumer).buildEvent();
         consumerCreatedEvent.setTimestamp(forcedDate);
 
         builder = eventFactory.getEventBuilder(Event.Target.CONSUMER,
                 Event.Type.MODIFIED);
-        Event consumerModifiedEvent = builder.setNewEntity(newConsumer).
-            setEventData(newConsumer).buildEvent();
+        Event consumerModifiedEvent = builder.setEventData(newConsumer).buildEvent();
         consumerModifiedEvent.setTimestamp(forcedDate);
 
         eventCurator.create(rulesDeletedEvent);

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
@@ -147,7 +147,6 @@ public class ConsumerResourceTest {
 
         this.i18n = I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK);
         when(eventBuilder.setEventData(any(Consumer.class))).thenReturn(eventBuilder);
-        when(eventBuilder.setNewEntity(any(Consumer.class))).thenReturn(eventBuilder);
         when(eventFactory.getEventBuilder(any(Target.class), any(Type.class))).thenReturn(eventBuilder);
 
         this.factValidator = new FactValidator(this.config, this.i18n);

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
@@ -128,8 +128,6 @@ public class ConsumerResourceUpdateTest {
         when(idCertService.regenerateIdentityCert(any(Consumer.class)))
             .thenReturn(new IdentityCertificate());
 
-        when(consumerEventBuilder.setNewEntity(any(Consumer.class)))
-            .thenReturn(consumerEventBuilder);
         when(consumerEventBuilder.setEventData(any(Consumer.class)))
             .thenReturn(consumerEventBuilder);
         when(eventFactory.getEventBuilder(any(Target.class), any(Type.class)))

--- a/server/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
@@ -132,8 +132,6 @@ public class HypervisorResourceTest {
         when(ownerCurator.lookupByKey(any(String.class))).thenReturn(new Owner());
         when(eventFactory.getEventBuilder(any(Target.class), any(Type.class)))
             .thenReturn(consumerEventBuilder);
-        when(consumerEventBuilder.setNewEntity(any(Consumer.class)))
-            .thenReturn(consumerEventBuilder);
         when(consumerEventBuilder.setEventData(any(Consumer.class)))
             .thenReturn(consumerEventBuilder);
     }


### PR DESCRIPTION
- Removed the newEntity field from Events
- EventBuilder's setEventData should now be used
for both created and deleted entities where
setNewEntity/setOldentity was used before.
- Overloaded setEventData as a utility to accept
both an old and a new entity for modification events.
- Removed verbose mode from LoggingListener and
the verbose mode property since it is no longer used.
- Added the eventData field to the normal audit log output.