### PR TITLE
[2.0] Improve performance of CancelJobJob

### DIFF
--- a/server/src/main/java/org/candlepin/pinsetter/core/PinsetterKernel.java
+++ b/server/src/main/java/org/candlepin/pinsetter/core/PinsetterKernel.java
@@ -57,6 +57,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -398,11 +399,16 @@ public class PinsetterKernel implements ModeChangeListener {
         }
     }
 
-    public void cancelJob(Serializable id, String group)
-        throws PinsetterException {
+    /**
+     * Cancels the specified job by deleting the job and all triggers from the scheduler.
+     * Assumes that the job is already marked as CANCELED in the JobStatus table.
+     *
+     * @param id the ID of the job to cancel
+     * @param group the job group that the job belongs to
+     * @throws PinsetterException if there is an error deleting the job from the schedule.
+     */
+    public void cancelJob(Serializable id, String group) throws PinsetterException {
         try {
-            // this deletes from the scheduler, it's already marked as
-            // canceled in the JobStatus table
             if (scheduler.deleteJob(jobKey((String) id, group))) {
                 log.info("Canceled job in scheduler: {}:{} ", group, id);
             }
@@ -410,6 +416,33 @@ public class PinsetterKernel implements ModeChangeListener {
         catch (SchedulerException e) {
             throw new PinsetterException("problem canceling " + group + ":" + id, e);
         }
+    }
+
+    /**
+     * Cancels the specified jobs by deleting the jobs and all triggers from the scheduler.
+     * Assumes that the jobs are already marked as CANCELED in the JobStatus table.
+     *
+     * @param toCancel the JobStatus records of the jobs to cancel.
+     * @throws PinsetterException if there is an error deleting the jobs from the schedule.
+     */
+    public void cancelJobs(Collection<JobStatus> toCancel) throws PinsetterException {
+        List<JobKey> jobsToDelete = new LinkedList<JobKey>();
+
+        for (JobStatus status : toCancel) {
+            JobKey key = jobKey(status.getId(), status.getGroup());
+            log.debug("Job {} from group {} will be deleted from the scheduler.",
+                key.getName(), key.getGroup());
+            jobsToDelete.add(key);
+        }
+
+        log.info("Deleting {} cancelled jobs from scheduler.", toCancel.size());
+        try {
+            scheduler.deleteJobs(jobsToDelete);
+        }
+        catch (SchedulerException se) {
+            throw new PinsetterException("Problem canceling jobs.", se);
+        }
+        log.info("Finished deleting jobs from scheduler");
     }
 
     /**

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/CancelJobJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/CancelJobJob.java
@@ -17,7 +17,6 @@ package org.candlepin.pinsetter.tasks;
 import org.candlepin.model.JobCurator;
 import org.candlepin.pinsetter.core.PinsetterException;
 import org.candlepin.pinsetter.core.PinsetterKernel;
-import org.candlepin.pinsetter.core.model.JobStatus;
 
 import com.google.inject.Inject;
 
@@ -62,14 +61,11 @@ public class CancelJobJob extends KingpinJob {
                 statusIds.add(key.getName());
             }
 
-            for (JobStatus j : this.jobCurator.findCanceledJobs(statusIds)) {
-                try {
-                    pinsetterKernel.cancelJob(j.getId(), j.getGroup());
-                    log.info("Canceled job: {}, {}", j.getId(), j.getGroup());
-                }
-                catch (PinsetterException e) {
-                    log.error("Exception canceling job {}", j.getId(), e);
-                }
+            try {
+                pinsetterKernel.cancelJobs(this.jobCurator.findCanceledJobs(statusIds));
+            }
+            catch (PinsetterException e) {
+                log.error("Exception canceling jobs.", e);
             }
         }
         catch (SchedulerException e) {

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/CancelJobJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/CancelJobJobTest.java
@@ -14,10 +14,14 @@
  */
 package org.candlepin.pinsetter.tasks;
 
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
-import static org.quartz.JobBuilder.*;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.atMost;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.quartz.JobBuilder.newJob;
 
 import org.candlepin.model.JobCurator;
 import org.candlepin.pinsetter.core.PinsetterException;
@@ -36,9 +40,11 @@ import org.quartz.JobKey;
 import org.quartz.SchedulerException;
 
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -72,22 +78,33 @@ public class CancelJobJobTest {
 
     @Test
     public void cancelTest() throws JobExecutionException, PinsetterException, SchedulerException {
-        JobDetail jd = newJob(Job.class)
-            .withIdentity("Kayfabe", "Deluxe")
+        JobDetail jd1 = newJob(Job.class)
+            .withIdentity("Job1", "G1")
             .build();
 
-        JobStatus js = new JobStatus(jd);
+        JobDetail jd2 = newJob(Job.class)
+            .withIdentity("Job2", "G1")
+            .build();
+
+        JobDetail jd3 = newJob(Job.class)
+            .withIdentity("Job1", "G2")
+            .build();
+
+        List<JobDetail> jobDetailList = Arrays.asList(jd1, jd2, jd3);
         Set<JobStatus> jl = new HashSet<JobStatus>();
-        jl.add(js);
+        for (JobDetail jd : jobDetailList) {
+            jl.add(new JobStatus(jd1));
+        }
 
         Set<JobKey> jobKeys = new HashSet<JobKey>();
-        jobKeys.add(new JobKey("Kayfabe"));
+        jobKeys.add(new JobKey("G1"));
+        jobKeys.add(new JobKey("G2"));
 
         when(pk.getSingleJobKeys()).thenReturn(jobKeys);
         when(j.findCanceledJobs(any(Collection.class))).thenReturn(jl);
 
         cancelJobJob.execute(ctx);
-        verify(pk, atLeastOnce()).cancelJob((Serializable) "Kayfabe", "Deluxe");
+        verify(pk, atMost(1)).cancelJobs(eq(jl));
     }
 
 }


### PR DESCRIPTION
Batched up job deletion in the scheduler to improve performance
of CancelJobJob when there are a lot of stale quartz jobs to
cancel.