### PR TITLE
[2.1] 1513695: Additional consumer locking on entitlement count

### DIFF
--- a/server/src/main/java/org/candlepin/bind/BindChain.java
+++ b/server/src/main/java/org/candlepin/bind/BindChain.java
@@ -95,6 +95,7 @@ public class BindChain {
     }
 
     public Collection<Entitlement> run() throws EntitlementRefusedException {
+        context.getLockedConsumer();
         if (preProcess(context)) {
             lock(context);
             if (execute(context)) {

--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -1769,6 +1769,7 @@ public class CandlepinPoolManager implements PoolManager {
 
             pool.setConsumed(pool.getConsumed() - entQuantity);
             Consumer consumer = ent.getConsumer();
+            consumerCurator.lockAndLoad(consumer);
 
             if (consumer.isManifestDistributor()) {
                 pool.setExported(pool.getExported() - entQuantity);
@@ -2083,6 +2084,10 @@ public class CandlepinPoolManager implements PoolManager {
                 this.entitlementCurator.listAllByIds(entitlementIds).list() :
                 Collections.<Entitlement>emptySet();
 
+            for (Entitlement e : entitlements) {
+                consumerCurator.lockAndLoad(e.getConsumer());
+            }
+
             // Mark remaining dependent entitlements dirty for this consumer
             this.entitlementCurator.markDependentEntitlementsDirty(entitlements, true);
 
@@ -2149,6 +2154,7 @@ public class CandlepinPoolManager implements PoolManager {
                             pool.setExported(pool.getExported() - quantity);
                         }
                     }
+                    consumer.removeEntitlement(entitlement);
                 }
 
                 this.poolCurator.updateAll(poolsToSave, false, false);


### PR DESCRIPTION
This addresses more places where the entitlement count changes are not made with conusmer locking. It covers entitlement revocation, pool deletion, and bulk pool deletion.

It does not guarantee that there are not more spots to investigate.