### PR TITLE
[M] Added a per-org products migration validation Liquibase task

### DIFF
--- a/server/code/setup/cpdb
+++ b/server/code/setup/cpdb
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# Copyright (c) 2012 Red Hat, Inc.
+# Copyright (c) 2017 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,
 # version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -47,36 +47,47 @@ def error_out(command, status, output):
 
 
 class DbSetup(object):
-    def __init__(self, username, password, db, community):
+    def __init__(self, username, password, db, community, verbose):
         self.username = username
         self.db = db
         self.password = password
         self.community = community
+        self.verbose = verbose
 
     def create(self):
         raise NotImplementedError("Implemented by subclasses")
 
     def initialize_schema(self):
-        print("Loading candlepin schema")
+        print("Loading Candlepin schema")
         self._run_liquibase("db/changelog/changelog-create.xml")
 
     def drop(self):
         raise NotImplementedError("Implemented by subclasses")
 
+    def validate(self):
+        """ Validates an existing candlepin database. """
+        print("Validating Candlepin database")
+        self._run_liquibase("db/changelog/changelog-validate.xml")
+
     def update(self):
         """ Upgrades an existing candlepin database. """
-        print("Migrating candlepin database")
+        print("Migrating Candlepin database")
         self._run_liquibase("db/changelog/changelog-update.xml")
 
     def _run_liquibase(self, changelog_path):
         # Figure out what to append to the classpath for liquibase:
         classpath = self.jdbc_jar
+
+        if os.path.exists('target/classes'):
+            classpath = "%s:%s" % (classpath, 'target/classes/')
+
         if os.path.exists(TOMCAT_CLASSPATH):
             classpath = "%s:%s" % (classpath, TOMCAT_CLASSPATH)
+
         if os.path.exists(JBOSS_CLASSPATH):
             classpath = "%s:%s" % (classpath, JBOSS_CLASSPATH)
-        liquibase_options = "--driver=%s --classpath=%s " \
-                "--changeLogFile=%s --url=%s --username=%s " % (
+
+        liquibase_options = "--driver=%s --classpath=%s --changeLogFile=%s --url=%s --username=%s" % (
             self.driver_class,
             classpath,
             changelog_path,
@@ -87,17 +98,18 @@ class DbSetup(object):
         if self.password:
             liquibase_options += " --password=%s" % self.password
 
+        # Add in output level. By default, Liquibase defaults to "off"
+        liquibase_options += " --logLevel=%s" % ('debug' if self.verbose else 'severe')
+
         print liquibase_options
 
-        output = run_command("liquibase %s migrate -Dcommunity=%s" % (
-            liquibase_options,
-            self.community))
+        output = run_command("liquibase %s migrate -Dcommunity=%s" % (liquibase_options, self.community))
         print output
 
 
 class OracleSetup(DbSetup):
-    def __init__(self, username, password, db, community, oracle_user, oracle_password):
-        super(OracleSetup, self).__init__(username, password, db, community)
+    def __init__(self, username, password, db, community, verbose, oracle_user, oracle_password):
+        super(OracleSetup, self).__init__(username, password, db, community, verbose)
         self.jdbc_jar = "/usr/lib/oracle/11.2/client64/lib/ojdbc6.jar"
         self.driver_class = "oracle.jdbc.OracleDriver"
         self.jdbc_url = "jdbc:oracle:thin:@//%s" % db
@@ -124,7 +136,7 @@ class OracleSetup(DbSetup):
             print("%s user already exists.  Skipping..." % self.username)
             return
 
-        print("Creating candlepin database")
+        print("Creating Candlepin database")
         out = self._runSql('create user %s identified by %s default tablespace users;' %
             (self.username, self.password))
         print out
@@ -133,14 +145,14 @@ class OracleSetup(DbSetup):
         print out
 
     def drop(self):
-        print("Dropping candlepin database")
+        print("Dropping Candlepin database")
         out = self._runSql('drop user %s cascade;' % self.username)
         print out
 
 
 class PostgresqlSetup(DbSetup):
-    def __init__(self, host, port, username, password, db, community):
-        super(PostgresqlSetup, self).__init__(username, password, db, community)
+    def __init__(self, host, port, username, password, db, community, verbose):
+        super(PostgresqlSetup, self).__init__(username, password, db, community, verbose)
         self.host = host
         self.port = port
         self.jdbc_jar = "/usr/share/java/postgresql-jdbc.jar"
@@ -191,47 +203,66 @@ if __name__ == "__main__":
     parser = OptionParser()
     parser.add_option("--create",
             dest="create", action="store_true", default=False,
-            help="create the Candlepin database")
+            help="create the Candlepin database; cannot be used with --update or --validate")
+
     parser.add_option("--schema-only",
             dest="schema_only", action="store_true", default=False,
             help="assumes database is already created by another tool and"
                  "applies schema to database; used with --create")
+
+    parser.add_option("--validate",
+            dest="validate", action="store_true", default=False,
+            help="validate the current state of the Candlepin database; cannot be used with --create")
+
     parser.add_option("--update",
             dest="update", action="store_true", default=False,
-            help="update the Candlepin database")
+            help="update the Candlepin database; cannot be used with --create")
 
     parser.add_option("--drop",
             dest="drop", action="store_true", default=False,
             help="drop the existing Candlepin database before creating")
+
     parser.add_option("-u", "--user",
             dest="dbuser", default="candlepin",
             help="database user to use")
+
     parser.add_option("-d", "--database",
             dest="db", default="candlepin",
             help="database name to use")
+
     parser.add_option("-p", "--password",
             dest="dbpassword",
             help="database password to use")
+
     parser.add_option("--dbhost",
             dest="dbhost",
             help="the database host to use (optional)")
+
     parser.add_option("--dbport",
             dest="dbport",
             help="the database port to use (optional)")
+
     parser.add_option("--community",
             action="store_true", default=False,
             dest="community",
             help="true if used in a community fashion")
+
     parser.add_option("--oracle",
             action="store_true", default=False,
             dest="oracle",
             help="run against an Oracle installation")
+
     parser.add_option("--oracle-user",
             dest="oracle_user", default="sys",
             help="Oracle DBA user. Defaults to 'sys'")
+
     parser.add_option("--oracle-password",
             dest="oracle_password",
             help="Oracle DBA password")
+
+    parser.add_option("--verbose",
+            dest="verbose", action="store_true", default=False,
+            help="enables verbose logging/output")
 
     (options, args) = parser.parse_args()
 
@@ -243,9 +274,16 @@ if __name__ == "__main__":
             print("ERROR: Please provide a password for the Candlepin database user.")
             sys.exit(1)
 
-    if (not options.create and not options.update) or \
-        (options.create and options.update):
-        print("ERROR: Please specify --create or --update.")
+    if (not options.create and not options.update and not options.validate):
+        print("ERROR: Please specify --create, --update or --validate.")
+        sys.exit(1)
+
+    if (options.create and options.validate):
+        print("ERROR: --create cannot be used with --validate")
+        sys.exit(1)
+
+    if (options.create and options.update):
+        print("ERROR: --create cannot be used with --update")
         sys.exit(1)
 
     if options.schema_only and not options.create:
@@ -257,17 +295,23 @@ if __name__ == "__main__":
         sys.exit(1)
 
     if options.oracle:
-        dbsetup = OracleSetup(options.dbuser, options.dbpassword, options.db,
-                options.community, options.oracle_user, options.oracle_password)
+        dbsetup = OracleSetup(options.dbuser, options.dbpassword, options.db, options.community,
+            options.verbose, options.oracle_user, options.oracle_password)
     else:
-        dbsetup = PostgresqlSetup(options.dbhost, options.dbport,
-            options.dbuser, options.dbpassword, options.db, options.community)
+        dbsetup = PostgresqlSetup(options.dbhost, options.dbport, options.dbuser, options.dbpassword,
+            options.db, options.community, options.verbose)
 
     if options.create:
         if options.drop:
             dbsetup.drop()
+
         if not options.schema_only:
             dbsetup.create()
+
         dbsetup.initialize_schema()
+
+    if options.validate:
+        dbsetup.validate()
+
     if options.update:
         dbsetup.update()

--- a/server/code/setup/cpsetup
+++ b/server/code/setup/cpsetup
@@ -143,7 +143,7 @@ class CertSetup(object):
             run_command_with_sudo('mkdir -p %s' % self.cert_home)
 
         if os.path.exists(self.ca_key) and os.path.exists(self.ca_cert):
-            print("Cerficiates already exist, skipping...")
+            print("Certificates already exist, skipping...")
             return
 
         print("Creating CA private key password")

--- a/server/src/main/java/org/candlepin/liquibase/PerOrgProductsMigrationValidationLiquibaseWrapper.java
+++ b/server/src/main/java/org/candlepin/liquibase/PerOrgProductsMigrationValidationLiquibaseWrapper.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.liquibase;
+
+
+
+/**
+ * Liquibase wrapper class for the per-org products upgrade task
+ */
+public class PerOrgProductsMigrationValidationLiquibaseWrapper
+    extends LiquibaseCustomTaskWrapper<PerOrgProductsMigrationValidationTask> {
+
+    public PerOrgProductsMigrationValidationLiquibaseWrapper() {
+        super(PerOrgProductsMigrationValidationTask.class);
+    }
+
+    // Nothing else to do here
+}

--- a/server/src/main/java/org/candlepin/liquibase/PerOrgProductsMigrationValidationTask.java
+++ b/server/src/main/java/org/candlepin/liquibase/PerOrgProductsMigrationValidationTask.java
@@ -1,0 +1,193 @@
+/**
+ * Copyright (c) 2009 - 2017 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.liquibase;
+
+import liquibase.database.Database;
+import liquibase.exception.DatabaseException;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+
+
+/**
+ * The PerOrgProductsMigrationValidationTask performs pre-migration validation on the current state of
+ * the database before migrating to per-org products.
+ */
+public class PerOrgProductsMigrationValidationTask extends LiquibaseCustomTask {
+
+    public PerOrgProductsMigrationValidationTask(Database database, CustomTaskLogger logger) {
+        super(database, logger);
+    }
+
+    /**
+     * Checks for any pools or subscriptions which contain bad data (typically products which do
+     * not exist).
+     *
+     * @param orgid
+     *  The id of the owner/organization for which to migrate product data
+     *
+     * @return
+     *  true if the check completed successfully; false otherwise
+     */
+    @SuppressWarnings("checkstyle:methodlength")
+    protected boolean checkForMalformedObjectRefs(String orgid) throws DatabaseException,
+        SQLException {
+
+        ResultSet badObjectRefs = this.executeQuery(
+            "SELECT DISTINCT u.product_id, u.pool_id, u.subscription_id " +
+            "FROM (SELECT NULLIF(p.productid, '') AS product_id, p.id AS pool_id, " +
+            "  NULL AS subscription_id " +
+            "    FROM cp_pool p " +
+            "    WHERE p.owner_id = ? " +
+            "  UNION " +
+            "  SELECT p.derivedproductid, p.id, NULL " +
+            "    FROM cp_pool p " +
+            "    WHERE p.owner_id = ? " +
+            "      AND NOT NULLIF(p.derivedproductid, '') IS NULL " +
+            "  UNION " +
+            "  SELECT NULLIF(pp.product_id, ''), p.id, NULL " +
+            "    FROM cp_pool p " +
+            "    JOIN cp_pool_products pp " +
+            "      ON p.id = pp.pool_id " +
+            "    WHERE p.owner_id = ? " +
+            "  UNION " +
+            "  SELECT NULLIF(s.product_id, ''), NULL, s.id " +
+            "    FROM cp_subscription s " +
+            "    WHERE s.owner_id = ? " +
+            "  UNION " +
+            "  SELECT s.derivedproduct_id, NULL, s.id " +
+            "    FROM cp_subscription s " +
+            "    WHERE s.owner_id = ? " +
+            "      AND NOT NULLIF(s.derivedproduct_id, '') IS NULL " +
+            "  UNION " +
+            "  SELECT NULLIF(sp.product_id, ''), NULL, s.id " +
+            "    FROM cp_subscription_products sp " +
+            "    JOIN cp_subscription s " +
+            "      ON s.id = sp.subscription_id " +
+            "    WHERE s.owner_id = ? " +
+            "  UNION " +
+            "  SELECT NULLIF(sdp.product_id, ''), NULL, s.id " +
+            "    FROM cp_sub_derivedprods sdp " +
+            "    JOIN cp_subscription s " +
+            "      ON s.id = sdp.subscription_id " +
+            "    WHERE s.owner_id = ?) u " +
+            "LEFT JOIN cp_product p " +
+            "  ON u.product_id = p.id " +
+            "WHERE p.id IS NULL",
+            orgid, orgid, orgid, orgid, orgid, orgid, orgid
+        );
+
+        boolean passed = true;
+
+        while (badObjectRefs.next()) {
+            passed = false;
+
+            String productId = badObjectRefs.getString(1);
+            String poolId = badObjectRefs.getString(2);
+            String subscriptionId = badObjectRefs.getString(3);
+
+            if (productId != null) {
+                if (poolId != null) {
+                    this.logger.error("  Pool \"%s\" references an unresolvable product: %s",
+                        poolId, productId);
+                }
+                else if (subscriptionId != null) {
+                    this.logger.error("  Subscription \"%s\" references an unresolvable product: %s",
+                        subscriptionId, productId);
+                }
+            }
+            else {
+                if (poolId != null) {
+                    this.logger.error("  Pool \"%s\" contains a null or empty product reference", poolId);
+                }
+                else if (subscriptionId != null) {
+                    this.logger.error("  Subscription \"%s\" contains a null or empty product reference",
+                        subscriptionId);
+                }
+            }
+        }
+
+        badObjectRefs.close();
+
+        // Check for bad content refs on our environments
+        badObjectRefs = this.executeQuery(
+            "  SELECT e.id, ec.contentid " +
+            "    FROM cp_environment e " +
+            "    JOIN cp_env_content ec ON e.id = ec.environment_id " +
+            "    LEFT JOIN cp_content c ON c.id = ec.contentid " +
+            "    WHERE e.owner_id = ? " +
+            "      AND c.id IS NULL",
+            orgid
+        );
+
+        while (badObjectRefs.next()) {
+            passed = false;
+
+            String envId = badObjectRefs.getString(1);
+            String contentId = badObjectRefs.getString(2);
+
+            this.logger.error("  Environment \"%s\" references unresolvable content: %s", envId, contentId);
+        }
+
+        badObjectRefs.close();
+
+        // Impl Note:
+        // We don't need to check activation key products, since the migration just deletes these if they
+        // exist.
+
+        return passed;
+    }
+
+    /**
+     * Executes this task
+     *
+     * @throws DatabaseException
+     *  if an error occurs while performing a database operation
+     *
+     * @throws SQLException
+     *  if an error occurs while executing an SQL statement
+     */
+    public void execute() throws DatabaseException, SQLException {
+        // Fetch our org count for prettier log messages
+        ResultSet countQuery = this.executeQuery("SELECT count(id) FROM cp_owner");
+        countQuery.next();
+        int count = countQuery.getInt(1);
+        countQuery.close();
+
+        boolean validated = true;
+        ResultSet orgids = this.executeQuery("SELECT id, account FROM cp_owner");
+        for (int index = 1; orgids.next(); ++index) {
+            String orgid = orgids.getString(1);
+            String account = orgids.getString(2);
+
+            this.logger.info("Validating data for org %s (%s) (%d of %d)", account, orgid, index, count);
+
+            // Check for malformed objects which may end up in a bad state if we migrate
+            boolean validationResult = this.checkForMalformedObjectRefs(orgid);
+
+            if (!validationResult) {
+                validated = false;
+                this.logger.error("Org %s (%s) failed data validation", account, orgid);
+            }
+        }
+        orgids.close();
+
+        if (!validated) {
+            throw new DatabaseException("One or more orgs failed data validation");
+        }
+    }
+
+}

--- a/server/src/main/resources/db/changelog/20171108140157-perorgproducts-migration-validation.xml
+++ b/server/src/main/resources/db/changelog/20171108140157-perorgproducts-migration-validation.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="20171108140157-1" author="crog">
+        <preConditions onSqlOutput="FAIL" onFail="CONTINUE">
+            <columnExists tableName="cp_pool" columnName="productid"/>
+            <columnExists tableName="cp_pool" columnName="derivedproductid"/>
+            <tableExists tableName="cp_subscription"/>
+        </preConditions>
+
+        <comment>Performs per-org-product specific migration validation</comment>
+
+        <customChange class="org.candlepin.liquibase.PerOrgProductsMigrationValidationLiquibaseWrapper"/>
+    </changeSet>
+
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/server/src/main/resources/db/changelog/changelog-validate.xml
+++ b/server/src/main/resources/db/changelog/changelog-validate.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <property name="project.name" value="candlepin"/>
+
+    <include file="db/changelog/20171108140157-perorgproducts-migration-validation.xml"/>
+</databaseChangeLog>


### PR DESCRIPTION
- Added a new set of liquibase tasks which perform database
  validation rather than modification. These are part of the new
  changelog-validate.xml file and are not included in any of the
  existing changelog collections.
- Updated cpdb to have a --validate option, which runs the new
  validation set of Liquibase tasks
- Added --verbose to cpdb, which sets the logging level in
  Liquibase to "debug"
- Added the PerOrgProductsMigrationValidationTask and Liquibase
  wrapper
- Minor whitespace and spelling corrections throughout cpdb and
  cpsetup