### PR TITLE
[M] 1513698: Additional consumer locking on entitlement count

### DIFF
--- a/server/spec/entitlement_resource_spec.rb
+++ b/server/spec/entitlement_resource_spec.rb
@@ -188,13 +188,21 @@ describe 'Entitlement Resource' do
     pool = create_pool_and_subscription(@owner['key'], prod.id, 50)
 
     t1 = Thread.new{register_and_consume(pool, "system", 5)}
+    t1a = Thread.new{register_unregister()}
     t2 = Thread.new{register_and_consume(pool, "candlepin", 7)}
+    t2a = Thread.new{register_unregister()}
     t3 = Thread.new{register_and_consume(pool, "system", 6)}
+    t3a = Thread.new{register_unregister()}
     t4 = Thread.new{register_and_consume(pool, "candlepin", 11)}
+    t4a = Thread.new{register_unregister()}
     t1.join
+    t1a.join
     t2.join
+    t2a.join
     t3.join
+    t3a.join
     t4.join
+    t4a.join
 
     consumed_pool = owner_client.get_pool(pool.id)
     consumed_pool['consumed'].should == 29
@@ -210,17 +218,29 @@ describe 'Entitlement Resource' do
     pool = create_pool_and_subscription(@owner['key'], prod.id, 3)
 
     t1 = Thread.new{register_and_consume(pool, "system", 1)}
+    t1a = Thread.new{register_unregister()}
     t2 = Thread.new{register_and_consume(pool, "candlepin", 1)}
+    t2a = Thread.new{register_unregister()}
     t3 = Thread.new{register_and_consume(pool, "system", 1)}
+    t3a = Thread.new{register_unregister()}
     t4 = Thread.new{register_and_consume(pool, "candlepin", 1)}
+    t4a = Thread.new{register_unregister()}
     t5 = Thread.new{register_and_consume(pool, "candlepin", 1)}
+    t5a = Thread.new{register_unregister()}
     t6 = Thread.new{register_and_consume(pool, "candlepin", 1)}
+    t6a = Thread.new{register_unregister()}
     t1.join
+    t1a.join
     t2.join
+    t2a.join
     t3.join
+    t3a.join
     t4.join
+    t4a.join
     t5.join
+    t5a.join
     t6.join
+    t6a.join
 
     consumed_pool = owner_client.get_pool(pool.id)
     consumed_pool['consumed'].should == 3
@@ -235,17 +255,29 @@ describe 'Entitlement Resource' do
     pool = create_pool_and_subscription(@owner['key'], prod.id, 3)
 
     t1 = Thread.new{register_consume_unregister(pool, "system", 1)}
+    t1a = Thread.new{register_unregister()}
     t2 = Thread.new{register_consume_unregister(pool, "candlepin", 1)}
+    t2a = Thread.new{register_unregister()}
     t3 = Thread.new{register_consume_unregister(pool, "system", 1)}
+    t3a = Thread.new{register_unregister()}
     t4 = Thread.new{register_consume_unregister(pool, "candlepin", 1)}
+    t4a = Thread.new{register_unregister()}
     t5 = Thread.new{register_consume_unregister(pool, "system", 1)}
+    t5a = Thread.new{register_unregister()}
     t6 = Thread.new{register_consume_unregister(pool, "candlepin", 1)}
+    t6a = Thread.new{register_unregister()}
     t1.join
+    t1a.join
     t2.join
+    t2a.join
     t3.join
+    t3a.join
     t4.join
+    t4a.join
     t5.join
+    t5a.join
     t6.join
+    t6a.join
 
     consumed_pool = owner_client.get_pool(pool.id)
     consumed_pool['consumed'].should == 0
@@ -267,15 +299,25 @@ describe 'Entitlement Resource' do
     cp_client = consumer_client(owner_client, random_string('consumer'), "candlepin")
 
     t1 = Thread.new{cp_client.consume_pool(pool1.id, {:quantity => 40})}
+    t1a = Thread.new{register_unregister()}
     t2 = Thread.new{cp_client.consume_pool(pool2.id, {:quantity => 30})}
+    t2a = Thread.new{register_unregister()}
     t3 = Thread.new{cp_client.consume_pool(pool3.id, {:quantity => 20})}
+    t3a = Thread.new{register_unregister()}
     t4 = Thread.new{cp_client.consume_pool(pool4.id, {:quantity => 25})}
+    t4a = Thread.new{register_unregister()}
     t5 = Thread.new{cp_client.consume_pool(pool5.id, {:quantity => 10})}
+    t5a = Thread.new{register_unregister()}
     t1.join
+    t1a.join
     t2.join
+    t2a.join
     t3.join
+    t3a.join
     t4.join
+    t4a.join
     t5.join
+    t5a.join
 
     consumer = cp_client.get_consumer()
     consumer['entitlementCount'].should == 125
@@ -296,15 +338,25 @@ describe 'Entitlement Resource' do
     cp_client = consumer_client(owner_client, random_string('consumer'), "candlepin")
 
     t1 = Thread.new{consume_delete_ent(pool1, cp_client, 40)}
+    t1a = Thread.new{register_unregister()}
     t2 = Thread.new{consume_delete_ent(pool2, cp_client, 30)}
+    t2a = Thread.new{register_unregister()}
     t3 = Thread.new{consume_delete_ent(pool3, cp_client, 20)}
+    t3a = Thread.new{register_unregister()}
     t4 = Thread.new{consume_delete_ent(pool4, cp_client, 25)}
+    t4a = Thread.new{register_unregister()}
     t5 = Thread.new{consume_delete_ent(pool5, cp_client, 10)}
+    t5a = Thread.new{register_unregister()}
     t1.join
+    t1a.join
     t2.join
+    t2a.join
     t3.join
+    t3a.join
     t4.join
+    t4a.join
     t5.join
+    t5a.join
 
     consumer = cp_client.get_consumer()
     consumer['entitlementCount'].should == 0
@@ -325,15 +377,25 @@ describe 'Entitlement Resource' do
     cp_client = consumer_client(owner_client, random_string('consumer'), "candlepin")
 
     t1 = Thread.new{consume_delete_pool(pool1, cp_client, 40)}
+    t1a = Thread.new{register_unregister()}
     t2 = Thread.new{consume_delete_pool(pool2, cp_client, 30)}
+    t2a = Thread.new{register_unregister()}
     t3 = Thread.new{consume_delete_pool(pool3, cp_client, 20)}
+    t3a = Thread.new{register_unregister()}
     t4 = Thread.new{consume_delete_pool(pool4, cp_client, 25)}
+    t4a = Thread.new{register_unregister()}
     t5 = Thread.new{consume_delete_pool(pool5, cp_client, 10)}
+    t5a = Thread.new{register_unregister()}
     t1.join
+    t1a.join
     t2.join
+    t2a.join
     t3.join
+    t3a.join
     t4.join
+    t4a.join
     t5.join
+    t5a.join
 
     consumer = cp_client.get_consumer()
     consumer['entitlementCount'].should == 0
@@ -345,9 +407,16 @@ describe 'Entitlement Resource' do
     cp_client = consumer_client(user, random_string('consumer'), consumer_type)
     begin
         cp_client.consume_pool(pool.id, {:quantity => quantity})
+
     rescue RestClient::Forbidden => e
         # tests will run that try to over consume, this is expected
     end
+    cp_client.unregister
+  end
+
+  def register_unregister()
+    user = user_client(@owner, random_string('user'))
+    cp_client = consumer_client(user, random_string('consumer'), "system")
     cp_client.unregister
   end
 

--- a/server/src/main/java/org/candlepin/bind/BindChain.java
+++ b/server/src/main/java/org/candlepin/bind/BindChain.java
@@ -95,6 +95,7 @@ public class BindChain {
     }
 
     public Collection<Entitlement> run() throws EntitlementRefusedException {
+        context.getLockedConsumer();
         if (preProcess(context)) {
             lock(context);
             if (execute(context)) {

--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -2098,9 +2098,11 @@ public class CandlepinPoolManager implements PoolManager {
                 this.entitlementCurator.listAllByIds(entitlementIds).list() :
                 Collections.<Entitlement>emptySet();
 
+            List<String> consumerIds = new ArrayList<String>();
             for (Entitlement e : entitlements) {
-                consumerCurator.lockAndLoad(e.getConsumer());
+                consumerIds.add(e.getConsumer().getId());
             }
+            consumerCurator.lockAndLoadByIds(consumerIds);
 
             // Mark remaining dependent entitlements dirty for this consumer
             this.entitlementCurator.markDependentEntitlementsDirty(entitlementIds);

--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -1783,6 +1783,7 @@ public class CandlepinPoolManager implements PoolManager {
 
             pool.setConsumed(pool.getConsumed() - entQuantity);
             Consumer consumer = ent.getConsumer();
+            consumerCurator.lockAndLoad(consumer);
 
             if (consumer.isManifestDistributor()) {
                 pool.setExported(pool.getExported() - entQuantity);
@@ -2097,6 +2098,10 @@ public class CandlepinPoolManager implements PoolManager {
                 this.entitlementCurator.listAllByIds(entitlementIds).list() :
                 Collections.<Entitlement>emptySet();
 
+            for (Entitlement e : entitlements) {
+                consumerCurator.lockAndLoad(e.getConsumer());
+            }
+
             // Mark remaining dependent entitlements dirty for this consumer
             this.entitlementCurator.markDependentEntitlementsDirty(entitlementIds);
 
@@ -2163,6 +2168,7 @@ public class CandlepinPoolManager implements PoolManager {
                             pool.setExported(pool.getExported() - quantity);
                         }
                     }
+                    consumer.removeEntitlement(entitlement);
                 }
 
                 this.poolCurator.updateAll(poolsToSave, false, false);


### PR DESCRIPTION
This addresses more places where the entitlement count changes are not made with conusmer locking. It covers entitlement revocation, pool deletion, and bulk pool deletion.

It does not guarantee that there are not more spots to investigate.