### PR TITLE
[M] 1510082: mode change breaks pinsetter

### DIFF
--- a/server/src/main/java/org/candlepin/pinsetter/core/PinsetterKernel.java
+++ b/server/src/main/java/org/candlepin/pinsetter/core/PinsetterKernel.java
@@ -134,6 +134,7 @@ public class PinsetterKernel implements ModeChangeListener {
     /**
      * Starts Pinsetter
      * This method does not return until the this.scheduler is shutdown
+     * Note: candlepin always starts in NORMAL mode.
      * @throws PinsetterException error occurred during Quartz or Hibernate
      * startup
      */
@@ -141,9 +142,6 @@ public class PinsetterKernel implements ModeChangeListener {
         try {
             scheduler.start();
             jobCurator.cancelOrphanedJobs(Collections.EMPTY_LIST);
-            if (modeManager.getLastCandlepinModeChange().getMode() != Mode.NORMAL) {
-                scheduler.pauseAll();
-            }
             modeManager.registerModeChangeListener(this);
             configure();
         }
@@ -587,34 +585,26 @@ public class PinsetterKernel implements ModeChangeListener {
         }
     }
 
-    private void pauseAll() {
-        try {
-            log.debug("Pinsetter Kernel is being paused");
-            scheduler.pauseAll();
-        }
-        catch (SchedulerException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private void resumeAll() {
-        try {
-            log.debug("Pinsetter Kernel is being resumed");
-            scheduler.resumeAll();
-        }
-        catch (SchedulerException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
     @Override
     public void modeChanged(Mode newMode) {
-        if (newMode == Mode.SUSPEND) {
-            pauseAll();
+
+        /* 1510082: Pause and un pause scheduler, never pause all jobs.
+           cause when we do, quartz pauses the thread group itself.
+           Later it does not resume the async thread group correctly, and as a result
+           no async jobs will run.
+         */
+        try {
+            if (newMode == Mode.SUSPEND) {
+                pauseScheduler();
+            }
+            else if (newMode == Mode.NORMAL) {
+                unpauseScheduler();
+            }
         }
-        else if (newMode == Mode.NORMAL) {
-            resumeAll();
+        catch (PinsetterException e) {
+            throw new RuntimeException(e);
         }
+
     }
 
 }


### PR DESCRIPTION
Pause and un pause scheduler, never pause all jobs. cause when we do, quartz pauses the thread group itself. Later it does not resume the async thread group correctly, and as a result no async jobs will run.
To test this PR, please test that:
* candlepin is able to schedule async jobs even when it is suspended and those jobs resume and run to completion once candlepin resumes to normal mode. ( as long as tomcat was not shut down inbetween those steps )
* cron jobs pause when candlepin moves to suspend mode and resume when candlepin resumes to normal mode.
* any scheduled async or cron jobs are cancelled when tomcat is shutdown while candlepin was in suspended mode.