### PR TITLE
[M] Prioritize cron jobs over async jobs

### DIFF
--- a/server/src/main/java/org/candlepin/pinsetter/core/PinsetterKernel.java
+++ b/server/src/main/java/org/candlepin/pinsetter/core/PinsetterKernel.java
@@ -328,10 +328,12 @@ public class PinsetterKernel implements ModeChangeListener {
         }
         try {
             for (JobEntry jobentry : pendingJobs) {
+                //Trigger cron jobs with higher priority than async ( default 5 )
                 Trigger trigger = newTrigger()
                     .withIdentity(jobentry.getJobName(), CRON_GROUP)
                     .withSchedule(cronSchedule(jobentry.getSchedule())
-                        .withMisfireHandlingInstructionDoNothing())
+                    .withMisfireHandlingInstructionDoNothing())
+                    .withPriority(7)
                     .build();
 
                 scheduleJob(
@@ -350,10 +352,12 @@ public class PinsetterKernel implements ModeChangeListener {
         throws PinsetterException {
 
         try {
+            //Trigger cron jobs with higher priority than async ( default 5 )
             Trigger trigger = newTrigger()
                 .withIdentity(job.getName(), CRON_GROUP)
                 .withSchedule(cronSchedule(crontab)
-                    .withMisfireHandlingInstructionDoNothing())
+                .withMisfireHandlingInstructionDoNothing())
+                .withPriority(7)
                 .build();
 
             scheduleJob(job, jobName, trigger);


### PR DESCRIPTION
To test PR:
* pause scheduler by making REST request:
POST https://localhost:8443/candlepin/jobs/scheduler ( request body: "false" )
* make any async job request :
curl -X PUT  -k -u admin:admin  "https://localhost:8443/candlepin/owners/admin/subscriptions" 

then use following sql to verify appropriate priorities:

> candlepin=# select distinct priority, trigger_group from qrtz_triggers;
 priority | trigger_group 
----------+---------------
        5 | async group
        7 | cron group

@