### PR TITLE
Add -q option when checking for database existence.

### DIFF
--- a/bin/bash_functions
+++ b/bin/bash_functions
@@ -134,7 +134,7 @@ recreate_postgresql() {
      export PGPASSWORD="$DBPASSWORD"
     fi
     # Check if candlepin db exists and drop it if so:
-    if [[ `psql -h $db_host -U $db_user -tAc "SELECT 1 FROM pg_database WHERE datname='$db_name'"` == "1" ]]; then
+    if [[ `psql -h $db_host -U $db_user -q -tAc "SELECT 1 FROM pg_database WHERE datname='$db_name'"` == "1" ]]; then
         info_msg "Database '$db_name' exists.  Dropping it."
         dropdb -h $db_host -w -U "$db_user" "$db_name"
     fi


### PR DESCRIPTION
Newer versions of PostgreSQL print out informational messages when psql
is invoked.  For example, if a user has "\pset pager off" set in their
.psqlrc file, the psql command will print a notice about this setting to
stdout.  This notice causes the conditional we use to check to see
whether the candlepin database exists or not to fail.  Consequently, the
database is not dropped and the subsequent createdb command fails since
the database already exists.  The -q option suppresses these
informational messages.