### PR TITLE
 [2.0] 1514472: entitlements are regenerated on content change of provided products

### DIFF
--- a/server/client/ruby/hostedtest_api.rb
+++ b/server/client/ruby/hostedtest_api.rb
@@ -205,7 +205,7 @@ module HostedTest
   # to update the upstream entity.
   #
   # input may be either a subscription or a pool, and there is no output
-  def update_pool_or_subscription(subOrPool)
+  def update_pool_or_subscription(subOrPool, refresh=true)
     if is_hosted?
       ensure_hostedtest_resource
       update_hostedtest_subscription(subOrPool)
@@ -214,7 +214,7 @@ module HostedTest
         when Date then subOrPool.startDate+1
         else raise "invalid date format"
       end
-      @cp.refresh_pools(subOrPool['owner']['key'], true)
+      @cp.refresh_pools(subOrPool['owner']['key'], true) if refresh
       sleep 1
     else
       @cp.update_pool(subOrPool['owner']['key'], subOrPool)

--- a/server/spec/client_v1_size_spec.rb
+++ b/server/spec/client_v1_size_spec.rb
@@ -33,7 +33,8 @@ describe 'Entitlement Certificate V1 Size' do
 
   after(:each) do
     @content_list.each do |content|
-      @cp.delete_content(@owner['key'], content.id)
+      # cant delete content in hosted mode as its locked
+      @cp.delete_content(@owner['key'], content.id) unless is_hosted?
     end
   end
 

--- a/server/spec/owner_content_resource_spec.rb
+++ b/server/spec/owner_content_resource_spec.rb
@@ -109,6 +109,8 @@ describe 'Owner Content Resource' do
   end
 
   it 'should force entitlements providing changed content to be regenerated' do
+    # tests standalone mode specific API. in hosted, we refresh, so this test is captured in refresh spec.
+    skip("candlepin running in hosted mode") if is_hosted?
     product_pool = create_pool_and_subscription(@owner['key'], @product.id, 100, [], '1888', '1234')
     consumer_client = consumer_client(@user,  random_string("consumer"))
 

--- a/server/spec/refresh_pools_spec.rb
+++ b/server/spec/refresh_pools_spec.rb
@@ -7,6 +7,7 @@ require 'rest_client'
 describe 'Refresh Pools' do
   include CandlepinMethods
   include VirtHelper
+  include CertificateMethods
 
   before(:each) do
     skip("candlepin running in standalone mode") unless is_hosted?
@@ -294,4 +295,255 @@ describe 'Refresh Pools' do
     pools.length.should == 1
   end
 
+  def concat_serials(normal_ent, bonus_ent)
+    normal_serial = normal_ent['certificates'][0]['serial']['id']
+    bonus_serial = bonus_ent['certificates'][0]['serial']['id']
+    'normalEnt:' + normal_serial.to_s + '::bonusEnt:' + bonus_serial.to_s
+  end
+
+  def test_entitlement_regeneration
+    @owner = create_owner random_string('test_owner')
+    @product = create_product(nil, nil, :attributes =>
+                {:version => '6.4',
+                 :arch => 'i386, x86_64',
+                 :sockets => 4,
+                 :cores => 8,
+                 :ram => 16,
+                 :warning_period => 15,
+                 :management_enabled => true,
+                 :stacking_id => '8888',
+		 :virt_limit => "unlimited",
+		 :host_limited => "true",
+                 :virt_only => 'false',
+                 :support_level => 'standard',
+                 :support_type => 'excellent',})
+
+    @provided_product = create_product(nil, nil, :attributes =>
+                {:version => '6.4',
+                 :arch => 'i386, x86_64',
+                 :sockets => 4,
+                 :cores => 8,
+                 :ram => 16,
+                 :warning_period => 15,
+                 :management_enabled => true,
+                 :stacking_id => '8888',
+                 :virt_only => 'false',
+                 :support_level => 'standard',
+                 :support_type => 'excellent',})
+
+    @derived_provided_product = create_product(nil, nil, :attributes =>
+                {:version => '6.4',
+                 :arch => 'i386, x86_64',
+                 :sockets => 4,
+                 :cores => 8,
+                 :ram => 16,
+                 :warning_period => 15,
+                 :management_enabled => true,
+                 :stacking_id => '8888',
+                 :virt_only => 'false',
+                 :support_level => 'standard',
+                 :support_type => 'excellent',})
+
+    @derived_product = create_product(nil, "derived product 1", {
+      :attributes => {
+          :cores => 2,
+          :sockets => 4
+      }
+    })
+
+    @content = create_content({:gpg_url => 'gpg_url',
+                               :content_url => '/content/dist/rhel/$releasever/$basearch/os',
+                               :metadata_expire => 6400,
+                               :required_tags => 'TAG1,TAG2',})
+
+    @content2 = create_content({:gpg_url => 'gpg_url',
+                               :content_url => '/content/dist/rhel/$releasever/$basearch/os',
+                               :metadata_expire => 6400,
+                               :required_tags => 'TAG1,TAG2',})
+
+    @content3 = create_content({:gpg_url => 'gpg_url',
+                               :content_url => '/content/dist/rhel/$releasever/$basearch/os',
+                               :metadata_expire => 6400,
+                               :required_tags => 'TAG1,TAG2',})
+
+    @cp.add_content_to_product(@owner['key'], @product.id, @content.id, false)
+    @cp.add_content_to_product(@owner['key'], @provided_product.id, @content2.id, false)
+    @cp.add_content_to_product(@owner['key'], @derived_provided_product.id, @content3.id, false)
+
+    @pool = create_pool_and_subscription(@owner['key'], @product.id, 10, [@provided_product.id],
+					 '12345', '6789', 'order1', nil, nil, false,
+					 {:derived_product_id => @derived_product['id'],
+                                          :derived_provided_products => [@derived_provided_product.id]
+                                         })
+    sub = get_hostedtest_subscription(@pool['subscriptionId'])
+
+    @bonus_pool = @cp.list_owner_pools(@owner['key']).select {|p| p['type'] == 'UNMAPPED_GUEST' }[0]
+
+    # create an entitlement with a product and content
+    @user = user_client(@owner, random_string('billy'))
+    @system = consumer_client(@user, random_string('system1'), :system, nil,
+                {'system.certificate_version' => '3.3',
+                 'uname.machine' => 'i386'})
+    @guest = consumer_client(@user, 'virty', :system, nil, {
+      'virt.is_guest' => true,
+      'system.certificate_version' => '3.3'
+    })
+
+    entitlement = @system.consume_pool(@pool['id'], {:quantity => 1})[0]
+    bonus_entitlement = @guest.consume_pool(@bonus_pool['id'], {:quantity => 1})[0]
+
+    json_body = extract_payload(entitlement['certificates'][0]['cert'])
+    bonus_json_body = extract_payload(bonus_entitlement['certificates'][0]['cert'])
+
+    serial_concat = concat_serials(entitlement, bonus_entitlement)
+
+    # verify serial does not change on simple refresh
+    @cp.refresh_pools(@owner['key'], false, false, false)
+    entitlement =  @cp.get_entitlement(entitlement['id'])
+    bonus_entitlement =  @cp.get_entitlement(bonus_entitlement['id'])
+
+    concat_serials(entitlement, bonus_entitlement).should == serial_concat
+
+    # modify sub object, update upstream sub but dont refresh
+    sub = yield(sub, @owner)
+    update_pool_or_subscription(sub, false)
+
+    # verify serial does not change on content update request that does not regenerate cert
+    entitlement =  @cp.get_entitlement(entitlement['id'])
+    bonus_entitlement =  @cp.get_entitlement(bonus_entitlement['id'])
+    concat_serials(entitlement, bonus_entitlement).should == serial_concat
+    # this time when we refresh, serial should change
+    @cp.refresh_pools(@owner['key'], false, false, false)
+    entitlement =  @cp.get_entitlement(entitlement['id'])
+    bonus_entitlement =  @cp.get_entitlement(bonus_entitlement['id'])
+    concat_serials(entitlement, bonus_entitlement).should_not == serial_concat
+    json_body = extract_payload(entitlement['certificates'][0]['cert'])
+    return json_body, @product
+  end
+
+  it 'regenerates entitlements when modifiedProductIds of content change' do
+    test_entitlement_regeneration { |sub, owner|
+      prod_id_2 = random_string('modifying_prod')
+      create_product(prod_id_2, prod_id_2, {
+        :owner => owner['key']
+      })
+      sub['product']['productContent'][0]['content']['modifiedProductIds'] = [prod_id_2]
+      sub
+    }
+  end
+
+  it 'regenerates entitlements when modifiedProductIds of content of a provided product change' do
+    test_entitlement_regeneration { |sub, owner|
+      prod_id_2 = random_string('modifying_prod')
+      create_product(prod_id_2, prod_id_2, {
+        :owner => owner['key']
+      })
+      sub['providedProducts'][0]['productContent'][0]['content']['modifiedProductIds'] = [prod_id_2]
+      sub
+    }
+  end
+
+  it 'regenerates entitlements when modifiedProductIds of content of a derived provided product change' do
+    test_entitlement_regeneration { |sub, owner|
+      prod_id_2 = random_string('modifying_prod')
+      create_product(prod_id_2, prod_id_2, {
+        :owner => owner['key']
+      })
+      sub['derivedProvidedProducts'][0]['productContent'][0]['content']['modifiedProductIds'] = [prod_id_2]
+      sub
+    }
+  end
+
+  it 'regenerates entitlements when provided product is added' do
+    pp_name = random_string('pp_name')
+    pp_id = random_string(nil, true)
+    json_body, main_product = test_entitlement_regeneration { |sub, owner|
+      pp = create_product(pp_id, pp_name, {:attributes =>
+                  {:version => '6.4',
+                   :arch => 'i386, x86_64',
+                   :sockets => 4,
+                   :cores => 8,
+                   :ram => 16,
+                   :warning_period => 15,
+                   :management_enabled => true,
+                   :stacking_id => '8888',
+                   :virt_only => 'false',
+                   :support_level => 'standard',
+                   :support_type => 'excellent',}, :owner => owner['key']})
+      pp_content = create_content({:gpg_url => 'gpg_url',
+                   :content_url => '/content/dist/rhel/$releasever/$basearch/os',
+                   :metadata_expire => 6400,
+                   :required_tags => 'TAG1,TAG2',})
+      pp['productContent'] = [{'content' => pp_content, 'enabled' => 'true'}]
+      sub['providedProducts'].push(pp)
+      sub
+    }
+    pp = json_body['products'].find {|p| p['id'] == pp_id}
+    pp['name'].should == pp_name
+  end
+
+  it 'regenerates entitlements when provided product is removed' do
+    json_body, main_product = test_entitlement_regeneration { |sub, owner|
+      sub['providedProducts'] = []
+      sub
+    }
+    json_body['products'].size.should == 1
+  end
+
+  it 'regenerates entitlements when label of a content changes' do
+    json_body, main_product = test_entitlement_regeneration { |sub, owner|
+      sub['product']['productContent'][0]['content']['label'] = 'shakeItOff'
+      sub
+    }
+    product_json = json_body['products'].find {|p| p['id'] == main_product['id']}
+    product_json['content'][0]['label'].should == 'shakeItOff'
+  end
+
+  it 'regenerates entitlements when releaseVer of a content changes' do
+    test_entitlement_regeneration { |sub|
+      sub['product']['productContent'][0]['content']['releaseVer'] = 'badBlood'
+      sub
+    }
+    # releasever is not in json
+  end
+
+  it 'regenerates entitlements when vendor of a content changes' do
+    json_body, main_product = test_entitlement_regeneration { |sub|
+      sub['product']['productContent'][0]['content']['vendor'] = 'blankSpace'
+      sub
+    }
+    product_json = json_body['products'].find {|p| p['id'] == main_product['id']}
+    product_json['content'][0]['vendor'].should == 'blankSpace'
+  end
+
+  it 'regenerates entitlements when adding a content' do
+    json_body, main_product = test_entitlement_regeneration { |sub|
+      productContent =
+        { "content"=>{ "created"=>"2017-11-24T13:41:39+0000",
+		       "updated"=>"2017-11-24T13:41:39+0000",
+		       "uuid"=>"theStroyOfUs",
+		       "id"=>"twentyTwo",
+		       "type"=>"yum",
+		       "label"=>"teardropsOnMyGuitar",
+		       "name"=>"swiftrocks",
+		       "vendor"=>"fifteen",
+		       "releaseVer"=>nil},
+          "enabled"=>true }
+
+      sub['product']['productContent'].push(productContent)
+      sub
+    }
+    product_json = json_body['products'].find {|p| p['id'] == main_product['id']}
+    content = product_json['content'].find {|c| c['id'] == 'twentyTwo'}
+    content['name'].should == 'swiftrocks'
+  end
+
+  it 'regenerates entitlements when deleting a content' do
+    json_body, main_product = test_entitlement_regeneration { |sub|
+      sub['product']['productContent'] = []
+      sub
+    }
+    product_json = json_body['products'].find {|p| p['id'] == main_product['id']}
+    product_json['content'].should == []
+  end
 end

--- a/server/src/main/java/org/candlepin/hostedtest/HostedTestSubscriptionResource.java
+++ b/server/src/main/java/org/candlepin/hostedtest/HostedTestSubscriptionResource.java
@@ -119,7 +119,7 @@ public class HostedTestSubscriptionResource {
         if (subscription.getId() == null || subscription.getId().trim().length() == 0) {
             subscription.setId(this.idGenerator.generateId());
         }
-        return adapter.createSubscription(resolverUtil.resolveSubscription(subscription));
+        return adapter.createSubscription(resolverUtil.resolveSubscriptionAndProduct(subscription));
     }
 
     /**
@@ -212,10 +212,10 @@ public class HostedTestSubscriptionResource {
         for (Entry<String, Boolean> entry : contentMap.entrySet()) {
             Content content = this.fetchContent(owner, entry.getKey());
             productContent.add(new ProductContent(product, content, entry.getValue()));
+            addContentToUpstreamSubscriptions(product, content, entry.getValue());
         }
 
         return this.productManager.addContentToProduct(product, productContent, owner, true);
-
     }
 
     @POST
@@ -240,8 +240,17 @@ public class HostedTestSubscriptionResource {
             product, Arrays.asList(new ProductContent(product, content, enabled)), owner, true
         );
 
+        addContentToUpstreamSubscriptions(product, content, enabled);
         return product.toDTO();
+    }
 
+    private void addContentToUpstreamSubscriptions(Product product, Content content, boolean enabled) {
+        List<Subscription> subs = adapter.getSubscriptions(product.toDTO());
+        for (Subscription sub: subs) {
+            if (sub.getProduct().getId().contentEquals(product.getId())) {
+                sub.getProduct().addContent(content, enabled);
+            }
+        }
     }
 
     @PUT

--- a/server/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
@@ -548,6 +548,19 @@ public class PoolRules {
         return incomingProvided;
     }
 
+    private boolean changedProductsInSet(Set<Product> products, Map<String, Product> changedProducts) {
+
+        if (products != null && changedProducts != null) {
+            for (Product product : products) {
+                if (product != null && changedProducts.get(product.getId()) != null) {
+                    return true;
+                }
+            }
+
+        }
+        return false;
+    }
+
     private boolean checkForChangedProducts(Product incomingProduct, Set<Product> incomingProvided,
         Pool existingPool, Map<String, Product> changedProducts) {
 
@@ -562,8 +575,12 @@ public class PoolRules {
             !currentProvided.equals(incomingProvided);
 
         // Check if the existing product is in the set of changed products
-        if (!productsChanged && changedProducts != null && pid != null) {
-            productsChanged = (changedProducts.get(pid) != null);
+        if (!productsChanged && changedProducts != null) {
+            if (pid != null) {
+                productsChanged = (changedProducts.get(pid) != null);
+            }
+            productsChanged = productsChanged ||
+                changedProductsInSet(incomingProvided, changedProducts);
         }
 
         if (productsChanged) {
@@ -582,7 +599,7 @@ public class PoolRules {
             productsChanged = !pool.getDerivedProduct().getId()
                 .equals(existingPool.getDerivedProduct().getId());
 
-            productsChanged = productsChanged ||
+            productsChanged |=
                 (changedProducts != null && changedProducts.containsKey(pool.getDerivedProduct().getId()));
         }
 
@@ -600,7 +617,8 @@ public class PoolRules {
             }
         }
 
-        productsChanged = productsChanged || !currentProvided.equals(incomingProvided);
+        productsChanged |= !currentProvided.equals(incomingProvided) ||
+            changedProductsInSet(incomingProvided, changedProducts);
 
         if (productsChanged) {
             // 998317: NPE during refresh causes refresh to abort.

--- a/server/src/main/java/org/candlepin/resource/util/ResolverUtil.java
+++ b/server/src/main/java/org/candlepin/resource/util/ResolverUtil.java
@@ -190,9 +190,8 @@ public class ResolverUtil {
     public Subscription resolveSubscription(Subscription subscription) {
         // Impl note:
         // We don't check that the subscription exists here, because it's
-        // entirely possible that it
-        // doesn't (i.e. during creation). We just need to make sure it's not
-        // null.
+        // entirely possible that it doesn't (i.e. during creation). We just
+        // need to make sure it's not null.
         if (subscription == null) {
             throw new BadRequestException(i18n.tr("No subscription specified"));
         }
@@ -213,6 +212,52 @@ public class ResolverUtil {
             this.validateProductData(product, owner, true);
         }
 
+        // TODO: Do we need to resolve Branding objects?
+
+        return subscription;
+    }
+
+    /**
+     * used to resolve subscription but it resolves the product too.
+     * currently used in hostedtest resources
+     * @param subscription
+     * @return the resolved subscription
+     */
+    public Subscription resolveSubscriptionAndProduct(Subscription subscription) {
+        // Impl note:
+        // We don't check that the subscription exists here, because it's
+        // entirely possible that it doesn't (i.e. during creation).
+        // We just need to make sure it's not null.
+        if (subscription == null) {
+            throw new BadRequestException(i18n.tr("No subscription specified"));
+        }
+
+        // Ensure the owner is set and is valid
+        Owner owner = this.resolveOwner(subscription.getOwner());
+        subscription.setOwner(owner);
+
+        subscription.setProduct(
+            new ProductData(this.resolveProduct(owner, subscription.getProduct().getId())));
+        if (subscription.getDerivedProduct() != null) {
+            ProductData p = new ProductData(
+                this.resolveProduct(owner, subscription.getDerivedProduct().getId()));
+            subscription.setDerivedProduct(p);
+        }
+
+        HashSet<ProductData> providedProducts = new HashSet<ProductData>();
+        for (ProductData product : subscription.getProvidedProducts()) {
+            if (product != null) {
+                providedProducts.add(new ProductData(this.resolveProduct(owner, product.getId())));
+            }
+        }
+        subscription.setProvidedProducts(providedProducts);
+        HashSet<ProductData> derivedProvidedProducts = new HashSet<ProductData>();
+        for (ProductData product : subscription.getDerivedProvidedProducts()) {
+            if (product != null) {
+                derivedProvidedProducts.add(new ProductData(this.resolveProduct(owner, product.getId())));
+            }
+        }
+        subscription.setDerivedProvidedProducts(derivedProvidedProducts);
         // TODO: Do we need to resolve Branding objects?
 
         return subscription;


### PR DESCRIPTION
 1514472: entitlements are regenerated on content change of provided products

* a previous commit had changed subscription resolution to no longer resolve product or content,
  this change undoes that so we can test this.
* added the spec test to test that refresh after content and product change does indeed regenerate ent