### PR TITLE
[2.1] 1514483: entitlements are regenerated on content change of provided products

### DIFF
--- a/server/client/ruby/hostedtest_api.rb
+++ b/server/client/ruby/hostedtest_api.rb
@@ -208,7 +208,7 @@ module HostedTest
   # to update the upstream entity.
   #
   # input may be either a subscription or a pool, and there is no output
-  def update_pool_or_subscription(subOrPool)
+  def update_pool_or_subscription(subOrPool, refresh=true)
     if is_hosted?
       ensure_hostedtest_resource
       update_hostedtest_subscription(subOrPool)
@@ -217,7 +217,7 @@ module HostedTest
         when Date then subOrPool.startDate+1
         else raise "invalid date format"
       end
-      @cp.refresh_pools(subOrPool['owner']['key'], true)
+      @cp.refresh_pools(subOrPool['owner']['key'], true) if refresh
       sleep 1
     else
       @cp.update_pool(subOrPool['owner']['key'], subOrPool)

--- a/server/spec/client_v1_size_spec.rb
+++ b/server/spec/client_v1_size_spec.rb
@@ -33,7 +33,8 @@ describe 'Entitlement Certificate V1 Size' do
 
   after(:each) do
     @content_list.each do |content|
-      @cp.delete_content(@owner['key'], content.id)
+      # cant delete content in hosted mode as its locked
+      @cp.delete_content(@owner['key'], content.id) unless is_hosted?
     end
   end
 

--- a/server/spec/owner_content_resource_spec.rb
+++ b/server/spec/owner_content_resource_spec.rb
@@ -109,6 +109,8 @@ describe 'Owner Content Resource' do
   end
 
   it 'should force entitlements providing changed content to be regenerated' do
+    # tests standalone mode specific API. in hosted, we refresh, so this test is captured in refresh spec.
+    skip("candlepin running in hosted mode") if is_hosted?
     product_pool = create_pool_and_subscription(@owner['key'], @product.id, 100, [], '1888', '1234')
     consumer_client = consumer_client(@user,  random_string("consumer"))
 

--- a/server/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
@@ -547,6 +547,19 @@ public class PoolRules {
         return incomingProvided;
     }
 
+    private boolean changedProductsInSet(Set<Product> products, Map<String, Product> changedProducts) {
+
+        if (products != null && changedProducts != null) {
+            for (Product product : products) {
+                if (product != null && changedProducts.get(product.getId()) != null) {
+                    return true;
+                }
+            }
+
+        }
+        return false;
+    }
+
     private boolean checkForChangedProducts(Product incomingProduct, Set<Product> incomingProvided,
         Pool existingPool, Map<String, Product> changedProducts) {
 
@@ -561,8 +574,12 @@ public class PoolRules {
             !currentProvided.equals(incomingProvided);
 
         // Check if the existing product is in the set of changed products
-        if (!productsChanged && changedProducts != null && pid != null) {
-            productsChanged = (changedProducts.get(pid) != null);
+        if (!productsChanged && changedProducts != null) {
+            if (pid != null) {
+                productsChanged = (changedProducts.get(pid) != null);
+            }
+            productsChanged = productsChanged ||
+                changedProductsInSet(incomingProvided, changedProducts);
         }
 
         if (productsChanged) {
@@ -581,7 +598,7 @@ public class PoolRules {
             productsChanged = !pool.getDerivedProduct().getId()
                 .equals(existingPool.getDerivedProduct().getId());
 
-            productsChanged = productsChanged ||
+            productsChanged |=
                 (changedProducts != null && changedProducts.containsKey(pool.getDerivedProduct().getId()));
         }
 
@@ -599,7 +616,8 @@ public class PoolRules {
             }
         }
 
-        productsChanged = productsChanged || !currentProvided.equals(incomingProvided);
+        productsChanged |= !currentProvided.equals(incomingProvided) ||
+            changedProductsInSet(incomingProvided, changedProducts);
 
         if (productsChanged) {
             // 998317: NPE during refresh causes refresh to abort.

--- a/server/src/main/java/org/candlepin/resource/util/ResolverUtil.java
+++ b/server/src/main/java/org/candlepin/resource/util/ResolverUtil.java
@@ -190,9 +190,8 @@ public class ResolverUtil {
     public Subscription resolveSubscription(Subscription subscription) {
         // Impl note:
         // We don't check that the subscription exists here, because it's
-        // entirely possible that it
-        // doesn't (i.e. during creation). We just need to make sure it's not
-        // null.
+        // entirely possible that it doesn't (i.e. during creation). We just
+        // need to make sure it's not null.
         if (subscription == null) {
             throw new BadRequestException(i18n.tr("No subscription specified"));
         }
@@ -213,6 +212,52 @@ public class ResolverUtil {
             this.validateProductData(product, owner, true);
         }
 
+        // TODO: Do we need to resolve Branding objects?
+
+        return subscription;
+    }
+
+    /**
+     * used to resolve subscription but it resolves the product too.
+     * currently used in hostedtest resources
+     * @param subscription
+     * @return the resolved subscription
+     */
+    public Subscription resolveSubscriptionAndProduct(Subscription subscription) {
+        // Impl note:
+        // We don't check that the subscription exists here, because it's
+        // entirely possible that it doesn't (i.e. during creation).
+        // We just need to make sure it's not null.
+        if (subscription == null) {
+            throw new BadRequestException(i18n.tr("No subscription specified"));
+        }
+
+        // Ensure the owner is set and is valid
+        Owner owner = this.resolveOwner(subscription.getOwner());
+        subscription.setOwner(owner);
+
+        subscription.setProduct(
+            new ProductData(this.resolveProduct(owner, subscription.getProduct().getId())));
+        if (subscription.getDerivedProduct() != null) {
+            ProductData p = new ProductData(
+                this.resolveProduct(owner, subscription.getDerivedProduct().getId()));
+            subscription.setDerivedProduct(p);
+        }
+
+        HashSet<ProductData> providedProducts = new HashSet<ProductData>();
+        for (ProductData product : subscription.getProvidedProducts()) {
+            if (product != null) {
+                providedProducts.add(new ProductData(this.resolveProduct(owner, product.getId())));
+            }
+        }
+        subscription.setProvidedProducts(providedProducts);
+        HashSet<ProductData> derivedProvidedProducts = new HashSet<ProductData>();
+        for (ProductData product : subscription.getDerivedProvidedProducts()) {
+            if (product != null) {
+                derivedProvidedProducts.add(new ProductData(this.resolveProduct(owner, product.getId())));
+            }
+        }
+        subscription.setDerivedProvidedProducts(derivedProvidedProducts);
         // TODO: Do we need to resolve Branding objects?
 
         return subscription;


### PR DESCRIPTION
 1514483: entitlements are regenerated on content change of provided products

* a previous commit had changed subscription resolution to no longer resolve product or content,
  this change undoes that so we can test this.
* added the spec test to test that refresh after content and product change does indeed regenerate ent