### PR TITLE
Update rubyzip usage in manifest_manipulator.rb

### DIFF
--- a/server/bin/cmv
+++ b/server/bin/cmv
@@ -5,8 +5,8 @@
 require 'optparse'
 require 'set'
 require 'tempfile'
-require 'zip/zip'
-require 'zip/zipfilesystem'
+require 'zip'
+require 'zip/filesystem'
 
 require File.expand_path('candlepin_api', File.dirname(__FILE__) + '/../client/ruby')
 
@@ -176,7 +176,7 @@ class SnapshotCommand < CMVCommand
             raise "Cannot write to snapshot file: #{options[:file]}"
         end
 
-        Zip::ZipOutputStream.open(options[:file]) do |zos|
+        Zip::OutputStream.open(options[:file]) do |zos|
             puts "Compiling snapshot..."
 
             self.get_deployment_data(candlepin, orgs) do |obj_path, zip_path, data|
@@ -257,7 +257,7 @@ class VerifyCommand < CMVCommand
             raise "Cannot read from snapshot file: #{options[:file]}"
         end
 
-        snapshot = Zip::ZipFile.open(options[:file])
+        snapshot = Zip::File.open(options[:file])
         processed_files = Set.new
         messages = []
 

--- a/server/bin/manifest_manipulator.rb
+++ b/server/bin/manifest_manipulator.rb
@@ -2,7 +2,7 @@
 
 require 'optparse'
 require 'json'
-require 'zip/zip'
+require 'zip'
 
 require_relative "../client/ruby/candlepin_api"
 
@@ -58,7 +58,7 @@ end
 FileUtils.remove_dir("tmp") if File.exist?("tmp")
 FileUtils.remove_dir("tmpexport") if File.exist?("tmpexport")
 
-Zip::ZipFile.open(@input) { |zip_file|
+Zip::File.open(@input) { |zip_file|
     zip_file.each { |f|
     f_path=File.join("tmp", f.name)
     FileUtils.mkdir_p(File.dirname(f_path))
@@ -66,7 +66,7 @@ Zip::ZipFile.open(@input) { |zip_file|
     }
 }
 
-Zip::ZipFile.open(File.join("tmp", "consumer_export.zip")) { |zip_file|
+Zip::File.open(File.join("tmp", "consumer_export.zip")) { |zip_file|
     zip_file.each { |f|
     f_path=File.join("tmpexport", f.name)
     FileUtils.mkdir_p(File.dirname(f_path))
@@ -96,7 +96,7 @@ print_and_pause "About to create manifest archive..."
 recursive_path = File.join("tmpexport", "**", "**")
 updated_inner_zip = File.join("tmp", "updatedinner.zip")
 
-Zip::ZipFile::open(updated_inner_zip, Zip::ZipFile::CREATE) {
+Zip::File::open(updated_inner_zip, Zip::File::CREATE) {
   |zipfile|
   Dir[recursive_path].each do |file|
     if File.file?(file)
@@ -107,7 +107,7 @@ end
 
 #add the inner zip to a new manifest
 File.delete(@output) if File.exist?(@output)
-Zip::ZipFile::open(@output, Zip::ZipFile::CREATE) {
+Zip::File::open(@output, Zip::File::CREATE) {
   |zipfile|
    zipfile.add("consumer_export.zip", updated_inner_zip)
    zipfile.add("signature", File.join("tmp", "signature"))


### PR DESCRIPTION
I was having trouble getting this utility to generate a manifest which could be imported to Candlepin. It looks like the script is supporting an older version of the rubyzip gem and once I updated the script to support the version which I had installed, things started working for me.

```
[vagrant@centos7-devel candlepin]$ gem list rubyzip

*** LOCAL GEMS ***

rubyzip (1.2.1)
```

Before:

```
[vagrant@centos7-devel candlepin]$ ./server/bin/manifest_manipulator.rb 
/home/vagrant/.rvm/rubies/ruby-2.2.4/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:55:in `require': cannot load such file -- zip/zip (LoadError)
        from /home/vagrant/.rvm/rubies/ruby-2.2.4/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from ./server/bin/manifest_manipulator.rb:5:in `<main>'
```

After:
```
[vagrant@centos7-devel candlepin]$ ./server/bin/manifest_manipulator.rb 
Usage: manifest_manipulator -i [FILE] -o [FILE] [[-k|--key] OWNER_KEY] [-p|--pause]
    -i, --input [FILE]               The input manifest to manipulate.
    -o, --output [FILE]              The name of the resulting manifest.
    -k, --key [OWNER_KEY]            import the resulting manifest to an owner
    -p, --pause                      interactive run, pause at every step
    -g, --goldenticket               make this a Golden Ticket manifest
    -h, --help 
```

Up to you whether this is a valuable change or not :)