### PR TITLE
1515093: Set the KeyPair object to lazy load.

### DIFF
--- a/server/src/main/java/org/candlepin/model/Consumer.java
+++ b/server/src/main/java/org/candlepin/model/Consumer.java
@@ -175,7 +175,7 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
     @JsonDeserialize(contentConverter = StringTrimmingConverter.class)
     private Map<String, String> facts;
 
-    @OneToOne(cascade = CascadeType.ALL)
+    @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private KeyPair keyPair;
 
     private Date lastCheckin;


### PR DESCRIPTION
Joining on the cp_key_pair table can take hundreds of milliseconds in
tables with many rows.  The KeyPair object is not even used in most
cases, so switching it to lazy loading will shave some time off our
queries at the expense of an additional query in the cases where we
actually need the KeyPair.