### PR TITLE
Update zanata URL (0.9.51)

### DIFF
--- a/common/po/zanata.xml
+++ b/common/po/zanata.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <config xmlns="http://zanata.org/namespace/config/">
-    <url>https://translate.zanata.org/zanata/</url>
+    <url>https://vendors.zanata.redhat.com/</url>
     <project>candlepin</project>
-    <project-version>master</project-version>
+    <project-version>candlepin-0.9.51-HOTFIX</project-version>
     <project-type>gettext</project-type>
     <locales>
         <locale>as</locale>


### PR DESCRIPTION
We're now using a different zanata instance for translations.
Also set the version to candlepin-0.9.51-HOTFIX