### PR TITLE
[2.1] 1499001: Fixed parameter limit issues with PoolCurator.listBySourceEntitlements

### DIFF
--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -1718,18 +1718,21 @@ public class CandlepinPoolManager implements PoolManager {
     @Traceable
     public void revokeEntitlements(List<Entitlement> entsToRevoke, Set<String> alreadyDeletedPools,
         boolean regenCertsAndStatuses) {
-        if (log.isDebugEnabled()) {
-            log.debug("Starting batch revoke of entitlements: {}", getEntIds(entsToRevoke));
-        }
 
         if (CollectionUtils.isEmpty(entsToRevoke)) {
             return;
         }
 
-        List<Pool> poolsToDelete = poolCurator.listBySourceEntitlements(entsToRevoke);
-        if (log.isDebugEnabled()) {
-            log.debug("Found additional pools to delete by source entitlements: {}",
-                getPoolIds(poolsToDelete));
+        log.debug("Starting batch revoke of {} entitlements", entsToRevoke.size());
+        if (log.isTraceEnabled()) {
+            log.trace("Entitlements IDs: {}", getEntIds(entsToRevoke));
+        }
+
+        Set<Pool> poolsToDelete = this.poolCurator.listBySourceEntitlements(entsToRevoke);
+
+        log.debug("Found {} additional pools to delete from source entitlements", poolsToDelete.size());
+        if (log.isTraceEnabled()) {
+            log.trace("Additional pool IDs: {}", getPoolIds(poolsToDelete));
         }
 
         List<Pool> poolsToLock = new ArrayList<Pool>();
@@ -1746,7 +1749,7 @@ public class CandlepinPoolManager implements PoolManager {
         }
 
         poolCurator.lockAndLoad(poolsToLock);
-        log.info("Batch revoking {} entitlements ", entsToRevoke.size());
+        log.info("Batch revoking {} entitlements", entsToRevoke.size());
         entsToRevoke = new ArrayList<Entitlement>(entsToRevoke);
 
         for (Pool pool : poolsToDelete) {

--- a/server/src/main/java/org/candlepin/model/ConsumerCurator.java
+++ b/server/src/main/java/org/candlepin/model/ConsumerCurator.java
@@ -514,6 +514,7 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
         if (guestId == null) {
             return null;
         }
+
         String guestLower = guestId.toLowerCase();
         if (cachedHosts.containsKey(guestLower)) {
             return cachedHosts.get(guestLower);

--- a/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -1032,7 +1032,8 @@ public class PoolManagerTest {
 
         List<Pool> poolsWithSource = createPoolsWithSourceEntitlement(e, product);
         poolsWithSource.get(0).getEntitlements().add(e3);
-        when(mockPoolCurator.listBySourceEntitlements(entsToDelete)).thenReturn(poolsWithSource);
+        Set<Pool> poolsWithSourceAsSet = new HashSet<Pool>(poolsWithSource);
+        when(mockPoolCurator.listBySourceEntitlements(entsToDelete)).thenReturn(poolsWithSourceAsSet);
 
         PreUnbindHelper preHelper = mock(PreUnbindHelper.class);
         ValidationResult result = new ValidationResult();
@@ -1046,7 +1047,7 @@ public class PoolManagerTest {
         manager.revokeEntitlements(entsToDelete);
         entsToDelete.add(e3);
         verify(entitlementCurator).batchDelete(eq(entsToDelete));
-        verify(mockPoolCurator).batchDelete(eq(poolsWithSource), anySetOf(String.class));
+        verify(mockPoolCurator).batchDelete(eq(poolsWithSourceAsSet), anySetOf(String.class));
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })

--- a/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
@@ -714,7 +714,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         poolCurator.create(pool4);
         poolCurator.create(pool5);
 
-        List<Pool> pools = poolCurator.listBySourceEntitlements(Arrays.asList(e, e2));
+        Set<Pool> pools = poolCurator.listBySourceEntitlements(Arrays.asList(e, e2));
         assertEquals(3, pools.size());
     }
 


### PR DESCRIPTION
- PoolCurator.listBySourceEntitlements now de-duplicates pools and entitlements
  before returning or recursing
- Some debug statements in CandlepinPoolManager are now trace statements, as
  their output was only useful in exceptional cases