### PR TITLE
Misc. validations on consumer registration. 

### DIFF
--- a/server/client/ruby/candlepin_api.rb
+++ b/server/client/ruby/candlepin_api.rb
@@ -78,7 +78,8 @@ class Candlepin
               owner_key=nil, activation_keys=[], installedProducts=[],
               environment=nil, capabilities=[], hypervisor_id=nil,
               content_tags=[], created_date=nil, last_checkin_date=nil,
-              annotations=nil, recipient_owner_key=nil, user_agent=nil)
+              annotations=nil, recipient_owner_key=nil, user_agent=nil,
+              entitlement_count=0, id_cert=nil)
 
     consumer = {
       :type => {:label => type},
@@ -95,6 +96,10 @@ class Candlepin
     consumer[:lastCheckin] = last_checkin_date if last_checkin_date
     consumer[:annotations] = annotations if annotations
     consumer[:recipientOwnerKey] = recipient_owner_key if recipient_owner_key
+
+    #note: ent count and id_cert are added to demonstrate erroneous input
+    consumer[:entitlementCount] = entitlement_count if entitlement_count
+    consumer[:idCert] = id_cert if id_cert
 
     params = {}
 

--- a/server/spec/consumer_resource_spec.rb
+++ b/server/spec/consumer_resource_spec.rb
@@ -20,6 +20,80 @@ describe 'Consumer Resource' do
     @consumer2 = consumer_client(@user2, random_string("consumer2"))
   end
 
+  it 'should not allow setting recipient owner on non share consumers' do
+    expect do
+      @user2.register(
+        random_string('orgBShare'),
+        :system,
+        nil,
+        {},
+        nil,
+        @owner2['key'],
+        [],
+        [],
+        nil,
+        [],
+        nil,
+        [],
+        nil,
+        nil,
+        nil,
+        @owner2['key'])
+    end.to raise_error(RestClient::BadRequest)
+  end
+
+  it 'should not allow setting entitlement count on register' do
+     consumer = @user2.register(
+        random_string('newConsumer'),
+        :system,
+        nil,
+        {},
+        nil,
+        @owner2['key'],
+        [],
+        [],
+        nil,
+        [],
+        nil,
+        [],
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+	3)
+     consumer['entitlementCount'].should == 0
+  end
+
+  it 'should not allow copying id cert to other consumers' do
+
+     consumer_old = @user2.register(random_string('consumer1'))
+     id_cert = consumer_old['idCert']
+
+     consumer = @user2.register(
+        random_string('newConsumer'),
+        :system,
+        nil,
+        {},
+        nil,
+        @owner2['key'],
+        [],
+        [],
+        nil,
+        [],
+        nil,
+        [],
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        0,
+        id_cert)
+
+     consumer['idCert'].should_not == id_cert
+  end
+
   it 'should receive paged data back when requested' do
     id_list = []
     (1..4).each do |i|

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -485,6 +485,20 @@ public class ConsumerResource {
         else {
             consumer.setCanActivate(subAdapter.canActivateSubscription(consumer));
             consumer.setAutoheal(true); // this is the default
+            if (StringUtils.isNotEmpty(consumer.getRecipientOwnerKey())) {
+                throw new BadRequestException(i18n.tr("Only share consumers can specify recipient owners"));
+            }
+        }
+
+        if (consumer.getEntitlementCount() != 0) {
+            log.warn("ignoring incoming entitlement count during register: {}",
+                consumer.getEntitlementCount());
+            consumer.setEntitlementCount(0);
+        }
+
+        if (consumer.getIdCert() != null) {
+            log.warn("ignoring incoming identity cert during register: {}", consumer.getIdCert());
+            consumer.setIdCert(null);
         }
 
         consumer.setOwner(owner);
@@ -617,7 +631,7 @@ public class ConsumerResource {
         if (!consumer.getReleaseVer().equals(new Release(null))) {
             throw new BadRequestException(i18n.tr("A unit type of \"share\" cannot have a release version"));
         }
-        if (!consumer.getInstalledProducts().isEmpty()) {
+        if (CollectionUtils.isNotEmpty(consumer.getInstalledProducts())) {
             throw new BadRequestException(i18n.tr("A unit type of \"share\" cannot have installed products"));
         }
         if (StringUtils.isNotBlank(consumer.getContentAccessMode())) {
@@ -730,8 +744,7 @@ public class ConsumerResource {
      * @param userName
      * @return a String object
      */
-    private String setUserName(Consumer consumer, Principal principal,
-        String userName) {
+    private String setUserName(Consumer consumer, Principal principal, String userName) {
         if (userName == null) {
             userName = principal.getUsername();
         }


### PR DESCRIPTION
found during DTO work, insignificant validations, committed separately to have an independent conversation


* in the create share consumer case if you don't provide and empty collection for installed products, we get an NPE. fixed now.
* today if you provide an id-cert in the POST register request, candlepin accepts it. this should not be allowed, each consumer should have a unique id cert generated by candlepin.
* today non-share consumers are allowed to specify recipient owners which does not make sense.
* we also accept entitlement count and persist it for some reason, intuitively that does not make sense.
