### PR TITLE
getting vagrant to work

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'stringex'
 gem 'digest-murmurhash'
 gem 'httpclient'
 gem 'activesupport', '~> 4.2'
-gem 'qpid_proton'
+gem 'qpid_proton', '~> 0.17.0'
 
 # Remove this once we are fully using the new Ruby bindings
 gem 'rest-client', '~> 1.6.0'

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   if Vagrant.has_plugin?("vagrant-hostmanager")
     config.hostmanager.enabled = true
     config.hostmanager.manage_host = true
-    config.hostmanager.manage_guest = true
+    config.hostmanager.manage_guest = false
     config.hostmanager.include_offline = true
   end
 

--- a/vagrant/roles/candlepin-user/tasks/main.yml
+++ b/vagrant/roles/candlepin-user/tasks/main.yml
@@ -7,21 +7,29 @@
   tags:
     - candlepin-user
 
-- name: Run Bundle install
-  command: /usr/local/bin/bundle install
-  args:
-      chdir: "{{candlepin_checkout}}"
+- name: Gem refreshing
+  command: gem update --system
   tags:
     - candlepin-user
-  ## TODO: new way whenever we want to switch to >= ansible-2.0.0 :
-  # - name: Run Bundle install
-  # bundler:
-  #   executable: /usr/local/bin/bundle
-  #   state: latest
-  #   user_install: true
-  #   chdir: "{{candlepin_checkout}}"
-  # tags:
-  #   - candlepin-user
+
+- name: Install gem dependencies
+  gem:
+    name: "{{item}}"
+    user_install: False
+  with_items:
+    - json_pure
+    - bundler
+  tags:
+    - candlepin-user
+
+- name: Run Bundle install
+  bundler:
+    executable: /usr/bin/bundle
+    state: latest
+    user_install: true
+    chdir: "{{candlepin_checkout}}"
+  tags:
+    - candlepin-user
 
 - name: Add JAVA_HOME to bashrc
   lineinfile:


### PR DESCRIPTION
The vagrant wasn't working.  Now it does.  Quick test is:
```
vagrant destroy
# faster than configuring nfs
CANDLEPIN_VAGRANT_NO_NFS='false' vagrant up
```

Fixes include:

- qpid_proton 1.18.x doesn't build due to a C compilation error, dropping to 1.17.0 - not sure what this effects, need input here.

- turned off guest management of vagrant's hostnamanger.  We don't actually need the guest to be managed and it was breaking dns resolution for many sites.

- Installing bundler and json_pure as both the candlepin user and root. Bundler will not install it if root has it (which we need for the executable), but then buildr fails because it cannot find the bundler gem.  Installing it in both places fixes this issue.  Open to better ideas.

- Using the bundler ansible module since it seems ansible 2 is the main thing now and it works a little faster.

Note:  If these changes to qpid are acceptable, I can merge this to the QE repos (which use the same ansible roles).  Currently spinning up of new candlepin servers is broken and this is blocking tests.
