### PR TITLE
[2.1] 1525204: Lock update consumer avoid to constraint violation with hypervi…

### DIFF
--- a/server/src/main/java/org/candlepin/model/Consumer.java
+++ b/server/src/main/java/org/candlepin/model/Consumer.java
@@ -148,7 +148,7 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
     @JoinColumn(name = "cont_acc_cert_id")
     private ContentAccessCertificate contentAccessCert;
 
-    @ManyToOne
+    @ManyToOne (fetch = FetchType.LAZY)
     @JoinColumn(nullable = false)
     @ForeignKey(name = "fk_consumer_consumer_type")
     private ConsumerType type;

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -1006,6 +1006,7 @@ public class ConsumerResource {
         @Context Principal principal) {
 
         Consumer toUpdate = consumerCurator.verifyAndLookupConsumer(uuid);
+        consumerCurator.lockAndLoad(toUpdate);
 
         VirtConsumerMap guestConsumerMap = new VirtConsumerMap();
         if (consumer.getGuestIds() != null) {

--- a/server/src/main/java/org/candlepin/sync/ConsumerExporter.java
+++ b/server/src/main/java/org/candlepin/sync/ConsumerExporter.java
@@ -15,6 +15,7 @@
 package org.candlepin.sync;
 
 import org.candlepin.model.Consumer;
+import org.candlepin.model.ConsumerType;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Inject;
@@ -33,8 +34,20 @@ public class ConsumerExporter {
 
     void export(ObjectMapper mapper, Writer writer, Consumer consumer,
         String weburl, String apiurl) throws IOException {
+
+        ConsumerType type = consumer.getType();
+        ConsumerType tdto = null;
+
+        if (type != null) {
+            tdto = new ConsumerType();
+
+            tdto.setId(type.getId());
+            tdto.setLabel(type.getLabel());
+            tdto.setManifest(type.isManifest());
+        }
+
         ConsumerDto dto = new ConsumerDto(consumer.getUuid(), consumer.getName(),
-            consumer.getType(), consumer.getOwner(), weburl, apiurl, consumer.getContentAccessMode());
+            tdto, consumer.getOwner(), weburl, apiurl, consumer.getContentAccessMode());
 
         mapper.writeValue(writer, dto);
     }


### PR DESCRIPTION
…sor checkin

To test, run the new spec test against 2.1 HOTFIX. You will be able to see the consumerUpdate failure.
The added locking will keep the violation from occurring.