### PR TITLE
[DTO] Implemented PoolDTO, EntitlementDTO and BrandingDTO

### DIFF
--- a/server/client/ruby/candlepin_api.rb
+++ b/server/client/ruby/candlepin_api.rb
@@ -1022,7 +1022,7 @@ class Candlepin
       'startDate' => start_date,
       'endDate'   => end_date,
       'quantity'  =>  quantity,
-      'product' => { 'id' => product_id },
+      'productId' => product_id,
       'providedProducts' => provided_products.collect { |pid| {'productId' => pid} }
     }
 
@@ -1043,13 +1043,12 @@ class Candlepin
     end
 
     if params[:derived_product_id]
-      pool['derivedProduct'] = { 'id' => params[:derived_product_id] }
+      pool['derivedProductId'] = params[:derived_product_id]
     end
 
     if params[:source_subscription]
-      pool['sourceSubscription'] = {}
-      pool['sourceSubscription']['subscriptionId'] = params[:source_subscription]['id']
-      pool['sourceSubscription']['subscriptionSubKey'] = 'master'
+      pool['subscriptionId'] = params[:source_subscription]['id']
+      pool['subscriptionSubKey'] = 'master'
     end
 
     if params[:derived_provided_products]

--- a/server/src/main/java/org/candlepin/dto/StandardTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/StandardTranslator.java
@@ -17,6 +17,8 @@ package org.candlepin.dto;
 import org.candlepin.audit.Event;
 import org.candlepin.dto.api.v1.ActivationKeyDTO;
 import org.candlepin.dto.api.v1.ActivationKeyTranslator;
+import org.candlepin.dto.api.v1.BrandingDTO;
+import org.candlepin.dto.api.v1.BrandingTranslator;
 import org.candlepin.dto.api.v1.CertificateDTO;
 import org.candlepin.dto.api.v1.CertificateSerialDTO;
 import org.candlepin.dto.api.v1.CertificateSerialTranslator;
@@ -27,19 +29,26 @@ import org.candlepin.dto.api.v1.ContentDTO;
 import org.candlepin.dto.api.v1.ContentTranslator;
 import org.candlepin.dto.api.v1.EventDTO;
 import org.candlepin.dto.api.v1.EventTranslator;
+import org.candlepin.dto.api.v1.EntitlementDTO;
+import org.candlepin.dto.api.v1.EntitlementTranslator;
 import org.candlepin.dto.api.v1.OwnerDTO;
 import org.candlepin.dto.api.v1.OwnerTranslator;
+import org.candlepin.dto.api.v1.PoolDTO;
+import org.candlepin.dto.api.v1.PoolTranslator;
 import org.candlepin.dto.api.v1.ProductDTO;
 import org.candlepin.dto.api.v1.ProductTranslator;
 import org.candlepin.dto.api.v1.UpstreamConsumerDTO;
 import org.candlepin.dto.api.v1.UpstreamConsumerTranslator;
 import org.candlepin.dto.shim.ContentDataTranslator;
 import org.candlepin.dto.shim.ProductDataTranslator;
-import org.candlepin.model.Certificate;
+import org.candlepin.model.Branding;
 import org.candlepin.model.CertificateSerial;
+import org.candlepin.model.Certificate;
 import org.candlepin.model.ConsumerType;
 import org.candlepin.model.Content;
+import org.candlepin.model.Entitlement;
 import org.candlepin.model.Owner;
+import org.candlepin.model.Pool;
 import org.candlepin.model.Product;
 import org.candlepin.model.UpstreamConsumer;
 import org.candlepin.model.activationkeys.ActivationKey;
@@ -68,6 +77,12 @@ public class StandardTranslator extends SimpleModelTranslator {
             new OwnerTranslator(), Owner.class, OwnerDTO.class);
         this.registerTranslator(
             new ProductTranslator(), Product.class, ProductDTO.class);
+        this.registerTranslator(
+            new PoolTranslator(), Pool.class, PoolDTO.class);
+        this.registerTranslator(
+            new BrandingTranslator(), Branding.class, BrandingDTO.class);
+        this.registerTranslator(
+            new EntitlementTranslator(), Entitlement.class, EntitlementDTO.class);
         this.registerTranslator(
             new UpstreamConsumerTranslator(), UpstreamConsumer.class, UpstreamConsumerDTO.class);
         this.registerTranslator(

--- a/server/src/main/java/org/candlepin/dto/api/v1/ActivationKeyDTO.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/ActivationKeyDTO.java
@@ -35,7 +35,7 @@ import java.util.Set;
  * A DTO representation of the ActivationKey entity
  */
 @ApiModel(parent = TimestampedCandlepinDTO.class, description = "DTO representing an activation key")
-public class ActivationKeyDTO  extends TimestampedCandlepinDTO<ActivationKeyDTO> {
+public class ActivationKeyDTO extends TimestampedCandlepinDTO<ActivationKeyDTO> {
     public static final long serialVersionUID = 1L;
 
     /**

--- a/server/src/main/java/org/candlepin/dto/api/v1/BrandingDTO.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/BrandingDTO.java
@@ -1,0 +1,219 @@
+/**
+ * Copyright (c) 2009 - 2017 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.dto.api.v1;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+
+/**
+ * A DTO representation of the Branding entity used internally by
+ * other DTO entities, like PoolDTO and SubscriptionDTO.
+ */
+@XmlAccessorType(XmlAccessType.PROPERTY)
+public class BrandingDTO extends TimestampedCandlepinDTO<BrandingDTO> {
+
+    public static final long serialVersionUID = 1L;
+
+    private String productId;
+    private String name;
+    private String type;
+
+    /**
+     * Initializes a new BrandingDTO instance with null values.
+     */
+    public BrandingDTO() {
+        // Intentionally left empty
+    }
+
+    /**
+     * Initializes a new BrandingDTO instance which is a shallow copy of the provided
+     * source entity.
+     *
+     * @param source
+     *  The source entity to copy
+     */
+    public BrandingDTO(BrandingDTO source) {
+        super(source);
+    }
+
+    /**
+     * Initializes a new BrandingDTO instance based on the given values.
+     *
+     * @param productId this branding's product id.
+     *
+     * @param name this branding's name.
+     *
+     * @param type this branding's type.
+     */
+    @JsonCreator
+    public BrandingDTO(
+        @JsonProperty("productId") String productId,
+        @JsonProperty("name") String name,
+        @JsonProperty("type") String type) {
+
+        if (productId == null || productId.isEmpty()) {
+            throw new IllegalArgumentException("productId is null or empty");
+        }
+
+        if (name == null || name.isEmpty()) {
+            throw new IllegalArgumentException("name is null or empty");
+        }
+
+        if (type == null || type.isEmpty()) {
+            throw new IllegalArgumentException("type is null or empty");
+        }
+
+        this.productId = productId;
+        this.name = name;
+        this.type = type;
+    }
+
+    /**
+     * Returns this branding's product id.
+     *
+     * @return this branding's product id.
+     */
+    public String getProductId() {
+        return productId;
+    }
+
+    /**
+     * Sets this branding's product id.
+     *
+     * @param productId the product id to set on this branding DTO.
+     *
+     * @return a reference to this branding DTO object.
+     */
+    public BrandingDTO setProductId(String productId) {
+        this.productId = productId;
+        return this;
+    }
+
+    /**
+     * Returns this branding's name.
+     *
+     * @return this branding's name.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Sets this branding's name.
+     *
+     * @param name the name to set on this branding DTO.
+     *
+     * @return a reference to this branding DTO object.
+     */
+    public BrandingDTO setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * Returns this branding's type.
+     *
+     * @return this branding's type.
+     */
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * Sets this branding's type.
+     *
+     * @param type the type to set on this branding DTO.
+     *
+     * @return a reference to this branding DTO object.
+     */
+    public BrandingDTO setType(String type) {
+        this.type = type;
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        return String.format("BrandingDTO [productId: %s, name: %s, type: %s]",
+                this.getProductId(), this.getName(), this.getType());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        }
+
+        if (obj instanceof BrandingDTO && super.equals(obj)) {
+            BrandingDTO that = (BrandingDTO) obj;
+
+            EqualsBuilder builder = new EqualsBuilder()
+                .append(this.getProductId(), that.getProductId())
+                .append(this.getName(), that.getName())
+                .append(this.getType(), that.getType());
+
+            return builder.isEquals();
+        }
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        HashCodeBuilder builder = new HashCodeBuilder(37, 7)
+            .append(super.hashCode())
+            .append(this.getProductId())
+            .append(this.getName())
+            .append(this.getType());
+
+        return builder.toHashCode();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public BrandingDTO clone() {
+        // Nothing to copy here. All fields are immutable types.
+
+        return super.clone();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public BrandingDTO populate(BrandingDTO source) {
+        super.populate(source);
+
+        this.setProductId(source.getProductId());
+        this.setName(source.getName());
+        this.setType(source.getType());
+
+        return this;
+    }
+}

--- a/server/src/main/java/org/candlepin/dto/api/v1/BrandingTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/BrandingTranslator.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2009 - 2017 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.dto.api.v1;
+
+import org.candlepin.dto.ModelTranslator;
+import org.candlepin.model.Branding;
+
+/**
+ * The BrandingTranslator provides translation from Branding model objects to BrandingDTOs
+ */
+public class BrandingTranslator extends TimestampedEntityTranslator<Branding, BrandingDTO> {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public BrandingDTO translate(Branding source) {
+        return this.translate(null, source);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public BrandingDTO translate(ModelTranslator translator, Branding source) {
+        return source != null ? this.populate(translator, source, new BrandingDTO()) : null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public BrandingDTO populate(Branding source, BrandingDTO destination) {
+        return this.populate(null, source, destination);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public BrandingDTO populate(ModelTranslator modelTranslator, Branding source, BrandingDTO dest) {
+        dest = super.populate(modelTranslator, source, dest);
+
+        dest.setProductId(source.getProductId());
+        dest.setName(source.getName());
+        dest.setType(source.getType());
+
+        return dest;
+    }
+}

--- a/server/src/main/java/org/candlepin/dto/api/v1/EntitlementDTO.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/EntitlementDTO.java
@@ -1,0 +1,495 @@
+/**
+ * Copyright (c) 2009 - 2017 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.dto.api.v1;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModel;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.candlepin.common.jackson.HateoasInclude;
+import org.candlepin.model.Consumer;
+import org.candlepin.util.SetView;
+import org.candlepin.util.Util;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * A DTO representation of the Entitlement entity
+ */
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.PROPERTY)
+@ApiModel(parent = TimestampedCandlepinDTO.class, description = "DTO representing an entitlement")
+@JsonFilter("EntitlementFilter")
+public class EntitlementDTO extends TimestampedCandlepinDTO<EntitlementDTO> implements LinkableDTO {
+
+    private static final long serialVersionUID = 1L;
+
+    private String id;
+    private OwnerDTO owner;
+    private Consumer consumer; //TODO: Turn into ConsumerDTO once that is introduced
+    private PoolDTO pool;
+    private Integer quantity;
+    private Boolean deletedFromPool;
+    private Set<CertificateDTO> certificates;
+    private Date startDate;
+    private Date endDate;
+
+    /**
+     * Initializes a new EntitlementDTO instance with null values.
+     */
+    public EntitlementDTO() {
+        // Intentionally left empty
+    }
+
+    /**
+     * Initializes a new EntitlementDTO instance which is a shallow copy of the provided
+     * source entity.
+     *
+     * @param source
+     *  The source entity to copy
+     */
+    public EntitlementDTO(EntitlementDTO source) {
+        super(source);
+    }
+
+    /**
+     * Retrieves the id field of this EntitlementDTO object.
+     *
+     * @return the id field of this EntitlementDTO object.
+     */
+    @HateoasInclude
+    public String getId() {
+        return this.id;
+    }
+
+    /**
+     * Sets the id to set on this EntitlementDTO object.
+     *
+     * @param id the id to set on this EntitlementDTO object.
+     *
+     * @return a reference to this EntitlementDTO object.
+     */
+    public EntitlementDTO setId(String id) {
+        this.id = id;
+        return this;
+    }
+
+    /**
+     * Returns the owner of this entitlement.
+     *
+     * @return the owner of this entitlement.
+     */
+    @JsonIgnore
+    public OwnerDTO getOwner() {
+        return this.owner;
+    }
+
+    /**
+     * Sets the owner of this entitlement.
+     *
+     * @param owner the owner to set.
+     *
+     * @return a reference to this EntitlementDTO object.
+     */
+    @JsonProperty
+    public EntitlementDTO setOwner(OwnerDTO owner) {
+        this.owner = owner;
+        return this;
+    }
+
+    /**
+     * Returns the consumer of this entitlement.
+     *
+     * @return return the associated Consumer.
+     */
+    //TODO: Replace with ConsumerDTO once that gets introduced.
+    public Consumer getConsumer() {
+        return consumer;
+    }
+
+    /**
+     * Associates the given consumer with this entitlement.
+     *
+     * @param consumer consumer to associate.
+     *
+     * @return a reference to this EntitlementDTO object.
+     */
+    //TODO: Replace with ConsumerDTO once that gets introduced.
+    public EntitlementDTO setConsumer(Consumer consumer) {
+        this.consumer = consumer;
+        return this;
+    }
+
+    /**
+     * Returns the pool of this entitlement.
+     *
+     * @return the pool of this entitlement.
+     */
+    public PoolDTO getPool() {
+        return this.pool;
+    }
+
+    /**
+     * Sets the pool of this entitlement.
+     *
+     * @param pool the pool to set.
+     *
+     * @return a reference to this EntitlementDTO object.
+     */
+    public EntitlementDTO setPool(PoolDTO pool) {
+        this.pool = pool;
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @HateoasInclude
+    @Override
+    public String getHref() {
+        return this.getId() != null ? String.format("/entitlements/%s", this.getId()) : null;
+    }
+
+    /**
+     * Retrieves the quantity of this entitlement.
+     *
+     * @return the quantity of this entitlement.
+     */
+    public Integer getQuantity() {
+        return quantity;
+    }
+
+    /**
+     * Sets the quantity of this entitlement.
+     *
+     * @param quantity the quantity to set.
+     *
+     * @return a reference to this EntitlementDTO object.
+     */
+    public EntitlementDTO setQuantity(Integer quantity) {
+        this.quantity = quantity;
+        return this;
+    }
+
+    /**
+     * Returns true if this entitlement is deleted from the pool, or false otherwise.
+     *
+     * @return if this entitlement is deleted from the pool or not.
+     */
+    @JsonIgnore
+    public Boolean isDeletedFromPool() {
+        return deletedFromPool;
+    }
+
+    /**
+     * Sets if this entitlement is is deleted from the pool or not.
+     *
+     * @param deletedFromPool if this entitlement is deleted from the pool or not.
+     *
+     * @return a reference to this EntitlementDTO object.
+     */
+    @JsonProperty
+    public EntitlementDTO setDeletedFromPool(Boolean deletedFromPool) {
+        this.deletedFromPool = deletedFromPool;
+        return this;
+    }
+
+    /**
+     * Retrieves a view of the certificates associated with the entitlement represented by this DTO.
+     * If the certificates have not yet been defined, this method returns null.
+     * <p></p>
+     * Note that the collection returned by this method is a view of the collection backing this
+     * set of certificates. Elements cannot be added to the collection, but elements may be removed.
+     * Changes made to the collection will be reflected by this certificates data instance.
+     *
+     * @return
+     *  the certificates associated with this key, or null if the certificates have not yet been defined
+     */
+    public Set<CertificateDTO> getCertificates() {
+        return this.certificates != null ? new SetView<CertificateDTO>(this.certificates) : null;
+    }
+
+    /**
+     * Sets the certificates of the entitlement represented by this DTO.
+     *
+     * @param certificates
+     *  A collection of certificate DTOs to attach to this entitlement DTO, or null to clear the content
+     *
+     * @throws IllegalArgumentException
+     *  if the collection contains null or incomplete certificate DTOs
+     *
+     * @return
+     *  a reference to this EntitlementDTO object.
+     */
+    public EntitlementDTO setCertificates(Set<CertificateDTO> certificates) {
+        if (certificates != null) {
+            if (this.certificates == null) {
+                this.certificates = new HashSet<CertificateDTO>();
+            }
+            else {
+                this.certificates.clear();
+            }
+
+            for (CertificateDTO dto : certificates) {
+                if (isNullOrIncomplete(dto)) {
+                    throw new IllegalArgumentException(
+                        "collection contains null or incomplete certificates");
+                }
+            }
+            this.certificates.addAll(certificates);
+        }
+        else {
+            this.certificates = null;
+        }
+        return this;
+    }
+
+    /**
+     * Adds the given certificate to this entitlement DTO.
+     *
+     * @param certificate the certificate DTO to add to this entitlement DTO.
+     *
+     * @throws IllegalArgumentException
+     *  if the certificate is null or incomplete
+     *
+     * @return true if this certificate was not already contained in this entitlement DTO.
+     */
+    @JsonIgnore
+    public boolean addCertificate(CertificateDTO certificate) {
+        if (isNullOrIncomplete(certificate)) {
+            throw new IllegalArgumentException("certificate is null or incomplete");
+        }
+
+        if (this.certificates == null) {
+            this.certificates = new HashSet<CertificateDTO>();
+        }
+
+        return this.certificates.add(certificate);
+    }
+
+    /*
+     * Utility method to validate certificate input.
+     */
+    private boolean isNullOrIncomplete(CertificateDTO certificate) {
+        return certificate == null || certificate.getSerial() == null ||
+            certificate.getId() == null || certificate.getId().isEmpty() ||
+            certificate.getKey() == null || certificate.getKey().isEmpty() ||
+            certificate.getCert() == null || certificate.getCert().isEmpty();
+    }
+
+    /**
+     * Returns the start date of this entitlement.
+     *
+     * @return Returns the startDate from the pool of this entitlement.
+     */
+    @JsonProperty
+    public Date getStartDate() {
+        return startDate;
+    }
+
+    /**
+     * Sets the start date of this entitlement.
+     *
+     * @param startDate the startDate of this entitlement.
+     *
+     * @return a reference to this EntitlementDTO object.
+     */
+    @JsonIgnore
+    public EntitlementDTO setStartDate(Date startDate) {
+        this.startDate = startDate;
+        return this;
+    }
+
+    /**
+     * Returns the end date of this entitlement.
+     *
+     * @return Returns the endDate of this entitlement.
+     */
+    @JsonProperty
+    public Date getEndDate() {
+        return endDate;
+    }
+
+    /**
+     * Sets the end date of this entitlement.
+     *
+     * @param endDate the endDate of this entitlement.
+     *
+     * @return a reference to this EntitlementDTO object.
+     */
+    @JsonIgnore
+    public EntitlementDTO setEndDate(Date endDate) {
+        this.endDate = endDate;
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        return String.format("EntitlementDTO [id: %s, product id: %s, pool id: %s, consumer uuid: %s]",
+            this.id,
+            this.pool != null ? pool.getProductId() : null,
+            this.pool != null ? pool.getId() : null,
+            this.consumer != null ? consumer.getUuid() : null);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        }
+
+        if (obj instanceof EntitlementDTO && super.equals(obj)) {
+            EntitlementDTO that = (EntitlementDTO) obj;
+
+            // Pull the nested object IDs, as we're not interested in verifying that the objects
+            // themselves are equal; just so long as they point to the same object.
+            String thisOwnerId = this.getOwner() != null ? this.getOwner().getId() : null;
+            String thatOwnerId = that.getOwner() != null ? that.getOwner().getId() : null;
+
+            String thisPoolId = this.getPool() != null ? this.getPool().getId() : null;
+            String thatPoolId = that.getPool() != null ? that.getPool().getId() : null;
+
+            String thisConsumerId = this.getConsumer() != null ? this.getConsumer().getUuid() : null;
+            String thatConsumerId = that.getConsumer() != null ? that.getConsumer().getUuid() : null;
+
+            EqualsBuilder builder = new EqualsBuilder()
+                .append(this.getId(), that.getId())
+                .append(thisOwnerId, thatOwnerId)
+                .append(thisPoolId, thatPoolId)
+                .append(thisConsumerId, thatConsumerId)
+                .append(this.getQuantity(), that.getQuantity())
+                .append(this.isDeletedFromPool(), that.isDeletedFromPool())
+                .append(this.getEndDate(), that.getEndDate())
+                .append(this.getStartDate(), that.getStartDate());
+
+            // Note that we're using the boolean operator here as a shorthand way to skip checks
+            // when the equality check has already failed.
+            boolean equals = builder.isEquals();
+
+            equals = equals && Util.collectionsAreEqual(this.getCertificates(), that.getCertificates(),
+                new Comparator<CertificateDTO>() {
+                    @Override
+                    public int compare(CertificateDTO c1, CertificateDTO c2) {
+                        if (c1 == c2) {
+                            return 0;
+                        }
+
+                        if (c1 != null && c1.getId() != null) {
+                            return c1.getId().compareTo(c2.getId());
+                        }
+
+                        return 1;
+                    }
+                });
+
+            return equals;
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        int certsHashCode = 0;
+        Collection<CertificateDTO> certificateDTOs = this.getCertificates();
+
+        if (certificateDTOs != null) {
+            for (CertificateDTO dto : certificateDTOs) {
+                certsHashCode = 31 * certsHashCode +
+                    (dto != null && dto.getId() != null ? dto.getId().hashCode() : 0);
+            }
+        }
+
+        HashCodeBuilder builder = new HashCodeBuilder(37, 7)
+            .append(super.hashCode())
+            .append(this.getId())
+            .append(this.getOwner() != null ? this.getOwner().getId() : null)
+            .append(this.getPool() != null ? this.getPool().getId() : null)
+            .append(this.getConsumer() != null ? this.getConsumer().getUuid() : null)
+            .append(this.getQuantity())
+            .append(this.isDeletedFromPool())
+            .append(this.getEndDate())
+            .append(this.getStartDate())
+            .append(certsHashCode);
+
+        return builder.toHashCode();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public EntitlementDTO clone() {
+        EntitlementDTO copy = (EntitlementDTO) super.clone();
+
+        OwnerDTO owner = this.getOwner();
+        copy.owner = owner != null ? owner.clone() : null;
+        PoolDTO pool = this.getPool();
+        copy.pool = pool != null ? pool.clone() : null;
+        Consumer consumer = this.getConsumer();
+        //TODO change Consumer to ConsumerDTO.
+        copy.consumer = consumer != null ?
+            new Consumer(consumer.getName(), consumer.getUsername(),
+                consumer.getOwner(), consumer.getType()) : null;
+        if (consumer != null) {
+            copy.consumer.setUuid(consumer.getUuid());
+        }
+
+        copy.certificates = this.getCertificates();
+
+        copy.endDate = this.endDate != null ? (Date) this.endDate.clone() : null;
+        copy.startDate = this.startDate != null ? (Date) this.startDate.clone() : null;
+
+        return copy;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public EntitlementDTO populate(EntitlementDTO source) {
+        super.populate(source);
+
+        this.setId(source.getId())
+            .setOwner(source.getOwner())
+            .setPool(source.getPool())
+            .setConsumer(source.getConsumer())
+            .setQuantity(source.getQuantity())
+            .setDeletedFromPool(source.isDeletedFromPool())
+            .setCertificates(source.getCertificates())
+            .setEndDate(source.getEndDate())
+            .setStartDate(source.getStartDate());
+
+        return this;
+    }
+}

--- a/server/src/main/java/org/candlepin/dto/api/v1/EntitlementTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/EntitlementTranslator.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2009 - 2017 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.dto.api.v1;
+
+import org.candlepin.dto.ModelTranslator;
+import org.candlepin.model.Certificate;
+import org.candlepin.model.Entitlement;
+import org.candlepin.model.EntitlementCertificate;
+import org.candlepin.model.Owner;
+import org.candlepin.model.Pool;
+
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * The EntitlementTranslator provides translation from Entitlement model objects to EntitlementDTOs.
+ */
+public class EntitlementTranslator extends TimestampedEntityTranslator<Entitlement, EntitlementDTO> {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public EntitlementDTO translate(Entitlement source) {
+        return this.translate(null, source);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public EntitlementDTO translate(ModelTranslator translator, Entitlement source) {
+        return source != null ? this.populate(translator, source, new EntitlementDTO()) : null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public EntitlementDTO populate(Entitlement source, EntitlementDTO destination) {
+        return this.populate(null, source, destination);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public EntitlementDTO populate(ModelTranslator modelTranslator, Entitlement source, EntitlementDTO dest) {
+        dest = super.populate(modelTranslator, source, dest);
+
+        dest.setId(source.getId());
+        dest.setQuantity(source.getQuantity());
+        dest.setDeletedFromPool(source.deletedFromPool());
+        dest.setStartDate(source.getStartDate());
+        dest.setEndDate(source.getEndDate());
+
+        if (modelTranslator != null) {
+            Owner owner = source.getOwner();
+            dest.setOwner(owner != null ? modelTranslator.translate(owner, OwnerDTO.class) : null);
+
+            Pool pool = source.getPool();
+            dest.setPool(pool != null ? modelTranslator.translate(pool, PoolDTO.class) : null);
+
+            Set<EntitlementCertificate> certs = source.getCertificates();
+            if (certs != null && !certs.isEmpty()) {
+                for (Certificate cert : certs) {
+                    if (cert != null) {
+                        dest.addCertificate(modelTranslator.translate(cert, CertificateDTO.class));
+                    }
+                }
+            }
+            else {
+                dest.setCertificates(Collections.<CertificateDTO>emptySet());
+            }
+
+            dest.setConsumer(source.getConsumer());
+        }
+
+        return dest;
+    }
+}

--- a/server/src/main/java/org/candlepin/dto/api/v1/PoolDTO.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/PoolDTO.java
@@ -1,0 +1,1548 @@
+/**
+ * Copyright (c) 2009 - 2017 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.dto.api.v1;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import io.swagger.annotations.ApiModel;
+
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.candlepin.common.jackson.HateoasInclude;
+import org.candlepin.jackson.CandlepinAttributeDeserializer;
+import org.candlepin.jackson.CandlepinLegacyAttributeSerializer;
+import org.candlepin.util.MapView;
+import org.candlepin.util.SetView;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A DTO representation of the Pool entity
+ */
+@XmlRootElement(name = "pool")
+@XmlAccessorType(XmlAccessType.PROPERTY)
+@ApiModel(parent = TimestampedCandlepinDTO.class, description = "DTO representing a Pool")
+@JsonFilter("PoolFilter")
+public class PoolDTO extends TimestampedCandlepinDTO<PoolDTO> implements LinkableDTO {
+    public static final long serialVersionUID = 1L;
+
+    /**
+     * Internal DTO object for ProvidedProduct
+     */
+    @JsonFilter("ProvidedProductFilter")
+    public static class ProvidedProductDTO {
+        private final String productId;
+        private final String productName;
+
+        @JsonCreator
+        public ProvidedProductDTO(
+            @JsonProperty("productId") String productId,
+            @JsonProperty("productName") String productName) {
+            if (productId == null || productId.isEmpty()) {
+                throw new IllegalArgumentException("The product id is null or empty.");
+            }
+
+            this.productId = productId;
+            this.productName = productName;
+        }
+
+        public String getProductId() {
+            return this.productId;
+        }
+
+        public String getProductName() {
+            return this.productName;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) {
+                return true;
+            }
+
+            if (obj instanceof ProvidedProductDTO) {
+                ProvidedProductDTO that = (ProvidedProductDTO) obj;
+
+                EqualsBuilder builder = new EqualsBuilder()
+                    .append(this.getProductId(), that.getProductId())
+                    .append(this.getProductName(), that.getProductName());
+
+                return builder.isEquals();
+            }
+
+            return false;
+        }
+
+        @Override
+        public int hashCode() {
+            HashCodeBuilder builder = new HashCodeBuilder(37, 7)
+                .append(this.getProductId())
+                .append(this.getProductName());
+
+            return builder.toHashCode();
+        }
+    }
+
+    private String id;
+    private String type;
+    private OwnerDTO owner;
+    private Boolean activeSubscription;
+    private Boolean createdByShare;
+    private Boolean hasSharedAncestor;
+    private EntitlementDTO sourceEntitlement;
+    private Long quantity;
+    private Date startDate;
+    private Date endDate;
+
+    private Map<String, String> attributes;
+    private String restrictedToUsername;
+    private String contractNumber;
+    private String accountNumber;
+    private String orderNumber;
+    private Long consumed;
+    private Long exported;
+    private Long shared;
+
+    private Set<BrandingDTO> branding;
+
+    private Map<String, String> calculatedAttributes;
+    private String upstreamPoolId;
+    private String upstreamEntitlementId;
+    private String upstreamConsumerId;
+
+    private String productName;
+    private String productId;
+
+    private Map<String, String> productAttributes;
+
+    private String stackId;
+    private Boolean stacked;
+    private String sourceStackId;
+
+    private Boolean developmentPool;
+
+    private Map<String, String> derivedProductAttributes;
+
+    private String derivedProductId;
+    private String derivedProductName;
+    private Set<ProvidedProductDTO> providedProducts;
+    private Set<ProvidedProductDTO> derivedProvidedProducts;
+
+    private String subscriptionSubKey;
+    private String subscriptionId;
+    private CertificateDTO certificate;
+
+    /**
+     * Initializes a new PoolDTO instance with null values.
+     */
+    public PoolDTO() {
+        // Intentionally left empty
+    }
+
+    /**
+     * Initializes a new PoolDTO instance which is a shallow copy of the provided
+     * source entity.
+     *
+     * @param source
+     *  The source entity to copy
+     */
+    public PoolDTO(PoolDTO source) {
+        super(source);
+    }
+
+    /**
+     * Returns the internal db id.
+     *
+     * @return the db id.
+     */
+    @HateoasInclude
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Sets the internal db id.
+     *
+     * @param id new db id.
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    public PoolDTO setId(String id) {
+        this.id = id;
+        return this;
+    }
+
+    /**
+     * Returns the pool's type.
+     *
+     * @return this pool's type.
+     */
+    @JsonProperty
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * Sets the pool's type.
+     *
+     * @param type set the pool type.
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    @JsonIgnore
+    public PoolDTO setType(String type) {
+        this.type = type;
+        return this;
+    }
+
+    /**
+     * Return the owner of this pool.
+     *
+     * @return the owner of this pool.
+     */
+    public OwnerDTO getOwner() {
+        return owner;
+    }
+
+    /**
+     * Sets the owner of this pool.
+     *
+     * @param owner set the owner of this pool.
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    public PoolDTO setOwner(OwnerDTO owner) {
+        this.owner = owner;
+        return this;
+    }
+
+    /**
+     * Returns true if this pool represents an active subscription, false otherwise.
+     *
+     * @return true if this pool represents an active subscription, false otherwise.
+     */
+    public Boolean isActiveSubscription() {
+        return activeSubscription;
+    }
+
+    /**
+     * Sets if this pool represents an active subscription or not.
+     *
+     * @param activeSubscription set if this pool represents an active subscription or not.
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    public PoolDTO setActiveSubscription(Boolean activeSubscription) {
+        this.activeSubscription = activeSubscription;
+        return this;
+    }
+
+    /**
+     * Returns true if this pool was created because of a share, false otherwise.
+     *
+     * @return true if this pool was created because of a share, false otherwise.
+     */
+    public Boolean isCreatedByShare() {
+        return createdByShare;
+    }
+
+    /**
+     * Set if this pool was created because of a share or not.
+     *
+     * @param createdByShare set if this pool was created because of a share or not.
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    public PoolDTO setCreatedByShare(Boolean createdByShare) {
+        this.createdByShare = createdByShare;
+        return this;
+    }
+
+    /**
+     * Checks if this pool or its ancestors were created as a result of a share.
+     *
+     * @return true if this pool or its parent was created because of a share.
+     */
+    @JsonProperty
+    public Boolean hasSharedAncestor() {
+        return hasSharedAncestor;
+    }
+
+    /**
+     * Sets whether or not this pool or any of its ancestors were created as
+     * a result of a share.
+     *
+     * @param hasSharedAncestor
+     *  true if this pool or any of its ancestors were created as a result of a share.
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    public PoolDTO setHasSharedAncestor(Boolean hasSharedAncestor) {
+        this.hasSharedAncestor = hasSharedAncestor;
+        return this;
+    }
+
+    /**
+     * Returns the source entitlement of this pool.
+     *
+     * @return the source entitlement.
+     */
+    public EntitlementDTO getSourceEntitlement() {
+        return sourceEntitlement;
+    }
+
+    /**
+     * Sets the source entitlement of this pool.
+     *
+     * @param sourceEntitlement set the source entitlement.
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    public PoolDTO setSourceEntitlement(EntitlementDTO sourceEntitlement) {
+        this.sourceEntitlement = sourceEntitlement;
+        return this;
+    }
+
+    /**
+     * Return this pool's quantity.
+     *
+     * @return this pool's quantity.
+     */
+    public Long getQuantity() {
+        return quantity;
+    }
+
+    /**
+     * Sets this pool's quantity.
+     *
+     * @param quantity set this pool's quantity.
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    public PoolDTO setQuantity(Long quantity) {
+        this.quantity = quantity;
+        return this;
+    }
+
+    /**
+     * Return the date the pool became active.
+     *
+     * @return when the pool became active.
+     */
+    public Date getStartDate() {
+        return startDate;
+    }
+
+    /**
+     * Sets the date the pool became active.
+     *
+     * @param startDate set the date that the pool became active.
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    public PoolDTO setStartDate(Date startDate) {
+        this.startDate = startDate;
+        return this;
+    }
+
+    /**
+     * Return the date the pool expires.
+     *
+     * @return when the pool expires.
+     */
+    public Date getEndDate() {
+        return endDate;
+    }
+
+    /**
+     * Set the date the pool expires.
+     *
+     * @param endDate set the date that the pool expires.
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    public PoolDTO setEndDate(Date endDate) {
+        this.endDate = endDate;
+        return this;
+    }
+
+    /**
+     * Retrieves a view of the attributes for the pool represented by this DTO. If the attributes
+     * have not yet been defined, this method returns null.
+     * <p></p>
+     * Note that the collection returned by this method is a view of the collection backing this
+     * set of attributes. Elements cannot be added to the collection, but elements may be removed.
+     * Changes made to the collection will be reflected by this pool DTO instance.
+     *
+     * @return the attributes associated with this pool, or null if they have not yet been defined.
+     */
+    @JsonSerialize(using = CandlepinLegacyAttributeSerializer.class)
+    public Map<String, String> getAttributes() {
+        return this.attributes != null ? new MapView<String, String>(this.attributes) : null;
+    }
+
+    /**
+     * Sets the attributes for this pool DTO.
+     *
+     * @param attributes
+     *  A map of attribute key, value pairs to assign to this pool DTO, or null to clear the
+     *  existing ones
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    @JsonDeserialize(using = CandlepinAttributeDeserializer.class)
+    public PoolDTO setAttributes(Map<String, String> attributes) {
+        if (attributes != null) {
+            if (this.attributes == null) {
+                this.attributes = new HashMap<String, String>();
+            }
+            else {
+                this.attributes.clear();
+            }
+            this.attributes.putAll(attributes);
+        }
+        else {
+            this.attributes = null;
+        }
+        return this;
+    }
+
+    /**
+     * Checks if the given attribute has been defined on this poolDTO.
+     *
+     * @param key
+     *  The key (name) of the attribute to lookup
+     *
+     * @throws IllegalArgumentException
+     *  if key is null
+     *
+     * @return
+     *  true if the attribute is defined for this pool; false otherwise
+     */
+    @JsonIgnore
+    public boolean hasAttribute(String key) {
+        if (key == null) {
+            throw new IllegalArgumentException("key is null");
+        }
+
+        if (this.attributes == null) {
+            return false;
+        }
+
+        return this.attributes.containsKey(key);
+    }
+
+    /**
+     * Removes the given attribute from this pool DTO.
+     *
+     * @param key
+     *  The key (name) of the attribute to remove
+     *
+     * @return
+     *  True if the attribute was removed; false otherwise.
+     */
+    @JsonIgnore
+    public boolean removeAttribute(String key) {
+        if (key == null) {
+            throw new IllegalArgumentException("key is null");
+        }
+
+        if (this.attributes == null) {
+            return false;
+        }
+
+        boolean present = this.attributes.containsKey(key);
+        this.attributes.remove(key);
+
+        return present;
+    }
+
+    /**
+     * Returns the username of the user to which this pool is restricted.
+     *
+     * @return the username of the user to which this pool is restricted.
+     */
+    public String getRestrictedToUsername() {
+        return restrictedToUsername;
+    }
+
+    /**
+     * Sets the username of the user to which this pool is restricted.
+     *
+     * @param restrictedToUsername the username of the user to which this pool is restricted.
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    public PoolDTO setRestrictedToUsername(String restrictedToUsername) {
+        this.restrictedToUsername = restrictedToUsername;
+        return this;
+    }
+
+    /**
+     * Return the contract number for this pool's subscription.
+     *
+     * @return the contract number.
+     */
+    public String getContractNumber() {
+        return contractNumber;
+    }
+
+    /**
+     * Sets the contract number for this pool's subscription.
+     *
+     * @param contractNumber set the contract number of this subscription
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    public PoolDTO setContractNumber(String contractNumber) {
+        this.contractNumber = contractNumber;
+        return this;
+    }
+
+    /**
+     * Returns this pool's account number.
+     *
+     * @return this pool's account number.
+     */
+    public String getAccountNumber() {
+        return accountNumber;
+    }
+
+    /**
+     * Sets this pool's account number.
+     *
+     * @param accountNumber the account number to set on this pool.
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    public PoolDTO setAccountNumber(String accountNumber) {
+        this.accountNumber = accountNumber;
+        return this;
+    }
+
+    /**
+     * Returns this pool's order number.
+     *
+     * @return this pool's order number.
+     */
+    public String getOrderNumber() {
+        return orderNumber;
+    }
+
+    /**
+     * Sets this pool's order number.
+     *
+     * @param orderNumber the order number to set on this pool.
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    public PoolDTO setOrderNumber(String orderNumber) {
+        this.orderNumber = orderNumber;
+        return this;
+    }
+
+    /**
+     * Returns the quantity of the pool that is currently consumed.
+     *
+     * @return the quantity currently consumed.
+     */
+    public Long getConsumed() {
+        return consumed;
+    }
+
+    /**
+     * Sets the quantity of the pool that is currently consumed.
+     *
+     * @param consumed set the activated uses.
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    public PoolDTO setConsumed(Long consumed) {
+        this.consumed = consumed;
+        return this;
+    }
+
+    /**
+     * Returns the quantity of the pool that is currently exported.
+     *
+     * @return quantity currently exported.
+     */
+    public Long getExported() {
+        return exported;
+    }
+
+    /**
+     * Sets the quantity of the pool that is currently exported.
+     *
+     * @param exported set the activated uses.
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    public PoolDTO setExported(Long exported) {
+        this.exported = exported;
+        return this;
+    }
+
+    /**
+     * Returns the quantity of entitlements in this pool shared to another org.
+     *
+     * @return the quantity of entitlements in this pool shared to another org.
+     */
+    public Long getShared() {
+        return shared;
+    }
+
+    /**
+     * Sets the quantity of entitlements in this pool shared to another org.
+     *
+     * @param shared the number to set the share count to
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    public PoolDTO setShared(Long shared) {
+        this.shared = shared;
+        return this;
+    }
+
+    /**
+     * Retrieves a view of the branding for the pool represented by this DTO. If the branding items
+     * have not yet been defined, this method returns null.
+     * <p></p>
+     * Note that the collection returned by this method is a view of the collection backing this
+     * set of branding items. Elements cannot be added to the collection, but elements may be removed.
+     * Changes made to the collection will be reflected by this pool DTO instance.
+     *
+     * @return
+     *  the branding items associated with this key, or null if they have not yet been defined
+     */
+    public Set<BrandingDTO> getBranding() {
+        return this.branding != null ? new SetView<BrandingDTO>(this.branding) : null;
+    }
+
+    /**
+     * Adds the collection of branding items to this Pool DTO.
+     *
+     * @param branding
+     *  A set of branding items to attach to this DTO, or null to clear the existing ones
+     *
+     * @return
+     *  A reference to this DTO
+     */
+    public PoolDTO setBranding(Set<BrandingDTO> branding) {
+        if (branding != null) {
+            if (this.branding == null) {
+                this.branding = new HashSet<BrandingDTO>();
+            }
+            else {
+                this.branding.clear();
+            }
+
+            for (BrandingDTO dto : branding) {
+                if (isNullOrIncomplete(dto)) {
+                    throw new IllegalArgumentException(
+                        "collection contains null or incomplete branding objects");
+                }
+            }
+
+            this.branding.addAll(branding);
+        }
+        else {
+            this.branding = null;
+        }
+        return this;
+    }
+
+    /**
+     * Adds the given branding to this pool DTO.
+     *
+     * @param branding
+     *  The branding to add to this pool DTO.
+     *
+     * @return
+     *  true if this branding was not already contained in this pool DTO.
+     */
+    @JsonIgnore
+    public boolean addBranding(BrandingDTO branding) {
+        if (isNullOrIncomplete(branding)) {
+            throw new IllegalArgumentException("branding is null or incomplete");
+        }
+
+        if (this.branding == null) {
+            this.branding = new HashSet<BrandingDTO>();
+        }
+
+        return this.branding.add(branding);
+    }
+
+    /**
+     * Utility method to validate BrandingDTO input
+     */
+    private boolean isNullOrIncomplete(BrandingDTO branding) {
+        return branding == null ||
+            branding.getProductId() == null || branding.getProductId().isEmpty() ||
+            branding.getName() == null || branding.getName().isEmpty() ||
+            branding.getType() == null || branding.getType().isEmpty();
+    }
+
+    /**
+     * Retrieves a view of the calculated attributes for the pool represented by this DTO. If the calculated
+     * attributes have not yet been defined, this method returns null.
+     * <p></p>
+     * Note that the collection returned by this method is a view of the collection backing this
+     * set of calculated attributes. Elements cannot be added to the collection, but elements may be removed.
+     * Changes made to the collection will be reflected by this pool DTO instance.
+     *
+     * @return the calculated attributes associated with this pool,
+     * or null if the they have not yet been defined.
+     */
+    public Map<String, String> getCalculatedAttributes() {
+        return this.calculatedAttributes != null ?
+            new MapView<String, String>(this.calculatedAttributes) : null;
+    }
+
+    /**
+     * Sets the calculated attributes for this pool DTO.
+     *
+     * @param calculatedAttributes
+     *  A map of calculated attribute key, value pairs to assign to this pool DTO, or null to clear the
+     *  existing ones
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    public PoolDTO setCalculatedAttributes(Map<String, String> calculatedAttributes) {
+        if (calculatedAttributes != null) {
+            if (this.calculatedAttributes == null) {
+                this.calculatedAttributes = new HashMap<String, String>();
+            }
+            else {
+                this.calculatedAttributes.clear();
+            }
+            this.calculatedAttributes.putAll(calculatedAttributes);
+        }
+        else {
+            this.calculatedAttributes = null;
+        }
+        return this;
+    }
+
+    /**
+     * Returns the upstream pool id.
+     *
+     * @return the upstream pool id.
+     */
+    public String getUpstreamPoolId() {
+        return upstreamPoolId;
+    }
+
+    /**
+     * Sets the upstream pool id.
+     *
+     * @param upstreamPoolId set the upstream pool id.
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    public PoolDTO setUpstreamPoolId(String upstreamPoolId) {
+        this.upstreamPoolId = upstreamPoolId;
+        return this;
+    }
+
+    /**
+     * Returns the upstream entitlement id.
+     *
+     * @return the upstream entitlement id.
+     */
+    public String getUpstreamEntitlementId() {
+        return upstreamEntitlementId;
+    }
+
+    /**
+     * Sets the upstream entitlement id.
+     *
+     * @param upstreamEntitlementId set the upstream entitlement id.
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    public PoolDTO setUpstreamEntitlementId(String upstreamEntitlementId) {
+        this.upstreamEntitlementId = upstreamEntitlementId;
+        return this;
+    }
+
+    /**
+     * Returns the upstream consumer id.
+     *
+     * @return the upstream consumer id.
+     */
+    public String getUpstreamConsumerId() {
+        return upstreamConsumerId;
+    }
+
+    /**
+     * Sets the upstream consumer id.
+     *
+     * @param upstreamConsumerId set the upstream consumer id.
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    public PoolDTO setUpstreamConsumerId(String upstreamConsumerId) {
+        this.upstreamConsumerId = upstreamConsumerId;
+        return this;
+    }
+
+    /**
+     * The Marketing/Operations product name for the
+     * <code>id</code>.
+     *
+     * @return the name
+     */
+    @JsonProperty
+    @HateoasInclude
+    public String getProductName() {
+        return productName;
+    }
+
+    /**
+     * Set the Marketing/Operations product name for the
+     * <code>id</code>.
+     *
+     * @param productName set the productName
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    @JsonIgnore
+    public PoolDTO setProductName(String productName) {
+        this.productName = productName;
+        return this;
+    }
+
+    /**
+     * Return the "top level" product this pool is for.
+     * Note that pools can also provide access to other products.
+     * See getProvidedProducts().
+     *
+     * @return Top level product ID.
+     */
+    @HateoasInclude
+    public String getProductId() {
+        return productId;
+    }
+
+    /**
+     * Set the "top level" product this pool is for.
+     * Note that pools can also provide access to other products.
+     * See getProvidedProducts().
+     *
+     * @param productId Top level product ID.
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    public PoolDTO setProductId(String productId) {
+        this.productId = productId;
+        return this;
+    }
+
+    /**
+     * Retrieves a view of the product attributes for the pool represented by this DTO. If the product
+     * attributes have not yet been defined, this method returns null.
+     * <p></p>
+     * Note that the collection returned by this method is a view of the collection backing this
+     * set of product attributes. Elements cannot be added to the collection, but elements may be removed.
+     * Changes made to the collection will be reflected by this pool DTO instance.
+     *
+     * @return the product attributes associated with this pool,
+     * or null if they have not yet been defined.
+     */
+    @JsonSerialize(using = CandlepinLegacyAttributeSerializer.class)
+    public Map<String, String> getProductAttributes() {
+        return this.productAttributes != null ? new MapView<String, String>(this.productAttributes) : null;
+    }
+
+    /**
+     * Sets the product attributes for this pool DTO.
+     *
+     * @param productAttributes
+     *  A map of product attribute key, value pairs to assign to this pool DTO, or null to clear the
+     *  existing ones
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    @JsonDeserialize(using = CandlepinAttributeDeserializer.class)
+    public PoolDTO setProductAttributes(Map<String, String> productAttributes) {
+        if (productAttributes != null) {
+            if (this.productAttributes == null) {
+                this.productAttributes = new HashMap<String, String>();
+            }
+            else {
+                this.productAttributes.clear();
+            }
+            this.productAttributes.putAll(productAttributes);
+        }
+        else {
+            this.productAttributes = null;
+        }
+        return this;
+    }
+
+    /**
+     * Checks if the given product attribute has been defined on this poolDTO.
+     *
+     * @param key
+     *  The key (name) of the product attribute to lookup
+     *
+     * @throws IllegalArgumentException
+     *  if key is null
+     *
+     * @return
+     *  true if the product attribute is defined for this pool; false otherwise
+     */
+    @JsonIgnore
+    public boolean hasProductAttribute(String key) {
+        if (key == null) {
+            throw new IllegalArgumentException("key is null");
+        }
+
+        if (this.productAttributes == null) {
+            return false;
+        }
+
+        return this.productAttributes.containsKey(key);
+    }
+
+    /**
+     * Returns the identifier of stacked products/pools.
+     *
+     * @return the identifier of stacked products/pools.
+     */
+    @JsonProperty
+    public String getStackId() {
+        return stackId;
+    }
+
+    /**
+     * Sets the identifier of stacked products/pools.
+     *
+     * @param stackId set the identifier of stacked products/pools.
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    @JsonIgnore
+    public PoolDTO setStackId(String stackId) {
+        this.stackId = stackId;
+        return this;
+    }
+
+    /**
+     * Returns true if this pool is stacked, false otherwise.
+     *
+     * @return true if this pool is stacked, false otherwise.
+     */
+    @JsonProperty
+    public Boolean isStacked() {
+        return stacked;
+    }
+
+    /**
+     * Sets if this pool is stacked or not.
+     *
+     * @param stacked set if this pool is stacked or not.
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    @JsonIgnore
+    public PoolDTO setStacked(Boolean stacked) {
+        this.stacked = stacked;
+        return this;
+    }
+
+    /**
+     * Returns true if this is a development pool, false otherwise.
+     *
+     * @return true if this is a development pool, false otherwise.
+     */
+    @JsonProperty
+    public Boolean isDevelopmentPool() {
+        return developmentPool;
+    }
+
+    /**
+     * Sets if this is a development pool or not.
+     *
+     * @param developmentPool set if this is a development pool or not.
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    @JsonIgnore
+    public PoolDTO setDevelopmentPool(Boolean developmentPool) {
+        this.developmentPool = developmentPool;
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @HateoasInclude
+    @Override
+    public String getHref() {
+        return this.getId() != null ? String.format("/pools/%s", this.getId()) : null;
+    }
+
+    /**
+     * Retrieves a view of the derived product attributes for the pool represented by this DTO.
+     * If the derived product attributes have not yet been defined, this method returns null.
+     * <p></p>
+     * Note that the collection returned by this method is a view of the collection backing this
+     * set of derived product attributes. Elements cannot be added to the collection,
+     * but elements may be removed.
+     * Changes made to the collection will be reflected by this pool DTO instance.
+     *
+     * @return the derived product attributes associated with this pool,
+     * or null if they have not yet been defined.
+     */
+    @JsonSerialize(using = CandlepinLegacyAttributeSerializer.class)
+    public Map<String, String> getDerivedProductAttributes() {
+        return this.derivedProductAttributes != null ?
+            new MapView<String, String>(this.derivedProductAttributes) : null;
+    }
+
+    /**
+     * Sets the derived product attributes for this pool DTO.
+     *
+     * @param derivedProductAttributes
+     *  A map of derived product attribute key, value pairs to assign to this pool DTO,
+     *  or null to clear the existing ones
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    @JsonDeserialize(using = CandlepinAttributeDeserializer.class)
+    public PoolDTO setDerivedProductAttributes(Map<String, String> derivedProductAttributes) {
+        if (derivedProductAttributes != null) {
+            if (this.derivedProductAttributes == null) {
+                this.derivedProductAttributes = new HashMap<String, String>();
+            }
+            else {
+                this.derivedProductAttributes.clear();
+            }
+            this.derivedProductAttributes.putAll(derivedProductAttributes);
+        }
+        else {
+            this.derivedProductAttributes = null;
+        }
+        return this;
+    }
+
+    /**
+     * Returns the derived product id of this pool.
+     *
+     * @return the derived product id of this pool.
+     */
+    public String getDerivedProductId() {
+        return derivedProductId;
+    }
+
+    /**
+     * Sets the derived product id of this pool.
+     *
+     * @param derivedProductId set the derived product id of this pool.
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    public PoolDTO setDerivedProductId(String derivedProductId) {
+        this.derivedProductId = derivedProductId;
+        return this;
+    }
+
+    /**
+     * Returns the derived product name of this pool.
+     *
+     * @return the derived product name of this pool.
+     */
+    @JsonProperty
+    public String getDerivedProductName() {
+        return derivedProductName;
+    }
+
+    /**
+     * Sets the derived product name of this pool.
+     *
+     * @param derivedProductName set the derived product name of this pool.
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    @JsonIgnore
+    public PoolDTO setDerivedProductName(String derivedProductName) {
+        this.derivedProductName = derivedProductName;
+        return this;
+    }
+
+    /**
+     * Retrieves a view of the provided products for the pool represented by this DTO.
+     * If the provided products have not yet been defined, this method returns null.
+     * <p></p>
+     * Note that the collection returned by this method is a view of the collection backing this
+     * set of provided products. Elements cannot be added to the collection, but elements may be removed.
+     * Changes made to the collection will be reflected by this pool DTO instance.
+     *
+     * @return
+     *  the provided products associated with this key, or null if they have not yet been defined
+     */
+    public Set<ProvidedProductDTO> getProvidedProducts() {
+        return this.providedProducts != null ? new SetView<ProvidedProductDTO>(this.providedProducts) : null;
+    }
+
+    /**
+     * Adds the collection of provided products to this Pool DTO.
+     *
+     * @param providedProducts
+     *  A set of provided products to attach to this DTO, or null to clear the existing ones
+     *
+     * @return
+     *  A reference to this DTO
+     */
+    public PoolDTO setProvidedProducts(Set<ProvidedProductDTO> providedProducts) {
+        if (providedProducts != null) {
+            if (this.providedProducts == null) {
+                this.providedProducts = new HashSet<ProvidedProductDTO>();
+            }
+            else {
+                this.providedProducts.clear();
+            }
+
+            for (ProvidedProductDTO dto : providedProducts) {
+                if (isNullOrIncomplete(dto)) {
+                    throw new IllegalArgumentException(
+                        "collection contains null or incomplete provided products");
+                }
+            }
+
+            this.providedProducts.addAll(providedProducts);
+        }
+        else {
+            this.providedProducts = null;
+        }
+        return this;
+    }
+
+    /**
+     * Adds the given provided product to this pool DTO.
+     *
+     * @param providedProduct
+     *  The provided product to add to this pool DTO.
+     *
+     * @return
+     *  true if this provided product was not already contained in this pool DTO.
+     */
+    @JsonIgnore
+    public boolean addProvidedProduct(ProvidedProductDTO providedProduct) {
+        if (isNullOrIncomplete(providedProduct)) {
+            throw new IllegalArgumentException("providedProduct is null or incomplete");
+        }
+
+        if (this.providedProducts == null) {
+            this.providedProducts = new HashSet<ProvidedProductDTO>();
+        }
+
+        return this.providedProducts.add(providedProduct);
+    }
+
+    /**
+     * Retrieves a view of the derived provided products for the pool represented by this DTO.
+     * If the derived provided products have not yet been defined, this method returns null.
+     * <p></p>
+     * Note that the collection returned by this method is a view of the collection backing this
+     * set of derived provided products. Elements cannot be added to the collection,
+     * but elements may be removed.
+     * Changes made to the collection will be reflected by this pool DTO instance.
+     *
+     * @return
+     *  the derived provided products associated with this key, or null if they have not yet been defined
+     */
+    public Set<ProvidedProductDTO> getDerivedProvidedProducts() {
+        return this.derivedProvidedProducts != null ?
+            new SetView<ProvidedProductDTO>(this.derivedProvidedProducts) : null;
+    }
+
+    /**
+     * Adds the collection of derived provided products to this Pool DTO.
+     *
+     * @param derivedProvidedProducts
+     *  A set of derived provided products to attach to this DTO, or null to clear the existing ones
+     *
+     * @return
+     *  A reference to this DTO
+     */
+    public PoolDTO setDerivedProvidedProducts(Set<ProvidedProductDTO> derivedProvidedProducts) {
+        if (derivedProvidedProducts != null) {
+            if (this.derivedProvidedProducts == null) {
+                this.derivedProvidedProducts = new HashSet<ProvidedProductDTO>();
+            }
+            else {
+                this.derivedProvidedProducts.clear();
+            }
+
+            for (ProvidedProductDTO dto : derivedProvidedProducts) {
+                if (isNullOrIncomplete(dto)) {
+                    throw new IllegalArgumentException(
+                        "collection contains null or incomplete derived provided products");
+                }
+            }
+
+            this.derivedProvidedProducts.addAll(derivedProvidedProducts);
+        }
+        else {
+            this.derivedProvidedProducts = null;
+        }
+        return this;
+    }
+
+    /**
+     * Adds the given derived provided product to this pool DTO.
+     *
+     * @param derivedProvidedProduct
+     *  The derived provided product to add to this pool DTO.
+     *
+     * @return
+     *  true if this derived provided product was not already contained in this pool DTO.
+     */
+    @JsonIgnore
+    public boolean addDerivedProvidedProduct(ProvidedProductDTO derivedProvidedProduct) {
+        if (isNullOrIncomplete(derivedProvidedProduct)) {
+            throw new IllegalArgumentException("derivedProvidedProduct is null or incomplete");
+        }
+
+        if (this.derivedProvidedProducts == null) {
+            this.derivedProvidedProducts = new HashSet<ProvidedProductDTO>();
+        }
+
+        return this.derivedProvidedProducts.add(derivedProvidedProduct);
+    }
+
+    /**
+     * Utility method to validate ProvidedProductDTO input
+     */
+    private boolean isNullOrIncomplete(ProvidedProductDTO derivedProvidedProduct) {
+        return derivedProvidedProduct == null ||
+            derivedProvidedProduct.getProductId() == null ||
+            derivedProvidedProduct.getProductId().isEmpty();
+    }
+
+    /**
+     * Returns the source stack id of this pool.
+     *
+     * @return the source stack id of this pool.
+     */
+    @JsonProperty
+    public String getSourceStackId() {
+        return sourceStackId;
+    }
+
+    /**
+     * Sets the source stack id of this pool.
+     *
+     * @param sourceStackId set the source stack id of this pool.
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    @JsonIgnore
+    public PoolDTO setSourceStackId(String sourceStackId) {
+        this.sourceStackId = sourceStackId;
+        return this;
+    }
+
+    /**
+     * Returns the subscription key of this pool.
+     *
+     * @return the subscription key of this pool.
+     */
+    public String getSubscriptionSubKey() {
+        return subscriptionSubKey;
+    }
+
+    /**
+     * Sets the subscription key of this pool.
+     *
+     * @param subscriptionSubKey set the subscription key of this pool.
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    public PoolDTO setSubscriptionSubKey(String subscriptionSubKey) {
+        this.subscriptionSubKey = subscriptionSubKey;
+        return this;
+    }
+
+    /**
+     * Returns the subscription id of this pool.
+     *
+     * @return the subscription id associated with this pool.
+     */
+    public String getSubscriptionId() {
+        return subscriptionId;
+    }
+
+    /**
+     * Sets the subscription id of this pool.
+     *
+     * @param subscriptionId set the subscription id associated with this pool.
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    public PoolDTO setSubscriptionId(String subscriptionId) {
+        this.subscriptionId = subscriptionId;
+        return this;
+    }
+
+    /**
+     * Returns the Subscription Certificate of this pool.
+     *
+     * @return the subscription certificate of this pool.
+     */
+    @JsonIgnore
+    public CertificateDTO getCertificate() {
+        return this.certificate;
+    }
+
+    /**
+     * Sets the Subscription Certificate of this pool.
+     *
+     * @param certificate the Subscription Certificate to set on this pool.
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    @JsonProperty
+    public PoolDTO setCertificate(CertificateDTO certificate) {
+        this.certificate = certificate;
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        return String.format("PoolDTO [id: %s, type: %s, product id: %s, product name: %s, quantity: %s]",
+            this.getId(), this.getType(), this.getProductId(), this.getProductName(),
+            this.getQuantity());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        }
+
+        if (obj instanceof PoolDTO && super.equals(obj)) {
+            PoolDTO that = (PoolDTO) obj;
+
+            // We are not interested in making sure nested objects are equal; we're only
+            // concerned with the reference to such an object.
+            String thisOwnerId = this.getOwner() != null ? this.getOwner().getId() : null;
+            String thatOwnerId = that.getOwner() != null ? that.getOwner().getId() : null;
+
+            String thisSourceEntitlementId =
+                this.getSourceEntitlement() != null ? this.getSourceEntitlement().getId() : null;
+            String thatSourceEntitlementId =
+                that.getSourceEntitlement() != null ? that.getSourceEntitlement().getId() : null;
+
+            String thisCertificateId =
+                this.getCertificate() != null ? this.getCertificate().getId() : null;
+            String thatCertificateId =
+                that.getCertificate() != null ? that.getCertificate().getId() : null;
+
+            EqualsBuilder builder = new EqualsBuilder()
+                .append(this.getId(), that.getId())
+                .append(this.getType(), that.getType())
+                .append(thisOwnerId, thatOwnerId)
+                .append(this.isActiveSubscription(), that.isActiveSubscription())
+                .append(this.isCreatedByShare(), that.isCreatedByShare())
+                .append(this.hasSharedAncestor(), that.hasSharedAncestor())
+                .append(thisSourceEntitlementId, thatSourceEntitlementId)
+                .append(this.getQuantity(), that.getQuantity())
+                .append(this.getStartDate(), that.getStartDate())
+                .append(this.getEndDate(), that.getEndDate())
+                .append(this.getAttributes(), that.getAttributes())
+                .append(this.getRestrictedToUsername(), that.getRestrictedToUsername())
+                .append(this.getContractNumber(), that.getContractNumber())
+                .append(this.getAccountNumber(), that.getAccountNumber())
+                .append(this.getOrderNumber(), that.getOrderNumber())
+                .append(this.getConsumed(), that.getConsumed())
+                .append(this.getExported(), that.getExported())
+                .append(this.getShared(), that.getShared())
+                .append(this.getBranding(), that.getBranding())
+                .append(this.getCalculatedAttributes(), that.getCalculatedAttributes())
+                .append(this.getUpstreamPoolId(), that.getUpstreamPoolId())
+                .append(this.getUpstreamEntitlementId(), that.getUpstreamEntitlementId())
+                .append(this.getUpstreamConsumerId(), that.getUpstreamConsumerId())
+                .append(this.getProductName(), that.getProductName())
+                .append(this.getProductId(), that.getProductId())
+                .append(this.getProductAttributes(), that.getProductAttributes())
+                .append(this.getStackId(), that.getStackId())
+                .append(this.isStacked(), that.isStacked())
+                .append(this.isDevelopmentPool(), that.isDevelopmentPool())
+                .append(this.getDerivedProductAttributes(), that.getDerivedProductAttributes())
+                .append(this.getDerivedProductId(), that.getDerivedProductId())
+                .append(this.getDerivedProductName(), that.getDerivedProductName())
+                .append(this.getProvidedProducts(), that.getProvidedProducts())
+                .append(this.getDerivedProvidedProducts(), that.getDerivedProvidedProducts())
+                .append(this.getSourceStackId(), that.getSourceStackId())
+                .append(this.getSubscriptionSubKey(), that.getSubscriptionSubKey())
+                .append(this.getSubscriptionId(), that.getSubscriptionId())
+                .append(thisCertificateId, thatCertificateId);
+
+            return builder.isEquals();
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        // Like with the equals method, we are not interested in hashing nested objects; we're only
+        // concerned with the reference to such an object.
+
+        HashCodeBuilder builder = new HashCodeBuilder(37, 7)
+            .append(super.hashCode())
+            .append(this.getId())
+            .append(this.getType())
+            .append(this.getOwner() != null ? this.getOwner().getId() : null)
+            .append(this.isActiveSubscription())
+            .append(this.isCreatedByShare())
+            .append(this.hasSharedAncestor())
+            .append(this.getSourceEntitlement() != null ? this.getSourceEntitlement().getId() : null)
+            .append(this.getQuantity())
+            .append(this.getStartDate())
+            .append(this.getEndDate())
+            .append(this.getAttributes())
+            .append(this.getRestrictedToUsername())
+            .append(this.getContractNumber())
+            .append(this.getAccountNumber())
+            .append(this.getOrderNumber())
+            .append(this.getConsumed())
+            .append(this.getExported())
+            .append(this.getShared())
+            .append(this.getBranding())
+            .append(this.getCalculatedAttributes())
+            .append(this.getUpstreamPoolId())
+            .append(this.getUpstreamEntitlementId())
+            .append(this.getUpstreamConsumerId())
+            .append(this.getProductName())
+            .append(this.getProductId())
+            .append(this.getProductAttributes())
+            .append(this.getStackId())
+            .append(this.isStacked())
+            .append(this.isDevelopmentPool())
+            .append(this.getDerivedProductAttributes())
+            .append(this.getDerivedProductId())
+            .append(this.getDerivedProductName())
+            .append(this.getProvidedProducts())
+            .append(this.getDerivedProvidedProducts())
+            .append(this.getSourceStackId())
+            .append(this.getSubscriptionSubKey())
+            .append(this.getSubscriptionId())
+            .append(this.getCertificate() != null ? this.getCertificate().getId() : null);
+
+        return builder.toHashCode();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public PoolDTO clone() {
+        PoolDTO copy = super.clone();
+
+        OwnerDTO owner = this.getOwner();
+        copy.owner = owner != null ? owner.clone() : null;
+
+        CertificateDTO certificate = this.getCertificate();
+        copy.certificate = certificate != null ? certificate.clone() : null;
+
+        copy.setAttributes(this.getAttributes());
+        copy.setCalculatedAttributes(this.getCalculatedAttributes());
+        copy.setProductAttributes(this.getProductAttributes());
+        copy.setDerivedProductAttributes(this.getDerivedProductAttributes());
+        copy.setBranding(this.getBranding());
+        copy.setProvidedProducts(this.getProvidedProducts());
+        copy.setDerivedProvidedProducts(this.getDerivedProvidedProducts());
+
+        copy.endDate = this.endDate != null ? (Date) this.endDate.clone() : null;
+        copy.startDate = this.startDate != null ? (Date) this.startDate.clone() : null;
+
+        return copy;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public PoolDTO populate(PoolDTO source) {
+        super.populate(source);
+
+        this.setId(source.getId());
+        this.setType(source.getType());
+        this.setOwner(source.getOwner());
+        this.setActiveSubscription(source.isActiveSubscription());
+        this.setCreatedByShare(source.isCreatedByShare());
+        this.setHasSharedAncestor(source.hasSharedAncestor());
+        this.setSourceEntitlement(source.getSourceEntitlement());
+        this.setQuantity(source.getQuantity());
+        this.setStartDate(source.getStartDate());
+        this.setEndDate(source.getEndDate());
+        this.setAttributes(source.getAttributes());
+        this.setRestrictedToUsername(source.getRestrictedToUsername());
+        this.setContractNumber(source.getContractNumber());
+        this.setAccountNumber(source.getAccountNumber());
+        this.setOrderNumber(source.getOrderNumber());
+        this.setConsumed(source.getConsumed());
+        this.setExported(source.getExported());
+        this.setShared(source.getShared());
+        this.setBranding(source.getBranding());
+        this.setCalculatedAttributes(source.getCalculatedAttributes());
+        this.setUpstreamPoolId(source.getUpstreamPoolId());
+        this.setUpstreamEntitlementId(source.getUpstreamEntitlementId());
+        this.setUpstreamConsumerId(source.getUpstreamConsumerId());
+        this.setProductName(source.getProductName());
+        this.setProductId(source.getProductId());
+        this.setProductAttributes(source.getProductAttributes());
+        this.setStackId(source.getStackId());
+        this.setStacked(source.isStacked());
+        this.setDevelopmentPool(source.isDevelopmentPool());
+        this.setDerivedProductAttributes(source.getDerivedProductAttributes());
+        this.setDerivedProductId(source.getDerivedProductId());
+        this.setDerivedProductName(source.getDerivedProductName());
+        this.setProvidedProducts(source.getProvidedProducts());
+        this.setDerivedProvidedProducts(source.getDerivedProvidedProducts());
+        this.setSourceStackId(source.getSourceStackId());
+        this.setSubscriptionSubKey(source.getSubscriptionSubKey());
+        this.setSubscriptionId(source.getSubscriptionId());
+        this.setCertificate(source.getCertificate());
+
+        return this;
+    }
+}

--- a/server/src/main/java/org/candlepin/dto/api/v1/PoolTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/PoolTranslator.java
@@ -1,0 +1,154 @@
+/**
+ * Copyright (c) 2009 - 2017 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.dto.api.v1;
+
+import org.candlepin.dto.ModelTranslator;
+import org.candlepin.model.Branding;
+import org.candlepin.model.Entitlement;
+import org.candlepin.model.Owner;
+import org.candlepin.model.Pool;
+import org.candlepin.model.Product;
+import org.candlepin.model.SubscriptionsCertificate;
+
+import java.util.Collections;
+import java.util.Set;
+
+
+/**
+ * The PoolTranslator provides translation from Pool model objects to PoolDTOs.
+ */
+public class PoolTranslator extends TimestampedEntityTranslator<Pool, PoolDTO> {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public PoolDTO translate(Pool source) {
+        return this.translate(null, source);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public PoolDTO translate(ModelTranslator translator, Pool source) {
+        return source != null ? this.populate(translator, source, new PoolDTO()) : null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public PoolDTO populate(Pool source, PoolDTO destination) {
+        return this.populate(null, source, destination);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @SuppressWarnings("checkstyle:methodlength")
+    public PoolDTO populate(ModelTranslator modelTranslator, Pool source, PoolDTO dest) {
+        dest = super.populate(modelTranslator, source, dest);
+
+        dest.setId(source.getId());
+        dest.setType(source.getType().toString());
+        dest.setActiveSubscription(source.getActiveSubscription());
+        dest.setCreatedByShare(source.isCreatedByShare());
+        dest.setHasSharedAncestor(source.hasSharedAncestor());
+        dest.setQuantity(source.getQuantity());
+        dest.setStartDate(source.getStartDate());
+        dest.setEndDate(source.getEndDate());
+        dest.setAttributes(source.getAttributes());
+        dest.setRestrictedToUsername(source.getRestrictedToUsername());
+        dest.setContractNumber(source.getContractNumber());
+        dest.setAccountNumber(source.getAccountNumber());
+        dest.setOrderNumber(source.getOrderNumber());
+        dest.setConsumed(source.getConsumed());
+        dest.setExported(source.getExported());
+        dest.setShared(source.getShared());
+        dest.setCalculatedAttributes(source.getCalculatedAttributes());
+        dest.setUpstreamPoolId(source.getUpstreamPoolId());
+        dest.setUpstreamEntitlementId(source.getUpstreamEntitlementId());
+        dest.setUpstreamConsumerId(source.getUpstreamConsumerId());
+        dest.setProductName(source.getProductName());
+        dest.setProductId(source.getProductId());
+        dest.setProductAttributes(source.getProductAttributes());
+        dest.setStackId(source.getStackId());
+        dest.setStacked(source.isStacked());
+        dest.setDevelopmentPool(source.isDevelopmentPool());
+        dest.setDerivedProductAttributes(source.getDerivedProductAttributes());
+        dest.setDerivedProductId(source.getDerivedProductId());
+        dest.setDerivedProductName(source.getDerivedProductName());
+        dest.setSourceStackId(source.getSourceStackId());
+        dest.setSubscriptionSubKey(source.getSubscriptionSubKey());
+        dest.setSubscriptionId(source.getSubscriptionId());
+
+        // Process nested objects if we have a model translator to use to the translation...
+        if (modelTranslator != null) {
+            Owner owner = source.getOwner();
+            dest.setOwner(owner != null ? modelTranslator.translate(owner, OwnerDTO.class) : null);
+
+            SubscriptionsCertificate subCertificate = source.getCertificate();
+            dest.setCertificate(subCertificate != null ?
+                modelTranslator.translate(subCertificate, CertificateDTO.class) : null);
+
+            Entitlement sourceEntitlement = source.getSourceEntitlement();
+            dest.setSourceEntitlement(sourceEntitlement != null ?
+                modelTranslator.translate(sourceEntitlement, EntitlementDTO.class) : null);
+
+            Set<Branding> branding = source.getBranding();
+            if (branding != null && !branding.isEmpty()) {
+                for (Branding brand : branding) {
+                    if (brand != null) {
+                        dest.addBranding(
+                            new BrandingDTO(brand.getProductId(), brand.getName(), brand.getType()));
+                    }
+                }
+            }
+            else {
+                dest.setBranding(Collections.<BrandingDTO>emptySet());
+            }
+
+            Set<Product> products = source.getProvidedProducts();
+            if (products != null && !products.isEmpty()) {
+                for (Product prod : products) {
+                    if (prod != null) {
+                        dest.addProvidedProduct(
+                            new PoolDTO.ProvidedProductDTO(prod.getId(), prod.getName()));
+                    }
+                }
+            }
+            else {
+                dest.setProvidedProducts(Collections.<PoolDTO.ProvidedProductDTO>emptySet());
+            }
+
+            Set<Product> derivedProducts = source.getDerivedProvidedProducts();
+            if (derivedProducts != null && !derivedProducts.isEmpty()) {
+                for (Product derivedProd : derivedProducts) {
+                    if (derivedProd != null) {
+                        dest.addDerivedProvidedProduct(
+                            new PoolDTO.ProvidedProductDTO(derivedProd.getId(), derivedProd.getName()));
+                    }
+                }
+            }
+            else {
+                dest.setDerivedProvidedProducts(Collections.<PoolDTO.ProvidedProductDTO>emptySet());
+            }
+        }
+
+        return dest;
+    }
+}

--- a/server/src/main/java/org/candlepin/model/Branding.java
+++ b/server/src/main/java/org/candlepin/model/Branding.java
@@ -25,7 +25,6 @@ import javax.persistence.Id;
 import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
-import javax.xml.bind.annotation.XmlTransient;
 
 /**
  * Brand mapping is carried on subscription data and passed to clients through entitlement
@@ -39,7 +38,7 @@ import javax.xml.bind.annotation.XmlTransient;
  */
 @Entity
 @Table(name = Branding.DB_TABLE)
-public class Branding extends AbstractHibernateObject {
+public class Branding extends AbstractHibernateObject<Branding> {
 
     /** Name of the table backing this object in the database */
     public static final String DB_TABLE = "cp_branding";
@@ -75,7 +74,6 @@ public class Branding extends AbstractHibernateObject {
         this.name = name;
     }
 
-    @XmlTransient
     public String getId() {
         return id;
     }

--- a/server/src/main/java/org/candlepin/model/Entitlement.java
+++ b/server/src/main/java/org/candlepin/model/Entitlement.java
@@ -19,8 +19,6 @@ import org.candlepin.common.jackson.HateoasInclude;
 import com.fasterxml.jackson.annotation.JsonFilter;
 
 import org.hibernate.annotations.BatchSize;
-import org.hibernate.annotations.ForeignKey;
-import org.hibernate.annotations.Index;
 
 import java.util.Date;
 import java.util.HashSet;
@@ -62,7 +60,7 @@ import javax.xml.bind.annotation.XmlTransient;
 @Entity
 @Table(name = Entitlement.DB_TABLE)
 @JsonFilter("EntitlementFilter")
-public class Entitlement extends AbstractHibernateObject
+public class Entitlement extends AbstractHibernateObject<Entitlement>
     implements Linkable, Owned, Named, ConsumerProperty, Comparable<Entitlement>, Eventful {
 
     /** Name of the table backing this object in the database */
@@ -76,23 +74,17 @@ public class Entitlement extends AbstractHibernateObject
     private String id;
 
     @ManyToOne
-    @ForeignKey(name = "fk_entitlement_owner")
     @JoinColumn(nullable = false)
-    @Index(name = "cp_entitlement_owner_fk_idx")
     @NotNull
     private Owner owner;
 
     @ManyToOne
-    @ForeignKey(name = "fk_entitlement_consumer")
     @JoinColumn(nullable = false)
-    @Index(name = "cp_entitlement_consumer_fk_idx")
     @NotNull
     private Consumer consumer;
 
     @ManyToOne
-    @ForeignKey(name = "fk_entitlement_pool")
     @JoinColumn(nullable = true)
-    @Index(name = "cp_entitlement_pool_fk_idx")
     @NotNull
     private Pool pool;
 

--- a/server/src/main/java/org/candlepin/model/Pool.java
+++ b/server/src/main/java/org/candlepin/model/Pool.java
@@ -82,7 +82,7 @@ import javax.xml.bind.annotation.XmlTransient;
 @Entity
 @Table(name = Pool.DB_TABLE)
 @JsonFilter("PoolFilter")
-public class Pool extends AbstractHibernateObject implements Persisted, Owned, Named, Comparable<Pool>,
+public class Pool extends AbstractHibernateObject<Pool> implements Owned, Named, Comparable<Pool>,
     Eventful {
 
     /** Name of the table backing this object in the database */
@@ -1171,11 +1171,6 @@ public class Pool extends AbstractHibernateObject implements Persisted, Owned, N
         return getConsumed() > this.quantity;
     }
 
-    @HateoasInclude
-    public String getHref() {
-        return "/pools/" + getId();
-    }
-
     /**
      * @return the subscriptionSubKey
      */
@@ -1413,6 +1408,7 @@ public class Pool extends AbstractHibernateObject implements Persisted, Owned, N
         if (sourceSubscription == null && !StringUtils.isBlank(subid)) {
             setSourceSubscription(new SourceSubscription());
         }
+
         if (sourceSubscription != null) {
             sourceSubscription.setSubscriptionId(subid);
             if (StringUtils.isBlank(sourceSubscription.getSubscriptionId()) &&
@@ -1426,6 +1422,7 @@ public class Pool extends AbstractHibernateObject implements Persisted, Owned, N
         if (sourceSubscription == null && !StringUtils.isBlank(subkey)) {
             setSourceSubscription(new SourceSubscription());
         }
+
         if (sourceSubscription != null) {
             sourceSubscription.setSubscriptionSubKey(subkey);
             if (StringUtils.isBlank(sourceSubscription.getSubscriptionId()) &&

--- a/server/src/main/java/org/candlepin/model/ProvidedProduct.java
+++ b/server/src/main/java/org/candlepin/model/ProvidedProduct.java
@@ -14,23 +14,14 @@
  */
 package org.candlepin.model;
 
-import com.fasterxml.jackson.annotation.JsonFilter;
-
 import org.apache.commons.lang.builder.HashCodeBuilder;
 
 import java.io.Serializable;
-
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlRootElement;
 
 /**
  * Represents a product provided by a Pool
  * ProvidedProduct
  */
-@XmlRootElement
-@XmlAccessorType(XmlAccessType.PROPERTY)
-@JsonFilter("ProvidedProductFilter")
 public class ProvidedProduct implements Serializable {
 
     private static final long serialVersionUID = -6596019311091733072L;
@@ -81,6 +72,7 @@ public class ProvidedProduct implements Serializable {
         if (this == anObject) {
             return true;
         }
+
         if (!(anObject instanceof ProvidedProduct)) {
             return false;
         }

--- a/server/src/main/java/org/candlepin/model/SourceStack.java
+++ b/server/src/main/java/org/candlepin/model/SourceStack.java
@@ -14,9 +14,6 @@
  */
 package org.candlepin.model;
 
-import org.candlepin.common.jackson.HateoasInclude;
-
-import org.hibernate.annotations.ForeignKey;
 import org.hibernate.annotations.GenericGenerator;
 
 import javax.persistence.Column;
@@ -30,21 +27,15 @@ import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlTransient;
 
 /**
  * PoolSourceStack represents the source of a derived pool from a stack.
  *
  * This allows us to enforce one-subpool-per-stack with a database constraint.
  */
-@XmlRootElement
-@XmlAccessorType(XmlAccessType.PROPERTY)
 @Entity
 @Table(name = SourceStack.DB_TABLE)
-public class SourceStack extends AbstractHibernateObject {
+public class SourceStack extends AbstractHibernateObject<SourceStack> {
 
     /** Name of the table backing this object in the database */
     public static final String DB_TABLE = "cp_pool_source_stack";
@@ -72,7 +63,6 @@ public class SourceStack extends AbstractHibernateObject {
      * pool.
      */
     @ManyToOne(fetch = FetchType.LAZY)
-    @ForeignKey(name = "fk_sourcestack_consumer")
     @JoinColumn(nullable = false)
     @NotNull
     private Consumer sourceConsumer;
@@ -81,9 +71,7 @@ public class SourceStack extends AbstractHibernateObject {
      * pool derived from the source
      */
     @OneToOne(fetch = FetchType.LAZY)
-    @ForeignKey(name = "fk_sourcestack_pool")
     @JoinColumn(nullable = false, unique = true)
-    @XmlTransient
     @NotNull
     private Pool derivedPool;
 
@@ -146,7 +134,6 @@ public class SourceStack extends AbstractHibernateObject {
     /**
      * @return the id
      */
-    @HateoasInclude
     public String getId() {
         return id;
     }

--- a/server/src/main/java/org/candlepin/model/SourceSubscription.java
+++ b/server/src/main/java/org/candlepin/model/SourceSubscription.java
@@ -14,8 +14,6 @@
  */
 package org.candlepin.model;
 
-import org.candlepin.common.jackson.HateoasInclude;
-
 import org.hibernate.annotations.GenericGenerator;
 
 import javax.persistence.Column;
@@ -27,20 +25,14 @@ import javax.persistence.JoinColumn;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import javax.validation.constraints.Size;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlTransient;
 
 /**
  * SourceSubscription represents the subscription
  * from which a pool was created.
  */
-@XmlRootElement
-@XmlAccessorType(XmlAccessType.PROPERTY)
 @Entity
 @Table(name = SourceSubscription.DB_TABLE)
-public class SourceSubscription extends AbstractHibernateObject {
+public class SourceSubscription extends AbstractHibernateObject<SourceSubscription> {
 
     /** Name of the table backing this object in the database */
     public static final String DB_TABLE = "cp2_pool_source_sub";
@@ -73,7 +65,6 @@ public class SourceSubscription extends AbstractHibernateObject {
      */
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(nullable = false, unique = true)
-    @XmlTransient
     private Pool pool;
 
     public SourceSubscription() {
@@ -130,7 +121,6 @@ public class SourceSubscription extends AbstractHibernateObject {
      * @return the id
      */
     @Override
-    @HateoasInclude
     public String getId() {
         return id;
     }

--- a/server/src/main/java/org/candlepin/model/SubscriptionsCertificate.java
+++ b/server/src/main/java/org/candlepin/model/SubscriptionsCertificate.java
@@ -44,7 +44,8 @@ import javax.xml.bind.annotation.XmlRootElement;
 @Entity
 @Table(name = SubscriptionsCertificate.DB_TABLE)
 @JsonFilter("SubscriptionCertificateFilter")
-public class SubscriptionsCertificate extends AbstractCertificate {
+public class SubscriptionsCertificate extends AbstractCertificate<SubscriptionsCertificate>
+    implements Certificate<SubscriptionsCertificate> {
 
     /** Name of the table backing this object in the database */
     public static final String DB_TABLE = "cp_certificate";

--- a/server/src/main/java/org/candlepin/resource/ActivationKeyResource.java
+++ b/server/src/main/java/org/candlepin/resource/ActivationKeyResource.java
@@ -19,6 +19,7 @@ import org.candlepin.common.exceptions.BadRequestException;
 import org.candlepin.controller.PoolManager;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.dto.api.v1.ActivationKeyDTO;
+import org.candlepin.dto.api.v1.PoolDTO;
 import org.candlepin.model.CandlepinQuery;
 import org.candlepin.model.Owner;
 import org.candlepin.model.OwnerProductCurator;
@@ -107,21 +108,21 @@ public class ActivationKeyResource {
     }
 
     @ApiOperation(notes = "Retrieves a list of Pools based on the Activation Key",
-        value = "Get Activation Key Pools", response = Pool.class, responseContainer = "list")
+        value = "Get Activation Key Pools", response = PoolDTO.class, responseContainer = "list")
     @ApiResponses({ @ApiResponse(code = 400, message = "")})
     @GET
     @Path("{activation_key_id}/pools")
     @Produces(MediaType.APPLICATION_JSON)
-    public Iterator<Pool> getActivationKeyPools(
+    public Iterator<PoolDTO> getActivationKeyPools(
         @PathParam("activation_key_id") @Verify(ActivationKey.class) String activationKeyId) {
 
         ActivationKey key = activationKeyCurator.verifyAndLookupKey(activationKeyId);
 
-        return new TransformedIterator<ActivationKeyPool, Pool>(key.getPools().iterator(),
-            new ElementTransformer<ActivationKeyPool, Pool>() {
+        return new TransformedIterator<ActivationKeyPool, PoolDTO>(key.getPools().iterator(),
+            new ElementTransformer<ActivationKeyPool, PoolDTO>() {
                 @Override
-                public Pool transform(ActivationKeyPool akp) {
-                    return akp.getPool();
+                public PoolDTO transform(ActivationKeyPool akp) {
+                    return translator.translate(akp.getPool(), PoolDTO.class);
                 }
             }
         );

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -44,6 +44,7 @@ import org.candlepin.controller.ManifestManager;
 import org.candlepin.controller.PoolManager;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.dto.api.v1.EventDTO;
+import org.candlepin.dto.api.v1.EntitlementDTO;
 import org.candlepin.model.CandlepinQuery;
 import org.candlepin.model.CdnCurator;
 import org.candlepin.model.Certificate;
@@ -1744,18 +1745,24 @@ public class ConsumerResource {
             }
         }
 
-        // we need to supply the compliance type for the pools
-        // the method in this class does not do quantity
+        List<EntitlementDTO> entitlementDTOs = null;
         if (entitlements != null) {
+            entitlementDTOs = new ArrayList<EntitlementDTO>();
+
             for (Entitlement ent : entitlements) {
+                // we need to supply the compliance type for the pools
+                // the method in this class does not do quantity
                 addCalculatedAttributes(ent);
+
+                entitlementDTOs.add(this.translator.translate(ent, EntitlementDTO.class));
             }
         }
+
         // Trigger events:
         entitler.sendEvents(entitlements);
 
         return Response.status(Response.Status.OK)
-            .type(MediaType.APPLICATION_JSON).entity(entitlements).build();
+            .type(MediaType.APPLICATION_JSON).entity(entitlementDTOs).build();
     }
 
     @ApiOperation(notes = "Retrieves a list of Pools and quantities that would be the " +
@@ -1819,7 +1826,7 @@ public class ConsumerResource {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/{consumer_uuid}/entitlements")
-    public List<Entitlement> listEntitlements(
+    public List<EntitlementDTO> listEntitlements(
         @PathParam("consumer_uuid") @Verify(Consumer.class) String consumerUuid,
         @QueryParam("product") String productId,
         @QueryParam("regen") @DefaultValue("true") Boolean regen,
@@ -1855,7 +1862,11 @@ public class ConsumerResource {
             }
         }
 
-        return entitlementsPage.getPageData();
+        List<EntitlementDTO> entitlementDTOs = new ArrayList<EntitlementDTO>();
+        for (Entitlement entitlement : entitlementsPage.getPageData()) {
+            entitlementDTOs.add(this.translator.translate(entitlement, EntitlementDTO.class));
+        }
+        return entitlementDTOs;
     }
 
     @ApiOperation(notes = "Retrieves the Owner associated to a Consumer", value = "getOwner")

--- a/server/src/main/java/org/candlepin/resource/PoolResource.java
+++ b/server/src/main/java/org/candlepin/resource/PoolResource.java
@@ -27,6 +27,8 @@ import org.candlepin.common.paging.PageRequest;
 import org.candlepin.controller.PoolManager;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.dto.api.v1.CertificateDTO;
+import org.candlepin.dto.api.v1.EntitlementDTO;
+import org.candlepin.dto.api.v1.PoolDTO;
 import org.candlepin.model.Cdn;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerCurator;
@@ -119,7 +121,7 @@ public class PoolResource {
     @Wrapped(element = "pools")
     @Deprecated
     @SecurityHole
-    public List<Pool> list(@QueryParam("owner") String ownerId,
+    public List<PoolDTO> list(@QueryParam("owner") String ownerId,
         @QueryParam("consumer") String consumerUuid,
         @QueryParam("product") String productId,
         @ApiParam("Use with consumerUuid to list all pools available to the consumer. " +
@@ -191,7 +193,12 @@ public class PoolResource {
 
         // Store the page for the LinkHeaderResponseFilter
         ResteasyProviderFactory.pushContext(Page.class, page);
-        return poolList;
+
+        List<PoolDTO> poolDTOs = new ArrayList<PoolDTO>();
+        for (Pool pool : poolList) {
+            poolDTOs.add(translator.translate(pool, PoolDTO.class));
+        }
+        return poolDTOs;
     }
 
     @ApiOperation(notes = "Retrieves a single Pool", value = "getPool")
@@ -200,7 +207,7 @@ public class PoolResource {
     @GET
     @Path("/{pool_id}")
     @Produces(MediaType.APPLICATION_JSON)
-    public Pool getPool(@PathParam("pool_id") @Verify(Pool.class) String id,
+    public PoolDTO getPool(@PathParam("pool_id") @Verify(Pool.class) String id,
         @QueryParam("consumer") String consumerUuid,
         @ApiParam("Uses ISO 8601 format") @QueryParam("activeon") String activeOn,
         @Context Principal principal) {
@@ -229,7 +236,8 @@ public class PoolResource {
                 calculatedAttributesUtil.buildCalculatedAttributes(toReturn, activeOnDate)
             );
             calculatedAttributesUtil.setQuantityAttributes(toReturn, c, activeOnDate);
-            return toReturn;
+
+            return translator.translate(toReturn, PoolDTO.class);
         }
 
         throw new NotFoundException(i18n.tr(
@@ -280,7 +288,7 @@ public class PoolResource {
     @GET
     @Path("{pool_id}/entitlements")
     @Produces(MediaType.APPLICATION_JSON)
-    public List<Entitlement> getPoolEntitlements(@PathParam("pool_id")
+    public List<EntitlementDTO> getPoolEntitlements(@PathParam("pool_id")
         @Verify(value = Pool.class, subResource = SubResource.ENTITLEMENTS) String id,
         @Context Principal principal) {
 
@@ -291,9 +299,11 @@ public class PoolResource {
                 "Subscription Pool with ID ''{0}'' could not be found.", id));
         }
 
-        List<Entitlement> entitlements = new ArrayList<Entitlement>();
-        entitlements.addAll(pool.getEntitlements());
-        return entitlements;
+        List<EntitlementDTO> entitlementDTOs = new ArrayList<EntitlementDTO>();
+        for (Entitlement entitlement : pool.getEntitlements()) {
+            entitlementDTOs.add(this.translator.translate(entitlement, EntitlementDTO.class));
+        }
+        return entitlementDTOs;
     }
 
     /**

--- a/server/src/test/java/org/candlepin/dto/api/v1/ActivationKeyDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/ActivationKeyDTOTest.java
@@ -26,6 +26,9 @@ import java.util.Set;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+/**
+ * Test suite for the ActivationKeyDTO class
+ */
 public class ActivationKeyDTOTest extends AbstractDTOTest<ActivationKeyDTO> {
 
     protected Map<String, Object> values;

--- a/server/src/test/java/org/candlepin/dto/api/v1/BrandingDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/BrandingDTOTest.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2009 - 2017 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.dto.api.v1;
+
+import org.candlepin.dto.AbstractDTOTest;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Test suite for the BrandingDTO class
+ */
+public class BrandingDTOTest extends AbstractDTOTest<BrandingDTO> {
+
+    protected Map<String, Object> values;
+
+    public BrandingDTOTest() {
+        super(BrandingDTO.class);
+
+        this.values = new HashMap<String, Object>();
+        this.values.put("ProductId", "test-product-id");
+        this.values.put("Name", "test-name");
+        this.values.put("Type", "test-type");
+
+        this.values.put("Created", new Date());
+        this.values.put("Updated", new Date());
+    }
+
+    @Override
+    protected Object getInputValueForMutator(String field) {
+        return this.values.get(field);
+    }
+
+    @Override
+    protected Object getOutputValueForAccessor(String field, Object input) {
+        // Nothing to do here
+        return input;
+    }
+}

--- a/server/src/test/java/org/candlepin/dto/api/v1/BrandingTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/BrandingTranslatorTest.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2009 - 2017 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.dto.api.v1;
+
+import org.candlepin.dto.AbstractTranslatorTest;
+import org.candlepin.dto.ModelTranslator;
+import org.candlepin.model.Branding;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Test suite for the BrandingTranslator class
+ */
+public class BrandingTranslatorTest extends
+    AbstractTranslatorTest<Branding, BrandingDTO, BrandingTranslator> {
+
+    protected BrandingTranslator translator = new BrandingTranslator();
+
+    @Override
+    protected void initModelTranslator(ModelTranslator modelTranslator) {
+        modelTranslator.registerTranslator(this.translator, Branding.class, BrandingDTO.class);
+    }
+
+    @Override
+    protected BrandingTranslator initObjectTranslator() {
+        return this.translator;
+    }
+
+    @Override
+    protected Branding initSourceObject() {
+        Branding source = new Branding();
+
+        source.setProductId("test-product-id");
+        source.setName("test-name");
+        source.setType("test-type");
+
+        return source;
+    }
+
+    @Override
+    protected BrandingDTO initDestinationObject() {
+        return new BrandingDTO();
+    }
+
+    @Override
+    protected void verifyOutput(Branding source, BrandingDTO dest, boolean childrenGenerated) {
+        if (source != null) {
+            assertEquals(source.getProductId(), dest.getProductId());
+            assertEquals(source.getName(), dest.getName());
+            assertEquals(source.getType(), dest.getType());
+        }
+        else {
+            assertNull(dest);
+        }
+    }
+}

--- a/server/src/test/java/org/candlepin/dto/api/v1/EntitlementDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/EntitlementDTOTest.java
@@ -1,0 +1,182 @@
+/**
+ * Copyright (c) 2009 - 2017 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.dto.api.v1;
+
+import org.candlepin.dto.AbstractDTOTest;
+import org.candlepin.model.Consumer;
+import org.candlepin.model.ConsumerType;
+import org.junit.Test;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test suite for the EntitlementDTO class
+ */
+public class EntitlementDTOTest  extends AbstractDTOTest<EntitlementDTO> {
+
+    protected Map<String, Object> values;
+
+    public EntitlementDTOTest() {
+        super(EntitlementDTO.class);
+
+        this.values = new HashMap<String, Object>();
+
+        OwnerDTO owner = new OwnerDTO();
+        owner.setId("owner_id");
+        owner.setKey("owner_key");
+        owner.setDisplayName("owner_name");
+        owner.setContentPrefix("content_prefix");
+        owner.setDefaultServiceLevel("service_level");
+        owner.setLogLevel("log_level");
+        owner.setAutobindDisabled(true);
+        owner.setContentAccessMode("content_access_mode");
+        owner.setContentAccessModeList("content_access_mode_list");
+
+        PoolDTO pool = new PoolDTO();
+        pool.setId("pool_id");
+        pool.setProductId("pool_product_id");
+        pool.setProductName("pool_product_name");
+
+        //TODO: change to ConsumerDTO once it gets introduced.
+        Consumer consumer = new Consumer();
+        consumer.setId("consumer_id");
+        consumer.setName("consumer_name");
+        consumer.setUsername("consumer_username");
+        consumer.setType(new ConsumerType());
+
+        Set<CertificateDTO> certs = new HashSet<CertificateDTO>();
+        CertificateDTO certificate = new CertificateDTO();
+        certificate.setId("cert-id");
+        certificate.setKey("cert-key");
+        certificate.setCert("cert");
+        certificate.setSerial(new CertificateSerialDTO());
+        certs.add(certificate);
+
+        this.values.put("Id", "test-id");
+        this.values.put("Owner", owner);
+        this.values.put("Pool", pool);
+        this.values.put("Consumer", consumer);
+        this.values.put("Quantity", 1);
+        this.values.put("DeletedFromPool", false);
+        this.values.put("Certificates", certs);
+        this.values.put("StartDate", new Date());
+        this.values.put("EndDate", new Date());
+        this.values.put("Created", new Date());
+        this.values.put("Updated", new Date());
+    }
+
+    @Override
+    protected Object getInputValueForMutator(String field) {
+        return this.values.get(field);
+    }
+
+    @Override
+    protected Object getOutputValueForAccessor(String field, Object input) {
+        // Nothing to do here
+        return input;
+    }
+
+    @Test
+    public void testAddCertificateWithAbsentCertificate() {
+        EntitlementDTO dto = new EntitlementDTO();
+
+        CertificateDTO certDTO = new CertificateDTO();
+        certDTO.setId("cert-id-1");
+        certDTO.setKey("cert-key-1");
+        certDTO.setCert("cert-cert-1");
+        certDTO.setSerial(new CertificateSerialDTO());
+        assertTrue(dto.addCertificate(certDTO));
+    }
+
+    @Test
+    public void testAddCertificateWithPresentCertificate() {
+        EntitlementDTO dto = new EntitlementDTO();
+
+        CertificateDTO certDTO = new CertificateDTO();
+        certDTO.setId("cert-id-2");
+        certDTO.setKey("cert-key-2");
+        certDTO.setCert("cert-cert-2");
+        certDTO.setSerial(new CertificateSerialDTO());
+        assertTrue(dto.addCertificate(certDTO));
+
+        CertificateDTO certDTO2 = new CertificateDTO();
+        certDTO2.setId("cert-id-2");
+        certDTO2.setKey("cert-key-2");
+        certDTO2.setCert("cert-cert-2");
+        certDTO2.setSerial(new CertificateSerialDTO());
+        assertFalse(dto.addCertificate(certDTO2));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddCertificateWithNullInput() {
+        EntitlementDTO dto = new EntitlementDTO();
+        dto.addCertificate(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddCertificateWithEmptyId() {
+        EntitlementDTO dto = new EntitlementDTO();
+
+        CertificateDTO certDTO = new CertificateDTO();
+        certDTO.setId("");
+        certDTO.setKey("cert-key-3");
+        certDTO.setCert("cert-cert-3");
+        certDTO.setSerial(new CertificateSerialDTO());
+        dto.addCertificate(certDTO);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddCertificateWithEmptyKey() {
+        EntitlementDTO dto = new EntitlementDTO();
+
+        CertificateDTO certDTO = new CertificateDTO();
+        certDTO.setId("cert-id-4");
+        certDTO.setKey("");
+        certDTO.setCert("cert-cert-4");
+        certDTO.setSerial(new CertificateSerialDTO());
+        dto.addCertificate(certDTO);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddCertificateWithEmptyCert() {
+        EntitlementDTO dto = new EntitlementDTO();
+
+        CertificateDTO certDTO = new CertificateDTO();
+        certDTO.setId("cert-id-5");
+        certDTO.setKey("cert-key-5");
+        certDTO.setCert("");
+        certDTO.setSerial(new CertificateSerialDTO());
+        dto.addCertificate(certDTO);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddCertificateWithNullSerial() {
+        EntitlementDTO dto = new EntitlementDTO();
+
+        CertificateDTO certDTO = new CertificateDTO();
+        certDTO.setId("cert-id-6");
+        certDTO.setKey("cert-key-6");
+        certDTO.setCert("cert-cert-6");
+        certDTO.setSerial(null);
+        dto.addCertificate(certDTO);
+    }
+}

--- a/server/src/test/java/org/candlepin/dto/api/v1/EntitlementTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/EntitlementTranslatorTest.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright (c) 2009 - 2017 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.dto.api.v1;
+
+import org.candlepin.dto.AbstractTranslatorTest;
+import org.candlepin.dto.ModelTranslator;
+import org.candlepin.model.Certificate;
+import org.candlepin.model.CertificateSerial;
+import org.candlepin.model.Consumer;
+import org.candlepin.model.Entitlement;
+import org.candlepin.model.EntitlementCertificate;
+
+import java.util.HashSet;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Test suite for the EntitlementTranslator class.
+ */
+public class EntitlementTranslatorTest extends
+    AbstractTranslatorTest<Entitlement, EntitlementDTO, EntitlementTranslator> {
+
+    protected EntitlementTranslator translator = new EntitlementTranslator();
+
+    private OwnerTranslatorTest ownerTranslatorTest = new OwnerTranslatorTest();
+    private CertificateTranslatorTest certificateTranslatorTest = new CertificateTranslatorTest();
+    private PoolTranslatorTest poolTranslatorTest = new PoolTranslatorTest();
+
+    @Override
+    protected void initModelTranslator(ModelTranslator modelTranslator) {
+        this.ownerTranslatorTest.initModelTranslator(modelTranslator);
+        this.certificateTranslatorTest.initModelTranslator(modelTranslator);
+        this.poolTranslatorTest.initModelTranslator(modelTranslator);
+
+        modelTranslator.registerTranslator(this.translator, Entitlement.class, EntitlementDTO.class);
+    }
+
+    @Override
+    protected EntitlementTranslator initObjectTranslator() {
+        return this.translator;
+    }
+
+    @Override
+    protected Entitlement initSourceObject() {
+        Entitlement source = new Entitlement();
+        source.setId("ent-id");
+        source.setQuantity(1);
+        source.setDeletedFromPool(false);
+
+        source.setOwner(this.ownerTranslatorTest.initSourceObject());
+        source.setPool(this.poolTranslatorTest.initSourceObject());
+
+        HashSet<EntitlementCertificate> certs = new HashSet<EntitlementCertificate>();
+        EntitlementCertificate entCert = new EntitlementCertificate();
+        entCert.setId("ent-cert-id");
+        entCert.setEntitlement(source);
+        entCert.setKey("ent-cert-key");
+        entCert.setCert("ent-cert-cert");
+        entCert.setSerial(new CertificateSerial());
+        certs.add(entCert);
+        source.setCertificates(certs);
+
+        //TODO: use ConsumerDTO once it gets introduced.
+        Consumer consumer = new Consumer();
+        consumer.setUuid("consumer-uuid");
+        source.setConsumer(consumer);
+
+        return source;
+    }
+
+    @Override
+    protected EntitlementDTO initDestinationObject() {
+        return new EntitlementDTO();
+    }
+
+    @Override
+    protected void verifyOutput(Entitlement source, EntitlementDTO dest, boolean childrenGenerated) {
+        if (source != null) {
+
+            assertEquals(source.getId(), dest.getId());
+            assertEquals(source.getQuantity(), dest.getQuantity());
+            assertEquals(source.deletedFromPool(), dest.isDeletedFromPool());
+
+            if (childrenGenerated) {
+                this.ownerTranslatorTest
+                    .verifyOutput(source.getOwner(), dest.getOwner(), true);
+
+                this.poolTranslatorTest.verifyOutput(source.getPool(), dest.getPool(), true);
+
+                // These getters' returned fields live on the pool, so they're children.
+                assertEquals(source.getStartDate(), dest.getStartDate());
+                assertEquals(source.getEndDate(), dest.getEndDate());
+
+                for (Certificate sourceCertificate : source.getCertificates()) {
+                    for (CertificateDTO certDTO : dest.getCertificates()) {
+
+                        assertNotNull(certDTO);
+                        assertNotNull(certDTO.getId());
+
+                        if (certDTO.getId().equals(sourceCertificate.getId())) {
+                            this.certificateTranslatorTest.verifyOutput(sourceCertificate, certDTO, true);
+                        }
+                    }
+                }
+
+                //TODO: use ConsumerTranslatorTest to verify once it gets introduced.
+                assertEquals(source.getConsumer(), dest.getConsumer());
+            }
+            else {
+                assertNull(dest.getOwner());
+                assertNull(dest.getPool());
+                assertNull(dest.getCertificates());
+                assertNull(dest.getConsumer());
+            }
+        }
+        else {
+            assertNull(dest);
+        }
+    }
+}

--- a/server/src/test/java/org/candlepin/dto/api/v1/PoolDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/PoolDTOTest.java
@@ -1,0 +1,376 @@
+/**
+ * Copyright (c) 2009 - 2017 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.dto.api.v1;
+
+import org.candlepin.dto.AbstractDTOTest;
+import org.candlepin.model.Pool;
+import org.junit.Test;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test suite for the PoolDTO class
+ */
+public class PoolDTOTest extends AbstractDTOTest<PoolDTO> {
+
+    protected Map<String, Object> values;
+
+    public PoolDTOTest() {
+        super(PoolDTO.class);
+
+        OwnerDTO owner = new OwnerDTO();
+        owner.setId("owner-id");
+        owner.setKey("owner-key");
+        owner.setDisplayName("owner-name");
+        owner.setContentPrefix("content-prefix");
+        owner.setDefaultServiceLevel("service-level");
+        owner.setLogLevel("log-level");
+        owner.setAutobindDisabled(true);
+        owner.setContentAccessMode("content-access-mode");
+        owner.setContentAccessModeList("content-access-mode-list");
+
+        EntitlementDTO entitlement = new EntitlementDTO();
+        entitlement.setId("entitlement-id");
+
+        BrandingDTO branding = new BrandingDTO();
+        branding.setName("branding-name");
+        branding.setProductId("branding-prod-id");
+        branding.setType("branding-type");
+
+        PoolDTO.ProvidedProductDTO providedProd =
+            new PoolDTO.ProvidedProductDTO("provided-product-id", "provided-product-name");
+
+        PoolDTO.ProvidedProductDTO derivedProvidedProd =
+            new PoolDTO.ProvidedProductDTO("derived-provided-product-id", "derived-provided-product-name");
+
+        CertificateDTO cert = new CertificateDTO();
+        cert.setId("cert-id");
+        cert.setKey("cert-key");
+        cert.setCert("cert-cert");
+        cert.setSerial(new CertificateSerialDTO());
+
+        this.values = new HashMap<String, Object>();
+        this.values.put("Id", "test-id");
+        this.values.put("Type", Pool.PoolType.NORMAL.toString());
+        this.values.put("Owner", owner);
+        this.values.put("ActiveSubscription", true);
+        this.values.put("CreatedByShare", true);
+        this.values.put("HasSharedAncestor", true);
+        this.values.put("SourceEntitlement", entitlement);
+        this.values.put("Quantity", 1L);
+        this.values.put("StartDate", new Date());
+        this.values.put("EndDate", new Date());
+
+        Map<String, String> attributes = new HashMap<String, String>();
+        attributes.put("attribute-key-1", "attribute-value-1");
+        attributes.put("attribute-key-2", "attribute-value-2");
+        this.values.put("Attributes", attributes);
+
+        this.values.put("RestrictedToUsername", "restricted-to-username-value");
+        this.values.put("ContractNumber", "2991");
+        this.values.put("AccountNumber", "2992");
+        this.values.put("OrderNumber", "2993");
+        this.values.put("Consumed", 5L);
+        this.values.put("Exported", 4L);
+        this.values.put("Shared", 3L);
+
+        Set<BrandingDTO> brandingSet = new HashSet<BrandingDTO>();
+        brandingSet.add(branding);
+        this.values.put("Branding", brandingSet);
+
+        Map<String, String> calculatedAttributes = new HashMap<String, String>();
+        calculatedAttributes.put("calc-attribute-key-1", "calc-attribute-value-1");
+        calculatedAttributes.put("calc-attribute-key-2", "calc-attribute-value-2");
+        this.values.put("CalculatedAttributes", calculatedAttributes);
+
+        this.values.put("UpstreamPoolId", "upstream-pool-id-1");
+        this.values.put("UpstreamEntitlementId", "upstream-entitlement-id-1");
+        this.values.put("UpstreamConsumerId", "upstream-consumer-id-1");
+        this.values.put("ProductName", "product-name-1");
+        this.values.put("ProductId", "product-id-1");
+
+        Map<String, String> productAttributes = new HashMap<String, String>();
+        productAttributes.put("prod-attribute-key-1", "prod-attribute-value-1");
+        productAttributes.put("prod-attribute-key-2", "prod-attribute-value-2");
+        this.values.put("ProductAttributes", productAttributes);
+
+        this.values.put("StackId", "stack-id-1");
+        this.values.put("Stacked", true);
+        this.values.put("DevelopmentPool", true);
+
+        Map<String, String> derivedProductAttributes = new HashMap<String, String>();
+        derivedProductAttributes.put("derived-prod-attribute-key-1", "derived-prod-attribute-value-1");
+        derivedProductAttributes.put("derived-prod-attribute-key-2", "derived-prod-attribute-value-2");
+        this.values.put("DerivedProductAttributes", derivedProductAttributes);
+
+        this.values.put("DerivedProductId", "derived-prod-id-1");
+        this.values.put("DerivedProductName", "derived-prod-name-1");
+
+        Set<PoolDTO.ProvidedProductDTO> providedProducts = new HashSet<PoolDTO.ProvidedProductDTO>();
+        providedProducts.add(providedProd);
+        this.values.put("ProvidedProducts", providedProducts);
+
+        Set<PoolDTO.ProvidedProductDTO> derivedProvidedProducts = new HashSet<PoolDTO.ProvidedProductDTO>();
+        derivedProvidedProducts.add(derivedProvidedProd);
+        this.values.put("DerivedProvidedProducts", derivedProvidedProducts);
+        this.values.put("SourceStackId", "source-stack-id-1");
+
+        this.values.put("SubscriptionSubKey", "subscription-key-1");
+        this.values.put("SubscriptionId", "subscription-id-1");
+
+        this.values.put("Certificate", cert);
+        this.values.put("Created", new Date());
+        this.values.put("Updated", new Date());
+    }
+
+    @Override
+    protected Object getInputValueForMutator(String field) {
+        return this.values.get(field);
+    }
+
+    @Override
+    protected Object getOutputValueForAccessor(String field, Object input) {
+        // Nothing to do here
+        return input;
+    }
+
+    @Test
+    public void testHasAttributeWithAbsentAttribute() {
+        PoolDTO dto = new PoolDTO();
+        assertFalse(dto.hasAttribute("attribute-key-1"));
+    }
+
+    @Test
+    public void testHasAttributeWithPresentAttribute() {
+        PoolDTO dto = new PoolDTO();
+        Map<String, String> attributes = new HashMap<String, String>();
+        attributes.put("attribute-key-2", "attribute-value-2");
+        dto.setAttributes(attributes);
+
+        assertTrue(dto.hasAttribute("attribute-key-2"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testHasAttributeWithNullInput() {
+        PoolDTO dto = new PoolDTO();
+        dto.hasAttribute(null);
+    }
+
+    @Test
+    public void testRemoveAttributeWithAbsentAttribute() {
+        PoolDTO dto = new PoolDTO();
+
+        assertFalse(dto.removeAttribute("attribute-key-3"));
+
+        dto.setAttributes(new HashMap<String, String>());
+
+        assertFalse(dto.removeAttribute("attribute-key-3"));
+    }
+
+    @Test
+    public void testRemoveAttributeWithPresentAttribute() {
+        PoolDTO dto = new PoolDTO();
+
+        Map<String, String> attributes = new HashMap<String, String>();
+        attributes.put("attribute-key-4", "attribute-value-4");
+        dto.setAttributes(attributes);
+
+        assertTrue(dto.removeAttribute("attribute-key-4"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testRemoveAttributeWithNullInput() {
+        PoolDTO dto = new PoolDTO();
+        dto.removeAttribute(null);
+    }
+
+    @Test
+    public void testHasProductAttributeWithAbsentProductAttribute() {
+        PoolDTO dto = new PoolDTO();
+        assertFalse(dto.hasProductAttribute("prod-attribute-key-1"));
+    }
+
+    @Test
+    public void testHasProductAttributeWithPresentProductAttribute() {
+        PoolDTO dto = new PoolDTO();
+        Map<String, String> productAttributes = new HashMap<String, String>();
+        productAttributes.put("prod-attribute-key-2", "prod-attribute-value-2");
+        dto.setProductAttributes(productAttributes);
+
+        assertTrue(dto.hasProductAttribute("prod-attribute-key-2"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testHasProductAttributeWithNullInput() {
+        PoolDTO dto = new PoolDTO();
+        dto.hasProductAttribute(null);
+    }
+
+    @Test
+    public void testAddProvidedProductWithAbsentProvidedProduct() {
+        PoolDTO dto = new PoolDTO();
+
+        PoolDTO.ProvidedProductDTO product =
+            new PoolDTO.ProvidedProductDTO("test-id-provided-product-1", "test-name-provided-product-1");
+        assertTrue(dto.addProvidedProduct(product));
+    }
+
+    @Test
+    public void testAddProvidedProductWithPresentProvidedProduct() {
+        PoolDTO dto = new PoolDTO();
+
+        PoolDTO.ProvidedProductDTO product =
+            new PoolDTO.ProvidedProductDTO("test-id-provided-product-2", "test-name-provided-product-2");
+        assertTrue(dto.addProvidedProduct(product));
+
+        PoolDTO.ProvidedProductDTO product2 =
+            new PoolDTO.ProvidedProductDTO("test-id-provided-product-2", "test-name-provided-product-2");
+        assertFalse(dto.addProvidedProduct(product2));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddProvidedProductWithNullInput() {
+        PoolDTO dto = new PoolDTO();
+        dto.addProvidedProduct(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddProvidedProductWithEmptyId() {
+        PoolDTO dto = new PoolDTO();
+
+        PoolDTO.ProvidedProductDTO product =
+            new PoolDTO.ProvidedProductDTO("", "test-name-provided-product-3");
+        dto.addProvidedProduct(product);
+    }
+
+    @Test
+    @SuppressWarnings("checkstyle:indentation")
+    public void testAddDerivedProvidedProductWithAbsentDerivedProvidedProduct() {
+        PoolDTO dto = new PoolDTO();
+
+        PoolDTO.ProvidedProductDTO product =
+            new PoolDTO.ProvidedProductDTO(
+                "test-id-derived-provided-product-1",
+                "test-name-derived-provided-product-1");
+        assertTrue(dto.addDerivedProvidedProduct(product));
+    }
+
+    @Test
+    @SuppressWarnings("checkstyle:indentation")
+    public void testAddDerivedProvidedProductWithPresentDerivedProvidedProduct() {
+        PoolDTO dto = new PoolDTO();
+
+        PoolDTO.ProvidedProductDTO product =
+            new PoolDTO.ProvidedProductDTO(
+                "test-id-derived-provided-product-2",
+                "test-name-derived-provided-product-2");
+        assertTrue(dto.addDerivedProvidedProduct(product));
+
+        PoolDTO.ProvidedProductDTO product2 =
+            new PoolDTO.ProvidedProductDTO(
+                "test-id-derived-provided-product-2",
+                "test-name-derived-provided-product-2");
+        assertFalse(dto.addDerivedProvidedProduct(product2));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddDerivedProvidedProductWithNullInput() {
+        PoolDTO dto = new PoolDTO();
+        dto.addDerivedProvidedProduct(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddDerivedProvidedProductWithEmptyId() {
+        PoolDTO dto = new PoolDTO();
+
+        PoolDTO.ProvidedProductDTO product =
+            new PoolDTO.ProvidedProductDTO("", "test-name-derived-provided-product-3");
+        dto.addDerivedProvidedProduct(product);
+    }
+
+    @Test
+    public void testAddBrandingWithAbsentBranding() {
+        PoolDTO dto = new PoolDTO();
+
+        BrandingDTO branding = new BrandingDTO();
+        branding.setProductId("test-branding-product-id-1");
+        branding.setName("test-branding-name-1");
+        branding.setType("test-branding-type-1");
+        assertTrue(dto.addBranding(branding));
+    }
+
+    @Test
+    public void testAddBrandingWithPresentBranding() {
+        PoolDTO dto = new PoolDTO();
+
+        BrandingDTO branding = new BrandingDTO();
+        branding.setProductId("test-branding-product-id-2");
+        branding.setName("test-branding-name-2");
+        branding.setType("test-branding-type-2");
+        assertTrue(dto.addBranding(branding));
+
+        BrandingDTO branding2 = new BrandingDTO();
+        branding2.setProductId("test-branding-product-id-2");
+        branding2.setName("test-branding-name-2");
+        branding2.setType("test-branding-type-2");
+        assertFalse(dto.addBranding(branding2));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddBrandingWithNullInput() {
+        PoolDTO dto = new PoolDTO();
+        dto.addBranding(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddBrandingWithEmptyProductId() {
+        PoolDTO dto = new PoolDTO();
+
+        BrandingDTO branding = new BrandingDTO();
+        branding.setProductId("");
+        branding.setName("test-branding-name-3");
+        branding.setType("test-branding-type-3");
+        dto.addBranding(branding);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddBrandingWithEmptyName() {
+        PoolDTO dto = new PoolDTO();
+
+        BrandingDTO branding = new BrandingDTO();
+        branding.setProductId("test-branding-product-id-4");
+        branding.setName("");
+        branding.setType("test-branding-type-4");
+        dto.addBranding(branding);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddBrandingWithEmptyType() {
+        PoolDTO dto = new PoolDTO();
+
+        BrandingDTO branding = new BrandingDTO();
+        branding.setProductId("test-branding-product-id-5");
+        branding.setName("test-branding-name-5");
+        branding.setType("");
+        dto.addBranding(branding);
+    }
+}

--- a/server/src/test/java/org/candlepin/dto/api/v1/PoolTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/PoolTranslatorTest.java
@@ -1,0 +1,289 @@
+/**
+ * Copyright (c) 2009 - 2017 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.dto.api.v1;
+
+
+import org.candlepin.dto.AbstractTranslatorTest;
+import org.candlepin.dto.ModelTranslator;
+import org.candlepin.model.Branding;
+import org.candlepin.model.CertificateSerial;
+import org.candlepin.model.Consumer;
+import org.candlepin.model.Entitlement;
+import org.candlepin.model.Pool;
+import org.candlepin.model.Product;
+import org.candlepin.model.ProvidedProduct;
+import org.candlepin.model.SourceStack;
+import org.candlepin.model.SourceSubscription;
+import org.candlepin.model.SubscriptionsCertificate;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test suite for the PoolTranslator class.
+ */
+public class PoolTranslatorTest extends
+    AbstractTranslatorTest<Pool, PoolDTO, PoolTranslator> {
+
+    protected PoolTranslator translator = new PoolTranslator();
+
+    // Using EntitlementTranslator instead of EntitlementTranslatorTest to avoid StackOverflow issues
+    // caused by bidirectional reference between Pool and Entitlement.
+    private EntitlementTranslator entitlementTranslator = new EntitlementTranslator();
+
+    private OwnerTranslatorTest ownerTranslatorTest = new OwnerTranslatorTest();
+    private ProductTranslatorTest productTranslatorTest = new ProductTranslatorTest();
+    private BrandingTranslatorTest brandingTranslatorTest = new BrandingTranslatorTest();
+    private CertificateTranslatorTest certificateTranslatorTest = new CertificateTranslatorTest();
+
+    @Override
+    protected void initModelTranslator(ModelTranslator modelTranslator) {
+        this.ownerTranslatorTest.initModelTranslator(modelTranslator);
+        this.productTranslatorTest.initModelTranslator(modelTranslator);
+        this.brandingTranslatorTest.initModelTranslator(modelTranslator);
+        this.certificateTranslatorTest.initModelTranslator(modelTranslator);
+
+        modelTranslator.registerTranslator(this.translator, Pool.class, PoolDTO.class);
+        modelTranslator.registerTranslator(this.entitlementTranslator,
+            Entitlement.class, EntitlementDTO.class);
+    }
+
+    @Override
+    protected PoolTranslator initObjectTranslator() {
+        return this.translator;
+    }
+
+    @Override
+    protected Pool initSourceObject() {
+        Pool source = new Pool();
+        source.setId("pool-id");
+
+        source.setOwner(this.ownerTranslatorTest.initSourceObject());
+        source.setProduct(this.productTranslatorTest.initSourceObject());
+        source.setDerivedProduct(this.productTranslatorTest.initSourceObject());
+
+        Entitlement entitlement = new Entitlement();
+        entitlement.setId("ent-id");
+        source.setSourceEntitlement(entitlement);
+
+        SubscriptionsCertificate subCert = new SubscriptionsCertificate();
+        subCert.setId("cert-id");
+        subCert.setKey("cert-key");
+        subCert.setCert("cert-cert");
+        subCert.setSerial(new CertificateSerial());
+        source.setCertificate(subCert);
+
+        SourceSubscription sourceSubscription = new SourceSubscription();
+        sourceSubscription.setId("source-sub-id-1");
+        sourceSubscription.setSubscriptionId("source-sub-subscription-id-1");
+        sourceSubscription.setSubscriptionSubKey("source-sub-subscription-sub-key-1");
+        source.setSourceSubscription(sourceSubscription);
+
+        source.setActiveSubscription(true);
+        source.setCreatedByShare(false);
+        source.setHasSharedAncestor(true);
+
+        source.setQuantity(1L);
+        source.setStartDate(new Date());
+        source.setEndDate(new Date());
+
+        Map<String, String> attributes = new HashMap<String, String>();
+        attributes.put(Pool.Attributes.SOURCE_POOL_ID, "true");
+        source.setAttributes(attributes);
+
+        source.setRestrictedToUsername("restricted-to-username-value");
+        source.setContractNumber("333");
+        source.setAccountNumber("444");
+        source.setOrderNumber("555");
+        source.setConsumed(6L);
+        source.setExported(7L);
+        source.setShared(8L);
+
+        Branding branding = new Branding();
+        branding.setId("branding-id-1");
+        branding.setName("branding-name-1");
+        branding.setProductId("branding-prod-id-1");
+        branding.setType("branding-type-1");
+        Set<Branding> brandingSet = new HashSet<Branding>();
+        brandingSet.add(branding);
+        source.setBranding(brandingSet);
+
+        Map<String, String> calculatedAttributes = new HashMap<String, String>();
+        calculatedAttributes.put("calc-attribute-key-3", "calc-attribute-value-3");
+        calculatedAttributes.put("calc-attribute-key-4", "calc-attribute-value-4");
+        source.setCalculatedAttributes(calculatedAttributes);
+
+        source.setUpstreamPoolId("upstream-pool-id-2");
+        source.setUpstreamEntitlementId("upstream-entitlement-id-2");
+        source.setUpstreamConsumerId("upstream-consumer-id-2");
+
+        source.setAttribute(Pool.Attributes.DEVELOPMENT_POOL, "true");
+
+        Product derivedProduct = new Product();
+        derivedProduct.setId("derived-product-id-2");
+        derivedProduct.setName("derived-product-name-2");
+        derivedProduct.setAttributes(new HashMap<String, String>());
+        derivedProduct.setAttribute(Product.Attributes.ARCHITECTURE, "POWER");
+        derivedProduct.setAttribute(Product.Attributes.STACKING_ID, "2221");
+        source.setDerivedProduct(derivedProduct);
+
+        ProvidedProduct providedProd = new ProvidedProduct();
+        providedProd.setProductId("provided-product-id-1");
+        providedProd.setProductName("provided-product-name-1");
+        Set<ProvidedProduct> providedProducts = new HashSet<ProvidedProduct>();
+        providedProducts.add(providedProd);
+        source.setProvidedProductDtos(providedProducts);
+
+        ProvidedProduct derivedProvidedProd = new ProvidedProduct();
+        derivedProvidedProd.setProductId("derived-provided-product-id-1");
+        derivedProvidedProd.setProductName("derived-provided-product-name-1");
+        Set<ProvidedProduct> derivedProvidedProducts = new HashSet<ProvidedProduct>();
+        derivedProvidedProducts.add(derivedProvidedProd);
+        source.setDerivedProvidedProductDtos(derivedProvidedProducts);
+
+        Consumer sourceConsumer = new Consumer();
+        sourceConsumer.setUuid("source-consumer-uuid");
+
+        SourceStack sourceStack = new SourceStack();
+        sourceStack.setSourceStackId("source-stack-source-stack-id-1");
+        sourceStack.setId("source-stack-id-1");
+        sourceStack.setSourceConsumer(sourceConsumer);
+        source.setSourceStack(sourceStack);
+
+        return source;
+    }
+
+    @Override
+    protected PoolDTO initDestinationObject() {
+        return new PoolDTO();
+    }
+
+    @Override
+    @SuppressWarnings("checkstyle:methodlength")
+    protected void verifyOutput(Pool source, PoolDTO dest, boolean childrenGenerated) {
+        if (source != null) {
+            assertEquals(source.getId(), dest.getId());
+            assertEquals(source.getType().toString(), dest.getType());
+            assertEquals(source.getActiveSubscription(), dest.isActiveSubscription());
+            assertEquals(source.isCreatedByShare(), dest.isCreatedByShare());
+            assertEquals(source.hasSharedAncestor(), dest.hasSharedAncestor());
+            assertEquals(source.getQuantity(), dest.getQuantity());
+            assertEquals(source.getStartDate(), dest.getStartDate());
+            assertEquals(source.getEndDate(), dest.getEndDate());
+            assertEquals(source.getAttributes(), dest.getAttributes());
+            assertEquals(source.getRestrictedToUsername(), dest.getRestrictedToUsername());
+            assertEquals(source.getContractNumber(), dest.getContractNumber());
+            assertEquals(source.getAccountNumber(), dest.getAccountNumber());
+            assertEquals(source.getOrderNumber(), dest.getOrderNumber());
+            assertEquals(source.getConsumed(), dest.getConsumed());
+            assertEquals(source.getExported(), dest.getExported());
+            assertEquals(source.getShared(), dest.getShared());
+            assertEquals(source.getCalculatedAttributes(), dest.getCalculatedAttributes());
+            assertEquals(source.getUpstreamPoolId(), dest.getUpstreamPoolId());
+            assertEquals(source.getUpstreamEntitlementId(), dest.getUpstreamEntitlementId());
+            assertEquals(source.getUpstreamConsumerId(), dest.getUpstreamConsumerId());
+            assertEquals(source.getProductName(), dest.getProductName());
+            assertEquals(source.getProductId(), dest.getProductId());
+            assertEquals(source.getProductAttributes(), dest.getProductAttributes());
+            assertEquals(source.getStackId(), dest.getStackId());
+            assertEquals(source.isStacked(), dest.isStacked());
+            assertEquals(source.isDevelopmentPool(), dest.isDevelopmentPool());
+            assertEquals(source.getDerivedProductAttributes(), dest.getDerivedProductAttributes());
+            assertEquals(source.getDerivedProductId(), dest.getDerivedProductId());
+            assertEquals(source.getDerivedProductName(), dest.getDerivedProductName());
+            assertEquals(source.getSourceStackId(), dest.getSourceStackId());
+            assertEquals(source.getSubscriptionSubKey(), dest.getSubscriptionSubKey());
+            assertEquals(source.getSubscriptionId(), dest.getSubscriptionId());
+
+            if (childrenGenerated) {
+                this.ownerTranslatorTest
+                    .verifyOutput(source.getOwner(), dest.getOwner(), true);
+
+                this.certificateTranslatorTest
+                    .verifyOutput(source.getCertificate(), dest.getCertificate(), true);
+
+                Entitlement sourceSourceEntitlement = source.getSourceEntitlement();
+                EntitlementDTO destSourceEntitlement = dest.getSourceEntitlement();
+                if (sourceSourceEntitlement != null) {
+                    assertEquals(sourceSourceEntitlement.getId(), destSourceEntitlement.getId());
+                }
+                else {
+                    assertNull(destSourceEntitlement);
+                }
+
+                for (Branding brandingSource : source.getBranding()) {
+                    for (BrandingDTO brandingDTO : dest.getBranding()) {
+
+                        assertNotNull(brandingDTO);
+                        assertNotNull(brandingDTO.getProductId());
+
+                        if (brandingDTO.getProductId().equals(brandingSource.getProductId())) {
+                            this.brandingTranslatorTest.verifyOutput(brandingSource, brandingDTO, true);
+                        }
+                    }
+                }
+
+                Set<Product> sourceProducts = source.getProvidedProducts();
+                Set<PoolDTO.ProvidedProductDTO> productsDTO = dest.getProvidedProducts();
+                verifyProductsOutput(sourceProducts, productsDTO);
+
+                Set<Product> sourceDerivedProducts = source.getDerivedProvidedProducts();
+                Set<PoolDTO.ProvidedProductDTO> derivedProductsDTO = dest.getDerivedProvidedProducts();
+                verifyProductsOutput(sourceDerivedProducts, derivedProductsDTO);
+            }
+            else {
+                assertNull(dest.getOwner());
+                assertNull(dest.getSourceEntitlement());
+                assertNull(dest.getBranding());
+                assertNull(dest.getProvidedProducts());
+                assertNull(dest.getDerivedProvidedProducts());
+                assertNull(dest.getCertificate());
+            }
+        }
+        else {
+            assertNull(dest);
+        }
+    }
+
+    /**
+     * Verifies that the pool's sets of products are translated properly.
+     *
+     * @param originalProducts the original set or products we check against.
+     *
+     * @param dtoProducts the translated DTO set of products that we need to verify.
+     */
+    private static void verifyProductsOutput(Set<Product> originalProducts,
+        Set<PoolDTO.ProvidedProductDTO> dtoProducts) {
+        for (Product productSource : originalProducts) {
+            for (PoolDTO.ProvidedProductDTO productDTO : dtoProducts) {
+
+                assertNotNull(productDTO);
+                assertNotNull(productDTO.getProductId());
+
+                if (productDTO.getProductId().equals(productSource.getId())) {
+                    assertTrue(productDTO.getProductName().equals(productSource.getName()));
+                }
+            }
+        }
+    }
+}

--- a/server/src/test/java/org/candlepin/dto/api/v1/ProductTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/ProductTranslatorTest.java
@@ -36,7 +36,7 @@ import java.util.Map;
 
 
 /**
- * Test suite for the UpstreamConsumerTranslator class
+ * Test suite for the ProductTranslator class
  */
 @RunWith(JUnitParamsRunner.class)
 public class ProductTranslatorTest extends

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceCreationTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceCreationTest.java
@@ -78,6 +78,7 @@ import org.mockito.stubbing.Answer;
 import org.xnap.commons.i18n.I18n;
 import org.xnap.commons.i18n.I18nFactory;
 
+import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -118,7 +119,7 @@ public class ConsumerResourceCreationTest {
     @Mock private ServiceLevelValidator serviceLevelValidator;
     @Mock private ConsumerBindUtil consumerBindUtil;
     @Mock private ConsumerEnricher consumerEnricher;
-    protected ModelTranslator modelTranslator;
+    @Inject protected ModelTranslator modelTranslator;
 
     private I18n i18n;
 
@@ -128,7 +129,6 @@ public class ConsumerResourceCreationTest {
     protected Owner owner;
     protected Role role;
     private User user;
-
     private GuestMigration testMigration;
     private Provider<GuestMigration> migrationProvider;
 

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
@@ -39,7 +39,6 @@ import org.candlepin.controller.ManifestManager;
 import org.candlepin.controller.OwnerManager;
 import org.candlepin.controller.PoolManager;
 import org.candlepin.dto.ModelTranslator;
-import org.candlepin.dto.StandardTranslator;
 import org.candlepin.model.CandlepinQuery;
 import org.candlepin.model.Cdn;
 import org.candlepin.model.CdnCurator;
@@ -112,6 +111,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
+import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.ws.rs.core.Response;
 
@@ -130,6 +130,7 @@ public class ConsumerResourceTest {
     private I18n i18n;
     private Configuration config;
     private FactValidator factValidator;
+    @Inject protected ModelTranslator modelTranslator;
 
     @Mock private ConsumerCurator mockedConsumerCurator;
     @Mock private OwnerCurator mockedOwnerCurator;
@@ -149,7 +150,6 @@ public class ConsumerResourceTest {
     @Mock private ConsumerTypeCurator mockConsumerTypeCurator;
     @Mock private DefaultContentAccessCertServiceAdapter mockContentAccessCertService;
     @Mock private EventSink sink;
-    private ModelTranslator translator;
 
     private GuestMigration testMigration;
     private Provider<GuestMigration> migrationProvider;
@@ -157,7 +157,6 @@ public class ConsumerResourceTest {
     @Before
     public void setUp() {
         this.config = new CandlepinCommonTestConfig();
-        this.translator = new StandardTranslator();
         this.i18n = I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK);
         when(eventBuilder.setEventData(any(Consumer.class))).thenReturn(eventBuilder);
         when(eventFactory.getEventBuilder(any(Target.class), any(Type.class))).thenReturn(eventBuilder);
@@ -179,7 +178,7 @@ public class ConsumerResourceTest {
             null, mockedPoolManager, null, mockedOwnerCurator, null, null, null,
             null, null, null, new CandlepinCommonTestConfig(), null, null, null,
             consumerBindUtil, null, null, factValidator,
-            null, consumerEnricher, migrationProvider, translator);
+            null, consumerEnricher, migrationProvider, modelTranslator);
 
         UserPrincipal uap = mock(UserPrincipal.class);
         when(uap.canAccess(any(Object.class), any(SubResource.class), any(Access.class))).thenReturn
@@ -208,7 +207,7 @@ public class ConsumerResourceTest {
             null, mockedPoolManager, null, mockedOwnerCurator, null, null, null,
             null, null, null, new CandlepinCommonTestConfig(), null, null, null,
             consumerBindUtil, null, null, factValidator,
-            null, consumerEnricher, migrationProvider, translator);
+            null, consumerEnricher, migrationProvider, modelTranslator);
 
         UserPrincipal uap = mock(UserPrincipal.class);
         when(uap.canAccess(any(Object.class), any(SubResource.class), any(Access.class))).thenReturn
@@ -247,7 +246,7 @@ public class ConsumerResourceTest {
             mockedEntitlementCertServiceAdapter, null, null, null, null, null, null, mockedPoolManager, null,
             null, null, null, null, null, null, null, this.config, null, null, null, consumerBindUtil,
             null, mockContentAccessCertService, this.factValidator, null, consumerEnricher,
-            migrationProvider, translator);
+            migrationProvider, modelTranslator);
 
         List<CertificateSerialDto> serials = consumerResource
             .getEntitlementCertificateSerials(consumer.getUuid());
@@ -284,7 +283,7 @@ public class ConsumerResourceTest {
             mockedEntitlementCertServiceAdapter, null, null, null, null, null, null,
             poolManager, null, null, null, null, null, null, null, null,
             this.config, null, null, null, consumerBindUtil,
-            null, null, this.factValidator, null, consumerEnricher, migrationProvider, translator);
+            null, null, this.factValidator, null, consumerEnricher, migrationProvider, modelTranslator);
 
         consumerResource.regenerateEntitlementCertificates(consumer.getUuid(), "9999", false);
     }
@@ -318,7 +317,7 @@ public class ConsumerResourceTest {
             null, mockedSubscriptionServiceAdapter, this.mockedOwnerServiceAdapter, null, null, null, null,
             null, null, null, null, null, mgr, null, null, null, null, null, null, null, null,
             this.config, null, null, null, consumerBindUtil, null, null, this.factValidator,
-            null, consumerEnricher, migrationProvider, translator);
+            null, consumerEnricher, migrationProvider, modelTranslator);
 
         cr.regenerateEntitlementCertificates(consumer.getUuid(), null, true);
         Mockito.verify(mgr, Mockito.times(1)).regenerateCertificatesOf(eq(consumer), eq(true));
@@ -347,7 +346,7 @@ public class ConsumerResourceTest {
             null, null, null, mockedIdSvc, null, null, sink, eventFactory, null, null,
             null, null, null, mockedOwnerCurator, null, null, null, null,
             null, null, this.config, null, null, null, consumerBindUtil,
-            null, null, this.factValidator, null, consumerEnricher, migrationProvider, translator);
+            null, null, this.factValidator, null, consumerEnricher, migrationProvider, modelTranslator);
 
         Consumer fooc = cr.regenerateIdentityCertificates(consumer.getUuid());
 
@@ -382,7 +381,7 @@ public class ConsumerResourceTest {
             null, ssa, this.mockedOwnerServiceAdapter, null, mockedIdSvc, null, null, sink, eventFactory,
             null, null, null, null, null, mockedOwnerCurator, null, null, rules, null,
             null, null, this.config, null, null, null, consumerBindUtil,
-            null, null, this.factValidator, null, consumerEnricher, migrationProvider, translator);
+            null, null, this.factValidator, null, consumerEnricher, migrationProvider, modelTranslator);
 
         Consumer c = cr.getConsumer(consumer.getUuid());
 
@@ -406,7 +405,7 @@ public class ConsumerResourceTest {
             null, ssa, this.mockedOwnerServiceAdapter, null, null, null, null, null, null, null, null, null,
             null, null, mockedOwnerCurator, null, null, rules, null, null, null,
             this.config, null, null, null, consumerBindUtil,
-            null, null, this.factValidator, null, consumerEnricher, migrationProvider, translator);
+            null, null, this.factValidator, null, consumerEnricher, migrationProvider, modelTranslator);
 
         Consumer c = cr.getConsumer(consumer.getUuid());
 
@@ -437,7 +436,7 @@ public class ConsumerResourceTest {
             null, null, null, null, null, i18n, null, null, null, null,
             null, null, null, oc, akc, null, null, null, null,
             null, this.config, null, null, null, consumerBindUtil,
-            null, null, this.factValidator, null, consumerEnricher, migrationProvider, translator);
+            null, null, this.factValidator, null, consumerEnricher, migrationProvider, modelTranslator);
 
         cr.create(c, nap, null, "testOwner", "testKey", true);
     }
@@ -458,8 +457,7 @@ public class ConsumerResourceTest {
             null, sa, this.mockedOwnerServiceAdapter, null, null, null, i18n, null, null, null, null, null,
             null, null, null, null, e, null, null, null, null,
             this.config, null, null, null, consumerBindUtil,
-            null, null, this.factValidator, null, consumerEnricher, migrationProvider, translator);
-
+            null, null, this.factValidator, null, consumerEnricher, migrationProvider, modelTranslator);
 
         Response r = cr.bind(
             "fakeConsumer", null, prodIds, null, null, null, false, null, null);
@@ -484,7 +482,7 @@ public class ConsumerResourceTest {
             null, null, null, null, null, null, null, null, null, null,
             null, null, null, e, null, null, null, null,
             this.config, null, null, null, consumerBindUtil,
-            null, null, this.factValidator, null, consumerEnricher, migrationProvider, translator);
+            null, null, this.factValidator, null, consumerEnricher, migrationProvider, modelTranslator);
 
         String dtStr = "2011-09-26T18:10:50.184081+00:00";
         Date dt = ResourceDateParser.parseDateString(dtStr);
@@ -507,7 +505,7 @@ public class ConsumerResourceTest {
             null, null, null, entitlementCurator, null, null, i18n, null, null, null,
             null, null, null, null, null, null, null, null, null, null,
             null, this.config, null, null, null, consumerBindUtil,
-            null, null, this.factValidator, null, consumerEnricher, migrationProvider, translator);
+            null, null, this.factValidator, null, consumerEnricher, migrationProvider, modelTranslator);
 
         consumerResource.unbindBySerial("fake uuid",
             Long.valueOf(1234L));
@@ -531,7 +529,7 @@ public class ConsumerResourceTest {
             null, null, null, entitlementCurator, null, null, i18n, null, null, null,
             null, null, null, null, null, null, null, null, null, null,
             null, this.config, null, null, null, consumerBindUtil,
-            null, null, this.factValidator, null, consumerEnricher, migrationProvider, translator);
+            null, null, this.factValidator, null, consumerEnricher, migrationProvider, modelTranslator);
 
         consumerResource.unbindByPool("fake-uuid", "Run Forest!");
     }
@@ -543,7 +541,7 @@ public class ConsumerResourceTest {
             null, null, null, null, null, null, i18n, null, null, null,
             null, null, null, null, null, null, null, null, null, null,
             null, this.config, null, null, null, consumerBindUtil,
-            null, null, this.factValidator, null, consumerEnricher, migrationProvider, translator);
+            null, null, this.factValidator, null, consumerEnricher, migrationProvider, modelTranslator);
 
         Consumer c = createConsumer();
         when(consumerCurator.verifyAndLookupConsumerWithEntitlements(eq(c.getUuid()))).thenReturn(c);
@@ -560,7 +558,7 @@ public class ConsumerResourceTest {
             null, null, null, null, null, null, i18n, null, null, null,
             null, null, null, null, null, null, null, null, null, null,
             null, this.config, null, null, null, consumerBindUtil,
-            null, null, this.factValidator, null, consumerEnricher, migrationProvider, translator);
+            null, null, this.factValidator, null, consumerEnricher, migrationProvider, modelTranslator);
 
         Consumer c = createConsumer();
         when(consumerCurator.verifyAndLookupConsumerWithEntitlements(eq(c.getUuid()))).thenReturn(c);
@@ -581,7 +579,7 @@ public class ConsumerResourceTest {
             null, null, null, null, null, null, i18n, null, null, null,
             null, null, null, null, null, null, null, null, null, null,
             null, this.config, null, null, null, consumerBindUtil,
-            null, null, this.factValidator, null, consumerEnricher, migrationProvider, translator);
+            null, null, this.factValidator, null, consumerEnricher, migrationProvider, modelTranslator);
 
         consumerResource.regenerateEntitlementCertificates("xyz", null, true);
     }
@@ -624,7 +622,7 @@ public class ConsumerResourceTest {
             null, null, null, null, null, i18n, null, null, null, null,
             usa, null,  null, oc, null, null, null, null, null,
             null, this.config, null, null, null, consumerBindUtil,
-            null, null, this.factValidator, null, consumerEnricher, migrationProvider, translator);
+            null, null, this.factValidator, null, consumerEnricher, migrationProvider, modelTranslator);
 
         cr.create(c, up, null, "testOwner", null, true);
     }
@@ -658,7 +656,7 @@ public class ConsumerResourceTest {
         ConsumerResource consumerResource = new ConsumerResource(
             null, null, null, null, null, null, null, null, i18n, null, null, null, null, null, null, null,
             oc, null, null, null, null, null, null, this.config, null, null, null, null, null, null,
-            this.factValidator, null, consumerEnricher, migrationProvider, translator);
+            this.factValidator, null, consumerEnricher, migrationProvider, modelTranslator);
 
         return consumerResource;
     }
@@ -690,7 +688,7 @@ public class ConsumerResourceTest {
         ConsumerResource cr = new ConsumerResource(mockedConsumerCurator, null, null, null, null, null, null,
             null, i18n, null, null, null, null, null, null, null, null, null, null, mockedComplianceRules,
             null, null, null, this.config, null, null, null, consumerBindUtil, null, null,
-            this.factValidator, null, consumerEnricher, migrationProvider, translator);
+            this.factValidator, null, consumerEnricher, migrationProvider, modelTranslator);
 
         Map<String, ComplianceStatus> results = cr.getComplianceStatusList(uuids);
         assertEquals(2, results.size());
@@ -705,7 +703,7 @@ public class ConsumerResourceTest {
             null, null, null, null, null, null, i18n, null, null, null,
             null, null, null, null, null, null, null, mockedComplianceRules,
             null, null, null, this.config, null, null, null, consumerBindUtil,
-            null, null, this.factValidator, null, consumerEnricher, migrationProvider, translator);
+            null, null, this.factValidator, null, consumerEnricher, migrationProvider, modelTranslator);
 
         cr.consumerExists("uuid");
     }
@@ -716,7 +714,7 @@ public class ConsumerResourceTest {
         ConsumerResource cr = new ConsumerResource(mockedConsumerCurator, null, null, null, null, null, null,
             null, i18n, null, null, null, null, null, null, null, null, null, null, mockedComplianceRules,
             null, null, null, this.config, null, null, null, consumerBindUtil, null, null,
-            this.factValidator, null, consumerEnricher, migrationProvider, translator);
+            this.factValidator, null, consumerEnricher, migrationProvider, modelTranslator);
 
         cr.consumerExists("uuid");
     }
@@ -726,7 +724,7 @@ public class ConsumerResourceTest {
         ConsumerResource cr = new ConsumerResource(
             null, null, null, null, null, null, null, null, i18n, null, null, null, null, null, null, null,
             null, null, null, null, null, null, null, this.config, null, null, null, null, null,
-            null, this.factValidator, null, consumerEnricher, migrationProvider, translator);
+            null, this.factValidator, null, consumerEnricher, migrationProvider, modelTranslator);
 
         cr.list(null, null, null, null, null, null, null);
     }
@@ -737,7 +735,7 @@ public class ConsumerResourceTest {
             mockedConsumerCurator, null, null, null, null, null, null, null, i18n, null, null, null, null,
             null, null, null, null, null, null, null, null, null, null, this.config, null, null, null, null,
             null, null, this.factValidator, new ConsumerTypeValidator(null, null),
-            consumerEnricher, migrationProvider, translator);
+            consumerEnricher, migrationProvider, modelTranslator);
 
         ArrayList<Consumer> consumers = new ArrayList<Consumer>();
 
@@ -758,7 +756,7 @@ public class ConsumerResourceTest {
             mockedConsumerCurator, null, null, null, null, null, null, null, i18n, null, null, null, null,
             null, null, null, mockedOwnerCurator, null, null, null, null, null, null, this.config, null, null,
             null, null, null, null, this.factValidator,
-            null, consumerEnricher, migrationProvider, translator);
+            null, consumerEnricher, migrationProvider, modelTranslator);
 
         ArrayList<Consumer> consumers = new ArrayList<Consumer>();
         CandlepinQuery cqmock = mock(CandlepinQuery.class);
@@ -780,7 +778,7 @@ public class ConsumerResourceTest {
         ConsumerResource cr = new ConsumerResource(
             mockedConsumerCurator, null, null, null, null, null, null, null, i18n, null, null, null, null,
             null, null, null, null, null, null, null, null, null, null, this.config, null, null, null, null,
-            null, null, this.factValidator, null, consumerEnricher, migrationProvider, translator);
+            null, null, this.factValidator, null, consumerEnricher, migrationProvider, modelTranslator);
 
         cr.list(null, null, null, new ArrayList<String>(), null, null, null);
     }
@@ -791,7 +789,7 @@ public class ConsumerResourceTest {
             mockedConsumerCurator, null, null, null, null, null, null, null, i18n, null, null, null, null,
             null, null, null, null, null, null, null, null, null, null, this.config, null, null, null, null,
             null, null, this.factValidator, new ConsumerTypeValidator(null, null),
-            consumerEnricher, migrationProvider, translator);
+            consumerEnricher, migrationProvider, modelTranslator);
 
         ArrayList<Consumer> consumers = new ArrayList<Consumer>();
         CandlepinQuery cqmock = mock(CandlepinQuery.class);
@@ -823,7 +821,7 @@ public class ConsumerResourceTest {
             mockedEntitlementCertServiceAdapter, null, null, null, null, null, null, mockedPoolManager, null,
             null, null, null, null, null, null, null, this.config, null, null, null, consumerBindUtil,
             null, mockContentAccessCertService, this.factValidator, null, consumerEnricher,
-            migrationProvider, translator));
+            migrationProvider, modelTranslator));
 
         List<CertificateSerialDto> serials = consumerResource
             .getEntitlementCertificateSerials(consumer.getUuid());
@@ -847,7 +845,7 @@ public class ConsumerResourceTest {
             mockedEntitlementCertServiceAdapter, null, null, null, null, null, null, mockedPoolManager, null,
             null, null, null, null, null, null, null, this.config, null, null, null, consumerBindUtil,
             null, mockContentAccessCertService, this.factValidator, null, consumerEnricher,
-            migrationProvider, translator));
+            migrationProvider, modelTranslator));
 
         Set<Long> serials = new HashSet<Long>();
         List<Certificate> certs = consumerResource
@@ -865,7 +863,7 @@ public class ConsumerResourceTest {
             mockedConsumerCurator, null, null, null, null, null, null, null, i18n, null, null, null, null,
             null, null, null, mockedOwnerCurator, null, null, null, null, null, null, this.config, null, null,
             null, null, manifestManager, null, this.factValidator, null, consumerEnricher,
-            migrationProvider, translator);
+            migrationProvider, modelTranslator);
 
         try {
             consumerResource.dryBind(consumer.getUuid(), "some-sla");
@@ -884,7 +882,7 @@ public class ConsumerResourceTest {
             mockedConsumerCurator, null, null, null, null, null, null, null, i18n, null, null, null, null,
             null, null, null, mockedOwnerCurator, null, null, null, null, null, null, this.config, null,
             mockedCdnCurator, null, null, manifestManager, null, this.factValidator, null,
-            consumerEnricher, migrationProvider, translator);
+            consumerEnricher, migrationProvider, modelTranslator);
 
         List<KeyValueParameter> extParams = new ArrayList<KeyValueParameter>();
         Owner owner = TestUtil.createOwner();

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
@@ -33,7 +33,6 @@ import org.candlepin.config.CandlepinCommonTestConfig;
 import org.candlepin.controller.Entitler;
 import org.candlepin.controller.PoolManager;
 import org.candlepin.dto.ModelTranslator;
-import org.candlepin.dto.StandardTranslator;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerCapability;
 import org.candlepin.model.ConsumerCurator;
@@ -77,6 +76,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.xnap.commons.i18n.I18n;
 import org.xnap.commons.i18n.I18nFactory;
 
+import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -109,20 +109,19 @@ public class ConsumerResourceUpdateTest {
     @Mock private ConsumerBindUtil consumerBindUtil;
     @Mock private ConsumerEnricher consumerEnricher;
     @Mock private Principal principal;
-    private ModelTranslator translator;
 
     private I18n i18n;
 
     private ConsumerResource resource;
     private Provider<GuestMigration> migrationProvider;
     private GuestMigration testMigration;
+    @Inject protected ModelTranslator modelTranslator;
 
     @Before
     public void init() throws Exception {
         Configuration config = new CandlepinCommonTestConfig();
 
         this.i18n = I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK);
-        this.translator = new StandardTranslator();
         testMigration = new GuestMigration(consumerCurator, eventFactory, sink);
         migrationProvider = Providers.of(testMigration);
 
@@ -134,7 +133,7 @@ public class ConsumerResourceUpdateTest {
             this.deletedConsumerCurator, this.environmentCurator, null,
             config, null, null, null, this.consumerBindUtil,
             null, null, new FactValidator(config, this.i18n),
-            null, consumerEnricher, migrationProvider, translator);
+            null, consumerEnricher, migrationProvider, modelTranslator);
 
         when(complianceRules.getStatus(any(Consumer.class), any(Date.class), any(Boolean.class),
             any(Boolean.class))).thenReturn(new ComplianceStatus(new Date()));

--- a/server/src/test/java/org/candlepin/resource/EntitlementResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/EntitlementResourceTest.java
@@ -26,6 +26,8 @@ import org.candlepin.common.paging.Page;
 import org.candlepin.common.paging.PageRequest;
 import org.candlepin.controller.CandlepinPoolManager;
 import org.candlepin.controller.Entitler;
+import org.candlepin.dto.ModelTranslator;
+import org.candlepin.dto.api.v1.EntitlementDTO;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerCurator;
 import org.candlepin.model.ConsumerType;
@@ -73,14 +75,16 @@ public class EntitlementResourceTest {
     @Mock private SubscriptionResource subResource;
     @Mock private EntitlementRules entRules;
     @Mock private EntitlementRulesTranslator messageTranslator;
+    @Mock protected ModelTranslator modelTranslator;
 
     private EntitlementResource entResource;
+
 
     @Before
     public void before() {
         i18n = I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK);
         entResource = new EntitlementResource(entitlementCurator, consumerCurator,
-            poolManager, i18n, entitler, entRules, messageTranslator);
+            poolManager, i18n, entitler, entRules, messageTranslator, modelTranslator);
         owner = new Owner("admin");
         consumer = new Consumer("myconsumer", "bill", owner,
             TestUtil.createConsumerType());
@@ -234,10 +238,15 @@ public class EntitlementResourceTest {
         Page<List<Entitlement>> page = new Page<List<Entitlement>>();
         page.setPageData(entitlements);
 
+        EntitlementDTO entitlementDTO = new EntitlementDTO();
+        entitlementDTO.setId("getEntitlementList");
+
         when(entitlementCurator.listAll(isA(EntitlementFilterBuilder.class), isA(PageRequest.class)))
                 .thenReturn(page);
+        when(modelTranslator.translate(isA(Entitlement.class),
+                eq(EntitlementDTO.class))).thenReturn(entitlementDTO);
 
-        List<Entitlement> result = entResource.listAllForConsumer(null, null, null, req);
+        List<EntitlementDTO> result = entResource.listAllForConsumer(null, null, null, req);
 
         assertEquals(1, result.size());
         assertEquals("getEntitlementList", result.get(0).getId());
@@ -260,12 +269,17 @@ public class EntitlementResourceTest {
         Page<List<Entitlement>> page = new Page<List<Entitlement>>();
         page.setPageData(entitlements);
 
+        EntitlementDTO entitlementDTO = new EntitlementDTO();
+        entitlementDTO.setId("getAllEntitlementsForConsumer");
+
         when(consumerCurator.findByUuid(eq(consumer.getUuid()))).thenReturn(consumer);
         when(
                 entitlementCurator.listByConsumer(isA(Consumer.class), anyString(),
                         isA(EntitlementFilterBuilder.class), isA(PageRequest.class))).thenReturn(page);
+        when(modelTranslator.translate(isA(Entitlement.class),
+            eq(EntitlementDTO.class))).thenReturn(entitlementDTO);
 
-        List<Entitlement> result = entResource.listAllForConsumer(consumer.getUuid(), null, null, req);
+        List<EntitlementDTO> result = entResource.listAllForConsumer(consumer.getUuid(), null, null, req);
 
         assertEquals(1, result.size());
         assertEquals("getAllEntitlementsForConsumer", result.get(0).getId());

--- a/server/src/test/java/org/candlepin/resource/GuestIdResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/GuestIdResourceTest.java
@@ -28,7 +28,6 @@ import org.candlepin.common.exceptions.NotFoundException;
 import org.candlepin.common.paging.Page;
 import org.candlepin.common.paging.PageRequest;
 import org.candlepin.dto.ModelTranslator;
-import org.candlepin.dto.StandardTranslator;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerCurator;
 import org.candlepin.model.ConsumerType;
@@ -51,6 +50,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.xnap.commons.i18n.I18n;
 import org.xnap.commons.i18n.I18nFactory;
 
+import javax.inject.Inject;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
@@ -72,13 +72,13 @@ public class GuestIdResourceTest {
     @Mock private EventSink sink;
     @Mock private ServiceLevelValidator mockedServiceLevelValidator;
     @Mock private ConsumerEnricher consumerEnricher;
-    private ModelTranslator translator;
 
     private GuestIdResource guestIdResource;
 
     private Consumer consumer;
     private Owner owner;
     private ConsumerType ct;
+    @Inject protected ModelTranslator modelTranslator;
 
     private GuestMigration testMigration;
     private Provider<GuestMigration> migrationProvider;
@@ -92,7 +92,6 @@ public class GuestIdResourceTest {
         owner = new Owner("test-owner", "Test Owner");
         ct = new ConsumerType(ConsumerTypeEnum.SYSTEM);
         consumer = new Consumer("consumer", "test", owner, ct);
-        translator = new StandardTranslator();
         guestIdResource = new GuestIdResource(guestIdCurator,
             consumerCurator, consumerResource, i18n, eventFactory, sink, migrationProvider);
         when(consumerCurator.findByUuid(consumer.getUuid())).thenReturn(consumer);
@@ -282,7 +281,7 @@ public class GuestIdResourceTest {
         public ConsumerResourceForTesting() {
             super(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null,
                 null, null, null, null, null, null, null, null, null, null, null, null, null,
-                null, null, null, null, consumerEnricher, null, translator);
+                null, null, null, null, consumerEnricher, null, modelTranslator);
         }
 
         public void checkForMigration(Consumer host, Consumer guest) {

--- a/server/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
@@ -34,7 +34,6 @@ import org.candlepin.common.config.Configuration;
 import org.candlepin.common.exceptions.BadRequestException;
 import org.candlepin.config.CandlepinCommonTestConfig;
 import org.candlepin.dto.ModelTranslator;
-import org.candlepin.dto.StandardTranslator;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerCurator;
 import org.candlepin.model.ConsumerType;
@@ -72,6 +71,7 @@ import org.mockito.stubbing.Answer;
 import org.xnap.commons.i18n.I18n;
 import org.xnap.commons.i18n.I18nFactory;
 
+import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -102,12 +102,13 @@ public class HypervisorResourceTest {
     @Mock private ConsumerBindUtil consumerBindUtil;
     @Mock private EventBuilder consumerEventBuilder;
     @Mock private ConsumerEnricher consumerEnricher;
-    private ModelTranslator translator;
 
     private ConsumerResource consumerResource;
     private I18n i18n;
     private ConsumerType hypervisorType;
     private HypervisorResource hypervisorResource;
+    @Inject
+    protected ModelTranslator modelTranslator;
 
     private Provider<GuestMigration> migrationProvider;
     private GuestMigration testMigration;
@@ -121,7 +122,6 @@ public class HypervisorResourceTest {
 
         this.i18n = I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK);
         this.hypervisorType = new ConsumerType(ConsumerTypeEnum.HYPERVISOR);
-        this.translator = new StandardTranslator();
         this.consumerResource = new ConsumerResource(this.consumerCurator,
             this.consumerTypeCurator, null, this.subscriptionService, this.ownerService, null,
             this.idCertService, null, this.i18n, this.sink, this.eventFactory, null, null,
@@ -129,7 +129,7 @@ public class HypervisorResourceTest {
             this.activationKeyCurator, null, this.complianceRules,
             this.deletedConsumerCurator, null, null, config,
             null, null, null, this.consumerBindUtil, null, null,
-            new FactValidator(config, this.i18n), null, consumerEnricher, migrationProvider, translator);
+            new FactValidator(config, this.i18n), null, consumerEnricher, migrationProvider, modelTranslator);
 
         hypervisorResource = new HypervisorResource(consumerResource,
             consumerCurator, i18n, ownerCurator, migrationProvider);

--- a/server/src/test/java/org/candlepin/resource/OwnerResourceUeberCertOperationsTest.java
+++ b/server/src/test/java/org/candlepin/resource/OwnerResourceUeberCertOperationsTest.java
@@ -32,6 +32,7 @@ import org.candlepin.model.EntitlementCertificateCurator;
 import org.candlepin.model.EntitlementCurator;
 import org.candlepin.model.Owner;
 import org.candlepin.model.OwnerCurator;
+import org.candlepin.model.ProductCurator;
 import org.candlepin.model.Role;
 import org.candlepin.model.RoleCurator;
 import org.candlepin.model.UeberCertificate;
@@ -57,6 +58,7 @@ public class OwnerResourceUeberCertOperationsTest extends DatabaseTestFixture {
     private static final String OWNER_NAME = "Jar_Jar_Binks";
 
     @Inject private OwnerCurator ownerCurator;
+    @Inject private ProductCurator productCurator;
     @Inject private ConsumerCurator consumerCurator;
     @Inject private ConsumerTypeCurator consumerTypeCurator;
     @Inject private EntitlementCurator entitlementCurator;
@@ -91,7 +93,8 @@ public class OwnerResourceUeberCertOperationsTest extends DatabaseTestFixture {
         setupPrincipal(principal);
 
         or = new OwnerResource(
-            ownerCurator, null, consumerCurator, i18n, null, null, null, null, null, poolManager, null, null,
+            ownerCurator, productCurator, null, consumerCurator, i18n, null, null, null,
+            null, null, poolManager, null, null,
             null, null, consumerTypeCurator, entCertCurator, entitlementCurator, ueberCertCurator,
             ueberCertGenerator, null,  null, contentOverrideValidator, serviceLevelValidator, null, null,
             null, null, null, this.modelTranslator);

--- a/server/src/test/java/org/candlepin/resource/PoolResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/PoolResourceTest.java
@@ -25,8 +25,9 @@ import org.candlepin.common.exceptions.BadRequestException;
 import org.candlepin.common.exceptions.ForbiddenException;
 import org.candlepin.common.exceptions.NotFoundException;
 import org.candlepin.controller.CandlepinPoolManager;
+import org.candlepin.dto.api.v1.EntitlementDTO;
+import org.candlepin.dto.api.v1.PoolDTO;
 import org.candlepin.model.Consumer;
-import org.candlepin.model.Entitlement;
 import org.candlepin.model.Owner;
 import org.candlepin.model.Pool;
 import org.candlepin.model.Product;
@@ -34,6 +35,7 @@ import org.candlepin.resource.util.CalculatedAttributesUtil;
 import org.candlepin.test.DatabaseTestFixture;
 import org.candlepin.test.TestUtil;
 
+import org.hamcrest.collection.IsCollectionWithSize;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -123,20 +125,21 @@ public class PoolResourceTest extends DatabaseTestFixture {
 
     @Test(expected = ForbiddenException.class)
     public void testUserCannotListAllPools() {
-        List<Pool> pools = poolResource.list(null, null, null, false, null, adminPrincipal, null);
+        List<PoolDTO> pools = poolResource.list(null, null, null, false, null, adminPrincipal, null);
         assertEquals(3, pools.size());
     }
 
     @Test
     public void testListAll() {
-        List<Pool> pools = poolResource.list(null, null, null, false, null,
+        List<PoolDTO> pools = poolResource.list(null, null, null, false, null,
             setupAdminPrincipal("superadmin"), null);
         assertEquals(3, pools.size());
     }
 
     @Test
     public void testListForOrg() {
-        List<Pool> pools = poolResource.list(owner1.getId(), null, null, false, null, adminPrincipal, null);
+        List<PoolDTO> pools = poolResource.list(owner1.getId(), null, null,
+            false, null, adminPrincipal, null);
         assertEquals(2, pools.size());
         Principal p = setupPrincipal(owner2, Access.ALL);
         pools = poolResource.list(owner2.getId(), null, null, false, null, p, null);
@@ -146,7 +149,8 @@ public class PoolResourceTest extends DatabaseTestFixture {
     @Ignore
     @Test
     public void testListForProduct() {
-        List<Pool> pools = poolResource.list(null, null, product1.getId(), false, null, adminPrincipal, null);
+        List<PoolDTO> pools = poolResource.list(null, null, product1.getId(),
+            false, null, adminPrincipal, null);
         assertEquals(2, pools.size());
         pools = poolResource.list(null, null, product2.getId(), false, null,
             adminPrincipal, null);
@@ -155,30 +159,31 @@ public class PoolResourceTest extends DatabaseTestFixture {
 
     @Test
     public void testListForOrgAndProduct() {
-        List<Pool> pools = poolResource.list(owner1.getId(), null, product1.getId(), false,
+        List<PoolDTO> pools = poolResource.list(owner1.getId(), null, product1.getId(), false,
             null, adminPrincipal, null);
         assertEquals(1, pools.size());
     }
 
     @Test(expected = NotFoundException.class)
     public void testCannotListPoolsInAnotherOwner() {
-        List<Pool> pools = poolResource.list(owner2.getId(), null, product2.getId(),
+        List<PoolDTO> pools = poolResource.list(owner2.getId(), null, product2.getId(),
             false, null, adminPrincipal, null);
         assertEquals(0, pools.size());
     }
 
     @Test
     public void testListConsumerAndProductFiltering() {
-        List<Pool> pools = poolResource.list(null, passConsumer.getUuid(),
+        List<PoolDTO> pools = poolResource.list(null, passConsumer.getUuid(),
             product1.getId(), false, null, adminPrincipal, null);
         assertEquals(1, pools.size());
 
-        verify(attrUtil, times(1)).setCalculatedAttributes(eq(pools), any(Date.class));
+        verify(attrUtil, times(1))
+            .setCalculatedAttributes((List<Pool>) argThat(IsCollectionWithSize.hasSize(1)), any(Date.class));
     }
 
     @Test(expected = NotFoundException.class)
     public void testCannotListPoolsForConsumerInAnotherOwner() {
-        List<Pool> pools = poolResource.list(null, failConsumer.getUuid(),
+        List<PoolDTO> pools = poolResource.list(null, failConsumer.getUuid(),
             product1.getId(), false, null, adminPrincipal, null);
         assertEquals(0, pools.size());
     }
@@ -194,11 +199,12 @@ public class PoolResourceTest extends DatabaseTestFixture {
     @Test
     public void testListConsumerFiltering() {
         setupPrincipal(new ConsumerPrincipal(passConsumer));
-        List<Pool> pools = poolResource.list(null, passConsumer.getUuid(), null, false,
+        List<PoolDTO> pools = poolResource.list(null, passConsumer.getUuid(), null, false,
             null, adminPrincipal, null);
         assertEquals(2, pools.size());
 
-        verify(attrUtil, times(1)).setCalculatedAttributes(eq(pools), any(Date.class));
+        verify(attrUtil, times(1))
+            .setCalculatedAttributes((List<Pool>) argThat(IsCollectionWithSize.hasSize(2)), any(Date.class));
     }
 
     @Test(expected = NotFoundException.class)
@@ -219,7 +225,7 @@ public class PoolResourceTest extends DatabaseTestFixture {
 
     @Test(expected = NotFoundException.class)
     public void ownerAdminCannotListAnotherOwnersPools() {
-        List<Pool> pools = poolResource.list(owner1.getId(), null, null, false, null,
+        List<PoolDTO> pools = poolResource.list(owner1.getId(), null, null, false, null,
             adminPrincipal, null);
         assertEquals(2, pools.size());
 
@@ -263,7 +269,7 @@ public class PoolResourceTest extends DatabaseTestFixture {
     public void testActiveOnDate() {
         // Need to be a super admin to do this:
         String activeOn = Integer.toString(START_YEAR + 1);
-        List<Pool> pools = poolResource.list(null, null, null, false, activeOn,
+        List<PoolDTO> pools = poolResource.list(null, null, null, false, activeOn,
             setupAdminPrincipal("superadmin"), null);
         assertEquals(3, pools.size());
 
@@ -275,7 +281,7 @@ public class PoolResourceTest extends DatabaseTestFixture {
 
     @Test
     public void testCalculatedAttributesEmpty() {
-        Pool p = poolResource.getPool(pool1.getId(), null, null, adminPrincipal);
+        PoolDTO p = poolResource.getPool(pool1.getId(), null, null, adminPrincipal);
         assertTrue(p.getCalculatedAttributes().isEmpty());
     }
 
@@ -292,8 +298,9 @@ public class PoolResourceTest extends DatabaseTestFixture {
         poolResource.getPool(pool1.getId(), "xyzzy", null, adminPrincipal);
     }
 
+    @Test
     public void testEmptyEntitlementList() {
-        List<Entitlement> ents =
+        List<EntitlementDTO> ents =
             poolResource.getPoolEntitlements(pool1.getId(),  adminPrincipal);
         assertEquals(0, ents.size());
     }


### PR DESCRIPTION
- Created PoolDTO/PoolTranslator and internal DTOs: ProvidedProductDTO, SourceSubscriptionDTO and SourceStackDTO.
- Created EntitlementDTO/EntitlementTranslator.
- Created BrandingDTO/BrandingTranslator, which is an internal DTO used by EntitlementDTO, and can be used by SubscriptionDTO once that gets introduced.
- Changed endpoints in PoolResource, ActivationKeyResource, OwnerResource, ConsumerResource and EntitlementResource to use the new DTOs when receiving/sending data.
- Removed JAXB/Jackson and annotations from Branding, ProvidedProduct, SourceStack, SourceSubscription model objects.
- API Changes: All the new DTO classes (internal and external), no longer use the @HateoasInclude annotation and therefore are serialized fully as nested objects of their parent serialized entities, instead of only few select fields of them.
- Removed some unused @Index/@ForeignKey hibernate annotations from Entitlement and SourceStack model classes.