### PR TITLE
[M] Fixed several Oracle-related SQL errors in Liquibase tasks

### DIFF
--- a/server/src/main/resources/db/changelog/20130425102131-distributor-capabilities.xml
+++ b/server/src/main/resources/db/changelog/20130425102131-distributor-capabilities.xml
@@ -6,6 +6,9 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
 
+    <!-- Include definitions for cert.type, timestamp.type, etc. -->
+    <include file="db/changelog/datatypes.xml"/>
+
     <!-- The Postgresql only changes in this file were an oversight and are corrected in
          a separate changelog, 20130611152026-add-missing-capability-indexes-on-oracle.xml -->
     <changeSet id="20130425102131" author="wpoteat" dbms="oracle,postgresql">
@@ -27,8 +30,10 @@
         </createIndex>
         <addForeignKeyConstraint baseColumnNames="consumer_id" baseTableName="cp_consumer_capability" baseTableSchemaName="public" constraintName="fk_cnsmr_capability_cnsmr" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="cp_consumer" referencedTableSchemaName="public" referencesUniqueColumn="false"/>
     </changeSet>
-    
+
     <changeSet id="20130425102131-2" author="wpoteat" dbms="oracle,postgresql">
+        <validCheckSum>7:99cf6849e828630689bead090ccca338</validCheckSum>
+
         <createTable tableName="cp_dist_version">
             <column name="id" type="VARCHAR(32)">
                 <constraints nullable="false" primaryKey="true" primaryKeyName="cp_dist_version_pkey"/>
@@ -39,15 +44,15 @@
             <column name="display_name" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="created" type="TIMESTAMP WITHOUT TIME ZONE"/>
-            <column name="updated" type="TIMESTAMP WITHOUT TIME ZONE"/>
+            <column name="created" type="${timestamp.type}"/>
+            <column name="updated" type="${timestamp.type}"/>
         </createTable>
     </changeSet>
     <changeSet id="20130425102131-3" author="wpoteat" dbms="postgresql">
         <createIndex tableName="cp_dist_version" indexName="cp_dist_version_id_idx">
             <column name="id"/>
         </createIndex>
-        <addUniqueConstraint columnNames="name" constraintName="cp_dist_version_name_key" deferrable="false" disabled="false" initiallyDeferred="false" tableName="cp_dist_version"/> 
+        <addUniqueConstraint columnNames="name" constraintName="cp_dist_version_name_key" deferrable="false" disabled="false" initiallyDeferred="false" tableName="cp_dist_version"/>
     </changeSet>
 
     <changeSet id="20130425102131-4" author="wpoteat" dbms="oracle,postgresql">
@@ -69,5 +74,5 @@
         </createIndex>
         <addForeignKeyConstraint baseColumnNames="dist_version_id" baseTableName="cp_dist_version_capability" baseTableSchemaName="public" constraintName="fk_dist_vrsn_capability" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="cp_dist_version" referencedTableSchemaName="public" referencesUniqueColumn="false"/>
     </changeSet>
-    
+
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/20130501152202-add-content-arch.xml
+++ b/server/src/main/resources/db/changelog/20130501152202-add-content-arch.xml
@@ -1,101 +1,106 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <databaseChangeLog
-            xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+    <!-- Include definitions for cert.type, timestamp.type, etc. -->
+    <include file="db/changelog/datatypes.xml"/>
 
 
-            <changeSet id="20130501152202-1" author="alikins" dbms="oracle,postgresql">
-                <comment>Add a cp_content_arch for content/arch mapping</comment>
-                <createTable tableName="cp_arch">
+    <changeSet id="20130501152202-1" author="alikins" dbms="oracle,postgresql">
+        <comment>Add a cp_content_arch for content/arch mapping</comment>
+        <createTable tableName="cp_arch">
 
-                    <column name="id" type="VARCHAR(255)">
-                        <constraints nullable="false" primaryKey="true" primaryKeyName="cp_arch_pkey"/>
-                    </column>
-                    <column name="label" type="VARCHAR(255)">
-                        <constraints nullable="false"/>
-                    </column>
-                   <column name="created" type="TIMESTAMP WITHOUT TIME ZONE"/>
-                   <column name="updated" type="TIMESTAMP WITHOUT TIME ZONE"/>
-               </createTable>
-            </changeSet>
+            <column name="id" type="VARCHAR(255)">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="cp_arch_pkey"/>
+            </column>
+            <column name="label" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+           <column name="created" type="${timestamp.type}"/>
+           <column name="updated" type="${timestamp.type}"/>
+       </createTable>
+    </changeSet>
 
-            <changeSet id="20130501152202-2" author="alikins" dbms="oracle,postgresql">
-            <createTable tableName="cp_content_arch">
-                    <column name="content_id" type="VARCHAR(255)">
-                        <constraints nullable="false"/>
-                    </column>
-                    <column name="arch_id" type="VARCHAR(255)">
-                        <constraints nullable="false"/>
-                   </column>
-                   <column name="created" type="TIMESTAMP WITHOUT TIME ZONE"/>
-                   <column name="updated" type="TIMESTAMP WITHOUT TIME ZONE"/>
-               </createTable>
-           </changeSet>
+    <changeSet id="20130501152202-2" author="alikins" dbms="oracle,postgresql">
+        <validCheckSum>7:21a6dfe6c97700d58f1f8149007b7d7b</validCheckSum>
 
-            <changeSet id="20130501152202-3" author="alikins" dbms="oracle,postgresql">
-                <addPrimaryKey columnNames="arch_id, content_id" constraintName="cp_content_arch_pkey" tableName="cp_content_arch"/>
-            </changeSet>
+        <createTable tableName="cp_content_arch">
+            <column name="content_id" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="arch_id" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+           </column>
+           <column name="created" type="${timestamp.type}"/>
+           <column name="updated" type="${timestamp.type}"/>
+       </createTable>
+   </changeSet>
 
-            <changeSet id="20130501152202-4" author="alikins" dbms="oracle,postgresql">
-                <addForeignKeyConstraint baseColumnNames="arch_id" baseTableName="cp_content_arch" constraintName="fk_content_arch_arch" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="cp_arch" referencesUniqueColumn="false"/>
-            </changeSet>
+    <changeSet id="20130501152202-3" author="alikins" dbms="oracle,postgresql">
+        <addPrimaryKey columnNames="arch_id, content_id" constraintName="cp_content_arch_pkey" tableName="cp_content_arch"/>
+    </changeSet>
 
-            <changeSet id="20130501152202-5" author="alikins" dbms="oracle,postgresql">
-                <addForeignKeyConstraint baseColumnNames="content_id" baseTableName="cp_content_arch" constraintName="fk_content_arch_content" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="cp_content" referencesUniqueColumn="false"/>
-            </changeSet>
+    <changeSet id="20130501152202-4" author="alikins" dbms="oracle,postgresql">
+        <addForeignKeyConstraint baseColumnNames="arch_id" baseTableName="cp_content_arch" constraintName="fk_content_arch_arch" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="cp_arch" referencesUniqueColumn="false"/>
+    </changeSet>
 
-            <changeSet id="20130501152202-6" author="alikins" dbms="oracle,postgresql">
-                <comment>populate arch table</comment>
-                <insert tableName="cp_arch">
-                    <column name="id" value="0"/>
-                    <column name="label" value="ALL"/>
-                </insert>
-                <insert tableName="cp_arch">
-                    <column name="id" value="1"/>
-                    <column name="label" value="x86_64"/>
-                </insert>
-                <insert tableName="cp_arch">
-                    <column name="id" value="2"/>
-                    <column name="label" value="i386"/>
-                </insert>
-                <insert tableName="cp_arch">
-                    <column name="id" value="3"/>
-                    <column name="label" value="i486"/>
-                </insert>
-                <insert tableName="cp_arch">
-                    <column name="id" value="4"/>
-                    <column name="label" value="i586"/>
-                </insert>
-                <insert tableName="cp_arch">
-                    <column name="id" value="5"/>
-                    <column name="label" value="i686"/>
-                </insert>
-                <insert tableName="cp_arch">
-                    <column name="id" value="6"/>
-                    <column name="label" value="ppc"/>
-                </insert>
-                <insert tableName="cp_arch">
-                    <column name="id" value="7"/>
-                    <column name="label" value="ppc64"/>
-                </insert>
-                <insert tableName="cp_arch">
-                    <column name="id" value="8"/>
-                    <column name="label" value="ia64"/>
-                </insert>
-                <insert tableName="cp_arch">
-                    <column name="id" value="9"/>
-                    <column name="label" value="arm"/>
-                </insert>
-                <insert tableName="cp_arch">
-                    <column name="id" value="10"/>
-                    <column name="label" value="s390"/>
-                </insert>
-                <insert tableName="cp_arch">
-                    <column name="id" value="11"/>
-                    <column name="label" value="s390x"/>
-                </insert>
-            </changeSet>
+    <changeSet id="20130501152202-5" author="alikins" dbms="oracle,postgresql">
+        <addForeignKeyConstraint baseColumnNames="content_id" baseTableName="cp_content_arch" constraintName="fk_content_arch_content" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="cp_content" referencesUniqueColumn="false"/>
+    </changeSet>
+
+    <changeSet id="20130501152202-6" author="alikins" dbms="oracle,postgresql">
+        <comment>populate arch table</comment>
+        <insert tableName="cp_arch">
+            <column name="id" value="0"/>
+            <column name="label" value="ALL"/>
+        </insert>
+        <insert tableName="cp_arch">
+            <column name="id" value="1"/>
+            <column name="label" value="x86_64"/>
+        </insert>
+        <insert tableName="cp_arch">
+            <column name="id" value="2"/>
+            <column name="label" value="i386"/>
+        </insert>
+        <insert tableName="cp_arch">
+            <column name="id" value="3"/>
+            <column name="label" value="i486"/>
+        </insert>
+        <insert tableName="cp_arch">
+            <column name="id" value="4"/>
+            <column name="label" value="i586"/>
+        </insert>
+        <insert tableName="cp_arch">
+            <column name="id" value="5"/>
+            <column name="label" value="i686"/>
+        </insert>
+        <insert tableName="cp_arch">
+            <column name="id" value="6"/>
+            <column name="label" value="ppc"/>
+        </insert>
+        <insert tableName="cp_arch">
+            <column name="id" value="7"/>
+            <column name="label" value="ppc64"/>
+        </insert>
+        <insert tableName="cp_arch">
+            <column name="id" value="8"/>
+            <column name="label" value="ia64"/>
+        </insert>
+        <insert tableName="cp_arch">
+            <column name="id" value="9"/>
+            <column name="label" value="arm"/>
+        </insert>
+        <insert tableName="cp_arch">
+            <column name="id" value="10"/>
+            <column name="label" value="s390"/>
+        </insert>
+        <insert tableName="cp_arch">
+            <column name="id" value="11"/>
+            <column name="label" value="s390x"/>
+        </insert>
+    </changeSet>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/20161109145238-add-owner-environment-content-access.xml
+++ b/server/src/main/resources/db/changelog/20161109145238-add-owner-environment-content-access.xml
@@ -4,16 +4,18 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <!-- Include definitions for cert.type, timestamp.type, etc. -->
     <include file="db/changelog/datatypes.xml"/>
 
     <changeSet id="20161109145238-1" author="wpoteat">
+        <validCheckSum>7:e7d90208e03c95b6b43ff73e4a6c441b</validCheckSum>
+
         <comment>add-owner-environment-content-access</comment>
         <createTable tableName="cp_owner_env_content_access">
             <column name="id" type="VARCHAR(32)">
-                <constraints nullable="false" primaryKey="true" primaryKeyName="cp_owner_env_content_access_pkey"/>
+                <constraints nullable="false" primaryKey="true" primaryKeyName="cp_owner_ec_access_pkey"/>
             </column>
             <column name="owner_id" type="VARCHAR(32)">
                 <constraints nullable="false"/>
@@ -33,7 +35,7 @@
         <addForeignKeyConstraint baseColumnNames="environment_id" baseTableName="cp_owner_env_content_access" constraintName="fk_owner_env_cont_acc_env" deferrable="false" initiallyDeferred="false" onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="cp_environment" referencesUniqueColumn="false"/>
     </changeSet>
     <changeSet author="wpoteat" id="20161109145238-02">
-        <addUniqueConstraint columnNames="owner_id, environment_id" constraintName="cp_owner_env_content_access_ukey" deferrable="false" disabled="false" initiallyDeferred="false" tableName="cp_owner_env_content_access"/>
+        <addUniqueConstraint columnNames="owner_id, environment_id" constraintName="cp_owner_ec_access_ukey" deferrable="false" disabled="false" initiallyDeferred="false" tableName="cp_owner_env_content_access"/>
     </changeSet>
 
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/20170202093945-add-ueber-cert-to-owner.xml
+++ b/server/src/main/resources/db/changelog/20170202093945-add-ueber-cert-to-owner.xml
@@ -61,9 +61,8 @@
 
     <changeSet id="20170202093945-3" author="mstead" dbms="oracle">
         <comment>Add indexes for the foreign keys in oracle.</comment>
-        <createIndex indexName="owner_fk" tableName="cp_ueber_cert" unique="true">
-            <column name="ueber_cert_id"/>
-        </createIndex>
+
+        <!-- Oracle automatically creates an index for the unique constraint -->
         <createIndex indexName="ueber_cert_serial_fk" tableName="cp_ueber_cert" unique="false">
             <column name="serial_id"/>
         </createIndex>

--- a/server/src/main/resources/db/changelog/20170206114359-convert-quanity-consumed-exported-to-columns.xml
+++ b/server/src/main/resources/db/changelog/20170206114359-convert-quanity-consumed-exported-to-columns.xml
@@ -4,47 +4,28 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <property
-    dbms="postgresql,oracle"
-    name="fill_in_quantity_consumed_value"
-    value="update cp_pool
-        set quantity_consumed = coalesce(subquery.quantity, 0)
-        FROM (select pool_id, sum(quantity) quantity from cp_entitlement ent group by pool_id) subquery
-        where cp_pool.id = subquery.pool_id;" />
+      dbms="postgresql, oracle, mysql"
+      name="fill_in_quantity_consumed_value"
+      value="UPDATE cp_pool SET quantity_consumed = coalesce(
+        (SELECT sum(cp_entitlement.quantity) FROM cp_entitlement WHERE cp_entitlement.pool_id = cp_pool.id), 0);"/>
 
     <property
-    dbms="mysql,hsqldb"
-    name="fill_in_quantity_consumed_value"
-    value="update cp_pool p set p.quantity_consumed =
-        coalesce((select sum(quantity) quantity from cp_entitlement ent where ent.pool_id = p.id),0);" />
+      dbms="postgresql,oracle, mysql"
+      name="fill_in_quantity_exported_value"
+      value="UPDATE cp_pool SET quantity_exported = coalesce(
+        (SELECT sum(cp_entitlement.quantity) FROM cp_entitlement
+          JOIN cp_consumer ON cp_consumer.id = cp_entitlement.consumer_id
+          JOIN cp_consumer_type ON cp_consumer_type.id = cp_consumer.type_id
+          WHERE cp_consumer_type.manifest = 'Y'
+          AND cp_entitlement.pool_id = cp_pool.id),
+        0);"/>
 
-    <property
-    dbms="postgresql,oracle"
-    name="fill_in_quantity_exported_value"
-    value="update cp_pool
-        set quantity_exported = coalesce(subquery.quantity, 0)
-        FROM (select ent.pool_id pool_id, sum(ent.quantity) quantity
-              from cp_entitlement ent, cp_consumer cons, cp_consumer_type ctype
-              where ent.consumer_id = cons.id
-              and cons.type_id = ctype.id
-              and ctype.manifest = 'Y'
-              group by ent.pool_id) subquery
-        where cp_pool.id = subquery.pool_id;" />
+    <changeSet id="20170206114359-1" author="wpoteat, crog" dbms="postgresql, oracle, mysql, hsqldb">
+        <validCheckSum>7:506efa873b8eb83ddc5971b6fb110753</validCheckSum>
 
-    <property
-    dbms="mysql, hsqldb"
-    name="fill_in_quantity_exported_value"
-    value="update cp_pool p set p.quantity_exported =
-        coalesce((select sum(ent.quantity) quantity
-              from cp_entitlement ent, cp_consumer cons, cp_consumer_type ctype
-              where ent.pool_id = p.id
-              and ent.consumer_id = cons.id
-              and cons.type_id = ctype.id
-              and ctype.manifest = 'Y'),0);" />
-
-    <changeSet id="20170206114359-1" author="wpoteat">
         <comment>Add columns for consumed and exported quantities to pool</comment>
         <addColumn tableName="cp_pool">
             <column name="quantity_consumed" type="${serial.type}" defaultValueNumeric="0">
@@ -54,8 +35,8 @@
                  <constraints nullable="false"/>
             </column>
         </addColumn>
-        <sql>${fill_in_quantity_consumed_value}</sql>
-        <sql>${fill_in_quantity_exported_value}</sql>
+        <sql dbms="postgresql, oracle, mysql">${fill_in_quantity_consumed_value}</sql>
+        <sql dbms="postgresql, oracle, mysql">${fill_in_quantity_exported_value}</sql>
         <rollback>
             alter table cp_pool drop column if exists quantity_consumed;
             alter table cp_pool drop column if exists quantity_exported;

--- a/server/src/main/resources/db/changelog/20170227140343-convert-consumer-entitlement-count-to-column.xml
+++ b/server/src/main/resources/db/changelog/20170227140343-convert-consumer-entitlement-count-to-column.xml
@@ -1,33 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <databaseChangeLog
-        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
-   <property
-     dbms="postgresql,oracle"
-     name="fill_in_entitlement_count_value"
-     value="update cp_consumer
-         set entitlement_count = coalesce(subquery.quantity, 0)
-         FROM (select consumer_id, sum(quantity) quantity from cp_entitlement ent group by consumer_id) subquery
-         where cp_consumer.id = subquery.consumer_id;" />
+    <property
+        dbms="postgresql, mysql, oracle"
+        name="fill_in_entitlement_count_value"
+        value="UPDATE cp_consumer SET entitlement_count = coalesce(
+            (SELECT sum(cp_entitlement.quantity)
+                FROM cp_entitlement WHERE cp_entitlement.consumer_id = cp_consumer.id), 0);"/>
 
-     <property
-     dbms="mysql,hsqldb"
-     name="fill_in_entitlement_count_value"
-     value="update cp_consumer c set c.entitlement_count =
-         coalesce((select sum(quantity) quantity from cp_entitlement ent where ent.consumer_id = c.id),0);" />
+     <changeSet id="20170227140343-1" author="wpoteat, crog" dbms="postgresql, mysql, oracle, hsqldb">
+        <validCheckSum>7:124ba8236ee0308696be406ea2a5958a</validCheckSum>
 
-     <changeSet id="20170227140343-1" author="wpoteat">
          <comment>Add column for entitlement quantity on consumer</comment>
          <addColumn tableName="cp_consumer">
              <column name="entitlement_count" type="${serial.type}" defaultValueNumeric="0">
                   <constraints nullable="false"/>
              </column>
          </addColumn>
-         <sql>${fill_in_entitlement_count_value}</sql>
+         <sql dbms="postgresql, mysql, oracle">${fill_in_entitlement_count_value}</sql>
          <rollback>
              alter table cp_consumer drop column if exists entitlement_count;
          </rollback>

--- a/server/src/main/resources/db/changelog/20170301083925-update-revoked-cert-serial-data.xml
+++ b/server/src/main/resources/db/changelog/20170301083925-update-revoked-cert-serial-data.xml
@@ -1,69 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <databaseChangeLog
-        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <property dbms="postgresql, mysql" name="unrevoked_value" value="false"/>
+    <property dbms="oracle" name="unrevoked_value" value="0"/>
+
+    <property dbms="postgresql, mysql" name="revoked_value" value="true"/>
+    <property dbms="oracle" name="revoked_value" value="1"/>
 
     <changeSet id="20170301083925-1" author="mstead">
+        <validCheckSum>7:e5dc16a5b9672bbdf38bdac361c9d289</validCheckSum>
+
         <comment>
             Calculate the value of the field for all known serials
             based on existence of entitlement certificates.
         </comment>
 
-        <sql dbms="postgresql,oracle">
-            update cp_cert_serial cs
-            set revoked = true
-            from
-                (select cs.id from cp_cert_serial cs
-                 left outer join cp_ent_certificate ec on ec.serial_id = cs.id
-                 left outer join cp_cdn_certificate cdnc on cs.id = cdnc.serial_id
-                 left outer join cp_id_cert idcert on cs.id = idcert.serial_id
-                 left outer join cp_cont_access_cert cacert on cs.id = cacert.serial_id
-                 left outer join cp_ueber_cert ueber on cs.id = ueber.serial_id
-                 where ec.id is null and cdnc.id is null and idcert.id is null and cacert.id is null and ueber.id is null
-                 ) revoked_cert
-            where cs.id = revoked_cert.id;
+        <sql dbms="postgresql, oracle, mysql">
+            UPDATE cp_cert_serial cs SET revoked = ${revoked_value}
+                WHERE revoked = ${unrevoked_value}
+                AND NOT EXISTS (SELECT 1 FROM cp_ent_certificate ec WHERE ec.serial_id = cs.id)
+                AND NOT EXISTS (SELECT 1 FROM cp_cdn_certificate cc WHERE cc.serial_id = cs.id)
+                AND NOT EXISTS (SELECT 1 FROM cp_id_cert ic WHERE ic.serial_id = cs.id)
+                AND NOT EXISTS (SELECT 1 FROM cp_cont_access_cert cac WHERE cac.serial_id = cs.id)
+                AND NOT EXISTS (SELECT 1 FROM cp_ueber_cert uc WHERE uc.serial_id = cs.id);
         </sql>
-
-        <sql dbms="mysql">
-            update cp_cert_serial cs
-            left outer join cp_ent_certificate ec on ec.serial_id = cs.id
-            left outer join cp_cdn_certificate cdnc on cs.id = cdnc.serial_id
-            left outer join cp_id_cert idcert on cs.id = idcert.serial_id
-            left outer join cp_cont_access_cert cacert on cs.id = cacert.serial_id
-            left outer join cp_ueber_cert ueber on cs.id = ueber.serial_id
-            set revoked = true
-            where ec.id is null and cdnc.id is null and idcert.id is null and cacert.id is null and ueber.id is null;
-        </sql>
-
-        <rollback>
-            <sql dbms="postgresql,oracle">
-                update cp_cert_serial cs
-                set revoked = false
-                from
-                (select cs.id from cp_cert_serial cs
-                left outer join cp_ent_certificate ec on ec.serial_id = cs.id
-                left outer join cp_cdn_certificate cdnc on cs.id = cdnc.serial_id
-                left outer join cp_id_cert idcert on cs.id = idcert.serial_id
-                left outer join cp_cont_access_cert cacert on cs.id = cacert.serial_id
-                left outer join cp_ueber_cert ueber on cs.id = ueber.serial_id
-                where ec.id is null and cdnc.id is null and idcert.id is null and cacert.id is null and ueber.id is null
-                ) revoked_cert
-                where cs.id = revoked_cert.id;
-            </sql>
-            <sql dbms="mysql">
-                update cp_cert_serial cs
-                left outer join cp_ent_certificate ec on ec.serial_id = cs.id
-                left outer join cp_cdn_certificate cdnc on cs.id = cdnc.serial_id
-                left outer join cp_id_cert idcert on cs.id = idcert.serial_id
-                left outer join cp_cont_access_cert cacert on cs.id = cacert.serial_id
-                left outer join cp_ueber_cert ueber on cs.id = ueber.serial_id
-                set revoked = false
-                where ec.id is null and cdnc.id is null and idcert.id is null and cacert.id is null and ueber.id is null;
-            </sql>
-        </rollback>
     </changeSet>
 
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/20171017062314-add-target-index-on-job-table.xml
+++ b/server/src/main/resources/db/changelog/20171017062314-add-target-index-on-job-table.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="20171017062314-1" author="vrjain">
         <preConditions onFail="MARK_RAN">

--- a/server/src/main/resources/db/changelog/20171020150559-add-index-to-cp-consumer-content-tags.xml
+++ b/server/src/main/resources/db/changelog/20171020150559-add-index-to-cp-consumer-content-tags.xml
@@ -6,7 +6,9 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
-    <changeSet id="20171020150559-1" author="awood">
+    <changeSet id="20171020150559-1" author="awood" dbms="mysql,postgresql,hsqldb">
+        <validCheckSum>7:34b116c4ac1794421c8f955001fee798</validCheckSum>
+
         <comment>Add index to cp_consumer_content_tags</comment>
 
         <createIndex indexName="content_tags_consumer_id_idx"

--- a/server/src/main/resources/db/changelog/datatypes.xml
+++ b/server/src/main/resources/db/changelog/datatypes.xml
@@ -4,10 +4,12 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
 
-    <property name="timestamp.type" value="TIMESTAMP WITHOUT TIME ZONE" dbms="oracle,postgresql,hsqldb"/>
+    <property name="timestamp.type" value="TIMESTAMP WITHOUT TIME ZONE" dbms="postgresql,hsqldb"/>
+    <property name="timestamp.type" value="TIMESTAMP" dbms="oracle"/>
     <property name="timestamp.type" value="DATETIME" dbms="mysql"/>
 
-    <property name="date.type" value="TIMESTAMP WITHOUT TIME ZONE" dbms="postgresql,oracle,hsqldb"/>
+    <property name="date.type" value="TIMESTAMP WITHOUT TIME ZONE" dbms="postgresql,hsqldb"/>
+    <property name="date.type" value="TIMESTAMP" dbms="oracle"/>
     <property name="date.type" value="DATETIME" dbms="mysql"/>
 
     <property name="serial.type" value="BIGINT" dbms="oracle,mysql,hsqldb"/>


### PR DESCRIPTION
- Several Liquibase change sets have been updated to address errors
  which occurred when running against Oracle databases
- Optimized a few queries to work faster and/or require less
  separation between the database plaforms
- Removed an unneeded rollback task in the update-revoked-cert-serial
  task