### PR TITLE
[DTO] Fixed content detection in products

### DIFF
--- a/server/src/main/java/org/candlepin/controller/ContentManager.java
+++ b/server/src/main/java/org/candlepin/controller/ContentManager.java
@@ -726,7 +726,7 @@ public class ContentManager {
      * @return
      *  true if this content would be changed by the given DTO; false otherwise
      */
-    public boolean isChangedBy(Content entity, ContentDTO dto) {
+    public static boolean isChangedBy(Content entity, ContentDTO dto) {
         if (dto.getId() != null && !dto.getId().equals(entity.getId())) {
             return true;
         }
@@ -800,7 +800,7 @@ public class ContentManager {
      * @return
      *  true if this content would be changed by the given DTO; false otherwise
      */
-    public boolean isChangedBy(Content entity, ContentData dto) {
+    public static boolean isChangedBy(Content entity, ContentData dto) {
         if (dto.getId() != null && !dto.getId().equals(entity.getId())) {
             return true;
         }

--- a/server/src/main/java/org/candlepin/controller/ProductManager.java
+++ b/server/src/main/java/org/candlepin/controller/ProductManager.java
@@ -740,7 +740,7 @@ public class ProductManager {
      * @return
      *  true if this product would be changed by the given DTO; false otherwise
      */
-    private boolean isChangedBy(Product entity, ProductDTO dto) {
+    public static boolean isChangedBy(Product entity, ProductDTO dto) {
         // Check simple properties first
         if (dto.getId() != null && !dto.getId().equals(entity.getId())) {
             return true;
@@ -794,8 +794,10 @@ public class ProductManager {
                                 // At this point, we've either matched the UUIDs (which means we're
                                 // referencing identical products) or the UUID isn't present on the DTO, but
                                 // the IDs match (which means we're pointing toward the same product).
-                                return update.isEnabled() != null &&
-                                    update.isEnabled().equals(existing.isEnabled()) ? 0 : 1;
+
+                                return (update.isEnabled() != null &&
+                                    !update.isEnabled().equals(existing.isEnabled())) ||
+                                    ContentManager.isChangedBy(content, cdto) ? 1 : 0;
                             }
                         }
                     }
@@ -805,7 +807,7 @@ public class ProductManager {
             };
 
             if (!Util.collectionsAreEqual((Collection) entity.getProductContent(),
-                (Collection) productContent)) {
+                (Collection) productContent, comparator)) {
 
                 return true;
             }
@@ -827,7 +829,7 @@ public class ProductManager {
      * @return
      *  true if this product would be changed by the given DTO; false otherwise
      */
-    private boolean isChangedBy(Product entity, ProductData dto) {
+    public static boolean isChangedBy(Product entity, ProductData dto) {
         // Check simple properties first
         if (dto.getId() != null && !dto.getId().equals(entity.getId())) {
             return true;
@@ -881,8 +883,10 @@ public class ProductManager {
                                 // At this point, we've either matched the UUIDs (which means we're
                                 // referencing identical products) or the UUID isn't present on the DTO, but
                                 // the IDs match (which means we're pointing toward the same product).
-                                return update.isEnabled() != null &&
-                                    update.isEnabled().equals(existing.isEnabled()) ? 0 : 1;
+
+                                return (update.isEnabled() != null &&
+                                    !update.isEnabled().equals(existing.isEnabled())) ||
+                                    ContentManager.isChangedBy(content, cdto) ? 1 : 0;
                             }
                         }
                     }
@@ -892,7 +896,7 @@ public class ProductManager {
             };
 
             if (!Util.collectionsAreEqual((Collection) entity.getProductContent(),
-                (Collection) productContent)) {
+                (Collection) productContent, comparator)) {
 
                 return true;
             }

--- a/server/src/main/java/org/candlepin/dto/api/v1/OwnerDTO.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/OwnerDTO.java
@@ -24,8 +24,6 @@ import org.apache.commons.lang.builder.HashCodeBuilder;
 
 import java.util.Date;
 
-
-
 /**
  * A DTO representation of the Owner entity
  */

--- a/server/src/main/java/org/candlepin/hostedtest/HostedTestSubscriptionResource.java
+++ b/server/src/main/java/org/candlepin/hostedtest/HostedTestSubscriptionResource.java
@@ -232,6 +232,7 @@ public class HostedTestSubscriptionResource {
             ContentDTO cdto = this.translator.translate(content, ContentDTO.class);
 
             changed |= pdto.addContent(cdto, enabled);
+            addContentToUpstreamSubscriptions(product, content, enabled);
         }
 
         if (changed) {
@@ -239,6 +240,15 @@ public class HostedTestSubscriptionResource {
         }
 
         return this.translator.translate(product, ProductDTO.class);
+    }
+
+    private void addContentToUpstreamSubscriptions(Product product, Content content, boolean enabled) {
+        List<Subscription> subs = adapter.getSubscriptions(product.toDTO());
+        for (Subscription sub: subs) {
+            if (sub.getProduct().getId().contentEquals(product.getId())) {
+                sub.getProduct().addContent(content, enabled);
+            }
+        }
     }
 
     @POST

--- a/server/src/main/java/org/candlepin/hostedtest/HostedTestSubscriptionServiceAdapter.java
+++ b/server/src/main/java/org/candlepin/hostedtest/HostedTestSubscriptionServiceAdapter.java
@@ -16,17 +16,19 @@ package org.candlepin.hostedtest;
 
 import org.candlepin.model.Consumer;
 import org.candlepin.model.Owner;
+import org.candlepin.model.dto.ProductContentData;
 import org.candlepin.model.dto.ProductData;
 import org.candlepin.model.dto.Subscription;
 import org.candlepin.service.SubscriptionServiceAdapter;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.HashMap;
 
 
 
@@ -117,8 +119,37 @@ public class HostedTestSubscriptionServiceAdapter implements SubscriptionService
             productMap.put(s.getProduct().getId(), new ArrayList<Subscription>());
         }
 
+        this.clearUuids(s.getProduct());
+        this.clearUuids(s.getDerivedProduct());
+
+        if (CollectionUtils.isNotEmpty(s.getProvidedProducts())) {
+            for (ProductData pdata : s.getProvidedProducts()) {
+                this.clearUuids(pdata);
+            }
+        }
+
+        if (CollectionUtils.isNotEmpty(s.getDerivedProvidedProducts())) {
+            for (ProductData pdata : s.getDerivedProvidedProducts()) {
+                this.clearUuids(pdata);
+            }
+        }
+
         productMap.get(s.getProduct().getId()).add(s);
         return s;
+    }
+
+    private void clearUuids(ProductData pdata) {
+        if (pdata != null) {
+            pdata.setUuid(null);
+
+            if (pdata.getProductContent() != null) {
+                for (ProductContentData pcdata : pdata.getProductContent()) {
+                    if (pcdata.getContent() != null) {
+                        pcdata.getContent().setUuid(null);
+                    }
+                }
+            }
+        }
     }
 
     public Subscription updateSubscription(Subscription ss) {


### PR DESCRIPTION
what was changed and why:
* addContentToUpstreamSubscriptions was removed, which breaks two tests in entitlement_certificate_v3_spec.rb because the upstream subscriptions were not being updated with the new content, as is currently done in master. this PR adds it back.
* we added a ProductContentDTO comparator in ProductManager but never used it, fixed in this PR.
* ProductManager simply uses ContentManager.isChangedBy. uuid comparision for content is now skipped ( as it is in master ) which fixes the spec tests in refresh_pools_spec.rb
* to verify it was broken, compare results in target branch and PR branch : 
  * deploy in hosted mode
  * buildr rspec:refresh_pools:"regenerates entitlements when" 