### PR TITLE
mark changesMade on name change in performConsumerUpdates

### DIFF
--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -1119,7 +1119,7 @@ public class ConsumerResource {
 
             log.info("Updating consumer name: {} -> {}", toUpdate.getName(), updated.getName());
             toUpdate.setName(updated.getName());
-
+            changesMade = true;
             // get the new name into the id cert if we are using the cert
             if (isIdCert) {
                 IdentityCertificate ic = generateIdCert(toUpdate, true);

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
@@ -754,6 +754,7 @@ public class ConsumerResourceUpdateTest {
         updated.setName("new name");
 
         resource.updateConsumer(consumer.getUuid(), updated, principal);
+        verify(consumerCurator, times(1)).update(eq(consumer));
 
         assertEquals(updated.getName(), consumer.getName());
         assertNotNull(consumer.getIdCert());


### PR DESCRIPTION
* To verify the fix, run updatedNameRegeneratesIdCert unit test before and after the fix.
* The current test is not ideal because it relies on the object being manipulated in the method, improved it in dtos branch.