### PR TITLE
[M] 1531106: Round 4 of ueber data cleanup.

### DIFF
--- a/server/src/main/resources/db/changelog/20180110092945-cleanup-uebercerts-round4-premigration.xml
+++ b/server/src/main/resources/db/changelog/20180110092945-cleanup-uebercerts-round4-premigration.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <!-- POSTGRES, ORACLE, HSQLDB QUERIES -->
+    <property
+            dbms="postgresql,oracle,hsqldb"
+            name="round4_premigration_cleanup_ueber_subs"
+            value="delete from cp_subscription where id in (select s.id from cp_subscription s inner join cp_product p on s.product_id = p.id where p.name LIKE '%_ueber_product');" />
+
+    <property
+            dbms="postgresql,oracle,hsqldb"
+            name="round4_premigration_cleanup_ueber_ent_certs"
+            value="delete from cp_ent_certificate where entitlement_id in (select e.id from cp_entitlement e inner join cp_pool p on e.pool_id = p.id where p.productname LIKE '%_ueber_product');" />
+
+    <property
+            dbms="postgresql,oracle,hsqldb"
+            name="round4_premigration_cleanup_ueber_ents"
+            value="delete from cp_entitlement where pool_id in (select id from cp_pool p where p.productname LIKE '%_ueber_product');" />
+
+    <property
+            dbms="postgresql,oracle,hsqldb"
+            name="round4_premigration_cleanup_ueber_pools"
+            value="delete from cp_pool where productname like '%_ueber_product%';" />
+
+    <property
+            dbms="postgresql,oracle,hsqldb"
+            name="round4_premigration_cleanup_ueber_content"
+            value="delete from cp_content where id in (select id from cp_content where name = 'ueber_content');" />
+
+    <property
+            dbms="postgresql,oracle,hsqldb"
+            name="round4_premigration_cleanup_ueber_products"
+            value="delete from cp_product where name like '%_ueber_product';" />
+
+    <property
+            dbms="postgresql,oracle,hsqldb"
+            name="round4_premigration_cleanup_ueber_consumers"
+            value="delete from cp_consumer where name = 'ueber_cert_consumer';" />
+
+    <!-- MySQL Queries -->
+    <property
+            dbms="mysql"
+            name="round4_premigration_cleanup_ueber_subs"
+            value="delete s from cp_subscription s inner join cp_product p on s.product_id = p.id where p.name LIKE '%_ueber_product';" />
+
+    <property
+            dbms="mysql"
+            name="round4_premigration_cleanup_ueber_ent_certs"
+            value="delete ec from cp_ent_certificate ec inner join cp_entitlement e on ec.entitlement_id = e.id inner join cp_pool p on e.pool_id = p.id where p.productname like '%_ueber_product';" />
+
+    <property
+            dbms="mysql"
+            name="round4_premigration_cleanup_ueber_ents"
+            value="delete e from cp_entitlement e inner join cp_pool p on e.pool_id = p.id where p.productname like '%_ueber_product';" />
+
+    <property
+            dbms="mysql"
+            name="round4_premigration_cleanup_ueber_pools"
+            value="delete p from cp_pool p where p.productname like '%_ueber_product';" />
+
+    <property
+            dbms="mysql"
+            name="round4_premigration_cleanup_ueber_content"
+            value="delete c from cp_content c
+               inner join cp_product_content pc on pc.content_id=c.id inner join cp_product p on p.id=pc.product_id where p.name LIKE '%_ueber_product';" />
+
+    <property
+            dbms="mysql"
+            name="round4_premigration_cleanup_ueber_products"
+            value="delete p from cp_product p where p.name LIKE '%_ueber_product';" />
+
+    <property
+            dbms="mysql"
+            name="round4_premigration_cleanup_ueber_consumers"
+            value="delete c from cp_consumer c where c.name = 'ueber_cert_consumer';" />
+
+    <changeSet id="20180110092945-1" author="vrjain">
+        <preConditions onFail="MARK_RAN">
+            <and>
+                <tableExists tableName="cp_subscription" />
+                <columnExists tableName="cp_pool" columnName="productname" />
+            </and>
+        </preConditions>
+        <comment>Round 4 of ueber data cleanup.
+                            Since pre-org migration is now stricter,
+                            we need to clean up ueber certs while the data is in
+                            pre migrated format. the sql here is identical to
+                            round 3 in 0.9.54 </comment>
+
+        <sql>${round4_premigration_cleanup_ueber_subs}</sql>
+        <sql>${round4_premigration_cleanup_ueber_ent_certs}</sql>
+        <sql>${round4_premigration_cleanup_ueber_ents}</sql>
+        <sql>${round4_premigration_cleanup_ueber_pools}</sql>
+        <sql>${round4_premigration_cleanup_ueber_content}</sql>
+        <sql>${round4_premigration_cleanup_ueber_products}</sql>
+        <sql>${round4_premigration_cleanup_ueber_consumers}</sql>
+
+    </changeSet>
+
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/server/src/main/resources/db/changelog/changelog-testing.xml
+++ b/server/src/main/resources/db/changelog/changelog-testing.xml
@@ -2261,6 +2261,7 @@
     <include file="db/changelog/20150211111319-add-last-guest-update-table.xml"/>
     <include file="db/changelog/20150316122833-add-entitlement-end-date-override.xml"/>
     <include file="db/changelog/20150311151612-force-all-content-metadataexpire-to-0.xml"/>
+    <include file="db/changelog/20180110092945-cleanup-uebercerts-round4-premigration.xml"/>
     <include file="db/changelog/20150210094558-perorgproducts-phase-1.xml"/>
     <include file="db/changelog/20150401140006-add-pool-type-to-db.xml"/>
     <include file="db/changelog/20150416090438-mysql-quartz-longblob.xml"/>

--- a/server/src/main/resources/db/changelog/changelog-update.xml
+++ b/server/src/main/resources/db/changelog/changelog-update.xml
@@ -81,6 +81,7 @@
     <include file="db/changelog/20150211111319-add-last-guest-update-table.xml"/>
     <include file="db/changelog/20150316122833-add-entitlement-end-date-override.xml"/>
     <include file="db/changelog/20150311151612-force-all-content-metadataexpire-to-0.xml"/>
+    <include file="db/changelog/20180110092945-cleanup-uebercerts-round4-premigration.xml"/>
     <include file="db/changelog/20150210094558-perorgproducts-phase-1.xml"/>
     <include file="db/changelog/20150401140006-add-pool-type-to-db.xml"/>
     <include file="db/changelog/20150416090438-mysql-quartz-longblob.xml"/>


### PR DESCRIPTION
Since pre-org migration is now stricter,
we need to clean up ueber certs while the data is in
pre migrated format. the sql here is identical to
round 3 in 0.9.54

the scenario that breaks: upgrade from 0.9.54.X where X < 18 to 2.1, master, 2.2.
for testing steps, please use comments in #1459 

reviewer: please verify upgrade from 0.9.54.17 to 0.9.54-HOTFIX as well, and  confirm my finding that we don't have an issue there.