### PR TITLE
[2.1] 1533211: Set the default enabled value for Environment Content to Null

### DIFF
--- a/server/spec/environment_spec.rb
+++ b/server/spec/environment_spec.rb
@@ -66,6 +66,30 @@ describe 'Environments' do
     envs[0]['id'].should == 'testenv2'
   end
 
+  it 'sets content.enabled to nil by default' do
+    content = create_content
+    job = @org_admin.promote_content(@env['id'], [{:contentId => content['id']}])
+    wait_for_job(job['id'], 15)
+    @env = @org_admin.get_environment(@env['id'])
+    @env['environmentContent'][0]['enabled'].should == nil
+  end
+
+  it 'can have enabled content' do
+    content = create_content
+    job = @org_admin.promote_content(@env['id'], [{:contentId => content['id'],:enabled => true}])
+    wait_for_job(job['id'], 15)
+    @env = @org_admin.get_environment(@env['id'])
+    @env['environmentContent'][0]['enabled'].should == true
+  end
+
+  it 'can have disabled content' do
+    content = create_content
+    job = @org_admin.promote_content(@env['id'], [{:contentId => content['id'],:enabled => false}])
+    wait_for_job(job['id'], 15)
+    @env = @org_admin.get_environment(@env['id'])
+    @env['environmentContent'][0]['enabled'].should == false
+  end
+
   it 'can have promoted content' do
     content = create_content
     job = @org_admin.promote_content(@env['id'], [{:contentId => content['id']}])

--- a/server/src/main/java/org/candlepin/model/dto/EnvironmentContent.java
+++ b/server/src/main/java/org/candlepin/model/dto/EnvironmentContent.java
@@ -23,16 +23,15 @@ public class EnvironmentContent {
 
     private String environmentId;
     private String contentId;
-    private boolean enabled;
+    private Boolean enabled;
 
     /**
      * Creates a new, empty EnvironmentContent instance with the default values. By default, the
-     * environment and content IDs will be null, while the enabled flag will be set to true.
+     * environment and content IDs will be null, while the enabled flag will be set to null.
      */
     public EnvironmentContent() {
         this.environmentId = null;
         this.contentId = null;
-        this.enabled = true;
     }
 
     /**
@@ -47,7 +46,7 @@ public class EnvironmentContent {
      * @param enabled
      *  The initial value to use for the enabled flag
      */
-    public EnvironmentContent(String environmentId, String contentId, boolean enabled) {
+    public EnvironmentContent(String environmentId, String contentId, Boolean enabled) {
         this.environmentId = environmentId;
         this.contentId = contentId;
         this.enabled = enabled;
@@ -101,7 +100,7 @@ public class EnvironmentContent {
      * @return
      *  The current state of the enabled flag
      */
-    public boolean getEnabled() {
+    public Boolean getEnabled() {
         return this.enabled;
     }
 
@@ -111,7 +110,7 @@ public class EnvironmentContent {
      * @param enabled
      *  The new state for the enabled flag
      */
-    public void setEnabled(boolean enabled) {
+    public void setEnabled(Boolean enabled) {
         this.enabled = enabled;
     }
 


### PR DESCRIPTION
We depend on the database value of null, true, or false, to determine
whether the environment has overridden the default value. When the
DTO was added in Candlepin 2.x it was set to true by default and thus
the environment was always overriding the value from the engineering
product.