### PR TITLE
[M] Add version requirement to Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,7 +114,7 @@ DEPENDENCIES
   pry
   pry-byebug
   pry-stack_explorer
-  qpid_proton
+  qpid_proton (~> 0.17.0)
   rest-client (~> 1.6.0)
   rspec (~> 3.0)
   rubocop (= 0.36.0)


### PR DESCRIPTION
`buildr` keeps making this change every time I run it.  I'm not sure why.  I'm using buildr 1.5.3 on Ruby 2.3.4.

The change itself seem innocuous since we already have the `~> 0.17.0` requirement in `Gemfile`.  If no one else is seeing this issue, maybe it's something in my environment.