### PR TITLE
[m] Clear uuids in HostedTestSubscriptionServiceAdapter

### DIFF
--- a/server/src/main/java/org/candlepin/hostedtest/HostedTestSubscriptionServiceAdapter.java
+++ b/server/src/main/java/org/candlepin/hostedtest/HostedTestSubscriptionServiceAdapter.java
@@ -16,10 +16,12 @@ package org.candlepin.hostedtest;
 
 import org.candlepin.model.Consumer;
 import org.candlepin.model.Owner;
+import org.candlepin.model.dto.ProductContentData;
 import org.candlepin.model.dto.ProductData;
 import org.candlepin.model.dto.Subscription;
 import org.candlepin.service.SubscriptionServiceAdapter;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -117,8 +119,35 @@ public class HostedTestSubscriptionServiceAdapter implements SubscriptionService
             productMap.put(s.getProduct().getId(), new ArrayList<Subscription>());
         }
 
+        this.clearUuids(s.getProduct());
+        this.clearUuids(s.getDerivedProduct());
+        if (CollectionUtils.isNotEmpty(s.getProvidedProducts())) {
+            for (ProductData productData : s.getProvidedProducts()) {
+                this.clearUuids(productData);
+            }
+        }
+        if (CollectionUtils.isNotEmpty(s.getDerivedProvidedProducts())) {
+            for (ProductData productData : s.getDerivedProvidedProducts()) {
+                this.clearUuids(productData);
+            }
+        }
+
         productMap.get(s.getProduct().getId()).add(s);
         return s;
+    }
+
+    private void clearUuids(ProductData pdata) {
+        if (pdata != null) {
+            pdata.setUuid(null);
+            if (pdata.getProductContent() != null) {
+                for (ProductContentData pcdata : pdata.getProductContent()) {
+                    if (pcdata.getContent() != null) {
+                        pcdata.getContent().setUuid(null);
+                    }
+                }
+            }
+
+        }
     }
 
     public Subscription updateSubscription(Subscription ss) {


### PR DESCRIPTION
* discovered this during DTO work. we dont get uuids from the adapters, so the adapters were changed to reflect that
* to expose why that is a problem, adding an optimization in detecting content changes