### PR TITLE
Remove pin to qpid_proton 0.17.x gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'stringex'
 gem 'digest-murmurhash'
 gem 'httpclient'
 gem 'activesupport', '~> 4.2'
-gem 'qpid_proton', '~> 0.17.0'
+gem 'qpid_proton'
 
 # Remove this once we are fully using the new Ruby bindings
 gem 'rest-client', '~> 1.6.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,7 +34,6 @@ GEM
     digest-murmurhash (1.1.1)
     httpclient (2.8.3)
     i18n (0.8.4)
-    json (2.1.0)
     json_pure (1.8.3)
     method_source (0.8.2)
     mime-types (1.25.1)
@@ -61,8 +60,7 @@ GEM
     pry-stack_explorer (0.4.9.2)
       binding_of_caller (>= 0.7)
       pry (>= 0.9.11)
-    qpid_proton (0.17.0)
-      json
+    qpid_proton (0.18.1)
     rainbow (2.2.2)
       rake
     rake (0.9.2.2)


### PR DESCRIPTION
This change wasn't reflected in the Gemfile.lock and was causing the file to be updated continually.  Remove it for now until we figure out something better.