### PR TITLE
Do not use the rubygems provide proton bindings on Vagrant.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ buildconf/scripts/import_products.json
 .rvmrc
 .ruby-version
 .ruby-gemset
+.bundle
 
 # Vagrant
 .vagrant/

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,10 @@ gem 'stringex'
 gem 'digest-murmurhash'
 gem 'httpclient'
 gem 'activesupport', '~> 4.2'
-gem 'qpid_proton', '~> 0.17.0'
+
+group 'proton' do
+  gem 'qpid_proton'
+end
 
 # Remove this once we are fully using the new Ruby bindings
 gem 'rest-client', '~> 1.6.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,4 +122,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-   1.14.6
+   1.16.1

--- a/server/bin/qpid_watch.py
+++ b/server/bin/qpid_watch.py
@@ -1,0 +1,139 @@
+#! /usr/bin/python
+from __future__ import print_function, unicode_literals
+
+import sys
+import argparse
+import logging
+import proton
+import proton.handlers
+import proton.reactor
+import proton.utils
+
+logging.basicConfig()
+log = logging.getLogger("qpid_watch")
+
+
+class TimeoutError(Exception):
+    pass
+
+
+class QpidWatcher(proton.handlers.MessagingHandler):
+    def __init__(self, args):
+        super(QpidWatcher, self).__init__()
+
+        if args.ssl_cert and args.ssl_key:
+            self.ssl_domain = proton.SSLDomain(proton.SSLDomain.MODE_CLIENT)
+            self.ssl_domain.set_credentials(args.ssl_cert, args.ssl_key, None)
+            # Bad practice, but this is meant for dev testing only.
+            self.ssl_domain.set_peer_authentication(proton.SSLDomain.ANONYMOUS_PEER)
+        else:
+            self.ssl_domain = None
+
+        self.received = 0
+        self.expected = args.messages
+        self.url = args.address
+        self.source = args.source
+        self.timeout = args.timeout
+        self.subject = args.subject
+        self.show_message = args.show_message
+
+    def on_start(self, event):
+        conn = event.container.connect(url=self.url, ssl_domain=self.ssl_domain)
+
+        if self.timeout > 0:
+            self.last_event = event.container.mark()
+            event.container.schedule(self.timeout, self)
+
+        # Note that Copy() does not actually consume the message off the queue!
+        self.receiver = event.container.create_receiver(conn, self.source, options=proton.reactor.Copy())
+
+    def on_timer_task(self, event):
+        elapsed = event.container.mark() - self.last_event
+        # elapsed is in milliseconds
+        if elapsed > self.timeout * 1000:
+            raise TimeoutError("No activity for %d seconds" % self.timeout)
+        else:
+            # Reschedule for the next timeout period
+            event.container.schedule(self.timeout, self)
+
+    def on_message(self, event):
+        self.last_event = event.container.mark()
+        if event.message.id and event.message.id < self.received:
+            # ignore duplicate message
+            return
+        if self.expected == -1 or self.received < self.expected:
+            # If a subject to filter on is given and the message matches or if no filter is present
+            if (self.subject and event.message.subject in self.subject) or not self.subject:
+                self.received += 1
+                log.debug(event.message)
+                if self.show_message:
+                    print(event.message.body)
+
+            if self.received == self.expected:
+                log.debug("Closing connection")
+                event.receiver.close()
+                event.connection.close()
+                event.container.stop()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser("Watch a Qpid queue for a message")
+    parser.add_argument("-c", "--ssl-cert", help="Certificate to use to connect to Qpid over SSL")
+    parser.add_argument("-k", "--ssl-key", help="Key to use to connect to Qpid over SSL")
+    parser.add_argument("-a", "--address", help="connection string to use (defaults to %(default)s)",
+        default="amqps://localhost:5671")
+    parser.add_argument("-s", "--source", help="Qpid source to listen to (defaults to '%(default)s')",
+        default="event")
+    parser.add_argument("-t", "--timeout", help="Seconds to wait before timeout; -1 waits indefinitely"
+        " (defaults to %(default)d s)", type=int, default=30)
+    parser.add_argument("-m", "--messages", help="number of messages to receive; -1 receives indefinitely"
+        " (defaults to %(default)d)", type=int, default=-1)
+    parser.add_argument("--subject", help="subject to watch for", action="append")
+    parser.add_argument("--show-message", help="show the message received", action="store_true",
+        default=False)
+
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("-v", "--verbose", help="verbose mode", action="store_true")
+    group.add_argument("-q", "--quiet", help="quiet mode", action="store_true")
+
+    args = parser.parse_args()
+
+    # XOR the cert and key arguments.  We want either both or none at all.
+    if bool(args.ssl_cert) ^ bool(args.ssl_key):
+        parser.exit("You must specify both the SSL certificate and key if you are going to use SSL")
+
+    if not (args.messages > 0 or args.messages == -1):
+        parser.exit("--messages must either be a positive integer or -1")
+
+    if args.verbose:
+        log.setLevel(logging.DEBUG)
+    else:
+        log.setLevel(logging.INFO)
+
+    log.debug(args)
+    qpid_watcher = QpidWatcher(args)
+
+    try:
+        rc = 0
+        reactor = proton.reactor.Container(qpid_watcher)
+        if args.timeout > 0:
+            reactor.timeout = args.timeout
+        reactor.run()
+    except KeyboardInterrupt:
+        # Throw an error if the user KeyboardInterrupts before the number of messages to receive has been hit
+        rc = 1
+    except TimeoutError as e:
+        rc = 2
+        log.debug(e, exc_info=e)
+        print("Connection timed out")
+    except Exception as e:
+        rc = 3
+        log.exception("Unknown error")
+    finally:
+        if not args.quiet:
+            output = "%d messages received" % qpid_watcher.received
+            if args.messages > 0:
+                output += " (%d expected)" % args.messages
+            print(output)
+        sys.exit(rc)
+

--- a/server/spec/candlepin_scenarios.rb
+++ b/server/spec/candlepin_scenarios.rb
@@ -1,9 +1,14 @@
 require 'candlepin_api'
 require 'hostedtest_api'
-require 'qpid_proton'
 
 require 'pp'
 require 'zip'
+
+begin
+  require 'qpid_proton'
+rescue LoadError
+  # This is okay
+end
 
 module CandlepinMethods
 

--- a/server/spec/qpid_spec.rb
+++ b/server/spec/qpid_spec.rb
@@ -2,238 +2,246 @@
 require 'spec_helper'
 require 'candlepin_scenarios'
 
-# To run this spec test it is necessary to have Qpid up and configured.
-#
-# In Jenkins environment, this shouldn't be a problem. The cp-test script
-# has -q switch that will run configure-qpid.sh during candlepin server
-# deploy.
-#
-# Outside of Jenkins environment, you must install Qpid and run the
-# configure-qpid.sh yourself. Also you must enable AMQP (Qpid) in your
-# candlepin config file. This can be done either manually or just by
-# using deploy.sh script with -q switch.
-describe 'Qpid Broker' do
+begin
+  require 'qpid_proton'
 
-  include CandlepinMethods
+  # To run this spec test it is necessary to have Qpid up and configured.
+  #
+  # In Jenkins environment, this shouldn't be a problem. The cp-test script
+  # has -q switch that will run configure-qpid.sh during candlepin server
+  # deploy.
+  #
+  # Outside of Jenkins environment, you must install Qpid and run the
+  # configure-qpid.sh yourself. Also you must enable AMQP (Qpid) in your
+  # candlepin config file. This can be done either manually or just by
+  # using deploy.sh script with -q switch.
+  #
+  # To skip these tests altogether, run `bundle install --without=proton`
+  describe 'Qpid Broker' do
+    include CandlepinMethods
 
+    def assert_mode(mode, status = nil)
+      if status == nil
+        status = @cp.get('/status')
+      end
 
-  def assert_mode(mode, status = nil)
-    if status == nil
-      status = @cp.get('/status')
+      expect(status).to have_key("mode")
+      expect(status["mode"]).to eq(mode)
     end
 
-    expect(status).to have_key("mode")
-    expect(status["mode"]).to eq(mode)
-  end
+    def assert_mode_and_reason(mode, reason, status = nil)
+      if status == nil
+        status = @cp.get('/status')
+      end
 
-  def assert_mode_and_reason(mode, reason, status = nil)
-    if status == nil
-      status = @cp.get('/status')
+      expect(status).to have_key("mode")
+      expect(status).to have_key("modeReason")
+      expect(status["mode"]).to eq(mode)
+      expect(status["modeReason"]).to eq(reason)
     end
 
-    expect(status).to have_key("mode")
-    expect(status).to have_key("modeReason")
-    expect(status["mode"]).to eq(mode)
-    expect(status["modeReason"]).to eq(reason)
-  end
+    def wait_for_mode(mode, max_wait_time = 90, poll_delay = 3)
+      ellapsed = 0
+      last_status = nil
 
-  def wait_for_mode(mode, max_wait_time = 90, poll_delay = 3)
-    ellapsed = 0
-    last_status = nil
+      loop do
+        begin
+          last_status = @cp.get('/status')
+          expect(last_status).to have_key("mode")
 
-    loop do
-      begin
-        last_status = @cp.get('/status')
-        expect(last_status).to have_key("mode")
+          if last_status['mode'] == mode
+            break
+          end
+        rescue
+          # Likely connection refused or timed out waiting on candlepin. Just ignore it and we'll try
+          # again in a few seconds
+          last_status = nil
+        end
 
-        if last_status['mode'] == mode
+        break if ellapsed >= max_wait_time
+
+        sleep poll_delay
+        ellapsed += poll_delay
+      end
+
+      return last_status
+    end
+
+    def wait_for_event(subject, max_wait_time = 90)
+      start_time = Time.now
+
+      loop do
+        begin
+          timeout = max_wait_time - (Time.now - start_time)
+          break if timeout <= 0
+
+          msgs = @cq.receive(1, true, timeout)
+
+          msgs.each do |msg|
+            if msg.subject == subject
+              return msg
+            end
+          end
+        rescue Qpid::Proton::TimeoutError
+          # Return nil since we didn't receive the message in time.
           break
         end
-      rescue
-        # Likely connection refused or timed out waiting on candlepin. Just ignore it and we'll try
-        # again in a few seconds
-        last_status = nil
       end
 
-      break if ellapsed >= max_wait_time
-
-      sleep poll_delay
-      ellapsed += poll_delay
+      return nil
     end
 
-    return last_status
-  end
+    before(:each) do
+      @cq = CandlepinQpid.new('amqps://localhost:5671/allmsg', 'server/bin/qpid/keys/qpid_ca.crt', 'server/bin/qpid/keys/qpid_ca.key')
+      skip("Qpid keys not found, skipping Qpid spec tests") if @cq.no_keys?
 
-  def wait_for_event(subject, max_wait_time = 90)
-    start_time = Time.now
+      # Create an owner to guarantee we have an event to consume.
+      expect(create_owner(random_string('test_owner'))).to have_key("created")
 
-    loop do
+      # Consume any existing messages that may be in the queue already, blocking until we receive
+      # at least one.
+      msgs = @cq.receive
+      expect(msgs.length).to be > 0
+    end
+
+    it 'should detect FLOW_STOP' do
+      assert_mode("NORMAL")
+
+      # Create a queue that will initiate flow control after 3 messages
+      queue = "flowStopQueue"
+      @cq.create_queue(queue, 'event', '--flow-stop-count=3')
+      # puts "Queue created: #{queue}"
+
+      # Create two users to generate two messages
+      owners = 0
+
+      # puts "Creating first block of owners..."
+      2.times do
+        owners += 1
+        create_owner(random_string("test-owner_#{owners}"))
+      end
+
+      # We should still be in a good state here
+      assert_mode("NORMAL")
+
+      # Create additional owners, which should fill our queue and cause a FLOW_STOP
+      # puts "Creating second block of owners..."
+      3.times do
+        owners += 1
+        create_owner(random_string("test-owner_#{owners}"))
+      end
+
+      # We should eventually be suspended with a FLOW_STOPPED error
+      status = wait_for_mode("SUSPEND")
+      assert_mode_and_reason("SUSPEND", "QPID_FLOW_STOPPED", status)
+
+      # Removing the queue should restore normal operations...
+      # puts "Removing queue: #{queue}"
+      @cq.delete_queue(queue)
+
+      status = wait_for_mode("NORMAL")
+      assert_mode_and_reason("NORMAL", "QPID_UP", status)
+    end
+
+    it 'should transition to SUSPEND mode' do
+      assert_mode("NORMAL")
+
+      # puts "Candlepin is in Normal mode. Stopping Qpid"
+      @cq.stop
+
+      status = wait_for_mode("SUSPEND")
+      assert_mode_and_reason("SUSPEND", "QPID_DOWN", status)
+
+      # puts "Candlepin is in Suspend mode. Creating owner"
+
       begin
-        timeout = max_wait_time - (Time.now - start_time)
-        break if timeout <= 0
+        create_owner random_string('test_owner')
+        fail("Expected error did not occur")
+      rescue RestClient::ServiceUnavailable => un
+        displayMessage = JSON.parse(un.response.body)["displayMessage"]
+        displayMessage.should == 'Candlepin is in Suspend mode, please check /status resource to get more details'
+      end
 
-        msgs = @cq.receive(1, true, timeout)
+      # puts "Starting Qpid"
+      @cq.start
 
-        msgs.each do |msg|
-          if msg.subject == subject
-            return msg
-          end
-        end
-      rescue Qpid::Proton::TimeoutError
-        # Return nil since we didn't receive the message in time.
-        break
+      status = wait_for_mode("NORMAL")
+      assert_mode_and_reason("NORMAL", "QPID_UP", status)
+
+      # puts "Candlepin in Normal mode. Creating owner"
+      owner = create_owner(random_string('test_owner'))
+      expect(owner).to have_key("created")
+
+      start_time = Time.now
+      loop do
+        event = wait_for_event('owner.created', 90 - (Time.now - start_time))
+        expect(event).to_not be_nil
+        expect(event.body).to_not be_nil
+
+        body = JSON.parse(event.body)
+        break if body['targetName'] == owner['key']
       end
     end
 
-    return nil
-  end
+    it 'should transition to NORMAL mode' do
+      assert_mode("NORMAL")
 
-  before(:each) do
-    @cq = CandlepinQpid.new('amqps://localhost:5671/allmsg', 'server/bin/qpid/keys/qpid_ca.crt', 'server/bin/qpid/keys/qpid_ca.key')
-    skip("Qpid keys not found, skipping Qpid spec tests") if @cq.no_keys?
+      # puts "Stopping Qpid and creating owner..."
+      @cq.stop
+      expect(create_owner(random_string('test_owner'))).to have_key("created")
 
-    # Create an owner to guarantee we have an event to consume.
-    expect(create_owner(random_string('test_owner'))).to have_key("created")
+      status = wait_for_mode("SUSPEND")
+      assert_mode_and_reason("SUSPEND", "QPID_DOWN", status)
 
-    # Consume any existing messages that may be in the queue already, blocking until we receive
-    # at least one.
-    msgs = @cq.receive
-    expect(msgs.length).to be > 0
-  end
+      # puts "Restarting Qpid and querying queues..."
+      @cq.start
 
-  it 'should detect FLOW_STOP' do
-    assert_mode("NORMAL")
+      # puts "Waiting for Candlepin to reconnect to Qpid..."
+      status = wait_for_mode("NORMAL")
+      assert_mode("NORMAL", status)
 
-    # Create a queue that will initiate flow control after 3 messages
-    queue = "flowStopQueue"
-    @cq.create_queue(queue, 'event', '--flow-stop-count=3')
-    # puts "Queue created: #{queue}"
+      # puts "Reconnected. Creating owner and waiting for the message..."
+      owner = create_owner(random_string('test_owner'))
+      expect(owner).to have_key("created")
 
-    # Create two users to generate two messages
-    owners = 0
+      start_time = Time.now
+      loop do
+        event = wait_for_event('owner.created', 90 - (Time.now - start_time))
+        expect(event).to_not be_nil
+        expect(event.body).to_not be_nil
 
-    # puts "Creating first block of owners..."
-    2.times do
-      owners += 1
-      create_owner(random_string("test-owner_#{owners}"))
+        body = JSON.parse(event.body)
+        break if body['targetName'] == owner['key']
+      end
     end
 
-    # We should still be in a good state here
-    assert_mode("NORMAL")
+    it 'should start in SUSPEND mode without Qpid' do
+      def start_tomcat()
+        `if which supervisorctl > /dev/null 2>&1; then sudo supervisorctl start tomcat; else sudo systemctl start tomcat; fi`
+      end
 
-    # Create additional owners, which should fill our queue and cause a FLOW_STOP
-    # puts "Creating second block of owners..."
-    3.times do
-      owners += 1
-      create_owner(random_string("test-owner_#{owners}"))
-    end
+      def stop_tomcat()
+        `if which supervisorctl > /dev/null 2>&1; then sudo supervisorctl stop tomcat; else sudo systemctl stop tomcat; fi`
+      end
 
-    # We should eventually be suspended with a FLOW_STOPPED error
-    status = wait_for_mode("SUSPEND")
-    assert_mode_and_reason("SUSPEND", "QPID_FLOW_STOPPED", status)
+      assert_mode("NORMAL")
+      stop_tomcat
 
-    # Removing the queue should restore normal operations...
-    # puts "Removing queue: #{queue}"
-    @cq.delete_queue(queue)
+      @cq.stop
+      start_tomcat
 
-    status = wait_for_mode("NORMAL")
-    assert_mode_and_reason("NORMAL", "QPID_UP", status)
-  end
+      status = wait_for_mode("SUSPEND")
+      assert_mode("SUSPEND", status)
 
-  it 'should transition to SUSPEND mode' do
-    assert_mode("NORMAL")
+      @cq.start
 
-    # puts "Candlepin is in Normal mode. Stopping Qpid"
-    @cq.stop
-
-    status = wait_for_mode("SUSPEND")
-    assert_mode_and_reason("SUSPEND", "QPID_DOWN", status)
-
-    # puts "Candlepin is in Suspend mode. Creating owner"
-
-    begin
-      create_owner random_string('test_owner')
-      fail("Expected error did not occur")
-    rescue RestClient::ServiceUnavailable => un
-      displayMessage = JSON.parse(un.response.body)["displayMessage"]
-      displayMessage.should == 'Candlepin is in Suspend mode, please check /status resource to get more details'
-    end
-
-    # puts "Starting Qpid"
-    @cq.start
-
-    status = wait_for_mode("NORMAL")
-    assert_mode_and_reason("NORMAL", "QPID_UP", status)
-
-    # puts "Candlepin in Normal mode. Creating owner"
-    owner = create_owner(random_string('test_owner'))
-    expect(owner).to have_key("created")
-
-    start_time = Time.now
-    loop do
-      event = wait_for_event('owner.created', 90 - (Time.now - start_time))
-      expect(event).to_not be_nil
-      expect(event.body).to_not be_nil
-
-      body = JSON.parse(event.body)
-      break if body['targetName'] == owner['key']
+      status = wait_for_mode("NORMAL")
+      assert_mode("NORMAL", status)
     end
   end
-
-  it 'should transition to NORMAL mode' do
-    assert_mode("NORMAL")
-
-    # puts "Stopping Qpid and creating owner..."
-    @cq.stop
-    expect(create_owner(random_string('test_owner'))).to have_key("created")
-
-    status = wait_for_mode("SUSPEND")
-    assert_mode_and_reason("SUSPEND", "QPID_DOWN", status)
-
-    # puts "Restarting Qpid and querying queues..."
-    @cq.start
-
-    # puts "Waiting for Candlepin to reconnect to Qpid..."
-    status = wait_for_mode("NORMAL")
-    assert_mode("NORMAL", status)
-
-    # puts "Reconnected. Creating owner and waiting for the message..."
-    owner = create_owner(random_string('test_owner'))
-    expect(owner).to have_key("created")
-
-    start_time = Time.now
-    loop do
-      event = wait_for_event('owner.created', 90 - (Time.now - start_time))
-      expect(event).to_not be_nil
-      expect(event.body).to_not be_nil
-
-      body = JSON.parse(event.body)
-      break if body['targetName'] == owner['key']
-    end
+rescue LoadError
+  describe 'Qpid Broker' do
+    skip("qpid_proton is not available.  Skipping these tests")
   end
-
-  it 'should start in SUSPEND mode without Qpid' do
-    def start_tomcat()
-      `if which supervisorctl > /dev/null 2>&1; then sudo supervisorctl start tomcat; else sudo systemctl start tomcat; fi`
-    end
-
-    def stop_tomcat()
-      `if which supervisorctl > /dev/null 2>&1; then sudo supervisorctl stop tomcat; else sudo systemctl stop tomcat; fi`
-    end
-
-    assert_mode("NORMAL")
-    stop_tomcat
-
-    @cq.stop
-    start_tomcat
-
-    status = wait_for_mode("SUSPEND")
-    assert_mode("SUSPEND", status)
-
-    @cq.start
-
-    status = wait_for_mode("NORMAL")
-    assert_mode("NORMAL", status)
-  end
-
 end
+

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -84,3 +84,11 @@ tasks that are dependant on the existance of the variable 'my_cool_var'.
 1. Optionally specify the port to connect to the profiling agent by setting the `CANDLEPIN_YOURKIT_AGENT_PORT`.
    The default port is 35675.
 1. Run `vagrant up`
+
+## Testing QPID
+In order to run the qpid tests a few additional steps must be completed manually.
+1. Ensure that the rubygem-qpid_proton rpm is installed.
+1. Install the proton bundle: `bundle install --with proton` This will error due to version mismatch.  
+1. Update the qpid_proton gem: `bundle update qpid_proton` 
+1. Install qpid (from the /vagrant/server directory): `./bin/deploy -qag`
+1. Run the QPID tests: `buildr rspec:qpid` 

--- a/vagrant/roles/candlepin-root/tasks/main.yml
+++ b/vagrant/roles/candlepin-root/tasks/main.yml
@@ -30,6 +30,7 @@
     - postgresql
     - qpid-proton-c-devel
     - qpid-proton-c
+    - rubygem-qpid_proton
     - zlib
     - zlib-devel
     - liquibase

--- a/vagrant/roles/candlepin-user/tasks/main.yml
+++ b/vagrant/roles/candlepin-user/tasks/main.yml
@@ -8,7 +8,7 @@
     - candlepin-user
 
 - name: Run Bundle install
-  command: /usr/bin/bundle install
+  command: /usr/bin/bundle install --without=proton
   args:
       chdir: "{{candlepin_checkout}}"
   tags:


### PR DESCRIPTION
Also includes a script that uses the python proton bindings so that developers can easily spy on the queue and watch events flow through.  Theoretically, this script might be enough to spec test with, but I have difficulty with it starting too slow to catch events in the spec test.  We'd have to start it, have it not block, and then watch for the event coming through.

I thought it would just be easier to have the vagrant image rely on the qpid_proton provided via Yum while developers can do a `bundle install`

This PR also returns the Qpid version to 0.17.0 which is what Jenkins wants.  Developers should just use `bundle install --without=proton` to avoid the issue altogether.  Theoretically, it would be possible to segregate the two tests that actually require the qpid_proton library and only skip them instead of the entire qpid suite which tests for other things that don't require the library.