### PR TITLE
1501846: Fix usage of incorrect Liquibase schema version

### DIFF
--- a/server/src/main/resources/db/changelog/20171017062314-add-target-index-on-job-table.xml
+++ b/server/src/main/resources/db/changelog/20171017062314-add-target-index-on-job-table.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="20171017062314-1" author="vrjain">
         <preConditions onFail="MARK_RAN">


### PR DESCRIPTION
Using a version that's not packaged in the Liquibase jar file results in
Liquibase trying to download the schema.  That breaks offline
installations.