### PR TITLE
Awood/schema check test

### DIFF
--- a/server/src/main/resources/db/changelog/20120411152729-insert-quartz-locks.xml
+++ b/server/src/main/resources/db/changelog/20120411152729-insert-quartz-locks.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="20120411152729" author="dgoodwin" dbms="postgresql">
         <comment>Add the default quartz lock columns.</comment>

--- a/server/src/main/resources/db/changelog/20120413094334-insert-default-consumer-types.xml
+++ b/server/src/main/resources/db/changelog/20120413094334-insert-default-consumer-types.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
 
     <changeSet id="20120413094334" author="dgoodwin" dbms="postgresql">

--- a/server/src/main/resources/db/changelog/20120416134048-insert-uebercert-consumer-type.xml
+++ b/server/src/main/resources/db/changelog/20120416134048-insert-uebercert-consumer-type.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
 
     <changeSet id="20120416134048" author="mstead" dbms="postgresql">

--- a/server/src/main/resources/db/changelog/20120420143629-consumer-release-to-varchar.xml
+++ b/server/src/main/resources/db/changelog/20120420143629-consumer-release-to-varchar.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
 
     <changeSet id="20120420143629" author="alikins" dbms="postgresql">

--- a/server/src/main/resources/db/changelog/20120426124534-quartz-2-migration.xml
+++ b/server/src/main/resources/db/changelog/20120426124534-quartz-2-migration.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <!-- drop tables that are no longer used -->
     <changeSet id="20120426124534-0" author="awood" dbms="postgresql">

--- a/server/src/main/resources/db/changelog/20120522140529-expand-import-record.xml
+++ b/server/src/main/resources/db/changelog/20120522140529-expand-import-record.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
 
     <changeSet id="20120522140529" author="wpoteat" dbms="postgresql">

--- a/server/src/main/resources/db/changelog/20120523102544-add-owner-default-sla.xml
+++ b/server/src/main/resources/db/changelog/20120523102544-add-owner-default-sla.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
 
     <changeSet id="20120523102544" author="dgoodwin" dbms="postgresql">

--- a/server/src/main/resources/db/changelog/20120607124900-add-entitlement-dirty-column.xml
+++ b/server/src/main/resources/db/changelog/20120607124900-add-entitlement-dirty-column.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
 
     <changeSet id="20120607124900" author="awood" dbms="postgresql">

--- a/server/src/main/resources/db/changelog/20120608114047-expand-import-record-webapp-prefix.xml
+++ b/server/src/main/resources/db/changelog/20120608114047-expand-import-record-webapp-prefix.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
 
     <changeSet id="20120608114047" author="wpoteat" dbms="postgresql">

--- a/server/src/main/resources/db/changelog/20120720091214-add-foreign-key-indexes.xml
+++ b/server/src/main/resources/db/changelog/20120720091214-add-foreign-key-indexes.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
 
     <changeSet id="20120720091214" author="bkearney" dbms="postgresql">

--- a/server/src/main/resources/db/changelog/20121004150608-add-file-name-to-import-record.xml
+++ b/server/src/main/resources/db/changelog/20121004150608-add-file-name-to-import-record.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
 
     <changeSet id="20121004150608" author="wpoteat" dbms="postgresql">

--- a/server/src/main/resources/db/changelog/20121015121627-add-rules-cp-version-column.xml
+++ b/server/src/main/resources/db/changelog/20121015121627-add-rules-cp-version-column.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
 
     <changeSet id="20121015121627" author="dgoodwin" dbms="postgresql">

--- a/server/src/main/resources/db/changelog/20121019144118-create-upstream-consumer.xml
+++ b/server/src/main/resources/db/changelog/20121019144118-create-upstream-consumer.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
 
     <changeSet id="20121019144118-1" author="jesusr" dbms="postgresql">

--- a/server/src/main/resources/db/changelog/20130114143642-add-order-number-to-subscription.xml
+++ b/server/src/main/resources/db/changelog/20130114143642-add-order-number-to-subscription.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
 
     <changeSet id="20130114143642" author="wpoteat" dbms="postgresql">

--- a/server/src/main/resources/db/changelog/20130124112705-add-reliant-product.xml
+++ b/server/src/main/resources/db/changelog/20130124112705-add-reliant-product.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
 
     <changeSet id="20130124112705" author="wpoteat" dbms="postgresql">

--- a/server/src/main/resources/db/changelog/20130201110620-versioned-rules.xml
+++ b/server/src/main/resources/db/changelog/20130201110620-versioned-rules.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
 
     <changeSet id="20130201110620" author="dgoodwin" dbms="postgresql">

--- a/server/src/main/resources/db/changelog/20130201162323-drop-rules-candlepin-version.xml
+++ b/server/src/main/resources/db/changelog/20130201162323-drop-rules-candlepin-version.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
 
     <changeSet id="20130201162323" author="dgoodwin" dbms="postgresql">

--- a/server/src/main/resources/db/changelog/20130206153101-add-upstream-ids-to-suscription.xml
+++ b/server/src/main/resources/db/changelog/20130206153101-add-upstream-ids-to-suscription.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
 
     <changeSet id="20130206153101" author="wpoteat" dbms="postgresql">

--- a/server/src/main/resources/db/changelog/20130212124537-insert-katello-consumer-types.xml
+++ b/server/src/main/resources/db/changelog/20130212124537-insert-katello-consumer-types.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
 
     <changeSet id="20130212124537-community" author="bkearney" dbms="postgresql">

--- a/server/src/main/resources/db/changelog/20130315171104-migrate-upstream-uuid.xml
+++ b/server/src/main/resources/db/changelog/20130315171104-migrate-upstream-uuid.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="20130315171104-1" author="jesusr" dbms="postgresql">
         <preConditions onFail="MARK_RAN">

--- a/server/src/main/resources/db/changelog/20130319110704-drop-upstream-uuid.xml
+++ b/server/src/main/resources/db/changelog/20130319110704-drop-upstream-uuid.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
 
     <changeSet id="2013031911070" author="jesusr" dbms="postgresql">

--- a/server/src/main/resources/db/changelog/20130319112409-drop-columns-from-import-record.xml
+++ b/server/src/main/resources/db/changelog/20130319112409-drop-columns-from-import-record.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="20130319112409" author="jesusr" dbms="postgresql">
         <comment>Drop the upstream_uuid from owner after upgrade.</comment>

--- a/server/src/main/resources/db/changelog/20130319175255-order-number-to-pool.xml
+++ b/server/src/main/resources/db/changelog/20130319175255-order-number-to-pool.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
 
     <changeSet id="20130319175255" author="wpoteat" dbms="postgresql">

--- a/server/src/main/resources/db/changelog/20130329094102-drop-account-and-contract-from-entitlement.xml
+++ b/server/src/main/resources/db/changelog/20130329094102-drop-account-and-contract-from-entitlement.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="20130329094102" author="wpoteat" dbms="postgresql">
         <comment>Drop the account and contract from entitlement. Was redundant.</comment>

--- a/server/src/main/resources/db/changelog/20130402153704-add-upstream-consumer-fk.xml
+++ b/server/src/main/resources/db/changelog/20130402153704-add-upstream-consumer-fk.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
 
     <changeSet id="20130402153704-1" author="awood" dbms="postgresql">

--- a/server/src/main/resources/db/changelog/20130402164325-create-oracle-schema.xml
+++ b/server/src/main/resources/db/changelog/20130402164325-create-oracle-schema.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
     <changeSet author="awood" id="1364932903575-1-1" dbms="oracle">
         <createTable tableName="cp_activation_key">
             <column name="id" type="VARCHAR(32)">

--- a/server/src/main/resources/db/changelog/20130403095818-reconcile-postgresql-with-oracle.xml
+++ b/server/src/main/resources/db/changelog/20130403095818-reconcile-postgresql-with-oracle.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <!-- Most of these changes are simply reducing a name to fit within Oracle's 30 character limit. -->
     <changeSet id="20130403095818-1" author="awood" dbms="postgresql">

--- a/server/src/main/resources/db/changelog/20130425102131-distributor-capabilities.xml
+++ b/server/src/main/resources/db/changelog/20130425102131-distributor-capabilities.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <!-- Include definitions for cert.type, timestamp.type, etc. -->
     <include file="db/changelog/datatypes.xml"/>

--- a/server/src/main/resources/db/changelog/20130429105623-distributor-version-addition.xml
+++ b/server/src/main/resources/db/changelog/20130429105623-distributor-version-addition.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <property name="now" value="sysdate" dbms="oracle"/>
     <property name="now" value="LOCALTIMESTAMP" dbms="postgresql"/>

--- a/server/src/main/resources/db/changelog/20130501152202-add-content-arch.xml
+++ b/server/src/main/resources/db/changelog/20130501152202-add-content-arch.xml
@@ -4,7 +4,7 @@
     xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <!-- Include definitions for cert.type, timestamp.type, etc. -->
     <include file="db/changelog/datatypes.xml"/>

--- a/server/src/main/resources/db/changelog/20130514152949-consumer_installed_product_add_version.xml
+++ b/server/src/main/resources/db/changelog/20130514152949-consumer_installed_product_add_version.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
 
     <changeSet id="20130514152949" author="ckozak" dbms="oracle,postgresql">

--- a/server/src/main/resources/db/changelog/20130515095101-consumer_installed_product_arch_column.xml
+++ b/server/src/main/resources/db/changelog/20130515095101-consumer_installed_product_arch_column.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
 
     <changeSet id="20130515095101" author="ckozak" dbms="oracle,postgresql">

--- a/server/src/main/resources/db/changelog/20130531164013-remove-arch-table.xml
+++ b/server/src/main/resources/db/changelog/20130531164013-remove-arch-table.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="20130531164013-0" author="alikins" dbms="oracle,postgresql">
         <comment>Drop fks on cp_arch</comment>

--- a/server/src/main/resources/db/changelog/20130611101437-add-subscription-derivedproduct.xml
+++ b/server/src/main/resources/db/changelog/20130611101437-add-subscription-derivedproduct.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
 
     <changeSet id="20130611101437-1" author="dgoodwin" dbms="oracle,postgresql">

--- a/server/src/main/resources/db/changelog/20130611152026-add-missing-capability-indexes-on-oracle.xml
+++ b/server/src/main/resources/db/changelog/20130611152026-add-missing-capability-indexes-on-oracle.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
 
     <changeSet id="20130611152026" author="dgoodwin" dbms="oracle">

--- a/server/src/main/resources/db/changelog/20130624133949-add-sub-product-dist-version-capability.xml
+++ b/server/src/main/resources/db/changelog/20130624133949-add-sub-product-dist-version-capability.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
 
     <changeSet id="20130624133949" author="mstead" dbms="oracle,postgresql">

--- a/server/src/main/resources/db/changelog/20130705140300-add-certv3-capability.xml
+++ b/server/src/main/resources/db/changelog/20130705140300-add-certv3-capability.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="20130705140300" author="awood" dbms="oracle,postgresql">
         <comment>Add the cert_v3 capability to SAM 1.3 and Satellite 6.0</comment>

--- a/server/src/main/resources/db/changelog/20130715142926-add-cdn-url-to-subscription.xml
+++ b/server/src/main/resources/db/changelog/20130715142926-add-cdn-url-to-subscription.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
 
     <changeSet id="20130715142926" author="wpoteat" dbms="postgresql,oracle">

--- a/server/src/main/resources/db/changelog/20130717133146-ownerkey-and-displayname-in-deletedconsumer.xml
+++ b/server/src/main/resources/db/changelog/20130717133146-ownerkey-and-displayname-in-deletedconsumer.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
 
     <changeSet id="20130717133146" author="beav" dbms="oracle,postgresql">

--- a/server/src/main/resources/db/changelog/20130722140547-add-cdn-table.xml
+++ b/server/src/main/resources/db/changelog/20130722140547-add-cdn-table.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <!-- Include definitions for cert.type, timestamp.type, etc. -->
     <include file="db/changelog/datatypes.xml"/>

--- a/server/src/main/resources/db/changelog/20130723134939-add-linked-stack-id-to-pool.xml
+++ b/server/src/main/resources/db/changelog/20130723134939-add-linked-stack-id-to-pool.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
 
     <changeSet id="20130723134939" author="mstead" dbms="oracle,postgresql">

--- a/server/src/main/resources/db/changelog/20130725093910-add-source-consumer-to-pool.xml
+++ b/server/src/main/resources/db/changelog/20130725093910-add-source-consumer-to-pool.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
 
     <changeSet id="20130725093910" author="dgoodwin" dbms="oracle,postgresql">

--- a/server/src/main/resources/db/changelog/20130829085043-add-sat-5.6-dist-version.xml
+++ b/server/src/main/resources/db/changelog/20130829085043-add-sat-5.6-dist-version.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
 
     <changeSet id="20130829085043" author="wpoteat" dbms="oracle,postgresql">

--- a/server/src/main/resources/db/changelog/20130904120007-remove-ent-date-copies.xml
+++ b/server/src/main/resources/db/changelog/20130904120007-remove-ent-date-copies.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
 
     <changeSet id="20130904120007" author="dgoodwin" dbms="oracle,postgresql">

--- a/server/src/main/resources/db/changelog/20130912153356-create-import-upstream-consumer.xml
+++ b/server/src/main/resources/db/changelog/20130912153356-create-import-upstream-consumer.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <!-- Include definitions for cert.type, timestamp.type, etc. -->
     <include file="db/changelog/datatypes.xml"/>

--- a/server/src/main/resources/db/changelog/20130916125243-create-mysql-schema.xml
+++ b/server/src/main/resources/db/changelog/20130916125243-create-mysql-schema.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <property name="now" value="NOW()" dbms="mysql"/>
 

--- a/server/src/main/resources/db/changelog/20130920132949-add-delete-cascade-pool-products.xml
+++ b/server/src/main/resources/db/changelog/20130920132949-add-delete-cascade-pool-products.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="20130920132949" author="jesusr">
         <comment>Drop the pool id fk constraint</comment>

--- a/server/src/main/resources/db/changelog/20131002150608-consumer-content-override.xml
+++ b/server/src/main/resources/db/changelog/20131002150608-consumer-content-override.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <!-- Include definitions for cert.type, timestamp.type, etc. -->
     <include file="db/changelog/datatypes.xml"/>

--- a/server/src/main/resources/db/changelog/20131007121855-add_class_to_jobstatus.xml
+++ b/server/src/main/resources/db/changelog/20131007121855-add_class_to_jobstatus.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
 
     <changeSet id="20131007121855" author="ckozak">

--- a/server/src/main/resources/db/changelog/20131025111347-migrate-import-upstream-consumer.xml
+++ b/server/src/main/resources/db/changelog/20131025111347-migrate-import-upstream-consumer.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="20131025111347" author="wpoteat">
         <addDefaultValue

--- a/server/src/main/resources/db/changelog/20131025150828-nullable_actkey_pool_version.xml
+++ b/server/src/main/resources/db/changelog/20131025150828-nullable_actkey_pool_version.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <property name="quantity.type" value="BIGINT" dbms="oracle"/>
     <property name="quantity.type" value="int8" dbms="postgresql"/>

--- a/server/src/main/resources/db/changelog/20131101140657-fix-foreign-key-names-subscription-products.xml
+++ b/server/src/main/resources/db/changelog/20131101140657-fix-foreign-key-names-subscription-products.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
 
     <changeSet id="20131101140657" author="bkearney">

--- a/server/src/main/resources/db/changelog/20131106133841-general-purpose-permissions.xml
+++ b/server/src/main/resources/db/changelog/20131106133841-general-purpose-permissions.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
 
     <property name="access.type" value="INTEGER" dbms="postgresql,mysql"/>

--- a/server/src/main/resources/db/changelog/20131113000723-add-owner-log-level.xml
+++ b/server/src/main/resources/db/changelog/20131113000723-add-owner-log-level.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
 
     <changeSet id="20131113000723" author="awood">

--- a/server/src/main/resources/db/changelog/20131125163340-fix-permission-access-enum.xml
+++ b/server/src/main/resources/db/changelog/20131125163340-fix-permission-access-enum.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="20131125163340" author="dgoodwin">
         <comment>Add new column for converted strings.</comment>

--- a/server/src/main/resources/db/changelog/20131126095353-add-guest-attributes.xml
+++ b/server/src/main/resources/db/changelog/20131126095353-add-guest-attributes.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
 
     <changeSet id="20131126095353" author="ckozak">

--- a/server/src/main/resources/db/changelog/20140114145843-add-jobquery-index.xml
+++ b/server/src/main/resources/db/changelog/20140114145843-add-jobquery-index.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="20140114145843" author="ckozak">
         <comment>Add index for uniqueByOwner job queries</comment>

--- a/server/src/main/resources/db/changelog/20140115110932-add-overrides-and-release-to-actkey.xml
+++ b/server/src/main/resources/db/changelog/20140115110932-add-overrides-and-release-to-actkey.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet author="ckozak" id="20140115110932-00">
         <comment>Add new activation key features.</comment>

--- a/server/src/main/resources/db/changelog/20140205152431-fix-mysql-datetimes.xml
+++ b/server/src/main/resources/db/changelog/20140205152431-fix-mysql-datetimes.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
 
     <changeSet id="20140205152431" author="dgoodwin" dbms="mysql">

--- a/server/src/main/resources/db/changelog/20140206083156-fix-mysql-rules-column-type.xml
+++ b/server/src/main/resources/db/changelog/20140206083156-fix-mysql-rules-column-type.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
 
     <changeSet id="20140206083156" author="dgoodwin" dbms="mysql">

--- a/server/src/main/resources/db/changelog/20140210083318-add-hypervisorid.xml
+++ b/server/src/main/resources/db/changelog/20140210083318-add-hypervisorid.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <!-- Include definitions for cert.type, timestamp.type, etc. -->
     <include file="db/changelog/datatypes.xml"/>

--- a/server/src/main/resources/db/changelog/20140211110052-mysql-longblobs.xml
+++ b/server/src/main/resources/db/changelog/20140211110052-mysql-longblobs.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <!-- BLOBs in MySQL can only hold up to 64KB whereas LONGBLOBs hold up to 4GB.
          See http://dev.mysql.com/doc/refman/5.5/en/storage-requirements.html -->

--- a/server/src/main/resources/db/changelog/20140224154022-cascade-content-deletion.xml
+++ b/server/src/main/resources/db/changelog/20140224154022-cascade-content-deletion.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
 
     <changeSet id="20140224154022" author="ckozak">

--- a/server/src/main/resources/db/changelog/20140226200158-add-hypervisorid-index.xml
+++ b/server/src/main/resources/db/changelog/20140226200158-add-hypervisorid-index.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
 
     <changeSet id="20140226200158" author="ckozak">

--- a/server/src/main/resources/db/changelog/20140306150357-constrain-one-subpool-per-stack.xml
+++ b/server/src/main/resources/db/changelog/20140306150357-constrain-one-subpool-per-stack.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <!-- Include definitions for cert.type, timestamp.type, etc. -->
     <include file="db/changelog/datatypes.xml"/>

--- a/server/src/main/resources/db/changelog/20140311170628-add-rulessource.xml
+++ b/server/src/main/resources/db/changelog/20140311170628-add-rulessource.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
 
     <changeSet id="20140311170628" author="ckozak">

--- a/server/src/main/resources/db/changelog/20140312102320-sla-on-activation-key.xml
+++ b/server/src/main/resources/db/changelog/20140312102320-sla-on-activation-key.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
 
     <changeSet id="20140312102320" author="wpoteat">

--- a/server/src/main/resources/db/changelog/20140313155734-create-branding.xml
+++ b/server/src/main/resources/db/changelog/20140313155734-create-branding.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <!-- Include definitions for cert.type, timestamp.type, etc. -->
     <include file="db/changelog/datatypes.xml"/>

--- a/server/src/main/resources/db/changelog/20140317115036-index-facts-consumerid.xml
+++ b/server/src/main/resources/db/changelog/20140317115036-index-facts-consumerid.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
 
     <changeSet id="20140317115036" author="ckozak">

--- a/server/src/main/resources/db/changelog/20140408160212-add-pool-source-sub-table.xml
+++ b/server/src/main/resources/db/changelog/20140408160212-add-pool-source-sub-table.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <!-- Include definitions for cert.type, timestamp.type, etc. -->
     <include file="db/changelog/datatypes.xml"/>

--- a/server/src/main/resources/db/changelog/20140506122111-remove-certserial-revoked.xml
+++ b/server/src/main/resources/db/changelog/20140506122111-remove-certserial-revoked.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
 
     <changeSet id="20140506122111-0" author="ckozak">

--- a/server/src/main/resources/db/changelog/20140616140315-remove-reliant-product.xml
+++ b/server/src/main/resources/db/changelog/20140616140315-remove-reliant-product.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
 
     <changeSet id="20140616140315" author="wpoteat">

--- a/server/src/main/resources/db/changelog/20140811163932-compliance-on-startdate.xml
+++ b/server/src/main/resources/db/changelog/20140811163932-compliance-on-startdate.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
 
     <changeSet id="20140811163932" author="ckozak">

--- a/server/src/main/resources/db/changelog/20140815131046-drop-event-entity-id-not-null.xml
+++ b/server/src/main/resources/db/changelog/20140815131046-drop-event-entity-id-not-null.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
 
     <changeSet id="20140815131046" author="wpoteat">

--- a/server/src/main/resources/db/changelog/20140911164800-add-activation-key-description.xml
+++ b/server/src/main/resources/db/changelog/20140911164800-add-activation-key-description.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
 
     <changeSet id="20140911164800" author="csnyder">

--- a/server/src/main/resources/db/changelog/20140916131808-activation-key-expansion.xml
+++ b/server/src/main/resources/db/changelog/20140916131808-activation-key-expansion.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet author="wpoteat" id="20140916131808-1" dbms="postgresql">
         <createTable tableName="cp_activationkey_product">

--- a/server/src/main/resources/db/changelog/20141126150611-create-content-tags-table.xml
+++ b/server/src/main/resources/db/changelog/20141126150611-create-content-tags-table.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="20141126150611-1" author="awood">
         <comment>Create content tags table</comment>

--- a/server/src/main/resources/db/changelog/20141203123727-add-compliance-status-hash-column.xml
+++ b/server/src/main/resources/db/changelog/20141203123727-add-compliance-status-hash-column.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="20141203123727-1" author="mstead">
         <comment>Add complianceStatusHash column to consumer</comment>

--- a/server/src/main/resources/db/changelog/20150123105016-add-consumer-checkin-table.xml
+++ b/server/src/main/resources/db/changelog/20150123105016-add-consumer-checkin-table.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <!-- Include definitions for cert.type, timestamp.type, etc. -->
     <include file="db/changelog/datatypes.xml"/>

--- a/server/src/main/resources/db/changelog/20150210094558-perorgproducts-phase-1.xml
+++ b/server/src/main/resources/db/changelog/20150210094558-perorgproducts-phase-1.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <!-- Include definitions for cert.type, timestamp.type, etc. -->
     <include file="db/changelog/datatypes.xml"/>

--- a/server/src/main/resources/db/changelog/20150211111319-add-last-guest-update-table.xml
+++ b/server/src/main/resources/db/changelog/20150211111319-add-last-guest-update-table.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <!-- Include definitions for cert.type, timestamp.type, etc. -->
     <include file="db/changelog/datatypes.xml"/>

--- a/server/src/main/resources/db/changelog/20150311151612-force-all-content-metadataexpire-to-0.xml
+++ b/server/src/main/resources/db/changelog/20150311151612-force-all-content-metadataexpire-to-0.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="20150311151612-1" author="dgoodwin">
         <comment>Force all content metadataexpire to 0. Only takes effect in standalone servers as in upstream these tables are empty.</comment>

--- a/server/src/main/resources/db/changelog/20150316122833-add-entitlement-end-date-override.xml
+++ b/server/src/main/resources/db/changelog/20150316122833-add-entitlement-end-date-override.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <!-- Include definitions for cert.type, timestamp.type, etc. -->
     <include file="db/changelog/datatypes.xml"/>

--- a/server/src/main/resources/db/changelog/20150401140006-add-pool-type-to-db.xml
+++ b/server/src/main/resources/db/changelog/20150401140006-add-pool-type-to-db.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="20150401140006-1" author="crog">
         <comment>Add the pool type field to the cp_pool table</comment>

--- a/server/src/main/resources/db/changelog/20150416090438-mysql-quartz-longblob.xml
+++ b/server/src/main/resources/db/changelog/20150416090438-mysql-quartz-longblob.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="20150416090438-1" author="wpoteat" dbms="mysql">
         <comment>Use LONGBLOB instead of BLOB for job_data column.</comment>

--- a/server/src/main/resources/db/changelog/20150424150412-add-owner-id-to-jobstatus.xml
+++ b/server/src/main/resources/db/changelog/20150424150412-add-owner-id-to-jobstatus.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="20150424150412-1" author="mstead">
         <preConditions onFail="MARK_RAN">

--- a/server/src/main/resources/db/changelog/20150430115844-job-status-result-data.xml
+++ b/server/src/main/resources/db/changelog/20150430115844-job-status-result-data.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="20150430115844-1" author="wpoteat" dbms="mysql">
         <comment>Add field for result data</comment>

--- a/server/src/main/resources/db/changelog/20150615155037-add-consumer-annotations.xml
+++ b/server/src/main/resources/db/changelog/20150615155037-add-consumer-annotations.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="20150615155037-1" author="wpoteat">
         <comment>add-consumer-annotations</comment>

--- a/server/src/main/resources/db/changelog/20150616090156-per-org-products-column-def-fix.xml
+++ b/server/src/main/resources/db/changelog/20150616090156-per-org-products-column-def-fix.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="20150616090156-1" author="crog">
         <comment>Fix for bad column definition in the original per-org products changeset</comment>

--- a/server/src/main/resources/db/changelog/20150729082417-content-unique-owner-label.xml
+++ b/server/src/main/resources/db/changelog/20150729082417-content-unique-owner-label.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
 <!--     <changeSet id="20150729082417-1" author="wpoteat">
         <addUniqueConstraint tableName="cp2_content"

--- a/server/src/main/resources/db/changelog/20150818110722-upgrade-to-quartz-2-dot-2.xml
+++ b/server/src/main/resources/db/changelog/20150818110722-upgrade-to-quartz-2-dot-2.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <property name="trigger.table_name" value="qrtz_fired_triggers" dbms="postgresql,hsqldb"/>
     <property name="trigger.table_name" value="QRTZ_FIRED_TRIGGERS" dbms="mysql"/>

--- a/server/src/main/resources/db/changelog/20150820140403-revert-to-lastcheckin-column.xml
+++ b/server/src/main/resources/db/changelog/20150820140403-revert-to-lastcheckin-column.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <!-- Include definitions for cert.type, timestamp.type, etc. -->
     <include file="db/changelog/datatypes.xml"/>

--- a/server/src/main/resources/db/changelog/20150915094638-add-reporter-id-to-hypervisor-id.xml
+++ b/server/src/main/resources/db/changelog/20150915094638-add-reporter-id-to-hypervisor-id.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="20150915094638-1" author="vrjain">
         <preConditions onFail="MARK_RAN">

--- a/server/src/main/resources/db/changelog/20160224171417-drop-stat-history-table.xml
+++ b/server/src/main/resources/db/changelog/20160224171417-drop-stat-history-table.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="20160224171417-1" author="vrjain">
         <comment> we dont need no statistics</comment>

--- a/server/src/main/resources/db/changelog/20160412131122-add-unique-constraint-to-product-certificate-rows.xml
+++ b/server/src/main/resources/db/changelog/20160412131122-add-unique-constraint-to-product-certificate-rows.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="20160412131122-1" author="awood">
         <comment>Add unique constraint to product certificate rows.</comment>

--- a/server/src/main/resources/db/changelog/20160419092221-add-db-file-storage.xml
+++ b/server/src/main/resources/db/changelog/20160419092221-add-db-file-storage.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <!-- Postgres automatically maps blob type to bytea so we must use oid to map -->
     <!-- to java.sql.Blob type which gives us streaming capabilities.             -->

--- a/server/src/main/resources/db/changelog/20160419110701-oracle-add-indexes-for-foreign-keys.xml
+++ b/server/src/main/resources/db/changelog/20160419110701-oracle-add-indexes-for-foreign-keys.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="20160419110701-1" author="vrjain" dbms="oracle">
         <comment>Add indexes for foreign keys in oracle</comment>

--- a/server/src/main/resources/db/changelog/20160714130753-add_lower_columns.xml
+++ b/server/src/main/resources/db/changelog/20160714130753-add_lower_columns.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="20160714130753-1" author="fnguyen">
         <comment>Adding columns to hold lower case data. This allows 

--- a/server/src/main/resources/db/changelog/20160722162105-remove-bad-ueber-cert-data.xml
+++ b/server/src/main/resources/db/changelog/20160722162105-remove-bad-ueber-cert-data.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
     <!-- POSTGRES/ORACLE QUERIES -->
     <property
         dbms="postgresql,oracle,hsqldb"

--- a/server/src/main/resources/db/changelog/20160812153414-simplify-attribute-tables.xml
+++ b/server/src/main/resources/db/changelog/20160812153414-simplify-attribute-tables.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="20160812153414-1" author="crog">
         <dropPrimaryKey tableName="cp_pool_attribute"/>

--- a/server/src/main/resources/db/changelog/20160907121757-add-autobind-disabled-column-to-owner.xml
+++ b/server/src/main/resources/db/changelog/20160907121757-add-autobind-disabled-column-to-owner.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="20160907121757-1" author="mstead">
         <comment>Adds autobind_disabled column to cp_owners table.</comment>

--- a/server/src/main/resources/db/changelog/20161012144719-add-content-access-mode-column-to-owner.xml
+++ b/server/src/main/resources/db/changelog/20161012144719-add-content-access-mode-column-to-owner.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="20161012144719-1" author="wpoteat">
         <comment>Adds content_access_mode columns to cp_owners table.</comment>

--- a/server/src/main/resources/db/changelog/20161013145834-add-content-access-cert-column-to-consumer.xml
+++ b/server/src/main/resources/db/changelog/20161013145834-add-content-access-cert-column-to-consumer.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <!-- Include definitions for cert.type, timestamp.type, etc. -->
     <include file="db/changelog/datatypes.xml"/>

--- a/server/src/main/resources/db/changelog/20161025100925-remove-unique-content-name-constraint.xml
+++ b/server/src/main/resources/db/changelog/20161025100925-remove-unique-content-name-constraint.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="20161025100925-1" author="awood" dbms="postgresql">
         <!-- Add a precondition since many customers have already run this by hand -->

--- a/server/src/main/resources/db/changelog/20161025103454-cleanup-ueber-certs-round2.xml
+++ b/server/src/main/resources/db/changelog/20161025103454-cleanup-ueber-certs-round2.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <!-- POSTGRES/ORACLE QUERIES -->
 

--- a/server/src/main/resources/db/changelog/20161129104417-add-content-access-mode-column-to-consumer.xml
+++ b/server/src/main/resources/db/changelog/20161129104417-add-content-access-mode-column-to-consumer.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="20161129104417-1" author="wpoteat">
         <comment>Adds content_access_mode column to cp_consumers table.</comment>

--- a/server/src/main/resources/db/changelog/20170125112728-cleanup-uebercerts-round3-2-0.xml
+++ b/server/src/main/resources/db/changelog/20170125112728-cleanup-uebercerts-round3-2-0.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <!-- POSTGRES/ORACLE QUERIES -->
 

--- a/server/src/main/resources/db/changelog/20170130144529-perorgproducts-phase-2.xml
+++ b/server/src/main/resources/db/changelog/20170130144529-perorgproducts-phase-2.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="20170130144529-1" author="crog">
         <dropTable tableName="cp2_installed_products"/>

--- a/server/src/main/resources/db/changelog/20170202093945-add-ueber-cert-to-owner.xml
+++ b/server/src/main/resources/db/changelog/20170202093945-add-ueber-cert-to-owner.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <!-- Include definitions for cert.type, timestamp.type, etc. -->
     <include file="db/changelog/datatypes.xml"/>

--- a/server/src/main/resources/db/changelog/20170206133825-add-share-consumer-type.xml
+++ b/server/src/main/resources/db/changelog/20170206133825-add-share-consumer-type.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="20170206133825-1" author="awood">
         <comment>Add share consumer type</comment>

--- a/server/src/main/resources/db/changelog/20170214115606-uber-cert-rewrite.xml
+++ b/server/src/main/resources/db/changelog/20170214115606-uber-cert-rewrite.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <!-- ********************************************************************* -->
     <!-- *** Postgres/Oracle cleanup                                        ** -->

--- a/server/src/main/resources/db/changelog/20170220133446-add-correlation-id-to-job.xml
+++ b/server/src/main/resources/db/changelog/20170220133446-add-correlation-id-to-job.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="20170220133446-1" author="wpoteat">
         <comment>Adds correlation_id column to cp_job table.</comment>

--- a/server/src/main/resources/db/changelog/20170224113816-add-productshare-table.xml
+++ b/server/src/main/resources/db/changelog/20170224113816-add-productshare-table.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <!-- Include definitions for cert.type, timestamp.type, etc. -->
     <include file="db/changelog/datatypes.xml"/>

--- a/server/src/main/resources/db/changelog/20170323142254-add-revoked-column-to-cert-serial.xml
+++ b/server/src/main/resources/db/changelog/20170323142254-add-revoked-column-to-cert-serial.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="20170323142254-1" author="mstead">
         <comment>Add a revoked column to cert serial</comment>

--- a/server/src/main/resources/db/changelog/20170404164458-add-share-quantity-column-to-pools.xml
+++ b/server/src/main/resources/db/changelog/20170404164458-add-share-quantity-column-to-pools.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <include file="db/changelog/datatypes.xml"/>
 

--- a/server/src/main/resources/db/changelog/20170421055601-add-recipient-owner-to-consumer.xml
+++ b/server/src/main/resources/db/changelog/20170421055601-add-recipient-owner-to-consumer.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="20170421055601-1" author="vrjain">
         <comment> add-recipient-owner-to-consumer</comment>

--- a/server/src/main/resources/db/changelog/20170510130908-remove-pool-version.xml
+++ b/server/src/main/resources/db/changelog/20170510130908-remove-pool-version.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="20170510130908-1" author="vrjain">
         <comment> remove pool version</comment>

--- a/server/src/main/resources/db/changelog/20170518143217-remove-obsoleted-dirty-column.xml
+++ b/server/src/main/resources/db/changelog/20170518143217-remove-obsoleted-dirty-column.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="20170518143217-1" author="crog">
         <comment>remove obsoleted dirty column</comment>

--- a/server/src/main/resources/db/changelog/20170612091842-default-content-access-list.xml
+++ b/server/src/main/resources/db/changelog/20170612091842-default-content-access-list.xml
@@ -4,7 +4,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="20170612091842-1" author="wpoteat">
         <sql>

--- a/server/src/main/resources/db/changelog/changelog-create.xml
+++ b/server/src/main/resources/db/changelog/changelog-create.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
-<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
     <property name="project.name" value="candlepin"/>
     <changeSet author="dgoodwin" id="1332854949306-1000" dbms="postgresql">
         <createTable tableName="cp_activation_key">

--- a/server/src/main/resources/db/changelog/changelog-update.xml
+++ b/server/src/main/resources/db/changelog/changelog-update.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
     <property name="project.name" value="candlepin"/>
     <include file="db/changelog/20120416134048-insert-uebercert-consumer-type.xml"/>
     <include file="db/changelog/20120420143629-consumer-release-to-varchar.xml"/>

--- a/server/src/main/resources/db/changelog/datatypes.xml
+++ b/server/src/main/resources/db/changelog/datatypes.xml
@@ -2,7 +2,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <property name="timestamp.type" value="TIMESTAMP WITHOUT TIME ZONE" dbms="postgresql,hsqldb"/>
     <property name="timestamp.type" value="TIMESTAMP" dbms="oracle"/>

--- a/server/src/test/java/org/candlepin/liquibase/SchemaCompatibilityTest.java
+++ b/server/src/test/java/org/candlepin/liquibase/SchemaCompatibilityTest.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) 2009 - 2018 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.liquibase;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.FileVisitResult;
+import java.nio.file.FileVisitor;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.nio.file.Paths;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
+
+/**
+ * Test to ensure that none of our Liquibase changesets use a schema version newer than what is provided in
+ * the Liquibase jar.  If we use a newer version, Java will attempt to download the schema which breaks
+ * disconnected installations.
+ *
+ * This class is not really a unit test, per se, but there's not really a better place for it.
+ */
+public class SchemaCompatibilityTest {
+    private static final String EXPECTED_XSD_VERSION = "3.1";
+
+    @Test
+    public void verifySchemaVersion() throws Exception {
+        List<File> changesets = gatherChangesets();
+        XPath xPath = XPathFactory.newInstance().newXPath();
+        // the the schemaLocation attribute node within the databaseChangeLog element
+        String expression = "/databaseChangeLog/@schemaLocation";
+        Pattern xsdPattern = Pattern.compile("http://www.liquibase" +
+            ".org/xml/ns/dbchangelog/dbchangelog-(\\d.\\d).xsd");
+
+        List<String> warnings = new ArrayList<String>();
+        for (File f : changesets) {
+            DocumentBuilderFactory builderFactory = DocumentBuilderFactory.newInstance();
+            DocumentBuilder builder = builderFactory.newDocumentBuilder();
+            Document changeset = builder.parse(f);
+
+            Node schemaLocation = (Node) xPath.compile(expression).evaluate(changeset,
+                XPathConstants.NODE);
+
+            if (schemaLocation == null) {
+                warnings.add("Missing schemaLocation attribute for " + f);
+            }
+            else {
+                String location = schemaLocation.getNodeValue();
+                Matcher matcher = xsdPattern.matcher(location);
+                if (matcher.find()) {
+                    String xsdVersion = matcher.group(1);
+                    if (!EXPECTED_XSD_VERSION.equals(xsdVersion)) {
+                        warnings.add("XSD version mismatch (found: " + xsdVersion + ", expected: " +
+                            EXPECTED_XSD_VERSION + ") for " + f);
+                    }
+                }
+                else {
+                    warnings.add("Could not parse schemaLocation value for " + f);
+                }
+            }
+        }
+
+        if (!warnings.isEmpty()) {
+            Assert.fail(String.join("\n", warnings));
+        }
+    }
+
+    private List<File> gatherChangesets() throws Exception {
+        PathMatcher xmlMatcher = FileSystems.getDefault().getPathMatcher("glob:*.xml");
+        Path resources = Paths.get("src", "main", "resources", "db", "changelog");
+
+        List<File> matches = new ArrayList<File>();
+        Files.walkFileTree(resources, new FileVisitor<Path>() {
+            @Override
+            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                if (xmlMatcher.matches(file.getFileName())) {
+                    matches.add(file.toFile());
+                }
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException {
+                throw new IOException("Could not visit" + file);
+            }
+
+            @Override
+            public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                return FileVisitResult.CONTINUE;
+            }
+        });
+
+        return matches;
+    }
+}


### PR DESCRIPTION
If you want to test this test, try
* Deleting the `schemaLocation` attribute from the `databaseChangeLog` element.
* Changing the `schemaLocation` value to something that doesn't match the regex (e.g. `xsi:schemaLocation="foo"`.
* Changing the schema URL to something that is not "3.1".

Any of those changes will result in a test failure with a unique message.

This PR also converts all existing changesets to use version 3.1.  This should not be an issue since we've made version switches in the past with no ill effects.
