### PR TITLE
[M] Refactored the HostedTestSubscriptionServiceAdapter

### DIFF
--- a/server/client/ruby/candlepin_api.rb
+++ b/server/client/ruby/candlepin_api.rb
@@ -546,6 +546,8 @@ class Candlepin
       end
     end
 
+    sleep 1
+
     # If we only have one job detail, return the status directly; otherwise return a collection of job results
     return (status.length == 1 ? status[0]['result'] : status.map {|detail| detail['result']})
   end
@@ -1029,18 +1031,15 @@ class Candlepin
   end
 
   def create_pool(owner_key, product_id, params={})
-    quantity = params[:quantity] || 1
-    provided_products = params[:provided_products] || []
-
     start_date = params[:start_date] || DateTime.now
     end_date = params[:end_date] || start_date + 365
 
     pool = {
       'startDate' => start_date,
       'endDate'   => end_date,
-      'quantity'  =>  quantity,
+      'quantity'  =>  params[:quantity] || 1,
       'product' => { 'id' => product_id },
-      'providedProducts' => provided_products.collect { |pid| {'productId' => pid} }
+      'providedProducts' => [],
     }
 
     if params[:branding]
@@ -1072,6 +1071,10 @@ class Candlepin
     elsif params[:subscriptionId] || params[:subscriptionSubKey]
       pool['subscriptionId'] = params[:subscriptionId] || "sub_id-#{rand(9)}#{rand(9)}#{rand(9)}"
       pool['subscriptionSubKey'] = params[:subscriptionSubKey] || 'master'
+    end
+
+    if params[:provided_products]
+      pool['providedProducts'] = params[:provided_products].collect { |pid| {'productId' => pid} }
     end
 
     if params[:derived_provided_products]

--- a/server/client/ruby/hostedtest_api.rb
+++ b/server/client/ruby/hostedtest_api.rb
@@ -14,74 +14,6 @@ module HostedTest
     return @@hostedtest_alive
   end
 
-  def create_hostedtest_subscription(owner_key, product_id, quantity=1, params={})
-
-    provided_products = params[:provided_products] || []
-    start_date = params[:start_date] || DateTime.now
-    end_date = params[:end_date] || start_date + 365
-
-    subscription = {
-      'startDate' => start_date,
-      'endDate'   => end_date,
-      'quantity'  =>  quantity,
-      'product' =>  { 'id' => product_id },
-      'owner' =>  { 'key' => owner_key }
-    }
-
-    if params[:upstream_pool_id]
-      subscription['upstreamPoolId'] = params[:upstream_pool_id]
-    end
-
-    if params[:contract_number]
-      subscription['contractNumber'] = params[:contract_number]
-    end
-
-    if params[:account_number]
-      subscription['accountNumber'] = params[:account_number]
-    end
-
-    if params[:order_number]
-      subscription['orderNumber'] = params[:order_number]
-    end
-
-    if params[:branding]
-      subscription['branding'] = params[:branding]
-    end
-
-    if params[:derived_product_id]
-      subscription['derivedProduct'] = { 'id' => params[:derived_product_id] }
-    end
-
-    if params[:provided_products]
-      subscription['providedProducts'] = params[:provided_products].collect { |pid| {'id' => pid} }
-    end
-
-    if params[:derived_provided_products]
-      subscription['derivedProvidedProducts'] = params[:derived_provided_products].collect { |pid| {'id' => pid} }
-    end
-    return @cp.post("/hostedtest/subscriptions", {}, subscription)
-  end
-
-  def update_hostedtest_subscription(subscription)
-    return @cp.put("/hostedtest/subscriptions", {}, subscription)
-  end
-
-  def get_all_hostedtest_subscriptions()
-    return @cp.get('/hostedtest/subscriptions/')
-  end
-
-  def get_hostedtest_subscription(id)
-    return @cp.get("/hostedtest/subscriptions/#{id}")
-  end
-
-  def delete_hostedtest_subscription(id)
-    return @cp.delete("/hostedtest/subscriptions/#{id}", {}, nil, true)
-  end
-
-  def delete_all_hostedtest_subscriptions()
-    @cp.delete('/hostedtest/subscriptions/', {}, nil, true)
-  end
-
   def is_hosted?
     if @@hosted_mode.nil?
       @@hosted_mode = ! @cp.get_status()['standalone']
@@ -98,180 +30,204 @@ module HostedTest
 
   def ensure_hostedtest_resource()
     if is_hosted? && !is_hostedtest_alive?
-      raise "Could not find hostedtest rest API. Please run \'deploy -ha\' or add the following to candlepin.conf:\n" \
+      raise "Could not find hostedtest rest API. Please run \'deploy -Ha\' or add the following to candlepin.conf:\n" \
           " module.config.hosted.configuration.module=org.candlepin.hostedtest.AdapterOverrideModule"
     end
   end
 
-  def add_batch_content_to_product(owner_key, product_id, content_ids, enabled=true)
-    if is_hosted?
-      data = {}
-      content_ids.each do |id|
-        data[id] = enabled
+  def clear_upstream_data()
+    @cp.delete('/hostedtest')
+  end
+
+  def create_upstream_subscription(subscription_id, owner_key, product_id, params = {})
+    start_date = params.delete(:start_date) || Date.today
+    end_date = params.delete(:end_date) || start_date + 365
+
+    # Define subscription with defaults & specified params
+    subscription = {
+      :startDate => start_date,
+      :endDate   => end_date,
+      :product =>  { :id => product_id },
+      :owner =>  { :key => owner_key },
+      :quantity => 1
+    }
+
+    # Merge, but convert some snake-case keys to camel case
+    keys = [:account_number, :contract_number, :order_number, :upstream_pool_id,
+      :provided_products, :derived_product, :derived_provided_products,
+      'account_number', 'contract_number', 'order_number', 'upstream_pool_id',
+      'provided_products', 'derived_product', 'derived_provided_products']
+
+    params.each do |key, value|
+      if keys.include?(key)
+        key = key.to_s.gsub!(/_(\w)/){$1.upcase}
       end
-      @cp.post("/hostedtest/subscriptions/owners/#{owner_key}/products/#{product_id}/batch_content", {}, data)
-    else
-      @cp.add_batch_content_to_product(owner_key, product_id, content_ids, true)
+
+      subscription[key] = value
     end
+
+    # Forcefully set identifier
+    subscription[:id] = subscription_id
+
+    return @cp.post('hostedtest/subscriptions', {}, subscription)
   end
 
-  def add_content_to_product(owner_key, product_id, content_id, enabled=true)
-    if is_hosted?
-      @cp.post("/hostedtest/subscriptions/owners/#{owner_key}/products/#{product_id}/content/#{content_id}", {:enabled => enabled})
-    else
-      @cp.add_content_to_product(owner_key, product_id, content_id, true)
-    end
+  def list_upstream_subscriptions()
+    return @cp.get('/hostedtest/subscriptions')
   end
 
-  def update_product(owner_key, product_id, params={})
-    if is_hosted?
-      product = {
-        :id => product_id
-      }
-      product[:name] = params[:name] if params[:name]
-      product[:multiplier] = params[:multiplier] if params[:multiplier]
-      product[:attributes] = params[:attributes] if params[:attributes]
-      product[:dependentProductIds] = params[:dependentProductIds] if params[:dependentProductIds]
-      product[:relies_on] = params[:relies_on] if params[:relies_on]
-
-      @cp.put("/hostedtest/subscriptions/owners/#{owner_key}/products/#{product_id}", {}, product)
-    else
-      @cp.update_product(owner_key, product_id, params)
-    end
+  def get_upstream_subscription(subscription_id)
+    return @cp.get("/hostedtest/subscriptions/#{subscription_id}")
   end
 
-  # Lets users be agnostic of what mode we are in, standalone or hosted.
-  # Always returns the main pool that was created ( unless running in hosted mode and refresh is skipped )
-  # not to be used to create custom pool
-  def create_pool_and_subscription(owner_key, product_id, quantity=1,
-                          provided_products=[], contract_number='',
-                          account_number='', order_number='',
-                          start_date=nil, end_date=nil, skip_refresh=false, params={})
+  def update_upstream_subscription(subscription_id, params = {})
+    subscription = {}
 
-    params[:start_date] = start_date
-    params[:end_date] = end_date
-    params[:contract_number] = contract_number
-    params[:account_number] = account_number
-    params[:order_number] = order_number
-    params[:quantity] = quantity
-    params[:provided_products] = provided_products
-    pool = nil
-    if is_hosted?
-      ensure_hostedtest_resource
-      sub = create_hostedtest_subscription(owner_key, product_id, quantity, params)
-      if not skip_refresh
-        active_on = Date.strptime(sub['startDate'], "%Y-%m-%d")+1
-        @cp.refresh_pools(owner_key)
-        pool = find_main_pool(owner_key, sub['id'], activeon=active_on, true)
+    # Merge, but convert some snake-case keys to camel case
+    keys = [:account_number, :contract_number, :order_number, :upstream_pool_id, :start_date, :end_date,
+      :provided_products, :derived_product, :derived_provided_products,
+      'account_number', 'contract_number', 'order_number', 'upstream_pool_id', 'start_date', 'end_date',
+      'provided_products', 'derived_product', 'derived_provided_products']
+
+    params.each do |key, value|
+      if keys.include?(key)
+        key = key.to_s.gsub!(/_(\w)/){$1.upcase}
       end
-    else
-      params[:subscription_id] = random_str('source_sub')
-      params[:upstream_pool_id] = random_str('upstream')
-      pool = @cp.create_pool(owner_key, product_id, params)
+
+      subscription[key] = value
     end
-    return pool
+
+    # Forcefully set identifier
+    subscription[:id] = subscription_id
+
+    return @cp.put("/hostedtest/subscriptions/#{subscription_id}", {}, subscription)
   end
 
-  # Lets users be agnostic of what mode we are in, standalone or hosted.
-  # if we are running in hosted mode, delete the upstream subscription and refresh pools.
-  # else, simply delete the pool
-  def delete_pool_and_subscription(pool)
-    if is_hosted?
-      ensure_hostedtest_resource
-      delete_hostedtest_subscription(pool.subscriptionId)
-      @cp.refresh_pools(pool['owner']['key'])
-    else
-      @cp.delete_pool(pool.id)
-    end
+  def delete_upstream_subscription(subscription_id)
+    return @cp.delete("/hostedtest/subscriptions/#{subscription_id}")
   end
 
-  # Lets users be agnostic of what mode we are in, standalone or hosted.
-  # This method is used when we need to update the upstream subscription's details.
-  # first we fetch the upstrean pool ( if standalone mode ) or subscription ( if hosted mode )
-  # using get_pool_or_subscription(pool) and then use update_pool_or_subscription
-  # to update the upstream entity.
-  #
-  # input is always a pool, but the out may be either a subscription or a pool
-  def get_pool_or_subscription(pool)
-    if is_hosted?
-      ensure_hostedtest_resource
-      return get_hostedtest_subscription(pool.subscriptionId)
-    else
-      return pool
-    end
+  def create_upstream_product(product_id, params = {})
+    # Create a product with some defaults for required fields
+    product = {
+      :multiplier => 1
+    }
+
+    # Merge provided params in
+    product.merge!(params)
+
+    # Forcefully set identifier and name (if absent)
+    product[:id] = product_id
+    product[:name] = product_id if !product[:name]
+
+    return @cp.post('hostedtest/products', {}, product)
   end
 
-  # Lets users be agnostic of what mode we are in, standalone or hosted.
-  # This method is used when we need to update the upstream subscription's details.
-  # first we fetch the upstrean pool ( if standalone mode ) or subscription ( if hosted mode )
-  # using get_pool_or_subscription(pool) and then use update_pool_or_subscription
-  # to update the upstream entity.
-  #
-  # input may be either a subscription or a pool, and there is no output
-  def update_pool_or_subscription(subOrPool, refresh=true)
-    if is_hosted?
-      ensure_hostedtest_resource
-      update_hostedtest_subscription(subOrPool)
-      active_on = case subOrPool.startDate
-        when String then Date.strptime(subOrPool.startDate, "%Y-%m-%d")+1
-        when Date then subOrPool.startDate+1
-        else raise "invalid date format"
+  def list_upstream_products()
+    return @cp.get('/hostedtest/products')
+  end
+
+  def get_upstream_product(product_id)
+    return @cp.get("/hostedtest/products/#{product_id}")
+  end
+
+  def update_upstream_product(product_id, params = {})
+    product = {}.merge(params)
+
+    # Forcefully set identifier
+    product[:id] = product_id
+
+    return @cp.put("/hostedtest/products/#{product_id}", {}, product)
+  end
+
+  def delete_upstream_product(product_id)
+    return @cp.delete("/hostedtest/products/#{product_id}")
+  end
+
+  def create_upstream_content(content_id, params = {})
+    # Create a content with some defaults for required fields
+    content = {
+      :label => 'label',
+      :type => 'yum',
+      :vendor => 'vendor'
+    }
+
+    # Merge, but convert some snake-case keys to camel case
+    keys = [:content_url, :gpg_url, :modified_product_ids, :metadata_expire, :required_tags,
+      'content_url', 'gpg_url', 'modified_product_ids', 'metadata_expire', 'required_tags']
+
+    params.each do |key, value|
+      if keys.include?(key)
+        key = key.to_s.gsub!(/_(\w)/){$1.upcase}
       end
-      @cp.refresh_pools(subOrPool['owner']['key'], true) if refresh
-      sleep 1
-    else
-      @cp.update_pool(subOrPool['owner']['key'], subOrPool)
+
+      content[key] = value
     end
+
+    # Forcefully assign the ID and name (if absent)
+    content[:id] = content_id
+    content[:name] = content_id if !content[:name]
+
+    return @cp.post('hostedtest/content', {}, content)
   end
 
-  # Lets users be agnostic of what mode we are in, standalone or hosted.
-  # This method is used when we need to update the dependent entities of a
-  # upstream subscription or pool. simply fetching and updating the subscription forces
-  # a re-resolve of products, owners, etc.
-  #
-  # input is alwasy a pool, and there is no output
-  def refresh_upstream_subscription(pool)
-    if is_hosted?
-      ensure_hostedtest_resource
-      sub = get_hostedtest_subscription(pool.subscriptionId)
-      update_hostedtest_subscription(sub)
-      @cp.refresh_pools(pool['owner']['key'])
-    end
+  def list_upstream_contents()
+    return @cp.get('/hostedtest/content')
   end
 
-  # List all the pools for the given owner, and find one that matches
-  # a specific subscription ID. (we often want to verify what pool was used,
-  # but the pools are created indirectly after a refresh so it's hard to
-  # locate a specific reference without this)
-  def find_main_pool(owner_key, sub_id, activeon=nil, return_normal)
-    pools = @cp.list_owner_pools(owner_key, {:activeon => activeon})
-    pools.each do |pool|
-      if pool['subscriptionId'] == sub_id && (!return_normal || pool['type'] == 'NORMAL')
-        return pool
+  def get_upstream_content(content_id)
+    return @cp.get("/hostedtest/content/#{content_id}")
+  end
+
+  def update_upstream_content(content_id, params = {})
+    content = {}
+
+    # Merge, but convert some snake-case keys to camel case
+    keys = [:content_url, :gpg_url, :modified_product_ids, :metadata_expire, :required_tags,
+      'content_url', 'gpg_url', 'modified_product_ids', 'metadata_expire', 'required_tags']
+
+    params.each do |key, value|
+      if keys.include?(key)
+        key = key.to_s.gsub!(/_(\w)/){$1.upcase}
       end
+
+      content[key] = value
     end
-    return nil
+
+    # Forcefully set identifier
+    content[:id] = content_id
+
+    return @cp.put("/hostedtest/content/#{content_id}", {}, content)
   end
 
-  def random_str(prefix=nil, numeric_only=false)
-    if prefix
-      prefix = "#{prefix}-"
-    end
+  def delete_upstream_content(content_id)
+    return @cp.delete("/hostedtest/content/#{content_id}")
+  end
 
-    if numeric_only
-      suffix = rand(9999999)
-    else
-      # This is actually a bit faster than using SecureRandom.  Go figure.
-      o = [('a'..'z'), ('A'..'Z'), ('0'..'9')].map { |i| i.to_a }.flatten
-      suffix = (0..7).map { o[rand(o.length)] }.join
+  def add_batch_content_to_product_upstream(product_id, content_ids, enabled=true)
+    data = {}
+    content_ids.each do |id|
+      data[id] = enabled
     end
-    "#{prefix}#{suffix}"
+    @cp.post("/hostedtest/products/#{product_id}/content", {}, data)
+  end
+
+  def add_content_to_product_upstream(product_id, content_id, enabled = true)
+    @cp.post("/hostedtest/products/#{product_id}/content/#{content_id}", { :enabled => enabled })
+  end
+
+  def remove_batch_content_from_product_upstream(product_id, content_ids)
+    @cp.delete("/hostedtest/products/#{product_id}/content", {}, content_ids)
+  end
+
+  def remove_content_from_product_upstream(product_id, content_id)
+    @cp.delete("/hostedtest/products/#{product_id}/content/#{content_id}")
   end
 
   def cleanup_subscriptions
     if is_hosted?
       ensure_hostedtest_resource
-      delete_all_hostedtest_subscriptions
+      clear_upstream_data
     end
   end
 

--- a/server/spec/activation_key_spec.rb
+++ b/server/spec/activation_key_spec.rb
@@ -15,8 +15,8 @@ describe 'Activation Keys' do
     mallory = create_owner random_string('test_owner')
     @mallory_client = user_client(mallory, random_string('testuser'))
 
-    create_pool_and_subscription(@owner['key'], @product.id, 37, [], '', '', '', nil, nil, true)
-    create_pool_and_subscription(@owner['key'], @product2.id, 37)
+    @cp.create_pool(@owner['key'], @product.id, {:quantity => 37})
+    @cp.create_pool(@owner['key'], @product2.id, {:quantity => 37})
 
     @pool = @cp.list_pools(:owner => @owner.id, :product => @product['id']).first
     @pool2 = @cp.list_pools(:owner => @owner.id, :product => @product2['id']).first
@@ -171,7 +171,7 @@ describe 'Activation Keys' do
     product1 = create_product(random_string('product'),
                               random_string('product'),
                               {:attributes => {:support_level => 'VIP'}})
-    create_pool_and_subscription(@owner['key'], product1.id, 30)
+    @cp.create_pool(@owner['key'], product1.id, {:quantity => 30})
     service_activation_key = @cp.create_activation_key(@owner['key'], random_string('test_token'), 'VIP')
     service_activation_key['serviceLevel'].should == 'VIP'
   end
@@ -183,8 +183,8 @@ describe 'Activation Keys' do
     product2 = create_product(random_string('product'),
                               random_string('product'),
                               {:attributes => {:support_level => 'Ultra-VIP'}})
-    create_pool_and_subscription(@owner['key'], product1.id, 30, [], '', '', '', nil, nil, true)
-    create_pool_and_subscription(@owner['key'], product2.id, 30)
+    @cp.create_pool(@owner['key'], product1.id, {:quantity => 30})
+    @cp.create_pool(@owner['key'], product2.id, {:quantity => 30})
 
     service_activation_key = @cp.create_activation_key(@owner['key'], random_string('test_token'), 'VIP')
     service_activation_key['serviceLevel'].should == 'VIP'

--- a/server/spec/autobind_disabled_for_owner_spec.rb
+++ b/server/spec/autobind_disabled_for_owner_spec.rb
@@ -35,8 +35,8 @@ describe 'Autobind Disabled On Owner' do
     skip("candlepin running in standalone mode") if not is_hosted?
 
     # active subscription to allow this all to work
-    active_prod = create_product()
-    active_sub = create_pool_and_subscription(@owner['key'], active_prod.id, 10)
+    upstream_prod = create_upstream_product(random_string("test_prod"))
+    upstream_sub = create_upstream_subscription(random_string("test_sub"), @owner['key'], upstream_prod.id, {:quantity => 10})
     @cp.refresh_pools(@owner['key'])
 
     dev_product = create_product("dev_product", "Dev Product", {:attributes => { :expires_after => "60"}})

--- a/server/spec/autobind_spec.rb
+++ b/server/spec/autobind_spec.rb
@@ -62,12 +62,34 @@ describe 'Autobind On Owner' do
       }
     })
 
-    # create 4 pools, all must provide product "prod" . none of them
-    # should provide enough sockets to heal the host on it's own
-    create_pool_and_subscription(owner['key'], prod['id'], 10)['id']
-    create_pool_and_subscription(owner['key'], prod1['id'], 30, [prod['id']])['id']
-    create_pool_and_subscription(owner['key'], prod2['id'], 30, [prod['id']])['id']
-    create_pool_and_subscription(owner['key'], prod3['id'], 30, [prod['id']])['id']
+    # create 4 pools, all must provide product "prod." none of them
+    # should provide enough sockets to heal the host on its own
+    @cp.create_pool(owner['key'], prod['id'], {
+      :quantity => 10,
+      :subscription_id => random_string('source_sub'),
+      :upstream_pool_id => random_string('upstream')
+    })
+
+    @cp.create_pool(owner['key'], prod1['id'], {
+      :quantity => 30,
+      :provided_products => [prod['id']],
+      :subscription_id => random_string('source_sub'),
+      :upstream_pool_id => random_string('upstream')
+    })
+
+    @cp.create_pool(owner['key'], prod2['id'], {
+      :quantity => 30,
+      :provided_products => [prod['id']],
+      :subscription_id => random_string('source_sub'),
+      :upstream_pool_id => random_string('upstream')
+    })
+
+    @cp.create_pool(owner['key'], prod3['id'], {
+      :quantity => 30,
+      :provided_products => [prod['id']],
+      :subscription_id => random_string('source_sub'),
+      :upstream_pool_id => random_string('upstream')
+    })
 
     # create a guest with "prod" as an installed product
     guest_uuid =  random_string('guest')
@@ -134,7 +156,11 @@ describe 'Autobind On Owner' do
     orgB = random_string('orgB')
     create_owner(orgB)
 
-    shared_pool = create_pool_and_subscription(owner_key, prod['id'])
+    shared_pool = @cp.create_pool(owner_key, prod['id'], {
+      :subscription_id => random_string('source_sub'),
+      :upstream_pool_id => random_string('upstream')
+    })
+
     share_consumer = @cp.register(
       random_string('orgBShare'),
       :share,
@@ -173,7 +199,7 @@ describe 'Autobind On Owner' do
     )
 
     # OrgB now has a shared pool and an unshared pool for prod
-    pool = create_pool_and_subscription(orgB, prod['id'])
+    pool = @cp.create_pool(orgB, prod['id'])
     ent = @cp.consume_product(prod['id'], :uuid => orgBconsumer['uuid'])
 
     expect(ent.first['pool']['id']).to_not eq(orgBshared_pool['id'])

--- a/server/spec/cert_revocation_spec.rb
+++ b/server/spec/cert_revocation_spec.rb
@@ -16,9 +16,8 @@ describe 'Certificate Revocation List', :serial => true do
     @monitoring_prod = create_product random_string('monitoring')
 
     #entitle owner for the virt and monitoring products.
-    @monitoring_pool = create_pool_and_subscription(@owner['key'], @monitoring_prod.id, 6,
-				[], '', '', '', nil, nil, true)
-    create_pool_and_subscription(@owner['key'], @virt_prod.id, 3)
+    @monitoring_pool = @cp.create_pool(@owner['key'], @monitoring_prod.id, {:quantity => 6})
+    @cp.create_pool(@owner['key'], @virt_prod.id, {:quantity => 3})
 
     #create consumer
     username = random_string('billy')

--- a/server/spec/client_v1_size_spec.rb
+++ b/server/spec/client_v1_size_spec.rb
@@ -8,27 +8,44 @@ describe 'Entitlement Certificate V1 Size' do
     @owner = create_owner random_string('test_owner')
     @content_list = create_batch_content(200)
 
-    @product1 = create_product(nil, nil, :attributes =>
-                {:version => '6.4',
-                 :warning_period => 15,
-                 :management_enabled => true,
-                 :virt_only => 'false',
-                 :support_level => 'standard',
-                 :support_type => 'excellent',})
+    @product1 = create_product(nil, nil, :attributes => {
+      :version => '6.4',
+      :warning_period => 15,
+      :management_enabled => true,
+      :virt_only => 'false',
+      :support_level => 'standard',
+      :support_type => 'excellent'
+    })
+
     @cp.add_content_to_product(@owner['key'], @product1.id, @content_list[0].id, true)
-    create_pool_and_subscription(@owner['key'], @product1.id, 10, [], '12345', '6789', 'order1')
-    @product2 = create_product(nil, nil, :attributes =>
-                {:version => '6.4',
-                 :warning_period => 15,
-                 :management_enabled => true,
-                 :virt_only => 'false',
-                 :support_level => 'standard',
-                 :support_type => 'excellent',})
+
+    @cp.create_pool(@owner['key'], @product1.id, {
+      :quantity => 10,
+      :contract_number => '12345',
+      :account_number => '6789',
+      :order_number => 'order1'
+    })
+
+    @product2 = create_product(nil, nil, :attributes => {
+      :version => '6.4',
+      :warning_period => 15,
+      :management_enabled => true,
+      :virt_only => 'false',
+      :support_level => 'standard',
+      :support_type => 'excellent'
+    })
+
     @cp.add_content_to_product(@owner['key'], @product2.id, @content_list[0].id, true)
-    create_pool_and_subscription(@owner['key'], @product2.id, 10, [], '12345', '6789', 'order1')
+
+    @cp.create_pool(@owner['key'], @product2.id, {
+      :quantity => 10,
+      :contract_number => '12345',
+      :account_number => '6789',
+      :order_number => 'order1'
+    })
+
     @user = user_client(@owner, random_string('billy'))
-    @system = consumer_client(@user, random_string('system1'), :system, nil,
-                {'system.certificate_version' => '1.0'})
+    @system = consumer_client(@user, random_string('system1'), :system, nil, {'system.certificate_version' => '1.0'})
   end
 
   after(:each) do
@@ -45,7 +62,8 @@ describe 'Entitlement Certificate V1 Size' do
     (1..10).each do |i|
       content_ids << @content_list[i].id
     end
-    add_batch_content_to_product(@owner['key'], @product1.id, content_ids, true)
+
+    @cp.add_batch_content_to_product(@owner['key'], @product1.id, content_ids, true)
     @cp.regenerate_entitlement_certificates_for_product(@product1.id)
     ent2 = @system.get_entitlement(ent1.id)
     ent2.certificates[0].serial.id.should_not == ent1.certificates[0].serial.id
@@ -56,7 +74,7 @@ describe 'Entitlement Certificate V1 Size' do
     (11..200).each do |i|
       content_ids.push(@content_list[i].id)
     end
-    add_batch_content_to_product(@owner['key'], @product1.id, content_ids, true)
+    @cp.add_batch_content_to_product(@owner['key'], @product1.id, content_ids, true)
     @cp.regenerate_entitlement_certificates_for_product(@product1.id)
     ent3 = @system.get_entitlement(ent1.id)
     ent3.certificates[0].serial.id.should == ent2.certificates[0].serial.id
@@ -77,9 +95,9 @@ describe 'Entitlement Certificate V1 Size' do
     ent1 = @system.consume_product(@product1.id)[0]
     ent2 = @system.consume_product(@product2.id)[0]
     (1..200).each do |i|
-      add_content_to_product(@owner['key'], @product1.id, @content_list[i].id, true)
+      @cp.add_content_to_product(@owner['key'], @product1.id, @content_list[i].id, true)
     end
-    add_content_to_product(@owner['key'], @product2.id, @content_list[1].id, true)
+    @cp.add_content_to_product(@owner['key'], @product2.id, @content_list[1].id, true)
     @cp.regenerate_entitlement_certificates_for_product(@product1.id)
     @cp.regenerate_entitlement_certificates_for_product(@product2.id)
 

--- a/server/spec/compliance_reasons_spec.rb
+++ b/server/spec/compliance_reasons_spec.rb
@@ -32,7 +32,12 @@ describe 'Single Entitlement Compliance Reasons' do
                  :management_enabled => true,
                  :support_level => 'standard',
                  :support_type => 'excellent',})
-    @product1_pool = create_pool_and_subscription(@owner['key'], @product1.id, 100, [], '1888', '1234')
+
+    @product1_pool = @cp.create_pool(@owner['key'], @product1.id, {
+      :quantity => 100,
+      :contract_number => '1888',
+      :account_number => '1234'
+    })
 
     @user = user_client(@owner, random_string('test-user'))
   end
@@ -371,28 +376,35 @@ describe 'Stacking Compliance Reasons' do
 
     @stack_id = random_string('test-stack-id')
     # Create a stackable RAM product.
-    @stackable_product_1 = create_product(nil, random_string("Stackable"), :attributes =>
-                {:version => '1.2',
-                 :ram => 4,
-                 :sockets => 2,
-                 :cores => 10,
-                 :arch => 'x86_64',
-                 :vcpu => 8,
-                 :support_level => 'standard',
-                 :support_type => 'excellent',
-                 :'multi-entitlement' => 'yes',
-                 :stacking_id => @stack_id})
-    @stackable_pool_1 = create_pool_and_subscription(@owner['key'], @stackable_product_1.id, 10)
+    @stackable_product_1 = create_product(nil, random_string("Stackable"), :attributes => {
+      :version => '1.2',
+      :ram => 4,
+      :sockets => 2,
+      :cores => 10,
+      :arch => 'x86_64',
+      :vcpu => 8,
+      :support_level => 'standard',
+      :support_type => 'excellent',
+      :'multi-entitlement' => 'yes',
+      :stacking_id => @stack_id
+    })
 
-    @not_covered_product = create_product(nil, random_string("Not Covered Product"), :attributes =>
-                {:version => '6.4',
-                 :sockets => 2,
-                 :warning_period => 15,
-                 :management_enabled => true,
-                 :support_level => 'standard',
-                 :support_type => 'excellent',})
-    @not_covered_product_pool = create_pool_and_subscription(@owner['key'], @not_covered_product.id, 100, [],
-                                                              '1999', '3332')
+    @stackable_pool_1 = @cp.create_pool(@owner['key'], @stackable_product_1.id, {:quantity => 10})
+
+    @not_covered_product = create_product(nil, random_string("Not Covered Product"), :attributes => {
+      :version => '6.4',
+      :sockets => 2,
+      :warning_period => 15,
+      :management_enabled => true,
+      :support_level => 'standard',
+      :support_type => 'excellent',
+    })
+
+    @not_covered_product_pool = @cp.create_pool(@owner['key'], @not_covered_product.id, {
+      :quantity => 100,
+      :contract_number => '1999',
+      :account_number => '3332'
+    })
 
     @user = user_client(@owner, random_string('test-user'))
   end

--- a/server/spec/conditional_content_spec.rb
+++ b/server/spec/conditional_content_spec.rb
@@ -15,14 +15,18 @@ describe 'Conditional Content and Dependent Entitlements' do
 
     # This bundled product contains all of the provided products our conditional content will require
     @bundled_product_1 = create_product()
-    @bundled_pool_1 = create_pool_and_subscription(@owner['key'], @bundled_product_1.id, 10,
-      [@required_product_1.id, @required_product_2.id, @required_product_3.id])
+    @bundled_pool_1 = @cp.create_pool(@owner['key'], @bundled_product_1.id, {
+      :quantity => 10,
+      :provided_products => [@required_product_1.id, @required_product_2.id, @required_product_3.id]
+    })
 
     # This bundled product only contains two of the provided products our conditional content
     # will require
     @bundled_product_2 = create_product()
-    @bundled_pool_2 = create_pool_and_subscription(@owner['key'], @bundled_product_2.id, 10,
-      [@required_product_1.id, @required_product_2.id])
+    @bundled_pool_2 = @cp.create_pool(@owner['key'], @bundled_product_2.id, {
+      :quantity => 10,
+      :provided_products => [@required_product_1.id, @required_product_2.id]
+    })
 
     # Create our dependent provided product, which carries content sets -- each of which of which
     # requires one of the provided products above
@@ -36,7 +40,10 @@ describe 'Conditional Content and Dependent Entitlements' do
 
     # Create a dependent pool, providing only the product containing our conditional content
     @dependent_product = create_product()
-    @dependent_pool = create_pool_and_subscription(@owner['key'], @dependent_product.id, 10, [@dependent_provided_product.id])
+    @dependent_pool = @cp.create_pool(@owner['key'], @dependent_product.id, {
+      :quantity => 10,
+      :provided_products => [@dependent_provided_product.id]
+    })
 
     owner_client = user_client(@owner, random_string('testowner'))
     @consumer_cp = consumer_client(owner_client, random_string('consumer123'))
@@ -225,8 +232,8 @@ describe 'Conditional Content and Dependent Entitlements' do
     expect(content_repo_type(dependent_cert, @conditional_content_3.id)).to eq('yum')
 
     # Unbind the pools to revoke our entitlements...
-    delete_pool_and_subscription(@bundled_pool_1)
-    delete_pool_and_subscription(@bundled_pool_2)
+    @cp.delete_pool(@bundled_pool_1['id'])
+    @cp.delete_pool(@bundled_pool_2['id'])
     @cp.refresh_pools(@owner['key'])
 
     # Re-fetch the modifier entitlement...

--- a/server/spec/consumer_bonus_pool_provided_spec.rb
+++ b/server/spec/consumer_bonus_pool_provided_spec.rb
@@ -17,21 +17,28 @@ describe 'Consumer Resource Host/Guest' do
     uuid1 = random_string('system.uuid')
     guests = [{'guestId' => uuid1}]
 
-    std_product = create_product(random_string('product'),
-      random_string('product'),
-      {:attributes => {:virt_limit => "5",
-                       :host_limited => 'true'},
-      :owner => @owner1['key']})
-    provided_product = create_product(random_string('product'),
-      random_string('product'),
-      {:owner => @owner1['key']})
+    std_product = create_product(random_string('product'), random_string('product'), {
+      :attributes => {
+        :virt_limit => "5",
+        :host_limited => 'true'
+      },
+      :owner => @owner1['key']
+    })
 
-    create_pool_and_subscription(@owner1['key'], std_product.id, 10, [provided_product.id])
+    provided_product = create_product(random_string('product'), random_string('product'), {:owner => @owner1['key']})
+
+    @cp.create_pool(@owner1['key'], std_product.id, {
+      :quantity => 10,
+      :provided_products => [provided_product.id],
+      :subscription_id => random_string('source_sub'),
+      :upstream_pool_id => random_string('upstream')
+    })
+
     all_pools =  @user1.list_owner_pools(@owner1['key'])
     all_pools.size.should == 2
-    unmapped_pool = all_pools.find {|p| p['type'] == 'UNMAPPED_GUEST'} 
-    normal_pool = all_pools.find {|p| p['type'] == 'NORMAL'} 
-    
+    unmapped_pool = all_pools.find {|p| p['type'] == 'UNMAPPED_GUEST'}
+    normal_pool = all_pools.find {|p| p['type'] == 'NORMAL'}
+
     normal_pool['providedProducts'].size.should == 1
     unmapped_pool['providedProducts'].size.should == 1
   end

--- a/server/spec/consumer_resource_dev_spec.rb
+++ b/server/spec/consumer_resource_dev_spec.rb
@@ -15,24 +15,27 @@ describe 'Consumer Dev Resource' do
 
     # active subscription to allow this all to work
     active_prod = create_product()
-    @active_sub = create_pool_and_subscription(@owner['key'], active_prod.id, 10)
+    @active_sub = @cp.create_pool(@owner['key'], active_prod.id, {:quantity => 10})
     pools = @cp.list_owner_pools(@owner['key'])
     pools.length.should eq(1)
 
-    @dev_product = create_product("dev_product",
-                                  "Dev Product",
-                                  {:attributes => { :expires_after => "60"}})
-    @dev_product_2 = create_product("2nd_dev_product",
-                                  "Dev Product",
-                                  {:attributes => { :expires_after => "60"}})
-    @p_product1 = create_product("p_product_1",
-                                  "Provided Product 1")
-    @p_product2 = create_product("p_product",
-                                  "Provided Product 2")
+    @dev_product = create_product("dev_product", "Dev Product", {
+      :attributes => { :expires_after => "60" }
+    })
+
+    @dev_product_2 = create_product("2nd_dev_product", "Dev Product", {
+      :attributes => { :expires_after => "60" }
+    })
+
+    @p_product1 = create_product("p_product_1", "Provided Product 1")
+    @p_product2 = create_product("p_product", "Provided Product 2")
     @consumer = consumer_client(@user, @consumername, :system, 'dev_user', facts = {:dev_sku => "dev_product"})
+
     installed = [
-        {'productId' => @p_product1.id, 'productName' => @p_product1.name},
-        {'productId' => @p_product2.id, 'productName' => @p_product2.name}]
+      {'productId' => @p_product1.id, 'productName' => @p_product1.name},
+      {'productId' => @p_product2.id, 'productName' => @p_product2.name}
+    ]
+
     @consumer.update_consumer({:installedProducts => installed})
   end
 

--- a/server/spec/consumer_resource_host_guest_spec.rb
+++ b/server/spec/consumer_resource_host_guest_spec.rb
@@ -201,28 +201,43 @@ describe 'Consumer Resource Host/Guest' do
     uuid3 = random_string('system.uuid')
     guests = [{'guestId' => uuid1}, {'guestId' => uuid2}, {'guestId' => uuid3}]
 
-    vip_product = create_product(random_string('product'),
-      random_string('product'),
-      {:attributes => {:support_level => 'VIP',
-                       :virt_limit => "5",
-                       :host_limited => 'true'},
-      :owner => @owner1['key']})
-    std_product = create_product(random_string('product'),
-      random_string('product'),
-      {:attributes => {:support_level => 'Standard',
-                       :virt_limit => "5",
-                       :host_limited => 'true'},
-      :owner => @owner1['key']})
-    provided_product = create_product(random_string('product'),
-      random_string('product'),
-      {:owner => @owner1['key']})
+    vip_product = create_product(random_string('product'), random_string('product'), {
+      :attributes => {
+        :support_level => 'VIP',
+        :virt_limit => "5",
+        :host_limited => 'true'
+      },
+      :owner => @owner1['key']
+    })
 
-    create_pool_and_subscription(@owner1['key'], vip_product.id, 10, [provided_product.id],
-				'', '', '', nil, nil, true)
-    create_pool_and_subscription(@owner1['key'], std_product.id, 10, [provided_product.id])
+    std_product = create_product(random_string('product'), random_string('product'), {
+      :attributes => {
+        :support_level => 'Standard',
+        :virt_limit => "5",
+        :host_limited => 'true'
+      },
+      :owner => @owner1['key']
+    })
 
-    installed = [
-        {'productId' => provided_product.id, 'productName' => provided_product.name}]
+    provided_product = create_product(random_string('product'), random_string('product'), {
+      :owner => @owner1['key']
+    })
+
+    @cp.create_pool(@owner1['key'], vip_product.id, {
+      :quantity => 10,
+      :provided_products => [provided_product.id],
+      :subscription_id => random_string('source_sub'),
+      :upstream_pool_id => random_string('upstream')
+    })
+
+    @cp.create_pool(@owner1['key'], std_product.id, {
+      :quantity => 10,
+      :provided_products => [provided_product.id],
+      :subscription_id => random_string('source_sub'),
+      :upstream_pool_id => random_string('upstream')
+    })
+
+    installed = [{'productId' => provided_product.id, 'productName' => provided_product.name}]
 
     user_cp = user_client(@owner1, random_string('test-user'))
     host_consumer = user_cp.register(random_string('host'), :system, nil, {}, nil, nil, [], [])

--- a/server/spec/core_and_ram_spec.rb
+++ b/server/spec/core_and_ram_spec.rb
@@ -8,32 +8,42 @@ describe 'Core and RAM Limiting' do
     @owner = create_owner random_string('test_owner')
 
     # Create a product limiting by core and sockets and ram.
-    @core_and_socket_product = create_product(nil, random_string("Product1"), :attributes =>
-                {:version => '1.2',
-                 :cores => 16,
-                 :ram => 8,
-                 :sockets => 4,
-                 :warning_period => 15,
-                 :management_enabled => true,
-                 :support_level => 'standard',
-                 :support_type => 'excellent',})
-    @core_socket_pool = create_pool_and_subscription(@owner['key'], @core_and_socket_product.id, 10,
-                                              [], '18881', '1222')
+    @core_and_socket_product = create_product(nil, random_string("Product1"), :attributes => {
+      :version => '1.2',
+      :cores => 16,
+      :ram => 8,
+      :sockets => 4,
+      :warning_period => 15,
+      :management_enabled => true,
+      :support_level => 'standard',
+      :support_type => 'excellent',
+    })
+
+    @core_socket_pool = @cp.create_pool(@owner['key'], @core_and_socket_product.id, {
+      :quantity => 10,
+      :contract_number => '18881',
+      :account_number => '1222'
+    })
 
     # Create a product limiting by core and sockets and ram for multi-entitlement.
-    @core_and_socket_product_2 = create_product(nil, random_string("Product1"), :attributes =>
-                {:version => '1.2',
-                 :cores => 16,
-                 :ram => 8,
-                 :sockets => 4,
-                 :warning_period => 15,
-                 :management_enabled => true,
-                 :support_level => 'standard',
-                 :support_type => 'excellent',
-                 :'multi-entitlement' => 'yes',
-                 :stacking_id => '88888888'})
-    @core_socket_pool_2 = create_pool_and_subscription(@owner['key'], @core_and_socket_product_2.id, 100,
-                                              [], '18882', '1223')
+    @core_and_socket_product_2 = create_product(nil, random_string("Product1"), :attributes => {
+      :version => '1.2',
+      :cores => 16,
+      :ram => 8,
+      :sockets => 4,
+      :warning_period => 15,
+      :management_enabled => true,
+      :support_level => 'standard',
+      :support_type => 'excellent',
+      :'multi-entitlement' => 'yes',
+      :stacking_id => '88888888'
+    })
+
+    @core_socket_pool_2 = @cp.create_pool(@owner['key'], @core_and_socket_product_2.id, {
+      :quantity => 100,
+      :contract_number => '18882',
+      :account_number => '1223'
+    })
 
     @user = user_client(@owner, random_string('test-user'))
   end
@@ -239,14 +249,11 @@ describe 'Core and RAM Limiting' do
       :owner => owner['key']
     )
 
-    installed = [
-        {'productId' => prod1.id, 'productName' => prod1.name},
-    ]
+    installed = [{'productId' => prod1.id, 'productName' => prod1.name}]
     system.update_consumer({:installedProducts => installed})
 
-    create_pool_and_subscription(owner['key'], prod1.id, 2,
-				[], '', '', '', nil, nil, true)
-    create_pool_and_subscription(owner['key'], prod2.id, 3)
+    @cp.create_pool(owner['key'], prod1.id, {:quantity => 2})
+    @cp.create_pool(owner['key'], prod2.id, {:quantity => 3})
 
     entitlements=[]
     for pool in system.list_owner_pools(owner['key']) do

--- a/server/spec/core_spec.rb
+++ b/server/spec/core_spec.rb
@@ -8,26 +8,37 @@ describe 'Core Limiting' do
     @owner = create_owner random_string('test_owner')
 
     # Create a product limiting by core only.
-    @core_product = create_product(nil, random_string("Product1"), :attributes =>
-                {:version => '6.4',
-                 :cores => 8,
-                 :warning_period => 15,
-                 :management_enabled => true,
-                 :support_level => 'standard',
-                 :support_type => 'excellent',})
-    @core_pool = create_pool_and_subscription(@owner['key'], @core_product.id, 10, [], '1888', '1234')
+    @core_product = create_product(nil, random_string("Product1"), :attributes => {
+      :version => '6.4',
+      :cores => 8,
+      :warning_period => 15,
+      :management_enabled => true,
+      :support_level => 'standard',
+      :support_type => 'excellent',
+    })
+
+    @core_pool = @cp.create_pool(@owner['key'], @core_product.id, {
+      :quantity => 10,
+      :contract_number => '1888',
+      :account_number => '1234'
+    })
 
     # Create a product limiting by core and sockets.
-    @core_and_socket_product = create_product(nil, random_string("Product2"), :attributes =>
-                {:version => '1.2',
-                 :cores => 16,
-                 :sockets => 4,
-                 :warning_period => 15,
-                 :management_enabled => true,
-                 :support_level => 'standard',
-                 :support_type => 'excellent',})
-    @core_socket_pool = create_pool_and_subscription(@owner['key'], @core_and_socket_product.id, 10,
-                                              [], '18881', '1222')
+    @core_and_socket_product = create_product(nil, random_string("Product2"), :attributes => {
+      :version => '1.2',
+      :cores => 16,
+      :sockets => 4,
+      :warning_period => 15,
+      :management_enabled => true,
+      :support_level => 'standard',
+      :support_type => 'excellent',
+    })
+
+    @core_socket_pool = @cp.create_pool(@owner['key'], @core_and_socket_product.id, {
+      :quantity => 10,
+      :contract_number => '18881',
+      :account_number => '1222'
+    })
 
     @user = user_client(@owner, random_string('test-user'))
   end

--- a/server/spec/custom_product_spec.rb
+++ b/server/spec/custom_product_spec.rb
@@ -13,19 +13,27 @@ describe 'Custom Product' do
  it 'create custom products and subscribe' do
     owner_client = user_client(@owner, random_string('testuser'))
 
-    product1 = create_product(
-        @owner['key'] + '_product_1', @owner['key'] + '_product_1', {:custom => false}
-    )
-    product2 = create_product(
-        'bacon', @owner['key'] + '_product_2', {:custom => true}
-    )
+    product1 = create_product(@owner['key'] + '_product_1', @owner['key'] + '_product_1', {:custom => false})
+    product2 = create_product('bacon', @owner['key'] + '_product_2', {:custom => true})
     content = create_content({:metadata_expire => 6000, :required_tags => "TAG1,TAG2"})
+
     @cp.add_content_to_product(@owner['key'], product1.id, content.id)
     @cp.add_content_to_product(@owner['key'], product2.id, content.id)
     @end_date = Date.new(2025, 5, 29)
 
-    create_pool_and_subscription(@owner['key'], product1.id, 2, [], '', '12345', '6789', nil, @end_date, true)
-    create_pool_and_subscription(@owner['key'], product2.id, 4, [], '', '12345', '6789', nil, @end_date)
+    @cp.create_pool(@owner['key'], product1.id, {
+      :quantity => 2,
+      :contract_number => '12345',
+      :account_number => '6789',
+      :end_date => @end_date
+    })
+
+    @cp.create_pool(@owner['key'], product2.id, {
+      :quantity => 4,
+      :contract_number => '12345',
+      :account_number => '6789',
+      :end_date => @end_date
+    })
 
     pool1 = @cp.list_pools(:owner => @owner.id, :product => product1.id)[0]
     pool2 = @cp.list_pools(:owner => @owner.id, :product => product2.id)[0]
@@ -36,7 +44,6 @@ describe 'Custom Product' do
 
     product1.id.should == @owner['key'] + '_product_1'
     product2.id.should_not == ''
-
  end
 
 

--- a/server/spec/derived_product_import_spec.rb
+++ b/server/spec/derived_product_import_spec.rb
@@ -43,17 +43,20 @@ describe 'Import', :serial => true do
         'multi-entitlement' => "yes"
       }
     })
+
     derived_product = create_product(nil, nil, {
       :attributes => {
           :cores => '6',
           :sockets=>'8'
       }
     })
-    datacenter_pool = create_pool_and_subscription(@owner['key'], stacked_datacenter_product.id,
-      10, [], '222', '', '', nil, nil, false,
-      {
-        :derived_product_id => derived_product.id
-      })
+
+    datacenter_pool = @cp.create_pool(@owner['key'], stacked_datacenter_product.id, {
+      :quantity => 10,
+      :contract_number => '222',
+      :derived_product_id => derived_product.id
+    })
+
     pool = @cp.list_owner_pools(@owner['key'], {:product => stacked_datacenter_product.id})[0]
 
     # create the distributor consumer
@@ -70,7 +73,7 @@ describe 'Import', :serial => true do
 
     # remove client at 'host'
     consumer_client.unregister consumer_client.uuid
-    delete_pool_and_subscription(datacenter_pool)
+    @cp.delete_pool(datacenter_pool['id'])
 
     # import to make org at 'distributor'
     import_user_client = user_client(@dist_owner, random_string("user"))
@@ -117,7 +120,7 @@ describe 'Import', :serial => true do
     # remove created subs
     @cp.list_owner_pools(@dist_owner['key']).each do |p|
         if p.type == 'NORMAL' then
-          delete_pool_and_subscription(p)
+          @cp.delete_pool(p['id'])
         end
     end
   end

--- a/server/spec/distributor_capability_spec.rb
+++ b/server/spec/distributor_capability_spec.rb
@@ -137,18 +137,20 @@ describe 'Distributor Capability' do
   # shows blocking for capability deficiency as well as showing
   # distributor consumers not needing cert version validation
   it 'can stop bind based on consumer capabilities' do
-    @product = create_product(nil, nil, :attributes =>
-                {:cores => 8})
-    create_pool_and_subscription(@owner['key'], @product.id, 10, [], '12345', '6789', 'order1')
+    @product = create_product(nil, nil, :attributes => {:cores => 8})
+    @cp.create_pool(@owner['key'], @product.id, {
+      :quantity => 10,
+      :contract_number => '12345',
+      :account_number => '6789',
+      :order_number => 'order1'
+    })
 
     consumer = @user.register(random_string("consumer"), :candlepin, nil, {})
     entitlements = @cp.consume_product(@product.id, {:uuid => consumer.uuid})
     entitlements.should == []
 
     name = random_string("WidgetvBillion")
-    create_distributor_version(name,
-                                "Widget Billion",
-                               ["cores"])
+    create_distributor_version(name, "Widget Billion", ["cores"])
     facts = {
       'distributor_version' => name
     }

--- a/server/spec/domain_consumer_spec.rb
+++ b/server/spec/domain_consumer_spec.rb
@@ -12,9 +12,8 @@ describe 'Domain Consumer' do
         :attributes => { :requires_consumer_type => :domain }
     })
 
-    create_pool_and_subscription(@owner['key'], @monitoring.id, 4,
-				[], '', '', '', nil, nil, true)
-    create_pool_and_subscription(@owner['key'], @domain_product.id, 4)
+    @cp.create_pool(@owner['key'], @monitoring.id, {:quantity => 4})
+    @cp.create_pool(@owner['key'], @domain_product.id, {:quantity => 4})
   end
 
   it 'should not be able to consume non domain specific products' do

--- a/server/spec/entitlement_migrate_spec.rb
+++ b/server/spec/entitlement_migrate_spec.rb
@@ -7,9 +7,8 @@ describe 'Entitlement Migrate' do
 
   before(:each) do
     @owner = create_owner random_string 'owner'
-    @product = create_product(nil, random_string('product'),
-                 :attributes => {:cores => 8})
-    create_pool_and_subscription(@owner['key'], @product.id, 25)
+    @product = create_product(nil, random_string('product'), :attributes => {:cores => 8})
+    @cp.create_pool(@owner['key'], @product.id, {:quantity => 25})
 
     #create consumer
     @user = user_client(@owner, random_string('user'))

--- a/server/spec/entitlement_spec.rb
+++ b/server/spec/entitlement_spec.rb
@@ -8,43 +8,66 @@ describe 'Entitlements' do
   before(:each) do
     @owner = create_owner random_string 'test_owner'
     @monitoring = create_product(nil, random_string('monitoring'))
-    @virt = create_product(nil, random_string('virtualization_host'),
-      {:attributes => {"multi-entitlement" => "yes"}})
-    @super_awesome = create_product(nil, random_string('super_awesome'),
-                                    :attributes => {
-                                      'cpu.cpu_socket(s)' => 4,
-                                      'variant' => "Satellite Starter Pack"
-                                    })
-    @virt_limit = create_product(nil, random_string('virt_limit'),
-      {:attributes => {"virt_limit" => "10"}})
 
-    @instance_based = create_product(nil, random_string('instance_based'),
-                                    :attributes => { 'instance_multiplier' => 2,
-                                        'multi-entitlement' => 'yes' })
+    @virt = create_product(nil, random_string('virtualization_host'), :attributes => {
+      "multi-entitlement" => "yes"
+    })
+
+    @super_awesome = create_product(nil, random_string('super_awesome'), :attributes => {
+      'cpu.cpu_socket(s)' => 4,
+      'variant' => "Satellite Starter Pack"
+    })
+
+    @virt_limit = create_product(nil, random_string('virt_limit'), :attributes => {
+      "virt_limit" => "10"
+    })
+
+    @instance_based = create_product(nil, random_string('instance_based'), :attributes => {
+      'instance_multiplier' => 2,
+      'multi-entitlement' => 'yes'
+    })
 
     @ram = @cp.create_product(@owner['key'], random_string("ram-pack"), random_string("RAM Limiting Package"), {
       :attributes => {"ram" => "4"}})
 
     @ram_provided = create_product(nil, random_string("ram provided"), {})
-    content = create_content({:metadata_expire => 6000,
-                                  :required_tags => "TAG1,TAG2"})
-    content2 = create_content({:metadata_expire => 6000,
-                                      :required_tags => "TAG1,TAG2"})
+    content = create_content({:metadata_expire => 6000, :required_tags => "TAG1,TAG2"})
+    content2 = create_content({:metadata_expire => 6000, :required_tags => "TAG1,TAG2"})
     @cp.add_content_to_product(@owner['key'], @ram_provided.id, content.id)
     @cp.add_content_to_product(@owner['key'], @ram_provided.id, content2.id)
 
     #entitle owner for the virt and monitoring products.
-    create_pool_and_subscription(@owner['key'], @virt.id, 20,
-				[], '', '', '', nil, nil, true)
-    create_pool_and_subscription(@owner['key'], @monitoring.id, 4,
-				[], '', '', '', nil, nil, true)
-    create_pool_and_subscription(@owner['key'], @super_awesome.id, 4,
-				[], '', '', '', nil, nil, true)
-    create_pool_and_subscription(@owner['key'], @virt_limit.id, 5,
-				[], '', '', '', nil, nil, true)
-    create_pool_and_subscription(@owner['key'], @instance_based.id, 10,
-				[], '', '', '', nil, nil, true)
-    create_pool_and_subscription(@owner['key'], @ram.id, 4, [@ram_provided.id])
+    @cp.create_pool(@owner['key'], @virt.id, {
+      :quantity => 20,
+      :subscription_id => random_string('source_sub'),
+      :upstream_pool_id => random_string('upstream')
+    })
+    @cp.create_pool(@owner['key'], @monitoring.id, {
+      :quantity => 4,
+      :subscription_id => random_string('source_sub'),
+      :upstream_pool_id => random_string('upstream')
+    })
+    @cp.create_pool(@owner['key'], @super_awesome.id, {
+      :quantity => 4,
+      :subscription_id => random_string('source_sub'),
+      :upstream_pool_id => random_string('upstream')
+    })
+    @cp.create_pool(@owner['key'], @virt_limit.id, {
+      :quantity => 5,
+      :subscription_id => random_string('source_sub'),
+      :upstream_pool_id => random_string('upstream')
+    })
+    @cp.create_pool(@owner['key'], @instance_based.id, {
+      :quantity => 10,
+      :subscription_id => random_string('source_sub'),
+      :upstream_pool_id => random_string('upstream')
+    })
+    @cp.create_pool(@owner['key'], @ram.id, {
+      :quantity => 4,
+      :provided_products => [@ram_provided.id],
+      :subscription_id => random_string('source_sub'),
+      :upstream_pool_id => random_string('upstream')
+    })
 
     #create consumer
     @user = user_client(@owner, random_string('billy'))

--- a/server/spec/environment_cert_v3_spec.rb
+++ b/server/spec/environment_cert_v3_spec.rb
@@ -34,7 +34,7 @@ describe 'Environments Certificate V3' do
         }])
     wait_for_job(job['id'], 15)
 
-    pool = create_pool_and_subscription(@owner['key'], product['id'], 10)
+    pool = @cp.create_pool(@owner['key'], product['id'], {:quantity => 10})
     ent = consumer_cp.consume_pool(pool['id'], {:quantity => 1})[0]
 
     value = extension_from_cert(ent['certificates'][0]['cert'], "1.3.6.1.4.1.2312.9.6")
@@ -62,13 +62,10 @@ describe 'Environments Certificate V3' do
     @cp.add_content_to_product(@owner['key'], product['id'], content2['id'])
 
     # Override enabled to false:
-    job = @org_admin.promote_content(@env['id'],
-        [{
-          :contentId => content['id']
-        }])
+    job = @org_admin.promote_content(@env['id'], [{ :contentId => content['id'] }])
     wait_for_job(job['id'], 15)
 
-    pool = create_pool_and_subscription(@owner['key'], product['id'], 10)
+    pool = @cp.create_pool(@owner['key'], product['id'], {:quantity => 10})
     ent = consumer_cp.consume_pool(pool['id'], {:quantity => 1})[0]
 
     value = extension_from_cert(ent['certificates'][0]['cert'], "1.3.6.1.4.1.2312.9.6")

--- a/server/spec/environment_spec.rb
+++ b/server/spec/environment_spec.rb
@@ -223,7 +223,7 @@ describe 'Environments' do
         }])
     wait_for_job(job['id'], 15)
 
-    pool = create_pool_and_subscription(@owner['key'], product['id'], 10)
+    pool = @cp.create_pool(@owner['key'], product['id'], {:quantity => 10})
     ent = consumer_cp.consume_pool(pool['id'], {:quantity => 1})[0]
 
     x509 = OpenSSL::X509::Certificate.new(ent['certificates'][0]['cert'])
@@ -254,7 +254,7 @@ describe 'Environments' do
         }])
     wait_for_job(job['id'], 15)
 
-    pool = create_pool_and_subscription(@owner['key'], product['id'], 10)
+    pool = @cp.create_pool(@owner['key'], product['id'], {:quantity => 10})
     ent = consumer_cp.consume_pool(pool['id'], {:quantity => 1})[0]
 
     x509 = OpenSSL::X509::Certificate.new(ent['certificates'][0]['cert'])

--- a/server/spec/hypervisor_check_in_spec.rb
+++ b/server/spec/hypervisor_check_in_spec.rb
@@ -729,8 +729,8 @@ describe 'Hypervisor Resource', :type => :virt do
       {'virt.uuid' => uuid1, 'virt.is_guest' => 'true'}, nil, owner['key'], [], [])
     # Create a product/subscription
     super_awesome = create_product(nil, random_string('super_awesome'),
-                            :attributes => { "virt_limit" => "10", "host_limited" => "true" }, :owner => owner['key'])
-    create_pool_and_subscription(owner['key'], super_awesome.id, 20)
+      :attributes => { "virt_limit" => "10", "host_limited" => "true" }, :owner => owner['key'])
+    @cp.create_pool(owner['key'], super_awesome.id, {:quantity => 20})
     consumer_client = Candlepin.new(nil, nil, host_consumer['idCert']['cert'], host_consumer['idCert']['key'])
     new_consumer_client = Candlepin.new(nil, nil, new_host_consumer['idCert']['cert'], new_host_consumer['idCert']['key'])
     guest_client = Candlepin.new(nil, nil, guest_consumer['idCert']['cert'], guest_consumer['idCert']['key'])
@@ -788,8 +788,8 @@ describe 'Hypervisor Resource', :type => :virt do
       {'virt.uuid' => uuid1, 'virt.is_guest' => 'true'}, nil, owner['key'], [], [])
     # Create a product/subscription
     super_awesome = create_product(nil, random_string('super_awesome'),
-                            :attributes => { "virt_limit" => "10", "host_limited" => "true" }, :owner => owner['key'])
-    create_pool_and_subscription(owner['key'], super_awesome.id, 20)
+      :attributes => { "virt_limit" => "10", "host_limited" => "true" }, :owner => owner['key'])
+    @cp.create_pool(owner['key'], super_awesome.id, {:quantity => 20})
     consumer_client = Candlepin.new(nil, nil, host_consumer['idCert']['cert'], host_consumer['idCert']['key'])
     new_consumer_client = Candlepin.new(nil, nil, new_host_consumer['idCert']['cert'], new_host_consumer['idCert']['key'])
     guest_client = Candlepin.new(nil, nil, guest_consumer['idCert']['cert'], guest_consumer['idCert']['key'])
@@ -876,8 +876,10 @@ describe 'Hypervisor Resource', :type => :virt do
       "sockets" => 1,
       "instance_multiplier" => 2,
       "multi-entitlement" => "yes",
-      "host_limited" => "true"}})
-    create_pool_and_subscription(owner['key'], prod1['id'], 10, [prod['id']])
+      "host_limited" => "true"}
+    })
+
+    @cp.create_pool(owner['key'], prod1['id'], {:quantity => 10, :provided_products => [prod['id']]})
 
     guest_facts = {
       "virt.is_guest"=>"true",

--- a/server/spec/instance_spec.rb
+++ b/server/spec/instance_spec.rb
@@ -11,8 +11,7 @@ describe 'Instance Based Subscriptions' do
 
     #create_product() creates products with numeric IDs by default
     @eng_product = create_product()
-    installed_prods = [{'productId' => @eng_product['id'],
-      'productName' => @eng_product['name']}]
+    installed_prods = [{'productId' => @eng_product['id'], 'productName' => @eng_product['name']}]
 
     # For linking the host and the guest:
     @uuid = random_string('system.uuid')
@@ -38,24 +37,22 @@ describe 'Instance Based Subscriptions' do
       }
     })
 
-    create_pool_and_subscription(@owner['key'], @instance_product.id,
-      10, [@eng_product['id']])
-    @pools = @cp.list_pools :owner => @owner.id, \
-      :product => @instance_product.id
+    @cp.create_pool(@owner['key'], @instance_product.id, {
+      :quantity => 10,
+      :provided_products => [@eng_product['id']],
+      :subscription_id => random_string('source_sub'),
+      :upstream_pool_id => random_string('upstream')
+    })
+
+    @pools = @cp.list_pools :owner => @owner.id, :product => @instance_product.id
     @pools.size.should == 2
     instance_pools = @pools.reject do |p|
       has_attribute(p['attributes'], 'unmapped_guests_only')
     end
     instance_pools.size.should == 1
-    # In hosted, we increase the quantity on the subscription. However in standalone,
-    # we assume this already has happened in hosted and the accurate quantity was
-    # exported
+
     @instance_pool = instance_pools.first
-    if is_hosted?
-      @instance_pool.quantity.should == 20
-    else
-      @instance_pool.quantity.should == 10
-    end
+    @instance_pool.quantity.should == 10
   end
 
   it 'should auto-subscribe physical systems with quantity 2 per socket pair' do

--- a/server/spec/job_status_spec.rb
+++ b/server/spec/job_status_spec.rb
@@ -10,7 +10,7 @@ describe 'Job Status' do
     @user = user_client(@owner, random_string("test_user"))
     @monitoring = create_product
 
-    create_pool_and_subscription(@owner['key'], @monitoring.id, 4)
+    @cp.create_pool(@owner['key'], @monitoring.id, {:quantity => 4})
   end
 
   it 'should contain the owner key' do
@@ -43,7 +43,7 @@ describe 'Job Status' do
   it 'should only find jobs with the correct owner key' do
     owner2 = create_owner(random_string('some_owner'))
     product = create_product(nil, nil, :owner => owner2['key'])
-    create_pool_and_subscription(owner2['key'], product.id, 100)
+    @cp.create_pool(owner2['key'], product.id, {:quantity => 100})
 
     jobs = []
     # Just some random numbers here

--- a/server/spec/multiplier_spec.rb
+++ b/server/spec/multiplier_spec.rb
@@ -11,7 +11,7 @@ describe 'Multiplier Products' do
 
   it 'should have the correct quantity' do
     calendaring = create_product('8723775392', 'Calendaring - 25 Pack', :multiplier => 25)
-    create_pool_and_subscription(@owner['key'], calendaring.id, 4)
+    @cp.create_pool(@owner['key'], calendaring.id, {:quantity => 4})
 
     pools = @user.list_pools :owner => @owner.id
 
@@ -21,7 +21,7 @@ describe 'Multiplier Products' do
 
   it 'should default the multiplier to 1 if it is negative' do
     product = create_product('23049', 'Some Product', :multiplier => -10)
-    create_pool_and_subscription(@owner['key'], product.id, 34)
+    @cp.create_pool(@owner['key'], product.id, {:quantity => 34})
 
     pools = @user.list_pools :owner => @owner.id
 
@@ -31,7 +31,7 @@ describe 'Multiplier Products' do
 
   it 'should default the multiplier to 1 if it is zero' do
     product = create_product('9382533329', 'Some Other Product', :multiplier => 0)
-    create_pool_and_subscription(@owner['key'], product.id, 18)
+    @cp.create_pool(@owner['key'], product.id, {:quantity => 18})
 
     pools = @user.list_pools :owner => @owner.id
 
@@ -41,7 +41,7 @@ describe 'Multiplier Products' do
 
   it 'should have the correct quantity after a refresh' do
     product = create_product('875875844', 'Product - 100 Pack', :multiplier => 100)
-    create_pool_and_subscription(@owner['key'], product.id, 5)
+    @cp.create_pool(@owner['key'], product.id, {:quantity => 5})
 
     # Now we refresh again to update the pool
     @cp.refresh_pools @owner['key']

--- a/server/spec/one_sub_pool_per_stack_spec.rb
+++ b/server/spec/one_sub_pool_per_stack_spec.rb
@@ -83,32 +83,57 @@ describe 'One Sub Pool Per Stack' do
 
     @stacked_provided_product2 =  create_product()
 
-    create_pool_and_subscription(@owner['key'],
-      @virt_limit_product.id, 10, [@virt_limit_provided_product.id], "123", "321", "333",
-      nil, nil, true)
-    create_pool_and_subscription(@owner['key'],
-      @virt_limit_product.id, 10, [], "456", '', '', nil, @now + 380, true)
-    create_pool_and_subscription(@owner['key'],
-      @virt_limit_product2.id, 10, [], "444", '', '', nil, @now + 380, true)
-    create_pool_and_subscription(@owner['key'],
-      @regular_stacked_product.id, 4, [@regular_stacked_provided_product.id], "789",
-      "","", nil, nil, true)
-    create_pool_and_subscription(@owner['key'],
-      @non_stacked_product.id, 2, [], "234", "", "", nil, nil, true)
-    create_pool_and_subscription(@owner['key'], @stacked_datacenter_product.id,
-      10, [], '222', '', '', nil, nil, true,
-      {
-        :derived_product_id => @derived_product.id,
-        :derived_provided_products => [@derived_provided_product.id]
-      })
-    create_pool_and_subscription(@owner['key'],
-      @stacked_product_diff_id.id, 2, [], "888", '', '', @now - 3, @now + 6)
+    @cp.create_pool(@owner['key'], @virt_limit_product.id, {
+      :quantity => 10,
+      :provided_products => [@virt_limit_provided_product.id],
+      :contract_number => "123",
+      :account_number => "321",
+      :order_number => "333",
+    })
+
+    @cp.create_pool(@owner['key'], @virt_limit_product.id, {
+      :quantity => 10,
+      :contract_number => "456",
+      :end_date => @now + 380,
+    })
+
+    @cp.create_pool(@owner['key'], @virt_limit_product2.id, {
+      :quantity => 10,
+      :contract_number => "444",
+      :end_date => @now + 380,
+    })
+
+    @cp.create_pool(@owner['key'], @regular_stacked_product.id, {
+      :quantity => 4,
+      :provided_products => [@regular_stacked_provided_product.id],
+      :contract_number => "789",
+    })
+
+    @cp.create_pool(@owner['key'], @non_stacked_product.id, {
+      :quantity => 2,
+      :contract_number => "234",
+    })
+
+    @cp.create_pool(@owner['key'], @stacked_datacenter_product.id, {
+      :quantity => 10,
+      :contract_number => '222',
+      :derived_product_id => @derived_product.id,
+      :derived_provided_products => [@derived_provided_product.id],
+    })
+
+    @cp.create_pool(@owner['key'], @stacked_product_diff_id.id, {
+      :quantity => 2,
+      :contract_number => "888",
+      :start_date => @now - 3,
+      :end_date => @now + 6,
+    })
 
     # Determine our pools by matching on contract number.
     pools = @user.list_pools :owner => @owner.id
 
     # test does not use unmapped guest pools
     filter_unmapped_guest_pools(pools)
+
 
     @initial_pool_count = pools.size
     @initial_pool_count.should == 7

--- a/server/spec/owner_content_resource_spec.rb
+++ b/server/spec/owner_content_resource_spec.rb
@@ -111,7 +111,11 @@ describe 'Owner Content Resource' do
   it 'should force entitlements providing changed content to be regenerated' do
     # tests standalone mode specific API. in hosted, we refresh, so this test is captured in refresh spec.
     skip("candlepin running in hosted mode") if is_hosted?
-    product_pool = create_pool_and_subscription(@owner['key'], @product.id, 100, [], '1888', '1234')
+    product_pool = @cp.create_pool(@owner['key'], @product.id, {
+      :quantity => 100,
+      :contract_number => '1888',
+      :account_number => '1234'
+    })
     consumer_client = consumer_client(@user,  random_string("consumer"))
 
     consumer_client.consume_pool(product_pool.id, {:quantity => 1})

--- a/server/spec/owner_product_resource_spec.rb
+++ b/server/spec/owner_product_resource_spec.rb
@@ -12,12 +12,13 @@ describe 'Owner Product Resource' do
     @derived_product = create_product random_string('derived_product')
     @derived_prov_product = create_product random_string('derived_provided_product')
 
-    create_pool_and_subscription(@owner['key'], @product.id,
-      10, [@prov_product.id], '222', '', '', nil, nil, false,
-      {
-        :derived_product_id => @derived_product.id,
-        :derived_provided_products => [@derived_prov_product.id]
-      })
+    @cp.create_pool(@owner['key'], @product.id, {
+      :quantity => 10,
+      :provided_products => [@prov_product.id],
+      :contract_number => '222',
+      :derived_product_id => @derived_product.id,
+      :derived_provided_products => [@derived_prov_product.id]
+    })
   end
 
   it 'should fail when fetching non-existing products' do
@@ -104,7 +105,7 @@ describe 'Owner Product Resource' do
     owner = create_owner(random_string('owner'), nil)
     product = create_product(random_string("test_id"), random_string("test_name"), {:owner => owner['key']})
     provided_product = create_product(nil, nil, {:owner => owner['key']})
-    create_pool_and_subscription(owner['key'], product.id, 10, [provided_product.id])
+    @cp.create_pool(owner['key'], product.id, {:quantity => 10, :provided_products => [provided_product.id]})
     user = user_client(owner, random_string('billy'))
     system = consumer_client(user, 'system6')
     system.consume_product(product.id)
@@ -128,7 +129,7 @@ describe 'Owner Product Resource' do
 
     provided_product = create_product(nil, nil, {:owner => owner['key']})
 
-    create_pool_and_subscription(owner['key'], product.id, 10, [provided_product.id])
+    @cp.create_pool(owner['key'], product.id, {:quantity => 10, :provided_products => [provided_product.id]})
 
     pool = owner_client.list_pools(:owner => owner.id)
     pool.length.should eq(1)
@@ -318,51 +319,27 @@ describe 'Owner Product Resource' do
   end
 
   it 'bad request on attempt to delete product attached to sub' do
-    if is_hosted? then
-      lambda do
-        @cp.delete_product(@owner['key'], @product.id)
-      end.should raise_exception(RestClient::Forbidden)
-    else
-      lambda do
-        @cp.delete_product(@owner['key'], @product.id)
-      end.should raise_exception(RestClient::BadRequest)
-    end
+    lambda do
+      @cp.delete_product(@owner['key'], @product.id)
+    end.should raise_exception(RestClient::BadRequest)
   end
 
   it 'bad request on attempt to delete provided product attached to sub' do
-    if is_hosted? then
-      lambda do
-        @cp.delete_product(@owner['key'], @prov_product.id)
-      end.should raise_exception(RestClient::Forbidden)
-    else
-      lambda do
-        @cp.delete_product(@owner['key'], @prov_product.id)
-      end.should raise_exception(RestClient::BadRequest)
-    end
+    lambda do
+      @cp.delete_product(@owner['key'], @prov_product.id)
+    end.should raise_exception(RestClient::BadRequest)
   end
 
   it 'bad request on attempt to delete derived product attached to sub' do
-    if is_hosted? then
-      lambda do
-        @cp.delete_product(@owner['key'], @derived_product.id)
-      end.should raise_exception(RestClient::Forbidden)
-    else
-      lambda do
-        @cp.delete_product(@owner['key'], @derived_product.id)
-      end.should raise_exception(RestClient::BadRequest)
-    end
+    lambda do
+      @cp.delete_product(@owner['key'], @derived_product.id)
+    end.should raise_exception(RestClient::BadRequest)
   end
 
   it 'bad request on attempt to delete derived provided product attached to sub' do
-    if is_hosted? then
-      lambda do
-        @cp.delete_product(@owner['key'], @derived_prov_product.id)
-      end.should raise_exception(RestClient::Forbidden)
-    else
-      lambda do
-        @cp.delete_product(@owner['key'], @derived_prov_product.id)
-      end.should raise_exception(RestClient::BadRequest)
-    end
+    lambda do
+      @cp.delete_product(@owner['key'], @derived_prov_product.id)
+    end.should raise_exception(RestClient::BadRequest)
   end
 end
 

--- a/server/spec/owner_resource_spec.rb
+++ b/server/spec/owner_resource_spec.rb
@@ -45,7 +45,7 @@ describe 'Owner Resource' do
         :owner => owner['key']
       }
     )
-    create_pool_and_subscription(owner['key'], product1.id, 10)
+    @cp.create_pool(owner['key'], product1.id, {:quantity => 10})
 
     levels = consumer_client.list_owner_service_levels(owner['key'])
     levels.size.should == 1
@@ -78,7 +78,7 @@ describe 'Owner Resource' do
   it "lets owners list pools" do
     owner = create_owner random_string("test_owner1")
     product = create_product(nil, nil, :owner => owner['key'])
-    create_pool_and_subscription(owner['key'], product.id, 10)
+    @cp.create_pool(owner['key'], product.id, {:quantity => 10})
     pools = @cp.list_owner_pools(owner['key'])
     pools.length.should == 1
   end
@@ -87,22 +87,24 @@ describe 'Owner Resource' do
     owner = create_owner random_string("test_owner1")
     product = create_product(nil, nil, :owner => owner['key'])
     (1..4).each do |i|
-      create_pool_and_subscription(owner['key'], product.id, 10)
+      @cp.create_pool(owner['key'], product.id, {:quantity => 10})
     end
     pools = @cp.list_owner_pools(owner['key'], {:page => 1, :per_page => 2, :sort_by => "id", :order => "asc"})
     pools.length.should == 2
     (pools[0].id <=> pools[1].id).should == -1
   end
 
-  it "lets owners update subscription" do
+  it "lets owners update pools" do
     owner = create_owner random_string("test_owner1")
     product = create_product(nil, nil, :owner => owner['key'])
-    pool = create_pool_and_subscription(owner['key'], product.id, 10)
-    poolOrSub = get_pool_or_subscription(pool)
+
+    pool = @cp.create_pool(owner['key'], product.id, {:quantity => 10})
+
     tomorrow = (DateTime.now + 1)
-    poolOrSub.startDate = tomorrow
-    update_pool_or_subscription(poolOrSub)
-    updatedPool = @cp.get_pool(pool.id)
+    pool.startDate = tomorrow
+
+    @cp.update_pool(owner['key'], pool)
+    updatedPool = @cp.get_pool(pool['id']);
 
     # parse the received start date and convert it back to our local time zone
     startDate = DateTime.strptime(updatedPool.startDate).new_offset(tomorrow.offset)
@@ -116,7 +118,7 @@ describe 'Owner Resource' do
     system = consumer_client(user, "system")
     product = create_product(nil, nil, :owner => owner['key'])
     (1..4).each do |i|
-      create_pool_and_subscription(owner['key'], product.id, 10)
+      @cp.create_pool(owner['key'], product.id, {:quantity => 10})
     end
     # Make sure there are 4 available pools
     @cp.list_owner_pools(owner['key'], {:consumer => system.uuid}).length.should == 4
@@ -157,7 +159,7 @@ describe 'Owner Resource' do
     rw_owner_client = user_client(owner, random_string('testuser'), false)
     super_admin_client = user_client(owner, random_string('testuser'), false, true)
     product = create_product(nil, nil, :owner => owner['key'])
-    create_pool_and_subscription(owner['key'], product.id, 10)
+    @cp.create_pool(owner['key'], product.id, {:quantity => 10})
 
     lambda do
       ro_owner_client.refresh_pools(owner['key'])
@@ -220,7 +222,7 @@ describe 'Owner Resource' do
         :owner => owner['key']
       }
     )
-    create_pool_and_subscription(owner['key'], product1.id, 10)
+    @cp.create_pool(owner['key'], product1.id, {:quantity => 10})
     owner = @cp.get_owner(owner['key'])
     owner['defaultServiceLevel'].should be_nil
 
@@ -255,9 +257,8 @@ describe 'Owner Resource' do
         :owner => owner['key']
       }
     )
-    create_pool_and_subscription(owner['key'], product1.id, 10,
-      [], '', '', '', nil, nil, true)
-    create_pool_and_subscription(owner['key'], product2.id, 10)
+    @cp.create_pool(owner['key'], product1.id, {:quantity => 10})
+    @cp.create_pool(owner['key'], product2.id, {:quantity => 10})
 
     # Set an initial service level:
     owner['defaultServiceLevel'] = 'VIP'
@@ -313,7 +314,7 @@ describe 'Owner Resource' do
         :owner => owner['key']
       }
     )
-    create_pool_and_subscription(owner['key'], product1.id, 10)
+    @cp.create_pool(owner['key'], product1.id, {:quantity => 10})
     product2 = create_product(
       random_string("test_id"),
       random_string("test_name"),
@@ -324,7 +325,7 @@ describe 'Owner Resource' do
         :owner => owner['key']
       }
     )
-    create_pool_and_subscription(owner['key'], product2.id, 10)
+    @cp.create_pool(owner['key'], product2.id, {:quantity => 10})
     product3 = create_product(
       random_string("test_id"),
       random_string("test_name"),
@@ -335,7 +336,7 @@ describe 'Owner Resource' do
         :owner => owner['key']
       }
     )
-    create_pool_and_subscription(owner['key'], product3.id, 10)
+    @cp.create_pool(owner['key'], product3.id, {:quantity => 10})
     levels = @cp.list_owner_service_levels(owner['key'])
     levels.length.should == 2
   end
@@ -377,11 +378,9 @@ describe 'Owner Resource' do
       }
     )
 
-    create_pool_and_subscription(owner['key'], product1.id, 10,
-      [], '', '', '', nil, nil, true)
-    create_pool_and_subscription(owner['key'], product2.id, 10,
-      [], '', '', '', nil, nil, true)
-    create_pool_and_subscription(owner['key'], product3.id, 10)
+    @cp.create_pool(owner['key'], product1.id, {:quantity => 10})
+    @cp.create_pool(owner['key'], product2.id, {:quantity => 10})
+    @cp.create_pool(owner['key'], product3.id, {:quantity => 10})
 
     levels = consumer_client.list_owner_service_levels(owner['key'])
     levels.size.should == 1
@@ -399,7 +398,7 @@ describe 'Owner Resource' do
       random_string("test_name"),
       :owner => owner['key']
     )
-    create_pool_and_subscription(owner['key'], product.id, 10)
+    @cp.create_pool(owner['key'], product.id, {:quantity => 10})
 
     user = user_client(owner, random_string("billy"))
     system = consumer_client(user, "system")
@@ -446,7 +445,7 @@ describe 'Owner Resource' do
       random_string("test_name"),
       :owner => owner['key']
     )
-    create_pool_and_subscription(owner['key'], product.id, 10)
+    @cp.create_pool(owner['key'], product.id, {:quantity => 10})
 
     user = user_client(owner, "robot ninja")
     system = consumer_client(user, "system")
@@ -458,7 +457,7 @@ describe 'Owner Resource' do
     c = @cp.get_consumer(system.uuid)
     c['entitlementCount'].should == 1
 
-    create_pool_and_subscription(owner['key'], product.id, 10)
+    @cp.create_pool(owner['key'], product.id, {:quantity => 10})
 
     job = user.autoheal_org(owner['key'])
     wait_for_job(job['id'], 30)
@@ -611,8 +610,8 @@ describe 'Owner Resource Pool Filter Tests' do
       }
     )
 
-    create_pool_and_subscription(@owner['key'], @product1.id, 10, [], '', '', '', nil, nil, true)
-    create_pool_and_subscription(@owner['key'], @product2.id, 10)
+    @cp.create_pool(@owner['key'], @product1.id, {:quantity => 10})
+    @cp.create_pool(@owner['key'], @product2.id, {:quantity => 10})
 
     pools = @cp.list_owner_pools(@owner['key'])
     pools.length.should == 2
@@ -658,7 +657,10 @@ describe 'Owner Resource Pool Filter Tests' do
     provided_product2 = create_product(random_string("prod2"), random_string("product2"), {:owner => owner['key']})
     provided_product3 = create_product(random_string("prod3"), random_string("product3"), {:owner => owner['key']})
 
-    create_pool_and_subscription(owner['key'], product.id, 10, [provided_product.id, provided_product2.id, provided_product3.id])
+    @cp.create_pool(owner['key'], product.id, {
+      :quantity => 10,
+      :provided_products => [provided_product.id, provided_product2.id, provided_product3.id]
+    })
 
     pools = @cp.list_owner_pools(owner['key'], { :consumer => consumer.uuid, :matches => target_prod_name })
     pools.length.should eq(1)
@@ -671,7 +673,12 @@ describe 'Owner Resource Pool Filter Tests' do
 
   it 'should allow user to list standard pool by subscription id' do
       product = create_product(nil, nil)
-      pool = create_pool_and_subscription(@owner['key'], product.id, 5)
+      pool = @cp.create_pool(@owner['key'], product.id, {
+        :quantity => 5,
+        :subscription_id => random_string('source_sub'),
+        :upstream_pool_id => random_string('upstream')
+      })
+
       user = user_client(@owner, random_string('user'))
       # needs to be an owner level user
       user.get_pools_for_subscription(@owner['key'], pool.subscriptionId).size.should == 1
@@ -679,7 +686,12 @@ describe 'Owner Resource Pool Filter Tests' do
 
   it 'should allow user to list bonus pool also by subscription id' do
       product = create_product(nil, nil, {:attributes => {"virt_limit" => "unlimited"}})
-      pool = create_pool_and_subscription(@owner['key'], product.id, 5)
+      pool = @cp.create_pool(@owner['key'], product.id, {
+        :quantity => 5,
+        :subscription_id => random_string('source_sub'),
+        :upstream_pool_id => random_string('upstream')
+      })
+
       user = user_client(@owner, random_string('user'))
       # needs to be an owner level user
       user.get_pools_for_subscription(@owner['key'], pool.subscriptionId).size.should == 2
@@ -738,9 +750,17 @@ describe 'Owner Resource Owner Info Tests' do
     @owner = create_owner(random_string("an_owner"))
 
     # Create a product limiting by all of our attributes.
-    @product = create_product(nil, random_string("Product1"), :attributes =>
-                {"version" => '6.4', "sockets" => 2, "multi-entitlement" => "true"})
-    create_pool_and_subscription(@owner['key'], @product.id, 100, [], '1888', '1234')
+    @product = create_product(nil, random_string("Product1"), :attributes => {
+      "version" => '6.4',
+      "sockets" => 2,
+      "multi-entitlement" => "true"
+    })
+
+    @cp.create_pool(@owner['key'], @product.id, {
+      :quantity => 100,
+      :contract_number => '1888',
+      :account_number => '1234'
+    })
 
     @owner_client = user_client(@owner, random_string('owner_admin_user'))
     @owner_client.register(random_string('system_consumer'), :system, nil, {})
@@ -803,9 +823,8 @@ describe 'Owner Resource Entitlement List Tests' do
     @virt_prod= create_product(nil, 'virtualization')
 
     #entitle owner for the virt and monitoring products.
-    create_pool_and_subscription(@owner['key'], @monitoring_prod.id, 6,
-      [], '', '', '', nil, nil, true)
-    create_pool_and_subscription(@owner['key'], @virt_prod.id, 6)
+    @cp.create_pool(@owner['key'], @monitoring_prod.id, {:quantity => 6})
+    @cp.create_pool(@owner['key'], @virt_prod.id, {:quantity => 6})
 
     #create consumer
     user = user_client(@owner, random_string('billy'))
@@ -845,11 +864,11 @@ describe 'Owner Resource Future Pool Tests' do
     @owner = create_owner random_string 'test_owner'
     @product1 = create_product(random_string('product'), random_string('product'),{:owner => @owner['key']})
     @product2 = create_product(random_string('product'), random_string('product'),{:owner => @owner['key']})
-    @current_pool = create_pool_and_subscription(@owner['key'], @product1.id, 10, [], '', '', '', @now - 1)
+    @current_pool = @cp.create_pool(@owner['key'], @product1.id, {:quantity => 10, :start_date => @now - 1})
     start1 = @now + 400
     start2 = @now + 800
-    @future_pool1 = create_pool_and_subscription(@owner['key'], @product2.id, 10, [], '', '', '', start1)
-    @future_pool2 = create_pool_and_subscription(@owner['key'], @product2.id, 10, [], '', '', '', start2)
+    @future_pool1 = @cp.create_pool(@owner['key'], @product2.id, {:quantity => 10, :start_date => start1})
+    @future_pool2 = @cp.create_pool(@owner['key'], @product2.id, {:quantity => 10, :start_date => start2})
   end
 
   it 'can fetch current pools' do
@@ -1014,7 +1033,7 @@ describe 'Owner Resource counting feature' do
     params = {:attributes => {'type' => product_type}}
     p = create_product(@owner['key'], params)
 
-    pool = create_pool_and_subscription(@owner['key'], p.id, 1)
+    pool = @cp.create_pool(@owner['key'], p.id, {:quantity => 1})
     @owner_cp.consume_pool(pool.id, params={:uuid => consumer.uuid, :quantity => 1})
     p.id #sku
   end
@@ -1027,7 +1046,12 @@ describe 'Owner Resource counting feature' do
 
   def create_product_and_bint_it_to_consumer_return_subId(consumer)
     p = create_product(@owner['key'])
-    pool = create_pool_and_subscription(@owner['key'], p.id, 1)
+    pool = @cp.create_pool(@owner['key'], p.id, {
+      :quantity => 1,
+      :subscription_id => random_string('source_sub'),
+      :upstream_pool_id => random_string('upstream')
+    })
+
     @owner_cp.consume_pool(pool.id, params={:uuid => consumer.uuid, :quantity => 1})
     pool.subscriptionId
   end
@@ -1041,7 +1065,13 @@ describe 'Owner Resource counting feature' do
   def create_product_and_bint_it_to_consumer_return_contractNr(consumer)
     p = create_product(@owner['key'])
     cn = random_string('contract_nr')
-    pool = create_pool_and_subscription(@owner['key'], p.id, 1, [], cn)
+    pool = @cp.create_pool(@owner['key'], p.id, {
+      :quantity => 1,
+      :contract_number => cn,
+      :subscription_id => random_string('source_sub'),
+      :upstream_pool_id => random_string('upstream')
+    })
+
     @owner_cp.consume_pool(pool.id, params={:uuid => consumer.uuid, :quantity => 1})
     pool.contractNumber
   end

--- a/server/spec/pool_unlimited_master_spec.rb
+++ b/server/spec/pool_unlimited_master_spec.rb
@@ -51,10 +51,29 @@ describe 'Unlimited Master Pools' do
       }
     })
 
-    @pool_no_virt = create_pool_and_subscription(@owner['key'], @product_no_virt.id, -1, [], '', '', '', nil, nil, false)
-    @pool_unlimited_virt = create_pool_and_subscription(@owner['key'], @product_unlimited_virt.id, -1, [], '', '', '', nil, nil, false)
-    @pool_virt = create_pool_and_subscription(@owner['key'], @product_virt.id, -1, [], '', '', '', nil, nil, false)
-    @pool_virt_host_dep = create_pool_and_subscription(@owner['key'], @product_virt_host_dep.id, -1, [], '', '', '', nil, nil, false)
+    @pool_no_virt = @cp.create_pool(@owner['key'], @product_no_virt.id, {
+      :quantity => -1,
+      :subscription_id => random_string('source_sub'),
+      :upstream_pool_id => random_string('upstream')
+    })
+
+    @pool_unlimited_virt = @cp.create_pool(@owner['key'], @product_unlimited_virt.id, {
+      :quantity => -1,
+      :subscription_id => random_string('source_sub'),
+      :upstream_pool_id => random_string('upstream')
+    })
+
+    @pool_virt = @cp.create_pool(@owner['key'], @product_virt.id, {
+      :quantity => -1,
+      :subscription_id => random_string('source_sub'),
+      :upstream_pool_id => random_string('upstream')
+    })
+
+    @pool_virt_host_dep = @cp.create_pool(@owner['key'], @product_virt_host_dep.id, {
+      :quantity => -1,
+      :subscription_id => random_string('source_sub'),
+      :upstream_pool_id => random_string('upstream')
+    })
 
     @pools = @cp.list_pools :owner => @owner.id, :product => @product_unlimited_virt.id
     @pools.size.should == 2

--- a/server/spec/product_resource_spec.rb
+++ b/server/spec/product_resource_spec.rb
@@ -12,12 +12,13 @@ describe 'Product Resource' do
     @derived_product = create_product random_string('derived_product')
     @derived_prov_product = create_product random_string('derived_provided_product')
 
-    create_pool_and_subscription(@owner['key'], @product.id,
-      10, [@prov_product.id], '222', '', '', nil, nil, false,
-      {
-        :derived_product_id => @derived_product.id,
-        :derived_provided_products => [@derived_prov_product.id]
-      })
+    @cp.create_pool(@owner['key'], @product.id, {
+      :quantity => 10,
+      :provided_products => [@prov_product.id],
+      :contract_number => '222',
+      :derived_product_id => @derived_product.id,
+      :derived_provided_products => [@derived_prov_product.id]
+    })
   end
 
   it 'should fail when fetching non-existing products' do

--- a/server/spec/refresh_pools_spec.rb
+++ b/server/spec/refresh_pools_spec.rb
@@ -4,8 +4,11 @@ require 'candlepin_scenarios'
 require 'rubygems'
 require 'rest_client'
 
+
 describe 'Refresh Pools' do
   include CandlepinMethods
+  include AttributeHelper
+  include CertificateMethods
   include VirtHelper
   include CertificateMethods
 
@@ -40,14 +43,11 @@ describe 'Refresh Pools' do
 
     # Create 6 subscriptions to different products
     6.times do |i|
-      name = random_string("product-#{i}")
-      product = create_product(name, name, :owner => owner['key'])
-
-      create_pool_and_subscription(owner['key'], product.id)
+      product = create_upstream_product(random_string("product-#{i}"))
+      create_upstream_subscription(random_string("sub-#{i}"), owner['key'], product.id)
     end
 
-    # @cp.refresh_pools(owner['key'])
-
+    @cp.refresh_pools(owner['key'])
     @cp.list_pools({:owner => owner.id}).length.should == 6
   end
 
@@ -56,10 +56,8 @@ describe 'Refresh Pools' do
 
     # Create 6 subscriptions to different products
     6.times do |i|
-      name = random_string("product-#{i}")
-      product = create_product(name, name, :owner => owner['key'])
-
-      create_pool_and_subscription(owner['key'], product.id)
+      product = create_upstream_product(random_string("product-#{i}"))
+      create_upstream_subscription(random_string("sub-#{i}"), owner['key'], product.id)
     end
 
     @cp.refresh_pools(owner['key'])
@@ -71,229 +69,584 @@ describe 'Refresh Pools' do
   end
 
   it 'detects changes in provided products' do
-    owner = create_owner random_string
-    product = create_product(random_string, random_string, :owner => owner['key'])
-    provided1 = create_product(random_string, random_string, :owner => owner['key'])
-    provided2 = create_product(random_string, random_string, :owner => owner['key'])
-    provided3 = create_product(random_string, random_string, :owner => owner['key'])
-    pool = create_pool_and_subscription(owner['key'], product.id, 500, [provided1.id, provided2.id])
+    owner_key = random_string('test_owner')
+    owner = create_owner(owner_key)
+
+    product = create_upstream_product(random_string('test_prod'))
+    provided = []
+
+    3.times do |i|
+      provided << create_upstream_product(random_string("provided-#{i}"))
+    end
+
+    sub = create_upstream_subscription(random_string('test_sub'), owner_key, product.id, {
+      :provided_products => provided[0..1]
+    })
+
+    @cp.refresh_pools(owner_key)
     pools = @cp.list_pools({:owner => owner.id})
-    pools.length.should == 1
-    pools[0].providedProducts.length.should == 2
-    # Remove the old provided products and add a new one:
-    sub = get_hostedtest_subscription(pool.subscriptionId)
-    sub.providedProducts = [@cp.get_product(owner['key'], provided3.id)]
-    update_hostedtest_subscription(sub)
-    @cp.refresh_pools(owner['key'])
+
+    expect(pools.length).to eq(1)
+    expect(pools[0].providedProducts.length).to eq(2)
+
+    provided_ids = provided[0..1].collect { |p| p.id }
+    pools[0].providedProducts.each do |p|
+      expect(provided_ids).to include(p.productId)
+      provided_ids.delete(p.productId)
+    end
+
+    # Remove the old provided products and add a new one...
+    sub.providedProducts = [provided[2]]
+    update_upstream_subscription(sub.id, sub)
+
+    @cp.refresh_pools(owner_key)
     pools = @cp.list_pools({:owner => owner.id})
-    pools[0].providedProducts.length.should == 1
+
+    expect(pools.length).to eq(1)
+    expect(pools[0].providedProducts.length).to eq(1)
+    expect(pools[0].providedProducts[0].productId).to eq(provided[2].id)
   end
 
   it 'deletes expired subscriptions\' pools and entitlements' do
-    owner = create_owner random_string
-    product = create_product(random_string, random_string, :owner => owner['key'])
-    pool = create_pool_and_subscription(owner['key'], product.id, 500, [])
+    owner_key = random_string('test_owner')
+    owner = create_owner(owner_key)
+
+    product = create_upstream_product(random_string('test_prod'))
+    sub = create_upstream_subscription(random_string('test_sub'), owner_key, product.id, { :quantity => 500 })
+
+    @cp.refresh_pools(owner_key)
     pools = @cp.list_pools({:owner => owner.id})
-    pools.length.should == 1
+    expect(pools.length).to eq(1)
 
-    user = user_client(owner, random_string("user"))
+    user = user_client(owner, random_string('test_user'))
+    consumer = consumer_client(user, random_string('test_consumer'))
+    entitlements = consumer.consume_pool(pools.first.id, {:quantity => 1})
+    expect(entitlements.length).to eq(1)
 
-    consumer_id = random_string("consumer")
-    consumer = consumer_client(user, consumer_id)
-    consumer.consume_pool(pools.first.id, {:quantity => 1}).size.should == 1
+    consumer = @cp.get_consumer(consumer.uuid)
+    expect(consumer.entitlementCount).to eq(1)
 
-    # Update the subscription to be expired so that pool, and entitlements are removed.
-    now = DateTime.now
-    sub = get_hostedtest_subscription(pool.subscriptionId)
-    sub.startDate = now - 20
-    sub.endDate = now - 10
-    update_hostedtest_subscription(sub)
-    @cp.refresh_pools(owner['key'])
-    @cp.list_pools({:owner => owner.id}).size.should == 0
-    @cp.get_consumer(consumer.uuid).entitlementCount.should == 0
+    # Update subscription such that it's expired, then refresh. The entitlements should be removed.
+    update_upstream_subscription(sub.id, {
+      :start_date => Date.today - 20,
+      :end_date => Date.today - 10
+    })
+    @cp.refresh_pools(owner_key)
+
+    pools = @cp.list_pools({:owner => owner.id})
+    consumer = @cp.get_consumer(consumer.uuid)
+
+    expect(pools.length).to eq(0)
+    expect(consumer.entitlementCount).to eq(0)
   end
 
   it 'regenerates entitlements' do
-    owner = create_owner random_string
-    product = create_product(random_string, random_string, :owner => owner['key'])
-    new_product = create_product(random_string, random_string, :owner => owner['key'])
-    pool = create_pool_and_subscription(owner['key'], product.id, 500, [])
+    owner_key = random_string('test_owner')
+    owner = create_owner(owner_key)
+
+    product1 = create_upstream_product(random_string('test_prod1'))
+    product2 = create_upstream_product(random_string('test_prod2'))
+    sub = create_upstream_subscription(random_string('test_sub'), owner_key, product1.id)
+
+    @cp.refresh_pools(owner_key)
     pools = @cp.list_pools({:owner => owner.id})
-    pools.length.should == 1
+    expect(pools.length).to eq(1)
 
-    user = user_client(owner, random_string("user"))
+    user = user_client(owner, random_string('test_user'))
+    consumer = consumer_client(user, random_string('test_consumer'))
+    entitlements = consumer.consume_pool(pools.first.id, {:quantity => 1})
+    expect(entitlements.length).to eq(1)
 
-    consumer_id = random_string("consumer")
-    consumer = consumer_client(user, consumer_id)
-    ents = consumer.consume_pool(pools.first.id, {:quantity => 1})
-    ents.size.should == 1
-    ent = ents[0]
-    old_cert = ent['certificates'][0]
+    consumer = @cp.get_consumer(consumer.uuid)
+    expect(consumer.entitlementCount).to eq(1)
+
+    entitlement = entitlements.first
+    old_cert = entitlement['certificates'].first
     old_serial = old_cert['serial']['serial']
 
-    # Change the product on subscription to trigger a regenerate:
-    sub = get_hostedtest_subscription(pool.subscriptionId)
-    sub['product'] = {'id' => new_product['id']}
-    update_hostedtest_subscription(sub)
-    @cp.refresh_pools(owner['key'], false, false, true)
-    ent = @cp.get_entitlement(ent['id'])
-    new_cert = ent['certificates'][0]
-    new_serial = new_cert['serial']['serial']
-    new_serial.should_not == old_serial
+    # Update the subscription's product to trigger an entitlement regeneration
+    update_upstream_subscription(sub.id, {
+      :product => { :id => product2.id }
+    })
+    @cp.refresh_pools(owner_key)
 
-    @cp.get_consumer(consumer.uuid).entitlementCount.should == 1
+    consumer = @cp.get_consumer(consumer.uuid)
+    expect(consumer.entitlementCount).to eq(1)
+
+    updated_ent = @cp.get_entitlement(entitlement['id'])
+    new_cert = updated_ent['certificates'].first
+    new_serial = new_cert['serial']['serial']
+
+    expect(new_serial).to_not eq(old_serial)
   end
 
   it 'handle derived products being removed' do
-   # 998317: is caused by refresh pools dying with an NPE
-   # this happens when subscriptions no longer have
-   # derived products resulting in a null during the refresh
-   # which we didn't handle in all cases.
+    # 998317: is caused by refresh pools dying with an NPE
+    # this happens when subscriptions no longer have
+    # derived products resulting in a null during the refresh
+    # which we didn't handle in all cases.
+    owner_key = random_string('test_owner')
+    owner = create_owner(owner_key)
 
-    owner = create_owner random_string
-    # create subscription with sub-pool data:
-    datacenter_product = create_product(nil, nil, {
+    datacenter_product = create_upstream_product(random_string('dc_prod'), {
       :attributes => {
         :virt_limit => "unlimited",
         :stacking_id => "stackme",
         :sockets => "2",
         'multi-entitlement' => "yes"
-      },
-      :owner => owner['key']
+      }
     })
-    derived_product = create_product(nil, nil, {
+
+    derived_product = create_upstream_product(random_string('derived_prod'), {
       :attributes => {
-          :cores => 2,
-          :sockets=>4
-      },
-      :owner => owner['key']
+        :cores => 2,
+        :sockets=>4
+      }
     })
-    eng_product = create_product('300', nil, :owner => owner['key'])
 
-    pool1 = create_pool_and_subscription(owner['key'], datacenter_product.id,
-      10, [], '', '', '', nil, nil, false,
-      {
-        :derived_product_id => derived_product['id'],
-        :derived_provided_products => ['300']
-      })
-    # extra unmapped guest pool will be labeled with provided product
-    pools = @cp.list_pools :owner => owner.id,
-      :product => datacenter_product.id
-    pools.size.should == 1
-    pools[0]['derivedProvidedProducts'].length.should == 1
+    derived_eng_product = create_upstream_product(random_string(nil, true))
 
-    # let's remove the derivedProducts - this simulates
-    # the scenario that caues the bug
-    sub1 = get_hostedtest_subscription(pool1.subscriptionId)
-    sub1['derivedProduct'] = nil
-    sub1['derivedProvidedProducts'] = nil
-    update_hostedtest_subscription(sub1)
+    eng_product = create_upstream_product(random_string('eng_prod'))
 
-    # this is the refresh we are actually testing
-    # it should succeed
-    @cp.refresh_pools(owner['key'])
+    sub = create_upstream_subscription(random_string('dc_sub'), owner_key, datacenter_product.id, {
+      :quantity => 10,
+      :derived_product => derived_product,
+      :derived_provided_products => [derived_eng_product]
+    })
 
-    # let's verify it removed them correctly
-    # extra unmapped pool now shows datacenter product
-    pools = @cp.list_pools :owner => owner.id, \
-      :product => datacenter_product.id
-    pools.length.should == 2
-    pools[0]['derivedProvidedProducts'].length.should == 0
+    @cp.refresh_pools(owner_key)
+    pools = @cp.list_pools({:owner => owner.id})
+    expect(pools.length).to eq(2) # We're expecting the base pool + a virt-only bonus pool for guests
+
+    # Swap pools if necessary
+    if pools[0].productId != datacenter_product.id
+      pools[0], pools[1] = pools[1], pools[0]
+    end
+
+    expect(pools.first).to have_key('derivedProvidedProducts')
+    expect(pools.first.derivedProvidedProducts.length).to eq(1)
+
+    update_upstream_subscription(sub.id, {
+      :derived_product => nil,
+      :derived_provided_products => []
+    })
+
+    @cp.refresh_pools(owner_key)
+
+    pools = @cp.list_pools :owner => owner.id, :product => datacenter_product.id
+    expect(pools.length).to eq(2)
+
+    # Swap pools if necessary
+    if pools[0].productId != datacenter_product.id
+      pools[0], pools[1] = pools[1], pools[0]
+    end
+
+    expect(pools.first).to have_key('derivedProvidedProducts')
+    expect(pools.first.derivedProvidedProducts.length).to eq(0)
   end
 
-  it 'can migrate subscription' do
-    # Create the initial owner and generate the pools.
-    owner1 = create_owner random_string('initial-owner')
-    name = random_string("product")
-    product1 = create_product(name, name, :owner => owner1['key'])
-    pool = create_pool_and_subscription(owner1['key'], product1.id)
-    owner1_pools = @cp.list_pools({:owner => owner1.id})
-    owner1_pools.length.should == 1
+  it 'can migrate subscriptions' do
+    owner_key1 = random_string('test_owner_1')
+    owner_key2 = random_string('test_owner_2')
+    owner1 = create_owner(owner_key1)
+    owner2 = create_owner(owner_key2)
 
-    # Create another owner and migrate the subscription
-    owner2 = create_owner random_string('migrated-owner')
-    product2 = create_product(name, name, :owner => owner2['key'])
+    product = create_upstream_product(random_string('test_prod'))
+    sub = create_upstream_subscription(random_string('test_sub'), owner_key1, product.id)
 
-    # migrate the subscription to another owner.
-    sub = get_hostedtest_subscription(pool.subscriptionId)
-    sub["owner"] = owner2
-    update_hostedtest_subscription(sub)
-    @cp.refresh_pools(owner1["key"])
-    @cp.refresh_pools(owner2["key"])
+    @cp.refresh_pools(owner_key1)
+    @cp.refresh_pools(owner_key2)
 
-    # Check that the pools are removed from the first owner
-    @cp.list_pools({:owner => owner1.id}).length.should == 0
-    @cp.list_pools({:owner => owner2.id}).length.should == 1
+    pools1 = @cp.list_pools({:owner => owner1.id})
+    pools2 = @cp.list_pools({:owner => owner2.id})
+    expect(pools1.length).to eq(1)
+    expect(pools2.length).to eq(0)
+
+    # Update sub to be owned by the second owner
+    update_upstream_subscription(sub.id, { :owner => { :key => owner_key2 }})
+
+    @cp.refresh_pools(owner_key1)
+    @cp.refresh_pools(owner_key2)
+
+    pools1 = @cp.list_pools({:owner => owner1.id})
+    pools2 = @cp.list_pools({:owner => owner2.id})
+    expect(pools1.length).to eq(0)
+    expect(pools2.length).to eq(1)
   end
 
   it 'removes pools from other owners when subscription is migrated' do
-    # Create the initial owner and generate the pools.
-    owner1 = create_owner random_string('initial-owner')
-    name = random_string("product")
-    product1 = create_product(name, name, :owner => owner1['key'])
-    pool = create_pool_and_subscription(owner1['key'], product1.id)
-    owner1_pools = @cp.list_pools({:owner => owner1.id})
-    owner1_pools.length.should == 1
+    owner_key1 = random_string('test_owner_1')
+    owner_key2 = random_string('test_owner_2')
+    owner1 = create_owner(owner_key1)
+    owner2 = create_owner(owner_key2)
 
-    # Create another owner and migrate the subscription
-    owner2 = create_owner random_string('migrated-owner')
-    product2 = create_product(name, name, :owner => owner2['key'])
+    product = create_upstream_product(random_string('test_prod'))
+    sub = create_upstream_subscription(random_string('test_sub'), owner_key1, product.id)
 
-    # migrate the subscription to another owner.
-    sub = get_hostedtest_subscription(pool.subscriptionId)
-    sub["owner"] = owner2
-    update_hostedtest_subscription(sub)
+    @cp.refresh_pools(owner_key1)
+    @cp.refresh_pools(owner_key2)
 
-    # Refresh the second owner so that the pools are updated.
-    @cp.refresh_pools(owner2["key"], true)
-    sleep 1
-    # Initial owner should have all pools removed.
-    @cp.list_pools({:owner => owner1.id}).length.should == 0
+    pools1 = @cp.list_pools({:owner => owner1.id})
+    pools2 = @cp.list_pools({:owner => owner2.id})
+    expect(pools1.length).to eq(1)
+    expect(pools2.length).to eq(0)
 
-    # Pools should now be created for the second owner since
-    # the subscription was migrated.
-    @cp.list_pools({:owner => owner2.id}).length.should == 1
+    # Update sub to be owned by the second owner
+    update_upstream_subscription(sub.id, { :owner => { :key => owner_key2 }})
+
+    @cp.refresh_pools(owner_key2)
+
+    pools1 = @cp.list_pools({:owner => owner1.id})
+    pools2 = @cp.list_pools({:owner => owner2.id})
+    expect(pools1.length).to eq(0)
+    expect(pools2.length).to eq(1)
   end
 
   # Testing bug #1150234:
   it 'can change attributes and revoke entitlements at same time' do
-    owner = create_owner random_string
-    user = user_client(owner, random_string('virt_user'))
-    product = create_product(
-      random_string,
-      random_string,
-      {
-        :attributes => {'multi-entitlement' => "yes"},
-        :owner => owner['key']
+    owner_key = random_string('test_owner')
+    owner = create_owner(owner_key)
+
+    product = create_upstream_product(random_string('multient_prod'), {
+      :attributes => {
+        'multi-entitlement' => 'yes'
       }
-    )
-    create_pool_and_subscription(owner['key'], product.id, 2)
+    })
 
-    user = user_client(owner, random_string("user"))
-    host = consumer_client(user, 'host', :system, nil)
+    sub = create_upstream_subscription(random_string('multient_sub'), owner_key, product.id, {
+      :quantity => 2
+    })
 
-    pools = @cp.list_pools({:owner => owner.id, :product => product.id})
-    pools.length.should == 1
-    # We'll consume quantity 2, later we will reduce the pool to 1 forcing a
-    # revoke of this entitlement:
-    @cp.consume_pool(pools[0]['id'], {:uuid => host.uuid, :quantity => 2})
-    @cp.refresh_pools(owner['key'], false, false, false)
+    user = user_client(owner, random_string('test_user'))
+    consumer_client = consumer_client(user, random_string('test_consumer'))
 
-    pool = @cp.list_pools({:owner => owner.id, :product => product.id})[0]
+    @cp.refresh_pools(owner_key)
+    pools = @cp.list_pools({:owner => owner.id})
+    expect(pools.length).to eq(1)
 
-    # Modify product attributes:
-    attrs = product['attributes']
-    attrs << {:name => 'newattribute', :value => 'something'}
-    update_product(owner['key'], product.id, :attributes => attrs)
+    # We'll consume quantity 2, later we will reduce the pool to 1 forcing revokation of this entitlement
+    entitlements = consumer_client.consume_pool(pools.first.id, { :quantity => 2 })
+    expect(entitlements.length).to eq(1)
 
-    # Reduce the subscription quantity:
-    sub = get_hostedtest_subscription(pool.subscriptionId)
-    sub['quantity'] = 1
-    update_hostedtest_subscription(sub)
+    # FIXME: This seems like a bug. Our entitlement count here should be 1, right?
+    consumer = @cp.get_consumer(consumer_client.uuid)
+    expect(consumer.entitlementCount).to eq(2)
 
-    @cp.refresh_pools(owner['key'], false, false, false)
-    pools = @cp.list_pools({:owner => owner.id, :product => product.id})
-    pools.length.should == 1
+    # Add a new attribute to the product
+    update_upstream_product(product.id, {
+      :attributes => {
+        'new_attrib' => 'new value',
+        'multi-entitlement' => 'yes'
+      }
+    })
+
+    # ...and reduce the quantity available on the subscription
+    update_upstream_subscription(sub.id, {
+      :quantity => 1
+    })
+
+    # Refresh pools for this org
+    @cp.refresh_pools(owner_key)
+
+    pools = @cp.list_pools({:owner => owner.id})
+    expect(pools.length).to eq(1)
+
+    # Verify the pool's product now contains the new attribute
+    expect(pools.first).to have_key('productAttributes')
+
+    attributes = normalize_attributes(pools.first.productAttributes)
+    expect(attributes).to eq({
+      'new_attrib' => 'new value',
+      'multi-entitlement' => 'yes'
+    })
+
+    # Verify that the entitlement was revoked
+    consumer = @cp.get_consumer(consumer_client.uuid)
+    expect(consumer.entitlementCount).to eq(0)
+
+    lambda do
+      @cp.get_entitlement(entitlements[0].id)
+    end.should raise_exception(RestClient::ResourceNotFound)
+  end
+
+  it 'regenerates entitlements when content for an entitled pool changes' do
+    owner_key = random_string('test_owner')
+    owner = create_owner(owner_key)
+
+    content_id = random_string('test_content')
+    content = create_upstream_content(content_id, { :label => 'test_label', :content_url => 'http://www.url.com' })
+
+    product_id = random_string(nil, true)
+    product = create_upstream_product(product_id)
+
+    add_content_to_product_upstream(product_id, content_id)
+
+    sub_id = random_string('test_subscription')
+    create_upstream_subscription(sub_id, owner_key, product_id)
+
+    @cp.refresh_pools(owner_key)
+    pools = @cp.list_pools({:owner => owner.id})
+    expect(pools.length).to eq(1)
+
+    # Verify the content exists in its initial state
+    ds_content = @cp.get_content(owner_key, content_id)
+    expect(ds_content).to_not be_nil
+    expect(ds_content.label).to eq('test_label')
+
+    # Consume the pool so we have an entitlement
+    user = user_client(owner, random_string('test_user'))
+    consumer_client = consumer_client(user, random_string('test_consumer'), :system, nil,
+      { 'system.certificate_version' => '3.0' })
+
+    entitlements = consumer_client.consume_pool(pools.first.id, { :quantity => 1 })
+    expect(entitlements.length).to eq(1)
+
+    consumer = @cp.get_consumer(consumer_client.uuid)
+    expect(consumer.entitlementCount).to eq(1)
+
+    entitlement = entitlements.first
+    ent_cert = entitlement['certificates'].first
+    ent_cert_serial = ent_cert['serial']['serial']
+
+    # Modify the content for this product/sub
+    update_upstream_content(content_id, { :label => 'updated_label' })
+
+    @cp.refresh_pools(owner_key)
+    pools = @cp.list_pools({:owner => owner.id})
+    expect(pools.length).to eq(1)
+
+    # Verify the content change has been pulled down
+    ds_content = @cp.get_content(owner_key, content_id)
+    expect(ds_content).to_not be_nil
+    expect(ds_content.label).to eq('updated_label')
+
+    # Verify the entitlement cert has changed as a result
+    updated_ent = @cp.get_entitlement(entitlement['id'])
+    updated_cert = updated_ent['certificates'].first
+    updated_cert_serial = updated_cert['serial']['serial']
+
+    expect(updated_cert_serial).to_not eq(ent_cert_serial)
+  end
+
+  it 'regenerates entitlements when products for an entitled pool changes' do
+    owner_key = random_string('test_owner')
+    owner = create_owner(owner_key)
+
+    content_id = random_string('test_content')
+    content = create_upstream_content(content_id, { :content_url => 'http://www.url.com' })
+
+    product_id = random_string(nil, true)
+    product = create_upstream_product(product_id, { :name => 'test_prod' })
+
+    add_content_to_product_upstream(product_id, content_id)
+
+    sub_id = random_string('test_subscription')
+    create_upstream_subscription(sub_id, owner_key, product_id)
+
+    @cp.refresh_pools(owner_key)
+    pools = @cp.list_pools({:owner => owner.id})
+    expect(pools.length).to eq(1)
+
+    # Verify the product exists in its initial state
+    ds_product = @cp.get_product(owner_key, product_id)
+    expect(ds_product).to_not be_nil
+    expect(ds_product.name).to eq('test_prod')
+
+    # Consume the pool so we have an entitlement
+    user = user_client(owner, random_string('test_user'))
+    consumer_client = consumer_client(user, random_string('test_consumer'), :system, nil,
+      { 'system.certificate_version' => '3.0' })
+
+    entitlements = consumer_client.consume_pool(pools.first.id, { :quantity => 1 })
+    expect(entitlements.length).to eq(1)
+
+    consumer = @cp.get_consumer(consumer_client.uuid)
+    expect(consumer.entitlementCount).to eq(1)
+
+    entitlement = entitlements.first
+    ent_cert = entitlement['certificates'].first
+    ent_cert_serial = ent_cert['serial']['serial']
+
+    # Modify the product for this sub
+    update_upstream_product(product_id, { :name => 'updated_name' })
+
+    @cp.refresh_pools(owner_key)
+    pools = @cp.list_pools({:owner => owner.id})
+    expect(pools.length).to eq(1)
+
+    # Verify the product change has been pulled down
+    ds_product = @cp.get_product(owner_key, product_id)
+    expect(ds_product).to_not be_nil
+    expect(ds_product.name).to eq('updated_name')
+
+    # Verify the entitlement cert has changed as a result
+    updated_ent = @cp.get_entitlement(entitlement['id'])
+    updated_cert = updated_ent['certificates'].first
+    updated_cert_serial = updated_cert['serial']['serial']
+
+    expect(updated_cert_serial).to_not eq(ent_cert_serial)
+  end
+
+  it 'regenerates entitlements when required products change' do
+    owner_key = random_string('test_owner')
+    owner = create_owner(owner_key)
+
+    sku_id1 = random_string('required_prod', true)
+    sku_id2 = random_string('dependent_prod', true)
+    sku_prod1 = create_upstream_product(sku_id1)
+    sku_prod2 = create_upstream_product(sku_id2)
+
+    eng_id1 = random_string(nil, true)
+    eng_id2 = random_string(nil, true)
+    eng_prod1 = create_upstream_product(eng_id1)
+    eng_prod2 = create_upstream_product(eng_id2)
+
+    content_id1 = random_string('test_content_1')
+    content1 = create_upstream_content(content_id1, { :content_url => 'http://www.url.com/c1' })
+
+    content_id2 = random_string('test_content_2')
+    content2 = create_upstream_content(content_id2, { :content_url => 'http://www.url.com/c2' })
+
+    content_id3 = random_string('test_content_3')
+    content3 = create_upstream_content(content_id3, { :content_url => 'http://www.url.com/c3' })
+
+    add_content_to_product_upstream(eng_id1, content_id1)
+    add_content_to_product_upstream(eng_id2, content_id2)
+    add_content_to_product_upstream(eng_id2, content_id3)
+
+    sub_id1 = random_string('test_subscription_1')
+    sub1 = create_upstream_subscription(sub_id1, owner_key, sku_id1, { :provided_products => [eng_prod1] })
+
+    sub_id2 = random_string('test_subscription_2')
+    sub2 = create_upstream_subscription(sub_id2, owner_key, sku_id2, { :provided_products => [eng_prod2] })
+
+    @cp.refresh_pools(owner_key)
+    pools = @cp.list_pools({:owner => owner.id})
+    expect(pools.length).to eq(2)
+
+    # Rearrange the pools if they're backward
+    if pools.first.productId == sku_id2
+      pools[0], pools[1] = pools[1], pools[0]
+    end
+
+    products = @cp.list_products_by_owner(owner_key)
+    expect(products.length).to eq(4)
+
+    content = @cp.list_content(owner_key)
+    expect(content.length).to eq(3)
+
+    # Consume both pools
+    user = user_client(owner, random_string('test_user'))
+    consumer_client = consumer_client(user, random_string('test_consumer'), :system, nil,
+      { 'system.certificate_version' => '3.0' })
+
+    pool_ents = []
+
+    entitlements = consumer_client.consume_pool(pools[0].id, { :quantity => 1 })
+    expect(entitlements.length).to eq(1)
+    pool_ents << entitlements.first
+
+    entitlements = consumer_client.consume_pool(pools[1].id, { :quantity => 1 })
+    expect(entitlements.length).to eq(1)
+    pool_ents << entitlements.first
+
+    entitlements = @cp.list_entitlements({ :uuid => consumer_client.uuid })
+    expect(entitlements.length).to eq(2)
+
+    payload1 = extract_payload(pool_ents[0].certificates.first['cert'])
+    payload2 = extract_payload(pool_ents[1].certificates.first['cert'])
+
+    # Verify the entitlements contains the products and content
+    expect(payload1).to have_key('products')
+    expect(payload1.products.length).to eq(1)
+    expect(payload1.products.first.id).to eq(eng_id1)
+    expect(payload1.products.first).to have_key('content')
+    expect(payload1.products.first.content.length).to eq(1)
+    expect(payload1.products.first.content.first.id).to eq(content1.id)
+    expect(payload1.products.first.content.first.path).to eq(content1.contentUrl)
+
+    expect(payload2).to have_key('products')
+    expect(payload2.products.length).to eq(1)
+    expect(payload2.products.first).to have_key('content')
+    expect(payload2.products.first.id).to eq(eng_id2)
+    expect(payload2.products.first.content.length).to eq(2)
+
+    if payload2.products.first.content[0].id == content2.id
+      expect(payload2.products.first.content[0].id).to eq(content2.id)
+      expect(payload2.products.first.content[0].path).to eq(content2.contentUrl)
+      expect(payload2.products.first.content[1].id).to eq(content3.id)
+      expect(payload2.products.first.content[1].path).to eq(content3.contentUrl)
+    else
+      expect(payload2.products.first.content[0].id).to eq(content3.id)
+      expect(payload2.products.first.content[0].path).to eq(content3.contentUrl)
+      expect(payload2.products.first.content[1].id).to eq(content2.id)
+      expect(payload2.products.first.content[1].path).to eq(content2.contentUrl)
+    end
+
+    ent_cert = pool_ents[1]['certificates'].first
+    ent_cert_serial = ent_cert['serial']['serial']
+
+    # Add a dependent product to content2 for a product the consumer is entitled to
+    update_upstream_content(content_id2, { :modified_product_ids => [eng_id1] })
+    @cp.refresh_pools(owner_key)
+
+    # Verify the content change has been pulled down
+    content = @cp.get_content(owner_key, content_id2)
+    expect(content.modifiedProductIds).to eq([eng_id1])
+
+    # Verify the entitlement has been regenerated
+    updated_ent = @cp.get_entitlement(pool_ents[1]['id'])
+    updated_cert = updated_ent['certificates'].first
+    updated_cert_serial = updated_cert['serial']['serial']
+
+    expect(updated_cert_serial).to_not eq(ent_cert_serial)
+
+    # Verify the content path is still present in the entitlement
+    payload = extract_payload(updated_ent['certificates'].first['cert'])
+
+    expect(payload).to have_key('products')
+    expect(payload.products.length).to eq(1)
+    expect(payload.products.first).to have_key('content')
+    expect(payload.products.first.id).to eq(eng_id2)
+    expect(payload.products.first.content.length).to eq(2)
+
+    if payload.products.first.content[0].id == content2.id
+      expect(payload.products.first.content[0].id).to eq(content2.id)
+      expect(payload.products.first.content[0].path).to eq(content2.contentUrl)
+      expect(payload.products.first.content[1].id).to eq(content3.id)
+      expect(payload.products.first.content[1].path).to eq(content3.contentUrl)
+    else
+      expect(payload.products.first.content[0].id).to eq(content3.id)
+      expect(payload.products.first.content[0].path).to eq(content3.contentUrl)
+      expect(payload.products.first.content[1].id).to eq(content2.id)
+      expect(payload.products.first.content[1].path).to eq(content2.contentUrl)
+    end
+
+    # Add a dependent product to content3 for a product the consumer is NOT entitled to
+    update_upstream_content(content_id3, { :modified_product_ids => ['fake_pid'] })
+    @cp.refresh_pools(owner_key)
+
+    # Verify the content change has been pulled down
+    content = @cp.get_content(owner_key, content_id3)
+    expect(content.modifiedProductIds).to eq(['fake_pid'])
+
+    # Verify the entitlement has been regenerated
+    updated_ent = @cp.get_entitlement(pool_ents[1]['id'])
+    updated_cert = updated_ent['certificates'].first
+    updated_cert_serial = updated_cert['serial']['serial']
+
+    expect(updated_cert_serial).to_not eq(ent_cert_serial)
+
+    # Verify the content path is still present in the entitlement
+    payload = extract_payload(updated_ent['certificates'].first['cert'])
+
+    expect(payload).to have_key('products')
+    expect(payload.products.length).to eq(1)
+    expect(payload.products.first).to have_key('content')
+    expect(payload.products.first.id).to eq(eng_id2)
+    expect(payload.products.first.content.length).to eq(1)
+    expect(payload.products.first.content.first.id).to eq(content2.id)
+    expect(payload.products.first.content.first.path).to eq(content2.contentUrl)
   end
 
   def concat_serials(normal_ent, bonus_ent)
@@ -303,95 +656,131 @@ describe 'Refresh Pools' do
   end
 
   def test_entitlement_regeneration
-    @owner = create_owner random_string('test_owner')
-    @product = create_product(nil, nil, :attributes =>
-                {:version => '6.4',
-                 :arch => 'i386, x86_64',
-                 :sockets => 4,
-                 :cores => 8,
-                 :ram => 16,
-                 :warning_period => 15,
-                 :management_enabled => true,
-                 :stacking_id => '8888',
-		 :virt_limit => "unlimited",
-		 :host_limited => "true",
-                 :virt_only => 'false',
-                 :support_level => 'standard',
-                 :support_type => 'excellent',})
+    owner_key = random_string('test_owner')
+    owner = create_owner(owner_key)
 
-    @provided_product = create_product(nil, nil, :attributes =>
-                {:version => '6.4',
-                 :arch => 'i386, x86_64',
-                 :sockets => 4,
-                 :cores => 8,
-                 :ram => 16,
-                 :warning_period => 15,
-                 :management_enabled => true,
-                 :stacking_id => '8888',
-                 :virt_only => 'false',
-                 :support_level => 'standard',
-                 :support_type => 'excellent',})
-
-    @derived_provided_product = create_product(nil, nil, :attributes =>
-                {:version => '6.4',
-                 :arch => 'i386, x86_64',
-                 :sockets => 4,
-                 :cores => 8,
-                 :ram => 16,
-                 :warning_period => 15,
-                 :management_enabled => true,
-                 :stacking_id => '8888',
-                 :virt_only => 'false',
-                 :support_level => 'standard',
-                 :support_type => 'excellent',})
-
-    @derived_product = create_product(nil, "derived product 1", {
+    product = create_upstream_product(random_string(nil, true), {
+      :name => random_string('prod', true),
       :attributes => {
-          :cores => 2,
-          :sockets => 4
+        :version => '6.4',
+        :arch => 'i386, x86_64',
+        :sockets => 4,
+        :cores => 8,
+        :ram => 16,
+        :warning_period => 15,
+        :management_enabled => true,
+        :stacking_id => '8888',
+        :virt_limit => "unlimited",
+        :host_limited => "true",
+        :virt_only => 'false',
+        :support_level => 'standard',
+        :support_type => 'excellent'
       }
     })
 
-    @content = create_content({:gpg_url => 'gpg_url',
-                               :content_url => '/content/dist/rhel/$releasever/$basearch/os',
-                               :metadata_expire => 6400,
-                               :required_tags => 'TAG1,TAG2',})
-
-    @content2 = create_content({:gpg_url => 'gpg_url',
-                               :content_url => '/content/dist/rhel/$releasever/$basearch/os',
-                               :metadata_expire => 6400,
-                               :required_tags => 'TAG1,TAG2',})
-
-    @content3 = create_content({:gpg_url => 'gpg_url',
-                               :content_url => '/content/dist/rhel/$releasever/$basearch/os',
-                               :metadata_expire => 6400,
-                               :required_tags => 'TAG1,TAG2',})
-
-    @cp.add_content_to_product(@owner['key'], @product.id, @content.id, false)
-    @cp.add_content_to_product(@owner['key'], @provided_product.id, @content2.id, false)
-    @cp.add_content_to_product(@owner['key'], @derived_provided_product.id, @content3.id, false)
-
-    @pool = create_pool_and_subscription(@owner['key'], @product.id, 10, [@provided_product.id],
-					 '12345', '6789', 'order1', nil, nil, false,
-					 {:derived_product_id => @derived_product['id'],
-                                          :derived_provided_products => [@derived_provided_product.id]
-                                         })
-    sub = get_hostedtest_subscription(@pool['subscriptionId'])
-
-    @bonus_pool = @cp.list_owner_pools(@owner['key']).select {|p| p['type'] == 'UNMAPPED_GUEST' }[0]
-
-    # create an entitlement with a product and content
-    @user = user_client(@owner, random_string('billy'))
-    @system = consumer_client(@user, random_string('system1'), :system, nil,
-                {'system.certificate_version' => '3.3',
-                 'uname.machine' => 'i386'})
-    @guest = consumer_client(@user, 'virty', :system, nil, {
-      'virt.is_guest' => true,
-      'system.certificate_version' => '3.3'
+    prov_product = create_upstream_product(random_string(nil, true), {
+      :name => random_string('prov_prod', true),
+      :attributes => {
+        :version => '6.4',
+        :arch => 'i386, x86_64',
+        :sockets => 4,
+        :cores => 8,
+        :ram => 16,
+        :warning_period => 15,
+        :management_enabled => true,
+        :stacking_id => '8888',
+        :virt_only => 'false',
+        :support_level => 'standard',
+        :support_type => 'excellent'
+      }
     })
 
-    entitlement = @system.consume_pool(@pool['id'], {:quantity => 1})[0]
-    bonus_entitlement = @guest.consume_pool(@bonus_pool['id'], {:quantity => 1})[0]
+    der_product = create_upstream_product(random_string(nil, true), {
+      :name => random_string('der_prod', true),
+      :attributes => {
+        :cores => 2,
+        :sockets => 4
+      }
+    })
+
+    der_prov_product = create_upstream_product(random_string(nil, true), {
+      :name => random_string('der_prov_prod', true),
+      :attributes => {
+        :version => '6.4',
+        :arch => 'i386, x86_64',
+        :sockets => 4,
+        :cores => 8,
+        :ram => 16,
+        :warning_period => 15,
+        :management_enabled => true,
+        :stacking_id => '8888',
+        :virt_only => 'false',
+        :support_level => 'standard',
+        :support_type => 'excellent'
+      }
+    })
+
+    content_id1 = random_string('test_content_1')
+    content1 = create_upstream_content(content_id1, {
+      :gpg_url => 'gpg_url',
+      :content_url => '/content/dist/rhel/$releasever/$basearch/os',
+      :metadata_expire => 6400,
+      :required_tags => 'TAG1,TAG2'
+    })
+
+    content_id2 = random_string('test_content_2')
+    content2 = create_upstream_content(content_id2, {
+      :gpg_url => 'gpg_url',
+      :content_url => '/content/dist/rhel/$releasever/$basearch/os',
+      :metadata_expire => 6400,
+      :required_tags => 'TAG1,TAG2'
+    })
+
+    content_id3 = random_string('test_content_3')
+    content3 = create_upstream_content(content_id3, {
+      :gpg_url => 'gpg_url',
+      :content_url => '/content/dist/rhel/$releasever/$basearch/os',
+      :metadata_expire => 6400,
+      :required_tags => 'TAG1,TAG2'
+    })
+
+    add_content_to_product_upstream(product.id, content_id1, false)
+    add_content_to_product_upstream(prov_product.id, content_id2, false)
+    add_content_to_product_upstream(der_prov_product.id, content_id3, false)
+
+    sub_id = random_string('test_subscription_1')
+    sub = create_upstream_subscription(sub_id, owner_key, product.id, {
+      :quantity => 10,
+      :contract_number => '12345',
+      :account_number => '6789',
+      :order_number => 'order1',
+      :provided_products => [prov_product],
+      :derived_product => der_product,
+      :derived_provided_products => [der_prov_product]
+    })
+
+    @cp.refresh_pools(owner_key)
+    pools = @cp.list_pools({:owner => owner.id})
+    expect(pools.length).to eq(2) # Expecting base pool + bonus pool
+
+    pool = pools.select {|p| p['type'] != 'UNMAPPED_GUEST' }[0]
+    bonus_pool = pools.select {|p| p['type'] == 'UNMAPPED_GUEST' }[0]
+
+
+    # create an entitlement with a product and content
+    user = user_client(owner, random_string('billy'))
+    system = consumer_client(user, random_string('system1'), :system, nil, {
+      'system.certificate_version' => '3.3',
+      'uname.machine' => 'i386'
+    })
+
+    guest = consumer_client(user, 'virty', :system, nil, {
+      'system.certificate_version' => '3.3',
+      'virt.is_guest' => true
+    })
+
+    entitlement = system.consume_pool(pool['id'], {:quantity => 1})[0]
+    bonus_entitlement = guest.consume_pool(bonus_pool['id'], {:quantity => 1})[0]
 
     json_body = extract_payload(entitlement['certificates'][0]['cert'])
     bonus_json_body = extract_payload(bonus_entitlement['certificates'][0]['cert'])
@@ -399,151 +788,193 @@ describe 'Refresh Pools' do
     serial_concat = concat_serials(entitlement, bonus_entitlement)
 
     # verify serial does not change on simple refresh
-    @cp.refresh_pools(@owner['key'], false, false, false)
+    @cp.refresh_pools(owner_key, false, false, false)
     entitlement =  @cp.get_entitlement(entitlement['id'])
     bonus_entitlement =  @cp.get_entitlement(bonus_entitlement['id'])
 
     concat_serials(entitlement, bonus_entitlement).should == serial_concat
 
-    # modify sub object, update upstream sub but dont refresh
-    sub = yield(sub, @owner)
-    update_pool_or_subscription(sub, false)
+    # Yield to encapsulating test, applying any change it may have made
+    sub = yield(owner, sub)
+    update_upstream_subscription(sub.id, sub)
 
     # verify serial does not change on content update request that does not regenerate cert
     entitlement =  @cp.get_entitlement(entitlement['id'])
     bonus_entitlement =  @cp.get_entitlement(bonus_entitlement['id'])
     concat_serials(entitlement, bonus_entitlement).should == serial_concat
+
     # this time when we refresh, serial should change
-    @cp.refresh_pools(@owner['key'], false, false, false)
+    @cp.refresh_pools(owner_key, false, false, false)
     entitlement =  @cp.get_entitlement(entitlement['id'])
     bonus_entitlement =  @cp.get_entitlement(bonus_entitlement['id'])
     concat_serials(entitlement, bonus_entitlement).should_not == serial_concat
     json_body = extract_payload(entitlement['certificates'][0]['cert'])
-    return json_body, @product
+
+    return json_body, product
   end
 
   it 'regenerates entitlements when modifiedProductIds of content change' do
-    test_entitlement_regeneration { |sub, owner|
-      prod_id_2 = random_string('modifying_prod')
-      create_product(prod_id_2, prod_id_2, {
-        :owner => owner['key']
-      })
-      sub['product']['productContent'][0]['content']['modifiedProductIds'] = [prod_id_2]
-      sub
+    test_entitlement_regeneration { |owner, subscription|
+      product_id2 = random_string(nil, true)
+      product2 = create_upstream_product(product_id2, { :name => 'test_prod_2' })
+
+      content = subscription['product']['productContent'].first['content']
+      content.modifiedProductIds = [product_id2]
+      update_upstream_content(content.id, content)
+
+      subscription
     }
   end
 
   it 'regenerates entitlements when modifiedProductIds of content of a provided product change' do
-    test_entitlement_regeneration { |sub, owner|
-      prod_id_2 = random_string('modifying_prod')
-      create_product(prod_id_2, prod_id_2, {
-        :owner => owner['key']
-      })
-      sub['providedProducts'][0]['productContent'][0]['content']['modifiedProductIds'] = [prod_id_2]
-      sub
+    test_entitlement_regeneration { |owner, subscription|
+      product_id2 = random_string(nil, true)
+      product2 = create_upstream_product(product_id2, { :name => 'test_prod_2' })
+
+      content = subscription['providedProducts'][0]['productContent'][0]['content']
+      content.modifiedProductIds = [product_id2]
+      update_upstream_content(content.id, content)
+
+      subscription
     }
   end
 
   it 'regenerates entitlements when modifiedProductIds of content of a derived provided product change' do
-    test_entitlement_regeneration { |sub, owner|
-      prod_id_2 = random_string('modifying_prod')
-      create_product(prod_id_2, prod_id_2, {
-        :owner => owner['key']
-      })
-      sub['derivedProvidedProducts'][0]['productContent'][0]['content']['modifiedProductIds'] = [prod_id_2]
-      sub
+    test_entitlement_regeneration { |owner, subscription|
+      product_id2 = random_string(nil, true)
+      product2 = create_upstream_product(product_id2, { :name => 'test_prod_2' })
+
+      content = subscription['derivedProvidedProducts'][0]['productContent'][0]['content']
+      content.modifiedProductIds = [product_id2]
+      update_upstream_content(content.id, content)
+
+      subscription
     }
   end
 
   it 'regenerates entitlements when provided product is added' do
-    pp_name = random_string('pp_name')
-    pp_id = random_string(nil, true)
-    json_body, main_product = test_entitlement_regeneration { |sub, owner|
-      pp = create_product(pp_id, pp_name, {:attributes =>
-                  {:version => '6.4',
-                   :arch => 'i386, x86_64',
-                   :sockets => 4,
-                   :cores => 8,
-                   :ram => 16,
-                   :warning_period => 15,
-                   :management_enabled => true,
-                   :stacking_id => '8888',
-                   :virt_only => 'false',
-                   :support_level => 'standard',
-                   :support_type => 'excellent',}, :owner => owner['key']})
-      pp_content = create_content({:gpg_url => 'gpg_url',
-                   :content_url => '/content/dist/rhel/$releasever/$basearch/os',
-                   :metadata_expire => 6400,
-                   :required_tags => 'TAG1,TAG2',})
-      pp['productContent'] = [{'content' => pp_content, 'enabled' => 'true'}]
-      sub['providedProducts'].push(pp)
-      sub
+    prov_product_id = random_string(nil, true)
+
+    json_body, main_product = test_entitlement_regeneration { |owner, subscription|
+      prov_product = create_upstream_product(prov_product_id, {
+        :name => 'test_prov_prod',
+        :version => '6.4',
+        :arch => 'i386, x86_64',
+        :sockets => 4,
+        :cores => 8,
+        :ram => 16,
+        :warning_period => 15,
+        :management_enabled => true,
+        :stacking_id => '8888',
+        :virt_only => 'false',
+        :support_level => 'standard',
+        :support_type => 'excellent'
+      })
+
+      content_id = random_string('test_content_')
+      content = create_upstream_content(content_id, {
+        :gpg_url => 'gpg_url',
+        :content_url => '/content/dist/rhel/$releasever/$basearch/os',
+        :metadata_expire => 6400,
+        :required_tags => 'TAG1,TAG2'
+      })
+
+      add_content_to_product_upstream(prov_product.id, content_id)
+
+      subscription['providedProducts'].push(prov_product)
+
+      subscription
     }
-    pp = json_body['products'].find {|p| p['id'] == pp_id}
-    pp['name'].should == pp_name
+
+    prov_product = json_body['products'].find {|p| p['id'] == prov_product_id}
+    expect(prov_product).to_not be_nil
   end
 
   it 'regenerates entitlements when provided product is removed' do
-    json_body, main_product = test_entitlement_regeneration { |sub, owner|
-      sub['providedProducts'] = []
-      sub
+    json_body, main_product = test_entitlement_regeneration { |owner, subscription|
+      subscription['providedProducts'] = []
+      subscription
     }
+
     json_body['products'].size.should == 1
   end
 
   it 'regenerates entitlements when label of a content changes' do
-    json_body, main_product = test_entitlement_regeneration { |sub, owner|
-      sub['product']['productContent'][0]['content']['label'] = 'shakeItOff'
-      sub
+    json_body, main_product = test_entitlement_regeneration { |owner, subscription|
+      content = subscription['product']['productContent'].first['content']
+      content.label = 'shakeItOff'
+      update_upstream_content(content.id, content)
+
+      subscription
     }
+
     product_json = json_body['products'].find {|p| p['id'] == main_product['id']}
     product_json['content'][0]['label'].should == 'shakeItOff'
   end
 
   it 'regenerates entitlements when releaseVer of a content changes' do
-    test_entitlement_regeneration { |sub|
-      sub['product']['productContent'][0]['content']['releaseVer'] = 'badBlood'
-      sub
+    test_entitlement_regeneration { |owner, subscription|
+      content = subscription['product']['productContent'].first['content']
+      content.releaseVer = 'badBlood'
+      update_upstream_content(content.id, content)
+
+      subscription
     }
+
     # releasever is not in json
   end
 
   it 'regenerates entitlements when vendor of a content changes' do
-    json_body, main_product = test_entitlement_regeneration { |sub|
-      sub['product']['productContent'][0]['content']['vendor'] = 'blankSpace'
-      sub
+    json_body, main_product = test_entitlement_regeneration { |owner, subscription|
+      content = subscription['product']['productContent'].first['content']
+      content.vendor = 'blankSpace'
+      update_upstream_content(content.id, content)
+
+      subscription
     }
+
     product_json = json_body['products'].find {|p| p['id'] == main_product['id']}
     product_json['content'][0]['vendor'].should == 'blankSpace'
   end
 
   it 'regenerates entitlements when adding a content' do
-    json_body, main_product = test_entitlement_regeneration { |sub|
-      productContent =
-        { "content"=>{ "created"=>"2017-11-24T13:41:39+0000",
-		       "updated"=>"2017-11-24T13:41:39+0000",
-		       "uuid"=>"theStroyOfUs",
-		       "id"=>"twentyTwo",
-		       "type"=>"yum",
-		       "label"=>"teardropsOnMyGuitar",
-		       "name"=>"swiftrocks",
-		       "vendor"=>"fifteen",
-		       "releaseVer"=>nil},
-          "enabled"=>true }
+    json_body, main_product = test_entitlement_regeneration { |owner, subscription|
+      product = subscription['product']
 
-      sub['product']['productContent'].push(productContent)
-      sub
+      content = create_upstream_content("twentyTwo", {
+        :type => "yum",
+        :label => "teardropsOnMyGuitar",
+        :name => "swiftrocks",
+        :vendor => "fifteen",
+        :releaseVer => nil
+      })
+
+      add_content_to_product_upstream(product.id, content.id)
+
+      # Need to return the updated, upstream subscription here so we don't risk clobbering the addition.
+      # We shouldn't, anyway, but there's no need to risk it unnecessarily.
+      get_upstream_subscription(subscription.id)
     }
+
     product_json = json_body['products'].find {|p| p['id'] == main_product['id']}
     content = product_json['content'].find {|c| c['id'] == 'twentyTwo'}
-    content['name'].should == 'swiftrocks'
+
+    expect(content).to_not be_nil
+    expect(content['name']).to eq('swiftrocks')
   end
 
   it 'regenerates entitlements when deleting a content' do
-    json_body, main_product = test_entitlement_regeneration { |sub|
-      sub['product']['productContent'] = []
-      sub
+    json_body, main_product = test_entitlement_regeneration { |owner, subscription|
+      product = subscription['product']
+      content = product['productContent'].first['content']
+
+      remove_content_from_product_upstream(product.id, content.id)
+
+      # Need to return the updated, upstream subscription here so we don't risk clobbering the removal.
+      # We shouldn't, anyway, but there's no need to risk it unnecessarily.
+      get_upstream_subscription(subscription.id)
     }
+
     product_json = json_body['products'].find {|p| p['id'] == main_product['id']}
     product_json['content'].should == []
   end

--- a/server/spec/serialization_spec.rb
+++ b/server/spec/serialization_spec.rb
@@ -8,8 +8,7 @@ describe 'Consumer serialization' do
   before(:each) do
     @owner = create_owner(random_string("test_owner"))
     @owner_client = user_client(@owner, random_string('testuser'))
-    @consumer_client = consumer_client(@owner_client, random_string(),
-        "candlepin")
+    @consumer_client = consumer_client(@owner_client, random_string(), "candlepin")
     @consumer = @cp.get_consumer(@consumer_client.uuid)
   end
 
@@ -29,7 +28,7 @@ describe 'Pool serialization' do
     @owner_client = user_client(@owner, random_string('testuser'))
     product1 = create_product()
 
-    @pool = create_pool_and_subscription(@owner['key'], product1.id, 2)
+    @pool = @cp.create_pool(@owner['key'], product1.id, {:quantity => 2})
   end
 
   it 'references owner as a link' do
@@ -48,10 +47,9 @@ describe 'Entitlement Serialization' do
     @owner_client = user_client(@owner, random_string('testuser'))
     product1 = create_product()
 
-    @pool = create_pool_and_subscription(@owner['key'], product1.id, 2)
+    @pool = @cp.create_pool(@owner['key'], product1.id, {:quantity => 2})
 
-    consumer_client = consumer_client(@owner_client, random_string(),
-        "candlepin")
+    consumer_client = consumer_client(@owner_client, random_string(), "candlepin")
     ent_id = consumer_client.consume_pool(@pool.id, {:quantity => 1})[0]['id']
     @ent = @cp.get_entitlement(ent_id)
   end

--- a/server/spec/sku_level_enable_override_spec.rb
+++ b/server/spec/sku_level_enable_override_spec.rb
@@ -24,7 +24,7 @@ describe 'SKU Level Enable Override' do
     product = create_product(nil, nil,  {:attributes => { :content_override_enabled => @content_list }})
     providedProduct = create_product
     @cp.add_content_to_product(@owner['key'], providedProduct['id'], @content1['id'], false)
-    pool = create_pool_and_subscription(@owner['key'], product['id'], 10, [providedProduct.id])
+    pool = @cp.create_pool(@owner['key'], product.id, {:quantity => 10, :provided_products => [providedProduct.id]})
     ent = consumer_cp.consume_pool(pool['id'], {:quantity => 1})[0]
 
     json_body = extract_payload(ent['certificates'][0]['cert'])
@@ -49,7 +49,7 @@ describe 'SKU Level Enable Override' do
     product = create_product(nil, nil,  {:attributes => { :content_override_disabled => @content_list }})
     providedProduct = create_product
     @cp.add_content_to_product(@owner['key'], providedProduct['id'], @content2['id'], true)
-    pool = create_pool_and_subscription(@owner['key'], product.id, 10, [providedProduct.id])
+    pool = @cp.create_pool(@owner['key'], product.id, {:quantity => 10, :provided_products => [providedProduct.id]})
     ent = consumer_cp.consume_pool(pool['id'], {:quantity => 1})[0]
 
     json_body = extract_payload(ent['certificates'][0]['cert'])
@@ -78,7 +78,7 @@ describe 'SKU Level Enable Override' do
     product = create_product(nil, nil,  {:attributes => { :content_override_disabled => @content_list }})
     providedProduct = create_product
     @cp.add_content_to_product(@owner['key'], providedProduct['id'], @content3['id'], false)
-    pool = create_pool_and_subscription(@owner['key'], product.id, 10, [providedProduct.id])
+    pool = @cp.create_pool(@owner['key'], product.id, {:quantity => 10, :provided_products => [providedProduct.id]})
 
     # Override enabled to true:
     job = @org_admin.promote_content(env['id'],
@@ -112,7 +112,7 @@ describe 'SKU Level Enable Override' do
     product = create_product(nil, nil,  {:attributes => { :content_override_enabled => @content_list }})
     providedProduct = create_product
     @cp.add_content_to_product(@owner['key'], providedProduct['id'], @content1['id'], false)
-    pool = create_pool_and_subscription(@owner['key'], product.id, 10, [providedProduct.id])
+    pool = @cp.create_pool(@owner['key'], product.id, {:quantity => 10, :provided_products => [providedProduct.id]})
     ent = consumer_cp.consume_pool(pool['id'], {:quantity => 1})[0]
 
     x509 = OpenSSL::X509::Certificate.new(ent['certificates'][0]['cert'])
@@ -129,7 +129,7 @@ describe 'SKU Level Enable Override' do
     product = create_product(nil, nil,  {:attributes => { :content_override_disabled => @content_list }})
     providedProduct = create_product
     @cp.add_content_to_product(@owner['key'], providedProduct['id'], @content2['id'], true)
-    pool = create_pool_and_subscription(@owner['key'], product.id, 10, [providedProduct.id])
+    pool = @cp.create_pool(@owner['key'], product.id, {:quantity => 10, :provided_products => [providedProduct.id]})
     ent = consumer_cp.consume_pool(pool['id'], {:quantity => 1})[0]
 
     x509 = OpenSSL::X509::Certificate.new(ent['certificates'][0]['cert'])
@@ -150,7 +150,7 @@ describe 'SKU Level Enable Override' do
     product = create_product(nil, nil,  {:attributes => { :content_override_disabled => @content_list }})
     providedProduct = create_product
     @cp.add_content_to_product(@owner['key'], providedProduct['id'], @content3['id'], false)
-    pool = create_pool_and_subscription(@owner['key'], product.id, 10, [providedProduct.id])
+    pool = @cp.create_pool(@owner['key'], product.id, {:quantity => 10, :provided_products => [providedProduct.id]})
     # Override enabled to true:
     job = @org_admin.promote_content(env['id'],
         [{

--- a/server/spec/storage_band_spec.rb
+++ b/server/spec/storage_band_spec.rb
@@ -8,23 +8,25 @@ describe 'Band Limiting' do
     @owner = create_owner random_string('test_owner')
 
     # Create a product limiting by band.
-    @ceph_product = create_product(
-        random_string("storage-limited-sku"),
-        random_string("Storage Limited"),
-        :multiplier => 256,
-        :attributes => {
-            :version => '6.4',
-             # storage_band will always be defined as 1, or not set.
-            :storage_band => 1,
-            :warning_period => 15,
-            :stacking_id => "ceph-node",
-            :'multi-entitlement' => "yes",
-            :support_level => 'standard',
-            :support_type => 'excellent'
-        }
-    )
+    @ceph_product = create_product(random_string("storage-limited-sku"), random_string("Storage Limited"), {
+      :multiplier => 256,
+      :attributes => {
+        :version => '6.4',
+         # storage_band will always be defined as 1, or not set.
+        :storage_band => 1,
+        :warning_period => 15,
+        :stacking_id => "ceph-node",
+        :'multi-entitlement' => "yes",
+        :support_level => 'standard',
+        :support_type => 'excellent'
+      }
+    })
 
-    @ceph_pool = create_pool_and_subscription(@owner['key'], @ceph_product.id, 2, [], '1888', '1234')
+    @ceph_pool = @cp.create_pool(@owner['key'], @ceph_product.id, {
+      :quantity => 2,
+      :contract_number => '1888',
+      :account_number => '1234'
+    })
     @ceph_pool.should_not be_nil
 
     @user = user_client(@owner, random_string('test-user'))

--- a/server/spec/subscription_resource_spec.rb
+++ b/server/spec/subscription_resource_spec.rb
@@ -14,23 +14,47 @@ describe 'Subscription Resource' do
   end
 
   it 'should allow owners to create subscriptions and retrieve all' do
-      create_pool_and_subscription(@owner['key'], @some_product.id, 2,
-				[], '', '', '', nil, nil, true)
-      create_pool_and_subscription(@owner['key'], @another_product.id, 3,
-				[], '', '', '', nil, nil, true)
-      create_pool_and_subscription(@owner['key'], @one_more_product.id, 2)
+      @cp.create_pool(@owner['key'], @some_product.id, {
+        :quantity => 2,
+        :subscription_id => random_string('source_sub'),
+        :upstream_pool_id => random_string('upstream')
+      })
+
+      @cp.create_pool(@owner['key'], @another_product.id, {
+        :quantity => 3,
+        :subscription_id => random_string('source_sub'),
+        :upstream_pool_id => random_string('upstream')
+      })
+
+      @cp.create_pool(@owner['key'], @one_more_product.id, {
+        :quantity => 2,
+        :subscription_id => random_string('source_sub'),
+        :upstream_pool_id => random_string('upstream')
+      })
+
       @cp.list_subscriptions(@owner['key']).size.should == 3
   end
 
   it 'should allow admins to delete subscriptions' do
-      pool = create_pool_and_subscription(@owner['key'], @monitoring_product.id, 5)
+      pool = @cp.create_pool(@owner['key'], @monitoring_product.id, {
+        :quantity => 5,
+        :subscription_id => random_string('source_sub'),
+        :upstream_pool_id => random_string('upstream')
+      })
+
       @cp.list_subscriptions(@owner['key']).size.should == 1
-      delete_pool_and_subscription(pool)
+
+      @cp.delete_pool(pool.id)
       @cp.list_subscriptions(@owner['key']).size.should == 0
   end
 
   it 'should not allow clients to fetch subscriptions using id' do
-      pool = create_pool_and_subscription(@owner['key'], @one_more_product.id, 2)
+      pool = @cp.create_pool(@owner['key'], @one_more_product.id, {
+        :quantity => 2,
+        :subscription_id => random_string('source_sub'),
+        :upstream_pool_id => random_string('upstream')
+      })
+
       begin
           @cp.get_subscription(pool['subscriptionId'])
           fail("Should not allow to fetch subscription")
@@ -40,7 +64,12 @@ describe 'Subscription Resource' do
   end
 
   it 'should not allow clients to fetch subscription cert using subscription id' do
-      pool = create_pool_and_subscription(@owner['key'], @one_more_product.id, 2)
+      pool = @cp.create_pool(@owner['key'], @one_more_product.id, {
+        :quantity => 2,
+        :subscription_id => random_string('source_sub'),
+        :upstream_pool_id => random_string('upstream')
+      })
+
       begin
           @cp.get_subscription_cert(pool['subscriptionId'])
           fail("Should not allow to fetch subscription")

--- a/server/spec/system_admin_spec.rb
+++ b/server/spec/system_admin_spec.rb
@@ -64,7 +64,7 @@ describe 'System Admins' do
 
   def create_pool
     product = create_product
-    return create_pool_and_subscription(@owner['key'], product.id, 10)
+    return @cp.create_pool(@owner['key'], product.id, {:quantity => 10})
   end
 
   it "can create entitlements only for their systems" do
@@ -156,7 +156,7 @@ describe 'System admins with read-only on org' do
   # TODO: duplicated with above:
   def create_pool
     product = create_product
-    return create_pool_and_subscription(@owner['key'], product.id, 10)
+    return @cp.create_pool(@owner['key'], product.id, {:quantity => 10})
   end
 
   it 'can list their owners' do

--- a/server/spec/ueber_cert_spec.rb
+++ b/server/spec/ueber_cert_spec.rb
@@ -43,11 +43,26 @@ describe 'Uebercert' do
     @cp.add_content_to_product(owner1['key'], prod1.id, content2.id, true)
     @cp.add_content_to_product(owner1['key'], prod2.id, content3.id, true)
 
-    create_pool_and_subscription(owner1['key'], prod1.id, 10, [], '12345', '6789', 'order1',
-                nil, nil, true)
-    create_pool_and_subscription(owner1['key'], prod2.id, 10, [], 'abcde', 'fghi', 'order2',
-                nil, nil, true)
-    create_pool_and_subscription(owner1['key'], prod3.id, 10, [], 'qwert', 'yuio', 'order3')
+    @cp.create_pool(owner1['key'], prod1.id, {
+      :quantity => 10,
+      :contract_number => '12345',
+      :account_number => '6789',
+      :order_number => 'order1',
+    })
+
+    @cp.create_pool(owner1['key'], prod2.id, {
+      :quantity => 10,
+      :contract_number => 'abcde',
+      :account_number => 'fghi',
+      :order_number => 'order2',
+    })
+
+    @cp.create_pool(owner1['key'], prod3.id, {
+      :quantity => 10,
+      :contract_number => 'qwert',
+      :account_number => 'yuio',
+      :order_number => 'order3',
+    })
 
     # generate and verify cert
     ueber_cert = @cp.generate_ueber_cert(owner1['key'])

--- a/server/spec/unbind_spec.rb
+++ b/server/spec/unbind_spec.rb
@@ -9,7 +9,7 @@ describe 'Unbind' do
     @user = user_client(@owner, random_string('guy'))
     @monitoring = create_product(nil, random_string('monitoring'))
 
-    create_pool_and_subscription(@owner['key'], @monitoring.id, 4)
+    @cp.create_pool(@owner['key'], @monitoring.id, {:quantity => 4})
   end
 
   it 'should remove a single entitlement' do
@@ -28,7 +28,7 @@ describe 'Unbind' do
     consumer = consumer_client(@user, 'consumer')
 
     testing = create_product(nil, random_string('testing'))
-    create_pool_and_subscription(@owner['key'], testing.id, 4)
+    @cp.create_pool(@owner['key'], testing.id, {:quantity => 4})
 
     pool1 = consumer.list_pools(
       :product => @monitoring.id,
@@ -79,7 +79,7 @@ describe 'Unbind' do
 
   it 'should leave other entitlements intact' do
     virt_host = create_product(nil, random_string('virt_host'))
-    pool = create_pool_and_subscription(@owner['key'], virt_host.id, 5)
+    pool = @cp.create_pool(@owner['key'], virt_host.id, {:quantity => 5})
 
     consumer = consumer_client(@user, 'consumer')
     pool = consumer.list_pools(

--- a/server/spec/unmapped_guest_spec.rb
+++ b/server/spec/unmapped_guest_spec.rb
@@ -20,7 +20,12 @@ describe 'Unmapped Guest Pools' do
         :'multi-entitlement' => 'yes'
       }
     })
-    create_pool_and_subscription(@owner['key'], @virt_limit_product.id, 10)
+
+    @cp.create_pool(@owner['key'], @virt_limit_product.id, {
+      :quantity => 10,
+      :subscription_id => random_string('source_sub'),
+      :upstream_pool_id => random_string('upstream')
+    })
 
     # should only be the base pool and the bonus pool for unmapped guests
     @pools = @user.list_pools :owner => @owner.id, :product => @virt_limit_product.id
@@ -75,7 +80,6 @@ describe 'Unmapped Guest Pools' do
         @host1_client.consume_pool(pool['id'], {:quantity => 1})
       end
     end
-    @cp.refresh_pools(@owner['key'])
 
     # should be the base pool, the bonus pool for unmapped guests, plus a pool for the host's guests
     @pools = @user.list_pools :owner => @owner.id, :product => @virt_limit_product.id
@@ -99,7 +103,6 @@ describe 'Unmapped Guest Pools' do
         @host1_client.consume_pool(pool['id'], {:quantity => 1})
       end
     end
-    @cp.refresh_pools(@owner['key'])
 
     # should be the base pool, the bonus pool for unmapped guests, plus a pool for the host's guests
     @pools = @user.list_pools :owner => @owner.id, :product => @virt_limit_product.id
@@ -180,7 +183,6 @@ describe 'Unmapped Guest Pools' do
         @host2_client.consume_pool(pool['id'], :quantity => 1)
       end
     end
-    @cp.refresh_pools(@owner['key'])
 
     # should be the base pool, the bonus pool for unmapped guests, plus two pools for the hosts' guests
     @pools = @user.list_pools :owner => @owner.id, :product => @virt_limit_product.id

--- a/server/spec/virt_only_spec.rb
+++ b/server/spec/virt_only_spec.rb
@@ -74,7 +74,7 @@ describe 'Virt Only Pools' do
       }
     })
 
-    create_pool_and_subscription(@owner['key'], product.id, 10)
+    @cp.create_pool(@owner['key'], product.id, {:quantity => 10})
 
     product
   end

--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -210,7 +210,7 @@ public class CandlepinPoolManager implements PoolManager {
         log.debug("Fetching subscriptions from adapter...");
         List<Subscription> subscriptions = subAdapter.getSubscriptions(owner);
 
-        log.debug("Done. Processing subscriptions...");
+        log.debug("Done. Processing {} subscriptions...", subscriptions.size());
         for (Subscription subscription : subscriptions) {
             if (subscription == null) {
                 continue;
@@ -827,7 +827,6 @@ public class CandlepinPoolManager implements PoolManager {
      *  The owner the pool will be assigned to
      */
     private Pool convertToMasterPoolImpl(Subscription sub, Owner owner, Map<String, Product> productMap) {
-
         if (sub == null) {
             throw new IllegalArgumentException("subscription is null");
         }

--- a/server/src/main/java/org/candlepin/hostedtest/HostedTestSubscriptionServiceAdapter.java
+++ b/server/src/main/java/org/candlepin/hostedtest/HostedTestSubscriptionServiceAdapter.java
@@ -16,19 +16,22 @@ package org.candlepin.hostedtest;
 
 import org.candlepin.model.Consumer;
 import org.candlepin.model.Owner;
+import org.candlepin.model.dto.ContentData;
 import org.candlepin.model.dto.ProductContentData;
 import org.candlepin.model.dto.ProductData;
 import org.candlepin.model.dto.Subscription;
 import org.candlepin.service.SubscriptionServiceAdapter;
 
-import org.apache.commons.collections.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
 
 
 
@@ -41,145 +44,1389 @@ import java.util.HashMap;
 public class HostedTestSubscriptionServiceAdapter implements SubscriptionServiceAdapter {
     private static Logger log = LoggerFactory.getLogger(HostedTestSubscriptionServiceAdapter.class);
 
-    private static Map<String, Subscription> idMap = new HashMap<String, Subscription>();
-    private static Map<String, List<Subscription>> ownerMap = new HashMap<String, List<Subscription>>();
-    private static Map<String, List<Subscription>> productMap = new HashMap<String, List<Subscription>>();
+    // Impl note:
+    // These are static due to a limitation with our customizable modules that allows guice to make
+    // multiple instances of this class rather than letting us create a singleton.
 
-    @Override
-    public List<Subscription> getSubscriptions(Owner owner) {
-        if (ownerMap.containsKey(owner.getKey())) {
-            return ownerMap.get(owner.getKey());
-        }
-        return new ArrayList<Subscription>();
+    // Subscription mapping. Subscriptions themselves are mapped by subscription ID to DTO. Since
+    // we don't store owners (orgs) at this level, we just maintain a mapping of owner keys
+    // (account) to subscription IDs.
+    protected static Map<String, Subscription> subscriptions;
+    protected static Map<String, Set<String>> ownerSubscriptionMap;
+
+    // At the time of writing, upstream product and content data is global; no need to separate these
+    // by org. Mapped by RHID to DTO
+    protected static Map<String, ProductData> productData;
+    protected static Map<String, ContentData> contentData;
+
+    // These are used to provide reverse lookups from child objects back to their parents
+    protected static Map<String, Set<String>> contentProductMap;
+    protected static Map<String, Set<String>> productSubscriptionMap;
+
+    static {
+        subscriptions = new HashMap<String, Subscription>();
+        ownerSubscriptionMap = new HashMap<String, Set<String>>();
+
+        productData = new HashMap<String, ProductData>();
+        contentData = new HashMap<String, ContentData>();
+
+        contentProductMap = new HashMap<String, Set<String>>();
+        productSubscriptionMap = new HashMap<String, Set<String>>();
     }
 
+    /**
+     * Creates a new HostedTestSubscriptionServiceAdapter instance
+     */
+    public HostedTestSubscriptionServiceAdapter() {
+        // Intentionally left empty
+    }
+
+    /**
+     * Clears all data for this service adapter
+     */
+    public void clearData() {
+        subscriptions.clear();
+        ownerSubscriptionMap.clear();
+        productData.clear();
+        contentData.clear();
+        contentProductMap.clear();
+        productSubscriptionMap.clear();
+    }
+
+    // Methods required by the SubscriptionServiceAdapter interface
+    /**
+     * {@inheritDoc}
+     */
     @Override
-    public List<String> getSubscriptionIds(Owner owner) {
-        List<String> ids = new ArrayList<String>();
-        List<Subscription> subscriptions = ownerMap.get(owner.getKey());
-        if (subscriptions != null) {
-            for (Subscription subscription : subscriptions) {
-                ids.add(subscription.getId());
+    public List<Subscription> getSubscriptions(Owner owner) {
+        if (owner == null || owner.getKey() == null) {
+            throw new IllegalArgumentException("owner is null or does not have a valid key");
+        }
+
+        Set<String> subIds = this.ownerSubscriptionMap.get(owner.getKey());
+        List<Subscription> subs = new ArrayList<Subscription>(subIds != null ? subIds.size() + 1 : 1);
+
+        if (subIds != null) {
+            for (String sid : subIds) {
+                Subscription subscription = this.subscriptions.get(sid);
+
+                if (subscription == null) {
+                    // Sanity check; this shouldn't happen
+                    throw new IllegalStateException("No subscription found for subscription ID: " + sid);
+                }
+
+                subs.add(subscription);
             }
         }
 
-        return ids;
+        return subs;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
-    public List<Subscription> getSubscriptions(ProductData product) {
-        if (productMap.containsKey(product.getId())) {
-            return productMap.get(product.getId());
+    public List<String> getSubscriptionIds(Owner owner) {
+        if (owner == null || owner.getKey() == null) {
+            throw new IllegalArgumentException("owner is null or does not have a valid key");
         }
-        return new ArrayList<Subscription>();
+
+        Set<String> subIds = this.ownerSubscriptionMap.get(owner.getKey());
+        return subIds != null ? new ArrayList<String>(subIds) : new ArrayList<String>();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public Subscription getSubscription(String subscriptionId) {
-        return idMap.get(subscriptionId);
+        return subscriptions.get(subscriptionId);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public List<Subscription> getSubscriptions() {
-        List<Subscription> result = new ArrayList<Subscription>();
-        for (String id : idMap.keySet()) {
-            result.add(idMap.get(id));
-        }
-        return result;
+        return new ArrayList<Subscription>(subscriptions.values());
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<Subscription> getSubscriptions(ProductData product) {
+        if (product == null || product.getId() == null) {
+            throw new IllegalArgumentException("product is null or lacks a product ID");
+        }
+
+        Set<String> subIds = productSubscriptionMap.get(product.getId());
+        List<Subscription> subs = new ArrayList<Subscription>(subIds != null ? subIds.size() + 1 : 1);
+
+        if (subIds != null) {
+            for (String sid : subIds) {
+                Subscription subscription = subscriptions.get(sid);
+
+                if (subscription == null) {
+                    // Sanity check; this shouldn't happen
+                    throw new IllegalStateException("No subscription found for subscription ID: " + sid);
+                }
+
+                subs.add(subscription);
+            }
+        }
+
+        return subs;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Subscription createSubscription(Subscription dto) {
+        if (dto == null || dto.getId() == null || dto.getId().trim().isEmpty()) {
+            throw new IllegalArgumentException("dto is null or does not have a valid ID");
+        }
+
+        if (dto.getOwner() == null || dto.getOwner().getKey() == null ||
+            dto.getOwner().getKey().trim().isEmpty()) {
+
+            throw new IllegalArgumentException("dto contains incomplete owner information");
+        }
+
+        if (subscriptions.containsKey(dto.getId())) {
+            throw new IllegalStateException("subscription already exists: " + dto.getId());
+        }
+
+        // Resolve product references
+        dto = this.resolveSubscriptionProductRefs(dto);
+
+        // Store subscription
+        subscriptions.put(dto.getId(), dto);
+
+        // Update product=>subscription mappings
+        this.updateProductSubscriptionMapping(dto.getId());
+
+        // Update owner=>subscription mapping
+        this.updateSubscriptionOwnerMapping(dto.getId());
+
+        // return
+        return dto;
+    }
+
+    /**
+     * Updates the subscription with the given subscription ID using the data from the provided
+     * DTO. If a subscription with the given ID cannot be found, an exception is thrown.
+     *
+     * @param subscriptionId
+     *  The ID of the subscription to update
+     *
+     * @param dto
+     *  The DTO containing the updates to apply to the subscription
+     *
+     * @throws IllegalArgumentException
+     *  if the given subscription ID or dto is null
+     *
+     * @throws IllegalStateException
+     *  if a subscription with the given ID cannot be found
+     *
+     * @return
+     *  The updated subscription
+     */
+    public Subscription updateSubscription(String subscriptionId, Subscription dto) {
+        if (subscriptionId == null) {
+            throw new IllegalArgumentException("subscriptionId is null");
+        }
+
+        if (dto == null) {
+            throw new IllegalArgumentException("dto is null");
+        }
+
+        Subscription sdata = subscriptions.get(subscriptionId);
+        if (sdata == null) {
+            String msg = String.format("Unable to find a subscription with ID \"%s\"", subscriptionId);
+            throw new IllegalStateException(msg);
+        }
+
+        // Resolve the DTO's product references
+        dto = this.resolveSubscriptionProductRefs(dto);
+
+        // Check if the owner has been specified and, if so, if it's complete.
+        if (dto.getOwner() != null && (dto.getOwner().getKey() == null ||
+            dto.getOwner().getKey().trim().isEmpty())) {
+
+            throw new IllegalArgumentException("dto contains incomplete owner information");
+        }
+
+        // Apply changes
+        if (dto.getOwner() != null) {
+            sdata.setOwner(dto.getOwner());
+        }
+
+        if (dto.getProduct() != null) {
+            sdata.setProduct(dto.getProduct());
+        }
+
+        // Impl note:
+        // This is a special case where we need to always set the value, since using null to
+        // represent no-change would prevent unsetting this value, or would require a special
+        // product representation (which is arguably worse than just specially allowing null)
+        sdata.setDerivedProduct(dto.getDerivedProduct());
+
+        if (dto.getProvidedProducts() != null) {
+            sdata.setProvidedProducts(dto.getProvidedProducts());
+        }
+
+        if (dto.getDerivedProvidedProducts() != null) {
+            sdata.setDerivedProvidedProducts(dto.getDerivedProvidedProducts());
+        }
+
+        if (dto.getBranding() != null) {
+            sdata.setBranding(dto.getBranding());
+        }
+
+        if (dto.getQuantity() != null) {
+            sdata.setQuantity(dto.getQuantity());
+        }
+
+        if (dto.getStartDate() != null) {
+            sdata.setStartDate(dto.getStartDate());
+        }
+
+        if (dto.getEndDate() != null) {
+            sdata.setEndDate(dto.getEndDate());
+        }
+
+        if (dto.getContractNumber() != null) {
+            sdata.setContractNumber(!dto.getContractNumber().isEmpty() ? dto.getContractNumber() : null);
+        }
+
+        if (dto.getAccountNumber() != null) {
+            sdata.setAccountNumber(!dto.getAccountNumber().isEmpty() ? dto.getAccountNumber() : null);
+        }
+
+        if (dto.getModified() != null) {
+            sdata.setModified(dto.getModified());
+        }
+
+        if (dto.getOrderNumber() != null) {
+            sdata.setOrderNumber(dto.getOrderNumber());
+        }
+
+        if (dto.getUpstreamPoolId() != null) {
+            sdata.setUpstreamPoolId(!dto.getUpstreamPoolId().isEmpty() ? dto.getUpstreamPoolId() : null);
+        }
+
+        if (dto.getUpstreamEntitlementId() != null) {
+            sdata.setUpstreamEntitlementId(!dto.getUpstreamEntitlementId().isEmpty() ?
+                dto.getUpstreamEntitlementId() : null);
+        }
+
+        if (dto.getUpstreamConsumerId() != null) {
+            sdata.setUpstreamConsumerId(!dto.getUpstreamConsumerId().isEmpty() ?
+                dto.getUpstreamConsumerId() : null);
+        }
+
+        if (dto.getCertificate() != null) {
+            sdata.setCertificate(dto.getCertificate());
+        }
+
+        if (dto.getCdn() != null) {
+            sdata.setCdn(dto.getCdn());
+        }
+
+        // Update mappings
+        this.updateProductSubscriptionMapping(subscriptionId);
+        this.updateSubscriptionOwnerMapping(subscriptionId);
+
+        return sdata;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void deleteSubscription(Subscription dto) {
+        if (dto == null || dto.getId() == null || dto.getId().trim().isEmpty()) {
+            throw new IllegalArgumentException("dto is null or does not have a valid ID");
+        }
+
+        this.deleteSubscription(dto.getId());
+    }
+
+    public Subscription deleteSubscription(String subscriptionId) {
+        if (subscriptionId == null) {
+            throw new IllegalArgumentException("subscriptionId is null");
+        }
+
+        if (!subscriptions.containsKey(subscriptionId)) {
+            String msg = String.format("Unable to find a subscription with ID \"%s\"", subscriptionId);
+            throw new IllegalStateException(msg);
+        }
+
+        Subscription sdata = subscriptions.remove(subscriptionId);
+
+        // Remove any product=>subscription mappings for this subscription ID
+        for (Set<String> subIds : productSubscriptionMap.values()) {
+            subIds.remove(subscriptionId);
+        }
+
+        // Remove owner=>subscription mappings
+        // Impl note: we hit all of the owners, since there's no guarantee we'll still have a
+        // valid owner key on the subscription object.
+        Iterator<Map.Entry<String, Set<String>>> ei = ownerSubscriptionMap.entrySet().iterator();
+        while (ei.hasNext()) {
+            Map.Entry<String, Set<String>> entry = ei.next();
+            Set<String> subIds = entry.getValue();
+
+            if (subIds.remove(subscriptionId) && subIds.isEmpty()) {
+                ei.remove();
+            }
+        }
+
+        return sdata;
+    }
+
+    /**
+     * Resolves and corrects the product references on the specified subscription DTO. If the DTO
+     * contains invalid product references, this method throws an exception.
+     *
+     * @param dto
+     *  The subscription DTO on which to resolve product references
+     *
+     * @throws IllegalArgumentException
+     *  if the given DTO is null
+     *
+     * @throws IllegalStateException
+     *  if the DTO has null product references or references products which does not exist
+     *
+     * @return
+     *  The updated subscription DTO
+     */
+    protected Subscription resolveSubscriptionProductRefs(Subscription dto) {
+        if (dto == null) {
+            throw new IllegalArgumentException("dto is null or does not have a valid ID");
+        }
+
+        // product
+        if (dto.getProduct() != null) {
+            dto.setProduct(this.resolveSubscriptionProduct(dto.getProduct()));
+        }
+
+        // derived product
+        if (dto.getDerivedProduct() != null) {
+            dto.setDerivedProduct(this.resolveSubscriptionProduct(dto.getDerivedProduct()));
+        }
+
+        // provided products
+        if (dto.getProvidedProducts() != null) {
+            Set<ProductData> resolved = new HashSet<ProductData>();
+
+            for (ProductData provided : dto.getProvidedProducts()) {
+                resolved.add(this.resolveSubscriptionProduct(provided));
+            }
+
+            dto.setProvidedProducts(resolved);
+        }
+
+        // derived provided products
+        if (dto.getDerivedProvidedProducts() != null) {
+            Set<ProductData> resolved = new HashSet<ProductData>();
+
+            for (ProductData provided : dto.getDerivedProvidedProducts()) {
+                resolved.add(this.resolveSubscriptionProduct(provided));
+            }
+
+            dto.setDerivedProvidedProducts(resolved);
+        }
+
+        return dto;
+    }
+
+    /**
+     * Resolves the product specified by the given product DTO to one mapped by this adapter. If
+     * the DTO is null, lacks an ID or references a product that doesn't exist, this method throws
+     * an exception.
+     *
+     * @param dto
+     *  The product DTO to resolve
+     *
+     * @throws IllegalStateException
+     *  if the DTO cannot be resolved to an existing product
+     *
+     * @return
+     *  the resolved product
+     */
+    private ProductData resolveSubscriptionProduct(ProductData dto) {
+        if (dto == null || dto.getId() == null) {
+            throw new IllegalStateException("Subscription contains a malformed product reference");
+        }
+
+        if (!this.productData.containsKey(dto.getId())) {
+            throw new IllegalStateException("Subscription references a non-existent product: " + dto.getId());
+        }
+
+        return productData.get(dto.getId());
+    }
+
+    /**
+     * Updates the product=>subscription mappings for the specified subscription ID. If the
+     * subscription contains invalid product mappings, this method throws an exception.
+     *
+     * @param subscriptionId
+     *  The ID of the subscription for which to update product=>subscription mappings
+     *
+     * @throws IllegalArgumentException
+     *  if subscriptionId is null or invalid
+     *
+     * @throws IllegalStateException
+     *  if the subscription contains malformed product references
+     */
+    protected void updateProductSubscriptionMapping(String subscriptionId) {
+        if (subscriptionId == null || !subscriptions.containsKey(subscriptionId)) {
+            throw new IllegalArgumentException("subscriptionId is null or invalid");
+        }
+
+        Subscription sub = subscriptions.get(subscriptionId);
+        Set<String> productIds = new HashSet<String>();
+
+        if (sub.getProduct() != null) {
+            productIds.add(sub.getProduct().getId());
+        }
+
+        // derived product
+        if (sub.getDerivedProduct() != null) {
+            productIds.add(sub.getDerivedProduct().getId());
+        }
+
+        // provided products
+        if (sub.getProvidedProducts() != null) {
+            for (ProductData provided : sub.getProvidedProducts()) {
+                // If this is a null ref, we'll throw an exception later in the validation step
+                productIds.add(provided != null ? provided.getId() : null);
+            }
+        }
+
+        // derived provided products
+        if (sub.getDerivedProvidedProducts() != null) {
+            for (ProductData provided : sub.getDerivedProvidedProducts()) {
+                // If this is a null ref, we'll throw an exception later in the validation step
+                productIds.add(provided != null ? provided.getId() : null);
+            }
+        }
+
+        // Validate fetched product IDs...
+        for (String pid : productIds) {
+            if (!productData.containsKey(pid)) {
+                String msg = String.format("Subscription \"%s\" contains a malformed product reference",
+                    subscriptionId);
+
+                throw new IllegalStateException(msg);
+            }
+        }
+
+        // Remove mappings for products that are no longer referenced by this subscription...
+        Iterator<Map.Entry<String, Set<String>>> ei = productSubscriptionMap.entrySet().iterator();
+        while (ei.hasNext()) {
+            Map.Entry<String, Set<String>> entry = ei.next();
+            String pid = entry.getKey();
+            Set<String> subIds = entry.getValue();
+
+            if (!productIds.contains(pid) && subIds.remove(subscriptionId) && subIds.isEmpty()) {
+                ei.remove();
+            }
+        }
+
+        for (String pid : productIds) {
+            Set<String> subIds = productSubscriptionMap.get(pid);
+            if (subIds == null) {
+                subIds = new HashSet<String>();
+                productSubscriptionMap.put(pid, subIds);
+            }
+
+            subIds.add(subscriptionId);
+        }
+    }
+
+    /**
+     * Updates the owner=>subscription mappings for the specified subscription ID. If the specified
+     * subscription does not exist, this method throws an exception
+     *
+     * @param subscriptionId
+     *  The ID of the subscription for which to update owner=>subscription mappings
+     *
+     * @throws IllegalArgumentException
+     *  if subscriptionId is null or invalid
+     */
+    protected void updateSubscriptionOwnerMapping(String subscriptionId) {
+        if (subscriptionId == null || !subscriptions.containsKey(subscriptionId)) {
+            throw new IllegalArgumentException("subscriptionId is null or invalid");
+        }
+
+        Subscription sub = subscriptions.get(subscriptionId);
+        String ownerKey = sub.getOwner().getKey();
+
+        // Clear all owner mappings for this sub
+        Iterator<Map.Entry<String, Set<String>>> ei = ownerSubscriptionMap.entrySet().iterator();
+        while (ei.hasNext()) {
+            Map.Entry<String, Set<String>> entry = ei.next();
+            Set<String> subIds = entry.getValue();
+
+            if (subIds.remove(subscriptionId) && subIds.isEmpty()) {
+                ei.remove();
+            }
+        }
+
+        // Create new mapping
+        Set<String> subIds = ownerSubscriptionMap.get(ownerKey);
+        if (subIds == null) {
+            subIds = new HashSet<String>();
+            ownerSubscriptionMap.put(ownerKey, subIds);
+        }
+        subIds.add(subscriptionId);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public boolean hasUnacceptedSubscriptionTerms(Owner owner) {
         return false;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void sendActivationEmail(String subscriptionId) {
         // method intentionally left blank
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public boolean canActivateSubscription(Consumer consumer) {
         return false;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void activateSubscription(Consumer consumer, String email, String emailLocale) {
         // method intentionally left blank
     }
 
-    @Override
-    public Subscription createSubscription(Subscription s) {
-        idMap.put(s.getId(), s);
-        if (!ownerMap.containsKey(s.getOwner().getKey())) {
-            ownerMap.put(s.getOwner().getKey(), new ArrayList<Subscription>());
-        }
-        ownerMap.get(s.getOwner().getKey()).add(s);
-        if (!productMap.containsKey(s.getProduct().getId())) {
-            productMap.put(s.getProduct().getId(), new ArrayList<Subscription>());
-        }
-
-        this.clearUuids(s.getProduct());
-        this.clearUuids(s.getDerivedProduct());
-        if (CollectionUtils.isNotEmpty(s.getProvidedProducts())) {
-            for (ProductData productData : s.getProvidedProducts()) {
-                this.clearUuids(productData);
-            }
-        }
-        if (CollectionUtils.isNotEmpty(s.getDerivedProvidedProducts())) {
-            for (ProductData productData : s.getDerivedProvidedProducts()) {
-                this.clearUuids(productData);
-            }
-        }
-
-        productMap.get(s.getProduct().getId()).add(s);
-        return s;
-    }
-
-    private void clearUuids(ProductData pdata) {
-        if (pdata != null) {
-            pdata.setUuid(null);
-            if (pdata.getProductContent() != null) {
-                for (ProductContentData pcdata : pdata.getProductContent()) {
-                    if (pcdata.getContent() != null) {
-                        pcdata.getContent().setUuid(null);
-                    }
-                }
-            }
-
-        }
-    }
-
-    public Subscription updateSubscription(Subscription ss) {
-        deleteSubscription(ss.getId());
-        Subscription s = createSubscription(ss);
-        return s;
-    }
-
-    @Override
-    public void deleteSubscription(Subscription s) {
-        deleteSubscription(s.getId());
-    }
-
-    public boolean deleteSubscription(String id) {
-        if (idMap.containsKey(id)) {
-            Subscription s = idMap.remove(id);
-            ownerMap.get(s.getOwner().getKey()).remove(s);
-            productMap.get(s.getProduct().getId()).remove(s);
-            return true;
-        }
-        return false;
-    }
-
-    public void deleteAllSubscriptions() {
-        idMap.clear();
-        ownerMap.clear();
-        productMap.clear();
-    }
-
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public boolean isReadOnly() {
         return false;
     }
 
+    // Required CRUD operations for our children objects.
+
+    /**
+     * Creates (stores) the given product DTO. If the provided DTO does not have a valid product
+     * ID, this method throws an exception.
+     *
+     * @param dto
+     *  The DTO representing the product to create/store
+     *
+     * @throws IllegalArgumentException
+     *  if the product does not contain a valid product ID
+     *
+     * @throws IllegalStateException
+     *  if a product with the same product ID already exists
+     *
+     * @return
+     *  the "new" product instance
+     */
+    public ProductData createProduct(ProductData dto) {
+        if (dto == null || dto.getId() == null || dto.getId().trim().isEmpty()) {
+            throw new IllegalArgumentException("dto is null or does not have a valid ID");
+        }
+
+        if (dto.getName() == null || dto.getName().trim().isEmpty()) {
+            throw new IllegalArgumentException("dto does not have a valid name");
+        }
+
+        if (this.productData.containsKey(dto.getId())) {
+            throw new IllegalStateException("product already exists: " + dto.getId());
+        }
+
+        // Verify all the referenced content exists and, if so, make sure we used the content
+        // that exists in our maps rather than what was received.
+        if (dto.getProductContent() != null) {
+            dto = this.resolveProductContentRefs(dto);
+        }
+
+        // Store product
+        productData.put(dto.getId(), dto);
+
+        // Update mapping
+        this.updateContentProductMapping(dto.getId());
+
+        return dto;
+    }
+
+    /**
+     * Fetches the product data for the given product ID. If no such product could be found, this
+     * method returns null
+     *
+     * @param productId
+     *  The ID of the product to fetch
+     *
+     * @return
+     *  The product data for the given product ID, or null if the product could not be found
+     */
+    public ProductData getProduct(String productId) {
+        return productData.get(productId);
+    }
+
+    /**
+     * Fetches the set of all known products. If there are no known products, this method returns
+     * an empty set.
+     *
+     * @return
+     *  A set of all known products
+     */
+    public Set<ProductData> getProducts() {
+        return new HashSet<ProductData>(productData.values());
+    }
+
+    /**
+     * Fetches the products for the given product IDs. If a matching product object cannot be found
+     * for a given product ID, it will be silently ignored. If there are no matching product
+     * objects, this method returns an empty set.
+     *
+     * @param productIds
+     *  A collection of IDs of the product to fetch
+     *
+     * @return
+     *  A set of product objects for the requested product IDs
+     */
+    public Set<ProductData> getProducts(Iterable<String> productIds) {
+        Set<ProductData> output = new HashSet<ProductData>();
+
+        if (productIds != null && productIds.iterator().hasNext()) {
+            for (String productId : productIds) {
+                ProductData pdata = productData.get(productId);
+
+                if (pdata != null) {
+                    output.add(pdata);
+                }
+            }
+        }
+
+        return output;
+    }
+
+    /**
+     * Updates the product with the given product ID using the data from the provided DTO. If a
+     * product with the given ID cannot be found, an exception is thrown.
+     *
+     * @param productId
+     *  The ID of the product to update
+     *
+     * @param dto
+     *  The DTO containing the updates to apply to the product
+     *
+     * @throws IllegalArgumentException
+     *  if the given product ID or dto is null
+     *
+     * @throws IllegalStateException
+     *  if a product with the given ID cannot be found
+     *
+     * @return
+     *  The updated product
+     */
+    public ProductData updateProduct(String productId, ProductData dto) {
+        if (productId == null) {
+            throw new IllegalArgumentException("productId is null");
+        }
+
+        if (dto == null) {
+            throw new IllegalArgumentException("dto is null");
+        }
+
+        ProductData pdata = productData.get(productId);
+        if (pdata == null) {
+            String msg = String.format("Unable to find a product with ID \"%s\"", productId);
+            throw new IllegalStateException(msg);
+        }
+
+        // Resolve the DTO's content references
+        dto = this.resolveProductContentRefs(dto);
+
+        // Apply updates...
+        if (dto.getName() != null) {
+            pdata.setName(dto.getName());
+        }
+
+        if (dto.getMultiplier() != null) {
+            pdata.setMultiplier(dto.getMultiplier());
+        }
+
+        if (dto.getAttributes() != null) {
+            pdata.setAttributes(dto.getAttributes());
+        }
+
+        if (dto.getProductContent() != null) {
+            pdata.setProductContent(dto.getProductContent());
+            this.updateContentProductMapping(productId);
+        }
+
+        if (dto.getDependentProductIds() != null) {
+            pdata.setDependentProductIds(dto.getDependentProductIds());
+        }
+
+        if (dto.isLocked() != null) {
+            pdata.setLocked(dto.isLocked());
+        }
+
+        this.updateAffectedSubscriptions(productId);
+
+        return pdata;
+    }
+
+    /**
+     * Deletes the specified product. If a product with the given ID cannot be found or the product
+     * is still associated with one or more subscriptions, an exception is thrown.
+     *
+     * @param productId
+     *  The ID of the product to delete
+     *
+     * @throws IllegalArgumentException
+     *  if the given product ID is null
+     *
+     * @throws IllegalStateException
+     *  if a product with the given ID cannot be found or the product is still associated with one
+     *  or more subscriptions
+     *
+     * @return
+     *  The last known state of the now-deleted product
+     */
+    public ProductData deleteProduct(String productId) {
+        if (productId == null) {
+            throw new IllegalArgumentException("productId is null");
+        }
+
+        if (!productData.containsKey(productId)) {
+            String msg = String.format("Unable to find a product with ID \"%s\"", productId);
+            throw new IllegalStateException(msg);
+        }
+
+        if (this.productSubscriptionMap.containsKey(productId)) {
+            String msg = String.format("Product is still referenced by one or more subscriptions: \"%s\"",
+                productId);
+
+            throw new IllegalStateException(msg);
+        }
+
+        ProductData pdata = productData.remove(productId);
+
+        // Update our content=>product mappings
+        if (pdata.getProductContent() != null) {
+            for (ProductContentData pcdata : pdata.getProductContent()) {
+                ContentData cdata = pcdata.getContent();
+
+                if (cdata != null && contentProductMap.containsKey(cdata.getId())) {
+                    Set<String> pids = contentProductMap.get(cdata.getId());
+
+                    if (pids.remove(pdata.getId()) && pids.isEmpty()) {
+                        contentProductMap.remove(cdata.getId());
+                    }
+                }
+            }
+        }
+
+        return pdata;
+    }
+
+    /**
+     * Resolves and corrects the content references on the specified product DTO. If the DTO
+     * contains invalid content references, this method throws an exception.
+     *
+     * @param dto
+     *  The product DTO on which to resolve content references
+     *
+     * @throws IllegalArgumentException
+     *  if the given DTO is null
+     *
+     * @throws IllegalStateException
+     *  if the DTO has null content references or references content which does not exist
+     *
+     * @return
+     *  The updated product DTO
+     */
+    protected ProductData resolveProductContentRefs(ProductData dto) {
+        if (dto == null) {
+            throw new IllegalArgumentException("dto is null");
+        }
+
+        if (dto.getProductContent() != null) {
+            for (Iterator<ProductContentData> pci = dto.getProductContent().iterator(); pci.hasNext();) {
+                ProductContentData pcdata = pci.next();
+
+                // Remove any null join objects
+                if (pcdata == null) {
+                    pci.remove();
+                }
+
+                // Make sure the content is present and has an ID
+                if (pcdata.getContent() == null || pcdata.getContent().getId() == null) {
+                    throw new IllegalStateException("Product contains a malformed content reference");
+                }
+
+                // Make sure the content exists
+                String cid = pcdata.getContent().getId();
+                ContentData cdata = contentData.get(cid);
+                if (cdata == null) {
+                    throw new IllegalStateException("Product references a non-existent content: " + cid);
+                }
+
+                // Replace the content reference with the one we currently have mapped.
+                pcdata.setContent(cdata);
+            }
+        }
+
+        return dto;
+    }
+
+    /**
+     * Updates the content=>product mappings for the specified product ID. If the product contains
+     * invalid content mappings, this method throws an exception.
+     *
+     * @param productId
+     *  The ID of the product for which to update content=>product mappings
+     *
+     * @throws IllegalArgumentException
+     *  if productId is null or invalid
+     *
+     * @throws IllegalStateException
+     *  if the product contains malformed content references
+     */
+    protected void updateContentProductMapping(String productId) {
+        if (productId == null || !productData.containsKey(productId)) {
+            throw new IllegalArgumentException("productId is null or invalid");
+        }
+
+        ProductData pdata = productData.get(productId);
+        Set<String> contentIds = new HashSet<String>();
+
+        // Gather content IDs
+        if (pdata.getProductContent() != null) {
+            for (ProductContentData pcdata : pdata.getProductContent()) {
+                if (pcdata == null || pcdata.getContent() == null ||
+                    !contentData.containsKey(pcdata.getContent().getId())) {
+
+                    String msg = String.format("Product \"%s\" contains malformed content references",
+                        productId);
+
+                    throw new IllegalStateException(msg);
+                }
+
+                contentIds.add(pcdata.getContent().getId());
+            }
+        }
+
+        // Remove mappings for content that is no longer referenced by this product...
+        Iterator<Map.Entry<String, Set<String>>> ei = contentProductMap.entrySet().iterator();
+        while (ei.hasNext()) {
+            Map.Entry<String, Set<String>> entry = ei.next();
+            String cid = entry.getKey();
+            Set<String> pids = entry.getValue();
+
+            if (!contentIds.contains(cid) && pids.remove(productId) && pids.isEmpty()) {
+                ei.remove();
+            }
+        }
+
+        // Add/update the existing mappings
+        for (String cid : contentIds) {
+            Set<String> pids = contentProductMap.get(cid);
+            if (pids == null) {
+                pids = new HashSet<String>();
+                contentProductMap.put(cid, pids);
+            }
+
+            pids.add(productId);
+        }
+    }
+
+    /**
+     * Replaces the ProductData reference with the correct reference on all subscriptions
+     * referencing the given productId.
+     *
+     * @param productId
+     *  The ID of the product for which to update subscriptions
+     *
+     * @throws IllegalArgumentException
+     *  if productId is null or invalid
+     */
+    protected void updateAffectedSubscriptions(String productId) {
+        if (productId == null || !productData.containsKey(productId)) {
+            throw new IllegalArgumentException("productId is null or invalid");
+        }
+
+        if (productSubscriptionMap.containsKey(productId)) {
+            ProductData pdata = productData.get(productId);
+
+            for (String subId : productSubscriptionMap.get(productId)) {
+                Subscription sub = subscriptions.get(subId);
+
+                // product
+                if (sub.getProduct() != null && productId.equals(sub.getProduct().getId())) {
+                    sub.setProduct(pdata);
+                }
+
+                // derived product
+                if (sub.getDerivedProduct() != null && productId.equals(sub.getDerivedProduct().getId())) {
+                    sub.setDerivedProduct(pdata);
+                }
+
+                // provided products
+                if (sub.getProvidedProducts() != null) {
+                    // Impl note:
+                    // At the time of writing, Subscription does not encapsulate its provided products
+                    // collection. We do a bunch of extra work to protect us from that behavior and any
+                    // potential future changes that would clean it up (like the looming DTO refactor).
+
+                    Set<ProductData> products = new HashSet<ProductData>(sub.getProvidedProducts());
+                    boolean replace = false;
+
+                    for (Iterator<ProductData> ppi = products.iterator(); ppi.hasNext();) {
+                        ProductData provided = ppi.next();
+
+                        if (provided != null && productId.equals(provided.getId())) {
+                            ppi.remove();
+                            replace = true;
+                        }
+                    }
+
+                    if (replace) {
+                        products.add(pdata);
+                        sub.setProvidedProducts(products);
+                    }
+                }
+
+                // derived provided products
+                if (sub.getDerivedProvidedProducts() != null) {
+                    Set<ProductData> products = new HashSet<ProductData>(sub.getDerivedProvidedProducts());
+                    boolean replace = false;
+
+                    for (Iterator<ProductData> ppi = products.iterator(); ppi.hasNext();) {
+                        ProductData provided = ppi.next();
+
+                        if (provided != null && productId.equals(provided.getId())) {
+                            ppi.remove();
+                            replace = true;
+                        }
+                    }
+
+                    if (replace) {
+                        products.add(pdata);
+                        sub.setDerivedProvidedProducts(products);
+                    }
+                }
+            }
+        }
+    }
+
+
+
+    /**
+     * Creates (stores) the given content DTO. If the provided DTO does not have a valid content
+     * ID or a content with the given ID already exists, this method throws an exception.
+     *
+     * @param dto
+     *  The DTO representing the content to create/store
+     *
+     * @throws IllegalArgumentException
+     *  if the content does not contain a valid content ID
+     *
+     * @throws IllegalStateException
+     *  if a content with the same content ID already exists, or the provided content is incomplete
+     *
+     * @return
+     *  the "new" content instance
+     */
+    public ContentData createContent(ContentData dto) {
+        if (dto == null || dto.getId() == null || dto.getId().trim().isEmpty()) {
+            throw new IllegalArgumentException("dto is null or does not have a valid ID");
+        }
+
+        if (contentData.containsKey(dto.getId())) {
+            throw new IllegalStateException("content already exists: " + dto.getId());
+        }
+
+        // These fields are required by Candlepin. If we let them be null/empty, we'll get
+        // exceptions during refresh
+        if (dto.getName() == null || dto.getName().trim().isEmpty() ||
+            dto.getType() == null || dto.getType().trim().isEmpty() ||
+            dto.getLabel() == null || dto.getLabel().trim().isEmpty() ||
+            dto.getVendor() == null || dto.getVendor().trim().isEmpty()) {
+
+            throw new IllegalStateException("content is incomplete");
+        }
+
+        contentData.put(dto.getId(), dto);
+        return dto;
+    }
+
+    /**
+     * Fetches the content data for the given content ID. If no such content could be found, this
+     * method returns null
+     *
+     * @param contentId
+     *  The ID of the content to fetch
+     *
+     * @return
+     *  The content data for the given content ID, or null if the content could not be found
+     */
+    public ContentData getContent(String contentId) {
+        return contentData.get(contentId);
+    }
+
+    /**
+     * Fetches the set of all known content. If there are no known content, this method returns
+     * an empty set.
+     *
+     * @return
+     *  A set of all known content
+     */
+    public Set<ContentData> getContent() {
+        return new HashSet<ContentData>(contentData.values());
+    }
+
+    /**
+     * Fetches the content for the given content IDs. If a matching content object cannot be found
+     * for a given content ID, it will be silently ignored. If there are no matching content
+     * objects, this method returns an empty set.
+     *
+     * @param contentIds
+     *  A collection of IDs of the content to fetch
+     *
+     * @return
+     *  A set of content objects for the requested content IDs
+     */
+    public Set<ContentData> getContent(Iterable<String> contentIds) {
+        Set<ContentData> output = new HashSet<ContentData>();
+
+        if (contentIds != null && contentIds.iterator().hasNext()) {
+            for (String contentId : contentIds) {
+                ContentData cdata = contentData.get(contentId);
+
+                if (cdata != null) {
+                    output.add(cdata);
+                }
+            }
+        }
+
+        return output;
+    }
+
+    /**
+     * Updates the content with the given content ID using the data from the provided DTO. If a
+     * content with the given ID cannot be found, an exception is thrown.
+     *
+     * @param contentId
+     *  The ID of the content to update
+     *
+     * @param dto
+     *  The DTO containing the updates to apply to the content
+     *
+     * @throws IllegalArgumentException
+     *  if the given content ID is null
+     *
+     * @throws IllegalStateException
+     *  if a content with the given ID cannot be found
+     *
+     * @return
+     *  The updated content
+     */
+    public ContentData updateContent(String contentId, ContentData dto) {
+        if (contentId == null) {
+            throw new IllegalArgumentException("contentId is null");
+        }
+
+        if (dto == null) {
+            throw new IllegalArgumentException("dto is null");
+        }
+
+        ContentData cdata = this.contentData.get(contentId);
+        if (cdata == null) {
+            String msg = String.format("Unable to find a content with ID \"%s\"", contentId);
+            throw new IllegalStateException(msg);
+        }
+
+        // Apply changes
+        if (dto.getType() != null) {
+            cdata.setType(dto.getType());
+        }
+
+        if (dto.getLabel() != null) {
+            cdata.setLabel(dto.getLabel());
+        }
+
+        if (dto.getName() != null) {
+            cdata.setName(dto.getName());
+        }
+
+        if (dto.getVendor() != null) {
+            cdata.setVendor(dto.getVendor());
+        }
+
+        if (dto.getContentUrl() != null) {
+            cdata.setContentUrl(dto.getContentUrl());
+        }
+
+        if (dto.getRequiredTags() != null) {
+            cdata.setRequiredTags(dto.getRequiredTags());
+        }
+
+        if (dto.getReleaseVersion() != null) {
+            cdata.setReleaseVersion(dto.getReleaseVersion());
+        }
+
+        if (dto.getGpgUrl() != null) {
+            cdata.setGpgUrl(dto.getGpgUrl());
+        }
+
+        if (dto.getMetadataExpire() != null) {
+            cdata.setMetadataExpire(dto.getMetadataExpire());
+        }
+
+        if (dto.getModifiedProductIds() != null) {
+            cdata.setModifiedProductIds(dto.getModifiedProductIds());
+        }
+
+        if (dto.getArches() != null) {
+            cdata.setArches(dto.getArches());
+        }
+
+        if (dto.isLocked() != null) {
+            cdata.setLocked(dto.isLocked());
+        }
+
+        this.updateAffectedProducts(contentId);
+        return cdata;
+    }
+
+    /**
+     * Deletes the specified content, removing it from any products to which it is currently
+     * attached. If a content with the given ID cannot be found, an exception is thrown.
+     *
+     * @param contentId
+     *  The ID of the content to delete
+     *
+     * @throws IllegalArgumentException
+     *  if the given content ID is null
+     *
+     * @throws IllegalStateException
+     *  if a content with the given ID cannot be found
+     *
+     * @return
+     *  The last known state of the now-deleted content
+     */
+    public ContentData deleteContent(String contentId) {
+        if (contentId == null) {
+            throw new IllegalArgumentException("contentId is null");
+        }
+
+        if (!contentData.containsKey(contentId)) {
+            String msg = String.format("Unable to find a content with ID \"%s\"", contentId);
+            throw new IllegalStateException(msg);
+        }
+
+        ContentData cdata = contentData.remove(contentId);
+
+        this.updateAffectedProducts(contentId);
+        this.contentProductMap.remove(contentId);
+
+        return cdata;
+    }
+
+
+    /**
+     * Replaces or removes the ContentData reference with the correct reference on all products
+     * referencing the given contentId. This will also trigger an update on all the subscriptions
+     * referencing the affected products.
+     *
+     * @param contentId
+     *  The ID of the content for which to update products
+     *
+     * @throws IllegalArgumentException
+     *  if contentId is null
+     */
+    protected void updateAffectedProducts(String contentId) {
+        if (contentId == null) {
+            throw new IllegalArgumentException("contentId is null");
+        }
+
+        ContentData cdata = contentData.get(contentId);
+        Set<String> pids = contentProductMap.get(contentId);
+
+        if (pids != null) {
+            for (String pid : pids) {
+                ProductData pdata = productData.get(pid);
+
+                if (pdata.getProductContent() == null) {
+                    // sanity check; this shouldn't happen unless someone else is fiddling with our data.
+                    String msg = String.format("State mismatch! content=>product mapping does not match " +
+                        "product=>content mapping for product, content pair: %s, %s",
+                        pid, contentId);
+
+                    throw new IllegalStateException(msg);
+                }
+
+                Iterator<ProductContentData> pci = pdata.getProductContent().iterator();
+                while (pci.hasNext()) {
+                    ProductContentData pcdata = pci.next();
+                    // More sanity checking...
+                    if (pcdata == null) {
+                        String msg = String.format("State mismatch! Product contains a null ProductContent " +
+                            "reference: %s", pid);
+
+                        throw new IllegalStateException(msg);
+                    }
+
+                    ContentData current = pcdata.getContent();
+                    // Annnnd even more sanity checks...
+                    if (current == null || current.getId() == null) {
+                        String msg = String.format("State mismatch! Product references null content or " +
+                            "content without a valid content ID: %s", pid);
+
+                        throw new IllegalStateException(msg);
+                    }
+
+                    if (contentId.equals(current.getId())) {
+                        if (cdata != null) {
+                            pcdata.setContent(cdata);
+                        }
+                        else {
+                            pci.remove();
+                        }
+
+                        // We could break here in normal circumstances, but it's safer to check all
+                        // of the products in the event some out-of-band changes have been occurring.
+                    }
+                }
+
+                // Update the subscriptions affected by this product change...
+                this.updateAffectedSubscriptions(pid);
+            }
+        }
+    }
+
+    /**
+     * Adds the specified content to the product. If a product with the given ID cannot be found,
+     * or any of the specified content cannot be resolved, this method throws an exception.
+     *
+     * @param productId
+     *  The ID of the product to receive the specified content
+     *
+     * @param contentIdMap
+     *  A mapping of content ID to its respective enabled flag for the product
+     *
+     * @throws IllegalArgumentException
+     *  if product ID is null
+     *
+     * @throws IllegalStateException
+     *  if the product or any content cannot be found
+     *
+     * @return
+     *  the updated product
+     */
+    public ProductData addContentToProduct(String productId, Map<String, Boolean> contentIdMap) {
+        if (productId == null) {
+            throw new IllegalArgumentException("productId is null");
+        }
+
+        ProductData pdata = productData.get(productId);
+        if (pdata == null) {
+            String msg = String.format("Unable to find a product with ID \"%s\"", productId);
+            throw new IllegalStateException(msg);
+        }
+
+        if (contentIdMap != null && !contentIdMap.isEmpty()) {
+            // Validate inbound content IDs
+            for (String cid : contentIdMap.keySet()) {
+                if (!contentData.containsKey(cid)) {
+                    String msg = String.format("Unable to find a content with ID \"%s\"", cid);
+                    throw new IllegalStateException(msg);
+                }
+            }
+
+            // Update product accordingly...
+            for (Map.Entry<String, Boolean> entry : contentIdMap.entrySet()) {
+                String cid = entry.getKey();
+                Boolean enabled = entry.getValue();
+
+                ProductContentData pcdata = pdata.getProductContent(cid);
+                if (pcdata != null) {
+                    pcdata.setEnabled(enabled != null ? enabled : true);
+                }
+                else {
+                    ContentData cdata = contentData.get(cid);
+                    pdata.addContent(cdata, enabled != null ? enabled : true);
+                }
+            }
+
+            this.updateContentProductMapping(productId);
+            this.updateAffectedSubscriptions(productId);
+        }
+
+        return pdata;
+    }
+
+    /**
+     * Removes the specified content from the product. If a product with the given ID cannot be found,
+     * or any of the specified content cannot be resolved, this method throws an exception.
+     *
+     * @param productId
+     *  The ID of the product to receive the specified content
+     *
+     * @param contentIds
+     *  A collection of IDs of content to remove from the product
+     *
+     * @throws IllegalArgumentException
+     *  if product ID is null
+     *
+     * @throws IllegalStateException
+     *  if the product cannot be found
+     *
+     * @return
+     *  the updated product
+     */
+    public ProductData removeContentFromProduct(String productId, Iterable<String> contentIds) {
+        if (productId == null) {
+            throw new IllegalArgumentException("productId is null");
+        }
+
+        ProductData pdata = productData.get(productId);
+        if (pdata == null) {
+            String msg = String.format("Unable to find a product with ID \"%s\"", productId);
+            throw new IllegalStateException(msg);
+        }
+
+        if (contentIds != null) {
+            boolean changed = false;
+
+            // Update product accordingly...
+            for (String cid : contentIds) {
+                changed |= pdata.removeContent(cid);
+            }
+
+            if (changed) {
+                this.updateContentProductMapping(productId);
+                this.updateAffectedSubscriptions(productId);
+            }
+        }
+
+        return pdata;
+    }
 }

--- a/server/src/main/java/org/candlepin/model/dto/Subscription.java
+++ b/server/src/main/java/org/candlepin/model/dto/Subscription.java
@@ -313,10 +313,12 @@ public class Subscription extends CandlepinDTO implements Owned, Named, Eventful
     }
 
     public void setProvidedProducts(Collection<ProductData> providedProducts) {
-        this.providedProducts.clear();
+        if (providedProducts != this.providedProducts) {
+            this.providedProducts.clear();
 
-        if (providedProducts != null) {
-            this.providedProducts.addAll(providedProducts);
+            if (providedProducts != null) {
+                this.providedProducts.addAll(providedProducts);
+            }
         }
     }
 
@@ -365,10 +367,12 @@ public class Subscription extends CandlepinDTO implements Owned, Named, Eventful
     }
 
     public void setDerivedProvidedProducts(Collection<ProductData> subProvidedProducts) {
-        this.derivedProvidedProducts.clear();
+        if (subProvidedProducts != this.derivedProvidedProducts) {
+            this.derivedProvidedProducts.clear();
 
-        if (subProvidedProducts != null) {
-            this.derivedProvidedProducts.addAll(subProvidedProducts);
+            if (subProvidedProducts != null) {
+                this.derivedProvidedProducts.addAll(subProvidedProducts);
+            }
         }
     }
 


### PR DESCRIPTION
- Removed any "local" object modeling from the hosted test framework,
  instead changing everything over to only deal with the DTOs used
  by upstream Candlepin adapters
- Added new explicit endpoints for managing "upstream" products and
  content with the hosted test framework
- Removed all of the old or ambiguous spec-level hosted test APIs,
  as these made it unclear what a given test was actually creating
  in the testing environment
- Updated several rspec tests to use the new APIs where appropriate,
  or the standard object creation APIs where an upstream source is
  not explicitly needed or desired