### PR TITLE
Various DTO fixes in equals/hashcode/populate methods and ignored tests.

### DIFF
--- a/server/src/main/java/org/candlepin/dto/api/v1/ConsumerDTO.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/ConsumerDTO.java
@@ -906,7 +906,8 @@ public class ConsumerDTO extends TimestampedCandlepinDTO<ConsumerDTO> implements
                 .append(this.getAnnotations(), that.getAnnotations())
                 .append(this.getContentAccessMode(), that.getContentAccessMode())
                 .append(this.getType(), that.getType())
-                .append(this.getIdCert(), that.getIdCert());
+                .append(this.getIdCert(), that.getIdCert())
+                .append(this.getGuestIds(), that.getGuestIds());
 
             return builder.isEquals();
         }
@@ -947,7 +948,8 @@ public class ConsumerDTO extends TimestampedCandlepinDTO<ConsumerDTO> implements
             .append(this.getAnnotations())
             .append(this.getContentAccessMode())
             .append(this.getType())
-            .append(this.getIdCert());
+            .append(this.getIdCert())
+            .append(this.getGuestIds());
 
         return builder.toHashCode();
     }

--- a/server/src/main/java/org/candlepin/dto/api/v1/EnvironmentDTO.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/EnvironmentDTO.java
@@ -367,13 +367,24 @@ public class EnvironmentDTO extends TimestampedCandlepinDTO<EnvironmentDTO> {
     public int hashCode() {
         String thisOid = this.getOwner() != null ? this.getOwner().getId() : null;
 
+        // Map.values doesn't properly implement .hashCode, so we need to manually calculate
+        // this ourselves using the algorithm defined by list.hashCode()
+        int ecHashCode = 0;
+        Collection<EnvironmentContentDTO> environmentContent = this.getEnvironmentContent();
+
+        if (environmentContent != null) {
+            for (EnvironmentContentDTO dto : environmentContent) {
+                ecHashCode = 31 * ecHashCode + (dto != null ? dto.hashCode() : 0);
+            }
+        }
+
         HashCodeBuilder builder = new HashCodeBuilder(37, 7)
             .append(super.hashCode())
             .append(this.getId())
             .append(this.getName())
             .append(this.getDescription())
             .append(thisOid)
-            .append(this.getEnvironmentContent());
+            .append(ecHashCode);
 
         return builder.toHashCode();
     }

--- a/server/src/main/java/org/candlepin/dto/api/v1/UpstreamConsumerDTO.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/UpstreamConsumerDTO.java
@@ -185,7 +185,8 @@ public class UpstreamConsumerDTO extends TimestampedCandlepinDTO<UpstreamConsume
                 .append(this.getWebUrl(), that.getWebUrl())
                 .append(this.getOwnerId(), that.getOwnerId())
                 .append(this.getConsumerType(), that.getConsumerType())
-                .append(this.getIdentityCertificate(), that.getIdentityCertificate());
+                .append(this.getIdentityCertificate(), that.getIdentityCertificate())
+                .append(this.getContentAccessMode(), that.getContentAccessMode());
 
             return builder.isEquals();
         }
@@ -207,7 +208,8 @@ public class UpstreamConsumerDTO extends TimestampedCandlepinDTO<UpstreamConsume
             .append(this.getWebUrl())
             .append(this.getOwnerId())
             .append(this.getConsumerType())
-            .append(this.getIdentityCertificate());
+            .append(this.getIdentityCertificate())
+            .append(this.getContentAccessMode());
 
         return builder.toHashCode();
     }
@@ -243,6 +245,7 @@ public class UpstreamConsumerDTO extends TimestampedCandlepinDTO<UpstreamConsume
         this.setOwnerId(source.getOwnerId());
         this.setConsumerType(source.getConsumerType());
         this.setIdentityCertificate(source.getIdentityCertificate());
+        this.setContentAccessMode(source.getContentAccessMode());
 
         return this;
     }

--- a/server/src/test/java/org/candlepin/dto/AbstractDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/AbstractDTOTest.java
@@ -234,7 +234,7 @@ public abstract class AbstractDTOTest<T extends CandlepinDTO<T>> {
         Object input = this.getInputValueForMutator(field);
         methods[1].invoke(dtoA, input);
 
-        assumeFalse(dtoA.equals(dtoB));
+        assertFalse(dtoA.equals(dtoB));
 
         methods[1].invoke(dtoB, input);
 
@@ -255,7 +255,7 @@ public abstract class AbstractDTOTest<T extends CandlepinDTO<T>> {
             Object input = this.getInputValueForMutator(field);
             methods[1].invoke(dtoA, input);
 
-            assumeFalse(dtoA.equals(dtoB));
+            assertFalse(dtoA.equals(dtoB));
 
             methods[1].invoke(dtoB, input);
         }
@@ -276,7 +276,7 @@ public abstract class AbstractDTOTest<T extends CandlepinDTO<T>> {
         Object input = this.getInputValueForMutator(field);
         methods[1].invoke(dtoA, input);
 
-        assumeFalse(dtoA.hashCode() == dtoB.hashCode());
+        assertFalse(dtoA.hashCode() == dtoB.hashCode());
 
         methods[1].invoke(dtoB, input);
 
@@ -297,11 +297,11 @@ public abstract class AbstractDTOTest<T extends CandlepinDTO<T>> {
             Object input = this.getInputValueForMutator(field);
             methods[1].invoke(dtoA, input);
 
-            assumeFalse(dtoA.hashCode() == dtoB.hashCode());
+            assertFalse(dtoA.hashCode() == dtoB.hashCode());
 
             methods[1].invoke(dtoB, input);
 
-            assumeTrue(dtoA.hashCode() == dtoB.hashCode());
+            assertTrue(dtoA.hashCode() == dtoB.hashCode());
         }
 
         assertEquals(dtoA.hashCode(), dtoB.hashCode());
@@ -320,7 +320,7 @@ public abstract class AbstractDTOTest<T extends CandlepinDTO<T>> {
         Object input = this.getInputValueForMutator(field);
         methods[1].invoke(dtoA, input);
 
-        assumeFalse(dtoA.equals(dtoB));
+        assertFalse(dtoA.equals(dtoB));
 
         dtoB.populate(dtoA);
         assertEquals(dtoA, dtoB);

--- a/server/src/test/java/org/candlepin/dto/api/v1/ActivationKeyDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/ActivationKeyDTOTest.java
@@ -83,7 +83,7 @@ public class ActivationKeyDTOTest extends AbstractDTOTest<ActivationKeyDTO> {
     }
 
     /**
-     * @{inheritDocs}
+     * {@inheritDoc}
      */
     @Override
     protected Object getInputValueForMutator(String field) {
@@ -91,7 +91,7 @@ public class ActivationKeyDTOTest extends AbstractDTOTest<ActivationKeyDTO> {
     }
 
     /**
-     * @{inheritDocs}
+     * {@inheritDoc}
      */
     @Override
     protected Object getOutputValueForAccessor(String field, Object input) {

--- a/server/src/test/java/org/candlepin/dto/api/v1/BrandingDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/BrandingDTOTest.java
@@ -39,11 +39,17 @@ public class BrandingDTOTest extends AbstractDTOTest<BrandingDTO> {
         this.values.put("Updated", new Date());
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     protected Object getInputValueForMutator(String field) {
         return this.values.get(field);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     protected Object getOutputValueForAccessor(String field, Object input) {
         // Nothing to do here

--- a/server/src/test/java/org/candlepin/dto/api/v1/CapabilityDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/CapabilityDTOTest.java
@@ -16,6 +16,7 @@ package org.candlepin.dto.api.v1;
 
 import org.candlepin.dto.AbstractDTOTest;
 
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -32,10 +33,12 @@ public class CapabilityDTOTest extends AbstractDTOTest<CapabilityDTO> {
         this.values = new HashMap<String, Object>();
         this.values.put("Id", "test_value");
         this.values.put("Name", "test_value");
+        this.values.put("Created", new Date());
+        this.values.put("Updated", new Date());
     }
 
     /**
-     * @{inheritDocs}
+     * {@inheritDoc}
      */
     @Override
     protected Object getInputValueForMutator(String field) {
@@ -43,7 +46,7 @@ public class CapabilityDTOTest extends AbstractDTOTest<CapabilityDTO> {
     }
 
     /**
-     * @{inheritDocs}
+     * {@inheritDoc}
      */
     @Override
     protected Object getOutputValueForAccessor(String field, Object input) {

--- a/server/src/test/java/org/candlepin/dto/api/v1/CdnDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/CdnDTOTest.java
@@ -43,11 +43,17 @@ public class CdnDTOTest extends AbstractDTOTest<CdnDTO> {
         this.values.put("Updated", new Date());
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     protected Object getInputValueForMutator(String field) {
         return this.values.get(field);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     protected Object getOutputValueForAccessor(String field, Object input) {
         // Nothing to do here

--- a/server/src/test/java/org/candlepin/dto/api/v1/CertificateDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/CertificateDTOTest.java
@@ -50,7 +50,7 @@ public class CertificateDTOTest extends AbstractDTOTest<CertificateDTO> {
     }
 
     /**
-     * @{inheritDocs}
+     * {@inheritDoc}
      */
     @Override
     protected Object getInputValueForMutator(String field) {
@@ -58,7 +58,7 @@ public class CertificateDTOTest extends AbstractDTOTest<CertificateDTO> {
     }
 
     /**
-     * @{inheritDocs}
+     * {@inheritDoc}
      */
     @Override
     protected Object getOutputValueForAccessor(String field, Object input) {

--- a/server/src/test/java/org/candlepin/dto/api/v1/CertificateSerialDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/CertificateSerialDTOTest.java
@@ -39,12 +39,13 @@ public class CertificateSerialDTOTest extends AbstractDTOTest<CertificateSerialD
         this.values.put("Date", new Date());
         this.values.put("Collected", true);
         this.values.put("Revoked", true);
+        this.values.put("Expiration", new Date());
         this.values.put("Created", new Date());
         this.values.put("Updated", new Date());
     }
 
     /**
-     * @{inheritDocs}
+     * {@inheritDoc}
      */
     @Override
     protected Object getInputValueForMutator(String field) {
@@ -52,7 +53,7 @@ public class CertificateSerialDTOTest extends AbstractDTOTest<CertificateSerialD
     }
 
     /**
-     * @{inheritDocs}
+     * {@inheritDoc}
      */
     @Override
     protected Object getOutputValueForAccessor(String field, Object input) {

--- a/server/src/test/java/org/candlepin/dto/api/v1/ConsumerDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/ConsumerDTOTest.java
@@ -90,13 +90,13 @@ public class ConsumerDTOTest extends AbstractDTOTest<ConsumerDTO> {
         this.values.put("Id", "test-id");
         this.values.put("Uuid", "test-uuid");
         this.values.put("Name", "test-name");
-        this.values.put("UserName", "test-user-name");
+        this.values.put("Username", "test-user-name");
         this.values.put("EntitlementStatus", "test-entitlement-status");
         this.values.put("ServiceLevel", "test-service-level");
-        this.values.put("ReleaseVer", "test-release-ver");
+        this.values.put("ReleaseVersion", "test-release-ver");
         this.values.put("Owner", this.ownerDTOTest.getPopulatedDTOInstance());
         this.values.put("Environment", this.environmentDTOTest.getPopulatedDTOInstance());
-        this.values.put("EntitlementCount", 0L);
+        this.values.put("EntitlementCount", 1L);
         this.values.put("Facts", facts);
         this.values.put("LastCheckin", new Date());
         this.values.put("InstalledProducts", installedProducts);
@@ -104,11 +104,11 @@ public class ConsumerDTOTest extends AbstractDTOTest<ConsumerDTO> {
         this.values.put("Capabilities", capabilityDTOS);
         this.values.put("HypervisorId", hypervisorIdDTOTest.getPopulatedDTOInstance());
         this.values.put("ContentTags", contentTags);
-        this.values.put("AutoHeal", Boolean.TRUE);
+        this.values.put("Autoheal", Boolean.TRUE);
         this.values.put("RecipientOwnerKey", "test-recipient-owner");
         this.values.put("Annotations", "test-annotations");
         this.values.put("ContentAccessMode", "test-content-access-mode");
-        this.values.put("ConsumerType", type);
+        this.values.put("Type", type);
         this.values.put("IdentityCertificate", cert);
         this.values.put("GuestIds", guestIdDTOS);
         this.values.put("Created", new Date());
@@ -124,10 +124,13 @@ public class ConsumerDTOTest extends AbstractDTOTest<ConsumerDTO> {
         this.values.put("addInstalledProduct", installedProductDTO);
         this.values.put("removeInstalledProduct", installedProductDTO.getProductId());
 
+        CertificateDTO idCert = new CertificateDTO();
+        cert.setId("cert-id");
+        this.values.put("IdCert", idCert);
     }
 
     /**
-     * @{inheritDocs}
+     * {@inheritDoc}
      */
     @Override
     protected Object getInputValueForMutator(String field) {
@@ -135,7 +138,7 @@ public class ConsumerDTOTest extends AbstractDTOTest<ConsumerDTO> {
     }
 
     /**
-     * @{inheritDocs}
+     * {@inheritDoc}
      */
     @Override
     protected Object getOutputValueForAccessor(String field, Object input) {

--- a/server/src/test/java/org/candlepin/dto/api/v1/ConsumerInstalledProductDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/ConsumerInstalledProductDTOTest.java
@@ -39,10 +39,12 @@ public class ConsumerInstalledProductDTOTest extends AbstractDTOTest<ConsumerIns
         this.values.put("Status", "test_value");
         this.values.put("StartDate", new Date());
         this.values.put("EndDate", new Date());
+        this.values.put("Created", new Date());
+        this.values.put("Updated", new Date());
     }
 
     /**
-     * @{inheritDocs}
+     * {@inheritDoc}
      */
     @Override
     protected Object getInputValueForMutator(String field) {
@@ -50,7 +52,7 @@ public class ConsumerInstalledProductDTOTest extends AbstractDTOTest<ConsumerIns
     }
 
     /**
-     * @{inheritDocs}
+     * {@inheritDoc}
      */
     @Override
     protected Object getOutputValueForAccessor(String field, Object input) {

--- a/server/src/test/java/org/candlepin/dto/api/v1/ConsumerTypeDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/ConsumerTypeDTOTest.java
@@ -41,7 +41,7 @@ public class ConsumerTypeDTOTest extends AbstractDTOTest<ConsumerTypeDTO> {
     }
 
     /**
-     * @{inheritDocs}
+     * {@inheritDoc}
      */
     @Override
     protected Object getInputValueForMutator(String field) {
@@ -49,7 +49,7 @@ public class ConsumerTypeDTOTest extends AbstractDTOTest<ConsumerTypeDTO> {
     }
 
     /**
-     * @{inheritDocs}
+     * {@inheritDoc}
      */
     @Override
     protected Object getOutputValueForAccessor(String field, Object input) {

--- a/server/src/test/java/org/candlepin/dto/api/v1/ContentDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/ContentDTOTest.java
@@ -21,6 +21,7 @@ import org.candlepin.dto.AbstractDTOTest;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -48,14 +49,16 @@ public class ContentDTOTest extends AbstractDTOTest<ContentDTO> {
         this.values.put("RequiredTags", "test_value");
         this.values.put("ReleaseVersion", "test_value");
         this.values.put("GpgUrl", "test_value");
-        this.values.put("MetadataExpire", 1234L);
+        this.values.put("MetadataExpiration", 1234L);
         this.values.put("ModifiedProductIds", Arrays.asList("1", "2", "3"));
         this.values.put("Arches", "test_value");
         this.values.put("Locked", Boolean.TRUE);
+        this.values.put("Created", new Date());
+        this.values.put("Updated", new Date());
     }
 
     /**
-     * @{inheritDocs}
+     * {@inheritDoc}
      */
     @Override
     protected Object getInputValueForMutator(String field) {
@@ -63,7 +66,7 @@ public class ContentDTOTest extends AbstractDTOTest<ContentDTO> {
     }
 
     /**
-     * @{inheritDocs}
+     * {@inheritDoc}
      */
     @Override
     protected Object getOutputValueForAccessor(String field, Object input) {

--- a/server/src/test/java/org/candlepin/dto/api/v1/EntitlementDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/EntitlementDTOTest.java
@@ -84,11 +84,17 @@ public class EntitlementDTOTest  extends AbstractDTOTest<EntitlementDTO> {
         this.values.put("Updated", new Date());
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     protected Object getInputValueForMutator(String field) {
         return this.values.get(field);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     protected Object getOutputValueForAccessor(String field, Object input) {
         // Nothing to do here

--- a/server/src/test/java/org/candlepin/dto/api/v1/EnvironmentDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/EnvironmentDTOTest.java
@@ -18,6 +18,7 @@ import org.candlepin.dto.AbstractDTOTest;
 import org.candlepin.dto.api.v1.EnvironmentDTO.EnvironmentContentDTO;
 
 import java.util.Collection;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -47,12 +48,14 @@ public class EnvironmentDTOTest extends AbstractDTOTest<EnvironmentDTO> {
         this.values.put("Id", "test_value");
         this.values.put("Name", "test_value");
         this.values.put("Description", "test_value");
-        this.values.put("ProductContent", environmentContent);
+        this.values.put("EnvironmentContent", environmentContent);
         this.values.put("Owner", ownerDTOTest.getPopulatedDTOInstance());
+        this.values.put("Created", new Date());
+        this.values.put("Updated", new Date());
     }
 
     /**
-     * @{inheritDocs}
+     * {@inheritDoc}
      */
     @Override
     protected Object getInputValueForMutator(String field) {
@@ -60,7 +63,7 @@ public class EnvironmentDTOTest extends AbstractDTOTest<EnvironmentDTO> {
     }
 
     /**
-     * @{inheritDocs}
+     * {@inheritDoc}
      */
     @Override
     protected Object getOutputValueForAccessor(String field, Object input) {

--- a/server/src/test/java/org/candlepin/dto/api/v1/GuestIdDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/GuestIdDTOTest.java
@@ -15,6 +15,8 @@
 package org.candlepin.dto.api.v1;
 
 import org.candlepin.dto.AbstractDTOTest;
+
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -37,10 +39,12 @@ public class GuestIdDTOTest extends AbstractDTOTest<GuestIdDTO> {
         this.values.put("Id", "test_value");
         this.values.put("GuestId", "test_value");
         this.values.put("Attributes", attributes);
+        this.values.put("Created", new Date());
+        this.values.put("Updated", new Date());
     }
 
     /**
-     * @{inheritDocs}
+     * {@inheritDoc}
      */
     @Override
     protected Object getInputValueForMutator(String field) {
@@ -48,7 +52,7 @@ public class GuestIdDTOTest extends AbstractDTOTest<GuestIdDTO> {
     }
 
     /**
-     * @{inheritDocs}
+     * {@inheritDoc}
      */
     @Override
     protected Object getOutputValueForAccessor(String field, Object input) {

--- a/server/src/test/java/org/candlepin/dto/api/v1/HypervisorIdDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/HypervisorIdDTOTest.java
@@ -16,6 +16,7 @@ package org.candlepin.dto.api.v1;
 
 import org.candlepin.dto.AbstractDTOTest;
 
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -33,10 +34,12 @@ public class HypervisorIdDTOTest extends AbstractDTOTest<HypervisorIdDTO> {
         this.values.put("Id", "test_value");
         this.values.put("HypervisorId", "test_value");
         this.values.put("ReporterId", "test_value");
+        this.values.put("Created", new Date());
+        this.values.put("Updated", new Date());
     }
 
     /**
-     * @{inheritDocs}
+     * {@inheritDoc}
      */
     @Override
     protected Object getInputValueForMutator(String field) {
@@ -44,7 +47,7 @@ public class HypervisorIdDTOTest extends AbstractDTOTest<HypervisorIdDTO> {
     }
 
     /**
-     * @{inheritDocs}
+     * {@inheritDoc}
      */
     @Override
     protected Object getOutputValueForAccessor(String field, Object input) {

--- a/server/src/test/java/org/candlepin/dto/api/v1/JobStatusDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/JobStatusDTOTest.java
@@ -50,11 +50,17 @@ public class JobStatusDTOTest extends AbstractDTOTest<JobStatusDTO> {
         this.values.put("Updated", new Date());
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     protected Object getInputValueForMutator(String field) {
         return this.values.get(field);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     protected Object getOutputValueForAccessor(String field, Object input) {
         // Nothing to do here

--- a/server/src/test/java/org/candlepin/dto/api/v1/OwnerDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/OwnerDTOTest.java
@@ -69,7 +69,7 @@ public class OwnerDTOTest extends AbstractDTOTest<OwnerDTO> {
     }
 
     /**
-     * @{inheritDocs}
+     * {@inheritDoc}
      */
     @Override
     protected Object getInputValueForMutator(String field) {
@@ -77,7 +77,7 @@ public class OwnerDTOTest extends AbstractDTOTest<OwnerDTO> {
     }
 
     /**
-     * @{inheritDocs}
+     * {@inheritDoc}
      */
     @Override
     protected Object getOutputValueForAccessor(String field, Object input) {

--- a/server/src/test/java/org/candlepin/dto/api/v1/PoolDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/PoolDTOTest.java
@@ -142,11 +142,17 @@ public class PoolDTOTest extends AbstractDTOTest<PoolDTO> {
         this.values.put("Updated", new Date());
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     protected Object getInputValueForMutator(String field) {
         return this.values.get(field);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     protected Object getOutputValueForAccessor(String field, Object input) {
         // Nothing to do here

--- a/server/src/test/java/org/candlepin/dto/api/v1/ProductDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/ProductDTOTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
@@ -56,6 +57,12 @@ public class ProductDTOTest extends AbstractDTOTest<ProductDTO> {
             attributes.put("attrib-" + i, "value-" + i);
         }
 
+        Collection<String> dependentProductIds = new LinkedList<String>();
+
+        for (int i = 0; i < 5; ++i) {
+            dependentProductIds.add("dependentProdId" + i);
+        }
+
         this.values = new HashMap<String, Object>();
         this.values.put("Uuid", "test_value");
         this.values.put("Id", "test_value");
@@ -73,10 +80,15 @@ public class ProductDTOTest extends AbstractDTOTest<ProductDTO> {
         this.values.put("Locked", Boolean.TRUE);
         this.values.put("ProductContent", productContent);
         this.values.put("Attributes", attributes);
+        this.values.put("DependentProductIds", dependentProductIds);
+        this.values.put("Multiplier", 3L);
+        this.values.put("Href", "test-href");
+        this.values.put("Created", new Date());
+        this.values.put("Updated", new Date());
     }
 
     /**
-     * @{inheritDocs}
+     * {@inheritDoc}
      */
     @Override
     protected Object getInputValueForMutator(String field) {
@@ -84,7 +96,7 @@ public class ProductDTOTest extends AbstractDTOTest<ProductDTO> {
     }
 
     /**
-     * @{inheritDocs}
+     * {@inheritDoc}
      */
     @Override
     protected Object getOutputValueForAccessor(String field, Object input) {

--- a/server/src/test/java/org/candlepin/dto/api/v1/UpstreamConsumerDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/UpstreamConsumerDTOTest.java
@@ -51,12 +51,14 @@ public class UpstreamConsumerDTOTest extends AbstractDTOTest<UpstreamConsumerDTO
         this.values.put("WebUrl", "test-web-url");
         this.values.put("ConsumerType", type);
         this.values.put("IdentityCertificate", cert);
+        this.values.put("OwnerId", "test-owner-id");
+        this.values.put("ContentAccessMode", "test-content-access-mode");
         this.values.put("Created", new Date());
         this.values.put("Updated", new Date());
     }
 
     /**
-     * @{inheritDocs}
+     * {@inheritDoc}
      */
     @Override
     protected Object getInputValueForMutator(String field) {
@@ -64,7 +66,7 @@ public class UpstreamConsumerDTOTest extends AbstractDTOTest<UpstreamConsumerDTO
     }
 
     /**
-     * @{inheritDocs}
+     * {@inheritDoc}
      */
     @Override
     protected Object getOutputValueForAccessor(String field, Object input) {


### PR DESCRIPTION
- Fixed equals/hashcode/populate methods in ConsumerDTO, EnvironmentDTO, UpstreamConsumerDTO.
- Fixed a lot of DTO unit tests that were silently ignored due to missing fields during setup. Also fixed the inheritDoc annotation.