### PR TITLE
Awood/1478549 update hornetq

### DIFF
--- a/buildfile
+++ b/buildfile
@@ -138,7 +138,7 @@ HSQLDB_OLD = 'org.hsqldb:hsqldb:jar:1.8.0.10'
 ORACLE = ['com.oracle:ojdbc6:jar:11.2.0', 'org.quartz-scheduler:quartz-oracle:jar:2.1.5']
 
 COMMONS = ['commons-codec:commons-codec:jar:1.4',
-           'commons-collections:commons-collections:jar:3.2',
+           'commons-collections:commons-collections:jar:3.2.2',
            'commons-io:commons-io:jar:1.4',
            'commons-lang:commons-lang:jar:2.5']
 
@@ -164,7 +164,7 @@ GUICE =  [group('guice-assistedinject', 'guice-multibindings',
            'aopalliance:aopalliance:jar:1.0',
            'javax.inject:javax.inject:jar:1']
 
-COLLECTIONS = 'com.google.guava:guava:jar:13.0'
+COLLECTIONS = 'com.google.guava:guava:jar:19.0'
 
 OAUTH= [group('oauth',
               'oauth-provider',
@@ -173,14 +173,20 @@ OAUTH= [group('oauth',
 
 QUARTZ = 'org.quartz-scheduler:quartz:jar:2.2.1'
 
-HORNETQ = [group('hornetq-server',
-                 'hornetq-core-client',
-                 'hornetq-commons',
-                 'hornetq-journal',
-                 # 'hornetq-resources', #Native libs for libaio
-                 :under=>'org.hornetq',
-                 :version=>'2.4.7.Final'),
-            'io.netty:netty-all:jar:4.0.13.Final']
+ACTIVEMQ = [group('artemis-server',
+                  'artemis-core-client',
+                  'artemis-commons',
+                  'artemis-selector',
+                  'artemis-journal',
+                  :under => 'org.apache.activemq',
+                  :version => '2.4.0'),
+            'io.netty:netty-all:jar:4.1.16.Final',
+            'commons-beanutils:commons-beanutils:jar:1.9.3',
+            # 'commons-logging:commons-logging:jar:1.2',
+            'org.jgroups:jgroups:jar:3.6.13.Final',
+            'org.apache.geronimo.specs:geronimo-json_1.0_spec:jar:1.0-alpha-1',
+            'org.apache.johnzon:johnzon-core:jar:0.9.5'
+           ]
 
 SCHEMASPY = 'net.sourceforge:schemaSpy:jar:4.1.1'
 
@@ -375,7 +381,7 @@ define "candlepin" do
       GETTEXT_COMMONS,
       GUICE,
       HIBERNATE,
-      HORNETQ,
+      ACTIVEMQ,
       JACKSON,
       LIQUIBASE,
       LOGGING,

--- a/buildfile
+++ b/buildfile
@@ -75,14 +75,14 @@ JUKITO = ['org.jukito:jukito:jar:1.4']
 
 LOGBACK = [group('logback-core', 'logback-classic',
                  :under => 'ch.qos.logback',
-                 :version => '1.1.3')]
+                 :version => '1.2.3')]
 
 # Artifacts that bridge other logging frameworks to slf4j. Mime4j uses
 # JCL for example.
 SLF4J_BRIDGES = [group('jcl-over-slf4j', 'log4j-over-slf4j',
                        :under => 'org.slf4j',
                        :version => '1.7.12')]
-SLF4J = 'org.slf4j:slf4j-api:jar:1.7.12'
+SLF4J = 'org.slf4j:slf4j-api:jar:1.7.25'
 
 LOGGING = [LOGBACK, SLF4J_BRIDGES, SLF4J]
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -25,7 +25,7 @@
     <org.liquibase-liquibase-core.version>3.1.0</org.liquibase-liquibase-core.version>
     <com.mattbertolini-liquibase-slf4j.version>1.2.1</com.mattbertolini-liquibase-slf4j.version>
     <commons-codec-commons-codec.version>1.4</commons-codec-commons-codec.version>
-    <commons-collections-commons-collections.version>3.2</commons-collections-commons-collections.version>
+    <commons-collections-commons-collections.version>3.2.2</commons-collections-commons-collections.version>
     <commons-io-commons-io.version>1.4</commons-io-commons-io.version>
     <commons-lang-commons-lang.version>2.5</commons-lang-commons-lang.version>
     <ch.qos.logback-logback-core.version>1.2.3</ch.qos.logback-logback-core.version>
@@ -42,7 +42,7 @@
     <aopalliance-aopalliance.version>1.0</aopalliance-aopalliance.version>
     <javax.inject-javax.inject.version>1</javax.inject-javax.inject.version>
     <com.googlecode.gettext-commons-gettext-commons.version>0.9.8</com.googlecode.gettext-commons-gettext-commons.version>
-    <com.google.guava-guava.version>13.0</com.google.guava-guava.version>
+    <com.google.guava-guava.version>19.0</com.google.guava-guava.version>
     <javax.servlet-servlet-api.version>2.5</javax.servlet-servlet-api.version>
     <org.jboss.resteasy-jaxrs-api.version>3.0.10.Final</org.jboss.resteasy-jaxrs-api.version>
     <org.jboss.resteasy-resteasy-jaxrs.version>3.0.10.Final</org.jboss.resteasy-resteasy-jaxrs.version>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -28,11 +28,11 @@
     <commons-collections-commons-collections.version>3.2</commons-collections-commons-collections.version>
     <commons-io-commons-io.version>1.4</commons-io-commons-io.version>
     <commons-lang-commons-lang.version>2.5</commons-lang-commons-lang.version>
-    <ch.qos.logback-logback-core.version>1.1.3</ch.qos.logback-logback-core.version>
-    <ch.qos.logback-logback-classic.version>1.1.3</ch.qos.logback-logback-classic.version>
+    <ch.qos.logback-logback-core.version>1.2.3</ch.qos.logback-logback-core.version>
+    <ch.qos.logback-logback-classic.version>1.2.3</ch.qos.logback-logback-classic.version>
     <org.slf4j-jcl-over-slf4j.version>1.7.12</org.slf4j-jcl-over-slf4j.version>
     <org.slf4j-log4j-over-slf4j.version>1.7.12</org.slf4j-log4j-over-slf4j.version>
-    <org.slf4j-slf4j-api.version>1.7.12</org.slf4j-slf4j-api.version>
+    <org.slf4j-slf4j-api.version>1.7.25</org.slf4j-slf4j-api.version>
     <com.google.inject.extensions-guice-assistedinject.version>3.0</com.google.inject.extensions-guice-assistedinject.version>
     <com.google.inject.extensions-guice-multibindings.version>3.0</com.google.inject.extensions-guice-multibindings.version>
     <com.google.inject.extensions-guice-servlet.version>3.0</com.google.inject.extensions-guice-servlet.version>

--- a/server/bin/deploy
+++ b/server/bin/deploy
@@ -28,6 +28,7 @@ gendb() {
         # queue to fire:
         info_msg "Cleaning hornetq journal"
         $SUDO rm -rf /var/lib/candlepin/hornetq/*
+        $SUDO rm -rf /var/lib/candlepin/activemq-artemis/*
     else
         MESSAGE="Updating Database"
         CHANGELOG="changelog-update.xml"

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -85,11 +85,11 @@
     <com.fasterxml.jackson.module-jackson-module-jaxb-annotations.version>2.9.4</com.fasterxml.jackson.module-jackson-module-jaxb-annotations.version>
     <com.fasterxml.jackson.datatype-jackson-datatype-hibernate5.version>2.9.4</com.fasterxml.jackson.datatype-jackson-datatype-hibernate5.version>
     <org.liquibase-liquibase-core.version>3.1.0</org.liquibase-liquibase-core.version>
-    <ch.qos.logback-logback-core.version>1.1.3</ch.qos.logback-logback-core.version>
-    <ch.qos.logback-logback-classic.version>1.1.3</ch.qos.logback-logback-classic.version>
+    <ch.qos.logback-logback-core.version>1.2.3</ch.qos.logback-logback-core.version>
+    <ch.qos.logback-logback-classic.version>1.2.3</ch.qos.logback-logback-classic.version>
     <org.slf4j-jcl-over-slf4j.version>1.7.12</org.slf4j-jcl-over-slf4j.version>
     <org.slf4j-log4j-over-slf4j.version>1.7.12</org.slf4j-log4j-over-slf4j.version>
-    <org.slf4j-slf4j-api.version>1.7.12</org.slf4j-slf4j-api.version>
+    <org.slf4j-slf4j-api.version>1.7.25</org.slf4j-slf4j-api.version>
     <net.oauth.core-oauth.version>20100527</net.oauth.core-oauth.version>
     <net.oauth.core-oauth-provider.version>20100527</net.oauth.core-oauth-provider.version>
     <javax.servlet-servlet-api.version>2.5</javax.servlet-servlet-api.version>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -32,9 +32,9 @@
     <geronimo-spec-geronimo-spec-jms.version>1.1-rc4</geronimo-spec-geronimo-spec-jms.version>
     <org.bouncycastle-bcmail-jdk16.version>1.46</org.bouncycastle-bcmail-jdk16.version>
     <org.bouncycastle-bcprov-jdk16.version>1.46</org.bouncycastle-bcprov-jdk16.version>
-    <com.google.guava-guava.version>13.0</com.google.guava-guava.version>
+    <com.google.guava-guava.version>19.0</com.google.guava-guava.version>
     <commons-codec-commons-codec.version>1.4</commons-codec-commons-codec.version>
-    <commons-collections-commons-collections.version>3.2</commons-collections-commons-collections.version>
+    <commons-collections-commons-collections.version>3.2.2</commons-collections-commons-collections.version>
     <commons-io-commons-io.version>1.4</commons-io-commons-io.version>
     <commons-lang-commons-lang.version>2.5</commons-lang-commons-lang.version>
     <com.googlecode.gettext-commons-gettext-commons.version>0.9.8</com.googlecode.gettext-commons-gettext-commons.version>
@@ -71,11 +71,16 @@
     <org.hibernate.javax.persistence-hibernate-jpa-2.1-api.version>1.0.0.Final</org.hibernate.javax.persistence-hibernate-jpa-2.1-api.version>
     <javax.validation-validation-api.version>1.0.0.GA</javax.validation-validation-api.version>
     <javax.transaction-jta.version>1.1</javax.transaction-jta.version>
-    <org.hornetq-hornetq-server.version>2.4.7.Final</org.hornetq-hornetq-server.version>
-    <org.hornetq-hornetq-core-client.version>2.4.7.Final</org.hornetq-hornetq-core-client.version>
-    <org.hornetq-hornetq-commons.version>2.4.7.Final</org.hornetq-hornetq-commons.version>
-    <org.hornetq-hornetq-journal.version>2.4.7.Final</org.hornetq-hornetq-journal.version>
-    <io.netty-netty-all.version>4.0.13.Final</io.netty-netty-all.version>
+    <org.apache.activemq-artemis-server.version>2.4.0</org.apache.activemq-artemis-server.version>
+    <org.apache.activemq-artemis-core-client.version>2.4.0</org.apache.activemq-artemis-core-client.version>
+    <org.apache.activemq-artemis-commons.version>2.4.0</org.apache.activemq-artemis-commons.version>
+    <org.apache.activemq-artemis-selector.version>2.4.0</org.apache.activemq-artemis-selector.version>
+    <org.apache.activemq-artemis-journal.version>2.4.0</org.apache.activemq-artemis-journal.version>
+    <io.netty-netty-all.version>4.1.16.Final</io.netty-netty-all.version>
+    <commons-beanutils-commons-beanutils.version>1.9.3</commons-beanutils-commons-beanutils.version>
+    <org.jgroups-jgroups.version>3.6.13.Final</org.jgroups-jgroups.version>
+    <org.apache.geronimo.specs-geronimo-json_1.0_spec.version>1.0-alpha-1</org.apache.geronimo.specs-geronimo-json_1.0_spec.version>
+    <org.apache.johnzon-johnzon-core.version>0.9.5</org.apache.johnzon-johnzon-core.version>
     <com.fasterxml.jackson.core-jackson-annotations.version>2.9.4</com.fasterxml.jackson.core-jackson-annotations.version>
     <com.fasterxml.jackson.core-jackson-core.version>2.9.4</com.fasterxml.jackson.core-jackson-core.version>
     <com.fasterxml.jackson.core-jackson-databind.version>2.9.4</com.fasterxml.jackson.core-jackson-databind.version>
@@ -725,9 +730,9 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.hornetq</groupId>
-      <artifactId>hornetq-server</artifactId>
-      <version>${org.hornetq-hornetq-server.version}</version>
+      <groupId>org.apache.activemq</groupId>
+      <artifactId>artemis-server</artifactId>
+      <version>${org.apache.activemq-artemis-server.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -736,9 +741,9 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.hornetq</groupId>
-      <artifactId>hornetq-core-client</artifactId>
-      <version>${org.hornetq-hornetq-core-client.version}</version>
+      <groupId>org.apache.activemq</groupId>
+      <artifactId>artemis-core-client</artifactId>
+      <version>${org.apache.activemq-artemis-core-client.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -747,9 +752,9 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.hornetq</groupId>
-      <artifactId>hornetq-commons</artifactId>
-      <version>${org.hornetq-hornetq-commons.version}</version>
+      <groupId>org.apache.activemq</groupId>
+      <artifactId>artemis-commons</artifactId>
+      <version>${org.apache.activemq-artemis-commons.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -758,9 +763,20 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.hornetq</groupId>
-      <artifactId>hornetq-journal</artifactId>
-      <version>${org.hornetq-hornetq-journal.version}</version>
+      <groupId>org.apache.activemq</groupId>
+      <artifactId>artemis-selector</artifactId>
+      <version>${org.apache.activemq-artemis-selector.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.activemq</groupId>
+      <artifactId>artemis-journal</artifactId>
+      <version>${org.apache.activemq-artemis-journal.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -772,6 +788,50 @@
       <groupId>io.netty</groupId>
       <artifactId>netty-all</artifactId>
       <version>${io.netty-netty-all.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>commons-beanutils</groupId>
+      <artifactId>commons-beanutils</artifactId>
+      <version>${commons-beanutils-commons-beanutils.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.jgroups</groupId>
+      <artifactId>jgroups</artifactId>
+      <version>${org.jgroups-jgroups.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.geronimo.specs</groupId>
+      <artifactId>geronimo-json_1.0_spec</artifactId>
+      <version>${org.apache.geronimo.specs-geronimo-json_1.0_spec.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.johnzon</groupId>
+      <artifactId>johnzon-core</artifactId>
+      <version>${org.apache.johnzon-johnzon-core.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>

--- a/server/src/main/java/org/candlepin/audit/EventFilter.java
+++ b/server/src/main/java/org/candlepin/audit/EventFilter.java
@@ -28,7 +28,8 @@ import java.util.Set;
 
 /**
  * This class is used to filter audit events so that they cannot enter
- * HornetQ queues.
+ * ActiveMQ queues.
+ *
  * This functionality is introduced as a hack to limit number of
  * audited events. Many users of Candlepin reported high memory usage
  * and crashes. Those issues were challenging to reproduce and

--- a/server/src/main/java/org/candlepin/audit/ListenerWrapper.java
+++ b/server/src/main/java/org/candlepin/audit/ListenerWrapper.java
@@ -18,9 +18,9 @@ import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import org.hornetq.api.core.HornetQException;
-import org.hornetq.api.core.client.ClientMessage;
-import org.hornetq.api.core.client.MessageHandler;
+import org.apache.activemq.artemis.api.core.ActiveMQException;
+import org.apache.activemq.artemis.api.core.client.ClientMessage;
+import org.apache.activemq.artemis.api.core.client.MessageHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,7 +44,7 @@ public class ListenerWrapper implements MessageHandler {
         String body = msg.getBodyBuffer().readString();
         log.debug("Got event: {}", body);
 
-        // Exceptions thrown here will cause the event to remain in hornetq:
+        // Exceptions thrown here will cause the event to remain in ActiveMQ:
         try {
             Event event = mapper.readValue(body, Event.class);
             listener.onEvent(event);
@@ -64,10 +64,10 @@ public class ListenerWrapper implements MessageHandler {
 
         try {
             msg.acknowledge();
-            log.debug("Hornetq message acknowledged for listener: " + listener);
+            log.debug("ActiveMQ message acknowledged for listener: " + listener);
         }
-        catch (HornetQException e) {
-            log.error("Unable to acknowledge hornetq msg", e);
+        catch (ActiveMQException e) {
+            log.error("Unable to acknowledge ActiveMQ msg", e);
         }
     }
 

--- a/server/src/main/java/org/candlepin/audit/QueueStatus.java
+++ b/server/src/main/java/org/candlepin/audit/QueueStatus.java
@@ -19,7 +19,7 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 
 /**
- * Simple DTO for returning status of the HornetQ queues. Used for checking if events
+ * Simple DTO for returning status of the ActiveMQ queues. Used for checking if events
  * are piling up for some reason or being delivered correctly.
  */
 @XmlRootElement

--- a/server/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/server/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -63,44 +63,48 @@ public class ConfigProperties {
     public static final String CA_CERT_UPSTREAM = "candlepin.upstream_ca_cert";
     public static final String CA_KEY_PASSWORD = "candlepin.ca_key_password";
 
-    public static final String HORNETQ_ENABLED = "candlepin.audit.hornetq.enable";
-    public static final String HORNETQ_BASE_DIR = "candlepin.audit.hornetq.base_dir";
+    /*
+     * XXX The actual property key refers to HornetQ which was ActiveMQ's ancestor.  We have to keep the
+     * key unchanged for compatibility reasons.
+     */
+    public static final String ACTIVEMQ_ENABLED = "candlepin.audit.hornetq.enable";
+    public static final String ACTIVEMQ_BASE_DIR = "candlepin.audit.hornetq.base_dir";
     /**
      * This number is large message size. Any message
      * that is bigger than this number is regarded as large.
-     * That means that HornetQ will page this message
+     * That means that ActiveMQ will page this message
      * to a disk. Setting this number to something high
      * e.g. 1 000 0000 will effectively disable the
      * functionality. This is handy when you expect a lot of
      * messages and you do not want to run out of disk space.
      */
-    public static final String HORNETQ_LARGE_MSG_SIZE = "candlepin.audit.hornetq.large_msg_size";
+    public static final String ACTIVEMQ_LARGE_MSG_SIZE = "candlepin.audit.hornetq.large_msg_size";
 
     /**
      * Setting number of server threads that will be
-     * created for Hornet. -1 means that default value
+     * created for ActiveMQ. -1 means that default value
      * will be used.
      */
-    public static final String HORNETQ_MAX_SCHEDULED_THREADS =
+    public static final String ACTIVEMQ_MAX_SCHEDULED_THREADS =
         "candlepin.audit.hornetq.max_scheduled_threads";
-    public static final String HORNETQ_MAX_THREADS = "candlepin.audit.hornetq.max_threads";
+    public static final String ACTIVEMQ_MAX_THREADS = "candlepin.audit.hornetq.max_threads";
     /**
      * This can be either BLOCK or PAGE. When set to PAGE then
-     * Hornet will keep only up to HORNET_MAX_QUEUE_SIZE
+     * ActiveMQ will keep only up to ACTIVEMQ_MAX_QUEUE_SIZE
      * kilobytes of queue messages in memory. Anything above
-     * HORNET_MAX_QUEUE_SIZE will be paged to a hard disk.
+     * ACTIVEMQ_MAX_QUEUE_SIZE will be paged to a hard disk.
      * When set to BLOCK then after reaching
-     * HORNET_MAX_QUEUE_SIZE, all the producers will be blocked until
+     * ACTIVEMQ_MAX_QUEUE_SIZE, all the producers will be blocked until
      * the queues are freed up by consumers. Thus, BLOCK
      * may be dangerous when consumers fail, because
      * producers will timeout.
      */
-    public static final String HORNETQ_ADDRESS_FULL_POLICY = "candlepin.audit.hornetq.address_full_policy";
-    public static final String HORNETQ_MAX_QUEUE_SIZE = "candlepin.audit.hornetq.max_queue_size";
+    public static final String ACTIVEMQ_ADDRESS_FULL_POLICY = "candlepin.audit.hornetq.address_full_policy";
+    public static final String ACTIVEMQ_MAX_QUEUE_SIZE = "candlepin.audit.hornetq.max_queue_size";
     /**
-     * This is applicable only for PAGE setting of HORNETQ_ADDRESS_FULL_POLICY.
+     * This is applicable only for PAGE setting of ACTIVEMQ_ADDRESS_FULL_POLICY.
      */
-    public static final String HORNETQ_MAX_PAGE_SIZE = "candlepin.audit.hornetq.max_page_size";
+    public static final String ACTIVEMQ_MAX_PAGE_SIZE = "candlepin.audit.hornetq.max_page_size";
 
     public static final String AUDIT_LISTENERS = "candlepin.audit.listeners";
     public static final String AUDIT_LOG_FILE = "candlepin.audit.log_file";
@@ -120,7 +124,7 @@ public class ConfigProperties {
     /**
      * Can be set to DO_FILTER or DO_NOT_FILTER.
      * When set to DO_FILTER, then events that are not either in DO_FILTER nor DO_NOT_FILTER
-     * will be filtered, meaning they will not enter HORNETQ.
+     * will be filtered, meaning they will not enter ActiveMQ.
      */
     public static final String AUDIT_FILTER_DEFAULT_POLICY = "candlepin.audit.filter.policy";
 
@@ -303,15 +307,15 @@ public class ConfigProperties {
 
             this.put(ACTIVATION_DEBUG_PREFIX, "");
 
-            this.put(HORNETQ_ENABLED, "true");
-            this.put(HORNETQ_BASE_DIR, "/var/lib/candlepin/hornetq");
-            this.put(HORNETQ_LARGE_MSG_SIZE, Integer.toString(100 * 1024));
+            this.put(ACTIVEMQ_ENABLED, "true");
+            this.put(ACTIVEMQ_BASE_DIR, "/var/lib/candlepin/activemq-artemis");
+            this.put(ACTIVEMQ_LARGE_MSG_SIZE, Integer.toString(100 * 1024));
 
-            this.put(HORNETQ_MAX_THREADS, "-1");
-            this.put(HORNETQ_MAX_SCHEDULED_THREADS, "-1");
-            this.put(HORNETQ_ADDRESS_FULL_POLICY, "PAGE");
-            this.put(HORNETQ_MAX_QUEUE_SIZE, "10");
-            this.put(HORNETQ_MAX_PAGE_SIZE, "1");
+            this.put(ACTIVEMQ_MAX_THREADS, "-1");
+            this.put(ACTIVEMQ_MAX_SCHEDULED_THREADS, "-1");
+            this.put(ACTIVEMQ_ADDRESS_FULL_POLICY, "PAGE");
+            this.put(ACTIVEMQ_MAX_QUEUE_SIZE, "10");
+            this.put(ACTIVEMQ_MAX_PAGE_SIZE, "1");
             this.put(AUDIT_LISTENERS,
                 "org.candlepin.audit.DatabaseListener," +
                 "org.candlepin.audit.LoggingListener," +

--- a/server/src/main/java/org/candlepin/guice/CandlepinContextListener.java
+++ b/server/src/main/java/org/candlepin/guice/CandlepinContextListener.java
@@ -15,11 +15,11 @@
 package org.candlepin.guice;
 
 import static org.candlepin.config.ConfigProperties.ENCRYPTED_PROPERTIES;
-import static org.candlepin.config.ConfigProperties.HORNETQ_ENABLED;
+import static org.candlepin.config.ConfigProperties.ACTIVEMQ_ENABLED;
 import static org.candlepin.config.ConfigProperties.PASSPHRASE_SECRET_FILE;
 
 import org.candlepin.audit.AMQPBusPublisher;
-import org.candlepin.audit.HornetqContextListener;
+import org.candlepin.audit.ActiveMQContextListener;
 import org.candlepin.audit.QpidQmf;
 import org.candlepin.audit.QpidQmf.QpidStatus;
 import org.candlepin.common.config.Configuration;
@@ -89,7 +89,7 @@ import io.swagger.converter.ModelConverters;
 public class CandlepinContextListener extends GuiceResteasyBootstrapServletContextListener {
     public static final String CONFIGURATION_NAME = Configuration.class.getName();
 
-    private HornetqContextListener hornetqListener;
+    private ActiveMQContextListener activeMQContextListener;
     private PinsetterContextListener pinsetterListener;
     private LoggerContextListener loggerListener;
 
@@ -165,13 +165,13 @@ public class CandlepinContextListener extends GuiceResteasyBootstrapServletConte
             mw.startPeriodicExecutions();
         }
 
-        if (config.getBoolean(HORNETQ_ENABLED)) {
+        if (config.getBoolean(ACTIVEMQ_ENABLED)) {
             try {
-                hornetqListener = injector.getInstance(HornetqContextListener.class);
-                hornetqListener.contextInitialized(injector);
+                activeMQContextListener = injector.getInstance(ActiveMQContextListener.class);
+                activeMQContextListener.contextInitialized(injector);
             }
             catch (Exception e) {
-                log.error("Exception occurred while trying to load HornetQ", e);
+                log.error("Exception occurred while trying to load ActiveMQ", e);
             }
         }
 
@@ -198,8 +198,8 @@ public class CandlepinContextListener extends GuiceResteasyBootstrapServletConte
     @Override
     public void contextDestroyed(ServletContextEvent event) {
         super.contextDestroyed(event);
-        if (config.getBoolean(HORNETQ_ENABLED)) {
-            hornetqListener.contextDestroyed();
+        if (config.getBoolean(ACTIVEMQ_ENABLED)) {
+            activeMQContextListener.contextDestroyed();
         }
         pinsetterListener.contextDestroyed();
         loggerListener.contextDestroyed();

--- a/server/src/main/java/org/candlepin/guice/CandlepinModule.java
+++ b/server/src/main/java/org/candlepin/guice/CandlepinModule.java
@@ -415,7 +415,7 @@ public class CandlepinModule extends AbstractModule {
     }
 
     private void configureEventSink() {
-        if (config.getBoolean(ConfigProperties.HORNETQ_ENABLED)) {
+        if (config.getBoolean(ConfigProperties.ACTIVEMQ_ENABLED)) {
             bind(EventSink.class).to(EventSinkImpl.class);
         }
         else {

--- a/server/src/main/java/org/candlepin/jackson/PoolSerializer.java
+++ b/server/src/main/java/org/candlepin/jackson/PoolSerializer.java
@@ -35,7 +35,7 @@ import java.util.Set;
  * so it didn't require any special handling. But since now, the provided
  * products are taken from reference cache, this PoolSerializer is necessary
  * in various places: Rules, REST response
- * serialization, HornetQ, AMQP. The reason for choosing
+ * serialization, ActiveMQ, AMQP. The reason for choosing
  * JsonSerializer extension is that it is a simplest way to insert code just
  * before default serialization of a Pool. Without disturbing other extensions
  * that we already have in serialization (filtering, Hateoas)

--- a/server/src/main/java/org/candlepin/resource/AdminResource.java
+++ b/server/src/main/java/org/candlepin/resource/AdminResource.java
@@ -108,7 +108,7 @@ public class AdminResource {
     @Produces({MediaType.APPLICATION_JSON})
     @Path("queues")
     @ApiOperation(
-        notes = "Basic information on the HornetQ queues and how many messages are pending in each.",
+        notes = "Basic information on the ActiveMQ queues and how many messages are pending in each.",
         value = "Get Queue Stats")
     public List<QueueStatus> getQueueStats() {
         return sink.getQueueInfo();

--- a/server/src/test/java/org/candlepin/audit/EventSinkImplTest.java
+++ b/server/src/test/java/org/candlepin/audit/EventSinkImplTest.java
@@ -43,13 +43,13 @@ import org.candlepin.test.TestUtil;
 import com.fasterxml.jackson.core.JsonGenerationException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import org.hornetq.api.core.HornetQBuffers;
-import org.hornetq.api.core.HornetQException;
-import org.hornetq.api.core.client.ClientMessage;
-import org.hornetq.api.core.client.ClientProducer;
-import org.hornetq.api.core.client.ClientSession;
-import org.hornetq.api.core.client.ClientSessionFactory;
-import org.hornetq.api.core.client.ServerLocator;
+import org.apache.activemq.artemis.api.core.ActiveMQBuffers;
+import org.apache.activemq.artemis.api.core.ActiveMQException;
+import org.apache.activemq.artemis.api.core.client.ClientMessage;
+import org.apache.activemq.artemis.api.core.client.ClientProducer;
+import org.apache.activemq.artemis.api.core.client.ClientSession;
+import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
+import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -91,7 +91,7 @@ public class EventSinkImplTest {
         when(mockClientSession.createProducer(anyString())).thenReturn(mockClientProducer);
         when(mockClientSession.createMessage(anyBoolean())).thenReturn(mockClientMessage);
         when(mockClientMessage.getBodyBuffer()).thenReturn(
-            HornetQBuffers.fixedBuffer(2000));
+            ActiveMQBuffers.fixedBuffer(2000));
         when(mockSessionFactory.getServerLocator()).thenReturn(mockLocator);
         this.mapper = spy(new ObjectMapper());
         this.eventSinkImpl = createEventSink(mockSessionFactory);
@@ -124,7 +124,7 @@ public class EventSinkImplTest {
     public void eventSinkShouldThrowExceptionWhenSessionCreationFailsInConstructor()
         throws Exception {
         final ClientSessionFactory csFactory = mock(ClientSessionFactory.class);
-        doThrow(new HornetQException()).when(csFactory.createSession());
+        doThrow(new ActiveMQException()).when(csFactory.createSession());
         createEventSink(csFactory);
         fail("Runtime exception should have been thrown.");
     }
@@ -138,7 +138,7 @@ public class EventSinkImplTest {
     @Test(expected = RuntimeException.class)
     public void eventSinkShouldThrowExceptionWhenProducerCreationFailsInConstructor()
         throws Exception {
-        doThrow(new HornetQException()).when(
+        doThrow(new ActiveMQException()).when(
             mockClientSession.createProducer(anyString()));
         createEventSink(mockSessionFactory);
         fail("Runtime exception should have been thrown.");

--- a/server/src/test/java/org/candlepin/audit/EventSourceTest.java
+++ b/server/src/test/java/org/candlepin/audit/EventSourceTest.java
@@ -20,11 +20,11 @@ import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import org.hornetq.api.core.HornetQException;
-import org.hornetq.api.core.HornetQExceptionType;
-import org.hornetq.api.core.client.ClientConsumer;
-import org.hornetq.api.core.client.ClientSession;
-import org.hornetq.api.core.client.ClientSessionFactory;
+import org.apache.activemq.artemis.api.core.ActiveMQException;
+import org.apache.activemq.artemis.api.core.ActiveMQExceptionType;
+import org.apache.activemq.artemis.api.core.client.ClientConsumer;
+import org.apache.activemq.artemis.api.core.client.ClientSession;
+import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -66,7 +66,7 @@ public class EventSourceTest {
     @Test(expected = RuntimeException.class)
     public void shouldThrowRunTimeExceptionWhenSessionCreateFailsDuringEventSourceCreation()
         throws Exception {
-        doThrow(new HornetQException()).when(clientSession).start();
+        doThrow(new ActiveMQException()).when(clientSession).start();
         createEventSourceStubbedWithFactoryCreation();
         fail("Should have thrown runtime exception");
     }
@@ -74,7 +74,7 @@ public class EventSourceTest {
     @Test
     public void shouldNotThrowExceptionWhenQueueCreationFails() throws Exception {
         EventSource eventSource = createEventSourceStubbedWithFactoryCreation();
-        doThrow(new HornetQException(HornetQExceptionType.QUEUE_DOES_NOT_EXIST))
+        doThrow(new ActiveMQException(ActiveMQExceptionType.QUEUE_DOES_NOT_EXIST))
             .when(clientSession).createQueue(anyString(), anyString(), eq(true));
         EventListener eventListener = mock(EventListener.class);
         eventSource.registerListener(eventListener);
@@ -104,7 +104,7 @@ public class EventSourceTest {
         ClientConsumer mockCC = mock(ClientConsumer.class);
         when(clientSession.createConsumer(anyString()))
             .thenReturn(mockCC);
-        doThrow(new HornetQException(HornetQExceptionType.QUEUE_EXISTS))
+        doThrow(new ActiveMQException(ActiveMQExceptionType.QUEUE_EXISTS))
             .when(clientSession).createQueue(anyString(), anyString());
         EventListener eventListener = mock(EventListener.class);
         //invoke
@@ -128,7 +128,7 @@ public class EventSourceTest {
     public void shouldStopAndCloseSessionOnShutdownWhenExceptionThrownOnStop()
         throws Exception {
         EventSource eventSource = createEventSourceStubbedWithFactoryCreation();
-        doThrow(new HornetQException()).when(clientSession).stop();
+        doThrow(new ActiveMQException()).when(clientSession).stop();
 
         eventSource.shutDown();
 
@@ -139,7 +139,7 @@ public class EventSourceTest {
     public void shouldStopAndCloseSessionOnShutdownWhenExceptionThrownOnClose()
         throws Exception {
         EventSource eventSource = createEventSourceStubbedWithFactoryCreation();
-        doThrow(new HornetQException()).when(clientSession).close();
+        doThrow(new ActiveMQException()).when(clientSession).close();
 
         eventSource.shutDown();
         verify(this.clientSession).stop();

--- a/server/src/test/java/org/candlepin/config/CandlepinCommonTestConfig.java
+++ b/server/src/test/java/org/candlepin/config/CandlepinCommonTestConfig.java
@@ -39,7 +39,7 @@ public class CandlepinCommonTestConfig extends MapConfiguration {
             setProperty(ConfigProperties.CA_KEY, key);
             setProperty(ConfigProperties.CA_KEY_PASSWORD, "password");
             setProperty(ConfigProperties.SYNC_WORK_DIR, "/tmp");
-            setProperty(ConfigProperties.HORNETQ_LARGE_MSG_SIZE, "0");
+            setProperty(ConfigProperties.ACTIVEMQ_LARGE_MSG_SIZE, "0");
 
             setProperty(DatabaseConfigFactory.IN_OPERATOR_BLOCK_SIZE, "10");
             setProperty(DatabaseConfigFactory.CASE_OPERATOR_BLOCK_SIZE, "10");

--- a/server/src/test/java/org/candlepin/guice/CandlepinContextListenerTest.java
+++ b/server/src/test/java/org/candlepin/guice/CandlepinContextListenerTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.*;
 
 import org.candlepin.TestingModules;
 import org.candlepin.audit.AMQPBusPublisher;
-import org.candlepin.audit.HornetqContextListener;
+import org.candlepin.audit.ActiveMQContextListener;
 import org.candlepin.common.config.Configuration;
 import org.candlepin.common.config.ConfigurationException;
 import org.candlepin.common.config.ConfigurationPrefixes;
@@ -59,7 +59,7 @@ import javax.servlet.ServletContextEvent;
 public class CandlepinContextListenerTest {
     private Configuration config;
     private CandlepinContextListener listener;
-    private HornetqContextListener hqlistener;
+    private ActiveMQContextListener hqlistener;
     private PinsetterContextListener pinlistener;
     private AMQPBusPublisher buspublisher;
     private ScheduledExecutorService executorService;
@@ -80,7 +80,7 @@ public class CandlepinContextListenerTest {
             new MapConfiguration(ConfigProperties.DEFAULT_PROPERTIES));
         when(config.strippedSubset(eq(ConfigurationPrefixes.LOGGING_CONFIG_PREFIX)))
             .thenReturn(new MapConfiguration());
-        hqlistener = mock(HornetqContextListener.class);
+        hqlistener = mock(ActiveMQContextListener.class);
         pinlistener = mock(PinsetterContextListener.class);
         buspublisher = mock(AMQPBusPublisher.class);
         executorService = mock(ScheduledExecutorService.class);
@@ -116,7 +116,7 @@ public class CandlepinContextListenerTest {
 
     @Test
     public void contextInitialized() {
-        when(config.getBoolean(eq(ConfigProperties.HORNETQ_ENABLED))).thenReturn(true);
+        when(config.getBoolean(eq(ConfigProperties.ACTIVEMQ_ENABLED))).thenReturn(true);
         prepareForInitialization();
         listener.contextInitialized(evt);
         verify(hqlistener).contextInitialized(any(Injector.class));
@@ -151,8 +151,8 @@ public class CandlepinContextListenerTest {
     }
 
     @Test
-    public void hornetQDisabled() {
-        when(config.getBoolean(eq(ConfigProperties.HORNETQ_ENABLED))).thenReturn(false);
+    public void activeMQDisabled() {
+        when(config.getBoolean(eq(ConfigProperties.ACTIVEMQ_ENABLED))).thenReturn(false);
         prepareForInitialization();
         listener.contextInitialized(evt);
         verifyNoMoreInteractions(hqlistener);
@@ -160,7 +160,7 @@ public class CandlepinContextListenerTest {
 
     @Test
     public void contextDestroyed() {
-        when(config.getBoolean(eq(ConfigProperties.HORNETQ_ENABLED))).thenReturn(true);
+        when(config.getBoolean(eq(ConfigProperties.ACTIVEMQ_ENABLED))).thenReturn(true);
         prepareForInitialization();
 
         // we actually have to call contextInitialized before we
@@ -235,7 +235,7 @@ public class CandlepinContextListenerTest {
         @Override
         protected void configure() {
             bind(PinsetterContextListener.class).toInstance(pinlistener);
-            bind(HornetqContextListener.class).toInstance(hqlistener);
+            bind(ActiveMQContextListener.class).toInstance(hqlistener);
             bind(AMQPBusPublisher.class).toInstance(buspublisher);
             bind(ScheduledExecutorService.class).toInstance(executorService);
         }


### PR DESCRIPTION
Move from HornetQ to Apache ActiveMQ Artemis (which is the next incarnation of HornetQ) in order to address an open CVE.

While looking at the CVE list, I also updated Logback since that was there too.

There is one consideration to keep in mind.  I changed the directory that stores the journal, etc. from /var/lib/candlepin/hornetq to /var/lib/candlepin/activemq-artemis.  Using the old directory with ActiveMQ Artemis will result in a deployment failures since Artemis won't read the old journal.  Changing the directory name should, in my opinion, be sufficient but it will leave the old `hornetq` directory.  We have the option of adding a `%pre` section to the Candlepin spec file that will remove any existing `/var/lib/candlepin/hornetq` directory.

It is also possible, but very unlikely, that someone will not be using the default value (which I have changed) for `candlepin.audit.hornetq.base_dir`.  If they have this value set, they'll hit deployment errors since Candlepin will start up and try to read old journals.  I don't know of a great way around this issue since the incompatibility is a one time issue (i.e. once the issue is resolved it won't reoccur so we don't need Candlepin to continually check configuration settings on subsequent deployments).