### PR TITLE
1531627: Reduce possibility of lock waits on Async Hypervisor Check in

### DIFF
--- a/server/bin/gen_fake_report.py
+++ b/server/bin/gen_fake_report.py
@@ -1,0 +1,94 @@
+#!/bin/python
+import uuid
+import json
+import argparse
+import random
+import sys
+
+
+class AbstractVirtWhoReportGenerator(object):
+
+    def __init__(self, num_hypervisors, num_guests):
+        self.hypervisors = num_hypervisors
+        self.guests = num_guests
+
+    def generate(self):
+        # Returns a json representation of the generated report
+        return json.dumps(self._generate())
+
+    def gen_hypervisor(self, num_guests, min_guests=0, max_guests=None):
+        # Subclasses should implement this method to return a hypervisor with
+        # The given number of guests.
+        # Min guests, max_guests should allow for variation in the amount of
+        # guests for the hypervisor.
+        # Should return a dictionary representation of the guest
+        raise NotImplemented()
+
+    def gen_guest(self):
+        # Generate a guest. Should return a dictionary representation of the
+        # guest
+        return {
+            "guestId": str(uuid.uuid4()),
+            "state": random.choice(range(1, 6))
+        }
+
+
+class VirtWhoReportGenerator(AbstractVirtWhoReportGenerator):
+
+    def _generate(self):
+        report = {}
+        for x in range(0, self.hypervisors):
+            report[str(uuid.uuid4())] = [self.gen_guest() for y in
+                range(0, self.guests)]
+        return report
+
+
+class AsyncVirtWhoReportGenerator(AbstractVirtWhoReportGenerator):
+
+    def gen_hypervisor(self, num_guests, min_guests=0, max_guests=None):
+        return {"hypervisorId": {"hypervisorId": str(uuid.uuid4())},
+                "guestIds": [self.gen_guest() for x in range(0, num_guests)]}
+
+    def _generate(self):
+        report = {'hypervisors': [self.gen_hypervisor(self.guests) for x in
+                                  range(0, self.hypervisors)]}
+        return report
+
+
+def init_parser():
+    parser = argparse.ArgumentParser(description="Generate a fake report to be sent by virt-who")
+    parser.add_argument('--hypervisors', metavar='N', type=int,
+                        help="The number of hypervisors to include.",
+                        action="store", dest="num_hypervisors")
+    parser.add_argument('--guests', metavar="N", type=int, dest="num_guests", default=1)
+    parser.add_argument('--reports', metavar="N", type=int, dest="num_reports", default=1)
+    parser.add_argument('--format', type=str, dest="format", choices=['async', 'sync'], help="The format of report to generate ('sync' or 'async')")
+    parser.add_argument("-o", nargs="?", type=argparse.FileType('w'),
+                        default=sys.stdout, dest='outfile')
+    args = parser.parse_args()
+
+    args.format = str.lower(args.format).strip()
+
+    return args
+
+
+def get_generator(format='sync'):
+    format_to_generator_map = {
+        'sync': VirtWhoReportGenerator,
+        'async': AsyncVirtWhoReportGenerator
+    }
+    return format_to_generator_map[format]
+
+
+def init_generator(args):
+    return get_generator(args.format)(args.num_hypervisors, args.num_guests)
+
+
+if __name__ == '__main__':
+    args = init_parser()
+
+    generator_class = get_generator(format=args.format)
+    generator = generator_class(args.num_hypervisors, args.num_guests)
+    for x in range(args.num_reports):
+        report = generator.generate()
+        args.outfile.write(report + '\n')

--- a/server/client/ruby/candlepin_api.rb
+++ b/server/client/ruby/candlepin_api.rb
@@ -140,6 +140,23 @@ class Candlepin
     return post_text(path, params, json_data, 'json')
   end
 
+  def hypervisor_update_file(owner, json_file, create_missing=nil, reporter_id=nil)
+    path = get_path("hypervisors") + "/#{owner}"
+    params = {}
+
+    params[:create_missing] = create_missing unless create_missing.nil?
+    params[:reporter_id] = reporter_id unless reporter_id.nil?
+
+    json_data = ''
+    File.open(json_file) do |f|
+      f.each_line do |line|
+        json_data << "\n" << line
+      end
+    end
+
+    return post_text(path, params, json_data, 'json')
+  end
+
   def remove_deletion_record(deleted_uuid)
     path = get_path("consumers") + "/#{deleted_uuid}/deletionrecord"
     return delete(path)

--- a/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
+++ b/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
@@ -179,7 +179,20 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
      */
     @Transactional
     public E create(E entity) {
-        save(entity);
+        return create(entity, true);
+    }
+
+    /**
+     * @param entity to be created.
+     * @param flush whether or not to flush after the persist.
+     * @return newly created entity.
+     */
+    @Transactional
+    public E create(E entity, boolean flush) {
+        getEntityManager().persist(entity);
+        if (flush) {
+            flush();
+        }
         return entity;
     }
 
@@ -545,8 +558,7 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
 
     @Transactional
     protected void save(E anObject) {
-        getEntityManager().persist(anObject);
-        flush();
+        create(anObject, true);
     }
 
     public void flush() {

--- a/server/src/main/java/org/candlepin/model/ConsumerCurator.java
+++ b/server/src/main/java/org/candlepin/model/ConsumerCurator.java
@@ -27,6 +27,7 @@ import com.google.inject.persist.Transactional;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.hibernate.Criteria;
+import org.hibernate.FetchMode;
 import org.hibernate.Hibernate;
 import org.hibernate.Query;
 import org.hibernate.ReplicationMode;
@@ -42,6 +43,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -52,6 +54,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 
 import javax.persistence.LockModeType;
+import javax.persistence.TypedQuery;
 
 
 
@@ -75,11 +78,10 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
 
     @Transactional
     @Override
-    public Consumer create(Consumer entity) {
+    public Consumer create(Consumer entity, boolean flush) {
         entity.ensureUUID();
         this.validateFacts(entity);
-
-        return super.create(entity);
+        return super.create(entity, flush);
     }
 
     @Override
@@ -395,7 +397,7 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
         Consumer existingConsumer = find(updatedConsumer.getId());
 
         if (existingConsumer == null) {
-            return this.create(updatedConsumer);
+            return this.create(updatedConsumer, flush);
         }
 
         // TODO: Are any of these read-only?
@@ -468,9 +470,19 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
      */
     @Transactional
     public Set<Consumer> bulkUpdate(Set<Consumer> consumers) {
+        return bulkUpdate(consumers, true);
+    }
+
+    /**
+     * @param consumers consumers to update
+     * @param flush whether to flush or not
+     * @return updated consumers
+     */
+    @Transactional
+    public Set<Consumer> bulkUpdate(Set<Consumer> consumers, boolean flush) {
         Set<Consumer> toReturn = new HashSet<Consumer>();
         for (Consumer toUpdate : consumers) {
-            toReturn.add(update(toUpdate));
+            toReturn.add(update(toUpdate, flush));
         }
 
         return toReturn;
@@ -543,6 +555,66 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
     }
 
     /**
+     * Creates a mapping of input guest IDs to GuestID objects currently tracked and stored in the
+     * backing database. If a given guest ID is not present in the database, it will be mapped to
+     * a null value.
+     *
+     * @param guestIds
+     *  A collection of guest IDs to map to existing GuestID objects
+     *
+     * @param owner
+     *  The owner to which the mapping lookup should be scoped
+     *
+     * @return
+     *  a mapping of guest IDs to GuestID objects
+     */
+    public Map<String, GuestId> getGuestIdMap(Iterable<String> guestIds, Owner owner) {
+        if (guestIds == null || owner == null) {
+            return Collections.<String, GuestId>emptyMap();
+        }
+
+        String hql = "SELECT gid FROM GuestId gid " +
+            "WHERE gid.consumer.owner = :owner AND gid.guestIdLower IN (:guest_ids)" +
+            "ORDER BY gid.updated DESC";
+
+        TypedQuery<GuestId> query = this.getEntityManager().createQuery(hql, GuestId.class);
+        Map<String, GuestId> output = new HashMap<String, GuestId>();
+
+        for (List<String> block : this.partition(guestIds)) {
+            List<String> sanitized = new ArrayList<String>(block.size());
+
+            for (String guestId : block) {
+                if (guestId != null && !guestId.isEmpty() && !output.containsKey(guestId)) {
+                    sanitized.add(guestId.toLowerCase());
+                    output.put(guestId, null);
+                }
+            }
+
+            List<GuestId> guests = query
+                .setParameter("owner", owner)
+                .setParameter("guest_ids", sanitized)
+                .getResultList();
+
+            if (guests != null) {
+                for (GuestId fetched : guests) {
+                    GuestId existing = output.get(fetched.getGuestId());
+
+                    if (existing == null || this.safeDateAfter(fetched.getUpdated(), existing.getUpdated())) {
+                        output.put(fetched.getGuestId(), fetched);
+                    }
+                }
+            }
+        }
+
+        return output;
+    }
+
+    private boolean safeDateAfter(Date d1, Date d2) {
+        return d1 != null && (d2 == null || d1.after(d2));
+    }
+
+
+    /**
      * Get guest consumers for a host consumer.
      *
      * @param consumer host consumer to find the guests for
@@ -613,7 +685,7 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
     public VirtConsumerMap getHostConsumersMap(Owner owner, Iterable<String> hypervisorIds) {
         VirtConsumerMap hypervisorMap = new VirtConsumerMap();
 
-        for (Consumer consumer : this.getHypervisorsBulk(hypervisorIds, owner.getKey())) {
+        for (Consumer consumer : this.getHypervisorsBulk(hypervisorIds, owner.getId())) {
             hypervisorMap.add(consumer.getHypervisorId().getHypervisorId(), consumer);
         }
 
@@ -622,12 +694,12 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
 
     /**
      * @param hypervisorIds list of unique hypervisor identifiers
-     * @param ownerKey Org namespace to search
+     * @param ownerId Org namespace to search
      * @return Consumer that matches the given
      */
     @SuppressWarnings("unchecked")
     @Transactional
-    public CandlepinQuery<Consumer> getHypervisorsBulk(Iterable<String> hypervisorIds, String ownerKey) {
+    public CandlepinQuery<Consumer> getHypervisorsBulk(Iterable<String> hypervisorIds, String ownerId) {
         if (hypervisorIds == null || !hypervisorIds.iterator().hasNext()) {
             return this.cpQueryFactory.<Consumer>buildQuery();
         }
@@ -635,9 +707,10 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
         DetachedCriteria criteria = DetachedCriteria.forClass(Consumer.class)
             .createAlias("owner", "o")
             .createAlias("hypervisorId", "hvsr")
-            .add(Restrictions.eq("o.key", ownerKey))
+            .add(Restrictions.eq("o.id", ownerId))
             .add(this.getHypervisorIdRestriction(hypervisorIds))
-            .addOrder(Order.asc("hvsr.hypervisorId"));
+            .addOrder(Order.asc("hvsr.hypervisorId"))
+            .setFetchMode("type", FetchMode.SELECT);
 
         return this.cpQueryFactory.<Consumer>buildQuery(this.currentSession(), criteria)
             .setLockMode(LockModeType.PESSIMISTIC_WRITE);
@@ -654,11 +727,11 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
 
     @SuppressWarnings("unchecked")
     @Transactional
-    public CandlepinQuery<Consumer> getHypervisorsForOwner(String ownerKey) {
+    public CandlepinQuery<Consumer> getHypervisorsForOwner(String ownerId) {
         DetachedCriteria criteria = this.createSecureDetachedCriteria()
             .createAlias("owner", "o")
             .createAlias("hypervisorId", "hvsr")
-            .add(Restrictions.eq("o.key", ownerKey))
+            .add(Restrictions.eq("o.id", ownerId))
             .add(Restrictions.isNotNull("hvsr.hypervisorId"));
 
         return this.cpQueryFactory.<Consumer>buildQuery(this.currentSession(), criteria);

--- a/server/src/main/java/org/candlepin/model/VirtConsumerMap.java
+++ b/server/src/main/java/org/candlepin/model/VirtConsumerMap.java
@@ -19,6 +19,7 @@ import org.candlepin.util.Util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -72,6 +73,10 @@ public class VirtConsumerMap {
         }
 
         return null;
+    }
+
+    public Collection<Consumer> getConsumers() {
+        return virtUuidToConsumerMap.values();
     }
 
     public int size() {

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -282,7 +282,7 @@ public class ConsumerResource {
      * @param consumer
      *  The consumer containing the facts to sanitize
      */
-    private void sanitizeConsumerFacts(Consumer consumer) {
+    public void sanitizeConsumerFacts(Consumer consumer) {
         if (consumer != null) {
             Map<String, String> facts = consumer.getFacts();
 
@@ -1224,7 +1224,7 @@ public class ConsumerResource {
      * @param incoming incoming consumer
      * @return a boolean
      */
-    private boolean checkForFactsUpdate(Consumer existing, Consumer incoming) {
+    public boolean checkForFactsUpdate(Consumer existing, Consumer incoming) {
         if (incoming.getFacts() == null) {
             log.debug("Facts not included in this consumer update, skipping update.");
             return false;

--- a/server/src/main/java/org/candlepin/resource/EntitlementResource.java
+++ b/server/src/main/java/org/candlepin/resource/EntitlementResource.java
@@ -110,8 +110,7 @@ public class EntitlementResource {
 
     private void verifyExistence(Object o, String id) {
         if (o == null) {
-            throw new RuntimeException(
-                i18n.tr("Object with ID ''{0}'' could not found.", id));
+            throw new RuntimeException(i18n.tr("Object with ID ''{0}'' could not found.", id));
         }
     }
 

--- a/server/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -1583,10 +1583,11 @@ public class OwnerResource {
     public CandlepinQuery<Consumer> getHypervisors(
         @PathParam("owner_key") @Verify(Owner.class) String ownerKey,
         @QueryParam("hypervisor_id") List<String> hypervisorIds) {
-
-        return (hypervisorIds == null || hypervisorIds.isEmpty()) ?
-            this.consumerCurator.getHypervisorsForOwner(ownerKey) :
-            this.consumerCurator.getHypervisorsBulk(hypervisorIds, ownerKey);
+        Owner owner = ownerCurator.lookupByKey(ownerKey);
+        CandlepinQuery<Consumer> out = (hypervisorIds == null || hypervisorIds.isEmpty()) ?
+            this.consumerCurator.getHypervisorsForOwner(owner.getId()) :
+            this.consumerCurator.getHypervisorsBulk(hypervisorIds, owner.getId());
+        return out;
     }
 
     private ConflictOverrides processConflictOverrideParams(String[] overrideConflicts) {

--- a/server/src/main/java/org/candlepin/resource/dto/HypervisorUpdateResultUuids.java
+++ b/server/src/main/java/org/candlepin/resource/dto/HypervisorUpdateResultUuids.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) 2009 - 2018 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.resource.dto;
+
+import org.candlepin.model.Consumer;
+
+import java.io.Serializable;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * DTO that encapsulates the results from
+ * <code>HypervisorResource.hypervisorCheckInAsync</code>.
+ *
+ * <pre>
+ *     created: List of consumer UUIDS that have just been created.
+ *     updated: List of host consumers UUIDs that have had their guest IDs updated.
+ *     unchanged: List of host consumers UUIDs that have not been changed.
+ *     failed: a list of strings formated as '{host_virt_id}: Error message'.
+ * </pre>
+ */
+public class HypervisorUpdateResultUuids implements Serializable {
+    // TODO Once we have removed the need to store serialized java objects as the resultData of JobStatus
+    // this class (and HypervisorUpdateResult) should be removed and replaced.
+    private static final long serialVersionUID = -42133742L;
+    private Set<String> created;
+    private Set<String> updated;
+    private Set<String> unchanged;
+    private Set<String> failed;
+
+    public HypervisorUpdateResultUuids() {
+        this.created = new HashSet<String>();
+        this.updated = new HashSet<String>();
+        this.unchanged = new HashSet<String>();
+        this.failed = new HashSet<String>();
+    }
+
+    public boolean wasCreated(Consumer c) {
+        return created.contains(c.getUuid());
+    }
+
+    public boolean wasUpdated(Consumer c) {
+        return updated.contains(c.getUuid());
+    }
+
+    public boolean wasUnchanged(Consumer c) {
+        return unchanged.contains(c.getUuid());
+    }
+
+    public boolean wasCreated(String uuid) {
+        return created.contains(uuid);
+    }
+
+    public boolean wasUpdated(String uuid) {
+        return updated.contains(uuid);
+    }
+
+    public boolean wasUnchanged(String uuid) {
+        return unchanged.contains(uuid);
+    }
+
+    public void created(Consumer c) {
+        this.created.add(c.getUuid());
+    }
+
+    public void updated(Consumer c) {
+        this.updated.add(c.getUuid());
+    }
+
+    public void unchanged(Consumer c) {
+        this.unchanged.add(c.getUuid());
+    }
+
+    public void created(String uuid) {
+        this.created.add(uuid);
+    }
+
+    public void updated(String uuid) {
+        this.updated.add(uuid);
+    }
+
+    public void unchanged(String uuid) {
+        this.unchanged.add(uuid);
+    }
+
+    public void failed(String hostVirtId, String errorMessage) {
+        String error = errorMessage == null ? "" : errorMessage;
+        this.failed.add(hostVirtId + ": " + error);
+    }
+
+    public Set<String> getCreated() {
+        return created;
+    }
+
+    public Set<String> getUpdated() {
+        return updated;
+    }
+
+    public Set<String> getUnchanged() {
+        return unchanged;
+    }
+
+    public Set<String> getFailedUpdate() {
+        return failed;
+    }
+
+    @Override
+    public String toString() {
+        return "Created: " + created.size() + ", Updated: " + updated.size() +
+            ", Unchanged:" + unchanged.size() + ", Failed: " + failed.size();
+    }
+
+}

--- a/server/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
@@ -847,7 +847,7 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
         List<String> hypervisorIds = new LinkedList<String>();
         hypervisorIds.add(hypervisorid);
         hypervisorIds.add("not really a hypervisor");
-        List<Consumer> results = consumerCurator.getHypervisorsBulk(hypervisorIds, owner.getKey()).list();
+        List<Consumer> results = consumerCurator.getHypervisorsBulk(hypervisorIds, owner.getId()).list();
         assertEquals(1, results.size());
         assertEquals(consumer, results.get(0));
     }
@@ -861,7 +861,7 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
         List<String> hypervisorIds = new LinkedList<String>();
         hypervisorIds.add(hypervisorid.toUpperCase());
         hypervisorIds.add("NOT really a hypervisor");
-        List<Consumer> results = consumerCurator.getHypervisorsBulk(hypervisorIds, owner.getKey()).list();
+        List<Consumer> results = consumerCurator.getHypervisorsBulk(hypervisorIds, owner.getId()).list();
         assertEquals(1, results.size());
         assertEquals(consumer, results.get(0));
     }
@@ -874,7 +874,7 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
         consumer.setHypervisorId(new HypervisorId(hypervisorid));
         consumer = consumerCurator.create(consumer);
         List<Consumer> results = consumerCurator
-            .getHypervisorsBulk(new LinkedList<String>(), owner.getKey())
+            .getHypervisorsBulk(new LinkedList<String>(), owner.getId())
             .list();
 
         assertEquals(0, results.size());
@@ -891,7 +891,7 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
         consumer2 = consumerCurator.create(consumer2);
         Consumer nonHypervisor = new Consumer("testConsumer3", "testUser3", owner, ct);
         nonHypervisor = consumerCurator.create(nonHypervisor);
-        List<Consumer> results = consumerCurator.getHypervisorsForOwner(owner.getKey()).list();
+        List<Consumer> results = consumerCurator.getHypervisorsForOwner(owner.getId()).list();
         assertEquals(1, results.size());
         assertEquals(consumer, results.get(0));
     }

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceCreationTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceCreationTest.java
@@ -133,7 +133,7 @@ public class ConsumerResourceCreationTest {
     public void init() throws Exception {
         this.i18n = I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK);
 
-        testMigration = new GuestMigration(consumerCurator, factory, sink);
+        testMigration = new GuestMigration(consumerCurator);
         migrationProvider = Providers.of(testMigration);
 
         this.config = initConfig();
@@ -160,6 +160,14 @@ public class ConsumerResourceCreationTest {
                 return invocation.getArguments()[0];
             }
         });
+
+        when(consumerCurator.create(any(Consumer.class), any(Boolean.class))).thenAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                return invocation.getArguments()[0];
+            }
+        });
+
         when(consumerTypeCurator.lookupByLabel(system.getLabel())).thenReturn(system);
         when(userService.findByLogin(USER)).thenReturn(user);
         when(idCertService.generateIdentityCert(any(Consumer.class)))

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
@@ -17,8 +17,6 @@ package org.candlepin.resource;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
-import org.candlepin.audit.EventFactory;
-import org.candlepin.audit.EventSink;
 import org.candlepin.auth.Access;
 import org.candlepin.auth.ConsumerPrincipal;
 import org.candlepin.auth.Principal;
@@ -557,8 +555,7 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
     @SuppressWarnings("unchecked")
     @Test
     public void testRegenerateEntitlementCertificateWithValidConsumerByEntitlement() {
-        GuestMigration testMigration = new GuestMigration(consumerCurator, mock(EventFactory.class), mock
-            (EventSink.class));
+        GuestMigration testMigration = new GuestMigration(consumerCurator);
         Provider<GuestMigration> migrationProvider = Providers.of(testMigration);
 
         ConsumerResource cr = new ConsumerResource(

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
@@ -159,7 +159,7 @@ public class ConsumerResourceTest {
 
         this.factValidator = new FactValidator(this.config, this.i18n);
 
-        testMigration = new GuestMigration(mockedConsumerCurator, eventFactory, sink);
+        testMigration = new GuestMigration(mockedConsumerCurator);
         migrationProvider = Providers.of(testMigration);
     }
 

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
@@ -120,7 +120,7 @@ public class ConsumerResourceUpdateTest {
 
         this.i18n = I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK);
 
-        testMigration = new GuestMigration(consumerCurator, eventFactory, sink);
+        testMigration = new GuestMigration(consumerCurator);
         migrationProvider = Providers.of(testMigration);
 
         this.resource = new ConsumerResource(this.consumerCurator,
@@ -376,49 +376,6 @@ public class ConsumerResourceUpdateTest {
         updated.setGuestIds(new ArrayList<GuestId>());
         this.resource.updateConsumer(existing.getUuid(), updated, principal);
         assertTrue(existing.getGuestIds().isEmpty());
-    }
-
-    @Test
-    public void ensureCreateEventIsSentWhenGuestIdIsAddedToConsumer() {
-        String uuid = "TEST_CONSUMER";
-        Consumer existing = createConsumerWithGuests(new String[0]);
-        existing.setUuid(uuid);
-
-        when(this.consumerCurator.verifyAndLookupConsumer(uuid)).thenReturn(existing);
-
-        // Create a consumer with 1 new guest.
-        Consumer updated = createConsumerWithGuests("Guest 1");
-
-        Event expectedEvent = new Event();
-        when(this.eventFactory.guestIdCreated(updated.getGuestIds().get(0)))
-            .thenReturn(expectedEvent);
-        when(this.consumerCurator.getGuestConsumersMap(any(Owner.class), any(Set.class))).
-            thenReturn(new VirtConsumerMap());
-
-        this.resource.updateConsumer(existing.getUuid(), updated, principal);
-        verify(sink).queueEvent(eq(expectedEvent));
-    }
-
-    @Test
-    public void ensureEventIsSentWhenGuestIdIsremovedFromConsumer() {
-        String uuid = "TEST_CONSUMER";
-        Consumer existing = createConsumerWithGuests("Guest 1", "Guest 2");
-        existing.setUuid(uuid);
-
-        when(this.consumerCurator.verifyAndLookupConsumer(uuid)).thenReturn(existing);
-
-        // Create a consumer with one less guest id.
-        Consumer updated = createConsumerWithGuests("Guest 2");
-
-        Event expectedEvent = new Event();
-        when(this.eventFactory.guestIdDeleted(existing.getGuestIds().get(0)))
-            .thenReturn(expectedEvent);
-
-        when(this.consumerCurator.getGuestConsumersMap(any(Owner.class), any(Set.class))).
-            thenReturn(new VirtConsumerMap());
-
-        this.resource.updateConsumer(existing.getUuid(), updated, principal);
-        verify(sink).queueEvent(eq(expectedEvent));
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/resource/GuestIdResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/GuestIdResourceTest.java
@@ -82,7 +82,7 @@ public class GuestIdResourceTest {
 
     @Before
     public void setUp() {
-        testMigration = Mockito.spy(new GuestMigration(consumerCurator, eventFactory, sink));
+        testMigration = Mockito.spy(new GuestMigration(consumerCurator));
         migrationProvider = Providers.of(testMigration);
 
         i18n = I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK);

--- a/server/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
@@ -14,13 +14,10 @@
  */
 package org.candlepin.resource;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import org.candlepin.audit.Event.Target;
 import org.candlepin.audit.Event.Type;
@@ -113,7 +110,7 @@ public class HypervisorResourceTest {
     public void setupTest() {
         Configuration config = new CandlepinCommonTestConfig();
 
-        testMigration = new GuestMigration(consumerCurator, eventFactory, sink);
+        testMigration = new GuestMigration(consumerCurator);
         migrationProvider = Providers.of(testMigration);
 
         this.i18n = I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK);
@@ -137,6 +134,14 @@ public class HypervisorResourceTest {
                 return invocation.getArguments()[0];
             }
         });
+
+        when(consumerCurator.create(any(Consumer.class), any(Boolean.class)))
+            .thenAnswer(new Answer<Object>() {
+                @Override
+                public Object answer(InvocationOnMock invocation) throws Throwable {
+                    return invocation.getArguments()[0];
+                }
+            });
         when(complianceRules.getStatus(any(Consumer.class), any(Date.class), any(Boolean.class)))
             .thenReturn(new ComplianceStatus(new Date()));
 
@@ -388,7 +393,6 @@ public class HypervisorResourceTest {
         when(consumerCurator.getGuestConsumersMap(any(Owner.class), any(Set.class)))
             .thenReturn(new VirtConsumerMap());
 
-        when(ownerCurator.lookupByKey(eq(owner.getKey()))).thenReturn(owner);
         when(principal.canAccess(eq(owner), eq(SubResource.CONSUMERS), eq(Access.CREATE)))
             .thenReturn(true);
         when(consumerTypeCurator.lookupByLabel(eq(ConsumerTypeEnum.HYPERVISOR.getLabel())))


### PR DESCRIPTION
This is essentially a forward port of bz 1531628.
The biggest difference here is this version of the fix reuses existing guest id entries where applicable to ensure a guest is only mapped to one host (for a given organization).

Note: I will remove the lock wait repro script and squash the commits post-review.