### PR TITLE
Qpid reconnect attempts now have a constant interval.

### DIFF
--- a/server/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/server/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -165,21 +165,9 @@ public class ConfigProperties {
     public static final String QPID_QMF_RECEIVE_TIMEOUT = "candlepin.amqp.qmf.receive_timeout";
 
     /**
-     * The delay is calculated using formula:
-     *
-     * INITIAL_DELAY + (DELAY_GROWTH * FAILED_ATTEMPTS)
-     *
-     * The MAX_DELAY gives ability to put upper limit to the resulting delay
-     * (-1 means unbounded). Its possible to also set the GROWTH to 0 which
-     * effectively disables incrementing the delay and the delay
-     * becomes fixed INITIAL_DELAY
+     * Period to wait between attempts to reconnect to Qpid.
      */
-    public static final String QPID_MODE_TANSITIONER_DELAY_GROWTH =
-        "candlepin.amqp.suspend.transitioner_delay_growth";
-    public static final String QPID_MODE_TRANSITIONER_INITIAL_DELAY =
-        "candlepin.amqp.suspend.transitioner_initial_delay";
-    public static final String QPID_MODE_TRANSITIONER_MAX_DELAY =
-        "candlepin.amqp.suspend.transitioner_max_delay";
+    public static final String QPID_MODE_TRANSITIONER_DELAY = "candlepin.amqp.suspend.transitioner_delay";
 
     // Hibernate
     public static final String DB_PASSWORD = JPA_CONFIG_PREFIX + "hibernate.connection.password";
@@ -379,9 +367,7 @@ public class ConfigProperties {
             this.put(AMQP_TRUSTSTORE_PASSWORD, "password");
             this.put(SUSPEND_MODE_ENABLED, "true");
             this.put(QPID_QMF_RECEIVE_TIMEOUT, "5000");
-            this.put(QPID_MODE_TANSITIONER_DELAY_GROWTH, "10");
-            this.put(QPID_MODE_TRANSITIONER_INITIAL_DELAY, "10");
-            this.put(QPID_MODE_TRANSITIONER_MAX_DELAY, "300"); // 300 seconds = 5 minutes
+            this.put(QPID_MODE_TRANSITIONER_DELAY, "10");
 
             this.put(AMQP_CONNECTION_RETRY_INTERVAL, "10"); // Every 10 seconds
             this.put(AMQP_CONNECTION_RETRY_ATTEMPTS, "1"); // Try for 10 seconds (1*10s)

--- a/server/src/test/java/org/candlepin/guice/CandlepinContextListenerTest.java
+++ b/server/src/test/java/org/candlepin/guice/CandlepinContextListenerTest.java
@@ -184,8 +184,6 @@ public class CandlepinContextListenerTest {
         when(config.getBoolean(
                 eq(ConfigProperties.AMQP_INTEGRATION_ENABLED))).thenReturn(true);
         when(config.getBoolean(eq(ConfigProperties.SUSPEND_MODE_ENABLED))).thenReturn(true);
-        when(config.getLong(ConfigProperties.QPID_MODE_TANSITIONER_DELAY_GROWTH)).thenReturn(100L);
-        when(config.getLong(ConfigProperties.QPID_MODE_TRANSITIONER_INITIAL_DELAY)).thenReturn(100L);
         prepareForInitialization();
         // we actually have to call contextInitialized before we
         // can call contextDestroyed, otherwise the listener's


### PR DESCRIPTION
Previously, the class responsible for attempting to reconnect to Qpid
would begin with a small interval between attempts and then gradually
grow that interval so that reconnect attempts would grow farther and
farther apart.

This commit removes that functionality and replaces it with a constant
interval between reconnection attempts.  The previous algorithm provided
little tangible benefit and added additional code and configuration
complexity.