### PR TITLE
Pull corrected translations from Zanata.

### DIFF
--- a/common/po/fr.po
+++ b/common/po/fr.po
@@ -1,5 +1,6 @@
 # croe <croe@redhat.com>, 2017. #zanata
 # ljanda <ljanda@redhat.com>, 2017. #zanata
+# awood <awood@redhat.com>, 2018. #zanata
 # khowell <khowell@redhat.com>, 2018. #zanata
 msgid ""
 msgstr ""
@@ -9,8 +10,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2018-01-25 08:40+0000\n"
-"Last-Translator: khowell <khowell@redhat.com>\n"
+"PO-Revision-Date: 2018-02-27 04:43+0000\n"
+"Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
 "Language-Team: French\n"
 "Language: fr\n"
 "Plural-Forms: nplurals=2; plural=(n > 1)\n"
@@ -388,14 +389,14 @@ msgstr "Erreur lors de l''obtention de la clé d''unité OAuth"
 #: server/src/main/java/org/candlepin/bind/BindContext.java:94
 #, java-format
 msgid "Subscription pool(s) {0} do not exist."
-msgstr "Pool(s) d'abonnement) {0} non existant(s)."
+msgstr "Pool(s) d''abonnement) {0} non existant(s)."
 
 #: server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java:374
 #: server/src/main/java/org/candlepin/resource/util/ResolverUtil.java:58
 msgid "No owner specified, or owner lacks identifying information"
 msgstr ""
-"Aucun propriétaire spécifié ou le propriétaire manque d'informations "
-"d'identification"
+"Aucun propriétaire spécifié ou le propriétaire manque d''informations "
+"d''identification"
 
 #: server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java:383
 #: server/src/main/java/org/candlepin/resource/util/ResolverUtil.java:66
@@ -407,19 +408,19 @@ msgstr "Impossible de trouver un propriétaire avec la clé \"{0}\""
 #: server/src/main/java/org/candlepin/resource/util/ResolverUtil.java:74
 #, java-format
 msgid "Unable to find an owner with the ID \"{0}\""
-msgstr "Impossible de trouver un propriétaire avec la l'ID \"{0}\""
+msgstr "Impossible de trouver un propriétaire avec la l''ID \"{0}\""
 
 #: server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java:1894
 msgid ""
 "Unmapped guest entitlement expired without establishing a host/guest mapping."
 ""
 msgstr ""
-"Les droits de l'invité non mappés ont expiré sans établir de mappage hôte/"
+"Les droits de l''invité non mappés ont expiré sans établir de mappage hôte/"
 "invité."
 
 #: server/src/main/java/org/candlepin/controller/Entitler.java:210
 msgid "Auto-attach is disabled for owner '{0}'."
-msgstr "Auto-attach désactivé pour le propriétaire '{0}'."
+msgstr "Auto-attach désactivé pour le propriétaire ''{0}''."
 
 #: server/src/main/java/org/candlepin/controller/Entitler.java:260
 #: server/src/main/java/org/candlepin/controller/Entitler.java:500
@@ -434,20 +435,20 @@ msgstr ""
 #, java-format
 msgid "SKU product not available to this development unit: ''{0}''"
 msgstr ""
-"Le produit SKU n'est pas disponible pour cette unité de développement : "
+"Le produit SKU n''est pas disponible pour cette unité de développement : "
 "''{0}''"
 
 #: server/src/main/java/org/candlepin/controller/Entitler.java:476
 #, java-format
 msgid "Installed product not available to this development unit: ''{0}''"
 msgstr ""
-"Le produit installé n'est pas disponible pour cette unité de développement : "
-"''{0}''"
+"Le produit installé n''est pas disponible pour cette unité de développement :"
+" ''{0}''"
 
 #: server/src/main/java/org/candlepin/controller/ManifestManager.java:203
 #, java-format
 msgid "The requested manifest file was not found: {0}"
-msgstr "Le fichier de manifeste demandé n'a pas été trouvé : {0}"
+msgstr "Le fichier de manifeste demandé n''a pas été trouvé : {0}"
 
 #: server/src/main/java/org/candlepin/controller/ManifestManager.java:259
 #, java-format
@@ -457,7 +458,8 @@ msgstr "Impossible de trouver le manifeste spécifié par id : {0}"
 #: server/src/main/java/org/candlepin/controller/ManifestManager.java:265
 #, java-format
 msgid "Could not validate export against specifed consumer: {0}"
-msgstr "N'a pas pu valider l'exportation pour le consommateur spécifié : {0}"
+msgstr ""
+"N''a pas pu valider l''exportation pour le consommateur spécifié : {0}"
 
 #: server/src/main/java/org/candlepin/controller/ManifestManager.java:290
 #, java-format
@@ -506,7 +508,7 @@ msgstr "Impossible de trouver le propriétaire avec la clé \"{0}\"."
 #: server/src/main/java/org/candlepin/resource/OwnerProductResource.java:183
 #, java-format
 msgid "Content with ID \"{0}\" could not be found."
-msgstr "Impossible de trouver le contenu avec l'ID \"{0}\"."
+msgstr "Impossible de trouver le contenu avec l''ID \"{0}\"."
 
 #: server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java:770
 msgid "Request failed due to concurrent modification, please re-try."
@@ -615,17 +617,17 @@ msgstr "Supporte architecture {1} mais le system est {2}."
 #: server/src/main/java/org/candlepin/policy/js/compliance/StatusReasonMessageGenerator.java:57
 #, java-format
 msgid "Only supports {1} of {2} sockets."
-msgstr "Ne supporte qu'{1} socket parmi {2}."
+msgstr "Ne supporte qu''{1} socket parmi {2}."
 
 #: server/src/main/java/org/candlepin/policy/js/compliance/StatusReasonMessageGenerator.java:59
 #, java-format
 msgid "Only supports {1} of {2} cores."
-msgstr "Ne supporte qu'{1} cores parmi {2}."
+msgstr "Ne supporte qu''{1} cores parmi {2}."
 
 #: server/src/main/java/org/candlepin/policy/js/compliance/StatusReasonMessageGenerator.java:61
 #, java-format
 msgid "Only supports {1}GB of {2}GB of RAM."
-msgstr "Ne supporte qu' {1}Go parmi {2}Go de RAM."
+msgstr "Ne supporte qu'' {1}Go parmi {2}Go de RAM."
 
 #: server/src/main/java/org/candlepin/policy/js/compliance/StatusReasonMessageGenerator.java:63
 #, java-format
@@ -635,20 +637,20 @@ msgstr "Ne supporte que {1} parmi {2} invités virtuels."
 #: server/src/main/java/org/candlepin/policy/js/compliance/StatusReasonMessageGenerator.java:65
 #, java-format
 msgid "Only supports {1} of {2} vCPUs."
-msgstr "Ne supporte qu' {1} parmi {2} vCPU."
+msgstr "Ne supporte qu'' {1} parmi {2} vCPU."
 
 #: server/src/main/java/org/candlepin/policy/js/compliance/StatusReasonMessageGenerator.java:67
 msgid ""
 "Guest has not been reported on any host and is using a temporary unmapped "
 "guest subscription."
 msgstr ""
-"L'invité n'a pas été reporté sur un hôte et utilise un abonnement invité non "
-"mappé temporaire."
+"L''invité n''a pas été reporté sur un hôte et utilise un abonnement invité "
+"non mappé temporaire."
 
 #: server/src/main/java/org/candlepin/policy/js/compliance/StatusReasonMessageGenerator.java:70
 #, java-format
 msgid "Only supports {1}TB of {2}TB of storage."
-msgstr "Ne supporte qu' {1}To of {2}To de stockage."
+msgstr "Ne supporte qu'' {1}To of {2}To de stockage."
 
 #: server/src/main/java/org/candlepin/policy/js/compliance/StatusReasonMessageGenerator.java:72
 #, java-format
@@ -679,7 +681,8 @@ msgid ""
 "This unit has already had the subscription matching pool ID ''{1}'' attached."
 ""
 msgstr ""
-"Cette unité a déjà l'ID de pool qu’abonnement correspondant ''{1}'' attaché."
+"Cette unité a déjà l''ID de pool qu’abonnement correspondant ''{1}'' attaché."
+""
 
 #: server/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRulesTranslator.java:159
 #, java-format
@@ -698,14 +701,14 @@ msgstr ""
 #, java-format
 msgid "Multi-entitlement not supported for pool with ID ''{1}''."
 msgstr ""
-"Droits d'accès multiples non pris en charge pour le pool ayant comme ID "
+"Droits d''accès multiples non pris en charge pour le pool ayant comme ID "
 "''{1}''."
 
 #: server/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRulesTranslator.java:165
 #, java-format
 msgid "Pool ''{1}'' is restricted to guests running on host: ''{4}''."
 msgstr ""
-"Accès limité au pool ''{1}'' pour les invités qui exécutent sur l'hôte : "
+"Accès limité au pool ''{1}'' pour les invités qui exécutent sur l''hôte : "
 "''{4}''."
 
 #: server/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRulesTranslator.java:167
@@ -742,34 +745,35 @@ msgstr ""
 msgid ""
 "Unit does not support instance based calculation required by pool ''{1}''"
 msgstr ""
-"L'unité ne prend pas en charge le calcul basé instance requis par le pool "
+"L''unité ne prend pas en charge le calcul basé instance requis par le pool "
 "''{1}''"
 
 #: server/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRulesTranslator.java:179
 #, java-format
 msgid "Unit does not support band calculation required by pool ''{1}''"
 msgstr ""
-"L'unité ne prend pas en charge le calcul de la bande requis par le pool "
+"L''unité ne prend pas en charge le calcul de la bande requis par le pool "
 "''{1}''"
 
 #: server/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRulesTranslator.java:181
 #, java-format
 msgid "Unit does not support core calculation required by pool ''{1}''"
 msgstr ""
-"L'unité ne prend pas en charge le calcul de cores requis par le pool ''{1}''"
+"L''unité ne prend pas en charge le calcul de cores requis par le pool "
+"''{1}''"
 
 #: server/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRulesTranslator.java:183
 #, java-format
 msgid "Unit does not support RAM calculation required by pool ''{1}''"
 msgstr ""
-"L'unité ne prend pas en charge le calcul de RAM requis par le pool ''{1}''"
+"L''unité ne prend pas en charge le calcul de RAM requis par le pool ''{1}''"
 
 #: server/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRulesTranslator.java:185
 #, java-format
 msgid "Unit does not support derived products data required by pool ''{1}''"
 msgstr ""
-"L'unité ne prend pas en charge les données de produits dérivés requis par le "
-"pool ''{1}''"
+"L''unité ne prend pas en charge les données de produits dérivés requis par "
+"le pool ''{1}''"
 
 #: server/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRulesTranslator.java:187
 #, java-format
@@ -782,28 +786,28 @@ msgid ""
 "Pool is restricted to virtual guests in their first day of existence: "
 "''{1}''"
 msgstr ""
-"Accès limité au pool aux invités virtuels le premier jour d'existence : "
+"Accès limité au pool aux invités virtuels le premier jour d''existence : "
 "''{1}''"
 
 #: server/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRulesTranslator.java:191
 #, java-format
 msgid "Pool ''{1}'' is a shared pool and sharing a shared pool is prohibited."
 msgstr ""
-"Le pool ''{1}'' est un pool partagé et partager un pool partagé n'est pas "
+"Le pool ''{1}'' est un pool partagé et partager un pool partagé n''est pas "
 "autorisé."
 
 #: server/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRulesTranslator.java:193
 #, java-format
 msgid "Pool ''{1}'' is a development pool and sharing it is prohibited."
 msgstr ""
-"Le pool ''{1}'' est un pool de développement et le partager n'est pas "
+"Le pool ''{1}'' est un pool de développement et le partager n''est pas "
 "autorisé."
 
 #: server/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRulesTranslator.java:195
 #, java-format
 msgid "Pool ''{1}'' is an unmapped guest pool and sharing it is prohibited."
 msgstr ""
-"Le pool ''{1}'' est un pool d'invités non mappé et le partager n'est pas "
+"Le pool ''{1}'' est un pool d''invités non mappé et le partager n''est pas "
 "autorisé."
 
 #: server/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRulesTranslator.java:197
@@ -811,13 +815,13 @@ msgstr ""
 msgid ""
 "Pool is restricted when it is temporary and begins in the future: ''{1}''"
 msgstr ""
-"L'accès au pool est limité si temporaire et démarrera dans le futur : "
+"L''accès au pool est limité si temporaire et démarrera dans le futur : "
 "''{1}''"
 
 #: server/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRulesTranslator.java:199
 #, java-format
 msgid "Unable to attach pool with ID ''{1}''.: {0}."
-msgstr "Impossible d'attacher le pool ayant comme ID ''{1}''.: {0}."
+msgstr "Impossible d''attacher le pool ayant comme ID ''{1}''.: {0}."
 
 #: server/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRulesTranslator.java:207
 #, java-format
@@ -830,7 +834,8 @@ msgstr "Ce système a déjà un abonnement pour le produit ''{1}'' attaché."
 msgid ""
 "There are not enough free subscriptions available for the product ''{1}''"
 msgstr ""
-"Il n'y a pas suffisamment d'abonnements disponibles pour le produit ''{1}''"
+"Il n''y a pas suffisamment d''abonnements disponibles pour le produit "
+"''{1}''"
 
 #: server/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRulesTranslator.java:211
 #, java-format
@@ -846,14 +851,14 @@ msgstr ""
 #: server/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRulesTranslator.java:215
 #, java-format
 msgid "Unable to attach subscription for the product ''{1}'': {0}."
-msgstr "Impossible d'attacher un abonnement pour le produit ''{1}'': {0}."
+msgstr "Impossible d''attacher un abonnement pour le produit ''{1}'': {0}."
 
 #: server/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRulesTranslator.java:223
 #, java-format
 msgid ""
 "Insufficient pool quantity available for adjustment to entitlement ''{1}''."
 msgstr ""
-"Quantité de pool insuffisante pour ajustement possible au droit d'accès "
+"Quantité de pool insuffisante pour ajustement possible au droit d''accès "
 "''{1}''."
 
 #: server/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRulesTranslator.java:225
@@ -862,26 +867,27 @@ msgstr ""
 msgid ""
 "Multi-entitlement not supported for pool connected with entitlement ''{1}''."
 msgstr ""
-"Droits d'accès multiples non pris en charge pour le pool associé au droit "
-"d'accès ''{1}''."
+"Droits d''accès multiples non pris en charge pour le pool associé au droit "
+"d''accès ''{1}''."
 
 #: server/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRulesTranslator.java:229
 #, java-format
 msgid "Unable to adjust quantity for the entitlement with id ''{1}'': {0}"
 msgstr ""
-"Impossible d'ajuster la quantité pour le droit d'accès ayant comme id "
+"Impossible d''ajuster la quantité pour le droit d''accès ayant comme id "
 "''{1}'': {0}"
 
 #: server/src/main/java/org/candlepin/resource/ActivationKeyResource.java:188
 #, java-format
 msgid "Pool ID \"{0}\" has already been registered with this activation key"
-msgstr "L'ID de pool \"{0}\" a déjà été enregistré avec cette clé d'activation"
+msgstr ""
+"L''ID de pool \"{0}\" a déjà été enregistré avec cette clé d''activation"
 
 #: server/src/main/java/org/candlepin/resource/ActivationKeyResource.java:232
 #, java-format
 msgid "Product ID \"{0}\" has already been registered with this activation key"
 msgstr ""
-"L'ID de produit \"{0}\" a déjà été enregistré avec cette clé d'activation"
+"L''ID de produit \"{0}\" a déjà été enregistré avec cette clé d''activation"
 
 #: server/src/main/java/org/candlepin/resource/ActivationKeyResource.java:286
 #: server/src/main/java/org/candlepin/resource/OwnerResource.java:444
@@ -976,58 +982,58 @@ msgstr ""
 #: server/src/main/java/org/candlepin/resource/ConsumerResource.java:811
 msgid "A unit type of \"share\" cannot be used with activation keys"
 msgstr ""
-"Un type d'unité « partagé » ne peut pas être utilisé avec des clés "
-"d'activation."
+"Un type d''unité « partagé » ne peut pas être utilisé avec des clés "
+"d''activation."
 
 #: server/src/main/java/org/candlepin/resource/ConsumerResource.java:814
 msgid "A unit type of \"share\" cannot have a service level"
-msgstr "Un type d'unité « partagé » ne peut pas avoir un niveau de service."
+msgstr "Un type d''unité « partagé » ne peut pas avoir un niveau de service."
 
 #: server/src/main/java/org/candlepin/resource/ConsumerResource.java:817
 msgid "A unit type of \"share\" cannot have a release version"
 msgstr ""
-"Un type d'unité « partagé » ne peut pas avoir un numéro de version de "
+"Un type d''unité « partagé » ne peut pas avoir un numéro de version de "
 "publication"
 
 #: server/src/main/java/org/candlepin/resource/ConsumerResource.java:820
 msgid "A unit type of \"share\" cannot have installed products"
-msgstr "Un type d'unité « partagé » ne peut pas avoir de produits installés"
+msgstr "Un type d''unité « partagé » ne peut pas avoir de produits installés"
 
 #: server/src/main/java/org/candlepin/resource/ConsumerResource.java:824
 msgid "A unit type of \"share\" cannot have a content access mode"
 msgstr ""
-"Un type d'unité « partagé » ne peut pas avoir un mode d'accès au contenu"
+"Un type d''unité « partagé » ne peut pas avoir un mode d''accès au contenu"
 
 #: server/src/main/java/org/candlepin/resource/ConsumerResource.java:827
 msgid "A unit type of \"share\" cannot have guest IDs"
-msgstr "Un type d'unité « partagé » ne peut pas avoir d'ID d'invité"
+msgstr "Un type d''unité « partagé » ne peut pas avoir d''ID d''invité"
 
 #: server/src/main/java/org/candlepin/resource/ConsumerResource.java:830
 msgid "A unit type of \"share\" cannot have a hypervisor ID"
-msgstr "Un type d'unité « partagé » ne peut pas avoir d'ID d'hyperviseur"
+msgstr "Un type d''unité « partagé » ne peut pas avoir d''ID d''hyperviseur"
 
 #: server/src/main/java/org/candlepin/resource/ConsumerResource.java:834
 msgid "A unit type of \"share\" must specify a recipient org key"
-msgstr "Un type d'unité « partagé » doit indiquer une clé org destinataire"
+msgstr "Un type d''unité « partagé » doit indiquer une clé org destinataire"
 
 #: server/src/main/java/org/candlepin/resource/ConsumerResource.java:837
 msgid "A unit type of \"share\" cannot be a virtual guest"
-msgstr "Un type d'unité « partagé » ne peut pas être un invité virtuel"
+msgstr "Un type d''unité « partagé » ne peut pas être un invité virtuel"
 
 #: server/src/main/java/org/candlepin/resource/ConsumerResource.java:858
 #: server/src/main/java/org/candlepin/resource/ConsumerResource.java:1352
 msgid "The consumer cannot be assigned a content access mode."
-msgstr "On ne peut pas assigner au consommateur un mode d'accès au contenu."
+msgstr "On ne peut pas assigner au consommateur un mode d''accès au contenu."
 
 #: server/src/main/java/org/candlepin/resource/ConsumerResource.java:863
 #: server/src/main/java/org/candlepin/resource/ConsumerResource.java:1346
 msgid "The consumer cannot use the supplied content access mode."
 msgstr ""
-"Le consommateur ne peut pas utiliser le mode d'accès au contenu fourni."
+"Le consommateur ne peut pas utiliser le mode d''accès au contenu fourni."
 
 #: server/src/main/java/org/candlepin/resource/ConsumerResource.java:871
 msgid "Org required to register with activation keys."
-msgstr "Org devant s'enregistrer avec des clés d'activation."
+msgstr "Org devant s''enregistrer avec des clés d''activation."
 
 # translation auto-copied from project Candlepin, version master, document
 # keys, author samfreemanz
@@ -1054,7 +1060,7 @@ msgstr ""
 msgid "You may not create a manifest consumer via Subscription Manager."
 msgstr ""
 "Vous ne pourrez sans doute pas créer de consommateur de manifeste par "
-"l'intermédiaire du gestionnaire d'abonnements."
+"l''intermédiaire du gestionnaire d''abonnements."
 
 #: server/src/main/java/org/candlepin/resource/ConsumerResource.java:925
 msgid "None of the activation keys specified exist for this org."
@@ -1131,17 +1137,17 @@ msgstr "Impossible d''annuler l''enregistrement {0} {1} car : {2}"
 #: server/src/main/java/org/candlepin/resource/ConsumerResource.java:1791
 #: server/src/main/java/org/candlepin/resource/ConsumerResource.java:1794
 msgid "Cannot retrieve content access certificate"
-msgstr "Impossible d'extraire le certificat de droit d'accès au contenu"
+msgstr "Impossible d''extraire le certificat de droit d''accès au contenu"
 
 #: server/src/main/java/org/candlepin/resource/ConsumerResource.java:1648
 msgid "Content access body can not be requested for a share consumer"
 msgstr ""
-"Le corps de texte du droit d'accès au contenu n'est pas accessible à un "
+"Le corps de texte du droit d''accès au contenu n''est pas accessible à un "
 "consommateur partagé"
 
 #: server/src/main/java/org/candlepin/resource/ConsumerResource.java:1653
 msgid "Content access mode does not allow this request."
-msgstr "Le mode d'accès au contenu n'autorise pas cette requête."
+msgstr "Le mode d''accès au contenu n''autorise pas cette requête."
 
 #: server/src/main/java/org/candlepin/resource/ConsumerResource.java:1725
 msgid "Unable to create entitlement certificate archive"
@@ -1166,7 +1172,7 @@ msgstr "Impossible de spécifier une quantité lors de la liaison automatique."
 #: server/src/main/java/org/candlepin/resource/ConsumerResource.java:1931
 #, java-format
 msgid "Ignoring request to auto-attach. It is disabled for org ''{0}''."
-msgstr "Demande d'auto-attach ignorée. Désactivé pour org ''{0}''."
+msgstr "Demande d''auto-attach ignorée. Désactivé pour org ''{0}''."
 
 #: server/src/main/java/org/candlepin/resource/ConsumerResource.java:1977
 msgid "Owner has autobind disabled."
@@ -1196,13 +1202,13 @@ msgstr ""
 #, java-format
 msgid "No entitlements for consumer ''{0}'' with pool id ''{1}''"
 msgstr ""
-"Aucun droit d'accès pour le consommateur ''{0}'' avec ID de pool ''{1}''"
+"Aucun droit d''accès pour le consommateur ''{0}'' avec ID de pool ''{1}''"
 
 #: server/src/main/java/org/candlepin/resource/ConsumerResource.java:2270
 #: server/src/main/java/org/candlepin/resource/ConsumerResource.java:2327
 #: server/src/main/java/org/candlepin/resource/ConsumerResource.java:2371
 msgid "Can not export manifest of a share consumer"
-msgstr "Impossible d'exporter un manifeste des consommateur partagé"
+msgstr "Impossible d''exporter un manifeste des consommateur partagé"
 
 # translation auto-copied from project Candlepin, version master, document
 # keys
@@ -1224,7 +1230,7 @@ msgstr "Le système avec l''UUID {0} n''est pas un invité virtuel."
 msgid ""
 "This host is under a different organization that you do not have access to"
 msgstr ""
-"Cet hôte est sous une autre organisation à laquelle vous n'avez pas accès"
+"Cet hôte est sous une autre organisation à laquelle vous n''avez pas accès"
 
 #: server/src/main/java/org/candlepin/resource/ConsumerResource.java:2628
 #, java-format
@@ -1255,7 +1261,7 @@ msgstr "Le type d''unité avec l''ID {0} est introuvable."
 #: server/src/main/java/org/candlepin/resource/ContentResource.java:101
 #, java-format
 msgid "Content with UUID \"{0}\" could not be found."
-msgstr "Le contenu ayant pour UUID \"{0}\" n'a pas pu être trouvé."
+msgstr "Le contenu ayant pour UUID \"{0}\" n''a pas pu être trouvé."
 
 #: server/src/main/java/org/candlepin/resource/ContentResource.java:113
 #: server/src/main/java/org/candlepin/resource/ContentResource.java:123
@@ -1263,7 +1269,7 @@ msgstr "Le contenu ayant pour UUID \"{0}\" n'a pas pu être trouvé."
 #: server/src/main/java/org/candlepin/resource/ContentResource.java:142
 msgid "Organization-agnostic content write operations are not supported."
 msgstr ""
-"Les opérations de rédaction de contenu, indépendamment de l'entreprise, ne "
+"Les opérations de rédaction de contenu, indépendamment de l''entreprise, ne "
 "sont pas prises en charge."
 
 #: server/src/main/java/org/candlepin/resource/DistributorVersionResource.java:106
@@ -1336,7 +1342,7 @@ msgstr "Environnement inconnu : {0}"
 msgid "No environment specified, or environment lacks owner information"
 msgstr ""
 "Aucun environnement spécifié, ou des informations sur le propriétaire de "
-"l'environnement sont manquantes"
+"l''environnement sont manquantes"
 
 #: server/src/main/java/org/candlepin/resource/EnvironmentResource.java:192
 msgid "No content ID specified"
@@ -1345,12 +1351,12 @@ msgstr "Aucun ID de contenu spécifié"
 #: server/src/main/java/org/candlepin/resource/EnvironmentResource.java:200
 #, java-format
 msgid "Unable to find content with the ID \"{0}\"."
-msgstr "Impossible de trouver un contenu avec l'ID \"{0}\""
+msgstr "Impossible de trouver un contenu avec l''ID \"{0}\""
 
 #: server/src/main/java/org/candlepin/resource/EnvironmentResource.java:244
 #, java-format
 msgid "The content with id {0} has already been promoted in this environment."
-msgstr "Le contenu avec l'ID {0} a déjà été promu dans cet environnement."
+msgstr "Le contenu avec l''ID {0} a déjà été promu dans cet environnement."
 
 #: server/src/main/java/org/candlepin/resource/EnvironmentResource.java:261
 #, java-format
@@ -1360,12 +1366,12 @@ msgstr "Une partie du contenu est déjà associée à Environnement : {0}"
 #: server/src/main/java/org/candlepin/resource/EnvironmentResource.java:307
 #, java-format
 msgid "Content does not exist in environment: {0}"
-msgstr "Aucun contenu dans l'environnement : {0}"
+msgstr "Aucun contenu dans l''environnement : {0}"
 
 #: server/src/main/java/org/candlepin/resource/EnvironmentResource.java:322
 #, java-format
 msgid "One of the content does not exist in the environment anymore: {0}"
-msgstr "Une partie du contenu n'existe plus dans l'environnement : {0}"
+msgstr "Une partie du contenu n''existe plus dans l''environnement : {0}"
 
 # translation auto-copied from project Candlepin, version master, document
 # keys, author samfreemanz
@@ -1393,8 +1399,8 @@ msgstr "L’invité avec l’UUID {0} est introuvable."
 #: server/src/main/java/org/candlepin/resource/HypervisorResource.java:139
 msgid "Host to guest mapping was not provided for hypervisor check-in."
 msgstr ""
-"L'hôte pour le mappage d'invité n'a pas été fourni pour l'enregistrement de "
-"l'hyperviseur."
+"L''hôte pour le mappage d''invité n''a pas été fourni pour l''enregistrement "
+"de l''hyperviseur."
 
 #: server/src/main/java/org/candlepin/resource/HypervisorResource.java:207
 #, java-format
@@ -1404,8 +1410,8 @@ msgstr "Impossible de trouver l’hyperviseur dans org ''{0}''"
 #: server/src/main/java/org/candlepin/resource/HypervisorResource.java:275
 msgid "Host to guest mapping was not provided for hypervisor update."
 msgstr ""
-"L'hôte pour le mappage d'invité n'a pas été fourni pour la mise à jour de "
-"l'hyperviseur."
+"L''hôte pour le mappage d''invité n''a pas été fourni pour la mise à jour de "
+"l''hyperviseur."
 
 #: server/src/main/java/org/candlepin/resource/JobResource.java:128
 msgid ""
@@ -1537,13 +1543,13 @@ msgstr ""
 #: server/src/main/java/org/candlepin/resource/OwnerResource.java:948
 msgid "You must assign a Content Access Mode from the mode list."
 msgstr ""
-"Vous devez assigner un Mode d'accès au contenu issu de la liste des modes "
-"d'accès."
+"Vous devez assigner un Mode d''accès au contenu issu de la liste des modes "
+"d''accès."
 
 #: server/src/main/java/org/candlepin/resource/OwnerResource.java:953
 #: server/src/main/java/org/candlepin/resource/OwnerResource.java:1031
 msgid "The content access mode is not allowed for this owner."
-msgstr "Le mode d'accès au contenu n'est pas autorisé pour ce propriétaire."
+msgstr "Le mode d''accès au contenu n''est pas autorisé pour ce propriétaire."
 
 #: server/src/main/java/org/candlepin/resource/OwnerResource.java:966
 #, java-format
@@ -1560,7 +1566,7 @@ msgstr "Impossible de créer le propriétaire  : {0}"
 msgid ""
 "The owner content access mode cannot be set directly in standalone mode."
 msgstr ""
-"Le mode d'accès au contenu du propriétaire ne peut pas être défini "
+"Le mode d''accès au contenu du propriétaire ne peut pas être défini "
 "directement en mode autonome."
 
 #: server/src/main/java/org/candlepin/resource/OwnerResource.java:1077
@@ -1569,8 +1575,8 @@ msgid ""
 "owner ''{0}'' cannot be deleted while there is a share consumer. You may use "
 "'force' to bypass."
 msgstr ""
-"propriétaire ''{0}'' ne peut pas être supprimé tant qu'il y a un "
-"consommateur partagé. Vous pouvez utiliser 'force' pour contourner ce "
+"propriétaire ''{0}'' ne peut pas être supprimé tant qu''il y a un "
+"consommateur partagé. Vous pouvez utiliser ''force'' pour contourner ce "
 "problème."
 
 # translation auto-copied from project Candlepin, version master, document
@@ -1585,7 +1591,7 @@ msgid ""
 "The activation key name ''{0}'' must be alphanumeric or include the "
 "characters ''-'' or ''_''"
 msgstr ""
-"Le nom de la clé d'activation \"{0}\" doit contenir des caractères "
+"Le nom de la clé d''activation \"{0}\" doit contenir des caractères "
 "alphanumériques ou les caractères - ou _"
 
 #: server/src/main/java/org/candlepin/resource/OwnerResource.java:1250
@@ -1643,8 +1649,8 @@ msgid ""
 "Cannot update shared pools, This should be triggered by updating the share "
 "entitlement instead"
 msgstr ""
-"Impossible de mettre à jour les pools partagés. Devrait s'activer quand vous "
-"mettrez le droit d'accès partagé à jour."
+"Impossible de mettre à jour les pools partagés. Devrait s''activer quand "
+"vous mettrez le droit d''accès partagé à jour."
 
 # translation auto-copied from project Candlepin, version master, document
 # keys
@@ -1655,7 +1661,7 @@ msgstr "Erreur lors de la lecture de l''archive d''export"
 
 #: server/src/main/java/org/candlepin/resource/OwnerResource.java:2060
 msgid "Error storing uploaded archive for asynchronous processing."
-msgstr "Erreur du chargement de l'archive lors du traitement asynchrone."
+msgstr "Erreur du chargement de l''archive lors du traitement asynchrone."
 
 #: server/src/main/java/org/candlepin/resource/OwnerResource.java:2132
 #, java-format
@@ -1734,17 +1740,17 @@ msgid ""
 "entitlement instead"
 msgstr ""
 "Impossible de supprimer les pools partagés. Cela devrait avoir lieu quand "
-"vous supprimerez le droit d'accès"
+"vous supprimerez le droit d''accès"
 
 #: server/src/main/java/org/candlepin/resource/PoolResource.java:327
 #, java-format
 msgid "Pool with ID ''{0}'' could not be found."
-msgstr "Le pool ayant comme ID ''{0}'' n'a pas pu être trouvé."
+msgstr "Le pool ayant comme ID ''{0}'' n''a pas pu être trouvé."
 
 #: server/src/main/java/org/candlepin/resource/PoolResource.java:332
 #, java-format
 msgid "A certificate was not found for pool \"{0}\""
-msgstr "Un certificat pour le pool \"{0}\" n'a pas pu être trouvé."
+msgstr "Un certificat pour le pool \"{0}\" n''a pas pu être trouvé."
 
 #: server/src/main/java/org/candlepin/resource/ProductResource.java:111
 #, java-format
@@ -1761,7 +1767,7 @@ msgid ""
 "Organization-agnostic product write operations are no longer supported."
 msgstr ""
 "Les opérations de rédaction de contenu de produit, indépendamment de "
-"l'entreprise, ne sont pas prises en charge."
+"l''entreprise, ne sont pas prises en charge."
 
 #: server/src/main/java/org/candlepin/resource/ProductResource.java:265
 #: server/src/main/java/org/candlepin/resource/ProductResource.java:282
@@ -1836,7 +1842,7 @@ msgstr ""
 #: server/src/main/java/org/candlepin/resource/SubscriptionResource.java:182
 #, java-format
 msgid "A subscription with the ID \"{0}\" could not be found."
-msgstr "Impossible de trouver un abonnement avec l'ID \"{0}\"."
+msgstr "Impossible de trouver un abonnement avec l''ID \"{0}\"."
 
 #: server/src/main/java/org/candlepin/resource/UserResource.java:150
 #, java-format
@@ -1857,7 +1863,7 @@ msgstr "{0}{1}"
 msgid ""
 "None of the subscriptions on the activation key were available for attaching."
 ""
-msgstr "Aucun abonnement lié à la clé d'activation ne peut être attaché."
+msgstr "Aucun abonnement lié à la clé d''activation ne peut être attaché."
 
 #: server/src/main/java/org/candlepin/resource/util/ConsumerBindUtil.java:132
 #, java-format
@@ -1876,15 +1882,15 @@ msgstr "Type d''unité inconnu : {0}"
 #: server/src/main/java/org/candlepin/resource/util/ResolverUtil.java:181
 msgid "No product specified, or product lacks identifying information"
 msgstr ""
-"Aucun produit spécifié, ou des informations d'identification du produit sont "
-"manquantes"
+"Aucun produit spécifié, ou des informations d''identification du produit "
+"sont manquantes"
 
 #: server/src/main/java/org/candlepin/resource/util/ResolverUtil.java:104
 #: server/src/main/java/org/candlepin/resource/util/ResolverUtil.java:170
 #, java-format
 msgid "Unable to find a product with the ID \"{0}\" for owner \"{1}\""
 msgstr ""
-"Impossible de trouver un produit avec l'ID \"{0}\" pour le propriétaire "
+"Impossible de trouver un produit avec l''ID \"{0}\" pour le propriétaire "
 "\"{1}\""
 
 #: server/src/main/java/org/candlepin/resource/util/ResolverUtil.java:116
@@ -1901,7 +1907,7 @@ msgstr "Impossible de trouver un produit ayant comme UUID \"{0}\""
 #: server/src/main/java/org/candlepin/resteasy/DateFormatter.java:78
 #: server/src/main/java/org/candlepin/resteasy/DateFormatter.java:91
 msgid "Unable to parse date parameter"
-msgstr "Impossible d'analyser le paramètre de date"
+msgstr "Impossible d''analyser le paramètre de date"
 
 # translation auto-copied from project Candlepin, version master, document
 # keys, author samfreemanz
@@ -1921,8 +1927,8 @@ msgid ""
 "to address this problem. See knowledge database https://access.redhat.com/"
 "knowledge/node/129003 for more information."
 msgstr ""
-"Trop d'ensembles de contenu pour le certificat {0}. Un client plus récent "
-"peut être disponible pour répondre à ce problème. Pour plus d'informations, "
+"Trop d''ensembles de contenu pour le certificat {0}. Un client plus récent "
+"peut être disponible pour répondre à ce problème. Pour plus d''informations, "
 "consulter la base de données de connaissances https://access.redhat.com/"
 "knowledge/node/129003."
 
@@ -1956,11 +1962,11 @@ msgstr ""
 #: server/src/main/java/org/candlepin/sync/EntitlementImporter.java:195
 #, java-format
 msgid "Unable to find product with ID: {0}"
-msgstr "Impossible de trouver le produit avec l'ID : {0}"
+msgstr "Impossible de trouver le produit avec l''ID : {0}"
 
 #: server/src/main/java/org/candlepin/sync/Importer.java:187
 msgid "Uploaded manifest file does not exist."
-msgstr "Le fichier de manifeste chargé n'existe pas."
+msgstr "Le fichier de manifeste chargé n''existe pas."
 
 # translation auto-copied from project Candlepin, version master, document
 # keys, author samfreemanz

--- a/common/po/ja.po
+++ b/common/po/ja.po
@@ -1,6 +1,7 @@
 # amoewaki <amoewaki@redhat.com>, 2017. #zanata
 # ljanda <ljanda@redhat.com>, 2017. #zanata
 # amoewaki <amoewaki@redhat.com>, 2018. #zanata
+# awood <awood@redhat.com>, 2018. #zanata
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
@@ -9,8 +10,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2018-02-15 09:48+0000\n"
-"Last-Translator: amoewaki <amoewaki@redhat.com>\n"
+"PO-Revision-Date: 2018-02-27 04:43+0000\n"
+"Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
 "Language-Team: Japanese\n"
 "Language: ja\n"
 "Plural-Forms: nplurals=1; plural=0\n"
@@ -409,7 +410,7 @@ msgstr "ホストとゲストのマッピングが確立されないまま、マ
 
 #: server/src/main/java/org/candlepin/controller/Entitler.java:210
 msgid "Auto-attach is disabled for owner '{0}'."
-msgstr "所有者 '{0}' の自動アタッチは無効です。"
+msgstr "所有者 ''{0}'' の自動アタッチは無効です。"
 
 #: server/src/main/java/org/candlepin/controller/Entitler.java:260
 #: server/src/main/java/org/candlepin/controller/Entitler.java:500
@@ -1441,7 +1442,7 @@ msgstr "この所有者のコンテンツアクセスモードは、スタンド
 msgid ""
 "owner ''{0}'' cannot be deleted while there is a share consumer. You may use "
 "'force' to bypass."
-msgstr "共有コンシューマーがある場合は、所有者 ''{0}'' を削除できません。'force' を使用すればこの問題を回避できます。"
+msgstr "共有コンシューマーがある場合は、所有者 ''{0}'' を削除できません。''force'' を使用すればこの問題を回避できます。"
 
 # translation auto-copied from project Candlepin, version master, document
 # keys, author khasida
@@ -1573,7 +1574,7 @@ msgstr "コンシューマ: {0} は見つかりません"
 #: server/src/main/java/org/candlepin/resource/PoolResource.java:299
 #, java-format
 msgid "Subscription Pool with ID ''{0}'' could not be found."
-msgstr "ID ''{0}' のサブスクリプションプールは見つかりませんでした。"
+msgstr "ID ''{0}'' のサブスクリプションプールは見つかりませんでした。"
 
 #: server/src/main/java/org/candlepin/resource/PoolResource.java:256
 #, java-format

--- a/common/po/ko.po
+++ b/common/po/ko.po
@@ -1,5 +1,6 @@
 # eukim <eukim@redhat.com>, 2017. #zanata
 # ljanda <ljanda@redhat.com>, 2017. #zanata
+# awood <awood@redhat.com>, 2018. #zanata
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
@@ -8,8 +9,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2017-11-20 03:53+0000\n"
-"Last-Translator: eukim <eukim@redhat.com>\n"
+"PO-Revision-Date: 2018-02-27 04:43+0000\n"
+"Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
 "Language-Team: Korean\n"
 "Language: ko\n"
 "Plural-Forms: nplurals=1; plural=0\n"
@@ -408,7 +409,7 @@ msgstr "호스트/게스트 매핑 설정없이 매핑되지 않은 게스트 �
 
 #: server/src/main/java/org/candlepin/controller/Entitler.java:210
 msgid "Auto-attach is disabled for owner '{0}'."
-msgstr "소유자  '{0}'의 자동 연결이 비활성화되어 있습니다. "
+msgstr "소유자  ''{0}''의 자동 연결이 비활성화되어 있습니다. "
 
 #: server/src/main/java/org/candlepin/controller/Entitler.java:260
 #: server/src/main/java/org/candlepin/controller/Entitler.java:500
@@ -665,7 +666,7 @@ msgstr "풀 ''{1}''은/는 호스트에서 실행 중인 게스트로 제한됩�
 #: server/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRulesTranslator.java:167
 #, java-format
 msgid "Pool ''{1}'' is restricted to a specific consumer."
-msgstr "풀 ''{1}'은/는 특정 소비자로 제한됩니다. "
+msgstr "풀 ''{1}''은/는 특정 소비자로 제한됩니다. "
 
 #: server/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRulesTranslator.java:169
 msgid "Pool not available to subscription management applications."
@@ -777,7 +778,7 @@ msgstr "가상 시스템에만 서브스크립션 ''{1}''을/를 연결할 수 �
 #: server/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRulesTranslator.java:215
 #, java-format
 msgid "Unable to attach subscription for the product ''{1}'': {0}."
-msgstr "제품 ''{1}'에 대한 서브스크립션을 연결할 수 없습니다: {0}"
+msgstr "제품 ''{1}''에 대한 서브스크립션을 연결할 수 없습니다: {0}"
 
 #: server/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRulesTranslator.java:223
 #, java-format
@@ -1440,7 +1441,7 @@ msgstr "소유자 컨텐츠 액세스 모드는 독립형 모드에서 직접 �
 msgid ""
 "owner ''{0}'' cannot be deleted while there is a share consumer. You may use "
 "'force' to bypass."
-msgstr "공유 소비자가 있을 경우 소유자 ''{0}''을/를 삭제할 수 없습니다. 'force'를 사용하여 우회할 수 있습니다. "
+msgstr "공유 소비자가 있을 경우 소유자 ''{0}''을/를 삭제할 수 없습니다. ''force''를 사용하여 우회할 수 있습니다. "
 
 # translation auto-copied from project Candlepin, version master, document
 # keys, author eukim
@@ -1591,7 +1592,7 @@ msgstr "공유 풀을 삭제할 수 없습니다. 공유 인타이틀먼트를 �
 #: server/src/main/java/org/candlepin/resource/PoolResource.java:327
 #, java-format
 msgid "Pool with ID ''{0}'' could not be found."
-msgstr "ID '{0}''을/를 갖는 풀을 찾을 수 없습니다. "
+msgstr "ID ''{0}''을/를 갖는 풀을 찾을 수 없습니다. "
 
 #: server/src/main/java/org/candlepin/resource/PoolResource.java:332
 #, java-format

--- a/common/po/zh_CN.po
+++ b/common/po/zh_CN.po
@@ -1,5 +1,6 @@
 # ljanda <ljanda@redhat.com>, 2017. #zanata
 # tfu <tfu@redhat.com>, 2017. #zanata
+# awood <awood@redhat.com>, 2018. #zanata
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
@@ -8,8 +9,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2017-11-15 07:34+0000\n"
-"Last-Translator: tfu <tfu@redhat.com>\n"
+"PO-Revision-Date: 2018-02-27 04:43+0000\n"
+"Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
 "Language-Team: Chinese (Simplified, China)\n"
 "Language: zh_Hans\n"
 "Plural-Forms: nplurals=1; plural=0\n"
@@ -408,7 +409,7 @@ msgstr "未映射的虚拟机权限尚未建立主机/虚拟机映射就已过�
 
 #: server/src/main/java/org/candlepin/controller/Entitler.java:210
 msgid "Auto-attach is disabled for owner '{0}'."
-msgstr "所有者 '{0}' 的自动附加功能已被禁用。"
+msgstr "所有者 ''{0}'' 的自动附加功能已被禁用。"
 
 #: server/src/main/java/org/candlepin/controller/Entitler.java:260
 #: server/src/main/java/org/candlepin/controller/Entitler.java:500
@@ -1440,7 +1441,7 @@ msgstr "所有者内容访问模式无法在独立模式中直接设置。"
 msgid ""
 "owner ''{0}'' cannot be deleted while there is a share consumer. You may use "
 "'force' to bypass."
-msgstr "当有共享消费者时，所有者 ''{0}'' 不能被删除。您需要使用 'force' 来跳过这个限制。"
+msgstr "当有共享消费者时，所有者 ''{0}'' 不能被删除。您需要使用 ''force'' 来跳过这个限制。"
 
 # translation auto-copied from project Candlepin, version master, document
 # keys, author xhuang


### PR DESCRIPTION
We had several translations that incorrectly escaped single quotes.  I
corrected the translations, pushed them to Zanata, and then pulled them
back.  Zanata apparently performs some clean-up (deleting trailing
whitespace, etc) so I made the pull to avoid conflicts in the future.