### PR TITLE
Implemented ProductDTO for manifest import/export.

### DIFF
--- a/server/src/main/java/org/candlepin/dto/StandardTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/StandardTranslator.java
@@ -158,11 +158,17 @@ public class StandardTranslator extends SimpleModelTranslator {
             new org.candlepin.dto.manifest.v1.ConsumerTypeTranslator(),
             ConsumerType.class, org.candlepin.dto.manifest.v1.ConsumerTypeDTO.class);
         this.registerTranslator(
+            new org.candlepin.dto.manifest.v1.ContentTranslator(),
+            Content.class, org.candlepin.dto.manifest.v1.ContentDTO.class);
+        this.registerTranslator(
             new org.candlepin.dto.manifest.v1.EntitlementTranslator(),
             Entitlement.class, org.candlepin.dto.manifest.v1.EntitlementDTO.class);
         this.registerTranslator(
             new org.candlepin.dto.manifest.v1.PoolTranslator(),
             Pool.class, org.candlepin.dto.manifest.v1.PoolDTO.class);
+        this.registerTranslator(
+            new org.candlepin.dto.manifest.v1.ProductTranslator(),
+            Product.class, org.candlepin.dto.manifest.v1.ProductDTO.class);
 
         // Shims
         /////////////////////////////////////////////

--- a/server/src/main/java/org/candlepin/dto/api/v1/PoolQuantityTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/PoolQuantityTranslator.java
@@ -19,7 +19,7 @@ import org.candlepin.dto.ObjectTranslator;
 import org.candlepin.model.PoolQuantity;
 
 /**
- * The BrandingTranslator provides translation from Branding model objects to BrandingDTOs
+ * The PoolQuantityTranslator provides translation from PoolQuantity model objects to PoolQuantityDTOs.
  */
 public class PoolQuantityTranslator implements ObjectTranslator<PoolQuantity, PoolQuantityDTO> {
 

--- a/server/src/main/java/org/candlepin/dto/manifest/v1/ConsumerDTO.java
+++ b/server/src/main/java/org/candlepin/dto/manifest/v1/ConsumerDTO.java
@@ -52,6 +52,28 @@ public class ConsumerDTO extends CandlepinDTO<ConsumerDTO> {
         }
     }
 
+
+    /* TODO: Some fields that used to be exported, are no longer, so they are missing from this DTO.
+     * A decision needs to be made if any of them will need to be included.
+     *
+     * Fields we don't export any more (because they are not accessed during the import):
+     * - consumer.owner.parentOwner
+     * - consumer.owner.key
+     * - consumer.owner.displayName
+     * - consumer.owner.contentPrefix
+     * - consumer.owner.lastRefreshed
+     * - consumer.owner.defaultServiceLevel
+     * - consumer.owner.upstreamConsumer
+     * - consumer.owner.logLevel
+     * - consumer.owner.contentAccessMode
+     * - consumer.owner.contentAccessModeList
+     * - consumer.owner.href
+     * - consumer.owner.created
+     * - consumer.owner.updated
+     * - consumer.owner.autobindDisabled
+     *
+     */
+
     protected String uuid;
     protected String name;
     protected String owner;

--- a/server/src/main/java/org/candlepin/dto/manifest/v1/ContentDTO.java
+++ b/server/src/main/java/org/candlepin/dto/manifest/v1/ContentDTO.java
@@ -1,0 +1,596 @@
+/**
+ * Copyright (c) 2009 - 2018 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.dto.manifest.v1;
+
+import org.candlepin.dto.TimestampedCandlepinDTO;
+import org.candlepin.util.SetView;
+
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+
+
+/**
+ * DTO representing the content data exposed to the manifest import/export framework.
+ */
+@XmlRootElement
+public class ContentDTO extends TimestampedCandlepinDTO<ContentDTO> {
+    public static final long serialVersionUID = 1L;
+
+    protected String id;
+    protected String type;
+    protected String label;
+    protected String name;
+    protected String vendor;
+    protected String contentUrl;
+    protected String requiredTags;
+    protected String releaseVer;
+    protected String gpgUrl;
+    protected Set<String> modifiedProductIds;
+    protected String arches;
+    protected Long metadataExpire;
+    protected String uuid;
+
+    /**
+     * Initializes a new ContentDTO instance with null values.
+     */
+    public ContentDTO() {
+        super();
+    }
+
+    /**
+     * Initializes a new ContentDTO instance with the specified values.
+     * <p/></p>
+     * <strong>Note</strong>: This constructor passes the provided values to their respective
+     * mutator methods, and does not capture any exceptions they may throw due to malformed
+     * values.
+     *
+     * @param id
+     *  The ID of the content to be represented by this DTO; cannot be null
+     *
+     * @param name
+     *  The name of the content to be represented by this DTO
+     *
+     * @param type
+     *  The type of the content to be represented by this DTO
+     *
+     * @param label
+     *  The label of the content to be represented by this DTO
+     *
+     * @param vendor
+     *  The vendor of the content to be represented by this DTO
+     */
+    public ContentDTO(String id, String name, String type, String label, String vendor) {
+        super();
+
+        this.setId(id);
+        this.setName(name);
+        this.setType(type);
+        this.setLabel(label);
+        this.setVendor(vendor);
+    }
+
+    /**
+     * Initializes a new ContentDTO instance using the data contained by the given DTO.
+     *
+     * @param source
+     *  The source DTO from which to copy data
+     *
+     * @throws IllegalArgumentException
+     *  if source is null
+     */
+    public ContentDTO(ContentDTO source) {
+        if (source == null) {
+            throw new IllegalArgumentException("source is null");
+        }
+
+        this.populate(source);
+    }
+
+    /**
+     * Retrieves the ID of the content represented by this DTO. If the ID has not yet been
+     * defined, this method returns null.
+     *
+     * @return
+     *  the ID of the content, or null if the ID has not yet been defined
+     */
+    public String getId() {
+        return this.id;
+    }
+
+    /**
+     * Sets the ID of the content represented by this DTO.
+     *
+     * @param id
+     *  The ID of the content represented by this DTO
+     *
+     * @return
+     *  a reference to this DTO
+     */
+    public ContentDTO setId(String id) {
+        this.id = id;
+        return this;
+    }
+
+    /**
+     * Retrieves the UUID of the content represented by this DTO. If the UUID has not yet been
+     * defined, this method returns null.
+     *
+     * @return
+     *  the UUID of the content, or null if the UUID has not yet been defined
+     */
+    public String getUuid() {
+        return this.uuid;
+    }
+
+    /**
+     * Sets the UUID of the content represented by this DTO.
+     *
+     * @param uuid
+     *  The UUID of the content represented by this DTO, or null to clear the UUID
+     *
+     * @return
+     *  a reference to this DTO
+     */
+    public ContentDTO setUuid(String uuid) {
+        this.uuid = uuid;
+        return this;
+    }
+
+    /**
+     * Retrieves the type of the content represented by this DTO. If the type has not yet been
+     * defined, this method returns null.
+     *
+     * @return
+     *  the type of the content, or null if the type has not yet been defined
+     */
+    public String getType() {
+        return this.type;
+    }
+
+    /**
+     * Sets the type of the content represented by this DTO.
+     *
+     * @param type
+     *  The type of the content represented by this DTO, or null to clear the type
+     *
+     * @return
+     *  a reference to this DTO
+     */
+    public ContentDTO setType(String type) {
+        this.type = type;
+        return this;
+    }
+
+    /**
+     * Retrieves the label of the content represented by this DTO. If the label has not yet been
+     * defined, this method returns null.
+     *
+     * @return
+     *  the label of the content, or null if the label has not yet been defined
+     */
+    public String getLabel() {
+        return this.label;
+    }
+
+    /**
+     * Sets the label of the content represented by this DTO.
+     *
+     * @param label
+     *  The label of the content represented by this DTO, or null to clear the label
+     *
+     * @return
+     *  a reference to this DTO
+     */
+    public ContentDTO setLabel(String label) {
+        this.label = label;
+        return this;
+    }
+
+    /**
+     * Retrieves the name of the content represented by this DTO. If the name has not yet been
+     * defined, this method returns null.
+     *
+     * @return
+     *  the name of the content, or null if the name has not yet been defined
+     */
+    public String getName() {
+        return this.name;
+    }
+
+    /**
+     * Sets the name of the content represented by this DTO.
+     *
+     * @param name
+     *  The name of the content represented by this DTO, or null to clear the name
+     *
+     * @return
+     *  a reference to this DTO
+     */
+    public ContentDTO setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * Retrieves the vendor of the content represented by this DTO. If the vendor has not yet been
+     * defined, this method returns null.
+     *
+     * @return
+     *  the vendor of the content, or null if the vendor has not yet been defined
+     */
+    public String getVendor() {
+        return this.vendor;
+    }
+
+    /**
+     * Sets the vendor of the content represented by this DTO.
+     *
+     * @param vendor
+     *  The vendor of the content represented by this DTO, or null to clear the vendor
+     *
+     * @return
+     *  a reference to this DTO
+     */
+    public ContentDTO setVendor(String vendor) {
+        this.vendor = vendor;
+        return this;
+    }
+
+    /**
+     * Retrieves the content URL of the content represented by this DTO. If the content URL has not
+     * yet been defined, this method returns null.
+     *
+     * @return
+     *  the content URL of the content, or null if the content URL has not yet been defined
+     */
+    public String getContentUrl() {
+        return this.contentUrl;
+    }
+
+    /**
+     * Sets the content URL of the content represented by this DTO.
+     *
+     * @param contentUrl
+     *  The content URL of the content represented by this DTO, or null to clear the content URL
+     *
+     * @return
+     *  a reference to this DTO
+     */
+    public ContentDTO setContentUrl(String contentUrl) {
+        this.contentUrl = contentUrl;
+        return this;
+    }
+
+    /**
+     * Retrieves the required tags of the content represented by this DTO. If the required tags has
+     * not yet been defined, this method returns null.
+     *
+     * @return
+     *  the required tags of the content, or null if the required tags has not yet been defined
+     */
+    public String getRequiredTags() {
+        return this.requiredTags;
+    }
+
+    /**
+     * Sets the required tags of the content represented by this DTO.
+     *
+     * @param requiredTags
+     *  The required tags of the content represented by this DTO, or null to clear the required
+     *  tags
+     *
+     * @return
+     *  a reference to this DTO
+     */
+    public ContentDTO setRequiredTags(String requiredTags) {
+        this.requiredTags = requiredTags;
+        return this;
+    }
+
+    /**
+     * Retrieves the release version of the content represented by this DTO. If the release version
+     * has not yet been defined, this method returns null.
+     *
+     * @return
+     *  the release version of the content, or null if the release version has not yet been defined
+     */
+    public String getReleaseVersion() {
+        return this.releaseVer;
+    }
+
+    /**
+     * Sets the release version of the content represented by this DTO.
+     *
+     * @param releaseVer
+     *  The release version of the content represented by this DTO, or null to clear the release
+     *  version
+     *
+     * @return
+     *  a reference to this DTO
+     */
+    public ContentDTO setReleaseVersion(String releaseVer) {
+        this.releaseVer = releaseVer;
+        return this;
+    }
+
+    /**
+     * Retrieves the GPG URL of the content represented by this DTO. If the GPG URL has not yet been
+     * defined, this method returns null.
+     *
+     * @return
+     *  the GPG URL of the content, or null if the GPG URL has not yet been defined
+     */
+    public String getGpgUrl() {
+        return this.gpgUrl;
+    }
+
+    /**
+     * Sets the GPG URL of the content represented by this DTO.
+     *
+     * @param gpgUrl
+     *  The GPG URL of the content represented by this DTO, or null to clear the GPG URL
+     *
+     * @return
+     *  a reference to this DTO
+     */
+    public ContentDTO setGpgUrl(String gpgUrl) {
+        this.gpgUrl = gpgUrl;
+        return this;
+    }
+
+    /**
+     * Retrieves the collection of IDs representing products that are modified by this content. If
+     * the modified product IDs have not yet been defined, this method returns null.
+     *
+     * @return
+     *  the modified product IDs of the content, or null if the modified product IDs have not yet
+     *  been defined
+     */
+    public Collection<String> getModifiedProductIds() {
+        return this.modifiedProductIds != null ? new SetView(this.modifiedProductIds) : null;
+    }
+
+    /**
+     * Adds the specified product ID as a product ID to be modified by the content represented by
+     * this DTO. If the product ID is already modified in this DTO, it will not be added again.
+     *
+     * @param productId
+     *  The product ID to add as a modified product ID to this DTO
+     *
+     * @return
+     *  true if the product ID was added successfully; false otherwise
+     */
+    public boolean addModifiedProductId(String productId) {
+        if (productId == null) {
+            throw new IllegalArgumentException("productId is null");
+        }
+
+        if (this.modifiedProductIds == null) {
+            this.modifiedProductIds = new HashSet<String>();
+        }
+
+        return this.modifiedProductIds.add(productId);
+    }
+
+    /**
+     * Removes the specified product ID from the collection of product IDs to be modified by the
+     * content represented by this DTO. If the product ID is not modified by this DTO, this method
+     * does nothing
+     *
+     * @param productId
+     *  The product ID to remove from the modified product IDs on this DTO
+     *
+     * @throws IllegalArgumentException
+     *  if productId is null
+     *
+     * @return
+     *  true if the product ID was removed successfully; false otherwise
+     */
+    public boolean removeModifiedProductId(String productId) {
+        if (productId == null) {
+            throw new IllegalArgumentException("productId is null");
+        }
+
+        return this.modifiedProductIds != null ? this.modifiedProductIds.remove(productId) : false;
+    }
+
+    /**
+     * Sets the modified product IDs for the content represented by this DTO. Any previously
+     * existing modified product IDs will be cleared before assigning the given product IDs.
+     *
+     * @param modifiedProductIds
+     *  A collection of product IDs to be modified by the content content, or null to clear the
+     *  existing modified product IDs
+     *
+     * @return
+     *  a reference to this DTO
+     */
+    public ContentDTO setModifiedProductIds(Collection<String> modifiedProductIds) {
+        if (modifiedProductIds != null) {
+            if (this.modifiedProductIds == null) {
+                this.modifiedProductIds = new HashSet<String>();
+            }
+            else {
+                this.modifiedProductIds.clear();
+            }
+
+            this.modifiedProductIds.addAll(modifiedProductIds);
+        }
+        else {
+            this.modifiedProductIds = null;
+        }
+
+        return this;
+    }
+
+    /**
+     * Retrieves the arches of the content represented by this DTO. If the arches has not yet been
+     * defined, this method returns null.
+     *
+     * @return
+     *  the arches of the content, or null if the arches has not yet been defined
+     */
+    public String getArches() {
+        return this.arches;
+    }
+
+    /**
+     * Sets the arches of the content represented by this DTO.
+     *
+     * @param arches
+     *  The arches of the content represented by this DTO, or null to clear the arches
+     *
+     * @return
+     *  a reference to this DTO
+     */
+    public ContentDTO setArches(String arches) {
+        this.arches = arches;
+        return this;
+    }
+
+    /**
+     * Retrieves the metadata expiration of the content represented by this DTO. If the metadata
+     * expiration has not yet been defined, this method returns null.
+     *
+     * @return
+     *  the metadata expiration of the content, or null if the metadata expiration has not yet been
+     *  defined
+     */
+    public Long getMetadataExpire() {
+        return this.metadataExpire;
+    }
+
+    /**
+     * Sets the metadata expiration of the content represented by this DTO.
+     *
+     * @param metadataExpire
+     *  The metadata expiration of the content represented by this DTO, or null to clear the
+     *  metadata expiration
+     *
+     * @return
+     *  a reference to this DTO
+     */
+    public ContentDTO setMetadataExpire(Long metadataExpire) {
+        this.metadataExpire = metadataExpire;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("ContentDTO [id: %s, name: %s, label: %s]", this.id, this.name, this.label);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        }
+
+        if (obj instanceof ContentDTO && super.equals(obj)) {
+            ContentDTO that = (ContentDTO) obj;
+
+            EqualsBuilder builder = new EqualsBuilder()
+                .append(this.getUuid(), that.getUuid())
+                .append(this.getId(), that.getId())
+                .append(this.getType(), that.getType())
+                .append(this.getLabel(), that.getLabel())
+                .append(this.getName(), that.getName())
+                .append(this.getVendor(), that.getVendor())
+                .append(this.getContentUrl(), that.getContentUrl())
+                .append(this.getRequiredTags(), that.getRequiredTags())
+                .append(this.getReleaseVersion(), that.getReleaseVersion())
+                .append(this.getGpgUrl(), that.getGpgUrl())
+                .append(this.getMetadataExpire(), that.getMetadataExpire())
+
+                .append(this.getModifiedProductIds(), that.getModifiedProductIds())
+                .append(this.getArches(), that.getArches());
+
+            return builder.isEquals();
+        }
+
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        HashCodeBuilder builder = new HashCodeBuilder(7, 17)
+            .append(super.hashCode())
+            .append(this.getUuid())
+            .append(this.getId())
+            .append(this.getType())
+            .append(this.getLabel())
+            .append(this.getName())
+            .append(this.getVendor())
+            .append(this.getContentUrl())
+            .append(this.getRequiredTags())
+            .append(this.getReleaseVersion())
+            .append(this.getGpgUrl())
+            .append(this.getMetadataExpire())
+            .append(this.getModifiedProductIds())
+            .append(this.getArches());
+
+        return builder.toHashCode();
+    }
+
+    @Override
+    public ContentDTO clone() {
+        ContentDTO copy = super.clone();
+
+        copy.setModifiedProductIds(this.modifiedProductIds);
+
+        return copy;
+    }
+
+    /**
+     * Populates this DTO with the data from the given source DTO.
+     *
+     * @param source
+     *  The source DTO from which to copy data
+     *
+     * @throws IllegalArgumentException
+     *  if source is null
+     *
+     * @return
+     *  a reference to this DTO
+     */
+    @Override
+    public ContentDTO populate(ContentDTO source) {
+        super.populate(source);
+
+        this.setUuid(source.getUuid());
+        this.setId(source.getId());
+        this.setType(source.getType());
+        this.setLabel(source.getLabel());
+        this.setName(source.getName());
+        this.setVendor(source.getVendor());
+        this.setContentUrl(source.getContentUrl());
+        this.setRequiredTags(source.getRequiredTags());
+        this.setReleaseVersion(source.getReleaseVersion());
+        this.setGpgUrl(source.getGpgUrl());
+        this.setMetadataExpire(source.getMetadataExpire());
+        this.setModifiedProductIds(source.getModifiedProductIds());
+        this.setArches(source.getArches());
+
+        return this;
+    }
+
+}

--- a/server/src/main/java/org/candlepin/dto/manifest/v1/ContentTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/manifest/v1/ContentTranslator.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2009 - 2018 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.dto.manifest.v1;
+
+import org.candlepin.dto.ModelTranslator;
+import org.candlepin.dto.TimestampedEntityTranslator;
+import org.candlepin.model.Content;
+
+
+
+/**
+ * The ContentTranslator provides translation from Content model objects to
+ * ContentDTOs as used by the manifest import/export framework.
+ */
+public class ContentTranslator extends TimestampedEntityTranslator<Content, ContentDTO> {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ContentDTO translate(Content source) {
+        return this.translate(null, source);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ContentDTO translate(ModelTranslator translator, Content source) {
+        return source != null ? this.populate(translator, source, new ContentDTO()) : null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ContentDTO populate(Content source, ContentDTO destination) {
+        return this.populate(null, source, destination);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ContentDTO populate(ModelTranslator translator, Content source, ContentDTO destination) {
+        destination = super.populate(translator, source, destination);
+
+        destination.setUuid(source.getUuid());
+        destination.setMetadataExpire(source.getMetadataExpire());
+        destination.setId(source.getId());
+        destination.setType(source.getType());
+        destination.setLabel(source.getLabel());
+        destination.setName(source.getName());
+        destination.setVendor(source.getVendor());
+        destination.setContentUrl(source.getContentUrl());
+        destination.setRequiredTags(source.getRequiredTags());
+        destination.setReleaseVersion(source.getReleaseVersion());
+        destination.setGpgUrl(source.getGpgUrl());
+        destination.setModifiedProductIds(source.getModifiedProductIds());
+        destination.setArches(source.getArches());
+
+        return destination;
+    }
+
+}

--- a/server/src/main/java/org/candlepin/dto/manifest/v1/EntitlementDTO.java
+++ b/server/src/main/java/org/candlepin/dto/manifest/v1/EntitlementDTO.java
@@ -42,6 +42,59 @@ public class EntitlementDTO extends CandlepinDTO<EntitlementDTO> {
 
     private static final long serialVersionUID = 1L;
 
+    /* TODO: Some fields that used to be exported, are no longer, so they are missing from this DTO.
+     * A decision needs to be made if any of them will need to be included.
+     *
+     * Fields we don't export any more
+     * (because they are not accessed or they are overriden during import anyway):
+     * - entitlement.href
+     * - entitlement.startDate
+     * - entitlement.endDate
+     * - entitlement.created
+     * - entitlement.updated
+     *
+     * - entitlement.certificates.created
+     * - entitlement.certificates.updated
+     *
+     * - entitlement.certificates.serial.revoked
+     * - entitlement.certificates.serial.serial
+     *
+     * - entitlement.pool.created
+     * - entitlement.pool.updated
+     * - entitlement.pool.type
+     * - entitlement.pool.owner
+     * - entitlement.pool.activeSubscription
+     * - entitlement.pool.createdByShare
+     * - entitlement.pool.hasSharedAncestor
+     * - entitlement.pool.sourceEntitlement
+     * - entitlement.pool.quantity
+     * - entitlement.pool.startDate
+     * - entitlement.pool.endDate
+     * - entitlement.pool.attributes
+     * - entitlement.pool.restrictedToUsername
+     * - entitlement.pool.consumed
+     * - entitlement.pool.exported
+     * - entitlement.pool.shared
+     * - entitlement.pool.calculatedAttributes
+     * - entitlement.pool.upstreamPoolId
+     * - entitlement.pool.upstreamEntitlementId
+     * - entitlement.pool.upstreamConsumerId
+     * - entitlement.pool.productAttributes
+     * - entitlement.pool.derivedProductAttributes
+     * - entitlement.pool.derivedProductName
+     * - entitlement.pool.stacked
+     * - entitlement.pool.stackId
+     * - entitlement.pool.developmentPool
+     * - entitlement.pool.sourceStackId
+     * - entitlement.pool.subscriptionSubKey
+     * - entitlement.pool.subscriptionId
+     *
+     * - entitlement.pool.branding.id (not to be confused with productId)
+     * - entitlement.pool.branding.created
+     * - entitlement.pool.branding.updated
+     *
+     */
+
     private String id;
     private PoolDTO pool;
     private Integer quantity;

--- a/server/src/main/java/org/candlepin/dto/manifest/v1/ProductDTO.java
+++ b/server/src/main/java/org/candlepin/dto/manifest/v1/ProductDTO.java
@@ -1,0 +1,876 @@
+/**
+ * Copyright (c) 2009 - 2018 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.dto.manifest.v1;
+
+import org.candlepin.dto.CandlepinDTO;
+import org.candlepin.dto.TimestampedCandlepinDTO;
+import org.candlepin.jackson.CandlepinAttributeDeserializer;
+import org.candlepin.jackson.CandlepinLegacyAttributeSerializer;
+import org.candlepin.util.MapView;
+import org.candlepin.util.SetView;
+import org.candlepin.util.Util;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+
+
+/**
+ * DTO representing the product data exposed to the manifest import/export framework.
+ */
+@XmlRootElement
+public class ProductDTO extends TimestampedCandlepinDTO<ProductDTO> {
+    public static final long serialVersionUID = 1L;
+
+    /**
+     * Join object DTO for joining products to content
+     */
+    public static class ProductContentDTO extends CandlepinDTO<ProductContentDTO> {
+        protected final ContentDTO content;
+        protected Boolean enabled;
+
+        @JsonCreator
+        public ProductContentDTO(
+            @JsonProperty("content") ContentDTO content,
+            @JsonProperty("enabled") Boolean enabled) {
+
+            if (content == null || content.getId() == null) {
+                throw new IllegalArgumentException("content is null or is missing an identifier");
+            }
+
+            this.content = content;
+            this.setEnabled(enabled);
+        }
+
+        public ContentDTO getContent() {
+            return this.content;
+        }
+
+        public ProductContentDTO setEnabled(Boolean enabled) {
+            this.enabled = enabled;
+            return this;
+        }
+
+        public Boolean isEnabled() {
+            return this.enabled;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) {
+                return true;
+            }
+
+            if (obj instanceof ProductContentDTO) {
+                ProductContentDTO that = (ProductContentDTO) obj;
+
+                EqualsBuilder builder = new EqualsBuilder()
+                    .append(this.getContent().getId(), that.getContent().getId())
+                    .append(this.isEnabled(), that.isEnabled());
+
+                return builder.isEquals();
+            }
+
+            return false;
+        }
+
+        @Override
+        public int hashCode() {
+            HashCodeBuilder builder = new HashCodeBuilder(37, 7)
+                .append(this.getContent().getId())
+                .append(this.isEnabled());
+
+            return builder.toHashCode();
+        }
+    }
+
+    protected String uuid;
+    protected Long multiplier;
+    protected String id;
+    protected String name;
+
+    @JsonSerialize(using = CandlepinLegacyAttributeSerializer.class)
+    @JsonDeserialize(using = CandlepinAttributeDeserializer.class)
+    protected Map<String, String> attributes;
+
+    protected Map<String, ProductContentDTO> productContent;
+    protected Set<String> dependentProductIds;
+    protected Boolean locked;
+
+    /**
+     * Initializes a new ProductDTO instance with null values.
+     */
+    public ProductDTO() {
+        super();
+    }
+
+    /**
+     * Initializes a new ProductDTO instance with the specified Red Hat ID and name.
+     * <p/></p>
+     * <strong>Note</strong>: This constructor passes the provided values to their respective
+     * mutator methods, and does not capture any exceptions they may throw as due to malformed
+     * values.
+     *
+     * @param id
+     *  The ID of the product to be represented by this DTO; cannot be null
+     *
+     * @param name
+     *  The name of the product to be represented by this DTO
+     */
+    public ProductDTO(String id, String name) {
+        super();
+
+        this.setId(id);
+        this.setName(name);
+    }
+
+    /**
+     * Initializes a new ProductDTO instance using the data contained by the given DTO.
+     *
+     * @param source
+     *  The source DTO from which to copy data
+     *
+     * @throws IllegalArgumentException
+     *  if source is null
+     */
+    public ProductDTO(ProductDTO source) {
+        if (source == null) {
+            throw new IllegalArgumentException("source is null");
+        }
+
+        this.populate(source);
+    }
+
+    /**
+     * Retrieves the UUID of the product represented by this DTO. If the UUID has not yet been
+     * defined, this method returns null.
+     *
+     * @return
+     *  the UUID of the product, or null if the UUID has not yet been defined
+     */
+    public String getUuid() {
+        return this.uuid;
+    }
+
+    /**
+     * Sets the UUID of the product represented by this DTO.
+     *
+     * @param uuid
+     *  The UUID of the product represented by this DTO, or null to clear the UUID
+     *
+     * @return
+     *  a reference to this DTO
+     */
+    public ProductDTO setUuid(String uuid) {
+        this.uuid = uuid;
+        return this;
+    }
+
+    /**
+     * Retrieves the multiplier of the product represented by this DTO. If the multiplier has not
+     * yet been defined, this method returns null.
+     *
+     * @return
+     *  the multiplier of the product, or null if the multiplier has not yet been defined
+     */
+    public Long getMultiplier() {
+        return this.multiplier;
+    }
+
+    /**
+     * Sets the multiplier of the product represented by this DTO.
+     *
+     * @param multiplier
+     *  The multiplier of the product represented by this DTO, or null to clear the multiplier
+     *
+     * @return
+     *  a reference to this DTO
+     */
+    public ProductDTO setMultiplier(Long multiplier) {
+        this.multiplier = multiplier;
+        return this;
+    }
+
+    /**
+     * Retrieves the ID of the product represented by this DTO. If the ID has not yet been
+     * defined, this method returns null.
+     *
+     * @return
+     *  the ID of the product, or null if the ID has not yet been defined
+     */
+    public String getId() {
+        return this.id;
+    }
+
+    /**
+     * Sets the ID of the product represented by this DTO.
+     *
+     * @param id
+     *  The ID of the product represented by this DTO
+     *
+     * @return
+     *  a reference to this DTO
+     */
+    public ProductDTO setId(String id) {
+        this.id = id;
+        return this;
+    }
+
+    /**
+     * Retrieves the UUID of the product represented by this DTO. If the UUID has not yet been
+     * defined, this method returns null.
+     *
+     * @return
+     *  the UUID of the product, or null if the UUID has not yet been defined
+     */
+    public String getName() {
+        return this.name;
+    }
+
+    /**
+     * Sets the name of the product represented by this DTO.
+     *
+     * @param name
+     *  The name of the product represented by this DTO, or null to clear the name
+     *
+     * @return
+     *  a reference to this DTO
+     */
+    public ProductDTO setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * Retrieves a view of the attributes for the product represented by this DTO. If the product
+     * attributes have not yet been defined, this method returns null.
+     * <p></p>
+     * Note that the collection returned by this method is a view of the collection backing this
+     * product data. Elements cannot be added to the collection, but elements may be removed.
+     * Changes made to the collection will be reflected by this product data instance.
+     *
+     * @return
+     *  the attributes of the product, or null if the attributes have not yet been defined
+     */
+    public Map<String, String> getAttributes() {
+        return this.attributes != null ? new MapView(this.attributes) : null;
+    }
+
+    /**
+     * Retrieves the value associated with the given attribute. If the attribute is not set, this
+     * method returns null.
+     *
+     * @param key
+     *  The key (name) of the attribute to lookup
+     *
+     * @throws IllegalArgumentException
+     *  if key is null
+     *
+     * @return
+     *  the value set for the given attribute, or null if the attribute is not set
+     */
+    @JsonIgnore
+    public String getAttributeValue(String key) {
+        if (key == null) {
+            throw new IllegalArgumentException("key is null");
+        }
+
+        return this.attributes != null ? this.attributes.get(key) : null;
+    }
+
+    /**
+     * Checks if the given attribute has been defined on this product DTO.
+     *
+     * @param key
+     *  The key (name) of the attribute to lookup
+     *
+     * @throws IllegalArgumentException
+     *  if key is null
+     *
+     * @return
+     *  true if the attribute is defined for this product; false otherwise
+     */
+    @JsonIgnore
+    public boolean hasAttribute(String key) {
+        if (key == null) {
+            throw new IllegalArgumentException("key is null");
+        }
+
+        return this.attributes != null && this.attributes.containsKey(key);
+    }
+
+    /**
+     * Sets the specified attribute for this product DTO. If the attribute has already been set for
+     * this product, the existing value will be overwritten.
+     *
+     * @param key
+     *  The name or key of the attribute to set
+     *
+     * @param value
+     *  The value to assign to the attribute
+     *
+     * @throws IllegalArgumentException
+     *  if key is null
+     *
+     * @return
+     *  a reference to this DTO
+     */
+    @JsonIgnore
+    public ProductDTO setAttribute(String key, String value) {
+        if (key == null) {
+            throw new IllegalArgumentException("key is null");
+        }
+
+        if (this.attributes == null) {
+            this.attributes = new HashMap<String, String>();
+        }
+
+        // Impl note:
+        // We can't standardize the value at all here; some attributes allow null, some expect
+        // empty strings, and others have their own sential values. Unless we make a concerted
+        // effort to fix all of these inconsistencies with a massive database update, we can't
+        // perform any input sanitation/massaging.
+        this.attributes.put(key, value);
+        return this;
+    }
+
+    /**
+     * Removes the product attribute with the given attribute key from this product DTO.
+     *
+     * @param key
+     *  The key (name) of the attribute to remove
+     *
+     * @throws IllegalArgumentException
+     *  if key is null
+     *
+     * @return
+     *  true if the attribute was removed successfully; false otherwise
+     */
+    @JsonIgnore
+    public boolean removeAttribute(String key) {
+        if (key == null) {
+            throw new IllegalArgumentException("key is null");
+        }
+
+        if (this.attributes != null && this.attributes.containsKey(key)) {
+            this.attributes.remove(key);
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Sets the attributes of the product represented by this DTO.
+     *
+     * @param attributes
+     *  A map of product attributes to attach to this DTO, or null to clear the attributes
+     *
+     * @return
+     *  a reference to this DTO
+     */
+    public ProductDTO setAttributes(Map<String, String> attributes) {
+        if (attributes != null) {
+            if (this.attributes == null) {
+                this.attributes = new HashMap<String, String>();
+            }
+            else {
+                this.attributes.clear();
+            }
+
+            this.attributes.putAll(attributes);
+        }
+        else {
+            this.attributes = null;
+        }
+
+        return this;
+    }
+
+    /**
+     * Retrieves the content of the product represented by this DTO. If the product content has not
+     * yet been defined, this method returns null.
+     * <p></p>
+     * Note that the collection returned by this method is a view of the collection backing this
+     * product data. Elements cannot be added to the collection, but elements may be removed.
+     * Changes made to the collection will be reflected by this product data instance.
+     *
+     * @return
+     *  the content of the product, or null if the content not yet been defined
+     */
+    public Collection<ProductContentDTO> getProductContent() {
+        return this.productContent != null ? this.productContent.values() : null;
+    }
+
+    /**
+     * Retrieves the product content for the specified content ID. If no such content has been
+     * associated with this product DTO, this method returns null.
+     *
+     * @param contentId
+     *  The ID of the content to retrieve
+     *
+     * @throws IllegalArgumentException
+     *  if contentId is null
+     *
+     * @return
+     *  the product content associated with this DTO using the given ID, or null if such content
+     *  does not exist
+     */
+    @JsonIgnore
+    public ProductContentDTO getProductContent(String contentId) {
+        if (contentId == null) {
+            throw new IllegalArgumentException("contentId is null");
+        }
+
+        return this.productContent != null ? this.productContent.get(contentId) : null;
+    }
+
+    /**
+     * Retrieves the unwrapped content for the specified content ID. If no such content has been
+     * associated with this product, this method returns null.
+     *
+     * @param contentId
+     *  The ID of the content to retrieve
+     *
+     * @throws IllegalArgumentException
+     *  if contentId is null
+     *
+     * @return
+     *  the content associated with this DTO using the given ID, or null if such content does not
+     */
+    @JsonIgnore
+    public ContentDTO getContent(String contentId) {
+        if (contentId == null) {
+            throw new IllegalArgumentException("contentId is null");
+        }
+
+        ProductContentDTO pc = this.productContent != null ? this.productContent.get(contentId) : null;
+        return pc != null ? pc.getContent() : null;
+    }
+
+    /**
+     * Checks if any content with the given content ID has been associated with this product.
+     *
+     * @param contentId
+     *  The ID of the content to check
+     *
+     * @throws IllegalArgumentException
+     *  if contentId is null
+     *
+     * @return
+     *  true if any content with the given content ID has been associated with this product; false
+     *  otherwise
+     */
+    @JsonIgnore
+    public boolean hasContent(String contentId) {
+        if (contentId == null) {
+            throw new IllegalArgumentException("contentId is null");
+        }
+
+        return this.productContent != null && this.productContent.containsKey(contentId);
+    }
+
+    /**
+     * Adds the given content to this product DTO. If a matching content has already been added to
+     * this product, it will be overwritten by the specified content.
+     *
+     * @param dto
+     *  The product content DTO to add to this product
+     *
+     * @throws IllegalArgumentException
+     *  if content is null or incomplete
+     *
+     * @return
+     *  true if adding the content resulted in a change to this product; false otherwise
+     */
+    @JsonIgnore
+    public boolean addProductContent(ProductContentDTO dto) {
+        if (dto == null) {
+            throw new IllegalArgumentException("dto is null");
+        }
+
+        if (dto.getContent() == null || dto.getContent().getId() == null) {
+            throw new IllegalArgumentException("dto references incomplete content");
+        }
+
+        // We're operating under the assumption that we won't be doing janky things like
+        // adding product content, then changing its ID. It's too bad this isn't all immutable...
+
+        boolean changed = false;
+        boolean matched = false;
+        String contentId = dto.getContent().getId();
+
+
+        if (this.productContent == null) {
+            this.productContent = new HashMap<String, ProductContentDTO>();
+            changed = true;
+        }
+        else {
+            ProductContentDTO existing = this.productContent.get(dto.getContent().getId());
+            changed = !dto.equals(existing);
+        }
+
+        if (changed) {
+            this.productContent.put(dto.getContent().getId(), dto);
+        }
+
+        return changed;
+    }
+
+    /**
+     * Adds the given content to this product DTO. If a matching content has already been added to
+     * this product, it will be overwritten by the specified content.
+     *
+     * @param dto
+     *  The product content DTO to add to this product
+     *
+     * @throws IllegalArgumentException
+     *  if content is null
+     *
+     * @return
+     *  true if adding the content resulted in a change to this product; false otherwise
+     */
+    @JsonIgnore
+    public boolean addContent(ContentDTO dto, boolean enabled) {
+        if (dto == null) {
+            throw new IllegalArgumentException("dto is null");
+        }
+
+        return this.addProductContent(new ProductContentDTO(dto, enabled));
+    }
+
+    /**
+     * Removes the content with the given content ID from this product DTO.
+     *
+     * @param contentId
+     *  The ID of the content to remove
+     *
+     * @throws IllegalArgumentException
+     *  if contentId is null
+     *
+     * @return
+     *  true if the content was removed successfully; false otherwise
+     */
+    @JsonIgnore
+    public boolean removeContent(String contentId) {
+        if (contentId == null) {
+            throw new IllegalArgumentException("contentId is null");
+        }
+
+        boolean updated = false;
+
+        if (this.productContent != null) {
+            ProductContentDTO existing = this.productContent.remove(contentId);
+            updated = (existing != null);
+        }
+
+        return updated;
+    }
+
+    /**
+     * Removes the content represented by the given content DTO from this product. Any content with
+     * the same ID as the ID of the given content DTO will be removed.
+     *
+     * @param dto
+     *  The product content DTO representing the content to remove from this product
+     *
+     * @throws IllegalArgumentException
+     *  if content is null or incomplete
+     *
+     * @return
+     *  true if the content was removed successfully; false otherwise
+     */
+    @JsonIgnore
+    public boolean removeContent(ContentDTO dto) {
+        if (dto == null) {
+            throw new IllegalArgumentException("dto is null");
+        }
+
+        if (dto.getId() == null) {
+            throw new IllegalArgumentException("dto is incomplete");
+        }
+
+        return this.removeContent(dto.getId());
+    }
+
+    /**
+     * Removes the content represented by the given content DTO from this product. Any content with
+     * the same ID as the ID of the given content DTO will be removed.
+     *
+     * @param dto
+     *  The product content DTO representing the content to remove from this product
+     *
+     * @throws IllegalArgumentException
+     *  if dto is null or incomplete
+     *
+     * @return
+     *  true if the content was removed successfully; false otherwise
+     */
+    @JsonIgnore
+    public boolean removeProductContent(ProductContentDTO dto) {
+        if (dto == null) {
+            throw new IllegalArgumentException("dto is null");
+        }
+
+        if (dto.getContent() == null || dto.getContent().getId() == null) {
+            throw new IllegalArgumentException("dto is incomplete");
+        }
+
+        return this.removeContent(dto.getContent().getId());
+    }
+
+    /**
+     * Sets the content of the product represented by this DTO.
+     *
+     * @param productContent
+     *  A collection of product content DTO to attach to this DTO, or null to clear the content
+     *
+     * @throws IllegalArgumentException
+     *  if the collection contains null or incomplete content DTOs
+     *
+     * @return
+     *  a reference to this DTO
+     */
+    public ProductDTO setProductContent(Collection<ProductContentDTO> productContent) {
+        if (productContent != null) {
+            if (this.productContent == null) {
+                this.productContent = new HashMap<String, ProductContentDTO>();
+            }
+            else {
+                this.productContent.clear();
+            }
+
+            for (ProductContentDTO dto : productContent) {
+                if (dto == null || dto.getContent() == null || dto.getContent().getId() == null) {
+                    throw new IllegalArgumentException("collection contains null or incomplete dtos");
+                }
+
+                this.productContent.put(dto.getContent().getId(), dto);
+            }
+        }
+        else {
+            this.productContent = null;
+        }
+
+        return this;
+    }
+
+    /**
+     * Retrieves the dependent product IDs of the product represented by this DTO. If the product
+     * dependent product IDs have not yet been defined, this method returns null.
+     * <p></p>
+     * Note that the collection returned by this method is a view of the collection backing this
+     * product data. Elements cannot be added to the collection, but elements may be removed.
+     * Changes made to the collection will be reflected by this product data instance.
+     *
+     * @return
+     *  the dependent product IDs of the product, or null if the dependent product IDs have not yet
+     *  been defined
+     */
+    public Collection<String> getDependentProductIds() {
+        return this.dependentProductIds != null ? new SetView(this.dependentProductIds) : null;
+    }
+
+    /**
+     * Adds the ID of the specified product as a dependent product of this product. If the product
+     * is already a dependent product, it will not be added again.
+     *
+     * @param productId
+     *  The ID of the product to add as a dependent product
+     *
+     * @throws IllegalArgumentException
+     *  if productId is null
+     *
+     * @return
+     *  true if the dependent product was added successfully; false otherwise
+     */
+    @JsonIgnore
+    public boolean addDependentProductId(String productId) {
+        if (productId == null) {
+            throw new IllegalArgumentException("productId is null");
+        }
+
+        if (this.dependentProductIds == null) {
+            this.dependentProductIds = new HashSet<String>();
+        }
+
+        return this.dependentProductIds.add(productId);
+    }
+
+    /**
+     * Removes the specified product as a dependent product of this product. If the product is not
+     * dependent on this product, this method does nothing.
+     *
+     * @param productId
+     *  The ID of the product to add as a dependent product
+     *
+     * @throws IllegalArgumentException
+     *  if productId is null
+     *
+     * @return
+     *  true if the dependent product was removed successfully; false otherwise
+     */
+    @JsonIgnore
+    public boolean removeDependentProductId(String productId) {
+        return this.dependentProductIds != null && this.dependentProductIds.remove(productId);
+    }
+
+    /**
+     * Sets the dependent product IDs of the product represented by this DTO.
+     *
+     * @param dependentProductIds
+     *  A collection of dependent product IDs to attach to this DTO, or null to clear the
+     *  dependent products
+     *
+     * @return
+     *  a reference to this DTO
+     */
+    public ProductDTO setDependentProductIds(Collection<String> dependentProductIds) {
+        if (dependentProductIds != null) {
+            if (this.dependentProductIds == null) {
+                this.dependentProductIds = new HashSet<String>();
+            }
+            else {
+                this.dependentProductIds.clear();
+            }
+
+            for (String pid : dependentProductIds) {
+                this.addDependentProductId(pid);
+            }
+        }
+        else {
+            this.dependentProductIds = null;
+        }
+
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("ProductDTO [id = %s, uuid = %s, name = %s]", this.getId(), this.getUuid(),
+            this.getName());
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        }
+
+        if (obj instanceof ProductDTO && super.equals(obj)) {
+            ProductDTO that = (ProductDTO) obj;
+
+            EqualsBuilder builder = new EqualsBuilder()
+                .append(this.getUuid(), that.getUuid())
+                .append(this.getMultiplier(), that.getMultiplier())
+                .append(this.getId(), that.getId())
+                .append(this.getName(), that.getName())
+                .append(this.getAttributes(), that.getAttributes())
+                .append(this.getDependentProductIds(), that.getDependentProductIds());
+
+            // As with many collections here, we need to explicitly check the elements ourselves,
+            // since it seems very common for collection implementations to not properly implement
+            // .equals
+            // Note that we're using the boolean operator here as a shorthand way to skip checks
+            // when the equality check has already failed.
+            boolean equals = builder.isEquals();
+
+            // Check product content
+            equals = equals && Util.collectionsAreEqual(this.getProductContent(), that.getProductContent());
+
+            return equals;
+        }
+
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        // Map.values doesn't properly implement .hashCode, so we need to manually calculate
+        // this ourselves using the algorithm defined by list.hashCode()
+        int pcHashCode = 0;
+        Collection<ProductContentDTO> productContent = this.getProductContent();
+
+        if (productContent != null) {
+            for (ProductContentDTO dto : productContent) {
+                pcHashCode = 31 * pcHashCode + (dto != null ? dto.hashCode() : 0);
+            }
+        }
+
+        HashCodeBuilder builder = new HashCodeBuilder(37, 7)
+            .append(super.hashCode())
+            .append(this.getUuid())
+            .append(this.getMultiplier())
+            .append(this.getId())
+            .append(this.getName())
+            .append(this.getAttributes())
+            .append(this.getDependentProductIds())
+            .append(pcHashCode);
+
+        return builder.toHashCode();
+    }
+
+    @Override
+    public ProductDTO clone() {
+        ProductDTO copy = super.clone();
+
+        copy.setAttributes(this.getAttributes());
+        copy.setProductContent(this.getProductContent());
+        copy.setDependentProductIds(this.getDependentProductIds());
+
+        return copy;
+    }
+
+    /**
+     * Populates this DTO with the data from the given source DTO.
+     *
+     * @param source
+     *  The source DTO from which to copy data
+     *
+     * @throws IllegalArgumentException
+     *  if source is null
+     *
+     * @return
+     *  a reference to this DTO
+     */
+    public ProductDTO populate(ProductDTO source) {
+        super.populate(source);
+
+        this.setUuid(source.getUuid());
+        this.setMultiplier(source.getMultiplier());
+        this.setId(source.getId());
+        this.setName(source.getName());
+        this.setAttributes(source.getAttributes());
+        this.setProductContent(source.getProductContent());
+        this.setDependentProductIds(source.getDependentProductIds());
+
+        return this;
+    }
+}

--- a/server/src/main/java/org/candlepin/dto/manifest/v1/ProductTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/manifest/v1/ProductTranslator.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2009 - 2018 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.dto.manifest.v1;
+
+import org.candlepin.dto.ModelTranslator;
+import org.candlepin.dto.ObjectTranslator;
+import org.candlepin.dto.TimestampedEntityTranslator;
+import org.candlepin.model.Content;
+import org.candlepin.model.Product;
+import org.candlepin.model.ProductContent;
+
+import java.util.Collection;
+import java.util.Collections;
+
+
+
+/**
+ * The ProductTranslator provides translation from Product model objects to ProductDTOs
+ */
+public class ProductTranslator extends TimestampedEntityTranslator<Product, ProductDTO> {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ProductDTO translate(Product source) {
+        return this.translate(null, source);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ProductDTO translate(ModelTranslator translator, Product source) {
+        return source != null ? this.populate(translator, source, new ProductDTO()) : null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ProductDTO populate(Product source, ProductDTO destination) {
+        return this.populate(null, source, destination);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ProductDTO populate(ModelTranslator modelTranslator, Product source, ProductDTO destination) {
+        destination = super.populate(modelTranslator, source, destination);
+
+        destination.setUuid(source.getUuid());
+        destination.setMultiplier(source.getMultiplier());
+        destination.setId(source.getId());
+        destination.setName(source.getName());
+        destination.setAttributes(source.getAttributes());
+        destination.setDependentProductIds(source.getDependentProductIds());
+
+        if (modelTranslator != null) {
+            Collection<ProductContent> productContent = source.getProductContent();
+            destination.setProductContent(Collections.emptyList());
+
+            if (productContent != null) {
+                ObjectTranslator<Content, ContentDTO> contentTranslator = modelTranslator
+                    .findTranslatorByClass(Content.class, ContentDTO.class);
+
+                for (ProductContent pc : productContent) {
+                    if (pc != null) {
+                        ContentDTO dto = contentTranslator.translate(modelTranslator, pc.getContent());
+
+                        if (dto != null) {
+                            destination.addContent(dto, pc.isEnabled());
+                        }
+                    }
+                }
+            }
+        }
+        else {
+            destination.setProductContent(Collections.emptyList());
+        }
+
+        return destination;
+    }
+
+}

--- a/server/src/main/java/org/candlepin/sync/Importer.java
+++ b/server/src/main/java/org/candlepin/sync/Importer.java
@@ -747,15 +747,8 @@ public class Importer {
             if (product.getName().endsWith(".json")) {
                 log.debug("Importing product {} for owner {}", product.getName(), owner.getKey());
 
-                Reader reader = null;
-                try {
-                    reader = new FileReader(product);
+                try (Reader reader = new FileReader(product)) {
                     productsToImport.add(importer.createObject(mapper, reader, owner));
-                }
-                finally {
-                    if (reader != null) {
-                        reader.close();
-                    }
                 }
             }
         }

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/ContentDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/ContentDTOTest.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) 2009 - 2018 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.dto.manifest.v1;
+
+import static org.junit.Assert.*;
+
+import org.candlepin.dto.AbstractDTOTest;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+
+
+/**
+ * Test suite for the ContentDTO (manifest import/export) class
+ */
+public class ContentDTOTest extends AbstractDTOTest<ContentDTO> {
+
+    protected Map<String, Object> values;
+
+    public ContentDTOTest() {
+        super(ContentDTO.class);
+
+        this.values = new HashMap<>();
+        this.values.put("Id", "test_value");
+        this.values.put("Uuid", "test_value");
+        this.values.put("MetadataExpire", 3L);
+        this.values.put("Type", "test_value");
+        this.values.put("Label", "test_value");
+        this.values.put("Name", "test_value");
+        this.values.put("Vendor", "test_value");
+        this.values.put("ContentUrl", "test_value");
+        this.values.put("RequiredTags", "test_value");
+        this.values.put("ReleaseVersion", "test_value");
+        this.values.put("GpgUrl", "test_value");
+        this.values.put("ModifiedProductIds", Arrays.asList("1", "2", "3"));
+        this.values.put("Arches", "test_value");
+        this.values.put("Created", new Date());
+        this.values.put("Updated", new Date());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected Object getInputValueForMutator(String field) {
+        return this.values.get(field);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected Object getOutputValueForAccessor(String field, Object input) {
+        // Nothing to do here
+        return input;
+    }
+
+    @Test
+    public void testAddModifiedProducts() {
+        ContentDTO dto = new ContentDTO();
+        dto.setModifiedProductIds(Arrays.asList("1", "2"));
+        assertEquals(new HashSet<>(Arrays.asList("1", "2")), dto.getModifiedProductIds());
+
+        dto.addModifiedProductId("3");
+        assertEquals(new HashSet<>(Arrays.asList("1", "2", "3")), dto.getModifiedProductIds());
+    }
+
+    @Test
+    public void testAddModifiedProductsNoChange() {
+        ContentDTO dto = new ContentDTO();
+        dto.setModifiedProductIds(Arrays.asList("1", "2"));
+        assertEquals(new HashSet<>(Arrays.asList("1", "2")), dto.getModifiedProductIds());
+
+        dto.addModifiedProductId("2");
+        assertEquals(new HashSet<>(Arrays.asList("1", "2")), dto.getModifiedProductIds());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddModifiedProductsWithNullValue() {
+        ContentDTO dto = new ContentDTO();
+        dto.setModifiedProductIds(Arrays.asList("1", "2"));
+        assertEquals(new HashSet<>(Arrays.asList("1", "2")), dto.getModifiedProductIds());
+
+        dto.addModifiedProductId(null);
+    }
+
+    @Test
+    public void testRemoveModifiedProducts() {
+        ContentDTO dto = new ContentDTO();
+        dto.setModifiedProductIds(Arrays.asList("1", "2"));
+        assertEquals(new HashSet<>(Arrays.asList("1", "2")), dto.getModifiedProductIds());
+
+        dto.removeModifiedProductId("3");
+        assertEquals(new HashSet<>(Arrays.asList("1", "2")), dto.getModifiedProductIds());
+    }
+
+    @Test
+    public void testRemoveModifiedProductsNoChange() {
+        ContentDTO dto = new ContentDTO();
+        dto.setModifiedProductIds(Arrays.asList("1", "2"));
+        assertEquals(new HashSet<>(Arrays.asList("1", "2")), dto.getModifiedProductIds());
+
+        dto.removeModifiedProductId("3");
+        assertEquals(new HashSet<>(Arrays.asList("1", "2")), dto.getModifiedProductIds());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testRemoveModifiedProductsWithNullValue() {
+        ContentDTO dto = new ContentDTO();
+        dto.setModifiedProductIds(Arrays.asList("1", "2"));
+        assertEquals(new HashSet<>(Arrays.asList("1", "2")), dto.getModifiedProductIds());
+
+        dto.removeModifiedProductId(null);
+    }
+}

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/ContentTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/ContentTranslatorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+ * Copyright (c) 2009 - 2018 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,7 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.dto.api.v1;
+package org.candlepin.dto.manifest.v1;
 
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
@@ -29,7 +29,7 @@ import java.util.Arrays;
 
 
 /**
- * Test suite for the ContentTranslator class
+ * Test suite for the ContentTranslator (manifest import/export) class
  */
 @RunWith(JUnitParamsRunner.class)
 public class ContentTranslatorTest extends
@@ -52,6 +52,7 @@ public class ContentTranslatorTest extends
         Content source = new Content();
 
         source.setUuid("test_value");
+        source.setMetadataExpire(3L);
         source.setId("test_value");
         source.setType("test_value");
         source.setLabel("test_value");
@@ -61,10 +62,8 @@ public class ContentTranslatorTest extends
         source.setRequiredTags("test_value");
         source.setReleaseVersion("test_value");
         source.setGpgUrl("test_value");
-        source.setMetadataExpire(1234L);
         source.setModifiedProductIds(Arrays.asList("1", "2", "3"));
         source.setArches("test_value");
-        source.setLocked(Boolean.TRUE);
 
         return source;
     }
@@ -82,6 +81,7 @@ public class ContentTranslatorTest extends
             // childrenGenerated flag
 
             assertEquals(source.getUuid(), dto.getUuid());
+            assertEquals(source.getMetadataExpire(), dto.getMetadataExpire());
             assertEquals(source.getId(), dto.getId());
             assertEquals(source.getType(), dto.getType());
             assertEquals(source.getLabel(), dto.getLabel());
@@ -91,10 +91,8 @@ public class ContentTranslatorTest extends
             assertEquals(source.getRequiredTags(), dto.getRequiredTags());
             assertEquals(source.getReleaseVersion(), dto.getReleaseVersion());
             assertEquals(source.getGpgUrl(), dto.getGpgUrl());
-            assertEquals(source.getMetadataExpire(), dto.getMetadataExpiration());
             assertEquals(source.getModifiedProductIds(), dto.getModifiedProductIds());
             assertEquals(source.getArches(), dto.getArches());
-            assertEquals(source.isLocked(), dto.isLocked());
         }
         else {
             assertNull(dto);

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/ProductDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/ProductDTOTest.java
@@ -1,0 +1,159 @@
+/**
+ * Copyright (c) 2009 - 2018 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.dto.manifest.v1;
+
+import static org.junit.Assert.*;
+
+import org.candlepin.dto.AbstractDTOTest;
+
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Map;
+
+
+
+/**
+ * Test suite for the ProductDTO (manifest import/export) class
+ */
+public class ProductDTOTest extends AbstractDTOTest<ProductDTO> {
+
+    protected ContentDTOTest contentDTOTest = new ContentDTOTest();
+
+    protected Map<String, Object> values;
+
+    public ProductDTOTest() {
+        super(ProductDTO.class);
+
+        Collection<ProductDTO.ProductContentDTO> productContent = new LinkedList<>();
+
+        for (int i = 0; i < 5; ++i) {
+            ContentDTO content = this.contentDTOTest.getPopulatedDTOInstance();
+            content.setId(content.getId() + "-" + i);
+
+            productContent.add(new ProductDTO.ProductContentDTO(content, i % 2 != 0));
+        }
+
+        Map<String, String> attributes = new HashMap<>();
+
+        for (int i = 0; i < 5; ++i) {
+            attributes.put("attrib-" + i, "value-" + i);
+        }
+
+        Collection<String> dependentProductIds = new LinkedList<>();
+
+        for (int i = 0; i < 5; ++i) {
+            dependentProductIds.add("dependentProdId" + i);
+        }
+
+        this.values = new HashMap<>();
+        this.values.put("Id", "test_value");
+        this.values.put("Uuid", "test_value");
+        this.values.put("Multiplier", 3L);
+        this.values.put("Name", "test_value");
+        this.values.put("Locked", Boolean.TRUE);
+        this.values.put("ProductContent", productContent);
+        this.values.put("Attributes", attributes);
+        this.values.put("DependentProductIds", dependentProductIds);
+        this.values.put("Created", new Date());
+        this.values.put("Updated", new Date());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected Object getInputValueForMutator(String field) {
+        return this.values.get(field);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected Object getOutputValueForAccessor(String field, Object input) {
+        // Nothing to do here
+        return input;
+    }
+
+    @Test
+    public void testHasAttributeWithAbsentAttribute() {
+        ProductDTO dto = new ProductDTO();
+        assertFalse(dto.hasAttribute("attrib"));
+    }
+
+    @Test
+    public void testHasAttributeWithPresentAttribute() {
+        ProductDTO dto = new ProductDTO();
+        dto.setAttribute("attrib", "value");
+
+        assertTrue(dto.hasAttribute("attrib"));
+    }
+
+    @Test
+    public void testAttributeCRUDOps() {
+        ProductDTO dto = new ProductDTO();
+        String attrib = "test-attrib";
+
+        assertFalse(dto.hasAttribute(attrib));
+        String value = dto.getAttributeValue(attrib);
+        assertNull(value);
+
+        dto.setAttribute(attrib, "val");
+
+        assertTrue(dto.hasAttribute(attrib));
+        value = dto.getAttributeValue(attrib);
+        assertEquals("val", value);
+
+        dto.setAttribute(attrib, null);
+
+        assertTrue(dto.hasAttribute(attrib));
+        value = dto.getAttributeValue(attrib);
+        assertNull(value);
+
+        dto.removeAttribute(attrib);
+
+        assertFalse(dto.hasAttribute(attrib));
+        value = dto.getAttributeValue(attrib);
+        assertNull(value);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetAttributeWithNullAttribute() {
+        ProductDTO dto = new ProductDTO();
+        dto.getAttributeValue(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSetAttributeWithNullAttribute() {
+        ProductDTO dto = new ProductDTO();
+        dto.setAttribute(null, "value");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testHasAttributeWithNullAttribute() {
+        ProductDTO dto = new ProductDTO();
+        dto.hasAttribute(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testRemoveAttributeWithNullAttribute() {
+        ProductDTO dto = new ProductDTO();
+        dto.removeAttribute(null);
+    }
+}

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/ProductTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/ProductTranslatorTest.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) 2009 - 2018 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.dto.manifest.v1;
+
+import org.candlepin.dto.AbstractTranslatorTest;
+import org.candlepin.dto.ModelTranslator;
+import org.candlepin.model.Content;
+import org.candlepin.model.Product;
+import org.candlepin.model.ProductContent;
+import org.candlepin.test.TestUtil;
+
+import static org.junit.Assert.*;
+
+import junitparams.JUnitParamsRunner;
+
+import org.junit.runner.RunWith;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Map;
+
+
+
+/**
+ * Test suite for the ProductTranslator (manifest import/export) class
+ */
+@RunWith(JUnitParamsRunner.class)
+public class ProductTranslatorTest extends
+    AbstractTranslatorTest<Product, ProductDTO, ProductTranslator> {
+
+    protected ContentTranslator contentTranslator = new ContentTranslator();
+    protected ProductTranslator productTranslator = new ProductTranslator();
+
+    protected ContentTranslatorTest contentTranslatorTest = new ContentTranslatorTest();
+
+    @Override
+    protected void initModelTranslator(ModelTranslator modelTranslator) {
+        modelTranslator.registerTranslator(this.contentTranslator, Content.class, ContentDTO.class);
+        modelTranslator.registerTranslator(this.productTranslator, Product.class, ProductDTO.class);
+    }
+
+    @Override
+    protected ProductTranslator initObjectTranslator() {
+        return this.productTranslator;
+    }
+
+    @Override
+    protected Product initSourceObject() {
+        Product source = new Product();
+
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put("attrib_1", "attrib_value_1");
+        attributes.put("attrib_2", "attrib_value_2");
+        attributes.put("attrib_3", "attrib_value_3");
+
+        Collection<String> depProdIds = new LinkedList<>();
+        depProdIds.add("dep_prod_1");
+        depProdIds.add("dep_prod_2");
+        depProdIds.add("dep_prod_3");
+
+        source.setId("test_id");
+        source.setName("test_name");
+        source.setAttributes(attributes);
+        source.setDependentProductIds(depProdIds);
+        source.setUuid("test_uuid");
+        source.setMultiplier(3L);
+
+        for (int i = 0; i < 3; ++i) {
+            Content content = TestUtil.createContent("content-" + i);
+            source.addContent(content, true);
+        }
+
+        return source;
+    }
+
+    @Override
+    protected ProductDTO initDestinationObject() {
+        // Nothing fancy to do here.
+        return new ProductDTO();
+    }
+
+    @Override
+    protected void verifyOutput(Product source, ProductDTO dto, boolean childrenGenerated) {
+        if (source != null) {
+            assertEquals(source.getUuid(), dto.getUuid());
+            assertEquals(source.getMultiplier(), dto.getMultiplier());
+            assertEquals(source.getId(), dto.getId());
+            assertEquals(source.getName(), dto.getName());
+            assertEquals(source.getAttributes(), dto.getAttributes());
+            assertEquals(source.getDependentProductIds(), dto.getDependentProductIds());
+
+            assertNotNull(dto.getProductContent());
+
+            if (childrenGenerated) {
+                for (ProductContent pc : source.getProductContent()) {
+                    for (ProductDTO.ProductContentDTO pcdto : dto.getProductContent()) {
+                        Content content = pc.getContent();
+                        ContentDTO cdto = pcdto.getContent();
+
+                        assertNotNull(cdto);
+                        assertNotNull(cdto.getId());
+
+                        if (cdto.getId().equals(content.getId())) {
+                            assertEquals(pc.isEnabled(), pcdto.isEnabled());
+
+                            // Pass the content off to the ContentTranslatorTest to verify it
+                            this.contentTranslatorTest.verifyOutput(content, cdto, true);
+                        }
+                    }
+                }
+            }
+            else {
+                assertTrue(dto.getProductContent().isEmpty());
+            }
+        }
+        else {
+            assertNull(dto);
+        }
+    }
+}


### PR DESCRIPTION
- ContentDTO was also added as a dependent of ProductDTO.
- Import and export endpoints do NOT use ProductDTO yet (this will be addressed in another task).
- Added comments with lists of fields we no longer export on ProductDTO, EntitlementDTO, ConsumerDTO and their nested DTOs.