### PR TITLE
Custom UserType for job result data

### DIFF
--- a/common/src/main/java/org/candlepin/common/filter/LoggingFilter.java
+++ b/common/src/main/java/org/candlepin/common/filter/LoggingFilter.java
@@ -60,6 +60,7 @@ public class LoggingFilter implements Filter {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public void doFilter(ServletRequest request, ServletResponse response,
         FilterChain chain) throws IOException, ServletException {
 

--- a/common/src/test/java/org/candlepin/common/jackson/DynamicPropertyFilterTest.java
+++ b/common/src/test/java/org/candlepin/common/jackson/DynamicPropertyFilterTest.java
@@ -66,6 +66,7 @@ public class DynamicPropertyFilterTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void nonEmptyIsSerializable() {
         //Implicitly return true
         when(dynamicFilterData.isAttributeExcluded(anyList()))

--- a/server/src/main/java/org/candlepin/hibernate/ResultDataUserType.java
+++ b/server/src/main/java/org/candlepin/hibernate/ResultDataUserType.java
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) 2009 - 2018 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.hibernate;
+
+import org.hibernate.HibernateException;
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.type.StandardBasicTypes;
+import org.hibernate.usertype.UserType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.Objects;
+
+/**
+ * ResultDataUserType handles writing objects that are job results to the resultData column in cp_job.
+ * Initially Candlepin stored serialized Java objects into this column, but later revisions stored JSON
+ * instead.  This class takes care of reading in the data irrespective of the storage format.
+ */
+public class ResultDataUserType implements UserType {
+    private static final Logger log = LoggerFactory.getLogger(ResultDataUserType.class);
+
+    @Override
+    public int[] sqlTypes() {
+        return new int[] { Types.VARBINARY };
+    }
+
+    @Override
+    public Class returnedClass() {
+        return Object.class;
+    }
+
+    @Override
+    public boolean equals(Object x, Object y) throws HibernateException {
+        return Objects.equals(x, y);
+    }
+
+    @Override
+    public int hashCode(Object x) throws HibernateException {
+        return Objects.hashCode(x);
+    }
+
+    @Override
+    public Object nullSafeGet(ResultSet rs, String[] names, SessionImplementor session, Object owner)
+        throws HibernateException, SQLException {
+        byte[] data = StandardBasicTypes.BINARY.nullSafeGet(rs, names[0], session);
+        return deserialize(data);
+    }
+
+    @Override
+    public void nullSafeSet(PreparedStatement st, Object value, int index, SessionImplementor session)
+        throws HibernateException, SQLException {
+        StandardBasicTypes.BINARY.nullSafeSet(st, serialize(value), index, session);
+    }
+
+    private byte[] serialize(Object value) {
+        byte[] data;
+        if (value == null) {
+            data = null;
+        }
+        else {
+            try (
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                ObjectOutputStream oos = new ObjectOutputStream(baos);
+            ) {
+                oos.writeObject(value);
+                data = baos.toByteArray();
+            }
+            catch (IOException ioe) {
+                throw new RuntimeException(ioe);
+            }
+        }
+        return data;
+    }
+
+    private Object deserialize(byte[] data) {
+        if (data == null) {
+            return null;
+        }
+        else {
+            Object result;
+
+            try (
+                ByteArrayInputStream bais = new ByteArrayInputStream(data);
+                ObjectInputStream ois = new ObjectInputStream(bais);
+            ) {
+                result = ois.readObject();
+            }
+            catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+            return result;
+        }
+    }
+
+    @Override
+    public Object deepCopy(Object value) throws HibernateException {
+        // We serialize and then deserialize the object.  This is slow but we know nothing about the object
+        // type.  Hibernate actually does something similar for mutable objects in its internal types.
+        return deserialize(serialize(value));
+    }
+
+    @Override
+    public boolean isMutable() {
+        return true;
+    }
+
+    @Override
+    public Serializable disassemble(Object value) throws HibernateException {
+        return (byte[]) deepCopy(value);
+    }
+
+    @Override
+    public Object assemble(Serializable cached, Object owner) throws HibernateException {
+        return deepCopy(cached);
+    }
+
+    @Override
+    public Object replace(Object original, Object target, Object owner) throws HibernateException {
+        return deepCopy(original);
+    }
+}

--- a/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
+++ b/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
@@ -978,6 +978,7 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
      * @return
      *  A locked entity instance, or null if a matching entity could not be found
      */
+    @SuppressWarnings("unchecked")
     protected E lockAndLoadById(Class<E> entityClass, Serializable id) {
         EntityManager entityManager = this.getEntityManager();
         SessionImpl session = (SessionImpl) this.currentSession();

--- a/server/src/main/java/org/candlepin/model/ImportRecord.java
+++ b/server/src/main/java/org/candlepin/model/ImportRecord.java
@@ -88,7 +88,7 @@ public class ImportRecord extends AbstractHibernateObject {
     private ImportUpstreamConsumer upstreamConsumer;
 
     @SuppressWarnings("unused")
-    private ImportRecord() {
+    protected ImportRecord() {
         // JPA
     }
 

--- a/server/src/main/java/org/candlepin/model/ImportRecord.java
+++ b/server/src/main/java/org/candlepin/model/ImportRecord.java
@@ -162,4 +162,8 @@ public class ImportRecord extends AbstractHibernateObject {
         this.upstreamConsumer = upstreamConsumer;
     }
 
+    @Override
+    public String toString() {
+        return "ImportRecord (owner=" + owner + ", status=" + status + ")";
+    }
 }

--- a/server/src/main/java/org/candlepin/model/dto/PoolIdAndErrors.java
+++ b/server/src/main/java/org/candlepin/model/dto/PoolIdAndErrors.java
@@ -53,4 +53,8 @@ public class PoolIdAndErrors implements Serializable {
         this.errors = errors;
     }
 
+    @Override
+    public String toString() {
+        return "Pool " + poolId + " had " + errors.size() + " errors";
+    }
 }

--- a/server/src/main/java/org/candlepin/model/dto/PoolIdAndQuantity.java
+++ b/server/src/main/java/org/candlepin/model/dto/PoolIdAndQuantity.java
@@ -54,4 +54,9 @@ public class PoolIdAndQuantity implements Serializable {
     public void addQuantity(Integer quantity) {
         this.quantity += quantity;
     }
+
+    @Override
+    public String toString() {
+        return "Pool " + poolId + " with quantity " + quantity;
+    }
 }

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/RefreshPoolsForProductJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/RefreshPoolsForProductJob.java
@@ -19,7 +19,6 @@ import static org.quartz.JobBuilder.*;
 import org.candlepin.common.filter.LoggingFilter;
 import org.candlepin.controller.PoolManager;
 import org.candlepin.controller.Refresher;
-import org.candlepin.model.OwnerProductCurator;
 import org.candlepin.model.Product;
 import org.candlepin.model.ProductCurator;
 import org.candlepin.pinsetter.core.model.JobStatus;
@@ -42,7 +41,6 @@ import org.quartz.JobExecutionException;
  */
 public class RefreshPoolsForProductJob extends KingpinJob {
 
-    private OwnerProductCurator ownerProductCurator;
     private PoolManager poolManager;
     private ProductCurator productCurator;
     private SubscriptionServiceAdapter subAdapter;
@@ -51,10 +49,8 @@ public class RefreshPoolsForProductJob extends KingpinJob {
     public static final String LAZY_REGEN = "lazy_regen";
 
     @Inject
-    public RefreshPoolsForProductJob(OwnerProductCurator ownerProductCurator, ProductCurator productCurator,
-        PoolManager poolManager, SubscriptionServiceAdapter subAdapter, OwnerServiceAdapter ownerAdapter) {
-
-        this.ownerProductCurator = ownerProductCurator;
+    public RefreshPoolsForProductJob(ProductCurator productCurator, PoolManager poolManager,
+        SubscriptionServiceAdapter subAdapter, OwnerServiceAdapter ownerAdapter) {
         this.poolManager = poolManager;
         this.productCurator = productCurator;
         this.subAdapter = subAdapter;

--- a/server/src/main/java/org/candlepin/sync/ExportResult.java
+++ b/server/src/main/java/org/candlepin/sync/ExportResult.java
@@ -50,4 +50,8 @@ public class ExportResult implements Serializable {
         return this.href;
     }
 
+    @Override
+    public String toString() {
+        return "Export for consumer " + exportedConsumer;
+    }
 }


### PR DESCRIPTION
This PR is the first half of the effort to stop storing serialized objects in cp_job's resultData column.  The idea is that once this is merged we can modify the ResultDataUserType so that it can load either serialized objects (for legacy records) **or** UTF8 JSON stored in the column as bytes.  Storing the JSON in a `bytea` column seems a little hacky but it's backwards compatible and won't require a DB migration.  The DB migration would be tricky since migrating it will require writing a custom task in Java that deserializes the data from the column, re-serializes the data as JSON, and then writes it to the column of type `text`.

I'm filing this partly to avoid bit-rot while I'm working on something else this week and also to get opinions on whether this solution is acceptable to the team.