### PR TITLE
Add SubjectKeyIdentifierWriter extension point back into Candlepin.

### DIFF
--- a/server/src/main/java/org/candlepin/guice/DefaultConfig.java
+++ b/server/src/main/java/org/candlepin/guice/DefaultConfig.java
@@ -14,6 +14,8 @@
  */
 package org.candlepin.guice;
 
+import org.candlepin.pki.SubjectKeyIdentifierWriter;
+import org.candlepin.pki.impl.DefaultSubjectKeyIdentifierWriter;
 import org.candlepin.service.ContentAccessCertServiceAdapter;
 import org.candlepin.service.EntitlementCertServiceAdapter;
 import org.candlepin.service.ExportExtensionAdapter;
@@ -47,6 +49,7 @@ class DefaultConfig extends AbstractModule {
         bind(HttpServletDispatcher.class).asEagerSingleton();
         bind(ScriptEngineProvider.class);
         bind(OwnerServiceAdapter.class).to(DefaultOwnerServiceAdapter.class);
+        bind(SubjectKeyIdentifierWriter.class).to(DefaultSubjectKeyIdentifierWriter.class);
         bind(IdentityCertServiceAdapter.class).to(DefaultIdentityCertServiceAdapter.class);
         bind(EntitlementCertServiceAdapter.class).to(DefaultEntitlementCertServiceAdapter.class);
         bind(ContentAccessCertServiceAdapter.class).to(DefaultContentAccessCertServiceAdapter.class);

--- a/server/src/main/java/org/candlepin/pki/PKIUtility.java
+++ b/server/src/main/java/org/candlepin/pki/PKIUtility.java
@@ -59,10 +59,12 @@ public abstract class PKIUtility {
     public static final String SIGNATURE_ALGO = "SHA256WithRSA";
 
     protected PKIReader reader;
+    protected SubjectKeyIdentifierWriter subjectKeyWriter;
     protected Configuration config;
 
-    public PKIUtility(PKIReader reader, Configuration config) {
+    public PKIUtility(PKIReader reader, SubjectKeyIdentifierWriter subjectKeyWriter, Configuration config) {
         this.reader = reader;
+        this.subjectKeyWriter = subjectKeyWriter;
         this.config = config;
     }
 

--- a/server/src/main/java/org/candlepin/pki/SubjectKeyIdentifierWriter.java
+++ b/server/src/main/java/org/candlepin/pki/SubjectKeyIdentifierWriter.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2009 - 2018 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.pki;
+
+import java.io.IOException;
+import java.security.KeyPair;
+import java.security.NoSuchAlgorithmException;
+import java.util.Set;
+
+/**
+ * SubjectKeyIdentifierWriter is an interface to write the SubjectKeyIdentifier extension to a certificate.
+ * The default implementation generates the SubjectKeyIdentifier extension normally.  Hosted Candlepin
+ * environments can have different requirements for the SubjectKeyIdentifier, however.  For example, if a
+ * certificate size is too large, certain content delivery providers may only send the SubjectKeyIdentifier
+ * extension so it may be necessary to hijack the extension as an alternative communications channel.
+ */
+public interface SubjectKeyIdentifierWriter {
+    /**
+     * This method returns the SubjectKeyIdentifier extension that will be written into a certificate.
+     *
+     * @param clientKeyPair
+     * @param extensions
+     * @return DER encoded subject key identifier as a byte array
+     * @throws IOException thrown if error reading cert
+     * @throws NoSuchAlgorithmException thrown if JcaX509ExtensionUtils can't be created
+     */
+    byte[] getSubjectKeyIdentifier(KeyPair clientKeyPair, Set<X509ExtensionWrapper> extensions)
+        throws IOException, NoSuchAlgorithmException;
+}

--- a/server/src/main/java/org/candlepin/pki/impl/DefaultSubjectKeyIdentifierWriter.java
+++ b/server/src/main/java/org/candlepin/pki/impl/DefaultSubjectKeyIdentifierWriter.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2009 - 2018 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.pki.impl;
+
+import org.candlepin.pki.SubjectKeyIdentifierWriter;
+import org.candlepin.pki.X509ExtensionWrapper;
+
+import org.bouncycastle.cert.jcajce.JcaX509ExtensionUtils;
+
+import java.io.IOException;
+import java.security.KeyPair;
+import java.security.NoSuchAlgorithmException;
+import java.util.Set;
+
+/**
+ * Default implementation of SubjectKeyIdentifierWriter.  This implementation is exactly what you might
+ * expect but hosted candlepin instances have use cases that require custom SubjectKeyIdentifiers so they may
+ * write and bind other implementations of the SubjectKeyIdentifierWriter interface.
+ */
+public class DefaultSubjectKeyIdentifierWriter implements SubjectKeyIdentifierWriter {
+
+    @Override
+    public byte[] getSubjectKeyIdentifier(KeyPair clientKeyPair, Set<X509ExtensionWrapper> extensions)
+        throws IOException, NoSuchAlgorithmException {
+        return new JcaX509ExtensionUtils().createSubjectKeyIdentifier(clientKeyPair.getPublic()).getEncoded();
+    }
+}

--- a/server/src/test/java/org/candlepin/TestingModules.java
+++ b/server/src/test/java/org/candlepin/TestingModules.java
@@ -53,7 +53,9 @@ import org.candlepin.pinsetter.core.PinsetterTriggerListener;
 import org.candlepin.pinsetter.tasks.CertificateRevocationListTask;
 import org.candlepin.pki.PKIReader;
 import org.candlepin.pki.PKIUtility;
+import org.candlepin.pki.SubjectKeyIdentifierWriter;
 import org.candlepin.pki.impl.BouncyCastlePKIUtility;
+import org.candlepin.pki.impl.DefaultSubjectKeyIdentifierWriter;
 import org.candlepin.policy.criteria.CriteriaRules;
 import org.candlepin.policy.js.JsRunner;
 import org.candlepin.policy.js.JsRunnerProvider;
@@ -279,6 +281,7 @@ public class TestingModules {
             bind(ProductResource.class);
             bind(DateSource.class).to(DateSourceForTesting.class).asEagerSingleton();
             bind(Enforcer.class).to(EnforcerForTesting.class); // .to(JavascriptEnforcer.class);
+            bind(SubjectKeyIdentifierWriter.class).to(DefaultSubjectKeyIdentifierWriter.class);
             bind(PKIUtility.class).to(BouncyCastlePKIUtility.class);
             bind(PKIReader.class).to(PKIReaderForTesting.class).asEagerSingleton();
             bind(SubscriptionServiceAdapter.class).to(ImportSubscriptionServiceAdapter.class);

--- a/server/src/test/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapterTest.java
+++ b/server/src/test/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapterTest.java
@@ -1643,7 +1643,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
 
     @Test
     public void testDetachedEntitlementDataNotAddedToCertV1() throws Exception {
-        KeyPair keyPair = new BouncyCastlePKIUtility(null, null).generateNewKeyPair();
+        KeyPair keyPair = new BouncyCastlePKIUtility(null, null, null).generateNewKeyPair();
         when(keyPairCurator.getConsumerKeyPair(any(Consumer.class))).thenReturn(keyPair);
 
         when(mockedPKI.getPemEncoded(any(X509Certificate.class))).thenReturn("".getBytes());

--- a/server/src/test/java/org/candlepin/sync/ImporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/ImporterTest.java
@@ -715,7 +715,7 @@ public class ImporterTest {
 
     @Test
     public void importConsumer() throws Exception {
-        PKIUtility pki = new BouncyCastlePKIUtility(null, null);
+        PKIUtility pki = new BouncyCastlePKIUtility(null, null, null);
 
         OwnerCurator oc = mock(OwnerCurator.class);
         ConsumerType type = new ConsumerType(ConsumerTypeEnum.CANDLEPIN);


### PR DESCRIPTION
Hosted-mode Candlepin instances can have special requirements around the
SubjectKeyIdentifier extension written into certificates.  This
extension point was removed in the process of upgrading to a newer
release of BouncyCastle.