### PR TITLE
1546236: Properly handle connections when they are recreated

### DIFF
--- a/server/src/main/java/org/candlepin/audit/QpidConnection.java
+++ b/server/src/main/java/org/candlepin/audit/QpidConnection.java
@@ -18,10 +18,7 @@ package org.candlepin.audit;
 import org.candlepin.audit.Event.Target;
 import org.candlepin.audit.Event.Type;
 import org.candlepin.common.config.Configuration;
-import org.candlepin.config.ConfigProperties;
-import org.candlepin.controller.ModeManager;
-import org.candlepin.controller.SuspendModeTransitioner;
-import org.candlepin.model.CandlepinModeChange.Mode;
+import org.candlepin.controller.QpidStatusListener;
 import org.candlepin.util.Util;
 
 import com.google.inject.Inject;
@@ -54,7 +51,8 @@ import javax.naming.NamingException;
  * @author fnguyen
  *
  */
-public class QpidConnection {
+public class QpidConnection implements QpidStatusListener {
+
     /**
      * This connection factory is created only once upon startup,
      * it is configured using many options that we also allow user
@@ -82,10 +80,8 @@ public class QpidConnection {
     private Map<Target, Map<Type, TopicPublisher>> producerMap;
     private static Logger log = LoggerFactory.getLogger(QpidConnection.class);
     private InitialContext ctx = null;
-    private STATUS connectionStatus = STATUS.JMS_OBJECTS_STALE;
+    private boolean isFlowStopped = false;
     private QpidConfigBuilder config;
-    private SuspendModeTransitioner modeTransitioner;
-    private ModeManager modeManager;
     private Configuration candlepinConfig;
 
     /**
@@ -94,32 +90,10 @@ public class QpidConnection {
      */
     private static Object connectionLock = new Object();
 
-    /**
-     * Status of the connection as Candlepin sees it
-     * @author fnguyen
-     *
-     */
-    public enum STATUS {
-        CONNECTED,
-        /**
-         * Represents situation when connection to Qpid was disrupted.
-         * JMS objects becomes stale and need to be recreated as per
-         * JMS specification
-         */
-        JMS_OBJECTS_STALE
-    }
-
-    public void setConnectionStatus(STATUS connectionStatus) {
-        this.connectionStatus = connectionStatus;
-    }
-
     @Inject
-    public QpidConnection(QpidConfigBuilder config, SuspendModeTransitioner modeTransitioner,
-        ModeManager modeManager, Configuration candlepinConfiguration) {
+    public QpidConnection(QpidConfigBuilder config, Configuration candlepinConfiguration) {
         try {
             this.config = config;
-            this.modeTransitioner = modeTransitioner;
-            this.modeManager = modeManager;
             this.candlepinConfig = candlepinConfiguration;
             ctx = new InitialContext(config.buildConfigurationProperties());
             connectionFactory = createConnectionFactory();
@@ -141,17 +115,19 @@ public class QpidConnection {
      * @throws Exception
      */
     public void sendTextMessage(Target target, Type type, String msg) {
-        try {
-            /**
-             * When Candlepin is in NORMAL mode and at the same time the
-             * JMS objects are stale, it is necessary to recreate them.
-             */
-            if (connectionStatus == STATUS.JMS_OBJECTS_STALE &&
-                modeManager.getLastCandlepinModeChange().getMode() == Mode.NORMAL) {
-                log.debug("Recreating the stale JMS objects");
-                connect();
-            }
+        // Don't bother to try and send the message if we know the connection
+        // became unavailable or if the queue is FLOW_STOPPED. Throw and exception
+        // and let HornetQ attempt to resend it later.
+        if (connection == null) {
+            throw new RuntimeException("Message not sent: No connection to Qpid.");
+        }
 
+        if (this.isFlowStopped) {
+            throw new RuntimeException("Message not sent: Qpid queue is FLOW_STOPPED.");
+        }
+
+        try {
+            log.debug("Sending message to Qpid - {}:{}", target, type);
             Map<Type, TopicPublisher> m = this.producerMap.get(target);
             if (m != null) {
                 TopicPublisher tp = m.get(type);
@@ -159,14 +135,7 @@ public class QpidConnection {
             }
         }
         catch (Exception ex) {
-            log.error("Error sending text message");
-            connectionStatus = STATUS.JMS_OBJECTS_STALE;
-            if (candlepinConfig
-                .getBoolean(ConfigProperties.SUSPEND_MODE_ENABLED)) {
-                modeTransitioner.transitionAppropriately();
-            }
-
-            throw new RuntimeException("Error sending event to message bus", ex);
+            throw new RuntimeException("Error sending event to Qpid message bus", ex);
         }
     }
 
@@ -184,7 +153,6 @@ public class QpidConnection {
             Map<Target, Map<Type, TopicPublisher>> pm = new HashMap<>();
             buildAllTopicPublishers(pm);
             producerMap = pm;
-            connectionStatus = STATUS.CONNECTED;
         }
 
     }
@@ -206,8 +174,12 @@ public class QpidConnection {
      * Closes off all the resources held
      */
     public void close() {
-        connectionStatus = STATUS.JMS_OBJECTS_STALE;
+        closeConnection();
+        Util.closeSafely(this.ctx, "AMQPContext");
+        Util.closeSafely(this.connectionFactory, "AMQPConnection");
+    }
 
+    private void closeConnection() {
         for (Entry<Target, Map<Type, TopicPublisher>> entry : this.producerMap.entrySet()) {
             for (Entry<Type, TopicPublisher> tpMap : entry.getValue().entrySet()) {
                 Util.closeSafely(tpMap.getValue(),
@@ -216,8 +188,7 @@ public class QpidConnection {
         }
         Util.closeSafely(this.session, "AMQPSession");
         Util.closeSafely(this.connection, "AMQPConnection");
-        Util.closeSafely(this.ctx, "AMQPContext");
-        Util.closeSafely(this.connectionFactory, "AMQPConnection");
+        this.connection = null;
     }
 
     private AMQConnectionFactory createConnectionFactory()
@@ -248,7 +219,6 @@ public class QpidConnection {
         return connectionFactory;
     }
 
-
     /**
      * Creates new topic session on this connection. It is important to understand that when
      * Connection to Qpid fails, we need to reestablish all the JMS objects, as per JMS
@@ -269,6 +239,40 @@ public class QpidConnection {
      */
     public Topic lookupTopic(String name) throws NamingException {
         return (Topic) ctx.lookup(name);
+    }
+
+    /**
+     * Called each time the QpidStatusMonitor checks for a Qpid status update,
+     * and based on this change, updates the connection.
+     *
+     * @param oldStatus the status of Qpid on the previous update.
+     * @param newStatus the current status of Qpid.
+     */
+    @Override
+    public void onStatusUpdate(QpidStatus oldStatus, QpidStatus newStatus) {
+        if (QpidStatus.CONNECTED.equals(newStatus) && !QpidStatus.CONNECTED.equals(oldStatus)) {
+            // When the status changes to CONNECTED, rebuild the connection to QPID. Since the connection
+            // went down, the JMS objects are stale, it is necessary to recreate them.
+            log.info("Attempting to connect to QPID");
+            try {
+                connect();
+            }
+            catch (Exception e) {
+                throw new RuntimeException("Unable to connect to Qpid.", e);
+            }
+        }
+        else if (QpidStatus.DOWN.equals(newStatus) && !QpidStatus.DOWN.equals(oldStatus)) {
+            // If the connection changes to DOWN, close the existing connection to
+            // ensure that we don't leave a stale one open.
+            log.debug("Connection to Qpid was lost. Closing current connection.");
+            closeConnection();
+        }
+
+        // Qpid queue is in flow_stopped and will not accept any new messages
+        // until it catches up. Set the state so that we can use it to prevent
+        // sending messages until the state goes back to connected.
+        this.isFlowStopped = QpidStatus.FLOW_STOPPED.equals(newStatus);
+        log.debug("Qpid is flow stopped: {}", this.isFlowStopped);
     }
 
     /**

--- a/server/src/main/java/org/candlepin/audit/QpidQmf.java
+++ b/server/src/main/java/org/candlepin/audit/QpidQmf.java
@@ -56,26 +56,6 @@ public class QpidQmf {
     private String lastFlowStoppedQueue = "";
     private Configuration config;
 
-    /**
-     * Status of the connection to Qpid Broker
-     * @author fnguyen
-     */
-    public enum QpidStatus {
-        /**
-         * Qpid is up and running
-         */
-        CONNECTED,
-
-        /**
-         * Qpid is up but the exchange is flow stopped
-         */
-        FLOW_STOPPED,
-        /**
-         * Qpid is down
-         */
-        DOWN
-    }
-
     @Inject
     public QpidQmf(QpidConnection qpidConnection, Configuration config) throws URISyntaxException {
         this.qpidConnection = qpidConnection;

--- a/server/src/main/java/org/candlepin/audit/QpidStatus.java
+++ b/server/src/main/java/org/candlepin/audit/QpidStatus.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2009 - 2018 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package org.candlepin.audit;
+
+/**
+ * Represents the status of the connection to the Qpid broker.
+ */
+public enum QpidStatus {
+    /**
+     * Qpid is up and running.
+     */
+    CONNECTED,
+
+    /**
+     * Qpid is up but the exchange is flow stopped.
+     */
+    FLOW_STOPPED,
+    /**
+     * Qpid is down.
+     */
+    DOWN
+}

--- a/server/src/main/java/org/candlepin/controller/QpidStatusListener.java
+++ b/server/src/main/java/org/candlepin/controller/QpidStatusListener.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2009 - 2018 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package org.candlepin.controller;
+
+import org.candlepin.audit.QpidStatus;
+
+/**
+ * An interface for objects that would like to listen for Qpid status updates.
+ */
+public interface QpidStatusListener {
+
+    /**
+     * Called when QpidStatusMonitor determines the latest Qpid status.
+     *
+     * @param oldStatus the status of Qpid on the previous update.
+     * @param newStatus the current status of Qpid.
+     */
+    void onStatusUpdate(QpidStatus oldStatus, QpidStatus newStatus);
+}

--- a/server/src/main/java/org/candlepin/controller/QpidStatusMonitor.java
+++ b/server/src/main/java/org/candlepin/controller/QpidStatusMonitor.java
@@ -1,0 +1,153 @@
+/**
+ * Copyright (c) 2009 - 2018 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package org.candlepin.controller;
+
+import com.google.inject.Inject;
+import org.candlepin.audit.QpidConnection;
+import org.candlepin.audit.QpidQmf;
+import org.candlepin.audit.QpidStatus;
+import org.candlepin.common.config.Configuration;
+import org.candlepin.config.ConfigProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ *  A process that checks the current state of Qpid and notifies any listeners
+ *  when the Qpid state has changed.
+ */
+public class QpidStatusMonitor implements Runnable {
+
+    private static Logger log = LoggerFactory.getLogger(QpidStatusMonitor.class);
+
+    private Configuration config;
+    private ScheduledExecutorService executorService;
+    private QpidConnection qpidConnection;
+    private QpidQmf qmf;
+    private List<QpidStatusListener> listeners;
+    private QpidStatus lastStatus;
+    private int delay;
+
+    @Inject
+    public QpidStatusMonitor(Configuration config, ScheduledExecutorService execService) {
+        this.config = config;
+        this.executorService = execService;
+        this.listeners = new LinkedList<QpidStatusListener>();
+
+        delay = config.getInt(ConfigProperties.QPID_MODE_TRANSITIONER_DELAY);
+        if (delay < 1) {
+            int defaultDelay = Integer.parseInt(
+                ConfigProperties.DEFAULT_PROPERTIES.get(ConfigProperties.QPID_MODE_TRANSITIONER_DELAY));
+            log.warn("{} is an invalid delay setting. Must be greater than 0. Defaulting to {}", delay,
+                defaultDelay);
+            delay = defaultDelay;
+        }
+        this.lastStatus = QpidStatus.DOWN;
+    }
+
+    /**
+     * Other dependencies are injected using method injection so
+     * that Guice can handle circular dependencies
+     */
+    @Inject
+    public void setQmf(QpidQmf qmf) {
+        this.qmf = qmf;
+    }
+
+    @Inject
+    public void setQpidConnection(QpidConnection qpidConnection) {
+        this.qpidConnection = qpidConnection;
+    }
+
+    /**
+     * Executes a single monitoring check.
+     */
+    @Override
+    public void run() {
+        try {
+            log.debug("Executing Qpid status check...");
+            monitor();
+        }
+        finally {
+            log.debug("Next check will be in {} seconds.", delay);
+        }
+    }
+
+    /**
+     * Adds a listener that will be notified when the connection status changes.
+     *
+     * @param listener the listener to be added.
+     */
+    public void addStatusChangeListener(QpidStatusListener listener) {
+        this.listeners.add(listener);
+    }
+
+    /**
+     * Starts/schedules the connection monitoring process. The check will be run at a configured
+     * interval.
+     *
+     * @see ConfigProperties
+     */
+    public void schedule() {
+        log.info("Starting Qpid Status Monitor. Checks will be performed every {} seconds.", delay);
+        executorService.scheduleWithFixedDelay(this, 10, delay, TimeUnit.SECONDS);
+    }
+
+    /**
+     * Monitors the Qpid connection and notifies all listeners when the connection status changes.
+     * If a listener throws an exception, the exception is logged and the next listener is notified
+     * in turn.
+     *
+     * This method should handle all exceptions to ensure that the executor service continues to
+     * schedule the periodic job.
+     */
+    private synchronized void monitor() {
+        QpidStatus status;
+        try {
+            status = qmf.getStatus();
+        }
+        catch (Throwable t) {
+            log.error("Error while executing status monitoring check", t);
+            /*
+             * Nothing more we can do here, since this is scheduled thread. We must
+             * hope that this error won't infinitely recur with each scheduled execution
+             */
+            return;
+        }
+
+        log.debug("Qpid connection status - Old: {} New: {}", this.lastStatus, status);
+        notifyListeners(this.lastStatus, status);
+
+        this.lastStatus = status;
+    }
+
+    private void notifyListeners(QpidStatus oldStatus, QpidStatus newStatus) {
+        for (QpidStatusListener listener : this.listeners) {
+            try {
+                // If a listener throws an exception, log it, and move to the next listener.
+                // We don't want to skip other listeners just because another failed.
+                listener.onStatusUpdate(oldStatus, newStatus);
+            }
+            catch (Exception e) {
+                log.warn("Failed to notify status listener.", e);
+            }
+        }
+    }
+}

--- a/server/src/main/java/org/candlepin/controller/SuspendModeTransitioner.java
+++ b/server/src/main/java/org/candlepin/controller/SuspendModeTransitioner.java
@@ -14,13 +14,8 @@
  */
 package org.candlepin.controller;
 
-import org.candlepin.audit.QpidConnection;
-import org.candlepin.audit.QpidConnection.STATUS;
-import org.candlepin.audit.QpidQmf;
-import org.candlepin.audit.QpidQmf.QpidStatus;
+import org.candlepin.audit.QpidStatus;
 import org.candlepin.cache.CandlepinCache;
-import org.candlepin.common.config.Configuration;
-import org.candlepin.config.ConfigProperties;
 import org.candlepin.model.CandlepinModeChange;
 import org.candlepin.model.CandlepinModeChange.Mode;
 import org.candlepin.model.CandlepinModeChange.Reason;
@@ -30,49 +25,25 @@ import com.google.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.math.BigInteger;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Logic to transition Candlepin between different modes (SUSPEND, NORMAL) based
- * on what is the current status of Qpid Broker.
- *
- * This logic can also be run periodically using startPeriodicExecutions
+ * on what the current status of Qpid Broker. This class is notified of state
+ * changes by listening for events from the QpidStatusMonitor.
  *
  * Using this class, clients can attempt to transition to appropriate mode. The
  * attempt may be no-op if no transition is required.
- * @author fnguyen
  *
  */
-public class SuspendModeTransitioner implements Runnable {
+public class SuspendModeTransitioner implements QpidStatusListener {
     private static Logger log = LoggerFactory.getLogger(SuspendModeTransitioner.class);
 
-    private int delay;
-    private BigInteger failedAttempts = BigInteger.ZERO;
-    /**
-     * Single threaded periodic task.
-     */
-    private ScheduledExecutorService execService;
     private ModeManager modeManager;
-    private QpidQmf qmf;
-    private QpidConnection qpidConnection;
     private CandlepinCache candlepinCache;
 
     @Inject
-    public SuspendModeTransitioner(Configuration config, ScheduledExecutorService execService,
-        CandlepinCache cache) {
-        this.execService = execService;
+    public SuspendModeTransitioner(CandlepinCache cache) {
         this.candlepinCache = cache;
-
-        delay = config.getInt(ConfigProperties.QPID_MODE_TRANSITIONER_DELAY);
-        if (delay < 1) {
-            int defaultDelay = Integer.parseInt(
-                ConfigProperties.DEFAULT_PROPERTIES.get(ConfigProperties.QPID_MODE_TRANSITIONER_DELAY));
-            log.warn("{} is an invalid delay setting. Must be greater than 0. Defaulting to {}", delay,
-                defaultDelay);
-            delay = defaultDelay;
-        }
     }
 
     /**
@@ -85,46 +56,16 @@ public class SuspendModeTransitioner implements Runnable {
         this.modeManager = modeManager;
     }
 
-    @Inject
-    public void setQmf(QpidQmf qmf) {
-        this.qmf = qmf;
-    }
-
-    @Inject
-    public void setQpidConnection(QpidConnection qpidConnection) {
-        this.qpidConnection = qpidConnection;
-    }
-
     /**
-     * Enables to run the transitioning logic periodically.
+     * Called each time the QpidStatusMonitor checks for a Qpid status update,
+     * and based on this change, updates the candlepin mode.
+     *
+     * @param oldStatus the status of Qpid on the previous update.
+     * @param newStatus the current status of Qpid.
      */
-    public void startPeriodicExecutions() {
-        log.info("Starting Suspend Mode Transitioner");
-        schedule();
-    }
-
-    /**
-     * Schedules execution of the Suspend Mode check run every N seconds (where N is
-     * configurable).
-     */
-    private void schedule() {
-        log.debug("Next Transitioner check will run after {} seconds", delay);
-        if (failedAttempts.compareTo(BigInteger.ZERO) > 0) {
-            log.info("SuspendModeTransitioner failed to reconnect to the Qpid Broker " +
-                "{} times. Next attempt in {} seconds", failedAttempts, delay);
-        }
-        execService.schedule(this, delay, TimeUnit.SECONDS);
-    }
-
     @Override
-    public void run() {
-        log.debug("Executing periodic transition attempt");
-        try {
-            transitionAppropriately();
-        }
-        finally {
-            schedule();
-        }
+    public void onStatusUpdate(QpidStatus oldStatus, QpidStatus newStatus) {
+        transitionAppropriately(newStatus);
     }
 
     /**
@@ -139,64 +80,47 @@ public class SuspendModeTransitioner implements Runnable {
      * Qpid up, the transitioner will try to reconnect to the broker. This reconnect
      * may fail. In that case the transition to NORMAL mode shouldn't go through.
      */
-    public synchronized void transitionAppropriately() {
+    private synchronized void transitionAppropriately(QpidStatus status) {
         log.debug("Attempting to transition to appropriate Mode");
-        try {
-            QpidStatus status = qmf.getStatus();
-            CandlepinModeChange modeChange = modeManager.getLastCandlepinModeChange();
+        CandlepinModeChange modeChange = modeManager.getLastCandlepinModeChange();
+        log.debug("Qpid status is {}, the current mode is {}", status, modeChange);
 
-            log.debug("Qpid status is {}, the current mode is {}", status, modeChange);
-
-            if (status != QpidStatus.CONNECTED) {
-                qpidConnection.setConnectionStatus(STATUS.JMS_OBJECTS_STALE);
-            }
-
-            if (modeChange.getMode() == Mode.SUSPEND) {
-                switch (status) {
-                    case CONNECTED:
-                        log.info("Connection to qpid is restored! Reconnecting Qpid and" +
-                            " entering NORMAL mode");
-                        failedAttempts = BigInteger.ZERO;
-                        modeManager.enterMode(Mode.NORMAL, Reason.QPID_UP);
-                        cleanStatusCache();
-                        break;
-                    case FLOW_STOPPED:
-                    case DOWN:
-                        failedAttempts = failedAttempts.add(BigInteger.ONE);
-                        log.debug("Staying in {} mode. So far {} failed attempts", status, failedAttempts);
-                        break;
-                    default:
-                        throw new RuntimeException("Unknown status: " + status);
-                }
-            }
-            else if (modeChange.getMode() == Mode.NORMAL) {
-                switch (status) {
-                    case FLOW_STOPPED:
-                        log.debug("Will need to transition Candlepin into SUSPEND Mode because " +
-                            "the Qpid connection is flow stopped");
-                        modeManager.enterMode(Mode.SUSPEND, Reason.QPID_FLOW_STOPPED);
-                        cleanStatusCache();
-                        break;
-                    case DOWN:
-                        log.debug("Will need to transition Candlepin into SUSPEND Mode because " +
-                            "the Qpid connection is down");
-                        modeManager.enterMode(Mode.SUSPEND, Reason.QPID_DOWN);
-                        cleanStatusCache();
-                        break;
-                    case CONNECTED:
-                        log.debug("Connection to Qpid is ok and current mode is NORMAL. No-op!");
-                        break;
-                    default:
-                        throw new RuntimeException("Unknown status: " + status);
-                }
+        if (modeChange.getMode() == Mode.SUSPEND) {
+            switch (status) {
+                case CONNECTED:
+                    log.info("Connection to qpid is restored! Reconnecting Qpid and" +
+                        " entering NORMAL mode");
+                    modeManager.enterMode(Mode.NORMAL, Reason.QPID_UP);
+                    cleanStatusCache();
+                    break;
+                case FLOW_STOPPED:
+                case DOWN:
+                    log.debug("Staying in {} mode.", status);
+                    break;
+                default:
+                    throw new RuntimeException("Unknown status: " + status);
             }
         }
-        catch (Throwable t) {
-            log.error("Error while executing period Suspend Transitioner check", t);
-            /*
-             * Nothing more we can do here, since this is scheduled thread. We must
-             * hope that this error won't infinitely recur with each scheduled execution
-             */
+        else if (modeChange.getMode() == Mode.NORMAL) {
+            switch (status) {
+                case FLOW_STOPPED:
+                    log.debug("Will need to transition Candlepin into SUSPEND Mode because " +
+                        "the Qpid connection is flow stopped");
+                    modeManager.enterMode(Mode.SUSPEND, Reason.QPID_FLOW_STOPPED);
+                    cleanStatusCache();
+                    break;
+                case DOWN:
+                    log.debug("Will need to transition Candlepin into SUSPEND Mode because " +
+                        "the Qpid connection is down");
+                    modeManager.enterMode(Mode.SUSPEND, Reason.QPID_DOWN);
+                    cleanStatusCache();
+                    break;
+                case CONNECTED:
+                    log.debug("Connection to Qpid is ok and current mode is NORMAL. No-op!");
+                    break;
+                default:
+                    throw new RuntimeException("Unknown status: " + status);
+            }
         }
     }
 
@@ -207,4 +131,5 @@ public class SuspendModeTransitioner implements Runnable {
     private void cleanStatusCache() {
         candlepinCache.getStatusCache().clear();
     }
+
 }

--- a/server/src/test/java/org/candlepin/controller/QpidStatusMonitorTest.java
+++ b/server/src/test/java/org/candlepin/controller/QpidStatusMonitorTest.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2009 - 2016 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package org.candlepin.controller;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import org.candlepin.audit.QpidQmf;
+import org.candlepin.audit.QpidStatus;
+import org.candlepin.common.config.Configuration;
+import org.candlepin.config.ConfigProperties;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+@RunWith(MockitoJUnitRunner.class)
+public class QpidStatusMonitorTest {
+
+    @Mock private QpidStatusListener listener;
+    @Mock private QpidQmf qmf;
+    @Mock private Configuration config;
+    @Mock private ScheduledExecutorService executorService;
+
+    private QpidStatusMonitor monitor;
+    private int configuredDelay = 20;
+
+    @Before
+    public void beforeTest() {
+        assertNotNull(listener);
+        assertNotNull(qmf);
+        when(config.getInt(eq(ConfigProperties.QPID_MODE_TRANSITIONER_DELAY))).thenReturn(configuredDelay);
+
+        monitor = new QpidStatusMonitor(config, executorService);
+        monitor.setQmf(qmf);
+    }
+
+    @Test
+    public void testSchedulingAtConfiguredDelay() {
+        monitor.schedule();
+        verify(executorService, times(1))
+            .scheduleWithFixedDelay(eq(monitor), eq(10L), eq((long) configuredDelay), eq(TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void listenersAreNotified() {
+        when(qmf.getStatus()).thenReturn(QpidStatus.CONNECTED);
+        monitor.addStatusChangeListener(listener);
+        monitor.run();
+        verify(listener, times(1)).onStatusUpdate(any(QpidStatus.class), any(QpidStatus.class));
+    }
+
+    @Test
+    public void verifyStatusChangeValuesWhenTransitioning() {
+        monitor.addStatusChangeListener(listener);
+        when(qmf.getStatus())
+            .thenReturn(QpidStatus.CONNECTED)
+            .thenReturn(QpidStatus.FLOW_STOPPED)
+            .thenReturn(QpidStatus.DOWN);
+
+        monitor.run();
+        verify(listener, times(1)).onStatusUpdate(eq(QpidStatus.DOWN), eq(QpidStatus.CONNECTED));
+
+        monitor.run();
+        verify(listener, times(1)).onStatusUpdate(eq(QpidStatus.CONNECTED), eq(QpidStatus.FLOW_STOPPED));
+
+        monitor.run();
+        verify(listener, times(1)).onStatusUpdate(eq(QpidStatus.FLOW_STOPPED), eq(QpidStatus.DOWN));
+
+        verifyNoMoreInteractions(listener);
+    }
+
+}

--- a/server/src/test/java/org/candlepin/controller/SuspendModeTransitionerTest.java
+++ b/server/src/test/java/org/candlepin/controller/SuspendModeTransitionerTest.java
@@ -16,13 +16,9 @@ package org.candlepin.controller;
 
 import static org.mockito.Mockito.*;
 
-import org.candlepin.audit.QpidConnection;
-import org.candlepin.audit.QpidConnection.STATUS;
-import org.candlepin.audit.QpidQmf;
-import org.candlepin.audit.QpidQmf.QpidStatus;
+import org.candlepin.audit.QpidStatus;
 import org.candlepin.cache.CandlepinCache;
 import org.candlepin.cache.StatusCache;
-import org.candlepin.config.CandlepinCommonTestConfig;
 import org.candlepin.model.CandlepinModeChange;
 import org.candlepin.model.CandlepinModeChange.Mode;
 import org.candlepin.model.CandlepinModeChange.Reason;
@@ -34,16 +30,11 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.Date;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 
 
 @RunWith(MockitoJUnitRunner.class)
 public class SuspendModeTransitionerTest {
     @Mock private ModeManager modeManager;
-    @Mock private QpidQmf qmf;
-    @Mock private QpidConnection qpidConnection;
-    @Mock private ScheduledExecutorService execService;
     @Mock private CandlepinCache candlepinCache;
     @Mock private StatusCache cache;
 
@@ -55,11 +46,8 @@ public class SuspendModeTransitionerTest {
     @Before
     public void setUp() {
         when(candlepinCache.getStatusCache()).thenReturn(cache);
-        CandlepinCommonTestConfig testConfig = new CandlepinCommonTestConfig();
-        transitioner = new SuspendModeTransitioner(testConfig, execService, candlepinCache);
+        transitioner = new SuspendModeTransitioner(candlepinCache);
         transitioner.setModeManager(modeManager);
-        transitioner.setQmf(qmf);
-        transitioner.setQpidConnection(qpidConnection);
         startupModeChange = new CandlepinModeChange(new Date(), Mode.NORMAL, Reason.STARTUP);
         downModeChange = new CandlepinModeChange(new Date(), Mode.SUSPEND, Reason.QPID_DOWN);
         normalModeChange = new CandlepinModeChange(new Date(), Mode.NORMAL, Reason.QPID_UP);
@@ -67,88 +55,57 @@ public class SuspendModeTransitionerTest {
 
     @Test
     public void normalConnected() {
-        when(qmf.getStatus()).thenReturn(QpidStatus.CONNECTED);
         when(modeManager.getLastCandlepinModeChange()).thenReturn(startupModeChange);
 
-        transitioner.transitionAppropriately();
+        transitioner.onStatusUpdate(QpidStatus.DOWN, QpidStatus.CONNECTED);
 
-        verify(qmf, times(1)).getStatus();
         verify(modeManager, times(1)).getLastCandlepinModeChange();
-        verifyNoMoreInteractions(execService, modeManager, qmf);
+        verifyNoMoreInteractions(modeManager);
     }
 
     @Test
     public void stillDisconnected() {
-        when(qmf.getStatus()).thenReturn(QpidStatus.DOWN);
         when(modeManager.getLastCandlepinModeChange()).thenReturn(downModeChange);
 
-        transitioner.transitionAppropriately();
+        transitioner.onStatusUpdate(QpidStatus.CONNECTED, QpidStatus.DOWN);
 
-        verify(qpidConnection, times(1)).setConnectionStatus(STATUS.JMS_OBJECTS_STALE);
-        verify(qmf, times(1)).getStatus();
         verify(modeManager, times(1)).getLastCandlepinModeChange();
-        verifyNoMoreInteractions(execService, qpidConnection, modeManager, qmf);
+        verifyNoMoreInteractions(modeManager);
     }
 
 
     @Test
     public void transitionFromDownToConnected() throws Exception {
-        when(qmf.getStatus()).thenReturn(QpidStatus.CONNECTED);
         when(modeManager.getLastCandlepinModeChange()).thenReturn(downModeChange);
 
-        transitioner.transitionAppropriately();
+        transitioner.onStatusUpdate(QpidStatus.DOWN, QpidStatus.CONNECTED);
 
-        verify(qmf, times(1)).getStatus();
         verify(modeManager, times(1)).getLastCandlepinModeChange();
         verify(modeManager, times(1)).enterMode(Mode.NORMAL, Reason.QPID_UP);
-        verifyNoMoreInteractions(execService, qpidConnection, qmf, modeManager);
+        verifyNoMoreInteractions(modeManager);
     }
 
     @Test
-    public void transitionFromConnectedToDown()
-        throws Exception {
-        when(qmf.getStatus()).thenReturn(QpidStatus.DOWN);
+    public void transitionFromConnectedToDown() throws Exception {
         when(modeManager.getLastCandlepinModeChange()).thenReturn(normalModeChange);
 
-        transitioner.transitionAppropriately();
+        transitioner.onStatusUpdate(QpidStatus.CONNECTED, QpidStatus.DOWN);
 
-        verify(qpidConnection, times(1)).setConnectionStatus(STATUS.JMS_OBJECTS_STALE);
-        verify(qmf, times(1)).getStatus();
         verify(modeManager, times(1)).getLastCandlepinModeChange();
         verify(modeManager, times(1)).enterMode(Mode.SUSPEND, Reason.QPID_DOWN);
-        verifyNoMoreInteractions(execService, qpidConnection, qmf, modeManager);
+        verifyNoMoreInteractions(modeManager);
     }
 
     @Test
     public void transitionFromConnectedToFlowStopped()
         throws Exception {
-        when(qmf.getStatus()).thenReturn(QpidStatus.FLOW_STOPPED);
         when(modeManager.getLastCandlepinModeChange()).thenReturn(normalModeChange);
 
-        transitioner.transitionAppropriately();
+        transitioner.onStatusUpdate(QpidStatus.CONNECTED, QpidStatus.FLOW_STOPPED);
 
-        verify(qpidConnection, times(1)).setConnectionStatus(STATUS.JMS_OBJECTS_STALE);
-        verify(qmf, times(1)).getStatus();
         verify(modeManager, times(1)).getLastCandlepinModeChange();
         verify(modeManager, times(1)).enterMode(Mode.SUSPEND, Reason.QPID_FLOW_STOPPED);
-        verifyNoMoreInteractions(execService, qpidConnection, qmf, modeManager);
+        verifyNoMoreInteractions(modeManager);
     }
 
-    @Test
-    public void constantPolling() throws Exception {
-        when(qmf.getStatus())
-            .thenReturn(QpidStatus.CONNECTED)
-            .thenReturn(QpidStatus.DOWN);
-        when(modeManager.getLastCandlepinModeChange())
-            .thenReturn(downModeChange)
-            .thenReturn(normalModeChange)
-            .thenReturn(downModeChange);
-
-        for (int i = 0; i < 10; i++) {
-            transitioner.run();
-        }
-
-        verify(execService, times(10)).schedule(transitioner, 10, TimeUnit.SECONDS);
-        verifyNoMoreInteractions(execService);
-    }
 }

--- a/server/src/test/java/org/candlepin/guice/CandlepinContextListenerTest.java
+++ b/server/src/test/java/org/candlepin/guice/CandlepinContextListenerTest.java
@@ -22,6 +22,8 @@ import static org.mockito.Mockito.*;
 import org.candlepin.TestingModules;
 import org.candlepin.audit.AMQPBusPublisher;
 import org.candlepin.audit.ActiveMQContextListener;
+import org.candlepin.audit.QpidQmf;
+import org.candlepin.audit.QpidStatus;
 import org.candlepin.common.config.Configuration;
 import org.candlepin.common.config.ConfigurationException;
 import org.candlepin.common.config.ConfigurationPrefixes;
@@ -66,6 +68,7 @@ public class CandlepinContextListenerTest {
     private ServletContextEvent evt;
     private ServletContext ctx;
     private VerifyConfigRead configRead;
+    private QpidQmf qmf;
 
     @SuppressWarnings("checkstyle:visibilitymodifier")
     @ClassRule
@@ -85,6 +88,7 @@ public class CandlepinContextListenerTest {
         buspublisher = mock(AMQPBusPublisher.class);
         executorService = mock(ScheduledExecutorService.class);
         configRead = mock(VerifyConfigRead.class);
+        qmf = mock(QpidQmf.class);
 
         // for testing we override the getModules and readConfiguration methods
         // so we can insert our mock versions of listeners to verify
@@ -224,6 +228,7 @@ public class CandlepinContextListenerTest {
         when(ctx.getAttribute(eq(Registry.class.getName()))).thenReturn(registry);
         when(ctx.getAttribute(eq(ResteasyProviderFactory.class.getName()))).thenReturn(rpfactory);
         when(ctx.getAttribute(eq(CandlepinContextListener.CONFIGURATION_NAME))).thenReturn(config);
+        when(qmf.getStatus()).thenReturn(QpidStatus.CONNECTED);
     }
 
     public class ContextListenerTestModule extends AbstractModule {
@@ -234,6 +239,7 @@ public class CandlepinContextListenerTest {
             bind(ActiveMQContextListener.class).toInstance(hqlistener);
             bind(AMQPBusPublisher.class).toInstance(buspublisher);
             bind(ScheduledExecutorService.class).toInstance(executorService);
+            bind(QpidQmf.class).toInstance(qmf);
         }
     }
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1546236

Whenever the QpidConnection needed to be rebuilt, the existing
connection was being disregarded and a new one created. The old
connections were not getting cleaned up causing candlepin to
exhaust all connections available to Qpid.

This was primarily surfacing when HornetQ would try to resend
failed messages but the Qpid queue was in FLOW_STOPPED. In
this case, QpidConnection would be marked as stale because of the
exception, and would create a new connection to Qpid, leaving
the other around. In the case of FLOW_STOPPED, a new connection
isn't required - we just need to wait for the queue to catch up.

Since the exceptions thrown by Qpid for the various failure
cases, we could never tell exactly when to recreate the connection
or when the connection was Ok.

This patch addresses this PR by monitoring the Qpid status and
only creating new connections when required as well as cleaning
up after itself.

Notes:
- Pulled Qpid connection checking via QMF into an isolated service
  separate from SuspendModeTransitioner.
- Added a listener framework for objects to be notified when the latest
  Qpid status is determined.
- SuspendModeTransitioner now listens for Qpid status updates instead
  of running the checks itself.
- QpidConnection now listens for status updates so that it can better
  manage its connection state (connect, reconnect)
  * When Qpid is FLOW_STOPPPED, block message sending to Qpid until
    it is notified that Qpid is able to accept the message.
  * When notified that Qpid went down, close the old connection so that
    it is no longer hanging around.
  * When notified that Qpid is back up, re-create the connection again.


When deploying the patch, apply the following to the candlepin config to see the logging info:

```
log4j.logger.org.candlepin.controller.QpidStatusMonitor=DEBUG
log4j.logger.org.candlepin.controller.SuspendModeTransitioner=DEBUG
log4j.logger.org.candlepin.audit.QpidConnection=DEBUG
```