### PR TITLE
1365248: Reconcile registered consumers and hypevisors

### DIFF
--- a/server/src/main/java/org/candlepin/pinsetter/tasks/HypervisorUpdateJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/HypervisorUpdateJob.java
@@ -188,7 +188,7 @@ public class HypervisorUpdateJob extends KingpinJob {
      * {@inheritDoc}
      *
      * Executes {@link ConsumerResource#create(org.candlepin.model.Consumer, org.candlepin.auth.Principal,
-     *  java.utl.String, java.utl.String, java.utl.String)}
+     *  java.lang.String, java.lang.String, java.lang.String)}
      * Executes (@link ConusmerResource#performConsumerUpdates(java.utl.String, org.candlepin.model.Consumer)}
      * as a pinsetter job.
      *
@@ -250,8 +250,8 @@ public class HypervisorUpdateJob extends KingpinJob {
                     }
                     else {
                         log.debug("Registering new host consumer for hypervisor ID: {}", hypervisorId);
-                        Consumer newHost = createConsumerForHypervisorId(hypervisorId, owner, principal,
-                            incoming);
+                        Consumer newHost = createConsumerForHypervisorId(hypervisorId, jobReporterId, owner,
+                            principal, incoming);
 
                         // Since we just created this new consumer, we can migrate the guests immediately
                         GuestMigration guestMigration = new GuestMigration(consumerCurator)
@@ -277,13 +277,18 @@ public class HypervisorUpdateJob extends KingpinJob {
                             hypervisorId, ownerKey, knownHost.getHypervisorId().getReporterId(),
                             jobReporterId);
                     }
+                    boolean typeUpdated = false;
+                    if (!hypervisorType.getId().equals(knownHost.getTypeId())) {
+                        typeUpdated = true;
+                        knownHost.setType(hypervisorType);
+                    }
 
                     GuestMigration guestMigration = new GuestMigration(consumerCurator)
                         .buildMigrationManifest(incoming, knownHost);
 
                     boolean factsUpdated = consumerResource.checkForFactsUpdate(knownHost, incoming);
 
-                    if (factsUpdated || guestMigration.isMigrationPending()) {
+                    if (factsUpdated || guestMigration.isMigrationPending() || typeUpdated) {
                         knownHost.setLastCheckin(new Date());
                         guestMigration.migrate(false);
                         result.updated(knownHost);
@@ -400,7 +405,7 @@ public class HypervisorUpdateJob extends KingpinJob {
     /*
      * Create a new hypervisor type consumer to represent the incoming hypervisorId
      */
-    private Consumer createConsumerForHypervisorId(String incHypervisorId,
+    private Consumer createConsumerForHypervisorId(String incHypervisorId, String reporterId,
         Owner owner, Principal principal, Consumer incoming) {
         Consumer consumer = new Consumer();
         if (incoming.getName() != null) {
@@ -432,6 +437,7 @@ public class HypervisorUpdateJob extends KingpinJob {
 
         // Create HypervisorId
         HypervisorId hypervisorId = new HypervisorId(consumer, owner, incHypervisorId);
+        hypervisorId.setReporterId(reporterId);
         consumer.setHypervisorId(hypervisorId);
 
         // TODO: Refactor this to not call resource methods directly

--- a/server/src/main/java/org/candlepin/resource/HypervisorResource.java
+++ b/server/src/main/java/org/candlepin/resource/HypervisorResource.java
@@ -91,7 +91,6 @@ public class HypervisorResource {
     private Provider<GuestMigration> migrationProvider;
     private ModelTranslator translator;
     private GuestIdResource guestIdResource;
-
     private ConsumerType hypervisorType;
 
     @Inject
@@ -99,7 +98,6 @@ public class HypervisorResource {
         ConsumerTypeCurator consumerTypeCurator, I18n i18n, OwnerCurator ownerCurator,
         Provider<GuestMigration> migrationProvider, ModelTranslator translator,
         GuestIdResource guestIdResource) {
-
         this.consumerResource = consumerResource;
         this.consumerCurator = consumerCurator;
         this.consumerTypeCurator = consumerTypeCurator;
@@ -208,6 +206,7 @@ public class HypervisorResource {
                 log.debug("Syncing virt host: {} ({} guest IDs)", hypervisorId, hostEntry.getValue().size());
 
                 boolean hostConsumerCreated = false;
+                boolean updatedType = false;
                 // Attempt to find a consumer for the given hypervisorId
                 Consumer consumer = null;
                 if (hypervisorConsumersMap.get(hypervisorId) == null) {
@@ -223,6 +222,10 @@ public class HypervisorResource {
                 }
                 else {
                     consumer = hypervisorConsumersMap.get(hypervisorId);
+                    if (!hypervisorType.getId().equals(consumer.getTypeId())) {
+                        consumer.setType(hypervisorType);
+                        updatedType = true;
+                    }
                 }
                 List<GuestId> guestIds = new ArrayList<>();
                 guestIdResource.populateEntities(guestIds, hostEntry.getValue());
@@ -235,7 +238,7 @@ public class HypervisorResource {
                 if (hostConsumerCreated) {
                     result.created(consumer);
                 }
-                else if (guestIdsUpdated) {
+                else if (guestIdsUpdated || updatedType) {
                     result.updated(consumer);
                 }
                 else {

--- a/server/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
@@ -146,8 +146,9 @@ public class HypervisorResourceTest {
             this.consumerTypeCurator, this.consumerResource, this.i18n, this.eventFactory, this.sink,
             migrationProvider, modelTranslator);
 
-        hypervisorResource = new HypervisorResource(consumerResource, consumerCurator, consumerTypeCurator,
-            i18n, ownerCurator, migrationProvider, modelTranslator, guestIdResource);
+        this.hypervisorResource = new HypervisorResource(consumerResource,
+            consumerCurator, consumerTypeCurator, i18n, ownerCurator, migrationProvider, modelTranslator,
+            guestIdResource);
 
         // Ensure that we get the consumer that was passed in back from the create call.
         when(consumerCurator.create(any(Consumer.class))).thenAnswer(new Answer<Object>() {
@@ -215,6 +216,7 @@ public class HypervisorResourceTest {
     @Test
     public void hypervisorCheckInCreatesNewConsumer() throws Exception {
         Owner owner = new Owner("admin");
+        owner.setId("test-id");
 
         Map<String, List<GuestIdDTO>> hostGuestMap = new HashMap<>();
         hostGuestMap.put("test-host", new ArrayList(Arrays.asList(new GuestIdDTO("GUEST_A"),
@@ -368,6 +370,7 @@ public class HypervisorResourceTest {
     @Test
     public void ensureEmptyHypervisorIdsAreIgnored() throws Exception {
         Owner owner = new Owner("admin");
+        owner.setId("test-id");
 
         Map<String, List<GuestIdDTO>> hostGuestMap = new HashMap<>();
         hostGuestMap.put("", new ArrayList(Arrays.asList(new GuestIdDTO("GUEST_A"),


### PR DESCRIPTION
Will affect libvirt scenarios
Uses the system_uuid, when available, to match an existing
 consumer to a new hypervisor or an existing hypervisor to a new consumer.
Will work when the system_uuid on the hypervisor is used
 as the submitted hypervisor id.