### PR TITLE
Serialize job results as JSON

### DIFF
--- a/server/src/main/java/org/candlepin/dto/api/v1/JobStatusDTO.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/JobStatusDTO.java
@@ -45,7 +45,6 @@ public class JobStatusDTO extends TimestampedCandlepinDTO<JobStatusDTO> {
     private String ownerId;
     private String correlationId;
 
-    //TODO: this will need to be updated once HypervisorUpdateJob's resultData get simplified.
     private Object resultData;
     private Boolean done;
 

--- a/server/src/main/java/org/candlepin/hibernate/ResultDataUserType.java
+++ b/server/src/main/java/org/candlepin/hibernate/ResultDataUserType.java
@@ -14,9 +14,23 @@
  */
 package org.candlepin.hibernate;
 
+import com.fasterxml.jackson.core.JsonEncoding;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.AnnotationIntrospector;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.introspect.AnnotationIntrospectorPair;
+import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
+import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
+import com.fasterxml.jackson.datatype.hibernate5.Hibernate5Module;
+import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
+
 import org.hibernate.HibernateException;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.type.StandardBasicTypes;
+import org.hibernate.usertype.DynamicParameterizedType;
 import org.hibernate.usertype.UserType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,14 +46,44 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.Objects;
+import java.util.Properties;
 
 /**
  * ResultDataUserType handles writing objects that are job results to the resultData column in cp_job.
  * Initially Candlepin stored serialized Java objects into this column, but later revisions stored JSON
  * instead.  This class takes care of reading in the data irrespective of the storage format.
+ *
+ * It also takes care of casting the data to the correct Java type.  Hibernate provides us with the type of
+ * the annotated field via elements of the DynamicParameterizedType class which we can then use to cast the
+ * object we've read back.  The JobStatus class that uses this UserType ultimately stores the result data
+ * as an Object but at least readers of the data can downcast correctly later if they know what type the
+ * job is storing.
  */
-public class ResultDataUserType implements UserType {
+public class ResultDataUserType implements UserType, DynamicParameterizedType {
     private static final Logger log = LoggerFactory.getLogger(ResultDataUserType.class);
+    public static final String JSON_CLASS = "jsonClass";
+
+    private ObjectMapper mapper;
+    private Class<?> jsonClass;
+
+    public ResultDataUserType() {
+        mapper = new ObjectMapper();
+
+        Hibernate5Module hbm = new Hibernate5Module();
+        hbm.enable(Hibernate5Module.Feature.FORCE_LAZY_LOADING);
+        mapper.registerModule(hbm);
+
+        AnnotationIntrospector primary = new JacksonAnnotationIntrospector();
+        AnnotationIntrospector secondary = new JaxbAnnotationIntrospector(mapper.getTypeFactory());
+        AnnotationIntrospector pair = new AnnotationIntrospectorPair(primary, secondary);
+        mapper.setAnnotationIntrospector(pair);
+
+        SimpleFilterProvider filterProvider = new SimpleFilterProvider();
+
+        // We're not going to want any of the JSON filters like DynamicPropertyFilter that we apply elsewhere
+        filterProvider.setFailOnUnknownId(false);
+        mapper.setFilterProvider(filterProvider);
+    }
 
     @Override
     public int[] sqlTypes() {
@@ -48,7 +92,7 @@ public class ResultDataUserType implements UserType {
 
     @Override
     public Class returnedClass() {
-        return Object.class;
+        return jsonClass;
     }
 
     @Override
@@ -71,20 +115,68 @@ public class ResultDataUserType implements UserType {
     @Override
     public void nullSafeSet(PreparedStatement st, Object value, int index, SessionImplementor session)
         throws HibernateException, SQLException {
-        StandardBasicTypes.BINARY.nullSafeSet(st, serialize(value), index, session);
+        StandardBasicTypes.BINARY.nullSafeSet(st, serializeJson(value), index, session);
     }
 
-    private byte[] serialize(Object value) {
+    private Object deserialize(byte[] data) {
+        if (data == null) {
+            return null;
+        }
+
+        Object result;
+        try {
+            result = deserializeJson(data);
+        }
+        catch (JsonParseException e) {
+            /* If we can't deserialize the result data, try to deserialize it as a Java object since that
+             * is the legacy format.
+             */
+            log.debug("Could not read result data as JSON. Trying as Java object.");
+            result = deserializeJava(data);
+        }
+        catch (Exception e) {
+            // This catch will also catch IOException which readValue also throws but for low level IO errors
+            // that we likely wouldn't want to send on to deserializeJava
+            log.warn("Could not read result data");
+            throw new RuntimeException(e);
+        }
+
+        return result;
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> T deserializeJson(byte[] data) throws IOException {
+        try (JsonParser parser = mapper.getFactory().createParser(data)) {
+            try {
+                return (T) mapper.readValue(parser, jsonClass);
+            }
+            catch (JsonMappingException e) {
+                log.warn("Could not deserialize into " + jsonClass.getName() + ". Trying Object.", e);
+                return (T) mapper.readValue(parser, Object.class);
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> T deserializeJava(byte[] data) {
+        try (ByteArrayInputStream bais = new ByteArrayInputStream(data);
+            ObjectInputStream ois = new ObjectInputStream(bais)) {
+            return (T) ois.readObject();
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private byte[] serializeJson(Object value) {
         byte[] data;
         if (value == null) {
             data = null;
         }
         else {
-            try (
-                ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                ObjectOutputStream oos = new ObjectOutputStream(baos);
-            ) {
-                oos.writeObject(value);
+            try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                JsonGenerator generator = mapper.getFactory().createGenerator(baos, JsonEncoding.UTF8)) {
+                mapper.writeValue(generator, value);
                 data = baos.toByteArray();
             }
             catch (IOException ioe) {
@@ -94,23 +186,14 @@ public class ResultDataUserType implements UserType {
         return data;
     }
 
-    private Object deserialize(byte[] data) {
-        if (data == null) {
-            return null;
+    private byte[] serializeJava(Object value) {
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+            oos.writeObject(value);
+            return baos.toByteArray();
         }
-        else {
-            Object result;
-
-            try (
-                ByteArrayInputStream bais = new ByteArrayInputStream(data);
-                ObjectInputStream ois = new ObjectInputStream(bais);
-            ) {
-                result = ois.readObject();
-            }
-            catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-            return result;
+        catch (IOException e) {
+            throw new RuntimeException("Could not serialize Java object", e);
         }
     }
 
@@ -118,11 +201,12 @@ public class ResultDataUserType implements UserType {
     public Object deepCopy(Object value) throws HibernateException {
         // We serialize and then deserialize the object.  This is slow but we know nothing about the object
         // type.  Hibernate actually does something similar for mutable objects in its internal types.
-        return deserialize(serialize(value));
+        return deserializeJava(serializeJava(value));
     }
 
     @Override
     public boolean isMutable() {
+        // We don't strictly know if the type is mutable or not, but it's prudent to assume it is
         return true;
     }
 
@@ -139,5 +223,45 @@ public class ResultDataUserType implements UserType {
     @Override
     public Object replace(Object original, Object target, Object owner) throws HibernateException {
         return deepCopy(original);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void setParameterValues(Properties parameters) {
+        ParameterType reader = (ParameterType) parameters.get(PARAMETER_TYPE);
+
+        if (reader != null) {
+            jsonClass = reader.getReturnedClass();
+        }
+        else {
+            // The else is encountered if the entity is configured via XML
+            String jsonClassName = (String) parameters.get(JSON_CLASS);
+            try {
+                jsonClass = classForName(jsonClassName, this.getClass());
+            }
+            catch (ClassNotFoundException exception) {
+                throw new HibernateException("Class not found: " + jsonClass, exception);
+            }
+        }
+    }
+
+    /**
+     * Load a Class based on a fully-qualified name.  Borrowed from an internal Hibernate utility class.
+     *
+     * @param name the name of the class to find
+     * @param caller the class of the caller
+     * @return a Class object corresponding to the name given
+     * @throws ClassNotFoundException if the class is not found
+     */
+    private Class<?> classForName(String name, Class caller) throws ClassNotFoundException {
+        try {
+            ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+            if (classLoader != null) {
+                return classLoader.loadClass(name);
+            }
+        }
+        catch (Throwable ignore) {
+        }
+        return Class.forName(name, true, caller.getClassLoader());
     }
 }

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/EntitlerJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/EntitlerJob.java
@@ -50,6 +50,7 @@ import org.slf4j.LoggerFactory;
 import org.xnap.commons.i18n.I18n;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -93,7 +94,7 @@ public class EntitlerJob extends KingpinJob {
                 consumed[i] = new PoolIdAndQuantity(ents.get(i).getPool().getId(), ents.get(i)
                         .getQuantity());
             }
-            ctx.setResult(consumed);
+            ctx.setResult(Arrays.asList(consumed));
             poolCurator.clear();
         }
         catch (EntitlementRefusedException e) {

--- a/server/src/main/resources/META-INF/persistence.xml
+++ b/server/src/main/resources/META-INF/persistence.xml
@@ -48,7 +48,8 @@
     <persistence-unit name="testingUserType" transaction-type="RESOURCE_LOCAL">
         <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
         <class>org.candlepin.hibernate.EmptyStringUserTypeTest$Thing</class>
-         <exclude-unlisted-classes>true</exclude-unlisted-classes>
+        <class>org.candlepin.hibernate.ResultDataUserTypeTest$ResultData</class>
+        <exclude-unlisted-classes>true</exclude-unlisted-classes>
         <validation-mode>NONE</validation-mode>
         <properties>
             <property name="hibernate.dialect" value="org.hibernate.dialect.HSQLDialect"/>

--- a/server/src/test/java/org/candlepin/hibernate/ResultDataUserTypeTest.java
+++ b/server/src/test/java/org/candlepin/hibernate/ResultDataUserTypeTest.java
@@ -1,0 +1,294 @@
+/**
+ * Copyright (c) 2009 - 2018 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.hibernate;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import org.hibernate.annotations.Type;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Id;
+import javax.persistence.Persistence;
+import javax.persistence.Table;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * Test for ResultDataUserType
+ */
+public class ResultDataUserTypeTest {
+    private EntityManagerFactory emf;
+    private EntityManager em;
+
+    /**
+     * Silly class to serialize in different ways to test ResultDataUserType
+     */
+    @XmlRootElement
+    @XmlAccessorType(XmlAccessType.PROPERTY)
+    public static class JsonThing implements Serializable {
+        private String name;
+        private Date created;
+        private int age;
+        private boolean approved;
+        private List<String> favoriteAnimals;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public Date getCreated() {
+            return created;
+        }
+
+        public void setCreated(Date created) {
+            this.created = created;
+        }
+
+        public int getAge() {
+            return age;
+        }
+
+        public void setAge(int age) {
+            this.age = age;
+        }
+
+        public boolean isApproved() {
+            return approved;
+        }
+
+        public void setApproved(boolean approved) {
+            this.approved = approved;
+        }
+
+        public List<String> getFavoriteAnimals() {
+            return favoriteAnimals;
+        }
+
+        public void setFavoriteAnimals(List<String> favoriteAnimals) {
+            this.favoriteAnimals = favoriteAnimals;
+        }
+    }
+
+    /**
+     * Entity that will represent a table with a bytea[] column meant to hold various objects
+     */
+    @Entity
+    @Table(name = "ResultData")
+    public static class ResultData {
+        @Id
+        private int id;
+
+        // VARBINARY is like bytea in PostgreSQL. See https://stackoverflow.com/a/9693743/6124862
+        @Column(columnDefinition = "VARBINARY(1000000)")
+        @Type(type = "org.candlepin.hibernate.ResultDataUserType")
+        private JsonThing resultData;
+
+        @Column(columnDefinition = "VARBINARY(1000000)")
+        @Type(type = "org.candlepin.hibernate.ResultDataUserType")
+        private Object untypedData;
+
+        @Column(columnDefinition = "VARBINARY(1000000)")
+        @Type(type = "org.candlepin.hibernate.ResultDataUserType")
+        private Serializable unmappableData;
+
+        public int getId() {
+            return id;
+        }
+
+        public void setId(int id) {
+            this.id = id;
+        }
+
+        public JsonThing getResultData() {
+            return resultData;
+        }
+
+        public void setResultData(JsonThing resultData) {
+            this.resultData = resultData;
+        }
+
+        public Object getUntypedData() {
+            return untypedData;
+        }
+
+        public void setUntypedData(Object untypedData) {
+            this.untypedData = untypedData;
+        }
+
+        public Serializable getUnmappableData() {
+            return unmappableData;
+        }
+
+        public void setUnmappableData(Serializable unmappableData) {
+            this.unmappableData = unmappableData;
+        }
+    }
+
+    @Before
+    public void setUp() {
+        emf =  Persistence.createEntityManagerFactory("testingUserType");
+        em = emf.createEntityManager();
+    }
+
+    @After
+    public void tearDown() {
+        em.close();
+        emf.close();
+    }
+
+    @Test
+    public void testUserTypeWritesAndReadsJson() {
+        JsonThing expectedThing = new JsonThing();
+        expectedThing.setName("Abe Lincoln");
+        expectedThing.setAge(50);
+        expectedThing.setApproved(true);
+        expectedThing.setCreated(new Date());
+        expectedThing.setFavoriteAnimals(Arrays.asList("dog", "cat", "horse"));
+
+        ResultData resultDataRow = new ResultData();
+        resultDataRow.setResultData(expectedThing);
+        resultDataRow.setId(1);
+
+        em.getTransaction().begin();
+        em.persist(resultDataRow);
+        em.getTransaction().commit();
+        em.clear();
+
+        resultDataRow = em.find(ResultData.class, 1);
+
+        JsonThing actualThing = resultDataRow.getResultData();
+        assertEquals("Abe Lincoln", actualThing.getName());
+        assertEquals(50, actualThing.getAge());
+        assertEquals(true, actualThing.isApproved());
+        assertNotNull(actualThing.getCreated());
+        assertEquals(Arrays.asList("dog", "cat", "horse"), actualThing.getFavoriteAnimals());
+    }
+
+    /**
+     * If we don't provide a type with a Jackson mapping, we should get back a version of the data placed in
+     * a Map.
+     */
+    @Test
+    public void testReturnsMapIfNoMappingAtAll() {
+        JsonThing untypedThing = new JsonThing();
+        untypedThing.setName("George Washington");
+        untypedThing.setAge(60);
+        untypedThing.setApproved(true);
+        untypedThing.setCreated(new Date());
+        untypedThing.setFavoriteAnimals(Arrays.asList("lion", "tiger", "bear"));
+
+        ResultData resultDataRow = new ResultData();
+        resultDataRow.setUntypedData(untypedThing);
+        resultDataRow.setId(1);
+
+        em.getTransaction().begin();
+        em.persist(resultDataRow);
+        em.getTransaction().commit();
+        em.clear();
+
+        resultDataRow = em.find(ResultData.class, 1);
+
+        Object actualUntypedThing = resultDataRow.getUntypedData();
+        assertThat(actualUntypedThing, instanceOf(Map.class));
+
+        Map actualThing = (Map) actualUntypedThing;
+        assertEquals("George Washington", actualThing.get("name"));
+        assertEquals(60, actualThing.get("age"));
+        assertEquals(true, actualThing.get("approved"));
+        assertNotNull(actualThing.get("created"));
+        assertEquals(Arrays.asList("lion", "tiger", "bear"), actualThing.get("favoriteAnimals"));
+    }
+
+    /**
+     * The unmappableData field is of type Serializable which has no constructor, meaning Jackson can't
+     * instantiate it to map the data.  This test will check to make sure that if Jackson can't do the
+     * mapping, at least we get an version of the data placed in a Map.
+     */
+    @Test
+    public void testDeserializesToMapIfMappingFails() {
+        JsonThing badThing = new JsonThing();
+        badThing.setName("Herbert Hoover");
+
+        ResultData resultDataRow = new ResultData();
+        resultDataRow.setUnmappableData(badThing);
+        resultDataRow.setId(1);
+
+        em.getTransaction().begin();
+        em.persist(resultDataRow);
+        em.getTransaction().commit();
+        em.clear();
+
+        resultDataRow = em.find(ResultData.class, 1);
+
+        Object actualUntypedThing = resultDataRow.getUnmappableData();
+        assertThat(actualUntypedThing, instanceOf(Map.class));
+
+        Map actualThing = (Map) actualUntypedThing;
+        assertEquals("Herbert Hoover", actualThing.get("name"));
+    }
+
+    @Test
+    public void testUserTypeReadsSerializedInstance() throws Exception {
+        JsonThing byteSerializedThing = new JsonThing();
+        byteSerializedThing.setName("Harry Truman");
+        byteSerializedThing.setAge(65);
+        byteSerializedThing.setApproved(true);
+        byteSerializedThing.setCreated(new Date());
+        byteSerializedThing.setFavoriteAnimals(Arrays.asList("duck", "goose", "chicken"));
+
+        byte[] serializedBytes;
+        try (
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            ObjectOutputStream oos = new ObjectOutputStream(baos)
+        ) {
+            oos.writeObject(byteSerializedThing);
+            serializedBytes = baos.toByteArray();
+        }
+
+        em.getTransaction().begin();
+        em.createNativeQuery("INSERT INTO ResultData (id, resultData) VALUES (1, ?)")
+            .setParameter(1, serializedBytes).executeUpdate();
+        em.getTransaction().commit();
+        em.clear();
+
+        ResultData resultDataRow = em.find(ResultData.class, 1);
+        JsonThing actualThing = resultDataRow.getResultData();
+        assertEquals("Harry Truman", actualThing.getName());
+        assertEquals(65, actualThing.getAge());
+        assertEquals(true, actualThing.isApproved());
+        assertNotNull(actualThing.getCreated());
+        assertEquals(Arrays.asList("duck", "goose", "chicken"), actualThing.getFavoriteAnimals());
+    }
+}

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/EntitlerJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/EntitlerJobTest.java
@@ -121,10 +121,10 @@ public class EntitlerJobTest extends BaseJobTest{
         verify(e).sendEvents(eq(ents));
         ArgumentCaptor<Object> argumentCaptor = ArgumentCaptor.forClass(Object.class);
         verify(ctx).setResult(argumentCaptor.capture());
-        PoolIdAndQuantity[] result = (PoolIdAndQuantity[]) argumentCaptor.getValue();
-        assertEquals(1, result.length);
-        assertEquals(pool, result[0].getPoolId());
-        assertEquals(100, result[0].getQuantity().intValue());
+        List<PoolIdAndQuantity> result = (List<PoolIdAndQuantity>) argumentCaptor.getValue();
+        assertEquals(1, result.size());
+        assertEquals(pool, result.get(0).getPoolId());
+        assertEquals(100, result.get(0).getQuantity().intValue());
     }
 
     /**


### PR DESCRIPTION
Testing:
* Deploy Candlepin from master
* Run `buildr rspec:import` 3 or 4 times to get some rows in `cp_job`
* Deploy this branch
* Run `buildr rspec:import` 3 or 4 times to get some more rows in `cp_job`
* Connect to the database and take a look at the `resultdata` column.  My preferred tool for doing this is JetBrain's DataGrip because it will show the data as characters if it can.  `psql` will always encode the data in hex, but if the data in the column starts with `\x7b22` that's ASCII for `{"` which means it's JSON.
![datagrip_example](https://user-images.githubusercontent.com/17975/37526038-ca5039c6-2904-11e8-9969-8cd23d4238d2.png)
* Run `client/ruby/cpc get_job JOB_ID` for a job id with JSON result data and a job with serialized object result data.
* There shouldn't be any detectable behavior differences in how the results are returned and displayed.
* Note that reading the serialized object data **can only be performed once**.  After reading it, Hibernate writes it back as JSON.  This behavior was not intentional on my part, but it seems desirable since we want to get rid of these legacy records if we can.  It's not running `nullSafeSet` every time we do a read though: just when the serialized Java object is read the first time (I checked via the debugger).
