### PR TITLE
[M] Changed Consumer.type to Consumer.typeId

### DIFF
--- a/server/src/main/java/org/candlepin/bind/BindContext.java
+++ b/server/src/main/java/org/candlepin/bind/BindContext.java
@@ -16,6 +16,8 @@ package org.candlepin.bind;
 
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerCurator;
+import org.candlepin.model.ConsumerType;
+import org.candlepin.model.ConsumerTypeCurator;
 import org.candlepin.model.Entitlement;
 import org.candlepin.model.Pool;
 import org.candlepin.model.PoolCurator;
@@ -53,16 +55,20 @@ public class BindContext {
     private EntitlementRefusedException exception;
     private PoolCurator poolCurator;
     private ConsumerCurator consumerCurator;
+    private ConsumerTypeCurator consumerTypeCurator;
     private I18n i18n;
 
     @Inject
     public BindContext(PoolCurator poolCurator,
         ConsumerCurator consumerCurator,
+        ConsumerTypeCurator consumerTypeCurator,
         I18n i18n,
         @Assisted Consumer consumer,
         @Assisted Map<String, Integer> quantities) {
+
         this.poolCurator = poolCurator;
         this.consumerCurator = consumerCurator;
+        this.consumerTypeCurator = consumerTypeCurator;
         this.i18n = i18n;
         this.consumer = consumer;
         this.quantities = quantities;
@@ -74,6 +80,10 @@ public class BindContext {
 
     public Consumer getConsumer() {
         return consumer;
+    }
+
+    public ConsumerType getConsumerType() {
+        return this.consumerTypeCurator.getConsumerType(this.getConsumer());
     }
 
     public Map<String, PoolQuantity> getPoolQuantities() {
@@ -112,6 +122,7 @@ public class BindContext {
         if (lockedConsumer == null) {
             lockedConsumer = consumerCurator.lockAndLoad(consumer);
         }
+
         return lockedConsumer;
     }
 

--- a/server/src/main/java/org/candlepin/bind/ComplianceOp.java
+++ b/server/src/main/java/org/candlepin/bind/ComplianceOp.java
@@ -15,6 +15,8 @@
 package org.candlepin.bind;
 
 import org.candlepin.model.Consumer;
+import org.candlepin.model.ConsumerType;
+import org.candlepin.model.ConsumerType.ConsumerTypeEnum;
 import org.candlepin.model.Entitlement;
 import org.candlepin.model.PoolQuantity;
 import org.candlepin.policy.js.compliance.ComplianceRules;
@@ -74,10 +76,14 @@ public class ComplianceOp implements BindOperation {
     @Override
     public boolean execute(BindContext context) {
         Consumer consumer = context.getLockedConsumer();
+        ConsumerType ctype = context.getConsumerType();
+
         complianceRules.updateEntsOnStart(consumer);
-        if (!consumer.isManifestDistributor() && !consumer.isShare()) {
+
+        if (!ctype.isManifest() && !ctype.isType(ConsumerTypeEnum.SHARE)) {
             complianceRules.applyStatus(consumer, status, false);
         }
+
         return true;
     }
 }

--- a/server/src/main/java/org/candlepin/bind/HandleCertificatesOp.java
+++ b/server/src/main/java/org/candlepin/bind/HandleCertificatesOp.java
@@ -15,6 +15,7 @@
 package org.candlepin.bind;
 
 import org.candlepin.controller.EntitlementCertificateGenerator;
+import org.candlepin.model.ConsumerType.ConsumerTypeEnum;
 import org.candlepin.model.Entitlement;
 import org.candlepin.model.EntitlementCertificate;
 import org.candlepin.model.EntitlementCertificateCurator;
@@ -49,6 +50,7 @@ public class HandleCertificatesOp implements BindOperation {
     @Inject
     public HandleCertificatesOp(EntitlementCertificateGenerator ecGenerator, EntitlementCertificateCurator
         ecCurator, EntitlementCurator eCurator) {
+
         this.ecGenerator = ecGenerator;
         this.ecCurator = ecCurator;
         this.eCurator = eCurator;
@@ -61,8 +63,7 @@ public class HandleCertificatesOp implements BindOperation {
      */
     @Override
     public boolean preProcess(BindContext context) {
-
-        if (!context.getConsumer().isShare()) {
+        if (!context.getConsumerType().isType(ConsumerTypeEnum.SHARE)) {
             List<String> poolIds = new LinkedList<>();
             Map<String, Product> products = new HashMap<>();
             Map<String, PoolQuantity> poolQuantities = context.getPoolQuantities();
@@ -79,8 +80,7 @@ public class HandleCertificatesOp implements BindOperation {
                 context.getEntitlementMap(),
                 false);
 
-            modifyingEnts = this.eCurator.getDependentEntitlementIdsForPools(context.getConsumer(),
-                poolIds);
+            modifyingEnts = this.eCurator.getDependentEntitlementIdsForPools(context.getConsumer(), poolIds);
         }
 
         return true;
@@ -92,8 +92,7 @@ public class HandleCertificatesOp implements BindOperation {
      */
     @Override
     public boolean execute(BindContext context) {
-
-        if (!context.getConsumer().isShare()) {
+        if (!context.getConsumerType().isType(ConsumerTypeEnum.SHARE)) {
             Map<String, Entitlement> ents = context.getEntitlementMap();
             for (Entitlement ent: ents.values()) {
                 EntitlementCertificate cert = certs.get(ent.getPool().getId());

--- a/server/src/main/java/org/candlepin/controller/RevocationOp.java
+++ b/server/src/main/java/org/candlepin/controller/RevocationOp.java
@@ -16,6 +16,9 @@ package org.candlepin.controller;
 
 import com.google.inject.persist.Transactional;
 import org.candlepin.common.exceptions.ForbiddenException;
+import org.candlepin.model.ConsumerType;
+import org.candlepin.model.ConsumerTypeCurator;
+import org.candlepin.model.ConsumerType.ConsumerTypeEnum;
 import org.candlepin.model.Entitlement;
 import org.candlepin.model.Pool;
 import org.candlepin.model.PoolCurator;
@@ -30,6 +33,7 @@ import java.util.Map;
 import java.util.Set;
 
 
+
 /**
  * Created by wpoteat on 5/11/17.
  */
@@ -40,13 +44,16 @@ public class RevocationOp {
     private Map<Pool, List<Pool>> sharedPools;
     private Map<Pool, Long> poolNewConsumed;
     private PoolCurator poolCurator;
+    private ConsumerTypeCurator consumerTypeCurator;
 
-    public RevocationOp(PoolCurator poolCurator, List<Pool> pools) {
+    public RevocationOp(PoolCurator poolCurator, ConsumerTypeCurator consumerTypeCurator, List<Pool> pools) {
         entitlementsToRevoke = new HashSet<>();
         shareEntitlementsToAdjust = new HashMap<>();
         sharedPools = new HashMap<>();
         poolNewConsumed = new HashMap<>();
+
         this.poolCurator = poolCurator;
+        this.consumerTypeCurator = consumerTypeCurator;
         this.pools = pools;
     }
 
@@ -168,7 +175,9 @@ public class RevocationOp {
         long existing = pool.getQuantity();
         for (Entitlement ent : entitlements) {
             if (newConsumed > existing) {
-                if (!ent.getConsumer().isShare()) {
+                ConsumerType ctype = this.consumerTypeCurator.getConsumerType(ent.getConsumer());
+
+                if (!ctype.isType(ConsumerTypeEnum.SHARE)) {
                     if (ent.getPool().isCreatedByShare()) {
                         Entitlement source = ent.getPool().getSourceEntitlement();
                         // the source entitlement may have already been adjusted in the shared pool reduction

--- a/server/src/main/java/org/candlepin/dto/StandardTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/StandardTranslator.java
@@ -59,6 +59,7 @@ import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerCapability;
 import org.candlepin.model.ConsumerInstalledProduct;
 import org.candlepin.model.ConsumerType;
+import org.candlepin.model.ConsumerTypeCurator;
 import org.candlepin.model.Content;
 import org.candlepin.model.Entitlement;
 import org.candlepin.model.Environment;
@@ -75,6 +76,8 @@ import org.candlepin.model.dto.ContentData;
 import org.candlepin.model.dto.ProductData;
 import org.candlepin.pinsetter.core.model.JobStatus;
 
+import com.google.inject.Inject;
+
 
 
 /**
@@ -83,7 +86,9 @@ import org.candlepin.pinsetter.core.model.JobStatus;
  */
 public class StandardTranslator extends SimpleModelTranslator {
 
-    public StandardTranslator() {
+    @Inject
+    public StandardTranslator(ConsumerTypeCurator consumerTypeCurator) {
+
         // API translators
         /////////////////////////////////////////////
         this.registerTranslator(
@@ -99,11 +104,11 @@ public class StandardTranslator extends SimpleModelTranslator {
         this.registerTranslator(
             new CertificateTranslator(), Certificate.class, CertificateDTO.class);
         this.registerTranslator(
+            new org.candlepin.dto.api.v1.ConsumerTranslator(consumerTypeCurator),
+            Consumer.class, org.candlepin.dto.api.v1.ConsumerDTO.class);
+        this.registerTranslator(
             new ConsumerInstalledProductTranslator(), ConsumerInstalledProduct.class,
             ConsumerInstalledProductDTO.class);
-        this.registerTranslator(
-            new org.candlepin.dto.api.v1.ConsumerTranslator(),
-            Consumer.class, org.candlepin.dto.api.v1.ConsumerDTO.class);
         this.registerTranslator(
             new org.candlepin.dto.api.v1.ConsumerTypeTranslator(),
             ConsumerType.class, org.candlepin.dto.api.v1.ConsumerTypeDTO.class);
@@ -152,7 +157,7 @@ public class StandardTranslator extends SimpleModelTranslator {
             new org.candlepin.dto.manifest.v1.CertificateSerialTranslator(),
             CertificateSerial.class, org.candlepin.dto.manifest.v1.CertificateSerialDTO.class);
         this.registerTranslator(
-            new org.candlepin.dto.manifest.v1.ConsumerTranslator(),
+            new org.candlepin.dto.manifest.v1.ConsumerTranslator(consumerTypeCurator),
             Consumer.class, org.candlepin.dto.manifest.v1.ConsumerDTO.class);
         this.registerTranslator(
             new org.candlepin.dto.manifest.v1.ConsumerTypeTranslator(),
@@ -188,7 +193,7 @@ public class StandardTranslator extends SimpleModelTranslator {
         // Rules framework translators
         /////////////////////////////////////////////
         this.registerTranslator(
-            new org.candlepin.dto.rules.v1.ConsumerTranslator(),
+            new org.candlepin.dto.rules.v1.ConsumerTranslator(consumerTypeCurator),
             Consumer.class, org.candlepin.dto.rules.v1.ConsumerDTO.class);
         this.registerTranslator(
             new org.candlepin.dto.rules.v1.ConsumerTypeTranslator(),

--- a/server/src/main/java/org/candlepin/dto/api/v1/ConsumerTypeDTO.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/ConsumerTypeDTO.java
@@ -42,6 +42,10 @@ public class ConsumerTypeDTO extends CandlepinDTO<ConsumerTypeDTO> {
         // Intentionally left empty
     }
 
+    // TODO:
+    // Remove these constructors; they're coupled to the actual entity and we need to not carry
+    // forward extraneous constructors without reason
+
     public ConsumerTypeDTO(ConsumerTypeEnum type) {
         this.label = type.getLabel();
         this.manifest = type.isManifest();

--- a/server/src/main/java/org/candlepin/dto/manifest/v1/ConsumerTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/manifest/v1/ConsumerTranslator.java
@@ -17,13 +17,27 @@ package org.candlepin.dto.manifest.v1;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.dto.ObjectTranslator;
 import org.candlepin.model.Consumer;
+import org.candlepin.model.ConsumerType;
+import org.candlepin.model.ConsumerTypeCurator;
 import org.candlepin.model.Owner;
+
+
 
 /**
  * The ConsumerTranslator provides translation from Consumer model objects to
  * ConsumerDTOs, as used by the manifest import/export API.
  */
 public class ConsumerTranslator implements ObjectTranslator<Consumer, ConsumerDTO> {
+
+    private ConsumerTypeCurator consumerTypeCurator;
+
+    public ConsumerTranslator(ConsumerTypeCurator consumerTypeCurator) {
+        if (consumerTypeCurator == null) {
+            throw new IllegalArgumentException("ConsumerTypeCurator is null");
+        }
+
+        this.consumerTypeCurator = consumerTypeCurator;
+    }
 
     /**
      * {@inheritDoc}
@@ -70,7 +84,15 @@ public class ConsumerTranslator implements ObjectTranslator<Consumer, ConsumerDT
         if (translator != null) {
             Owner owner = source.getOwner();
             dest.setOwner(owner != null ? translator.translate(owner, OwnerDTO.class) : null);
-            dest.setType(translator.translate(source.getType(), ConsumerTypeDTO.class));
+
+            // Temporary measure to maintain API compatibility
+            if (source.getTypeId() != null) {
+                ConsumerType ctype = this.consumerTypeCurator.getConsumerType(source);
+                dest.setType(translator.translate(ctype, ConsumerTypeDTO.class));
+            }
+            else {
+                dest.setType(null);
+            }
         }
         else {
             dest.setOwner(null);

--- a/server/src/main/java/org/candlepin/dto/rules/v1/ConsumerTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/rules/v1/ConsumerTranslator.java
@@ -19,15 +19,29 @@ import org.candlepin.dto.TimestampedEntityTranslator;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerCapability;
 import org.candlepin.model.ConsumerInstalledProduct;
+import org.candlepin.model.ConsumerType;
+import org.candlepin.model.ConsumerTypeCurator;
 
 import java.util.HashSet;
 import java.util.Set;
+
+
 
 /**
  * The ConsumerTranslator provides translation from Consumer model objects to
  * ConsumerDTOs, as used by the Rules framework.
  */
 public class ConsumerTranslator extends TimestampedEntityTranslator<Consumer, ConsumerDTO> {
+
+    private ConsumerTypeCurator consumerTypeCurator;
+
+    public ConsumerTranslator(ConsumerTypeCurator consumerTypeCurator) {
+        if (consumerTypeCurator == null) {
+            throw new IllegalArgumentException("ConsumerTypeCurator is null");
+        }
+
+        this.consumerTypeCurator = consumerTypeCurator;
+    }
 
     /**
      * {@inheritDoc}
@@ -92,7 +106,14 @@ public class ConsumerTranslator extends TimestampedEntityTranslator<Consumer, Co
                 dest.setCapabilities(capabilitiesDTO);
             }
 
-            dest.setType(translator.translate(source.getType(), ConsumerTypeDTO.class));
+            // Temporary measure to maintain API compatibility
+            if (source.getTypeId() != null) {
+                ConsumerType ctype = this.consumerTypeCurator.getConsumerType(source);
+                dest.setType(translator.translate(ctype, ConsumerTypeDTO.class));
+            }
+            else {
+                dest.setType(null);
+            }
         }
         else {
             dest.setOwner(null);

--- a/server/src/main/java/org/candlepin/guice/CandlepinModule.java
+++ b/server/src/main/java/org/candlepin/guice/CandlepinModule.java
@@ -427,8 +427,6 @@ public class CandlepinModule extends AbstractModule {
     }
 
     protected void configureModelTranslator() {
-        ModelTranslator modelTranslator = new StandardTranslator();
-
-        bind(ModelTranslator.class).toInstance(modelTranslator);
+        bind(ModelTranslator.class).to(StandardTranslator.class).asEagerSingleton();
     }
 }

--- a/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
+++ b/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
@@ -553,7 +553,7 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
 
     @Transactional
     protected <T> T get(Class<T> clazz, Serializable id) {
-        return clazz.cast(currentSession().get(clazz, id));
+        return this.currentSession().get(clazz, id);
     }
 
     @Transactional

--- a/server/src/main/java/org/candlepin/model/ConsumerType.java
+++ b/server/src/main/java/org/candlepin/model/ConsumerType.java
@@ -40,23 +40,6 @@ public class ConsumerType extends AbstractHibernateObject<ConsumerType> {
     /** Name of the table backing this object in the database */
     public static final String DB_TABLE = "cp_consumer_type";
 
-    @Id
-    @GeneratedValue(generator = "system-uuid")
-    @GenericGenerator(name = "system-uuid", strategy = "uuid")
-    @Column(length = 32)
-    @NotNull
-    private String id;
-
-    @Column(nullable = false, unique = true)
-    @Size(max = 255)
-    @NotNull
-    private String label;
-
-    @Column(nullable = false, length = 1)
-    @Type(type = "yes_no")
-    @NotNull
-    private boolean manifest = false;
-
     /**
      * Initial DB values that are part of a "basic" install ConsumerTypeEnum
      */
@@ -88,6 +71,24 @@ public class ConsumerType extends AbstractHibernateObject<ConsumerType> {
             return getLabel();
         }
     }
+
+
+    @Id
+    @GeneratedValue(generator = "system-uuid")
+    @GenericGenerator(name = "system-uuid", strategy = "uuid")
+    @Column(length = 32)
+    @NotNull
+    private String id;
+
+    @Column(nullable = false, unique = true)
+    @Size(max = 255)
+    @NotNull
+    private String label;
+
+    @Column(nullable = false, length = 1)
+    @Type(type = "yes_no")
+    @NotNull
+    private boolean manifest = false;
 
     /**
      * default ctor
@@ -142,7 +143,7 @@ public class ConsumerType extends AbstractHibernateObject<ConsumerType> {
     }
 
     public boolean isType(ConsumerTypeEnum type) {
-        return this.label.equals(type.getLabel());
+        return type != null && type.getLabel().equals(this.getLabel());
     }
 
     /**

--- a/server/src/main/java/org/candlepin/model/ConsumerTypeCurator.java
+++ b/server/src/main/java/org/candlepin/model/ConsumerTypeCurator.java
@@ -29,6 +29,33 @@ public class ConsumerTypeCurator extends AbstractHibernateCurator<ConsumerType> 
     }
 
     /**
+     * Fetches the ConsumerType for the specified consumer. If the consumer does not have a defined
+     * type ID, or the type ID is invalid, this method throws an exception.
+     *
+     * @param consumer
+     *  The consumer for which to fetch the ConsumerType object
+     *
+     * @throws IllegalStateException
+     *  if the consumer has no defined type ID or the type ID is invalid
+     *
+     * @return
+     *  A ConsumerType instance for the specified consumer
+     */
+    public ConsumerType getConsumerType(Consumer consumer) {
+        ConsumerType type = null;
+
+        if (consumer != null && consumer.getTypeId() != null) {
+            type = this.find(consumer.getTypeId());
+
+            if (type == null) {
+                throw new IllegalStateException("consumer is not associated with a valid type: " + consumer);
+            }
+        }
+
+        return type;
+    }
+
+    /**
      * lookup the ConsumerType by its label.
      *
      * @param label type to lookup

--- a/server/src/main/java/org/candlepin/model/OwnerInfoCurator.java
+++ b/server/src/main/java/org/candlepin/model/OwnerInfoCurator.java
@@ -143,7 +143,6 @@ public class OwnerInfoCurator {
     @SuppressWarnings("checkstyle:indentation")
     private void setConsumerCountsByComplianceStatus(Owner owner, OwnerInfo info) {
         Criteria countCriteria = consumerCurator.createSecureCriteria()
-            .createAlias("type", "t")
             .add(Restrictions.eq("owner", owner))
             .add(Restrictions.isNotNull("entitlementStatus"))
             .setProjection(Projections.projectionList()

--- a/server/src/main/java/org/candlepin/model/UeberCertificateGenerator.java
+++ b/server/src/main/java/org/candlepin/model/UeberCertificateGenerator.java
@@ -43,6 +43,8 @@ import java.util.LinkedList;
 import java.util.Set;
 import java.util.TimeZone;
 
+
+
 /**
  * UeberCertificateGenerator
  */
@@ -61,6 +63,7 @@ public class UeberCertificateGenerator {
     private X509ExtensionUtil extensionUtil;
     private OwnerCurator ownerCurator;
     private UeberCertificateCurator ueberCertCurator;
+    private ConsumerTypeCurator consumerTypeCurator;
     private I18n i18n;
 
     @Inject
@@ -72,6 +75,7 @@ public class UeberCertificateGenerator {
         CertificateSerialCurator serialCurator,
         OwnerCurator ownerCurator,
         UeberCertificateCurator ueberCertCurator,
+        ConsumerTypeCurator consumerTypeCurator,
         I18n i18n) {
 
         this.idGenerator = idGenerator;
@@ -81,6 +85,7 @@ public class UeberCertificateGenerator {
         this.extensionUtil = extensionUtil;
         this.ownerCurator = ownerCurator;
         this.ueberCertCurator = ueberCertCurator;
+        this.consumerTypeCurator = consumerTypeCurator;
         this.i18n = i18n;
     }
 
@@ -106,7 +111,13 @@ public class UeberCertificateGenerator {
     }
 
     private UeberCertificate generateUeberCert(Owner owner, String generatedByUsername) throws Exception {
-        UeberCertData ueberCertData = new UeberCertData(owner, generatedByUsername);
+        ConsumerType ueberCertType = this.consumerTypeCurator.lookupByLabel(UEBER_CERT_CONSUMER_TYPE);
+        if (ueberCertType == null) {
+            // The ueber cert consumer type doesn't exist yet; let's create it now.
+            ueberCertType = this.consumerTypeCurator.create(new ConsumerType(UEBER_CERT_CONSUMER_TYPE));
+        }
+
+        UeberCertData ueberCertData = new UeberCertData(owner, generatedByUsername, ueberCertType);
 
         CertificateSerial serial = new CertificateSerial(ueberCertData.getEndDate());
         serialCurator.create(serial);
@@ -159,6 +170,7 @@ public class UeberCertificateGenerator {
      */
     private class UeberCertData {
         private Owner owner;
+        private ConsumerType ueberCertType;
         private Consumer consumer;
         private Product product;
         private Content content;
@@ -168,11 +180,12 @@ public class UeberCertificateGenerator {
         private Date startDate;
         private Date endDate;
 
-        public UeberCertData(Owner owner, String generatedByUsername) {
+        public UeberCertData(Owner owner, String generatedByUsername, ConsumerType ueberCertType) {
             startDate = Calendar.getInstance().getTime();
             endDate = lateIn2049();
 
             this.owner = owner;
+            this.ueberCertType = ueberCertType;
             this.consumer = createUeberConsumer(generatedByUsername, owner);
             this.product = createUeberProductForOwner(idGenerator, owner);
             this.content = createUeberContent(idGenerator, owner, product);
@@ -212,8 +225,7 @@ public class UeberCertificateGenerator {
         }
 
         private Consumer createUeberConsumer(String username, Owner owner) {
-            ConsumerType type = new ConsumerType(UEBER_CERT_CONSUMER_TYPE);
-            Consumer consumer = new Consumer(UEBER_CERT_CONSUMER, username, owner, type);
+            Consumer consumer = new Consumer(UEBER_CERT_CONSUMER, username, owner, this.ueberCertType);
             return consumer;
         }
 

--- a/server/src/main/java/org/candlepin/model/UeberCertificateGenerator.java
+++ b/server/src/main/java/org/candlepin/model/UeberCertificateGenerator.java
@@ -111,11 +111,7 @@ public class UeberCertificateGenerator {
     }
 
     private UeberCertificate generateUeberCert(Owner owner, String generatedByUsername) throws Exception {
-        ConsumerType ueberCertType = this.consumerTypeCurator.lookupByLabel(UEBER_CERT_CONSUMER_TYPE);
-        if (ueberCertType == null) {
-            // The ueber cert consumer type doesn't exist yet; let's create it now.
-            ueberCertType = this.consumerTypeCurator.create(new ConsumerType(UEBER_CERT_CONSUMER_TYPE));
-        }
+        ConsumerType ueberCertType = this.consumerTypeCurator.lookupByLabel(UEBER_CERT_CONSUMER_TYPE, true);
 
         UeberCertData ueberCertData = new UeberCertData(owner, generatedByUsername, ueberCertType);
 

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/HypervisorUpdateJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/HypervisorUpdateJob.java
@@ -104,10 +104,7 @@ public class HypervisorUpdateJob extends KingpinJob {
         this.subAdapter = subAdapter;
         this.complianceRules = complianceRules;
 
-        this.hypervisorType = consumerTypeCurator.lookupByLabel(ConsumerTypeEnum.HYPERVISOR.getLabel());
-        if (this.hypervisorType == null) {
-            this.hypervisorType = consumerTypeCurator.create(new ConsumerType(ConsumerTypeEnum.HYPERVISOR));
-        }
+        this.hypervisorType = consumerTypeCurator.lookupByLabel(ConsumerTypeEnum.HYPERVISOR.getLabel(), true);
     }
 
     public static JobStatus scheduleJob(JobCurator jobCurator,

--- a/server/src/main/java/org/candlepin/policy/criteria/CriteriaRules.java
+++ b/server/src/main/java/org/candlepin/policy/criteria/CriteriaRules.java
@@ -16,7 +16,9 @@ package org.candlepin.policy.criteria;
 
 import org.candlepin.common.config.Configuration;
 import org.candlepin.model.Consumer;
+import org.candlepin.model.ConsumerType;
 import org.candlepin.model.ConsumerCurator;
+import org.candlepin.model.ConsumerTypeCurator;
 import org.candlepin.model.Pool;
 import org.candlepin.model.PoolFilterBuilder;
 
@@ -43,11 +45,15 @@ public class CriteriaRules  {
 
     protected Configuration config;
     protected ConsumerCurator consumerCurator;
+    protected ConsumerTypeCurator consumerTypeCurator;
 
     @Inject
-    public CriteriaRules(Configuration config, ConsumerCurator consumerCurator) {
+    public CriteriaRules(Configuration config, ConsumerCurator consumerCurator,
+        ConsumerTypeCurator consumerTypeCurator) {
+
         this.config = config;
         this.consumerCurator = consumerCurator;
+        this.consumerTypeCurator = consumerTypeCurator;
     }
 
     /**
@@ -69,10 +75,11 @@ public class CriteriaRules  {
         }
 
         List<Criterion> criteriaFilters = new LinkedList<>();
+        ConsumerType ctype = this.consumerTypeCurator.getConsumerType(consumer);
 
         // Don't load virt_only pools if this consumer isn't a guest
         // or a manifest consumer
-        if (consumer.isManifestDistributor()) {
+        if (ctype.isManifest()) {
             DetachedCriteria requiresHost = DetachedCriteria.forClass(Pool.class, "pool2")
                 .createAlias("pool2.attributes", "attrib")
                 .add(Restrictions.eqProperty("pool2.id", "id"))

--- a/server/src/main/java/org/candlepin/policy/js/consumer/ConsumerRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/consumer/ConsumerRules.java
@@ -16,12 +16,17 @@ package org.candlepin.policy.js.consumer;
 
 import org.candlepin.controller.PoolManager;
 import org.candlepin.model.Consumer;
+import org.candlepin.model.ConsumerType;
+import org.candlepin.model.ConsumerType.ConsumerTypeEnum;
+import org.candlepin.model.ConsumerTypeCurator;
 import org.candlepin.model.Pool;
 import org.candlepin.model.PoolCurator;
 
 import com.google.inject.Inject;
 
 import java.util.List;
+
+
 
 /**
  * ConsumerRules
@@ -30,24 +35,28 @@ public class ConsumerRules {
 
     private PoolCurator poolCurator;
     private PoolManager poolManager;
+    private ConsumerTypeCurator consumerTypeCurator;
 
     @Inject
-    public ConsumerRules(PoolManager poolManager, PoolCurator poolCurator) {
+    public ConsumerRules(PoolManager poolManager, PoolCurator poolCurator,
+        ConsumerTypeCurator consumerTypeCurator) {
+
         this.poolManager = poolManager;
         this.poolCurator = poolCurator;
+        this.consumerTypeCurator = consumerTypeCurator;
     }
 
     public void onConsumerDelete(Consumer consumer) {
+        ConsumerType ctype = this.consumerTypeCurator.getConsumerType(consumer);
 
         // Cleanup user restricted pools:
-        if (consumer.getType().getLabel().equals("person")) {
+        if (ctype.isType(ConsumerTypeEnum.PERSON)) {
             List<Pool> userRestrictedPools = poolCurator
                 .listPoolsRestrictedToUser(consumer.getUsername());
 
             for (Pool pool : userRestrictedPools) {
                 poolManager.deletePool(pool);
             }
-
         }
     }
 }

--- a/server/src/main/java/org/candlepin/policy/js/export/ExportRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/export/ExportRules.java
@@ -14,18 +14,25 @@
  */
 package org.candlepin.policy.js.export;
 
+import org.candlepin.model.ConsumerType;
+import org.candlepin.model.ConsumerTypeCurator;
 import org.candlepin.model.Entitlement;
 import org.candlepin.model.Pool;
 
 import com.google.inject.Inject;
+
+
 
 /**
  *
  */
 public class ExportRules {
 
+    private ConsumerTypeCurator consumerTypeCurator;
+
     @Inject
-    public ExportRules() {
+    public ExportRules(ConsumerTypeCurator consumerTypeCurator) {
+        this.consumerTypeCurator = consumerTypeCurator;
     }
 
     public boolean canExport(Entitlement entitlement) {
@@ -35,7 +42,9 @@ public class ExportRules {
         // applied to pools internally by candlepin, but some tests were doing this so
         // we will continue doing the same.
         Boolean poolDerived = pool.hasAttribute(Pool.Attributes.DERIVED_POOL);
-        return !entitlement.getConsumer().isManifestDistributor() || !poolDerived;
+        ConsumerType ctype = this.consumerTypeCurator.getConsumerType(entitlement.getConsumer());
+
+        return !ctype.isManifest() || !poolDerived;
     }
 
 }

--- a/server/src/main/java/org/candlepin/policy/js/quantity/QuantityRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/quantity/QuantityRules.java
@@ -52,6 +52,7 @@ public class QuantityRules {
 
     @Inject
     public QuantityRules(JsRunner jsRules, RulesObjectMapper mapper, ModelTranslator translator) {
+
         this.jsRules = jsRules;
         this.mapper = mapper;
         this.translator = translator;

--- a/server/src/main/java/org/candlepin/resource/HypervisorResource.java
+++ b/server/src/main/java/org/candlepin/resource/HypervisorResource.java
@@ -108,10 +108,7 @@ public class HypervisorResource {
         this.translator = translator;
         this.guestIdResource = guestIdResource;
 
-        this.hypervisorType = consumerTypeCurator.lookupByLabel(ConsumerTypeEnum.HYPERVISOR.getLabel());
-        if (this.hypervisorType == null) {
-            this.hypervisorType = consumerTypeCurator.create(new ConsumerType(ConsumerTypeEnum.HYPERVISOR));
-        }
+        this.hypervisorType = consumerTypeCurator.lookupByLabel(ConsumerTypeEnum.HYPERVISOR.getLabel(), true);
     }
 
     /**

--- a/server/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -1127,6 +1127,7 @@ public class OwnerResource {
         for (Entitlement entitlement : entitlementsPage.getPageData()) {
             entitlementDTOs.add(this.translator.translate(entitlement, EntitlementDTO.class));
         }
+
         return entitlementDTOs;
     }
 
@@ -1760,7 +1761,7 @@ public class OwnerResource {
     public PoolDTO createPool(@PathParam("owner_key") @Verify(Owner.class) String ownerKey,
         @ApiParam(name = "pool", required = true) PoolDTO inputPoolDTO) {
 
-        log.info("Creating custom pool for owner {}: {}" + ownerKey, inputPoolDTO);
+        log.info("Creating custom pool for owner {}: {}", ownerKey, inputPoolDTO);
 
         Pool pool = new Pool();
 

--- a/server/src/main/java/org/candlepin/resource/PoolResource.java
+++ b/server/src/main/java/org/candlepin/resource/PoolResource.java
@@ -295,14 +295,14 @@ public class PoolResource {
         Pool pool = poolManager.find(id);
 
         if (pool == null) {
-            throw new NotFoundException(i18n.tr(
-                "Subscription Pool with ID \"{0}\" could not be found.", id));
+            throw new NotFoundException(i18n.tr("Subscription Pool with ID \"{0}\" could not be found.", id));
         }
 
         List<EntitlementDTO> entitlementDTOs = new ArrayList<>();
         for (Entitlement entitlement : pool.getEntitlements()) {
             entitlementDTOs.add(this.translator.translate(entitlement, EntitlementDTO.class));
         }
+
         return entitlementDTOs;
     }
 

--- a/server/src/test/java/org/candlepin/TestingModules.java
+++ b/server/src/test/java/org/candlepin/TestingModules.java
@@ -333,7 +333,7 @@ public class TestingModules {
             install(new FactoryModuleBuilder().build(PreEntitlementRulesCheckOpFactory.class));
 
             // Bind model translator
-            bind(ModelTranslator.class).toInstance(new StandardTranslator());
+            bind(ModelTranslator.class).to(StandardTranslator.class).asEagerSingleton();
         }
     }
 }

--- a/server/src/test/java/org/candlepin/auth/ConsumerPrincipalTest.java
+++ b/server/src/test/java/org/candlepin/auth/ConsumerPrincipalTest.java
@@ -90,8 +90,10 @@ public class ConsumerPrincipalTest {
 
     @Test
     public void equalsDifferentConsumer() {
-        Consumer c = new Consumer("Test Consumer", "test-consumer", new Owner("o1"),
-            new ConsumerType(ConsumerType.ConsumerTypeEnum.SYSTEM));
+        ConsumerType ctype = new ConsumerType(ConsumerType.ConsumerTypeEnum.SYSTEM);
+        ctype.setId("test-ctype");
+
+        Consumer c = new Consumer("Test Consumer", "test-consumer", new Owner("o1"), ctype);
         ConsumerPrincipal cp = new ConsumerPrincipal(c);
         assertFalse(principal.equals(cp));
     }

--- a/server/src/test/java/org/candlepin/auth/SSLAuthTest.java
+++ b/server/src/test/java/org/candlepin/auth/SSLAuthTest.java
@@ -69,9 +69,11 @@ public class SSLAuthTest {
      */
     @Test
     public void correctUserName() throws Exception {
+        ConsumerType ctype = new ConsumerType(ConsumerTypeEnum.SYSTEM);
+        ctype.setId("test-ctype");
+
         Owner owner = new Owner("test owner");
-        Consumer consumer = new Consumer("machine_name", "test user", owner,
-            new ConsumerType(ConsumerTypeEnum.SYSTEM));
+        Consumer consumer = new Consumer("machine_name", "test user", owner, ctype);
         ConsumerPrincipal expected = new ConsumerPrincipal(consumer);
 
         String dn = "CN=453-44423-235";
@@ -113,7 +115,7 @@ public class SSLAuthTest {
 
         when(idCert.getSubjectX500Principal()).thenReturn(principal);
         when(this.httpRequest.getAttribute("javax.servlet.request.X509Certificate"))
-                .thenReturn(new X509Certificate[]{idCert});
+            .thenReturn(new X509Certificate[]{idCert});
     }
 
 }

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/ConsumerTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/ConsumerTranslatorTest.java
@@ -23,7 +23,6 @@ import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerType;
 import org.candlepin.model.ConsumerTypeCurator;
-import org.candlepin.model.Owner;
 
 import org.junit.runner.RunWith;
 

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/ConsumerTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/ConsumerTranslatorTest.java
@@ -15,14 +15,21 @@
 package org.candlepin.dto.manifest.v1;
 
 import static org.junit.Assert.*;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
 
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.Consumer;
+import org.candlepin.model.ConsumerType;
+import org.candlepin.model.ConsumerTypeCurator;
+import org.candlepin.model.Owner;
 
 import org.junit.runner.RunWith;
 
 import junitparams.JUnitParamsRunner;
+
+
 
 /**
  * Test suite for the ConsumerTranslator (manifest import/export) class
@@ -31,7 +38,9 @@ import junitparams.JUnitParamsRunner;
 public class ConsumerTranslatorTest extends
     AbstractTranslatorTest<Consumer, ConsumerDTO, ConsumerTranslator> {
 
-    protected ConsumerTranslator translator = new ConsumerTranslator();
+    protected ConsumerTypeCurator mockConsumerTypeCurator;
+
+    protected ConsumerTranslator translator;
 
     protected ConsumerTypeTranslatorTest consumerTypeTranslatorTest = new ConsumerTypeTranslatorTest();
     protected OwnerTranslatorTest ownerTranslatorTest = new OwnerTranslatorTest();
@@ -41,8 +50,10 @@ public class ConsumerTranslatorTest extends
         this.consumerTypeTranslatorTest.initModelTranslator(modelTranslator);
         this.ownerTranslatorTest.initModelTranslator(modelTranslator);
 
-        modelTranslator.registerTranslator(
-            this.translator, Consumer.class, ConsumerDTO.class);
+        this.mockConsumerTypeCurator = mock(ConsumerTypeCurator.class);
+        this.translator = new ConsumerTranslator(this.mockConsumerTypeCurator);
+
+        modelTranslator.registerTranslator(this.translator, Consumer.class, ConsumerDTO.class);
     }
 
     @Override
@@ -52,13 +63,17 @@ public class ConsumerTranslatorTest extends
 
     @Override
     protected Consumer initSourceObject() {
+        ConsumerType ctype = this.consumerTypeTranslatorTest.initSourceObject();
         Consumer consumer = new Consumer();
 
         consumer.setUuid("consumer_uuid");
         consumer.setName("consumer_name");
         consumer.setOwner(this.ownerTranslatorTest.initSourceObject());
         consumer.setContentAccessMode("test_content_access_mode");
-        consumer.setType(this.consumerTypeTranslatorTest.initSourceObject());
+        consumer.setType(ctype);
+
+        when(mockConsumerTypeCurator.find(eq(ctype.getId()))).thenReturn(ctype);
+        when(mockConsumerTypeCurator.getConsumerType(eq(consumer))).thenReturn(ctype);
 
         return consumer;
     }
@@ -79,7 +94,9 @@ public class ConsumerTranslatorTest extends
 
             if (childrenGenerated) {
                 this.ownerTranslatorTest.verifyOutput(source.getOwner(), dest.getOwner(), true);
-                this.consumerTypeTranslatorTest.verifyOutput(source.getType(), dest.getType(), true);
+
+                ConsumerType ctype = this.mockConsumerTypeCurator.getConsumerType(source);
+                this.consumerTypeTranslatorTest.verifyOutput(ctype, dest.getType(), true);
             }
             else {
                 assertNull(dest.getOwner());

--- a/server/src/test/java/org/candlepin/dto/rules/v1/ConsumerTypeTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/rules/v1/ConsumerTypeTranslatorTest.java
@@ -48,6 +48,7 @@ public class ConsumerTypeTranslatorTest extends
     @Override
     public ConsumerType initSourceObject() {
         ConsumerType type = new ConsumerType();
+        type.setId("test_id");
         type.setLabel("type_label");
         type.setManifest(true);
 

--- a/server/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
@@ -1032,8 +1032,11 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
     public void shouldCountOwnerConsumersOnlyWithTypeLabels() {
         Consumer c1 = createConsumer(owner);
         Consumer c2 = createConsumer(owner);
-        String l1 = c1.getType().getLabel();
-        String l2 = c2.getType().getLabel();
+        ConsumerType c1t = consumerTypeCurator.getConsumerType(c1);
+        ConsumerType c2t = consumerTypeCurator.getConsumerType(c2);
+        String l1 = c1t.getLabel();
+        String l2 = c2t.getLabel();
+
         assertNotEquals(l1, l2);
         HashSet<String> typeLabels = new HashSet<>(1);
         typeLabels.add(l1);
@@ -1048,8 +1051,10 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
     public void testDisjunctionInCountingWithTypeLabels() {
         Consumer c1 = createConsumer(owner);
         Consumer c2 = createConsumer(owner);
-        String l1 = c1.getType().getLabel();
-        String l2 = c2.getType().getLabel();
+        ConsumerType c1t = consumerTypeCurator.getConsumerType(c1);
+        ConsumerType c2t = consumerTypeCurator.getConsumerType(c2);
+        String l1 = c1t.getLabel();
+        String l2 = c2t.getLabel();
 
         assertNotEquals(l1, l2);
         HashSet<String> typeLabels = new HashSet<>(1);
@@ -1273,8 +1278,7 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
         List<String> c = new ArrayList<>();
         c.add("unknown-contract");
 
-        int count = consumerCurator.countConsumers(owner.getKey(), typeLabels,
-            skus, subscriptionIds, c);
+        int count = consumerCurator.countConsumers(owner.getKey(), typeLabels, skus, subscriptionIds, c);
 
         assertEquals(0, count);
     }
@@ -1292,21 +1296,24 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
         Consumer c2 = createConsumerAndBindItToProduct(owner, skuProduct);
         Consumer c3 = createConsumerAndBindItToProduct(owner, skuProduct, subscriptionId);
         Consumer c4 = createConsumerAndBindItToProduct(owner, skuProduct, subscriptionId, poolContract);
+        ConsumerType c1t = consumerTypeCurator.getConsumerType(c1);
+        ConsumerType c2t = consumerTypeCurator.getConsumerType(c2);
+        ConsumerType c3t = consumerTypeCurator.getConsumerType(c3);
+        ConsumerType c4t = consumerTypeCurator.getConsumerType(c4);
 
         Set<String> labels = new HashSet<>();
         List<String> skus = new ArrayList<>();
         List<String> subIds = new ArrayList<>();
         List<String> contracts = new ArrayList<>();
-        labels.add(c1.getType().getLabel());
-        labels.add(c2.getType().getLabel());
-        labels.add(c3.getType().getLabel());
-        labels.add(c4.getType().getLabel());
+        labels.add(c1t.getLabel());
+        labels.add(c2t.getLabel());
+        labels.add(c3t.getLabel());
+        labels.add(c4t.getLabel());
         skus.add(sku);
         subIds.add(subscriptionId);
         contracts.add(poolContract);
 
-        int count = consumerCurator.countConsumers(owner.getKey(), typeLabels, skus,
-            subIds, contracts);
+        int count = consumerCurator.countConsumers(owner.getKey(), typeLabels, skus, subIds, contracts);
 
         assertEquals(1, count);
     }

--- a/server/src/test/java/org/candlepin/model/ConsumerTypeCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ConsumerTypeCuratorTest.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.model;
+
+import static org.junit.Assert.*;
+
+import org.candlepin.model.ConsumerType.ConsumerTypeEnum;
+import org.candlepin.test.DatabaseTestFixture;
+
+import org.junit.Test;
+
+
+
+/**
+ * Test suite for the ConsumerTypeCurator
+ */
+public class ConsumerTypeCuratorTest extends DatabaseTestFixture {
+
+
+    @Test
+    public void testGetConsumerType() {
+        ConsumerType ctype = this.createConsumerType();
+        Consumer consumer = new Consumer();
+
+        consumer.setTypeId(ctype.getId());
+
+        ConsumerType test = this.consumerTypeCurator.getConsumerType(consumer);
+        assertSame(ctype, test);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetConsumerTypeRequiresConsumer() {
+        this.consumerTypeCurator.getConsumerType(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetConsumerTypeRequiresConsumerWithType() {
+        ConsumerType ctype = this.createConsumerType();
+        Consumer consumer = new Consumer();
+
+        this.consumerTypeCurator.getConsumerType(consumer);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testGetConsumerTypeExpectsValidConsumerTypeId() {
+        ConsumerType ctype = this.createConsumerType();
+        Consumer consumer = new Consumer();
+
+        consumer.setTypeId("bad-type-id");
+
+        this.consumerTypeCurator.getConsumerType(consumer);
+    }
+
+    @Test
+    public void testLookupByLabel() {
+        String label = "test-label";
+        ConsumerType ctype = this.createConsumerType(label, false);
+
+        ConsumerType test = this.consumerTypeCurator.lookupByLabel(label);
+        assertSame(ctype, test);
+    }
+
+    @Test
+    public void testLookupByLabelForBadLabel() {
+        String label = "test-label";
+        ConsumerType ctype = this.createConsumerType(label, false);
+
+        ConsumerType test = this.consumerTypeCurator.lookupByLabel("bad_label");
+        assertNull(test);
+    }
+
+    @Test
+    public void testLookupByLabelExistingTypeWithCreation() {
+        String label = "test-label";
+        ConsumerType ctype = this.createConsumerType(label, false);
+
+        ConsumerType test = this.consumerTypeCurator.lookupByLabel(label, true);
+        assertSame(ctype, test);
+    }
+
+    @Test
+    public void testLookupByLabelNewTypeWithCreation() {
+        String label = "new-ctype";
+        ConsumerType ctype = this.createConsumerType("test-type", true);
+
+        ConsumerType test = this.consumerTypeCurator.lookupByLabel(label, true);
+        assertNotNull(test);
+        assertNotSame(ctype, test);
+
+        assertEquals(label, test.getLabel());
+    }
+
+    @Test
+    public void testLookupByLabelNewTypeFromEnumWithCreation() {
+        ConsumerTypeEnum cte = ConsumerTypeEnum.CANDLEPIN;
+        ConsumerType ctype = this.createConsumerType("test-type", true);
+
+        ConsumerType test = this.consumerTypeCurator.lookupByLabel(cte.getLabel(), true);
+        assertNotNull(test);
+        assertNotSame(ctype, test);
+
+        assertEquals(cte.getLabel(), test.getLabel());
+        assertEquals(cte.isManifest(), test.isManifest());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testLookupByLabelWithNullLabel() {
+        this.consumerTypeCurator.lookupByLabel(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testLookupByLabelWithNullLabelAndCreation() {
+        this.consumerTypeCurator.lookupByLabel(null, true);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testLookupByLabelWithEmptyLabel() {
+        this.consumerTypeCurator.lookupByLabel("");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testLookupByLabelWithEmptyLabelAndCreation() {
+        this.consumerTypeCurator.lookupByLabel("", true);
+    }
+}

--- a/server/src/test/java/org/candlepin/model/EntitlementCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/EntitlementCuratorTest.java
@@ -1220,7 +1220,10 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
         assertTrue(poolIds.contains(dependentEnt.getId()));
 
         // Bind the ents for the distributor consumer
-        assertTrue(distributor.isManifestDistributor());
+        ConsumerType ctype = this.consumerTypeCurator.getConsumerType(distributor);
+        assertNotNull(ctype);
+        assertTrue(ctype.isManifest());
+
         assertNotNull(this.bind(distributor, requiredPool));
         Entitlement distributorDependentEnt = this.bind(distributor, dependentPool);
         assertNotNull(distributorDependentEnt);
@@ -1262,7 +1265,10 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
         assertEquals(0, poolIds.size());
 
         // Bind the ents for the distributor consumer
-        assertTrue(distributor.isManifestDistributor());
+        ConsumerType ctype = this.consumerTypeCurator.getConsumerType(distributor);
+        assertNotNull(ctype);
+        assertTrue(ctype.isManifest());
+
         assertNotNull(this.bind(distributor, requiredPool));
         Entitlement distributorDependentEnt = this.bind(distributor, dependentPool);
         assertNotNull(distributorDependentEnt);

--- a/server/src/test/java/org/candlepin/model/EventCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/EventCuratorTest.java
@@ -34,10 +34,6 @@ import javax.inject.Inject;
 
 
 public class EventCuratorTest extends DatabaseTestFixture {
-    @Inject private OwnerCurator ownerCurator;
-    @Inject private ConsumerCurator consumerCurator;
-    @Inject private ConsumerTypeCurator consumerTypeCurator;
-    @Inject private EventCurator eventCurator;
     @Inject private EventFactory eventFactory;
 
     private Owner owner;
@@ -50,10 +46,10 @@ public class EventCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void testCreate() {
-        Consumer newConsumer = new Consumer("consumername", "user", owner,
-            new ConsumerType("system"));
-        consumerTypeCurator.create(newConsumer.getType());
-        consumerCurator.create(newConsumer);
+        ConsumerType consumerType = this.consumerTypeCurator.create(new ConsumerType("system"));
+
+        Consumer newConsumer = new Consumer("consumername", "user", owner, consumerType);
+        newConsumer = consumerCurator.create(newConsumer);
 
         setupPrincipal(owner, Access.ALL);
         Event event = eventFactory.consumerCreated(newConsumer);
@@ -66,29 +62,25 @@ public class EventCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void testSecondarySorting() {
+        ConsumerType consumerType = this.consumerTypeCurator.create(new ConsumerType("system"));
 
-        Consumer newConsumer = new Consumer("consumername", "user", owner,
-            new ConsumerType("system"));
-        consumerTypeCurator.create(newConsumer.getType());
-        consumerCurator.create(newConsumer);
+        Consumer newConsumer = new Consumer("consumername", "user", owner, consumerType);
+        newConsumer = consumerCurator.create(newConsumer);
 
         setupPrincipal(owner, Access.ALL);
 
         // Force all events to have exact same timestamp:
         Date forcedDate = new Date();
 
-        EventBuilder builder = eventFactory.getEventBuilder(Event.Target.RULES,
-            Event.Type.DELETED);
+        EventBuilder builder = eventFactory.getEventBuilder(Event.Target.RULES, Event.Type.DELETED);
         Event rulesDeletedEvent = builder.setEventData(new Rules()).buildEvent();
         rulesDeletedEvent.setTimestamp(forcedDate);
 
-        builder = eventFactory.getEventBuilder(Event.Target.CONSUMER,
-                Event.Type.CREATED);
+        builder = eventFactory.getEventBuilder(Event.Target.CONSUMER, Event.Type.CREATED);
         Event consumerCreatedEvent = builder.setEventData(newConsumer).buildEvent();
         consumerCreatedEvent.setTimestamp(forcedDate);
 
-        builder = eventFactory.getEventBuilder(Event.Target.CONSUMER,
-                Event.Type.MODIFIED);
+        builder = eventFactory.getEventBuilder(Event.Target.CONSUMER, Event.Type.MODIFIED);
         Event consumerModifiedEvent = builder.setEventData(newConsumer).buildEvent();
         consumerModifiedEvent.setTimestamp(forcedDate);
 

--- a/server/src/test/java/org/candlepin/model/OwnerTest.java
+++ b/server/src/test/java/org/candlepin/model/OwnerTest.java
@@ -90,17 +90,14 @@ public class OwnerTest extends DatabaseTestFixture {
     @Test
     public void bidirectionalConsumers() throws Exception {
         beginTransaction();
-        Owner o = createOwner();
-        ConsumerType consumerType = TestUtil.createConsumerType();
-        Consumer c1 = TestUtil.createConsumer(consumerType, o);
-        Consumer c2 = TestUtil.createConsumer(consumerType, o);
+        Owner o = this.createOwner();
+        ConsumerType consumerType = this.createConsumerType();
+        Consumer c1 = this.createConsumer(o, consumerType);
+        Consumer c2 = this.createConsumer(o, consumerType);
         o.addConsumer(c1);
         o.addConsumer(c2);
 
-        ownerCurator.create(o);
-        consumerTypeCurator.create(consumerType);
-        consumerCurator.create(c1);
-        consumerCurator.create(c2);
+        ownerCurator.merge(o);
         commitTransaction();
 
         assertEquals(2, o.getConsumers().size());
@@ -112,9 +109,9 @@ public class OwnerTest extends DatabaseTestFixture {
     @Test
     public void objectMapper() {
         Owner o = createOwner();
-        ConsumerType consumerType = TestUtil.createConsumerType();
-        Consumer c1 = TestUtil.createConsumer(consumerType, o);
-        Consumer c2 = TestUtil.createConsumer(consumerType, o);
+        ConsumerType consumerType = this.createConsumerType();
+        Consumer c1 = this.createConsumer(o, consumerType);
+        Consumer c2 = this.createConsumer(o, consumerType);
         o.addConsumer(c1);
         o.addConsumer(c2);
         Set<Consumer> consumers = o.getConsumers();

--- a/server/src/test/java/org/candlepin/model/PoolCuratorEntitlementRulesTest.java
+++ b/server/src/test/java/org/candlepin/model/PoolCuratorEntitlementRulesTest.java
@@ -54,11 +54,14 @@ public class PoolCuratorEntitlementRulesTest extends DatabaseTestFixture {
 
         product = this.createProduct(owner);
 
-        consumer = TestUtil.createConsumer(owner);
+
+        ConsumerType ctype = new ConsumerType("system");
+        ctype = this.consumerTypeCurator.create(ctype);
+
+        consumer = this.createConsumer(owner);
         consumer.setFact("cpu_cores", "4");
-        consumer.setType(new ConsumerType("system"));
-        consumerTypeCurator.create(consumer.getType());
-        consumerCurator.create(consumer);
+        consumer.setType(ctype);
+        consumer = consumerCurator.merge(consumer);
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
@@ -103,10 +103,17 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         pool.setDerivedProvidedProducts(derivedProvidedProducts);
         poolCurator.create(pool);
 
-        consumer = TestUtil.createConsumer(owner);
+        consumer = this.createMockConsumer(owner, false);
         consumer.setFact("cpu_cores", "4");
-        consumerTypeCurator.create(consumer.getType());
-        consumerCurator.create(consumer);
+        consumer = consumerCurator.merge(consumer);
+    }
+
+    protected Consumer createMockConsumer(Owner owner, boolean manifestType) {
+        ConsumerType ctype = this.createConsumerType(manifestType);
+        Consumer consumer = new Consumer("TestConsumer" + TestUtil.randomInt(), "User", owner, ctype);
+        consumer = this.consumerCurator.create(consumer);
+
+        return consumer;
     }
 
     @Test
@@ -125,10 +132,9 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         Owner owner = this.createOwner();
         Product product = this.createProduct(owner);
 
-        Consumer consumer = TestUtil.createConsumer(owner);
+        Consumer consumer = this.createMockConsumer(owner, false);
         consumer.setFact("cpu_cores", "4");
-        consumerTypeCurator.create(consumer.getType());
-        consumerCurator.create(consumer);
+        consumer = consumerCurator.merge(consumer);
 
         Pool pool = createPool(owner, product, 100L,
             TestUtil.createDate(2000, 3, 2), TestUtil.createDate(2005, 3, 2));
@@ -150,10 +156,9 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         Owner owner = this.createOwner();
         Product product = this.createProduct(owner);
 
-        Consumer consumer = TestUtil.createConsumer(owner);
+        Consumer consumer = this.createMockConsumer(owner, false);
         consumer.setFact("cpu_cores", "4");
-        consumerTypeCurator.create(consumer.getType());
-        consumerCurator.create(consumer);
+        consumer = consumerCurator.merge(consumer);
 
         Pool pool = createPool(owner, product, 100L,
             TestUtil.createDate(2000, 3, 2), TestUtil.createDate(2005, 3, 2));
@@ -1737,11 +1742,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void testUpdateQuantityColumnsOnPool() {
-        Consumer consumer = TestUtil.createConsumer(owner);
-        ConsumerType ct = consumer.getType();
-        ct.setManifest(true);
-        consumerTypeCurator.create(ct);
-        consumerCurator.create(consumer);
+        Consumer consumer = createMockConsumer(owner, true);
 
         Pool pool = createPool(owner, product, 20L,
             TestUtil.createDate(2010, 3, 2), TestUtil.createDate(
@@ -1763,10 +1764,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void testUpdateQuantityColumnsOnPoolNotManifest() {
-        Consumer consumer = TestUtil.createConsumer(owner);
-        ConsumerType ct = consumer.getType();
-        consumerTypeCurator.create(ct);
-        consumerCurator.create(consumer);
+        Consumer consumer = this.createConsumer(owner);
 
         Pool pool = createPool(owner, product, 20L,
             TestUtil.createDate(2010, 3, 2), TestUtil.createDate(
@@ -1788,10 +1786,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void testMarkCertificatesDirtyForPoolsWithNormalProduct() {
-        Consumer consumer = TestUtil.createConsumer(owner);
-        ConsumerType ct = consumer.getType();
-        consumerTypeCurator.create(ct);
-        consumerCurator.create(consumer);
+        Consumer consumer = this.createConsumer(owner);
 
         Pool pool = createPool(owner, product, -1L, TestUtil.createDate(2017, 3, 27),
             TestUtil.createDate(Calendar.getInstance().get(Calendar.YEAR) + 1, 3, 27));
@@ -1818,10 +1813,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         }
         productIds.add(product.getId());
 
-        Consumer consumer = TestUtil.createConsumer(owner);
-        ConsumerType ct = consumer.getType();
-        consumerTypeCurator.create(ct);
-        consumerCurator.create(consumer);
+        Consumer consumer = this.createConsumer(owner);
 
         Pool pool = createPool(owner, product, -1L, TestUtil.createDate(2017, 3, 27),
             TestUtil.createDate(Calendar.getInstance().get(Calendar.YEAR) + 1, 3, 27));
@@ -1842,10 +1834,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void testMarkCertificatesDirtyForPoolsWithProvidedProduct() {
-        Consumer consumer = TestUtil.createConsumer(owner);
-        ConsumerType ct = consumer.getType();
-        consumerTypeCurator.create(ct);
-        consumerCurator.create(consumer);
+        Consumer consumer = this.createConsumer(owner);
 
         Product parent = TestUtil.createProduct();
         productCurator.create(parent);
@@ -2228,10 +2217,11 @@ public class PoolCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void testUpdateQuantityColumnsOnSharedPool() {
-        Consumer consumer = TestUtil.createConsumer(owner);
         ConsumerType shareType = new ConsumerType("share");
-        consumer.setType(shareType);
         consumerTypeCurator.create(shareType);
+
+        Consumer consumer = TestUtil.createConsumer(owner);
+        consumer.setType(shareType);
         consumerCurator.create(consumer);
 
         Pool pool = createPool(owner, product, 20L,
@@ -2254,10 +2244,11 @@ public class PoolCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void testFetchSharedPoolsOf() {
-        consumer = TestUtil.createConsumer(owner);
         ConsumerType share = new ConsumerType("share");
-        consumer.setType(share);
         consumerTypeCurator.create(share);
+
+        consumer = TestUtil.createConsumer(owner);
+        consumer.setType(share);
         consumerCurator.create(consumer);
 
         Pool pool = createPool(owner, product, 1L,

--- a/server/src/test/java/org/candlepin/model/PoolTest.java
+++ b/server/src/test/java/org/candlepin/model/PoolTest.java
@@ -110,12 +110,10 @@ public class PoolTest extends DatabaseTestFixture {
             poolCurator.create(pool);
             owner = pool.getOwner();
 
-            consumer = TestUtil.createConsumer(owner);
+            consumer = this.createConsumer(owner);
 
             productCurator.create(prod1);
             poolCurator.create(pool);
-            consumerTypeCurator.create(consumer.getType());
-            consumerCurator.create(consumer);
 
             commitTransaction();
         }

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/EntitleByProductsJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/EntitleByProductsJobTest.java
@@ -52,8 +52,11 @@ public class EntitleByProductsJobTest extends BaseJobTest {
     public void init() {
         super.init();
         consumerUuid = "49bd6a8f-e9f8-40cc-b8d7-86cafd687a0e";
-        consumer = new Consumer("Test Consumer", "test-consumer", new Owner("test-owner"),
-                new ConsumerType("system"));
+
+        ConsumerType ctype = new ConsumerType("system");
+        ctype.setId("test-ctype");
+
+        consumer = new Consumer("Test Consumer", "test-consumer", new Owner("test-owner"), ctype);
         consumer.setUuid(consumerUuid);
         e = mock(Entitler.class);
     }

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/EntitlerJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/EntitlerJobTest.java
@@ -70,8 +70,11 @@ public class EntitlerJobTest extends BaseJobTest{
     public void init() {
         super.init();
         consumerUuid = "49bd6a8f-e9f8-40cc-b8d7-86cafd687a0e";
-        consumer = new Consumer("Test Consumer", "test-consumer", new Owner("test-owner"),
-            new ConsumerType("system"));
+
+        ConsumerType ctype = new ConsumerType("system");
+        ctype.setId("test-ctype");
+
+        consumer = new Consumer("Test Consumer", "test-consumer", new Owner("test-owner"), ctype);
         consumer.setUuid(consumerUuid);
         e = mock(Entitler.class);
         pC = mock(PoolCurator.class);

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/HypervisorUpdateJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/HypervisorUpdateJobTest.java
@@ -60,7 +60,7 @@ import javax.inject.Provider;
 /**
  * HypervisorUpdateJobTest
  */
-public class HypervisorUpdateJobTest extends BaseJobTest{
+public class HypervisorUpdateJobTest extends BaseJobTest {
 
     private Owner owner;
     private Principal principal;
@@ -94,8 +94,11 @@ public class HypervisorUpdateJobTest extends BaseJobTest{
         subAdapter = mock(SubscriptionServiceAdapter.class);
         complianceRules = mock(ComplianceRules.class);
         when(owner.getId()).thenReturn("joe");
-        when(consumerTypeCurator.create(any(ConsumerType.class))).thenReturn(new ConsumerType(ConsumerTypeEnum
-            .HYPERVISOR));
+
+        ConsumerType ctype = new ConsumerType(ConsumerTypeEnum.HYPERVISOR);
+        ctype.setId("test-ctype");
+
+        when(consumerTypeCurator.create(any(ConsumerType.class))).thenReturn(ctype);
         when(owner.getKey()).thenReturn("joe");
         when(principal.getUsername()).thenReturn("joe user");
 

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/HypervisorUpdateJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/HypervisorUpdateJobTest.java
@@ -98,7 +98,10 @@ public class HypervisorUpdateJobTest extends BaseJobTest {
         ConsumerType ctype = new ConsumerType(ConsumerTypeEnum.HYPERVISOR);
         ctype.setId("test-ctype");
 
-        when(consumerTypeCurator.create(any(ConsumerType.class))).thenReturn(ctype);
+        when(consumerTypeCurator.lookupByLabel(eq(ConsumerTypeEnum.HYPERVISOR.getLabel()))).thenReturn(ctype);
+        when(consumerTypeCurator.lookupByLabel(eq(ConsumerTypeEnum.HYPERVISOR.getLabel()), anyBoolean()))
+            .thenReturn(ctype);
+
         when(owner.getKey()).thenReturn("joe");
         when(principal.getUsername()).thenReturn("joe user");
 

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/UndoImportsJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/UndoImportsJobTest.java
@@ -133,10 +133,9 @@ public class UndoImportsJobTest extends DatabaseTestFixture {
         // Create owner w/upstream consumer
         Owner owner1 = TestUtil.createOwner();
         Owner owner2 = TestUtil.createOwner();
-        ConsumerType type = TestUtil.createConsumerType();
+        ConsumerType type = this.createConsumerType();
         UpstreamConsumer uc1 = new UpstreamConsumer("uc1", null, type, "uc1");
         UpstreamConsumer uc2 = new UpstreamConsumer("uc2", null, type, "uc2");
-        this.consumerTypeCurator.create(type);
         this.ownerCurator.create(owner1);
         this.ownerCurator.create(owner2);
         owner1.setUpstreamConsumer(uc1);
@@ -226,12 +225,8 @@ public class UndoImportsJobTest extends DatabaseTestFixture {
 
             case ENTITLEMENT_DERIVED:
                 pool.setAttribute(Pool.Attributes.DERIVED_POOL, "true");
-                consumer = TestUtil.createConsumer(owner);
-                entitlement = TestUtil.createEntitlement(owner, consumer, pool, null);
-
-                this.consumerTypeCurator.create(consumer.getType());
-                this.consumerCurator.create(consumer);
-                this.entitlementCurator.create(entitlement);
+                consumer = this.createConsumer(owner);
+                entitlement = this.createEntitlement(owner, consumer, pool, null);
 
                 pool.setSourceEntitlement(entitlement);
                 break;

--- a/server/src/test/java/org/candlepin/policy/EnforcerTest.java
+++ b/server/src/test/java/org/candlepin/policy/EnforcerTest.java
@@ -107,9 +107,7 @@ public class EnforcerTest extends DatabaseTestFixture {
         owner = createOwner();
         ownerCurator.create(owner);
 
-        consumer = TestUtil.createConsumer(owner);
-        consumerTypeCurator.create(consumer.getType());
-        consumerCurator.create(consumer);
+        consumer = this.createConsumer(owner);
 
         BufferedReader reader = new BufferedReader(new InputStreamReader(
             getClass().getResourceAsStream("/rules/test-rules.js")));
@@ -128,10 +126,10 @@ public class EnforcerTest extends DatabaseTestFixture {
 
         JsRunner jsRules = new JsRunnerProvider(rulesCurator, cacheProvider).get();
 
-        translator = new StandardTranslator();
+        translator = new StandardTranslator(consumerTypeCurator);
 
         enforcer = new EntitlementRules(
-            new DateSourceForTesting(2010, 1, 1), jsRules, i18n, config, consumerCurator,
+            new DateSourceForTesting(2010, 1, 1), jsRules, i18n, config, consumerCurator, consumerTypeCurator,
             mockProductCurator,
             new RulesObjectMapper(new ProductCachedSerializationModule(mockProductCurator)),
             mockOwnerCurator, mockOwnerProductCurator, mockProductShareCurator, mockProductManager,
@@ -237,8 +235,9 @@ public class EnforcerTest extends DatabaseTestFixture {
         product.setAttribute(PRODUCT_CPULIMITED, "2");
         product = this.createProduct(product, owner);
 
-        ValidationResult result = enforcer.preEntitlement(
-            TestUtil.createConsumer(),
+        Consumer consumer = this.createConsumer(owner);
+
+        ValidationResult result = enforcer.preEntitlement(consumer,
             entitlementPoolWithMembersAndExpiration(owner, product, 1, 2, expiryDate(2000, 1, 1)), 1);
 
         assertFalse(result.isSuccessful());

--- a/server/src/test/java/org/candlepin/policy/ExportRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/ExportRulesTest.java
@@ -16,11 +16,13 @@ package org.candlepin.policy;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerType;
+import org.candlepin.model.ConsumerTypeCurator;
 import org.candlepin.model.Entitlement;
 import org.candlepin.model.Pool;
 import org.candlepin.model.Product;
@@ -51,6 +53,7 @@ public class ExportRulesTest {
 
     private ExportRules exportRules;
 
+    @Mock private ConsumerTypeCurator consumerTypeCuratorMock;
     @Mock private RulesCurator rulesCuratorMock;
 
     @Before
@@ -63,21 +66,28 @@ public class ExportRulesTest {
         when(rulesCuratorMock.getUpdated()).thenReturn(new Date());
         when(rulesCuratorMock.getRules()).thenReturn(rules);
 
-        exportRules = new ExportRules();
+        exportRules = new ExportRules(consumerTypeCuratorMock);
     }
 
     @Test
     public void cannotExportProduct() throws NoSuchMethodException {
         Entitlement entitlement = mock(Entitlement.class);
+
         Consumer consumer = mock(Consumer.class);
-        ConsumerType type = mock(ConsumerType.class);
+        ConsumerType consumerType = new ConsumerType("system");
+        consumerType.setId("consumer_type");
+        consumerType.setManifest(true);
+
         Product p = TestUtil.createProduct("12345");
         Pool pool = new Pool();
         pool.setAttribute(Pool.Attributes.DERIVED_POOL, "true");
 
         when(entitlement.getPool()).thenReturn(pool);
         when(entitlement.getConsumer()).thenReturn(consumer);
-        when(consumer.isManifestDistributor()).thenReturn(true);
+
+        when(consumer.getTypeId()).thenReturn(consumerType.getId());
+        when(consumerTypeCuratorMock.find(eq(consumerType.getId()))).thenReturn(consumerType);
+        when(consumerTypeCuratorMock.getConsumerType(eq(consumer))).thenReturn(consumerType);
 
         assertFalse(exportRules.canExport(entitlement));
     }
@@ -85,8 +95,11 @@ public class ExportRulesTest {
     @Test
     public void canExportProductConsumer() throws NoSuchMethodException {
         Entitlement entitlement = mock(Entitlement.class);
+
         Consumer consumer = mock(Consumer.class);
-        ConsumerType consumerType = mock(ConsumerType.class);
+        ConsumerType consumerType = new ConsumerType("system");
+        consumerType.setId("consumer_type");
+
         Pool pool = mock(Pool.class);
         Product product = mock(Product.class);
 
@@ -98,8 +111,10 @@ public class ExportRulesTest {
         when(pool.getProductId()).thenReturn("12345");
         when(product.getAttributes()).thenReturn(new HashMap<>());
         when(pool.getAttributes()).thenReturn(attributes);
-        when(consumer.getType()).thenReturn(consumerType);
-        when(consumerType.getLabel()).thenReturn("system");
+
+        when(consumer.getTypeId()).thenReturn(consumerType.getId());
+        when(consumerTypeCuratorMock.find(eq(consumerType.getId()))).thenReturn(consumerType);
+        when(consumerTypeCuratorMock.getConsumerType(eq(consumer))).thenReturn(consumerType);
 
         assertTrue(exportRules.canExport(entitlement));
     }
@@ -107,8 +122,11 @@ public class ExportRulesTest {
     @Test
     public void canExportProductVirt() throws NoSuchMethodException {
         Entitlement entitlement = mock(Entitlement.class);
+
         Consumer consumer = mock(Consumer.class);
-        ConsumerType consumerType = mock(ConsumerType.class);
+        ConsumerType consumerType = new ConsumerType("candlepin");
+        consumerType.setId("consumer_type");
+
         Pool pool = mock(Pool.class);
         Product product = mock(Product.class);
 
@@ -117,8 +135,10 @@ public class ExportRulesTest {
         when(pool.getProductId()).thenReturn("12345");
         when(product.getAttributes()).thenReturn(new HashMap<>());
         when(pool.getAttributes()).thenReturn(new HashMap<>());
-        when(consumer.getType()).thenReturn(consumerType);
-        when(consumerType.getLabel()).thenReturn("candlepin");
+
+        when(consumer.getTypeId()).thenReturn(consumerType.getId());
+        when(consumerTypeCuratorMock.find(eq(consumerType.getId()))).thenReturn(consumerType);
+        when(consumerTypeCuratorMock.getConsumerType(eq(consumer))).thenReturn(consumerType);
 
         assertTrue(exportRules.canExport(entitlement));
     }

--- a/server/src/test/java/org/candlepin/policy/PoolRulesStackDerivedTest.java
+++ b/server/src/test/java/org/candlepin/policy/PoolRulesStackDerivedTest.java
@@ -133,8 +133,10 @@ public class PoolRulesStackDerivedTest {
         principal = TestUtil.createOwnerPrincipal();
         owner = principal.getOwners().get(0);
 
-        consumer = new Consumer("consumer", "registeredbybob", owner,
-            new ConsumerType(ConsumerTypeEnum.SYSTEM));
+        ConsumerType ctype = new ConsumerType(ConsumerTypeEnum.SYSTEM);
+        ctype.setId("test-ctype");
+
+        consumer = new Consumer("consumer", "registeredbybob", owner, ctype);
 
         // Two subtly different products stacked together:
         prod1 = TestUtil.createProduct("prod1", "prod1");

--- a/server/src/test/java/org/candlepin/policy/js/RulesObjectMapperTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/RulesObjectMapperTest.java
@@ -18,7 +18,6 @@ import static org.junit.Assert.assertFalse;
 
 import org.candlepin.jackson.ProductCachedSerializationModule;
 import org.candlepin.model.Consumer;
-import org.candlepin.model.ConsumerType;
 import org.candlepin.model.Entitlement;
 import org.candlepin.model.EntitlementCertificate;
 import org.candlepin.model.IdentityCertificate;
@@ -63,7 +62,7 @@ public class RulesObjectMapperTest {
     @Test
     public void filterConsumerIdCert() {
         Consumer c = new Consumer();
-        c.setType(new ConsumerType(ConsumerType.ConsumerTypeEnum.SYSTEM));
+        c.setTypeId("test-ctype");
         IdentityCertificate cert = new IdentityCertificate();
         cert.setCert("FILTERMEPLEASE");
         cert.setKey("KEY");

--- a/server/src/test/java/org/candlepin/policy/js/activationkey/ActivationKeyRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/activationkey/ActivationKeyRulesTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.dto.StandardTranslator;
 import org.candlepin.jackson.ProductCachedSerializationModule;
+import org.candlepin.model.ConsumerTypeCurator;
 import org.candlepin.model.Owner;
 import org.candlepin.model.Pool;
 import org.candlepin.model.Product;
@@ -60,6 +61,8 @@ public class ActivationKeyRulesTest {
     @Mock private RulesCurator rulesCuratorMock;
     @Mock private Provider<JsRunnerRequestCache> cacheProvider;
     @Mock private JsRunnerRequestCache cache;
+    @Mock private ConsumerTypeCurator mockConsumerTypeCurator;
+
     private I18n i18n;
     private JsRunnerProvider provider;
     private Owner owner = TestUtil.createOwner();
@@ -72,8 +75,7 @@ public class ActivationKeyRulesTest {
         i18n = I18nFactory.getI18n(getClass(), "org.candlepin.i18n.Messages", locale,
             I18nFactory.FALLBACK);
         // Load the default production rules:
-        InputStream is = this.getClass().getResourceAsStream(
-            RulesCurator.DEFAULT_RULES_FILE);
+        InputStream is = this.getClass().getResourceAsStream(RulesCurator.DEFAULT_RULES_FILE);
         Rules rules = new Rules(Util.readFile(is));
         when(rulesCuratorMock.getUpdated()).thenReturn(new Date());
         when(rulesCuratorMock.getRules()).thenReturn(rules);
@@ -81,7 +83,7 @@ public class ActivationKeyRulesTest {
 
         provider = new JsRunnerProvider(rulesCuratorMock, cacheProvider);
         ProductCurator productCurator = mock(ProductCurator.class);
-        translator = new StandardTranslator();
+        translator = new StandardTranslator(mockConsumerTypeCurator);
         actKeyRules = new ActivationKeyRules(provider.get(), i18n,
                 new RulesObjectMapper(new ProductCachedSerializationModule(productCurator)), translator);
     }

--- a/server/src/test/java/org/candlepin/policy/js/compliance/ComplianceRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/compliance/ComplianceRulesTest.java
@@ -32,9 +32,10 @@ import org.candlepin.dto.StandardTranslator;
 import org.candlepin.model.CandlepinQuery;
 import org.candlepin.jackson.ProductCachedSerializationModule;
 import org.candlepin.model.Consumer;
-import org.candlepin.model.ConsumerCurator;
-import org.candlepin.model.ConsumerInstalledProduct;
 import org.candlepin.model.ConsumerType;
+import org.candlepin.model.ConsumerCurator;
+import org.candlepin.model.ConsumerTypeCurator;
+import org.candlepin.model.ConsumerInstalledProduct;
 import org.candlepin.model.Entitlement;
 import org.candlepin.model.EntitlementCurator;
 import org.candlepin.model.GuestId;
@@ -91,6 +92,7 @@ public class ComplianceRulesTest {
     private static final String STACK_ID_2 = "my-stack-2";
 
     @Mock private ConsumerCurator consumerCurator;
+    @Mock private ConsumerTypeCurator consumerTypeCurator;
     @Mock private EntitlementCurator entCurator;
     @Mock private RulesCurator rulesCuratorMock;
     @Mock private EventSink eventSink;
@@ -106,9 +108,10 @@ public class ComplianceRulesTest {
 
     @Before
     public void setUp() {
-        translator = new StandardTranslator();
-
         MockitoAnnotations.initMocks(this);
+
+        translator = new StandardTranslator(consumerTypeCurator);
+
         Locale locale = new Locale("en_US");
         i18n = I18nFactory.getI18n(getClass(), "org.candlepin.i18n.Messages", locale, I18nFactory.FALLBACK);
         // Load the default production rules:
@@ -119,7 +122,7 @@ public class ComplianceRulesTest {
         when(cacheProvider.get()).thenReturn(cache);
         provider = new JsRunnerProvider(rulesCuratorMock, cacheProvider);
         compliance = new ComplianceRules(provider.get(), entCurator, new StatusReasonMessageGenerator(i18n),
-            eventSink, consumerCurator,
+            eventSink, consumerCurator, consumerTypeCurator,
             new RulesObjectMapper(new ProductCachedSerializationModule(productCurator)), translator);
 
         owner = new Owner("test");
@@ -136,7 +139,7 @@ public class ComplianceRulesTest {
     public void additivePropertiesCanStillDeserialize() {
         JsRunner mockRunner = mock(JsRunner.class);
         compliance = new ComplianceRules(mockRunner, entCurator, new StatusReasonMessageGenerator(i18n),
-            eventSink, consumerCurator,
+            eventSink, consumerCurator, consumerTypeCurator,
             new RulesObjectMapper(new ProductCachedSerializationModule(productCurator)), translator);
 
         when(mockRunner.runJsFunction(any(Class.class), eq("get_status"),
@@ -148,8 +151,14 @@ public class ComplianceRulesTest {
     }
 
     private Consumer mockConsumer(Product ... installedProducts) {
+        ConsumerType ctype = new ConsumerType(ConsumerType.ConsumerTypeEnum.SYSTEM);
+        ctype.setId("test-ctype-" + TestUtil.randomInt());
+
         Consumer consumer = new Consumer();
-        consumer.setType(new ConsumerType(ConsumerType.ConsumerTypeEnum.SYSTEM));
+        consumer.setType(ctype);
+
+        when(this.consumerTypeCurator.find(eq(ctype.getId()))).thenReturn(ctype);
+        when(this.consumerTypeCurator.getConsumerType(eq(consumer))).thenReturn(ctype);
 
         for (Product product : installedProducts) {
             consumer.addInstalledProduct(new ConsumerInstalledProduct(product.getId(), product.getName()));
@@ -273,8 +282,7 @@ public class ComplianceRulesTest {
     private Consumer mockFullyEntitledConsumer() {
         Consumer c = mockConsumer(PRODUCT_1, PRODUCT_2);
         List<Entitlement> ents = new LinkedList<>();
-        ents.add(mockEntitlement(c, TestUtil.createProduct("Awesome Product"),
-            PRODUCT_1, PRODUCT_2));
+        ents.add(mockEntitlement(c, TestUtil.createProduct("Awesome Product"), PRODUCT_1, PRODUCT_2));
         mockEntCurator(c, ents);
         return c;
     }
@@ -293,8 +301,7 @@ public class ComplianceRulesTest {
     public void entitledProducts() {
         Consumer c = mockConsumer(PRODUCT_1, PRODUCT_2);
         List<Entitlement> ents = new LinkedList<>();
-        ents.add(mockEntitlement(c, TestUtil.createProduct("Awesome Product"),
-            PRODUCT_1));
+        ents.add(mockEntitlement(c, TestUtil.createProduct("Awesome Product"), PRODUCT_1));
         mockEntCurator(c, ents);
 
         ComplianceStatus status = compliance.getStatus(c, TestUtil.createDate(2011, 8, 30));

--- a/server/src/test/java/org/candlepin/policy/js/compliance/StatusReasonMessageGeneratorTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/compliance/StatusReasonMessageGeneratorTest.java
@@ -55,8 +55,10 @@ public class StatusReasonMessageGeneratorTest {
             I18nFactory.FALLBACK);
         generator = new StatusReasonMessageGenerator(i18n);
         owner = new Owner("test");
+        ConsumerType ctype = new ConsumerType(ConsumerType.ConsumerTypeEnum.SYSTEM);
+        ctype.setId("test-ctype");
         consumer = new Consumer();
-        consumer.setType(new ConsumerType(ConsumerType.ConsumerTypeEnum.SYSTEM));
+        consumer.setType(ctype);
         ent1 = mockEntitlement(consumer, TestUtil.createProduct("id1", "Nonstacked Product"));
         ent1.setId("ent1");
         entStacked1 = mockBaseStackedEntitlement(consumer, "stack",
@@ -72,9 +74,7 @@ public class StatusReasonMessageGeneratorTest {
     public void testSocketsMessage() {
         ComplianceReason reason = buildReason("SOCKETS", buildGeneralAttributes("8", "4"));
         generator.setMessage(consumer, reason, new Date());
-        assertEquals(
-            "Only supports 4 of 8 sockets.",
-            reason.getMessage());
+        assertEquals("Only supports 4 of 8 sockets.", reason.getMessage());
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/policy/js/compliance/hash/ComplianceStatusHasherTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/compliance/hash/ComplianceStatusHasherTest.java
@@ -322,8 +322,10 @@ public class ComplianceStatusHasherTest {
     }
 
     private Consumer createConsumer(Owner owner) {
-        Consumer consumer = new Consumer("test-consumer", "test-consumer", owner,
-            new ConsumerType(ConsumerType.ConsumerTypeEnum.SYSTEM));
+        ConsumerType ctype = new ConsumerType(ConsumerType.ConsumerTypeEnum.SYSTEM);
+        ctype.setId("test-ctype");
+
+        Consumer consumer = new Consumer("test-consumer", "test-consumer", owner, ctype);
         consumer.setId("1");
         consumer.setUuid("12345");
         consumer.setFact("ram", "4");

--- a/server/src/test/java/org/candlepin/policy/js/entitlement/HostedVirtLimitEntitlementRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/entitlement/HostedVirtLimitEntitlementRulesTest.java
@@ -71,7 +71,8 @@ public class HostedVirtLimitEntitlementRulesTest extends EntitlementRulesTestFix
     public void hostedVirtLimitAltersBonusPoolQuantity() {
         when(config.getBoolean(ConfigProperties.STANDALONE)).thenReturn(false);
         Subscription s = createVirtLimitSub("virtLimitProduct", 10, "10");
-        consumer.setType(new ConsumerType(ConsumerTypeEnum.CANDLEPIN));
+        ConsumerType ctype = this.mockConsumerType(new ConsumerType(ConsumerTypeEnum.CANDLEPIN));
+        consumer.setType(ctype);
         Pool p = TestUtil.copyFromSub(s);
         when(poolManagerMock.isManaged(eq(p))).thenReturn(true);
         List<Pool> pools = poolRules.createAndEnrichPools(p, new LinkedList<>());
@@ -122,7 +123,8 @@ public class HostedVirtLimitEntitlementRulesTest extends EntitlementRulesTestFix
     public void batchHostedVirtLimitAltersBonusPoolQuantity() {
         when(config.getBoolean(ConfigProperties.STANDALONE)).thenReturn(false);
 
-        consumer.setType(new ConsumerType(ConsumerTypeEnum.CANDLEPIN));
+        ConsumerType ctype = this.mockConsumerType(new ConsumerType(ConsumerTypeEnum.CANDLEPIN));
+        consumer.setType(ctype);
         Subscription s = createVirtLimitSub("virtLimitProduct", 10, "10");
         Pool p = TestUtil.copyFromSub(s);
         when(poolManagerMock.isManaged(eq(p))).thenReturn(true);
@@ -317,7 +319,8 @@ public class HostedVirtLimitEntitlementRulesTest extends EntitlementRulesTestFix
     @Test
     public void exportAllPhysicalZeroBonusPoolQuantity() {
         when(config.getBoolean(ConfigProperties.STANDALONE)).thenReturn(false);
-        consumer.setType(new ConsumerType(ConsumerTypeEnum.CANDLEPIN));
+        ConsumerType ctype = this.mockConsumerType(new ConsumerType(ConsumerTypeEnum.CANDLEPIN));
+        consumer.setType(ctype);
         Subscription s = createVirtLimitSub("virtLimitProduct", 10, "unlimited");
         Pool p = TestUtil.copyFromSub(s);
         when(poolManagerMock.isManaged(eq(p))).thenReturn(true);
@@ -370,7 +373,8 @@ public class HostedVirtLimitEntitlementRulesTest extends EntitlementRulesTestFix
     @Test
     public void hostedVirtLimitDoesNotAlterQuantitiesForHostLimited() {
         when(config.getBoolean(ConfigProperties.STANDALONE)).thenReturn(false);
-        consumer.setType(new ConsumerType(ConsumerTypeEnum.CANDLEPIN));
+        ConsumerType ctype = this.mockConsumerType(new ConsumerType(ConsumerTypeEnum.CANDLEPIN));
+        consumer.setType(ctype);
 
         Pool virtBonusPool = setupVirtLimitPool();
         virtBonusPool.setQuantity(100L);

--- a/server/src/test/java/org/candlepin/policy/js/entitlement/ManifestEntitlementRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/entitlement/ManifestEntitlementRulesTest.java
@@ -44,19 +44,30 @@ import java.util.Set;
  */
 public class ManifestEntitlementRulesTest extends EntitlementRulesTestFixture {
 
+    private Consumer createMockConsumer(boolean manifestDistributor) {
+        ConsumerType type = TestUtil.createConsumerType();
+        type.setManifest(manifestDistributor);
+
+        Consumer consumer = TestUtil.createConsumer();
+        consumer.setType(type);
+
+        when(consumerTypeCurator.getConsumerType(eq(consumer))).thenReturn(type);
+        when(consumerTypeCurator.find(eq(type.getId()))).thenReturn(type);
+
+        return consumer;
+    }
+
     @Test
     public void postEntitlement() {
-        Consumer c = mock(Consumer.class);
+        Consumer c = this.createMockConsumer(true);
         PoolManager pm = mock(PoolManager.class);
         Entitlement e = mock(Entitlement.class);
-        ConsumerType type = mock(ConsumerType.class);
         Pool pool = mock(Pool.class);
         Product product = mock(Product.class);
 
         when(e.getPool()).thenReturn(pool);
         when(e.getConsumer()).thenReturn(c);
-        when(c.getType()).thenReturn(type);
-        when(type.isManifest()).thenReturn(true);
+
         when(pool.getProductId()).thenReturn("testProd");
         when(product.getAttributes()).thenReturn(new HashMap<>());
         when(pool.getAttributes()).thenReturn(new HashMap<>());
@@ -71,9 +82,8 @@ public class ManifestEntitlementRulesTest extends EntitlementRulesTestFixture {
     @Test
     public void preEntitlementIgnoresSocketAttributeChecking() {
         // Test with sockets to make sure that they are skipped.
-        Consumer c = TestUtil.createConsumer();
+        Consumer c = this.createMockConsumer(true);
         c.setFact("cpu.socket(s)", "12");
-        c.getType().setManifest(true);
 
         Product prod = TestUtil.createProduct();
         prod.setAttribute(Product.Attributes.SOCKETS, "2");
@@ -87,11 +97,10 @@ public class ManifestEntitlementRulesTest extends EntitlementRulesTestFixture {
     @Test
     public void preEntitlementNoCoreCapableBindError() {
         // Test with sockets to make sure that they are skipped.
-        Consumer c = TestUtil.createConsumer();
+        Consumer c = this.createMockConsumer(true);
         c.setFact("cpu.core(s)_per_socket", "2");
         Set<ConsumerCapability> caps = new HashSet<>();
         c.setCapabilities(caps);
-        c.getType().setManifest(true);
 
         Product prod = TestUtil.createProduct();
         prod.setAttribute(Product.Attributes.CORES, "2");
@@ -108,11 +117,10 @@ public class ManifestEntitlementRulesTest extends EntitlementRulesTestFixture {
     @Test
     public void preEntitlementNoCoreCapableListWarn() {
         // Test with sockets to make sure that they are skipped.
-        Consumer c = TestUtil.createConsumer();
+        Consumer c = this.createMockConsumer(true);
         c.setFact("cpu.core(s)_per_socket", "2");
         Set<ConsumerCapability> caps = new HashSet<>();
         c.setCapabilities(caps);
-        c.getType().setManifest(true);
 
         Product prod = TestUtil.createProduct();
         prod.setAttribute(Product.Attributes.CORES, "2");
@@ -128,13 +136,12 @@ public class ManifestEntitlementRulesTest extends EntitlementRulesTestFixture {
     @Test
     public void preEntitlementSuccessCoreCapable() {
         // Test with sockets to make sure that they are skipped.
-        Consumer c = TestUtil.createConsumer();
+        Consumer c = this.createMockConsumer(true);
         c.setFact("cpu.core(s)_per_socket", "2");
         Set<ConsumerCapability> caps = new HashSet<>();
         ConsumerCapability cc = new ConsumerCapability(c, "cores");
         caps.add(cc);
         c.setCapabilities(caps);
-        c.getType().setManifest(true);
 
         Product prod = TestUtil.createProduct();
         prod.setAttribute(Product.Attributes.CORES, "2");
@@ -149,11 +156,10 @@ public class ManifestEntitlementRulesTest extends EntitlementRulesTestFixture {
     @Test
     public void preEntitlementNoRamCapableBindError() {
         // Test with sockets to make sure that they are skipped.
-        Consumer c = TestUtil.createConsumer();
+        Consumer c = this.createMockConsumer(true);
         c.setFact("memory.memtotal", "2000000");
         Set<ConsumerCapability> caps = new HashSet<>();
         c.setCapabilities(caps);
-        c.getType().setManifest(true);
 
         Product prod = TestUtil.createProduct();
         prod.setAttribute(Product.Attributes.RAM, "2");
@@ -170,11 +176,10 @@ public class ManifestEntitlementRulesTest extends EntitlementRulesTestFixture {
     @Test
     public void preEntitlementNoRamCapableListWarn() {
         // Test with sockets to make sure that they are skipped.
-        Consumer c = TestUtil.createConsumer();
+        Consumer c = this.createMockConsumer(true);
         c.setFact("memory.memtotal", "2000000");
         Set<ConsumerCapability> caps = new HashSet<>();
         c.setCapabilities(caps);
-        c.getType().setManifest(true);
 
         Product prod = TestUtil.createProduct();
         prod.setAttribute(Product.Attributes.RAM, "2");
@@ -191,13 +196,12 @@ public class ManifestEntitlementRulesTest extends EntitlementRulesTestFixture {
     @Test
     public void preEntitlementSuccessRamCapable() {
         // Test with sockets to make sure that they are skipped.
-        Consumer c = TestUtil.createConsumer();
+        Consumer c = this.createMockConsumer(true);
         c.setFact("memory.memtotal", "2000000");
         Set<ConsumerCapability> caps = new HashSet<>();
         ConsumerCapability cc = new ConsumerCapability(c, "ram");
         caps.add(cc);
         c.setCapabilities(caps);
-        c.getType().setManifest(true);
 
         Product prod = TestUtil.createProduct();
         prod.setAttribute(Product.Attributes.RAM, "2");
@@ -212,10 +216,9 @@ public class ManifestEntitlementRulesTest extends EntitlementRulesTestFixture {
     @Test
     public void preEntitlementNoInstanceCapableBindError() {
         // Test with sockets to make sure that they are skipped.
-        Consumer c = TestUtil.createConsumer();
+        Consumer c = this.createMockConsumer(true);
         Set<ConsumerCapability> caps = new HashSet<>();
         c.setCapabilities(caps);
-        c.getType().setManifest(true);
 
         Product prod = TestUtil.createProduct();
         prod.setAttribute(Product.Attributes.INSTANCE_MULTIPLIER, "2");
@@ -232,10 +235,9 @@ public class ManifestEntitlementRulesTest extends EntitlementRulesTestFixture {
     @Test
     public void preEntitlementNoInstanceCapableListWarn() {
         // Test with sockets to make sure that they are skipped.
-        Consumer c = TestUtil.createConsumer();
+        Consumer c = this.createMockConsumer(true);
         Set<ConsumerCapability> caps = new HashSet<>();
         c.setCapabilities(caps);
-        c.getType().setManifest(true);
 
         Product prod = TestUtil.createProduct();
         prod.setAttribute(Product.Attributes.INSTANCE_MULTIPLIER, "2");
@@ -245,19 +247,17 @@ public class ManifestEntitlementRulesTest extends EntitlementRulesTestFixture {
         assertNotNull(results);
         assertEquals(0, results.getErrors().size());
         ValidationWarning warning = results.getWarnings().get(0);
-        assertEquals("rulewarning.instance.unsupported.by.consumer",
-            warning.getResourceKey());
+        assertEquals("rulewarning.instance.unsupported.by.consumer", warning.getResourceKey());
     }
 
     @Test
     public void preEntitlementSuccessInstanceCapable() {
         // Test with sockets to make sure that they are skipped.
-        Consumer c = TestUtil.createConsumer();
+        Consumer c = this.createMockConsumer(true);
         Set<ConsumerCapability> caps = new HashSet<>();
         ConsumerCapability cc = new ConsumerCapability(c, "instance_multiplier");
         caps.add(cc);
         c.setCapabilities(caps);
-        c.getType().setManifest(true);
 
         Product prod = TestUtil.createProduct();
         prod.setAttribute(Product.Attributes.INSTANCE_MULTIPLIER, "2");
@@ -271,8 +271,7 @@ public class ManifestEntitlementRulesTest extends EntitlementRulesTestFixture {
 
     @Test
     public void preEntitlementShouldNotAllowConsumptionFromDerivedPools() {
-        Consumer c = TestUtil.createConsumer();
-        c.getType().setManifest(true);
+        Consumer c = this.createMockConsumer(true);
 
         Product prod = TestUtil.createProduct();
         Pool p = TestUtil.createPool(prod);
@@ -288,8 +287,7 @@ public class ManifestEntitlementRulesTest extends EntitlementRulesTestFixture {
 
     @Test
     public void preEntitlementShouldNotAllowListOfDerivedPools() {
-        Consumer c = TestUtil.createConsumer();
-        c.getType().setManifest(true);
+        Consumer c = this.createMockConsumer(true);
 
         Product prod = TestUtil.createProduct();
         Pool p = TestUtil.createPool(prod);
@@ -305,8 +303,7 @@ public class ManifestEntitlementRulesTest extends EntitlementRulesTestFixture {
 
     @Test
     public void preEntitlementShouldNotAllowConsumptionFromRequiresHostPools() {
-        Consumer c = TestUtil.createConsumer();
-        c.getType().setManifest(true);
+        Consumer c = this.createMockConsumer(true);
 
         Product prod = TestUtil.createProduct();
         Pool p = TestUtil.createPool(prod);
@@ -322,8 +319,7 @@ public class ManifestEntitlementRulesTest extends EntitlementRulesTestFixture {
 
     @Test
     public void preEntitlementShouldNotAllowListOfRequiresHostPools() {
-        Consumer c = TestUtil.createConsumer();
-        c.getType().setManifest(true);
+        Consumer c = this.createMockConsumer(true);
 
         Product prod = TestUtil.createProduct();
         Pool p = TestUtil.createPool(prod);
@@ -340,8 +336,7 @@ public class ManifestEntitlementRulesTest extends EntitlementRulesTestFixture {
 
     @Test
     public void preEntitlementShouldNotAllowOverConsumptionOfEntitlements() {
-        Consumer c = TestUtil.createConsumer();
-        c.getType().setManifest(true);
+        Consumer c = this.createMockConsumer(true);
 
         Product prod = TestUtil.createProduct();
         Pool p = TestUtil.createPool(prod);
@@ -356,9 +351,8 @@ public class ManifestEntitlementRulesTest extends EntitlementRulesTestFixture {
 
     @Test
     public void preEntitlementNoDerivedProductCapabilityProducesErrorOnBind() {
-        Consumer c = TestUtil.createConsumer();
+        Consumer c = this.createMockConsumer(true);
         c.setCapabilities(new HashSet<>());
-        c.getType().setManifest(true);
 
         Product prod = TestUtil.createProduct();
         Product derived = TestUtil.createProduct("sub-prod-id");
@@ -371,15 +365,13 @@ public class ManifestEntitlementRulesTest extends EntitlementRulesTestFixture {
         assertTrue(results.getWarnings().isEmpty());
 
         ValidationError error = results.getErrors().get(0);
-        assertEquals("rulefailed.derivedproduct.unsupported.by.consumer",
-            error.getResourceKey());
+        assertEquals("rulefailed.derivedproduct.unsupported.by.consumer", error.getResourceKey());
     }
 
     @Test
     public void preEntitlementNoDerivedProductCapabilityProducesWarningOnList() {
-        Consumer c = TestUtil.createConsumer();
+        Consumer c = this.createMockConsumer(true);
         c.setCapabilities(new HashSet<>());
-        c.getType().setManifest(true);
 
         Product prod = TestUtil.createProduct();
         Product derived = TestUtil.createProduct("sub-prod-id");
@@ -392,15 +384,13 @@ public class ManifestEntitlementRulesTest extends EntitlementRulesTestFixture {
         assertTrue(results.getErrors().isEmpty());
 
         ValidationWarning warning = results.getWarnings().get(0);
-        assertEquals("rulewarning.derivedproduct.unsupported.by.consumer",
-            warning.getResourceKey());
+        assertEquals("rulewarning.derivedproduct.unsupported.by.consumer", warning.getResourceKey());
     }
 
     @Test
     public void preEntitlementNoDerivedProductCapabilityProducesErrorOnBestPools() {
-        Consumer c = TestUtil.createConsumer();
+        Consumer c = this.createMockConsumer(true);
         c.setCapabilities(new HashSet<>());
-        c.getType().setManifest(true);
 
         Product prod = TestUtil.createProduct();
         Product derived = TestUtil.createProduct("sub-prod-id");
@@ -413,17 +403,15 @@ public class ManifestEntitlementRulesTest extends EntitlementRulesTestFixture {
         assertTrue(results.getWarnings().isEmpty());
 
         ValidationError error = results.getErrors().get(0);
-        assertEquals("rulefailed.derivedproduct.unsupported.by.consumer",
-            error.getResourceKey());
+        assertEquals("rulefailed.derivedproduct.unsupported.by.consumer", error.getResourceKey());
     }
 
     @Test
     public void preEntitlementWithDerivedProductCapabilitySuccessOnBind() {
-        Consumer c = TestUtil.createConsumer();
+        Consumer c = this.createMockConsumer(true);
         HashSet<ConsumerCapability> capabilities = new HashSet<>();
         capabilities.add(new ConsumerCapability(c, "derived_product"));
         c.setCapabilities(capabilities);
-        c.getType().setManifest(true);
 
         Product prod = TestUtil.createProduct();
         Product derived = TestUtil.createProduct("sub-prod-id");
@@ -437,11 +425,10 @@ public class ManifestEntitlementRulesTest extends EntitlementRulesTestFixture {
 
     @Test
     public void preEntitlementWithDerivedProductCapabilitySuccessOnBestPools() {
-        Consumer c = TestUtil.createConsumer();
+        Consumer c = this.createMockConsumer(true);
         HashSet<ConsumerCapability> capabilities = new HashSet<>();
         capabilities.add(new ConsumerCapability(c, "derived_product"));
         c.setCapabilities(capabilities);
-        c.getType().setManifest(true);
 
         Product prod = TestUtil.createProduct();
         Product derived = TestUtil.createProduct("sub-prod-id");

--- a/server/src/test/java/org/candlepin/policy/js/entitlement/PostEntitlementRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/entitlement/PostEntitlementRulesTest.java
@@ -157,7 +157,8 @@ public class PostEntitlementRulesTest extends EntitlementRulesTestFixture {
     @Test
     public void noSubPoolsForDistributorBinds() {
         when(config.getBoolean(ConfigProperties.STANDALONE)).thenReturn(true);
-        consumer.setType(new ConsumerType(ConsumerTypeEnum.CANDLEPIN));
+        ConsumerType ctype = this.mockConsumerType(new ConsumerType(ConsumerTypeEnum.CANDLEPIN));
+        consumer.setType(ctype);
         Pool pool = setupVirtLimitPool();
         Entitlement e = new Entitlement(pool, consumer, 1);
 

--- a/server/src/test/java/org/candlepin/resource/ConsumerContentOverrideResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerContentOverrideResourceTest.java
@@ -78,17 +78,19 @@ public class ConsumerContentOverrideResourceTest extends DatabaseTestFixture {
 
     @Before
     public void setUp() {
-        consumer = new Consumer("test-consumer", "test-user", new Owner(
-            "Test Owner"), new ConsumerType("test-consumer-type-"));
+        ConsumerType ctype = new ConsumerType("test-consumer-type");
+        ctype.setId("test-ctype");
+
+        consumer = new Consumer("test-consumer", "test-user", new Owner("Test Owner"), ctype);
+
         MultivaluedMap<String, String> mvm = new MultivaluedMapImpl<>();
         mvm.add("consumer_uuid", consumer.getUuid());
         context = mock(UriInfo.class);
         when(context.getPathParameters()).thenReturn(mvm);
 
-        when(consumerCurator.verifyAndLookupConsumer(
-            eq(consumer.getUuid()))).thenReturn(consumer);
-        when(overrideRules.canOverrideForConsumer(
-            any(String.class))).thenReturn(true);
+        when(consumerCurator.verifyAndLookupConsumer(eq(consumer.getUuid()))).thenReturn(consumer);
+        when(overrideRules.canOverrideForConsumer(any(String.class))).thenReturn(true);
+
         i18n = I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK);
         contentOverrideValidator = new ContentOverrideValidator(i18n, overrideRules);
         resource = new ConsumerContentOverrideResource(consumerContentOverrideCurator,

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceEntitlementRulesTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceEntitlementRulesTest.java
@@ -61,8 +61,7 @@ public class ConsumerResourceEntitlementRulesTest extends DatabaseTestFixture {
 
     @Before
     public void setUp() {
-        standardSystemType = consumerTypeCurator.create(
-                new ConsumerType("standard-system"));
+        standardSystemType = consumerTypeCurator.create(new ConsumerType("standard-system"));
         owner = ownerCurator.create(new Owner("test-owner"));
         ownerCurator.create(owner);
 
@@ -80,24 +79,22 @@ public class ConsumerResourceEntitlementRulesTest extends DatabaseTestFixture {
     public void testMaxMembership() {
         // 10 entitlements available, lets try to entitle 11 consumers.
         for (int i = 0; i < pool.getQuantity(); i++) {
-            Consumer c = TestUtil.createConsumer(consumer.getType(), owner);
+            Consumer c = TestUtil.createConsumer(standardSystemType, owner);
             consumerCurator.create(c);
             consumerResource.bind(c.getUuid(), pool.getId(),
                 null, 1, null, null, false, null, null);
         }
 
         // Now for the 11th:
-        Consumer c = TestUtil.createConsumer(consumer.getType(), owner);
+        Consumer c = TestUtil.createConsumer(standardSystemType, owner);
         consumerCurator.create(c);
-        consumerResource.bind(c.getUuid(), pool.getId(), null, 1, null, null,
-            false, null, null);
+        consumerResource.bind(c.getUuid(), pool.getId(), null, 1, null, null, false, null, null);
     }
 
     @Test(expected = RuntimeException.class)
     public void testEntitlementsHaveExpired() {
         dateSource.currentDate(TestDateUtil.date(2030, 1, 13));
-        consumerResource.bind(consumer.getUuid(), pool.getId(), null,
-            null, null, null, false, null, null);
+        consumerResource.bind(consumer.getUuid(), pool.getId(), null, null, null, null, false, null, null);
     }
 
     @Override

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
@@ -127,9 +127,9 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
     @Before
     public void setUp() {
         standardSystemType = consumerTypeCurator.create(new ConsumerType("standard-system"));
-        standardSystemTypeDTO = new ConsumerTypeDTO(standardSystemType.getLabel());
+        standardSystemTypeDTO = modelTranslator.translate(standardSystemType, ConsumerTypeDTO.class);
         personType = consumerTypeCurator.create(new ConsumerType(ConsumerTypeEnum.PERSON));
-        personTypeDTO = new ConsumerTypeDTO(personType.getLabel());
+        personTypeDTO = modelTranslator.translate(personType, ConsumerTypeDTO.class);
         owner = ownerCurator.create(new Owner("test-owner"));
         ownerDTO = modelTranslator.translate(owner, OwnerDTO.class);
         owner.setDefaultServiceLevel(DEFAULT_SERVICE_LEVEL);
@@ -576,7 +576,8 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
         Provider<GuestMigration> migrationProvider = Providers.of(testMigration);
 
         ConsumerResource cr = new ConsumerResource(
-            this.consumerCurator, null, null, null, null, this.entitlementCurator, null, null, null, null,
+            this.consumerCurator, this.consumerTypeCurator, null, null, null, this.entitlementCurator, null,
+            null, null, null,
             null, null, null, null, this.poolManager, null, null, null, null, null, null, null, null,
             new CandlepinCommonTestConfig(), null, null, null, mock(ConsumerBindUtil.class),
             null, null, null, null, consumerEnricher, migrationProvider, this.modelTranslator);

--- a/server/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
@@ -183,6 +183,7 @@ public class HypervisorResourceTest {
             }
 
             when(consumerTypeCurator.lookupByLabel(eq(ctype.getLabel()))).thenReturn(ctype);
+            when(consumerTypeCurator.lookupByLabel(eq(ctype.getLabel()), anyBoolean())).thenReturn(ctype);
             when(consumerTypeCurator.find(eq(ctype.getId()))).thenReturn(ctype);
 
             doAnswer(new Answer<ConsumerType>() {

--- a/server/src/test/java/org/candlepin/resource/JobResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/JobResourceTest.java
@@ -24,6 +24,7 @@ import org.candlepin.dto.ModelTranslator;
 import org.candlepin.dto.StandardTranslator;
 import org.candlepin.dto.api.v1.JobStatusDTO;
 import org.candlepin.model.CandlepinQuery;
+import org.candlepin.model.ConsumerTypeCurator;
 import org.candlepin.model.JobCurator;
 import org.candlepin.model.TransformedCandlepinQuery;
 import org.candlepin.pinsetter.core.PinsetterException;
@@ -55,6 +56,8 @@ public class JobResourceTest {
     private JobResource jobResource;
     @Mock private JobCurator jobCurator;
     @Mock private PinsetterKernel pinsetterKernel;
+    @Mock private ConsumerTypeCurator consumerTypeCurator;
+
     private I18n i18n;
     private ModelTranslator translator;
 
@@ -62,7 +65,7 @@ public class JobResourceTest {
     public void init() {
         MockitoAnnotations.initMocks(this);
         i18n = I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK);
-        translator = new StandardTranslator();
+        translator = new StandardTranslator(this.consumerTypeCurator);
         jobResource = new JobResource(jobCurator, pinsetterKernel, i18n, translator);
     }
 

--- a/server/src/test/java/org/candlepin/resource/PersonConsumerResourceCreationLiberalNameRules.java
+++ b/server/src/test/java/org/candlepin/resource/PersonConsumerResourceCreationLiberalNameRules.java
@@ -19,7 +19,6 @@ import static org.mockito.Mockito.when;
 import org.candlepin.auth.Access;
 import org.candlepin.auth.permissions.PermissionFactory.PermissionType;
 import org.candlepin.common.exceptions.BadRequestException;
-import org.candlepin.dto.api.v1.ConsumerTypeDTO;
 import org.candlepin.model.ConsumerType;
 import org.candlepin.model.Owner;
 import org.candlepin.model.PermissionBlueprint;
@@ -28,6 +27,8 @@ import org.candlepin.model.User;
 
 import org.junit.Test;
 
+
+
 /**
  * PersonConsumerResourceCreationLiberalNameRules
  */
@@ -35,9 +36,8 @@ public class PersonConsumerResourceCreationLiberalNameRules extends
     ConsumerResourceCreationLiberalNameRules {
 
     @Override
-    public ConsumerType initSystem() {
-        ConsumerType systemtype = new ConsumerType(
-            ConsumerType.ConsumerTypeEnum.PERSON);
+    public ConsumerType initConsumerType() {
+        ConsumerType systemtype = new ConsumerType(ConsumerType.ConsumerTypeEnum.PERSON);
 
         // create an owner, an ownerperm, and roles for the user we provide
         // as coming from userService
@@ -52,11 +52,6 @@ public class PersonConsumerResourceCreationLiberalNameRules extends
 
         return systemtype;
 
-    }
-
-    @Override
-    public ConsumerTypeDTO initSystemDto() {
-        return this.modelTranslator.translate(initSystem(), ConsumerTypeDTO.class);
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/resource/PersonConsumerResourceCreationTest.java
+++ b/server/src/test/java/org/candlepin/resource/PersonConsumerResourceCreationTest.java
@@ -19,7 +19,6 @@ import static org.mockito.Mockito.when;
 import org.candlepin.auth.Access;
 import org.candlepin.auth.permissions.PermissionFactory.PermissionType;
 import org.candlepin.common.exceptions.BadRequestException;
-import org.candlepin.dto.api.v1.ConsumerTypeDTO;
 import org.candlepin.model.ConsumerType;
 import org.candlepin.model.Owner;
 import org.candlepin.model.PermissionBlueprint;
@@ -28,31 +27,32 @@ import org.candlepin.model.User;
 
 import org.junit.Test;
 
+
+
 /**
  * PersonConsumerResourceCreationTest If
  * ConsumerResource.CONSUMER_PERSON_NAME_PATTERN is different than
  * CONSUMER_SYSTEM_NAME_PATTERN, this will need different tests.
  */
-public class PersonConsumerResourceCreationTest extends
-    ConsumerResourceCreationTest {
-    public ConsumerType initSystem() {
-        ConsumerType systemtype = new ConsumerType(
-            ConsumerType.ConsumerTypeEnum.PERSON);
+public class PersonConsumerResourceCreationTest extends ConsumerResourceCreationTest {
+
+    public ConsumerType initConsumerType() {
+        ConsumerType ctype = new ConsumerType(ConsumerType.ConsumerTypeEnum.PERSON);
+        this.mockConsumerType(ctype);
+
         // create an owner, a ownerperm, and roles for the user we prodive
         // as coming from userService
         owner = new Owner("test_owner");
-        PermissionBlueprint p = new PermissionBlueprint(PermissionType.OWNER, owner,
-            Access.ALL);
+        PermissionBlueprint p = new PermissionBlueprint(PermissionType.OWNER, owner, Access.ALL);
+
         User user = new User("anyuser", "");
         role = new Role();
         role.addPermission(p);
         role.addUser(user);
-        when(userService.findByLogin("anyuser")).thenReturn(user);
-        return systemtype;
-    }
 
-    public ConsumerTypeDTO initSystemDto() {
-        return this.modelTranslator.translate(initSystem(), ConsumerTypeDTO.class);
+        when(userService.findByLogin("anyuser")).thenReturn(user);
+
+        return ctype;
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/resource/PoolResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/PoolResourceTest.java
@@ -41,7 +41,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.xnap.commons.i18n.I18n;
 
 import java.util.Date;
 import java.util.List;
@@ -49,11 +48,11 @@ import java.util.List;
 import javax.inject.Inject;
 
 
+
 /**
  * PoolResourceTest
  */
 public class PoolResourceTest extends DatabaseTestFixture {
-    @Inject private I18n i18n;
     @Inject private CandlepinPoolManager poolManager;
 
     private Owner owner1;
@@ -88,36 +87,29 @@ public class PoolResourceTest extends DatabaseTestFixture {
         product1Owner2 = this.createProduct(PRODUCT_CPULIMITED, PRODUCT_CPULIMITED, owner2);
         product2 = this.createProduct(owner1);
 
-        pool1 = createPool(owner1, product1, 500L,
+        pool1 = this.createPool(owner1, product1, 500L,
              TestUtil.createDate(START_YEAR, 1, 1), TestUtil.createDate(END_YEAR, 1, 1));
-        pool2 = createPool(owner1, product2, 500L,
+        pool2 = this.createPool(owner1, product2, 500L,
              TestUtil.createDate(START_YEAR, 1, 1), TestUtil.createDate(END_YEAR, 1, 1));
-        pool3 = createPool(owner2 , product1Owner2, 500L,
+        pool3 = this.createPool(owner2 , product1Owner2, 500L,
              TestUtil.createDate(START_YEAR, 1, 1), TestUtil.createDate(END_YEAR, 1, 1));
-        poolCurator.create(pool1);
-        poolCurator.create(pool2);
-        poolCurator.create(pool3);
 
         poolResource = new PoolResource(consumerCurator, ownerCurator, i18n,
             poolManager, attrUtil, this.modelTranslator);
 
         // Consumer system with too many cpu cores:
-
-        failConsumer = TestUtil.createConsumer(createOwner());
+        failConsumer = this.createConsumer(createOwner());
         failConsumer.setFact("cpu_cores", "4");
-        consumerTypeCurator.create(failConsumer.getType());
-        consumerCurator.create(failConsumer);
+        this.consumerCurator.merge(failConsumer);
 
         // Consumer system with appropriate number of cpu cores:
-        passConsumer = TestUtil.createConsumer(owner1);
+        passConsumer = this.createConsumer(owner1);
         passConsumer.setFact("cpu_cores", "2");
-        consumerTypeCurator.create(passConsumer.getType());
-        consumerCurator.create(passConsumer);
+        this.consumerCurator.merge(passConsumer);
 
-        foreignConsumer = TestUtil.createConsumer(owner2);
+        foreignConsumer = this.createConsumer(owner2);
         foreignConsumer.setFact("cpu_cores", "2");
-        consumerTypeCurator.create(foreignConsumer.getType());
-        consumerCurator.create(foreignConsumer);
+        this.consumerCurator.merge(foreignConsumer);
 
         // Run most of these tests as an owner admin:
         adminPrincipal = setupPrincipal(owner1, Access.ALL);
@@ -300,8 +292,7 @@ public class PoolResourceTest extends DatabaseTestFixture {
 
     @Test
     public void testEmptyEntitlementList() {
-        List<EntitlementDTO> ents =
-            poolResource.getPoolEntitlements(pool1.getId(),  adminPrincipal);
+        List<EntitlementDTO> ents = poolResource.getPoolEntitlements(pool1.getId(),  adminPrincipal);
         assertEquals(0, ents.size());
     }
 

--- a/server/src/test/java/org/candlepin/resource/SubscriptionResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/SubscriptionResourceTest.java
@@ -63,9 +63,7 @@ public class SubscriptionResourceTest  {
             I18nFactory.READ_PROPERTIES | I18nFactory.FALLBACK
         );
 
-        this.subResource = new SubscriptionResource(
-            subService, consumerCurator, poolManager, i18n
-        );
+        this.subResource = new SubscriptionResource(subService, consumerCurator, poolManager, i18n);
     }
 
     @Test(expected = NotFoundException.class)

--- a/server/src/test/java/org/candlepin/resource/util/ConsumerBindUtilTest.java
+++ b/server/src/test/java/org/candlepin/resource/util/ConsumerBindUtilTest.java
@@ -24,6 +24,7 @@ import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerContentOverrideCurator;
 import org.candlepin.model.ConsumerInstalledProduct;
 import org.candlepin.model.ConsumerType;
+import org.candlepin.model.ConsumerType.ConsumerTypeEnum;
 import org.candlepin.model.Owner;
 import org.candlepin.model.Pool;
 import org.candlepin.model.Product;
@@ -75,6 +76,9 @@ public class ConsumerBindUtilTest {
     @Before
     public void init() throws Exception {
         this.i18n = I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK);
+
+        this.system = new ConsumerType(ConsumerTypeEnum.SYSTEM);
+        this.system.setId("test-ctype-" + TestUtil.randomInt());
 
         consumerBindUtil = new ConsumerBindUtil(
             this.entitler,

--- a/server/src/test/java/org/candlepin/resteasy/filter/VerifyAuthorizationFilterTest.java
+++ b/server/src/test/java/org/candlepin/resteasy/filter/VerifyAuthorizationFilterTest.java
@@ -14,7 +14,7 @@
  */
 package org.candlepin.resteasy.filter;
 
-import static org.mockito.Matchers.eq;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 import org.candlepin.auth.Principal;
@@ -24,7 +24,6 @@ import org.candlepin.auth.permissions.PermissionFactory;
 import org.candlepin.common.util.SuppressSwaggerCheck;
 import org.candlepin.common.exceptions.ForbiddenException;
 import org.candlepin.model.Consumer;
-import org.candlepin.model.ConsumerCurator;
 import org.candlepin.resteasy.ResourceLocatorMap;
 import org.candlepin.test.DatabaseTestFixture;
 
@@ -68,7 +67,6 @@ import javax.ws.rs.core.UriInfo;
 
 @RunWith(MockitoJUnitRunner.class)
 public class VerifyAuthorizationFilterTest extends DatabaseTestFixture {
-    @Inject private ConsumerCurator consumerCurator;
     @Inject private Provider<I18n> i18nProvider;
     @Inject private StoreFactory storeFactory;
     @Inject private SSLAuth sslAuth;
@@ -169,15 +167,12 @@ public class VerifyAuthorizationFilterTest extends DatabaseTestFixture {
 
     @Test
     public void testAccessToConsumer() throws Exception {
-        mockReq = MockHttpRequest.create("POST",
-            "http://localhost/candlepin/fake/123");
+        mockReq = MockHttpRequest.create("POST", "http://localhost/candlepin/fake/123");
         ResteasyProviderFactory.pushContext(HttpRequest.class, mockReq);
         mockReq.setAttribute(ResteasyProviderFactory.class.getName(), ResteasyProviderFactory.getInstance());
 
         Consumer c = createConsumer(createOwner());
         methodInjector.setArguments(new Object[] {c.getUuid()});
-        when(consumerCurator.getConsumer(eq(c.getUuid()))).thenReturn(c);
-        when(consumerCurator.findByUuid(eq(c.getUuid()))).thenReturn(c);
 
         X500Principal dn = new X500Principal("CN=" + c.getUuid() + ", C=US, L=Raleigh");
 
@@ -197,16 +192,13 @@ public class VerifyAuthorizationFilterTest extends DatabaseTestFixture {
 
     @Test(expected = ForbiddenException.class)
     public void noAccessToOtherConsumer() throws Exception {
-        mockReq = MockHttpRequest.create("POST",
-            "http://localhost/candlepin/fake/123");
+        mockReq = MockHttpRequest.create("POST", "http://localhost/candlepin/fake/123");
         ResteasyProviderFactory.pushContext(HttpRequest.class, mockReq);
         mockReq.setAttribute(ResteasyProviderFactory.class.getName(), ResteasyProviderFactory.getInstance());
 
         Consumer c = createConsumer(createOwner());
         Consumer c2 = createConsumer(createOwner());
         methodInjector.setArguments(new Object[] {c2.getUuid()});
-        when(consumerCurator.getConsumer(eq(c.getUuid()))).thenReturn(c);
-        when(consumerCurator.findByUuid(eq(c2.getUuid()))).thenReturn(c2);
 
         X500Principal dn = new X500Principal("CN=" + c.getUuid() + ", C=US, L=Raleigh");
 
@@ -246,8 +238,6 @@ public class VerifyAuthorizationFilterTest extends DatabaseTestFixture {
         protected void configure() {
             PermissionFactory factory = mock(PermissionFactory.class);
             bind(PermissionFactory.class).toInstance(factory);
-            ConsumerCurator mockCc = mock(ConsumerCurator.class);
-            bind(ConsumerCurator.class).toInstance(mockCc);
             bind(StoreFactory.class);
             bind(FakeResource.class);
         }

--- a/server/src/test/java/org/candlepin/sync/ConsumerExporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/ConsumerExporterTest.java
@@ -15,6 +15,8 @@
 package org.candlepin.sync;
 
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
 
 import org.candlepin.common.config.MapConfiguration;
 import org.candlepin.config.ConfigProperties;
@@ -22,11 +24,15 @@ import org.candlepin.dto.ModelTranslator;
 import org.candlepin.dto.StandardTranslator;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerType;
+import org.candlepin.model.ConsumerTypeCurator;
 import org.candlepin.test.TestUtil;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -35,8 +41,10 @@ import java.util.HashMap;
 /**
  * ConsumerExporterTest
  */
+@RunWith(MockitoJUnitRunner.class)
 public class ConsumerExporterTest {
 
+    @Mock private ConsumerTypeCurator mockConsumerTypeCurator;
     private ModelTranslator translator;
 
     @Test
@@ -48,7 +56,7 @@ public class ConsumerExporterTest {
                 }
             }));
 
-        translator = new StandardTranslator();
+        translator = new StandardTranslator(mockConsumerTypeCurator);
         ConsumerExporter exporter = new ConsumerExporter(translator);
         ConsumerType ctype = new ConsumerType("candlepin");
         ctype.setId("8888");
@@ -61,6 +69,9 @@ public class ConsumerExporterTest {
         consumer.setName("testy consumer");
         consumer.setType(ctype);
         consumer.setContentAccessMode("access_mode");
+
+        when(mockConsumerTypeCurator.getConsumerType(eq(consumer))).thenReturn(ctype);
+        when(mockConsumerTypeCurator.find(eq(ctype.getId()))).thenReturn(ctype);
 
         exporter.export(mapper, writer, consumer, "/subscriptions", "/candlepin");
 

--- a/server/src/test/java/org/candlepin/sync/ConsumerTypeExporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/ConsumerTypeExporterTest.java
@@ -21,11 +21,15 @@ import org.candlepin.config.ConfigProperties;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.dto.StandardTranslator;
 import org.candlepin.model.ConsumerType;
+import org.candlepin.model.ConsumerTypeCurator;
 import org.candlepin.test.TestUtil;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -34,8 +38,10 @@ import java.util.HashMap;
 /**
  * ConsumerTypeExporterTest
  */
+@RunWith(MockitoJUnitRunner.class)
 public class ConsumerTypeExporterTest {
 
+    @Mock private ConsumerTypeCurator mockConsumerTypeCurator;
     private ModelTranslator translator;
 
     @Test
@@ -48,7 +54,7 @@ public class ConsumerTypeExporterTest {
             }
         ));
 
-        translator = new StandardTranslator();
+        translator = new StandardTranslator(mockConsumerTypeCurator);
         ConsumerTypeExporter consumerType = new ConsumerTypeExporter(translator);
 
         StringWriter writer = new StringWriter();

--- a/server/src/test/java/org/candlepin/sync/ExporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/ExporterTest.java
@@ -122,7 +122,7 @@ public class ExporterTest {
     public void setUp() {
         ctc = mock(ConsumerTypeCurator.class);
         me = new MetaExporter();
-        translator = new StandardTranslator();
+        translator = new StandardTranslator(ctc);
         ce = new ConsumerExporter(translator);
         cte = new ConsumerTypeExporter(translator);
         rc = mock(RulesCurator.class);
@@ -445,6 +445,9 @@ public class ExporterTest {
         idcert.setUpdated(new Date());
         when(consumer.getIdCert()).thenReturn(idcert);
 
+        ConsumerType ctype = new ConsumerType(ConsumerTypeEnum.CANDLEPIN);
+        ctype.setId("test-ctype");
+
         KeyPair keyPair = createKeyPair();
         when(consumer.getKeyPair()).thenReturn(keyPair);
         when(pki.getPemEncoded(keyPair.getPrivateKey())).thenReturn("privateKey".getBytes());
@@ -452,7 +455,10 @@ public class ExporterTest {
         when(consumer.getUuid()).thenReturn("8auuid");
         when(consumer.getName()).thenReturn("consumer_name");
         when(consumer.getContentAccessMode()).thenReturn("access_mode");
-        when(consumer.getType()).thenReturn(new ConsumerType(ConsumerTypeEnum.CANDLEPIN));
+        when(consumer.getTypeId()).thenReturn(ctype.getId());
+
+        when(ctc.getConsumerType(eq(consumer))).thenReturn(ctype);
+        when(ctc.find(eq(ctype.getId()))).thenReturn(ctype);
 
         CandlepinQuery cqmock = mock(CandlepinQuery.class);
         when(cqmock.iterator()).thenReturn(Arrays.asList(new ConsumerType("system")).iterator());
@@ -494,13 +500,18 @@ public class ExporterTest {
         idcert.setUpdated(new Date());
         when(consumer.getIdCert()).thenReturn(idcert);
 
+        ConsumerType ctype = new ConsumerType(ConsumerTypeEnum.CANDLEPIN);
+        ctype.setId("test-ctype");
+
         KeyPair keyPair = createKeyPair();
         when(consumer.getKeyPair()).thenReturn(keyPair);
         when(pki.getPemEncoded(keyPair.getPrivateKey())).thenReturn("privateKey".getBytes());
         when(pki.getPemEncoded(keyPair.getPublicKey())).thenReturn("publicKey".getBytes());
         when(consumer.getUuid()).thenReturn("8auuid");
         when(consumer.getName()).thenReturn("consumer_name");
-        when(consumer.getType()).thenReturn(new ConsumerType(ConsumerTypeEnum.CANDLEPIN));
+        when(consumer.getTypeId()).thenReturn(ctype.getId());
+        when(ctc.getConsumerType(eq(consumer))).thenReturn(ctype);
+        when(ctc.find(eq(ctype.getId()))).thenReturn(ctype);
 
         DistributorVersion dv = new DistributorVersion("test-dist-ver");
         Set<DistributorVersionCapability> dvcSet = new HashSet<>();
@@ -802,9 +813,10 @@ public class ExporterTest {
             assertEquals("8auuid", c.getUuid());
             assertEquals("consumer_name", c.getName());
             assertEquals("access_mode", c.getContentAccessMode());
+
             ConsumerType type = new ConsumerType(ConsumerTypeEnum.CANDLEPIN);
             assertEquals(type.getLabel(), c.getType().getLabel());
-            assertEquals(type.getId(), c.getType().getId());
+            assertEquals(type.isManifest(), c.getType().isManifest());
         }
     }
 

--- a/server/src/test/java/org/candlepin/test/DatabaseTestFixture.java
+++ b/server/src/test/java/org/candlepin/test/DatabaseTestFixture.java
@@ -396,24 +396,42 @@ public class DatabaseTestFixture {
         return content;
     }
 
+    protected Consumer createConsumer(Owner owner, ConsumerType ctype) {
+        if (ctype == null) {
+            ctype = this.createConsumerType();
+        }
+
+        Consumer consumer = new Consumer("test-consumer", "test-user", owner, ctype);
+
+        return this.consumerCurator.create(consumer);
+    }
+
     protected Consumer createConsumer(Owner owner) {
-        ConsumerType type = new ConsumerType("test-consumer-type-" + TestUtil.randomInt());
-        Consumer c = new Consumer("test-consumer", "test-user", owner, type);
-        return persistConsumer(type, c);
+        return this.createConsumer(owner, null);
     }
 
     protected Consumer createDistributor(Owner owner) {
-        ConsumerType type = new ConsumerType("test-distributor-type-" + TestUtil.randomInt());
-        type.setManifest(true);
-        Consumer c = new Consumer("test-distributor", "test-user", owner, type);
-        return persistConsumer(type, c);
+        ConsumerType type = this.createConsumerType(true);
+        Consumer consumer = new Consumer("test-distributor", "test-user", owner, type);
+
+        return this.consumerCurator.create(consumer);
     }
 
-    private Consumer persistConsumer(ConsumerType type, Consumer consumer) {
-        consumerTypeCurator.create(type);
-        consumer.setType(type);
-        consumerCurator.create(consumer);
-        return consumer;
+    protected ConsumerType createConsumerType() {
+        return this.createConsumerType(false);
+    }
+
+    protected ConsumerType createConsumerType(boolean manifest) {
+        String label = "test-distributor-type-" + TestUtil.randomInt();
+
+        return this.createConsumerType(label, manifest);
+    }
+
+    protected ConsumerType createConsumerType(String label, boolean manifest) {
+        ConsumerType ctype = new ConsumerType(label);
+        ctype.setManifest(manifest);
+
+        return this.consumerTypeCurator.create(ctype);
     }
 
     protected Entitlement createEntitlement(Owner owner, Consumer consumer, Pool pool,

--- a/server/src/test/java/org/candlepin/test/TestUtil.java
+++ b/server/src/test/java/org/candlepin/test/TestUtil.java
@@ -129,7 +129,10 @@ public class TestUtil {
     }
 
     public static Consumer createDistributor() {
-        return createConsumer(new ConsumerType(ConsumerType.ConsumerTypeEnum.CANDLEPIN), createOwner());
+        ConsumerType ctype = new ConsumerType(ConsumerType.ConsumerTypeEnum.CANDLEPIN);
+        ctype.setId("test-ctype-" + randomInt());
+
+        return createConsumer(ctype, createOwner());
     }
 
     /**
@@ -144,6 +147,7 @@ public class TestUtil {
             owner,
             createConsumerType()
         );
+
         consumer.setCreated(new Date());
         consumer.setFact("foo", "bar");
         consumer.setFact("foo1", "bar1");
@@ -152,7 +156,10 @@ public class TestUtil {
     }
 
     public static ConsumerType createConsumerType() {
-        return new ConsumerType("test-consumer-type-" + randomInt());
+        ConsumerType ctype = new ConsumerType("test-consumer-type-" + randomInt());
+        ctype.setId("test-ctype-" + randomInt());
+
+        return ctype;
     }
 
     private static final Random RANDOM = new Random(System.currentTimeMillis());


### PR DESCRIPTION
- Changed Consumer.type from a nested ConsumerType instance to the
  string-based typeId field
- Added the utility method ConsumerTypeCurator.getConsumerType, which
  fetches the ConsumerType using the typeId field
- Updated several methods and tests in accordance with this change