### PR TITLE
Add back manifest fields for EntitlementDTO/ConsumerDTO/CertificateDTO

### DIFF
--- a/server/src/main/java/org/candlepin/dto/StandardTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/StandardTranslator.java
@@ -164,11 +164,17 @@ public class StandardTranslator extends SimpleModelTranslator {
             new org.candlepin.dto.manifest.v1.EntitlementTranslator(),
             Entitlement.class, org.candlepin.dto.manifest.v1.EntitlementDTO.class);
         this.registerTranslator(
+            new org.candlepin.dto.manifest.v1.OwnerTranslator(),
+            Owner.class, org.candlepin.dto.manifest.v1.OwnerDTO.class);
+        this.registerTranslator(
             new org.candlepin.dto.manifest.v1.PoolTranslator(),
             Pool.class, org.candlepin.dto.manifest.v1.PoolDTO.class);
         this.registerTranslator(
             new org.candlepin.dto.manifest.v1.ProductTranslator(),
             Product.class, org.candlepin.dto.manifest.v1.ProductDTO.class);
+        this.registerTranslator(
+            new org.candlepin.dto.manifest.v1.UpstreamConsumerTranslator(),
+            UpstreamConsumer.class, org.candlepin.dto.manifest.v1.UpstreamConsumerDTO.class);
 
         // Shims
         /////////////////////////////////////////////

--- a/server/src/main/java/org/candlepin/dto/api/v1/PoolTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/PoolTranslator.java
@@ -114,8 +114,7 @@ public class PoolTranslator extends TimestampedEntityTranslator<Pool, PoolDTO> {
             if (branding != null && !branding.isEmpty()) {
                 for (Branding brand : branding) {
                     if (brand != null) {
-                        dest.addBranding(
-                            new BrandingDTO(brand.getProductId(), brand.getName(), brand.getType()));
+                        dest.addBranding(modelTranslator.translate(brand, BrandingDTO.class));
                     }
                 }
             }

--- a/server/src/main/java/org/candlepin/dto/manifest/v1/BrandingDTO.java
+++ b/server/src/main/java/org/candlepin/dto/manifest/v1/BrandingDTO.java
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.candlepin.dto.CandlepinDTO;
+import org.candlepin.dto.TimestampedCandlepinDTO;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -28,10 +28,11 @@ import javax.xml.bind.annotation.XmlAccessorType;
  * for the manifest import/export framework.
  */
 @XmlAccessorType(XmlAccessType.PROPERTY)
-public class BrandingDTO extends CandlepinDTO<BrandingDTO> {
+public class BrandingDTO extends TimestampedCandlepinDTO<BrandingDTO> {
 
     public static final long serialVersionUID = 1L;
 
+    private String id;
     private String productId;
     private String name;
     private String type;
@@ -65,9 +66,14 @@ public class BrandingDTO extends CandlepinDTO<BrandingDTO> {
      */
     @JsonCreator
     public BrandingDTO(
+        @JsonProperty("id") String id,
         @JsonProperty("productId") String productId,
         @JsonProperty("name") String name,
         @JsonProperty("type") String type) {
+
+        if (id == null || id.isEmpty()) {
+            throw new IllegalArgumentException("id is null or empty");
+        }
 
         if (productId == null || productId.isEmpty()) {
             throw new IllegalArgumentException("productId is null or empty");
@@ -81,9 +87,31 @@ public class BrandingDTO extends CandlepinDTO<BrandingDTO> {
             throw new IllegalArgumentException("type is null or empty");
         }
 
+        this.id = id;
         this.productId = productId;
         this.name = name;
         this.type = type;
+    }
+
+    /**
+     * Returns this branding's internal DB id.
+     *
+     * @return this branding's internal DB id.
+     */
+    public String getId() {
+        return this.id;
+    }
+
+    /**
+     * Sets this branding's internal DB id.
+     *
+     * @param id the internal DB id to set on this branding DTO.
+     *
+     * @return a reference to this branding DTO object.
+     */
+    public BrandingDTO setId(String id) {
+        this.id = id;
+        return this;
     }
 
     /**
@@ -167,10 +195,11 @@ public class BrandingDTO extends CandlepinDTO<BrandingDTO> {
             return true;
         }
 
-        if (obj instanceof BrandingDTO) {
+        if (obj instanceof BrandingDTO && super.equals(obj)) {
             BrandingDTO that = (BrandingDTO) obj;
 
             EqualsBuilder builder = new EqualsBuilder()
+                .append(this.getId(), that.getId())
                 .append(this.getProductId(), that.getProductId())
                 .append(this.getName(), that.getName())
                 .append(this.getType(), that.getType());
@@ -186,6 +215,8 @@ public class BrandingDTO extends CandlepinDTO<BrandingDTO> {
     @Override
     public int hashCode() {
         HashCodeBuilder builder = new HashCodeBuilder(37, 7)
+            .append(super.hashCode())
+            .append(this.getId())
             .append(this.getProductId())
             .append(this.getName())
             .append(this.getType());
@@ -210,6 +241,7 @@ public class BrandingDTO extends CandlepinDTO<BrandingDTO> {
     public BrandingDTO populate(BrandingDTO source) {
         super.populate(source);
 
+        this.setId(source.getId());
         this.setProductId(source.getProductId());
         this.setName(source.getName());
         this.setType(source.getType());

--- a/server/src/main/java/org/candlepin/dto/manifest/v1/BrandingTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/manifest/v1/BrandingTranslator.java
@@ -15,14 +15,14 @@
 package org.candlepin.dto.manifest.v1;
 
 import org.candlepin.dto.ModelTranslator;
-import org.candlepin.dto.ObjectTranslator;
+import org.candlepin.dto.TimestampedEntityTranslator;
 import org.candlepin.model.Branding;
 
 /**
  * The BrandingTranslator provides translation from Branding model objects to BrandingDTOs,
  * for the manifest import/export framework.
  */
-public class BrandingTranslator implements ObjectTranslator<Branding, BrandingDTO> {
+public class BrandingTranslator extends TimestampedEntityTranslator<Branding, BrandingDTO> {
 
     /**
      * {@inheritDoc}
@@ -53,14 +53,9 @@ public class BrandingTranslator implements ObjectTranslator<Branding, BrandingDT
      */
     @Override
     public BrandingDTO populate(ModelTranslator modelTranslator, Branding source, BrandingDTO dest) {
-        if (source == null) {
-            throw new IllegalArgumentException("source is null");
-        }
+        dest = super.populate(modelTranslator, source, dest);
 
-        if (dest == null) {
-            throw new IllegalArgumentException("destination is null");
-        }
-
+        dest.setId(source.getId());
         dest.setProductId(source.getProductId());
         dest.setName(source.getName());
         dest.setType(source.getType());

--- a/server/src/main/java/org/candlepin/dto/manifest/v1/CertificateDTO.java
+++ b/server/src/main/java/org/candlepin/dto/manifest/v1/CertificateDTO.java
@@ -16,14 +16,14 @@ package org.candlepin.dto.manifest.v1;
 
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.candlepin.dto.CandlepinDTO;
+import org.candlepin.dto.TimestampedCandlepinDTO;
 
 
 /**
  * The CertificateDTO is a DTO representing most Candlepin certificates
  * as used by the manifest import/export framework.
  */
-public class CertificateDTO extends CandlepinDTO<CertificateDTO> {
+public class CertificateDTO extends TimestampedCandlepinDTO<CertificateDTO> {
     public static final long serialVersionUID = 1L;
 
     protected String id;
@@ -105,7 +105,7 @@ public class CertificateDTO extends CandlepinDTO<CertificateDTO> {
             return true;
         }
 
-        if (obj instanceof CertificateDTO) {
+        if (obj instanceof CertificateDTO && super.equals(obj)) {
             CertificateDTO that = (CertificateDTO) obj;
 
             EqualsBuilder builder = new EqualsBuilder()
@@ -126,6 +126,7 @@ public class CertificateDTO extends CandlepinDTO<CertificateDTO> {
     @Override
     public int hashCode() {
         HashCodeBuilder builder = new HashCodeBuilder(37, 7)
+            .append(super.hashCode())
             .append(this.getId())
             .append(this.getKey())
             .append(this.getCert())

--- a/server/src/main/java/org/candlepin/dto/manifest/v1/CertificateSerialDTO.java
+++ b/server/src/main/java/org/candlepin/dto/manifest/v1/CertificateSerialDTO.java
@@ -18,6 +18,7 @@ import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.candlepin.dto.TimestampedCandlepinDTO;
 
+import java.math.BigInteger;
 import java.util.Date;
 
 
@@ -28,8 +29,10 @@ public class CertificateSerialDTO extends TimestampedCandlepinDTO<CertificateSer
     public static final long serialVersionUID = 1L;
 
     protected Long id;
+    protected BigInteger serial;
     protected Date expiration;
     protected Boolean collected;
+    protected Boolean revoked;
 
     /**
      * Initializes a new CertificateSerialDTO instance with null values.
@@ -58,6 +61,15 @@ public class CertificateSerialDTO extends TimestampedCandlepinDTO<CertificateSer
         return this;
     }
 
+    public BigInteger getSerial() {
+        return this.serial;
+    }
+
+    public CertificateSerialDTO setSerial(BigInteger serial) {
+        this.serial = serial;
+        return this;
+    }
+
     public Date getExpiration() {
         return this.expiration;
     }
@@ -76,6 +88,15 @@ public class CertificateSerialDTO extends TimestampedCandlepinDTO<CertificateSer
         return this;
     }
 
+    public Boolean isRevoked() {
+        return this.revoked;
+    }
+
+    public CertificateSerialDTO setRevoked(Boolean revoked) {
+        this.revoked = revoked;
+        return this;
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -85,8 +106,8 @@ public class CertificateSerialDTO extends TimestampedCandlepinDTO<CertificateSer
         String date = expiration != null ? String.format("%1$tF %1$tT%1$tz", expiration) : null;
 
         return String.format(
-            "CertificateSerialDTO [id: %s, expiration: %s, collected: %s]",
-            this.getId(), date, this.isCollected());
+            "CertificateSerialDTO [id: %s, serial: %s, expiration: %s, collected: %s, revoked: %s]",
+            this.getId(), this.getSerial(), date, this.isCollected(), this.isRevoked());
     }
 
     /**
@@ -103,8 +124,10 @@ public class CertificateSerialDTO extends TimestampedCandlepinDTO<CertificateSer
 
             EqualsBuilder builder = new EqualsBuilder()
                 .append(this.getId(), that.getId())
+                .append(this.getSerial(), that.getSerial())
                 .append(this.getExpiration(), that.getExpiration())
-                .append(this.isCollected(), that.isCollected());
+                .append(this.isCollected(), that.isCollected())
+                .append(this.isRevoked(), that.isRevoked());
 
             return builder.isEquals();
         }
@@ -120,8 +143,10 @@ public class CertificateSerialDTO extends TimestampedCandlepinDTO<CertificateSer
         HashCodeBuilder builder = new HashCodeBuilder(37, 7)
             .append(super.hashCode())
             .append(this.getId())
+            .append(this.getSerial())
             .append(this.getExpiration())
-            .append(this.isCollected());
+            .append(this.isCollected())
+            .append(this.isRevoked());
 
         return builder.toHashCode();
     }
@@ -147,8 +172,10 @@ public class CertificateSerialDTO extends TimestampedCandlepinDTO<CertificateSer
         super.populate(source);
 
         this.setId(source.getId());
+        this.setSerial(source.getSerial());
         this.setExpiration(source.getExpiration());
         this.setCollected(source.isCollected());
+        this.setRevoked(source.isRevoked());
 
         return this;
     }

--- a/server/src/main/java/org/candlepin/dto/manifest/v1/CertificateSerialTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/manifest/v1/CertificateSerialTranslator.java
@@ -60,8 +60,10 @@ public class CertificateSerialTranslator extends
         dest = super.populate(translator, source, dest);
 
         dest.setId(source.getId());
+        dest.setSerial(source.getSerial());
         dest.setExpiration(source.getExpiration());
         dest.setCollected(source.isCollected());
+        dest.setRevoked(source.isRevoked());
 
         return dest;
     }

--- a/server/src/main/java/org/candlepin/dto/manifest/v1/CertificateTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/manifest/v1/CertificateTranslator.java
@@ -15,7 +15,7 @@
 package org.candlepin.dto.manifest.v1;
 
 import org.candlepin.dto.ModelTranslator;
-import org.candlepin.dto.ObjectTranslator;
+import org.candlepin.dto.TimestampedEntityTranslator;
 import org.candlepin.model.Certificate;
 
 
@@ -24,7 +24,7 @@ import org.candlepin.model.Certificate;
  * The CertificateTranslator provides translation from Certificate model objects to
  * CertificateDTOs as used by the manifest import/export framework.
  */
-public class CertificateTranslator implements ObjectTranslator<Certificate, CertificateDTO> {
+public class CertificateTranslator extends TimestampedEntityTranslator<Certificate, CertificateDTO> {
 
     /**
      * {@inheritDoc}
@@ -55,13 +55,7 @@ public class CertificateTranslator implements ObjectTranslator<Certificate, Cert
      */
     @Override
     public CertificateDTO populate(ModelTranslator translator, Certificate source, CertificateDTO dest) {
-        if (source == null) {
-            throw new IllegalArgumentException("source is null");
-        }
-
-        if (dest == null) {
-            throw new IllegalArgumentException("destination is null");
-        }
+        dest = super.populate(translator, source, dest);
 
         dest.setId(source.getId());
         dest.setKey(source.getKey());

--- a/server/src/main/java/org/candlepin/dto/manifest/v1/ConsumerTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/manifest/v1/ConsumerTranslator.java
@@ -68,8 +68,8 @@ public class ConsumerTranslator implements ObjectTranslator<Consumer, ConsumerDT
 
         // Process nested objects if we have a ModelTranslator to use to the translation...
         if (translator != null) {
-            Owner sourceOwner = source.getOwner();
-            dest.setOwner(sourceOwner != null ? sourceOwner.getId() : null);
+            Owner owner = source.getOwner();
+            dest.setOwner(owner != null ? translator.translate(owner, OwnerDTO.class) : null);
             dest.setType(translator.translate(source.getType(), ConsumerTypeDTO.class));
         }
         else {

--- a/server/src/main/java/org/candlepin/dto/manifest/v1/EntitlementDTO.java
+++ b/server/src/main/java/org/candlepin/dto/manifest/v1/EntitlementDTO.java
@@ -16,10 +16,11 @@ package org.candlepin.dto.manifest.v1;
 
 import com.fasterxml.jackson.annotation.JsonFilter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.candlepin.common.jackson.HateoasInclude;
-import org.candlepin.dto.CandlepinDTO;
+import org.candlepin.dto.TimestampedCandlepinDTO;
 import org.candlepin.util.SetView;
 import org.candlepin.util.Util;
 
@@ -27,6 +28,7 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import java.util.Collection;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -38,7 +40,7 @@ import java.util.Set;
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @JsonFilter("EntitlementFilter")
-public class EntitlementDTO extends CandlepinDTO<EntitlementDTO> {
+public class EntitlementDTO extends TimestampedCandlepinDTO<EntitlementDTO> {
 
     private static final long serialVersionUID = 1L;
 
@@ -96,9 +98,14 @@ public class EntitlementDTO extends CandlepinDTO<EntitlementDTO> {
      */
 
     private String id;
+    private OwnerDTO owner;
+    private ConsumerDTO consumer;
     private PoolDTO pool;
     private Integer quantity;
+    private Boolean deletedFromPool;
     private Set<CertificateDTO> certificates;
+    private Date startDate;
+    private Date endDate;
 
     /**
      * Initializes a new EntitlementDTO instance with null values.
@@ -141,6 +148,50 @@ public class EntitlementDTO extends CandlepinDTO<EntitlementDTO> {
     }
 
     /**
+     * Returns the owner of this entitlement.
+     *
+     * @return the owner of this entitlement.
+     */
+    @JsonIgnore
+    public OwnerDTO getOwner() {
+        return this.owner;
+    }
+
+    /**
+     * Sets the owner of this entitlement.
+     *
+     * @param owner the owner to set.
+     *
+     * @return a reference to this EntitlementDTO object.
+     */
+    @JsonProperty
+    public EntitlementDTO setOwner(OwnerDTO owner) {
+        this.owner = owner;
+        return this;
+    }
+
+    /**
+     * Returns the consumer of this entitlement.
+     *
+     * @return return the associated Consumer.
+     */
+    public ConsumerDTO getConsumer() {
+        return consumer;
+    }
+
+    /**
+     * Associates the given consumer with this entitlement.
+     *
+     * @param consumer consumer to associate.
+     *
+     * @return a reference to this EntitlementDTO object.
+     */
+    public EntitlementDTO setConsumer(ConsumerDTO consumer) {
+        this.consumer = consumer;
+        return this;
+    }
+
+    /**
      * Returns the pool of this entitlement.
      *
      * @return the pool of this entitlement.
@@ -179,6 +230,29 @@ public class EntitlementDTO extends CandlepinDTO<EntitlementDTO> {
      */
     public EntitlementDTO setQuantity(Integer quantity) {
         this.quantity = quantity;
+        return this;
+    }
+
+    /**
+     * Returns true if this entitlement is deleted from the pool, or false otherwise.
+     *
+     * @return if this entitlement is deleted from the pool or not.
+     */
+    @JsonIgnore
+    public Boolean isDeletedFromPool() {
+        return deletedFromPool;
+    }
+
+    /**
+     * Sets if this entitlement is is deleted from the pool or not.
+     *
+     * @param deletedFromPool if this entitlement is deleted from the pool or not.
+     *
+     * @return a reference to this EntitlementDTO object.
+     */
+    @JsonProperty
+    public EntitlementDTO setDeletedFromPool(Boolean deletedFromPool) {
+        this.deletedFromPool = deletedFromPool;
         return this;
     }
 
@@ -266,14 +340,61 @@ public class EntitlementDTO extends CandlepinDTO<EntitlementDTO> {
     }
 
     /**
+     * Returns the start date of this entitlement.
+     *
+     * @return Returns the startDate from the pool of this entitlement.
+     */
+    @JsonProperty
+    public Date getStartDate() {
+        return startDate;
+    }
+
+    /**
+     * Sets the start date of this entitlement.
+     *
+     * @param startDate the startDate of this entitlement.
+     *
+     * @return a reference to this EntitlementDTO object.
+     */
+    @JsonIgnore
+    public EntitlementDTO setStartDate(Date startDate) {
+        this.startDate = startDate;
+        return this;
+    }
+
+    /**
+     * Returns the end date of this entitlement.
+     *
+     * @return Returns the endDate of this entitlement.
+     */
+    @JsonProperty
+    public Date getEndDate() {
+        return endDate;
+    }
+
+    /**
+     * Sets the end date of this entitlement.
+     *
+     * @param endDate the endDate of this entitlement.
+     *
+     * @return a reference to this EntitlementDTO object.
+     */
+    @JsonIgnore
+    public EntitlementDTO setEndDate(Date endDate) {
+        this.endDate = endDate;
+        return this;
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override
     public String toString() {
-        return String.format("EntitlementDTO [id: %s, product id: %s, pool id: %s]",
+        return String.format("EntitlementDTO [id: %s, product id: %s, pool id: %s, consumer uuid: %s]",
             this.id,
             this.pool != null ? pool.getProductId() : null,
-            this.pool != null ? pool.getId() : null);
+            this.pool != null ? pool.getId() : null,
+            this.consumer != null ? consumer.getUuid() : null);
     }
 
     /**
@@ -285,16 +406,29 @@ public class EntitlementDTO extends CandlepinDTO<EntitlementDTO> {
             return true;
         }
 
-        if (obj instanceof EntitlementDTO) {
+        if (obj instanceof EntitlementDTO && super.equals(obj)) {
             EntitlementDTO that = (EntitlementDTO) obj;
+
+            // Pull the nested object IDs, as we're not interested in verifying that the objects
+            // themselves are equal; just so long as they point to the same object.
+            String thisOwnerId = this.getOwner() != null ? this.getOwner().getId() : null;
+            String thatOwnerId = that.getOwner() != null ? that.getOwner().getId() : null;
 
             String thisPoolId = this.getPool() != null ? this.getPool().getId() : null;
             String thatPoolId = that.getPool() != null ? that.getPool().getId() : null;
 
+            String thisConsumerId = this.getConsumer() != null ? this.getConsumer().getUuid() : null;
+            String thatConsumerId = that.getConsumer() != null ? that.getConsumer().getUuid() : null;
+
             EqualsBuilder builder = new EqualsBuilder()
                 .append(this.getId(), that.getId())
+                .append(thisOwnerId, thatOwnerId)
                 .append(thisPoolId, thatPoolId)
-                .append(this.getQuantity(), that.getQuantity());
+                .append(thisConsumerId, thatConsumerId)
+                .append(this.getQuantity(), that.getQuantity())
+                .append(this.isDeletedFromPool(), that.isDeletedFromPool())
+                .append(this.getEndDate(), that.getEndDate())
+                .append(this.getStartDate(), that.getStartDate());
 
             // Note that we're using the boolean operator here as a shorthand way to skip checks
             // when the equality check has already failed.
@@ -335,9 +469,15 @@ public class EntitlementDTO extends CandlepinDTO<EntitlementDTO> {
         }
 
         HashCodeBuilder builder = new HashCodeBuilder(37, 7)
+            .append(super.hashCode())
             .append(this.getId())
+            .append(this.getOwner() != null ? this.getOwner().getId() : null)
             .append(this.getPool() != null ? this.getPool().getId() : null)
+            .append(this.getConsumer() != null ? this.getConsumer().getUuid() : null)
             .append(this.getQuantity())
+            .append(this.isDeletedFromPool())
+            .append(this.getEndDate())
+            .append(this.getStartDate())
             .append(certsHashCode);
 
         return builder.toHashCode();
@@ -348,12 +488,21 @@ public class EntitlementDTO extends CandlepinDTO<EntitlementDTO> {
      */
     @Override
     public EntitlementDTO clone() {
-        EntitlementDTO copy = super.clone();
+        EntitlementDTO copy = (EntitlementDTO) super.clone();
+
+        OwnerDTO owner = this.getOwner();
+        copy.owner = owner != null ? owner.clone() : null;
 
         PoolDTO pool = this.getPool();
         copy.pool = pool != null ? pool.clone() : null;
 
+        ConsumerDTO consumer = this.getConsumer();
+        copy.consumer = consumer != null ? consumer.clone() : null;
+
         copy.setCertificates(this.getCertificates());
+
+        copy.endDate = this.endDate != null ? (Date) this.endDate.clone() : null;
+        copy.startDate = this.startDate != null ? (Date) this.startDate.clone() : null;
 
         return copy;
     }
@@ -366,9 +515,14 @@ public class EntitlementDTO extends CandlepinDTO<EntitlementDTO> {
         super.populate(source);
 
         this.setId(source.getId())
+            .setOwner(source.getOwner())
             .setPool(source.getPool())
+            .setConsumer(source.getConsumer())
             .setQuantity(source.getQuantity())
-            .setCertificates(source.getCertificates());
+            .setDeletedFromPool(source.isDeletedFromPool())
+            .setCertificates(source.getCertificates())
+            .setEndDate(source.getEndDate())
+            .setStartDate(source.getStartDate());
 
         return this;
     }

--- a/server/src/main/java/org/candlepin/dto/manifest/v1/EntitlementTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/manifest/v1/EntitlementTranslator.java
@@ -15,10 +15,12 @@
 package org.candlepin.dto.manifest.v1;
 
 import org.candlepin.dto.ModelTranslator;
-import org.candlepin.dto.ObjectTranslator;
+import org.candlepin.dto.TimestampedEntityTranslator;
 import org.candlepin.model.Certificate;
+import org.candlepin.model.Consumer;
 import org.candlepin.model.Entitlement;
 import org.candlepin.model.EntitlementCertificate;
+import org.candlepin.model.Owner;
 import org.candlepin.model.Pool;
 
 import java.util.Collections;
@@ -28,7 +30,7 @@ import java.util.Set;
  * The EntitlementTranslator provides translation from Entitlement model objects to EntitlementDTOs
  * as used by the manifest import/export framework.
  */
-public class EntitlementTranslator implements ObjectTranslator<Entitlement, EntitlementDTO> {
+public class EntitlementTranslator extends TimestampedEntityTranslator<Entitlement, EntitlementDTO> {
 
     /**
      * {@inheritDoc}
@@ -59,20 +61,24 @@ public class EntitlementTranslator implements ObjectTranslator<Entitlement, Enti
      */
     @Override
     public EntitlementDTO populate(ModelTranslator modelTranslator, Entitlement source, EntitlementDTO dest) {
-        if (source == null) {
-            throw new IllegalArgumentException("source is null");
-        }
-
-        if (dest == null) {
-            throw new IllegalArgumentException("destination is null");
-        }
+        dest = super.populate(modelTranslator, source, dest);
 
         dest.setId(source.getId());
         dest.setQuantity(source.getQuantity());
+        dest.setDeletedFromPool(source.deletedFromPool());
+        dest.setStartDate(source.getStartDate());
+        dest.setEndDate(source.getEndDate());
 
         if (modelTranslator != null) {
+            Owner owner = source.getOwner();
+            dest.setOwner(owner != null ? modelTranslator.translate(owner, OwnerDTO.class) : null);
+
             Pool pool = source.getPool();
             dest.setPool(pool != null ? modelTranslator.translate(pool, PoolDTO.class) : null);
+
+            Consumer consumer = source.getConsumer();
+            dest.setConsumer(consumer != null ?
+                modelTranslator.translate(consumer, ConsumerDTO.class) : null);
 
             Set<EntitlementCertificate> certs = source.getCertificates();
             if (certs != null && !certs.isEmpty()) {

--- a/server/src/main/java/org/candlepin/dto/manifest/v1/OwnerDTO.java
+++ b/server/src/main/java/org/candlepin/dto/manifest/v1/OwnerDTO.java
@@ -1,0 +1,348 @@
+/**
+ * Copyright (c) 2009 - 2018 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.dto.manifest.v1;
+
+import org.candlepin.common.jackson.HateoasInclude;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.candlepin.dto.TimestampedCandlepinDTO;
+
+import java.util.Date;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * A DTO representation of the Owner entity as used by the manifest import/export mechanism.
+ */
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.PROPERTY)
+@JsonFilter("OwnerFilter")
+public class OwnerDTO extends TimestampedCandlepinDTO<OwnerDTO> {
+    public static final long serialVersionUID = 1L;
+
+    protected String id;
+    protected String key;
+    protected String displayName;
+    protected OwnerDTO parentOwner;
+    protected String contentPrefix;
+    protected String defaultServiceLevel;
+    protected UpstreamConsumerDTO upstreamConsumer;
+    protected String logLevel;
+    protected Boolean autobindDisabled;
+    protected String contentAccessMode;
+    protected String contentAccessModeList;
+    protected Date lastRefreshed;
+
+    /**
+     * Initializes a new OwnerDTO instance with null values.
+     */
+    public OwnerDTO() {
+        // Intentionally left empty
+    }
+
+    /**
+     * Initializes a new OwnerDTO instance which is a shallow copy of the provided
+     * source entity.
+     *
+     * @param source
+     *  The source entity to copy
+     */
+    public OwnerDTO(OwnerDTO source) {
+        super(source);
+    }
+
+    /**
+     * Constructor with required parameters.
+     *
+     * @param key Owner's unique identifier
+     * @param displayName Owner's name - suitable for UI
+     */
+    public OwnerDTO(String key, String displayName) {
+        this();
+
+        this.key = key;
+        this.displayName = displayName;
+    }
+
+    /**
+     * Creates an Owner with only a name
+     *
+     * @param name to be used for both the display name and the key
+     */
+    public OwnerDTO(String name) {
+        this(name, name);
+    }
+
+    @HateoasInclude
+    @JsonProperty
+    public String getId() {
+        return this.id;
+    }
+
+    @JsonIgnore
+    public OwnerDTO setId(String id) {
+        this.id = id;
+        return this;
+    }
+
+    @HateoasInclude
+    public String getKey() {
+        return key;
+    }
+
+    public OwnerDTO setKey(String key) {
+        this.key = key;
+        return this;
+    }
+
+    @HateoasInclude
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public OwnerDTO setDisplayName(String displayName) {
+        this.displayName = displayName;
+        return this;
+    }
+
+    @JsonProperty
+    public OwnerDTO getParentOwner() {
+        return this.parentOwner;
+    }
+
+    @JsonIgnore
+    public OwnerDTO setParentOwner(OwnerDTO parentOwner) {
+        this.parentOwner = parentOwner;
+        return this;
+    }
+
+    public String getContentPrefix() {
+        return contentPrefix;
+    }
+
+    public OwnerDTO setContentPrefix(String contentPrefix) {
+        this.contentPrefix = contentPrefix;
+        return this;
+    }
+
+    public String getDefaultServiceLevel() {
+        return defaultServiceLevel;
+    }
+
+    public OwnerDTO setDefaultServiceLevel(String defaultServiceLevel) {
+        this.defaultServiceLevel = defaultServiceLevel;
+        return this;
+    }
+
+    @JsonProperty
+    public UpstreamConsumerDTO getUpstreamConsumer() {
+        return upstreamConsumer;
+    }
+
+    @JsonIgnore
+    public OwnerDTO setUpstreamConsumer(UpstreamConsumerDTO upstreamConsumer) {
+        this.upstreamConsumer = upstreamConsumer;
+        return this;
+    }
+
+    public String getLogLevel() {
+        return logLevel;
+    }
+
+    public OwnerDTO setLogLevel(String logLevel) {
+        this.logLevel = logLevel;
+        return this;
+    }
+
+    @JsonProperty
+    public Boolean isAutobindDisabled() {
+        return autobindDisabled;
+    }
+
+    @JsonIgnore
+    public OwnerDTO setAutobindDisabled(Boolean autobindDisabled) {
+        this.autobindDisabled = autobindDisabled;
+        return this;
+    }
+
+    public String getContentAccessMode() {
+        return contentAccessMode;
+    }
+
+    public OwnerDTO setContentAccessMode(String contentAccessMode) {
+        this.contentAccessMode = contentAccessMode;
+        return this;
+    }
+
+    public String getContentAccessModeList() {
+        return contentAccessModeList;
+    }
+
+    public OwnerDTO setContentAccessModeList(String contentAccessModeList) {
+        this.contentAccessModeList = contentAccessModeList;
+        return this;
+    }
+
+    /**
+     * Fetches the date this owner was last refreshed, or null if the owner has not been refreshed
+     * or this field has not been set.
+     *
+     * @return
+     *  the date this owner was last refreshed, or null if the owner has not been refreshed or this
+     *  field is not defined
+     */
+    @JsonProperty
+    public Date getLastRefreshed() {
+        return lastRefreshed;
+    }
+
+    /**
+     * Sets or clears the date this owner was last refreshed.
+     *
+     * @param lastRefreshed
+     *  The date this owner was last refreshed, or null to clear the last refresh value
+     *
+     * @return
+     *  A reference to this DTO
+     */
+    @JsonIgnore
+    public OwnerDTO setLastRefreshed(Date lastRefreshed) {
+        this.lastRefreshed = lastRefreshed;
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        return String.format("OwnerDTO [id: %s, key: %s]", this.getId(), this.getKey());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        }
+
+        if (obj instanceof OwnerDTO && super.equals(obj)) {
+            OwnerDTO that = (OwnerDTO) obj;
+
+            // Pull the parent owner IDs, as we're not interested in verifying that the parent owners
+            // themselves are equal; just so long as they point to the same parent owner.
+            String lpoid = this.getParentOwner() != null ? this.getParentOwner().getId() : null;
+            String rpoid = that.getParentOwner() != null ? that.getParentOwner().getId() : null;
+
+            // Same with the upstream consumer
+            String lucid = this.getUpstreamConsumer() != null ? this.getUpstreamConsumer().getId() : null;
+            String rucid = that.getUpstreamConsumer() != null ? that.getUpstreamConsumer().getId() : null;
+
+            EqualsBuilder builder = new EqualsBuilder()
+                .append(this.getId(), that.getId())
+                .append(this.getKey(), that.getKey())
+                .append(this.getDisplayName(), that.getDisplayName())
+                .append(lpoid, rpoid)
+                .append(this.getContentPrefix(), that.getContentPrefix())
+                .append(this.getDefaultServiceLevel(), that.getDefaultServiceLevel())
+                .append(lucid, rucid)
+                .append(this.getLogLevel(), that.getLogLevel())
+                .append(this.isAutobindDisabled(), that.isAutobindDisabled())
+                .append(this.getContentAccessMode(), that.getContentAccessMode())
+                .append(this.getContentAccessModeList(), that.getContentAccessModeList())
+                .append(this.getLastRefreshed(), that.getLastRefreshed());
+
+            return builder.isEquals();
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        // Like with the equals method, we are not interested in hashing nested objects; we're only
+        // concerned with the reference to such an object.
+
+        HashCodeBuilder builder = new HashCodeBuilder(37, 7)
+            .append(super.hashCode())
+            .append(this.getId())
+            .append(this.getKey())
+            .append(this.getDisplayName())
+            .append(this.getParentOwner() != null ? this.getParentOwner().getId() : null)
+            .append(this.getContentPrefix())
+            .append(this.getDefaultServiceLevel())
+            .append(this.getUpstreamConsumer() != null ? this.getUpstreamConsumer().getId() : null)
+            .append(this.getLogLevel())
+            .append(this.isAutobindDisabled())
+            .append(this.getContentAccessMode())
+            .append(this.getContentAccessModeList())
+            .append(this.getLastRefreshed());
+
+        return builder.toHashCode();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public OwnerDTO clone() {
+        OwnerDTO copy = super.clone();
+
+        OwnerDTO parent = this.getParentOwner();
+        copy.parentOwner = parent != null ? (OwnerDTO) parent.clone() : null;
+
+        UpstreamConsumerDTO consumer = this.getUpstreamConsumer();
+        copy.upstreamConsumer = consumer != null ? (UpstreamConsumerDTO) consumer.clone() : null;
+
+        Date lastRefreshed = this.getLastRefreshed();
+        copy.lastRefreshed = lastRefreshed != null ? (Date) lastRefreshed.clone() : null;
+
+        return copy;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public OwnerDTO populate(OwnerDTO source) {
+        super.populate(source);
+
+        this.setId(source.getId());
+        this.setKey(source.getKey());
+        this.setDisplayName(source.getDisplayName());
+        this.setParentOwner(source.getParentOwner());
+        this.setContentPrefix(source.getContentPrefix());
+        this.setDefaultServiceLevel(source.getDefaultServiceLevel());
+        this.setUpstreamConsumer(source.getUpstreamConsumer());
+        this.setLogLevel(source.getLogLevel());
+        this.setAutobindDisabled(source.isAutobindDisabled());
+        this.setContentAccessMode(source.getContentAccessMode());
+        this.setContentAccessModeList(source.getContentAccessModeList());
+        this.setLastRefreshed(source.getLastRefreshed());
+
+        return this;
+    }
+}

--- a/server/src/main/java/org/candlepin/dto/manifest/v1/OwnerTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/manifest/v1/OwnerTranslator.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2009 - 2018 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.dto.manifest.v1;
+
+import org.candlepin.dto.ModelTranslator;
+import org.candlepin.dto.TimestampedEntityTranslator;
+import org.candlepin.model.Owner;
+import org.candlepin.model.UpstreamConsumer;
+
+
+
+/**
+ * The OwnerTranslator provides translation from Owner model objects to OwnerDTOs
+ * as used by the manifest import/export mechanism.
+ */
+public class OwnerTranslator extends TimestampedEntityTranslator<Owner, OwnerDTO> {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public OwnerDTO translate(Owner source) {
+        return this.translate(null, source);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public OwnerDTO translate(ModelTranslator translator, Owner source) {
+        return source != null ? this.populate(translator, source, new OwnerDTO()) : null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public OwnerDTO populate(Owner source, OwnerDTO destination) {
+        return this.populate(null, source, destination);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public OwnerDTO populate(ModelTranslator translator, Owner source, OwnerDTO dest) {
+        dest = super.populate(translator, source, dest);
+
+        dest.setId(source.getId());
+        dest.setKey(source.getKey());
+        dest.setDisplayName(source.getDisplayName());
+        dest.setContentPrefix(source.getContentPrefix());
+        dest.setDefaultServiceLevel(source.getDefaultServiceLevel());
+        dest.setLogLevel(source.getLogLevel());
+        dest.setAutobindDisabled(source.isAutobindDisabled());
+        dest.setContentAccessMode(source.getContentAccessMode());
+        dest.setContentAccessModeList(source.getContentAccessModeList());
+        dest.setLastRefreshed(source.getLastRefreshed());
+
+        // TODO: Should this actually follow the nested child rules of all the other objects?
+        Owner parent = source.getParentOwner();
+        dest.setParentOwner(parent != null ? this.translate(translator, parent) : null);
+
+        // Process nested objects if we have a model translator to use to the translation...
+        if (translator != null) {
+            UpstreamConsumer consumer = source.getUpstreamConsumer();
+            dest.setUpstreamConsumer(translator.translate(consumer, UpstreamConsumerDTO.class));
+        }
+        else {
+            dest.setUpstreamConsumer(null);
+        }
+
+        return dest;
+    }
+
+}

--- a/server/src/main/java/org/candlepin/dto/manifest/v1/PoolDTO.java
+++ b/server/src/main/java/org/candlepin/dto/manifest/v1/PoolDTO.java
@@ -19,17 +19,24 @@ import com.fasterxml.jackson.annotation.JsonFilter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.candlepin.common.jackson.HateoasInclude;
-import org.candlepin.dto.CandlepinDTO;
+import org.candlepin.dto.TimestampedCandlepinDTO;
+import org.candlepin.jackson.CandlepinAttributeDeserializer;
+import org.candlepin.jackson.CandlepinLegacyAttributeSerializer;
+import org.candlepin.util.MapView;
 import org.candlepin.util.SetView;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -38,7 +45,7 @@ import java.util.Set;
 @XmlRootElement(name = "pool")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @JsonFilter("PoolFilter")
-public class PoolDTO extends CandlepinDTO<PoolDTO> {
+public class PoolDTO extends TimestampedCandlepinDTO<PoolDTO> {
     public static final long serialVersionUID = 1L;
 
     /**
@@ -99,21 +106,56 @@ public class PoolDTO extends CandlepinDTO<PoolDTO> {
     }
 
     private String id;
+    private String type;
+    private OwnerDTO owner;
+    private Boolean activeSubscription;
+    private Boolean createdByShare;
+    private Boolean hasSharedAncestor;
+    private EntitlementDTO sourceEntitlement;
+    private Long quantity;
 
+    private Map<String, String> attributes;
+    private String restrictedToUsername;
     private String contractNumber;
     private String accountNumber;
     private String orderNumber;
+    private Long consumed;
+    private Long exported;
+    private Long shared;
 
     private Set<BrandingDTO> branding;
 
+    private Map<String, String> calculatedAttributes;
+    private String upstreamPoolId;
+    private String upstreamEntitlementId;
+    private String upstreamConsumerId;
+
+    private String productName;
     private String productId;
+
+    private Map<String, String> productAttributes;
+
+    private String stackId;
+    private Boolean stacked;
+    private String sourceStackId;
+
+    private Boolean developmentPool;
+
+    private Map<String, String> derivedProductAttributes;
+
     private String derivedProductId;
+    private String derivedProductName;
 
     private Set<ProvidedProductDTO> providedProducts;
     private Set<ProvidedProductDTO> derivedProvidedProducts;
 
+    private String subscriptionSubKey;
+    private String subscriptionId;
+
     private Date startDate;
     private Date endDate;
+
+    private CertificateDTO certificate;
 
     /**
      * Initializes a new PoolDTO instance with null values.
@@ -154,6 +196,271 @@ public class PoolDTO extends CandlepinDTO<PoolDTO> {
         this.id = id;
         return this;
     }
+
+    /**
+     * Returns the pool's type.
+     *
+     * @return this pool's type.
+     */
+    @JsonProperty
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * Sets the pool's type.
+     *
+     * @param type set the pool type.
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    @JsonIgnore
+    public PoolDTO setType(String type) {
+        this.type = type;
+        return this;
+    }
+
+    /**
+     * Return the owner of this pool.
+     *
+     * @return the owner of this pool.
+     */
+    public OwnerDTO getOwner() {
+        return owner;
+    }
+
+    /**
+     * Sets the owner of this pool.
+     *
+     * @param owner set the owner of this pool.
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    public PoolDTO setOwner(OwnerDTO owner) {
+        this.owner = owner;
+        return this;
+    }
+
+    /**
+     * Returns true if this pool represents an active subscription, false otherwise.
+     *
+     * @return true if this pool represents an active subscription, false otherwise.
+     */
+    public Boolean isActiveSubscription() {
+        return activeSubscription;
+    }
+
+    /**
+     * Sets if this pool represents an active subscription or not.
+     *
+     * @param activeSubscription set if this pool represents an active subscription or not.
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    public PoolDTO setActiveSubscription(Boolean activeSubscription) {
+        this.activeSubscription = activeSubscription;
+        return this;
+    }
+
+    /**
+     * Returns true if this pool was created because of a share, false otherwise.
+     *
+     * @return true if this pool was created because of a share, false otherwise.
+     */
+    public Boolean isCreatedByShare() {
+        return createdByShare;
+    }
+
+    /**
+     * Set if this pool was created because of a share or not.
+     *
+     * @param createdByShare set if this pool was created because of a share or not.
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    public PoolDTO setCreatedByShare(Boolean createdByShare) {
+        this.createdByShare = createdByShare;
+        return this;
+    }
+
+    /**
+     * Checks if this pool or its ancestors were created as a result of a share.
+     *
+     * @return true if this pool or its parent was created because of a share.
+     */
+    @JsonProperty
+    public Boolean hasSharedAncestor() {
+        return hasSharedAncestor;
+    }
+
+    /**
+     * Sets whether or not this pool or any of its ancestors were created as
+     * a result of a share.
+     *
+     * @param hasSharedAncestor
+     *  true if this pool or any of its ancestors were created as a result of a share.
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    public PoolDTO setHasSharedAncestor(Boolean hasSharedAncestor) {
+        this.hasSharedAncestor = hasSharedAncestor;
+        return this;
+    }
+
+    /**
+     * Returns the source entitlement of this pool.
+     *
+     * @return the source entitlement.
+     */
+    public EntitlementDTO getSourceEntitlement() {
+        return sourceEntitlement;
+    }
+
+    /**
+     * Sets the source entitlement of this pool.
+     *
+     * @param sourceEntitlement set the source entitlement.
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    public PoolDTO setSourceEntitlement(EntitlementDTO sourceEntitlement) {
+        this.sourceEntitlement = sourceEntitlement;
+        return this;
+    }
+
+    /**
+     * Return this pool's quantity.
+     *
+     * @return this pool's quantity.
+     */
+    public Long getQuantity() {
+        return quantity;
+    }
+
+    /**
+     * Sets this pool's quantity.
+     *
+     * @param quantity set this pool's quantity.
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    public PoolDTO setQuantity(Long quantity) {
+        this.quantity = quantity;
+        return this;
+    }
+
+    /**
+     * Retrieves a view of the attributes for the pool represented by this DTO. If the attributes
+     * have not yet been defined, this method returns null.
+     * <p></p>
+     * Note that the collection returned by this method is a view of the collection backing this
+     * set of attributes. Elements cannot be added to the collection, but elements may be removed.
+     * Changes made to the collection will be reflected by this pool DTO instance.
+     *
+     * @return the attributes associated with this pool, or null if they have not yet been defined.
+     */
+    @JsonSerialize(using = CandlepinLegacyAttributeSerializer.class)
+    public Map<String, String> getAttributes() {
+        return this.attributes != null ? new MapView<>(this.attributes) : null;
+    }
+
+    /**
+     * Sets the attributes for this pool DTO.
+     *
+     * @param attributes
+     *  A map of attribute key, value pairs to assign to this pool DTO, or null to clear the
+     *  existing ones
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    @JsonDeserialize(using = CandlepinAttributeDeserializer.class)
+    public PoolDTO setAttributes(Map<String, String> attributes) {
+        if (attributes != null) {
+            if (this.attributes == null) {
+                this.attributes = new HashMap<>();
+            }
+            else {
+                this.attributes.clear();
+            }
+            this.attributes.putAll(attributes);
+        }
+        else {
+            this.attributes = null;
+        }
+        return this;
+    }
+
+    /**
+     * Checks if the given attribute has been defined on this poolDTO.
+     *
+     * @param key
+     *  The key (name) of the attribute to lookup
+     *
+     * @throws IllegalArgumentException
+     *  if key is null
+     *
+     * @return
+     *  true if the attribute is defined for this pool; false otherwise
+     */
+    @JsonIgnore
+    public boolean hasAttribute(String key) {
+        if (key == null) {
+            throw new IllegalArgumentException("key is null");
+        }
+
+        if (this.attributes == null) {
+            return false;
+        }
+
+        return this.attributes.containsKey(key);
+    }
+
+    /**
+     * Removes the given attribute from this pool DTO.
+     *
+     * @param key
+     *  The key (name) of the attribute to remove
+     *
+     * @return
+     *  True if the attribute was removed; false otherwise.
+     */
+    @JsonIgnore
+    public boolean removeAttribute(String key) {
+        if (key == null) {
+            throw new IllegalArgumentException("key is null");
+        }
+
+        if (this.attributes == null) {
+            return false;
+        }
+
+        boolean present = this.attributes.containsKey(key);
+        this.attributes.remove(key);
+
+        return present;
+    }
+
+    /**
+     * Returns the username of the user to which this pool is restricted.
+     *
+     * @return the username of the user to which this pool is restricted.
+     */
+    public String getRestrictedToUsername() {
+        return restrictedToUsername;
+    }
+
+    /**
+     * Sets the username of the user to which this pool is restricted.
+     *
+     * @param restrictedToUsername the username of the user to which this pool is restricted.
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    public PoolDTO setRestrictedToUsername(String restrictedToUsername) {
+        this.restrictedToUsername = restrictedToUsername;
+        return this;
+    }
+
 
     /**
      * Return the contract number for this pool's subscription.
@@ -299,6 +606,198 @@ public class PoolDTO extends CandlepinDTO<PoolDTO> {
     }
 
     /**
+     * Returns the quantity of the pool that is currently consumed.
+     *
+     * @return the quantity currently consumed.
+     */
+    public Long getConsumed() {
+        return consumed;
+    }
+
+    /**
+     * Sets the quantity of the pool that is currently consumed.
+     *
+     * @param consumed set the activated uses.
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    public PoolDTO setConsumed(Long consumed) {
+        this.consumed = consumed;
+        return this;
+    }
+
+    /**
+     * Returns the quantity of the pool that is currently exported.
+     *
+     * @return quantity currently exported.
+     */
+    public Long getExported() {
+        return exported;
+    }
+
+    /**
+     * Sets the quantity of the pool that is currently exported.
+     *
+     * @param exported set the activated uses.
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    public PoolDTO setExported(Long exported) {
+        this.exported = exported;
+        return this;
+    }
+
+    /**
+     * Returns the quantity of entitlements in this pool shared to another org.
+     *
+     * @return the quantity of entitlements in this pool shared to another org.
+     */
+    public Long getShared() {
+        return shared;
+    }
+
+    /**
+     * Sets the quantity of entitlements in this pool shared to another org.
+     *
+     * @param shared the number to set the share count to
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    public PoolDTO setShared(Long shared) {
+        this.shared = shared;
+        return this;
+    }
+
+    /**
+     * Retrieves a view of the calculated attributes for the pool represented by this DTO. If the calculated
+     * attributes have not yet been defined, this method returns null.
+     * <p></p>
+     * Note that the collection returned by this method is a view of the collection backing this
+     * set of calculated attributes. Elements cannot be added to the collection, but elements may be removed.
+     * Changes made to the collection will be reflected by this pool DTO instance.
+     *
+     * @return the calculated attributes associated with this pool,
+     * or null if the they have not yet been defined.
+     */
+    public Map<String, String> getCalculatedAttributes() {
+        return this.calculatedAttributes != null ? new MapView<>(this.calculatedAttributes) : null;
+    }
+
+    /**
+     * Sets the calculated attributes for this pool DTO.
+     *
+     * @param calculatedAttributes
+     *  A map of calculated attribute key, value pairs to assign to this pool DTO, or null to clear the
+     *  existing ones
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    public PoolDTO setCalculatedAttributes(Map<String, String> calculatedAttributes) {
+        if (calculatedAttributes != null) {
+            if (this.calculatedAttributes == null) {
+                this.calculatedAttributes = new HashMap<>();
+            }
+            else {
+                this.calculatedAttributes.clear();
+            }
+            this.calculatedAttributes.putAll(calculatedAttributes);
+        }
+        else {
+            this.calculatedAttributes = null;
+        }
+        return this;
+    }
+
+    /**
+     * Returns the upstream pool id.
+     *
+     * @return the upstream pool id.
+     */
+    public String getUpstreamPoolId() {
+        return upstreamPoolId;
+    }
+
+    /**
+     * Sets the upstream pool id.
+     *
+     * @param upstreamPoolId set the upstream pool id.
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    public PoolDTO setUpstreamPoolId(String upstreamPoolId) {
+        this.upstreamPoolId = upstreamPoolId;
+        return this;
+    }
+
+    /**
+     * Returns the upstream entitlement id.
+     *
+     * @return the upstream entitlement id.
+     */
+    public String getUpstreamEntitlementId() {
+        return upstreamEntitlementId;
+    }
+
+    /**
+     * Sets the upstream entitlement id.
+     *
+     * @param upstreamEntitlementId set the upstream entitlement id.
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    public PoolDTO setUpstreamEntitlementId(String upstreamEntitlementId) {
+        this.upstreamEntitlementId = upstreamEntitlementId;
+        return this;
+    }
+
+    /**
+     * Returns the upstream consumer id.
+     *
+     * @return the upstream consumer id.
+     */
+    public String getUpstreamConsumerId() {
+        return upstreamConsumerId;
+    }
+
+    /**
+     * Sets the upstream consumer id.
+     *
+     * @param upstreamConsumerId set the upstream consumer id.
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    public PoolDTO setUpstreamConsumerId(String upstreamConsumerId) {
+        this.upstreamConsumerId = upstreamConsumerId;
+        return this;
+    }
+
+    /**
+     * The Marketing/Operations product name for the
+     * <code>id</code>.
+     *
+     * @return the name
+     */
+    @JsonProperty
+    @HateoasInclude
+    public String getProductName() {
+        return productName;
+    }
+
+    /**
+     * Set the Marketing/Operations product name for the
+     * <code>id</code>.
+     *
+     * @param productName set the productName
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    @JsonIgnore
+    public PoolDTO setProductName(String productName) {
+        this.productName = productName;
+        return this;
+    }
+
+    /**
      * Return the "top level" product this pool is for.
      * Note that pools can also provide access to other products.
      * See getProvidedProducts().
@@ -325,6 +824,208 @@ public class PoolDTO extends CandlepinDTO<PoolDTO> {
     }
 
     /**
+     * Retrieves a view of the product attributes for the pool represented by this DTO. If the product
+     * attributes have not yet been defined, this method returns null.
+     * <p></p>
+     * Note that the collection returned by this method is a view of the collection backing this
+     * set of product attributes. Elements cannot be added to the collection, but elements may be removed.
+     * Changes made to the collection will be reflected by this pool DTO instance.
+     *
+     * @return the product attributes associated with this pool,
+     * or null if they have not yet been defined.
+     */
+    @JsonSerialize(using = CandlepinLegacyAttributeSerializer.class)
+    public Map<String, String> getProductAttributes() {
+        return this.productAttributes != null ? new MapView<>(this.productAttributes) : null;
+    }
+
+    /**
+     * Sets the product attributes for this pool DTO.
+     *
+     * @param productAttributes
+     *  A map of product attribute key, value pairs to assign to this pool DTO, or null to clear the
+     *  existing ones
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    @JsonDeserialize(using = CandlepinAttributeDeserializer.class)
+    public PoolDTO setProductAttributes(Map<String, String> productAttributes) {
+        if (productAttributes != null) {
+            if (this.productAttributes == null) {
+                this.productAttributes = new HashMap<>();
+            }
+            else {
+                this.productAttributes.clear();
+            }
+            this.productAttributes.putAll(productAttributes);
+        }
+        else {
+            this.productAttributes = null;
+        }
+        return this;
+    }
+
+    /**
+     * Checks if the given product attribute has been defined on this poolDTO.
+     *
+     * @param key
+     *  The key (name) of the product attribute to lookup
+     *
+     * @throws IllegalArgumentException
+     *  if key is null
+     *
+     * @return
+     *  true if the product attribute is defined for this pool; false otherwise
+     */
+    @JsonIgnore
+    public boolean hasProductAttribute(String key) {
+        if (key == null) {
+            throw new IllegalArgumentException("key is null");
+        }
+
+        if (this.productAttributes == null) {
+            return false;
+        }
+
+        return this.productAttributes.containsKey(key);
+    }
+
+    /**
+     * Returns the identifier of stacked products/pools.
+     *
+     * @return the identifier of stacked products/pools.
+     */
+    @JsonProperty
+    public String getStackId() {
+        return stackId;
+    }
+
+    /**
+     * Sets the identifier of stacked products/pools.
+     *
+     * @param stackId set the identifier of stacked products/pools.
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    @JsonIgnore
+    public PoolDTO setStackId(String stackId) {
+        this.stackId = stackId;
+        return this;
+    }
+
+    /**
+     * Returns true if this pool is stacked, false otherwise.
+     *
+     * @return true if this pool is stacked, false otherwise.
+     */
+    @JsonProperty
+    public Boolean isStacked() {
+        return stacked;
+    }
+
+    /**
+     * Sets if this pool is stacked or not.
+     *
+     * @param stacked set if this pool is stacked or not.
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    @JsonIgnore
+    public PoolDTO setStacked(Boolean stacked) {
+        this.stacked = stacked;
+        return this;
+    }
+
+    /**
+     * Returns the source stack id of this pool.
+     *
+     * @return the source stack id of this pool.
+     */
+    @JsonProperty
+    public String getSourceStackId() {
+        return sourceStackId;
+    }
+
+    /**
+     * Sets the source stack id of this pool.
+     *
+     * @param sourceStackId set the source stack id of this pool.
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    @JsonIgnore
+    public PoolDTO setSourceStackId(String sourceStackId) {
+        this.sourceStackId = sourceStackId;
+        return this;
+    }
+
+    /**
+     * Returns true if this is a development pool, false otherwise.
+     *
+     * @return true if this is a development pool, false otherwise.
+     */
+    @JsonProperty
+    public Boolean isDevelopmentPool() {
+        return developmentPool;
+    }
+
+    /**
+     * Sets if this is a development pool or not.
+     *
+     * @param developmentPool set if this is a development pool or not.
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    @JsonIgnore
+    public PoolDTO setDevelopmentPool(Boolean developmentPool) {
+        this.developmentPool = developmentPool;
+        return this;
+    }
+
+    /**
+     * Retrieves a view of the derived product attributes for the pool represented by this DTO.
+     * If the derived product attributes have not yet been defined, this method returns null.
+     * <p></p>
+     * Note that the collection returned by this method is a view of the collection backing this
+     * set of derived product attributes. Elements cannot be added to the collection,
+     * but elements may be removed.
+     * Changes made to the collection will be reflected by this pool DTO instance.
+     *
+     * @return the derived product attributes associated with this pool,
+     * or null if they have not yet been defined.
+     */
+    @JsonSerialize(using = CandlepinLegacyAttributeSerializer.class)
+    public Map<String, String> getDerivedProductAttributes() {
+        return this.derivedProductAttributes != null ? new MapView<>(this.derivedProductAttributes) : null;
+    }
+
+    /**
+     * Sets the derived product attributes for this pool DTO.
+     *
+     * @param derivedProductAttributes
+     *  A map of derived product attribute key, value pairs to assign to this pool DTO,
+     *  or null to clear the existing ones
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    @JsonDeserialize(using = CandlepinAttributeDeserializer.class)
+    public PoolDTO setDerivedProductAttributes(Map<String, String> derivedProductAttributes) {
+        if (derivedProductAttributes != null) {
+            if (this.derivedProductAttributes == null) {
+                this.derivedProductAttributes = new HashMap<>();
+            }
+            else {
+                this.derivedProductAttributes.clear();
+            }
+            this.derivedProductAttributes.putAll(derivedProductAttributes);
+        }
+        else {
+            this.derivedProductAttributes = null;
+        }
+        return this;
+    }
+
+    /**
      * Returns the derived product id of this pool.
      *
      * @return the derived product id of this pool.
@@ -342,6 +1043,29 @@ public class PoolDTO extends CandlepinDTO<PoolDTO> {
      */
     public PoolDTO setDerivedProductId(String derivedProductId) {
         this.derivedProductId = derivedProductId;
+        return this;
+    }
+
+    /**
+     * Returns the derived product name of this pool.
+     *
+     * @return the derived product name of this pool.
+     */
+    @JsonProperty
+    public String getDerivedProductName() {
+        return derivedProductName;
+    }
+
+    /**
+     * Sets the derived product name of this pool.
+     *
+     * @param derivedProductName set the derived product name of this pool.
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    @JsonIgnore
+    public PoolDTO setDerivedProductName(String derivedProductName) {
+        this.derivedProductName = derivedProductName;
         return this;
     }
 
@@ -496,6 +1220,47 @@ public class PoolDTO extends CandlepinDTO<PoolDTO> {
             derivedProvidedProduct.getProductId().isEmpty();
     }
 
+    /**
+     * Returns the subscription key of this pool.
+     *
+     * @return the subscription key of this pool.
+     */
+    public String getSubscriptionSubKey() {
+        return subscriptionSubKey;
+    }
+
+    /**
+     * Sets the subscription key of this pool.
+     *
+     * @param subscriptionSubKey set the subscription key of this pool.
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    public PoolDTO setSubscriptionSubKey(String subscriptionSubKey) {
+        this.subscriptionSubKey = subscriptionSubKey;
+        return this;
+    }
+
+    /**
+     * Returns the subscription id of this pool.
+     *
+     * @return the subscription id associated with this pool.
+     */
+    public String getSubscriptionId() {
+        return subscriptionId;
+    }
+
+    /**
+     * Sets the subscription id of this pool.
+     *
+     * @param subscriptionId set the subscription id associated with this pool.
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    public PoolDTO setSubscriptionId(String subscriptionId) {
+        this.subscriptionId = subscriptionId;
+        return this;
+    }
 
     /**
      * Returns the start date of this pool.
@@ -540,12 +1305,36 @@ public class PoolDTO extends CandlepinDTO<PoolDTO> {
     }
 
     /**
+     * Returns the Subscription Certificate of this pool.
+     *
+     * @return the subscription certificate of this pool.
+     */
+    @JsonIgnore
+    public CertificateDTO getCertificate() {
+        return this.certificate;
+    }
+
+    /**
+     * Sets the Subscription Certificate of this pool.
+     *
+     * @param certificate the Subscription Certificate to set on this pool.
+     *
+     * @return a reference to this PoolDTO object.
+     */
+    @JsonProperty
+    public PoolDTO setCertificate(CertificateDTO certificate) {
+        this.certificate = certificate;
+        return this;
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override
     public String toString() {
-        return String.format("PoolDTO [id: %s, product id: %s, derived product id: %s, end date: %s]",
-            this.getId(), this.getProductId(), this.getDerivedProductId(), this.getEndDate());
+        return String.format("PoolDTO [id: %s, type: %s, product id: %s, product name: %s, quantity: %s]",
+            this.getId(), this.getType(), this.getProductId(), this.getProductName(),
+            this.getQuantity());
     }
 
     /**
@@ -557,21 +1346,63 @@ public class PoolDTO extends CandlepinDTO<PoolDTO> {
             return true;
         }
 
-        if (obj instanceof PoolDTO) {
+        if (obj instanceof PoolDTO && super.equals(obj)) {
             PoolDTO that = (PoolDTO) obj;
+
+            // We are not interested in making sure nested objects are equal; we're only
+            // concerned with the reference to such an object.
+            String thisOwnerId = this.getOwner() != null ? this.getOwner().getId() : null;
+            String thatOwnerId = that.getOwner() != null ? that.getOwner().getId() : null;
+
+            String thisSourceEntitlementId =
+                this.getSourceEntitlement() != null ? this.getSourceEntitlement().getId() : null;
+            String thatSourceEntitlementId =
+                that.getSourceEntitlement() != null ? that.getSourceEntitlement().getId() : null;
+
+            String thisCertificateId =
+                this.getCertificate() != null ? this.getCertificate().getId() : null;
+            String thatCertificateId =
+                that.getCertificate() != null ? that.getCertificate().getId() : null;
 
             EqualsBuilder builder = new EqualsBuilder()
                 .append(this.getId(), that.getId())
+                .append(this.getType(), that.getType())
+                .append(thisOwnerId, thatOwnerId)
+                .append(this.isActiveSubscription(), that.isActiveSubscription())
+                .append(this.isCreatedByShare(), that.isCreatedByShare())
+                .append(this.hasSharedAncestor(), that.hasSharedAncestor())
+                .append(thisSourceEntitlementId, thatSourceEntitlementId)
+                .append(this.getQuantity(), that.getQuantity())
+                .append(this.getStartDate(), that.getStartDate())
+                .append(this.getEndDate(), that.getEndDate())
+                .append(this.getAttributes(), that.getAttributes())
+                .append(this.getRestrictedToUsername(), that.getRestrictedToUsername())
                 .append(this.getContractNumber(), that.getContractNumber())
                 .append(this.getAccountNumber(), that.getAccountNumber())
                 .append(this.getOrderNumber(), that.getOrderNumber())
+                .append(this.getConsumed(), that.getConsumed())
+                .append(this.getExported(), that.getExported())
+                .append(this.getShared(), that.getShared())
                 .append(this.getBranding(), that.getBranding())
+                .append(this.getCalculatedAttributes(), that.getCalculatedAttributes())
+                .append(this.getUpstreamPoolId(), that.getUpstreamPoolId())
+                .append(this.getUpstreamEntitlementId(), that.getUpstreamEntitlementId())
+                .append(this.getUpstreamConsumerId(), that.getUpstreamConsumerId())
+                .append(this.getProductName(), that.getProductName())
                 .append(this.getProductId(), that.getProductId())
+                .append(this.getProductAttributes(), that.getProductAttributes())
+                .append(this.getStackId(), that.getStackId())
+                .append(this.isStacked(), that.isStacked())
+                .append(this.isDevelopmentPool(), that.isDevelopmentPool())
+                .append(this.getDerivedProductAttributes(), that.getDerivedProductAttributes())
                 .append(this.getDerivedProductId(), that.getDerivedProductId())
+                .append(this.getDerivedProductName(), that.getDerivedProductName())
                 .append(this.getProvidedProducts(), that.getProvidedProducts())
                 .append(this.getDerivedProvidedProducts(), that.getDerivedProvidedProducts())
-                .append(this.getStartDate(), that.getStartDate())
-                .append(this.getEndDate(), that.getEndDate());
+                .append(this.getSourceStackId(), that.getSourceStackId())
+                .append(this.getSubscriptionSubKey(), that.getSubscriptionSubKey())
+                .append(this.getSubscriptionId(), that.getSubscriptionId())
+                .append(thisCertificateId, thatCertificateId);
 
             return builder.isEquals();
         }
@@ -585,17 +1416,45 @@ public class PoolDTO extends CandlepinDTO<PoolDTO> {
     @Override
     public int hashCode() {
         HashCodeBuilder builder = new HashCodeBuilder(37, 7)
+            .append(super.hashCode())
             .append(this.getId())
+            .append(this.getType())
+            .append(this.getOwner() != null ? this.getOwner().getId() : null)
+            .append(this.isActiveSubscription())
+            .append(this.isCreatedByShare())
+            .append(this.hasSharedAncestor())
+            .append(this.getSourceEntitlement() != null ? this.getSourceEntitlement().getId() : null)
+            .append(this.getQuantity())
+            .append(this.getStartDate())
+            .append(this.getEndDate())
+            .append(this.getAttributes())
+            .append(this.getRestrictedToUsername())
             .append(this.getContractNumber())
             .append(this.getAccountNumber())
             .append(this.getOrderNumber())
+            .append(this.getConsumed())
+            .append(this.getExported())
+            .append(this.getShared())
             .append(this.getBranding())
+            .append(this.getCalculatedAttributes())
+            .append(this.getUpstreamPoolId())
+            .append(this.getUpstreamEntitlementId())
+            .append(this.getUpstreamConsumerId())
+            .append(this.getProductName())
             .append(this.getProductId())
+            .append(this.getProductAttributes())
+            .append(this.getStackId())
+            .append(this.isStacked())
+            .append(this.isDevelopmentPool())
+            .append(this.getDerivedProductAttributes())
             .append(this.getDerivedProductId())
+            .append(this.getDerivedProductName())
             .append(this.getProvidedProducts())
             .append(this.getDerivedProvidedProducts())
-            .append(this.getEndDate())
-            .append(this.getStartDate());
+            .append(this.getSourceStackId())
+            .append(this.getSubscriptionSubKey())
+            .append(this.getSubscriptionId())
+            .append(this.getCertificate() != null ? this.getCertificate().getId() : null);
 
         return builder.toHashCode();
     }
@@ -607,6 +1466,16 @@ public class PoolDTO extends CandlepinDTO<PoolDTO> {
     public PoolDTO clone() {
         PoolDTO copy = super.clone();
 
+        OwnerDTO owner = this.getOwner();
+        copy.owner = owner != null ? owner.clone() : null;
+
+        CertificateDTO certificate = this.getCertificate();
+        copy.certificate = certificate != null ? certificate.clone() : null;
+
+        copy.setAttributes(this.getAttributes());
+        copy.setCalculatedAttributes(this.getCalculatedAttributes());
+        copy.setProductAttributes(this.getProductAttributes());
+        copy.setDerivedProductAttributes(this.getDerivedProductAttributes());
         copy.setBranding(this.getBranding());
         copy.setProvidedProducts(this.getProvidedProducts());
         copy.setDerivedProvidedProducts(this.getDerivedProvidedProducts());
@@ -625,16 +1494,43 @@ public class PoolDTO extends CandlepinDTO<PoolDTO> {
         super.populate(source);
 
         this.setId(source.getId());
+        this.setType(source.getType());
+        this.setOwner(source.getOwner());
+        this.setActiveSubscription(source.isActiveSubscription());
+        this.setCreatedByShare(source.isCreatedByShare());
+        this.setHasSharedAncestor(source.hasSharedAncestor());
+        this.setSourceEntitlement(source.getSourceEntitlement());
+        this.setQuantity(source.getQuantity());
+        this.setStartDate(source.getStartDate());
+        this.setEndDate(source.getEndDate());
+        this.setAttributes(source.getAttributes());
+        this.setRestrictedToUsername(source.getRestrictedToUsername());
         this.setContractNumber(source.getContractNumber());
         this.setAccountNumber(source.getAccountNumber());
         this.setOrderNumber(source.getOrderNumber());
+        this.setConsumed(source.getConsumed());
+        this.setExported(source.getExported());
+        this.setShared(source.getShared());
         this.setBranding(source.getBranding());
+        this.setCalculatedAttributes(source.getCalculatedAttributes());
+        this.setUpstreamPoolId(source.getUpstreamPoolId());
+        this.setUpstreamEntitlementId(source.getUpstreamEntitlementId());
+        this.setUpstreamConsumerId(source.getUpstreamConsumerId());
+        this.setProductName(source.getProductName());
         this.setProductId(source.getProductId());
+        this.setProductAttributes(source.getProductAttributes());
+        this.setStackId(source.getStackId());
+        this.setStacked(source.isStacked());
+        this.setDevelopmentPool(source.isDevelopmentPool());
+        this.setDerivedProductAttributes(source.getDerivedProductAttributes());
         this.setDerivedProductId(source.getDerivedProductId());
+        this.setDerivedProductName(source.getDerivedProductName());
         this.setProvidedProducts(source.getProvidedProducts());
         this.setDerivedProvidedProducts(source.getDerivedProvidedProducts());
-        this.setEndDate(source.getEndDate());
-        this.setStartDate(source.getStartDate());
+        this.setSourceStackId(source.getSourceStackId());
+        this.setSubscriptionSubKey(source.getSubscriptionSubKey());
+        this.setSubscriptionId(source.getSubscriptionId());
+        this.setCertificate(source.getCertificate());
 
         return this;
     }

--- a/server/src/main/java/org/candlepin/dto/manifest/v1/PoolTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/manifest/v1/PoolTranslator.java
@@ -17,8 +17,11 @@ package org.candlepin.dto.manifest.v1;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.dto.ObjectTranslator;
 import org.candlepin.model.Branding;
+import org.candlepin.model.Entitlement;
+import org.candlepin.model.Owner;
 import org.candlepin.model.Pool;
 import org.candlepin.model.Product;
+import org.candlepin.model.SubscriptionsCertificate;
 
 import java.util.Collections;
 import java.util.Set;
@@ -68,23 +71,56 @@ public class PoolTranslator implements ObjectTranslator<Pool, PoolDTO> {
         }
 
         dest.setId(source.getId());
+        dest.setType(source.getType().toString());
+        dest.setActiveSubscription(source.getActiveSubscription());
+        dest.setCreatedByShare(source.isCreatedByShare());
+        dest.setHasSharedAncestor(source.hasSharedAncestor());
+        dest.setQuantity(source.getQuantity());
+        dest.setStartDate(source.getStartDate());
+        dest.setEndDate(source.getEndDate());
+        dest.setAttributes(source.getAttributes());
+        dest.setRestrictedToUsername(source.getRestrictedToUsername());
         dest.setContractNumber(source.getContractNumber());
         dest.setAccountNumber(source.getAccountNumber());
         dest.setOrderNumber(source.getOrderNumber());
+        dest.setConsumed(source.getConsumed());
+        dest.setExported(source.getExported());
+        dest.setShared(source.getShared());
+        dest.setCalculatedAttributes(source.getCalculatedAttributes());
+        dest.setUpstreamPoolId(source.getUpstreamPoolId());
+        dest.setUpstreamEntitlementId(source.getUpstreamEntitlementId());
+        dest.setUpstreamConsumerId(source.getUpstreamConsumerId());
+        dest.setProductName(source.getProductName());
         dest.setProductId(source.getProductId());
+        dest.setProductAttributes(source.getProductAttributes());
+        dest.setStackId(source.getStackId());
+        dest.setStacked(source.isStacked());
+        dest.setDevelopmentPool(source.isDevelopmentPool());
+        dest.setDerivedProductAttributes(source.getDerivedProductAttributes());
         dest.setDerivedProductId(source.getDerivedProductId());
-        dest.setStartDate(source.getStartDate());
-        dest.setEndDate(source.getEndDate());
+        dest.setDerivedProductName(source.getDerivedProductName());
+        dest.setSourceStackId(source.getSourceStackId());
+        dest.setSubscriptionSubKey(source.getSubscriptionSubKey());
+        dest.setSubscriptionId(source.getSubscriptionId());
 
         // Process nested objects if we have a model translator to use to the translation...
         if (modelTranslator != null) {
+            Owner owner = source.getOwner();
+            dest.setOwner(owner != null ? modelTranslator.translate(owner, OwnerDTO.class) : null);
+
+            SubscriptionsCertificate subCertificate = source.getCertificate();
+            dest.setCertificate(subCertificate != null ?
+                modelTranslator.translate(subCertificate, CertificateDTO.class) : null);
+
+            Entitlement sourceEntitlement = source.getSourceEntitlement();
+            dest.setSourceEntitlement(sourceEntitlement != null ?
+                modelTranslator.translate(sourceEntitlement, EntitlementDTO.class) : null);
 
             Set<Branding> branding = source.getBranding();
             if (branding != null && !branding.isEmpty()) {
                 for (Branding brand : branding) {
                     if (brand != null) {
-                        dest.addBranding(
-                            new BrandingDTO(brand.getProductId(), brand.getName(), brand.getType()));
+                        dest.addBranding(modelTranslator.translate(brand, BrandingDTO.class));
                     }
                 }
             }

--- a/server/src/main/java/org/candlepin/dto/manifest/v1/UpstreamConsumerDTO.java
+++ b/server/src/main/java/org/candlepin/dto/manifest/v1/UpstreamConsumerDTO.java
@@ -1,0 +1,250 @@
+/**
+ * Copyright (c) 2009 - 2018 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.dto.manifest.v1;
+
+import org.candlepin.common.jackson.HateoasArrayExclude;
+import org.candlepin.common.jackson.HateoasInclude;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.candlepin.dto.TimestampedCandlepinDTO;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * A DTO representation of the UpstreamConsumer entity as used by the manifest import/export mechanism.
+ */
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.PROPERTY)
+@JsonFilter("ApiHateoas")
+public class UpstreamConsumerDTO extends TimestampedCandlepinDTO<UpstreamConsumerDTO> {
+    public static final long serialVersionUID = 1L;
+
+    protected String id;
+    protected String uuid;
+    protected String name;
+    protected String apiUrl;
+    protected String webUrl;
+    protected String ownerId;
+    protected String contentAccessMode;
+    protected ConsumerTypeDTO consumerType;
+    protected CertificateDTO identityCert;
+
+    /**
+     * Initializes a new UpstreamConsumerDTO instance with null values.
+     */
+    public UpstreamConsumerDTO() {
+        // Intentionally left empty
+    }
+
+    /**
+     * Initializes a new UpstreamConsumerDTO instance which is a shallow copy of the provided
+     * source entity.
+     *
+     * @param source
+     *  The source entity to copy
+     */
+    public UpstreamConsumerDTO(UpstreamConsumerDTO source) {
+        super(source);
+    }
+
+    @HateoasInclude
+    public String getId() {
+        return this.id;
+    }
+
+    public UpstreamConsumerDTO setId(String id) {
+        this.id = id;
+        return this;
+    }
+
+    @HateoasInclude
+    public String getUuid() {
+        return this.uuid;
+    }
+
+    public UpstreamConsumerDTO setUuid(String uuid) {
+        this.uuid = uuid;
+        return this;
+    }
+
+    @HateoasInclude
+    public String getName() {
+        return this.name;
+    }
+
+    public UpstreamConsumerDTO setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public String getApiUrl() {
+        return this.apiUrl;
+    }
+
+    public UpstreamConsumerDTO setApiUrl(String apiUrl) {
+        this.apiUrl = apiUrl;
+        return this;
+    }
+
+    public String getWebUrl() {
+        return this.webUrl;
+    }
+
+    public UpstreamConsumerDTO setWebUrl(String webUrl) {
+        this.webUrl = webUrl;
+        return this;
+    }
+
+    public String getOwnerId() {
+        return this.ownerId;
+    }
+
+    public UpstreamConsumerDTO setOwnerId(String ownerId) {
+        this.ownerId = ownerId;
+        return this;
+    }
+
+    @JsonProperty("type")
+    public ConsumerTypeDTO getConsumerType() {
+        return this.consumerType;
+    }
+
+    @JsonProperty("type")
+    public UpstreamConsumerDTO setConsumerType(ConsumerTypeDTO consumerType) {
+        this.consumerType = consumerType;
+        return this;
+    }
+
+    @JsonProperty("idCert")
+    @HateoasArrayExclude
+    public CertificateDTO getIdentityCertificate() {
+        return this.identityCert;
+    }
+
+    @JsonProperty("idCert")
+    public UpstreamConsumerDTO setIdentityCertificate(CertificateDTO identityCert) {
+        this.identityCert = identityCert;
+        return this;
+    }
+
+    public String getContentAccessMode() {
+        return this.contentAccessMode;
+    }
+
+    public UpstreamConsumerDTO setContentAccessMode(String contentAccessMode) {
+        this.contentAccessMode = contentAccessMode;
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        return String.format("UpstreamConsumerDTO [uuid: %s, name: %s, owner id: %s]",
+            this.getUuid(), this.getName(), this.getOwnerId());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        }
+
+        if (obj instanceof UpstreamConsumerDTO && super.equals(obj)) {
+            UpstreamConsumerDTO that = (UpstreamConsumerDTO) obj;
+
+            EqualsBuilder builder = new EqualsBuilder()
+                .append(this.getId(), that.getId())
+                .append(this.getUuid(), that.getUuid())
+                .append(this.getName(), that.getName())
+                .append(this.getApiUrl(), that.getApiUrl())
+                .append(this.getWebUrl(), that.getWebUrl())
+                .append(this.getOwnerId(), that.getOwnerId())
+                .append(this.getConsumerType(), that.getConsumerType())
+                .append(this.getIdentityCertificate(), that.getIdentityCertificate())
+                .append(this.getContentAccessMode(), that.getContentAccessMode());
+
+            return builder.isEquals();
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        HashCodeBuilder builder = new HashCodeBuilder(37, 7)
+            .append(super.hashCode())
+            .append(this.getId())
+            .append(this.getUuid())
+            .append(this.getName())
+            .append(this.getApiUrl())
+            .append(this.getWebUrl())
+            .append(this.getOwnerId())
+            .append(this.getConsumerType())
+            .append(this.getIdentityCertificate())
+            .append(this.getContentAccessMode());
+
+        return builder.toHashCode();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public UpstreamConsumerDTO clone() {
+        UpstreamConsumerDTO copy = super.clone();
+
+        ConsumerTypeDTO type = this.getConsumerType();
+        copy.consumerType = type != null ? (ConsumerTypeDTO) type.clone() : null;
+
+        CertificateDTO cert = this.getIdentityCertificate();
+        copy.identityCert = cert != null ? (CertificateDTO) cert.clone() : null;
+
+        return copy;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public UpstreamConsumerDTO populate(UpstreamConsumerDTO source) {
+        super.populate(source);
+
+        this.setId(source.getId());
+        this.setUuid(source.getUuid());
+        this.setName(source.getName());
+        this.setApiUrl(source.getApiUrl());
+        this.setWebUrl(source.getWebUrl());
+        this.setOwnerId(source.getOwnerId());
+        this.setConsumerType(source.getConsumerType());
+        this.setIdentityCertificate(source.getIdentityCertificate());
+        this.setContentAccessMode(source.getContentAccessMode());
+
+        return this;
+    }
+}

--- a/server/src/main/java/org/candlepin/dto/manifest/v1/UpstreamConsumerTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/manifest/v1/UpstreamConsumerTranslator.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2009 - 2018 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.dto.manifest.v1;
+
+import org.candlepin.dto.ModelTranslator;
+import org.candlepin.dto.TimestampedEntityTranslator;
+import org.candlepin.model.UpstreamConsumer;
+
+
+
+/**
+ * The UpstreamConsumerTranslator provides translation from UpstreamConsumer model objects to
+ * UpstreamConsumerDTOs as used by the manifest import/export framework.
+ */
+public class UpstreamConsumerTranslator extends
+    TimestampedEntityTranslator<UpstreamConsumer, UpstreamConsumerDTO> {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public UpstreamConsumerDTO translate(UpstreamConsumer source) {
+        return this.translate(null, source);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public UpstreamConsumerDTO translate(ModelTranslator translator, UpstreamConsumer source) {
+        return source != null ? this.populate(translator, source, new UpstreamConsumerDTO()) : null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public UpstreamConsumerDTO populate(UpstreamConsumer source, UpstreamConsumerDTO destination) {
+        return this.populate(null, source, destination);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public UpstreamConsumerDTO populate(ModelTranslator translator, UpstreamConsumer source,
+        UpstreamConsumerDTO dest) {
+
+        dest = super.populate(translator, source, dest);
+
+        dest.setId(source.getId());
+        dest.setUuid(source.getUuid());
+        dest.setName(source.getName());
+        dest.setOwnerId(source.getOwnerId());
+        dest.setApiUrl(source.getApiUrl());
+        dest.setWebUrl(source.getWebUrl());
+        dest.setContentAccessMode(source.getContentAccessMode());
+
+        // Process nested objects if we have a ModelTranslator to use to the translation...
+        if (translator != null) {
+            dest.setConsumerType(translator.translate(source.getType(), ConsumerTypeDTO.class));
+            dest.setIdentityCertificate(translator.translate(source.getIdCert(), CertificateDTO.class));
+        }
+        else {
+            dest.setConsumerType(null);
+            dest.setIdentityCertificate(null);
+        }
+
+        return dest;
+    }
+}

--- a/server/src/main/java/org/candlepin/sync/EntitlementImporter.java
+++ b/server/src/main/java/org/candlepin/sync/EntitlementImporter.java
@@ -14,10 +14,13 @@
  */
 package org.candlepin.sync;
 
+import org.candlepin.common.exceptions.BadRequestException;
+import org.candlepin.common.exceptions.NotFoundException;
 import org.candlepin.dto.manifest.v1.BrandingDTO;
 import org.candlepin.dto.manifest.v1.CertificateDTO;
 import org.candlepin.dto.manifest.v1.CertificateSerialDTO;
 import org.candlepin.dto.manifest.v1.EntitlementDTO;
+import org.candlepin.dto.manifest.v1.OwnerDTO;
 import org.candlepin.dto.manifest.v1.PoolDTO;
 import org.candlepin.model.Branding;
 import org.candlepin.model.Cdn;
@@ -26,11 +29,13 @@ import org.candlepin.model.CertificateSerial;
 import org.candlepin.model.CertificateSerialCurator;
 import org.candlepin.model.Entitlement;
 import org.candlepin.model.EntitlementCertificate;
+import org.candlepin.model.EntitlementCurator;
 import org.candlepin.model.Owner;
 import org.candlepin.model.Pool;
 import org.candlepin.model.Product;
 import org.candlepin.model.ProductCurator;
 import org.candlepin.model.ProvidedProduct;
+import org.candlepin.model.SourceStack;
 import org.candlepin.model.SubscriptionsCertificate;
 import org.candlepin.model.dto.ProductData;
 import org.candlepin.model.dto.Subscription;
@@ -60,14 +65,16 @@ public class EntitlementImporter {
     private CdnCurator cdnCurator;
     private I18n i18n;
     private ProductCurator productCurator;
+    private EntitlementCurator entitlementCurator;
 
-    public EntitlementImporter(CertificateSerialCurator csCurator,
-        CdnCurator cdnCurator, I18n i18n, ProductCurator productCurator) {
+    public EntitlementImporter(CertificateSerialCurator csCurator, CdnCurator cdnCurator, I18n i18n,
+        ProductCurator productCurator, EntitlementCurator entitlementCurator) {
 
         this.csCurator = csCurator;
         this.cdnCurator = cdnCurator;
         this.i18n = i18n;
         this.productCurator = productCurator;
+        this.entitlementCurator = entitlementCurator;
     }
 
     public Subscription importObject(ObjectMapper mapper, Reader reader, Owner owner,
@@ -186,12 +193,67 @@ public class EntitlementImporter {
             entity.setQuantity(dto.getQuantity());
         }
 
+        if (dto.getUpdated() != null) {
+            entity.setUpdated(dto.getUpdated());
+        }
+
+        if (dto.getCreated() != null) {
+            entity.setCreated(dto.getCreated());
+        }
+
+        if (dto.getStartDate() != null) {
+            entity.setStartDate(dto.getStartDate());
+        }
+
+        if (dto.getEndDate() != null) {
+            entity.setEndDate(dto.getEndDate());
+        }
+
         if (dto.getPool() != null) {
             PoolDTO poolDTO = dto.getPool();
             Pool poolEntity = new Pool();
 
             if (poolDTO.getId() != null) {
                 poolEntity.setId(poolDTO.getId());
+            }
+
+            if (poolDTO.getQuantity() != null) {
+                poolEntity.setQuantity(poolDTO.getQuantity());
+            }
+
+            if (poolDTO.isActiveSubscription() != null) {
+                poolEntity.setActiveSubscription(poolDTO.isActiveSubscription());
+            }
+
+            if (poolDTO.isCreatedByShare() != null) {
+                poolEntity.setCreatedByShare(poolDTO.isCreatedByShare());
+            }
+
+            if (poolDTO.hasSharedAncestor() != null) {
+                poolEntity.setHasSharedAncestor(poolDTO.hasSharedAncestor());
+            }
+
+            if (poolDTO.getRestrictedToUsername() != null) {
+                poolEntity.setRestrictedToUsername(poolDTO.getRestrictedToUsername());
+            }
+
+            if (poolDTO.getConsumed() != null) {
+                poolEntity.setConsumed(poolDTO.getConsumed());
+            }
+
+            if (poolDTO.getExported() != null) {
+                poolEntity.setExported(poolDTO.getExported());
+            }
+
+            if (poolDTO.getShared() != null) {
+                poolEntity.setShared(poolDTO.getShared());
+            }
+
+            if (poolDTO.getStackId() != null && poolDTO.getSourceStackId() != null) {
+                SourceStack sourceStack = new SourceStack();
+                sourceStack.setId(poolDTO.getStackId());
+                sourceStack.setSourceStackId(poolDTO.getSourceStackId());
+                poolEntity.setSourceStack(sourceStack);
             }
 
             if (poolDTO.getProductId() != null) {
@@ -210,6 +272,14 @@ public class EntitlementImporter {
                 poolEntity.setEndDate(poolDTO.getEndDate());
             }
 
+            if (poolDTO.getCreated() != null) {
+                poolEntity.setCreated(poolDTO.getCreated());
+            }
+
+            if (poolDTO.getUpdated() != null) {
+                poolEntity.setUpdated(poolDTO.getUpdated());
+            }
+
             if (poolDTO.getAccountNumber() != null) {
                 poolEntity.setAccountNumber(poolDTO.getAccountNumber());
             }
@@ -222,6 +292,74 @@ public class EntitlementImporter {
                 poolEntity.setContractNumber(poolDTO.getContractNumber());
             }
 
+            if (poolDTO.getOwner() != null) {
+                Owner ownerEntity = new Owner();
+                populateEntity(ownerEntity, poolDTO.getOwner());
+
+                poolEntity.setOwner(ownerEntity);
+            }
+
+            if (poolDTO.getUpstreamPoolId() != null) {
+                poolEntity.setUpstreamPoolId(poolDTO.getUpstreamPoolId());
+            }
+
+            if (poolDTO.getUpstreamConsumerId() != null) {
+                poolEntity.setUpstreamConsumerId(poolDTO.getUpstreamConsumerId());
+            }
+
+            if (poolDTO.getUpstreamEntitlementId() != null) {
+                poolEntity.setUpstreamEntitlementId(poolDTO.getUpstreamEntitlementId());
+            }
+
+            if (poolDTO.getSourceEntitlement() != null) {
+                EntitlementDTO sourceEntitlementDTO = poolDTO.getSourceEntitlement();
+                poolEntity.setSourceEntitlement(findEntitlement(sourceEntitlementDTO.getId()));
+            }
+
+            if (poolDTO.getSubscriptionSubKey() != null) {
+                poolEntity.setSubscriptionSubKey(poolDTO.getSubscriptionSubKey());
+            }
+
+            if (poolDTO.getSubscriptionId() != null) {
+                poolEntity.setSubscriptionId(poolDTO.getSubscriptionId());
+            }
+
+            if (poolDTO.getAttributes() != null) {
+                if (poolDTO.getAttributes().isEmpty()) {
+                    poolEntity.setAttributes(Collections.emptyMap());
+                }
+                else {
+                    poolEntity.setAttributes(poolDTO.getAttributes());
+                }
+            }
+
+            if (poolDTO.getCalculatedAttributes() != null) {
+                if (poolDTO.getCalculatedAttributes().isEmpty()) {
+                    poolEntity.setCalculatedAttributes(Collections.emptyMap());
+                }
+                else {
+                    poolEntity.setCalculatedAttributes(poolDTO.getCalculatedAttributes());
+                }
+            }
+
+            if (poolDTO.getProductAttributes() != null) {
+                if (poolDTO.getProductAttributes().isEmpty()) {
+                    poolEntity.setProductAttributes(Collections.emptyMap());
+                }
+                else {
+                    poolEntity.setProductAttributes(poolDTO.getProductAttributes());
+                }
+            }
+
+            if (poolDTO.getDerivedProductAttributes() != null) {
+                if (poolDTO.getDerivedProductAttributes().isEmpty()) {
+                    poolEntity.setDerivedProductAttributes(Collections.emptyMap());
+                }
+                else {
+                    poolEntity.setDerivedProductAttributes(poolDTO.getDerivedProductAttributes());
+                }
+            }
+
             if (poolDTO.getBranding() != null) {
                 if (poolDTO.getBranding().isEmpty()) {
                     poolEntity.setBranding(Collections.emptySet());
@@ -230,10 +368,14 @@ public class EntitlementImporter {
                     Set<Branding> branding = new HashSet<>();
                     for (BrandingDTO brandingDTO : poolDTO.getBranding()) {
                         if (brandingDTO != null) {
-                            branding.add(new Branding(
+                            Branding brandingEntity = new Branding(
                                 brandingDTO.getProductId(),
                                 brandingDTO.getType(),
-                                brandingDTO.getName()));
+                                brandingDTO.getName());
+                            brandingEntity.setId(brandingDTO.getId());
+                            brandingEntity.setCreated(brandingDTO.getCreated());
+                            brandingEntity.setUpdated(brandingDTO.getUpdated());
+                            branding.add(brandingEntity);
                         }
                     }
                     poolEntity.setBranding(branding);
@@ -291,6 +433,8 @@ public class EntitlementImporter {
                         entityCert.setId(dtoCert.getId());
                         entityCert.setKey(dtoCert.getKey());
                         entityCert.setCert(dtoCert.getCert());
+                        entityCert.setCreated(dtoCert.getCreated());
+                        entityCert.setUpdated(dtoCert.getUpdated());
 
                         if (dtoCert.getSerial() != null) {
                             CertificateSerialDTO dtoSerial = dtoCert.getSerial();
@@ -298,6 +442,9 @@ public class EntitlementImporter {
                             entitySerial.setId(dtoSerial.getId());
                             entitySerial.setCollected(dtoSerial.isCollected());
                             entitySerial.setExpiration(dtoSerial.getExpiration());
+                            entitySerial.setRevoked(dtoSerial.isRevoked());
+                            entitySerial.setSerial(dtoSerial.getSerial() != null ?
+                                dtoSerial.getSerial().longValueExact() : null);
                             entitySerial.setCreated(dtoSerial.getCreated());
                             entitySerial.setUpdated(dtoSerial.getUpdated());
 
@@ -310,6 +457,98 @@ public class EntitlementImporter {
             }
         }
     }
+
+
+    /**
+     * Populates the specified entity with data from the provided DTO.
+     * This method does not set the upstreamConsumer field.
+     *
+     * @param entity
+     *  The entity instance to populate
+     *
+     * @param dto
+     *  The DTO containing the data with which to populate the entity
+     *
+     * @throws IllegalArgumentException
+     *  if either entity or dto are null
+     */
+    protected void populateEntity(Owner entity, OwnerDTO dto) {
+        if (entity == null) {
+            throw new IllegalArgumentException("the owner model entity is null");
+        }
+
+        if (dto == null) {
+            throw new IllegalArgumentException("the owner dto is null");
+        }
+
+        if (dto.getId() != null) {
+            entity.setId(dto.getId());
+        }
+
+        if (dto.getDisplayName() != null) {
+            entity.setDisplayName(dto.getDisplayName());
+        }
+
+        if (dto.getKey() != null) {
+            entity.setKey(dto.getKey());
+        }
+
+        if (dto.getLastRefreshed() != null) {
+            entity.setLastRefreshed(dto.getLastRefreshed());
+        }
+
+        if (dto.getContentAccessMode() != null) {
+            entity.setContentAccessMode(dto.getContentAccessMode());
+        }
+
+        if (dto.getContentAccessModeList() != null) {
+            entity.setContentAccessModeList(dto.getContentAccessModeList());
+        }
+
+        if (dto.getCreated() != null) {
+            entity.setCreated(dto.getCreated());
+        }
+
+        if (dto.getUpdated() != null) {
+            entity.setUpdated(dto.getUpdated());
+        }
+
+        if (dto.getParentOwner() != null) {
+            OwnerDTO pdto = dto.getParentOwner();
+            Owner parent = new Owner();
+
+            if (pdto.getId() != null) {
+                parent.setId(pdto.getId());
+            }
+
+            if (pdto.getDisplayName() != null) {
+                parent.setDisplayName(pdto.getDisplayName());
+            }
+
+            if (pdto.getKey() != null) {
+                parent.setKey(pdto.getKey());
+            }
+
+            entity.setParentOwner(parent);
+        }
+
+        if (dto.getContentPrefix() != null) {
+            entity.setContentPrefix(dto.getContentPrefix());
+        }
+
+        if (dto.getDefaultServiceLevel() != null) {
+            entity.setDefaultServiceLevel(dto.getDefaultServiceLevel());
+        }
+
+        if (dto.getLogLevel() != null) {
+            entity.setLogLevel(dto.getLogLevel());
+        }
+
+        if (dto.isAutobindDisabled() != null) {
+            entity.setAutobindDisabled(dto.isAutobindDisabled());
+        }
+    }
+
 
     /*
      * Transfer associations to provided and derived provided products over to the
@@ -364,4 +603,34 @@ public class EntitlementImporter {
         return product;
     }
 
+    /**
+     * Returns the entitlement object that is identified by the given id, if it is found in the system.
+     * Otherwise, it throws a NotFoundException.
+     *
+     * @param entitlementId the id of the entitlement we are searching for.
+     *
+     * @return the entitlement that was found in the system based on the given id.
+     *
+     * @throws NotFoundException
+     *  if the entitlement with the given id was not found in the system.
+     *
+     * @throws BadRequestException
+     *  if the given Entitlement id is null or empty.
+     */
+    private Entitlement findEntitlement(String entitlementId) {
+        Entitlement entitlement = null;
+        if (entitlementId != null && !entitlementId.isEmpty()) {
+            entitlement = entitlementCurator.find(entitlementId);
+        }
+        else {
+            throw new BadRequestException(i18n.tr("Entitlement id is null or empty."));
+        }
+
+        if (entitlement == null) {
+            throw new NotFoundException(
+                    i18n.tr("Entitlement with id {0} could not be found.", entitlementId));
+        }
+
+        return entitlement;
+    }
 }

--- a/server/src/test/java/org/candlepin/dto/api/v1/PoolTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/PoolTranslatorTest.java
@@ -81,6 +81,10 @@ public class PoolTranslatorTest extends AbstractTranslatorTest<Pool, PoolDTO, Po
         source.setProduct(this.productTranslatorTest.initSourceObject());
         source.setDerivedProduct(this.productTranslatorTest.initSourceObject());
 
+        Set<Branding> brandingSet = new HashSet<>();
+        brandingSet.add(this.brandingTranslatorTest.initSourceObject());
+        source.setBranding(brandingSet);
+
         Entitlement entitlement = new Entitlement();
         entitlement.setId("ent-id");
         source.setSourceEntitlement(entitlement);
@@ -117,15 +121,6 @@ public class PoolTranslatorTest extends AbstractTranslatorTest<Pool, PoolDTO, Po
         source.setConsumed(6L);
         source.setExported(7L);
         source.setShared(8L);
-
-        Branding branding = new Branding();
-        branding.setId("branding-id-1");
-        branding.setName("branding-name-1");
-        branding.setProductId("branding-prod-id-1");
-        branding.setType("branding-type-1");
-        Set<Branding> brandingSet = new HashSet<>();
-        brandingSet.add(branding);
-        source.setBranding(brandingSet);
 
         Map<String, String> calculatedAttributes = new HashMap<>();
         calculatedAttributes.put("calc-attribute-key-3", "calc-attribute-value-3");

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/BrandingDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/BrandingDTOTest.java
@@ -16,6 +16,7 @@ package org.candlepin.dto.manifest.v1;
 
 import org.candlepin.dto.AbstractDTOTest;
 
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -30,9 +31,12 @@ public class BrandingDTOTest extends AbstractDTOTest<BrandingDTO> {
         super(BrandingDTO.class);
 
         this.values = new HashMap<>();
+        this.values.put("Id", "test-id");
         this.values.put("ProductId", "test-product-id");
         this.values.put("Name", "test-name");
         this.values.put("Type", "test-type");
+        this.values.put("Updated", new Date());
+        this.values.put("Created", new Date());
     }
 
     /**

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/BrandingTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/BrandingTranslatorTest.java
@@ -18,6 +18,8 @@ import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.Branding;
 
+import java.util.Date;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
@@ -43,9 +45,12 @@ public class BrandingTranslatorTest extends
     protected Branding initSourceObject() {
         Branding source = new Branding();
 
+        source.setProductId("test-id");
         source.setProductId("test-product-id");
         source.setName("test-name");
         source.setType("test-type");
+        source.setCreated(new Date());
+        source.setUpdated(new Date());
 
         return source;
     }
@@ -61,6 +66,8 @@ public class BrandingTranslatorTest extends
             assertEquals(source.getProductId(), dest.getProductId());
             assertEquals(source.getName(), dest.getName());
             assertEquals(source.getType(), dest.getType());
+            assertEquals(source.getUpdated(), dest.getUpdated());
+            assertEquals(source.getCreated(), dest.getCreated());
         }
         else {
             assertNull(dest);

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/CertificateDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/CertificateDTOTest.java
@@ -42,6 +42,8 @@ public class CertificateDTOTest extends AbstractDTOTest<CertificateDTO> {
         this.values.put("Key", "test-key");
         this.values.put("Cert", "test-cert");
         this.values.put("Serial", serial);
+        this.values.put("Created", new Date());
+        this.values.put("Updated", new Date());
     }
 
     /**

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/CertificateSerialTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/CertificateSerialTranslatorTest.java
@@ -52,8 +52,10 @@ public class CertificateSerialTranslatorTest extends
         CertificateSerial source = new CertificateSerial();
 
         // ID is automatically generated for this object
+        // ID is also used as the serial here
         source.setExpiration(new Date());
         source.setCollected(true);
+        source.setRevoked(true);
 
         return source;
     }
@@ -73,8 +75,10 @@ public class CertificateSerialTranslatorTest extends
             // childrenGenerated flag
 
             assertEquals(source.getId(), dest.getId());
+            assertEquals(source.getSerial(), dest.getSerial());
             assertEquals(source.getExpiration(), dest.getExpiration());
             assertEquals(source.isCollected(), dest.isCollected());
+            assertEquals(source.isRevoked(), dest.isRevoked());
         }
         else {
             assertNull(dest);

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/CertificateTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/CertificateTranslatorTest.java
@@ -26,6 +26,7 @@ import junitparams.JUnitParamsRunner;
 
 import org.junit.runner.RunWith;
 
+import java.util.Date;
 
 
 /**
@@ -60,6 +61,8 @@ public class CertificateTranslatorTest extends
         cert.setId("123");
         cert.setKey("cert_key");
         cert.setCert("cert_cert");
+        cert.setCreated(new Date());
+        cert.setUpdated(new Date());
         cert.setSerial(this.certificateTranslatorTest.initSourceObject());
 
         return cert;
@@ -77,6 +80,8 @@ public class CertificateTranslatorTest extends
             assertEquals(source.getId(), dest.getId());
             assertEquals(source.getKey(), dest.getKey());
             assertEquals(source.getCert(), dest.getCert());
+            assertEquals(source.getUpdated(), dest.getUpdated());
+            assertEquals(source.getCreated(), dest.getCreated());
 
             if (childrenGenerated) {
                 this.certificateTranslatorTest.verifyOutput(source.getSerial(), dest.getSerial(), true);

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/ConsumerDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/ConsumerDTOTest.java
@@ -35,10 +35,15 @@ public class ConsumerDTOTest extends AbstractDTOTest<ConsumerDTO> {
         type.setLabel("type_label");
         type.setManifest(true);
 
+        OwnerDTO owner = new OwnerDTO();
+        owner.setKey("key");
+        owner.setDisplayName("display-name");
+        owner.setId("id");
+
         this.values = new HashMap<>();
         this.values.put("Uuid", "test-uuid");
         this.values.put("Name", "test-name");
-        this.values.put("Owner", "test-owner-id");
+        this.values.put("Owner", owner);
         this.values.put("ContentAccessMode", "test-content-access-mode");
         this.values.put("Type", type);
         this.values.put("UrlWeb", "test-url-web");

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/ConsumerTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/ConsumerTranslatorTest.java
@@ -20,7 +20,6 @@ import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.Consumer;
 
-import org.candlepin.model.Owner;
 import org.junit.runner.RunWith;
 
 import junitparams.JUnitParamsRunner;
@@ -35,10 +34,12 @@ public class ConsumerTranslatorTest extends
     protected ConsumerTranslator translator = new ConsumerTranslator();
 
     protected ConsumerTypeTranslatorTest consumerTypeTranslatorTest = new ConsumerTypeTranslatorTest();
+    protected OwnerTranslatorTest ownerTranslatorTest = new OwnerTranslatorTest();
 
     @Override
     protected void initModelTranslator(ModelTranslator modelTranslator) {
         this.consumerTypeTranslatorTest.initModelTranslator(modelTranslator);
+        this.ownerTranslatorTest.initModelTranslator(modelTranslator);
 
         modelTranslator.registerTranslator(
             this.translator, Consumer.class, ConsumerDTO.class);
@@ -55,9 +56,7 @@ public class ConsumerTranslatorTest extends
 
         consumer.setUuid("consumer_uuid");
         consumer.setName("consumer_name");
-        Owner owner = new Owner();
-        owner.setId("owner_id");
-        consumer.setOwner(owner);
+        consumer.setOwner(this.ownerTranslatorTest.initSourceObject());
         consumer.setContentAccessMode("test_content_access_mode");
         consumer.setType(this.consumerTypeTranslatorTest.initSourceObject());
 
@@ -79,11 +78,7 @@ public class ConsumerTranslatorTest extends
             assertEquals(source.getContentAccessMode(), dest.getContentAccessMode());
 
             if (childrenGenerated) {
-                Owner sourceOwner = source.getOwner();
-                if (sourceOwner != null) {
-                    assertEquals(sourceOwner.getId(), dest.getOwner());
-                }
-
+                this.ownerTranslatorTest.verifyOutput(source.getOwner(), dest.getOwner(), true);
                 this.consumerTypeTranslatorTest.verifyOutput(source.getType(), dest.getType(), true);
             }
             else {

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/EntitlementDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/EntitlementDTOTest.java
@@ -17,6 +17,7 @@ package org.candlepin.dto.manifest.v1;
 import org.candlepin.dto.AbstractDTOTest;
 import org.junit.Test;
 
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -39,9 +40,27 @@ public class EntitlementDTOTest  extends AbstractDTOTest<EntitlementDTO> {
 
         this.values = new HashMap<>();
 
+        OwnerDTO owner = new OwnerDTO();
+        owner.setId("owner_id");
+        owner.setKey("owner_key");
+        owner.setDisplayName("owner_name");
+        owner.setContentPrefix("content_prefix");
+        owner.setDefaultServiceLevel("service_level");
+        owner.setLogLevel("log_level");
+        owner.setAutobindDisabled(true);
+        owner.setContentAccessMode("content_access_mode");
+        owner.setContentAccessModeList("content_access_mode_list");
+
         PoolDTO pool = new PoolDTO();
         pool.setId("pool_id");
         pool.setProductId("pool_product_id");
+        pool.setProductName("pool_product_name");
+
+        ConsumerDTO consumer = new ConsumerDTO();
+        consumer.setUuid("consumer_uuid");
+        consumer.setName("consumer_name");
+        consumer.setType(new ConsumerTypeDTO());
+        consumer.setOwner(new OwnerDTO());
 
         Set<CertificateDTO> certs = new HashSet<>();
         CertificateDTO certificate = new CertificateDTO();
@@ -52,9 +71,16 @@ public class EntitlementDTOTest  extends AbstractDTOTest<EntitlementDTO> {
         certs.add(certificate);
 
         this.values.put("Id", "test-id");
+        this.values.put("Owner", owner);
         this.values.put("Pool", pool);
+        this.values.put("Consumer", consumer);
         this.values.put("Quantity", 1);
+        this.values.put("DeletedFromPool", false);
         this.values.put("Certificates", certs);
+        this.values.put("StartDate", new Date());
+        this.values.put("EndDate", new Date());
+        this.values.put("Created", new Date());
+        this.values.put("Updated", new Date());
     }
 
     /**

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/OwnerDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/OwnerDTOTest.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2009 - 2018 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.dto.manifest.v1;
+
+import org.candlepin.dto.AbstractDTOTest;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+
+
+/**
+ * Test suite for the OwnerDTO (manifest import/export) class
+ */
+public class OwnerDTOTest extends AbstractDTOTest<OwnerDTO> {
+
+    protected Map<String, Object> values;
+
+    public OwnerDTOTest() {
+        super(OwnerDTO.class);
+
+        OwnerDTO parent = new OwnerDTO();
+        parent.setId("owner_id");
+        parent.setKey("owner_key");
+        parent.setDisplayName("owner_name");
+        parent.setContentPrefix("content_prefix");
+        parent.setDefaultServiceLevel("service_level");
+        parent.setLogLevel("log_level");
+        parent.setAutobindDisabled(true);
+        parent.setContentAccessMode("content_access_mode");
+        parent.setContentAccessModeList("content_access_mode_list");
+
+        UpstreamConsumerDTO consumer = new UpstreamConsumerDTO();
+        consumer.setId("consumer_id");
+        consumer.setUuid("consumer_uuid");
+        consumer.setName("consumer_name");
+        consumer.setApiUrl("http://www.url.com");
+        consumer.setWebUrl("http://www.url.com");
+        consumer.setOwnerId("owner_id");
+
+        this.values = new HashMap<>();
+        this.values.put("Id", "test-id");
+        this.values.put("Key", "test-key");
+        this.values.put("DisplayName", "test-name");
+        this.values.put("ParentOwner", parent);
+        this.values.put("ContentPrefix", "test-prefix");
+        this.values.put("DefaultServiceLevel", "test-service-level");
+        this.values.put("UpstreamConsumer", consumer);
+        this.values.put("LogLevel", "test-log-level");
+        this.values.put("AutobindDisabled", true);
+        this.values.put("ContentAccessMode", "test-access-mode");
+        this.values.put("ContentAccessModeList", "test-access-mode-list");
+        this.values.put("Created", new Date());
+        this.values.put("Updated", new Date());
+        this.values.put("LastRefreshed", new Date());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected Object getInputValueForMutator(String field) {
+        return this.values.get(field);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected Object getOutputValueForAccessor(String field, Object input) {
+        // Nothing to do here
+        return input;
+    }
+}

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/OwnerTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/OwnerTranslatorTest.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2009 - 2018 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.dto.manifest.v1;
+
+import org.candlepin.dto.AbstractTranslatorTest;
+import org.candlepin.dto.ModelTranslator;
+import org.candlepin.model.Owner;
+
+import static org.junit.Assert.*;
+
+import junitparams.JUnitParamsRunner;
+
+import org.junit.runner.RunWith;
+
+import java.util.Date;
+
+
+
+/**
+ * Test suite for the OwnerTranslator (import/export manifest) class
+ */
+@RunWith(JUnitParamsRunner.class)
+public class OwnerTranslatorTest extends
+    AbstractTranslatorTest<Owner, OwnerDTO, OwnerTranslator> {
+
+    protected OwnerTranslator translator = new OwnerTranslator();
+
+    protected UpstreamConsumerTranslatorTest upstreamConsumerTranslatorTest =
+        new UpstreamConsumerTranslatorTest();
+
+    @Override
+    protected void initModelTranslator(ModelTranslator modelTranslator) {
+        this.upstreamConsumerTranslatorTest.initModelTranslator(modelTranslator);
+        modelTranslator.registerTranslator(this.translator, Owner.class, OwnerDTO.class);
+    }
+
+    @Override
+    protected OwnerTranslator initObjectTranslator() {
+        return this.translator;
+    }
+
+    @Override
+    protected Owner initSourceObject() {
+        Owner parent = null;
+
+        for (int i = 0; i < 3; ++i) {
+            Owner owner = new Owner();
+
+            owner.setId("owner_id-" + i);
+            owner.setKey("owner_key-" + i);
+            owner.setDisplayName("owner_name-" + i);
+            owner.setParentOwner(parent);
+            owner.setContentPrefix("content_prefix-" + i);
+            owner.setDefaultServiceLevel("service_level-" + i);
+            owner.setUpstreamConsumer(this.upstreamConsumerTranslatorTest.initSourceObject());
+            owner.setLogLevel("log_level-" + i);
+            owner.setAutobindDisabled(true);
+            owner.setContentAccessModeList(String.format("cam%1$d-a,cam%1$d-b,cam%1$d-c", i));
+            owner.setContentAccessMode(String.format("cam%d-b", i));
+            owner.setLastRefreshed(new Date());
+
+            parent = owner;
+        }
+
+        return parent;
+    }
+
+    @Override
+    protected OwnerDTO initDestinationObject() {
+        // Nothing fancy to do here.
+        return new OwnerDTO();
+    }
+
+    @Override
+    protected void verifyOutput(Owner source, OwnerDTO dest, boolean childrenGenerated) {
+        if (source != null) {
+            assertEquals(source.getId(), dest.getId());
+            assertEquals(source.getKey(), dest.getKey());
+            assertEquals(source.getDisplayName(), dest.getDisplayName());
+            assertEquals(source.getContentPrefix(), dest.getContentPrefix());
+            assertEquals(source.getDefaultServiceLevel(), dest.getDefaultServiceLevel());
+            assertEquals(source.getLogLevel(), dest.getLogLevel());
+            assertEquals(source.isAutobindDisabled(), dest.isAutobindDisabled());
+            assertEquals(source.getContentAccessMode(), dest.getContentAccessMode());
+            assertEquals(source.getContentAccessModeList(), dest.getContentAccessModeList());
+            assertEquals(source.getLastRefreshed(), dest.getLastRefreshed());
+
+            // Parent owner is a special case, since it's recursion-based rather than relying on a
+            // factory to handle it. As such, it should always be present.
+            this.verifyOutput(source.getParentOwner(), dest.getParentOwner(), childrenGenerated);
+
+            if (childrenGenerated) {
+                this.upstreamConsumerTranslatorTest
+                    .verifyOutput(source.getUpstreamConsumer(), dest.getUpstreamConsumer(), true);
+            }
+            else {
+                assertNull(dest.getUpstreamConsumer());
+            }
+        }
+        else {
+            assertNull(dest);
+        }
+    }
+}

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/PoolDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/PoolDTOTest.java
@@ -15,6 +15,7 @@
 package org.candlepin.dto.manifest.v1;
 
 import org.candlepin.dto.AbstractDTOTest;
+import org.candlepin.model.Pool;
 import org.junit.Test;
 
 import java.util.Date;
@@ -36,6 +37,20 @@ public class PoolDTOTest extends AbstractDTOTest<PoolDTO> {
     public PoolDTOTest() {
         super(PoolDTO.class);
 
+        OwnerDTO owner = new OwnerDTO();
+        owner.setId("owner-id");
+        owner.setKey("owner-key");
+        owner.setDisplayName("owner-name");
+        owner.setContentPrefix("content-prefix");
+        owner.setDefaultServiceLevel("service-level");
+        owner.setLogLevel("log-level");
+        owner.setAutobindDisabled(true);
+        owner.setContentAccessMode("content-access-mode");
+        owner.setContentAccessModeList("content-access-mode-list");
+
+        EntitlementDTO entitlement = new EntitlementDTO();
+        entitlement.setId("entitlement-id");
+
         BrandingDTO branding = new BrandingDTO();
         branding.setName("branding-name");
         branding.setProductId("branding-prod-id");
@@ -47,19 +62,68 @@ public class PoolDTOTest extends AbstractDTOTest<PoolDTO> {
         PoolDTO.ProvidedProductDTO derivedProvidedProd =
             new PoolDTO.ProvidedProductDTO("derived-provided-product-id", "derived-provided-product-name");
 
+        CertificateDTO cert = new CertificateDTO();
+        cert.setId("cert-id");
+        cert.setKey("cert-key");
+        cert.setCert("cert-cert");
+        cert.setSerial(new CertificateSerialDTO());
+
         this.values = new HashMap<>();
         this.values.put("Id", "test-id");
+        this.values.put("Type", Pool.PoolType.NORMAL.toString());
+        this.values.put("Owner", owner);
+        this.values.put("ActiveSubscription", true);
+        this.values.put("CreatedByShare", true);
+        this.values.put("HasSharedAncestor", true);
+        this.values.put("SourceEntitlement", entitlement);
+        this.values.put("Quantity", 1L);
+        this.values.put("StartDate", new Date());
+        this.values.put("EndDate", new Date());
 
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put("attribute-key-1", "attribute-value-1");
+        attributes.put("attribute-key-2", "attribute-value-2");
+        this.values.put("Attributes", attributes);
+
+        this.values.put("RestrictedToUsername", "restricted-to-username-value");
         this.values.put("ContractNumber", "2991");
         this.values.put("AccountNumber", "2992");
         this.values.put("OrderNumber", "2993");
+        this.values.put("Consumed", 5L);
+        this.values.put("Exported", 4L);
+        this.values.put("Shared", 3L);
 
         Set<BrandingDTO> brandingSet = new HashSet<>();
         brandingSet.add(branding);
         this.values.put("Branding", brandingSet);
 
+        Map<String, String> calculatedAttributes = new HashMap<>();
+        calculatedAttributes.put("calc-attribute-key-1", "calc-attribute-value-1");
+        calculatedAttributes.put("calc-attribute-key-2", "calc-attribute-value-2");
+        this.values.put("CalculatedAttributes", calculatedAttributes);
+
+        this.values.put("UpstreamPoolId", "upstream-pool-id-1");
+        this.values.put("UpstreamEntitlementId", "upstream-entitlement-id-1");
+        this.values.put("UpstreamConsumerId", "upstream-consumer-id-1");
+        this.values.put("ProductName", "product-name-1");
         this.values.put("ProductId", "product-id-1");
+
+        Map<String, String> productAttributes = new HashMap<>();
+        productAttributes.put("prod-attribute-key-1", "prod-attribute-value-1");
+        productAttributes.put("prod-attribute-key-2", "prod-attribute-value-2");
+        this.values.put("ProductAttributes", productAttributes);
+
+        this.values.put("StackId", "stack-id-1");
+        this.values.put("Stacked", true);
+        this.values.put("DevelopmentPool", true);
+
+        Map<String, String> derivedProductAttributes = new HashMap<>();
+        derivedProductAttributes.put("derived-prod-attribute-key-1", "derived-prod-attribute-value-1");
+        derivedProductAttributes.put("derived-prod-attribute-key-2", "derived-prod-attribute-value-2");
+        this.values.put("DerivedProductAttributes", derivedProductAttributes);
+
         this.values.put("DerivedProductId", "derived-prod-id-1");
+        this.values.put("DerivedProductName", "derived-prod-name-1");
 
         Set<PoolDTO.ProvidedProductDTO> providedProducts = new HashSet<>();
         providedProducts.add(providedProd);
@@ -68,9 +132,14 @@ public class PoolDTOTest extends AbstractDTOTest<PoolDTO> {
         Set<PoolDTO.ProvidedProductDTO> derivedProvidedProducts = new HashSet<>();
         derivedProvidedProducts.add(derivedProvidedProd);
         this.values.put("DerivedProvidedProducts", derivedProvidedProducts);
+        this.values.put("SourceStackId", "source-stack-id-1");
 
-        this.values.put("StartDate", new Date());
-        this.values.put("EndDate", new Date());
+        this.values.put("SubscriptionSubKey", "subscription-key-1");
+        this.values.put("SubscriptionId", "subscription-id-1");
+
+        this.values.put("Certificate", cert);
+        this.values.put("Created", new Date());
+        this.values.put("Updated", new Date());
     }
 
     /**
@@ -88,6 +157,78 @@ public class PoolDTOTest extends AbstractDTOTest<PoolDTO> {
     protected Object getOutputValueForAccessor(String field, Object input) {
         // Nothing to do here
         return input;
+    }
+
+    @Test
+    public void testHasAttributeWithAbsentAttribute() {
+        PoolDTO dto = new PoolDTO();
+        assertFalse(dto.hasAttribute("attribute-key-1"));
+    }
+
+    @Test
+    public void testHasAttributeWithPresentAttribute() {
+        PoolDTO dto = new PoolDTO();
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put("attribute-key-2", "attribute-value-2");
+        dto.setAttributes(attributes);
+
+        assertTrue(dto.hasAttribute("attribute-key-2"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testHasAttributeWithNullInput() {
+        PoolDTO dto = new PoolDTO();
+        dto.hasAttribute(null);
+    }
+
+    @Test
+    public void testRemoveAttributeWithAbsentAttribute() {
+        PoolDTO dto = new PoolDTO();
+
+        assertFalse(dto.removeAttribute("attribute-key-3"));
+
+        dto.setAttributes(new HashMap<>());
+
+        assertFalse(dto.removeAttribute("attribute-key-3"));
+    }
+
+    @Test
+    public void testRemoveAttributeWithPresentAttribute() {
+        PoolDTO dto = new PoolDTO();
+
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put("attribute-key-4", "attribute-value-4");
+        dto.setAttributes(attributes);
+
+        assertTrue(dto.removeAttribute("attribute-key-4"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testRemoveAttributeWithNullInput() {
+        PoolDTO dto = new PoolDTO();
+        dto.removeAttribute(null);
+    }
+
+    @Test
+    public void testHasProductAttributeWithAbsentProductAttribute() {
+        PoolDTO dto = new PoolDTO();
+        assertFalse(dto.hasProductAttribute("prod-attribute-key-1"));
+    }
+
+    @Test
+    public void testHasProductAttributeWithPresentProductAttribute() {
+        PoolDTO dto = new PoolDTO();
+        Map<String, String> productAttributes = new HashMap<>();
+        productAttributes.put("prod-attribute-key-2", "prod-attribute-value-2");
+        dto.setProductAttributes(productAttributes);
+
+        assertTrue(dto.hasProductAttribute("prod-attribute-key-2"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testHasProductAttributeWithNullInput() {
+        PoolDTO dto = new PoolDTO();
+        dto.hasProductAttribute(null);
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/UpstreamConsumerDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/UpstreamConsumerDTOTest.java
@@ -16,29 +16,43 @@ package org.candlepin.dto.manifest.v1;
 
 import org.candlepin.dto.AbstractDTOTest;
 
-import java.math.BigInteger;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
 
+
 /**
- * Test suite for the CertificateSerialDTO (manifest import/export) class
+ * Test suite for the UpstreamConsumerDTO (manifest import/export) class
  */
-public class CertificateSerialDTOTest extends AbstractDTOTest<CertificateSerialDTO> {
+public class UpstreamConsumerDTOTest extends AbstractDTOTest<UpstreamConsumerDTO> {
 
     protected Map<String, Object> values;
 
-    public CertificateSerialDTOTest() {
-        super(CertificateSerialDTO.class);
+    public UpstreamConsumerDTOTest() {
+        super(UpstreamConsumerDTO.class);
+
+        ConsumerTypeDTO type = new ConsumerTypeDTO();
+        type.setId("type_id");
+        type.setLabel("type_label");
+        type.setManifest(true);
+
+        CertificateDTO cert = new CertificateDTO();
+        cert.setId("123");
+        cert.setKey("cert_key");
+        cert.setCert("cert_cert");
+        cert.setSerial(new CertificateSerialDTO());
 
         this.values = new HashMap<>();
-        this.values.put("Id", 12345L);
-        this.values.put("Serial", BigInteger.TEN);
-        this.values.put("Date", new Date());
-        this.values.put("Collected", true);
-        this.values.put("Revoked", true);
-        this.values.put("Expiration", new Date());
+        this.values.put("Id", "test-id");
+        this.values.put("Uuid", "test-uuid");
+        this.values.put("Name", "test-name");
+        this.values.put("ApiUrl", "test-api-url");
+        this.values.put("WebUrl", "test-web-url");
+        this.values.put("ConsumerType", type);
+        this.values.put("IdentityCertificate", cert);
+        this.values.put("OwnerId", "test-owner-id");
+        this.values.put("ContentAccessMode", "test-content-access-mode");
         this.values.put("Created", new Date());
         this.values.put("Updated", new Date());
     }

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/UpstreamConsumerTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/UpstreamConsumerTranslatorTest.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2009 - 2018 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.dto.manifest.v1;
+
+import org.candlepin.dto.AbstractTranslatorTest;
+import org.candlepin.dto.ModelTranslator;
+import org.candlepin.model.Certificate;
+import org.candlepin.model.IdentityCertificate;
+import org.candlepin.model.UpstreamConsumer;
+
+import static org.junit.Assert.*;
+
+import junitparams.JUnitParamsRunner;
+
+import org.junit.runner.RunWith;
+
+
+
+/**
+ * Test suite for the UpstreamConsumerTranslator (manifest import/export) class
+ */
+@RunWith(JUnitParamsRunner.class)
+public class UpstreamConsumerTranslatorTest extends
+    AbstractTranslatorTest<UpstreamConsumer, UpstreamConsumerDTO, UpstreamConsumerTranslator> {
+
+    protected UpstreamConsumerTranslator translator = new UpstreamConsumerTranslator();
+
+    protected CertificateTranslatorTest certificateTranslatorTest = new CertificateTranslatorTest();
+    protected ConsumerTypeTranslatorTest consumerTypeTranslatorTest = new ConsumerTypeTranslatorTest();
+
+
+    @Override
+    protected void initModelTranslator(ModelTranslator modelTranslator) {
+        this.certificateTranslatorTest.initModelTranslator(modelTranslator);
+        this.consumerTypeTranslatorTest.initModelTranslator(modelTranslator);
+        modelTranslator.registerTranslator(
+            this.translator, UpstreamConsumer.class, UpstreamConsumerDTO.class);
+    }
+
+    @Override
+    protected UpstreamConsumerTranslator initObjectTranslator() {
+        return this.translator;
+    }
+
+    @Override
+    protected UpstreamConsumer initSourceObject() {
+        UpstreamConsumer consumer = new UpstreamConsumer();
+
+        consumer.setId("consumer_id");
+        consumer.setUuid("consumer_uuid");
+        consumer.setName("consumer_name");
+        consumer.setApiUrl("http://www.url.com");
+        consumer.setWebUrl("http://www.url.com");
+        consumer.setOwnerId("owner_id");
+        consumer.setType(this.consumerTypeTranslatorTest.initSourceObject());
+        consumer.setIdCert((IdentityCertificate) this.certificateTranslatorTest.initSourceObject());
+
+        return consumer;
+    }
+
+    @Override
+    protected UpstreamConsumerDTO initDestinationObject() {
+        // Nothing fancy to do here.
+        return new UpstreamConsumerDTO();
+    }
+
+    @Override
+    protected void verifyOutput(UpstreamConsumer source, UpstreamConsumerDTO dest,
+        boolean childrenGenerated) {
+
+        if (source != null) {
+            assertEquals(source.getId(), dest.getId());
+            assertEquals(source.getUuid(), dest.getUuid());
+            assertEquals(source.getName(), dest.getName());
+            assertEquals(source.getApiUrl(), dest.getApiUrl());
+            assertEquals(source.getWebUrl(), dest.getWebUrl());
+            assertEquals(source.getOwnerId(), dest.getOwnerId());
+
+            if (childrenGenerated) {
+                this.certificateTranslatorTest
+                    .verifyOutput((Certificate) source.getIdCert(), dest.getIdentityCertificate(), true);
+
+                this.consumerTypeTranslatorTest
+                    .verifyOutput(source.getType(), dest.getConsumerType(), true);
+            }
+            else {
+                assertNull(dest.getConsumerType());
+                assertNull(dest.getIdentityCertificate());
+            }
+        }
+        else {
+            assertNull(dest);
+        }
+    }
+}

--- a/server/src/test/java/org/candlepin/sync/ConsumerImporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/ConsumerImporterTest.java
@@ -26,6 +26,7 @@ import org.candlepin.common.config.MapConfiguration;
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.dto.manifest.v1.ConsumerDTO;
 import org.candlepin.dto.manifest.v1.ConsumerTypeDTO;
+import org.candlepin.dto.manifest.v1.OwnerDTO;
 import org.candlepin.model.CertificateSerial;
 import org.candlepin.model.CertificateSerialCurator;
 import org.candlepin.model.IdentityCertificate;
@@ -112,13 +113,14 @@ public class ConsumerImporterTest {
 
     @Test
     public void importConsumerWithNullUuidOnOwnerShouldSetUuid() throws ImporterException {
+        OwnerDTO ownerDTO = mock(OwnerDTO.class);
         Owner owner = mock(Owner.class);
         ConsumerDTO consumer = mock(ConsumerDTO.class);
         ConsumerTypeDTO type = mock(ConsumerTypeDTO.class);
 
-        when(owner.getId()).thenReturn("test-owner-id");
+        when(ownerDTO.getId()).thenReturn("test-owner-id");
         when(consumer.getUuid()).thenReturn("test-uuid");
-        when(consumer.getOwner()).thenReturn("owner-id");
+        when(consumer.getOwner()).thenReturn(ownerDTO);
         when(consumer.getType()).thenReturn(type);
 
         IdentityCertificate idCert = new IdentityCertificate();
@@ -138,11 +140,12 @@ public class ConsumerImporterTest {
     @Test
     public void importConsumerWithSameUuidOnOwnerShouldDoNothing() throws ImporterException {
         Owner owner = mock(Owner.class);
+        OwnerDTO ownerDTO = mock(OwnerDTO.class);
         ConsumerDTO consumer = mock(ConsumerDTO.class);
         ConsumerTypeDTO type = mock(ConsumerTypeDTO.class);
         when(owner.getUpstreamUuid()).thenReturn("test-uuid");
         when(consumer.getUuid()).thenReturn("test-uuid");
-        when(consumer.getOwner()).thenReturn("owner-id");
+        when(consumer.getOwner()).thenReturn(ownerDTO);
         when(consumer.getType()).thenReturn(type);
 
         IdentityCertificate idCert = new IdentityCertificate();
@@ -178,10 +181,11 @@ public class ConsumerImporterTest {
     @Test
     public void importConsumerWithMismatchedUuidShouldThrowException() throws ImporterException {
         Owner owner = mock(Owner.class);
+        OwnerDTO ownerDTO = mock(OwnerDTO.class);
         ConsumerDTO consumer = mock(ConsumerDTO.class);
         when(owner.getUpstreamUuid()).thenReturn("another-test-uuid");
         when(consumer.getUuid()).thenReturn("test-uuid");
-        when(consumer.getOwner()).thenReturn("owner-id");
+        when(consumer.getOwner()).thenReturn(ownerDTO);
 
         try {
             importer.store(owner, consumer, new ConflictOverrides(), null);
@@ -197,11 +201,12 @@ public class ConsumerImporterTest {
     @Test
     public void importConsumerWithMismatchedUuidShouldNotThrowExceptionIfForced() throws ImporterException {
         Owner owner = mock(Owner.class);
+        OwnerDTO ownerDTO = mock(OwnerDTO.class);
         ConsumerDTO consumer = mock(ConsumerDTO.class);
         ConsumerTypeDTO type = mock(ConsumerTypeDTO.class);
         when(owner.getUpstreamUuid()).thenReturn("another-test-uuid");
         when(consumer.getUuid()).thenReturn("test-uuid");
-        when(consumer.getOwner()).thenReturn("owner-id");
+        when(consumer.getOwner()).thenReturn(ownerDTO);
         when(consumer.getType()).thenReturn(type);
 
         IdentityCertificate idCert = new IdentityCertificate();
@@ -234,11 +239,12 @@ public class ConsumerImporterTest {
     @Test
     public void importConsumerWithNullIdCertShouldNotFail() throws ImporterException {
         Owner owner = mock(Owner.class);
+        OwnerDTO ownerDTO = mock(OwnerDTO.class);
         ConsumerDTO consumer = mock(ConsumerDTO.class);
         ConsumerTypeDTO type = mock(ConsumerTypeDTO.class);
         when(owner.getUpstreamUuid()).thenReturn("test-uuid");
         when(consumer.getUuid()).thenReturn("test-uuid");
-        when(consumer.getOwner()).thenReturn("owner-id");
+        when(consumer.getOwner()).thenReturn(ownerDTO);
         when(consumer.getType()).thenReturn(type);
 
         importer.store(owner, consumer, new ConflictOverrides(), null);

--- a/server/src/test/java/org/candlepin/sync/EntitlementImporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/EntitlementImporterTest.java
@@ -31,6 +31,7 @@ import org.candlepin.model.CertificateSerialCurator;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.Entitlement;
 import org.candlepin.model.EntitlementCertificate;
+import org.candlepin.model.EntitlementCurator;
 import org.candlepin.model.Owner;
 import org.candlepin.model.Pool;
 import org.candlepin.model.Product;
@@ -68,6 +69,7 @@ public class EntitlementImporterTest {
     @Mock private CdnCurator cdnCurator;
     @Mock private ObjectMapper om;
     @Mock private ProductCurator mockProductCurator;
+    @Mock private EntitlementCurator ec;
 
     private Owner owner;
     private EntitlementImporter importer;
@@ -88,7 +90,7 @@ public class EntitlementImporterTest {
 
         i18n = I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK);
         this.importer = new EntitlementImporter(certSerialCurator, cdnCurator,
-            i18n, mockProductCurator);
+            i18n, mockProductCurator, ec);
 
         consumer = TestUtil.createConsumer(owner);
         consumerDTO = this.translator.translate(consumer, ConsumerDTO.class);

--- a/server/src/test/java/org/candlepin/sync/ImporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/ImporterTest.java
@@ -29,6 +29,7 @@ import org.candlepin.dto.ModelTranslator;
 import org.candlepin.dto.StandardTranslator;
 import org.candlepin.dto.manifest.v1.ConsumerDTO;
 import org.candlepin.dto.manifest.v1.ConsumerTypeDTO;
+import org.candlepin.dto.manifest.v1.OwnerDTO;
 import org.candlepin.jackson.ProductCachedSerializationModule;
 import org.candlepin.model.CertificateSerialCurator;
 import org.candlepin.model.ConsumerType;
@@ -38,6 +39,7 @@ import org.candlepin.model.DistributorVersion;
 import org.candlepin.model.DistributorVersionCapability;
 import org.candlepin.model.DistributorVersionCurator;
 import org.candlepin.model.Entitlement;
+import org.candlepin.model.EntitlementCurator;
 import org.candlepin.model.ExporterMetadata;
 import org.candlepin.model.ExporterMetadataCurator;
 import org.candlepin.model.IdentityCertificateCurator;
@@ -111,6 +113,7 @@ public class ImporterTest {
     private ClassLoader classLoader = getClass().getClassLoader();
     private SyncUtils su;
     private ProductCurator pc;
+    private EntitlementCurator ec;
     private SubscriptionReconciler mockSubReconciler;
     private ModelTranslator translator;
 
@@ -131,6 +134,7 @@ public class ImporterTest {
         i18n = I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK);
         config = new CandlepinCommonTestConfig();
         pc = Mockito.mock(ProductCurator.class);
+        ec = Mockito.mock(EntitlementCurator.class);
         ProductCachedSerializationModule productCachedModule = new ProductCachedSerializationModule(pc);
         su = new SyncUtils(config, productCachedModule);
         PrintStream ps = new PrintStream(
@@ -176,7 +180,7 @@ public class ImporterTest {
         when(emc.lookupByType(ExporterMetadata.TYPE_SYSTEM)).thenReturn(em);
         Importer i = new Importer(null, null, null, null, null, null,
             null, null, null, emc, null, null, i18n, null,
-            null, su, null, this.mockSubReconciler, this.translator);
+            null, su, null, this.mockSubReconciler, this.ec, this.translator);
         i.validateMetadata(ExporterMetadata.TYPE_SYSTEM, null, actual,
             new ConflictOverrides());
 
@@ -201,7 +205,7 @@ public class ImporterTest {
         when(emc.lookupByType(ExporterMetadata.TYPE_SYSTEM)).thenReturn(null);
         Importer i = new Importer(null, null, null, null, null, null,
             null, null, null, emc, null, null, i18n,
-            null, null, su, null, this.mockSubReconciler, this.translator);
+            null, null, su, null, this.mockSubReconciler, this.ec, this.translator);
         i.validateMetadata(ExporterMetadata.TYPE_SYSTEM, null, actualmeta,
             new ConflictOverrides());
         assertTrue(f.delete());
@@ -223,7 +227,7 @@ public class ImporterTest {
         when(emc.lookupByType(ExporterMetadata.TYPE_SYSTEM)).thenReturn(em);
         Importer i = new Importer(null, null, null, null, null, null,
             null, null, null, emc, null, null, i18n,
-            null, null, su, null, this.mockSubReconciler, this.translator);
+            null, null, su, null, this.mockSubReconciler, this.ec, this.translator);
         try {
             i.validateMetadata(ExporterMetadata.TYPE_SYSTEM, null, actualmeta,
                 new ConflictOverrides());
@@ -252,7 +256,7 @@ public class ImporterTest {
         when(emc.lookupByType(ExporterMetadata.TYPE_SYSTEM)).thenReturn(em);
         Importer i = new Importer(null, null, null, null, null, null,
             null, null, null, emc, null, null, i18n,
-            null, null, su, null, this.mockSubReconciler, this.translator);
+            null, null, su, null, this.mockSubReconciler, this.ec, this.translator);
         try {
             i.validateMetadata(ExporterMetadata.TYPE_SYSTEM, null, actualmeta,
                 new ConflictOverrides());
@@ -300,7 +304,7 @@ public class ImporterTest {
         when(emc.lookupByType(ExporterMetadata.TYPE_SYSTEM)).thenReturn(em);
         Importer i = new Importer(null, null, null, null, null, null,
             null, null, null, emc, null, null, i18n,
-            null, null, su, null, this.mockSubReconciler, this.translator);
+            null, null, su, null, this.mockSubReconciler, this.ec, this.translator);
         i.validateMetadata(ExporterMetadata.TYPE_SYSTEM, null, actualmeta,
             new ConflictOverrides());
         assertEquals(importDate, em.getExported());
@@ -313,7 +317,7 @@ public class ImporterTest {
         try {
             Importer i = new Importer(null, null, null, null, null, null,
                 null, null, null, null, null, null, i18n,
-                null, null, su, null, this.mockSubReconciler, this.translator);
+                null, null, su, null, this.mockSubReconciler, this.ec, this.translator);
 
             // null Type should cause exception
             i.validateMetadata(null, null, actualmeta, new ConflictOverrides());
@@ -332,7 +336,7 @@ public class ImporterTest {
             .thenReturn(null);
         Importer i = new Importer(null, null, null, null, null, null,
             null, null, null, emc, null, null, i18n,
-            null, null, su, null, this.mockSubReconciler, this.translator);
+            null, null, su, null, this.mockSubReconciler, this.ec, this.translator);
 
         // null Type should cause exception
         i.validateMetadata(ExporterMetadata.TYPE_PER_USER, null, actualmeta,
@@ -345,7 +349,7 @@ public class ImporterTest {
         throws IOException, ImporterException {
         Importer i = new Importer(null, null, null, null, null, null,
             null, null, config, null, null, null, i18n,
-            null, null, su, null, this.mockSubReconciler, this.translator);
+            null, null, su, null, this.mockSubReconciler, this.ec, this.translator);
         Owner owner = mock(Owner.class);
         ConflictOverrides co = mock(ConflictOverrides.class);
         File archive = new File(folder.getRoot(), "non_zip_file.zip");
@@ -365,7 +369,7 @@ public class ImporterTest {
         throws IOException, ImporterException {
         Importer i = new Importer(null, null, null, null, null, null,
             null, null, config, null, null, null, i18n,
-            null, null, su, null, this.mockSubReconciler, this.translator);
+            null, null, su, null, this.mockSubReconciler, this.ec, this.translator);
         Owner owner = mock(Owner.class);
         ConflictOverrides co = mock(ConflictOverrides.class);
 
@@ -386,7 +390,7 @@ public class ImporterTest {
         PKIUtility pki = mock(PKIUtility.class);
         Importer i = new Importer(null, null, null, null, null, null, null,
             pki, config, null, null, null, i18n,
-            null, null, su, null, this.mockSubReconciler, this.translator);
+            null, null, su, null, this.mockSubReconciler, this.ec, this.translator);
         Owner owner = mock(Owner.class);
         ConflictOverrides co = mock(ConflictOverrides.class);
 
@@ -409,7 +413,7 @@ public class ImporterTest {
         PKIUtility pki = mock(PKIUtility.class);
         Importer i = new Importer(null, null, null, null, null, null, null,
             pki, config, null, null, null, i18n,
-            null, null, su, null, this.mockSubReconciler, this.translator);
+            null, null, su, null, this.mockSubReconciler, this.ec, this.translator);
         Owner owner = mock(Owner.class);
         ConflictOverrides co = mock(ConflictOverrides.class);
 
@@ -439,7 +443,7 @@ public class ImporterTest {
         PKIUtility pki = mock(PKIUtility.class);
         Importer i = new Importer(null, null, null, null, null, null, null,
             pki, config, null, null, null, i18n,
-            null, null, su, null, this.mockSubReconciler, this.translator);
+            null, null, su, null, this.mockSubReconciler, this.ec, this.translator);
         Owner owner = mock(Owner.class);
         ConflictOverrides co = mock(ConflictOverrides.class);
 
@@ -480,7 +484,7 @@ public class ImporterTest {
         OwnerCurator oc = mock(OwnerCurator.class);
         Importer i = new Importer(null, null, null, oc, null, null, null,
             null, config, null, null, null, i18n,
-            null, null, su, null, this.mockSubReconciler, this.translator);
+            null, null, su, null, this.mockSubReconciler, this.ec, this.translator);
         Owner owner = mock(Owner.class);
         ConflictOverrides co = mock(ConflictOverrides.class);
 
@@ -499,7 +503,7 @@ public class ImporterTest {
         OwnerCurator oc = mock(OwnerCurator.class);
         Importer i = new Importer(null, null, null, oc, null, null, null,
             null, config, null, null, null, i18n,
-            null, null, su, null, this.mockSubReconciler, this.translator);
+            null, null, su, null, this.mockSubReconciler, this.ec, this.translator);
         Owner owner = mock(Owner.class);
         ConflictOverrides co = mock(ConflictOverrides.class);
         Map<String, File> importFiles = getTestImportFiles();
@@ -518,7 +522,7 @@ public class ImporterTest {
         OwnerCurator oc = mock(OwnerCurator.class);
         Importer i = new Importer(null, null, null, oc, null, null, null,
             null, config, null, null, null, i18n,
-            null, null, su, null, this.mockSubReconciler, this.translator);
+            null, null, su, null, this.mockSubReconciler, this.ec, this.translator);
         Owner owner = mock(Owner.class);
         ConflictOverrides co = mock(ConflictOverrides.class);
         Map<String, File> importFiles = getTestImportFiles();
@@ -539,7 +543,7 @@ public class ImporterTest {
         OwnerCurator oc = mock(OwnerCurator.class);
         Importer i = new Importer(null, null, ri, oc, null, null, null,
             null, config, null, null, null, i18n,
-            null, null, su, null, this.mockSubReconciler, this.translator);
+            null, null, su, null, this.mockSubReconciler, this.ec, this.translator);
         Owner owner = mock(Owner.class);
         ConflictOverrides co = mock(ConflictOverrides.class);
         Map<String, File> importFiles = getTestImportFiles();
@@ -603,7 +607,10 @@ public class ImporterTest {
         consumerDTO.setUrlWeb("foo.example.com/subscription");
         consumerDTO.setUrlApi("/candlepin");
         consumerDTO.setContentAccessMode("");
-        consumerDTO.setOwner("owner-id");
+        OwnerDTO ownerDTO = new OwnerDTO();
+        ownerDTO.setKey("admin");
+        ownerDTO.setDisplayName("Admin Owner");
+        consumerDTO.setOwner(ownerDTO);
 
         ConsumerType cpConsumerType = new ConsumerType(ConsumerTypeEnum.CANDLEPIN);
         when(ctc.lookupByLabel(eq("candlepin"))).thenReturn(cpConsumerType);
@@ -642,7 +649,7 @@ public class ImporterTest {
 
         Importer i = new Importer(ctc, pc, ri, oc, null, null, pm,
             null, config, emc, null, null, i18n,
-            null, null, su, null, this.mockSubReconciler, this.translator);
+            null, null, su, null, this.mockSubReconciler, this.ec, this.translator);
         List<Subscription> subscriptions = i.importObjects(owner, importFiles, co);
 
         assertEquals(1, subscriptions.size());
@@ -655,7 +662,7 @@ public class ImporterTest {
         OwnerCurator oc = mock(OwnerCurator.class);
         Importer i = new Importer(null, null, null, oc, null, null, null,
             null, config, null, null, null, i18n,
-            null, null, su, null, this.mockSubReconciler, this.translator);
+            null, null, su, null, this.mockSubReconciler, this.ec, this.translator);
         Owner owner = mock(Owner.class);
         ConflictOverrides co = mock(ConflictOverrides.class);
         Map<String, File> importFiles = getTestImportFiles();
@@ -725,7 +732,7 @@ public class ImporterTest {
         Importer i = new Importer(ctc, null, null, oc,
             mock(IdentityCertificateCurator.class), null, null,
             pki, null, null, mock(CertificateSerialCurator.class), null, i18n,
-            null, null, su, null, this.mockSubReconciler, this.translator);
+            null, null, su, null, this.mockSubReconciler, this.ec, this.translator);
         File[] upstream = createUpstreamFiles();
         Owner owner = new Owner("admin", "Admin Owner");
 
@@ -739,7 +746,10 @@ public class ImporterTest {
         consumerDTO.setUrlWeb("foo.example.com/subscription");
         consumerDTO.setUrlApi("/candlepin");
         consumerDTO.setContentAccessMode("access_mode");
-        consumerDTO.setOwner("owner-id");
+        OwnerDTO ownerDTO = new OwnerDTO();
+        ownerDTO.setKey("admin");
+        ownerDTO.setDisplayName("Admin Owner");
+        consumerDTO.setOwner(ownerDTO);
 
         File consumerfile = new File(folder.getRoot(), "consumer.json");
         mapper.writeValue(consumerfile, consumerDTO);
@@ -777,7 +787,7 @@ public class ImporterTest {
         DistributorVersionCurator dvc = mock(DistributorVersionCurator.class);
         Importer i = new Importer(null, null, null, null, null, null,
             null, null, null, null, null, null, i18n,
-            dvc, null, su, null, this.mockSubReconciler, this.translator);
+            dvc, null, su, null, this.mockSubReconciler, this.ec, this.translator);
         File[] distVer = new File[1];
         distVer[0] = new File(folder.getRoot(), "dist-ver.json");
         mapper.writeValue(distVer[0], createTestDistributerVersion());
@@ -793,7 +803,7 @@ public class ImporterTest {
         DistributorVersionCurator dvc = mock(DistributorVersionCurator.class);
         Importer i = new Importer(null, null, null, null, null, null,
             null, null, null, null, null, null, i18n,
-            dvc, null, su, null, this.mockSubReconciler, this.translator);
+            dvc, null, su, null, this.mockSubReconciler, this.ec, this.translator);
         when(dvc.findByName("test-dist-ver")).thenReturn(
             new DistributorVersion("test-dist-ver"));
         File[] distVer = new File[1];
@@ -824,7 +834,7 @@ public class ImporterTest {
         Map<String, File> importFiles = createAndSetImportFiles();
         Importer i = new Importer(null, null, ri, oc, null, null,
             null, null, config, emc, null, null, i18n,
-            null, null, su, null, this.mockSubReconciler, this.translator);
+            null, null, su, null, this.mockSubReconciler, this.ec, this.translator);
 
         ee.expect(RuntimeException.class);
         ee.expectMessage("Done with the test");
@@ -860,7 +870,7 @@ public class ImporterTest {
         ImportRecordCurator importRecordCurator = mock(ImportRecordCurator.class);
         Importer importer = new Importer(null, null, null, null, null, null, null, null, config, null,
             null, eventSinkMock, i18n,
-            null, null, su, importRecordCurator, this.mockSubReconciler, this.translator);
+            null, null, su, importRecordCurator, this.mockSubReconciler, this.ec, this.translator);
 
         Meta meta = new Meta("1.0", new Date(), "test-user", "candlepin", "testcdn");
 
@@ -896,7 +906,7 @@ public class ImporterTest {
         ImportRecordCurator importRecordCurator = mock(ImportRecordCurator.class);
         Importer importer = new Importer(null, null, null, null, null, null, null, null, config, null,
             null, eventSinkMock, i18n,
-            null, null, su, importRecordCurator, this.mockSubReconciler, this.translator);
+            null, null, su, importRecordCurator, this.mockSubReconciler, this.ec, this.translator);
 
         Meta meta = new Meta("1.0", new Date(), "test-user", "candlepin", "testcdn");
 
@@ -928,7 +938,7 @@ public class ImporterTest {
         ImportRecordCurator importRecordCurator = mock(ImportRecordCurator.class);
         Importer importer = new Importer(null, null, null, null, null, null, null, null, config, null,
             null, eventSinkMock, i18n,
-            null, null, su, importRecordCurator, this.mockSubReconciler, this.translator);
+            null, null, su, importRecordCurator, this.mockSubReconciler, this.ec, this.translator);
 
         Meta meta = new Meta("1.0", new Date(), "test-user", "candlepin", "testcdn");
 
@@ -950,7 +960,7 @@ public class ImporterTest {
         ImportRecordCurator importRecordCurator = mock(ImportRecordCurator.class);
         Importer importer = new Importer(null, null, null, null, null, null, null, null, config, null,
             null, eventSinkMock, i18n,
-            null, null, su, importRecordCurator, this.mockSubReconciler, this.translator);
+            null, null, su, importRecordCurator, this.mockSubReconciler, this.ec, this.translator);
 
         Map<String, Object> data = new HashMap<>();
         List<Subscription> subscriptions = new ArrayList<>();
@@ -983,7 +993,7 @@ public class ImporterTest {
         ImportRecordCurator importRecordCurator = mock(ImportRecordCurator.class);
         Importer importer = new Importer(null, null, null, null, null, null, null, null, config, null,
             null, eventSinkMock, i18n,
-            null, null, su, importRecordCurator, this.mockSubReconciler, this.translator);
+            null, null, su, importRecordCurator, this.mockSubReconciler, this.ec, this.translator);
 
         Map<String, Object> data = new HashMap<>();
         data.put("subscriptions", new ArrayList<Subscription>());

--- a/server/src/test/java/org/candlepin/sync/SubscriptionReconcilerTest.java
+++ b/server/src/test/java/org/candlepin/sync/SubscriptionReconcilerTest.java
@@ -29,6 +29,7 @@ import org.candlepin.model.CdnCurator;
 import org.candlepin.model.CertificateSerial;
 import org.candlepin.model.CertificateSerialCurator;
 import org.candlepin.model.EntitlementCertificate;
+import org.candlepin.model.EntitlementCurator;
 import org.candlepin.model.Owner;
 import org.candlepin.model.Pool;
 import org.candlepin.model.Pool.PoolType;
@@ -60,6 +61,7 @@ public class SubscriptionReconcilerTest {
     @Mock private CdnCurator cdnCurator;
     @Mock private ObjectMapper om;
     @Mock private ProductCurator pc;
+    @Mock private EntitlementCurator ec;
 
     private Owner owner;
     private EntitlementImporter importer;
@@ -74,7 +76,7 @@ public class SubscriptionReconcilerTest {
         this.reconciler = new SubscriptionReconciler(this.poolCurator);
 
         i18n = I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK);
-        this.importer = new EntitlementImporter(certSerialCurator, cdnCurator, i18n, pc);
+        this.importer = new EntitlementImporter(certSerialCurator, cdnCurator, i18n, pc, ec);
     }
 
     /*


### PR DESCRIPTION
- The following fields are now again included during manifest import/export:
    - identityCertificate.created
    - identityCertificate.updated
    - identityCertificate.serial.revoked
    - identityCertificate.serial.serial

    - entitlement.startDate
    - entitlement.endDate
    - entitlement.created
    - entitlement.updated

    - entitlement.certificates.created
    - entitlement.certificates.updated

    - entitlement.certificates.serial.revoked
    - entitlement.certificates.serial.serial

    - entitlement.pool.created
    - entitlement.pool.updated
    - entitlement.pool.type
    - entitlement.pool.owner
    - entitlement.pool.activeSubscription
    - entitlement.pool.createdByShare
    - entitlement.pool.hasSharedAncestor
    - entitlement.pool.sourceEntitlement
    - entitlement.pool.quantity
    - entitlement.pool.startDate
    - entitlement.pool.endDate
    - entitlement.pool.attributes
    - entitlement.pool.restrictedToUsername
    - entitlement.pool.consumed
    - entitlement.pool.exported
    - entitlement.pool.shared
    - entitlement.pool.calculatedAttributes
    - entitlement.pool.upstreamPoolId
    - entitlement.pool.upstreamEntitlementId
    - entitlement.pool.upstreamConsumerId
    - entitlement.pool.productAttributes
    - entitlement.pool.derivedProductAttributes
    - entitlement.pool.derivedProductName
    - entitlement.pool.stacked
    - entitlement.pool.stackId
    - entitlement.pool.developmentPool
    - entitlement.pool.sourceStackId
    - entitlement.pool.subscriptionSubKey
    - entitlement.pool.subscriptionId

    - entitlement.pool.branding.id (not to be confused with productId)
    - entitlement.pool.branding.created
    - entitlement.pool.branding.updated

    - consumer.owner.parentOwner
    - consumer.owner.key
    - consumer.owner.displayName
    - consumer.owner.contentPrefix
    - consumer.owner.lastRefreshed
    - consumer.owner.defaultServiceLevel
    - consumer.owner.upstreamConsumer
    - consumer.owner.logLevel
    - consumer.owner.contentAccessMode
    - consumer.owner.contentAccessModeList
    - consumer.owner.created
    - consumer.owner.updated
    - consumer.owner.autobindDisabled

- OwnerDTO and UpstreamConsumerDTO for manifest were also added as nested DTOs.