### PR TITLE
1552777: Add liquibase checksums for 2.1 upgrade

### DIFF
--- a/server/src/main/resources/db/changelog/20161109145238-add-owner-environment-content-access.xml
+++ b/server/src/main/resources/db/changelog/20161109145238-add-owner-environment-content-access.xml
@@ -11,10 +11,12 @@
 
     <changeSet id="20161109145238-1" author="wpoteat">
         <validCheckSum>7:e7d90208e03c95b6b43ff73e4a6c441b</validCheckSum>
+        <validCheckSum>7:bbc2d8aa1f2baa79d636c765a244fee8</validCheckSum>
 
         <comment>add-owner-environment-content-access</comment>
         <createTable tableName="cp_owner_env_content_access">
             <column name="id" type="VARCHAR(32)">
+                <!-- NOTE: in 2.1 primaryKeyName was cp_owner_env_content_access_pkey -->
                 <constraints nullable="false" primaryKey="true" primaryKeyName="cp_owner_ec_access_pkey"/>
             </column>
             <column name="owner_id" type="VARCHAR(32)">
@@ -35,6 +37,8 @@
         <addForeignKeyConstraint baseColumnNames="environment_id" baseTableName="cp_owner_env_content_access" constraintName="fk_owner_env_cont_acc_env" deferrable="false" initiallyDeferred="false" onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="cp_environment" referencesUniqueColumn="false"/>
     </changeSet>
     <changeSet author="wpoteat" id="20161109145238-02">
+        <validCheckSum>7:f0088c7c4134a1161a75334886f85f48</validCheckSum>
+        <!-- NOTE: in 2.1 constraintName was cp_owner_env_content_access_ukey -->
         <addUniqueConstraint columnNames="owner_id, environment_id" constraintName="cp_owner_ec_access_ukey" deferrable="false" disabled="false" initiallyDeferred="false" tableName="cp_owner_env_content_access"/>
     </changeSet>
 

--- a/server/src/main/resources/db/changelog/20170301083925-update-revoked-cert-serial-data.xml
+++ b/server/src/main/resources/db/changelog/20170301083925-update-revoked-cert-serial-data.xml
@@ -14,6 +14,7 @@
 
     <changeSet id="20170301083925-1" author="mstead">
         <validCheckSum>7:e5dc16a5b9672bbdf38bdac361c9d289</validCheckSum>
+        <validCheckSum>7:f6ab674c256df2b2a99789e343daf40b</validCheckSum>
 
         <comment>
             Calculate the value of the field for all known serials


### PR DESCRIPTION
During investigation, I discovered that between 2.1.12 and master, we renamed a primary key and a unique key, which poses risk if we later try to reference either of those objects, but I think this is somewhat unlikely.

I considered adding a changeset to drop and re-create them to ensure they have the same names regardless of whether a user is on a fresh install, or has upgraded from 2.1.12, but I feel it's better to spend effort on testing the upgrade paths, given the low risk, but I can be convinced to open up a separate PR to do so.

I left some comments in the problematic changeset, so that if we do find problems later on, it'll be easier to discover.

Hints for Testing
-----------------

Assuming you have a local postgresql DB set up per the developer instructions from candlepinproject.org...

The following commands put the database in the state of having run 2.1.12 liquibase migrations:

```sh
git checkout candlepin-2.1.12-1
sed -i '/qpid_proton/d' Gemfile  # workaround qpid_proton issues
bundle install; nopo=1 buildr build test=no
dropdb -U candlepin candlepin
createdb -U candlepin candlepin
liquibase --driver=org.postgresql.Driver --classpath=server/src/main/resources/:server/target/classes/:/usr/share/java/postgresql-jdbc.jar --changeLogFile=db/changelog/changelog-create.xml --url=jdbc:postgresql://localhost/candlepin --username=candlepin update -Dcommunity=True
```

The following commands will attempt a liquibase upgrade to 2.3.2-1

```sh
git checkout Gemfile  # undo sed hack
git checkout candlepin-2.3.2-1
sed -i '/qpid_proton/d' Gemfile  # workaround qpid_proton issues
bundle install; nopo=1 buildr build test=no
liquibase --driver=org.postgresql.Driver --classpath=server/src/main/resources/:server/target/classes/:/usr/share/java/postgresql-jdbc.jar --changeLogFile=db/changelog/changelog-update.xml --url=jdbc:postgresql://localhost/candlepin --username=candlepin update -Dcommunity=True
```

or to test the fix, replace the checkout with this branch :-)

```sh
git checkout Gemfile  # undo sed hack
git checkout khowell/liquibase_checksums
sed -i '/qpid_proton/d' Gemfile  # workaround qpid_proton issues
bundle install; nopo=1 buildr build test=no
liquibase --driver=org.postgresql.Driver --classpath=server/src/main/resources/:server/target/classes/:/usr/share/java/postgresql-jdbc.jar --changeLogFile=db/changelog/changelog-update.xml --url=jdbc:postgresql://localhost/candlepin --username=candlepin update -Dcommunity=True
```

You can test with liquibase 3.1 if you have groovy installed by replacing liquibase in the above commands with this script:

```groovy
#!/usr/bin/env groovy
@Grab(group='org.liquibase', module='liquibase-core', version='3.1.0')
@Grab(group='org.yaml', module='snakeyaml', version='1.20')
import liquibase.integration.commandline.Main

Main.main(args);
```

With `bin` on your `PATH`, you can create as `bin/liquibase-3.1`, and then you can simply replace `liquibase` with `liquibase-3.1` in the above commands.