### PR TITLE
[M] 1558060: Added precondition check to add-share-consumer task

### DIFF
--- a/server/src/main/resources/db/changelog/20170206133825-add-share-consumer-type.xml
+++ b/server/src/main/resources/db/changelog/20170206133825-add-share-consumer-type.xml
@@ -7,6 +7,12 @@
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="20170206133825-1" author="awood">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">
+                SELECT COUNT(id) FROM cp_consumer_type WHERE label = 'share'
+            </sqlCheck>
+        </preConditions>
+
         <comment>Add share consumer type</comment>
         <insert tableName="cp_consumer_type">
             <column name="id" value="1008"/>


### PR DESCRIPTION
- Added a pre-condition check to the Liquibase task to add a share
  consumer. This will prevent a failure that could occur in the
  event a consumer type named "share" already exists.