### PR TITLE
[2.1] Correct incorrect punctuation in user messages.

### DIFF
--- a/common/src/main/java/org/candlepin/common/resteasy/filter/PageRequestFilter.java
+++ b/common/src/main/java/org/candlepin/common/resteasy/filter/PageRequestFilter.java
@@ -104,7 +104,7 @@ public class PageRequestFilter implements ContainerRequestFilter {
 
         I18n i18n = this.i18nProvider.get();
         throw new BadRequestException(i18n.tr("the order parameter must be either" +
-                " ''ascending'' or ''descending''"));
+                " \"ascending\" or \"descending\""));
     }
 
     private Integer readInteger(String value) {

--- a/common/src/main/java/org/candlepin/common/validation/CandlepinMessageInterpolator.java
+++ b/common/src/main/java/org/candlepin/common/validation/CandlepinMessageInterpolator.java
@@ -32,60 +32,64 @@ import javax.validation.MessageInterpolator;
 /**
  * CandlepinMessageInterpolator
  */
+@SuppressWarnings("checkstyle:indentation")
 public class CandlepinMessageInterpolator implements MessageInterpolator {
-    @SuppressWarnings("checkstyle:indentation")
-    public static final Map<String, ValidationMessage> MESSAGES =
-        new HashMap<String, ValidationMessage>() {
-            {
-                put("{javax.validation.constraints.AssertFalse.message}",
-                    new ValidationMessage(I18n.marktr("must be false")));
-                put("{javax.validation.constraints.AssertTrue.message}",
-                    new ValidationMessage(I18n.marktr("must be true")));
-                put("{javax.validation.constraints.DigitsMax.message}",
-                    new ValidationMessage(I18n.marktr("must be less than or equal to {0}"), "value"));
-                put("{javax.validation.constraints.DigitsMin.message}",
-                    new ValidationMessage(I18n.marktr("must be greater than or equal to {0}"), "value"));
-                put("{javax.validation.constraints.Digits.message}",
-                    new ValidationMessage(I18n.marktr(
-                        "numeric value out of bounds (<{integer} digits>.<{fraction} digits> expected)"),
-                        "integer", "fraction"));
-                put("{javax.validation.constraints.Future.message}",
-                    new ValidationMessage(I18n.marktr("must be in the future")));
-                put("{javax.validation.constraints.Max.message}",
-                    new ValidationMessage(I18n.marktr("must be less than or equal to {0}"), "value"));
-                put("{javax.validation.constraints.Min.message}",
-                    new ValidationMessage(I18n.marktr("must be greater than or equal to {0}"), "value"));
-                put("{javax.validation.constraints.NotNull.message}",
-                    new ValidationMessage(I18n.marktr("may not be null")));
-                put("{javax.validation.constraints.Null.message}",
-                    new ValidationMessage(I18n.marktr("must be null")));
-                put("{javax.validation.constraints.Past.message}",
-                    new ValidationMessage(I18n.marktr("must be in the past")));
-                put("{javax.validation.constraints.Pattern.message}",
-                    new ValidationMessage(I18n.marktr("must match ''{regexp}''"), "regexp"));
-                put("{javax.validation.constraints.Size.message}",
-                    new ValidationMessage(I18n.marktr("size must be between {0} and {1}"), "min", "max"));
-                put("{org.hibernate.validator.constraints.CreditCardNumber.message}",
-                    new ValidationMessage(I18n.marktr("invalid credit card number")));
-                put("{org.hibernate.validator.constraints.Email.message}",
-                    new ValidationMessage(I18n.marktr("not a well-formed email address")));
-                put("{org.hibernate.validator.constraints.Length.message}",
-                    new ValidationMessage(I18n.marktr("size must be between {0} and {1}"), "min", "max"));
-                put("{org.hibernate.validator.constraints.NotBlank.message}",
-                    new ValidationMessage(I18n.marktr("may not be empty")));
-                put("{org.hibernate.validator.constraints.NotEmpty.message}",
-                    new ValidationMessage(I18n.marktr("may not be empty")));
-                put("{org.hibernate.validator.constraints.Range.message}",
-                    new ValidationMessage(I18n.marktr("must be between {min} and {max}"), "min", "max"));
-                put("{org.hibernate.validator.constraints.SafeHtml.message}",
-                    new ValidationMessage(I18n.marktr("may have unsafe HTML content")));
-                put("{org.hibernate.validator.constraints.ScriptAssert.message}",
-                    new ValidationMessage(I18n.marktr("script expression ''{0}'' didn't evaluate to true"),
-                        "script"));
-                put("{org.hibernate.validator.constraints.URL.message}",
-                    new ValidationMessage(I18n.marktr("must be a valid URL")));
-            }
-        };
+    public static final Map<String, ValidationMessage> MESSAGES;
+
+    static {
+        HashMap<String, ValidationMessage> msgs = new HashMap<String, ValidationMessage>();
+
+        msgs.put("{javax.validation.constraints.AssertFalse.message}",
+            new ValidationMessage(I18n.marktr("must be false")));
+        msgs.put("{javax.validation.constraints.AssertTrue.message}",
+            new ValidationMessage(I18n.marktr("must be true")));
+        msgs.put("{javax.validation.constraints.DigitsMax.message}",
+            new ValidationMessage(I18n.marktr("must be less than or equal to {0}"), "value"));
+        msgs.put("{javax.validation.constraints.DigitsMin.message}",
+            new ValidationMessage(I18n.marktr("must be greater than or equal to {0}"), "value"));
+        msgs.put("{javax.validation.constraints.Digits.message}",
+            new ValidationMessage(I18n.marktr(
+                "numeric value out of bounds (<{integer} digits>.<{fraction} digits> expected)"),
+                "integer", "fraction"));
+        msgs.put("{javax.validation.constraints.Future.message}",
+            new ValidationMessage(I18n.marktr("must be in the future")));
+        msgs.put("{javax.validation.constraints.Max.message}",
+            new ValidationMessage(I18n.marktr("must be less than or equal to {0}"), "value"));
+        msgs.put("{javax.validation.constraints.Min.message}",
+            new ValidationMessage(I18n.marktr("must be greater than or equal to {0}"), "value"));
+        msgs.put("{javax.validation.constraints.NotNull.message}",
+            new ValidationMessage(I18n.marktr("may not be null")));
+        msgs.put("{javax.validation.constraints.Null.message}",
+            new ValidationMessage(I18n.marktr("must be null")));
+        msgs.put("{javax.validation.constraints.Past.message}",
+            new ValidationMessage(I18n.marktr("must be in the past")));
+        msgs.put("{javax.validation.constraints.Pattern.message}",
+            new ValidationMessage(I18n.marktr("must match \"{regexp}\""), "regexp"));
+        msgs.put("{javax.validation.constraints.Size.message}",
+            new ValidationMessage(I18n.marktr("size must be between {0} and {1}"), "min", "max"));
+        msgs.put("{org.hibernate.validator.constraints.CreditCardNumber.message}",
+            new ValidationMessage(I18n.marktr("invalid credit card number")));
+        msgs.put("{org.hibernate.validator.constraints.Email.message}",
+            new ValidationMessage(I18n.marktr("not a well-formed email address")));
+        msgs.put("{org.hibernate.validator.constraints.Length.message}",
+            new ValidationMessage(I18n.marktr("size must be between {0} and {1}"), "min", "max"));
+        msgs.put("{org.hibernate.validator.constraints.NotBlank.message}",
+            new ValidationMessage(I18n.marktr("may not be empty")));
+        msgs.put("{org.hibernate.validator.constraints.NotEmpty.message}",
+            new ValidationMessage(I18n.marktr("may not be empty")));
+        msgs.put("{org.hibernate.validator.constraints.Range.message}",
+            new ValidationMessage(I18n.marktr("must be between {min} and {max}"), "min", "max"));
+        msgs.put("{org.hibernate.validator.constraints.SafeHtml.message}",
+            new ValidationMessage(I18n.marktr("may have unsafe HTML content")));
+        msgs.put("{org.hibernate.validator.constraints.ScriptAssert.message}",
+            new ValidationMessage(I18n.marktr("script expression \"{0}\" didn't evaluate to true"),
+                "script"));
+        msgs.put("{org.hibernate.validator.constraints.URL.message}",
+            new ValidationMessage(I18n.marktr("must be a valid URL")));
+
+
+        MESSAGES = Collections.<String, ValidationMessage>unmodifiableMap(msgs);
+    }
 
     /**
      * Validation message
@@ -134,8 +138,7 @@ public class CandlepinMessageInterpolator implements MessageInterpolator {
     }
 
     @Override
-    public String interpolate(String messageTemplate, Context context,
-        Locale locale) {
+    public String interpolate(String messageTemplate, Context context, Locale locale) {
         Map<String, Object> attrs = context.getConstraintDescriptor().getAttributes();
 
         ValidationMessage validationMessage = MESSAGES.get(messageTemplate);

--- a/server/spec/autobind_disabled_for_owner_spec.rb
+++ b/server/spec/autobind_disabled_for_owner_spec.rb
@@ -24,7 +24,7 @@ describe 'Autobind Disabled On Owner' do
       @consumer_cp.consume_product()
     rescue RestClient::BadRequest => e
       exception_thrown = true
-      ex_message = "Ignoring request to auto-attach. It is disabled for org '#{@owner['key']}'."
+      ex_message = "Ignoring request to auto-attach. It is disabled for org \"#{@owner['key']}\"."
       data = JSON.parse(e.response)
       data['displayMessage'].should == ex_message
     end

--- a/server/spec/consumer_resource_dev_spec.rb
+++ b/server/spec/consumer_resource_dev_spec.rb
@@ -88,7 +88,7 @@ it 'should not allow entitlement for consumer past expiration' do
     consumer = @user.register(random_string('system'), type=:system, nil, facts = {:dev_sku => "dev_product"}, @username,
               @owner['key'], [], [], nil, [], nil, [], created_date)
     consumer_client = Candlepin.new(nil, nil, consumer['idCert']['cert'], consumer['idCert']['key'])
-    expected_error = "Unable to attach subscription for the product 'dev_product': Subscriptions for dev_product expired on:"
+    expected_error = "Unable to attach subscription for the product \"dev_product\": Subscriptions for dev_product expired on:"
     begin
         consumer_client.consume_product()
         fail("Expected Forbidden since consumer is older than product expiry")

--- a/server/spec/derived_product_spec.rb
+++ b/server/spec/derived_product_spec.rb
@@ -186,7 +186,7 @@ describe 'Derived Products' do
   end
 
   it 'prevents distributor from attaching without necessisary capabilities' do
-    expected_error = "Unit does not support derived products data required by pool '%s'" % @main_pool['id']
+    expected_error = "Unit does not support derived products data required by pool \"%s\"" % @main_pool['id']
     begin
         @distributor_client.consume_pool @main_pool['id']
         fail("Expected Forbidden since distributor does not have capability")

--- a/server/spec/healing_spec.rb
+++ b/server/spec/healing_spec.rb
@@ -165,7 +165,7 @@ describe 'Healing' do
       consumer_cp.consume_product()
     rescue RestClient::BadRequest => e
       exception_thrown = true
-      ex_message = "Ignoring request to auto-attach. It is disabled for org '#{owner['key']}'."
+      ex_message = "Ignoring request to auto-attach. It is disabled for org \"#{owner['key']}\"."
       data = JSON.parse(e.response)
       data['displayMessage'].should == ex_message
     end

--- a/server/src/main/java/org/candlepin/controller/Entitler.java
+++ b/server/src/main/java/org/candlepin/controller/Entitler.java
@@ -204,7 +204,7 @@ public class Entitler {
         if (!consumer.isDev() && owner.autobindDisabled()) {
             log.info("Skipping auto-attach for consumer '{}'. Auto-attach is disabled for owner {}.",
                 consumer, owner.getKey());
-            throw new AutobindDisabledForOwnerException(i18n.tr("Auto-attach is disabled for owner '{0}'.",
+            throw new AutobindDisabledForOwnerException(i18n.tr("Auto-attach is disabled for owner \"{0}\".",
                 owner.getKey()));
         }
 
@@ -465,13 +465,13 @@ public class Entitler {
 
         if (!devProducts.foundSku()) {
             throw new ForbiddenException(i18n.tr("SKU product not available to this " +
-                "development unit: ''{0}''", expectedSku));
+                "development unit: \"{0}\"", expectedSku));
         }
 
         for (ConsumerInstalledProduct ip : consumer.getInstalledProducts()) {
             if (!devProducts.containsProduct(ip.getProductId())) {
                 log.warn(i18n.tr("Installed product not available to this " +
-                    "development unit: ''{0}''", ip.getProductId()));
+                    "development unit: \"{0}\"", ip.getProductId()));
             }
         }
     }

--- a/server/src/main/java/org/candlepin/controller/ManifestManager.java
+++ b/server/src/main/java/org/candlepin/controller/ManifestManager.java
@@ -297,7 +297,7 @@ public class ManifestManager {
         if (consumer.getType() == null ||
             !consumer.isManifestDistributor()) {
             throw new ForbiddenException(
-                i18n.tr("Unit {0} cannot be exported. A manifest cannot be made for units of type ''{1}''.",
+                i18n.tr("Unit {0} cannot be exported. A manifest cannot be made for units of type \"{1}\".",
                     consumerUuid, consumer.getType().getLabel()));
         }
 

--- a/server/src/main/java/org/candlepin/hostedtest/HostedTestSubscriptionResource.java
+++ b/server/src/main/java/org/candlepin/hostedtest/HostedTestSubscriptionResource.java
@@ -277,9 +277,7 @@ public class HostedTestSubscriptionResource {
         Product product = this.ownerProductCurator.getProductById(owner, productId);
 
         if (product == null) {
-            throw new NotFoundException(
-                i18n.tr("Product with ID ''{0}'' could not be found.", productId)
-            );
+            throw new NotFoundException(i18n.tr("Product with ID \"{0}\" could not be found.", productId));
         }
 
         return product;

--- a/server/src/main/java/org/candlepin/model/ConsumerCurator.java
+++ b/server/src/main/java/org/candlepin/model/ConsumerCurator.java
@@ -677,7 +677,7 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
         Consumer consumer = this.findByUuid(consumerUuid);
 
         if (consumer == null) {
-            throw new NotFoundException(i18n.tr("Unit with ID ''{0}'' could not be found.", consumerUuid));
+            throw new NotFoundException(i18n.tr("Unit with ID \"{0}\" could not be found.", consumerUuid));
         }
 
         return consumer;
@@ -686,7 +686,7 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
     public Consumer verifyAndLookupConsumerWithEntitlements(String consumerUuid) {
         Consumer consumer = this.findByUuid(consumerUuid);
         if (consumer == null) {
-            throw new NotFoundException(i18n.tr("Unit with ID ''{0}'' could not be found.", consumerUuid));
+            throw new NotFoundException(i18n.tr("Unit with ID \"{0}\" could not be found.", consumerUuid));
         }
 
         for (Entitlement e : consumer.getEntitlements()) {

--- a/server/src/main/java/org/candlepin/model/EntitlementCurator.java
+++ b/server/src/main/java/org/candlepin/model/EntitlementCurator.java
@@ -419,7 +419,7 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
             Product p = this.ownerProductCurator.getProductById(owner, productId);
             if (p == null) {
                 throw new BadRequestException(i18n.tr(
-                    "Product with ID ''{0}'' could not be found.", productId));
+                    "Product with ID \"{0}\" could not be found.", productId));
             }
             entitlementsPage = listByProduct(object, objectType, productId, pageRequest);
         }

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/HypervisorUpdateJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/HypervisorUpdateJob.java
@@ -197,7 +197,7 @@ public class HypervisorUpdateJob extends KingpinJob {
             Owner owner = ownerCurator.lookupByKey(ownerKey);
             if (owner == null) {
                 context.setResult("Nothing to do. Owner does not exist");
-                log.warn("Hypervisor update attempted against non-existent org id ''{0}''", ownerKey);
+                log.warn("Hypervisor update attempted against non-existent org id \"{0}\"", ownerKey);
                 return;
             }
 

--- a/server/src/main/java/org/candlepin/policy/js/activationkey/ActivationKeyRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/activationkey/ActivationKeyRules.java
@@ -76,10 +76,10 @@ public class ActivationKeyRules {
         String msg;
         if (error.equals("rulefailed.actkey.cannot.use.person.pools")) {
             msg = i18n.tr("Cannot add pools that are " +
-                "restricted to unit type ''person'' to activation keys.");
+                "restricted to unit type \"person\" to activation keys.");
         }
         else if (error.equals("rulefailed.already.exists")) {
-            msg = i18n.tr("Multi-entitlement not supported for pool ''{0}''", pool.getId());
+            msg = i18n.tr("Multi-entitlement not supported for pool \"{0}\"", pool.getId());
         }
         else if (error.equals("rulefailed.invalid.nonmultient.quantity")) {
             msg = i18n.tr("Error: Only pools with multi-entitlement product" +

--- a/server/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRules.java
@@ -373,7 +373,7 @@ public class EntitlementRules implements Enforcer {
 
         if (tokens.length < 3) {
             throw new IllegalArgumentException(
-                i18n.tr("''{0}'' Should contain name, priority and at least one attribute", toParse));
+                i18n.tr("\"{0}\" Should contain name, priority and at least one attribute", toParse));
         }
 
         Set<String> attributes = new HashSet<String>();

--- a/server/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRulesTranslator.java
+++ b/server/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRulesTranslator.java
@@ -154,49 +154,49 @@ public class EntitlementRulesTranslator {
         POOL_ERROR_MESSAGES = new HashMap<String, String>();
 
         POOL_ERROR_MESSAGES.put(PoolErrorKeys.ALREADY_ATTACHED,
-            I18n.marktr("This unit has already had the subscription matching pool ID ''{1}'' attached."));
+            I18n.marktr("This unit has already had the subscription matching pool ID \"{1}\" attached."));
         POOL_ERROR_MESSAGES.put(PoolErrorKeys.NO_ENTITLEMENTS_AVAILABLE,
-            I18n.marktr("No subscriptions are available from the pool with ID ''{1}''."));
+            I18n.marktr("No subscriptions are available from the pool with ID \"{1}\"."));
         POOL_ERROR_MESSAGES.put(PoolErrorKeys.CONSUMER_TYPE_MISMATCH,
-            I18n.marktr("Units of this type are not allowed to attach the pool with ID ''{1}''."));
+            I18n.marktr("Units of this type are not allowed to attach the pool with ID \"{1}\"."));
         POOL_ERROR_MESSAGES.put(PoolErrorKeys.MULTI_ENTITLEMENT_UNSUPPORTED,
-            I18n.marktr("Multi-entitlement not supported for pool with ID ''{1}''."));
+            I18n.marktr("Multi-entitlement not supported for pool with ID \"{1}\"."));
         POOL_ERROR_MESSAGES.put(PoolErrorKeys.VIRT_HOST_MISMATCH,
-            I18n.marktr("Pool ''{1}'' is restricted to guests running on host: ''{4}''."));
+            I18n.marktr("Pool \"{1}\" is restricted to guests running on host: \"{4}\"."));
         POOL_ERROR_MESSAGES.put(PoolErrorKeys.CONSUMER_MISMATCH,
-            I18n.marktr("Pool ''{1}'' is restricted to a specific consumer."));
+            I18n.marktr("Pool \"{1}\" is restricted to a specific consumer."));
         POOL_ERROR_MESSAGES.put(PoolErrorKeys.RESTRICTED_POOL,
             I18n.marktr("Pool not available to subscription management applications."));
         POOL_ERROR_MESSAGES.put(PoolErrorKeys.VIRT_ONLY,
-            I18n.marktr("Pool is restricted to virtual guests: ''{1}''."));
+            I18n.marktr("Pool is restricted to virtual guests: \"{1}\"."));
         POOL_ERROR_MESSAGES.put(PoolErrorKeys.PHYSICAL_ONLY,
-            I18n.marktr("Pool is restricted to physical systems: ''{1}''."));
+            I18n.marktr("Pool is restricted to physical systems: \"{1}\"."));
         POOL_ERROR_MESSAGES.put(PoolErrorKeys.QUANTITY_MISMATCH,
-            I18n.marktr("Subscription ''{2}'' must be attached using a quantity evenly divisible by {3}"));
+            I18n.marktr("Subscription \"{2}\" must be attached using a quantity evenly divisible by {3}"));
         POOL_ERROR_MESSAGES.put(PoolErrorKeys.INSTANCE_UNSUPPORTED_BY_CONSUMER,
-            I18n.marktr("Unit does not support instance based calculation required by pool ''{1}''"));
+            I18n.marktr("Unit does not support instance based calculation required by pool \"{1}\""));
         POOL_ERROR_MESSAGES.put(PoolErrorKeys.BAND_UNSUPPORTED_BY_CONSUMER,
-            I18n.marktr("Unit does not support band calculation required by pool ''{1}''"));
+            I18n.marktr("Unit does not support band calculation required by pool \"{1}\""));
         POOL_ERROR_MESSAGES.put(PoolErrorKeys.CORES_UNSUPPORTED_BY_CONSUMER,
-            I18n.marktr("Unit does not support core calculation required by pool ''{1}''"));
+            I18n.marktr("Unit does not support core calculation required by pool \"{1}\""));
         POOL_ERROR_MESSAGES.put(PoolErrorKeys.RAM_UNSUPPORTED_BY_CONSUMER,
-            I18n.marktr("Unit does not support RAM calculation required by pool ''{1}''"));
+            I18n.marktr("Unit does not support RAM calculation required by pool \"{1}\""));
         POOL_ERROR_MESSAGES.put(PoolErrorKeys.DERIVED_PRODUCT_DATA_UNSUPPORTED,
-            I18n.marktr("Unit does not support derived products data required by pool ''{1}''"));
+            I18n.marktr("Unit does not support derived products data required by pool \"{1}\""));
         POOL_ERROR_MESSAGES.put(PoolErrorKeys.UNMAPPED_GUEST_RESTRICTED,
-            I18n.marktr("Pool is restricted to unmapped virtual guests: ''{1}''"));
+            I18n.marktr("Pool is restricted to unmapped virtual guests: \"{1}\""));
         POOL_ERROR_MESSAGES.put(PoolErrorKeys.VIRTUAL_GUEST_RESTRICTED,
-            I18n.marktr("Pool is restricted to virtual guests in their first day of existence: ''{1}''"));
+            I18n.marktr("Pool is restricted to virtual guests in their first day of existence: \"{1}\""));
         POOL_ERROR_MESSAGES.put(PoolErrorKeys.SHARING_A_SHARE,
-            I18n.marktr("Pool ''{1}'' is a shared pool and sharing a shared pool is prohibited."));
+            I18n.marktr("Pool \"{1}\" is a shared pool and sharing a shared pool is prohibited."));
         POOL_ERROR_MESSAGES.put(PoolErrorKeys.SHARING_DEVELOPMENT_POOL,
-            I18n.marktr("Pool ''{1}'' is a development pool and sharing it is prohibited."));
+            I18n.marktr("Pool \"{1}\" is a development pool and sharing it is prohibited."));
         POOL_ERROR_MESSAGES.put(PoolErrorKeys.SHARING_UNMAPPED_GUEST_POOL,
-            I18n.marktr("Pool ''{1}'' is an unmapped guest pool and sharing it is prohibited."));
+            I18n.marktr("Pool \"{1}\" is an unmapped guest pool and sharing it is prohibited."));
         POOL_ERROR_MESSAGES.put(PoolErrorKeys.TEMPORARY_FUTURE_POOL,
-            I18n.marktr("Pool is restricted when it is temporary and begins in the future: ''{1}''"));
+            I18n.marktr("Pool is restricted when it is temporary and begins in the future: \"{1}\""));
         DEFAULT_POOL_ERROR_MESSAGE =
-            I18n.marktr("Unable to attach pool with ID ''{1}''.: {0}.");
+            I18n.marktr("Unable to attach pool with ID \"{1}\".: {0}.");
 
         // Product error messages can contain the following variables
         // {0} - Error key
@@ -204,15 +204,15 @@ public class EntitlementRulesTranslator {
         PRODUCT_ERROR_MESSAGES = new HashMap<String, String>();
 
         PRODUCT_ERROR_MESSAGES.put(ProductErrorKeys.ALREADY_ATTACHED,
-            I18n.marktr("This system already has a subscription for the product ''{1}'' attached."));
+            I18n.marktr("This system already has a subscription for the product \"{1}\" attached."));
         PRODUCT_ERROR_MESSAGES.put(ProductErrorKeys.NO_ENTITLEMENTS_AVAILABLE,
-            I18n.marktr("There are not enough free subscriptions available for the product ''{1}''"));
+            I18n.marktr("There are not enough free subscriptions available for the product \"{1}\""));
         PRODUCT_ERROR_MESSAGES.put(ProductErrorKeys.CONSUMER_TYPE_MISMATCH,
-            I18n.marktr("Units of this type are not allowed for the product ''{1}''."));
+            I18n.marktr("Units of this type are not allowed for the product \"{1}\"."));
         PRODUCT_ERROR_MESSAGES.put(ProductErrorKeys.VIRT_ONLY,
-            I18n.marktr("Only virtual systems can have subscription ''{1}'' attached."));
+            I18n.marktr("Only virtual systems can have subscription \"{1}\" attached."));
         DEFAULT_PRODUCT_ERROR_MESSAGE =
-            I18n.marktr("Unable to attach subscription for the product ''{1}'': {0}.");
+            I18n.marktr("Unable to attach subscription for the product \"{1}\": {0}.");
 
         // Entitlement error messages can contain the following variables
         // {0} - Error key
@@ -220,13 +220,13 @@ public class EntitlementRulesTranslator {
         ENTITLEMENT_ERROR_MESSAGES = new HashMap<String, String>();
 
         ENTITLEMENT_ERROR_MESSAGES.put(EntitlementErrorKeys.INSUFFICIENT_QUANTITY,
-            I18n.marktr("Insufficient pool quantity available for adjustment to entitlement ''{1}''."));
+            I18n.marktr("Insufficient pool quantity available for adjustment to entitlement \"{1}\"."));
         ENTITLEMENT_ERROR_MESSAGES.put(EntitlementErrorKeys.MULTI_ENTITLEMENT_UNSUPPORTED,
-            I18n.marktr("Multi-entitlement not supported for pool connected with entitlement ''{1}''."));
+            I18n.marktr("Multi-entitlement not supported for pool connected with entitlement \"{1}\"."));
         ENTITLEMENT_ERROR_MESSAGES.put(EntitlementErrorKeys.ALREADY_ATTACHED,
-            I18n.marktr("Multi-entitlement not supported for pool connected with entitlement ''{1}''."));
+            I18n.marktr("Multi-entitlement not supported for pool connected with entitlement \"{1}\"."));
         DEFAULT_ENTITLEMENT_ERROR_MESSAGE =
-            I18n.marktr("Unable to adjust quantity for the entitlement with id ''{1}'': {0}");
+            I18n.marktr("Unable to adjust quantity for the entitlement with id \"{1}\": {0}");
     }
 
     private static String getPoolErrorMessage(String key) {

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -683,7 +683,7 @@ public class ConsumerResource {
         if (type.isType(ConsumerTypeEnum.PERSON)) {
             if (keys.size() > 0) {
                 throw new BadRequestException(
-                        i18n.tr("A unit type of ''person'' cannot be used with activation keys"));
+                    i18n.tr("A unit type of \"person\" cannot be used with activation keys"));
             }
 
             if (!isConsumerPersonNameValid(consumer.getName())) {
@@ -847,7 +847,7 @@ public class ConsumerResource {
         ActivationKey key = activationKeyCurator.lookupForOwner(keyName, owner);
 
         if (key == null) {
-            throw new NotFoundException(i18n.tr("Activation key ''{0}'' not found for organization ''{1}''.",
+            throw new NotFoundException(i18n.tr("Activation key \"{0}\" not found for organization \"{1}\".",
                 keyName, owner.getKey()));
         }
 
@@ -866,13 +866,13 @@ public class ConsumerResource {
         }
 
         if (user == null) {
-            throw new NotFoundException(i18n.tr("User with ID ''{0}'' could not be found."));
+            throw new NotFoundException(i18n.tr("User with ID \"{0}\" could not be found."));
         }
 
         // When registering person consumers we need to be sure the username
         // has some association with the owner the consumer is destined for:
         if (!principal.canAccess(owner, SubResource.NONE, Access.ALL) && !principal.hasFullAccess()) {
-            throw new ForbiddenException(i18n.tr("User ''{0}'' has no roles for organization ''{1}''",
+            throw new ForbiddenException(i18n.tr("User \"{0}\" has no roles for organization \"{1}\"",
                 user.getUsername(), owner.getKey()));
         }
 
@@ -883,7 +883,7 @@ public class ConsumerResource {
             if (existing != null && existing.getType().isType(ConsumerTypeEnum.PERSON)) {
                 // TODO: This is not the correct error code for this situation!
                 throw new BadRequestException(
-                    i18n.tr("User ''{0}'' has already registered a personal consumer", user.getUsername()));
+                    i18n.tr("User \"{0}\" has already registered a personal consumer", user.getUsername()));
             }
 
             consumer.setName(user.getUsername());
@@ -983,7 +983,7 @@ public class ConsumerResource {
         ConsumerType type = consumerTypeCurator.lookupByLabel(label);
 
         if (type == null) {
-            throw new BadRequestException(i18n.tr("Unit type ''{0}'' could not be found.", label));
+            throw new BadRequestException(i18n.tr("Unit type \"{0}\" could not be found.", label));
         }
 
         return type;
@@ -1105,7 +1105,7 @@ public class ConsumerResource {
             Environment e = environmentCurator.find(environmentId);
             if (e == null) {
                 throw new NotFoundException(i18n.tr(
-                    "Environment with ID ''{0}'' could not be found.", environmentId));
+                    "Environment with ID \"{0}\" could not be found.", environmentId));
             }
             log.info("Updating environment to: {}", environmentId);
             toUpdate.setEnvironment(e);
@@ -1785,7 +1785,7 @@ public class ConsumerResource {
             }
             catch (AutobindDisabledForOwnerException e) {
                 throw new BadRequestException(i18n.tr("Ignoring request to auto-attach. " +
-                    "It is disabled for org ''{0}''.", consumer.getOwner().getKey()));
+                    "It is disabled for org \"{0}\".", consumer.getOwner().getKey()));
             }
         }
 
@@ -1854,7 +1854,7 @@ public class ConsumerResource {
 
         if (entitlement == null) {
             throw new NotFoundException(i18n.tr(
-                "Entitlement with ID ''{0}'' could not be found.", entitlementId));
+                "Entitlement with ID \"{0}\" could not be found.", entitlementId));
         }
         return entitlement;
     }
@@ -1961,7 +1961,7 @@ public class ConsumerResource {
         }
 
         throw new NotFoundException(i18n.tr(
-            "Entitlement with ID ''{0}'' could not be found.", dbid
+            "Entitlement with ID \"{0}\" could not be found.", dbid
         ));
     }
 
@@ -1984,7 +1984,7 @@ public class ConsumerResource {
             return;
         }
         throw new NotFoundException(i18n.tr(
-            "Entitlement Certificate with serial number ''{0}'' could not be found.",
+            "Entitlement Certificate with serial number \"{0}\" could not be found.",
             serial.toString())); // prevent serial number formatting.
     }
 
@@ -2006,7 +2006,7 @@ public class ConsumerResource {
         }
         else {
             throw new NotFoundException(i18n.tr(
-                "No entitlements for consumer ''{0}'' with pool id ''{1}''", consumerUuid, poolId));
+                "No entitlements for consumer \"{0}\" with pool id \"{1}\"", consumerUuid, poolId));
         }
     }
 
@@ -2444,7 +2444,7 @@ public class ConsumerResource {
     public void removeDeletionRecord(@PathParam("consumer_uuid") String uuid) {
         DeletedConsumer dc = deletedConsumerCurator.findByConsumerUuid(uuid);
         if (dc == null) {
-            throw new NotFoundException(i18n.tr("Deletion record for hypervisor ''{0}'' not found.", uuid));
+            throw new NotFoundException(i18n.tr("Deletion record for hypervisor \"{0}\" not found.", uuid));
         }
 
         deletedConsumerCurator.delete(dc);

--- a/server/src/main/java/org/candlepin/resource/ConsumerTypeResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerTypeResource.java
@@ -82,9 +82,7 @@ public class ConsumerTypeResource {
             return toReturn;
         }
 
-        throw new NotFoundException(
-            i18n.tr("Unit type with id ''{0}'' could not be found.", id)
-        );
+        throw new NotFoundException(i18n.tr("Unit type with id \"{0}\" could not be found.", id));
     }
 
     @ApiOperation(notes = "Creates a Consumer Type", value = "create")
@@ -132,8 +130,7 @@ public class ConsumerTypeResource {
         ConsumerType type = consumerTypeCurator.find(id);
 
         if (type == null) {
-            throw new BadRequestException(
-                i18n.tr("Unit type with id {0} could not be found.", id));
+            throw new BadRequestException(i18n.tr("Unit type with id {0} could not be found.", id));
         }
 
         consumerTypeCurator.delete(type);

--- a/server/src/main/java/org/candlepin/resource/EntitlementResource.java
+++ b/server/src/main/java/org/candlepin/resource/EntitlementResource.java
@@ -111,8 +111,7 @@ public class EntitlementResource {
 
     private void verifyExistence(Object o, String id) {
         if (o == null) {
-            throw new RuntimeException(
-                i18n.tr("Object with ID ''{0}'' could not found.", id));
+            throw new RuntimeException(i18n.tr("Object with ID \"{0}\" could not found.", id));
         }
     }
 
@@ -134,7 +133,7 @@ public class EntitlementResource {
         }
 
         throw new NotFoundException(i18n.tr(
-            "Unit ''{0}'' has no subscription for product ''{1}''.",
+            "Unit \"{0}\" has no subscription for product \"{1}\".",
                 consumerUuid, productId));
     }
 
@@ -156,7 +155,7 @@ public class EntitlementResource {
             Consumer consumer = consumerCurator.findByUuid(consumerUuid);
             if (consumer == null) {
                 throw new BadRequestException(
-                    i18n.tr("Unit with ID ''{0}'' could not be found.", consumerUuid));
+                    i18n.tr("Unit with ID \"{0}\" could not be found.", consumerUuid));
             }
             p = entitlementCurator.listByConsumer(consumer, null, filters, pageRequest);
         }
@@ -181,7 +180,7 @@ public class EntitlementResource {
 
         if (entitlement == null) {
             throw new NotFoundException(
-                i18n.tr("Entitlement with ID ''{0}'' could not be found.", entitlementId)
+                i18n.tr("Entitlement with ID \"{0}\" could not be found.", entitlementId)
             );
         }
 
@@ -221,8 +220,7 @@ public class EntitlementResource {
             }
         }
         else {
-            throw new NotFoundException(
-                i18n.tr("Entitlement with ID ''{0}'' could not be found.", id));
+            throw new NotFoundException(i18n.tr("Entitlement with ID \"{0}\" could not be found.", id));
         }
     }
 
@@ -241,7 +239,7 @@ public class EntitlementResource {
         Entitlement ent = entitlementCurator.find(entitlementId);
         if (ent == null) {
             throw new NotFoundException(i18n.tr(
-                "Entitlement with ID ''{0}'' could not be found.", entitlementId));
+                "Entitlement with ID \"{0}\" could not be found.", entitlementId));
         }
 
         Pool entPool = ent.getPool();
@@ -282,7 +280,7 @@ public class EntitlementResource {
             return;
         }
         throw new NotFoundException(
-            i18n.tr("Entitlement with ID ''{0}'' could not be found.", dbid));
+            i18n.tr("Entitlement with ID \"{0}\" could not be found.", dbid));
     }
 
     @ApiOperation(notes = "Regenerates the Entitlement Certificates for a Product",
@@ -333,12 +331,12 @@ public class EntitlementResource {
                 Consumer destinationConsumer = consumerCurator.verifyAndLookupConsumer(uuid);
                 if (!sourceConsumer.isManifestDistributor()) {
                     throw new BadRequestException(i18n.tr(
-                        "Entitlement migration is not permissible for units of type ''{0}''",
+                        "Entitlement migration is not permissible for units of type \"{0}\"",
                         sourceConsumer.getType().getLabel()));
                 }
                 if (!destinationConsumer.isManifestDistributor()) {
                     throw new BadRequestException(i18n.tr(
-                        "Entitlement migration is not permissible for units of type ''{0}''",
+                        "Entitlement migration is not permissible for units of type \"{0}\"",
                         destinationConsumer.getType().getLabel()));
                 }
                 if (!sourceConsumer.getOwner().getKey().equals(destinationConsumer.getOwner().getKey())) {
@@ -377,7 +375,7 @@ public class EntitlementResource {
         }
         else {
             throw new NotFoundException(
-                i18n.tr("Entitlement with ID ''{0}'' could not be found.", id));
+                i18n.tr("Entitlement with ID \"{0}\" could not be found.", id));
         }
         return Response.status(Response.Status.OK)
                 .type(MediaType.APPLICATION_JSON).entity(entitlements).build();

--- a/server/src/main/java/org/candlepin/resource/EventResource.java
+++ b/server/src/main/java/org/candlepin/resource/EventResource.java
@@ -86,6 +86,6 @@ public class EventResource {
             return toReturn;
         }
 
-        throw new NotFoundException(i18n.tr("Event with ID ''{0}'' could not be found.", uuid));
+        throw new NotFoundException(i18n.tr("Event with ID \"{0}\" could not be found.", uuid));
     }
 }

--- a/server/src/main/java/org/candlepin/resource/HypervisorResource.java
+++ b/server/src/main/java/org/candlepin/resource/HypervisorResource.java
@@ -194,7 +194,7 @@ public class HypervisorResource {
                     if (!createMissing) {
                         log.info("Unable to find hypervisor with id {} in org {}", hypervisorId, ownerKey);
                         result.failed(hypervisorId, i18n.tr(
-                            "Unable to find hypervisor in org ''{0}''", ownerKey));
+                            "Unable to find hypervisor in org \"{0}\"", ownerKey));
                         continue;
                     }
                     log.debug("Registering new host consumer for hypervisor ID: {}", hypervisorId);

--- a/server/src/main/java/org/candlepin/resource/OwnerProductResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerProductResource.java
@@ -153,9 +153,7 @@ public class OwnerProductResource {
         Product product = this.ownerProductCurator.getProductById(owner, productId);
 
         if (product == null) {
-            throw new NotFoundException(
-                i18n.tr("Product with ID ''{0}'' could not be found.", productId)
-            );
+            throw new NotFoundException(i18n.tr("Product with ID \"{0}\" could not be found.", productId));
         }
 
         return product;
@@ -395,11 +393,7 @@ public class OwnerProductResource {
 
         if (this.productCurator.productHasSubscriptions(owner, product)) {
             throw new BadRequestException(
-                i18n.tr(
-                    "Product with ID ''{0}'' cannot be deleted while subscriptions exist.",
-                    productId
-                )
-            );
+                i18n.tr("Product with ID \"{0}\" cannot be deleted while subscriptions exist.", productId));
         }
 
         this.productManager.removeProduct(owner, product);

--- a/server/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -380,8 +380,8 @@ public class OwnerResource {
 
         if (!force && consumerCurator.doesShareConsumerExist(owner)) {
             throw new BadRequestException(
-                i18n.tr("owner ''{0}'' cannot be deleted while there is a share consumer. " +
-                    "You may use 'force' to bypass.", owner.getKey()));
+                i18n.tr("owner \"{0}\" cannot be deleted while there is a share consumer. " +
+                    "You may use \"force\" to bypass.", owner.getKey()));
         }
 
         try {
@@ -551,13 +551,13 @@ public class OwnerResource {
 
         if (!testName.matches("[a-zA-Z0-9]*")) {
             throw new BadRequestException(
-                i18n.tr("The activation key name ''{0}'' must be alphanumeric or " +
-                    "include the characters ''-'' or ''_''", activationKey.getName()));
+                i18n.tr("The activation key name \"{0}\" must be alphanumeric or " +
+                    "include the characters \"-\" or \"_\"", activationKey.getName()));
         }
 
         if (activationKeyCurator.lookupForOwner(activationKey.getName(), owner) != null) {
             throw new BadRequestException(
-                i18n.tr("The activation key name ''{0}'' is already in use for owner {1}",
+                i18n.tr("The activation key name \"{0}\" is already in use for owner {1}",
                     activationKey.getName(), ownerKey));
         }
 

--- a/server/src/main/java/org/candlepin/resource/PoolResource.java
+++ b/server/src/main/java/org/candlepin/resource/PoolResource.java
@@ -225,7 +225,7 @@ public class PoolResource {
         }
 
         throw new NotFoundException(i18n.tr(
-            "Subscription Pool with ID ''{0}'' could not be found.", id));
+            "Subscription Pool with ID \"{0}\" could not be found.", id));
     }
 
     @ApiOperation(notes = "Remove a Pool", value = "deletePool")
@@ -237,7 +237,7 @@ public class PoolResource {
         Pool pool = poolManager.find(id);
         if (pool == null) {
             throw new NotFoundException(i18n.tr(
-                "Entitlement Pool with ID ''{0}'' could not be found.", id));
+                "Entitlement Pool with ID \"{0}\" could not be found.", id));
         }
 
         poolManager.deletePool(pool);
@@ -255,7 +255,7 @@ public class PoolResource {
 
         if (pool == null) {
             throw new NotFoundException(i18n.tr(
-                "Subscription Pool with ID ''{0}'' could not be found.", id));
+                "Subscription Pool with ID \"{0}\" could not be found.", id));
         }
 
         return pool.getCdn();
@@ -274,12 +274,11 @@ public class PoolResource {
 
         if (pool == null) {
             throw new NotFoundException(i18n.tr(
-                "Subscription Pool with ID ''{0}'' could not be found.", id));
+                "Subscription Pool with ID \"{0}\" could not be found.", id));
         }
 
         List<Entitlement> entitlements = new ArrayList<Entitlement>();
         entitlements.addAll(pool.getEntitlements());
         return entitlements;
     }
-
 }

--- a/server/src/main/java/org/candlepin/resource/ProductResource.java
+++ b/server/src/main/java/org/candlepin/resource/ProductResource.java
@@ -103,7 +103,7 @@ public class ProductResource {
 
         if (product == null) {
             throw new NotFoundException(
-                i18n.tr("Product with UUID ''{0}'' could not be found.", productUuid)
+                i18n.tr("Product with UUID \"{0}\" could not be found.", productUuid)
             );
         }
 

--- a/server/src/main/java/org/candlepin/resource/util/ConsumerBindUtil.java
+++ b/server/src/main/java/org/candlepin/resource/util/ConsumerBindUtil.java
@@ -129,7 +129,7 @@ public class ConsumerBindUtil {
                 onePassed = true;
             }
             catch (ForbiddenException e) {
-                log.warn(i18n.tr("Cannot bind to pool ''{0}'' in activation key ''{1}'': {2}",
+                log.warn(i18n.tr("Cannot bind to pool \"{0}\" in activation key \"{1}\": {2}",
                     akp.getPool().getId(), akp.getKey().getName(), e.getMessage()));
             }
         }

--- a/server/src/main/java/org/candlepin/util/ServiceLevelValidator.java
+++ b/server/src/main/java/org/candlepin/util/ServiceLevelValidator.java
@@ -64,10 +64,11 @@ public class ServiceLevelValidator {
                 }
             }
         }
+
         if (!invalidServiceLevels.isEmpty()) {
-            String error = i18n.tr("Service level ''{0}'' is not available " +
-                "to units of organization {1}.",
+            String error = i18n.tr("Service level \"{0}\" is not available to units of organization {1}.",
                 StringUtils.join(invalidServiceLevels, ", "), owner.getKey());
+
             throw new BadRequestException(error);
         }
     }

--- a/server/src/test/java/org/candlepin/controller/EntitlerTest.java
+++ b/server/src/test/java/org/candlepin/controller/EntitlerTest.java
@@ -319,8 +319,7 @@ public class EntitlerTest {
 
     @Test
     public void consumerDoesntSupportInstanceBased() {
-        String expected = "Unit does not support instance based " +
-            "calculation required by pool 'pool10'";
+        String expected = "Unit does not support instance based calculation required by pool \"pool10\"";
         try {
             bindByPoolErrorTest("rulefailed.instance.unsupported.by.consumer");
             fail();
@@ -332,8 +331,7 @@ public class EntitlerTest {
 
     @Test
     public void consumerDoesntSupportCores() {
-        String expected = "Unit does not support core " +
-            "calculation required by pool 'pool10'";
+        String expected = "Unit does not support core calculation required by pool \"pool10\"";
         try {
             bindByPoolErrorTest("rulefailed.cores.unsupported.by.consumer");
             fail();
@@ -345,8 +343,7 @@ public class EntitlerTest {
 
     @Test
     public void consumerDoesntSupportRam() {
-        String expected = "Unit does not support RAM " +
-            "calculation required by pool 'pool10'";
+        String expected = "Unit does not support RAM calculation required by pool \"pool10\"";
         try {
             bindByPoolErrorTest("rulefailed.ram.unsupported.by.consumer");
             fail();
@@ -358,8 +355,7 @@ public class EntitlerTest {
 
     @Test
     public void consumerDoesntSupportDerived() {
-        String expected = "Unit does not support derived products " +
-            "data required by pool 'pool10'";
+        String expected = "Unit does not support derived products data required by pool \"pool10\"";
         try {
             bindByPoolErrorTest("rulefailed.derivedproduct.unsupported.by.consumer");
             fail();
@@ -406,7 +402,7 @@ public class EntitlerTest {
 
     @Test
     public void virtOnly() {
-        String expected = "Pool is restricted to virtual guests: 'pool10'.";
+        String expected = "Pool is restricted to virtual guests: \"pool10\".";
         try {
             bindByPoolErrorTest("rulefailed.virt.only");
             fail();
@@ -418,7 +414,7 @@ public class EntitlerTest {
 
     @Test
     public void physicalOnly() throws Exception {
-        String expected = "Pool is restricted to physical systems: 'pool10'.";
+        String expected = "Pool is restricted to physical systems: \"pool10\".";
         try {
             bindByPoolErrorTest("rulefailed.physical.only");
             fail();
@@ -685,7 +681,7 @@ public class EntitlerTest {
             entitler.bindByProducts(ad);
         }
         catch (ForbiddenException fe) {
-            assertEquals(i18n.tr("SKU product not available to this development unit: ''{0}''",
+            assertEquals(i18n.tr("SKU product not available to this development unit: \"{0}\"",
                 p.getId()), fe.getMessage());
         }
     }

--- a/server/src/test/java/org/candlepin/controller/ManifestManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/ManifestManagerTest.java
@@ -416,7 +416,7 @@ public class ManifestManagerTest {
         catch (Exception e) {
             assertTrue(e instanceof ForbiddenException);
             String expectedMsg = String.format("Unit %s cannot be exported. A manifest cannot be made for " +
-                "units of type '%s'.", consumer.getUuid(), consumer.getType().getLabel());
+                "units of type \"%s\".", consumer.getUuid(), consumer.getType().getLabel());
             assertEquals(e.getMessage(), expectedMsg);
         }
     }
@@ -439,7 +439,7 @@ public class ManifestManagerTest {
         catch (Exception e) {
             assertTrue(e instanceof ForbiddenException);
             String expectedMsg = String.format("Unit %s cannot be exported. A manifest cannot be made for " +
-                "units of type '%s'.", consumer.getUuid(), consumer.getType().getLabel());
+                "units of type \"%s\".", consumer.getUuid(), consumer.getType().getLabel());
             assertEquals(e.getMessage(), expectedMsg);
         }
     }

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/EntitlerJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/EntitlerJobTest.java
@@ -206,7 +206,7 @@ public class EntitlerJobTest extends BaseJobTest{
         assertEquals(1, resultErrors.size());
         assertEquals("hello", resultErrors.get(0).getPoolId());
         assertEquals(1, resultErrors.get(0).getErrors().size());
-        assertEquals("No subscriptions are available from the pool with ID 'hello'.", resultErrors.get(0)
+        assertEquals("No subscriptions are available from the pool with ID \"hello\".", resultErrors.get(0)
             .getErrors().get(0));
     }
 

--- a/server/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
@@ -286,7 +286,7 @@ public class HypervisorResourceTest {
         assertEquals(1, result.getFailedUpdate().size());
 
         String failed = result.getFailedUpdate().iterator().next();
-        String expected = "test-host: Unable to find hypervisor in org 'admin'";
+        String expected = "test-host: Unable to find hypervisor in org \"admin\"";
         assertEquals(expected, failed);
     }
 


### PR DESCRIPTION
Single quotes need to be escaped with single quotes in po files. This is
an unusual escape sequence and it is not obvious to translators that the
translated key also needs to use two single quotes.  Double quotes are
escaped with a backslash.

Besides, quoting these strings in single quotes was grammatically
incorrect in the first place.