### PR TITLE
Optimized DTO usage in API endpoints

### DIFF
--- a/server/src/main/java/org/candlepin/dto/api/v1/HypervisorIdTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/HypervisorIdTranslator.java
@@ -57,7 +57,7 @@ public class HypervisorIdTranslator extends TimestampedEntityTranslator<Hypervis
 
         dest = super.populate(translator, source, dest);
 
-        dest.setId(source.getId().toString());
+        dest.setId(source.getId() != null ? source.getId().toString() : null);
         dest.setHypervisorId(source.getHypervisorId());
         dest.setReporterId(source.getReporterId());
 

--- a/server/src/main/java/org/candlepin/model/Consumer.java
+++ b/server/src/main/java/org/candlepin/model/Consumer.java
@@ -425,29 +425,26 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
     }
 
     /**
-     * Returns if the <code>other</code> consumer's facts are
-     * the same as the facts of this consumer.
+     * Returns if the <code>otherFacts</code> are
+     * the same as the facts of this consumer model entity.
      *
-     * @param other the Consumer whose facts to compare
+     * @param otherFacts the facts to compare
      * @return <code>true</code> if the facts are the same, <code>false</code> otherwise
      */
-    public boolean factsAreEqual(Consumer other) {
-        Map<String, String> myFacts = getFacts();
-        Map<String, String> otherFacts = other.getFacts();
-
-        if (myFacts == null && otherFacts == null) {
+    public boolean factsAreEqual(Map<String, String> otherFacts) {
+        if (this.getFacts() == null && otherFacts == null) {
             return true;
         }
 
-        if (myFacts == null || otherFacts == null) {
+        if (this.getFacts() == null || otherFacts == null) {
             return false;
         }
 
-        if (myFacts.size() != otherFacts.size()) {
+        if (this.getFacts().size() != otherFacts.size()) {
             return false;
         }
 
-        for (Entry<String, String> entry : myFacts.entrySet()) {
+        for (Entry<String, String> entry : this.getFacts().entrySet()) {
             String myVal = entry.getValue();
             String otherVal = otherFacts.get(entry.getKey());
 

--- a/server/src/main/java/org/candlepin/resource/ActivationKeyResource.java
+++ b/server/src/main/java/org/candlepin/resource/ActivationKeyResource.java
@@ -29,9 +29,7 @@ import org.candlepin.model.Release;
 import org.candlepin.jackson.ProductCachedSerializationModule;
 import org.candlepin.model.activationkeys.ActivationKey;
 import org.candlepin.model.activationkeys.ActivationKeyCurator;
-import org.candlepin.model.activationkeys.ActivationKeyPool;
 import org.candlepin.policy.js.activationkey.ActivationKeyRules;
-import org.candlepin.util.ElementTransformer;
 import org.candlepin.util.ServiceLevelValidator;
 import org.candlepin.util.TransformedIterator;
 
@@ -119,12 +117,7 @@ public class ActivationKeyResource {
         ActivationKey key = activationKeyCurator.verifyAndLookupKey(activationKeyId);
 
         return new TransformedIterator<>(key.getPools().iterator(),
-            new ElementTransformer<ActivationKeyPool, PoolDTO>() {
-                @Override
-                public PoolDTO transform(ActivationKeyPool akp) {
-                    return translator.translate(akp.getPool(), PoolDTO.class);
-                }
-            }
+            akp -> translator.translate(akp.getPool(), PoolDTO.class)
         );
     }
 

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -1252,10 +1252,8 @@ public class ConsumerResource {
             validateShareConsumerUpdate(toUpdate, dto, principal);
         }
 
-        Consumer consumerEntity = new Consumer();
-        populateEntity(consumerEntity, dto);
         GuestMigration guestMigration = migrationProvider.get();
-        guestMigration.buildMigrationManifest(consumerEntity, toUpdate);
+        guestMigration.buildMigrationManifest(dto, toUpdate);
 
         if (performConsumerUpdates(dto, toUpdate, guestMigration)) {
             try {

--- a/server/src/main/java/org/candlepin/resource/ContentResource.java
+++ b/server/src/main/java/org/candlepin/resource/ContentResource.java
@@ -108,7 +108,7 @@ public class ContentResource {
     @POST
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
-    public ContentDTO createContent(Content content) {
+    public ContentDTO createContent(ContentDTO content) {
         throw new BadRequestException(this.i18n.tr(
             "Organization-agnostic content write operations are not supported."));
     }
@@ -118,7 +118,7 @@ public class ContentResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
     @Path("/batch")
-    public Iterable<ContentDTO> createBatchContent(List<Content> contents) {
+    public Iterable<ContentDTO> createBatchContent(List<ContentDTO> contents) {
         throw new BadRequestException(this.i18n.tr(
             "Organization-agnostic content write operations are not supported."));
     }
@@ -128,7 +128,7 @@ public class ContentResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
     @Path("/{content_uuid}")
-    public ContentDTO updateContent(@PathParam("content_uuid") String contentUuid, Content changes) {
+    public ContentDTO updateContent(@PathParam("content_uuid") String contentUuid, ContentDTO changes) {
         throw new BadRequestException(this.i18n.tr(
             "Organization-agnostic content write operations are not supported."));
     }

--- a/server/src/main/java/org/candlepin/resource/GuestIdResource.java
+++ b/server/src/main/java/org/candlepin/resource/GuestIdResource.java
@@ -42,7 +42,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xnap.commons.i18n.I18n;
 
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -199,21 +198,18 @@ public class GuestIdResource {
         Consumer toUpdate = consumerCurator.findByUuid(consumerUuid);
 
         // Create a skeleton consumer for consumerResource.performConsumerUpdates
-        Consumer consumer = new Consumer();
-        List<GuestId> guestIds = new ArrayList<>();
-        populateEntities(guestIds, guestIdDTOs);
-        consumer.setGuestIds(guestIds);
+        ConsumerDTO consumer = new ConsumerDTO();
+        consumer.setGuestIds(guestIdDTOs);
 
         Set<String> allGuestIds = new HashSet<>();
-        for (GuestId gid : consumer.getGuestIds()) {
+        for (GuestIdDTO gid : consumer.getGuestIds()) {
             allGuestIds.add(gid.getGuestId());
         }
         VirtConsumerMap guestConsumerMap = consumerCurator.getGuestConsumersMap(
             toUpdate.getOwner(), allGuestIds);
 
         GuestMigration guestMigration = migrationProvider.get().buildMigrationManifest(consumer, toUpdate);
-        if (consumerResource.performConsumerUpdates(this.translator.translate(consumer, ConsumerDTO.class),
-            toUpdate, guestMigration)) {
+        if (consumerResource.performConsumerUpdates(consumer, toUpdate, guestMigration)) {
 
             if (guestMigration.isMigrationPending()) {
                 guestMigration.migrate();

--- a/server/src/main/java/org/candlepin/resource/GuestIdResource.java
+++ b/server/src/main/java/org/candlepin/resource/GuestIdResource.java
@@ -24,6 +24,7 @@ import org.candlepin.common.exceptions.BadRequestException;
 import org.candlepin.common.exceptions.ForbiddenException;
 import org.candlepin.common.exceptions.NotFoundException;
 import org.candlepin.dto.ModelTranslator;
+import org.candlepin.dto.api.v1.ConsumerDTO;
 import org.candlepin.dto.api.v1.GuestIdDTO;
 import org.candlepin.model.CandlepinQuery;
 import org.candlepin.model.Consumer;
@@ -211,7 +212,9 @@ public class GuestIdResource {
             toUpdate.getOwner(), allGuestIds);
 
         GuestMigration guestMigration = migrationProvider.get().buildMigrationManifest(consumer, toUpdate);
-        if (consumerResource.performConsumerUpdates(consumer, toUpdate, guestMigration)) {
+        if (consumerResource.performConsumerUpdates(this.translator.translate(consumer, ConsumerDTO.class),
+            toUpdate, guestMigration)) {
+
             if (guestMigration.isMigrationPending()) {
                 guestMigration.migrate();
             }

--- a/server/src/main/java/org/candlepin/resource/HypervisorResource.java
+++ b/server/src/main/java/org/candlepin/resource/HypervisorResource.java
@@ -22,6 +22,7 @@ import org.candlepin.auth.UpdateConsumerCheckIn;
 import org.candlepin.common.exceptions.BadRequestException;
 import org.candlepin.common.exceptions.NotFoundException;
 import org.candlepin.dto.ModelTranslator;
+import org.candlepin.dto.api.v1.ConsumerDTO;
 import org.candlepin.dto.api.v1.GuestIdDTO;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerCurator;
@@ -311,7 +312,8 @@ public class HypervisorResource {
         withIds.setGuestIds(guestIds);
 
         GuestMigration guestMigration = migrationProvider.get().buildMigrationManifest(withIds, consumer);
-        boolean guestIdsUpdated = consumerResource.performConsumerUpdates(withIds, consumer, guestMigration);
+        boolean guestIdsUpdated = consumerResource.performConsumerUpdates(
+            this.translator.translate(withIds, ConsumerDTO.class), consumer, guestMigration);
         if (guestIdsUpdated) {
             if (guestMigration.isMigrationPending()) {
                 guestMigration.migrate();
@@ -339,7 +341,9 @@ public class HypervisorResource {
         consumer.setHypervisorId(hypervisorId);
 
         // Create Consumer
-        return consumerResource.createConsumerFromEntity(consumer,
+        return consumerResource.createConsumerFromDTO(
+            this.translator.translate(consumer, ConsumerDTO.class),
+            this.hypervisorType,
             principal,
             null,
             owner.getKey(),

--- a/server/src/main/java/org/candlepin/resource/ProductResource.java
+++ b/server/src/main/java/org/candlepin/resource/ProductResource.java
@@ -20,6 +20,7 @@ import org.candlepin.common.exceptions.BadRequestException;
 import org.candlepin.common.exceptions.NotFoundException;
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.dto.ModelTranslator;
+import org.candlepin.dto.api.v1.OwnerDTO;
 import org.candlepin.dto.api.v1.ProductCertificateDTO;
 import org.candlepin.dto.api.v1.ProductDTO;
 import org.candlepin.model.CandlepinQuery;
@@ -257,7 +258,7 @@ public class ProductResource {
     @GET
     @Path("/owners")
     @Produces(MediaType.APPLICATION_JSON)
-    public CandlepinQuery<Owner> getProductOwners(
+    public CandlepinQuery<OwnerDTO> getProductOwners(
         @ApiParam(value = "Multiple product UUIDs", required = true)
         @QueryParam("product") List<String> productUuids) {
 
@@ -265,7 +266,8 @@ public class ProductResource {
             throw new BadRequestException(i18n.tr("No product IDs specified"));
         }
 
-        return this.ownerCurator.lookupOwnersWithProduct(productUuids);
+        return this.translator.translateQuery(
+            this.ownerCurator.lookupOwnersWithProduct(productUuids), OwnerDTO.class);
     }
 
     @ApiOperation(notes = "Refreshes Pools by Product", value = "refreshPoolsForProduct")

--- a/server/src/main/java/org/candlepin/util/ContentOverrideValidator.java
+++ b/server/src/main/java/org/candlepin/util/ContentOverrideValidator.java
@@ -15,6 +15,7 @@
 package org.candlepin.util;
 
 import org.candlepin.common.exceptions.BadRequestException;
+import org.candlepin.dto.api.v1.ActivationKeyDTO;
 import org.candlepin.model.ContentOverride;
 import org.candlepin.policy.js.override.OverrideRules;
 
@@ -25,8 +26,6 @@ import org.xnap.commons.i18n.I18n;
 
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
 import java.util.Set;
 
 /**
@@ -61,9 +60,18 @@ public class ContentOverrideValidator {
         }
     }
 
-    public void validate(ContentOverride override) {
-        List<ContentOverride> tmpList = new LinkedList<>();
-        tmpList.add(override);
-        validate(tmpList);
+    public void validateDTOs(Collection<ActivationKeyDTO.ActivationKeyContentOverrideDTO> overrides) {
+        Set<String> invalidOverrides = new HashSet<>();
+        for (ActivationKeyDTO.ActivationKeyContentOverrideDTO override : overrides) {
+            if (!overrideRules.canOverrideForConsumer(override.getName())) {
+                invalidOverrides.add(override.getName());
+            }
+        }
+
+        if (!invalidOverrides.isEmpty()) {
+            String error = i18n.tr("Not allowed to override values for: {0}",
+                StringUtils.join(invalidOverrides, ", "));
+            throw new BadRequestException(error);
+        }
     }
 }

--- a/server/src/test/java/org/candlepin/model/ConsumerTest.java
+++ b/server/src/test/java/org/candlepin/model/ConsumerTest.java
@@ -268,12 +268,12 @@ public class ConsumerTest extends DatabaseTestFixture {
         second.setFact("key2", "two");
         second.setFact("key3", "3");
 
-        assertTrue(first.factsAreEqual(second));
+        assertTrue(first.factsAreEqual(second.getFacts()));
     }
 
     @Test
     public void defaultFactsEqual() {
-        assertTrue(new Consumer().factsAreEqual(new Consumer()));
+        assertTrue(new Consumer().factsAreEqual(new Consumer().getFacts()));
     }
 
     @Test
@@ -290,7 +290,7 @@ public class ConsumerTest extends DatabaseTestFixture {
         second.setFact("key2", "2");
         second.setFact("key3", "3");
 
-        assertFalse(first.factsAreEqual(second));
+        assertFalse(first.factsAreEqual(second.getFacts()));
     }
 
     @Test
@@ -305,7 +305,7 @@ public class ConsumerTest extends DatabaseTestFixture {
 
         second.setFact("key1", "1");
 
-        assertFalse(first.factsAreEqual(second));
+        assertFalse(first.factsAreEqual(second.getFacts()));
     }
 
     @Test
@@ -321,7 +321,7 @@ public class ConsumerTest extends DatabaseTestFixture {
         second.setFact("key2", "2");
         second.setFact("key3", "3");
 
-        assertFalse(first.factsAreEqual(second));
+        assertFalse(first.factsAreEqual(second.getFacts()));
     }
 
     @Test
@@ -336,7 +336,7 @@ public class ConsumerTest extends DatabaseTestFixture {
         second.setFact("key1", "1");
         second.setFact("key2", null);
 
-        assertTrue(first.factsAreEqual(second));
+        assertTrue(first.factsAreEqual(second.getFacts()));
     }
 
     @Test
@@ -351,7 +351,7 @@ public class ConsumerTest extends DatabaseTestFixture {
         second.setFact("key1", "1");
         second.setFact("key2", "two");
 
-        assertFalse(first.factsAreEqual(second));
+        assertFalse(first.factsAreEqual(second.getFacts()));
     }
 
     @Test
@@ -362,7 +362,7 @@ public class ConsumerTest extends DatabaseTestFixture {
         Consumer second = new Consumer();
         second.setFact("key1", "1");
 
-        assertFalse(first.factsAreEqual(second));
+        assertFalse(first.factsAreEqual(second.getFacts()));
     }
 
     @Test
@@ -373,7 +373,7 @@ public class ConsumerTest extends DatabaseTestFixture {
         Consumer second = new Consumer();
         second.setFacts(null);
 
-        assertFalse(first.factsAreEqual(second));
+        assertFalse(first.factsAreEqual(second.getFacts()));
     }
 
     @Test
@@ -384,7 +384,7 @@ public class ConsumerTest extends DatabaseTestFixture {
         Consumer second = new Consumer();
         second.setFact("key1", null);
 
-        assertFalse(first.factsAreEqual(second));
+        assertFalse(first.factsAreEqual(second.getFacts()));
     }
 
     @Test
@@ -395,7 +395,7 @@ public class ConsumerTest extends DatabaseTestFixture {
         Consumer second = new Consumer();
         second.setFacts(null);
 
-        assertTrue(first.factsAreEqual(second));
+        assertTrue(first.factsAreEqual(second.getFacts()));
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/HypervisorUpdateJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/HypervisorUpdateJobTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 
 import org.candlepin.auth.Principal;
+import org.candlepin.dto.api.v1.ConsumerDTO;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerCurator;
 import org.candlepin.model.ConsumerType;
@@ -228,8 +229,9 @@ public class HypervisorUpdateJobTest extends BaseJobTest {
             consumerResource, i18n, subAdapter, complianceRules);
         injector.injectMembers(job);
         job.execute(ctx);
-        verify(consumerResource, never()).createConsumerFromEntity(any(Consumer.class), any(Principal.class),
-            anyString(), anyString(), anyString(), eq(false));
+        verify(consumerResource, never()).createConsumerFromDTO(any(ConsumerDTO.class),
+            any(ConsumerType.class), any(Principal.class), anyString(), anyString(), anyString(),
+            eq(false));
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
@@ -897,15 +897,17 @@ public class ConsumerResourceUpdateTest {
 
         Consumer update = getFakeConsumer();
         update.setCapabilities(caps1);
-        assertFalse(resource.performConsumerUpdates(update, existing, testMigration));
+        assertFalse(resource.performConsumerUpdates(
+            this.translator.translate(update, ConsumerDTO.class), existing, testMigration));
 
         update.setCapabilities(caps2);
-        assertTrue(resource.performConsumerUpdates(update, existing, testMigration));
+        assertTrue(resource.performConsumerUpdates(
+            this.translator.translate(update, ConsumerDTO.class), existing, testMigration));
 
         // need a new consumer here, can't null out capabilities
         update = getFakeConsumer();
-        assertFalse(resource.performConsumerUpdates(update, existing, testMigration));
-
+        assertFalse(resource.performConsumerUpdates(
+            this.translator.translate(update, ConsumerDTO.class), existing, testMigration));
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/resource/ContentResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/ContentResourceTest.java
@@ -29,12 +29,9 @@ import org.candlepin.model.CandlepinQuery;
 import org.candlepin.model.Content;
 import org.candlepin.model.ContentCurator;
 import org.candlepin.model.EmptyCandlepinQuery;
-import org.candlepin.model.Environment;
-import org.candlepin.model.EnvironmentContent;
 import org.candlepin.model.EnvironmentContentCurator;
 import org.candlepin.model.Owner;
 import org.candlepin.model.OwnerCurator;
-import org.candlepin.model.Product;
 import org.candlepin.model.ProductCurator;
 import org.candlepin.service.impl.DefaultUniqueIdGenerator;
 
@@ -44,7 +41,6 @@ import org.xnap.commons.i18n.I18n;
 import org.xnap.commons.i18n.I18nFactory;
 
 import java.util.Arrays;
-import java.util.List;
 import java.util.Locale;
 
 
@@ -110,79 +106,30 @@ public class ContentResourceTest {
     }
 
     @Test(expected = BadRequestException.class)
-    public void createContent() {
-        Content content = mock(Content.class);
-        when(content.getId()).thenReturn("10");
-        when(cc.find(eq("10"))).thenReturn(content);
-        assertEquals(content, cr.createContent(content));
+    public void createContentNoLongerSupported() {
+        ContentDTO contentDTO = mock(ContentDTO.class);
+        assertEquals(contentDTO, cr.createContent(contentDTO));
+
+        verify(cc, never()).create(any());
     }
 
     @Test(expected = BadRequestException.class)
-    public void createContentNull()  {
-        Content content = mock(Content.class);
-        when(content.getId()).thenReturn("10");
-        when(cc.find(eq(10L))).thenReturn(null);
-        cr.createContent(content);
-
-        verify(cc, never()).create(content);
-    }
-
-    @Test(expected = BadRequestException.class)
-    public void deleteContent() {
-        Owner owner = mock(Owner.class);
-        Content content = mock(Content.class);
-        when(content.getId()).thenReturn("10");
-        when(cc.find(eq("10"))).thenReturn(content);
-        EnvironmentContent ec = new EnvironmentContent(mock(Environment.class), content, true);
-        List<EnvironmentContent> envContents = Arrays.asList(ec);
-        when(envContentCurator.lookupByContent(owner, content.getId())).thenReturn(envContents);
-
+    public void deleteContentNoLongerSupported() {
         cr.remove("10");
 
-        verify(cc, never()).delete(eq(content));
-        verify(envContentCurator, never()).delete(eq(ec));
+        verify(cc, never()).delete(any());
+        verify(envContentCurator, never()).delete(any());
     }
 
     @Test(expected = BadRequestException.class)
-    public void deleteContentNull() {
-        Content content = mock(Content.class);
-        when(content.getId()).thenReturn("10");
-        when(cc.find(eq("10"))).thenReturn(null);
-        cr.remove("10");
-        verify(cc, never()).delete(eq(content));
-    }
-
-    @Test(expected = BadRequestException.class)
-    public void testUpdateContent() {
-        final String productId = "productId";
+    public void testUpdateContentNoLongerSupported() {
         final String contentId = "10";
+        ContentDTO contentDTO = mock(ContentDTO.class);
 
-        Owner owner = mock(Owner.class);
-        Product product = mock(Product.class);
-        Content content = mock(Content.class);
-        CandlepinQuery cqmock = mock(CandlepinQuery.class);
+        cr.updateContent(contentId, contentDTO);
 
-        when(product.getId()).thenReturn(productId);
-        when(content.getId()).thenReturn(contentId);
-        when(cqmock.list()).thenReturn(Arrays.asList(product));
-
-        when(cc.find(any(String.class))).thenReturn(content);
-        when(cc.merge(any(Content.class))).thenReturn(content);
-        when(productCurator.getProductsByContent(eq(owner), eq(Arrays.asList(contentId))))
-            .thenReturn(cqmock);
-
-        cr.updateContent(contentId, content);
-
-        verify(cc, never()).find(eq(contentId));
-        verify(cc, never()).merge(eq(content));
-        verify(productCurator, never()).getProductsByContent(owner, Arrays.asList(contentId));
-    }
-
-    @Test(expected = BadRequestException.class)
-    public void testUpdateContentThrowsExceptionWhenContentDoesNotExist() {
-        Content content = mock(Content.class);
-        when(cc.find(any(String.class))).thenReturn(null);
-
-        cr.updateContent("someId", content);
+        verify(cc, never()).find(any());
+        verify(cc, never()).merge(any());
+        verify(productCurator, never()).getProductsByContent(any(), any());
     }
 }

--- a/server/src/test/java/org/candlepin/resource/GuestIdResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/GuestIdResourceTest.java
@@ -28,6 +28,7 @@ import org.candlepin.common.exceptions.NotFoundException;
 import org.candlepin.common.paging.Page;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.dto.StandardTranslator;
+import org.candlepin.dto.api.v1.ConsumerDTO;
 import org.candlepin.dto.api.v1.GuestIdDTO;
 import org.candlepin.model.CandlepinQuery;
 import org.candlepin.model.Consumer;
@@ -141,14 +142,14 @@ public class GuestIdResourceTest {
     public void updateGuests() {
         List<GuestIdDTO> guestIds = new LinkedList<>();
         guestIds.add(new GuestIdDTO("1"));
-        when(consumerResource.performConsumerUpdates(any(Consumer.class),
+        when(consumerResource.performConsumerUpdates(any(ConsumerDTO.class),
             eq(consumer), any(GuestMigration.class))).
             thenReturn(true);
 
         guestIdResource.updateGuests(consumer.getUuid(), guestIds);
 
         Mockito.verify(consumerResource, Mockito.times(1))
-            .performConsumerUpdates(any(Consumer.class), eq(consumer), any(GuestMigration.class));
+            .performConsumerUpdates(any(ConsumerDTO.class), eq(consumer), any(GuestMigration.class));
         // consumerResource returned true, so the consumer should be updated
         Mockito.verify(testMigration, Mockito.times(1)).migrate();
     }
@@ -159,13 +160,13 @@ public class GuestIdResourceTest {
         guestIds.add(new GuestIdDTO("1"));
 
         // consumerResource tells us nothing changed
-        when(consumerResource.performConsumerUpdates(any(Consumer.class),
+        when(consumerResource.performConsumerUpdates(any(ConsumerDTO.class),
             eq(consumer), any(GuestMigration.class))).
             thenReturn(false);
 
         guestIdResource.updateGuests(consumer.getUuid(), guestIds);
         Mockito.verify(consumerResource, Mockito.times(1))
-            .performConsumerUpdates(any(Consumer.class), eq(consumer), any(GuestMigration.class));
+            .performConsumerUpdates(any(ConsumerDTO.class), eq(consumer), any(GuestMigration.class));
         Mockito.verify(consumerCurator, Mockito.never()).update(eq(consumer));
     }
 

--- a/server/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
@@ -31,6 +31,7 @@ import org.candlepin.common.config.Configuration;
 import org.candlepin.common.exceptions.BadRequestException;
 import org.candlepin.config.CandlepinCommonTestConfig;
 import org.candlepin.dto.ModelTranslator;
+import org.candlepin.dto.StandardTranslator;
 import org.candlepin.dto.api.v1.GuestIdDTO;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerCurator;
@@ -38,6 +39,7 @@ import org.candlepin.model.ConsumerType;
 import org.candlepin.model.ConsumerType.ConsumerTypeEnum;
 import org.candlepin.model.ConsumerTypeCurator;
 import org.candlepin.model.DeletedConsumerCurator;
+import org.candlepin.model.EnvironmentCurator;
 import org.candlepin.model.GuestId;
 import org.candlepin.model.GuestIdCurator;
 import org.candlepin.model.IdentityCertificate;
@@ -71,7 +73,6 @@ import org.mockito.stubbing.Answer;
 import org.xnap.commons.i18n.I18n;
 import org.xnap.commons.i18n.I18nFactory;
 
-import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -103,14 +104,14 @@ public class HypervisorResourceTest {
     @Mock private EventBuilder consumerEventBuilder;
     @Mock private ConsumerEnricher consumerEnricher;
     @Mock private GuestIdCurator guestIdCurator;
+    @Mock private EnvironmentCurator environmentCurator;
     private GuestIdResource guestIdResource;
 
     private ConsumerResource consumerResource;
     private I18n i18n;
     private ConsumerType hypervisorType;
     private HypervisorResource hypervisorResource;
-
-    @Inject protected ModelTranslator modelTranslator;
+    private ModelTranslator modelTranslator;
 
     private Provider<GuestMigration> migrationProvider;
     private GuestMigration testMigration;
@@ -128,6 +129,8 @@ public class HypervisorResourceTest {
         this.hypervisorType.setId("test-hypervisor-ctype");
 
         this.mockConsumerType(this.hypervisorType);
+
+        this.modelTranslator = new StandardTranslator(this.consumerTypeCurator, this.environmentCurator);
 
         this.consumerResource = new ConsumerResource(this.consumerCurator,
             this.consumerTypeCurator, null, this.subscriptionService, this.ownerService, null,

--- a/server/src/test/java/org/candlepin/resource/OwnerResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/OwnerResourceTest.java
@@ -1167,7 +1167,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         OwnerResource ownerres = new OwnerResource(
             oc, pc, akc, null, i18n, null, null, null, null, null, null, null, null, null,
             null, null, null, null,
-            null, null, null, null, null, null, null, null, null, null,
+            null, null, null, null, contentOverrideValidator, null, null, null, null, null,
             null, this.modelTranslator);
 
         ownerres.createActivationKey("testOwner", ak);

--- a/server/src/test/java/org/candlepin/resource/ProductResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/ProductResourceTest.java
@@ -24,6 +24,7 @@ import org.candlepin.common.config.MapConfiguration;
 import org.candlepin.common.exceptions.BadRequestException;
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.dto.api.v1.ContentDTO;
+import org.candlepin.dto.api.v1.OwnerDTO;
 import org.candlepin.dto.api.v1.ProductCertificateDTO;
 import org.candlepin.dto.api.v1.ProductDTO;
 import org.candlepin.model.ContentCurator;
@@ -211,18 +212,23 @@ public class ProductResourceTest extends DatabaseTestFixture {
         Owner owner1 = owners.get(0);
         Owner owner2 = owners.get(1);
         Owner owner3 = owners.get(2);
+        OwnerDTO ownerDTO1 = this.modelTranslator.translate(owner1, OwnerDTO.class);
+        OwnerDTO ownerDTO2 = this.modelTranslator.translate(owner2, OwnerDTO.class);
+        OwnerDTO ownerDTO3 = this.modelTranslator.translate(owner3, OwnerDTO.class);
 
-        owners = productResource.getProductOwners(Arrays.asList("p1")).list();
-        assertEquals(Arrays.asList(owner1, owner2), owners);
+        List<OwnerDTO> ownersReturned = null;
 
-        owners = productResource.getProductOwners(Arrays.asList("p1", "p2")).list();
-        assertEquals(Arrays.asList(owner1, owner2, owner3), owners);
+        ownersReturned = productResource.getProductOwners(Arrays.asList("p1")).list();
+        assertEquals(Arrays.asList(ownerDTO1, ownerDTO2), ownersReturned);
 
-        owners = productResource.getProductOwners(Arrays.asList("p3")).list();
-        assertEquals(Arrays.asList(owner3), owners);
+        ownersReturned = productResource.getProductOwners(Arrays.asList("p1", "p2")).list();
+        assertEquals(Arrays.asList(ownerDTO1, ownerDTO2, ownerDTO3), ownersReturned);
 
-        owners = productResource.getProductOwners(Arrays.asList("nope")).list();
-        assertEquals(0, owners.size());
+        ownersReturned = productResource.getProductOwners(Arrays.asList("p3")).list();
+        assertEquals(Arrays.asList(ownerDTO3), ownersReturned);
+
+        ownersReturned = productResource.getProductOwners(Arrays.asList("nope")).list();
+        assertEquals(0, ownersReturned.size());
     }
 
     @Test(expected = BadRequestException.class)


### PR DESCRIPTION
- The following endpoints were optimized to do data assignment from DTO to entity (as opposed to from entity to entity) where possible, and also do data validation before data assignment:
  ConsumerResource.create
  ConsumerResource.updateConsumer
  OwnerResource.createOwner
  OwnerResource.updateOwner
  OwnerResource.createActivationKey
  OwnerResource.createEnv
  OwnerResource.createPool
  OwnerResource.updatePool

- Updated a few forgotten endpoints in ProductResource & ContentResource to use OwnerDTO and ContentDTO instead of the equivalent model entities.
- Refactored a few tests in ContentResourceTest that are testing deprecated endpoints.