### PR TITLE
Unify custom tasks under the LiquibaseCustomTask interfaces.

### DIFF
--- a/server/src/main/java/org/candlepin/liquibase/FixDuplicatePoolsLiquibaseWrapper.java
+++ b/server/src/main/java/org/candlepin/liquibase/FixDuplicatePoolsLiquibaseWrapper.java
@@ -14,48 +14,13 @@
  */
 package org.candlepin.liquibase;
 
-import liquibase.change.custom.CustomTaskChange;
-import liquibase.database.Database;
-import liquibase.database.jvm.JdbcConnection;
-import liquibase.exception.CustomChangeException;
-import liquibase.exception.SetupException;
-import liquibase.exception.ValidationErrors;
-import liquibase.resource.ResourceAccessor;
-
 /**
  * FixDuplicatePoolsLiquibaseWrapper class to be hooked by liquibase
  * in order to reconcile duplicate pool data.
  */
-public class FixDuplicatePoolsLiquibaseWrapper implements CustomTaskChange {
-
-    @Override
-    public String getConfirmationMessage() {
-        return null;
+public class FixDuplicatePoolsLiquibaseWrapper extends LiquibaseCustomTaskWrapper<FixDuplicatePoolsTask> {
+    public FixDuplicatePoolsLiquibaseWrapper() {
+        super(FixDuplicatePoolsTask.class);
     }
 
-    @Override
-    public void setFileOpener(ResourceAccessor resourceAccessor) {
-    }
-
-    @Override
-    public void setUp() throws SetupException {
-    }
-
-    @Override
-    public ValidationErrors validate(Database arg0) {
-        return null;
-    }
-
-    @Override
-    public void execute(Database db) throws CustomChangeException {
-        JdbcConnection conn = (JdbcConnection) db.getConnection();
-        FixDuplicatePools fixer = new FixDuplicatePools(conn, new LiquibaseCustomTaskLogger());
-
-        try {
-            fixer.execute();
-        }
-        catch (Exception e) {
-            throw new CustomChangeException(e);
-        }
-    }
 }


### PR DESCRIPTION
We can change the FixDuplicatePools class name without an issue since
the actual changelog XML only references the
FixDuplicatePoolsLiquibaseWrapper class name.