### PR TITLE
[M] Changed consumer.environment to consumer.environmentId

### DIFF
--- a/server/src/main/java/org/candlepin/dto/StandardTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/StandardTranslator.java
@@ -63,6 +63,7 @@ import org.candlepin.model.ConsumerTypeCurator;
 import org.candlepin.model.Content;
 import org.candlepin.model.Entitlement;
 import org.candlepin.model.Environment;
+import org.candlepin.model.EnvironmentCurator;
 import org.candlepin.model.GuestId;
 import org.candlepin.model.HypervisorId;
 import org.candlepin.model.Owner;
@@ -87,7 +88,8 @@ import com.google.inject.Inject;
 public class StandardTranslator extends SimpleModelTranslator {
 
     @Inject
-    public StandardTranslator(ConsumerTypeCurator consumerTypeCurator) {
+    public StandardTranslator(ConsumerTypeCurator consumerTypeCurator,
+        EnvironmentCurator environmentCurator) {
 
         // API translators
         /////////////////////////////////////////////
@@ -104,7 +106,7 @@ public class StandardTranslator extends SimpleModelTranslator {
         this.registerTranslator(
             new CertificateTranslator(), Certificate.class, CertificateDTO.class);
         this.registerTranslator(
-            new org.candlepin.dto.api.v1.ConsumerTranslator(consumerTypeCurator),
+            new org.candlepin.dto.api.v1.ConsumerTranslator(consumerTypeCurator, environmentCurator),
             Consumer.class, org.candlepin.dto.api.v1.ConsumerDTO.class);
         this.registerTranslator(
             new ConsumerInstalledProductTranslator(), ConsumerInstalledProduct.class,

--- a/server/src/main/java/org/candlepin/dto/api/v1/ConsumerTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/ConsumerTranslator.java
@@ -22,6 +22,8 @@ import org.candlepin.model.ConsumerType;
 import org.candlepin.model.ConsumerTypeCurator;
 import org.candlepin.model.ConsumerCapability;
 import org.candlepin.model.ConsumerInstalledProduct;
+import org.candlepin.model.Environment;
+import org.candlepin.model.EnvironmentCurator;
 import org.candlepin.model.Release;
 
 import java.util.ArrayList;
@@ -34,14 +36,22 @@ import java.util.Set;
  */
 public class ConsumerTranslator extends TimestampedEntityTranslator<Consumer, ConsumerDTO> {
 
-    private ConsumerTypeCurator consumerTypeCurator;
+    protected ConsumerTypeCurator consumerTypeCurator;
+    protected EnvironmentCurator environmentCurator;
 
-    public ConsumerTranslator(ConsumerTypeCurator consumerTypeCurator) {
+    public ConsumerTranslator(ConsumerTypeCurator consumerTypeCurator,
+        EnvironmentCurator environmentCurator) {
+
         if (consumerTypeCurator == null) {
             throw new IllegalArgumentException("ConsumerTypeCurator is null");
         }
 
+        if (environmentCurator == null) {
+            throw new IllegalArgumentException("environmentCurator is null");
+        }
+
         this.consumerTypeCurator = consumerTypeCurator;
+        this.environmentCurator = environmentCurator;
     }
 
     /**
@@ -99,7 +109,9 @@ public class ConsumerTranslator extends TimestampedEntityTranslator<Consumer, Co
         // Process nested objects if we have a ModelTranslator to use to the translation...
         if (translator != null) {
             dest.setOwner(translator.translate(source.getOwner(), OwnerDTO.class));
-            dest.setEnvironment(translator.translate(source.getEnvironment(), EnvironmentDTO.class));
+
+            Environment environment = this.environmentCurator.getConsumerEnvironment(source);
+            dest.setEnvironment(translator.translate(environment, EnvironmentDTO.class));
 
             Set<ConsumerInstalledProduct> installedProducts = source.getInstalledProducts();
             if (installedProducts != null) {

--- a/server/src/main/java/org/candlepin/model/Consumer.java
+++ b/server/src/main/java/org/candlepin/model/Consumer.java
@@ -154,9 +154,8 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
     @JoinColumn(nullable = false)
     private Owner owner;
 
-    @ManyToOne
-    @JoinColumn(nullable = true)
-    private Environment environment;
+    @Column(name = "environment_id")
+    private String environmentId;
 
     @Column(name = "entitlement_count")
     @NotNull
@@ -642,12 +641,59 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
         this.serviceLevel = level;
     }
 
-    public Environment getEnvironment() {
-        return environment;
+    /**
+     * Fetches the ID of the environment with which this consumer is associated. If the consumer is not
+     * associated with an environment, this method returns null.
+     *
+     * @return the ID of the environment for this consumer
+     */
+    public String getEnvironmentId() {
+        return this.environmentId;
     }
 
-    public void setEnvironment(Environment environment) {
-        this.environment = environment;
+    /**
+     * Sets or clears the environment ID for this consumer.
+     *
+     * It is advised to use the setEnvironment method rather than setting the ID directly, as this
+     * method does not perform any validation on the environment being set.
+     *
+     * @param environmentId
+     *  The ID of the environment to set for this consumer
+     *
+     * @return
+     *  A reference to this consumer
+     */
+    public Consumer setEnvironmentId(String environmentId) {
+        this.environmentId = environmentId != null && !environmentId.isEmpty() ? environmentId : null;
+        return this;
+    }
+
+    /**
+     * Sets or clears the environment ID for this consumer. If the environment is not null, but does not
+     * have an environment ID, this method throws an exception.
+     *
+     * @param environment
+     *  The environment to associate to this consumer, or null to clear the environment
+     *
+     * @throws IllegalStateException
+     *  if environment is not null, but does not have an environment ID
+     *
+     * @return
+     *  A reference to this consumer
+     */
+    public Consumer setEnvironment(Environment environment) {
+        if (environment != null) {
+            if (environment.getId() == null || environment.getId().isEmpty()) {
+                throw new IllegalStateException("environment has not been persisted");
+            }
+
+            this.environmentId = environment.getId();
+        }
+        else {
+            this.environmentId = null;
+        }
+
+        return this;
     }
 
     /**

--- a/server/src/main/java/org/candlepin/model/EntitlementCurator.java
+++ b/server/src/main/java/org/candlepin/model/EntitlementCurator.java
@@ -458,10 +458,32 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
         return this.cpQueryFactory.<Entitlement>buildQuery(this.currentSession(), criteria);
     }
 
+    /**
+     * Fetches a the entitlements used by consumers in the specified environment.
+     *
+     * @param environment
+     *  The environment for which to fetch entitlements
+     *
+     * @return
+     *  A CandlepinQuery to iterate over the entitlements in the specified environment
+     */
     public CandlepinQuery<Entitlement> listByEnvironment(Environment environment) {
+        return this.listByEnvironment(environment != null ? environment.getId() : null);
+    }
+
+    /**
+     * Fetches a the entitlements used by consumers in the specified environment.
+     *
+     * @param environmentId
+     *  The ID of the environment for which to fetch entitlements
+     *
+     * @return
+     *  A CandlepinQuery to iterate over the entitlements in the specified environment
+     */
+    public CandlepinQuery<Entitlement> listByEnvironment(String environmentId) {
         DetachedCriteria criteria = DetachedCriteria.forClass(Entitlement.class)
             .createCriteria("consumer")
-            .add(Restrictions.eq("environment", environment));
+            .add(Restrictions.eq("environmentId", environmentId));
 
         return this.cpQueryFactory.<Entitlement>buildQuery(this.currentSession(), criteria);
     }

--- a/server/src/main/java/org/candlepin/model/Environment.java
+++ b/server/src/main/java/org/candlepin/model/Environment.java
@@ -19,7 +19,6 @@ import org.hibernate.annotations.Index;
 
 import java.io.Serializable;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import javax.persistence.CascadeType;
@@ -35,7 +34,6 @@ import javax.validation.constraints.Size;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlTransient;
 
 
 
@@ -76,9 +74,6 @@ public class Environment extends AbstractHibernateObject implements Serializable
     @Column(length = 32)
     @NotNull
     private String id;
-
-    @OneToMany(mappedBy = "environment", targetEntity = Consumer.class)
-    private List<Consumer> consumers;
 
     @OneToMany(mappedBy = "environment", targetEntity = EnvironmentContent.class,
         cascade = CascadeType.ALL)
@@ -142,15 +137,6 @@ public class Environment extends AbstractHibernateObject implements Serializable
 
     public void setDescription(String description) {
         this.description = description;
-    }
-
-    @XmlTransient
-    public List<Consumer> getConsumers() {
-        return consumers;
-    }
-
-    public void setConsumers(List<Consumer> consumers) {
-        this.consumers = consumers;
     }
 
     @Override

--- a/server/src/main/java/org/candlepin/model/EnvironmentCurator.java
+++ b/server/src/main/java/org/candlepin/model/EnvironmentCurator.java
@@ -37,6 +37,72 @@ public class EnvironmentCurator extends AbstractHibernateCurator<Environment> {
         super(Environment.class);
     }
 
+    /**
+     * Fetches the environment for the specified consumer. If the consumer does not have a defined
+     * environment ID, this method returns null. If the consumer has an invalid environment ID,
+     * this method throws an exception.
+     *
+     * @param consumer
+     *  The consumer for which to fetch an Environment object
+     *
+     * @throws IllegalArgumentException
+     *  if consumer is null
+     *
+     * @throws IllegalStateException
+     *  if the consumer's defined environment ID is invalid
+     *
+     * @return
+     *  An Environment instance for the specified consumer, or null if the consumer does not have a
+     *  defined environment ID
+     */
+    public Environment getConsumerEnvironment(Consumer consumer) {
+        if (consumer == null) {
+            throw new IllegalArgumentException("consumer is null");
+        }
+
+        Environment environment = null;
+
+        if (consumer.getEnvironmentId() != null) {
+            environment = this.find(consumer.getEnvironmentId());
+
+            if (environment == null) {
+                throw new IllegalStateException(
+                    "consumer is not associated with a valid environment: " + consumer);
+            }
+        }
+
+        return environment;
+    }
+
+    /**
+     * Fetches the consumers associated with the specified environment.
+     *
+     * @param environment
+     *  The environment for which to fetch consumers
+     *
+     * @return
+     *  A CandlepinQuery to iterate the consumers associated with the specified environment
+     */
+    public CandlepinQuery<Consumer> getEnvironmentConsumers(Environment environment) {
+        return this.getEnvironmentConsumers(environment != null ? environment.getId() : null);
+    }
+
+    /**
+     * Fetches the consumers associated with the specified environment ID.
+     *
+     * @param environmentId
+     *  The ID of the environment for which to fetch consumers
+     *
+     * @return
+     *  A CandlepinQuery to iterate the consumers associated with the specified environment ID
+     */
+    public CandlepinQuery<Consumer> getEnvironmentConsumers(String environmentId) {
+        DetachedCriteria criteria = DetachedCriteria.forClass(Consumer.class)
+            .add(Restrictions.eq("environmentId", environmentId));
+
+        return this.cpQueryFactory.<Consumer>buildQuery(this.currentSession(), criteria);
+    }
+
     @SuppressWarnings("unchecked")
     public CandlepinQuery<Environment> listForOwner(Owner o) {
         DetachedCriteria criteria = this.createSecureDetachedCriteria()

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -1315,15 +1315,14 @@ public class ConsumerResource {
             changesMade = true;
         }
 
-        String environmentId = updated.getEnvironment() == null ? null : updated.getEnvironment().getId();
-        if (environmentId != null && (toUpdate.getEnvironment() == null ||
-            !toUpdate.getEnvironment().getId().equals(environmentId))) {
-            Environment e = environmentCurator.find(environmentId);
+        if (updated.getEnvironmentId() != null && (toUpdate.getEnvironmentId() == null ||
+            !toUpdate.getEnvironmentId().equals(updated.getEnvironmentId()))) {
+            Environment e = environmentCurator.find(updated.getEnvironmentId());
             if (e == null) {
                 throw new NotFoundException(i18n.tr(
-                    "Environment with ID \"{0}\" could not be found.", environmentId));
+                    "Environment with ID \"{0}\" could not be found.", updated.getEnvironmentId()));
             }
-            log.info("Updating environment to: {}", environmentId);
+            log.info("Updating environment to: {}", updated.getEnvironmentId());
             toUpdate.setEnvironment(e);
 
             // lazily regenerate certs, so the client can still work

--- a/server/src/main/java/org/candlepin/resource/EnvironmentResource.java
+++ b/server/src/main/java/org/candlepin/resource/EnvironmentResource.java
@@ -144,9 +144,11 @@ public class EnvironmentResource {
             throw new NotFoundException(i18n.tr("No such environment: {0}", envId));
         }
 
+        CandlepinQuery<Consumer> consumers = this.envCurator.getEnvironmentConsumers(e);
+
         // Cleanup all consumers and their entitlements:
         log.info("Deleting consumers in environment {}", e);
-        for (Consumer c : e.getConsumers()) {
+        for (Consumer c : consumers.list()) {
             log.info("Deleting consumer: {}", c);
 
             // We're about to delete these consumers; no need to regen/dirty their dependent

--- a/server/src/main/java/org/candlepin/util/X509ExtensionUtil.java
+++ b/server/src/main/java/org/candlepin/util/X509ExtensionUtil.java
@@ -261,12 +261,11 @@ public class X509ExtensionUtil  extends X509Util{
 
             // Check if we should override the enabled flag due to setting on promoted
             // content:
-            if ((consumer.getEnvironment() != null) && enableEnvironmentFiltering) {
+            if (enableEnvironmentFiltering && consumer.getEnvironmentId() != null) {
                 // we know content has been promoted at this point:
-                Boolean enabledOverride = promotedContent.get(
-                    pc.getContent().getId()).getEnabled();
+                Boolean enabledOverride = promotedContent.get(pc.getContent().getId()).getEnabled();
                 if (enabledOverride != null) {
-                    log.debug("overriding enabled flag: " + enabledOverride);
+                    log.debug("overriding enabled flag: {}", enabledOverride);
                     enabled = enabledOverride;
                 }
             }

--- a/server/src/main/java/org/candlepin/util/X509Util.java
+++ b/server/src/main/java/org/candlepin/util/X509Util.java
@@ -84,12 +84,10 @@ public abstract class X509Util {
 
         for (ProductContent pc : prod.getProductContent()) {
             // Filter any content not promoted to environment.
-            if (filterEnvironment &&
-                (consumer.getEnvironment() != null &&
-                !promotedContent.containsKey(pc.getContent().getId()))) {
+            if (filterEnvironment && consumer.getEnvironmentId() != null &&
+                !promotedContent.containsKey(pc.getContent().getId())) {
 
-                log.debug("Skipping content not promoted to environment: " +
-                    pc.getContent().getId());
+                log.debug("Skipping content not promoted to environment: {}" + pc.getContent());
                 continue;
             }
 

--- a/server/src/main/java/org/candlepin/util/X509V3ExtensionUtil.java
+++ b/server/src/main/java/org/candlepin/util/X509V3ExtensionUtil.java
@@ -354,13 +354,11 @@ public class X509V3ExtensionUtil extends X509Util {
 
         for (ProductContent pc : archApproriateProductContent) {
             Content content = new Content();
-            if (enableEnvironmentFiltering) {
-                if (consumer.getEnvironment() != null && !promotedContent.containsKey(
-                    pc.getContent().getId())) {
-                    log.debug("Skipping content not promoted to environment: " +
-                        pc.getContent().getId());
-                    continue;
-                }
+            if (enableEnvironmentFiltering && consumer.getEnvironmentId() != null &&
+                !promotedContent.containsKey(pc.getContent().getId())) {
+
+                log.debug("Skipping content not promoted to environment: {}", pc.getContent());
+                continue;
             }
 
             // Augment the content path with the prefix if it is passed in
@@ -391,25 +389,26 @@ public class X509V3ExtensionUtil extends X509Util {
             content.setArches(archesList);
 
             Boolean enabled = pc.isEnabled();
+
             // sku level content enable override. if on both lists, active wins.
             if (skuDisabled.contains(pc.getContent().getId())) {
                 enabled = false;
             }
+
             if (skuEnabled.contains(pc.getContent().getId())) {
                 enabled = true;
             }
 
-            // Check if we should override the enabled flag due to setting on promoted
-            // content
-            if ((consumer.getEnvironment() != null) && enableEnvironmentFiltering) {
+            // Check if we should override the enabled flag due to setting on promoted content
+            if (enableEnvironmentFiltering && consumer.getEnvironmentId() != null) {
                 // we know content has been promoted at this point
-                Boolean enabledOverride = promotedContent.get(
-                    pc.getContent().getId()).getEnabled();
+                Boolean enabledOverride = promotedContent.get(pc.getContent().getId()).getEnabled();
                 if (enabledOverride != null) {
-                    log.debug("overriding enabled flag: " + enabledOverride);
+                    log.debug("overriding enabled flag: {}", enabledOverride);
                     enabled = enabledOverride;
                 }
             }
+
             // only included if not the default value of true
             if (!enabled) {
                 content.setEnabled(enabled);

--- a/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -216,13 +216,14 @@ public class PoolManagerTest {
     }
 
     protected ConsumerType mockConsumerType(ConsumerType ctype) {
-        // Ensure the type has an ID
         if (ctype != null) {
+            // Ensure the type has an ID
             if (ctype.getId() == null) {
                 ctype.setId("test-ctype-" + ctype.getLabel() + "-" + TestUtil.randomInt());
             }
 
             when(consumerTypeCuratorMock.lookupByLabel(eq(ctype.getLabel()))).thenReturn(ctype);
+            when(consumerTypeCuratorMock.lookupByLabel(eq(ctype.getLabel()), anyBoolean())).thenReturn(ctype);
             when(consumerTypeCuratorMock.find(eq(ctype.getId()))).thenReturn(ctype);
 
             doAnswer(new Answer<ConsumerType>() {
@@ -231,15 +232,15 @@ public class PoolManagerTest {
                     Object[] args = invocation.getArguments();
                     Consumer consumer = (Consumer) args[0];
                     ConsumerTypeCurator curator = (ConsumerTypeCurator) invocation.getMock();
-
                     ConsumerType ctype = null;
 
-                    if (consumer != null && consumer.getTypeId() != null) {
-                        ctype = curator.find(consumer.getTypeId());
+                    if (consumer == null || consumer.getTypeId() == null) {
+                        throw new IllegalArgumentException("consumer is null or lacks a type ID");
+                    }
 
-                        if (ctype == null) {
-                            throw new IllegalStateException("No such consumer type: " + consumer.getTypeId());
-                        }
+                    ctype = curator.find(consumer.getTypeId());
+                    if (ctype == null) {
+                        throw new IllegalStateException("No such consumer type: " + consumer.getTypeId());
                     }
 
                     return ctype;

--- a/server/src/test/java/org/candlepin/policy/AutobindRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/AutobindRulesTest.java
@@ -32,6 +32,7 @@ import org.candlepin.model.ConsumerType.ConsumerTypeEnum;
 import org.candlepin.model.ConsumerTypeCurator;
 import org.candlepin.model.Content;
 import org.candlepin.model.Entitlement;
+import org.candlepin.model.EnvironmentCurator;
 import org.candlepin.model.GuestId;
 import org.candlepin.model.Owner;
 import org.candlepin.model.Pool;
@@ -80,6 +81,7 @@ public class AutobindRulesTest {
     @Mock private RulesCurator rulesCurator;
     @Mock private ProductCurator mockProductCurator;
     @Mock private ConsumerTypeCurator consumerTypeCurator;
+    @Mock private EnvironmentCurator environmentCurator;
 
     private ComplianceStatus compliance;
     private AutobindRules autobindRules; // TODO rename
@@ -105,7 +107,7 @@ public class AutobindRulesTest {
         when(cacheProvider.get()).thenReturn(cache);
         JsRunner jsRules = new JsRunnerProvider(rulesCurator, cacheProvider).get();
 
-        translator = new StandardTranslator(consumerTypeCurator);
+        translator = new StandardTranslator(consumerTypeCurator, environmentCurator);
         autobindRules = new AutobindRules(jsRules, mockProductCurator, consumerTypeCurator,
             new RulesObjectMapper(new ProductCachedSerializationModule(mockProductCurator)), translator);
 

--- a/server/src/test/java/org/candlepin/policy/EnforcerTest.java
+++ b/server/src/test/java/org/candlepin/policy/EnforcerTest.java
@@ -27,7 +27,6 @@ import org.candlepin.common.config.Configuration;
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.controller.ProductManager;
 import org.candlepin.dto.ModelTranslator;
-import org.candlepin.dto.StandardTranslator;
 import org.candlepin.jackson.ProductCachedSerializationModule;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.Entitlement;
@@ -91,7 +90,7 @@ public class EnforcerTest extends DatabaseTestFixture {
     @Mock private EventSink mockEventSink;
     @Mock private EventFactory mockEventFactory;
 
-    private ModelTranslator translator;
+    @Inject private ModelTranslator translator;
     private Enforcer enforcer;
     private Owner owner;
     private Consumer consumer;
@@ -125,8 +124,6 @@ public class EnforcerTest extends DatabaseTestFixture {
         when(cacheProvider.get()).thenReturn(cache);
 
         JsRunner jsRules = new JsRunnerProvider(rulesCurator, cacheProvider).get();
-
-        translator = new StandardTranslator(consumerTypeCurator);
 
         enforcer = new EntitlementRules(
             new DateSourceForTesting(2010, 1, 1), jsRules, i18n, config, consumerCurator, consumerTypeCurator,

--- a/server/src/test/java/org/candlepin/policy/js/activationkey/ActivationKeyRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/activationkey/ActivationKeyRulesTest.java
@@ -23,6 +23,7 @@ import org.candlepin.dto.ModelTranslator;
 import org.candlepin.dto.StandardTranslator;
 import org.candlepin.jackson.ProductCachedSerializationModule;
 import org.candlepin.model.ConsumerTypeCurator;
+import org.candlepin.model.EnvironmentCurator;
 import org.candlepin.model.Owner;
 import org.candlepin.model.Pool;
 import org.candlepin.model.Product;
@@ -62,6 +63,7 @@ public class ActivationKeyRulesTest {
     @Mock private Provider<JsRunnerRequestCache> cacheProvider;
     @Mock private JsRunnerRequestCache cache;
     @Mock private ConsumerTypeCurator mockConsumerTypeCurator;
+    @Mock private EnvironmentCurator environmentCurator;
 
     private I18n i18n;
     private JsRunnerProvider provider;
@@ -83,7 +85,7 @@ public class ActivationKeyRulesTest {
 
         provider = new JsRunnerProvider(rulesCuratorMock, cacheProvider);
         ProductCurator productCurator = mock(ProductCurator.class);
-        translator = new StandardTranslator(mockConsumerTypeCurator);
+        translator = new StandardTranslator(mockConsumerTypeCurator, environmentCurator);
         actKeyRules = new ActivationKeyRules(provider.get(), i18n,
                 new RulesObjectMapper(new ProductCachedSerializationModule(productCurator)), translator);
     }

--- a/server/src/test/java/org/candlepin/policy/js/compliance/ComplianceRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/compliance/ComplianceRulesTest.java
@@ -38,6 +38,7 @@ import org.candlepin.model.ConsumerTypeCurator;
 import org.candlepin.model.ConsumerInstalledProduct;
 import org.candlepin.model.Entitlement;
 import org.candlepin.model.EntitlementCurator;
+import org.candlepin.model.EnvironmentCurator;
 import org.candlepin.model.GuestId;
 import org.candlepin.model.Owner;
 import org.candlepin.model.Pool;
@@ -99,6 +100,7 @@ public class ComplianceRulesTest {
     @Mock private Provider<JsRunnerRequestCache> cacheProvider;
     @Mock private JsRunnerRequestCache cache;
     @Mock private ProductCurator productCurator;
+    @Mock private EnvironmentCurator environmentCurator;
 
     private ModelTranslator translator;
     private I18n i18n;
@@ -110,7 +112,7 @@ public class ComplianceRulesTest {
     public void setUp() {
         MockitoAnnotations.initMocks(this);
 
-        translator = new StandardTranslator(consumerTypeCurator);
+        translator = new StandardTranslator(consumerTypeCurator, environmentCurator);
 
         Locale locale = new Locale("en_US");
         i18n = I18nFactory.getI18n(getClass(), "org.candlepin.i18n.Messages", locale, I18nFactory.FALLBACK);

--- a/server/src/test/java/org/candlepin/policy/js/entitlement/EntitlementRulesTestFixture.java
+++ b/server/src/test/java/org/candlepin/policy/js/entitlement/EntitlementRulesTestFixture.java
@@ -16,6 +16,7 @@ package org.candlepin.policy.js.entitlement;
 
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.doAnswer;
 
@@ -34,6 +35,7 @@ import org.candlepin.model.ConsumerType;
 import org.candlepin.model.ConsumerType.ConsumerTypeEnum;
 import org.candlepin.model.ConsumerTypeCurator;
 import org.candlepin.model.EntitlementCurator;
+import org.candlepin.model.EnvironmentCurator;
 import org.candlepin.model.Owner;
 import org.candlepin.model.OwnerCurator;
 import org.candlepin.model.OwnerProductCurator;
@@ -105,6 +107,8 @@ public class EntitlementRulesTestFixture {
     protected EventSink eventSink;
     @Mock
     protected EventFactory eventFactory;
+    @Mock
+    protected EnvironmentCurator environmentCurator;
 
     protected Owner owner;
     protected ConsumerType consumerType;
@@ -130,7 +134,7 @@ public class EntitlementRulesTestFixture {
 
         JsRunner jsRules = new JsRunnerProvider(rulesCurator, cacheProvider).get();
 
-        translator = new StandardTranslator(consumerTypeCurator);
+        translator = new StandardTranslator(consumerTypeCurator, environmentCurator);
         enforcer = new EntitlementRules(
             new DateSourceImpl(),
             jsRules,
@@ -159,13 +163,14 @@ public class EntitlementRulesTestFixture {
     }
 
     protected ConsumerType mockConsumerType(ConsumerType ctype) {
-        // Ensure the type has an ID
         if (ctype != null) {
+            // Ensure the type has an ID
             if (ctype.getId() == null) {
                 ctype.setId("test-ctype-" + ctype.getLabel() + "-" + TestUtil.randomInt());
             }
 
             when(consumerTypeCurator.lookupByLabel(eq(ctype.getLabel()))).thenReturn(ctype);
+            when(consumerTypeCurator.lookupByLabel(eq(ctype.getLabel()), anyBoolean())).thenReturn(ctype);
             when(consumerTypeCurator.find(eq(ctype.getId()))).thenReturn(ctype);
 
             doAnswer(new Answer<ConsumerType>() {
@@ -174,15 +179,15 @@ public class EntitlementRulesTestFixture {
                     Object[] args = invocation.getArguments();
                     Consumer consumer = (Consumer) args[0];
                     ConsumerTypeCurator curator = (ConsumerTypeCurator) invocation.getMock();
-
                     ConsumerType ctype = null;
 
-                    if (consumer != null && consumer.getTypeId() != null) {
-                        ctype = curator.find(consumer.getTypeId());
+                    if (consumer == null || consumer.getTypeId() == null) {
+                        throw new IllegalArgumentException("consumer is null or lacks a type ID");
+                    }
 
-                        if (ctype == null) {
-                            throw new IllegalStateException("No such consumer type: " + consumer.getTypeId());
-                        }
+                    ctype = curator.find(consumer.getTypeId());
+                    if (ctype == null) {
+                        throw new IllegalStateException("No such consumer type: " + consumer.getTypeId());
                     }
 
                     return ctype;

--- a/server/src/test/java/org/candlepin/policy/js/entitlement/ManifestEntitlementRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/entitlement/ManifestEntitlementRulesTest.java
@@ -45,14 +45,11 @@ import java.util.Set;
 public class ManifestEntitlementRulesTest extends EntitlementRulesTestFixture {
 
     private Consumer createMockConsumer(boolean manifestDistributor) {
-        ConsumerType type = TestUtil.createConsumerType();
+        ConsumerType type = this.mockConsumerType(TestUtil.createConsumerType());
         type.setManifest(manifestDistributor);
 
         Consumer consumer = TestUtil.createConsumer();
         consumer.setType(type);
-
-        when(consumerTypeCurator.getConsumerType(eq(consumer))).thenReturn(type);
-        when(consumerTypeCurator.find(eq(type.getId()))).thenReturn(type);
 
         return consumer;
     }

--- a/server/src/test/java/org/candlepin/policy/js/quantity/QuantityRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/quantity/QuantityRulesTest.java
@@ -27,6 +27,7 @@ import org.candlepin.model.ConsumerType;
 import org.candlepin.model.ConsumerTypeCurator;
 import org.candlepin.model.Entitlement;
 import org.candlepin.model.EntitlementCertificate;
+import org.candlepin.model.EnvironmentCurator;
 import org.candlepin.model.GuestId;
 import org.candlepin.model.Owner;
 import org.candlepin.model.Pool;
@@ -85,6 +86,7 @@ public class QuantityRulesTest {
     @Mock private JsRunnerRequestCache cache;
     @Mock private ProductCurator productCurator;
     @Mock private ConsumerTypeCurator consumerTypeCurator;
+    @Mock private EnvironmentCurator environmentCurator;
 
     @Before
     public void setUp() {
@@ -98,7 +100,7 @@ public class QuantityRulesTest {
         when(cacheProvider.get()).thenReturn(cache);
         provider = new JsRunnerProvider(rulesCuratorMock, cacheProvider);
 
-        translator = new StandardTranslator(consumerTypeCurator);
+        translator = new StandardTranslator(consumerTypeCurator, environmentCurator);
         quantityRules = new QuantityRules(provider.get(), new RulesObjectMapper(
             new ProductCachedSerializationModule(productCurator)), translator);
 

--- a/server/src/test/java/org/candlepin/resource/GuestIdResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/GuestIdResourceTest.java
@@ -35,6 +35,7 @@ import org.candlepin.model.ConsumerCurator;
 import org.candlepin.model.ConsumerType;
 import org.candlepin.model.ConsumerType.ConsumerTypeEnum;
 import org.candlepin.model.ConsumerTypeCurator;
+import org.candlepin.model.EnvironmentCurator;
 import org.candlepin.model.GuestId;
 import org.candlepin.model.GuestIdCurator;
 import org.candlepin.model.Owner;
@@ -59,8 +60,9 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 
-import javax.inject.Inject;
 import javax.inject.Provider;
+
+
 
 /**
  * GuestIdResourceTest
@@ -78,14 +80,14 @@ public class GuestIdResourceTest {
     @Mock private EventSink sink;
     @Mock private ServiceLevelValidator mockedServiceLevelValidator;
     @Mock private ConsumerEnricher consumerEnricher;
-    private ModelTranslator translator;
+    @Mock private EnvironmentCurator environmentCurator;
 
     private GuestIdResource guestIdResource;
 
     private Consumer consumer;
     private Owner owner;
     private ConsumerType ct;
-    @Inject protected ModelTranslator modelTranslator;
+    protected ModelTranslator modelTranslator;
 
     private GuestMigration testMigration;
     private Provider<GuestMigration> migrationProvider;
@@ -95,15 +97,16 @@ public class GuestIdResourceTest {
         testMigration = Mockito.spy(new GuestMigration(consumerCurator));
         migrationProvider = Providers.of(testMigration);
 
+        this.modelTranslator = new StandardTranslator(this.consumerTypeCurator, this.environmentCurator);
+
         i18n = I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK);
         owner = new Owner("test-owner", "Test Owner");
         ct = new ConsumerType(ConsumerTypeEnum.SYSTEM);
         ct.setId("test-system-ctype");
 
         consumer = new Consumer("consumer", "test", owner, ct);
-        translator = new StandardTranslator(consumerTypeCurator);
         guestIdResource = new GuestIdResource(guestIdCurator, consumerCurator, consumerTypeCurator,
-            consumerResource, i18n, eventFactory, sink, migrationProvider, translator);
+            consumerResource, i18n, eventFactory, sink, migrationProvider, this.modelTranslator);
 
         when(consumerCurator.findByUuid(consumer.getUuid())).thenReturn(consumer);
         when(consumerCurator.verifyAndLookupConsumer(consumer.getUuid())).thenReturn(consumer);

--- a/server/src/test/java/org/candlepin/resource/JobResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/JobResourceTest.java
@@ -25,6 +25,7 @@ import org.candlepin.dto.StandardTranslator;
 import org.candlepin.dto.api.v1.JobStatusDTO;
 import org.candlepin.model.CandlepinQuery;
 import org.candlepin.model.ConsumerTypeCurator;
+import org.candlepin.model.EnvironmentCurator;
 import org.candlepin.model.JobCurator;
 import org.candlepin.model.TransformedCandlepinQuery;
 import org.candlepin.pinsetter.core.PinsetterException;
@@ -57,6 +58,7 @@ public class JobResourceTest {
     @Mock private JobCurator jobCurator;
     @Mock private PinsetterKernel pinsetterKernel;
     @Mock private ConsumerTypeCurator consumerTypeCurator;
+    @Mock private EnvironmentCurator environmentCurator;
 
     private I18n i18n;
     private ModelTranslator translator;
@@ -65,7 +67,7 @@ public class JobResourceTest {
     public void init() {
         MockitoAnnotations.initMocks(this);
         i18n = I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK);
-        translator = new StandardTranslator(this.consumerTypeCurator);
+        translator = new StandardTranslator(this.consumerTypeCurator, this.environmentCurator);
         jobResource = new JobResource(jobCurator, pinsetterKernel, i18n, translator);
     }
 

--- a/server/src/test/java/org/candlepin/resource/util/InstalledProductStatusCalculatorTest.java
+++ b/server/src/test/java/org/candlepin/resource/util/InstalledProductStatusCalculatorTest.java
@@ -30,6 +30,7 @@ import org.candlepin.model.ConsumerType;
 import org.candlepin.model.ConsumerTypeCurator;
 import org.candlepin.model.Entitlement;
 import org.candlepin.model.EntitlementCurator;
+import org.candlepin.model.EnvironmentCurator;
 import org.candlepin.model.GuestId;
 import org.candlepin.model.Owner;
 import org.candlepin.model.OwnerProductCurator;
@@ -90,6 +91,7 @@ public class InstalledProductStatusCalculatorTest {
     @Mock private ConsumerCurator consumerCurator;
     @Mock private ConsumerTypeCurator consumerTypeCurator;
     @Mock private EntitlementCurator entCurator;
+    @Mock private EnvironmentCurator environmentCurator;
     @Mock private RulesCurator rulesCuratorMock;
     @Mock private EventSink eventSink;
     @Mock private Provider<JsRunnerRequestCache> cacheProvider;
@@ -107,7 +109,7 @@ public class InstalledProductStatusCalculatorTest {
     public void setUp() {
         MockitoAnnotations.initMocks(this);
 
-        translator = new StandardTranslator(this.consumerTypeCurator);
+        translator = new StandardTranslator(this.consumerTypeCurator, this.environmentCurator);
 
         // Load the default production rules:
         InputStream is = this.getClass().getResourceAsStream(RulesCurator.DEFAULT_RULES_FILE);

--- a/server/src/test/java/org/candlepin/sync/ConsumerExporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/ConsumerExporterTest.java
@@ -25,6 +25,7 @@ import org.candlepin.dto.StandardTranslator;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerType;
 import org.candlepin.model.ConsumerTypeCurator;
+import org.candlepin.model.EnvironmentCurator;
 import org.candlepin.test.TestUtil;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -45,6 +46,7 @@ import java.util.HashMap;
 public class ConsumerExporterTest {
 
     @Mock private ConsumerTypeCurator mockConsumerTypeCurator;
+    @Mock private EnvironmentCurator mockEnvironmentCurator;
     private ModelTranslator translator;
 
     @Test
@@ -56,7 +58,7 @@ public class ConsumerExporterTest {
                 }
             }));
 
-        translator = new StandardTranslator(mockConsumerTypeCurator);
+        translator = new StandardTranslator(mockConsumerTypeCurator, mockEnvironmentCurator);
         ConsumerExporter exporter = new ConsumerExporter(translator);
         ConsumerType ctype = new ConsumerType("candlepin");
         ctype.setId("8888");

--- a/server/src/test/java/org/candlepin/sync/ConsumerTypeExporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/ConsumerTypeExporterTest.java
@@ -22,6 +22,7 @@ import org.candlepin.dto.ModelTranslator;
 import org.candlepin.dto.StandardTranslator;
 import org.candlepin.model.ConsumerType;
 import org.candlepin.model.ConsumerTypeCurator;
+import org.candlepin.model.EnvironmentCurator;
 import org.candlepin.test.TestUtil;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -42,6 +43,7 @@ import java.util.HashMap;
 public class ConsumerTypeExporterTest {
 
     @Mock private ConsumerTypeCurator mockConsumerTypeCurator;
+    @Mock private EnvironmentCurator mockEnvironmentCurator;
     private ModelTranslator translator;
 
     @Test
@@ -54,7 +56,7 @@ public class ConsumerTypeExporterTest {
             }
         ));
 
-        translator = new StandardTranslator(mockConsumerTypeCurator);
+        translator = new StandardTranslator(mockConsumerTypeCurator, mockEnvironmentCurator);
         ConsumerTypeExporter consumerType = new ConsumerTypeExporter(translator);
 
         StringWriter writer = new StringWriter();

--- a/server/src/test/java/org/candlepin/sync/EntitlementImporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/EntitlementImporterTest.java
@@ -35,6 +35,7 @@ import org.candlepin.model.ConsumerTypeCurator;
 import org.candlepin.model.Entitlement;
 import org.candlepin.model.EntitlementCertificate;
 import org.candlepin.model.EntitlementCurator;
+import org.candlepin.model.EnvironmentCurator;
 import org.candlepin.model.Owner;
 import org.candlepin.model.Pool;
 import org.candlepin.model.Product;
@@ -73,6 +74,7 @@ public class EntitlementImporterTest {
     @Mock private ObjectMapper om;
     @Mock private ProductCurator mockProductCurator;
     @Mock private EntitlementCurator ec;
+    @Mock private EnvironmentCurator mockEnvironmentCurator;
     @Mock private ConsumerTypeCurator mockConsumerTypeCurator;
 
     private Owner owner;
@@ -90,7 +92,7 @@ public class EntitlementImporterTest {
     @Before
     public void init() {
         this.owner = new Owner();
-        this.translator = new StandardTranslator(mockConsumerTypeCurator);
+        this.translator = new StandardTranslator(mockConsumerTypeCurator, mockEnvironmentCurator);
 
         i18n = I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK);
         this.importer = new EntitlementImporter(certSerialCurator, cdnCurator, i18n, mockProductCurator, ec);

--- a/server/src/test/java/org/candlepin/sync/ExporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/ExporterTest.java
@@ -40,6 +40,7 @@ import org.candlepin.model.DistributorVersionCapability;
 import org.candlepin.model.DistributorVersionCurator;
 import org.candlepin.model.Entitlement;
 import org.candlepin.model.EntitlementCurator;
+import org.candlepin.model.EnvironmentCurator;
 import org.candlepin.model.IdentityCertificate;
 import org.candlepin.model.KeyPair;
 import org.candlepin.model.Owner;
@@ -109,6 +110,7 @@ public class ExporterTest {
     private CdnCurator cdnc;
     private CdnExporter cdne;
     private EntitlementExporter ee;
+    private EnvironmentCurator mockEnvironmentCurator;
     private PKIUtility pki;
     private CandlepinCommonTestConfig config;
     private ExportRules exportRules;
@@ -121,8 +123,9 @@ public class ExporterTest {
     @Before
     public void setUp() {
         ctc = mock(ConsumerTypeCurator.class);
+        mockEnvironmentCurator = mock(EnvironmentCurator.class);
         me = new MetaExporter();
-        translator = new StandardTranslator(ctc);
+        translator = new StandardTranslator(ctc, mockEnvironmentCurator);
         ce = new ConsumerExporter(translator);
         cte = new ConsumerTypeExporter(translator);
         rc = mock(RulesCurator.class);

--- a/server/src/test/java/org/candlepin/sync/ImporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/ImporterTest.java
@@ -40,6 +40,7 @@ import org.candlepin.model.DistributorVersionCapability;
 import org.candlepin.model.DistributorVersionCurator;
 import org.candlepin.model.Entitlement;
 import org.candlepin.model.EntitlementCurator;
+import org.candlepin.model.EnvironmentCurator;
 import org.candlepin.model.ExporterMetadata;
 import org.candlepin.model.ExporterMetadataCurator;
 import org.candlepin.model.IdentityCertificateCurator;
@@ -114,6 +115,7 @@ public class ImporterTest {
     private SyncUtils su;
     private ProductCurator pc;
     private EntitlementCurator ec;
+    private EnvironmentCurator environmentCurator;
     private SubscriptionReconciler mockSubReconciler;
     private ConsumerTypeCurator consumerTypeCurator;
     private ModelTranslator translator;
@@ -136,6 +138,7 @@ public class ImporterTest {
         config = new CandlepinCommonTestConfig();
         pc = Mockito.mock(ProductCurator.class);
         ec = Mockito.mock(EntitlementCurator.class);
+        this.environmentCurator = Mockito.mock(EnvironmentCurator.class);
         ProductCachedSerializationModule productCachedModule = new ProductCachedSerializationModule(pc);
         su = new SyncUtils(config, productCachedModule);
         PrintStream ps = new PrintStream(
@@ -148,7 +151,7 @@ public class ImporterTest {
         this.mockSubReconciler = Mockito.mock(SubscriptionReconciler.class);
         this.consumerTypeCurator = Mockito.mock(ConsumerTypeCurator.class);
 
-        this.translator = new StandardTranslator(this.consumerTypeCurator);
+        this.translator = new StandardTranslator(this.consumerTypeCurator, this.environmentCurator);
     }
 
     @After
@@ -169,10 +172,8 @@ public class ImporterTest {
          * make sure version is > ABC
          */
         Date now = new Date();
-        File file = createFile("meta", "0.0.3", now,
-            "test_user", "prefix");
-        File actual = createFile("meta.json", "0.0.3", now,
-            "test_user", "prefix");
+        File file = createFile("meta", "0.0.3", now, "test_user", "prefix");
+        File actual = createFile("meta.json", "0.0.3", now, "test_user", "prefix");
         ExporterMetadataCurator emc = mock(ExporterMetadataCurator.class);
         ExporterMetadata em = new ExporterMetadata();
         Date daybefore = getDateBeforeDays(1);

--- a/server/src/test/java/org/candlepin/test/DatabaseTestFixture.java
+++ b/server/src/test/java/org/candlepin/test/DatabaseTestFixture.java
@@ -102,8 +102,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
 import java.util.Locale;
 
 import javax.inject.Inject;
@@ -486,15 +484,6 @@ public class DatabaseTestFixture {
         Environment environment = new Environment(id, name, owner);
         environment.setDescription(description);
 
-        if (consumers != null) {
-            // Ugly hack to deal with how environment currently encapsulates its collections
-            if (!(consumers instanceof List)) {
-                consumers = new LinkedList<>(consumers);
-            }
-
-            environment.setConsumers((List<Consumer>) consumers);
-        }
-
         if (content != null) {
             for (Content elem : content) {
                 EnvironmentContent envContent = new EnvironmentContent(environment, elem, true);
@@ -506,7 +495,17 @@ public class DatabaseTestFixture {
             }
         }
 
-        return this.environmentCurator.create(environment);
+        environment = this.environmentCurator.create(environment);
+
+        // Update consumers to point to the new environment
+        if (consumers != null) {
+            for (Consumer consumer : consumers) {
+                consumer.setEnvironmentId(environment.getId());
+                this.consumerCurator.merge(consumer);
+            }
+        }
+
+        return environment;
     }
 
     protected Owner createOwner() {


### PR DESCRIPTION
- Removed the nested Environment object from Consumer and changed it
  to an string ID
- Added the new method getConsumerEnvironment to EnvironmentCurator
  to do convenient lookups of a consumer's environment
- Several code and test changes in accordance with the environment
  separation