### PR TITLE
Enable a bypass of resolving custom products when adding subscriptions to the test adapters

### DIFF
--- a/server/src/main/java/org/candlepin/hostedtest/HostedTestSubscriptionResource.java
+++ b/server/src/main/java/org/candlepin/hostedtest/HostedTestSubscriptionResource.java
@@ -121,9 +121,14 @@ public class HostedTestSubscriptionResource {
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    public Subscription createSubscription(Subscription subscription) {
+    public Subscription createSubscription(
+        Subscription subscription,
+        @QueryParam("disable_resolution") Boolean disableResolution) {
         if (subscription.getId() == null || subscription.getId().trim().length() == 0) {
             subscription.setId(this.idGenerator.generateId());
+        }
+        if (disableResolution != null && disableResolution) {
+            return adapter.createSubscription(subscription);
         }
         return adapter.createSubscription(resolverUtil.resolveSubscriptionAndProduct(subscription));
     }


### PR DESCRIPTION
This enables the testing of the true hosted behavior where the entire
subscription definition comes in via the adapter. Prior to this change, product data is loaded from 
Candlepin via the resolver before being put into the HostedTestSubscriptionServiceAdapter in 
memory cache. This change enables setting things exactly as passed in the request JSON.  