### PR TITLE
1550190: Fixed Artemis resend on error to prevent lost messages

### DIFF
--- a/server/src/main/java/org/candlepin/audit/EventReceiver.java
+++ b/server/src/main/java/org/candlepin/audit/EventReceiver.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2009 - 2016 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.audit;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.activemq.artemis.api.core.ActiveMQException;
+import org.apache.activemq.artemis.api.core.ActiveMQExceptionType;
+import org.apache.activemq.artemis.api.core.client.ClientConsumer;
+import org.apache.activemq.artemis.api.core.client.ClientSession;
+import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Receives messages from an Artemis Queue. Each receiver creates and handles its own session.
+ */
+public class EventReceiver {
+    private static Logger log = LoggerFactory.getLogger(EventReceiver.class);
+    private ClientSession session;
+
+    public EventReceiver(EventListener listener, ClientSessionFactory sessionFactory,
+        ObjectMapper mapper) throws ActiveMQException {
+        String queueName = EventSource.QUEUE_ADDRESS + "." + listener.getClass().getCanonicalName();
+        log.debug("registering listener for {}", queueName);
+
+        // The client session is created without auto-acking enabled. This means
+        // that the client handlers will have to manage the session themselves.
+        // The session management will be done by each individual ListenerWrapper.
+        //
+        // A message ack batch size of 0 is specified to prevent duplicate messages
+        // if the server goes down before the batch ack size is reached.
+        session = sessionFactory.createSession(false, false, 0);
+
+        try {
+            // Create a durable queue that will be persisted to disk:
+            session.createQueue(EventSource.QUEUE_ADDRESS, queueName, true);
+            log.debug("created new event queue: {}", queueName);
+        }
+        catch (ActiveMQException e) {
+            // if the queue exists already we already created it in a previous run,
+            // so that's fine.
+            if (e.getType() != ActiveMQExceptionType.QUEUE_EXISTS) {
+                throw e;
+            }
+        }
+
+        ClientConsumer consumer = session.createConsumer(queueName);
+        consumer.setMessageHandler(new ListenerWrapper(listener, mapper, session));
+        session.start();
+    }
+
+    /**
+     * Close the current session.
+     */
+    public void close() {
+        // Use a separate try/catch to ensure that both methods
+        // are at least tried.
+        try {
+            this.session.stop();
+        }
+        catch (ActiveMQException e) {
+            log.warn("Error stopping client session", e);
+        }
+
+        try {
+            this.session.close();
+        }
+        catch (ActiveMQException e) {
+            log.warn("Error closing client session.", e);
+        }
+    }
+}

--- a/server/src/main/java/org/candlepin/audit/EventSource.java
+++ b/server/src/main/java/org/candlepin/audit/EventSource.java
@@ -17,16 +17,15 @@ package org.candlepin.audit;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Inject;
 
-import org.apache.activemq.artemis.api.core.ActiveMQException;
-import org.apache.activemq.artemis.api.core.ActiveMQExceptionType;
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
-import org.apache.activemq.artemis.api.core.client.ClientConsumer;
-import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.core.remoting.impl.invm.InVMConnectorFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.LinkedList;
+import java.util.List;
 
 /**
  * EventSource
@@ -34,9 +33,9 @@ import org.slf4j.LoggerFactory;
 public class EventSource {
     private static  Logger log = LoggerFactory.getLogger(EventSource.class);
     static final String QUEUE_ADDRESS = "event";
-    private ClientSession session;
     private ClientSessionFactory factory;
     private ObjectMapper mapper;
+    private List<EventReceiver> eventReceivers = new LinkedList<>();
 
 
     @Inject
@@ -45,12 +44,6 @@ public class EventSource {
 
         try {
             factory =  createSessionFactory();
-            // Specify a message ack batch size of 0 to have ActiveMQ immediately ack
-            // any message successfully received with the server. Not doing so can lead
-            // to duplicate messages if the server goes down before the batch ack size is
-            // reached.
-            session = factory.createSession(true, true, 0);
-            session.start();
         }
         catch (Exception e) {
             throw new RuntimeException(e);
@@ -67,39 +60,15 @@ public class EventSource {
     }
 
     protected void shutDown() {
-        try {
-            session.stop();
-            session.close();
-            factory.close();
-        }
-        catch (ActiveMQException e) {
-            log.warn("Exception while trying to shutdown ActiveMQ", e);
-        }
+        closeEventReceivers();
+        factory.close();
     }
 
-    void registerListener(EventListener listener) {
-        String queueName = QUEUE_ADDRESS + "." + listener.getClass().getCanonicalName();
-        log.debug("registering listener for {}", queueName);
+    void registerListener(EventListener listener) throws Exception {
+        this.eventReceivers.add(new EventReceiver(listener, factory, mapper));
+    }
 
-        try {
-            try {
-                // Create a durable queue that will be persisted to disk:
-                session.createQueue(QUEUE_ADDRESS, queueName, true);
-                log.debug("created new event queue " + queueName);
-            }
-            catch (ActiveMQException e) {
-                // if the queue exists already we already created it in a previous run,
-                // so that's fine.
-                if (e.getType() != ActiveMQExceptionType.QUEUE_EXISTS) {
-                    throw e;
-                }
-            }
-
-            ClientConsumer consumer = session.createConsumer(queueName);
-            consumer.setMessageHandler(new ListenerWrapper(listener, mapper));
-        }
-        catch (ActiveMQException e) {
-            log.error("Unable to register listener :" + listener, e);
-        }
+    private void closeEventReceivers() {
+        this.eventReceivers.forEach(EventReceiver::close);
     }
 }

--- a/server/src/main/java/org/candlepin/audit/ListenerWrapper.java
+++ b/server/src/main/java/org/candlepin/audit/ListenerWrapper.java
@@ -14,60 +14,75 @@
  */
 package org.candlepin.audit;
 
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
+import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.MessageHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 
 /**
- * ListnerWrapper
+ * A ListenerWrapper serves as a bridge between Artemis' message delevery and candlepin's
+ * Event handling. It is responsible for translating the message to an Event object,
+ * and passing it along to a candlepin EventListener for processing.
+ *
+ * The ListenerWrapper handles all client session management and ensures that the
+ * message remains on the message queue until it has been successfully processed by
+ * the listener.
  */
 public class ListenerWrapper implements MessageHandler {
 
     private EventListener listener;
     private static Logger log = LoggerFactory.getLogger(ListenerWrapper.class);
     private ObjectMapper mapper;
-    public ListenerWrapper(EventListener listener, ObjectMapper mapper) {
+    private ClientSession session;
+
+    public ListenerWrapper(EventListener listener, ObjectMapper mapper, ClientSession session) {
         this.listener = listener;
         this.mapper = mapper;
+        this.session = session;
     }
 
     @Override
     public void onMessage(ClientMessage msg) {
-        String body = msg.getBodyBuffer().readString();
-        log.debug("Got event: {}", body);
-
-        // Exceptions thrown here will cause the event to remain in ActiveMQ:
+        String body = "";
         try {
+            // Acknowledge the message so that the server knows that it was received.
+            // By doing this, the server can update the delivery counts which plays
+            // part in calculating redelivery delays.
+            msg.acknowledge();
+            log.debug("ActiveMQ message {} acknowledged for listener: {}", msg.getMessageID(), listener);
+
+            // Process the message via our EventListener framework.
+            body = msg.getBodyBuffer().readString();
+            log.debug("Got event: {}", body);
             Event event = mapper.readValue(body, Event.class);
             listener.onEvent(event);
-        }
-        catch (JsonMappingException e) {
-            log.error("Unable to deserialize event object from msg: " + body, e);
-            throw new RuntimeException("Error deserializing event", e);
-        }
-        catch (JsonParseException e) {
-            log.error("Unable to deserialize event object from msg: " + body, e);
-            throw new RuntimeException("Error deserializing event", e);
-        }
-        catch (IOException e) {
-            log.error("Unable to deserialize event object from msg: " + body, e);
-            throw new RuntimeException("Error deserializing event", e);
-        }
 
-        try {
-            msg.acknowledge();
-            log.debug("ActiveMQ message acknowledged for listener: " + listener);
+            // Finally commit the session so that the message is taken out of the queue.
+            session.commit();
         }
-        catch (ActiveMQException e) {
-            log.error("Unable to acknowledge ActiveMQ msg", e);
+        catch (Exception e) {
+            // Log a warning instead of a full stack trace to reduce log size.
+            String messageId = (msg == null) ? "" : Long.toString(msg.getMessageID());
+            String reason = (e.getCause() == null) ? e.getMessage() : e.getCause().getMessage();
+            log.error("Unable to process message {}: {}", messageId, reason);
+
+            // If debugging is enabled log a more in depth message.
+            log.debug("Unable to process message. Rolling back client session.\n{}", body, e);
+            try {
+                // When any exception occurs while processing the message, we need to roll back
+                // the session so that the message remains on the queue.
+                session.rollback();
+            }
+            catch (ActiveMQException amqe) {
+                log.error("Unable to roll back client session.", amqe);
+            }
+
+            // Session was rolled back, nothing left to do.
         }
     }
 

--- a/server/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/server/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -106,6 +106,28 @@ public class ConfigProperties {
      */
     public static final String ACTIVEMQ_MAX_PAGE_SIZE = "candlepin.audit.hornetq.max_page_size";
 
+    /**
+     * For more on Artemis redelivery delays, see:
+     * https://activemq.apache.org/artemis/docs/2.4.0/undelivered-messages.html
+     */
+
+    /**
+     * The number of milliseconds to wait before redelivering failed messages to the listeners.
+     */
+    public static final String ACTIVEMQ_REDELIVERY_DELAY = "candlepin.audit.hornetq.redelivery_delay";
+
+    /**
+     * The maximum number of milliseconds to wait before redelivering failed messages to the listeners.
+     */
+    public static final String ACTIVEMQ_MAX_REDELIVERY_DELAY = "candlepin.audit.hornetq.max_redelivery_delay";
+
+    /**
+     * A multiplier allowing the redelivery delay to increase to ACTIVEMQ_MAX_REDELIVERY_DELAY
+     * after each attempt to deliver a message.
+     */
+    public static final String ACTIVEMQ_REDELIVERY_MULTIPLIER =
+        "candlepin.audit.hornetq.redelivery_multiplier";
+
     public static final String AUDIT_LISTENERS = "candlepin.audit.listeners";
     public static final String AUDIT_LOG_FILE = "candlepin.audit.log_file";
     /**
@@ -304,6 +326,11 @@ public class ConfigProperties {
             this.put(ACTIVEMQ_ADDRESS_FULL_POLICY, "PAGE");
             this.put(ACTIVEMQ_MAX_QUEUE_SIZE, "10");
             this.put(ACTIVEMQ_MAX_PAGE_SIZE, "1");
+
+            this.put(ACTIVEMQ_REDELIVERY_DELAY, "5000");
+            this.put(ACTIVEMQ_MAX_REDELIVERY_DELAY, "60000");
+            this.put(ACTIVEMQ_REDELIVERY_MULTIPLIER, "2");
+
             this.put(AUDIT_LISTENERS,
                 "org.candlepin.audit.DatabaseListener," +
                 "org.candlepin.audit.LoggingListener," +

--- a/server/src/test/java/org/candlepin/audit/EventReceiverTest.java
+++ b/server/src/test/java/org/candlepin/audit/EventReceiverTest.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2009 - 2016 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.audit;
+
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
+import static org.junit.Assert.fail;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.activemq.artemis.api.core.ActiveMQException;
+import org.apache.activemq.artemis.api.core.ActiveMQExceptionType;
+import org.apache.activemq.artemis.api.core.client.ClientConsumer;
+import org.apache.activemq.artemis.api.core.client.ClientSession;
+import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+/**
+ * EventReceiverTest
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class EventReceiverTest {
+
+    @Mock ClientSessionFactory clientSessionFactory;
+    @Mock ClientSession clientSession;
+    @Mock EventListener eventListener;
+
+    @Test(expected = ActiveMQException.class)
+    public void shouldThrowActiveMQExceptionWhenSessionCreateFailsDuringEventSourceCreation()
+        throws Exception {
+        when(clientSessionFactory.createSession(eq(false), eq(false), eq(0))).thenReturn(clientSession);
+        when(clientSession.createConsumer(any(String.class))).thenReturn(mock(ClientConsumer.class));
+        doThrow(new ActiveMQException()).when(clientSession).start();
+
+        new EventReceiver(eventListener, clientSessionFactory, new ObjectMapper());
+        fail("Should have thrown ActiveMQException");
+    }
+
+    @Test(expected = ActiveMQException.class)
+    public void shouldThrowExceptionWhenQueueCreationFails() throws Exception {
+        when(clientSessionFactory.createSession(eq(false), eq(false), eq(0))).thenReturn(clientSession);
+        when(clientSession.createConsumer(any(String.class))).thenReturn(mock(ClientConsumer.class));
+        doThrow(new ActiveMQException(ActiveMQExceptionType.DISCONNECTED))
+            .when(clientSession).createQueue(anyString(), anyString(), eq(true));
+
+        new EventReceiver(eventListener, clientSessionFactory, new ObjectMapper());
+        verify(clientSession, never()).createConsumer(anyString()); //should not be invoked
+        verify(clientSession, never()).start();
+    }
+
+    @Test
+    public void shouldCreateNewConsumerWhenQueueExistsOnRegisterListenerCall()
+        throws Exception {
+        ClientConsumer mockCC = mock(ClientConsumer.class);
+        when(clientSessionFactory.createSession(eq(false), eq(false), eq(0))).thenReturn(clientSession);
+        when(clientSession.createConsumer(anyString())).thenReturn(mockCC);
+        doThrow(new ActiveMQException(ActiveMQExceptionType.QUEUE_EXISTS))
+            .when(clientSession).createQueue(anyString(), anyString());
+
+        new EventReceiver(eventListener, clientSessionFactory, new ObjectMapper());
+
+        verify(clientSession).createConsumer(anyString());
+        verify(mockCC).setMessageHandler(any(ListenerWrapper.class));
+        verify(clientSession).start();
+    }
+
+    @Test
+    public void shouldCreateNewConsumerWhenQueueDoesNotExistOnRegisterListenerCall()
+        throws Exception {
+        ClientConsumer mockCC = mock(ClientConsumer.class);
+        when(clientSessionFactory.createSession(eq(false), eq(false), eq(0))).thenReturn(clientSession);
+        when(clientSession.createConsumer(anyString())).thenReturn(mockCC);
+
+        new EventReceiver(eventListener, clientSessionFactory, new ObjectMapper());
+
+        //make sure queue is created.
+        verify(clientSession).createQueue(anyString(), anyString(), eq(true));
+        verify(clientSession).createConsumer(anyString());
+        verify(mockCC).setMessageHandler(any(ListenerWrapper.class));
+        verify(clientSession).start();
+    }
+
+}

--- a/server/src/test/java/org/candlepin/audit/EventSourceTest.java
+++ b/server/src/test/java/org/candlepin/audit/EventSourceTest.java
@@ -14,18 +14,15 @@
  */
 package org.candlepin.audit;
 
-import static org.junit.Assert.*;
 import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.apache.activemq.artemis.api.core.ActiveMQException;
-import org.apache.activemq.artemis.api.core.ActiveMQExceptionType;
 import org.apache.activemq.artemis.api.core.client.ClientConsumer;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -39,15 +36,87 @@ import org.mockito.runners.MockitoJUnitRunner;
 public class EventSourceTest {
 
     @Mock private ClientSessionFactory clientSessionFactory;
-    @Mock private ClientSession clientSession;
 
-    @Before
-    public void init() throws Exception {
-        when(clientSessionFactory.createSession(eq(true), eq(true), eq(0)))
-            .thenReturn(clientSession);
+    @Test
+    public void registeringNewListenerCreatesNewSessionAndStartsIt() throws Exception {
+        ClientSession clientSession = mock(ClientSession.class);
+        EventSource source = createEventSourceStubbedWithFactoryCreation();
+        when(clientSessionFactory.createSession(eq(false), eq(false), eq(0))).thenReturn(clientSession);
+        when(clientSession.createConsumer(any(String.class))).thenReturn(mock(ClientConsumer.class));
+
+        source.registerListener(mock(EventListener.class));
+        verify(clientSessionFactory).createSession(eq(false), eq(false), eq(0));
+        verify(clientSession).start();
     }
+
+    @Test
+    public void shouldStopAndCloseSessionsOnShutdown() throws Exception {
+        ClientSession session1 = mock(ClientSession.class);
+        ClientSession session2 = mock(ClientSession.class);
+
+        EventSource eventSource = createEventSourceStubbedWithFactoryCreation();
+        when(clientSessionFactory.createSession(eq(false), eq(false), eq(0)))
+            .thenReturn(session1).thenReturn(session2);
+        when(session1.createConsumer(any(String.class))).thenReturn(mock(ClientConsumer.class));
+        when(session2.createConsumer(any(String.class))).thenReturn(mock(ClientConsumer.class));
+
+        eventSource.registerListener(mock(EventListener.class));
+        eventSource.registerListener(mock(EventListener.class));
+        eventSource.shutDown();
+
+        // Verify that all client sessions were stopped and closed.
+        verify(session1).stop();
+        verify(session1).close();
+
+        verify(session2).stop();
+        verify(session2).close();
+
+        // Verify that the client session factory was closed.
+        verify(clientSessionFactory).close();
+    }
+
+    @Test
+    public void shouldStopAndCloseSessionOnShutdownWhenExceptionThrownOnStop() throws Exception {
+        ClientSession session = mock(ClientSession.class);
+
+        EventSource eventSource = createEventSourceStubbedWithFactoryCreation();
+        when(clientSessionFactory.createSession(eq(false), eq(false), eq(0))).thenReturn(session);
+        when(session.createConsumer(any(String.class))).thenReturn(mock(ClientConsumer.class));
+        doThrow(new ActiveMQException("Forced")).when(session).stop();
+
+        eventSource.registerListener(mock(EventListener.class));
+        eventSource.shutDown();
+
+        // Verify that close was at least still called.
+        verify(session).close();
+
+        // Verify that the client session factory was closed regardless of the exception.
+        verify(clientSessionFactory).close();
+    }
+
+    @Test
+    public void shouldStopAndCloseSessionOnShutdownWhenExceptionThrownOnClose() throws Exception {
+        ClientSession session = mock(ClientSession.class);
+
+        EventSource eventSource = createEventSourceStubbedWithFactoryCreation();
+        when(clientSessionFactory.createSession(eq(false), eq(false), eq(0))).thenReturn(session);
+        when(session.createConsumer(any(String.class))).thenReturn(mock(ClientConsumer.class));
+        doThrow(new ActiveMQException("Forced")).when(session).close();
+
+        eventSource.registerListener(mock(EventListener.class));
+        eventSource.shutDown();
+
+        // Verify that stop was at least still called.
+        verify(session).stop();
+
+        // Verify that the client session factory was closed regardless of the exception.
+        verify(clientSessionFactory).close();
+    }
+
     /**
-     * @return
+     * Creates a new EventSource with a mocked ClientSessionFactory.
+     *
+     * @return the new EventSource
      */
     private EventSource createEventSourceStubbedWithFactoryCreation() {
         return new EventSource(new ObjectMapper()) {
@@ -55,94 +124,6 @@ public class EventSourceTest {
                 return clientSessionFactory;
             }
         };
-    }
-
-    @Test
-    public void shouldStartSessionWhenCreatingEventSource() throws Exception {
-        createEventSourceStubbedWithFactoryCreation();
-        verify(this.clientSession).start();
-    }
-
-    @Test(expected = RuntimeException.class)
-    public void shouldThrowRunTimeExceptionWhenSessionCreateFailsDuringEventSourceCreation()
-        throws Exception {
-        doThrow(new ActiveMQException()).when(clientSession).start();
-        createEventSourceStubbedWithFactoryCreation();
-        fail("Should have thrown runtime exception");
-    }
-
-    @Test
-    public void shouldNotThrowExceptionWhenQueueCreationFails() throws Exception {
-        EventSource eventSource = createEventSourceStubbedWithFactoryCreation();
-        doThrow(new ActiveMQException(ActiveMQExceptionType.QUEUE_DOES_NOT_EXIST))
-            .when(clientSession).createQueue(anyString(), anyString(), eq(true));
-        EventListener eventListener = mock(EventListener.class);
-        eventSource.registerListener(eventListener);
-
-        verify(clientSession, never()).createConsumer(anyString()); //should not be invoked
-    }
-
-    @Test
-    public void shouldCreateNewConsumerWhenQueueDoesNotExistOnRegisterListenerCall()
-        throws Exception {
-        EventSource eventSource = createEventSourceStubbedWithFactoryCreation();
-        ClientConsumer mockCC = mock(ClientConsumer.class);
-        when(clientSession.createConsumer(anyString()))
-            .thenReturn(mockCC);
-        EventListener eventListener = mock(EventListener.class);
-        eventSource.registerListener(eventListener);
-
-        //make sure queue is created.
-        verify(clientSession).createQueue(anyString(), anyString(), eq(true));
-        verify(mockCC).setMessageHandler(any(ListenerWrapper.class));
-    }
-
-    @Test
-    public void shouldCreateNewConsumerWhenQueueExistsOnRegisterListenerCall()
-        throws Exception {
-        EventSource eventSource = createEventSourceStubbedWithFactoryCreation();
-        ClientConsumer mockCC = mock(ClientConsumer.class);
-        when(clientSession.createConsumer(anyString()))
-            .thenReturn(mockCC);
-        doThrow(new ActiveMQException(ActiveMQExceptionType.QUEUE_EXISTS))
-            .when(clientSession).createQueue(anyString(), anyString());
-        EventListener eventListener = mock(EventListener.class);
-        //invoke
-        eventSource.registerListener(eventListener);
-
-        //verify listener is still added.
-        verify(mockCC).setMessageHandler(any(ListenerWrapper.class));
-    }
-
-    @Test
-    public void shouldStopAndCloseSessionOnShutdown() throws Exception {
-        EventSource eventSource = createEventSourceStubbedWithFactoryCreation();
-
-        eventSource.shutDown();
-
-        verify(clientSession).stop();
-        verify(clientSession).close();
-    }
-
-    @Test
-    public void shouldStopAndCloseSessionOnShutdownWhenExceptionThrownOnStop()
-        throws Exception {
-        EventSource eventSource = createEventSourceStubbedWithFactoryCreation();
-        doThrow(new ActiveMQException()).when(clientSession).stop();
-
-        eventSource.shutDown();
-
-        assertTrue(true); //so sorry!
-    }
-
-    @Test
-    public void shouldStopAndCloseSessionOnShutdownWhenExceptionThrownOnClose()
-        throws Exception {
-        EventSource eventSource = createEventSourceStubbedWithFactoryCreation();
-        doThrow(new ActiveMQException()).when(clientSession).close();
-
-        eventSource.shutDown();
-        verify(this.clientSession).stop();
     }
 
 }


### PR DESCRIPTION
Before this patch, resend message on error wasn't working
all the time, which could sometimes lead to lost messages
that wouldn't make it to Qpid.

This patch moves from having one ClientSession receiving
messages for all queues, to using a ClientSession per
queue/listener.

Prior to this patch, client sessions were set to
auto-acknowledge and auto-commit messages. This is no
longer the case. Each listener's ListenerWrapper now
manages its session by committing on success and rolling
back on failure.

Another important change is that as soon as a listener
recieves a message, that message should be immediately
acknowledged so that the session can keep track of the
number of times a message was sent (despite success or
failure). This is key to allowing retry on error to
function correctly.

### Testing Notes
All steps to test this PR can be found in the BZ:
    https://bugzilla.redhat.com/show_bug.cgi?id=1550190

With this patch applied, you should notice that retries will begin to back off by 10 seconds up to a max of the amount configured in candlepin conf. By default the max is 1 minute.

Once Qpid comes back online, messages will be received based on the next retry time. 

