### PR TITLE
[M] 1562097: Renamed Event.consumerId to consumerUuid

### DIFF
--- a/server/src/main/java/org/candlepin/audit/Event.java
+++ b/server/src/main/java/org/candlepin/audit/Event.java
@@ -120,9 +120,9 @@ public class Event implements Persisted {
     @Size(max = 255)
     private String ownerId;
 
-    @Column(nullable = true)
+    @Column(name = "consumer_uuid", nullable = true)
     @Size(max = 255)
-    private String consumerId;
+    private String consumerUuid;
 
     // Generic id field in case a cross reference is needed to some other entity
     // Use with reference type
@@ -146,10 +146,10 @@ public class Event implements Persisted {
     public Event() {
     }
 
-    public Event(Type type, Target target, String targetName,
-        Principal principal, String ownerId, String consumerId,
-        String entityId, String eventData,
-        String referenceId, ReferenceType referenceType) {
+    public Event(Type type, Target target, String targetName, Principal principal, String ownerId,
+        String consumerUuid, String entityId, String eventData, String referenceId,
+        ReferenceType referenceType) {
+
         this.type = type;
         this.target = target;
         this.targetName = targetName;
@@ -160,7 +160,7 @@ public class Event implements Persisted {
 
         this.entityId = entityId;
         this.eventData = eventData;
-        this.consumerId = consumerId;
+        this.consumerUuid = consumerUuid;
         this.referenceId = referenceId;
         this.referenceType = referenceType;
 
@@ -262,17 +262,20 @@ public class Event implements Persisted {
 
     @Override
     public String toString() {
-        return "Event [" + "id=" + getId() + ", target=" + getTarget() +
-            ", type=" + getType() + ", time=" + getTimestamp() + ", entity=" +
-            getEntityId() + "]";
+        String date = this.getTimestamp() != null ?
+            String.format("%1$tF %1$tT%1$tz", this.getTimestamp()) :
+            null;
+
+        return String.format("Event [id: %s, target: %s, type: %s, time: %s, entity: %s]",
+            this.getId(), this.getTarget(), this.getType(), date, this.getEntityId());
     }
 
-    public String getConsumerId() {
-        return consumerId;
+    public String getConsumerUuid() {
+        return consumerUuid;
     }
 
-    public void setConsumerId(String consumerId) {
-        this.consumerId = consumerId;
+    public void setConsumerUuid(String consumerUuid) {
+        this.consumerUuid = consumerUuid;
     }
 
     /**

--- a/server/src/main/java/org/candlepin/audit/EventBuilder.java
+++ b/server/src/main/java/org/candlepin/audit/EventBuilder.java
@@ -107,8 +107,8 @@ public class EventBuilder {
 
                 if (entity instanceof ConsumerProperty) {
                     Consumer owningConsumer = ((ConsumerProperty) entity).getConsumer();
-                    if (owningConsumer != null && owningConsumer.getId() != null) {
-                        event.setConsumerId(owningConsumer.getId());
+                    if (owningConsumer != null && owningConsumer.getUuid() != null) {
+                        event.setConsumerUuid(owningConsumer.getUuid());
                     }
                 }
             }

--- a/server/src/main/java/org/candlepin/audit/EventFactory.java
+++ b/server/src/main/java/org/candlepin/audit/EventFactory.java
@@ -216,7 +216,6 @@ public class EventFactory {
 
     public Event complianceCreated(Consumer consumer, ComplianceStatus compliance) {
         Map<String, Object> eventData = new HashMap<>();
-        eventData.put("consumer_uuid", consumer.getUuid());
         eventData.put("status", compliance.getStatus());
 
         List<Map<String, String>> reasons = new ArrayList<>(compliance.getReasons().size());

--- a/server/src/main/java/org/candlepin/dto/api/v1/EventDTO.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/EventDTO.java
@@ -27,6 +27,8 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import java.util.Date;
 
+
+
 /**
  * A DTO representation of the Event entity
  */
@@ -104,7 +106,7 @@ public class EventDTO extends CandlepinDTO<EventDTO> {
     private Date timestamp;
     private String entityId;
     private String ownerId;
-    private String consumerId;
+    private String consumerUuid;
     private String referenceId;
     private String eventData;
     private String messageText;
@@ -280,23 +282,23 @@ public class EventDTO extends CandlepinDTO<EventDTO> {
     }
 
     /**
-     * Retrieves the consumer id of this EventDTO object.
+     * Retrieves the consumer UUID of this EventDTO object.
      *
-     * @return the consumer id of this EventDTO object.
+     * @return the consumer UUID of this EventDTO object.
      */
-    public String getConsumerId() {
-        return consumerId;
+    public String getConsumerUuid() {
+        return consumerUuid;
     }
 
     /**
-     * Sets the consumer id of this EventDTO object.
+     * Sets the consumer UUID of this EventDTO object.
      *
-     * @param consumerId the consumer id of this EventDTO object.
+     * @param consumerUuid the consumer UUID of this EventDTO object.
      *
      * @return a reference to this DTO object.
      */
-    public EventDTO setConsumerId(String consumerId) {
-        this.consumerId = consumerId;
+    public EventDTO setConsumerUuid(String consumerUuid) {
+        this.consumerUuid = consumerUuid;
         return this;
     }
 
@@ -452,7 +454,7 @@ public class EventDTO extends CandlepinDTO<EventDTO> {
             EqualsBuilder builder = new EqualsBuilder()
                 .append(this.getId(), that.getId())
                 .append(this.getTargetName(), that.getTargetName())
-                .append(this.getConsumerId(), that.getConsumerId())
+                .append(this.getConsumerUuid(), that.getConsumerUuid())
                 .append(this.getEntityId(), that.getEntityId())
                 .append(this.getMessageText(), that.getMessageText())
                 .append(this.getOwnerId(), that.getOwnerId())
@@ -479,7 +481,7 @@ public class EventDTO extends CandlepinDTO<EventDTO> {
         HashCodeBuilder builder = new HashCodeBuilder(37, 7)
             .append(this.getId())
             .append(this.getTargetName())
-            .append(this.getConsumerId())
+            .append(this.getConsumerUuid())
             .append(this.getEntityId())
             .append(this.getMessageText())
             .append(this.getOwnerId())
@@ -515,7 +517,7 @@ public class EventDTO extends CandlepinDTO<EventDTO> {
 
         this.setId(source.getId())
             .setTargetName(source.getTargetName())
-            .setConsumerId(source.getConsumerId())
+            .setConsumerUuid(source.getConsumerUuid())
             .setEntityId(source.getEntityId())
             .setMessageText(source.getMessageText())
             .setOwnerId(source.getOwnerId())

--- a/server/src/main/java/org/candlepin/dto/api/v1/EventTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/EventTranslator.java
@@ -63,7 +63,7 @@ public class EventTranslator implements ObjectTranslator<Event, EventDTO> {
 
         destination.setId(source.getId());
         destination.setTargetName(source.getTargetName());
-        destination.setConsumerId(source.getConsumerId());
+        destination.setConsumerUuid(source.getConsumerUuid());
         destination.setEntityId(source.getEntityId());
         destination.setMessageText(source.getMessageText());
         destination.setOwnerId(source.getOwnerId());

--- a/server/src/main/java/org/candlepin/model/EventCurator.java
+++ b/server/src/main/java/org/candlepin/model/EventCurator.java
@@ -72,7 +72,7 @@ public class EventCurator extends AbstractHibernateCurator<Event> {
     @SuppressWarnings("unchecked")
     public CandlepinQuery<Event> listMostRecent(int limit, Consumer consumer) {
         DetachedCriteria criteria = this.createEventCriteria()
-            .add(Restrictions.eq("consumerId", consumer.getId()));
+            .add(Restrictions.eq("consumerUuid", consumer.getUuid()));
 
         return this.cpQueryFactory.<Event>buildQuery(this.currentSession(), criteria)
             .setMaxResults(limit);

--- a/server/src/main/resources/db/changelog/20180329144902-change-cp-event-dot-consumer-id-to-consumer-uuid.xml
+++ b/server/src/main/resources/db/changelog/20180329144902-change-cp-event-dot-consumer-id-to-consumer-uuid.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="20180329144902-1" author="crog">
+        <preConditions onFail="MARK_RAN">
+            <columnExists tableName="cp_event" columnName="consumerid" />
+        </preConditions>
+
+        <comment>Change cp_event.consumer_id to consumer_uuid</comment>
+
+        <renameColumn tableName="cp_event" oldColumnName="consumerid" newColumnName="consumer_uuid" columnDataType="varchar(255)" />
+    </changeSet>
+
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/server/src/main/resources/db/changelog/changelog-create.xml
+++ b/server/src/main/resources/db/changelog/changelog-create.xml
@@ -1224,4 +1224,5 @@
     <include file="db/changelog/20171023140857-add-modified-prods-index.xml"/>
     <include file="db/changelog/20171017062314-add-target-index-on-job-table.xml"/>
     <include file="db/changelog/20180102110530-create-owner-refresh-date-column.xml"/>
+    <include file="db/changelog/20180329144902-change-cp-event-dot-consumer-id-to-consumer-uuid.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-testing.xml
+++ b/server/src/main/resources/db/changelog/changelog-testing.xml
@@ -2027,7 +2027,9 @@
         </createIndex>
     </changeSet>
     <changeSet author="awood" id="1413225753032-290">
-        <comment>Add the default quartz lock columns.</comment>
+        <comment>
+            Add the default quartz lock columns.
+        </comment>
         <insert tableName="QRTZ_LOCKS">
             <column name="LOCK_NAME" value="TRIGGER_ACCESS"/>
             <column name="SCHED_NAME" value="TestScheduler"/>
@@ -2314,4 +2316,5 @@
     <include file="db/changelog/20171023140857-add-modified-prods-index.xml"/>
     <include file="db/changelog/20171017062314-add-target-index-on-job-table.xml"/>
     <include file="db/changelog/20180102110530-create-owner-refresh-date-column.xml"/>
+    <include file="db/changelog/20180329144902-change-cp-event-dot-consumer-id-to-consumer-uuid.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-update.xml
+++ b/server/src/main/resources/db/changelog/changelog-update.xml
@@ -133,4 +133,5 @@
     <include file="db/changelog/20171023140857-add-modified-prods-index.xml"/>
     <include file="db/changelog/20171017062314-add-target-index-on-job-table.xml"/>
     <include file="db/changelog/20180102110530-create-owner-refresh-date-column.xml"/>
+    <include file="db/changelog/20180329144902-change-cp-event-dot-consumer-id-to-consumer-uuid.xml"/>
 </databaseChangeLog>

--- a/server/src/test/java/org/candlepin/audit/EventFactoryTest.java
+++ b/server/src/test/java/org/candlepin/audit/EventFactoryTest.java
@@ -99,7 +99,7 @@ public class EventFactoryTest {
             "\"message\":\"Only supports 2 of 12 sockets.\"}," +
             "{\"productName\":\"Awesome Middleware\"," +
             "\"message\":\"Supports architecture ppc64 but the system is x86_64.\"}]," +
-            "\"consumer_uuid\":\"48b09f4e-f18c-4765-9c41-9aed6f122739\",\"status\":\"invalid\"}";
+            "\"status\":\"invalid\"}";
         Event event = eventFactory.complianceCreated(consumer, status);
         assertEquals(expectedEventData, event.getEventData());
     }

--- a/server/src/test/java/org/candlepin/audit/ListenerWrapperTest.java
+++ b/server/src/test/java/org/candlepin/audit/ListenerWrapperTest.java
@@ -91,7 +91,7 @@ public class ListenerWrapperTest {
         StringWriter sw = new StringWriter();
         Event e = new Event();
         e.setId("10");
-        e.setConsumerId("20");
+        e.setConsumerUuid("20");
         e.setPrincipal(new PrincipalData("5678", "910112"));
         mapper.writeValue(sw, e);
         return sw.toString();

--- a/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -1839,7 +1839,7 @@ public class PoolManagerTest {
         pool.setEntitlements(entitlements);
 
         Event event = new Event();
-        event.setConsumerId(guest.getUuid());
+        event.setConsumerUuid(guest.getUuid());
         event.setOwnerId(owner.getId());
         event.setTarget(Target.ENTITLEMENT);
         event.setType(Type.EXPIRED);

--- a/server/src/test/java/org/candlepin/dto/api/v1/EventDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/EventDTOTest.java
@@ -40,7 +40,7 @@ public class EventDTOTest extends AbstractDTOTest<EventDTO> {
         this.values.put("Timestamp", new Date());
         this.values.put("EntityId", "entity-id");
         this.values.put("OwnerId", "owner-id");
-        this.values.put("ConsumerId", "consumer-id");
+        this.values.put("ConsumerUuid", "consumer-uuid");
         this.values.put("ReferenceId", "reference-id");
         this.values.put("EventData", "event-data");
         this.values.put("MessageText", "message-text");

--- a/server/src/test/java/org/candlepin/dto/api/v1/EventTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/EventTranslatorTest.java
@@ -49,7 +49,7 @@ public class EventTranslatorTest extends AbstractTranslatorTest<Event, EventDTO,
         Event source = new Event();
         source.setId("id");
         source.setTargetName("target-name");
-        source.setConsumerId("consumer-id");
+        source.setConsumerUuid("consumer-uuid");
         source.setEntityId("entity-id");
         source.setMessageText("message-text");
         source.setOwnerId("owner-id");
@@ -74,7 +74,7 @@ public class EventTranslatorTest extends AbstractTranslatorTest<Event, EventDTO,
         if (source != null) {
             assertEquals(source.getId(), dest.getId());
             assertEquals(source.getTargetName(), dest.getTargetName());
-            assertEquals(source.getConsumerId(), dest.getConsumerId());
+            assertEquals(source.getConsumerUuid(), dest.getConsumerUuid());
             assertEquals(source.getEntityId(), dest.getEntityId());
             assertEquals(source.getOwnerId(), dest.getOwnerId());
             assertEquals(source.getPrincipalStore(), dest.getPrincipalStore());


### PR DESCRIPTION
- Renamed Event.consumerId to consumerUuid, as the consumer ID isn't
  usable outside of Candlepin, and event consumers are expecting the UUID
- Renamed the cp_event.consumerid column to consumer_uuid in accordance
  with the field name change