### PR TITLE
HornetQ: Disable monitoring for in-vm connections

### DIFF
--- a/server/src/main/java/org/candlepin/audit/HornetqEventDispatcher.java
+++ b/server/src/main/java/org/candlepin/audit/HornetqEventDispatcher.java
@@ -72,6 +72,8 @@ public class HornetqEventDispatcher  {
         ServerLocator locator = HornetQClient.createServerLocatorWithoutHA(
             new TransportConfiguration(InVMConnectorFactory.class.getName()));
         locator.setMinLargeMessageSize(largeMsgSize);
+        locator.setConnectionTTL(-1);
+        locator.setClientFailureCheckPeriod(-1);
         return locator.createSessionFactory();
     }
 


### PR DESCRIPTION
Essentially, this makes our client `connection-ttl` and `client-failure-check-period` the same as if we were running on a newer version of HornetQ (see https://github.com/hornetq/hornetq/pull/1825).

This should help us to avoid getting into a bad state due to the behavior described in https://issues.jboss.org/browse/HORNETQ-1314.

See https://docs.jboss.org/hornetq/2.2.5.Final/user-manual/en/html/connection-ttl.html for details about what the parameters do.