### PR TITLE
[M] 1563436: Restore ConsumerTypeDTO constructor for legacy consumer JSON

### DIFF
--- a/server/spec/consumer_resource_spec.rb
+++ b/server/spec/consumer_resource_spec.rb
@@ -418,6 +418,34 @@ describe 'Consumer Resource' do
     end.should raise_exception(RestClient::BadRequest)
   end
 
+  it "should let a consumer register with consumer type as a label" do
+    # This is legacy functionality; this test should not be used to indicate expected or desired
+    # behavior going forward, but to note that at the time of writing, this functionality is
+    # required by older clients
+
+    owner = create_owner(random_string('owner'))
+    user_name = random_string('user')
+    client = user_client(owner, user_name)
+
+    path = client.get_path("consumers")
+
+    consumer = {
+      :uuid => random_string("someuuid"),
+      :type => "system",
+      :name => "test_consumer",
+      :facts => {},
+      :installedProducts => [],
+      :contentTags => [],
+    }
+
+    params = {
+      :owner => owner['key']
+    }
+
+    consumer = client.post(path, params, consumer)
+    expect(consumer).to_not be_nil
+  end
+
   it "does not let an owner reregister another owner's consumer" do
     linux_net = create_owner(random_string('linux_net'))
     greenfield = create_owner(random_string('greenfield_consulting'))

--- a/server/src/main/java/org/candlepin/dto/api/v1/ConsumerTypeDTO.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/ConsumerTypeDTO.java
@@ -15,7 +15,6 @@
 package org.candlepin.dto.api.v1;
 
 import org.candlepin.dto.CandlepinDTO;
-import org.candlepin.model.ConsumerType.ConsumerTypeEnum;
 
 import io.swagger.annotations.ApiModel;
 
@@ -42,15 +41,6 @@ public class ConsumerTypeDTO extends CandlepinDTO<ConsumerTypeDTO> {
         // Intentionally left empty
     }
 
-    // TODO:
-    // Remove these constructors; they're coupled to the actual entity and we need to not carry
-    // forward extraneous constructors without reason
-
-    public ConsumerTypeDTO(ConsumerTypeEnum type) {
-        this.label = type.getLabel();
-        this.manifest = type.isManifest();
-    }
-
     /**
      * Initializes a new ConsumerTypeDTO instance which is a shallow copy of the provided
      * source entity.
@@ -60,6 +50,21 @@ public class ConsumerTypeDTO extends CandlepinDTO<ConsumerTypeDTO> {
      */
     public ConsumerTypeDTO(ConsumerTypeDTO source) {
         super(source);
+    }
+
+    /**
+     * Creates a new ConsumerTypeDTO initialized with the given label.
+     *
+     * @param label
+     *  The label to set upon initialization
+     *
+     * @deprecated
+     *  This constructor is present purely to support legacy behavior and may be removed at any
+     *  point in the future
+     */
+    @Deprecated
+    public ConsumerTypeDTO(String label) {
+        this.setLabel(label);
     }
 
     public String getId() {

--- a/server/src/main/java/org/candlepin/dto/api/v1/GuestIdDTO.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/GuestIdDTO.java
@@ -55,15 +55,6 @@ public class GuestIdDTO extends TimestampedCandlepinDTO<GuestIdDTO> {
     }
 
     /**
-     * Convenience constructor for tests with required parameter guestId
-     */
-    public GuestIdDTO(String guestId) {
-        this();
-        this.guestId = guestId;
-        attributes = new HashMap<>();
-    }
-
-    /**
      * Initializes a new GuestIdDTO instance which is a shallow copy of the provided
      * source entity.
      *
@@ -72,6 +63,21 @@ public class GuestIdDTO extends TimestampedCandlepinDTO<GuestIdDTO> {
      */
     public GuestIdDTO(GuestIdDTO source) {
         super(source);
+    }
+
+    /**
+     * Creates a new GuestIdDTO initialized with the given guest ID.
+     *
+     * @param guestId
+     *  The guestId to set upon initialization
+     *
+     * @deprecated
+     *  This constructor is present purely to support legacy behavior and may be removed at any
+     *  point in the future
+     */
+    @Deprecated
+    public GuestIdDTO(String guestId) {
+        this.setGuestId(guestId);
     }
 
     /**
@@ -178,6 +184,7 @@ public class GuestIdDTO extends TimestampedCandlepinDTO<GuestIdDTO> {
                 .append(this.getId(), that.getId())
                 .append(this.getGuestId(), that.getGuestId())
                 .append(this.getAttributes(), that.getAttributes());
+
             return builder.isEquals();
         }
 

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
@@ -410,7 +410,7 @@ public class ConsumerResourceUpdateTest {
         ConsumerDTO updated = new ConsumerDTO();
         updated.setUuid(uuid);
 
-        GuestIdDTO expectedGuestId = new GuestIdDTO("Guest 2");
+        GuestIdDTO expectedGuestId = TestUtil.createGuestIdDTO("Guest 2");
         updated.addGuestId(expectedGuestId);
 
         when(this.consumerCurator.getGuestConsumersMap(any(String.class), any(Set.class))).
@@ -715,7 +715,7 @@ public class ConsumerResourceUpdateTest {
         String uuid = "A Consumer";
         String expectedFactName = "FACT1";
         String expectedFactValue = "F1";
-        GuestIdDTO expectedGuestId = new GuestIdDTO("GUEST_ID_1");
+        GuestIdDTO expectedGuestId = TestUtil.createGuestIdDTO("GUEST_ID_1");
 
         Consumer existing = getFakeConsumer();
         existing.setFacts(new HashMap<>());

--- a/server/src/test/java/org/candlepin/resource/GuestIdResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/GuestIdResourceTest.java
@@ -43,6 +43,7 @@ import org.candlepin.model.Owner;
 import org.candlepin.model.OwnerCurator;
 import org.candlepin.resource.util.ConsumerEnricher;
 import org.candlepin.resource.util.GuestMigration;
+import org.candlepin.test.TestUtil;
 import org.candlepin.util.ElementTransformer;
 import org.candlepin.util.ServiceLevelValidator;
 
@@ -138,13 +139,13 @@ public class GuestIdResourceTest {
         when(guestIdCurator.findByConsumerAndId(eq(consumer), any(String.class)))
             .thenReturn(new GuestId("guest"));
         GuestIdDTO result = guestIdResource.getGuestId(consumer.getUuid(), "some-id");
-        assertEquals(new GuestIdDTO("guest"), result);
+        assertEquals(TestUtil.createGuestIdDTO("guest"), result);
     }
 
     @Test
     public void updateGuests() {
         List<GuestIdDTO> guestIds = new LinkedList<>();
-        guestIds.add(new GuestIdDTO("1"));
+        guestIds.add(TestUtil.createGuestIdDTO("1"));
         when(consumerResource.performConsumerUpdates(any(ConsumerDTO.class),
             eq(consumer), any(GuestMigration.class))).
             thenReturn(true);
@@ -160,7 +161,7 @@ public class GuestIdResourceTest {
     @Test
     public void updateGuestsNoUpdate() {
         List<GuestIdDTO> guestIds = new LinkedList<>();
-        guestIds.add(new GuestIdDTO("1"));
+        guestIds.add(TestUtil.createGuestIdDTO("1"));
 
         // consumerResource tells us nothing changed
         when(consumerResource.performConsumerUpdates(any(ConsumerDTO.class),
@@ -175,7 +176,7 @@ public class GuestIdResourceTest {
 
     @Test
     public void updateGuest() {
-        GuestIdDTO guest = new GuestIdDTO("some_guest");
+        GuestIdDTO guest = TestUtil.createGuestIdDTO("some_guest");
         GuestId guestEnt = new GuestId();
         guestEnt.setId("some_id");
         guestIdResource.updateGuest(consumer.getUuid(), guest.getGuestId(), guest);
@@ -188,7 +189,7 @@ public class GuestIdResourceTest {
 
     @Test(expected = BadRequestException.class)
     public void updateGuestMismatchedGuestId() {
-        GuestIdDTO guest = new GuestIdDTO("some_guest");
+        GuestIdDTO guest = TestUtil.createGuestIdDTO("some_guest");
         guestIdResource.updateGuest(consumer.getUuid(), "other_id", guest);
     }
 
@@ -227,7 +228,7 @@ public class GuestIdResourceTest {
         Consumer guestConsumer =
             new Consumer("guest_consumer", "guest_consumer", owner, ct);
         GuestId originalGuest = new GuestId("guest-id", guestConsumer);
-        GuestIdDTO guest = new GuestIdDTO("guest-id");
+        GuestIdDTO guest = TestUtil.createGuestIdDTO("guest-id");
 
         when(guestIdCurator.findByGuestIdAndOrg(
             eq(guest.getGuestId()), eq(owner.getId()))).thenReturn(originalGuest);

--- a/server/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
@@ -217,8 +217,8 @@ public class HypervisorResourceTest {
         Owner owner = new Owner("admin");
 
         Map<String, List<GuestIdDTO>> hostGuestMap = new HashMap<>();
-        hostGuestMap.put("test-host", new ArrayList(Arrays.asList(new GuestIdDTO("GUEST_A"),
-            new GuestIdDTO("GUEST_B"))));
+        hostGuestMap.put("test-host", new ArrayList(Arrays.asList(TestUtil.createGuestIdDTO("GUEST_A"),
+            TestUtil.createGuestIdDTO("GUEST_B"))));
 
         when(ownerCurator.lookupByKey(eq(owner.getKey()))).thenReturn(owner);
         when(consumerCurator.getHostConsumersMap(any(Owner.class), any(Set.class)))
@@ -260,7 +260,7 @@ public class HypervisorResourceTest {
 
         Map<String, List<GuestIdDTO>> hostGuestMap = new HashMap<>();
         String hypervisorId = "test-host";
-        hostGuestMap.put(hypervisorId, new ArrayList(Arrays.asList(new GuestIdDTO("GUEST_B"))));
+        hostGuestMap.put(hypervisorId, new ArrayList(Arrays.asList(TestUtil.createGuestIdDTO("GUEST_B"))));
 
         Owner o = new Owner("owner-id", "Owner ID");
         o.setId("owner-id");
@@ -296,8 +296,8 @@ public class HypervisorResourceTest {
 
         Map<String, List<GuestIdDTO>> hostGuestMap = new HashMap<>();
         String expectedHostVirtId = "test-host-id";
-        hostGuestMap.put(expectedHostVirtId, new ArrayList(Arrays.asList(new GuestIdDTO("GUEST_A"),
-            new GuestIdDTO("GUEST_B"))));
+        hostGuestMap.put(expectedHostVirtId, new ArrayList(Arrays.asList(TestUtil.createGuestIdDTO("GUEST_A"),
+            TestUtil.createGuestIdDTO("GUEST_B"))));
 
         when(consumerCurator.getHostConsumersMap(any(Owner.class), any(Set.class)))
             .thenReturn(new VirtConsumerMap());
@@ -331,8 +331,8 @@ public class HypervisorResourceTest {
         Owner owner = new Owner("admin");
 
         Map<String, List<GuestIdDTO>> hostGuestMap = new HashMap<>();
-        hostGuestMap.put("test-host", new ArrayList(Arrays.asList(new GuestIdDTO("GUEST_A"),
-            new GuestIdDTO("GUEST_B"))));
+        hostGuestMap.put("test-host", new ArrayList(Arrays.asList(TestUtil.createGuestIdDTO("GUEST_A"),
+            TestUtil.createGuestIdDTO("GUEST_B"))));
 
         when(ownerCurator.lookupByKey(eq(owner.getKey()))).thenReturn(owner);
 
@@ -370,10 +370,10 @@ public class HypervisorResourceTest {
         Owner owner = new Owner("admin");
 
         Map<String, List<GuestIdDTO>> hostGuestMap = new HashMap<>();
-        hostGuestMap.put("", new ArrayList(Arrays.asList(new GuestIdDTO("GUEST_A"),
-            new GuestIdDTO("GUEST_B"))));
-        hostGuestMap.put("HYPERVISOR_A", new ArrayList(Arrays.asList(new GuestIdDTO("GUEST_C"),
-            new GuestIdDTO("GUEST_D"))));
+        hostGuestMap.put("", new ArrayList(Arrays.asList(TestUtil.createGuestIdDTO("GUEST_A"),
+            TestUtil.createGuestIdDTO("GUEST_B"))));
+        hostGuestMap.put("HYPERVISOR_A", new ArrayList(Arrays.asList(TestUtil.createGuestIdDTO("GUEST_C"),
+            TestUtil.createGuestIdDTO("GUEST_D"))));
 
         when(ownerCurator.lookupByKey(eq(owner.getKey()))).thenReturn(owner);
 
@@ -404,7 +404,7 @@ public class HypervisorResourceTest {
 
         Map<String, List<GuestIdDTO>> hostGuestMap = new HashMap<>();
         hostGuestMap.put("HYPERVISOR_A", new ArrayList(
-            Arrays.asList(new GuestIdDTO("GUEST_A"), new GuestIdDTO(""))));
+            Arrays.asList(TestUtil.createGuestIdDTO("GUEST_A"), TestUtil.createGuestIdDTO(""))));
         when(ownerCurator.lookupByKey(eq(owner.getKey()))).thenReturn(owner);
 
         when(consumerCurator.getHostConsumersMap(any(Owner.class), any(Set.class)))

--- a/server/src/test/java/org/candlepin/test/TestUtil.java
+++ b/server/src/test/java/org/candlepin/test/TestUtil.java
@@ -23,6 +23,7 @@ import org.candlepin.auth.permissions.Permission;
 import org.candlepin.dto.api.v1.ConsumerDTO;
 import org.candlepin.dto.api.v1.ConsumerTypeDTO;
 import org.candlepin.dto.api.v1.ContentDTO;
+import org.candlepin.dto.api.v1.GuestIdDTO;
 import org.candlepin.dto.api.v1.OwnerDTO;
 import org.candlepin.dto.api.v1.ProductDTO;
 import org.candlepin.dto.api.v1.ProductDTO.ProductContentDTO;
@@ -61,6 +62,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -578,6 +580,14 @@ public class TestUtil {
             createPool(owner, createProduct()),
             null
         );
+    }
+
+    public static GuestIdDTO createGuestIdDTO(String guestId) {
+        GuestIdDTO dto = new GuestIdDTO()
+            .setGuestId(guestId)
+            .setAttributes(Collections.<String, String>emptyMap());
+
+        return dto;
     }
 
     public void addPermissionToUser(User u, Access role, Owner o) {


### PR DESCRIPTION
- Return the removed ConsumerTypeDTO constructor which accepts a
  label to address an issue where an exception is thrown when a
  consumer type is sent as a label
- Removed an additional DTO constructor that slipped through the
  previous removal pass