### PR TITLE
[M] 1563367: Reduced log noise associated with the CancelJobJob

### DIFF
--- a/server/src/main/java/org/candlepin/audit/EventSinkImpl.java
+++ b/server/src/main/java/org/candlepin/audit/EventSinkImpl.java
@@ -183,7 +183,7 @@ public class EventSinkImpl implements EventSink {
             getClientProducer().send(message);
         }
         catch (Exception e) {
-            log.error("Error while trying to send event: " + event, e);
+            log.error("Error while trying to send event: {}", e);
         }
     }
 

--- a/server/src/main/java/org/candlepin/hibernate/EmptyStringInterceptor.java
+++ b/server/src/main/java/org/candlepin/hibernate/EmptyStringInterceptor.java
@@ -48,8 +48,9 @@ public class EmptyStringInterceptor extends EmptyInterceptor {
         boolean modified = false;
         for (int i = 0; i < types.length; i++) {
             if (types[i] instanceof StringType && "".equals(state[i])) {
-                log.debug("Attempting to write an empty string to the database" +
-                    " for " + propertyNames[i] + ".  Substituting null instead.");
+                log.debug("Attempting to write an empty string to the database for field \"{}\"; " +
+                    "Substituting null instead", propertyNames[i]);
+
                 state[i] = null;
                 modified = true;
             }

--- a/server/src/main/java/org/candlepin/pinsetter/core/PinsetterJobListener.java
+++ b/server/src/main/java/org/candlepin/pinsetter/core/PinsetterJobListener.java
@@ -138,6 +138,7 @@ public class PinsetterJobListener implements JobListener {
             else {
                 status.update(ctx);
             }
+
             curator.merge(status);
         }
         else {

--- a/server/src/main/java/org/candlepin/pinsetter/core/PinsetterKernel.java
+++ b/server/src/main/java/org/candlepin/pinsetter/core/PinsetterKernel.java
@@ -443,8 +443,11 @@ public class PinsetterKernel implements ModeChangeListener {
      *
      * @param toCancel the JobStatus records of the jobs to cancel.
      * @throws PinsetterException if there is an error deleting the jobs from the schedule.
+     *
+     * @return
+     *  The number of jobs cancelled as a result of a call to this method
      */
-    public void cancelJobs(Collection<JobStatus> toCancel) throws PinsetterException {
+    public int cancelJobs(Collection<JobStatus> toCancel) throws PinsetterException {
         List<JobKey> jobsToDelete = new LinkedList<>();
 
         for (JobStatus status : toCancel) {
@@ -454,14 +457,20 @@ public class PinsetterKernel implements ModeChangeListener {
             jobsToDelete.add(key);
         }
 
-        log.info("Deleting {} cancelled jobs from scheduler.", toCancel.size());
-        try {
-            scheduler.deleteJobs(jobsToDelete);
+        if (jobsToDelete.size() > 0) {
+            log.info("Deleting {} cancelled jobs from scheduler", jobsToDelete.size());
+
+            try {
+                scheduler.deleteJobs(jobsToDelete);
+            }
+            catch (SchedulerException se) {
+                throw new PinsetterException("Problem canceling jobs.", se);
+            }
+
+            log.info("Finished deleting jobs from scheduler");
         }
-        catch (SchedulerException se) {
-            throw new PinsetterException("Problem canceling jobs.", se);
-        }
-        log.info("Finished deleting jobs from scheduler");
+
+        return jobsToDelete.size();
     }
 
     /**

--- a/server/src/main/java/org/candlepin/pinsetter/core/model/JobStatus.java
+++ b/server/src/main/java/org/candlepin/pinsetter/core/model/JobStatus.java
@@ -240,12 +240,14 @@ public class JobStatus extends AbstractHibernateObject {
     }
 
     public void setResult(String result) {
-        // truncate the result to fit column
-        if (result == null || result.length() < RESULT_COL_LENGTH) {
-            this.result = result;
+        if (result != null && !result.isEmpty()) {
+            // truncate the result to fit column
+            this.result = result.length() >= RESULT_COL_LENGTH ?
+                result.substring(0, RESULT_COL_LENGTH) :
+                result;
         }
         else {
-            this.result = result.substring(0, RESULT_COL_LENGTH);
+            this.result = null;
         }
     }
 

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/CancelJobJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/CancelJobJob.java
@@ -17,6 +17,7 @@ package org.candlepin.pinsetter.tasks;
 import org.candlepin.model.JobCurator;
 import org.candlepin.pinsetter.core.PinsetterException;
 import org.candlepin.pinsetter.core.PinsetterKernel;
+import org.candlepin.pinsetter.core.model.JobStatus;
 
 import com.google.inject.Inject;
 
@@ -62,10 +63,14 @@ public class CancelJobJob extends KingpinJob {
             }
 
             try {
-                pinsetterKernel.cancelJobs(this.jobCurator.findCanceledJobs(statusIds));
+                Set<JobStatus> jobs = this.jobCurator.findCanceledJobs(statusIds);
+
+                if (jobs.size() > 0) {
+                    pinsetterKernel.cancelJobs(jobs);
+                }
             }
             catch (PinsetterException e) {
-                log.error("Exception canceling jobs.", e);
+                log.error("Exception canceling jobs", e);
             }
         }
         catch (SchedulerException e) {
@@ -75,6 +80,6 @@ public class CancelJobJob extends KingpinJob {
 
     @Override
     protected boolean logExecutionTime() {
-        return false;
+        return log.isTraceEnabled();
     }
 }


### PR DESCRIPTION
- The CancelJobJob no longer outputs messages regarding job cancelation
  when there are no jobs to cancel
- The JobStatus object now better handles empty result messages to avoid
  extra warnings in logs
- Changed the CancelJobJob's execution time logging to appear if
  Candlepin's log mode is set to TRACE