### PR TITLE
[M] Implemented DistributorVersionDTO for manifest import/export.

### DIFF
--- a/server/src/main/java/org/candlepin/dto/StandardTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/StandardTranslator.java
@@ -63,6 +63,7 @@ import org.candlepin.model.ConsumerInstalledProduct;
 import org.candlepin.model.ConsumerType;
 import org.candlepin.model.ConsumerTypeCurator;
 import org.candlepin.model.Content;
+import org.candlepin.model.DistributorVersion;
 import org.candlepin.model.Entitlement;
 import org.candlepin.model.Environment;
 import org.candlepin.model.EnvironmentCurator;
@@ -172,6 +173,9 @@ public class StandardTranslator extends SimpleModelTranslator {
         this.registerTranslator(
             new org.candlepin.dto.manifest.v1.ContentTranslator(),
             Content.class, org.candlepin.dto.manifest.v1.ContentDTO.class);
+        this.registerTranslator(
+            new org.candlepin.dto.manifest.v1.DistributorVersionTranslator(),
+            DistributorVersion.class, org.candlepin.dto.manifest.v1.DistributorVersionDTO.class);
         this.registerTranslator(
             new org.candlepin.dto.manifest.v1.EntitlementTranslator(),
             Entitlement.class, org.candlepin.dto.manifest.v1.EntitlementDTO.class);

--- a/server/src/main/java/org/candlepin/dto/manifest/v1/DistributorVersionDTO.java
+++ b/server/src/main/java/org/candlepin/dto/manifest/v1/DistributorVersionDTO.java
@@ -1,0 +1,347 @@
+/**
+ * Copyright (c) 2009 - 2018 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.dto.manifest.v1;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.candlepin.dto.CandlepinDTO;
+import org.candlepin.dto.TimestampedCandlepinDTO;
+import org.candlepin.util.SetView;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * A DTO representation of the DistributorVersion entity as used by the manifest import/export framework.
+ */
+@XmlRootElement(name = "distributorversion")
+@XmlAccessorType(XmlAccessType.PROPERTY)
+public class DistributorVersionDTO extends TimestampedCandlepinDTO<DistributorVersionDTO> {
+    public static final long serialVersionUID = 1L;
+
+    /**
+     * Internal DTO object for DistributorVersionCapability
+     */
+    @XmlRootElement(name = "distributorversioncapability")
+    @XmlAccessorType(XmlAccessType.PROPERTY)
+    public static class DistributorVersionCapabilityDTO
+        extends CandlepinDTO<DistributorVersionCapabilityDTO> {
+
+        private String id;
+        private String name;
+
+        @JsonCreator
+        public DistributorVersionCapabilityDTO(
+            @JsonProperty("id") String id,
+            @JsonProperty("name") String name) {
+            if (name == null || name.isEmpty()) {
+                throw new IllegalArgumentException(
+                    "The distributor version capability name is null or empty.");
+            }
+
+            this.id = id;
+            this.name = name;
+        }
+
+        public String getId() {
+            return this.id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public String getName() {
+            return this.name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) {
+                return true;
+            }
+
+            if (obj instanceof DistributorVersionCapabilityDTO) {
+                DistributorVersionCapabilityDTO that = (DistributorVersionCapabilityDTO) obj;
+
+                EqualsBuilder builder = new EqualsBuilder()
+                    .append(this.getId(), that.getId())
+                    .append(this.getName(), that.getName());
+
+                return builder.isEquals();
+            }
+
+            return false;
+        }
+
+        @Override
+        public int hashCode() {
+            HashCodeBuilder builder = new HashCodeBuilder(37, 7)
+                .append(this.getId())
+                .append(this.getName());
+
+            return builder.toHashCode();
+        }
+    }
+
+    private String id;
+    private String name;
+    private String displayName;
+    private Set<DistributorVersionCapabilityDTO> capabilities;
+
+    /**
+     * Initializes a new DistributorVersionDTO instance with null values.
+     */
+    public DistributorVersionDTO() {
+        // Intentionally left empty
+    }
+
+    /**
+     * Initializes a new DistributorVersionDTO instance which is a shallow copy of the provided
+     * source entity.
+     *
+     * @param source
+     *  The source entity to copy
+     */
+    public DistributorVersionDTO(DistributorVersionDTO source) {
+        super(source);
+    }
+
+    /**
+     * Retrieves the id field of this DistributorVersionDTO object.
+     *
+     * @return the id field of this DistributorVersionDTO object.
+     */
+    public String getId() {
+        return this.id;
+    }
+
+    /**
+     * Sets the id to set on this DistributorVersionDTO object.
+     *
+     * @param id the id to set on this DistributorVersionDTO object.
+     *
+     * @return a reference to this DTO object.
+     */
+    public DistributorVersionDTO setId(String id) {
+        this.id = id;
+        return this;
+    }
+
+    /**
+     * Retrieves the name field of this DistributorVersionDTO object.
+     *
+     * @return the name field of this DistributorVersionDTO object.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Sets the name to set on this DistributorVersionDTO object.
+     *
+     * @param name the name to set on this DistributorVersionDTO object.
+     *
+     * @return a reference to this DTO object.
+     */
+    public DistributorVersionDTO setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * Retrieves the display name field of this DistributorVersionDTO object.
+     *
+     * @return the display name field of this DistributorVersionDTO object.
+     */
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    /**
+     * Sets the display name to set on this DistributorVersionDTO object.
+     *
+     * @param displayName the display name to set on this DistributorVersionDTO object.
+     *
+     * @return a reference to this DTO object.
+     */
+    public DistributorVersionDTO setDisplayName(String displayName) {
+        this.displayName = displayName;
+        return this;
+    }
+
+    /**
+     * Retrieves a view of the capabilities for the distributor version represented by this DTO.
+     * If the capabilities have not yet been defined, this method returns null.
+     * <p></p>
+     * Note that the collection returned by this method is a view of the collection backing this
+     * set of capabilities. Elements cannot be added to the collection, but elements may be removed.
+     * Changes made to the collection will be reflected by this distributor version DTO instance.
+     *
+     * @return
+     *  the capabilities associated with this distributor version, or null if they have not yet been defined
+     */
+    public Set<DistributorVersionCapabilityDTO> getCapabilities() {
+        return this.capabilities != null ? new SetView<>(this.capabilities) : null;
+    }
+
+    /**
+     * Adds the collection of capabilities to this DistributorVersionDTO.
+     *
+     * @param capabilities
+     *  A set of capabilities to attach to this DTO, or null to clear the existing ones
+     *
+     * @return
+     *  A reference to this DTO
+     */
+    public DistributorVersionDTO setCapabilities(Set<DistributorVersionCapabilityDTO> capabilities) {
+        if (capabilities != null) {
+            if (this.capabilities == null) {
+                this.capabilities = new HashSet<>();
+            }
+            else {
+                this.capabilities.clear();
+            }
+
+            for (DistributorVersionCapabilityDTO dto : capabilities) {
+                if (isNullOrIncomplete(dto)) {
+                    throw new IllegalArgumentException(
+                        "collection contains null or incomplete capabilities");
+                }
+            }
+
+            this.capabilities.addAll(capabilities);
+        }
+        else {
+            this.capabilities = null;
+        }
+        return this;
+    }
+
+    /**
+     * Adds the given capability to this DistributorVersionDTO.
+     *
+     * @param capability
+     *  The capability to add to this DistributorVersionDTO.
+     *
+     * @return
+     *  true if this capability was not already contained in this DistributorVersionDTO.
+     */
+    @JsonIgnore
+    public boolean addCapability(DistributorVersionCapabilityDTO capability) {
+        if (isNullOrIncomplete(capability)) {
+            throw new IllegalArgumentException("capability is null or incomplete");
+        }
+
+        if (this.capabilities == null) {
+            this.capabilities = new HashSet<>();
+        }
+
+        return this.capabilities.add(capability);
+    }
+
+    /**
+     * Utility method to validate DistributorVersionCapabilityDTO input
+     */
+    private boolean isNullOrIncomplete(DistributorVersionCapabilityDTO capability) {
+        return capability == null || capability.getName() == null || capability.getName().isEmpty();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        return String.format("DistributorVersionDTO [id: %s, name: %s, displayName: %s]",
+            this.getId(), this.getName(), this.getDisplayName());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        }
+
+        if (obj instanceof DistributorVersionDTO && super.equals(obj)) {
+            DistributorVersionDTO that = (DistributorVersionDTO) obj;
+
+            EqualsBuilder builder = new EqualsBuilder()
+                .append(this.getId(), that.getId())
+                .append(this.getName(), that.getName())
+                .append(this.getDisplayName(), that.getDisplayName())
+                .append(this.getCapabilities(), that.getCapabilities());
+
+            return builder.isEquals();
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+
+        HashCodeBuilder builder = new HashCodeBuilder(37, 7)
+            .append(super.hashCode())
+            .append(this.getId())
+            .append(this.getName())
+            .append(this.getDisplayName())
+            .append(this.getCapabilities());
+
+        return builder.toHashCode();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public DistributorVersionDTO clone() {
+        DistributorVersionDTO copy = super.clone();
+
+        copy.setCapabilities(this.getCapabilities());
+
+        return copy;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public DistributorVersionDTO populate(DistributorVersionDTO source) {
+        super.populate(source);
+
+        this.setId(source.getId())
+            .setName(source.getName())
+            .setDisplayName(source.getDisplayName())
+            .setCapabilities(source.getCapabilities());
+
+        return this;
+    }
+}

--- a/server/src/main/java/org/candlepin/dto/manifest/v1/DistributorVersionTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/manifest/v1/DistributorVersionTranslator.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2009 - 2018 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.dto.manifest.v1;
+
+import org.candlepin.dto.ModelTranslator;
+import org.candlepin.dto.TimestampedEntityTranslator;
+import org.candlepin.model.DistributorVersion;
+import org.candlepin.model.DistributorVersionCapability;
+
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * The DistributorVersionTranslator provides translation from DistributorVersion model objects
+ * to DistributorVersionDTOs as used by the manifest import/export framework.
+ */
+public class DistributorVersionTranslator
+    extends TimestampedEntityTranslator<DistributorVersion, DistributorVersionDTO> {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public DistributorVersionDTO translate(DistributorVersion source) {
+        return this.translate(null, source);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public DistributorVersionDTO translate(ModelTranslator translator, DistributorVersion source) {
+        return source != null ? this.populate(translator, source, new DistributorVersionDTO()) : null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public DistributorVersionDTO populate(DistributorVersion source, DistributorVersionDTO destination) {
+        return this.populate(null, source, destination);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public DistributorVersionDTO populate(ModelTranslator modelTranslator, DistributorVersion source,
+        DistributorVersionDTO dest) {
+
+        dest = super.populate(modelTranslator, source, dest);
+
+        dest.setId(source.getId());
+        dest.setName(source.getName());
+        dest.setDisplayName(source.getDisplayName());
+
+        if (modelTranslator != null) {
+
+            Set<DistributorVersionCapability> capabilities = source.getCapabilities();
+            if (capabilities != null && !capabilities.isEmpty()) {
+                for (DistributorVersionCapability capability : capabilities) {
+                    if (capability != null) {
+                        dest.addCapability(new DistributorVersionDTO.DistributorVersionCapabilityDTO(
+                            capability.getId(), capability.getName()));
+                    }
+                }
+            }
+            else {
+                dest.setCapabilities(Collections.emptySet());
+            }
+        }
+
+        return dest;
+    }
+}

--- a/server/src/main/java/org/candlepin/sync/DistributorVersionExporter.java
+++ b/server/src/main/java/org/candlepin/sync/DistributorVersionExporter.java
@@ -14,6 +14,9 @@
  */
 package org.candlepin.sync;
 
+import com.google.inject.Inject;
+import org.candlepin.dto.ModelTranslator;
+import org.candlepin.dto.manifest.v1.DistributorVersionDTO;
 import org.candlepin.model.DistributorVersion;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -25,9 +28,17 @@ import java.io.Writer;
  * DistributorVersionExporter
  */
 public class DistributorVersionExporter {
+
+    private ModelTranslator translator;
+
+    @Inject
+    public DistributorVersionExporter(ModelTranslator translator) {
+        this.translator = translator;
+    }
+
     void export(ObjectMapper mapper, Writer writer, DistributorVersion version)
         throws IOException {
 
-        mapper.writeValue(writer, version);
+        mapper.writeValue(writer, this.translator.translate(version, DistributorVersionDTO.class));
     }
 }

--- a/server/src/main/java/org/candlepin/sync/Importer.java
+++ b/server/src/main/java/org/candlepin/sync/Importer.java
@@ -23,13 +23,13 @@ import org.candlepin.dto.manifest.v1.CdnDTO;
 import org.candlepin.dto.manifest.v1.CertificateDTO;
 import org.candlepin.dto.manifest.v1.ConsumerDTO;
 import org.candlepin.dto.manifest.v1.ConsumerTypeDTO;
+import org.candlepin.dto.manifest.v1.DistributorVersionDTO;
 import org.candlepin.dto.manifest.v1.ProductDTO;
 import org.candlepin.model.CdnCurator;
 import org.candlepin.model.CertificateSerialCurator;
 import org.candlepin.model.ConsumerType;
 import org.candlepin.model.ConsumerTypeCurator;
 import org.candlepin.model.ContentCurator;
-import org.candlepin.model.DistributorVersion;
 import org.candlepin.model.DistributorVersionCurator;
 import org.candlepin.model.EntitlementCurator;
 import org.candlepin.model.ExporterMetadata;
@@ -857,7 +857,7 @@ public class Importer {
 
     protected void importDistributorVersions(File[] versionFiles) throws IOException {
         DistributorVersionImporter importer = new DistributorVersionImporter(distVerCurator);
-        Set<DistributorVersion> distVers = new HashSet<>();
+        Set<DistributorVersionDTO> distVers = new HashSet<>();
 
         for (File verFile : versionFiles) {
             Reader reader = null;

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/DistributorVersionDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/DistributorVersionDTOTest.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2009 - 2018 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.dto.manifest.v1;
+
+import org.candlepin.dto.AbstractDTOTest;
+import org.junit.Test;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test suite for the DistributorVersionDTO (manifest import/export) class
+ */
+public class DistributorVersionDTOTest extends AbstractDTOTest<DistributorVersionDTO> {
+
+    protected Map<String, Object> values;
+
+    public DistributorVersionDTOTest() {
+        super(DistributorVersionDTO.class);
+
+        this.values = new HashMap<>();
+        this.values.put("Id", "test-id");
+        this.values.put("Name", "test-name");
+        this.values.put("DisplayName", "test-displayName");
+        this.values.put("Updated", new Date());
+        this.values.put("Created", new Date());
+
+        Set<DistributorVersionDTO.DistributorVersionCapabilityDTO> dvCapabilityDTOs = new HashSet<>();
+        for (int i = 0; i < 3; i++) {
+            DistributorVersionDTO.DistributorVersionCapabilityDTO dvCapabilityDTO =
+                new DistributorVersionDTO.DistributorVersionCapabilityDTO("id-" + i, "name-" + i);
+            dvCapabilityDTOs.add(dvCapabilityDTO);
+        }
+
+        this.values.put("Capabilities", dvCapabilityDTOs);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected Object getInputValueForMutator(String field) {
+        return this.values.get(field);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected Object getOutputValueForAccessor(String field, Object input) {
+        // Nothing to do here
+        return input;
+    }
+
+    @Test
+    public void testAddCapabilityWithAbsentCapability() {
+        DistributorVersionDTO dto = new DistributorVersionDTO();
+
+        DistributorVersionDTO.DistributorVersionCapabilityDTO dvcDTO =
+            new DistributorVersionDTO.DistributorVersionCapabilityDTO("dvc-id-1", "dvc-name-1");
+        assertTrue(dto.addCapability(dvcDTO));
+    }
+
+    @Test
+    public void testAddCapabilityWithPresentCapability() {
+        DistributorVersionDTO dto = new DistributorVersionDTO();
+
+        DistributorVersionDTO.DistributorVersionCapabilityDTO dvcDTO1 =
+            new DistributorVersionDTO.DistributorVersionCapabilityDTO("dvc-id-2", "dvc-name-2");
+        assertTrue(dto.addCapability(dvcDTO1));
+
+        DistributorVersionDTO.DistributorVersionCapabilityDTO dvcDTO2 =
+            new DistributorVersionDTO.DistributorVersionCapabilityDTO("dvc-id-2", "dvc-name-2");
+        assertFalse(dto.addCapability(dvcDTO2));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddCapabilityWithNullInput() {
+        DistributorVersionDTO dto = new DistributorVersionDTO();
+        dto.addCapability(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddCapabilityWithEmptyName() {
+        DistributorVersionDTO dto = new DistributorVersionDTO();
+
+        DistributorVersionDTO.DistributorVersionCapabilityDTO dvcDTO =
+            new DistributorVersionDTO.DistributorVersionCapabilityDTO("dvc-id-3", "");
+        dto.addCapability(dvcDTO);
+    }
+}

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/DistributorVersionTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/DistributorVersionTranslatorTest.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2009 - 2018 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.dto.manifest.v1;
+
+import org.candlepin.dto.AbstractTranslatorTest;
+import org.candlepin.dto.ModelTranslator;
+import org.candlepin.model.DistributorVersion;
+import org.candlepin.model.DistributorVersionCapability;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test suite for the DistributorVersionTranslator (manifest import/export) class
+ */
+public class DistributorVersionTranslatorTest
+    extends AbstractTranslatorTest<DistributorVersion, DistributorVersionDTO, DistributorVersionTranslator> {
+
+    protected DistributorVersionTranslator translator = new DistributorVersionTranslator();
+
+    @Override
+    protected void initModelTranslator(ModelTranslator modelTranslator) {
+        modelTranslator.registerTranslator(this.translator, DistributorVersion.class,
+            DistributorVersionDTO.class);
+    }
+
+    @Override
+    protected DistributorVersionTranslator initObjectTranslator() {
+        return this.translator;
+    }
+
+    @Override
+    protected DistributorVersion initSourceObject() {
+        DistributorVersion source = new DistributorVersion();
+        source.setId("id");
+        source.setName("name");
+        source.setDisplayName("displayName");
+
+        Set<DistributorVersionCapability> dvCapabilities = new HashSet<>();
+        for (int i = 0; i < 3; i++) {
+            DistributorVersionCapability dvCapability = new DistributorVersionCapability();
+            dvCapability.setId("id-" + i);
+            dvCapability.setName("name-" + i);
+            dvCapabilities.add(dvCapability);
+        }
+        source.setCapabilities(dvCapabilities);
+
+        return source;
+    }
+
+    @Override
+    protected DistributorVersionDTO initDestinationObject() {
+        return new DistributorVersionDTO();
+    }
+
+    @Override
+    protected void verifyOutput(DistributorVersion source, DistributorVersionDTO dest,
+        boolean childrenGenerated) {
+
+        if (source != null) {
+            assertEquals(source.getId(), dest.getId());
+            assertEquals(source.getName(), dest.getName());
+            assertEquals(source.getDisplayName(), dest.getDisplayName());
+
+            if (childrenGenerated) {
+                for (DistributorVersionCapability dvcEntity : source.getCapabilities()) {
+                    boolean verified = false;
+                    for (DistributorVersionDTO.DistributorVersionCapabilityDTO dvcDTO :
+                        dest.getCapabilities()) {
+
+                        assertNotNull(dvcDTO);
+                        assertNotNull(dvcDTO.getId());
+
+                        if (dvcDTO.getId().equals(dvcEntity.getId())) {
+                            assertEquals(dvcDTO.getName(), dvcEntity.getName());
+                            verified = true;
+                        }
+                    }
+                    assertTrue(verified);
+                }
+
+            }
+            else {
+                assertNull(dest.getCapabilities());
+            }
+        }
+        else {
+            assertNull(dest);
+        }
+    }
+}

--- a/server/src/test/java/org/candlepin/sync/ExporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/ExporterTest.java
@@ -145,7 +145,7 @@ public class ExporterTest {
         exportRules = mock(ExportRules.class);
         pprov = mock(PrincipalProvider.class);
         dvc = mock(DistributorVersionCurator.class);
-        dve = new DistributorVersionExporter();
+        dve = new DistributorVersionExporter(translator);
         cdnc = mock(CdnCurator.class);
         cdne = new CdnExporter(translator);
         pc = mock(ProductCurator.class);


### PR DESCRIPTION
- DistributorVersionDTO is used instead of DistributorVersion when importing/exporting a manifest.