### PR TITLE
[m] Lock less binds phase 2

### DIFF
--- a/server/src/main/java/org/candlepin/bind/CheckBonusPoolQuantitiesOp.java
+++ b/server/src/main/java/org/candlepin/bind/CheckBonusPoolQuantitiesOp.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.bind;
+
+import org.candlepin.controller.PoolManager;
+import org.candlepin.model.Consumer;
+import org.candlepin.model.Entitlement;
+
+import com.google.inject.Inject;
+
+import java.util.Map;
+
+/**
+ * This BindOperation will be replaced shortly in an upcoming PR, where we
+ * will split the implementation into pre-process and execute steps.
+ */
+public class CheckBonusPoolQuantitiesOp implements BindOperation {
+
+    private PoolManager poolManager;
+
+    @Inject
+    public CheckBonusPoolQuantitiesOp(PoolManager poolManager) {
+        this.poolManager = poolManager;
+    }
+
+    @Override
+    public boolean preProcess(BindContext context) {
+        return true;
+    }
+
+    @Override
+    public boolean execute(BindContext context) {
+        Consumer consumer = context.getLockedConsumer();
+        Map<String, Entitlement> entitlements = context.getEntitlementMap();
+
+        // we might have changed the bonus pool quantities, lets revoke ents if needed.
+        poolManager.checkBonusPoolQuantities(consumer.getOwnerId(), entitlements);
+        return true;
+    }
+
+}

--- a/server/src/main/java/org/candlepin/bind/PoolOperationCallback.java
+++ b/server/src/main/java/org/candlepin/bind/PoolOperationCallback.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2009 - 2017 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.bind;
+
+import org.candlepin.controller.PoolManager;
+import org.candlepin.model.Entitlement;
+import org.candlepin.model.Pool;
+import org.candlepin.model.SourceSubscription;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+/**
+ * Holds and represents operations to be performed at a later time.
+ * Currently, only holds relevant operations for PostBindBonusPoolsOp
+ */
+public class PoolOperationCallback {
+
+    private List<Pool> poolsToCreate = new ArrayList<>();
+    private Map<Pool, Long> poolUpdates = new HashMap<>();
+    private Map<Pool, String> poolSubscriptionIds = new HashMap<>();
+    private Map<Pool, Entitlement> poolEntitlements = new HashMap<>();
+
+    public List<Pool> getPoolCreates() {
+        return poolsToCreate;
+    }
+
+    public Map<Pool, Long> getPoolUpdates() {
+        return poolUpdates;
+    }
+
+    public Map<Pool, String> getPoolSubscriptionIds() {
+        return poolSubscriptionIds;
+    }
+
+    public Map<Pool, Entitlement> getPoolEntitlements() {
+        return poolEntitlements;
+    }
+
+    /**
+     * Accepts a pool to be created later
+     * @param pool the pool to be created
+     */
+    public void addPoolToCreate(Pool pool) {
+        poolsToCreate.add(pool);
+    }
+
+    /**
+     * Accepts a pool and a quantity to set on the pool at a later time
+     * @param pool the pool to set the quantity on
+     * @param quantity the quantity to set on the pool
+     */
+    public void setQuantityToPool(Pool pool, long quantity) {
+        poolUpdates.put(pool, quantity);
+    }
+
+    /**
+     * Adds all pending operations of an existing delayed operation to the current operation
+     * @param poolOperationCallback the poolOperationCallback to accept
+     */
+    public void appendCallback(PoolOperationCallback poolOperationCallback) {
+        Map<Pool, String> incomingSubscriptionIds = poolOperationCallback.getPoolSubscriptionIds();
+        poolSubscriptionIds.putAll(incomingSubscriptionIds);
+        Map<Pool, Entitlement> incomingEntitlementMap = poolOperationCallback.getPoolEntitlements();
+        poolEntitlements.putAll(incomingEntitlementMap);
+
+        List<Pool> poolCreates = poolOperationCallback.getPoolCreates();
+        poolsToCreate.addAll(poolOperationCallback.getPoolCreates());
+
+        for (Map.Entry<Pool, Long> poolUpdate: poolOperationCallback.getPoolUpdates().entrySet()) {
+            poolUpdates.put(poolUpdate.getKey(), poolUpdate.getValue());
+        }
+    }
+
+    /**
+     * Accepts a pool and a source subscription to be created later.
+     * @param pool the pool to set the source subscription on
+     * @param subscriptionId the subscription id of the source subscription
+     * @param entitlement the entitlement for the subscription sub key
+     */
+    public void createSourceSubscription(Pool pool, String subscriptionId, Entitlement entitlement) {
+        poolSubscriptionIds.put(pool, subscriptionId);
+        poolEntitlements.put(pool, entitlement);
+    }
+
+    /**
+     * Perform the operations marked.
+     * @param poolManager
+     */
+    public void apply(PoolManager poolManager) {
+
+        for (Entry<Pool, String> entry: poolSubscriptionIds.entrySet()) {
+            Entitlement entitlement = poolEntitlements.get(entry.getKey());
+            String subscriptionId = entry.getValue();
+            entry.getKey().setSourceSubscription(new SourceSubscription(subscriptionId, entitlement.getId()));
+        }
+        poolManager.createPools(poolsToCreate);
+        poolManager.setPoolQuantity(poolUpdates);
+    }
+}

--- a/server/src/main/java/org/candlepin/bind/PostBindBonusPoolsOp.java
+++ b/server/src/main/java/org/candlepin/bind/PostBindBonusPoolsOp.java
@@ -16,12 +16,25 @@ package org.candlepin.bind;
 
 import org.candlepin.controller.PoolManager;
 import org.candlepin.model.Consumer;
+import org.candlepin.model.ConsumerType;
+import org.candlepin.model.ConsumerType.ConsumerTypeEnum;
+import org.candlepin.model.ConsumerTypeCurator;
 import org.candlepin.model.Entitlement;
+import org.candlepin.model.Pool;
+import org.candlepin.model.PoolCurator;
 import org.candlepin.model.PoolQuantity;
+import org.candlepin.policy.js.entitlement.Enforcer;
 
 import com.google.inject.Inject;
 
+import org.apache.commons.collections.CollectionUtils;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
 
 /**
  * This BindOperation will be replaced shortly in an upcoming PR, where we
@@ -30,27 +43,81 @@ import java.util.Map;
 public class PostBindBonusPoolsOp implements BindOperation {
 
     private PoolManager poolManager;
+    private ConsumerTypeCurator consumerTypeCurator;
+    private PoolCurator poolCurator;
+    private Enforcer enforcer;
+    private List<Pool> subPoolsForStackIds = null;
+    PoolOperationCallback poolOperationCallback = new PoolOperationCallback();
 
     @Inject
-    public PostBindBonusPoolsOp(PoolManager poolManager) {
+    public PostBindBonusPoolsOp(PoolManager poolManager, ConsumerTypeCurator consumerTypeCurator,
+        PoolCurator poolCurator, Enforcer enforcer) {
         this.poolManager = poolManager;
+        this.consumerTypeCurator = consumerTypeCurator;
+        this.poolCurator = poolCurator;
+        this.enforcer = enforcer;
     }
 
     @Override
     public boolean preProcess(BindContext context) {
+        Consumer consumer = context.getConsumer();
+        Map<String, Entitlement> entitlements = context.getEntitlementMap();
+        Map<String, PoolQuantity> poolQuantities = context.getPoolQuantities();
+
+        Set<String> stackIds = new HashSet<>();
+
+        for (PoolQuantity poolQuantity : poolQuantities.values()) {
+            if (poolQuantity.getPool().isStacked()) {
+                stackIds.add(poolQuantity.getPool().getStackId());
+            }
+        }
+
+        ConsumerType ctype = this.consumerTypeCurator.getConsumerType(consumer);
+
+        // temporarily associate pools with entitlements for post bind bonus pool operations
+        for (Entry<String, Entitlement> entitlementEntry : entitlements.entrySet()) {
+            String poolId = entitlementEntry.getKey();
+            Entitlement entitlement = entitlementEntry.getValue();
+            entitlement.setPool(poolQuantities.get(poolId).getPool());
+        }
+
+        // Manifest and Share consumers should not contribute to the sharing org's stack,
+        // as these consumer types should not have created a stack derived pool in the first place.
+        // Therefore, we do not need to check if any stack derived pools need updating
+        if (!stackIds.isEmpty() && !ctype.isType(ConsumerTypeEnum.SHARE) && !ctype.isManifest()) {
+            subPoolsForStackIds = poolCurator.getSubPoolForStackIds(consumer, stackIds);
+            if (CollectionUtils.isNotEmpty(subPoolsForStackIds)) {
+                poolManager.updatePoolsFromStackWithoutDeletingStack(consumer,
+                    subPoolsForStackIds,
+                    entitlements.values());
+            }
+        }
+        else {
+            subPoolsForStackIds = new ArrayList<>();
+        }
+
+        poolOperationCallback.appendCallback(enforcer.postEntitlement(poolManager,
+            consumer,
+            context.getOwner(),
+            entitlements,
+            subPoolsForStackIds,
+            false,
+            poolQuantities
+        ));
+
+        // un-associate pools with entitlements.
+        for (Entitlement entitlement : entitlements.values()) {
+            entitlement.setPool(null);
+        }
+
         return true;
     }
 
     @Override
     public boolean execute(BindContext context) {
-        Consumer consumer = context.getLockedConsumer();
-        Map<String, Entitlement> entitlements = context.getEntitlementMap();
-        Map<String, PoolQuantity> poolQuantities = context.getPoolQuantities();
 
-        poolManager.handlePostEntitlement(poolManager, consumer, context.getOwner(), entitlements,
-            poolQuantities);
-        // we might have changed the bonus pool quantities, lets revoke ents if needed.
-        poolManager.checkBonusPoolQuantities(consumer.getOwnerId(), entitlements);
+        poolCurator.mergeAll(subPoolsForStackIds, false);
+        poolOperationCallback.apply(poolManager);
         return true;
     }
 

--- a/server/src/main/java/org/candlepin/controller/PoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/PoolManager.java
@@ -147,9 +147,9 @@ public interface PoolManager {
     Set<Pool> revokeEntitlements(List<Entitlement> ents);
     void revokeEntitlement(Entitlement entitlement);
 
-    Pool updatePoolQuantity(Pool pool, long adjust);
-
     Pool setPoolQuantity(Pool pool, long set);
+
+    void setPoolQuantity(Map<Pool, Long> poolQuantities);
 
     void regenerateDirtyEntitlements(Consumer consumer);
 
@@ -231,7 +231,8 @@ public interface PoolManager {
      * @param consumer
      * @param pools
      */
-    void updatePoolsFromStack(Consumer consumer, List<Pool> pool);
+    void updatePoolsFromStackWithoutDeletingStack(Consumer consumer,
+        List<Pool> pool, Collection<Entitlement> entitlements);
 
     /**
      * @param guest products we want to provide for
@@ -320,9 +321,6 @@ public interface PoolManager {
     void deletePools(Collection<Pool> pools);
 
     void deletePools(Collection<Pool> pools, Collection<String> alreadyDeletedPools);
-
-    void handlePostEntitlement(PoolManager manager, Consumer consumer, Owner owner,
-        Map<String, Entitlement> entitlements, Map<String, PoolQuantity> poolQuantityMap);
 
     void checkBonusPoolQuantities(String ownerId,
         Map<String, Entitlement> entitlements);

--- a/server/src/main/java/org/candlepin/model/Pool.java
+++ b/server/src/main/java/org/candlepin/model/Pool.java
@@ -1439,6 +1439,20 @@ public class Pool extends AbstractHibernateObject<Pool> implements Owned, Named,
         }
     }
 
+    /**
+     * adjusts current quantity by adding the input quantity
+     * @param quantityToAdjust the quantity to add
+     * @return the updated quantity
+     */
+    @JsonIgnore
+    public long adjustQuantity(long quantityToAdjust) {
+        long newCount = getQuantity() + quantityToAdjust;
+        if (newCount < 0) {
+            newCount = 0;
+        }
+        return newCount;
+    }
+
     @JsonIgnore
     public static Long parseQuantity(String quantity) {
         Long q;

--- a/server/src/main/java/org/candlepin/policy/js/entitlement/Enforcer.java
+++ b/server/src/main/java/org/candlepin/policy/js/entitlement/Enforcer.java
@@ -14,6 +14,7 @@
  */
 package org.candlepin.policy.js.entitlement;
 
+import org.candlepin.bind.PoolOperationCallback;
 import org.candlepin.controller.PoolManager;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.Entitlement;
@@ -138,9 +139,11 @@ public interface Enforcer {
      * @param c consumer
      * @param ents The entitlement that was just granted.
      * @param subPoolsForStackIds
+     * @return the delayedPoolOp encapsulating all the computed operations to perform later
      */
-    void postEntitlement(PoolManager poolManager, Consumer c, Owner owner, Map<String, Entitlement> ents,
-        List<Pool> subPoolsForStackIds, boolean isUpdate, Map<String, PoolQuantity> poolQuantityMap);
+    PoolOperationCallback postEntitlement(PoolManager poolManager, Consumer c, Owner owner, Map<String,
+        Entitlement> ents, List<Pool> subPoolsForStackIds, boolean isUpdate, Map<String,
+        PoolQuantity> poolQuantityMap);
 
     /**
      * Run post-entitlement actions.

--- a/server/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
@@ -206,7 +206,7 @@ public class PoolRules {
             // Using derived here because only one derived pool is created for
             // this subscription
             Pool bonusPool = PoolHelper.clonePool(masterPool, sku, virtQuantity, virtAttributes, "derived",
-                ownerProductCurator, null, productCurator);
+                ownerProductCurator, null, null, productCurator);
 
             log.info("Creating new derived pool: {}", bonusPool);
             return bonusPool;
@@ -387,8 +387,8 @@ public class PoolRules {
      * @return updates
      */
     public List<PoolUpdate> updatePoolsFromStack(Consumer consumer, Collection<Pool> pools,
-        boolean deleteIfNoStackedEnts) {
-        return updatePoolsFromStack(consumer, pools, null, deleteIfNoStackedEnts);
+        Collection<Entitlement> entitlements, boolean deleteIfNoStackedEnts) {
+        return updatePoolsFromStack(consumer, pools, entitlements, null, deleteIfNoStackedEnts);
     }
 
     /**
@@ -399,7 +399,8 @@ public class PoolRules {
      * @return updates
      */
     public List<PoolUpdate> updatePoolsFromStack(Consumer consumer, Collection<Pool> pools,
-        Collection<String> alreadyDeletedPools, boolean deleteIfNoStackedEnts) {
+        Collection<Entitlement> newEntitlements, Collection<String> alreadyDeletedPools,
+        boolean deleteIfNoStackedEnts) {
 
         Map<String, List<Entitlement>> entitlementMap = new HashMap<>();
         Set<String> sourceStackIds = new HashSet<>();
@@ -409,7 +410,12 @@ public class PoolRules {
             sourceStackIds.add(pool.getSourceStackId());
         }
 
-        for (Entitlement entitlement : this.entCurator.findByStackIds(consumer, sourceStackIds)) {
+        List<Entitlement> allEntitlements = this.entCurator.findByStackIds(consumer, sourceStackIds).list();
+        if (CollectionUtils.isNotEmpty(newEntitlements)) {
+            allEntitlements.addAll(newEntitlements);
+        }
+
+        for (Entitlement entitlement : allEntitlements) {
             List<Entitlement> ents = entitlementMap.get(entitlement.getPool().getStackId());
             if (ents == null) {
                 ents = new ArrayList<>();

--- a/server/src/main/java/org/candlepin/policy/js/pool/StackedSubPoolValueAccumulator.java
+++ b/server/src/main/java/org/candlepin/policy/js/pool/StackedSubPoolValueAccumulator.java
@@ -60,7 +60,11 @@ public class StackedSubPoolValueAccumulator {
      * @param nextStacked the entitlement to check.
      */
     private void updateEldest(Entitlement nextStacked) {
-        if (eldest == null || nextStacked.getCreated().before(eldest.getCreated())) {
+        // if the date is null, must be a entitlement about to be created
+        Date createdDate = (nextStacked.getCreated() == null) ?
+            new Date() : nextStacked.getCreated();
+
+        if (eldest == null || createdDate.before(eldest.getCreated())) {
             eldest = nextStacked;
         }
     }
@@ -94,8 +98,11 @@ public class StackedSubPoolValueAccumulator {
         // Keep track of the eldest with virt limit so that we can change the
         // quantity of the sub pool.
         if (nextStacked.getPool().hasMergedAttribute(Product.Attributes.VIRT_LIMIT)) {
+            // if the date is null, must be a entitlement about to be created
+            Date createdDate = (nextStacked.getCreated() == null) ?
+                new Date() : nextStacked.getCreated();
             if (eldestWithVirtLimit == null ||
-                nextStacked.getCreated().before(eldestWithVirtLimit.getCreated())) {
+                createdDate.before(eldestWithVirtLimit.getCreated())) {
                 eldestWithVirtLimit = nextStacked;
             }
         }

--- a/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -42,7 +42,9 @@ import org.candlepin.bind.BindChain;
 import org.candlepin.bind.BindChainFactory;
 import org.candlepin.bind.BindContext;
 import org.candlepin.bind.BindContextFactory;
+import org.candlepin.bind.CheckBonusPoolQuantitiesOp;
 import org.candlepin.bind.ComplianceOp;
+import org.candlepin.bind.PoolOperationCallback;
 import org.candlepin.bind.HandleCertificatesOp;
 import org.candlepin.bind.HandleEntitlementsOp;
 import org.candlepin.bind.PostBindBonusPoolsOp;
@@ -264,7 +266,9 @@ public class PoolManagerTest {
     private void setupBindChain() {
         final HandleEntitlementsOp entitlementsOp =
             new HandleEntitlementsOp(mockPoolCurator, entitlementCurator);
-        final PostBindBonusPoolsOp postBindBonusPoolsOp = new PostBindBonusPoolsOp(manager);
+        final PostBindBonusPoolsOp postBindBonusPoolsOp = new PostBindBonusPoolsOp(manager,
+            consumerTypeCuratorMock, mockPoolCurator, enforcerMock);
+        final CheckBonusPoolQuantitiesOp checkBonusPoolQuantitiesOp = new CheckBonusPoolQuantitiesOp(manager);
         final HandleCertificatesOp certificatesOp = new HandleCertificatesOp(mockECGenerator, certCuratorMock,
             entitlementCurator);
         final ComplianceOp complianceOp = new ComplianceOp(complianceRules);
@@ -314,6 +318,7 @@ public class PoolManagerTest {
                         mockPreEntitlementRulesCheckFactory,
                         entitlementsOp,
                         postBindBonusPoolsOp,
+                        checkBonusPoolQuantitiesOp,
                         certificatesOp,
                         complianceOp,
                         consumer,
@@ -1125,6 +1130,8 @@ public class PoolManagerTest {
         when(enforcerMock.preEntitlement(any(Consumer.class), any(Pool.class), anyInt(),
             any(CallerType.class))).thenReturn(result);
 
+        when(enforcerMock.postEntitlement(eq(manager), any(Consumer.class), any(Owner.class), anyMap(),
+            anyList(), eq(false), anyMap())).thenReturn(new PoolOperationCallback());
         when(result.isSuccessful()).thenReturn(true);
 
         List<PoolQuantity> bestPools = new ArrayList<>();
@@ -1406,7 +1413,8 @@ public class PoolManagerTest {
 
         when(enforcerMock.preEntitlement(any(Consumer.class), any(Pool.class), anyInt(),
             any(CallerType.class))).thenReturn(result);
-
+        when(enforcerMock.postEntitlement(eq(manager), any(Consumer.class), any(Owner.class), anyMap(),
+            anyList(), eq(false), anyMap())).thenReturn(new PoolOperationCallback());
         when(result.isSuccessful()).thenReturn(true);
 
         List<PoolQuantity> bestPools = new ArrayList<>();
@@ -1894,6 +1902,8 @@ public class PoolManagerTest {
         when(mockPoolCurator.lockAndLoad(pool)).thenReturn(pool);
         when(enforcerMock.update(any(Consumer.class), any(Entitlement.class), any(Integer.class)))
             .thenReturn(new ValidationResult());
+        when(enforcerMock.postEntitlement(eq(manager), any(Consumer.class), any(Owner.class), anyMap(),
+            anyList(), eq(true), anyMap())).thenReturn(new PoolOperationCallback());
         when(mockPoolCurator.getOversubscribedBySubscriptionIds(any(String.class), anyMap()))
             .thenReturn(Collections.singletonList(derivedPool));
         when(mockPoolCurator.retrieveOrderedEntitlementsOf(anyListOf(Pool.class)))
@@ -1962,6 +1972,8 @@ public class PoolManagerTest {
         when(mockPoolCurator.lockAndLoad(pool)).thenReturn(pool);
         when(enforcerMock.update(any(Consumer.class), any(Entitlement.class), any(Integer.class)))
             .thenReturn(new ValidationResult());
+        when(enforcerMock.postEntitlement(eq(manager), any(Consumer.class), any(Owner.class), anyMap(),
+            anyList(), eq(true), anyMap())).thenReturn(new PoolOperationCallback());
         when(mockPoolCurator.getOversubscribedBySubscriptionIds(any(String.class), anyMap())).thenReturn(
             Arrays.asList(derivedPool, derivedPool2, derivedPool3));
         when(mockPoolCurator.retrieveOrderedEntitlementsOf(eq(Arrays.asList(derivedPool)))).thenReturn(

--- a/server/src/test/java/org/candlepin/model/PoolTest.java
+++ b/server/src/test/java/org/candlepin/model/PoolTest.java
@@ -170,6 +170,25 @@ public class PoolTest extends DatabaseTestFixture {
     }
 
     @Test
+    public void testQuantityAdjust() {
+        Pool p = new Pool();
+        p.setQuantity(10L);
+        Long q = p.adjustQuantity(2L);
+        assertEquals((Long) 12L, (Long) q);
+
+        q = p.adjustQuantity(-2L);
+        assertEquals((Long) 8L, (Long) q);
+    }
+
+    @Test
+    public void testQuantityAdjustNonNegative() {
+        Pool p = new Pool();
+        p.setQuantity(0L);
+        Long q = p.adjustQuantity(-2L);
+        assertEquals((Long) 0L, (Long) q);
+    }
+
+    @Test
     public void testUnlimitedPool() {
         Product newProduct = this.createProduct(owner);
 

--- a/server/src/test/java/org/candlepin/policy/js/pool/PoolHelperTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/pool/PoolHelperTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import org.candlepin.bind.PoolOperationCallback;
 import org.candlepin.common.config.Configuration;
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.controller.PoolManager;
@@ -173,8 +174,9 @@ public class PoolHelperTest {
         attributes.put(targetPool2.getId(), PoolHelper.getFlattenedAttributes(targetPool2));
 
         when(pm.createPools(anyListOf(Pool.class))).then(returnsFirstArg());
-        List<Pool> pools = PoolHelper.createHostRestrictedPools(pm, cons, targetPools, entitlements,
-            attributes, productCurator);
+        PoolOperationCallback poolOperationCallback = PoolHelper.createHostRestrictedPools(pm,
+            cons, targetPools, entitlements, attributes, productCurator);
+        List<Pool> pools = poolOperationCallback.getPoolCreates();
 
         assertEquals(2, pools.size());
         Pool first = null, second = null;
@@ -235,9 +237,10 @@ public class PoolHelperTest {
         Map<String, Map<String, String>> attributes = new HashMap<>();
         attributes.put(targetPool.getId(), PoolHelper.getFlattenedAttributes(targetPool));
         when(pm.createPools(anyListOf(Pool.class))).then(returnsFirstArg());
-        List<Pool> hostRestrictedPools = PoolHelper.createHostRestrictedPools(pm, cons, targetPools,
-            entitlements, attributes, productCurator);
+        PoolOperationCallback poolOperationCallback = PoolHelper.createHostRestrictedPools(pm,
+            cons, targetPools, entitlements, attributes, productCurator);
 
+        List<Pool> hostRestrictedPools = poolOperationCallback.getPoolCreates();
         assertEquals(1, hostRestrictedPools.size());
         Pool hostRestrictedPool = hostRestrictedPools.get(0);
         assertEquals(targetPool.getId(), hostRestrictedPool.getAttributeValue("source_pool_id"));
@@ -269,7 +272,7 @@ public class PoolHelperTest {
         pool.getBranding().add(branding);
         String quant = "unlimited";
         Pool clone = PoolHelper.clonePool(pool, product2, quant, attributes, "TaylorSwift", null,
-            ent, productCurator);
+            ent, TestUtil.createConsumer(), productCurator);
         assertEquals(owner, clone.getOwner());
         assertEquals(new Long(-1L), clone.getQuantity());
         assertEquals(product2, clone.getProduct());

--- a/server/src/test/java/org/candlepin/test/EnforcerForTesting.java
+++ b/server/src/test/java/org/candlepin/test/EnforcerForTesting.java
@@ -14,6 +14,7 @@
  */
 package org.candlepin.test;
 
+import org.candlepin.bind.PoolOperationCallback;
 import org.candlepin.controller.PoolManager;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.Entitlement;
@@ -36,9 +37,10 @@ import java.util.Map;
 public class EnforcerForTesting implements Enforcer {
 
     @Override
-    public void postEntitlement(PoolManager manager, Consumer consumer, Owner owner, Map<String, Entitlement>
-        ent,
-        List<Pool> subPoolsForStackIds, boolean isUpdate, Map<String, PoolQuantity> poolQuantityMap) {
+    public PoolOperationCallback postEntitlement(PoolManager manager, Consumer consumer, Owner owner,
+        Map<String, Entitlement> ent, List<Pool> subPoolsForStackIds, boolean isUpdate,
+        Map<String, PoolQuantity> poolQuantityMap) {
+        return new PoolOperationCallback();
     }
 
     @Override


### PR DESCRIPTION
## Description
Today, all bind time pool operations are performed via a bind chain that passes around a shared bind context. The preProcess method performs most of the heavy weight operations, but does not perform any database operations untill the execute method is executed after the locks are placed.
In this PR, I have:
* created a DelayedPoolOp to capture the operations to perform once the locks are placed.
* split PostBindBonusPoolsOp into PostBindBonusPoolsOp and CheckBonusPoolsQuantitiesOp.
* Currently only PostBindBonusPoolsOp is lock-less in it's preProcessing. A following PR would tackle CheckBonusPoolsQuantitiesOp.
* PostBindBonusPoolsOp temporarily assigns the pools and entitlements in its preProcess step so pools and entitlements can be associated to create stack derived pools and keep the stack updated.


## Performance results:
### Test setup
* create an owner
* create a single pool with attributes virt-limit, stack_id and multi-entitlement.
* make sure quantity of pool > 1000
* create 100 hypervisor consumers
* using caracalla/bind.jmx , in 100 threads bind each consumer against the same pool. repeat this in a loop 10 times.
* The first bind should create stacked derived pools for each consumer, and following 9 binds should update the stack.

### Result
| Branch | Average  | Min | Max | Std Dev. | Error % |
| ------------- | ------------- |------------- |------------- |------------- |------------- |
| lock-less-2 | 5773  | 313 | 28667 | 4875.64 | 0.007 |
| lock-less-2 | 5924  | 384 | 33304 | 5032.88 | 0.008 |
| Master | 7196  | 282 | 32198 | 5255.77 | 0 |
| Master | 7941  | 318 | 34714 | 5656.93 | 0 |

### Errors observed in performance tests
w.r.t the 0.008% error observed in this branch, upon closer inspection of the logs, it was observed that this happens because the performance test was written in a way that we could have multiple requests from the same consumer trying to bind against the same pool. when that happens, we can get a ConstraintViolationException because the two requests have completed their pre-process step together, before a lock was placed on the consumer. This has been a known and acceptable risk of lock-less implementation, and the previously agreed upon solution was to fail all but one concurrent requests so the clients can try again later. Added an exception handling block in BindChain to do the same.