### PR TITLE
Insert owner level logging filter only when needed.

### DIFF
--- a/server/src/main/java/org/candlepin/guice/CandlepinContextListener.java
+++ b/server/src/main/java/org/candlepin/guice/CandlepinContextListener.java
@@ -189,6 +189,7 @@ public class CandlepinContextListener extends GuiceResteasyBootstrapServletConte
         pinsetterListener.contextInitialized();
 
         loggerListener = injector.getInstance(LoggerContextListener.class);
+        loggerListener.contextInitialized();
 
         /**
          * Custom ModelConverter to handle our specific serialization requirements

--- a/server/src/main/java/org/candlepin/logging/LoggerAndMDCFilter.java
+++ b/server/src/main/java/org/candlepin/logging/LoggerAndMDCFilter.java
@@ -14,14 +14,21 @@
  */
 package org.candlepin.logging;
 
+import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import org.slf4j.Marker;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.TurboFilterList;
 import ch.qos.logback.classic.turbo.MatchingFilter;
+import ch.qos.logback.classic.turbo.TurboFilter;
 import ch.qos.logback.core.spi.FilterReply;
 import ch.qos.logback.core.util.OptionHelper;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * This filter accepts events based on whether the log event is greater than
@@ -29,6 +36,8 @@ import ch.qos.logback.core.util.OptionHelper;
  * originating logger is a child of the topLogger parameter.
  */
 public class LoggerAndMDCFilter extends MatchingFilter {
+    private static org.slf4j.Logger log = LoggerFactory.getLogger(LoggerAndMDCFilter.class);
+
     private String key;
     private String topLogger;
 
@@ -66,8 +75,8 @@ public class LoggerAndMDCFilter extends MatchingFilter {
          * parent, but it's a de facto convention and logback doesn't surface any
          * other way to access child loggers.
          */
-        boolean isChild = (Logger.ROOT_LOGGER_NAME.equals(topLogger)) ? true :
-            logger.getName().startsWith(topLogger);
+        boolean isChild =
+            Logger.ROOT_LOGGER_NAME.equals(topLogger) || logger.getName().startsWith(topLogger);
 
         // If for some reason someone puts in a non-parseable value for the level in
         // the MDC, then we will default to INFO.
@@ -93,6 +102,45 @@ public class LoggerAndMDCFilter extends MatchingFilter {
 
         if (errors == 0) {
             super.start();
+        }
+    }
+
+    /**
+     * Inserts an instance of this TurboFilter into the logging context if it is not already present.  While
+     * they are fast (< 0.1ms), TurboFilters still result in some overhead.  Previously we enabled the
+     * LoggerAndMDCFilter in the logback configuration file, but in production instances, the filter's decide
+     * method will be called millions of times just to support a feature that is used very rarely.  This
+     * method and it's counterpart, removeFilter, can be used to only insert the filter when it is needed.
+     */
+    public static void insertFilter() {
+        LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+        TurboFilterList filterList = context.getTurboFilterList();
+
+        // Add the LoggerAndMDCFilter if it isn't already enabled
+        if (filterList.stream().noneMatch(f -> f instanceof LoggerAndMDCFilter)) {
+            log.info("Enabling LoggerAndMDCFilter TurboFilter");
+            LoggerAndMDCFilter filter = new LoggerAndMDCFilter();
+            filter.setKey("orgLogLevel");
+            filter.setTopLogger("org.candlepin");
+            filter.setOnMatch("ACCEPT");
+            filter.setName("LoggerAndMDCFilter");
+            context.addTurboFilter(filter);
+        }
+    }
+
+    /**
+     * Remove any instances of this TurboFilter from the logging context.
+     */
+    public static void removeFilter() {
+        LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+        TurboFilterList filterList = context.getTurboFilterList();
+        List<TurboFilter> deadFilters = filterList.stream()
+            .filter(LoggerAndMDCFilter.class::isInstance)
+            .collect(Collectors.toList());
+        filterList.removeAll(deadFilters);
+        if (!deadFilters.isEmpty()) {
+            log.info("No one else using org-level logging. Removed TurboFilters: {}",
+                deadFilters.stream().map(TurboFilter::getName).collect(Collectors.toList()));
         }
     }
 }

--- a/server/src/main/java/org/candlepin/logging/LoggerContextListener.java
+++ b/server/src/main/java/org/candlepin/logging/LoggerContextListener.java
@@ -14,10 +14,14 @@
  */
 package org.candlepin.logging;
 
+import org.candlepin.model.OwnerCurator;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import ch.qos.logback.classic.LoggerContext;
+
+import javax.inject.Inject;
 
 /**
  * In order to release the resources used by logback-classic, it is always a
@@ -30,6 +34,20 @@ import ch.qos.logback.classic.LoggerContext;
  * </a>
  */
 public class LoggerContextListener {
+    private OwnerCurator ownerCurator;
+
+    @Inject
+    public LoggerContextListener(OwnerCurator ownerCurator) {
+        this.ownerCurator = ownerCurator;
+    }
+
+    public void contextInitialized() {
+         // Add the TurboFilter only if there are owners with org-logging enabled
+        if (ownerCurator.ownerLoggingEnabled()) {
+            LoggerAndMDCFilter.insertFilter();
+        }
+    }
+
     public void contextDestroyed() {
         LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
         Logger logger = context.getLogger(Logger.ROOT_LOGGER_NAME);

--- a/server/src/main/java/org/candlepin/model/OwnerCurator.java
+++ b/server/src/main/java/org/candlepin/model/OwnerCurator.java
@@ -78,6 +78,13 @@ public class OwnerCurator extends AbstractHibernateCurator<Owner> {
         return owner;
     }
 
+    public boolean ownerLoggingEnabled() {
+        Long ownersWithLogging = (Long) getEntityManager()
+            .createQuery("SELECT COUNT(o) FROM Owner o WHERE logLevel IS NOT NULL")
+            .getSingleResult();
+        return ownersWithLogging > 0;
+    }
+
     @Transactional
     public Owner replicate(Owner owner) {
         this.currentSession().replicate(owner, ReplicationMode.EXCEPTION);

--- a/server/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -49,6 +49,7 @@ import org.candlepin.dto.api.v1.EnvironmentDTO;
 import org.candlepin.dto.api.v1.OwnerDTO;
 import org.candlepin.dto.api.v1.PoolDTO;
 import org.candlepin.dto.api.v1.UpstreamConsumerDTO;
+import org.candlepin.logging.LoggerAndMDCFilter;
 import org.candlepin.model.Branding;
 import org.candlepin.model.CandlepinQuery;
 import org.candlepin.model.Consumer;
@@ -917,6 +918,10 @@ public class OwnerResource {
             throw new BadRequestException(i18n.tr("Could not create the Owner: {0}", owner));
         }
 
+        if (owner.getLogLevel() != null) {
+            LoggerAndMDCFilter.insertFilter();
+        }
+
         log.info("Created owner: {}", owner);
         sink.emitOwnerCreated(owner);
 
@@ -988,6 +993,10 @@ public class OwnerResource {
 
         owner = ownerCurator.merge(owner);
         ownerCurator.flush();
+
+        if (owner.getLogLevel() != null) {
+            LoggerAndMDCFilter.insertFilter();
+        }
 
         // Refresh content access mode if necessary
         if (refreshContentAccess) {
@@ -1296,6 +1305,8 @@ public class OwnerResource {
         owner.setLogLevel(logLevel.toString());
         owner = ownerCurator.merge(owner);
 
+        LoggerAndMDCFilter.insertFilter();
+
         return this.translator.translate(owner, OwnerDTO.class);
     }
 
@@ -1313,6 +1324,11 @@ public class OwnerResource {
         Owner owner = findOwnerByKey(ownerKey);
         owner.setLogLevel(null);
         ownerCurator.merge(owner);
+
+        // Remove the TurboFilter only if there are no other owners with org-logging enabled
+        if (!ownerCurator.ownerLoggingEnabled()) {
+            LoggerAndMDCFilter.removeFilter();
+        }
     }
 
     /**

--- a/server/src/main/resources/logback.xml
+++ b/server/src/main/resources/logback.xml
@@ -2,12 +2,6 @@
 <configuration>
     <contextName>candlepin</contextName>
 
-    <turboFilter class="org.candlepin.logging.LoggerAndMDCFilter">
-        <key>orgLogLevel</key>
-        <topLogger>org.candlepin</topLogger>
-        <OnMatch>ACCEPT</OnMatch>
-    </turboFilter>
-
     <appender name="CandlepinAppender" class="ch.qos.logback.core.FileAppender">
         <file>/var/log/candlepin/candlepin.log</file>
         <encoder>
@@ -39,9 +33,9 @@
     </appender>
 
     <logger name="org.candlepin" level="INFO"/>
-     
-    <!-- With each attempt to connect Qpid, we get a warning message: 
-          Exception received while trying to verify hostname 
+
+    <!-- With each attempt to connect Qpid, we get a warning message:
+         "Exception received while trying to verify hostname"
          We decide to silence this in logs because it shouldn't have any significance to
          our usage of Qpid -->
     <logger name="org.apache.qpid.transport.network.security.ssl.SSLUtil" level="ERROR"/>

--- a/server/src/test/java/org/candlepin/logging/LoggerAndMDCFilterTest.java
+++ b/server/src/test/java/org/candlepin/logging/LoggerAndMDCFilterTest.java
@@ -19,11 +19,13 @@ import static org.junit.Assert.*;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.TurboFilterList;
 import ch.qos.logback.core.spi.FilterReply;
 
 /**
@@ -98,6 +100,42 @@ public class LoggerAndMDCFilterTest {
 
         assertEquals(FilterReply.DENY,
             filter.decide(null, logger, Level.DEBUG, null, null, null));
+    }
+
+    @Test
+    public void testInsertFilter() {
+        LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+        TurboFilterList filterList = context.getTurboFilterList();
+
+        assertTrue(filterList.stream().noneMatch(f -> f instanceof LoggerAndMDCFilter));
+
+        LoggerAndMDCFilter.insertFilter();
+        assertTrue(filterList.stream().anyMatch(f -> f instanceof LoggerAndMDCFilter));
+
+        int length = filterList.size();
+
+        LoggerAndMDCFilter.insertFilter();
+        assertEquals(length, filterList.size());
+    }
+
+    @Test
+    public void testRemoveFilter() {
+        LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+        TurboFilterList filterList = context.getTurboFilterList();
+
+        LoggerAndMDCFilter instance1 = new LoggerAndMDCFilter();
+        instance1.setName("instance1");
+
+        LoggerAndMDCFilter instance2 = new LoggerAndMDCFilter();
+        instance2.setName("instance2");
+
+        filterList.add(instance1);
+        filterList.add(instance2);
+
+        int originalLength = filterList.size();
+        LoggerAndMDCFilter.removeFilter();
+        assertEquals(originalLength - 2, filterList.size());
+        assertTrue(filterList.stream().noneMatch(f -> f instanceof LoggerAndMDCFilter));
     }
 
     @Test


### PR DESCRIPTION
The LoggerAndMDCFilter is responsible for logging messages at a given
level for specific owners.  We use this tool in production to get DEBUG
level messages for specific owners without having to log everyone else's
requests.  The filter is fast: the decide() method takes 0.1ms or less,
but it is still being run for *every* logging call.  Those tenths of a
millisecond add up over millions of invocations and all for a feature
that is used only rarely.

This patch inserts the LoggerAndMDCFilter when owner level logging is
requested and removes it when owner level logging is disabled.  It also
checks at servlet start-up time to see if owner level logging is
enabled anywhere and adds the filter if so.

----
Notes for testing:

Enable owner-level logging like so:
```
curl -k -v -u admin:admin  -X PUT "https://localhost:8443/candlepin/owners/snowwhite/log?level=DEBUG" 
```

Disable like so:
```
curl -k -v -u admin:admin  -X DELETE https://localhost:8443/candlepin/owners/snowwhite/log   
```

The following should be true:
* If any owner has logging enabled at servlet start up, the filter should be inserted.
* If owner logging is requested for an owner, the filter should only be inserted if it is not already present in the filter list
* If owner logging is disabled for an owner, the filter should be removed if and only if there are no other owners using owner logging.

I tested
* Enable logging for `admin`.  A message stating the filter has been added should appear.
* Enable logging for `snowwhite`.  No message should appear since the filter was already inserted.
* Disable logging for `snowwhite`. No message should appear since `admin` is still using owner logging.
* Disable logging for `admin`. A message should appear since no one else is using owner logging.
* Disable logging for `admin` again. No message should appear since the filter is not present in the filter list at all.
* Enable logging for `admin` and restart the server.  A message should appear since owner logging is still enabled for `admin`.