### PR TITLE
1566244: Speculative Fix For Failing CertificateRevocationListTask

### DIFF
--- a/server/spec/cert_revocation_spec.rb
+++ b/server/spec/cert_revocation_spec.rb
@@ -16,8 +16,7 @@ describe 'Certificate Revocation List', :serial => true do
     @monitoring_prod = create_product random_string('monitoring')
 
     #entitle owner for the virt and monitoring products.
-    @monitoring_pool = create_pool_and_subscription(@owner['key'], @monitoring_prod.id, 6,
-				[], '', '', '', nil, nil, true)
+    @monitoring_pool = create_pool_and_subscription(@owner['key'], @monitoring_prod.id, 6, [], '', '', '', nil, nil, true)
     create_pool_and_subscription(@owner['key'], @virt_prod.id, 3)
 
     #create consumer

--- a/server/src/main/java/org/candlepin/model/CertificateSerial.java
+++ b/server/src/main/java/org/candlepin/model/CertificateSerial.java
@@ -133,7 +133,7 @@ public class CertificateSerial extends AbstractHibernateObject<CertificateSerial
     }
 
     public BigInteger getSerial() {
-        return Util.toBigInt(this.getId());
+        return this.getId() != null ? BigInteger.valueOf(this.getId()) : null;
     }
 
     public void setSerial(Long serial) {

--- a/server/src/main/java/org/candlepin/model/CertificateSerialCurator.java
+++ b/server/src/main/java/org/candlepin/model/CertificateSerialCurator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ * Copyright (c) 2009 - 2018 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -14,21 +14,19 @@
  */
 package org.candlepin.model;
 
-import org.candlepin.util.Util;
-
-import com.google.common.collect.Iterables;
 import com.google.inject.persist.Transactional;
 
-import org.hibernate.Query;
 import org.hibernate.criterion.DetachedCriteria;
-import org.hibernate.criterion.Order;
 import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
 
+import java.util.Calendar;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
-import java.util.Map;
+import java.util.TimeZone;
+
+import javax.persistence.Query;
 
 
 
@@ -37,68 +35,129 @@ import java.util.Map;
  */
 public class CertificateSerialCurator extends AbstractHibernateCurator<CertificateSerial> {
 
-    private static int inClauseLimit = 1000;
-
     public CertificateSerialCurator() {
         super(CertificateSerial.class);
     }
 
     /**
-     * @return list of certificate serials which are revoked but not yet collected
-     * and put into CRL
+     * Fetches a collection of serials from uncollected, revoked certficiate serials. If there are
+     * no such certificate serials, this method returns an empty collection.
+     *
+     * @return
+     *  a collection of serials from uncollected, revoked certificate serials
      */
-    @SuppressWarnings("unchecked")
-    public CandlepinQuery<CertificateSerial> retrieveTobeCollectedSerials() {
+    public CandlepinQuery<Long> getUncollectedRevokedCertSerials() {
         DetachedCriteria criteria = DetachedCriteria.forClass(CertificateSerial.class)
             .add(Restrictions.eq("revoked", true))
-            .add(Restrictions.eq("collected", false));
+            .add(Restrictions.eq("collected", false))
+            .setProjection(Projections.id()); // Note: the ID *is* the serial for cert serials
 
-        return this.cpQueryFactory.<CertificateSerial>buildQuery(this.currentSession(), criteria);
-    }
-
-    @SuppressWarnings("unchecked")
-    public CandlepinQuery<CertificateSerial> getExpiredSerials() {
-        //TODO - Should date fields be truncated when checking expiration?
-
-        DetachedCriteria criteria = DetachedCriteria.forClass(CertificateSerial.class)
-            .add(Restrictions.le("expiration", Util.yesterday()))
-            .add(Restrictions.eq("revoked", true));
-
-        return this.cpQueryFactory.<CertificateSerial>buildQuery(this.currentSession(), criteria);
+        return this.cpQueryFactory.<Long>buildQuery(this.currentSession(), criteria);
     }
 
     /**
-     * Delete expired serials.
+     * Fetches a collection of serials from revoked certficiate serials that expired prior to
+     * midnight, yesterday in UTC. If there are no such certificate serials, this method returns an
+     * empty collection.
      *
-     * @return the number of rows deleted.
+     * @return
+     *  a collection of serials from revoked certficiate serials that expired prior to "today."
+     */
+    public CandlepinQuery<Long> getExpiredRevokedCertSerials() {
+        Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+
+        // Set to midnight first
+        cal.set(Calendar.MINUTE, 0);
+        cal.set(Calendar.SECOND, 0);
+        cal.set(Calendar.HOUR_OF_DAY, 0);
+        cal.set(Calendar.MILLISECOND, 0);
+
+        // Subtract a day to put us in "yesterday" relative to midnight UTC of whatever "today" is
+        cal.add(Calendar.DAY_OF_MONTH, -1);
+
+        return this.getExpiredRevokedCertSerials(cal.getTime());
+    }
+
+    /**
+     * Fetches a collection of serials from revoked certificate serials that expired prior to the
+     * specified cutoff date. If there are no such certificate serials, this method returns an empty
+     * collection.
+     *
+     * @param cutoff
+     *  The cutoff date to use for considering certificate serials "expired"
+     *
+     * @throws IllegalArgumentException
+     *  if the cutoff date is null
+     *
+     * @return
+     *  a collection of serials from revoked certficiate serials that expired prior to the specified
+     *  cutoff date
+     */
+    public CandlepinQuery<Long> getExpiredRevokedCertSerials(Date cutoff) {
+        if (cutoff == null) {
+            throw new IllegalArgumentException("cutoff is null");
+        }
+
+        DetachedCriteria criteria = DetachedCriteria.forClass(CertificateSerial.class)
+            .add(Restrictions.lt("expiration", cutoff))
+            .add(Restrictions.eq("revoked", true))
+            .setProjection(Projections.id()); // Note: the ID *is* the serial for cert serials
+
+        return this.cpQueryFactory.<Long>buildQuery(this.currentSession(), criteria);
+    }
+
+    /**
+     * Marks the specified serials as collected.
+     *
+     * @param serials
+     *  A collection of serials to mark as collected
+     *
+     * @return
+     *  the number of certificate serials updated
      */
     @Transactional
-    public int deleteExpiredSerials() {
-        // Some databases don't like to update based on a field that is being updated
-        // So we must get expired ids, and then delete them
-        @SuppressWarnings("unchecked")
-        List<String> ids = this.currentSession()
-            .createCriteria(CertificateSerial.class)
-            .add(Restrictions.le("expiration", Util.yesterday()))
-            .add(Restrictions.eq("revoked", true))
-            .setProjection(Projections.id())
-            .addOrder(Order.asc("id"))
-            .list();
+    public int markSerialsAsCollected(Collection<Long> serials) {
+        int updated = 0;
 
-        if (ids.isEmpty()) {
-            return 0;
+        if (serials != null && !serials.isEmpty()) {
+            // Impl note: the ID *is* the serial for cert serials. If this changes in the future, this query
+            // should change, not the input.
+            String hql = "UPDATE CertificateSerial cs SET collected = true WHERE id IN (:serials)";
+            Query query = this.getEntityManager().createQuery(hql);
+
+            for (Collection<Long> block : this.partition(serials)) {
+                updated += query.setParameter("serials", block).executeUpdate();
+            }
         }
 
-        String hql = "DELETE from CertificateSerial WHERE id IN (:expiredIds)";
-        Query query = this.currentSession().createQuery(hql);
+        return updated;
+    }
 
-        int removed = 0;
+    /**
+     * Deletes the certificate serials with the specified serials.
+     *
+     * @param serials
+     *  A collection of serials to delete
+     *
+     * @return
+     *  the number of certificate serials deleted
+     */
+    @Transactional
+    public int deleteSerials(Collection<Long> serials) {
+        int deleted = 0;
 
-        for (List<String> block : Iterables.partition(ids, getInBlockSize())) {
-            removed += query.setParameterList("expiredIds", block).executeUpdate();
+        if (serials != null && !serials.isEmpty()) {
+            // Impl note: the ID *is* the serial for cert serials. If this changes in the future, this query
+            // should change, not the input.
+            String hql = "DELETE from CertificateSerial WHERE id IN (:serials)";
+            Query query = this.getEntityManager().createQuery(hql);
+
+            for (Collection<Long> block : this.partition(serials)) {
+                deleted += query.setParameter("serials", block).executeUpdate();
+            }
         }
 
-        return removed;
+        return deleted;
     }
 
     @SuppressWarnings("unchecked")
@@ -119,17 +178,8 @@ public class CertificateSerialCurator extends AbstractHibernateCurator<Certifica
         return this.cpQueryFactory.<CertificateSerial>buildQuery(this.currentSession(), criteria);
     }
 
-    /*
-     * This method is really not necessary, but is probably the cleanest way to
-     * unit test.
-     */
-    public Collection<CertificateSerial> saveOrUpdateAll(Map<String, CertificateSerial> serialMap) {
-        return this.saveOrUpdateAll(serialMap.values(), false, false);
-    }
-
     @SuppressWarnings("unchecked")
     public List<Long> listEntitlementSerialIds(Consumer c) {
-        List<Long> resultList = null;
         String hql = "SELECT s.id" +
             "    FROM EntitlementCertificate ec" +
             "     JOIN ec.entitlement e" +
@@ -140,12 +190,12 @@ public class CertificateSerialCurator extends AbstractHibernateCurator<Certifica
             "       c.id=:consumerId" +
             "    AND" +
             "       p.endDate >= :nowDate";
-        javax.persistence.Query query = this.getEntityManager().createQuery(hql);
 
-        resultList = (List<Long>) query
+        Query query = this.getEntityManager().createQuery(hql);
+
+        return (List<Long>) query
             .setParameter("consumerId", c.getId())
             .setParameter("nowDate", new Date())
             .getResultList();
-        return resultList;
     }
 }

--- a/server/src/main/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapter.java
+++ b/server/src/main/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapter.java
@@ -519,7 +519,7 @@ public class DefaultEntitlementCertServiceAdapter extends BaseEntitlementCertSer
 
         // Serials need to be saved before the certs.
         log.debug("Persisting new certificate serials");
-        serialCurator.saveOrUpdateAll(serialMap);
+        serialCurator.saveOrUpdateAll(serialMap.values(), false, false);
 
         // Now that the serials have been saved, update the newly created
         // certs with their serials and add them to the entitlements.

--- a/server/src/main/java/org/candlepin/util/Util.java
+++ b/server/src/main/java/org/candlepin/util/Util.java
@@ -31,7 +31,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
-import java.math.BigInteger;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
@@ -129,6 +128,16 @@ public class Util {
         return addDaysToDt(-1);
     }
 
+    public static Date midnight() {
+        Calendar cal = Calendar.getInstance();
+        cal.set(Calendar.MINUTE, 0);
+        cal.set(Calendar.SECOND, 0);
+        cal.set(Calendar.HOUR_OF_DAY, 0);
+        cal.set(Calendar.MILLISECOND, 0);
+
+        return cal.getTime();
+    }
+
     public static Date addDaysToDt(int dayField) {
         Calendar calendar = Calendar.getInstance();
         calendar.add(Calendar.DAY_OF_MONTH, dayField);
@@ -155,17 +164,14 @@ public class Util {
         return calendar.getTime();
     }
 
-    public static Date roundToMidnight(Date dt) {
+    public static Date setToMidnight(Date dt) {
         Calendar cal = Calendar.getInstance();
         cal.setTime(dt);
-        cal.set(Calendar.MINUTE, 59);
-        cal.set(Calendar.SECOND, 59);
-        cal.set(Calendar.HOUR_OF_DAY, 23);
+        cal.set(Calendar.MINUTE, 0);
+        cal.set(Calendar.SECOND, 0);
+        cal.set(Calendar.HOUR_OF_DAY, 0);
+        cal.set(Calendar.MILLISECOND, 0);
         return cal.getTime();
-    }
-
-    public static BigInteger toBigInt(long l) {
-        return new BigInteger(String.valueOf(l));
     }
 
     public static Date toDate(String dt) {

--- a/server/src/test/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapterTest.java
+++ b/server/src/test/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapterTest.java
@@ -17,7 +17,6 @@ package org.candlepin.service.impl;
 import static org.candlepin.pki.impl.BouncyCastleProviderLoader.*;
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyMap;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.argThat;
 import static org.mockito.Matchers.eq;
@@ -1686,15 +1685,6 @@ public class DefaultEntitlementCertServiceAdapterTest {
         when(serial.getId()).thenReturn(1L);
 
         pool.setId("poolId");
-        doAnswer(new Answer<Map<String, CertificateSerial>>() {
-            @Override
-            public Map<String, CertificateSerial> answer(InvocationOnMock invocation) throws Throwable {
-                Object[] args = invocation.getArguments();
-                Map<String, CertificateSerial> map = (Map<String, CertificateSerial>) args[0];
-                map.put("poolId", serial);
-                return null;
-            }
-        }).when(serialCurator).saveOrUpdateAll(anyMap());
 
         EntitlementCertificate cert = certServiceAdapter.generateEntitlementCert(entitlement, product);
 

--- a/server/src/test/java/org/candlepin/util/UtilTest.java
+++ b/server/src/test/java/org/candlepin/util/UtilTest.java
@@ -35,7 +35,6 @@ import java.io.FileInputStream;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
-import java.math.BigInteger;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -44,6 +43,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.TimeZone;
+
+
 
 /**
  * Test Class for the Util class
@@ -132,24 +133,50 @@ public class UtilTest {
         assertFalse(curyear == c.get(Calendar.YEAR));
     }
 
-    @Ignore("This will fail on the last day of each month!")
     @Test
     public void tomorrow() {
-        Calendar c = Calendar.getInstance();
-        c.setTime(new Date());
-        int today = c.get(Calendar.DAY_OF_MONTH);
-        c.setTime(Util.tomorrow());
-        assertEquals(today + 1, c.get(Calendar.DAY_OF_MONTH));
+        // Due to the whole doing-stuff-takes-time thing, we need to allow a handful of milliseconds
+        // to pass over this test. We'll assume things are functioning correctly if the actual result
+        // is within a tolerable amount of milliseconds from our calculated time.
+        long tolerance = 500;
+
+        Calendar cal = Calendar.getInstance();
+        cal.add(Calendar.DAY_OF_MONTH, 1);
+
+        long expected = cal.getTimeInMillis();
+        long actual = Util.yesterday().getTime();
+
+        assertTrue(actual - expected <= tolerance);
     }
 
-    @Ignore("This will fail on the first day of each month!")
     @Test
     public void yesterday() {
-        Calendar c = Calendar.getInstance();
-        c.setTime(new Date());
-        int today = c.get(Calendar.DAY_OF_MONTH);
-        c.setTime(Util.yesterday());
-        assertEquals(today - 1, c.get(Calendar.DAY_OF_MONTH));
+        // Due to the whole doing-stuff-takes-time thing, we need to allow a handful of milliseconds
+        // to pass over this test. We'll assume things are functioning correctly if the actual result
+        // is within a tolerable amount of milliseconds from our calculated time.
+        long tolerance = 500;
+
+        Calendar cal = Calendar.getInstance();
+        cal.add(Calendar.DAY_OF_MONTH, -1);
+
+        long expected = cal.getTimeInMillis();
+        long actual = Util.yesterday().getTime();
+
+        assertTrue(actual - expected <= tolerance);
+    }
+
+    @Test
+    public void midnight() {
+        Calendar cal = Calendar.getInstance();
+        cal.set(Calendar.MINUTE, 0);
+        cal.set(Calendar.SECOND, 0);
+        cal.set(Calendar.HOUR_OF_DAY, 0);
+        cal.set(Calendar.MILLISECOND, 0);
+
+        Date expected = cal.getTime();
+        Date actual = Util.midnight();
+
+        assertEquals(expected, actual);
     }
 
     // This is pretty silly - basically doing the same thing the
@@ -222,30 +249,24 @@ public class UtilTest {
     }
 
     @Test
-    public void roundToMidnight() {
+    public void testSetToMidnight() {
         Date now = new Date();
-        Date midnight = Util.roundToMidnight(now);
+        Date midnight = Util.setToMidnight(now);
         assertFalse(now.equals(midnight));
 
         Calendar cal = Calendar.getInstance();
         cal.setTime(midnight);
-        assertEquals(23, cal.get(Calendar.HOUR_OF_DAY));
-        assertEquals(59, cal.get(Calendar.MINUTE));
-        assertEquals(59, cal.get(Calendar.SECOND));
+        assertEquals(0, cal.get(Calendar.HOUR_OF_DAY));
+        assertEquals(0, cal.get(Calendar.MINUTE));
+        assertEquals(0, cal.get(Calendar.SECOND));
         assertEquals(TimeZone.getDefault(), cal.getTimeZone());
 
-        Date stillmidnight = Util.roundToMidnight(midnight);
+        Date stillmidnight = Util.setToMidnight(midnight);
         cal.setTime(stillmidnight);
-        assertEquals(23, cal.get(Calendar.HOUR_OF_DAY));
-        assertEquals(59, cal.get(Calendar.MINUTE));
-        assertEquals(59, cal.get(Calendar.SECOND));
+        assertEquals(0, cal.get(Calendar.HOUR_OF_DAY));
+        assertEquals(0, cal.get(Calendar.MINUTE));
+        assertEquals(0, cal.get(Calendar.SECOND));
         assertEquals(TimeZone.getDefault(), cal.getTimeZone());
-    }
-
-    @Test
-    public void bigint() {
-        assertEquals(BigInteger.valueOf(10L), Util.toBigInt(10L));
-        assertEquals(BigInteger.valueOf(-10L), Util.toBigInt(-10L));
     }
 
     @Test


### PR DESCRIPTION
(cherry-pick from master)

- Heavily optimized the CrlFileUtil.syncCRLWithDB method, reducing
  overall memory load and substantially reducing method runtime
- CrlFileUtil.syncCRLWithDB now cleans up serials after successful
  synchronization
- Rewrote several methods in CertificateSerialCurator to return
  certificate serials (the actual serials as long integers) rather
  than full CertificateSerial instances
- Rewrote several tests in CertificateSerialCuratorTest in
  accordance with the changes to the curator
- Corrected a handful of utility methods and tests