### PR TITLE
Improved standardization of curator method verbiage

### DIFF
--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -382,7 +382,7 @@ public class CandlepinPoolManager implements PoolManager {
 
         if (owner.getKey() != null) {
             String ownerKey = owner.getKey();
-            owner = ownerCurator.lookupByKey(owner.getKey());
+            owner = ownerCurator.getByKey(owner.getKey());
 
             if (owner == null) {
                 throw new IllegalStateException(
@@ -391,7 +391,7 @@ public class CandlepinPoolManager implements PoolManager {
         }
         else {
             String id = owner.getId();
-            owner = ownerCurator.find(owner.getId());
+            owner = ownerCurator.get(owner.getId());
 
             if (owner == null) {
                 throw new IllegalStateException(i18n.tr("Unable to find an owner with the ID \"{0}\"", id));
@@ -413,9 +413,9 @@ public class CandlepinPoolManager implements PoolManager {
         }
         else {
             // If we don't have a subscription ID, this *is* the master pool, but we need to use
-            // the original, hopefully unmodified pool
+            // the original, hopefully unmodified, pool
             subscriptionPools = pool.getId() != null ?
-                Collections.<Pool>singletonList(this.poolCurator.find(pool.getId())) :
+                Collections.<Pool>singletonList(this.poolCurator.get(pool.getId())) :
                 Collections.<Pool>singletonList(pool);
         }
 
@@ -972,8 +972,8 @@ public class CandlepinPoolManager implements PoolManager {
         }
 
         Owner owner = sub.getOwner().getId() != null ?
-            this.ownerCurator.find(sub.getOwner().getId()) :
-            this.ownerCurator.lookupByKey(sub.getOwner().getKey());
+            this.ownerCurator.get(sub.getOwner().getId()) :
+            this.ownerCurator.getByKey(sub.getOwner().getKey());
 
         if (owner == null) {
             throw new IllegalStateException("Subscription references an owner which cannot be resolved: " +
@@ -1019,12 +1019,12 @@ public class CandlepinPoolManager implements PoolManager {
     // Remove these methods or update them to properly mirror the curator.
 
     @Override
-    public Pool find(String poolId) {
-        return this.poolCurator.find(poolId);
+    public Pool get(String poolId) {
+        return this.poolCurator.get(poolId);
     }
 
     @Override
-    public List<Pool> secureFind(Collection<String> poolIds) {
+    public List<Pool> secureGet(Collection<String> poolIds) {
         if (CollectionUtils.isNotEmpty(poolIds)) {
             return this.poolCurator.listAllByIds(poolIds).list();
         }
@@ -1033,14 +1033,14 @@ public class CandlepinPoolManager implements PoolManager {
     }
 
     @Override
-    public List<Pool> lookupBySubscriptionId(Owner owner, String id) {
-        return this.poolCurator.lookupBySubscriptionId(owner, id);
+    public List<Pool> getBySubscriptionId(Owner owner, String id) {
+        return this.poolCurator.getBySubscriptionId(owner, id);
     }
 
     @Override
-    public List<Pool> lookupBySubscriptionIds(String ownerId, Collection<String> subscriptionIds) {
+    public List<Pool> getBySubscriptionIds(String ownerId, Collection<String> subscriptionIds) {
         if (CollectionUtils.isNotEmpty(subscriptionIds)) {
-            return this.poolCurator.lookupBySubscriptionIds(ownerId, subscriptionIds);
+            return this.poolCurator.getBySubscriptionIds(ownerId, subscriptionIds);
         }
 
         return new ArrayList<>();
@@ -1119,7 +1119,7 @@ public class CandlepinPoolManager implements PoolManager {
         // fromPools will be empty if the dev pool was already created.
         if (consumer != null && consumer.isDev() && !fromPools.isEmpty()) {
             String poolId = fromPools.iterator().next();
-            PoolQuantity pq = new PoolQuantity(poolCurator.find(poolId), 1);
+            PoolQuantity pq = new PoolQuantity(poolCurator.get(poolId), 1);
             bestPools.add(pq);
         }
         else {
@@ -1592,7 +1592,7 @@ public class CandlepinPoolManager implements PoolManager {
         Map<String, PoolQuantity> poolQuantityMap = new HashMap<>();
         poolQuantityMap.put(pool.getId(), new PoolQuantity(pool, change));
 
-        Owner owner = ownerCurator.find(consumer.getOwnerId());
+        Owner owner = ownerCurator.get(consumer.getOwnerId());
 
         // the only thing we do here is decrement bonus pool quantity
         enforcer.postEntitlement(this, consumer, owner, entMap, new ArrayList<>(), true, poolQuantityMap);
@@ -1681,7 +1681,7 @@ public class CandlepinPoolManager implements PoolManager {
             excludePoolIds.add(pool.getId());
         }
 
-        List<Pool> overConsumedPools = poolCurator.lookupOversubscribedBySubscriptionIds(ownerId,
+        List<Pool> overConsumedPools = poolCurator.getOversubscribedBySubscriptionIds(ownerId,
             subEntitlementMap);
 
         List<Pool> derivedPools = new ArrayList<>();

--- a/server/src/main/java/org/candlepin/controller/EntitlementCertificateGenerator.java
+++ b/server/src/main/java/org/candlepin/controller/EntitlementCertificateGenerator.java
@@ -238,7 +238,7 @@ public class EntitlementCertificateGenerator {
         }
         else {
             for (String entitlementId : entitlementIds) {
-                Entitlement entitlement = entitlementCurator.find(entitlementId);
+                Entitlement entitlement = entitlementCurator.get(entitlementId);
 
                 if (entitlement == null) {
                     // If it has been deleted, that's fine; one less to regenerate

--- a/server/src/main/java/org/candlepin/controller/Entitler.java
+++ b/server/src/main/java/org/candlepin/controller/Entitler.java
@@ -124,12 +124,10 @@ public class Entitler {
             return bindByPoolQuantities(consumer, poolMap);
         }
         catch (EntitlementRefusedException e) {
-            // TODO: Could be multiple errors, but we'll just report the first
-            // one for now
-            Pool pool = poolCurator.find(poolId);
+            // TODO: Could be multiple errors, but we'll just report the first one for now
+            Pool pool = poolCurator.get(poolId);
             throw new ForbiddenException(messageTranslator.poolErrorToMessage(
-                pool, e.getResults().get(poolId).getErrors().get(0)
-            ));
+                pool, e.getResults().get(poolId).getErrors().get(0)));
         }
     }
 
@@ -248,11 +246,11 @@ public class Entitler {
                         host.getUuid(), e.getMessage());
                 }
 
-                /* Consumer is stale at this point.  Note that we use find() instead of
+                /* Consumer is stale at this point.  Note that we use get() instead of
                  * findByUuid() or getConsumer() since the latter two methods are secured
                  * to a specific host principal and bindByProducts can get called when
                  * a guest is switching hosts */
-                consumer = consumerCurator.find(consumer.getId());
+                consumer = consumerCurator.get(consumer.getId());
                 data.setConsumer(consumer);
             }
         }

--- a/server/src/main/java/org/candlepin/controller/ManifestManager.java
+++ b/server/src/main/java/org/candlepin/controller/ManifestManager.java
@@ -307,7 +307,7 @@ public class ManifestManager {
                     consumerUuid, ctype != null ? ctype.getLabel() : "unknown type"));
         }
 
-        if (!StringUtils.isBlank(cdnLabel) && cdnCurator.lookupByLabel(cdnLabel) == null) {
+        if (!StringUtils.isBlank(cdnLabel) && cdnCurator.getByLabel(cdnLabel) == null) {
             throw new ForbiddenException(
                 i18n.tr("A CDN with label {0} does not exist on this system.", cdnLabel));
         }

--- a/server/src/main/java/org/candlepin/controller/OwnerManager.java
+++ b/server/src/main/java/org/candlepin/controller/OwnerManager.java
@@ -134,7 +134,7 @@ public class OwnerManager {
             // parent being deleted
             // TODO: There has to be a more efficient way to do this...
             log.info("Deleting consumer: {}", consumer);
-            Consumer next = consumerCurator.find(consumer.getId());
+            Consumer next = consumerCurator.get(consumer.getId());
             if (next != null) {
                 consumerCurator.delete(next);
             }
@@ -157,7 +157,7 @@ public class OwnerManager {
             poolManager.deletePool(p);
         }
 
-        ExporterMetadata m = exportCurator.lookupByTypeAndOwner(ExporterMetadata.TYPE_PER_USER, owner);
+        ExporterMetadata m = exportCurator.getByTypeAndOwner(ExporterMetadata.TYPE_PER_USER, owner);
         if (m != null) {
             log.info("Deleting export metadata: {}", m);
             exportCurator.delete(m);

--- a/server/src/main/java/org/candlepin/controller/PoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/PoolManager.java
@@ -121,13 +121,13 @@ public interface PoolManager {
         Date entitleDate, String ownerId, String serviceLevelOverride, Collection<String> fromPools)
         throws EntitlementRefusedException;
 
-    Pool find(String poolId);
+    Pool get(String poolId);
 
-    List<Pool> secureFind(Collection<String> poolId);
+    List<Pool> secureGet(Collection<String> poolId);
 
-    List<Pool> lookupBySubscriptionId(Owner owner, String id);
+    List<Pool> getBySubscriptionId(Owner owner, String id);
 
-    List<Pool> lookupBySubscriptionIds(String ownerId, Collection<String> id);
+    List<Pool> getBySubscriptionIds(String ownerId, Collection<String> id);
 
     Refresher getRefresher(SubscriptionServiceAdapter subAdapter, OwnerServiceAdapter ownerAdapter);
     Refresher getRefresher(SubscriptionServiceAdapter subAdapter, OwnerServiceAdapter ownerAdapter,

--- a/server/src/main/java/org/candlepin/hostedtest/HostedTestSubscriptionResource.java
+++ b/server/src/main/java/org/candlepin/hostedtest/HostedTestSubscriptionResource.java
@@ -300,7 +300,7 @@ public class HostedTestSubscriptionResource {
     }
 
     protected Owner getOwnerByKey(String key) {
-        Owner owner = this.ownerCurator.lookupByKey(key);
+        Owner owner = this.ownerCurator.getByKey(key);
 
         if (owner == null) {
             throw new NotFoundException(i18n.tr("Owner with key \"{0}\" was not found.", key));

--- a/server/src/main/java/org/candlepin/model/CdnCurator.java
+++ b/server/src/main/java/org/candlepin/model/CdnCurator.java
@@ -22,8 +22,7 @@ import org.hibernate.criterion.Restrictions;
 /**
  * Subscription manager.
  */
-public class CdnCurator
-    extends AbstractHibernateCurator<Cdn> {
+public class CdnCurator extends AbstractHibernateCurator<Cdn> {
 
     @Inject
     public CdnCurator() {
@@ -35,10 +34,10 @@ public class CdnCurator
      * @param label CDN label
      * @return CDN whose label matches the given value.
      */
-    public Cdn lookupByLabel(String label) {
-        return (Cdn) currentSession()
-            .createCriteria(Cdn.class)
-            .add(Restrictions.eq("label", label)).uniqueResult();
+    public Cdn getByLabel(String label) {
+        return (Cdn) currentSession().createCriteria(Cdn.class)
+            .add(Restrictions.eq("label", label))
+            .uniqueResult();
     }
 
     /**

--- a/server/src/main/java/org/candlepin/model/ConsumerCurator.java
+++ b/server/src/main/java/org/candlepin/model/ConsumerCurator.java
@@ -156,7 +156,7 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
         List<String> options = q.list();
 
         if (options != null && options.size() != 0) {
-            result = this.find(options.get(0));
+            result = this.get(options.get(0));
         }
 
         return result;
@@ -240,7 +240,7 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
     @Transactional
     public Consumer findByUser(User user) {
         ConsumerType person = consumerTypeCurator
-            .lookupByLabel(ConsumerType.ConsumerTypeEnum.PERSON.getLabel());
+            .getByLabel(ConsumerType.ConsumerTypeEnum.PERSON.getLabel());
 
         if (person != null) {
             return (Consumer) createSecureCriteria()
@@ -392,7 +392,7 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
         // Validate inbound facts before even attempting to apply the update
         this.validateFacts(updatedConsumer);
 
-        Consumer existingConsumer = find(updatedConsumer.getId());
+        Consumer existingConsumer = this.get(updatedConsumer.getId());
 
         if (existingConsumer == null) {
             return this.create(updatedConsumer, flush);

--- a/server/src/main/java/org/candlepin/model/ConsumerTypeCurator.java
+++ b/server/src/main/java/org/candlepin/model/ConsumerTypeCurator.java
@@ -54,7 +54,7 @@ public class ConsumerTypeCurator extends AbstractHibernateCurator<ConsumerType> 
             throw new IllegalArgumentException("consumer is null or does not have a defined type ID");
         }
 
-        ConsumerType type = this.find(consumer.getTypeId());
+        ConsumerType type = this.get(consumer.getTypeId());
 
         if (type == null) {
             throw new IllegalStateException("consumer is not associated with a valid type: " + consumer);
@@ -64,13 +64,15 @@ public class ConsumerTypeCurator extends AbstractHibernateCurator<ConsumerType> 
     }
 
     /**
-     * lookup the ConsumerType by its label.
+     * Attempts to fetch a ConsumerType by its label.
      *
-     * @param label type to lookup
-     * @return ConsumerType whose label matches the given label.
+     * @param label
+     *  The label of the consumer type to fetch
+     *
+     * @return ConsumerType whose label matches the given label
      */
-    public ConsumerType lookupByLabel(String label) {
-        return this.lookupByLabel(label, false);
+    public ConsumerType getByLabel(String label) {
+        return this.getByLabel(label, false);
     }
 
     /**
@@ -90,7 +92,7 @@ public class ConsumerTypeCurator extends AbstractHibernateCurator<ConsumerType> 
      *  The consumer type with the specified label, or null if the label does not exist and the create flag
      *  is not set
      */
-    public ConsumerType lookupByLabel(String label, boolean createIfAbsent) {
+    public ConsumerType getByLabel(String label, boolean createIfAbsent) {
         if (label == null || label.isEmpty()) {
             throw new IllegalArgumentException("label is null or empty");
         }
@@ -129,7 +131,7 @@ public class ConsumerTypeCurator extends AbstractHibernateCurator<ConsumerType> 
      * @return all types matching the specified labels;
      */
     @SuppressWarnings("unchecked")
-    public List<ConsumerType> lookupByLabels(Collection<String> labels) {
+    public List<ConsumerType> getByLabels(Collection<String> labels) {
         return (List<ConsumerType>) currentSession().createCriteria(ConsumerType.class)
             .add(Restrictions.in("label", labels)).list();
     }

--- a/server/src/main/java/org/candlepin/model/ContentCurator.java
+++ b/server/src/main/java/org/candlepin/model/ContentCurator.java
@@ -50,7 +50,7 @@ public class ContentCurator extends AbstractHibernateCurator<Content> {
     @Override
     @Transactional
     public void delete(Content entity) {
-        Content toDelete = find(entity.getUuid());
+        Content toDelete = this.get(entity.getUuid());
         currentSession().delete(toDelete);
     }
 
@@ -66,7 +66,7 @@ public class ContentCurator extends AbstractHibernateCurator<Content> {
      *  was found.
      */
     @Transactional
-    public Content lookupByUuid(String uuid) {
+    public Content getByUuid(String uuid) {
         return (Content) currentSession().createCriteria(Content.class).setCacheable(true)
             .add(Restrictions.eq("uuid", uuid)).uniqueResult();
     }

--- a/server/src/main/java/org/candlepin/model/EntitlementCurator.java
+++ b/server/src/main/java/org/candlepin/model/EntitlementCurator.java
@@ -90,7 +90,7 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
     public Set<Entitlement> bulkUpdate(Set<Entitlement> entitlements) {
         Set<Entitlement> toReturn = new HashSet<>();
         for (Entitlement toUpdate : entitlements) {
-            Entitlement found = find(toUpdate.getId());
+            Entitlement found = this.get(toUpdate.getId());
             if (found != null) {
                 toReturn.add(found);
                 continue;
@@ -741,7 +741,7 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
      */
     @Transactional
     public void delete(Entitlement entity) {
-        Entitlement toDelete = find(entity.getId());
+        Entitlement toDelete = this.get(entity.getId());
 
         if (toDelete != null) {
             this.deleteImpl(toDelete);

--- a/server/src/main/java/org/candlepin/model/EnvironmentContentCurator.java
+++ b/server/src/main/java/org/candlepin/model/EnvironmentContentCurator.java
@@ -29,7 +29,7 @@ public class EnvironmentContentCurator extends AbstractHibernateCurator<Environm
         super(EnvironmentContent.class);
     }
 
-    public EnvironmentContent lookupByEnvironmentAndContent(Environment e, String contentId) {
+    public EnvironmentContent getByEnvironmentAndContent(Environment e, String contentId) {
         return (EnvironmentContent) this.currentSession().createCriteria(EnvironmentContent.class)
             .createAlias("content", "content")
             .add(Restrictions.eq("environment", e))
@@ -37,14 +37,14 @@ public class EnvironmentContentCurator extends AbstractHibernateCurator<Environm
             .uniqueResult();
     }
 
-    public EnvironmentContent lookupByEnvironmentAndContent(Environment e, Content content) {
+    public EnvironmentContent getByEnvironmentAndContent(Environment e, Content content) {
         return (EnvironmentContent) this.currentSession().createCriteria(EnvironmentContent.class)
             .add(Restrictions.eq("environment", e))
             .add(Restrictions.eq("content", content))
             .uniqueResult();
     }
 
-    public List<EnvironmentContent> lookupByContent(Owner owner, String contentId) {
+    public List<EnvironmentContent> getByContent(Owner owner, String contentId) {
         return this.currentSession().createCriteria(EnvironmentContent.class)
             .createAlias("environment", "environment")
             .createAlias("content", "content")

--- a/server/src/main/java/org/candlepin/model/EnvironmentCurator.java
+++ b/server/src/main/java/org/candlepin/model/EnvironmentCurator.java
@@ -63,7 +63,7 @@ public class EnvironmentCurator extends AbstractHibernateCurator<Environment> {
         Environment environment = null;
 
         if (consumer.getEnvironmentId() != null) {
-            environment = this.find(consumer.getEnvironmentId());
+            environment = this.get(consumer.getEnvironmentId());
 
             if (environment == null) {
                 throw new IllegalStateException(

--- a/server/src/main/java/org/candlepin/model/ExporterMetadataCurator.java
+++ b/server/src/main/java/org/candlepin/model/ExporterMetadataCurator.java
@@ -16,8 +16,9 @@ package org.candlepin.model;
 
 import com.google.inject.Inject;
 
-import org.hibernate.Criteria;
 import org.hibernate.criterion.Restrictions;
+
+
 
 /**
  * ExportMetadataCurator
@@ -29,17 +30,17 @@ public class ExporterMetadataCurator extends AbstractHibernateCurator<ExporterMe
         super(ExporterMetadata.class);
     }
 
-    public ExporterMetadata lookupByType(String type) {
-        Criteria query = currentSession().createCriteria(ExporterMetadata.class);
-        query.add(Restrictions.eq("type", type));
-        return (ExporterMetadata) query.uniqueResult();
+    public ExporterMetadata getByType(String type) {
+        return (ExporterMetadata) this.currentSession().createCriteria(ExporterMetadata.class)
+            .add(Restrictions.eq("type", type))
+            .uniqueResult();
     }
 
-    public ExporterMetadata lookupByTypeAndOwner(String type, Owner owner) {
-        Criteria query = currentSession().createCriteria(ExporterMetadata.class);
-        query.add(Restrictions.eq("type", type));
-        query.add(Restrictions.eq("owner", owner));
-        return (ExporterMetadata) query.uniqueResult();
+    public ExporterMetadata getByTypeAndOwner(String type, Owner owner) {
+        return (ExporterMetadata) this.currentSession().createCriteria(ExporterMetadata.class)
+            .add(Restrictions.eq("type", type))
+            .add(Restrictions.eq("owner", owner))
+            .uniqueResult();
     }
 
 }

--- a/server/src/main/java/org/candlepin/model/IdentityCertificateCurator.java
+++ b/server/src/main/java/org/candlepin/model/IdentityCertificateCurator.java
@@ -21,18 +21,16 @@ import org.hibernate.criterion.Restrictions;
 /**
  * IdentityCertificateCurator
  */
-public class IdentityCertificateCurator extends
-    AbstractHibernateCurator<IdentityCertificate> {
+public class IdentityCertificateCurator extends AbstractHibernateCurator<IdentityCertificate> {
 
     @Inject
     public IdentityCertificateCurator() {
         super(IdentityCertificate.class);
     }
 
-    public IdentityCertificate lookupBySerialNumber(
-        Long serialNumber) {
-        return (IdentityCertificate) currentSession().createCriteria(
-            IdentityCertificate.class).add(
-            Restrictions.eq("serial", serialNumber)).uniqueResult();
+    public IdentityCertificate getBySerialNumber(Long serialNumber) {
+        return (IdentityCertificate) currentSession().createCriteria(IdentityCertificate.class)
+            .add(Restrictions.eq("serial", serialNumber))
+            .uniqueResult();
     }
 }

--- a/server/src/main/java/org/candlepin/model/JobCurator.java
+++ b/server/src/main/java/org/candlepin/model/JobCurator.java
@@ -60,7 +60,7 @@ public class JobCurator extends AbstractHibernateCurator<JobStatus> {
     @Transactional
     public JobStatus cancel(String jobId) {
         this.cancelNoReturn(jobId);
-        JobStatus result = this.find(jobId);
+        JobStatus result = this.get(jobId);
         if (result != null) {
             this.refresh(result);
         }

--- a/server/src/main/java/org/candlepin/model/OwnerCurator.java
+++ b/server/src/main/java/org/candlepin/model/OwnerCurator.java
@@ -69,7 +69,7 @@ public class OwnerCurator extends AbstractHibernateCurator<Owner> {
             throw new IllegalArgumentException("ownerId is null");
         }
 
-        Owner owner = this.find(ownerId);
+        Owner owner = this.get(ownerId);
 
         if (owner == null) {
             throw new IllegalStateException("owner not found for the id: " + ownerId);
@@ -92,25 +92,25 @@ public class OwnerCurator extends AbstractHibernateCurator<Owner> {
     }
 
     /**
-     * @param key owner's unique key to lookup.
+     * @param key owner's unique key to fetch.
      * @return the owner whose key matches the one given.
      */
     @Transactional
-    public Owner lookupByKey(String key) {
+    public Owner getByKey(String key) {
         return (Owner) createSecureCriteria()
             .add(Restrictions.eq("key", key))
             .uniqueResult();
     }
 
     @Transactional
-    public CandlepinQuery<Owner> lookupByKeys(Collection<String> keys) {
+    public CandlepinQuery<Owner> getByKeys(Collection<String> keys) {
         DetachedCriteria criteria = this.createSecureDetachedCriteria()
             .add(CPRestrictions.in("key", keys));
 
         return this.cpQueryFactory.<Owner>buildQuery(this.currentSession(), criteria);
     }
 
-    public Owner lookupWithUpstreamUuid(String upstreamUuid) {
+    public Owner getByUpstreamUuid(String upstreamUuid) {
         return (Owner) createSecureCriteria()
             .createCriteria("upstreamConsumer")
             .add(Restrictions.eq("uuid", upstreamUuid))
@@ -122,7 +122,7 @@ public class OwnerCurator extends AbstractHibernateCurator<Owner> {
      * @param productIds
      * @return a list of owners
      */
-    public CandlepinQuery<Owner> lookupOwnersByActiveProduct(Collection<String> productIds) {
+    public CandlepinQuery<Owner> getOwnersByActiveProduct(Collection<String> productIds) {
         // NOTE: only used by superadmin API calls, no permissions filtering needed here.
         DetachedCriteria poolIdQuery = DetachedCriteria.forClass(Pool.class, "pool")
             .createAlias("pool.providedProducts", "providedProducts")
@@ -145,8 +145,8 @@ public class OwnerCurator extends AbstractHibernateCurator<Owner> {
     }
 
     /**
-     * Retrieves a list of owners which have pools referencing the specified product IDs. If no
-     * owners are associated with the given products, this method returns an empty list.
+     * Retrieves a list of owners which have pools referencing one or more of the specified product
+     * IDs. If no owners are associated with the given products, this method returns an empty list.
      *
      * @param productIds
      *  The product IDs for which to retrieve owners
@@ -155,7 +155,7 @@ public class OwnerCurator extends AbstractHibernateCurator<Owner> {
      *  a list of owners associated with the specified products
      */
     @SuppressWarnings("checkstyle:indentation")
-    public CandlepinQuery<Owner> lookupOwnersWithProduct(Collection<String> productIds) {
+    public CandlepinQuery<Owner> getOwnersWithProducts(Collection<String> productIds) {
         if (productIds != null && !productIds.isEmpty()) {
             Session session = this.currentSession();
 

--- a/server/src/main/java/org/candlepin/model/OwnerInfoCurator.java
+++ b/server/src/main/java/org/candlepin/model/OwnerInfoCurator.java
@@ -64,7 +64,7 @@ public class OwnerInfoCurator {
         this.poolCurator = poolCurator;
     }
 
-    public OwnerInfo lookupByOwner(Owner owner) {
+    public OwnerInfo getByOwner(Owner owner) {
         OwnerInfo info = new OwnerInfo();
         Date now = new Date();
 

--- a/server/src/main/java/org/candlepin/model/PoolCurator.java
+++ b/server/src/main/java/org/candlepin/model/PoolCurator.java
@@ -48,7 +48,6 @@ import org.hibernate.type.StringType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -87,13 +86,6 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
         super(Pool.class);
         this.consumerCurator = consumerCurator;
         this.consumerTypeCurator = consumerTypeCurator;
-    }
-
-    @Override
-    @Transactional
-    public Pool find(Serializable id) {
-        Pool pool = super.find(id);
-        return pool;
     }
 
     /**
@@ -811,7 +803,7 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
      * @return pools from the given subscription, sorted by pool.id to avoid deadlocks
      */
     @SuppressWarnings("unchecked")
-    public List<Pool> lookupBySubscriptionId(Owner owner, String subId) {
+    public List<Pool> getBySubscriptionId(Owner owner, String subId) {
         return createSecureCriteria()
             .createAlias("sourceSubscription", "sourceSub")
             .add(Restrictions.eq("owner", owner))
@@ -828,8 +820,8 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
      *         deadlocks
      */
     @SuppressWarnings("unchecked")
-    public List<Pool> lookupBySubscriptionIds(Owner owner, Collection<String> subIds) {
-        return lookupBySubscriptionIds(owner.getId(), subIds);
+    public List<Pool> getBySubscriptionIds(Owner owner, Collection<String> subIds) {
+        return this.getBySubscriptionIds(owner.getId(), subIds);
     }
 
     /**
@@ -841,7 +833,7 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
      *         deadlocks
      */
     @SuppressWarnings("unchecked")
-    public List<Pool> lookupBySubscriptionIds(String ownerId, Collection<String> subIds) {
+    public List<Pool> getBySubscriptionIds(String ownerId, Collection<String> subIds) {
         return createSecureCriteria()
             .createAlias("sourceSubscription", "sourceSub")
             .add(Restrictions.eq("owner.id", ownerId))
@@ -870,8 +862,7 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
      * @return Pools with too many entitlements for their new quantity.
      */
     @SuppressWarnings("unchecked")
-    public List<Pool> lookupOversubscribedBySubscriptionIds(String ownerId, Map<String, Entitlement>
-        subIdMap) {
+    public List<Pool> getOversubscribedBySubscriptionIds(String ownerId, Map<String, Entitlement> subIdMap) {
         List<Criterion> subIdMapCriteria = new ArrayList<>();
         Criterion[] exampleCriteria = new Criterion[0];
         for (Entry<String, Entitlement> entry : subIdMap.entrySet()) {
@@ -1083,7 +1074,8 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
      */
     @Transactional
     public void delete(Pool entity) {
-        Pool toDelete = find(entity.getId());
+        Pool toDelete = this.get(entity.getId());
+
         if (toDelete != null) {
             this.deleteImpl(toDelete);
             this.flush();

--- a/server/src/main/java/org/candlepin/model/ProductCurator.java
+++ b/server/src/main/java/org/candlepin/model/ProductCurator.java
@@ -91,7 +91,7 @@ public class ProductCurator extends AbstractHibernateCurator<Product> {
      *  a Product instance for the product with the specified name, or null if a matching product
      *  was not found.
      */
-    public Product lookupByName(Owner owner, String name) {
+    public Product getByName(Owner owner, String name) {
         return (Product) this.createSecureCriteria(OwnerProduct.class, null)
             .createAlias("owner", "owner")
             .createAlias("product", "product")
@@ -415,7 +415,7 @@ public class ProductCurator extends AbstractHibernateCurator<Product> {
     @Override
     @Transactional
     public void delete(Product entity) {
-        Product toDelete = find(entity.getUuid());
+        Product toDelete = this.get(entity.getUuid());
         currentSession().delete(toDelete);
     }
 

--- a/server/src/main/java/org/candlepin/model/RoleCurator.java
+++ b/server/src/main/java/org/candlepin/model/RoleCurator.java
@@ -44,7 +44,7 @@ public class RoleCurator extends AbstractHibernateCurator<Role> {
      * @param name role's unique name to lookup.
      * @return the role whose name matches the one given.
      */
-    public Role lookupByName(String name) {
+    public Role getByName(String name) {
         return (Role) currentSession().createCriteria(Role.class)
             .add(Restrictions.eq("name", name))
             .uniqueResult();

--- a/server/src/main/java/org/candlepin/model/UeberCertificateGenerator.java
+++ b/server/src/main/java/org/candlepin/model/UeberCertificateGenerator.java
@@ -91,7 +91,7 @@ public class UeberCertificateGenerator {
 
     @Transactional
     public UeberCertificate generate(String ownerKey, Principal principal) {
-        Owner owner = this.ownerCurator.lookupByKey(ownerKey);
+        Owner owner = this.ownerCurator.getByKey(ownerKey);
         if (owner == null) {
             throw new NotFoundException(i18n.tr("Unable to find an owner with key: {0}", ownerKey));
         }
@@ -111,7 +111,7 @@ public class UeberCertificateGenerator {
     }
 
     private UeberCertificate generateUeberCert(Owner owner, String generatedByUsername) throws Exception {
-        ConsumerType ueberCertType = this.consumerTypeCurator.lookupByLabel(UEBER_CERT_CONSUMER_TYPE, true);
+        ConsumerType ueberCertType = this.consumerTypeCurator.getByLabel(UEBER_CERT_CONSUMER_TYPE, true);
 
         UeberCertData ueberCertData = new UeberCertData(owner, generatedByUsername, ueberCertType);
 

--- a/server/src/main/java/org/candlepin/model/UserCurator.java
+++ b/server/src/main/java/org/candlepin/model/UserCurator.java
@@ -45,7 +45,7 @@ public class UserCurator extends AbstractHibernateCurator<User> {
 
     @Transactional
     public User update(User user) {
-        User existingUser = this.find(user.getId());
+        User existingUser = this.get(user.getId());
         if (existingUser == null) {
             return create(user);
         }

--- a/server/src/main/java/org/candlepin/model/activationkeys/ActivationKey.java
+++ b/server/src/main/java/org/candlepin/model/activationkeys/ActivationKey.java
@@ -111,6 +111,7 @@ public class ActivationKey extends AbstractHibernateObject<ActivationKey> implem
     private Boolean autoAttach;
 
     public ActivationKey() {
+        // Intentionally left empty
     }
 
     public ActivationKey(String name, Owner owner) {

--- a/server/src/main/java/org/candlepin/model/activationkeys/ActivationKeyCurator.java
+++ b/server/src/main/java/org/candlepin/model/activationkeys/ActivationKeyCurator.java
@@ -14,7 +14,6 @@
  */
 package org.candlepin.model.activationkeys;
 
-import org.candlepin.common.exceptions.BadRequestException;
 import org.candlepin.model.AbstractHibernateCurator;
 import org.candlepin.model.CandlepinQuery;
 import org.candlepin.model.Owner;
@@ -23,6 +22,8 @@ import com.google.inject.persist.Transactional;
 
 import org.hibernate.criterion.DetachedCriteria;
 import org.hibernate.criterion.Restrictions;
+
+
 
 /**
  * SubscriptionTokenCurator
@@ -50,28 +51,24 @@ public class ActivationKeyCurator extends AbstractHibernateCurator<ActivationKey
 
     @Transactional
     public ActivationKey update(ActivationKey key) {
+        // Why is a method named "update" calling into "save" which is a synonym for "create" rather than
+        // our update verb "merge" ????
+
         save(key);
         return key;
     }
 
     @Transactional
-    public ActivationKey lookupForOwner(String keyName, Owner owner) {
-        return (ActivationKey) currentSession().createCriteria(ActivationKey.class)
-            .add(Restrictions.eq("name", keyName)).add(Restrictions.eq("owner", owner))
+    public ActivationKey getByKeyName(Owner owner, String name) {
+        // Impl note:
+        // The usage of "uniqueResult" here is valid as long as we maintain the unique index on the
+        // (owner, name) tuple. At the time of writing this is present in the table definition, but
+        // could break things if removed.
+
+        return (ActivationKey) this.currentSession().createCriteria(ActivationKey.class)
+            .add(Restrictions.eq("owner", owner))
+            .add(Restrictions.eq("name", name))
             .uniqueResult();
     }
 
-    // TODO:
-    // Move this method to the ActivationKeyResource. The curator should not be returning resource-level
-    // exceptions
-    public ActivationKey verifyAndLookupKey(String activationKeyId) {
-        ActivationKey key = this.secureFind(activationKeyId);
-
-        if (key == null) {
-            throw new BadRequestException(
-                i18n.tr("ActivationKey with id {0} could not be found.",
-                    activationKeyId));
-        }
-        return key;
-    }
 }

--- a/server/src/main/java/org/candlepin/pinsetter/core/PinsetterJobListener.java
+++ b/server/src/main/java/org/candlepin/pinsetter/core/PinsetterJobListener.java
@@ -124,7 +124,7 @@ public class PinsetterJobListener implements JobListener {
 
     @Transactional
     private void updateJob(JobExecutionContext ctx, JobExecutionException exc) {
-        JobStatus status = curator.find(ctx.getJobDetail().getKey().getName());
+        JobStatus status = curator.get(ctx.getJobDetail().getKey().getName());
         if (status != null) {
             if (exc != null) {
                 log.error("Job [" + status.getId() + "] failed." , exc);

--- a/server/src/main/java/org/candlepin/pinsetter/core/PinsetterTriggerListener.java
+++ b/server/src/main/java/org/candlepin/pinsetter/core/PinsetterTriggerListener.java
@@ -73,10 +73,11 @@ public class PinsetterTriggerListener extends TriggerListenerSupport {
 
         try {
             String id = trigger.getJobKey().getName();
-            JobStatus js = jobCurator.find(id);
+            JobStatus js = jobCurator.get(id);
             if (js == null) {
                 throw new RuntimeException("No JobStatus for job with id of " + id);
             }
+
             // if may not refire again, change to fail
             if (!trigger.mayFireAgain()) {
                 log.warn("Job {} not allowed to fire again. Setting state to FAILED.", id);

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/ActiveEntitlementJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/ActiveEntitlementJob.java
@@ -47,7 +47,7 @@ public class ActiveEntitlementJob extends KingpinJob {
         // not uuids
         List<String> ids = consumerCurator.getConsumerIdsWithStartedEnts();
         for (String id : ids) {
-            Consumer c = consumerCurator.find(id);
+            Consumer c = consumerCurator.get(id);
             complianceRules.getStatus(c);
         }
     }

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/HealEntireOrgJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/HealEntireOrgJob.java
@@ -72,7 +72,7 @@ public class HealEntireOrgJob extends UniqueByEntityJob {
 
             JobDataMap map = ctx.getMergedJobDataMap();
             String ownerId = (String) map.get("ownerId");
-            Owner owner = ownerCurator.lookupByKey(ownerId);
+            Owner owner = ownerCurator.getByKey(ownerId);
             if (owner.isAutobindDisabled()) {
                 throw new BadRequestException(i18n.tr("Auto-attach is disabled for owner {0}.",
                     owner.getKey()));

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/HypervisorUpdateJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/HypervisorUpdateJob.java
@@ -104,7 +104,7 @@ public class HypervisorUpdateJob extends KingpinJob {
         this.subAdapter = subAdapter;
         this.complianceRules = complianceRules;
 
-        this.hypervisorType = consumerTypeCurator.lookupByLabel(ConsumerTypeEnum.HYPERVISOR.getLabel(), true);
+        this.hypervisorType = consumerTypeCurator.getByLabel(ConsumerTypeEnum.HYPERVISOR.getLabel(), true);
     }
 
     public static JobStatus scheduleJob(JobCurator jobCurator,
@@ -206,7 +206,7 @@ public class HypervisorUpdateJob extends KingpinJob {
 
             HypervisorUpdateResultUuids result = new HypervisorUpdateResultUuids();
 
-            Owner owner = ownerCurator.lookupByKey(ownerKey);
+            Owner owner = ownerCurator.getByKey(ownerKey);
             if (owner == null) {
                 context.setResult("Nothing to do. Owner does not exist");
                 log.warn("Hypervisor update attempted against non-existent org id \"{0}\"", ownerKey);

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/ImportJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/ImportJob.java
@@ -72,7 +72,7 @@ public class ImportJob extends UniqueByEntityJob {
         Throwable caught = null;
         Owner targetOwner = null;
         try {
-            targetOwner = ownerCurator.lookupByKey(ownerKey);
+            targetOwner = ownerCurator.getByKey(ownerKey);
             if (targetOwner == null) {
                 throw new NotFoundException(String.format("Owner %s was not found.", ownerKey));
             }

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/KingpinJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/KingpinJob.java
@@ -171,7 +171,7 @@ public abstract class KingpinJob implements Job {
         catch (EntityExistsException e) {
             // status exists, let's update it
             // in theory this should be the rare case
-            status = jobCurator.find(detail.getKey().getName());
+            status = jobCurator.get(detail.getKey().getName());
             jobCurator.merge(status);
         }
         catch (RuntimeException e) {

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/RefreshPoolsForProductJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/RefreshPoolsForProductJob.java
@@ -63,7 +63,7 @@ public class RefreshPoolsForProductJob extends KingpinJob {
         Boolean lazy = context.getMergedJobDataMap().getBoolean(LAZY_REGEN);
         StringBuilder result = new StringBuilder();
 
-        Product product = this.productCurator.find(productUuid);
+        Product product = this.productCurator.get(productUuid);
 
         if (product != null) {
             Refresher refresher = poolManager.getRefresher(this.subAdapter, this.ownerAdapter, lazy);

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/RefreshPoolsJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/RefreshPoolsJob.java
@@ -79,7 +79,7 @@ public class RefreshPoolsJob extends UniqueByEntityJob {
             JobDataMap map = context.getMergedJobDataMap();
             String ownerKey = map.getString(JobStatus.TARGET_ID);
             Boolean lazy = map.getBoolean(LAZY_REGEN);
-            Owner owner = ownerCurator.lookupByKey(ownerKey);
+            Owner owner = ownerCurator.getByKey(ownerKey);
 
             if (owner == null) {
                 context.setResult("Nothing to do. Owner no longer exists");

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/UndoImportsJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/UndoImportsJob.java
@@ -118,7 +118,7 @@ public class UndoImportsJob extends UniqueByEntityJob {
             String displayName = owner.getDisplayName();
 
             // Remove imports
-            ExporterMetadata metadata = this.exportCurator.lookupByTypeAndOwner(
+            ExporterMetadata metadata = this.exportCurator.getByTypeAndOwner(
                 ExporterMetadata.TYPE_PER_USER, owner);
 
             if (metadata == null) {

--- a/server/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRules.java
@@ -633,7 +633,7 @@ public class EntitlementRules implements Enforcer {
                 // exported, we need to add back the reduced bonus pool quantity.
                 int virtQuantity = Integer.parseInt(virtLimit) * entitlement.getQuantity();
                 if (virtQuantity > 0) {
-                    List<Pool> pools = poolManager.lookupBySubscriptionId(pool.getOwner(),
+                    List<Pool> pools = poolManager.getBySubscriptionId(pool.getOwner(),
                         pool.getSubscriptionId());
                     for (int idex = 0; idex < pools.size(); idex++) {
                         Pool derivedPool = pools.get(idex);
@@ -648,7 +648,7 @@ public class EntitlementRules implements Enforcer {
                 // was previously
                 // exported, we need to set the unlimited bonus pool quantity to
                 // -1.
-                List<Pool> pools = poolManager.lookupBySubscriptionId(pool.getOwner(),
+                List<Pool> pools = poolManager.getBySubscriptionId(pool.getOwner(),
                     pool.getSubscriptionId());
                 for (int idex = 0; idex < pools.size(); idex++) {
                     Pool derivedPool = pools.get(idex);
@@ -666,7 +666,7 @@ public class EntitlementRules implements Enforcer {
         Map<String, Entitlement> entitlementMap) {
         log.debug("Running post-bind share create");
 
-        Owner recipient = ownerCurator.lookupByKey(c.getRecipientOwnerKey());
+        Owner recipient = ownerCurator.getByKey(c.getRecipientOwnerKey());
         List<Pool> sharedPoolsToCreate = new ArrayList<>();
 
         for (Entitlement entitlement: entitlementMap.values()) {
@@ -953,7 +953,7 @@ public class EntitlementRules implements Enforcer {
             subscriptionIds.add(entitlement.getPool().getSubscriptionId());
         }
 
-        List<Pool> subscriptionPools = poolManager.lookupBySubscriptionIds(consumer.getOwnerId(),
+        List<Pool> subscriptionPools = poolManager.getBySubscriptionIds(consumer.getOwnerId(),
             subscriptionIds);
         Map<String, List<Pool>> subscriptionPoolMap = new HashMap<>();
 

--- a/server/src/main/java/org/candlepin/resource/ActivationKeyContentOverrideResource.java
+++ b/server/src/main/java/org/candlepin/resource/ActivationKeyContentOverrideResource.java
@@ -14,6 +14,7 @@
  */
 package org.candlepin.resource;
 
+import org.candlepin.common.exceptions.BadRequestException;
 import org.candlepin.model.activationkeys.ActivationKey;
 import org.candlepin.model.activationkeys.ActivationKeyContentOverride;
 import org.candlepin.model.activationkeys.ActivationKeyContentOverrideCurator;
@@ -29,14 +30,15 @@ import javax.ws.rs.Path;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.Authorization;
 
+
+
 /**
  * ActivationKeyContentOverrideResource
  */
 @Path("/activation_keys/{activation_key_id}/content_overrides")
 @Api(value = "activation_keys", authorizations = { @Authorization("basic") })
 public class ActivationKeyContentOverrideResource extends
-    ContentOverrideResource<ActivationKeyContentOverride,
-    ActivationKeyContentOverrideCurator,
+    ContentOverrideResource<ActivationKeyContentOverride, ActivationKeyContentOverrideCurator,
     ActivationKey> {
 
     private ActivationKeyCurator activationKeyCurator;
@@ -51,13 +53,24 @@ public class ActivationKeyContentOverrideResource extends
         ActivationKeyContentOverrideCurator contentOverrideCurator,
         ActivationKeyCurator activationKeyCurator,
         ContentOverrideValidator contentOverrideValidator, I18n i18n) {
+
         super(contentOverrideCurator, contentOverrideValidator, i18n, "activation_key_id");
         this.activationKeyCurator = activationKeyCurator;
     }
 
     @Override
     protected ActivationKey findParentById(String parentId) {
-        return activationKeyCurator.verifyAndLookupKey(parentId);
+        if (parentId == null || parentId.isEmpty()) {
+            throw new BadRequestException(i18n.tr("activation key ID is null or empty"));
+        }
+
+        ActivationKey key = this.activationKeyCurator.secureGet(parentId);
+
+        if (key == null) {
+            throw new BadRequestException(i18n.tr("ActivationKey with id {0} could not be found.", parentId));
+        }
+
+        return key;
     }
 
 }

--- a/server/src/main/java/org/candlepin/resource/ActivationKeyResource.java
+++ b/server/src/main/java/org/candlepin/resource/ActivationKeyResource.java
@@ -91,6 +91,33 @@ public class ActivationKeyResource {
         this.translator = translator;
     }
 
+    /**
+     * Fetches an activation key using the specified key ID. If a valid activation key could not be
+     * found, this method throws an exception.
+     *
+     * @param keyId
+     *  The ID of the activation key to fetch
+     *
+     * @throws BadRequestException
+     *  if the given ID is null, empty or is not associated with a valid activation key
+     *
+     * @return
+     *  an ActivationKey with the specified ID
+     */
+    protected ActivationKey fetchActivationKey(String keyId) {
+        if (keyId == null || keyId.isEmpty()) {
+            throw new BadRequestException(i18n.tr("activation key ID is null or empty"));
+        }
+
+        ActivationKey key = this.activationKeyCurator.secureGet(keyId);
+
+        if (key == null) {
+            throw new BadRequestException(i18n.tr("ActivationKey with id {0} could not be found.", keyId));
+        }
+
+        return key;
+    }
+
     @ApiOperation(notes = "Retrieves a single Activation Key", value = "Get Activation Key")
     @ApiResponses({ @ApiResponse(code = 400, message = "") })
     @GET
@@ -100,7 +127,7 @@ public class ActivationKeyResource {
         @PathParam("activation_key_id")
         @Verify(ActivationKey.class) String activationKeyId) {
 
-        ActivationKey key = activationKeyCurator.verifyAndLookupKey(activationKeyId);
+        ActivationKey key = this.fetchActivationKey(activationKeyId);
 
         return this.translator.translate(key, ActivationKeyDTO.class);
     }
@@ -114,7 +141,7 @@ public class ActivationKeyResource {
     public Iterator<PoolDTO> getActivationKeyPools(
         @PathParam("activation_key_id") @Verify(ActivationKey.class) String activationKeyId) {
 
-        ActivationKey key = activationKeyCurator.verifyAndLookupKey(activationKeyId);
+        ActivationKey key = this.fetchActivationKey(activationKeyId);
 
         return new TransformedIterator<>(key.getPools().iterator(),
             akp -> translator.translate(akp.getPool(), PoolDTO.class)
@@ -131,7 +158,7 @@ public class ActivationKeyResource {
         @PathParam("activation_key_id") @Verify(ActivationKey.class) String activationKeyId,
         @ApiParam(name = "update", required = true) ActivationKeyDTO update) {
 
-        ActivationKey toUpdate = activationKeyCurator.verifyAndLookupKey(activationKeyId);
+        ActivationKey toUpdate = this.fetchActivationKey(activationKeyId);
         if (update.getName() != null) {
             toUpdate.setName(update.getName());
         }
@@ -169,7 +196,7 @@ public class ActivationKeyResource {
         @PathParam("pool_id") @Verify(Pool.class) String poolId,
         @QueryParam("quantity") Long quantity) {
 
-        ActivationKey key = activationKeyCurator.verifyAndLookupKey(activationKeyId);
+        ActivationKey key = this.fetchActivationKey(activationKeyId);
         Pool pool = findPool(poolId);
 
         // Throws a BadRequestException if adding pool to key is a bad idea
@@ -198,7 +225,7 @@ public class ActivationKeyResource {
         @PathParam("pool_id")
         @Verify(Pool.class) String poolId) {
 
-        ActivationKey key = activationKeyCurator.verifyAndLookupKey(activationKeyId);
+        ActivationKey key = this.fetchActivationKey(activationKeyId);
         Pool pool = findPool(poolId);
         key.removePool(pool);
         activationKeyCurator.update(key);
@@ -216,7 +243,7 @@ public class ActivationKeyResource {
         @PathParam("activation_key_id") @Verify(ActivationKey.class) String activationKeyId,
         @PathParam("product_id") String productId) {
 
-        ActivationKey key = activationKeyCurator.verifyAndLookupKey(activationKeyId);
+        ActivationKey key = this.fetchActivationKey(activationKeyId);
         Product product = confirmProduct(key.getOwner(), productId);
 
         // Make sure we don't try to register the product ID twice.
@@ -240,7 +267,7 @@ public class ActivationKeyResource {
     public ActivationKeyDTO removeProductIdFromKey(
         @PathParam("activation_key_id") @Verify(ActivationKey.class) String activationKeyId,
         @PathParam("product_id") String productId) {
-        ActivationKey key = activationKeyCurator.verifyAndLookupKey(activationKeyId);
+        ActivationKey key = this.fetchActivationKey(activationKeyId);
         Product product = confirmProduct(key.getOwner(), productId);
         key.removeProduct(product);
         activationKeyCurator.update(key);
@@ -265,7 +292,7 @@ public class ActivationKeyResource {
     public void deleteActivationKey(
         @PathParam("activation_key_id")
         @Verify(ActivationKey.class) String activationKeyId) {
-        ActivationKey key = activationKeyCurator.verifyAndLookupKey(activationKeyId);
+        ActivationKey key = this.fetchActivationKey(activationKeyId);
 
         log.debug("Deleting activation key: {}", activationKeyId);
 
@@ -273,7 +300,7 @@ public class ActivationKeyResource {
     }
 
     private Pool findPool(String poolId) {
-        Pool pool = poolManager.find(poolId);
+        Pool pool = poolManager.get(poolId);
 
         if (pool == null) {
             throw new BadRequestException(i18n.tr("Pool with id {0} could not be found.", poolId));

--- a/server/src/main/java/org/candlepin/resource/CdnResource.java
+++ b/server/src/main/java/org/candlepin/resource/CdnResource.java
@@ -85,7 +85,7 @@ public class CdnResource {
     @Path("/{label}")
     public void delete(@PathParam("label") String label,
         @Context Principal principal) {
-        Cdn cdn = curator.lookupByLabel(label);
+        Cdn cdn = curator.getByLabel(label);
         if (cdn != null) {
             cdnManager.deleteCdn(cdn);
         }
@@ -98,7 +98,7 @@ public class CdnResource {
     public CdnDTO create(
         @ApiParam(name = "cdn", required = true) CdnDTO cdnDTOInput,
         @Context Principal principal) {
-        Cdn existing = curator.lookupByLabel(cdnDTOInput.getLabel());
+        Cdn existing = curator.getByLabel(cdnDTOInput.getLabel());
         if (existing != null) {
             throw new BadRequestException(i18n.tr(
                 "A CDN with the label {0} already exists", cdnDTOInput.getLabel()));
@@ -194,7 +194,7 @@ public class CdnResource {
     }
 
     private Cdn verifyAndLookupCdn(String label) {
-        Cdn cdn = curator.lookupByLabel(label);
+        Cdn cdn = curator.getByLabel(label);
 
         if (cdn == null) {
             throw new NotFoundException(i18n.tr("No such content delivery network: {0}",

--- a/server/src/main/java/org/candlepin/resource/CertificateSerialResource.java
+++ b/server/src/main/java/org/candlepin/resource/CertificateSerialResource.java
@@ -65,7 +65,7 @@ public class CertificateSerialResource {
     @Path("/{serial_id}")
     @Produces(MediaType.APPLICATION_JSON)
     public CertificateSerialDTO getCertificateSerial(@PathParam("serial_id") Long serialId) {
-        CertificateSerial serial = this.certificateSerialCurator.find(serialId);
+        CertificateSerial serial = this.certificateSerialCurator.get(serialId);
         return this.translator.translate(serial, CertificateSerialDTO.class);
     }
 }

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -415,7 +415,7 @@ public class ConsumerResource {
 
         Owner owner = null;
         if (ownerKey != null) {
-            owner = ownerCurator.lookupByKey(ownerKey);
+            owner = ownerCurator.getByKey(ownerKey);
             if (owner == null) {
                 throw new NotFoundException(i18n.tr(
                     "owner with key: {0} was not found.", ownerKey));
@@ -539,7 +539,7 @@ public class ConsumerResource {
         }
 
         if (dto.getEnvironment() != null) {
-            Environment env = environmentCurator.find(dto.getEnvironment().getId());
+            Environment env = environmentCurator.get(dto.getEnvironment().getId());
             if (env == null) {
                 throw new NotFoundException(i18n.tr("Environment \"{0}\" could not be found.",
                     dto.getEnvironment().getId()));
@@ -690,7 +690,7 @@ public class ConsumerResource {
         Consumer consumer = null;
         if (ownerKey != null && dto.getFact("system_uuid") != null &&
             !"true".equalsIgnoreCase(dto.getFact("virt.is_guest"))) {
-            Owner owner = ownerCurator.lookupByKey(ownerKey);
+            Owner owner = ownerCurator.getByKey(ownerKey);
             if (owner != null) {
                 consumer = consumerCurator.getHypervisor(dto.getFact("system_uuid"), owner);
                 if (consumer != null) {
@@ -707,14 +707,14 @@ public class ConsumerResource {
         if (dto.getUuid() != null) {
             consumer.setUuid(dto.getUuid());
         }
-        consumer.setOwner(ownerCurator.lookupByKey(ownerKey));
+        consumer.setOwner(ownerCurator.getByKey(ownerKey));
         populateEntity(consumer, dto);
 
         if (dto.getType() == null) {
             throw new BadRequestException(i18n.tr("Unit type must be specified."));
         }
 
-        ConsumerType ctype = this.consumerTypeCurator.lookupByLabel(dto.getType().getLabel());
+        ConsumerType ctype = this.consumerTypeCurator.getByLabel(dto.getType().getLabel());
         if (ctype == null) {
             throw new BadRequestException(i18n.tr("Invalid unit type: {0}", dto.getType().getLabel()));
         }
@@ -918,7 +918,7 @@ public class ConsumerResource {
         }
 
         String recipient = consumer.getRecipientOwnerKey();
-        Owner recipientOwner = ownerCurator.lookupByKey(recipient);
+        Owner recipientOwner = ownerCurator.getByKey(recipient);
         if (recipientOwner == null) {
             throw new NotFoundException(i18n.tr("owner with key: {0} was not found.", recipient));
         }
@@ -1125,7 +1125,7 @@ public class ConsumerResource {
     }
 
     private ActivationKey findKey(String keyName, Owner owner) {
-        ActivationKey key = activationKeyCurator.lookupForOwner(keyName, owner);
+        ActivationKey key = activationKeyCurator.getByKeyName(owner, keyName);
 
         if (key == null) {
             throw new NotFoundException(i18n.tr("Activation key \"{0}\" not found for organization \"{1}\".",
@@ -1190,7 +1190,7 @@ public class ConsumerResource {
 
         createOwnerIfNeeded(principal);
 
-        Owner owner = ownerCurator.lookupByKey(ownerKey);
+        Owner owner = ownerCurator.getByKey(ownerKey);
         if (owner == null) {
             throw new BadRequestException(i18n.tr("Organization {0} does not exist.", ownerKey));
         }
@@ -1247,7 +1247,7 @@ public class ConsumerResource {
         }
 
         for (Owner owner : ((UserPrincipal) principal).getOwners()) {
-            Owner existingOwner = ownerCurator.lookupByKey(owner.getKey());
+            Owner existingOwner = ownerCurator.getByKey(owner.getKey());
 
             if (existingOwner == null) {
                 log.info("Principal carries permission for owner that does not exist.");
@@ -1375,7 +1375,7 @@ public class ConsumerResource {
         String environmentId = updated.getEnvironment() == null ? null : updated.getEnvironment().getId();
         if (environmentId != null && (toUpdate.getEnvironmentId() == null ||
             !toUpdate.getEnvironmentId().equals(environmentId))) {
-            Environment e = environmentCurator.find(environmentId);
+            Environment e = environmentCurator.get(environmentId);
             if (e == null) {
                 throw new NotFoundException(i18n.tr(
                     "Environment with ID \"{0}\" could not be found.", environmentId));
@@ -1671,7 +1671,7 @@ public class ConsumerResource {
             this.poolManager.revokeAllEntitlements(toDelete, false);
         }
         catch (ForbiddenException e) {
-            ConsumerType ctype = this.consumerTypeCurator.find(toDelete.getTypeId());
+            ConsumerType ctype = this.consumerTypeCurator.get(toDelete.getTypeId());
 
             String msg = e.message().getDisplayMessage();
             throw new ForbiddenException(i18n.tr("Cannot unregister {0} {1} because: {2}",
@@ -2014,7 +2014,7 @@ public class ConsumerResource {
         }
 
         if (poolIdString != null && quantity == null) {
-            Pool pool = poolManager.find(poolIdString);
+            Pool pool = poolManager.get(poolIdString);
             quantity = pool != null ? consumerBindUtil.getQuantityToBind(pool, consumer) : 1;
         }
 
@@ -2130,7 +2130,7 @@ public class ConsumerResource {
     }
 
     private Entitlement verifyAndLookupEntitlement(String entitlementId) {
-        Entitlement entitlement = entitlementCurator.find(entitlementId);
+        Entitlement entitlement = entitlementCurator.get(entitlementId);
 
         if (entitlement == null) {
             throw new NotFoundException(i18n.tr(
@@ -2238,7 +2238,7 @@ public class ConsumerResource {
 
         consumerCurator.verifyAndLookupConsumer(consumerUuid);
 
-        Entitlement toDelete = entitlementCurator.find(dbid);
+        Entitlement toDelete = entitlementCurator.get(dbid);
         if (toDelete != null) {
             poolManager.revokeEntitlement(toDelete);
             return;

--- a/server/src/main/java/org/candlepin/resource/ConsumerTypeResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerTypeResource.java
@@ -115,7 +115,7 @@ public class ConsumerTypeResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/{id}")
     public ConsumerTypeDTO getConsumerType(@PathParam("id") String id) {
-        ConsumerType type = consumerTypeCurator.find(id);
+        ConsumerType type = consumerTypeCurator.get(id);
 
         if (type == null) {
             throw new NotFoundException(i18n.tr("Unit type with id \"{0}\" could not be found.", id));
@@ -152,7 +152,7 @@ public class ConsumerTypeResource {
     @Produces(MediaType.APPLICATION_JSON)
     public ConsumerTypeDTO update(
         @ApiParam(name = "consumerType", required = true) ConsumerTypeDTO dto) throws BadRequestException {
-        ConsumerType type = consumerTypeCurator.find(dto.getId());
+        ConsumerType type = consumerTypeCurator.get(dto.getId());
 
         if (type == null) {
             throw new NotFoundException(i18n.tr("Unit type with label {0} could not be found.", dto.getId()));
@@ -168,7 +168,7 @@ public class ConsumerTypeResource {
     @Path("/{id}")
     @Produces(MediaType.APPLICATION_JSON)
     public void deleteConsumerType(@PathParam("id") String id) {
-        ConsumerType type = consumerTypeCurator.find(id);
+        ConsumerType type = consumerTypeCurator.get(id);
 
         if (type == null) {
             throw new NotFoundException(i18n.tr("Unit type with id {0} could not be found.", id));

--- a/server/src/main/java/org/candlepin/resource/ContentOverrideResource.java
+++ b/server/src/main/java/org/candlepin/resource/ContentOverrideResource.java
@@ -51,10 +51,10 @@ public abstract class ContentOverrideResource<T extends ContentOverride,
     Curator extends ContentOverrideCurator<T, Parent>,
     Parent extends AbstractHibernateObject> {
 
-    private Curator contentOverrideCurator;
-    private ContentOverrideValidator contentOverrideValidator;
-    private String parentPath;
-    private I18n i18n;
+    protected Curator contentOverrideCurator;
+    protected ContentOverrideValidator contentOverrideValidator;
+    protected String parentPath;
+    protected I18n i18n;
 
     public ContentOverrideResource(Curator contentOverrideCurator,
         ContentOverrideValidator contentOverrideValidator,
@@ -121,8 +121,8 @@ public abstract class ContentOverrideResource<T extends ContentOverride,
         List<ContentOverride> entries) {
 
         String parentId = info.getPathParameters().getFirst(this.getParentPath());
-
         Parent parent = this.verifyAndGetParent(parentId, principal, Access.ALL);
+
         if (entries.size() == 0) {
             contentOverrideCurator.removeByParent(parent);
         }
@@ -145,6 +145,7 @@ public abstract class ContentOverrideResource<T extends ContentOverride,
                 }
             }
         }
+
         return contentOverrideCurator.getList(parent);
     }
 

--- a/server/src/main/java/org/candlepin/resource/ContentResource.java
+++ b/server/src/main/java/org/candlepin/resource/ContentResource.java
@@ -94,7 +94,7 @@ public class ContentResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/{content_uuid}")
     public ContentDTO getContent(@PathParam("content_uuid") String contentUuid) {
-        Content content = this.contentCurator.lookupByUuid(contentUuid);
+        Content content = this.contentCurator.getByUuid(contentUuid);
 
         if (content == null) {
             throw new NotFoundException(

--- a/server/src/main/java/org/candlepin/resource/EntitlementResource.java
+++ b/server/src/main/java/org/candlepin/resource/EntitlementResource.java
@@ -192,7 +192,7 @@ public class EntitlementResource {
     public EntitlementDTO getEntitlement(
         @PathParam("entitlement_id") @Verify(Entitlement.class) String entitlementId) {
 
-        Entitlement entitlement = entitlementCurator.find(entitlementId);
+        Entitlement entitlement = entitlementCurator.get(entitlementId);
 
         if (entitlement == null) {
             throw new NotFoundException(
@@ -226,7 +226,7 @@ public class EntitlementResource {
         }
 
         // Verify entitlement exists:
-        Entitlement entitlement = entitlementCurator.find(id);
+        Entitlement entitlement = entitlementCurator.get(id);
         if (entitlement != null) {
             // make sure that this will be a change
             if (!entitlement.getQuantity().equals(update.getQuantity())) {
@@ -251,7 +251,7 @@ public class EntitlementResource {
     public String getUpstreamCert(
         @PathParam("dbid") String entitlementId) {
 
-        Entitlement ent = entitlementCurator.find(entitlementId);
+        Entitlement ent = entitlementCurator.get(entitlementId);
         if (ent == null) {
             throw new NotFoundException(i18n.tr(
                 "Entitlement with ID \"{0}\" could not be found.", entitlementId));
@@ -289,7 +289,7 @@ public class EntitlementResource {
     @Produces(MediaType.WILDCARD)
     @Path("/{dbid}")
     public void unbind(@PathParam("dbid") String dbid) {
-        Entitlement toDelete = entitlementCurator.find(dbid);
+        Entitlement toDelete = entitlementCurator.get(dbid);
         if (toDelete != null) {
             poolManager.revokeEntitlement(toDelete);
             return;
@@ -334,7 +334,7 @@ public class EntitlementResource {
         @QueryParam("to_consumer") @Verify(Consumer.class) String uuid,
         @QueryParam("quantity") Integer quantity) {
         // confirm entitlement
-        Entitlement entitlement = entitlementCurator.find(id);
+        Entitlement entitlement = entitlementCurator.get(id);
         List<Entitlement> entitlements = new ArrayList<>();
 
         if (entitlement != null) {

--- a/server/src/main/java/org/candlepin/resource/EnvironmentResource.java
+++ b/server/src/main/java/org/candlepin/resource/EnvironmentResource.java
@@ -123,7 +123,7 @@ public class EnvironmentResource {
     @Produces(MediaType.APPLICATION_JSON)
     public EnvironmentDTO getEnv(
         @PathParam("env_id") @Verify(Environment.class) String envId) {
-        Environment e = envCurator.find(envId);
+        Environment e = envCurator.get(envId);
         if (e == null) {
             throw new NotFoundException(i18n.tr("No such environment: {0}", envId));
         }
@@ -139,7 +139,7 @@ public class EnvironmentResource {
     @Produces(MediaType.WILDCARD)
     @Path("/{env_id}")
     public void deleteEnv(@PathParam("env_id") @Verify(Environment.class) String envId) {
-        Environment e = envCurator.find(envId);
+        Environment e = envCurator.get(envId);
         if (e == null) {
             throw new NotFoundException(i18n.tr("No such environment: {0}", envId));
         }
@@ -237,7 +237,7 @@ public class EnvironmentResource {
                 promoteMe.getEnvironmentId(), promoteMe.getContentId()
             );
 
-            EnvironmentContent existing = this.envContentCurator.lookupByEnvironmentAndContent(
+            EnvironmentContent existing = this.envContentCurator.getByEnvironmentAndContent(
                 env, promoteMe.getContentId()
             );
 
@@ -303,7 +303,7 @@ public class EnvironmentResource {
 
         // Step through and validate all given content IDs before deleting
         for (String contentId : contentIds) {
-            EnvironmentContent envContent = envContentCurator.lookupByEnvironmentAndContent(e, contentId);
+            EnvironmentContent envContent = envContentCurator.getByEnvironmentAndContent(e, contentId);
 
             if (envContent == null) {
                 throw new NotFoundException(i18n.tr("Content does not exist in environment: {0}", contentId));
@@ -378,10 +378,9 @@ public class EnvironmentResource {
     }
 
     private Environment lookupEnvironment(String envId) {
-        Environment e = envCurator.find(envId);
+        Environment e = envCurator.get(envId);
         if (e == null) {
-            throw new NotFoundException(i18n.tr(
-                "No such environment: {0}", envId));
+            throw new NotFoundException(i18n.tr("No such environment: {0}", envId));
         }
         return e;
     }

--- a/server/src/main/java/org/candlepin/resource/EventResource.java
+++ b/server/src/main/java/org/candlepin/resource/EventResource.java
@@ -78,6 +78,7 @@ public class EventResource {
                 eventDTOs.add(this.translator.translate(event, EventDTO.class));
             }
         }
+
         return eventDTOs;
     }
 
@@ -87,7 +88,7 @@ public class EventResource {
     @Path("{uuid}")
     @Produces(MediaType.APPLICATION_JSON)
     public EventDTO getEvent(@PathParam("uuid") String uuid) {
-        Event toReturn = eventCurator.find(uuid);
+        Event toReturn = eventCurator.get(uuid);
 
         if (toReturn != null) {
             List<Event> events = new LinkedList<>();

--- a/server/src/main/java/org/candlepin/resource/GuestIdResource.java
+++ b/server/src/main/java/org/candlepin/resource/GuestIdResource.java
@@ -293,9 +293,9 @@ public class GuestIdResource {
 
     private GuestId validateGuestId(GuestId guest, String guestUuid) {
         if (guest == null) {
-            throw new NotFoundException(i18n.tr(
-                "Guest with UUID {0} could not be found.", guestUuid));
+            throw new NotFoundException(i18n.tr("Guest with UUID {0} could not be found.", guestUuid));
         }
+
         return guest;
     }
 
@@ -307,7 +307,7 @@ public class GuestIdResource {
                 consumerResource.deleteConsumer(guestConsumer.getUuid(), principal);
             }
             else {
-                ConsumerType type = this.consumerTypeCurator.find(guestConsumer.getTypeId());
+                ConsumerType type = this.consumerTypeCurator.get(guestConsumer.getTypeId());
 
                 throw new ForbiddenException(i18n.tr("Cannot unregister {0} {1} because: {2}",
                     type, guestConsumer.getName(), i18n.tr("Invalid Credentials")));

--- a/server/src/main/java/org/candlepin/resource/HypervisorResource.java
+++ b/server/src/main/java/org/candlepin/resource/HypervisorResource.java
@@ -107,7 +107,7 @@ public class HypervisorResource {
         this.translator = translator;
         this.guestIdResource = guestIdResource;
 
-        this.hypervisorType = consumerTypeCurator.lookupByLabel(ConsumerTypeEnum.HYPERVISOR.getLabel(), true);
+        this.hypervisorType = consumerTypeCurator.getByLabel(ConsumerTypeEnum.HYPERVISOR.getLabel(), true);
     }
 
     /**
@@ -298,7 +298,7 @@ public class HypervisorResource {
      * Get the owner or bust
      */
     private Owner getOwner(String ownerKey) {
-        Owner owner = ownerCurator.lookupByKey(ownerKey);
+        Owner owner = ownerCurator.getByKey(ownerKey);
         if (owner == null) {
             throw new NotFoundException(i18n.tr(
                 "owner with key: {0} was not found.", ownerKey));

--- a/server/src/main/java/org/candlepin/resource/JobResource.java
+++ b/server/src/main/java/org/candlepin/resource/JobResource.java
@@ -269,7 +269,7 @@ public class JobResource {
     @Produces(MediaType.APPLICATION_JSON)
     public JobStatusDTO getStatus(@PathParam("job_id") @Verify(JobStatus.class) String jobId,
         @QueryParam("result_data") @DefaultValue("false") boolean resultData) {
-        JobStatus js = curator.find(jobId);
+        JobStatus js = curator.get(jobId);
         js.cloakResultData(!resultData);
         return this.translator.translate(js, JobStatusDTO.class);
     }
@@ -280,7 +280,7 @@ public class JobResource {
     @Path("/{job_id}")
     @Produces(MediaType.APPLICATION_JSON)
     public JobStatusDTO cancel(@PathParam("job_id") @Verify(JobStatus.class) String jobId) {
-        JobStatus j = curator.find(jobId);
+        JobStatus j = curator.get(jobId);
         if (j.getState().equals(JobState.CANCELED)) {
             throw new BadRequestException(i18n.tr("job already canceled"));
         }
@@ -298,7 +298,7 @@ public class JobResource {
     @Consumes(MediaType.WILDCARD)
     public JobStatusDTO getStatusAndDeleteIfFinished(
         @PathParam("job_id") @Verify(JobStatus.class) String jobId) {
-        JobStatus status = curator.find(jobId);
+        JobStatus status = curator.get(jobId);
 
         if (status != null && status.getState() == JobState.FINISHED) {
             curator.delete(status);

--- a/server/src/main/java/org/candlepin/resource/OwnerContentResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerContentResource.java
@@ -121,7 +121,7 @@ public class OwnerContentResource {
      *  the Owner instance for the owner with the specified key.
      */
     protected Owner getOwnerByKey(String key) {
-        Owner owner = this.ownerCurator.lookupByKey(key);
+        Owner owner = this.ownerCurator.getByKey(key);
 
         if (owner == null) {
             throw new NotFoundException(i18n.tr("Owner with key \"{0}\" was not found.", key));

--- a/server/src/main/java/org/candlepin/resource/OwnerProductResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerProductResource.java
@@ -128,7 +128,7 @@ public class OwnerProductResource {
      * @httpcode 404
      */
     protected Owner getOwnerByKey(String key) {
-        Owner owner = this.ownerCurator.lookupByKey(key);
+        Owner owner = this.ownerCurator.getByKey(key);
         if (owner == null) {
             throw new NotFoundException(i18n.tr("Owner with key \"{0}\" was not found.", key));
         }

--- a/server/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -285,7 +285,7 @@ public class OwnerResource {
     private Owner findOwnerByKey(String key) {
         Owner owner;
         if (key != null && !key.isEmpty()) {
-            owner = ownerCurator.lookupByKey(key);
+            owner = ownerCurator.getByKey(key);
         }
         else {
             throw new BadRequestException(i18n.tr("Owner key is null or empty."));
@@ -315,7 +315,7 @@ public class OwnerResource {
     private Owner findOwnerById(String id) {
         Owner owner = null;
         if (id != null && !id.isEmpty()) {
-            owner = ownerCurator.find(id);
+            owner = ownerCurator.get(id);
         }
         else {
             throw new BadRequestException(i18n.tr("Owner id is null or empty."));
@@ -372,7 +372,7 @@ public class OwnerResource {
     private Entitlement findEntitlement(String entitlementId) {
         Entitlement entitlement = null;
         if (entitlementId != null && !entitlementId.isEmpty()) {
-            entitlement = entitlementCurator.find(entitlementId);
+            entitlement = entitlementCurator.get(entitlementId);
         }
         else {
             throw new BadRequestException(i18n.tr("Entitlement id is null or empty."));
@@ -433,7 +433,7 @@ public class OwnerResource {
     private Pool findPool(String poolId) {
         Pool pool;
         if (poolId != null && !poolId.isEmpty()) {
-            pool = poolManager.find(poolId);
+            pool = poolManager.get(poolId);
         }
         else {
             throw new BadRequestException(i18n.tr("Pool id is null or empty."));
@@ -521,11 +521,11 @@ public class OwnerResource {
 
             if (pdto.getId() != null) {
                 // look up by ID
-                parent = this.ownerCurator.find(pdto.getId());
+                parent = this.ownerCurator.get(pdto.getId());
             }
             else if (pdto.getKey() != null) {
                 // look up by key
-                parent = this.ownerCurator.lookupByKey(pdto.getKey());
+                parent = this.ownerCurator.getByKey(pdto.getKey());
             }
 
             if (parent == null) {
@@ -810,7 +810,7 @@ public class OwnerResource {
         responseContainer = "list")
     public CandlepinQuery<OwnerDTO> list(@QueryParam("key") String keyFilter) {
         CandlepinQuery<Owner> query = keyFilter != null ?
-            this.ownerCurator.lookupByKeys(Arrays.asList(keyFilter)) :
+            this.ownerCurator.getByKeys(Arrays.asList(keyFilter)) :
             this.ownerCurator.listAll();
 
         return this.translator.translateQuery(query, OwnerDTO.class);
@@ -866,7 +866,7 @@ public class OwnerResource {
     public OwnerInfo getOwnerInfo(@PathParam("owner_key")
         @Verify(value = Owner.class, subResource = SubResource.CONSUMERS) String ownerKey) {
         Owner owner = findOwnerByKey(ownerKey);
-        return ownerInfoCurator.lookupByOwner(owner);
+        return ownerInfoCurator.getByOwner(owner);
     }
 
     /**
@@ -1214,7 +1214,7 @@ public class OwnerResource {
 
         Owner owner = findOwnerByKey(ownerKey);
 
-        if (activationKeyCurator.lookupForOwner(dto.getName(), owner) != null) {
+        if (activationKeyCurator.getByKeyName(owner, dto.getName()) != null) {
             throw new BadRequestException(
                 i18n.tr("The activation key name \"{0}\" is already in use for owner {1}",
                         dto.getName(), ownerKey));
@@ -1468,11 +1468,10 @@ public class OwnerResource {
 
         ActivationKey key = null;
         if (activationKeyName != null) {
-            key = activationKeyCurator.lookupForOwner(activationKeyName, owner);
+            key = activationKeyCurator.getByKeyName(owner, activationKeyName);
             if (key == null) {
                 throw new BadRequestException(
-                    i18n.tr("ActivationKey with id {0} could not be found.", activationKeyName)
-                );
+                    i18n.tr("ActivationKey with id {0} could not be found.", activationKeyName));
             }
         }
 
@@ -1697,7 +1696,7 @@ public class OwnerResource {
         @QueryParam("auto_create_owner") @DefaultValue("false") Boolean autoCreateOwner,
         @QueryParam("lazy_regen") @DefaultValue("true") Boolean lazyRegen) {
 
-        Owner owner = ownerCurator.lookupByKey(ownerKey);
+        Owner owner = ownerCurator.getByKey(ownerKey);
         if (owner == null) {
             if (autoCreateOwner && ownerService.isOwnerKeyValidForCreation(ownerKey)) {
                 owner = this.ownerCurator.create(new Owner(ownerKey, ownerKey));
@@ -1792,7 +1791,7 @@ public class OwnerResource {
     public void updatePool(@PathParam("owner_key") @Verify(Owner.class) String ownerKey,
         @ApiParam(name = "pool", required = true) PoolDTO newPoolDTO) {
 
-        Pool currentPool = this.poolManager.find(newPoolDTO.getId());
+        Pool currentPool = this.poolManager.get(newPoolDTO.getId());
         if (currentPool == null) {
             throw new NotFoundException(
                 i18n.tr("Unable to find a pool with the ID \"{0}\"", newPoolDTO.getId()));
@@ -1914,7 +1913,7 @@ public class OwnerResource {
 
         Owner owner = findOwnerByKey(ownerKey);
 
-        if (this.exportCurator.lookupByTypeAndOwner(ExporterMetadata.TYPE_PER_USER, owner) == null) {
+        if (this.exportCurator.getByTypeAndOwner(ExporterMetadata.TYPE_PER_USER, owner) == null) {
             throw new NotFoundException("No import found for owner " + ownerKey);
         }
 
@@ -2161,7 +2160,7 @@ public class OwnerResource {
         @PathParam("owner_key") @Verify(Owner.class) String ownerKey,
         @QueryParam("hypervisor_id") List<String> hypervisorIds) {
 
-        Owner owner = ownerCurator.lookupByKey(ownerKey);
+        Owner owner = ownerCurator.getByKey(ownerKey);
         CandlepinQuery<Consumer> query = (hypervisorIds == null || hypervisorIds.isEmpty()) ?
             this.consumerCurator.getHypervisorsForOwner(owner.getId()) :
             this.consumerCurator.getHypervisorsBulk(hypervisorIds, owner.getId());

--- a/server/src/main/java/org/candlepin/resource/PoolResource.java
+++ b/server/src/main/java/org/candlepin/resource/PoolResource.java
@@ -163,8 +163,9 @@ public class PoolResource {
                 oId = c.getOwnerId();
             }
         }
+
         if (ownerId != null) {
-            Owner o = ownerCurator.secureFind(ownerId);
+            Owner o = ownerCurator.secureGet(ownerId);
             if (o == null) {
                 throw new NotFoundException(i18n.tr("owner: {0}", ownerId));
             }
@@ -212,14 +213,14 @@ public class PoolResource {
         @QueryParam("consumer") String consumerUuid,
         @ApiParam("Uses ISO 8601 format") @QueryParam("activeon") String activeOn,
         @Context Principal principal) {
-        Pool toReturn = poolManager.find(id);
+
+        Pool toReturn = poolManager.get(id);
 
         Consumer c = null;
         if (consumerUuid != null) {
             c = consumerCurator.findByUuid(consumerUuid);
             if (c == null) {
-                throw new NotFoundException(i18n.tr("consumer: {0} not found",
-                    consumerUuid));
+                throw new NotFoundException(i18n.tr("consumer: {0} not found", consumerUuid));
             }
 
             if (!principal.canAccess(c, SubResource.NONE, Access.READ_ONLY)) {
@@ -233,16 +234,16 @@ public class PoolResource {
             if (activeOn != null) {
                 activeOnDate = ResourceDateParser.parseDateString(activeOn);
             }
+
             toReturn.setCalculatedAttributes(
-                calculatedAttributesUtil.buildCalculatedAttributes(toReturn, activeOnDate)
-            );
+                calculatedAttributesUtil.buildCalculatedAttributes(toReturn, activeOnDate));
+
             calculatedAttributesUtil.setQuantityAttributes(toReturn, c, activeOnDate);
 
             return translator.translate(toReturn, PoolDTO.class);
         }
 
-        throw new NotFoundException(i18n.tr(
-            "Subscription Pool with ID \"{0}\" could not be found.", id));
+        throw new NotFoundException(i18n.tr("Subscription Pool with ID \"{0}\" could not be found.", id));
     }
 
     @ApiOperation(notes = "Remove a Pool", value = "deletePool")
@@ -251,18 +252,20 @@ public class PoolResource {
     @Path("/{pool_id}")
     @Produces(MediaType.APPLICATION_JSON)
     public void deletePool(@PathParam("pool_id") String id) {
-        Pool pool = poolManager.find(id);
+        Pool pool = poolManager.get(id);
         if (pool == null) {
-            throw new NotFoundException(i18n.tr(
-                "Entitlement Pool with ID \"{0}\" could not be found.", id));
+            throw new NotFoundException(i18n.tr("Entitlement Pool with ID \"{0}\" could not be found.", id));
         }
+
         if (pool.getType() != PoolType.NORMAL) {
             throw new BadRequestException(i18n.tr("Cannot delete bonus pools, as they are auto generated"));
         }
+
         if (pool.isCreatedByShare()) {
             throw new BadRequestException(i18n.tr("Cannot delete shared pools, This should be triggered by" +
                 " deleting the share entitlement instead"));
         }
+
         poolManager.deletePools(Collections.singleton(pool));
     }
 
@@ -274,11 +277,10 @@ public class PoolResource {
     public CdnDTO getPoolCdn(
         @PathParam("pool_id") @Verify(Pool.class) String id) {
 
-        Pool pool = poolManager.find(id);
+        Pool pool = poolManager.get(id);
 
         if (pool == null) {
-            throw new NotFoundException(i18n.tr(
-                "Subscription Pool with ID \"{0}\" could not be found.", id));
+            throw new NotFoundException(i18n.tr("Subscription Pool with ID \"{0}\" could not be found.", id));
         }
 
         return this.translator.translate(pool.getCdn(), CdnDTO.class);
@@ -293,7 +295,7 @@ public class PoolResource {
         @Verify(value = Pool.class, subResource = SubResource.ENTITLEMENTS) String id,
         @Context Principal principal) {
 
-        Pool pool = poolManager.find(id);
+        Pool pool = poolManager.get(id);
 
         if (pool == null) {
             throw new NotFoundException(i18n.tr("Subscription Pool with ID \"{0}\" could not be found.", id));
@@ -321,7 +323,7 @@ public class PoolResource {
      *  the certificate associated with the specified pool
      */
     protected SubscriptionsCertificate getPoolCertificate(String poolId) {
-        Pool pool = poolManager.find(poolId);
+        Pool pool = poolManager.get(poolId);
 
         if (pool == null) {
             throw new NotFoundException(i18n.tr(

--- a/server/src/main/java/org/candlepin/resource/ProductResource.java
+++ b/server/src/main/java/org/candlepin/resource/ProductResource.java
@@ -105,7 +105,7 @@ public class ProductResource {
      *  the Product instance for the product with the specified id
      */
     protected Product fetchProduct(String productUuid) {
-        Product product = this.productCurator.find(productUuid);
+        Product product = this.productCurator.get(productUuid);
 
         if (product == null) {
             throw new NotFoundException(
@@ -267,7 +267,7 @@ public class ProductResource {
         }
 
         return this.translator.translateQuery(
-            this.ownerCurator.lookupOwnersWithProduct(productUuids), OwnerDTO.class);
+            this.ownerCurator.getOwnersWithProducts(productUuids), OwnerDTO.class);
     }
 
     @ApiOperation(notes = "Refreshes Pools by Product", value = "refreshPoolsForProduct")
@@ -292,7 +292,7 @@ public class ProductResource {
         // TODO:
         // Replace this with the commented out block below once the job scheduling is no longer performed
         // via PinsetterAsyncFilter
-        ResultIterator<Owner> iterator = this.ownerCurator.lookupOwnersWithProduct(productUuids).iterate();
+        ResultIterator<Owner> iterator = this.ownerCurator.getOwnersWithProducts(productUuids).iterate();
         List<JobDetail> details = new LinkedList<>();
         while (iterator.hasNext()) {
             details.add(RefreshPoolsJob.forOwner(iterator.next(), lazyRegen));

--- a/server/src/main/java/org/candlepin/resource/RoleResource.java
+++ b/server/src/main/java/org/candlepin/resource/RoleResource.java
@@ -82,7 +82,7 @@ public class RoleResource {
         // Attach actual owner objects to each incoming permission:
         for (PermissionBlueprint p : role.getPermissions()) {
             Owner temp = p.getOwner();
-            Owner actual = ownerCurator.lookupByKey(temp.getKey());
+            Owner actual = ownerCurator.getByKey(temp.getKey());
             if (actual == null) {
                 throw new NotFoundException(i18n.tr("No such owner: {0}", temp.getKey()));
             }
@@ -135,7 +135,7 @@ public class RoleResource {
 
         // Attach actual owner objects to each incoming permission:
         Owner temp = permission.getOwner();
-        Owner real = ownerCurator.lookupByKey(temp.getKey());
+        Owner real = ownerCurator.getByKey(temp.getKey());
         permission.setOwner(real);
         existingRole.addPermission(permission);
 

--- a/server/src/main/java/org/candlepin/resource/util/ConsumerTypeValidator.java
+++ b/server/src/main/java/org/candlepin/resource/util/ConsumerTypeValidator.java
@@ -45,7 +45,7 @@ public class ConsumerTypeValidator {
 
     public List<ConsumerType> findAndValidateTypeLabels(Set<String> labels) {
         if (labels != null && !labels.isEmpty()) {
-            List<ConsumerType> types = consumerTypeCurator.lookupByLabels(labels);
+            List<ConsumerType> types = consumerTypeCurator.getByLabels(labels);
             validate(types, labels);
             return types;
         }

--- a/server/src/main/java/org/candlepin/resource/util/ResolverUtil.java
+++ b/server/src/main/java/org/candlepin/resource/util/ResolverUtil.java
@@ -60,7 +60,7 @@ public class ResolverUtil {
 
         if (owner.getKey() != null) {
             String key = owner.getKey();
-            owner = ownerCurator.lookupByKey(owner.getKey());
+            owner = ownerCurator.getByKey(owner.getKey());
 
             if (owner == null) {
                 throw new NotFoundException(i18n.tr("Unable to find an owner with the key \"{0}\"", key));
@@ -68,7 +68,7 @@ public class ResolverUtil {
         }
         else {
             String id = owner.getId();
-            owner = ownerCurator.find(owner.getId());
+            owner = ownerCurator.get(owner.getId());
 
             if (owner == null) {
                 throw new NotFoundException(i18n.tr("Unable to find an owner with the ID \"{0}\"", id));
@@ -153,7 +153,7 @@ public class ResolverUtil {
         if (dto != null) {
             if (dto.getUuid() != null) {
                 // UUID is set. Verify that product exists and matches the ID provided, if any
-                Product product = this.productCurator.find(dto.getUuid());
+                Product product = this.productCurator.get(dto.getUuid());
 
                 if (product == null) {
                     throw new NotFoundException(

--- a/server/src/main/java/org/candlepin/resteasy/filter/StoreFactory.java
+++ b/server/src/main/java/org/candlepin/resteasy/filter/StoreFactory.java
@@ -92,12 +92,12 @@ public class StoreFactory {
 
         @Override
         public Owner lookup(String key) {
-            return this.ownerCurator.lookupByKey(key);
+            return this.ownerCurator.getByKey(key);
         }
 
         @Override
         public List<Owner> lookup(Collection<String> keys) {
-            return this.ownerCurator.lookupByKeys(keys).list();
+            return this.ownerCurator.getByKeys(keys).list();
         }
 
         @Override
@@ -111,7 +111,7 @@ public class StoreFactory {
 
         @Override
         public Environment lookup(String key) {
-            return envCurator.secureFind(key);
+            return envCurator.secureGet(key);
         }
 
         @Override
@@ -159,7 +159,7 @@ public class StoreFactory {
 
         @Override
         public Entitlement lookup(String key) {
-            return entitlementCurator.secureFind(key);
+            return entitlementCurator.secureGet(key);
         }
 
         @Override
@@ -178,7 +178,7 @@ public class StoreFactory {
 
         @Override
         public Pool lookup(String key) {
-            return poolCurator.secureFind(key);
+            return poolCurator.secureGet(key);
         }
 
         @Override
@@ -197,7 +197,7 @@ public class StoreFactory {
 
         @Override
         public ActivationKey lookup(String key) {
-            return activationKeyCurator.secureFind(key);
+            return activationKeyCurator.secureGet(key);
         }
 
         @Override
@@ -216,7 +216,7 @@ public class StoreFactory {
 
         @Override
         public Product lookup(String key) {
-            return productCurator.find(key);
+            return productCurator.get(key);
         }
 
         @Override
@@ -235,7 +235,7 @@ public class StoreFactory {
 
         @Override
         public JobStatus lookup(String jobId) {
-            return jobCurator.find(jobId);
+            return jobCurator.get(jobId);
         }
 
         @Override

--- a/server/src/main/java/org/candlepin/service/impl/DefaultIdentityCertServiceAdapter.java
+++ b/server/src/main/java/org/candlepin/service/impl/DefaultIdentityCertServiceAdapter.java
@@ -71,8 +71,8 @@ public class DefaultIdentityCertServiceAdapter implements
             log.warn("Unable to delete null identity cert for consumer: {}", consumer.getUuid());
             return;
         }
-        IdentityCertificate certificate = idCertCurator
-            .find(consumer.getIdCert().getId());
+
+        IdentityCertificate certificate = idCertCurator.get(consumer.getIdCert().getId());
         if (certificate != null) {
             idCertCurator.delete(certificate);
         }
@@ -90,7 +90,7 @@ public class DefaultIdentityCertServiceAdapter implements
         IdentityCertificate certificate = null;
 
         if (consumer.getIdCert() != null) {
-            certificate = idCertCurator.find(consumer.getIdCert().getId());
+            certificate = idCertCurator.get(consumer.getIdCert().getId());
         }
 
         if (certificate != null) {
@@ -107,7 +107,7 @@ public class DefaultIdentityCertServiceAdapter implements
         IdentityCertificate certificate = null;
 
         if (consumer.getIdCert() != null) {
-            certificate = idCertCurator.find(consumer.getIdCert().getId());
+            certificate = idCertCurator.get(consumer.getIdCert().getId());
         }
 
         if (certificate != null) {

--- a/server/src/main/java/org/candlepin/service/impl/DefaultOwnerServiceAdapter.java
+++ b/server/src/main/java/org/candlepin/service/impl/DefaultOwnerServiceAdapter.java
@@ -56,7 +56,7 @@ public class DefaultOwnerServiceAdapter implements OwnerServiceAdapter {
     @Override
     public String getContentAccessMode(String ownerKey) {
         // Since we're acting as the upstream source, we'll just pass-through any existing value.
-        Owner owner = ownerKey != null ? this.ownerCurator.lookupByKey(ownerKey) : null;
+        Owner owner = ownerKey != null ? this.ownerCurator.getByKey(ownerKey) : null;
         if (owner == null) {
             throw new IllegalArgumentException("ownerKey does not represent a valid owner: " + ownerKey);
         }
@@ -70,7 +70,7 @@ public class DefaultOwnerServiceAdapter implements OwnerServiceAdapter {
     @Override
     public String getContentAccessModeList(String ownerKey) {
         // Since we're acting as the upstream source, we'll just pass-through any existing value.
-        Owner owner = ownerKey != null ? this.ownerCurator.lookupByKey(ownerKey) : null;
+        Owner owner = ownerKey != null ? this.ownerCurator.getByKey(ownerKey) : null;
         if (owner == null) {
             throw new IllegalArgumentException("ownerKey does not represent a valid owner: " + ownerKey);
         }

--- a/server/src/main/java/org/candlepin/service/impl/DefaultUserServiceAdapter.java
+++ b/server/src/main/java/org/candlepin/service/impl/DefaultUserServiceAdapter.java
@@ -109,7 +109,7 @@ public class DefaultUserServiceAdapter implements UserServiceAdapter {
 
     @Override
     public void deleteRole(String roleId) {
-        Role r = roleCurator.find(roleId);
+        Role r = roleCurator.get(roleId);
         roleCurator.delete(r);
     }
 
@@ -127,7 +127,7 @@ public class DefaultUserServiceAdapter implements UserServiceAdapter {
 
     @Override
     public Role getRole(String roleId) {
-        return roleCurator.find(roleId);
+        return roleCurator.get(roleId);
     }
 
     @Override

--- a/server/src/main/java/org/candlepin/sync/CdnImporter.java
+++ b/server/src/main/java/org/candlepin/sync/CdnImporter.java
@@ -55,7 +55,7 @@ public class CdnImporter {
         log.debug("Creating/updating cdns");
         for (CdnDTO cdnDTO : cdnSet) {
             // TODO: this should be using bulk entity lookup to improve performance
-            Cdn existing = curator.lookupByLabel(cdnDTO.getLabel());
+            Cdn existing = curator.getByLabel(cdnDTO.getLabel());
             if (existing == null) {
                 Cdn entity = new Cdn();
                 populateEntity(entity, cdnDTO);

--- a/server/src/main/java/org/candlepin/sync/ConsumerImporter.java
+++ b/server/src/main/java/org/candlepin/sync/ConsumerImporter.java
@@ -69,7 +69,7 @@ public class ConsumerImporter {
         }
 
         // Make sure no other owner is already using this upstream UUID:
-        Owner alreadyUsing = curator.lookupWithUpstreamUuid(consumer.getUuid());
+        Owner alreadyUsing = curator.getByUpstreamUuid(consumer.getUuid());
         if (alreadyUsing != null && !alreadyUsing.getKey().equals(owner.getKey())) {
             log.error("Cannot import manifest for org: {}", owner.getKey());
             log.error("Upstream distributor {} already in used by org: {}",
@@ -199,11 +199,11 @@ public class ConsumerImporter {
 
             if (pdto.getId() != null) {
                 // look up by ID
-                parent = this.curator.find(pdto.getId());
+                parent = this.curator.get(pdto.getId());
             }
             else if (pdto.getKey() != null) {
                 // look up by key
-                parent = this.curator.lookupByKey(pdto.getKey());
+                parent = this.curator.getByKey(pdto.getKey());
             }
 
             if (parent == null) {

--- a/server/src/main/java/org/candlepin/sync/ConsumerTypeImporter.java
+++ b/server/src/main/java/org/candlepin/sync/ConsumerTypeImporter.java
@@ -57,7 +57,7 @@ public class ConsumerTypeImporter {
     public void store(Set<ConsumerType> consumerTypes) {
         log.debug("Creating/updating consumer types");
         for (ConsumerType consumerType : consumerTypes) {
-            if (curator.lookupByLabel(consumerType.getLabel()) == null) {
+            if (curator.getByLabel(consumerType.getLabel()) == null) {
                 curator.create(consumerType);
                 log.debug("Created consumer type: " + consumerType.getLabel());
             }

--- a/server/src/main/java/org/candlepin/sync/EntitlementImporter.java
+++ b/server/src/main/java/org/candlepin/sync/EntitlementImporter.java
@@ -119,7 +119,7 @@ public class EntitlementImporter {
 
         String cdnLabel = meta.getCdnLabel();
         if (!StringUtils.isBlank(cdnLabel)) {
-            Cdn cdn = cdnCurator.lookupByLabel(cdnLabel);
+            Cdn cdn = cdnCurator.getByLabel(cdnLabel);
             if (cdn != null) {
                 subscription.setCdn(cdn);
             }
@@ -604,7 +604,7 @@ public class EntitlementImporter {
     private Entitlement findEntitlement(String entitlementId) {
         Entitlement entitlement = null;
         if (entitlementId != null && !entitlementId.isEmpty()) {
-            entitlement = entitlementCurator.find(entitlementId);
+            entitlement = entitlementCurator.get(entitlementId);
         }
         else {
             throw new BadRequestException(i18n.tr("Entitlement id is null or empty."));

--- a/server/src/main/java/org/candlepin/sync/Importer.java
+++ b/server/src/main/java/org/candlepin/sync/Importer.java
@@ -321,13 +321,13 @@ public class Importer {
 
         ExporterMetadata lastrun = null;
         if (ExporterMetadata.TYPE_SYSTEM.equals(type)) {
-            lastrun = expMetaCurator.lookupByType(type);
+            lastrun = expMetaCurator.getByType(type);
         }
         else if (ExporterMetadata.TYPE_PER_USER.equals(type)) {
             if (owner == null) {
                 throw new ImporterException(i18n.tr("Invalid owner"));
             }
-            lastrun = expMetaCurator.lookupByTypeAndOwner(type, owner);
+            lastrun = expMetaCurator.getByTypeAndOwner(type, owner);
         }
 
         if (lastrun == null) {
@@ -682,7 +682,7 @@ public class Importer {
             // because it could have an id not in our database. We need to
             // stick with the label. Hence we need to lookup the ACTUAL type
             // by label here before attempting to store the UpstreamConsumer
-            ConsumerType type = consumerTypeCurator.lookupByLabel(consumer.getType().getLabel());
+            ConsumerType type = consumerTypeCurator.getByLabel(consumer.getType().getLabel());
             consumer.setType(this.translator.translate(type, ConsumerTypeDTO.class));
 
             // in older manifests the web app prefix will not

--- a/server/src/main/resources/rules/default-rules.js
+++ b/server/src/main/resources/rules/default-rules.js
@@ -520,7 +520,7 @@ var Entitlement = {
                     //   needs to be adjusted based on the virt limit
                     var virt_quantity = parseInt(virt_limit) * entitlement.getQuantity();
                     if (virt_quantity > 0) {
-                        var pools = post.lookupBySubscriptionId(pool.getSubscriptionId());
+                        var pools = post.getBySubscriptionId(pool.getSubscriptionId());
                         for (var idex = 0 ; idex < pools.size(); idex++ ) {
                             var derivedPool = pools.get(idex);
                             if (derivedPool.getAttribute("pool_derived")) {
@@ -535,7 +535,7 @@ var Entitlement = {
                     //   A quantity of 0 will block future binds, whereas -1 does not.
                     if (pool.getQuantity() == pool.getExported()) {
                         //getting all pools matching the sub id. Filtering out the 'parent'.
-                        var pools = post.lookupBySubscriptionId(pool.getSubscriptionId());
+                        var pools = post.getBySubscriptionId(pool.getSubscriptionId());
                         for (var idex = 0 ; idex < pools.size(); idex++ ) {
                             var derivedPool = pools.get(idex);
                             if (derivedPool.getAttribute("pool_derived")) {
@@ -1335,7 +1335,7 @@ var Unbind = {
                 //   exported, we need to add back the reduced bonus pool quantity.
                 var virt_quantity = parseInt(virt_limit) * entitlement.getQuantity();
                 if (virt_quantity > 0) {
-                    var pools = post.lookupBySubscriptionId(pool.getSubscriptionId());
+                    var pools = post.getBySubscriptionId(pool.getSubscriptionId());
                     for (var idex = 0 ; idex < pools.size(); idex++ ) {
                         var derivedPool = pools.get(idex);
                         if (derivedPool.getAttribute("pool_derived")) {
@@ -1347,7 +1347,7 @@ var Unbind = {
             else {
                 // As we have unbound an entitlement from a physical pool that was previously
                 //   exported, we need to set the unlimited bonus pool quantity to -1.
-                var pools = post.lookupBySubscriptionId(pool.getSubscriptionId());
+                var pools = post.getBySubscriptionId(pool.getSubscriptionId());
                 for (var idex = 0 ; idex < pools.size(); idex++ ) {
                     var derivedPool = pools.get(idex);
                     if (derivedPool.getAttribute("pool_derived")) {

--- a/server/src/test/java/org/candlepin/auth/permissions/OwnerCuratorPermissionsTest.java
+++ b/server/src/test/java/org/candlepin/auth/permissions/OwnerCuratorPermissionsTest.java
@@ -80,10 +80,10 @@ public class OwnerCuratorPermissionsTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void testLookupByKeyOwnerPermissionFiltering() {
-        assertEquals(owner1, ownerCurator.lookupByKey(owner1.getKey()));
-        assertEquals(owner2, ownerCurator.lookupByKey(owner2.getKey()));
-        assertNull(ownerCurator.lookupByKey(owner3.getKey()));
+    public void testgetByKeyOwnerPermissionFiltering() {
+        assertEquals(owner1, ownerCurator.getByKey(owner1.getKey()));
+        assertEquals(owner2, ownerCurator.getByKey(owner2.getKey()));
+        assertNull(ownerCurator.getByKey(owner3.getKey()));
     }
 
 }

--- a/server/src/test/java/org/candlepin/controller/CdnManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/CdnManagerTest.java
@@ -38,7 +38,7 @@ public class CdnManagerTest extends DatabaseTestFixture {
     @Test
     public void testCreateCdn() throws Exception {
         Cdn cdn = createCdn("test_cdn");
-        Cdn fetched = curator.lookupByLabel(cdn.getLabel());
+        Cdn fetched = curator.getByLabel(cdn.getLabel());
         assertNotNull(fetched);
         assertEquals("test_cdn", fetched.getLabel());
     }
@@ -50,7 +50,7 @@ public class CdnManagerTest extends DatabaseTestFixture {
         cdn.setName("Updated CDN");
         manager.updateCdn(cdn);
 
-        Cdn fetched = curator.lookupByLabel(cdn.getLabel());
+        Cdn fetched = curator.getByLabel(cdn.getLabel());
         assertNotNull(fetched);
         assertEquals(cdn.getLabel(), fetched.getLabel());
         assertEquals("Updated CDN", fetched.getName());
@@ -60,7 +60,7 @@ public class CdnManagerTest extends DatabaseTestFixture {
     public void deleteCdn() throws Exception {
         Cdn cdn = createCdn("test_cdn");
         manager.deleteCdn(cdn);
-        assertNull(curator.lookupByLabel(cdn.getLabel()));
+        assertNull(curator.getByLabel(cdn.getLabel()));
     }
 
     @Test
@@ -77,10 +77,10 @@ public class CdnManagerTest extends DatabaseTestFixture {
         assertNotNull(pool.getCdn());
 
         manager.deleteCdn(cdn);
-        assertNull(curator.lookupByLabel(cdn.getLabel()));
+        assertNull(curator.getByLabel(cdn.getLabel()));
         poolCurator.clear();
 
-        Pool updatedPool = poolCurator.find(pool.getId());
+        Pool updatedPool = poolCurator.get(pool.getId());
         assertNull(updatedPool.getCdn());
     }
 
@@ -91,7 +91,7 @@ public class CdnManagerTest extends DatabaseTestFixture {
         assertNotNull(serial);
         assertFalse(serial.isRevoked());
         manager.deleteCdn(cdn);
-        CertificateSerial fetched = certSerialCurator.find(serial.getId());
+        CertificateSerial fetched = certSerialCurator.get(serial.getId());
         assertNotNull(fetched);
         assertTrue(fetched.isRevoked());
     }

--- a/server/src/test/java/org/candlepin/controller/ContentManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/ContentManagerTest.java
@@ -145,12 +145,12 @@ public class ContentManagerTest extends DatabaseTestFixture {
 
         // We expect the original to be kept around as an orphan until the orphan removal job
         // gets around to removing them
-        assertNotNull(this.contentCurator.find(content.getUuid()));
+        assertNotNull(this.contentCurator.get(content.getUuid()));
         assertEquals(0, this.ownerContentCurator.getOwnerCount(content));
         assertNotNull(this.ownerContentCurator.getContentById(owner, content.getId()));
 
         // The product should have also changed in the same way as a result of the content change
-        assertNotNull(this.productCurator.find(product.getUuid()));
+        assertNotNull(this.productCurator.get(product.getUuid()));
         assertEquals(0, this.ownerProductCurator.getOwnerCount(product));
         assertNotNull(this.ownerProductCurator.getProductById(owner, product.getId()));
 
@@ -260,7 +260,7 @@ public class ContentManagerTest extends DatabaseTestFixture {
         }
 
         assertFalse(this.ownerContentCurator.isContentMappedToOwner(content, owner));
-        assertNotNull(this.contentCurator.find(content.getUuid()));
+        assertNotNull(this.contentCurator.get(content.getUuid()));
         assertEquals(0, this.ownerContentCurator.getOwnerCount(content));
 
         if (regenCerts) {
@@ -296,7 +296,7 @@ public class ContentManagerTest extends DatabaseTestFixture {
 
         assertFalse(this.ownerContentCurator.isContentMappedToOwner(content, owner1));
         assertTrue(this.ownerContentCurator.isContentMappedToOwner(content, owner2));
-        assertNotNull(this.contentCurator.find(content.getUuid()));
+        assertNotNull(this.contentCurator.get(content.getUuid()));
 
         if (regenCerts) {
             verify(this.mockEntCertGenerator, times(1)).regenerateCertificatesOf(

--- a/server/src/test/java/org/candlepin/controller/EntitlementCertificateGeneratorTest.java
+++ b/server/src/test/java/org/candlepin/controller/EntitlementCertificateGeneratorTest.java
@@ -399,7 +399,7 @@ public class EntitlementCertificateGeneratorTest {
         HashMap<String, EntitlementCertificate> ecMap = new HashMap<>();
         ecMap.put(pool.getId(), new EntitlementCertificate());
 
-        when(this.mockEntitlementCurator.find(eq(entitlement.getId()))).thenReturn(entitlement);
+        when(this.mockEntitlementCurator.get(eq(entitlement.getId()))).thenReturn(entitlement);
         when(this.mockEntCertAdapter.generateEntitlementCerts(any(Consumer.class), any(Map.class),
             any(Map.class), any(Map.class), eq(true))).thenReturn(ecMap);
 

--- a/server/src/test/java/org/candlepin/controller/EntitlerTest.java
+++ b/server/src/test/java/org/candlepin/controller/EntitlerTest.java
@@ -263,7 +263,7 @@ public class EntitlerTest {
         List<Entitlement> eList = new ArrayList<>();
         eList.add(ent);
 
-        when(pm.find(eq(poolid))).thenReturn(pool);
+        when(pm.get(eq(poolid))).thenReturn(pool);
         Map<String, Integer> pQs = new HashMap<>();
         pQs.put(poolid, 1);
         when(pm.entitleByPools(eq(consumer), eq(pQs))).thenReturn(eList);
@@ -378,7 +378,7 @@ public class EntitlerTest {
             EntitlementRefusedException ere = new EntitlementRefusedException(fakeResult);
 
             when(pool.getId()).thenReturn(poolid);
-            when(poolCurator.find(eq(poolid))).thenReturn(pool);
+            when(poolCurator.get(eq(poolid))).thenReturn(pool);
             Map<String, Integer> pQs = new HashMap<>();
             pQs.put(poolid, 1);
             when(pm.entitleByPools(eq(consumer), eq(pQs))).thenThrow(ere);

--- a/server/src/test/java/org/candlepin/controller/ManifestManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/ManifestManagerTest.java
@@ -102,7 +102,7 @@ public class ManifestManagerTest {
         Consumer consumer = new Consumer("TestConsumer" + TestUtil.randomInt(), "User", owner, type);
 
         when(consumerTypeCurator.getConsumerType(eq(consumer))).thenReturn(type);
-        when(consumerTypeCurator.find(eq(type.getId()))).thenReturn(type);
+        when(consumerTypeCurator.get(eq(type.getId()))).thenReturn(type);
 
         return consumer;
     }
@@ -120,7 +120,7 @@ public class ManifestManagerTest {
         String apiUrl = "api-url";
 
         when(consumerCurator.verifyAndLookupConsumer(eq(consumer.getUuid()))).thenReturn(consumer);
-        when(cdnCurator.lookupByLabel(eq(cdn.getLabel()))).thenReturn(cdn);
+        when(cdnCurator.getByLabel(eq(cdn.getLabel()))).thenReturn(cdn);
 
         manager.generateManifestAsync(consumer.getUuid(), owner.getKey(), cdn.getLabel(), webAppPrefix,
             apiUrl,
@@ -141,7 +141,7 @@ public class ManifestManagerTest {
         List<Entitlement> ents = new ArrayList<>();
         when(entitlementCurator.listByConsumer(eq(consumer))).thenReturn(ents);
         when(consumerCurator.verifyAndLookupConsumer(eq(consumer.getUuid()))).thenReturn(consumer);
-        when(cdnCurator.lookupByLabel(eq(cdn.getLabel()))).thenReturn(cdn);
+        when(cdnCurator.getByLabel(eq(cdn.getLabel()))).thenReturn(cdn);
 
         manager.generateManifest(consumer.getUuid(), cdn.getLabel(), webAppPrefix, apiUrl, extData);
 
@@ -160,7 +160,7 @@ public class ManifestManagerTest {
         Event event = mock(Event.class);
         when(eventFactory.exportCreated(eq(consumer))).thenReturn(event);
         when(consumerCurator.verifyAndLookupConsumer(eq(consumer.getUuid()))).thenReturn(consumer);
-        when(cdnCurator.lookupByLabel(eq(cdn.getLabel()))).thenReturn(cdn);
+        when(cdnCurator.getByLabel(eq(cdn.getLabel()))).thenReturn(cdn);
 
         manager.generateManifest(consumer.getUuid(), cdn.getLabel(), webAppPrefix, apiUrl, new HashMap<>());
 
@@ -185,7 +185,7 @@ public class ManifestManagerTest {
         when(fileService.store(eq(ManifestFileType.EXPORT), any(File.class),
             eq(principal.getName()), any(String.class))).thenReturn(manifest);
         when(consumerCurator.verifyAndLookupConsumer(eq(consumer.getUuid()))).thenReturn(consumer);
-        when(cdnCurator.lookupByLabel(eq(cdn.getLabel()))).thenReturn(cdn);
+        when(cdnCurator.getByLabel(eq(cdn.getLabel()))).thenReturn(cdn);
 
         manager.generateAndStoreManifest(consumer.getUuid(), cdn.getLabel(), webAppPrefix, apiUrl,
             new HashMap<>());
@@ -208,7 +208,7 @@ public class ManifestManagerTest {
         List<Entitlement> ents = new ArrayList<>();
         when(entitlementCurator.listByConsumer(eq(consumer))).thenReturn(ents);
         when(consumerCurator.verifyAndLookupConsumer(eq(consumer.getUuid()))).thenReturn(consumer);
-        when(cdnCurator.lookupByLabel(eq(cdn.getLabel()))).thenReturn(cdn);
+        when(cdnCurator.getByLabel(eq(cdn.getLabel()))).thenReturn(cdn);
 
         File manifestFile = mock(File.class);
         when(exporter.getFullExport(eq(consumer), eq(cdn.getLabel()), eq(webAppPrefix),
@@ -247,7 +247,7 @@ public class ManifestManagerTest {
         when(fileService.store(eq(ManifestFileType.EXPORT), any(File.class),
             eq(principal.getName()), any(String.class))).thenReturn(manifest);
         when(consumerCurator.verifyAndLookupConsumer(eq(consumer.getUuid()))).thenReturn(consumer);
-        when(cdnCurator.lookupByLabel(eq(cdn.getLabel()))).thenReturn(cdn);
+        when(cdnCurator.getByLabel(eq(cdn.getLabel()))).thenReturn(cdn);
 
         List<Entitlement> ents = new ArrayList<>();
         when(entitlementCurator.listByConsumer(eq(consumer))).thenReturn(ents);
@@ -430,7 +430,7 @@ public class ManifestManagerTest {
         Map<String, String> extData = new HashMap<>();
 
         when(consumerCurator.verifyAndLookupConsumer(eq(consumer.getUuid()))).thenReturn(consumer);
-        when(cdnCurator.lookupByLabel(eq(cdn.getLabel()))).thenReturn(cdn);
+        when(cdnCurator.getByLabel(eq(cdn.getLabel()))).thenReturn(cdn);
 
         try {
             manager.generateManifest(consumer.getUuid(), cdn.getLabel(), webAppPrefix, apiUrl, extData);
@@ -455,7 +455,7 @@ public class ManifestManagerTest {
         Map<String, String> extData = new HashMap<>();
 
         when(consumerCurator.verifyAndLookupConsumer(eq(consumer.getUuid()))).thenReturn(consumer);
-        when(cdnCurator.lookupByLabel(eq(cdn.getLabel()))).thenReturn(cdn);
+        when(cdnCurator.getByLabel(eq(cdn.getLabel()))).thenReturn(cdn);
 
         try {
             manager.generateManifestAsync(consumer.getUuid(), owner.getKey(), cdn.getLabel(), webAppPrefix,
@@ -481,7 +481,7 @@ public class ManifestManagerTest {
         Map<String, String> extData = new HashMap<>();
 
         when(consumerCurator.verifyAndLookupConsumer(eq(consumer.getUuid()))).thenReturn(consumer);
-        when(cdnCurator.lookupByLabel(eq(cdn.getLabel()))).thenReturn(null);
+        when(cdnCurator.getByLabel(eq(cdn.getLabel()))).thenReturn(null);
 
         try {
             manager.generateManifestAsync(consumer.getUuid(), owner.getKey(), cdn.getLabel(), webAppPrefix,
@@ -507,7 +507,7 @@ public class ManifestManagerTest {
         Map<String, String> extData = new HashMap<>();
 
         when(consumerCurator.verifyAndLookupConsumer(eq(consumer.getUuid()))).thenReturn(consumer);
-        when(cdnCurator.lookupByLabel(eq(cdn.getLabel()))).thenReturn(null);
+        when(cdnCurator.getByLabel(eq(cdn.getLabel()))).thenReturn(null);
 
         try {
             manager.generateManifestAsync(consumer.getUuid(), owner.getKey(), cdn.getLabel(), webAppPrefix,

--- a/server/src/test/java/org/candlepin/controller/PoolManagerFunctionalTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerFunctionalTest.java
@@ -254,12 +254,12 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
         List<Entitlement> eList = poolManager.entitleByPools(parentSystem, poolQuantities);
         assertEquals(1, eList.size());
         assertEquals(Long.valueOf(3), monitoringPool.getConsumed());
-        consumerCurator.find(parentSystem.getId());
+        consumerCurator.get(parentSystem.getId());
         assertEquals(3, parentSystem.getEntitlementCount());
 
         poolManager.revokeEntitlement(eList.get(0));
         assertEquals(Long.valueOf(0), monitoringPool.getConsumed());
-        consumerCurator.find(parentSystem.getId());
+        consumerCurator.get(parentSystem.getId());
         assertEquals(0, parentSystem.getEntitlementCount());
     }
 
@@ -642,10 +642,10 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
         assertEquals(1, results.size());
         assertEquals(results.get(0).getPool(), pool1);
 
-        Entitlement e = entitlementCurator.find(results.get(0).getId());
+        Entitlement e = entitlementCurator.get(results.get(0).getId());
         poolManager.revokeEntitlement(e);
-        assertNull(poolCurator.find(pool1.getId()));
-        assertNotNull(poolCurator.find(pool2.getId()));
+        assertNull(poolCurator.get(pool1.getId()));
+        assertNotNull(poolCurator.get(pool2.getId()));
     }
 
     @Test
@@ -677,8 +677,8 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
         assertTrue(results.get(0).getPool() == pool1 || results.get(0).getPool() == pool2);
         assertTrue(results.get(1).getPool() == pool1 || results.get(1).getPool() == pool2);
 
-        pool1 = poolCurator.find(pool1.getId());
-        pool2 = poolCurator.find(pool2.getId());
+        pool1 = poolCurator.get(pool1.getId());
+        pool2 = poolCurator.get(pool2.getId());
 
         assertEquals(1, pool1.getConsumed().intValue());
         assertEquals(1, pool2.getConsumed().intValue());
@@ -710,7 +710,7 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
         poolCurator.merge(pool1);
         poolCurator.flush();
 
-        assertEquals(1, poolCurator.find(pool1.getId()).getConsumed().intValue());
+        assertEquals(1, poolCurator.get(pool1.getId()).getConsumed().intValue());
         Pool pool2 = createPool(owner, p, 1L, TestUtil.createDate(2000, 3, 2),
             TestUtil.createDate(2050, 3, 2));
         poolCurator.create(pool2);
@@ -759,7 +759,7 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
         pool1.setConsumed(1L);
         poolCurator.create(pool1);
 
-        assertEquals(1, poolCurator.find(pool1.getId()).getConsumed().intValue());
+        assertEquals(1, poolCurator.get(pool1.getId()).getConsumed().intValue());
         Pool pool2 = createPool(owner, p, 1L, TestUtil.createDate(2000, 3, 2),
             TestUtil.createDate(2050, 3, 2));
         pool2.setConsumed(1L);
@@ -791,8 +791,8 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
 
         this.poolManager.cleanupExpiredPools();
 
-        assertNotNull(this.poolCurator.find(activePool.getId()));
-        assertNull(this.poolCurator.find(expiredPool.getId()));
+        assertNotNull(this.poolCurator.get(activePool.getId()));
+        assertNull(this.poolCurator.get(expiredPool.getId()));
     }
 
     @Test
@@ -838,12 +838,12 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
 
         this.poolManager.cleanupExpiredPools();
 
-        assertNotNull(this.poolCurator.find(pools.get(0).getId())); // Active pool, no ent
-        assertNull(this.poolCurator.find(pools.get(1).getId()));    // Expired pool, no ent
-        assertNotNull(this.poolCurator.find(pools.get(2).getId())); // Active pool, active ent
-        assertNotNull(this.poolCurator.find(pools.get(3).getId())); // Expired pool, active ent
-        assertNotNull(this.poolCurator.find(pools.get(4).getId())); // Active pool, expired ent
-        assertNull(this.poolCurator.find(pools.get(5).getId()));    // Expired pool, expired ent
+        assertNotNull(this.poolCurator.get(pools.get(0).getId())); // Active pool, no ent
+        assertNull(this.poolCurator.get(pools.get(1).getId()));    // Expired pool, no ent
+        assertNotNull(this.poolCurator.get(pools.get(2).getId())); // Active pool, active ent
+        assertNotNull(this.poolCurator.get(pools.get(3).getId())); // Expired pool, active ent
+        assertNotNull(this.poolCurator.get(pools.get(4).getId())); // Active pool, expired ent
+        assertNull(this.poolCurator.get(pools.get(5).getId()));    // Expired pool, expired ent
     }
 
     @Test
@@ -869,10 +869,10 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
 
         this.poolManager.cleanupExpiredPools();
 
-        assertNotNull(this.poolCurator.find(pool1.getId()));        // Active pool, no attrib
-        assertNull(this.poolCurator.find(pool2.getId()));           // Expired pool, no attrib
-        assertNotNull(this.poolCurator.find(pool3.getId()));        // Active pool, derived attrib
-        assertNull(this.poolCurator.find(pool4.getId()));           // Expired pool, derived attrib
+        assertNotNull(this.poolCurator.get(pool1.getId()));        // Active pool, no attrib
+        assertNull(this.poolCurator.get(pool2.getId()));           // Expired pool, no attrib
+        assertNotNull(this.poolCurator.get(pool3.getId()));        // Active pool, derived attrib
+        assertNull(this.poolCurator.get(pool4.getId()));           // Expired pool, derived attrib
     }
 
     @Test
@@ -894,9 +894,9 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
 
         this.poolManager.cleanupExpiredPools();
 
-        assertNull(this.poolCurator.find(pool2.getId()));
-        assertNull(this.poolCurator.find(pool3.getId()));
-        assertNull(this.entitlementCurator.find(ent.getId()));
+        assertNull(this.poolCurator.get(pool2.getId()));
+        assertNull(this.poolCurator.get(pool3.getId()));
+        assertNull(this.entitlementCurator.get(ent.getId()));
     }
 
     @Test
@@ -910,7 +910,7 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
         List<Entitlement> entitlements = entitlementCurator.listByConsumer(parentSystem);
         assertTrue(entitlements.isEmpty());
 
-        CertificateSerial revoked = certSerialCurator.find(serial.getId());
+        CertificateSerial revoked = certSerialCurator.get(serial.getId());
         assertTrue("Entitlement cert serial should have been marked as revoked once deleted!",
             revoked.isRevoked());
     }

--- a/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -189,7 +189,7 @@ public class PoolManagerTest {
         product = TestUtil.createProduct();
         pool = TestUtil.createPool(owner, product);
 
-        when(mockOwnerCurator.lookupByKey(eq(owner.getKey()))).thenReturn(owner);
+        when(mockOwnerCurator.getByKey(eq(owner.getKey()))).thenReturn(owner);
 
         when(mockConfig.getInt(eq(ConfigProperties.PRODUCT_CACHE_MAX))).thenReturn(100);
         when(eventFactory.getEventBuilder(any(Target.class), any(Type.class))).thenReturn(eventBuilder);
@@ -232,9 +232,9 @@ public class PoolManagerTest {
                 ctype.setId("test-ctype-" + ctype.getLabel() + "-" + TestUtil.randomInt());
             }
 
-            when(consumerTypeCuratorMock.lookupByLabel(eq(ctype.getLabel()))).thenReturn(ctype);
-            when(consumerTypeCuratorMock.lookupByLabel(eq(ctype.getLabel()), anyBoolean())).thenReturn(ctype);
-            when(consumerTypeCuratorMock.find(eq(ctype.getId()))).thenReturn(ctype);
+            when(consumerTypeCuratorMock.getByLabel(eq(ctype.getLabel()))).thenReturn(ctype);
+            when(consumerTypeCuratorMock.getByLabel(eq(ctype.getLabel()), anyBoolean())).thenReturn(ctype);
+            when(consumerTypeCuratorMock.get(eq(ctype.getId()))).thenReturn(ctype);
 
             doAnswer(new Answer<ConsumerType>() {
                 @Override
@@ -248,7 +248,7 @@ public class PoolManagerTest {
                         throw new IllegalArgumentException("consumer is null or lacks a type ID");
                     }
 
-                    ctype = curator.find(consumer.getTypeId());
+                    ctype = curator.get(consumer.getTypeId());
                     if (ctype == null) {
                         throw new IllegalStateException("No such consumer type: " + consumer.getTypeId());
                     }
@@ -397,7 +397,7 @@ public class PoolManagerTest {
         mockSubsList(subscriptions);
 
         mockPoolsList(pools);
-        when(mockOwnerCurator.lookupByKey(owner.getKey())).thenReturn(owner);
+        when(mockOwnerCurator.getByKey(owner.getKey())).thenReturn(owner);
         this.mockProducts(owner, product);
         this.mockProductImport(owner, product);
         this.mockContentImport(owner, new Content[] {});
@@ -439,7 +439,7 @@ public class PoolManagerTest {
 
         mockSubsList(subscriptions);
         mockPoolsList(pools);
-        when(mockOwnerCurator.lookupByKey(owner.getKey())).thenReturn(owner);
+        when(mockOwnerCurator.getByKey(owner.getKey())).thenReturn(owner);
         this.mockProducts(owner, product);
         this.mockProductImport(owner, product);
         this.mockContentImport(owner, new Content[] {});
@@ -724,7 +724,7 @@ public class PoolManagerTest {
         this.mockContentImport(owner, new Content[] {});
 
         Owner owner = getOwner();
-        when(mockOwnerCurator.lookupByKey(owner.getKey())).thenReturn(owner);
+        when(mockOwnerCurator.getByKey(owner.getKey())).thenReturn(owner);
         this.manager.getRefresher(mockSubAdapter, mockOwnerAdapter).add(owner).run();
         List<Pool> poolsToDelete = Arrays.asList(p);
         verify(this.manager).deletePools(eq(poolsToDelete));
@@ -748,7 +748,7 @@ public class PoolManagerTest {
         mockPoolsList(pools);
 
         Owner owner = getOwner();
-        when(mockOwnerCurator.lookupByKey(owner.getKey())).thenReturn(owner);
+        when(mockOwnerCurator.getByKey(owner.getKey())).thenReturn(owner);
 
         this.mockProductImport(owner, product);
         this.mockContentImport(owner, new Content[] {});
@@ -785,7 +785,7 @@ public class PoolManagerTest {
         mockPoolsList(pools);
 
         Owner owner = getOwner();
-        when(mockOwnerCurator.lookupByKey(owner.getKey())).thenReturn(owner);
+        when(mockOwnerCurator.getByKey(owner.getKey())).thenReturn(owner);
 
         this.mockProductImport(owner, product);
         this.mockContentImport(owner, new Content[] {});
@@ -825,7 +825,7 @@ public class PoolManagerTest {
         when(mockPoolCurator.listByOwnerAndType(eq(owner), any(PoolType.class))).thenReturn(cqmock);
 
         Owner owner = getOwner();
-        when(mockOwnerCurator.lookupByKey(owner.getKey())).thenReturn(owner);
+        when(mockOwnerCurator.getByKey(owner.getKey())).thenReturn(owner);
         this.manager.getRefresher(mockSubAdapter, mockOwnerAdapter).add(owner).run();
         verify(this.manager, never()).deletePool(same(p));
     }
@@ -854,7 +854,7 @@ public class PoolManagerTest {
         this.mockContentImport(owner, new Content[] {});
 
         Owner owner = getOwner();
-        when(mockOwnerCurator.lookupByKey(owner.getKey())).thenReturn(owner);
+        when(mockOwnerCurator.getByKey(owner.getKey())).thenReturn(owner);
 
         this.manager.getRefresher(mockSubAdapter, mockOwnerAdapter).add(owner).run();
         verify(this.manager, never()).deletePool(same(p));
@@ -876,7 +876,7 @@ public class PoolManagerTest {
         mockPoolsList(pools);
 
         Owner owner = getOwner();
-        when(mockOwnerCurator.lookupByKey(owner.getKey())).thenReturn(owner);
+        when(mockOwnerCurator.getByKey(owner.getKey())).thenReturn(owner);
 
         this.mockProductImport(owner, product);
         this.mockContentImport(owner, new Content[] {});
@@ -915,7 +915,7 @@ public class PoolManagerTest {
         ArgumentCaptor<Pool> argPool = ArgumentCaptor.forClass(Pool.class);
 
         when(poolRulesMock.createAndEnrichPools(argPool.capture(), any(List.class))).thenReturn(newPools);
-        when(mockOwnerCurator.lookupByKey(owner.getKey())).thenReturn(owner);
+        when(mockOwnerCurator.getByKey(owner.getKey())).thenReturn(owner);
         this.mockProducts(owner, product);
         this.mockProductImport(owner, product);
         this.mockContentImport(owner, new Content[] {});
@@ -971,7 +971,7 @@ public class PoolManagerTest {
         when(poolRulesMock.updatePools(argPool.capture(), eq(pools), eq(s.getQuantity()), any(Map.class)))
             .thenReturn(updates);
 
-        when(mockOwnerCurator.lookupByKey(owner.getKey())).thenReturn(owner);
+        when(mockOwnerCurator.getByKey(owner.getKey())).thenReturn(owner);
         this.mockProducts(owner, product);
         this.mockProductImport(owner, product);
         this.mockContentImport(owner, new Content[] {});
@@ -1262,7 +1262,7 @@ public class PoolManagerTest {
 
         ValidationResult result = new ValidationResult();
         when(preHelper.getResult()).thenReturn(result);
-        when(mockOwnerCurator.lookupByKey(owner.getKey())).thenReturn(owner);
+        when(mockOwnerCurator.getByKey(owner.getKey())).thenReturn(owner);
         this.mockProducts(owner, product);
         this.mockProductImport(owner, product);
         this.mockContentImport(owner, new Content[] {});
@@ -1466,7 +1466,7 @@ public class PoolManagerTest {
 
         ValidationResult result = new ValidationResult();
         when(preHelper.getResult()).thenReturn(result);
-        when(mockOwnerCurator.lookupByKey(owner.getKey())).thenReturn(owner);
+        when(mockOwnerCurator.getByKey(owner.getKey())).thenReturn(owner);
         this.mockProducts(owner, product);
         this.mockProductImport(owner, product);
         this.mockContentImport(owner, new Content[] {});
@@ -1894,7 +1894,7 @@ public class PoolManagerTest {
         when(mockPoolCurator.lockAndLoad(pool)).thenReturn(pool);
         when(enforcerMock.update(any(Consumer.class), any(Entitlement.class), any(Integer.class)))
             .thenReturn(new ValidationResult());
-        when(mockPoolCurator.lookupOversubscribedBySubscriptionIds(any(String.class), anyMap()))
+        when(mockPoolCurator.getOversubscribedBySubscriptionIds(any(String.class), anyMap()))
             .thenReturn(Collections.singletonList(derivedPool));
         when(mockPoolCurator.retrieveOrderedEntitlementsOf(anyListOf(Pool.class)))
             .thenReturn(Collections.singletonList(derivedEnt));
@@ -1962,7 +1962,7 @@ public class PoolManagerTest {
         when(mockPoolCurator.lockAndLoad(pool)).thenReturn(pool);
         when(enforcerMock.update(any(Consumer.class), any(Entitlement.class), any(Integer.class)))
             .thenReturn(new ValidationResult());
-        when(mockPoolCurator.lookupOversubscribedBySubscriptionIds(any(String.class), anyMap())).thenReturn(
+        when(mockPoolCurator.getOversubscribedBySubscriptionIds(any(String.class), anyMap())).thenReturn(
             Arrays.asList(derivedPool, derivedPool2, derivedPool3));
         when(mockPoolCurator.retrieveOrderedEntitlementsOf(eq(Arrays.asList(derivedPool)))).thenReturn(
             Arrays.asList(derivedEnt, derivedEnt2));
@@ -2022,7 +2022,7 @@ public class PoolManagerTest {
         CandlepinQuery cqmock = mock(CandlepinQuery.class);
         when(cqmock.list()).thenReturn(pools);
         when(mockPoolCurator.listAllByIds(poolsArg.capture())).thenReturn(cqmock);
-        List<Pool> found = manager.secureFind(ids);
+        List<Pool> found = manager.secureGet(ids);
         List<String> argument = poolsArg.getValue();
         assertEquals(pools, found);
         assertEquals(argument, ids);
@@ -2030,15 +2030,15 @@ public class PoolManagerTest {
 
     @Test
     public void testNullArgumentsDontBreakStuff() {
-        manager.lookupBySubscriptionIds(owner.getId(), null);
-        manager.lookupBySubscriptionIds(owner.getId(), new ArrayList<>());
+        manager.getBySubscriptionIds(owner.getId(), null);
+        manager.getBySubscriptionIds(owner.getId(), new ArrayList<>());
         manager.createPools(null);
         manager.createPools(new ArrayList<>());
-        manager.secureFind(new ArrayList<>());
+        manager.secureGet(new ArrayList<>());
     }
 
     @Test
-    public void testlookupBySubscriptionIds() {
+    public void testgetBySubscriptionIds() {
         List<Pool> pools = new ArrayList<>();
         List<String> subids = new ArrayList<>();
         for (int i = 0; i < 5; i++) {
@@ -2049,9 +2049,9 @@ public class PoolManagerTest {
 
         Class<List<String>> listClass = (Class<List<String>>) (Class) ArrayList.class;
         ArgumentCaptor<List<String>> poolsArg = ArgumentCaptor.forClass(listClass);
-        when(mockPoolCurator.lookupBySubscriptionIds(anyString(), poolsArg.capture()))
+        when(mockPoolCurator.getBySubscriptionIds(anyString(), poolsArg.capture()))
             .thenReturn(pools);
-        List<Pool> found = manager.lookupBySubscriptionIds(owner.getId(), subids);
+        List<Pool> found = manager.getBySubscriptionIds(owner.getId(), subids);
         List<String> argument = poolsArg.getValue();
         assertEquals(pools, found);
         assertEquals(argument, subids);
@@ -2059,11 +2059,11 @@ public class PoolManagerTest {
 
     private void mockOwner(Owner owner) {
         if (owner.getId() != null) {
-            when(this.mockOwnerCurator.find(eq(owner.getId()))).thenReturn(owner);
+            when(this.mockOwnerCurator.get(eq(owner.getId()))).thenReturn(owner);
         }
 
         if (owner.getKey() != null) {
-            when(this.mockOwnerCurator.lookupByKey(eq(owner.getKey()))).thenReturn(owner);
+            when(this.mockOwnerCurator.getByKey(eq(owner.getKey()))).thenReturn(owner);
         }
     }
 

--- a/server/src/test/java/org/candlepin/controller/ProductManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/ProductManagerTest.java
@@ -127,7 +127,7 @@ public class ProductManagerTest extends DatabaseTestFixture {
 
         // We expect the original to be kept around as an orphan until the orphan removal job
         // gets around to removing them
-        assertNotNull(this.productCurator.find(product.getUuid()));
+        assertNotNull(this.productCurator.get(product.getUuid()));
         assertEquals(0, this.ownerProductCurator.getOwnerCount(product));
         assertNotNull(this.ownerProductCurator.getProductById(owner, product.getId()));
 
@@ -223,7 +223,7 @@ public class ProductManagerTest extends DatabaseTestFixture {
 
         // The product will be orphaned, but should still exist
         assertFalse(this.ownerProductCurator.isProductMappedToOwner(product, owner));
-        assertNotNull(this.productCurator.find(product.getUuid()));
+        assertNotNull(this.productCurator.get(product.getUuid()));
         assertEquals(0, this.ownerProductCurator.getOwnerCount(product));
 
         verifyZeroInteractions(this.mockEntCertGenerator);
@@ -242,7 +242,7 @@ public class ProductManagerTest extends DatabaseTestFixture {
 
         assertFalse(this.ownerProductCurator.isProductMappedToOwner(product, owner1));
         assertTrue(this.ownerProductCurator.isProductMappedToOwner(product, owner2));
-        assertNotNull(this.productCurator.find(product.getUuid()));
+        assertNotNull(this.productCurator.get(product.getUuid()));
         assertEquals(1, this.ownerProductCurator.getOwnerCount(product));
 
         verifyZeroInteractions(this.mockEntCertGenerator);
@@ -292,10 +292,10 @@ public class ProductManagerTest extends DatabaseTestFixture {
         // product itself, which should trigger the creation of a new product object (since reuse
         // is currently disabled). The old product will still, temporarily, exist as an orphan
         // until the orphan cleanup job has a chance to run and remove them.
-        assertNotNull(this.productCurator.find(product.getUuid()));
+        assertNotNull(this.productCurator.get(product.getUuid()));
         assertEquals(0, this.ownerProductCurator.getOwnerCount(product));
         assertNotNull(this.ownerProductCurator.getProductById(owner, product.getId()));
-        assertNotNull(this.contentCurator.find(content.getUuid()));
+        assertNotNull(this.contentCurator.get(content.getUuid()));
 
         if (regenCerts) {
             verify(this.mockEntCertGenerator, times(1)).regenerateCertificatesOf(

--- a/server/src/test/java/org/candlepin/controller/RefresherTest.java
+++ b/server/src/test/java/org/candlepin/controller/RefresherTest.java
@@ -120,7 +120,7 @@ public class RefresherTest {
         when(subAdapter.getSubscriptions(owner)).thenReturn(subscriptions);
         when(subAdapter.getSubscription("subId")).thenReturn(subscription);
 
-        when(poolManager.lookupBySubscriptionId(owner, "subId")).thenReturn(pools);
+        when(poolManager.getBySubscriptionId(owner, "subId")).thenReturn(pools);
 
         refresher.add(owner);
         refresher.add(product);
@@ -158,7 +158,7 @@ public class RefresherTest {
         when(subAdapter.getSubscriptions(eq(productData))).thenReturn(subscriptions);
         when(subAdapter.getSubscriptions(eq(productData2))).thenReturn(subscriptions);
         when(subAdapter.getSubscription("subId")).thenReturn(subscription);
-        when(poolManager.lookupBySubscriptionId(owner, "subId")).thenReturn(pools);
+        when(poolManager.getBySubscriptionId(owner, "subId")).thenReturn(pools);
 
         Pool mainPool = TestUtil.copyFromSub(subscription);
         when(poolManager.convertToMasterPool(subscription)).thenReturn(mainPool);

--- a/server/src/test/java/org/candlepin/dto/api/v1/ConsumerTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/ConsumerTranslatorTest.java
@@ -157,10 +157,10 @@ public class ConsumerTranslatorTest extends
         }
         consumer.setGuestIds(guestIds);
 
-        when(mockConsumerTypeCurator.find(eq(ctype.getId()))).thenReturn(ctype);
+        when(mockConsumerTypeCurator.get(eq(ctype.getId()))).thenReturn(ctype);
         when(mockConsumerTypeCurator.getConsumerType(eq(consumer))).thenReturn(ctype);
 
-        when(mockEnvironmentCurator.find(eq(environment.getId()))).thenReturn(environment);
+        when(mockEnvironmentCurator.get(eq(environment.getId()))).thenReturn(environment);
         when(mockEnvironmentCurator.getConsumerEnvironment(eq(consumer))).thenReturn(environment);
 
         return consumer;

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/ConsumerTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/ConsumerTranslatorTest.java
@@ -75,7 +75,7 @@ public class ConsumerTranslatorTest extends
         consumer.setContentAccessMode("test_content_access_mode");
         consumer.setType(ctype);
 
-        when(mockConsumerTypeCurator.find(eq(ctype.getId()))).thenReturn(ctype);
+        when(mockConsumerTypeCurator.get(eq(ctype.getId()))).thenReturn(ctype);
         when(mockConsumerTypeCurator.getConsumerType(eq(consumer))).thenReturn(ctype);
 
         return consumer;

--- a/server/src/test/java/org/candlepin/dto/rules/v1/ConsumerTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/rules/v1/ConsumerTranslatorTest.java
@@ -103,7 +103,7 @@ public class ConsumerTranslatorTest extends
         }
         consumer.setCapabilities(capabilities);
 
-        when(mockConsumerTypeCurator.find(eq(ctype.getId()))).thenReturn(ctype);
+        when(mockConsumerTypeCurator.get(eq(ctype.getId()))).thenReturn(ctype);
         when(mockConsumerTypeCurator.getConsumerType(eq(consumer))).thenReturn(ctype);
 
         return consumer;

--- a/server/src/test/java/org/candlepin/model/CertificateTest.java
+++ b/server/src/test/java/org/candlepin/model/CertificateTest.java
@@ -64,7 +64,7 @@ public class CertificateTest extends DatabaseTestFixture {
 
         SubscriptionsCertificate certificate = createSubCert("key", "cert");
         certificateCurator.create(certificate);
-        SubscriptionsCertificate lookedUp = certificateCurator.find(certificate
+        SubscriptionsCertificate lookedUp = certificateCurator.get(certificate
             .getId());
 
         assertNotNull(lookedUp);

--- a/server/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
@@ -523,7 +523,7 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
         Date dt = ResourceDateParser.parseDateString("2011-09-26T18:10:50.184081+00:00");
         consumerCurator.updateLastCheckin(consumer, dt);
         consumerCurator.refresh(consumer);
-        consumer = consumerCurator.find(consumer.getId());
+        consumer = consumerCurator.get(consumer.getId());
 
         assertEquals(consumer.getLastCheckin().getTime(), dt.getTime());
     }

--- a/server/src/test/java/org/candlepin/model/ConsumerTest.java
+++ b/server/src/test/java/org/candlepin/model/ConsumerTest.java
@@ -106,7 +106,7 @@ public class ConsumerTest extends DatabaseTestFixture {
 
     @Test
     public void testLookup() throws Exception {
-        Consumer lookedUp = consumerCurator.find(consumer.getId());
+        Consumer lookedUp = consumerCurator.get(consumer.getId());
         assertEquals(consumer.getId(), lookedUp.getId());
         assertEquals(consumer.getName(), lookedUp.getName());
 
@@ -121,7 +121,7 @@ public class ConsumerTest extends DatabaseTestFixture {
     public void testSetInitialization() throws Exception {
         Consumer noFacts = new Consumer(CONSUMER_NAME, USER_NAME, owner, consumerType);
         consumerCurator.create(noFacts);
-        noFacts = consumerCurator.find(noFacts.getId());
+        noFacts = consumerCurator.get(noFacts.getId());
         assertNotNull(noFacts.getFacts());
         assertNotNull(noFacts.getInstalledProducts());
         assertNotNull(noFacts.getGuestIds());
@@ -129,7 +129,7 @@ public class ConsumerTest extends DatabaseTestFixture {
 
     @Test
     public void testInfo() {
-        Consumer lookedUp = consumerCurator.find(consumer.getId());
+        Consumer lookedUp = consumerCurator.get(consumer.getId());
         Map<String, String> metadata = lookedUp.getFacts();
         assertEquals(2, metadata.keySet().size());
         assertEquals("bar", metadata.get("foo"));
@@ -149,7 +149,7 @@ public class ConsumerTest extends DatabaseTestFixture {
 
         consumerResource.updateConsumer(consumer.getUuid(), newConsumer, mock(Principal.class));
 
-        Consumer lookedUp = consumerCurator.find(consumer.getId());
+        Consumer lookedUp = consumerCurator.get(consumer.getId());
         Date lookedUpDate = lookedUp.getUpdated();
         assertEquals("FACT_VALUE", lookedUp.getFact("FACT"));
 
@@ -163,7 +163,7 @@ public class ConsumerTest extends DatabaseTestFixture {
         consumer2.setFact("foo", "bar2");
         consumerCurator.create(consumer2);
 
-        Consumer lookedUp = consumerCurator.find(consumer.getId());
+        Consumer lookedUp = consumerCurator.get(consumer.getId());
         Map<String, String> metadata = lookedUp.getFacts();
         assertEquals(2, metadata.keySet().size());
         assertEquals("bar", metadata.get("foo"));
@@ -171,7 +171,7 @@ public class ConsumerTest extends DatabaseTestFixture {
         assertEquals("bar1", metadata.get("foo1"));
         assertEquals("bar1", lookedUp.getFacts().get("foo1"));
 
-        Consumer lookedUp2 = consumerCurator.find(consumer2.getId());
+        Consumer lookedUp2 = consumerCurator.get(consumer2.getId());
         metadata = lookedUp2.getFacts();
         assertEquals(1, metadata.keySet().size());
         assertEquals("bar2", metadata.get("foo"));
@@ -182,23 +182,23 @@ public class ConsumerTest extends DatabaseTestFixture {
         consumer.setFact("foo", "notbar");
         consumerCurator.merge(consumer);
 
-        Consumer lookedUp = consumerCurator.find(consumer.getId());
+        Consumer lookedUp = consumerCurator.get(consumer.getId());
         assertEquals("notbar", lookedUp.getFact("foo"));
     }
 
     @Test
     public void testRemoveConsumedProducts() {
-        consumerCurator.delete(consumerCurator.find(consumer.getId()));
-        assertNull(consumerCurator.find(consumer.getId()));
+        consumerCurator.delete(consumerCurator.get(consumer.getId()));
+        assertNull(consumerCurator.get(consumer.getId()));
     }
 
     @Test
-    public void testLookupByUuidNonExistent() {
+    public void testgetByUuidNonExistent() {
         consumerCurator.findByUuid("this is not a uuid!");
     }
 
     @Test
-    public void testLookupByUuid() {
+    public void testgetByUuid() {
         Consumer consumer2 = new Consumer("consumer2", USER_NAME, owner, consumerType);
         consumerCurator.create(consumer2);
 
@@ -229,7 +229,7 @@ public class ConsumerTest extends DatabaseTestFixture {
         consumer.addEntitlement(e3);
         consumerCurator.merge(consumer);
 
-        Consumer lookedUp = consumerCurator.find(consumer.getId());
+        Consumer lookedUp = consumerCurator.get(consumer.getId());
         assertEquals(3, lookedUp.getEntitlements().size());
     }
 
@@ -251,7 +251,7 @@ public class ConsumerTest extends DatabaseTestFixture {
 
         consumerCurator.delete(consumer);
 
-        assertNull(consumerCurator.find(consumer.getId()));
+        assertNull(consumerCurator.get(consumer.getId()));
     }
 
     @Test
@@ -426,7 +426,7 @@ public class ConsumerTest extends DatabaseTestFixture {
 
     @Test
     public void testInstalledProducts() throws Exception {
-        Consumer lookedUp = consumerCurator.find(consumer.getId());
+        Consumer lookedUp = consumerCurator.get(consumer.getId());
         lookedUp.addInstalledProduct(
             new ConsumerInstalledProduct("someproduct", "someproductname")
         );
@@ -434,29 +434,29 @@ public class ConsumerTest extends DatabaseTestFixture {
             new ConsumerInstalledProduct("someproduct2", "someproductname2")
         );
         consumerCurator.update(lookedUp);
-        lookedUp = consumerCurator.find(consumer.getId());
+        lookedUp = consumerCurator.get(consumer.getId());
         assertEquals(2, lookedUp.getInstalledProducts().size());
         ConsumerInstalledProduct installed = lookedUp.getInstalledProducts().
             iterator().next();
         lookedUp.getInstalledProducts().remove(installed);
         consumerCurator.update(lookedUp);
-        lookedUp = consumerCurator.find(consumer.getId());
+        lookedUp = consumerCurator.get(consumer.getId());
         assertEquals(1, lookedUp.getInstalledProducts().size());
     }
 
     @Test
     public void testGuests() throws Exception {
-        Consumer lookedUp = consumerCurator.find(consumer.getId());
+        Consumer lookedUp = consumerCurator.get(consumer.getId());
         lookedUp.addGuestId(new GuestId("guest1"));
         lookedUp.addGuestId(new GuestId("guest2"));
         consumerCurator.update(lookedUp);
-        lookedUp = consumerCurator.find(consumer.getId());
+        lookedUp = consumerCurator.get(consumer.getId());
         assertEquals(2, lookedUp.getGuestIds().size());
         GuestId installed = lookedUp.getGuestIds().
             iterator().next();
         lookedUp.getGuestIds().remove(installed);
         consumerCurator.update(lookedUp);
-        lookedUp = consumerCurator.find(consumer.getId());
+        lookedUp = consumerCurator.get(consumer.getId());
         assertEquals(1, lookedUp.getGuestIds().size());
     }
 

--- a/server/src/test/java/org/candlepin/model/ConsumerTypeCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ConsumerTypeCuratorTest.java
@@ -64,38 +64,38 @@ public class ConsumerTypeCuratorTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void testLookupByLabel() {
+    public void testgetByLabel() {
         String label = "test-label";
         ConsumerType ctype = this.createConsumerType(label, false);
 
-        ConsumerType test = this.consumerTypeCurator.lookupByLabel(label);
+        ConsumerType test = this.consumerTypeCurator.getByLabel(label);
         assertSame(ctype, test);
     }
 
     @Test
-    public void testLookupByLabelForBadLabel() {
+    public void testgetByLabelForBadLabel() {
         String label = "test-label";
         ConsumerType ctype = this.createConsumerType(label, false);
 
-        ConsumerType test = this.consumerTypeCurator.lookupByLabel("bad_label");
+        ConsumerType test = this.consumerTypeCurator.getByLabel("bad_label");
         assertNull(test);
     }
 
     @Test
-    public void testLookupByLabelExistingTypeWithCreation() {
+    public void testgetByLabelExistingTypeWithCreation() {
         String label = "test-label";
         ConsumerType ctype = this.createConsumerType(label, false);
 
-        ConsumerType test = this.consumerTypeCurator.lookupByLabel(label, true);
+        ConsumerType test = this.consumerTypeCurator.getByLabel(label, true);
         assertSame(ctype, test);
     }
 
     @Test
-    public void testLookupByLabelNewTypeWithCreation() {
+    public void testgetByLabelNewTypeWithCreation() {
         String label = "new-ctype";
         ConsumerType ctype = this.createConsumerType("test-type", true);
 
-        ConsumerType test = this.consumerTypeCurator.lookupByLabel(label, true);
+        ConsumerType test = this.consumerTypeCurator.getByLabel(label, true);
         assertNotNull(test);
         assertNotSame(ctype, test);
 
@@ -103,11 +103,11 @@ public class ConsumerTypeCuratorTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void testLookupByLabelNewTypeFromEnumWithCreation() {
+    public void testgetByLabelNewTypeFromEnumWithCreation() {
         ConsumerTypeEnum cte = ConsumerTypeEnum.CANDLEPIN;
         ConsumerType ctype = this.createConsumerType("test-type", true);
 
-        ConsumerType test = this.consumerTypeCurator.lookupByLabel(cte.getLabel(), true);
+        ConsumerType test = this.consumerTypeCurator.getByLabel(cte.getLabel(), true);
         assertNotNull(test);
         assertNotSame(ctype, test);
 
@@ -116,22 +116,22 @@ public class ConsumerTypeCuratorTest extends DatabaseTestFixture {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testLookupByLabelWithNullLabel() {
-        this.consumerTypeCurator.lookupByLabel(null);
+    public void testgetByLabelWithNullLabel() {
+        this.consumerTypeCurator.getByLabel(null);
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testLookupByLabelWithNullLabelAndCreation() {
-        this.consumerTypeCurator.lookupByLabel(null, true);
+    public void testgetByLabelWithNullLabelAndCreation() {
+        this.consumerTypeCurator.getByLabel(null, true);
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testLookupByLabelWithEmptyLabel() {
-        this.consumerTypeCurator.lookupByLabel("");
+    public void testgetByLabelWithEmptyLabel() {
+        this.consumerTypeCurator.getByLabel("");
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testLookupByLabelWithEmptyLabelAndCreation() {
-        this.consumerTypeCurator.lookupByLabel("", true);
+    public void testgetByLabelWithEmptyLabelAndCreation() {
+        this.consumerTypeCurator.getByLabel("", true);
     }
 }

--- a/server/src/test/java/org/candlepin/model/ContentTest.java
+++ b/server/src/test/java/org/candlepin/model/ContentTest.java
@@ -57,7 +57,7 @@ public class ContentTest extends DatabaseTestFixture {
 
         contentCurator.create(content);
 
-        Content lookedUp = contentCurator.find(content.getUuid());
+        Content lookedUp = contentCurator.get(content.getUuid());
         assertEquals(content.getContentUrl(), lookedUp.getContentUrl());
         assertThat(lookedUp.getModifiedProductIds(), hasItem("ProductB"));
         assertEquals(metadataExpire, lookedUp.getMetadataExpire());
@@ -73,7 +73,7 @@ public class ContentTest extends DatabaseTestFixture {
         content.setArches(arches);
         contentCurator.create(content);
 
-        Content lookedUp = contentCurator.find(content.getUuid());
+        Content lookedUp = contentCurator.get(content.getUuid());
         assertEquals(lookedUp.getArches(), arches);
     }
 

--- a/server/src/test/java/org/candlepin/model/EntitlementCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/EntitlementCuratorTest.java
@@ -153,7 +153,7 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
         this.getEntityManager().clear();
 
         beginTransaction();
-        c = consumerCurator.find(c.getId());
+        c = consumerCurator.get(c.getId());
         c.setOwner(owner);
         for (Entitlement ent : c.getEntitlements()) {
             ent.getPool().getEntitlements().remove(ent);

--- a/server/src/test/java/org/candlepin/model/EnvironmentContentCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/EnvironmentContentCuratorTest.java
@@ -50,13 +50,13 @@ public class EnvironmentContentCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void create() {
-        envContent = environmentContentCurator.lookupByEnvironmentAndContent(e, c.getId());
+        envContent = environmentContentCurator.getByEnvironmentAndContent(e, c.getId());
         assertNotNull(envContent);
 
-        e = environmentCurator.find(e.getId());
+        e = environmentCurator.get(e.getId());
         assertEquals(1, e.getEnvironmentContent().size());
 
-        assertEquals(1, environmentContentCurator.lookupByContent(owner, c.getId()).size());
+        assertEquals(1, environmentContentCurator.getByContent(owner, c.getId()).size());
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/model/EnvironmentCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/EnvironmentCuratorTest.java
@@ -48,7 +48,7 @@ public class EnvironmentCuratorTest extends DatabaseTestFixture {
     @Test
     public void create() {
         assertEquals(1, envCurator.listAll().list().size());
-        Environment e = envCurator.find("env1");
+        Environment e = envCurator.get("env1");
         assertEquals(owner, e.getOwner());
     }
 
@@ -115,9 +115,9 @@ public class EnvironmentCuratorTest extends DatabaseTestFixture {
         this.environmentCurator.evict(environment1);
         this.environmentCurator.evict(environment2);
         this.environmentCurator.evict(environment3);
-        environment1 = this.environmentCurator.find(environment1.getId());
-        environment2 = this.environmentCurator.find(environment2.getId());
-        environment3 = this.environmentCurator.find(environment3.getId());
+        environment1 = this.environmentCurator.get(environment1.getId());
+        environment2 = this.environmentCurator.get(environment2.getId());
+        environment3 = this.environmentCurator.get(environment3.getId());
 
         assertNull(environment1);
         assertNull(environment2);

--- a/server/src/test/java/org/candlepin/model/EventCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/EventCuratorTest.java
@@ -55,7 +55,7 @@ public class EventCuratorTest extends DatabaseTestFixture {
         Event event = eventFactory.consumerCreated(newConsumer);
         eventCurator.create(event);
 
-        Event lookedUp = eventCurator.find(event.getId());
+        Event lookedUp = eventCurator.get(event.getId());
         assertEquals(Type.CREATED, lookedUp.getType());
         assertNotNull(lookedUp.getId());
     }

--- a/server/src/test/java/org/candlepin/model/ExporterMetadataCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ExporterMetadataCuratorTest.java
@@ -51,22 +51,22 @@ public class ExporterMetadataCuratorTest extends DatabaseTestFixture {
         em.setExported(new Date());
         assertNull(em.getId());
         ExporterMetadata emdb = emc.create(em);
-        ExporterMetadata emfound = emc.find(emdb.getId());
+        ExporterMetadata emfound = emc.get(emdb.getId());
         assertNotNull(emfound);
         assertNotNull(emfound.getId());
         assertEquals(emdb.getId(), emfound.getId());
     }
 
     @Test
-    public void lookupByType() {
+    public void getByType() {
         ExporterMetadata em = new ExporterMetadata();
         em.setType(ExporterMetadata.TYPE_SYSTEM);
         em.setExported(new Date());
         assertNull(em.getId());
         ExporterMetadata emdb = emc.create(em);
 
-        assertNull(emc.lookupByType(ExporterMetadata.TYPE_PER_USER));
-        assertEquals(emdb, emc.lookupByType(ExporterMetadata.TYPE_SYSTEM));
+        assertNull(emc.getByType(ExporterMetadata.TYPE_PER_USER));
+        assertEquals(emdb, emc.getByType(ExporterMetadata.TYPE_SYSTEM));
     }
 
     @Test
@@ -82,7 +82,7 @@ public class ExporterMetadataCuratorTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void lookupByTypeAndOwner() {
+    public void getByTypeAndOwner() {
         ExporterMetadata em = new ExporterMetadata();
         Owner owner = createOwner();
         em.setType(ExporterMetadata.TYPE_PER_USER);
@@ -90,7 +90,7 @@ public class ExporterMetadataCuratorTest extends DatabaseTestFixture {
         em.setOwner(owner);
         ExporterMetadata emdb = emc.create(em);
 
-        assertEquals(emdb, emc.lookupByTypeAndOwner(
+        assertEquals(emdb, emc.getByTypeAndOwner(
             ExporterMetadata.TYPE_PER_USER, owner));
     }
 }

--- a/server/src/test/java/org/candlepin/model/OwnerAccessControlTest.java
+++ b/server/src/test/java/org/candlepin/model/OwnerAccessControlTest.java
@@ -56,7 +56,7 @@ public class OwnerAccessControlTest extends DatabaseTestFixture {
         dto = resource.createOwner(dto);
 
         assertNotNull(dto.getId());
-        assertNotNull(ownerCurator.find(dto.getId()));
+        assertNotNull(ownerCurator.get(dto.getId()));
     }
 
     @Test(expected = ForbiddenException.class)

--- a/server/src/test/java/org/candlepin/model/OwnerContentCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/OwnerContentCuratorTest.java
@@ -538,8 +538,8 @@ public class OwnerContentCuratorTest extends DatabaseTestFixture {
 
         this.environmentCurator.evict(environment1);
         this.environmentCurator.evict(environment2);
-        environment1 = this.environmentCurator.find(environment1.getId());
-        environment2 = this.environmentCurator.find(environment2.getId());
+        environment1 = this.environmentCurator.get(environment1.getId());
+        environment2 = this.environmentCurator.get(environment2.getId());
 
         assertEquals(1, environment1.getEnvironmentContent().size());
         assertEquals(1, environment2.getEnvironmentContent().size());
@@ -576,8 +576,8 @@ public class OwnerContentCuratorTest extends DatabaseTestFixture {
 
         this.environmentCurator.evict(environment1);
         this.environmentCurator.evict(environment2);
-        environment1 = this.environmentCurator.find(environment1.getId());
-        environment2 = this.environmentCurator.find(environment2.getId());
+        environment1 = this.environmentCurator.get(environment1.getId());
+        environment2 = this.environmentCurator.get(environment2.getId());
 
         assertEquals(0, environment1.getEnvironmentContent().size());
         assertEquals(1, environment2.getEnvironmentContent().size());

--- a/server/src/test/java/org/candlepin/model/OwnerCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/OwnerCuratorTest.java
@@ -46,7 +46,7 @@ public class OwnerCuratorTest extends DatabaseTestFixture {
 
         this.ownerCurator.replicate(owner);
 
-        assertEquals("testing", this.ownerCurator.find("testing-primary-key").getKey());
+        assertEquals("testing", this.ownerCurator.get("testing-primary-key").getKey());
     }
 
     @Test(expected = RollbackException.class)
@@ -88,7 +88,7 @@ public class OwnerCuratorTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void testLookupMultipleOwnersByMultipleActiveProducts() {
+    public void testGetMultipleOwnersByMultipleActiveProducts() {
         Owner owner = createOwner();
         Owner owner2 = createOwner();
 
@@ -103,13 +103,13 @@ public class OwnerCuratorTest extends DatabaseTestFixture {
         List<String> productIds = new ArrayList<>();
         productIds.add(provided.getId());
         productIds.add(provided2.getId());
-        List<Owner> results = ownerCurator.lookupOwnersByActiveProduct(productIds).list();
+        List<Owner> results = ownerCurator.getOwnersByActiveProduct(productIds).list();
 
         assertEquals(2, results.size());
     }
 
     @Test
-    public void testLookupOwnerByActiveProduct() {
+    public void testGetOwnerByActiveProduct() {
         Owner owner = createOwner();
 
         Product product = this.createProduct(owner);
@@ -119,14 +119,14 @@ public class OwnerCuratorTest extends DatabaseTestFixture {
 
         List<String> productIds = new ArrayList<>();
         productIds.add(provided.getId());
-        List<Owner> results = ownerCurator.lookupOwnersByActiveProduct(productIds).list();
+        List<Owner> results = ownerCurator.getOwnersByActiveProduct(productIds).list();
 
         assertEquals(1, results.size());
         assertEquals(owner, results.get(0));
     }
 
     @Test
-    public void testLookupOwnersByActiveProductWithExpiredEntitlements() {
+    public void testGetOwnersByActiveProductWithExpiredEntitlements() {
         Owner owner = createOwner();
 
         Product product = this.createProduct(owner);
@@ -159,13 +159,13 @@ public class OwnerCuratorTest extends DatabaseTestFixture {
 
         List<String> productIds = new ArrayList<>();
         productIds.add(provided.getId());
-        List<Owner> results = ownerCurator.lookupOwnersByActiveProduct(productIds).list();
+        List<Owner> results = ownerCurator.getOwnersByActiveProduct(productIds).list();
 
         assertTrue(results.isEmpty());
     }
 
     @Test
-    public void lookupByUpstreamUuid() {
+    public void getByUpstreamUuid() {
         Owner owner = new Owner("owner1");
         // setup some data
         owner = ownerCurator.create(owner);
@@ -176,7 +176,7 @@ public class OwnerCuratorTest extends DatabaseTestFixture {
         ownerCurator.merge(owner);
 
         // ok let's see if this works
-        Owner found = ownerCurator.lookupWithUpstreamUuid("someuuid");
+        Owner found = ownerCurator.getByUpstreamUuid("someuuid");
 
         // verify all is well in the world
         assertNotNull(found);
@@ -269,28 +269,28 @@ public class OwnerCuratorTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void lookupOwnersWithProduct() {
+    public void testGetOwnersWithProducts() {
         List<Owner> owners = this.setupDBForLookupOwnersForProductTests();
         Owner owner1 = owners.get(0);
         Owner owner2 = owners.get(1);
         Owner owner3 = owners.get(2);
 
-        owners = this.ownerCurator.lookupOwnersWithProduct(Arrays.asList("p4")).list();
+        owners = this.ownerCurator.getOwnersWithProducts(Arrays.asList("p4")).list();
         assertEquals(Arrays.asList(owner1), owners);
 
-        owners = this.ownerCurator.lookupOwnersWithProduct(Arrays.asList("p5d")).list();
+        owners = this.ownerCurator.getOwnersWithProducts(Arrays.asList("p5d")).list();
         assertEquals(Arrays.asList(owner2), owners);
 
-        owners = this.ownerCurator.lookupOwnersWithProduct(Arrays.asList("p1")).list();
+        owners = this.ownerCurator.getOwnersWithProducts(Arrays.asList("p1")).list();
         assertEquals(Arrays.asList(owner1, owner2, owner3), owners);
 
-        owners = this.ownerCurator.lookupOwnersWithProduct(Arrays.asList("p3")).list();
+        owners = this.ownerCurator.getOwnersWithProducts(Arrays.asList("p3")).list();
         assertEquals(Arrays.asList(owner2, owner3), owners);
 
-        owners = this.ownerCurator.lookupOwnersWithProduct(Arrays.asList("p4", "p6")).list();
+        owners = this.ownerCurator.getOwnersWithProducts(Arrays.asList("p4", "p6")).list();
         assertEquals(Arrays.asList(owner1, owner3), owners);
 
-        owners = this.ownerCurator.lookupOwnersWithProduct(Arrays.asList("nope")).list();
+        owners = this.ownerCurator.getOwnersWithProducts(Arrays.asList("nope")).list();
         assertEquals(0, owners.size());
     }
 }

--- a/server/src/test/java/org/candlepin/model/OwnerInfoCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/OwnerInfoCuratorTest.java
@@ -65,7 +65,7 @@ public class OwnerInfoCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void testOwnerInfoNoConsumers() {
-        OwnerInfo info = ownerInfoCurator.lookupByOwner(owner);
+        OwnerInfo info = ownerInfoCurator.getByOwner(owner);
 
         Map<String, Integer> expectedConsumers = new HashMap<String, Integer>() {
             {
@@ -88,11 +88,11 @@ public class OwnerInfoCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void testOwnerInfoOneSystemNoEntitlements() {
-        ConsumerType type = consumerTypeCurator.lookupByLabel("system");
+        ConsumerType type = consumerTypeCurator.getByLabel("system");
         Consumer consumer = new Consumer("test-consumer", "test-user", owner, type);
         consumerCurator.create(consumer);
 
-        OwnerInfo info = ownerInfoCurator.lookupByOwner(owner);
+        OwnerInfo info = ownerInfoCurator.getByOwner(owner);
 
         Map<String, Integer> expectedConsumers = new HashMap<String, Integer>() {
             {
@@ -115,7 +115,7 @@ public class OwnerInfoCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void testOwnerInfoOneSystemEntitlement() {
-        ConsumerType type = consumerTypeCurator.lookupByLabel("system");
+        ConsumerType type = consumerTypeCurator.getByLabel("system");
         Consumer consumer = new Consumer("test-consumer", "test-user", owner, type);
         consumerCurator.create(consumer);
 
@@ -124,7 +124,7 @@ public class OwnerInfoCuratorTest extends DatabaseTestFixture {
         entitlement.setQuantity(1);
         entitlementCurator.create(entitlement);
 
-        OwnerInfo info = ownerInfoCurator.lookupByOwner(owner);
+        OwnerInfo info = ownerInfoCurator.getByOwner(owner);
 
         Map<String, Integer> expectedConsumers = new HashMap<String, Integer>() {
             {
@@ -147,7 +147,7 @@ public class OwnerInfoCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void testOwnerInfoOneSystemEntitlementWithQuantityOfTwo() {
-        ConsumerType type = consumerTypeCurator.lookupByLabel("system");
+        ConsumerType type = consumerTypeCurator.getByLabel("system");
         Consumer consumer = new Consumer("test-consumer", "test-user", owner, type);
         consumerCurator.create(consumer);
 
@@ -156,7 +156,7 @@ public class OwnerInfoCuratorTest extends DatabaseTestFixture {
         entitlement.setQuantity(2);
         entitlementCurator.create(entitlement);
 
-        OwnerInfo info = ownerInfoCurator.lookupByOwner(owner);
+        OwnerInfo info = ownerInfoCurator.getByOwner(owner);
 
         Map<String, Integer> expectedConsumers = new HashMap<String, Integer>() {
             {
@@ -179,7 +179,7 @@ public class OwnerInfoCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void testOwnerInfoOneOfEachEntitlement() {
-        ConsumerType type = consumerTypeCurator.lookupByLabel("system");
+        ConsumerType type = consumerTypeCurator.getByLabel("system");
         Consumer consumer = new Consumer("test-consumer", "test-user", owner, type);
         consumerCurator.create(consumer);
         EntitlementCertificate cert = createEntitlementCertificate("fake", "fake");
@@ -187,7 +187,7 @@ public class OwnerInfoCuratorTest extends DatabaseTestFixture {
         entitlement.setQuantity(1);
         entitlementCurator.create(entitlement);
 
-        type = consumerTypeCurator.lookupByLabel("domain");
+        type = consumerTypeCurator.getByLabel("domain");
         consumer = new Consumer("test-consumer", "test-user", owner, type);
         consumerCurator.create(consumer);
 
@@ -196,7 +196,7 @@ public class OwnerInfoCuratorTest extends DatabaseTestFixture {
         entitlement.setQuantity(1);
         entitlementCurator.create(entitlement);
 
-        OwnerInfo info = ownerInfoCurator.lookupByOwner(owner);
+        OwnerInfo info = ownerInfoCurator.getByOwner(owner);
 
         Map<String, Integer> expectedConsumers = new HashMap<String, Integer>() {
             {
@@ -219,12 +219,12 @@ public class OwnerInfoCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void testOwnerPoolEntitlementCountPoolOnly() {
-        ConsumerType type = consumerTypeCurator.lookupByLabel("domain");
+        ConsumerType type = consumerTypeCurator.getByLabel("domain");
         pool1.setAttribute(Pool.Attributes.REQUIRES_CONSUMER_TYPE, type.getLabel());
         owner.addEntitlementPool(pool1);
         this.poolCurator.merge(pool1);
 
-        OwnerInfo info = ownerInfoCurator.lookupByOwner(owner);
+        OwnerInfo info = ownerInfoCurator.getByOwner(owner);
 
         Map<String, Integer> expectedPoolCount = new HashMap<String, Integer>() {
             {
@@ -240,11 +240,11 @@ public class OwnerInfoCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void testOwnerPoolEntitlementCountProductOnly() {
-        ConsumerType type = consumerTypeCurator.lookupByLabel("system");
+        ConsumerType type = consumerTypeCurator.getByLabel("system");
         pool1.getProduct().setAttribute(Pool.Attributes.REQUIRES_CONSUMER_TYPE, type.getLabel());
         owner.addEntitlementPool(pool1);
 
-        OwnerInfo info = ownerInfoCurator.lookupByOwner(owner);
+        OwnerInfo info = ownerInfoCurator.getByOwner(owner);
 
         Map<String, Integer> expectedPoolCount = new HashMap<String, Integer>() {
             {
@@ -259,14 +259,14 @@ public class OwnerInfoCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void testOwnerPoolEntitlementPoolOverridesProduct() {
-        ConsumerType type = consumerTypeCurator.lookupByLabel("domain");
-        ConsumerType type2 = consumerTypeCurator.lookupByLabel("system");
+        ConsumerType type = consumerTypeCurator.getByLabel("domain");
+        ConsumerType type2 = consumerTypeCurator.getByLabel("system");
         pool1.setAttribute(Pool.Attributes.REQUIRES_CONSUMER_TYPE, type.getLabel());
         pool1.getProduct().setAttribute(Pool.Attributes.REQUIRES_CONSUMER_TYPE, type2.getLabel());
         owner.addEntitlementPool(pool1);
         this.poolCurator.merge(pool1);
 
-        OwnerInfo info = ownerInfoCurator.lookupByOwner(owner);
+        OwnerInfo info = ownerInfoCurator.getByOwner(owner);
 
         Map<String, Integer> expectedPoolCount = new HashMap<String, Integer>() {
             {
@@ -281,13 +281,13 @@ public class OwnerInfoCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void testConsumerTypeCountByPoolExcludesFuturePools() {
-        ConsumerType type = consumerTypeCurator.lookupByLabel("system");
+        ConsumerType type = consumerTypeCurator.getByLabel("system");
         pool1.setAttribute(Pool.Attributes.REQUIRES_CONSUMER_TYPE, type.getLabel());
         pool1.setStartDate(Util.tomorrow());
         owner.addEntitlementPool(pool1);
         this.poolCurator.merge(pool1);
 
-        OwnerInfo info = ownerInfoCurator.lookupByOwner(owner);
+        OwnerInfo info = ownerInfoCurator.getByOwner(owner);
 
         Map<String, Integer> expectedPoolCount = new HashMap<String, Integer>() {
             {
@@ -302,13 +302,13 @@ public class OwnerInfoCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void testConsumerTypeCountByPoolExcludesExpiredPools() {
-        ConsumerType type = consumerTypeCurator.lookupByLabel("system");
+        ConsumerType type = consumerTypeCurator.getByLabel("system");
         pool1.setAttribute(Pool.Attributes.REQUIRES_CONSUMER_TYPE, type.getLabel());
         pool1.setEndDate(Util.yesterday());
         owner.addEntitlementPool(pool1);
         this.poolCurator.merge(pool1);
 
-        OwnerInfo info = ownerInfoCurator.lookupByOwner(owner);
+        OwnerInfo info = ownerInfoCurator.getByOwner(owner);
 
         Map<String, Integer> expectedPoolCount = new HashMap<String, Integer>() {
             {
@@ -326,7 +326,7 @@ public class OwnerInfoCuratorTest extends DatabaseTestFixture {
     public void testConsumerTypeCountByPoolPutsDefaultsIntoSystem() {
         owner.addEntitlementPool(pool1);
 
-        OwnerInfo info = ownerInfoCurator.lookupByOwner(owner);
+        OwnerInfo info = ownerInfoCurator.getByOwner(owner);
 
         Map<String, Integer> expectedPoolCount = new HashMap<String, Integer>() {
             {
@@ -341,12 +341,12 @@ public class OwnerInfoCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void testOwnerPoolEnabledCountPoolOnly() {
-        ConsumerType type = consumerTypeCurator.lookupByLabel("domain");
+        ConsumerType type = consumerTypeCurator.getByLabel("domain");
         pool1.setAttribute(Pool.Attributes.ENABLED_CONSUMER_TYPES, type.getLabel());
         owner.addEntitlementPool(pool1);
         this.poolCurator.merge(pool1);
 
-        OwnerInfo info = ownerInfoCurator.lookupByOwner(owner);
+        OwnerInfo info = ownerInfoCurator.getByOwner(owner);
 
         Map<String, Integer> expectedPoolCount = new HashMap<String, Integer>() {
             {
@@ -359,12 +359,12 @@ public class OwnerInfoCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void testOwnerPoolEnabledCountProductOnly() {
-        ConsumerType type = consumerTypeCurator.lookupByLabel("system");
+        ConsumerType type = consumerTypeCurator.getByLabel("system");
         pool1.getProduct().setAttribute(Pool.Attributes.ENABLED_CONSUMER_TYPES, type.getLabel());
         owner.addEntitlementPool(pool1);
         this.poolCurator.merge(pool1);
 
-        OwnerInfo info = ownerInfoCurator.lookupByOwner(owner);
+        OwnerInfo info = ownerInfoCurator.getByOwner(owner);
 
         Map<String, Integer> expectedPoolCount = new HashMap<String, Integer>() {
             {
@@ -377,14 +377,14 @@ public class OwnerInfoCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void testOwnerPoolEnabledPoolOverridesProduct() {
-        ConsumerType type = consumerTypeCurator.lookupByLabel("domain");
-        ConsumerType type2 = consumerTypeCurator.lookupByLabel("system");
+        ConsumerType type = consumerTypeCurator.getByLabel("domain");
+        ConsumerType type2 = consumerTypeCurator.getByLabel("system");
         pool1.setAttribute(Pool.Attributes.ENABLED_CONSUMER_TYPES, type.getLabel());
         pool1.getProduct().setAttribute(Pool.Attributes.ENABLED_CONSUMER_TYPES, type2.getLabel());
         owner.addEntitlementPool(pool1);
         this.poolCurator.merge(pool1);
 
-        OwnerInfo info = ownerInfoCurator.lookupByOwner(owner);
+        OwnerInfo info = ownerInfoCurator.getByOwner(owner);
 
         Map<String, Integer> expectedPoolCount = new HashMap<String, Integer>() {
             {
@@ -397,12 +397,12 @@ public class OwnerInfoCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void testEnabledConsumerTypeCountByPoolExcludesFuturePools() {
-        ConsumerType type = consumerTypeCurator.lookupByLabel("system");
+        ConsumerType type = consumerTypeCurator.getByLabel("system");
         pool1.setAttribute(Pool.Attributes.ENABLED_CONSUMER_TYPES, type.getLabel());
         pool1.setStartDate(Util.tomorrow());
         owner.addEntitlementPool(pool1);
 
-        OwnerInfo info = ownerInfoCurator.lookupByOwner(owner);
+        OwnerInfo info = ownerInfoCurator.getByOwner(owner);
 
         Map<String, Integer> expectedPoolCount = new HashMap<>();
 
@@ -411,12 +411,12 @@ public class OwnerInfoCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void testEnabledConsumerTypeCountByPoolExcludesExpiredPools() {
-        ConsumerType type = consumerTypeCurator.lookupByLabel("system");
+        ConsumerType type = consumerTypeCurator.getByLabel("system");
         pool1.setAttribute(Pool.Attributes.ENABLED_CONSUMER_TYPES, type.getLabel());
         pool1.setEndDate(Util.yesterday());
         owner.addEntitlementPool(pool1);
 
-        OwnerInfo info = ownerInfoCurator.lookupByOwner(owner);
+        OwnerInfo info = ownerInfoCurator.getByOwner(owner);
 
         Map<String, Integer> expectedPoolCount = new HashMap<>();
 
@@ -425,13 +425,13 @@ public class OwnerInfoCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void testOwnerPoolMultiEnabledCount() {
-        ConsumerType type1 = consumerTypeCurator.lookupByLabel("domain");
-        ConsumerType type2 = consumerTypeCurator.lookupByLabel("system");
+        ConsumerType type1 = consumerTypeCurator.getByLabel("domain");
+        ConsumerType type2 = consumerTypeCurator.getByLabel("system");
         pool1.setAttribute(Pool.Attributes.ENABLED_CONSUMER_TYPES, type1.getLabel() + "," + type2.getLabel());
         owner.addEntitlementPool(pool1);
         this.poolCurator.merge(pool1);
 
-        OwnerInfo info = ownerInfoCurator.lookupByOwner(owner);
+        OwnerInfo info = ownerInfoCurator.getByOwner(owner);
 
         Map<String, Integer> expectedPoolCount = new HashMap<String, Integer>() {
             {
@@ -448,7 +448,7 @@ public class OwnerInfoCuratorTest extends DatabaseTestFixture {
         pool1.setAttribute(Pool.Attributes.ENABLED_CONSUMER_TYPES, "non-type");
         owner.addEntitlementPool(pool1);
 
-        OwnerInfo info = ownerInfoCurator.lookupByOwner(owner);
+        OwnerInfo info = ownerInfoCurator.getByOwner(owner);
 
         Map<String, Integer> expectedPoolCount = new HashMap<>();
 
@@ -459,7 +459,7 @@ public class OwnerInfoCuratorTest extends DatabaseTestFixture {
     public void testOwnerInfoEntitlementsConsumedByFamilyPutsFamilylessInNone() {
         owner.addEntitlementPool(pool1);
 
-        ConsumerType type = consumerTypeCurator.lookupByLabel("system");
+        ConsumerType type = consumerTypeCurator.getByLabel("system");
         Consumer consumer = new Consumer("test-consumer", "test-user", owner, type);
         consumerCurator.create(consumer);
 
@@ -469,7 +469,7 @@ public class OwnerInfoCuratorTest extends DatabaseTestFixture {
         entitlementCurator.create(entitlement);
         pool1.getEntitlements().add(entitlement);
 
-        OwnerInfo info = ownerInfoCurator.lookupByOwner(owner);
+        OwnerInfo info = ownerInfoCurator.getByOwner(owner);
 
         Map<String, OwnerInfo.ConsumptionTypeCounts> expected =
             new HashMap<String, OwnerInfo.ConsumptionTypeCounts>() {
@@ -488,7 +488,7 @@ public class OwnerInfoCuratorTest extends DatabaseTestFixture {
         pool1.setAttribute(Pool.Attributes.PRODUCT_FAMILY, "test family");
         pool1.getProduct().setAttribute(Pool.Attributes.PRODUCT_FAMILY, "bad test family");
 
-        ConsumerType type = consumerTypeCurator.lookupByLabel("system");
+        ConsumerType type = consumerTypeCurator.getByLabel("system");
         Consumer consumer = new Consumer("test-consumer", "test-user", owner, type);
         consumerCurator.create(consumer);
 
@@ -498,7 +498,7 @@ public class OwnerInfoCuratorTest extends DatabaseTestFixture {
         entitlementCurator.create(entitlement);
         pool1.getEntitlements().add(entitlement);
 
-        OwnerInfo info = ownerInfoCurator.lookupByOwner(owner);
+        OwnerInfo info = ownerInfoCurator.getByOwner(owner);
 
         Map<String, OwnerInfo.ConsumptionTypeCounts> expected =
             new HashMap<String, OwnerInfo.ConsumptionTypeCounts>() {
@@ -516,7 +516,7 @@ public class OwnerInfoCuratorTest extends DatabaseTestFixture {
 
         pool1.getProduct().setAttribute(Pool.Attributes.PRODUCT_FAMILY, "test family");
 
-        ConsumerType type = consumerTypeCurator.lookupByLabel("system");
+        ConsumerType type = consumerTypeCurator.getByLabel("system");
         Consumer consumer = new Consumer("test-consumer", "test-user", owner, type);
         consumerCurator.create(consumer);
 
@@ -526,7 +526,7 @@ public class OwnerInfoCuratorTest extends DatabaseTestFixture {
         entitlementCurator.create(entitlement);
         pool1.getEntitlements().add(entitlement);
 
-        OwnerInfo info = ownerInfoCurator.lookupByOwner(owner);
+        OwnerInfo info = ownerInfoCurator.getByOwner(owner);
 
         Map<String, OwnerInfo.ConsumptionTypeCounts> expected =
             new HashMap<String, OwnerInfo.ConsumptionTypeCounts>() {
@@ -545,7 +545,7 @@ public class OwnerInfoCuratorTest extends DatabaseTestFixture {
 
         pool1.getProduct().setAttribute(Pool.Attributes.VIRT_ONLY, "true");
 
-        ConsumerType type = consumerTypeCurator.lookupByLabel("system");
+        ConsumerType type = consumerTypeCurator.getByLabel("system");
         Consumer consumer = new Consumer("test-consumer", "test-user", owner, type);
         consumerCurator.create(consumer);
 
@@ -555,7 +555,7 @@ public class OwnerInfoCuratorTest extends DatabaseTestFixture {
         entitlementCurator.create(entitlement);
         pool1.getEntitlements().add(entitlement);
 
-        OwnerInfo info = ownerInfoCurator.lookupByOwner(owner);
+        OwnerInfo info = ownerInfoCurator.getByOwner(owner);
 
         Map<String, OwnerInfo.ConsumptionTypeCounts> expected =
             new HashMap<String, OwnerInfo.ConsumptionTypeCounts>() {
@@ -575,7 +575,7 @@ public class OwnerInfoCuratorTest extends DatabaseTestFixture {
         pool1.getProduct().setAttribute(Pool.Attributes.PRODUCT_FAMILY, "test family");
         pool1.getProduct().setAttribute(Pool.Attributes.VIRT_ONLY, "true");
 
-        ConsumerType type = consumerTypeCurator.lookupByLabel("system");
+        ConsumerType type = consumerTypeCurator.getByLabel("system");
         Consumer consumer = new Consumer("test-consumer", "test-user", owner, type);
         consumerCurator.create(consumer);
 
@@ -585,7 +585,7 @@ public class OwnerInfoCuratorTest extends DatabaseTestFixture {
         entitlementCurator.create(entitlement);
         pool1.getEntitlements().add(entitlement);
 
-        OwnerInfo info = ownerInfoCurator.lookupByOwner(owner);
+        OwnerInfo info = ownerInfoCurator.getByOwner(owner);
 
         Map<String, OwnerInfo.ConsumptionTypeCounts> expected =
             new HashMap<String, OwnerInfo.ConsumptionTypeCounts>() {
@@ -599,7 +599,7 @@ public class OwnerInfoCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void testConsumerGuestCount() {
-        ConsumerType type = consumerTypeCurator.lookupByLabel("system");
+        ConsumerType type = consumerTypeCurator.getByLabel("system");
         Consumer guest1 = new Consumer("test-consumer", "test-user", owner, type);
         guest1.setFact("virt.is_guest", "true");
         consumerCurator.create(guest1);
@@ -616,7 +616,7 @@ public class OwnerInfoCuratorTest extends DatabaseTestFixture {
         Consumer physical2 = new Consumer("test-consumer2", "test-user", owner, type);
         consumerCurator.create(physical2);
 
-        OwnerInfo info = ownerInfoCurator.lookupByOwner(owner);
+        OwnerInfo info = ownerInfoCurator.getByOwner(owner);
         assertEquals((Integer) 2, info.getConsumerGuestCounts().get(OwnerInfo.GUEST));
         assertEquals((Integer) 2, info.getConsumerGuestCounts().get(OwnerInfo.PHYSICAL));
 
@@ -624,7 +624,7 @@ public class OwnerInfoCuratorTest extends DatabaseTestFixture {
         // Create another owner to make sure we don't see another owners consumers:
         Owner anotherOwner = createOwner();
         ownerCurator.create(anotherOwner);
-        info = ownerInfoCurator.lookupByOwner(anotherOwner);
+        info = ownerInfoCurator.getByOwner(anotherOwner);
         assertEquals((Integer) 0, info.getConsumerGuestCounts().get(OwnerInfo.GUEST));
         assertEquals((Integer) 0, info.getConsumerGuestCounts().get(OwnerInfo.PHYSICAL));
     }
@@ -633,7 +633,7 @@ public class OwnerInfoCuratorTest extends DatabaseTestFixture {
     public void testConsumerCountsByEntitlementStatus() {
         setupConsumerCountTest("test-user");
 
-        OwnerInfo info = ownerInfoCurator.lookupByOwner(owner);
+        OwnerInfo info = ownerInfoCurator.getByOwner(owner);
         assertConsumerCountsByEntitlementStatus(info);
     }
 
@@ -645,7 +645,7 @@ public class OwnerInfoCuratorTest extends DatabaseTestFixture {
 
         // Should only get the counts for a single setup case above.
         // The test-user consumers should be ignored.
-        OwnerInfo info = ownerInfoCurator.lookupByOwner(owner);
+        OwnerInfo info = ownerInfoCurator.getByOwner(owner);
         assertConsumerCountsByEntitlementStatus(info);
     }
 
@@ -653,7 +653,7 @@ public class OwnerInfoCuratorTest extends DatabaseTestFixture {
     public void testPermissionsAppliedForConsumerCounts() {
         User mySystemsUser = setupOnlyMyConsumersPrincipal();
 
-        ConsumerType type = consumerTypeCurator.lookupByLabel("system");
+        ConsumerType type = consumerTypeCurator.getByLabel("system");
         Consumer consumer = new Consumer("my-system-1", mySystemsUser.getUsername(),
             owner, type);
         consumerCurator.create(consumer);
@@ -661,7 +661,7 @@ public class OwnerInfoCuratorTest extends DatabaseTestFixture {
         consumer = new Consumer("not-my-system", "another-user", owner, type);
         consumerCurator.create(consumer);
 
-        OwnerInfo info = ownerInfoCurator.lookupByOwner(owner);
+        OwnerInfo info = ownerInfoCurator.getByOwner(owner);
 
         Map<String, Integer> expectedConsumers = new HashMap<String, Integer>() {
             {
@@ -678,7 +678,7 @@ public class OwnerInfoCuratorTest extends DatabaseTestFixture {
     public void testPermissionsAppliedForConsumerTypeEntitlementEntitlementsConsumedByType() {
         User mySystemsUser = setupOnlyMyConsumersPrincipal();
 
-        ConsumerType type = consumerTypeCurator.lookupByLabel("system");
+        ConsumerType type = consumerTypeCurator.getByLabel("system");
         Consumer consumer = new Consumer("my-system-1", mySystemsUser.getUsername(),
             owner, type);
         consumerCurator.create(consumer);
@@ -700,7 +700,7 @@ public class OwnerInfoCuratorTest extends DatabaseTestFixture {
         entitlementCurator.create(otherEntitlement);
         consumerCurator.merge(consumer);
 
-        OwnerInfo info = ownerInfoCurator.lookupByOwner(owner);
+        OwnerInfo info = ownerInfoCurator.getByOwner(owner);
 
         Map<String, Integer> expectedConsumers = new HashMap<String, Integer>() {
             {
@@ -723,7 +723,7 @@ public class OwnerInfoCuratorTest extends DatabaseTestFixture {
     }
 
     private void setupConsumerCountTest(String username) {
-        ConsumerType systemType = consumerTypeCurator.lookupByLabel("system");
+        ConsumerType systemType = consumerTypeCurator.getByLabel("system");
         Consumer consumer1 = new Consumer("test-consumer1", username, owner, systemType);
         consumer1.setEntitlementStatus(ComplianceStatus.GREEN);
         consumerCurator.create(consumer1);

--- a/server/src/test/java/org/candlepin/model/OwnerTest.java
+++ b/server/src/test/java/org/candlepin/model/OwnerTest.java
@@ -102,7 +102,7 @@ public class OwnerTest extends DatabaseTestFixture {
 
         assertEquals(2, o.getConsumers().size());
 
-        Owner lookedUp = ownerCurator.find(o.getId());
+        Owner lookedUp = ownerCurator.get(o.getId());
         assertEquals(2, lookedUp.getConsumers().size());
     }
 

--- a/server/src/test/java/org/candlepin/model/PoolCuratorEntitlementRulesTest.java
+++ b/server/src/test/java/org/candlepin/model/PoolCuratorEntitlementRulesTest.java
@@ -85,7 +85,7 @@ public class PoolCuratorEntitlementRulesTest extends DatabaseTestFixture {
         poolQuantities.put(consumerPool.getId(), 1);
         anotherEntitler.entitleByPools(consumer, poolQuantities);
 
-        assertFalse(poolCurator.find(consumerPool.getId()).entitlementsAvailable(1));
+        assertFalse(poolCurator.get(consumerPool.getId()).entitlementsAvailable(1));
     }
 
     @Test(expected = EntitlementRefusedException.class)

--- a/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
@@ -535,7 +535,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         Pool pool = createPool(owner, p, 25L,
             TestUtil.createDate(1999, 1, 10), TestUtil.createDate(2099, 1, 9));
         poolCurator.create(pool);
-        pool = poolCurator.find(pool.getId());
+        pool = poolCurator.get(pool.getId());
 
         assertEquals("A Great Operating System", pool.getProductName());
     }
@@ -583,7 +583,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
 
         Pool pool = TestUtil.createPool(owner, product, providedProducts, 5);
         poolCurator.create(pool);
-        pool = poolCurator.find(pool.getId());
+        pool = poolCurator.get(pool.getId());
         assertTrue(pool.getProvidedProducts().size() > 0);
     }
 
@@ -602,14 +602,14 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         sub.setModified(new Date());
 
         Pool newPool = poolManager.createAndEnrichPools(sub).get(0);
-        List<Pool> pools = poolCurator.lookupBySubscriptionId(owner, sub.getId());
+        List<Pool> pools = poolCurator.getBySubscriptionId(owner, sub.getId());
 
         assertEquals(160L, pools.get(0).getQuantity().longValue());
         assertEquals(newPool.getQuantity(), pools.get(0).getQuantity());
     }
 
     @Test
-    public void testlookupBySubscriptionIds() {
+    public void testgetBySubscriptionIds() {
         Product product = new Product("someProduct", "An Extremely Great Product", 10L);
         product = this.createProduct(product, owner);
 
@@ -632,7 +632,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         p3.setSourceSubscription(new SourceSubscription(subId3, "master"));
         poolCurator.create(p3);
 
-        List<Pool> pools = poolCurator.lookupBySubscriptionIds(owner, Arrays.asList(subId1, subId2));
+        List<Pool> pools = poolCurator.getBySubscriptionIds(owner, Arrays.asList(subId1, subId2));
         assertEquals(2, pools.size());
         assertThat(pools, hasItems(p, p2));
         assertThat(pools, not(hasItem(p3)));
@@ -648,7 +648,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
             subIds.add(createPoolForCriteriaTest(product));
         }
 
-        List<Pool> pools = poolCurator.lookupBySubscriptionIds(owner, subIds);
+        List<Pool> pools = poolCurator.getBySubscriptionIds(owner, subIds);
         assertEquals(30, pools.size());
 
         for (Pool pool : pools) {
@@ -763,7 +763,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
             TestUtil.createDate(2050, 3, 2), TestUtil.createDate(2055, 3, 2));
         poolCurator.create(pool);
         String subid = pool.getSubscriptionId();
-        assertEquals(1, poolCurator.lookupBySubscriptionId(owner, subid).size());
+        assertEquals(1, poolCurator.getBySubscriptionId(owner, subid).size());
 
         Entitlement e = new Entitlement(pool, consumer, owner, 1);
         e.setId(Util.generateDbUUID());
@@ -773,14 +773,14 @@ public class PoolCuratorTest extends DatabaseTestFixture {
 
         Map<String, Entitlement> subMap = new HashMap<>();
         subMap.put(subid, e);
-        assertEquals(0, poolCurator.lookupOversubscribedBySubscriptionIds(owner.getId(), subMap).size());
+        assertEquals(0, poolCurator.getOversubscribedBySubscriptionIds(owner.getId(), subMap).size());
 
         e = new Entitlement(pool, consumer, owner, 1);
         e.setId(Util.generateDbUUID());
         entitlementCurator.create(e);
         pool.setConsumed(pool.getConsumed() + 1);
         poolCurator.merge(pool);
-        assertEquals(1, poolCurator.lookupOversubscribedBySubscriptionIds(owner.getId(), subMap).size());
+        assertEquals(1, poolCurator.getOversubscribedBySubscriptionIds(owner.getId(), subMap).size());
     }
 
     @Test
@@ -825,7 +825,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         overConsumedPool.setConsumed(overConsumedPool.getConsumed() + 2);
         poolCurator.merge(overConsumedPool);
 
-        List<Pool> gotPools = poolCurator.lookupOversubscribedBySubscriptionIds(owner.getId(), subIdMap);
+        List<Pool> gotPools = poolCurator.getOversubscribedBySubscriptionIds(owner.getId(), subIdMap);
         assertEquals(5, gotPools.size());
 
         assertThat(expectedPools, hasItems(gotPools.toArray(new Pool[0])));
@@ -867,7 +867,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
 
         Map<String, Entitlement> subMap = new HashMap<>();
         subMap.put(subid, sourceEnt);
-        assertEquals(0, poolCurator.lookupOversubscribedBySubscriptionIds(owner.getId(), subMap).size());
+        assertEquals(0, poolCurator.getOversubscribedBySubscriptionIds(owner.getId(), subMap).size());
 
         // Oversubscribe to the derived pool:
         Entitlement derivedEnt = new Entitlement(derivedPool, consumer, owner, 3);
@@ -878,12 +878,12 @@ public class PoolCuratorTest extends DatabaseTestFixture {
 
 
         // Passing the source entitlement should find the oversubscribed derived pool:
-        assertEquals(1, poolCurator.lookupOversubscribedBySubscriptionIds(owner.getId(), subMap).size());
+        assertEquals(1, poolCurator.getOversubscribedBySubscriptionIds(owner.getId(), subMap).size());
 
         subMap.clear();
         subMap.put(subid, derivedEnt);
         // Passing the derived entitlement should not see any oversubscribed pool:
-        assertEquals(0, poolCurator.lookupOversubscribedBySubscriptionIds(owner.getId(), subMap).size());
+        assertEquals(0, poolCurator.getOversubscribedBySubscriptionIds(owner.getId(), subMap).size());
     }
 
     @Test
@@ -893,7 +893,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
             TestUtil.createDate(2050, 3, 2), TestUtil.createDate(2055, 3, 2));
         poolCurator.create(pool);
         String subid = pool.getSubscriptionId();
-        assertEquals(1, poolCurator.lookupBySubscriptionId(owner, subid).size());
+        assertEquals(1, poolCurator.getBySubscriptionId(owner, subid).size());
 
 
         Entitlement e = new Entitlement(pool, consumer, owner, 1);
@@ -902,12 +902,12 @@ public class PoolCuratorTest extends DatabaseTestFixture {
 
         Map<String, Entitlement> subMap = new HashMap<>();
         subMap.put(subid, e);
-        assertEquals(0, poolCurator.lookupOversubscribedBySubscriptionIds(owner.getId(), subMap).size());
+        assertEquals(0, poolCurator.getOversubscribedBySubscriptionIds(owner.getId(), subMap).size());
 
         e = new Entitlement(pool, consumer, owner, 1);
         e.setId(Util.generateDbUUID());
         entitlementCurator.create(e);
-        assertEquals(0, poolCurator.lookupOversubscribedBySubscriptionIds(owner.getId(), subMap).size());
+        assertEquals(0, poolCurator.getOversubscribedBySubscriptionIds(owner.getId(), subMap).size());
     }
 
     @Test
@@ -1313,12 +1313,12 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         pool2.setSourceSubscription(new SourceSubscription(sourcePool.getSubscriptionId(), "derived"));
         poolCurator.create(pool2);
 
-        assertTrue(poolCurator.lookupBySubscriptionId(owner, sub.getId()).size() == 2);
+        assertTrue(poolCurator.getBySubscriptionId(owner, sub.getId()).size() == 2);
         poolManager.deletePool(sourcePool);
 
         // because we check for null now, we want to verify the
         // subpool gets deleted when the original pool is deleted.
-        Pool gone = poolCurator.find(pool2.getId());
+        Pool gone = poolCurator.get(pool2.getId());
         assertEquals(gone, null);
     }
 
@@ -1333,11 +1333,11 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         }
 
         for (Pool pool : pools) {
-            assertNotNull(poolCurator.find(pool.getId()));
+            assertNotNull(poolCurator.get(pool.getId()));
         }
         poolCurator.batchDelete(pools, null);
         for (Pool pool : pools) {
-            assertNull(poolCurator.find(pool.getId()));
+            assertNull(poolCurator.get(pool.getId()));
         }
     }
 
@@ -1355,11 +1355,11 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         }
 
         for (Pool pool : pools) {
-            assertNotNull(poolCurator.find(pool.getId()));
+            assertNotNull(poolCurator.get(pool.getId()));
         }
         poolCurator.batchDelete(pools, ids);
         for (Pool pool : pools) {
-            assertNotNull(poolCurator.find(pool.getId()));
+            assertNotNull(poolCurator.get(pool.getId()));
         }
     }
 
@@ -2209,7 +2209,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         this.poolCurator.clear();
 
         this.poolCurator.removeCdn(cdn);
-        Pool fetched = this.poolCurator.find(pool.getId());
+        Pool fetched = this.poolCurator.get(pool.getId());
 
         assertNotNull(fetched);
         assertNull(fetched.getCdn());

--- a/server/src/test/java/org/candlepin/model/PoolTest.java
+++ b/server/src/test/java/org/candlepin/model/PoolTest.java
@@ -195,7 +195,7 @@ public class PoolTest extends DatabaseTestFixture {
         pQs.put(consumerPool.getId(), 1);
         poolManager.entitleByPools(consumer, pQs);
 
-        consumerPool = poolCurator.find(consumerPool.getId());
+        consumerPool = poolCurator.get(consumerPool.getId());
         assertFalse(consumerPool.entitlementsAvailable(1));
         assertEquals(1, consumerPool.getEntitlements().size());
     }
@@ -221,7 +221,7 @@ public class PoolTest extends DatabaseTestFixture {
         pQs.put(consumerPool.getId(), 1);
         poolManager.entitleByPools(consumer, pQs);
 
-        assertEquals(1, consumerCurator.find(consumer.getId()).getEntitlements().size());
+        assertEquals(1, consumerCurator.get(consumer.getId()).getEntitlements().size());
     }
 
     // test subscription product changed exception
@@ -312,7 +312,7 @@ public class PoolTest extends DatabaseTestFixture {
 
         Pool pool = TestUtil.createPool(owner, parentProduct, providedProducts, 5);
         poolCurator.create(pool);
-        pool = poolCurator.find(pool.getId());
+        pool = poolCurator.get(pool.getId());
         assertEquals(1, pool.getProvidedProducts().size());
 
         // Clear the set and create a new one:
@@ -321,7 +321,7 @@ public class PoolTest extends DatabaseTestFixture {
         pool.addProvidedProduct(childProduct3);
         poolCurator.merge(pool);
 
-        pool = poolCurator.find(pool.getId());
+        pool = poolCurator.get(pool.getId());
         assertEquals(2, pool.getProvidedProducts().size());
     }
 
@@ -337,9 +337,9 @@ public class PoolTest extends DatabaseTestFixture {
         Entitlement ent = entitlements.get(0);
         assertTrue(ent.getQuantity() == 3);
         poolManager.adjustEntitlementQuantity(consumer, ent, 5);
-        Entitlement ent2 = entitlementCurator.find(ent.getId());
+        Entitlement ent2 = entitlementCurator.get(ent.getId());
         assertTrue(ent2.getQuantity() == 5);
-        Pool pool2 = poolCurator.find(pool.getId());
+        Pool pool2 = poolCurator.get(pool.getId());
         assertTrue(pool2.getConsumed() == 5);
         assertTrue(pool2.getEntitlements().size() == 1);
     }

--- a/server/src/test/java/org/candlepin/model/ProductCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ProductCuratorTest.java
@@ -165,7 +165,7 @@ public class ProductCuratorTest extends DatabaseTestFixture {
         prod.setAttribute("content_sets", jsonData);
         productCurator.create(prod);
 
-        Product lookedUp = productCurator.find(prod.getUuid());
+        Product lookedUp = productCurator.get(prod.getUuid());
         assertEquals(jsonData, lookedUp.getAttributeValue("content_sets"));
 
         data = mapper.readValue(lookedUp.getAttributeValue("content_sets"),
@@ -195,7 +195,7 @@ public class ProductCuratorTest extends DatabaseTestFixture {
         prod.setAttribute("content_sets", jsonData);
         productCurator.create(prod);
 
-        Product lookedUp = productCurator.find(prod.getUuid());
+        Product lookedUp = productCurator.get(prod.getUuid());
         assertEquals(jsonData, lookedUp.getAttributeValue("content_sets"));
 
         data = mapper.readValue(lookedUp.getAttributeValue("content_sets"),
@@ -235,7 +235,7 @@ public class ProductCuratorTest extends DatabaseTestFixture {
         prod.setDependentProductIds(dependentProductIds);
         productCurator.create(prod);
 
-        Product lookedUp = productCurator.find(prod.getUuid());
+        Product lookedUp = productCurator.get(prod.getUuid());
         assertThat(lookedUp.getDependentProductIds(), hasItem("ProductX"));
     }
 
@@ -266,7 +266,7 @@ public class ProductCuratorTest extends DatabaseTestFixture {
         Product prod = new Product("cp_test-label", "variant", "version", "arch", "", "SVC");
         productCurator.create(prod);
 
-        productCurator.find(prod.getUuid());
+        productCurator.get(prod.getUuid());
     }
 
     @Test
@@ -308,7 +308,7 @@ public class ProductCuratorTest extends DatabaseTestFixture {
         Product original = createTestProduct();
         productCurator.create(original);
 
-        Product modified = productCurator.find(original.getUuid());
+        Product modified = productCurator.get(original.getUuid());
         String newName = "new name";
         modified.setName(newName);
 
@@ -319,7 +319,7 @@ public class ProductCuratorTest extends DatabaseTestFixture {
 
         productCurator.merge(modified);
 
-        Product lookedUp = productCurator.find(original.getUuid());
+        Product lookedUp = productCurator.get(original.getUuid());
         assertEquals(newName, lookedUp.getName());
         assertEquals(3, lookedUp.getAttributes().size());
         assertEquals("a1", lookedUp.getAttributeValue("a1"));
@@ -560,7 +560,7 @@ public class ProductCuratorTest extends DatabaseTestFixture {
         p2.addContent(contentUpdate, true);
         productCurator.merge(p2);
 
-        Product result = productCurator.find(p.getUuid());
+        Product result = productCurator.get(p.getUuid());
         assertEquals(1, result.getProductContent().size());
     }
 

--- a/server/src/test/java/org/candlepin/model/RoleTest.java
+++ b/server/src/test/java/org/candlepin/model/RoleTest.java
@@ -46,7 +46,7 @@ public class RoleTest extends DatabaseTestFixture {
 
         Role r = createRole(owner);
 
-        Role lookedUp = roleCurator.find(r.getId());
+        Role lookedUp = roleCurator.get(r.getId());
         assertEquals(1, lookedUp.getPermissions().size());
         assertEquals(1, lookedUp.getUsers().size());
     }
@@ -86,7 +86,7 @@ public class RoleTest extends DatabaseTestFixture {
         role.addPermission(new PermissionBlueprint(PermissionType.OWNER, owner, Access.ALL));
         roleCurator.flush();
 
-        role = roleCurator.find(role.getId());
+        role = roleCurator.get(role.getId());
         assertEquals(1, role.getPermissions().size());
         PermissionBlueprint perm = role.getPermissions().iterator().next();
         assertNotNull(perm.getId());

--- a/server/src/test/java/org/candlepin/model/UeberCertificateCuratorTests.java
+++ b/server/src/test/java/org/candlepin/model/UeberCertificateCuratorTests.java
@@ -42,7 +42,7 @@ public class UeberCertificateCuratorTests extends DatabaseTestFixture {
     @Test
     public void ensureCertificateCreationAndGet() {
         UeberCertificate cert = this.createUeberCert(owner);
-        assertEquals(cert, ueberCertificateCurator.find(cert.getId()));
+        assertEquals(cert, ueberCertificateCurator.get(cert.getId()));
         assertEquals(cert, ueberCertificateCurator.findForOwner(owner));
     }
 
@@ -77,7 +77,7 @@ public class UeberCertificateCuratorTests extends DatabaseTestFixture {
         CertificateSerial serial = cert.getSerial();
         this.ueberCertificateCurator.deleteForOwner(owner);
         assertNull(this.ueberCertificateCurator.findForOwner(owner));
-        CertificateSerial fetchedSerial = certSerialCurator.find(serial.getId());
+        CertificateSerial fetchedSerial = certSerialCurator.get(serial.getId());
         assertTrue("Serial should have been revoked", fetchedSerial.isRevoked());
     }
 

--- a/server/src/test/java/org/candlepin/pinsetter/core/PinsetterJobListenerDatabaseTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/core/PinsetterJobListenerDatabaseTest.java
@@ -99,7 +99,7 @@ public class PinsetterJobListenerDatabaseTest {
         listener.jobWasExecuted(ctx, e);
 
         // verify the message stored is a substring of the long message
-        JobStatus verify = curator.find("name");
+        JobStatus verify = curator.get("name");
         assertEquals(longstr.substring(0, JobStatus.RESULT_COL_LENGTH),
             verify.getResult());
     }

--- a/server/src/test/java/org/candlepin/pinsetter/core/PinsetterJobListenerTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/core/PinsetterJobListenerTest.java
@@ -69,7 +69,7 @@ public class PinsetterJobListenerTest {
         when(ctx.getMergedJobDataMap()).thenReturn(map);
         when(detail.getKey()).thenReturn(jobKey("foo"));
         when(ctx.getJobDetail()).thenReturn(detail);
-        when(jcurator.find(eq("foo"))).thenReturn(status);
+        when(jcurator.get(eq("foo"))).thenReturn(status);
 
         listener.jobToBeExecuted(ctx);
 
@@ -91,7 +91,7 @@ public class PinsetterJobListenerTest {
 
         when(detail.getKey()).thenReturn(jobKey("foo"));
         when(ctx.getJobDetail()).thenReturn(detail);
-        when(jcurator.find(eq("foo"))).thenReturn(status);
+        when(jcurator.get(eq("foo"))).thenReturn(status);
 
         listener.jobWasExecuted(ctx, null);
 
@@ -107,7 +107,7 @@ public class PinsetterJobListenerTest {
 
         when(detail.getKey()).thenReturn(jobKey("foo"));
         when(ctx.getJobDetail()).thenReturn(detail);
-        when(jcurator.find(eq("foo"))).thenReturn(null);
+        when(jcurator.get(eq("foo"))).thenReturn(null);
 
         listener.jobWasExecuted(ctx, e);
 
@@ -128,7 +128,7 @@ public class PinsetterJobListenerTest {
         when(ctx.getMergedJobDataMap()).thenReturn(map);
         when(detail.getKey()).thenReturn(jobKey("foo"));
         when(ctx.getJobDetail()).thenReturn(detail);
-        when(jcurator.find(eq("foo"))).thenReturn(null);
+        when(jcurator.get(eq("foo"))).thenReturn(null);
 
         listener.jobToBeExecuted(ctx);
 
@@ -143,7 +143,7 @@ public class PinsetterJobListenerTest {
 
         when(detail.getKey()).thenReturn(jobKey("foo"));
         when(ctx.getJobDetail()).thenReturn(detail);
-        when(jcurator.find(eq("foo"))).thenReturn(status);
+        when(jcurator.get(eq("foo"))).thenReturn(status);
 
         listener.jobWasExecuted(ctx, null);
 
@@ -159,7 +159,7 @@ public class PinsetterJobListenerTest {
 
         when(detail.getKey()).thenReturn(jobKey("foo"));
         when(ctx.getJobDetail()).thenReturn(detail);
-        when(jcurator.find(eq("foo"))).thenReturn(status);
+        when(jcurator.get(eq("foo"))).thenReturn(status);
         when(e.getMessage()).thenReturn("job errored");
 
         listener.jobWasExecuted(ctx, e);
@@ -175,7 +175,7 @@ public class PinsetterJobListenerTest {
         JobDetail detail = mock(JobDetail.class);
         when(detail.getKey()).thenReturn(jobKey("foo"));
         when(ctx.getJobDetail()).thenReturn(detail);
-        when(jcurator.find(any(String.class))).thenThrow(new RuntimeException());
+        when(jcurator.get(any(String.class))).thenThrow(new RuntimeException());
         try {
             listener.jobWasExecuted(ctx, null);
         }
@@ -196,7 +196,7 @@ public class PinsetterJobListenerTest {
         when(ctx.getMergedJobDataMap()).thenReturn(map);
         when(detail.getKey()).thenReturn(jobKey("foo"));
         when(ctx.getJobDetail()).thenReturn(detail);
-        when(jcurator.find(any(String.class))).thenThrow(new RuntimeException());
+        when(jcurator.get(any(String.class))).thenThrow(new RuntimeException());
         try {
             listener.jobToBeExecuted(ctx);
         }
@@ -214,7 +214,7 @@ public class PinsetterJobListenerTest {
 
         when(detail.getKey()).thenReturn(jobKey("foo"));
         when(ctx.getJobDetail()).thenReturn(detail);
-        when(jcurator.find(eq("foo"))).thenReturn(status);
+        when(jcurator.get(eq("foo"))).thenReturn(status);
         String longstr = RandomStringUtils.randomAlphanumeric(
             JobStatus.RESULT_COL_LENGTH);
         when(e.getMessage()).thenReturn(longstr);
@@ -239,7 +239,7 @@ public class PinsetterJobListenerTest {
         when(ctx.getJobDetail()).thenReturn(detail);
 
         JobStatus status = new JobStatus(detail);
-        when(jcurator.find(eq("name"))).thenReturn(status);
+        when(jcurator.get(eq("name"))).thenReturn(status);
 
         String longstr = RandomStringUtils.randomAlphanumeric(300);
         when(e.getMessage()).thenReturn(longstr);

--- a/server/src/test/java/org/candlepin/pinsetter/core/PinsetterKernelTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/core/PinsetterKernelTest.java
@@ -171,7 +171,7 @@ public class PinsetterKernelTest {
         pk = new PinsetterKernel(config, jfactory, jlistener, jcurator,
                 sfactory, triggerListener, modeManager);
         JobStatus status = mock(JobStatus.class);
-        when(jcurator.find(startsWith(
+        when(jcurator.get(startsWith(
             Util.getClassName(JobCleaner.class)))).thenReturn(status);
         when(jcurator.create(any(JobStatus.class))).thenThrow(new EntityExistsException());
         pk.startup();

--- a/server/src/test/java/org/candlepin/pinsetter/core/PinsetterTriggerListenerTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/core/PinsetterTriggerListenerTest.java
@@ -52,7 +52,7 @@ public class PinsetterTriggerListenerTest {
         when(trigger.mayFireAgain()).thenReturn(true);
         when(trigger.getJobKey()).thenReturn(jobKey);
         when(trigger.getNextFireTime()).thenReturn(new Date());
-        when(jobCurator.find(Matchers.anyString())).thenReturn(jobStatus);
+        when(jobCurator.get(Matchers.anyString())).thenReturn(jobStatus);
 
         ptl.triggerMisfired(trigger);
         assert (jobStatus.getResult().startsWith("Will reattempt job at or after"));
@@ -68,7 +68,7 @@ public class PinsetterTriggerListenerTest {
         JobKey jobKey = new JobKey("mockName");
         when(trigger.mayFireAgain()).thenReturn(false);
         when(trigger.getJobKey()).thenReturn(jobKey);
-        when(jobCurator.find(Matchers.anyString())).thenReturn(jobStatus);
+        when(jobCurator.get(Matchers.anyString())).thenReturn(jobStatus);
 
         ptl.triggerMisfired(trigger);
         assert (jobStatus.getResult().startsWith("Failed run. Will not attempt again."));

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/ActiveEntitlementJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/ActiveEntitlementJobTest.java
@@ -78,7 +78,7 @@ public class ActiveEntitlementJobTest extends DatabaseTestFixture {
         assertEquals("valid", consumer.getEntitlementStatus());
 
         // Should have changed
-        assertTrue(entitlementCurator.find(ent.getId()).isUpdatedOnStart());
+        assertTrue(entitlementCurator.get(ent.getId()).isUpdatedOnStart());
     }
 
     @Test
@@ -93,7 +93,7 @@ public class ActiveEntitlementJobTest extends DatabaseTestFixture {
         job.toExecute(null);
 
         // Unchanged
-        assertTrue(entitlementCurator.find(ent.getId()).isUpdatedOnStart());
+        assertTrue(entitlementCurator.get(ent.getId()).isUpdatedOnStart());
     }
 
     @Test
@@ -115,6 +115,6 @@ public class ActiveEntitlementJobTest extends DatabaseTestFixture {
         assertFalse("valid".equals(consumer.getEntitlementStatus()));
 
         // Should not have changed
-        assertFalse(entitlementCurator.find(ent.getId()).isUpdatedOnStart());
+        assertFalse(entitlementCurator.get(ent.getId()).isUpdatedOnStart());
     }
 }

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/HypervisorUpdateJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/HypervisorUpdateJobTest.java
@@ -99,8 +99,8 @@ public class HypervisorUpdateJobTest extends BaseJobTest {
         ConsumerType ctype = new ConsumerType(ConsumerTypeEnum.HYPERVISOR);
         ctype.setId("test-ctype");
 
-        when(consumerTypeCurator.lookupByLabel(eq(ConsumerTypeEnum.HYPERVISOR.getLabel()))).thenReturn(ctype);
-        when(consumerTypeCurator.lookupByLabel(eq(ConsumerTypeEnum.HYPERVISOR.getLabel()), anyBoolean()))
+        when(consumerTypeCurator.getByLabel(eq(ConsumerTypeEnum.HYPERVISOR.getLabel()))).thenReturn(ctype);
+        when(consumerTypeCurator.getByLabel(eq(ConsumerTypeEnum.HYPERVISOR.getLabel()), anyBoolean()))
             .thenReturn(ctype);
 
         when(owner.getKey()).thenReturn("joe");
@@ -129,7 +129,7 @@ public class HypervisorUpdateJobTest extends BaseJobTest {
 
     @Test
     public void hypervisorUpdateExecCreate() throws JobExecutionException {
-        when(ownerCurator.lookupByKey(eq("joe"))).thenReturn(owner);
+        when(ownerCurator.getByKey(eq("joe"))).thenReturn(owner);
 
         JobDetail detail = HypervisorUpdateJob.forOwner(owner, hypervisorJson, true, principal, null);
         JobExecutionContext ctx = mock(JobExecutionContext.class);
@@ -146,7 +146,7 @@ public class HypervisorUpdateJobTest extends BaseJobTest {
 
     @Test
     public void reporterIdOnCreateTest() throws JobExecutionException {
-        when(ownerCurator.lookupByKey(eq("joe"))).thenReturn(owner);
+        when(ownerCurator.getByKey(eq("joe"))).thenReturn(owner);
 
         JobDetail detail = HypervisorUpdateJob.forOwner(owner, hypervisorJson, true, principal,
             "createReporterId");
@@ -166,7 +166,7 @@ public class HypervisorUpdateJobTest extends BaseJobTest {
 
     @Test
     public void hypervisorUpdateExecUpdate() throws JobExecutionException {
-        when(ownerCurator.lookupByKey(eq("joe"))).thenReturn(owner);
+        when(ownerCurator.getByKey(eq("joe"))).thenReturn(owner);
         Consumer hypervisor = new Consumer();
         String hypervisorId = "uuid_999";
         hypervisor.setHypervisorId(new HypervisorId(hypervisorId));
@@ -188,7 +188,7 @@ public class HypervisorUpdateJobTest extends BaseJobTest {
 
     @Test
     public void reporterIdOnUpdateTest() throws JobExecutionException {
-        when(ownerCurator.lookupByKey(eq("joe"))).thenReturn(owner);
+        when(ownerCurator.getByKey(eq("joe"))).thenReturn(owner);
         Consumer hypervisor = new Consumer();
         String hypervisorId = "uuid_999";
         hypervisor.setHypervisorId(new HypervisorId(hypervisorId));
@@ -210,7 +210,7 @@ public class HypervisorUpdateJobTest extends BaseJobTest {
 
     @Test
     public void hypervisorUpdateExecCreateNoHypervisorId() throws JobExecutionException {
-        when(ownerCurator.lookupByKey(eq("joe"))).thenReturn(owner);
+        when(ownerCurator.getByKey(eq("joe"))).thenReturn(owner);
 
         hypervisorJson =
                 "{\"hypervisors\":" +
@@ -236,7 +236,7 @@ public class HypervisorUpdateJobTest extends BaseJobTest {
 
     @Test
     public void hypervisorUpdateIgnoresEmptyGuestIds() throws Exception {
-        when(ownerCurator.lookupByKey(eq("joe"))).thenReturn(owner);
+        when(ownerCurator.getByKey(eq("joe"))).thenReturn(owner);
 
         hypervisorJson =
                 "{\"hypervisors\":" +
@@ -303,7 +303,7 @@ public class HypervisorUpdateJobTest extends BaseJobTest {
     public void ensureJobFailsWhenAutobindDisabledForTargetOwner() throws Exception {
         // Disabled autobind
         when(owner.isAutobindDisabled()).thenReturn(true);
-        when(ownerCurator.lookupByKey(eq("joe"))).thenReturn(owner);
+        when(ownerCurator.getByKey(eq("joe"))).thenReturn(owner);
 
         JobDetail detail = HypervisorUpdateJob.forOwner(owner, hypervisorJson, true, principal, null);
         JobExecutionContext ctx = mock(JobExecutionContext.class);

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/ImportJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/ImportJobTest.java
@@ -86,7 +86,7 @@ public class ImportJobTest extends BaseJobTest{
 
         JobDetail detail = job.scheduleImport(owner, archiveFilePath, uploadedFileName, co);
         when(ctx.getMergedJobDataMap()).thenReturn(detail.getJobDataMap());
-        when(ownerCurator.lookupByKey(eq(owner.getKey()))).thenReturn(owner);
+        when(ownerCurator.getByKey(eq(owner.getKey()))).thenReturn(owner);
         when(manifestManager.importStoredManifest(eq(owner), any(String.class),
             any(ConflictOverrides.class), eq(uploadedFileName))).thenReturn(record);
         job.execute(ctx);
@@ -103,7 +103,7 @@ public class ImportJobTest extends BaseJobTest{
 
         JobDetail detail = job.scheduleImport(owner, archiveFilePath, uploadedFileName, co);
         when(ctx.getMergedJobDataMap()).thenReturn(detail.getJobDataMap());
-        when(ownerCurator.lookupByKey(eq(owner.getKey()))).thenReturn(owner);
+        when(ownerCurator.getByKey(eq(owner.getKey()))).thenReturn(owner);
         when(manifestManager.importStoredManifest(eq(owner), any(String.class), any(ConflictOverrides.class),
             eq(uploadedFileName))).thenThrow(new ImporterException(expectedMessage));
 
@@ -126,7 +126,7 @@ public class ImportJobTest extends BaseJobTest{
 
         JobDetail detail = job.scheduleImport(owner, archiveFilePath, uploadedFileName, co);
         when(ctx.getMergedJobDataMap()).thenReturn(detail.getJobDataMap());
-        when(ownerCurator.lookupByKey(eq(owner.getKey()))).thenReturn(null);
+        when(ownerCurator.getByKey(eq(owner.getKey()))).thenReturn(null);
 
         try {
             job.execute(ctx);

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/RefreshPoolsJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/RefreshPoolsJobTest.java
@@ -65,7 +65,7 @@ public class RefreshPoolsJobTest extends BaseJobTest{
         when(ctx.getMergedJobDataMap()).thenReturn(jdm);
         when(jdm.getString(eq(JobStatus.TARGET_ID))).thenReturn("someownerkey");
         when(jdm.getBoolean(eq(RefreshPoolsJob.LAZY_REGEN))).thenReturn(true);
-        when(oc.lookupByKey(eq("someownerkey"))).thenReturn(owner);
+        when(oc.getByKey(eq("someownerkey"))).thenReturn(owner);
         when(owner.getDisplayName()).thenReturn("test owner");
         when(pm.getRefresher(eq(subAdapter), eq(ownerAdapter), eq(true))).thenReturn(refresher);
         when(refresher.add(eq(owner))).thenReturn(refresher);

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/UndoImportsJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/UndoImportsJobTest.java
@@ -171,8 +171,8 @@ public class UndoImportsJobTest extends DatabaseTestFixture {
             this.poolManager.listPoolsByOwner(owner1).list()
         );
         assertEquals(Arrays.asList(pool7, pool8, pool9), this.poolManager.listPoolsByOwner(owner2).list());
-        assertEquals(metadata1, exportCurator.lookupByTypeAndOwner(ExporterMetadata.TYPE_PER_USER, owner1));
-        assertEquals(metadata2, exportCurator.lookupByTypeAndOwner(ExporterMetadata.TYPE_PER_USER, owner2));
+        assertEquals(metadata1, exportCurator.getByTypeAndOwner(ExporterMetadata.TYPE_PER_USER, owner1));
+        assertEquals(metadata2, exportCurator.getByTypeAndOwner(ExporterMetadata.TYPE_PER_USER, owner2));
         assertEquals(0, this.importRecordCurator.findRecords(owner1).list().size());
         assertEquals(0, this.importRecordCurator.findRecords(owner2).list().size());
 
@@ -193,8 +193,8 @@ public class UndoImportsJobTest extends DatabaseTestFixture {
             this.poolManager.listPoolsByOwner(owner1).list());
 
         assertEquals(Arrays.asList(pool7, pool8, pool9), this.poolManager.listPoolsByOwner(owner2).list());
-        assertNull(exportCurator.lookupByTypeAndOwner(ExporterMetadata.TYPE_PER_USER, owner1));
-        assertEquals(metadata2, exportCurator.lookupByTypeAndOwner(ExporterMetadata.TYPE_PER_USER, owner2));
+        assertNull(exportCurator.getByTypeAndOwner(ExporterMetadata.TYPE_PER_USER, owner1));
+        assertEquals(metadata2, exportCurator.getByTypeAndOwner(ExporterMetadata.TYPE_PER_USER, owner2));
         assertNull(owner1.getUpstreamConsumer());
 
         List<ImportRecord> records = this.importRecordCurator.findRecords(owner1).list();

--- a/server/src/test/java/org/candlepin/policy/AutobindRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/AutobindRulesTest.java
@@ -119,8 +119,8 @@ public class AutobindRulesTest {
 
         consumer = new Consumer("test consumer", "test user", owner, ctype);
 
-        when(consumerTypeCurator.find(eq(ctype.getId()))).thenReturn(ctype);
-        when(consumerTypeCurator.lookupByLabel(eq(ctype.getLabel()))).thenReturn(ctype);
+        when(consumerTypeCurator.get(eq(ctype.getId()))).thenReturn(ctype);
+        when(consumerTypeCurator.getByLabel(eq(ctype.getLabel()))).thenReturn(ctype);
         when(consumerTypeCurator.getConsumerType(eq(consumer))).thenReturn(ctype);
 
         compliance = new ComplianceStatus();
@@ -186,8 +186,8 @@ public class AutobindRulesTest {
 
         consumer = new Consumer("test consumer", "test user", owner, ctype);
 
-        when(consumerTypeCurator.find(eq(ctype.getId()))).thenReturn(ctype);
-        when(consumerTypeCurator.lookupByLabel(eq(ctype.getLabel()))).thenReturn(ctype);
+        when(consumerTypeCurator.get(eq(ctype.getId()))).thenReturn(ctype);
+        when(consumerTypeCurator.getByLabel(eq(ctype.getLabel()))).thenReturn(ctype);
         when(consumerTypeCurator.getConsumerType(eq(consumer))).thenReturn(ctype);
 
         List<PoolQuantity> results = autobindRules.selectBestPools(consumer,

--- a/server/src/test/java/org/candlepin/policy/ExportRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/ExportRulesTest.java
@@ -86,7 +86,7 @@ public class ExportRulesTest {
         when(entitlement.getConsumer()).thenReturn(consumer);
 
         when(consumer.getTypeId()).thenReturn(consumerType.getId());
-        when(consumerTypeCuratorMock.find(eq(consumerType.getId()))).thenReturn(consumerType);
+        when(consumerTypeCuratorMock.get(eq(consumerType.getId()))).thenReturn(consumerType);
         when(consumerTypeCuratorMock.getConsumerType(eq(consumer))).thenReturn(consumerType);
 
         assertFalse(exportRules.canExport(entitlement));
@@ -113,7 +113,7 @@ public class ExportRulesTest {
         when(pool.getAttributes()).thenReturn(attributes);
 
         when(consumer.getTypeId()).thenReturn(consumerType.getId());
-        when(consumerTypeCuratorMock.find(eq(consumerType.getId()))).thenReturn(consumerType);
+        when(consumerTypeCuratorMock.get(eq(consumerType.getId()))).thenReturn(consumerType);
         when(consumerTypeCuratorMock.getConsumerType(eq(consumer))).thenReturn(consumerType);
 
         assertTrue(exportRules.canExport(entitlement));
@@ -137,7 +137,7 @@ public class ExportRulesTest {
         when(pool.getAttributes()).thenReturn(new HashMap<>());
 
         when(consumer.getTypeId()).thenReturn(consumerType.getId());
-        when(consumerTypeCuratorMock.find(eq(consumerType.getId()))).thenReturn(consumerType);
+        when(consumerTypeCuratorMock.get(eq(consumerType.getId()))).thenReturn(consumerType);
         when(consumerTypeCuratorMock.getConsumerType(eq(consumer))).thenReturn(consumerType);
 
         assertTrue(exportRules.canExport(entitlement));

--- a/server/src/test/java/org/candlepin/policy/js/compliance/ComplianceRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/compliance/ComplianceRulesTest.java
@@ -162,7 +162,7 @@ public class ComplianceRulesTest {
         Consumer consumer = new Consumer();
         consumer.setType(ctype);
 
-        when(this.consumerTypeCurator.find(eq(ctype.getId()))).thenReturn(ctype);
+        when(this.consumerTypeCurator.get(eq(ctype.getId()))).thenReturn(ctype);
         when(this.consumerTypeCurator.getConsumerType(eq(consumer))).thenReturn(ctype);
 
         for (Product product : installedProducts) {

--- a/server/src/test/java/org/candlepin/policy/js/entitlement/EntitlementRulesTestFixture.java
+++ b/server/src/test/java/org/candlepin/policy/js/entitlement/EntitlementRulesTestFixture.java
@@ -169,9 +169,9 @@ public class EntitlementRulesTestFixture {
                 ctype.setId("test-ctype-" + ctype.getLabel() + "-" + TestUtil.randomInt());
             }
 
-            when(consumerTypeCurator.lookupByLabel(eq(ctype.getLabel()))).thenReturn(ctype);
-            when(consumerTypeCurator.lookupByLabel(eq(ctype.getLabel()), anyBoolean())).thenReturn(ctype);
-            when(consumerTypeCurator.find(eq(ctype.getId()))).thenReturn(ctype);
+            when(consumerTypeCurator.getByLabel(eq(ctype.getLabel()))).thenReturn(ctype);
+            when(consumerTypeCurator.getByLabel(eq(ctype.getLabel()), anyBoolean())).thenReturn(ctype);
+            when(consumerTypeCurator.get(eq(ctype.getId()))).thenReturn(ctype);
 
             doAnswer(new Answer<ConsumerType>() {
                 @Override
@@ -185,7 +185,7 @@ public class EntitlementRulesTestFixture {
                         throw new IllegalArgumentException("consumer is null or lacks a type ID");
                     }
 
-                    ctype = curator.find(consumer.getTypeId());
+                    ctype = curator.get(consumer.getTypeId());
                     if (ctype == null) {
                         throw new IllegalStateException("No such consumer type: " + consumer.getTypeId());
                     }

--- a/server/src/test/java/org/candlepin/policy/js/entitlement/HostedVirtLimitEntitlementRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/entitlement/HostedVirtLimitEntitlementRulesTest.java
@@ -98,9 +98,9 @@ public class HostedVirtLimitEntitlementRulesTest extends EntitlementRulesTestFix
         List<Pool> poolList = new ArrayList<>();
         poolList.add(virtBonusPool);
         ArgumentCaptor<Set> captor = ArgumentCaptor.forClass(Set.class);
-        when(poolManagerMock.lookupBySubscriptionIds(anyString(), captor.capture()))
+        when(poolManagerMock.getBySubscriptionIds(anyString(), captor.capture()))
             .thenReturn(poolList);
-        when(poolManagerMock.lookupBySubscriptionId(eq(physicalPool.getOwner()),
+        when(poolManagerMock.getBySubscriptionId(eq(physicalPool.getOwner()),
             eq(physicalPool.getSubscriptionId())))
             .thenReturn(poolList);
 
@@ -176,12 +176,12 @@ public class HostedVirtLimitEntitlementRulesTest extends EntitlementRulesTestFix
         poolList.add(virtBonusPool2);
 
         ArgumentCaptor<Set> captor = ArgumentCaptor.forClass(Set.class);
-        when(poolManagerMock.lookupBySubscriptionIds(anyString(), captor.capture()))
+        when(poolManagerMock.getBySubscriptionIds(anyString(), captor.capture()))
             .thenReturn(poolList);
-        when(poolManagerMock.lookupBySubscriptionId(eq(physicalPool.getOwner()),
+        when(poolManagerMock.getBySubscriptionId(eq(physicalPool.getOwner()),
             eq(physicalPool.getSubscriptionId())))
             .thenReturn(poolList);
-        when(poolManagerMock.lookupBySubscriptionId(eq(physicalPool.getOwner()),
+        when(poolManagerMock.getBySubscriptionId(eq(physicalPool.getOwner()),
             eq(physicalPool2.getSubscriptionId())))
             .thenReturn(poolList2);
 
@@ -263,7 +263,7 @@ public class HostedVirtLimitEntitlementRulesTest extends EntitlementRulesTestFix
         Entitlement e = new Entitlement(physicalPool, consumer, owner, 1);
         List<Pool> poolList = new ArrayList<>();
         poolList.add(virtBonusPool);
-        when(poolManagerMock.lookupBySubscriptionId(eq(physicalPool.getOwner()),
+        when(poolManagerMock.getBySubscriptionId(eq(physicalPool.getOwner()),
             eq(physicalPool.getSubscriptionId())))
             .thenReturn(poolList);
 
@@ -353,9 +353,9 @@ public class HostedVirtLimitEntitlementRulesTest extends EntitlementRulesTestFix
         List<Pool> poolList = new ArrayList<>();
         poolList.add(virtBonusPool);
         ArgumentCaptor<Set> captor = ArgumentCaptor.forClass(Set.class);
-        when(poolManagerMock.lookupBySubscriptionIds(anyString(), captor.capture()))
+        when(poolManagerMock.getBySubscriptionIds(anyString(), captor.capture()))
             .thenReturn(poolList);
-        when(poolManagerMock.lookupBySubscriptionId(eq(physicalPool.getOwner()), eq("subId")))
+        when(poolManagerMock.getBySubscriptionId(eq(physicalPool.getOwner()), eq("subId")))
             .thenReturn(poolList);
         Map<String, Entitlement> entitlements = new HashMap<>();
         entitlements.put(physicalPool.getId(), e);
@@ -392,7 +392,7 @@ public class HostedVirtLimitEntitlementRulesTest extends EntitlementRulesTestFix
         Entitlement e = new Entitlement(virtBonusPool, consumer, owner, 1);
         List<Pool> poolList = new ArrayList<>();
         poolList.add(virtBonusPool);
-        when(poolManagerMock.lookupBySubscriptionId(eq(virtBonusPool.getOwner()),
+        when(poolManagerMock.getBySubscriptionId(eq(virtBonusPool.getOwner()),
             eq(virtBonusPool.getSubscriptionId())))
             .thenReturn(poolList);
 

--- a/server/src/test/java/org/candlepin/policy/js/quantity/QuantityRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/quantity/QuantityRulesTest.java
@@ -113,7 +113,7 @@ public class QuantityRulesTest {
 
         ctype = TestUtil.createConsumerType();
         consumer = TestUtil.createConsumer(owner);
-        when(consumerTypeCurator.find(eq(ctype.getId()))).thenReturn(ctype);
+        when(consumerTypeCurator.get(eq(ctype.getId()))).thenReturn(ctype);
         when(consumerTypeCurator.getConsumerType(eq(consumer))).thenReturn(ctype);
 
         Entitlement e = TestUtil.createEntitlement(owner, consumer, pool, new EntitlementCertificate());

--- a/server/src/test/java/org/candlepin/resource/ActivationKeyContentOverrideResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/ActivationKeyContentOverrideResourceTest.java
@@ -83,7 +83,7 @@ public class ActivationKeyContentOverrideResourceTest {
         when(context.getPathParameters()).thenReturn(mvm);
         akcor = new ActivationKeyContentOverrideResource(
             activationKeyContentOverrideCurator, akc, contentOverrideValidator, i18n);
-        when(akc.verifyAndLookupKey(eq(key.getId()))).thenReturn(key);
+        when(akc.secureGet(eq(key.getId()))).thenReturn(key);
         when(principal.canAccess(any(Object.class), any(SubResource.class),
             any(Access.class))).thenReturn(true);
     }

--- a/server/src/test/java/org/candlepin/resource/ActivationKeyResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/ActivationKeyResourceTest.java
@@ -151,8 +151,8 @@ public class ActivationKeyResourceTest extends DatabaseTestFixture {
         p.getProduct().setAttribute(Pool.Attributes.MULTI_ENTITLEMENT, "no");
         PoolManager poolManager = mock(PoolManager.class);
 
-        when(akc.verifyAndLookupKey(eq("testKey"))).thenReturn(ak);
-        when(poolManager.find(eq("testPool"))).thenReturn(p);
+        when(akc.secureGet(eq("testKey"))).thenReturn(ak);
+        when(poolManager.get(eq("testPool"))).thenReturn(p);
 
         ActivationKeyResource akr = new ActivationKeyResource(
             akc, i18n, poolManager, serviceLevelValidator, activationKeyRules, null,
@@ -168,8 +168,8 @@ public class ActivationKeyResourceTest extends DatabaseTestFixture {
         p.setQuantity(10L);
         PoolManager poolManager = mock(PoolManager.class);
 
-        when(akc.verifyAndLookupKey(eq("testKey"))).thenReturn(ak);
-        when(poolManager.find(eq("testPool"))).thenReturn(p);
+        when(akc.secureGet(eq("testKey"))).thenReturn(ak);
+        when(poolManager.get(eq("testPool"))).thenReturn(p);
 
         ActivationKeyResource akr = new ActivationKeyResource(
             akc, i18n, poolManager, serviceLevelValidator, activationKeyRules, null,
@@ -186,8 +186,8 @@ public class ActivationKeyResourceTest extends DatabaseTestFixture {
         p.setQuantity(10L);
         PoolManager poolManager = mock(PoolManager.class);
 
-        when(akc.verifyAndLookupKey(eq("testKey"))).thenReturn(ak);
-        when(poolManager.find(eq("testPool"))).thenReturn(p);
+        when(akc.secureGet(eq("testKey"))).thenReturn(ak);
+        when(poolManager.get(eq("testPool"))).thenReturn(p);
 
         ActivationKeyResource akr = new ActivationKeyResource(akc, i18n, poolManager,
             serviceLevelValidator, activationKeyRules, null,
@@ -204,8 +204,8 @@ public class ActivationKeyResourceTest extends DatabaseTestFixture {
         p.setQuantity(-1L);
         PoolManager poolManager = mock(PoolManager.class);
 
-        when(akc.verifyAndLookupKey(eq("testKey"))).thenReturn(ak);
-        when(poolManager.find(eq("testPool"))).thenReturn(p);
+        when(akc.secureGet(eq("testKey"))).thenReturn(ak);
+        when(poolManager.get(eq("testPool"))).thenReturn(p);
 
         ActivationKeyResource akr = new ActivationKeyResource(akc, i18n, poolManager,
             serviceLevelValidator, activationKeyRules, null,
@@ -223,8 +223,8 @@ public class ActivationKeyResourceTest extends DatabaseTestFixture {
         p.setQuantity(1L);
         PoolManager poolManager = mock(PoolManager.class);
 
-        when(akc.verifyAndLookupKey(eq("testKey"))).thenReturn(ak);
-        when(poolManager.find(eq("testPool"))).thenReturn(p);
+        when(akc.secureGet(eq("testKey"))).thenReturn(ak);
+        when(poolManager.get(eq("testPool"))).thenReturn(p);
 
         ActivationKeyResource akr = new ActivationKeyResource(
             akc, i18n, poolManager, serviceLevelValidator, activationKeyRules, null,
@@ -240,8 +240,8 @@ public class ActivationKeyResourceTest extends DatabaseTestFixture {
         p.getProduct().setAttribute(Pool.Attributes.REQUIRES_CONSUMER_TYPE, "candlepin");
         PoolManager poolManager = mock(PoolManager.class);
 
-        when(akc.verifyAndLookupKey(eq("testKey"))).thenReturn(ak);
-        when(poolManager.find(eq("testPool"))).thenReturn(p);
+        when(akc.secureGet(eq("testKey"))).thenReturn(ak);
+        when(poolManager.get(eq("testPool"))).thenReturn(p);
 
         ActivationKeyResource akr = new ActivationKeyResource(akc, i18n, poolManager,
             serviceLevelValidator, activationKeyRules, null,
@@ -259,9 +259,9 @@ public class ActivationKeyResourceTest extends DatabaseTestFixture {
         Pool p2 = genPool();
         p2.setAttribute(Pool.Attributes.REQUIRES_HOST, "host1");
 
-        when(akc.verifyAndLookupKey(eq("testKey"))).thenReturn(ak);
-        when(poolManager.find(eq("testPool1"))).thenReturn(p1);
-        when(poolManager.find(eq("testPool2"))).thenReturn(p2);
+        when(akc.secureGet(eq("testKey"))).thenReturn(ak);
+        when(poolManager.get(eq("testPool1"))).thenReturn(p1);
+        when(poolManager.get(eq("testPool2"))).thenReturn(p2);
 
         ActivationKeyResource akr = new ActivationKeyResource(akc, i18n, poolManager,
             serviceLevelValidator, activationKeyRules, null,
@@ -287,8 +287,8 @@ public class ActivationKeyResourceTest extends DatabaseTestFixture {
         p2.setAttribute(Pool.Attributes.REQUIRES_HOST, "host2");
 
         ak.addPool(p2, 1L);
-        when(akc.verifyAndLookupKey(eq("testKey"))).thenReturn(ak);
-        when(poolManager.find(eq("testPool1"))).thenReturn(p1);
+        when(akc.secureGet(eq("testKey"))).thenReturn(ak);
+        when(poolManager.get(eq("testPool1"))).thenReturn(p1);
 
         ActivationKeyResource akr = new ActivationKeyResource(akc, i18n, poolManager,
             serviceLevelValidator, activationKeyRules, null,
@@ -306,9 +306,9 @@ public class ActivationKeyResourceTest extends DatabaseTestFixture {
         Pool p2 = genPool();
         p2.setAttribute(Pool.Attributes.REQUIRES_HOST, "");
 
-        when(akc.verifyAndLookupKey(eq("testKey"))).thenReturn(ak);
-        when(poolManager.find(eq("testPool1"))).thenReturn(p1);
-        when(poolManager.find(eq("testPool2"))).thenReturn(p2);
+        when(akc.secureGet(eq("testKey"))).thenReturn(ak);
+        when(poolManager.get(eq("testPool1"))).thenReturn(p1);
+        when(poolManager.get(eq("testPool2"))).thenReturn(p2);
 
         ActivationKeyResource akr = new ActivationKeyResource(akc, i18n, poolManager,
             serviceLevelValidator, activationKeyRules, null,
@@ -327,8 +327,8 @@ public class ActivationKeyResourceTest extends DatabaseTestFixture {
         Pool p = genPool();
         PoolManager poolManager = mock(PoolManager.class);
 
-        when(akc.verifyAndLookupKey(eq("testKey"))).thenReturn(ak);
-        when(poolManager.find(eq("testPool"))).thenReturn(p);
+        when(akc.secureGet(eq("testKey"))).thenReturn(ak);
+        when(poolManager.get(eq("testPool"))).thenReturn(p);
 
         ActivationKeyResource akr = new ActivationKeyResource(akc, i18n, poolManager,
             serviceLevelValidator, activationKeyRules, null,

--- a/server/src/test/java/org/candlepin/resource/CertificateSerialResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/CertificateSerialResourceTest.java
@@ -73,7 +73,7 @@ public class CertificateSerialResourceTest {
         CertificateSerialCurator csc = mock(CertificateSerialCurator.class);
         CertificateSerialResource csr = new CertificateSerialResource(csc, this.modelTranslator);
         CertificateSerial cs = new CertificateSerial(10L);
-        when(csc.find(cs.getId())).thenReturn(cs);
+        when(csc.get(cs.getId())).thenReturn(cs);
 
         CertificateSerialDTO output = csr.getCertificateSerial(10L);
         assertNotNull(output);

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceCreationTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceCreationTest.java
@@ -196,7 +196,7 @@ public class ConsumerResourceCreationTest {
         cert.setId("testId");
         cert.setSerial(new CertificateSerial(new Date()));
         when(idCertService.generateIdentityCert(any(Consumer.class))).thenReturn(cert);
-        when(ownerCurator.lookupByKey(owner.getKey())).thenReturn(owner);
+        when(ownerCurator.getByKey(owner.getKey())).thenReturn(owner);
         when(complianceRules.getStatus(
             any(Consumer.class), any(Date.class), any(Boolean.class), any(Boolean.class)))
                 .thenReturn(new ComplianceStatus(new Date()));
@@ -213,9 +213,9 @@ public class ConsumerResourceCreationTest {
                 ctype.setId("test-ctype-" + ctype.getLabel() + "-" + TestUtil.randomInt());
             }
 
-            when(consumerTypeCurator.lookupByLabel(eq(ctype.getLabel()))).thenReturn(ctype);
-            when(consumerTypeCurator.lookupByLabel(eq(ctype.getLabel()), anyBoolean())).thenReturn(ctype);
-            when(consumerTypeCurator.find(eq(ctype.getId()))).thenReturn(ctype);
+            when(consumerTypeCurator.getByLabel(eq(ctype.getLabel()))).thenReturn(ctype);
+            when(consumerTypeCurator.getByLabel(eq(ctype.getLabel()), anyBoolean())).thenReturn(ctype);
+            when(consumerTypeCurator.get(eq(ctype.getId()))).thenReturn(ctype);
 
             doAnswer(new Answer<ConsumerType>() {
                 @Override
@@ -229,7 +229,7 @@ public class ConsumerResourceCreationTest {
                         throw new IllegalArgumentException("consumer is null or lacks a type ID");
                     }
 
-                    ctype = curator.find(consumer.getTypeId());
+                    ctype = curator.get(consumer.getTypeId());
                     if (ctype == null) {
                         throw new IllegalStateException("No such consumer type: " + consumer.getTypeId());
                     }
@@ -363,7 +363,7 @@ public class ConsumerResourceCreationTest {
 
     private List<String> mockActivationKeys() {
         ActivationKey key1 = new ActivationKey("key1", owner);
-        when(activationKeyCurator.lookupForOwner("key1", owner)).thenReturn(key1);
+        when(activationKeyCurator.getByKeyName(owner, "key1")).thenReturn(key1);
         List<String> keys = new LinkedList<>();
         keys.add(key1.getName());
         return keys;
@@ -393,7 +393,7 @@ public class ConsumerResourceCreationTest {
         ConsumerDTO consumer = TestUtil.createConsumerDTO("sys.example.com", null, null, systemDto);
         resource.create(consumer, p, null, owner.getKey(), createKeysString(keys), true);
         for (String keyName : keys) {
-            verify(activationKeyCurator).lookupForOwner(keyName, owner);
+            verify(activationKeyCurator).getByKeyName(owner, keyName);
         }
     }
 
@@ -409,7 +409,7 @@ public class ConsumerResourceCreationTest {
         // Create a key that has autobind disabled.
         ActivationKey key = new ActivationKey("autobind-disabled-key", owner);
         key.setAutoAttach(true);
-        when(activationKeyCurator.lookupForOwner(key.getName(), owner)).thenReturn(key);
+        when(activationKeyCurator.getByKeyName(owner, key.getName())).thenReturn(key);
 
         // No auth should be required for registering with keys:
         Principal p = new NoAuthPrincipal();

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
@@ -210,7 +210,7 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
             owner.getKey(), null, true);
 
         assertNotNull(submitted);
-        assertNotNull(consumerCurator.find(submitted.getId()));
+        assertNotNull(consumerCurator.get(submitted.getId()));
         assertEquals(standardSystemType.getLabel(), submitted.getType().getLabel());
         assertEquals(METADATA_VALUE, submitted.getFact(METADATA_NAME));
     }
@@ -242,7 +242,7 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
             true);
         assertNotNull(submitted);
         assertNotNull(submitted.getId());
-        assertNotNull(consumerCurator.find(submitted.getId()));
+        assertNotNull(consumerCurator.get(submitted.getId()));
         assertNotNull(consumerCurator.findByUuid(uuid));
         assertEquals(standardSystemType.getLabel(), submitted.getType()
             .getLabel());
@@ -263,7 +263,7 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
             USER_NAME, owner, standardSystemType));
         consumerResource.deleteConsumer(consumer.getUuid(), principal);
 
-        assertNull(consumerCurator.find(created.getId()));
+        assertNull(consumerCurator.get(created.getId()));
     }
 
     @Test
@@ -307,7 +307,7 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
         consumer = consumerCurator.findByUuid(consumer.getUuid());
         assertEquals(1, consumer.getEntitlements().size());
 
-        pool = poolManager.find(pool.getId());
+        pool = poolManager.get(pool.getId());
         assertEquals(Long.valueOf(1), pool.getConsumed());
         assertEquals(1, resultList.size());
         assertEquals(pool.getId(), resultList.get(0).getPool().getId());
@@ -330,7 +330,7 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
 
         assertNotNull(submitted);
         assertEquals(toSubmit.getUuid(), submitted.getUuid());
-        assertNotNull(consumerCurator.find(submitted.getId()));
+        assertNotNull(consumerCurator.get(submitted.getId()));
         assertEquals(standardSystemType.getLabel(), submitted.getType().getLabel());
         assertEquals(METADATA_VALUE, submitted.getFact(METADATA_NAME));
 
@@ -594,7 +594,7 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
 
         cr.regenerateEntitlementCertificates(this.consumer.getUuid(), ent.getId(), false);
 
-        Entitlement entWithRefreshedCerts = entitlementCurator.find(ent.getId());
+        Entitlement entWithRefreshedCerts = entitlementCurator.get(ent.getId());
         ent = this.modelTranslator.translate(entWithRefreshedCerts, EntitlementDTO.class);
         assertEquals(1, ent.getCertificates().size());
         CertificateDTO entCertAfter = ent.getCertificates().iterator().next();

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
@@ -186,9 +186,9 @@ public class ConsumerResourceTest {
                 ctype.setId("test-ctype-" + ctype.getLabel() + "-" + TestUtil.randomInt());
             }
 
-            when(mockConsumerTypeCurator.lookupByLabel(eq(ctype.getLabel()))).thenReturn(ctype);
-            when(mockConsumerTypeCurator.lookupByLabel(eq(ctype.getLabel()), anyBoolean())).thenReturn(ctype);
-            when(mockConsumerTypeCurator.find(eq(ctype.getId()))).thenReturn(ctype);
+            when(mockConsumerTypeCurator.getByLabel(eq(ctype.getLabel()))).thenReturn(ctype);
+            when(mockConsumerTypeCurator.getByLabel(eq(ctype.getLabel()), anyBoolean())).thenReturn(ctype);
+            when(mockConsumerTypeCurator.get(eq(ctype.getId()))).thenReturn(ctype);
 
             doAnswer(new Answer<ConsumerType>() {
                 @Override
@@ -202,7 +202,7 @@ public class ConsumerResourceTest {
                         throw new IllegalArgumentException("consumer is null or lacks a type ID");
                     }
 
-                    ctype = curator.find(consumer.getTypeId());
+                    ctype = curator.get(consumer.getTypeId());
                     if (ctype == null) {
                         throw new IllegalStateException("No such consumer type: " + consumer.getTypeId());
                     }
@@ -227,7 +227,7 @@ public class ConsumerResourceTest {
                 owner.setKey("test-owner-key-" + rand);
             }
 
-            when(mockOwnerCurator.lookupByKey(eq(owner.getKey()))).thenReturn(owner);
+            when(mockOwnerCurator.getByKey(eq(owner.getKey()))).thenReturn(owner);
         }
 
         return owner;
@@ -302,7 +302,7 @@ public class ConsumerResourceTest {
             .thenReturn(Boolean.TRUE);
 
         Owner o = mock(Owner.class);
-        when(mockOwnerCurator.lookupByKey(any(String.class))).thenReturn(o);
+        when(mockOwnerCurator.getByKey(any(String.class))).thenReturn(o);
 
         c.setFact("foo", "bar");
 
@@ -334,11 +334,11 @@ public class ConsumerResourceTest {
             .thenReturn(Boolean.TRUE);
 
         Owner o = mock(Owner.class);
-        when(mockOwnerCurator.lookupByKey(any(String.class))).thenReturn(o);
+        when(mockOwnerCurator.getByKey(any(String.class))).thenReturn(o);
 
         Owner o2 = mock(Owner.class);
         c.setRecipientOwnerKey("o2");
-        when(mockOwnerCurator.lookupByKey(eq("o2"))).thenReturn(o2);
+        when(mockOwnerCurator.getByKey(eq("o2"))).thenReturn(o2);
 
         when(uap.canAccess(eq(o2), eq(SubResource.ENTITLEMENTS), eq(Access.CREATE)))
             .thenReturn(Boolean.FALSE);
@@ -383,7 +383,7 @@ public class ConsumerResourceTest {
         when(e.getPool()).thenReturn(p);
         when(p.getSubscriptionId()).thenReturn("4444");
 
-        when(mockEntitlementCurator.find(eq("9999"))).thenReturn(e);
+        when(mockEntitlementCurator.get(eq("9999"))).thenReturn(e);
         when(mockSubscriptionServiceAdapter.getSubscription(eq("4444"))).thenReturn(s);
 
         when(mockEntitlementCertServiceAdapter.generateEntitlementCert(
@@ -536,7 +536,7 @@ public class ConsumerResourceTest {
         ConsumerContentOverrideCurator ccoc = mock(ConsumerContentOverrideCurator.class);
 
         when(ak.getId()).thenReturn("testKey");
-        when(akc.lookupForOwner(eq(owner.getKey()), eq(owner))).thenReturn(ak);
+        when(akc.getByKeyName(eq(owner), eq(owner.getKey()))).thenReturn(ak);
 
         ConsumerResource cr = new ConsumerResource(null, mockConsumerTypeCurator, null,
             null, null, null, null, null, i18n, null, null, null, null,
@@ -608,7 +608,7 @@ public class ConsumerResourceTest {
         ConsumerCurator consumerCurator = mock(ConsumerCurator.class);
         when(consumerCurator.verifyAndLookupConsumer(eq("fake uuid"))).thenReturn(consumer);
 
-        when(mockEntitlementCurator.find(any(Serializable.class))).thenReturn(null);
+        when(mockEntitlementCurator.get(any(Serializable.class))).thenReturn(null);
 
         ConsumerResource consumerResource = new ConsumerResource(mockConsumerCurator, mockConsumerTypeCurator,
             null, null, null, mockEntitlementCurator, null, null, i18n, null, null, null,
@@ -868,7 +868,7 @@ public class ConsumerResourceTest {
         when(cqmock.list()).thenReturn(consumers);
         when(cqmock.iterator()).thenReturn(consumers.iterator());
 
-        when(mockOwnerCurator.lookupByKey(eq("taylorOwner"))).thenReturn(new Owner());
+        when(mockOwnerCurator.getByKey(eq("taylorOwner"))).thenReturn(new Owner());
         when(mockConsumerCurator.searchOwnerConsumers(
             any(Owner.class), anyString(), (java.util.Collection<ConsumerType>) any(Collection.class),
             any(List.class), any(List.class), any(List.class), any(List.class), any(List.class),
@@ -1007,7 +1007,7 @@ public class ConsumerResourceTest {
 
         Cdn cdn = new Cdn("cdn-label", "test", "url");
 
-        when(mockCdnCurator.lookupByLabel(eq(cdn.getLabel()))).thenReturn(cdn);
+        when(mockCdnCurator.getByLabel(eq(cdn.getLabel()))).thenReturn(cdn);
 
         cr.exportDataAsync(null, consumer.getUuid(), cdn.getLabel(), "prefix", cdn.getUrl(), extParams);
         verify(manifestManager).generateManifestAsync(eq(consumer.getUuid()), eq(owner.getKey()),

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
@@ -170,9 +170,9 @@ public class ConsumerResourceUpdateTest {
                 ctype.setId("test-ctype-" + ctype.getLabel() + "-" + TestUtil.randomInt());
             }
 
-            when(consumerTypeCurator.lookupByLabel(eq(ctype.getLabel()))).thenReturn(ctype);
-            when(consumerTypeCurator.lookupByLabel(eq(ctype.getLabel()), anyBoolean())).thenReturn(ctype);
-            when(consumerTypeCurator.find(eq(ctype.getId()))).thenReturn(ctype);
+            when(consumerTypeCurator.getByLabel(eq(ctype.getLabel()))).thenReturn(ctype);
+            when(consumerTypeCurator.getByLabel(eq(ctype.getLabel()), anyBoolean())).thenReturn(ctype);
+            when(consumerTypeCurator.get(eq(ctype.getId()))).thenReturn(ctype);
 
             doAnswer(new Answer<ConsumerType>() {
                 @Override
@@ -186,7 +186,7 @@ public class ConsumerResourceUpdateTest {
                         throw new IllegalArgumentException("consumer is null or lacks a type ID");
                     }
 
-                    ctype = curator.find(consumer.getTypeId());
+                    ctype = curator.get(consumer.getTypeId());
                     if (ctype == null) {
                         throw new IllegalStateException("No such consumer type: " + consumer.getTypeId());
                     }
@@ -557,7 +557,7 @@ public class ConsumerResourceUpdateTest {
         existingMigratedTo.setUuid("MIGRATED_TO");
         when(this.consumerCurator.verifyAndLookupConsumer(existingMigratedTo.getUuid()))
             .thenReturn(existingMigratedTo);
-        when(this.consumerCurator.find(eq(guest1.getId()))).thenReturn(guest1);
+        when(this.consumerCurator.get(eq(guest1.getId()))).thenReturn(guest1);
 
         this.resource.updateConsumer(
             existingMigratedTo.getUuid(),
@@ -589,7 +589,7 @@ public class ConsumerResourceUpdateTest {
         when(this.consumerCurator.getGuestConsumersMap(any(String.class), any(Set.class))).
             thenReturn(mockVirtConsumerMap("Guest 1", guest1));
         // Ensure that the guest was not reported by another host.
-        when(this.consumerCurator.find(eq(guest1.getId()))).thenReturn(guest1);
+        when(this.consumerCurator.get(eq(guest1.getId()))).thenReturn(guest1);
 
         this.resource.updateConsumer(host.getUuid(), updatedHost, principal);
         verify(poolManager, never()).revokeEntitlement(eq(entitlement));
@@ -702,7 +702,7 @@ public class ConsumerResourceUpdateTest {
 
         when(this.consumerCurator.getGuestConsumersMap(any(String.class), any(Set.class))).
             thenReturn(mockVirtConsumerMap("Guest 1", guest1));
-        when(this.consumerCurator.find(eq(guest1.getId()))).thenReturn(guest1);
+        when(this.consumerCurator.get(eq(guest1.getId()))).thenReturn(guest1);
 
         this.resource.updateConsumer(host.getUuid(), updatedHost, principal);
 
@@ -765,7 +765,7 @@ public class ConsumerResourceUpdateTest {
         ConsumerDTO updated = new ConsumerDTO();
         updated.setEnvironment(translator.translate(changedEnvironment, EnvironmentDTO.class));
 
-        when(environmentCurator.find(changedEnvironment.getId())).thenReturn(changedEnvironment);
+        when(environmentCurator.get(changedEnvironment.getId())).thenReturn(changedEnvironment);
 
         resource.updateConsumer(existing.getUuid(), updated, principal);
 
@@ -788,7 +788,7 @@ public class ConsumerResourceUpdateTest {
         existing.setUuid(updated.getUuid());
 
         when(consumerCurator.verifyAndLookupConsumer(existing.getUuid())).thenReturn(existing);
-        when(environmentCurator.find(changedEnvironment.getId())).thenReturn(null);
+        when(environmentCurator.get(changedEnvironment.getId())).thenReturn(null);
 
         resource.updateConsumer(existing.getUuid(), updated, principal);
     }

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceVirtEntitlementTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceVirtEntitlementTest.java
@@ -145,7 +145,7 @@ public class ConsumerResourceVirtEntitlementTest extends DatabaseTestFixture {
                     10, null, null, false, null, null);
                 consumerResource.bind(guestConsumer.getUuid(), p.getId(), null,
                     10, null, null, false, null, null);
-                p = poolManager.find(p.getId());
+                p = poolManager.get(p.getId());
                 // ensure the correct # consumed from the bonus pool
                 assertTrue(p.getConsumed() == 20);
                 assertTrue(p.getQuantity() == 100);
@@ -160,7 +160,7 @@ public class ConsumerResourceVirtEntitlementTest extends DatabaseTestFixture {
         consumerResource.bind(manifestConsumer.getUuid(), parentPool.getId(), null, 7, null,
             null, false, null, null);
         for (Pool p : subscribedTo) {
-            p = poolManager.find(p.getId());
+            p = poolManager.get(p.getId());
             assertTrue(p.getConsumed() == 20);
             assertTrue(p.getQuantity() == 30);
         }
@@ -169,7 +169,7 @@ public class ConsumerResourceVirtEntitlementTest extends DatabaseTestFixture {
         consumerResource.bind(manifestConsumer.getUuid(), parentPool.getId(), null, 2, null,
             null, false, null, null);
         for (Pool p : subscribedTo) {
-            p = poolManager.find(p.getId());
+            p = poolManager.get(p.getId());
             assertTrue(p.getConsumed() == 10);
             assertTrue(p.getQuantity() == 10);
         }
@@ -178,7 +178,7 @@ public class ConsumerResourceVirtEntitlementTest extends DatabaseTestFixture {
         consumerResource.bind(systemConsumer.getUuid(), parentPool.getId(), null, 1, null,
             null, false, null, null);
         for (Pool p : subscribedTo) {
-            p = poolManager.find(p.getId());
+            p = poolManager.get(p.getId());
             assertTrue(p.getConsumed() == 10);
             assertTrue(p.getQuantity() == 10);
         }
@@ -202,7 +202,7 @@ public class ConsumerResourceVirtEntitlementTest extends DatabaseTestFixture {
                     10, null, null, false, null, null);
                 consumerResource.bind(guestConsumer.getUuid(), p.getId(), null,
                     10, null, null, false, null, null);
-                p = poolManager.find(p.getId());
+                p = poolManager.get(p.getId());
                 assertTrue(p.getConsumed() == 20);
                 assertTrue(p.getQuantity() == -1);
                 poolManager.getRefresher(subAdapter, ownerAdapter).add(owner).run();
@@ -227,7 +227,7 @@ public class ConsumerResourceVirtEntitlementTest extends DatabaseTestFixture {
         consumerResource.bind(manifestConsumer.getUuid(), parentPool.getId(), null, 3, null,
             null, false, null, null);
         for (Pool p : subscribedTo) {
-            p = poolManager.find(p.getId());
+            p = poolManager.get(p.getId());
             assertEquals(new Long(0), p.getConsumed());
             assertTrue(p.getQuantity() == 0);
         }

--- a/server/src/test/java/org/candlepin/resource/ConsumerTypeResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerTypeResourceTest.java
@@ -71,7 +71,7 @@ public class ConsumerTypeResourceTest extends DatabaseTestFixture {
     @Test
     public void testCreateType() {
         String label = "test_label";
-        ConsumerType existing = this.consumerTypeCurator.lookupByLabel(label);
+        ConsumerType existing = this.consumerTypeCurator.getByLabel(label);
 
         // Verify it doesn't exist already
         assertNull(existing);
@@ -91,7 +91,7 @@ public class ConsumerTypeResourceTest extends DatabaseTestFixture {
         this.consumerTypeCurator.clear();
 
         // Ensure the type actually hit the DB
-        existing = this.consumerTypeCurator.lookupByLabel(label);
+        existing = this.consumerTypeCurator.getByLabel(label);
         assertNotNull(existing);
         assertEquals(dto.getLabel(), existing.getLabel());
         assertEquals(dto.isManifest(), existing.isManifest());
@@ -122,7 +122,7 @@ public class ConsumerTypeResourceTest extends DatabaseTestFixture {
         this.consumerTypeCurator.clear();
 
         // Ensure the update actually hit the DB
-        ConsumerType existing = this.consumerTypeCurator.lookupByLabel(label);
+        ConsumerType existing = this.consumerTypeCurator.getByLabel(label);
         assertNotNull(existing);
         assertEquals(dto.getLabel(), existing.getLabel());
         assertEquals(manifest, existing.isManifest());
@@ -148,7 +148,7 @@ public class ConsumerTypeResourceTest extends DatabaseTestFixture {
         this.consumerTypeCurator.clear();
 
         // Ensure the update actually hit the DB
-        ConsumerType existing = this.consumerTypeCurator.find(this.testType.getId());
+        ConsumerType existing = this.consumerTypeCurator.get(this.testType.getId());
         assertNotNull(existing);
         assertEquals(label, existing.getLabel());
         assertEquals(dto.isManifest(), existing.isManifest());
@@ -173,7 +173,7 @@ public class ConsumerTypeResourceTest extends DatabaseTestFixture {
         this.consumerTypeCurator.clear();
 
         // Ensure the update changed nothing in the DB
-        ConsumerType existing = this.consumerTypeCurator.find(this.testType.getId());
+        ConsumerType existing = this.consumerTypeCurator.get(this.testType.getId());
         assertNotNull(existing);
         assertEquals(label, existing.getLabel());
         assertEquals(manifest, existing.isManifest());
@@ -198,7 +198,7 @@ public class ConsumerTypeResourceTest extends DatabaseTestFixture {
     @Test
     public void testDeleteType() {
         String id = this.testType.getId();
-        assertNotNull(this.consumerTypeCurator.find(id));
+        assertNotNull(this.consumerTypeCurator.get(id));
 
         this.consumerTypeResource.deleteConsumerType(id);
 
@@ -207,7 +207,7 @@ public class ConsumerTypeResourceTest extends DatabaseTestFixture {
         this.consumerTypeCurator.clear();
 
         // Verify the type no longer exists
-        assertNull(this.consumerTypeCurator.find(id));
+        assertNull(this.consumerTypeCurator.get(id));
     }
 
     @Test(expected = NotFoundException.class)

--- a/server/src/test/java/org/candlepin/resource/ContentResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/ContentResourceTest.java
@@ -85,7 +85,7 @@ public class ContentResourceTest {
 
     @Test(expected = NotFoundException.class)
     public void getContentNull() {
-        when(cc.find(anyLong())).thenReturn(null);
+        when(cc.get(anyLong())).thenReturn(null);
         cr.getContent("10");
     }
 
@@ -98,7 +98,7 @@ public class ContentResourceTest {
 
         when(cqmock.list()).thenReturn(Arrays.asList(owner));
         when(oc.listAll()).thenReturn(cqmock);
-        when(cc.lookupByUuid(eq("10"))).thenReturn(content);
+        when(cc.getByUuid(eq("10"))).thenReturn(content);
 
         ContentDTO output = cr.getContent("10");
 
@@ -128,7 +128,7 @@ public class ContentResourceTest {
 
         cr.updateContent(contentId, contentDTO);
 
-        verify(cc, never()).find(any());
+        verify(cc, never()).get(any());
         verify(cc, never()).merge(any());
         verify(productCurator, never()).getProductsByContent(any(), any());
     }

--- a/server/src/test/java/org/candlepin/resource/EntitlementResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/EntitlementResourceTest.java
@@ -107,9 +107,9 @@ public class EntitlementResourceTest {
                 ctype.setId("test-ctype-" + ctype.getLabel() + "-" + TestUtil.randomInt());
             }
 
-            when(consumerTypeCurator.lookupByLabel(eq(ctype.getLabel()))).thenReturn(ctype);
-            when(consumerTypeCurator.lookupByLabel(eq(ctype.getLabel()), anyBoolean())).thenReturn(ctype);
-            when(consumerTypeCurator.find(eq(ctype.getId()))).thenReturn(ctype);
+            when(consumerTypeCurator.getByLabel(eq(ctype.getLabel()))).thenReturn(ctype);
+            when(consumerTypeCurator.getByLabel(eq(ctype.getLabel()), anyBoolean())).thenReturn(ctype);
+            when(consumerTypeCurator.get(eq(ctype.getId()))).thenReturn(ctype);
 
             doAnswer(new Answer<ConsumerType>() {
                 @Override
@@ -123,7 +123,7 @@ public class EntitlementResourceTest {
                         throw new IllegalArgumentException("consumer is null or lacks a type ID");
                     }
 
-                    ctype = curator.find(consumer.getTypeId());
+                    ctype = curator.get(consumer.getTypeId());
                     if (ctype == null) {
                         throw new IllegalStateException("No such consumer type: " + consumer.getTypeId());
                     }
@@ -147,7 +147,7 @@ public class EntitlementResourceTest {
 
         e.getPool().setCertificate(subcert);
 
-        when(entitlementCurator.find(eq(e.getId()))).thenReturn(e);
+        when(entitlementCurator.get(eq(e.getId()))).thenReturn(e);
 
         String expected = "HELLOCERT";
         String result = entResource.getUpstreamCert(e.getId());
@@ -161,7 +161,7 @@ public class EntitlementResourceTest {
         Entitlement e = TestUtil.createEntitlement();
         e.setId("entitlementID");
         e.getPool().setSourceSubscription(null);
-        when(entitlementCurator.find(eq(e.getId()))).thenReturn(e);
+        when(entitlementCurator.get(eq(e.getId()))).thenReturn(e);
         entResource.getUpstreamCert(e.getId());
     }
 
@@ -186,7 +186,7 @@ public class EntitlementResourceTest {
         e.setId("entitlementID");
         e.getPool().setSourceStack(new SourceStack(consumer, "mystack"));
 
-        when(entitlementCurator.find(eq(e.getId()))).thenReturn(e);
+        when(entitlementCurator.get(eq(e.getId()))).thenReturn(e);
 
         String result = entResource.getUpstreamCert(e.getId());
         assertEquals(expected, result);
@@ -201,7 +201,7 @@ public class EntitlementResourceTest {
         Entitlement e = TestUtil.createEntitlement();
         e.setId("entitlementID");
         e.getPool().setSourceStack(new SourceStack(consumer, "mystack"));
-        when(entitlementCurator.find(eq(e.getId()))).thenReturn(e);
+        when(entitlementCurator.get(eq(e.getId()))).thenReturn(e);
 
         entResource.getUpstreamCert(e.getId());
     }
@@ -218,7 +218,7 @@ public class EntitlementResourceTest {
         e.setConsumer(sourceConsumer);
         e.setQuantity(25);
 
-        when(entitlementCurator.find(eq(e.getId()))).thenReturn(e);
+        when(entitlementCurator.get(eq(e.getId()))).thenReturn(e);
         when(consumerCurator.verifyAndLookupConsumer(eq(destConsumer.getUuid())))
             .thenReturn(destConsumer);
 
@@ -236,7 +236,7 @@ public class EntitlementResourceTest {
         e.setConsumer(consumer);
         e.setQuantity(25);
 
-        when(entitlementCurator.find(eq(e.getId()))).thenReturn(e);
+        when(entitlementCurator.get(eq(e.getId()))).thenReturn(e);
         when(consumerCurator.verifyAndLookupConsumer(eq(destConsumer.getUuid()))).thenReturn(destConsumer);
 
         entResource.migrateEntitlement(e.getId(), destConsumer.getUuid(), 15);
@@ -253,7 +253,7 @@ public class EntitlementResourceTest {
         e.setConsumer(sourceConsumer);
         e.setQuantity(25);
 
-        when(entitlementCurator.find(eq(e.getId()))).thenReturn(e);
+        when(entitlementCurator.get(eq(e.getId()))).thenReturn(e);
         when(consumerCurator.verifyAndLookupConsumer(eq(consumer.getUuid()))).thenReturn(consumer);
 
         entResource.migrateEntitlement(e.getId(), consumer.getUuid(), 15);
@@ -274,7 +274,7 @@ public class EntitlementResourceTest {
         e.setConsumer(sourceConsumer);
         e.setQuantity(25);
 
-        when(entitlementCurator.find(eq(e.getId()))).thenReturn(e);
+        when(entitlementCurator.get(eq(e.getId()))).thenReturn(e);
         when(consumerCurator.verifyAndLookupConsumer(eq(destConsumer.getUuid())))
             .thenReturn(destConsumer);
 

--- a/server/src/test/java/org/candlepin/resource/EventResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/EventResourceTest.java
@@ -64,7 +64,7 @@ public class EventResourceTest {
     @Test
     public void getevent() {
         Event e = getEvent();
-        when(ec.find(eq("8aba"))).thenReturn(e);
+        when(ec.get(eq("8aba"))).thenReturn(e);
         when(translator.translate(any(Event.class), any(Class.class))).thenReturn(getEventDTO());
         EventResource er = new EventResource(ec, null, injector.getInstance(EventAdapter.class), translator);
         assertEquals(getEventDTO(), er.getEvent("8aba"));
@@ -72,7 +72,7 @@ public class EventResourceTest {
 
     @Test(expected = NotFoundException.class)
     public void notfound() {
-        when(ec.find(anyString())).thenReturn(null);
+        when(ec.get(anyString())).thenReturn(null);
         EventResource er = new EventResource(ec,
             injector.getInstance(I18n.class),
             injector.getInstance(EventAdapter.class), translator);

--- a/server/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
@@ -169,7 +169,7 @@ public class HypervisorResourceTest {
         when(complianceRules.getStatus(any(Consumer.class), any(Date.class), any(Boolean.class)))
             .thenReturn(new ComplianceStatus(new Date()));
 
-        when(ownerCurator.lookupByKey(any(String.class))).thenReturn(new Owner());
+        when(ownerCurator.getByKey(any(String.class))).thenReturn(new Owner());
         when(eventFactory.getEventBuilder(any(Target.class), any(Type.class)))
             .thenReturn(consumerEventBuilder);
         when(consumerEventBuilder.setEventData(any(Consumer.class)))
@@ -183,9 +183,9 @@ public class HypervisorResourceTest {
                 ctype.setId("test-ctype-" + ctype.getLabel() + "-" + TestUtil.randomInt());
             }
 
-            when(consumerTypeCurator.lookupByLabel(eq(ctype.getLabel()))).thenReturn(ctype);
-            when(consumerTypeCurator.lookupByLabel(eq(ctype.getLabel()), anyBoolean())).thenReturn(ctype);
-            when(consumerTypeCurator.find(eq(ctype.getId()))).thenReturn(ctype);
+            when(consumerTypeCurator.getByLabel(eq(ctype.getLabel()))).thenReturn(ctype);
+            when(consumerTypeCurator.getByLabel(eq(ctype.getLabel()), anyBoolean())).thenReturn(ctype);
+            when(consumerTypeCurator.get(eq(ctype.getId()))).thenReturn(ctype);
 
             doAnswer(new Answer<ConsumerType>() {
                 @Override
@@ -199,7 +199,7 @@ public class HypervisorResourceTest {
                         throw new IllegalArgumentException("consumer is null or lacks a type ID");
                     }
 
-                    ctype = curator.find(consumer.getTypeId());
+                    ctype = curator.get(consumer.getTypeId());
                     if (ctype == null) {
                         throw new IllegalStateException("No such consumer type: " + consumer.getTypeId());
                     }
@@ -222,13 +222,13 @@ public class HypervisorResourceTest {
         hostGuestMap.put("test-host", new ArrayList(Arrays.asList(TestUtil.createGuestIdDTO("GUEST_A"),
             TestUtil.createGuestIdDTO("GUEST_B"))));
 
-        when(ownerCurator.lookupByKey(eq(owner.getKey()))).thenReturn(owner);
+        when(ownerCurator.getByKey(eq(owner.getKey()))).thenReturn(owner);
         when(consumerCurator.getHostConsumersMap(any(Owner.class), any(Set.class)))
             .thenReturn(new VirtConsumerMap());
         when(consumerCurator.getGuestConsumersMap(any(String.class), any(Set.class)))
             .thenReturn(new VirtConsumerMap());
 
-        when(ownerCurator.lookupByKey(eq(owner.getKey()))).thenReturn(owner);
+        when(ownerCurator.getByKey(eq(owner.getKey()))).thenReturn(owner);
         when(principal.canAccess(eq(owner), eq(SubResource.CONSUMERS), eq(Access.CREATE)))
             .thenReturn(true);
         when(idCertService.generateIdentityCert(any(Consumer.class)))
@@ -272,7 +272,7 @@ public class HypervisorResourceTest {
         existing.addGuestId(new GuestId("GUEST_A"));
         existing.setType(this.hypervisorType);
 
-        when(ownerCurator.lookupByKey(eq(owner.getKey()))).thenReturn(owner);
+        when(ownerCurator.getByKey(eq(owner.getKey()))).thenReturn(owner);
         // Force update
         when(consumerCurator.getHostConsumersMap(any(Owner.class), any(Set.class)))
             .thenReturn(mockHypervisorConsumerMap(hypervisorId, existing));
@@ -313,7 +313,7 @@ public class HypervisorResourceTest {
         RuntimeException exception = new RuntimeException(expectedMessage);
 
         // Simulate failure  when checking the owner
-        when(ownerCurator.lookupByKey(eq(owner.getKey()))).thenReturn(owner);
+        when(ownerCurator.getByKey(eq(owner.getKey()))).thenReturn(owner);
         when(principal.canAccess(eq(owner), eq(SubResource.CONSUMERS), eq(Access.CREATE))).
             thenReturn(true);
         when(consumerCurator.create(any(Consumer.class)))
@@ -336,14 +336,14 @@ public class HypervisorResourceTest {
         hostGuestMap.put("test-host", new ArrayList(Arrays.asList(TestUtil.createGuestIdDTO("GUEST_A"),
             TestUtil.createGuestIdDTO("GUEST_B"))));
 
-        when(ownerCurator.lookupByKey(eq(owner.getKey()))).thenReturn(owner);
+        when(ownerCurator.getByKey(eq(owner.getKey()))).thenReturn(owner);
 
         when(consumerCurator.getHostConsumersMap(any(Owner.class), any(Set.class)))
             .thenReturn(new VirtConsumerMap());
         when(consumerCurator.getGuestConsumersMap(any(String.class), any(Set.class)))
             .thenReturn(new VirtConsumerMap());
 
-        when(ownerCurator.lookupByKey(eq(owner.getKey()))).thenReturn(owner);
+        when(ownerCurator.getByKey(eq(owner.getKey()))).thenReturn(owner);
         when(principal.canAccess(eq(owner), eq(SubResource.CONSUMERS), eq(Access.CREATE)))
             .thenReturn(true);
         when(idCertService.generateIdentityCert(any(Consumer.class)))
@@ -378,14 +378,14 @@ public class HypervisorResourceTest {
         hostGuestMap.put("HYPERVISOR_A", new ArrayList(Arrays.asList(TestUtil.createGuestIdDTO("GUEST_C"),
             TestUtil.createGuestIdDTO("GUEST_D"))));
 
-        when(ownerCurator.lookupByKey(eq(owner.getKey()))).thenReturn(owner);
+        when(ownerCurator.getByKey(eq(owner.getKey()))).thenReturn(owner);
 
         when(consumerCurator.getHostConsumersMap(any(Owner.class), any(Set.class)))
             .thenReturn(new VirtConsumerMap());
         when(consumerCurator.getGuestConsumersMap(any(String.class), any(Set.class)))
             .thenReturn(new VirtConsumerMap());
 
-        when(ownerCurator.lookupByKey(eq(owner.getKey()))).thenReturn(owner);
+        when(ownerCurator.getByKey(eq(owner.getKey()))).thenReturn(owner);
         when(principal.canAccess(eq(owner), eq(SubResource.CONSUMERS), eq(Access.CREATE)))
             .thenReturn(true);
         when(idCertService.generateIdentityCert(any(Consumer.class)))
@@ -408,14 +408,14 @@ public class HypervisorResourceTest {
         Map<String, List<GuestIdDTO>> hostGuestMap = new HashMap<>();
         hostGuestMap.put("HYPERVISOR_A", new ArrayList(
             Arrays.asList(TestUtil.createGuestIdDTO("GUEST_A"), TestUtil.createGuestIdDTO(""))));
-        when(ownerCurator.lookupByKey(eq(owner.getKey()))).thenReturn(owner);
+        when(ownerCurator.getByKey(eq(owner.getKey()))).thenReturn(owner);
 
         when(consumerCurator.getHostConsumersMap(any(Owner.class), any(Set.class)))
             .thenReturn(new VirtConsumerMap());
         when(consumerCurator.getGuestConsumersMap(any(String.class), any(Set.class)))
             .thenReturn(new VirtConsumerMap());
 
-        when(ownerCurator.lookupByKey(eq(owner.getKey()))).thenReturn(owner);
+        when(ownerCurator.getByKey(eq(owner.getKey()))).thenReturn(owner);
         when(principal.canAccess(eq(owner), eq(SubResource.CONSUMERS), eq(Access.CREATE)))
             .thenReturn(true);
         when(idCertService.generateIdentityCert(any(Consumer.class)))
@@ -439,7 +439,7 @@ public class HypervisorResourceTest {
 
         Map<String, List<GuestIdDTO>> hostGuestMap = new HashMap<>();
         hostGuestMap.put("HYPERVISOR_A", null);
-        when(ownerCurator.lookupByKey(eq(owner.getKey()))).thenReturn(owner);
+        when(ownerCurator.getByKey(eq(owner.getKey()))).thenReturn(owner);
 
         when(consumerCurator.getHostConsumersMap(any(Owner.class), any(Set.class)))
             .thenReturn(new VirtConsumerMap());
@@ -468,7 +468,7 @@ public class HypervisorResourceTest {
 
         Map<String, List<GuestIdDTO>> hostGuestMap = new HashMap<>();
         hostGuestMap.put("HYPERVISOR_A", new ArrayList());
-        when(ownerCurator.lookupByKey(eq(owner.getKey()))).thenReturn(owner);
+        when(ownerCurator.getByKey(eq(owner.getKey()))).thenReturn(owner);
 
         try {
             hypervisorResource.hypervisorUpdate(hostGuestMap, principal, owner.getKey(), true);

--- a/server/src/test/java/org/candlepin/resource/JobResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/JobResourceTest.java
@@ -109,14 +109,14 @@ public class JobResourceTest {
     @Test
     public void getStatusAndDeleteIfFinishedTest() {
         //nothing to delete..
-        when(jobCurator.find("bogus_id")).thenReturn(new JobStatus());
+        when(jobCurator.get("bogus_id")).thenReturn(new JobStatus());
         jobResource.getStatusAndDeleteIfFinished("foobar");
         verify(jobCurator, never()).delete(any(JobStatus.class));
 
         //now lets make a deletable JobStatus
         JobStatus finishedJobStatus = new JobStatus();
         finishedJobStatus.setState(JobState.FINISHED);
-        when(jobCurator.find("deletable_id")).thenReturn(finishedJobStatus);
+        when(jobCurator.get("deletable_id")).thenReturn(finishedJobStatus);
         jobResource.getStatusAndDeleteIfFinished("deletable_id");
         verify(jobCurator, atLeastOnce()).delete(finishedJobStatus);
     }
@@ -129,7 +129,7 @@ public class JobResourceTest {
         JobStatus canceledJobStatus = new JobStatus();
         canceledJobStatus.setState(JobState.CANCELED);
 
-        when(jobCurator.find("cancel_id")).thenReturn(createdJobStatus);
+        when(jobCurator.get("cancel_id")).thenReturn(createdJobStatus);
         when(jobCurator.cancel("cancel_id")).thenReturn(canceledJobStatus);
         jobResource.cancel("cancel_id");
         verify(jobCurator, atLeastOnce()).cancel("cancel_id");

--- a/server/src/test/java/org/candlepin/resource/OwnerContentResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/OwnerContentResourceTest.java
@@ -260,7 +260,7 @@ public class OwnerContentResourceTest extends DatabaseTestFixture {
         assertNull(this.ownerContentCurator.getContentById(owner, content.getId()));
 
         this.environmentCurator.evict(environment);
-        environment = this.environmentCurator.find(environment.getId());
+        environment = this.environmentCurator.get(environment.getId());
 
         assertEquals(0, environment.getEnvironmentContent().size());
     }
@@ -284,7 +284,7 @@ public class OwnerContentResourceTest extends DatabaseTestFixture {
             assertNotNull(this.ownerContentCurator.getContentById(owner, content.getId()));
 
             this.environmentCurator.evict(environment);
-            environment = this.environmentCurator.find(environment.getId());
+            environment = this.environmentCurator.get(environment.getId());
 
             assertEquals(1, environment.getEnvironmentContent().size());
 

--- a/server/src/test/java/org/candlepin/resource/OwnerProductResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/OwnerProductResourceTest.java
@@ -166,7 +166,7 @@ public class OwnerProductResourceTest extends DatabaseTestFixture {
         Owner o = mock(Owner.class);
         Product p = mock(Product.class);
 
-        when(oc.lookupByKey(eq("owner"))).thenReturn(o);
+        when(oc.getByKey(eq("owner"))).thenReturn(o);
         when(opc.getProductById(eq(o), eq("10"))).thenReturn(p);
 
         Set<Subscription> subs = new HashSet<>();

--- a/server/src/test/java/org/candlepin/resource/OwnerResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/OwnerResourceTest.java
@@ -166,7 +166,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
     @Test
     public void testCreateOwner() {
         assertNotNull(owner);
-        assertNotNull(ownerCurator.find(owner.getId()));
+        assertNotNull(ownerCurator.get(owner.getId()));
         assertTrue(owner.getPools().isEmpty());
     }
 
@@ -174,7 +174,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
     public void testSimpleDeleteOwner() {
         String id = owner.getId();
         ownerResource.deleteOwner(owner.getKey(), true, false);
-        owner = ownerCurator.find(id);
+        owner = ownerCurator.get(id);
         assertNull(owner);
     }
 
@@ -234,7 +234,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
 
         poolManager.getRefresher(subAdapter, ownerAdapter).add(owner).run();
 
-        pool = poolCurator.find(pool.getId());
+        pool = poolCurator.get(pool.getId());
         assertEquals(sub.getId(), pool.getSubscriptionId());
         assertEquals(sub.getQuantity(), pool.getQuantity());
         assertEquals(sub.getStartDate(), pool.getStartDate());
@@ -275,7 +275,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
 
         // Trigger the refresh:
         poolManager.getRefresher(subAdapter, ownerAdapter).add(owner).run();
-        assertNull("Pool not having subscription should have been deleted", poolCurator.find(poolId));
+        assertNull("Pool not having subscription should have been deleted", poolCurator.get(poolId));
     }
 
     @Test
@@ -333,7 +333,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         // Trigger the refresh:
         poolManager.getRefresher(subAdapter, ownerAdapter).add(owner).run();
 
-        List<Pool> pools = poolCurator.lookupBySubscriptionId(owner, sub.getId());
+        List<Pool> pools = poolCurator.getBySubscriptionId(owner, sub.getId());
         assertEquals(2, pools.size());
         String bonusId =  "";
         String masterId = "";
@@ -351,10 +351,10 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         // Trigger the refresh:
         poolManager.getRefresher(subAdapter, ownerAdapter).add(owner).run();
 
-        assertNull("Original Master Pool should be gone", poolCurator.find(masterId));
-        assertNotNull("Bonus Pool should be the same", poolCurator.find(bonusId));
+        assertNull("Original Master Pool should be gone", poolCurator.get(masterId));
+        assertNotNull("Bonus Pool should be the same", poolCurator.get(bonusId));
         // master pool should have been recreated
-        pools = poolCurator.lookupBySubscriptionId(owner, sub.getId());
+        pools = poolCurator.getBySubscriptionId(owner, sub.getId());
         assertEquals(2, pools.size());
         boolean newMaster = false;
         for (Pool p : pools) {
@@ -388,7 +388,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         // Trigger the refresh:
         poolManager.getRefresher(subAdapter, ownerAdapter).add(owner).run();
 
-        List<Pool> pools = poolCurator.lookupBySubscriptionId(owner, sub.getId());
+        List<Pool> pools = poolCurator.getBySubscriptionId(owner, sub.getId());
         assertEquals(2, pools.size());
         String bonusId =  "";
         String masterId = "";
@@ -406,10 +406,10 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         // Trigger the refresh:
         poolManager.getRefresher(subAdapter, ownerAdapter).add(owner).run();
 
-        assertNull("Original bonus pool should be gone", poolCurator.find(bonusId));
-        assertNotNull("Master pool should be the same", poolCurator.find(masterId));
+        assertNull("Original bonus pool should be gone", poolCurator.get(bonusId));
+        assertNotNull("Master pool should be the same", poolCurator.get(masterId));
         // master pool should have been recreated
-        pools = poolCurator.lookupBySubscriptionId(owner, sub.getId());
+        pools = poolCurator.getBySubscriptionId(owner, sub.getId());
         assertEquals(2, pools.size());
         boolean newBonus = false;
         for (Pool p : pools) {
@@ -878,13 +878,13 @@ public class OwnerResourceTest extends DatabaseTestFixture {
     @Test
     public void testEntitlementsRevocationWithLifoOrder() throws Exception {
         Pool pool = doTestEntitlementsRevocationCommon(7, 4, 5);
-        assertEquals(5L, this.poolCurator.find(pool.getId()).getConsumed().longValue());
+        assertEquals(5L, this.poolCurator.get(pool.getId()).getConsumed().longValue());
     }
 
     @Test
     public void testEntitlementsRevocationWithNoOverflow() throws Exception {
         Pool pool = doTestEntitlementsRevocationCommon(10, 4, 5);
-        assertEquals(9L, this.poolCurator.find(pool.getId()).getConsumed().longValue());
+        assertEquals(9L, this.poolCurator.get(pool.getId()).getConsumed().longValue());
     }
 
     @Test
@@ -944,7 +944,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
             oc, pc, null, null, i18n, null, null, null, null, null, null, null, null, null, null, null, null,
             null, null, null, null, null, null, null, null, null, null,
             null, null, this.modelTranslator);
-        when(oc.lookupByKey(anyString())).thenReturn(o);
+        when(oc.getByKey(anyString())).thenReturn(o);
         ActivationKeyDTO key = new ActivationKeyDTO();
         key = ownerres.createActivationKey(owner.getKey(), key);
     }
@@ -959,7 +959,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
             oc, pc, null, null, i18n, null, null, null, null, null, null, null, null, null, null, null, null,
             null, null, null, null, null, null, null, null, null, null, null,
             null, this.modelTranslator);
-        when(oc.lookupByKey(anyString())).thenReturn(o);
+        when(oc.getByKey(anyString())).thenReturn(o);
         ActivationKeyDTO key = new ActivationKeyDTO();
         key.setReleaseVersion(TestUtil.getStringOfSize(256));
 
@@ -993,13 +993,13 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         Consumer consumer = createConsumer(retrieved);
         Consumer consumer1 = createConsumer(retrieved);
 
-        pool = this.poolCurator.find(pool.getId());
+        pool = this.poolCurator.get(pool.getId());
         createEntitlementWithQ(pool, retrieved, consumer, e1, "01/02/2010");
         createEntitlementWithQ(pool, retrieved, consumer1, e2, "01/01/2010");
         assertEquals(pool.getConsumed(), Long.valueOf(e1 + e2));
 
         poolManager.getRefresher(subAdapter, ownerAdapter).add(retrieved).run();
-        pool = poolCurator.find(pool.getId());
+        pool = poolCurator.get(pool.getId());
         return pool;
     }
 
@@ -1041,14 +1041,14 @@ public class OwnerResourceTest extends DatabaseTestFixture {
 
         assertNotNull(pout);
         assertNotNull(pout.getId());
-        assertNotNull(this.ownerCurator.find(pout.getId()));
+        assertNotNull(this.ownerCurator.get(pout.getId()));
 
         OwnerDTO cout = this.ownerResource.createOwner(child);
 
         assertNotNull(cout);
         assertNotNull(cout.getId());
 
-        Owner owner = this.ownerCurator.find(cout.getId());
+        Owner owner = this.ownerCurator.get(cout.getId());
 
         assertNotNull(owner);
         assertNotNull(owner.getParentOwner());
@@ -1136,7 +1136,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
             serviceLevelValidator, null, null, null, null, null,
             this.modelTranslator);
 
-        when(oc.lookupByKey(eq("testOwner"))).thenReturn(o);
+        when(oc.getByKey(eq("testOwner"))).thenReturn(o);
         ConstraintViolationException ce = new ConstraintViolationException(null, null, null);
         PersistenceException pe = new PersistenceException(ce);
         Mockito.doThrow(pe).when(ownerManager).cleanupAndDelete(eq(o), eq(true));
@@ -1153,8 +1153,8 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         ProductCurator pc = mock(ProductCurator.class);
 
         when(ak.getName()).thenReturn("testKey");
-        when(akc.lookupForOwner(eq("testKey"), eq(o))).thenReturn(akOld);
-        when(oc.lookupByKey(eq("testOwner"))).thenReturn(o);
+        when(akc.getByKeyName(eq(o), eq("testKey"))).thenReturn(akOld);
+        when(oc.getByKey(eq("testOwner"))).thenReturn(o);
 
         OwnerResource ownerres = new OwnerResource(
             oc, pc, akc, null, i18n, null, null, null, null, null, null, null, null, null,
@@ -1406,7 +1406,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
             null, null, null, null, null, contentOverrideValidator, serviceLevelValidator, null,
             null, null, null, null, this.modelTranslator);
 
-        when(oc.lookupByKey(eq("admin"))).thenReturn(owner);
+        when(oc.getByKey(eq("admin"))).thenReturn(owner);
         when(owner.getUpstreamConsumer()).thenReturn(upstream);
 
         List<UpstreamConsumerDTO> results = ownerres.getUpstreamConsumers(p, "admin");
@@ -1421,11 +1421,11 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         ownerCurator.create(owner);
         ownerResource.setLogLevel(owner.getKey(), "ALL");
 
-        owner = ownerCurator.lookupByKey(owner.getKey());
+        owner = ownerCurator.getByKey(owner.getKey());
         assertEquals(owner.getLogLevel(), "ALL");
 
         ownerResource.deleteLogLevel(owner.getKey());
-        owner = ownerCurator.lookupByKey(owner.getKey());
+        owner = ownerCurator.getByKey(owner.getKey());
         assertNull(owner.getLogLevel());
     }
 
@@ -1662,7 +1662,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
             uc, ucg, null, null, null, null, null, null, null, null,
             null, this.modelTranslator);
 
-        when(oc.lookupByKey(eq("admin"))).thenReturn(owner);
+        when(oc.getByKey(eq("admin"))).thenReturn(owner);
         when(ucg.generate(eq(owner.getKey()), eq(principal))).thenReturn(entCert);
 
         UeberCertificate result = resource.createUeberCertificate(principal, owner.getKey());

--- a/server/src/test/java/org/candlepin/resource/ProductResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/ProductResourceTest.java
@@ -130,7 +130,7 @@ public class ProductResourceTest extends DatabaseTestFixture {
         ProductResource pr = new ProductResource(pc, null, null, config, i18n, this.modelTranslator);
         Owner o = mock(Owner.class);
         Product p = mock(Product.class);
-        // when(pc.lookupById(eq(o), eq("10"))).thenReturn(p);
+        // when(pc.getById(eq(o), eq("10"))).thenReturn(p);
         Set<Subscription> subs = new HashSet<>();
         Subscription s = mock(Subscription.class);
         subs.add(s);

--- a/server/src/test/java/org/candlepin/resource/util/InstalledProductStatusCalculatorTest.java
+++ b/server/src/test/java/org/candlepin/resource/util/InstalledProductStatusCalculatorTest.java
@@ -872,7 +872,7 @@ public class InstalledProductStatusCalculatorTest {
 
         consumer.setFact("cpu.cpu_socket(s)", "4");
 
-        when(this.consumerTypeCurator.find(eq(ctype.getId()))).thenReturn(ctype);
+        when(this.consumerTypeCurator.get(eq(ctype.getId()))).thenReturn(ctype);
         when(this.consumerTypeCurator.getConsumerType(eq(consumer))).thenReturn(ctype);
 
         return consumer;

--- a/server/src/test/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapterTest.java
+++ b/server/src/test/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapterTest.java
@@ -310,7 +310,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
         consumer.setUuid("test-consumer");
 
         when(this.mockConsumerTypeCurator.getConsumerType(eq(consumer))).thenReturn(type);
-        when(this.mockConsumerTypeCurator.find(eq(type.getId()))).thenReturn(type);
+        when(this.mockConsumerTypeCurator.get(eq(type.getId()))).thenReturn(type);
 
         entitlement = new Entitlement();
         entitlement.setQuantity(new Integer(ENTITLEMENT_QUANTITY));
@@ -359,7 +359,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
                 environment.setId("test-env-" + environment.getName() + "-" + TestUtil.randomInt());
             }
 
-            when(this.mockEnvironmentCurator.find(eq(environment.getId()))).thenReturn(environment);
+            when(this.mockEnvironmentCurator.get(eq(environment.getId()))).thenReturn(environment);
 
             doAnswer(new Answer<Environment>() {
                 @Override
@@ -374,7 +374,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
                     }
 
                     if (consumer.getEnvironmentId() != null) {
-                        environment = curator.find(consumer.getEnvironmentId());
+                        environment = curator.get(consumer.getEnvironmentId());
 
                         if (environment == null) {
                             throw new IllegalStateException("No such environment: " +
@@ -930,7 +930,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
 
         consumer.setType(ctype);
 
-        when(mockConsumerTypeCurator.find(eq(ctype.getId()))).thenReturn(ctype);
+        when(mockConsumerTypeCurator.get(eq(ctype.getId()))).thenReturn(ctype);
         when(mockConsumerTypeCurator.getConsumerType(consumer)).thenReturn(ctype);
 
         Set<ConsumerCapability> set = new HashSet<>();
@@ -957,7 +957,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
 
         consumer.setType(ctype);
 
-        when(mockConsumerTypeCurator.find(eq(ctype.getId()))).thenReturn(ctype);
+        when(mockConsumerTypeCurator.get(eq(ctype.getId()))).thenReturn(ctype);
         when(mockConsumerTypeCurator.getConsumerType(consumer)).thenReturn(ctype);
 
         DefaultEntitlementCertServiceAdapter entAdapter = this.initCertServiceAdapter();
@@ -979,7 +979,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
 
         consumer.setType(ctype);
 
-        when(mockConsumerTypeCurator.find(eq(ctype.getId()))).thenReturn(ctype);
+        when(mockConsumerTypeCurator.get(eq(ctype.getId()))).thenReturn(ctype);
         when(mockConsumerTypeCurator.getConsumerType(consumer)).thenReturn(ctype);
 
         DefaultEntitlementCertServiceAdapter entAdapter = this.initCertServiceAdapter();

--- a/server/src/test/java/org/candlepin/service/impl/DefaultIdentityCertServiceAdapterTest.java
+++ b/server/src/test/java/org/candlepin/service/impl/DefaultIdentityCertServiceAdapterTest.java
@@ -83,7 +83,7 @@ public class DefaultIdentityCertServiceAdapterTest {
         when(consumer.getUuid()).thenReturn(Util.generateUUID());
         KeyPair kp = createKeyPair();
         when(kpc.getConsumerKeyPair(consumer)).thenReturn(kp);
-        when(idcur.find(consumer.getId())).thenReturn(null);
+        when(idcur.get(consumer.getId())).thenReturn(null);
         when(csc.create(any(CertificateSerial.class))).thenAnswer(
             new Answer<CertificateSerial>() {
                 public CertificateSerial answer(InvocationOnMock invocation) {
@@ -125,8 +125,8 @@ public class DefaultIdentityCertServiceAdapterTest {
         IdentityCertificate mockic = mock(IdentityCertificate.class);
 
         when(consumer.getIdCert()).thenReturn(mockic);
-        when(idcur.find(mockic.getId())).thenReturn(mockic);
-        when(idcur.find(consumer.getId())).thenReturn(mockic);
+        when(idcur.get(mockic.getId())).thenReturn(mockic);
+        when(idcur.get(consumer.getId())).thenReturn(mockic);
 
         IdentityCertificate ic = dicsa.generateIdentityCert(consumer);
 
@@ -140,7 +140,7 @@ public class DefaultIdentityCertServiceAdapterTest {
         IdentityCertificate mockic = mock(IdentityCertificate.class);
         when(consumer.getIdCert()).thenReturn(mockic);
         when(mockic.getId()).thenReturn("43");
-        when(idcur.find(mockic.getId())).thenReturn(mockic);
+        when(idcur.get(mockic.getId())).thenReturn(mockic);
 
 
         KeyPair kp = createKeyPair();
@@ -188,7 +188,7 @@ public class DefaultIdentityCertServiceAdapterTest {
         Consumer consumer = mock(Consumer.class);
         when(consumer.getId()).thenReturn("42L");
         when(consumer.getUuid()).thenReturn(Util.generateUUID());
-        when(idcur.find(consumer.getId())).thenReturn(null);
+        when(idcur.get(consumer.getId())).thenReturn(null);
 
 
         KeyPair kp = createKeyPair();

--- a/server/src/test/java/org/candlepin/sync/ConsumerExporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/ConsumerExporterTest.java
@@ -75,7 +75,7 @@ public class ConsumerExporterTest {
         consumer.setContentAccessMode("access_mode");
 
         when(mockConsumerTypeCurator.getConsumerType(eq(consumer))).thenReturn(ctype);
-        when(mockConsumerTypeCurator.find(eq(ctype.getId()))).thenReturn(ctype);
+        when(mockConsumerTypeCurator.get(eq(ctype.getId()))).thenReturn(ctype);
 
         exporter.export(mapper, writer, consumer, "/subscriptions", "/candlepin");
 

--- a/server/src/test/java/org/candlepin/sync/ConsumerImporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/ConsumerImporterTest.java
@@ -173,7 +173,7 @@ public class ConsumerImporterTest {
         Owner anotherOwner = new Owner("other", "Other");
         anotherOwner.setId("blah");
         anotherOwner.setUpstreamConsumer(uc);
-        when(curator.lookupWithUpstreamUuid(consumer.getUuid())).thenReturn(anotherOwner);
+        when(curator.getByUpstreamUuid(consumer.getUuid())).thenReturn(anotherOwner);
 
         importer.store(owner, consumer, new ConflictOverrides(), null);
     }

--- a/server/src/test/java/org/candlepin/sync/ConsumerTypeImporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/ConsumerTypeImporterTest.java
@@ -82,7 +82,7 @@ public class ConsumerTypeImporterTest {
 
         ConsumerTypeCurator curator = mock(ConsumerTypeCurator.class);
 
-        when(curator.lookupByLabel("prosumer")).thenReturn(testType);
+        when(curator.getByLabel("prosumer")).thenReturn(testType);
 
         ConsumerTypeImporter importer = new ConsumerTypeImporter(curator);
         importer.store(new HashSet<ConsumerType>() {
@@ -102,7 +102,7 @@ public class ConsumerTypeImporterTest {
 
         ConsumerTypeCurator curator = mock(ConsumerTypeCurator.class);
 
-        when(curator.lookupByLabel("prosumer")).thenReturn(null);
+        when(curator.getByLabel("prosumer")).thenReturn(null);
 
         ConsumerTypeImporter importer = new ConsumerTypeImporter(curator);
         importer.store(new HashSet<ConsumerType>() {

--- a/server/src/test/java/org/candlepin/sync/EntitlementImporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/EntitlementImporterTest.java
@@ -113,7 +113,7 @@ public class EntitlementImporterTest {
         consumerDTO.setUrlApi("");
 
         when(this.mockConsumerTypeCurator.getConsumerType(eq(consumer))).thenReturn(ctype);
-        when(this.mockConsumerTypeCurator.find(eq(ctype.getId()))).thenReturn(ctype);
+        when(this.mockConsumerTypeCurator.get(eq(ctype.getId()))).thenReturn(ctype);
 
         cert = createEntitlementCertificate("my-test-key", "my-cert");
         cert.setId("test-id");
@@ -123,7 +123,7 @@ public class EntitlementImporterTest {
         meta = new Meta();
         meta.setCdnLabel("test-cdn");
         testCdn = new Cdn("test-cdn", "Test CDN", "https://test.url.com");
-        when(cdnCurator.lookupByLabel("test-cdn")).thenReturn(testCdn);
+        when(cdnCurator.getByLabel("test-cdn")).thenReturn(testCdn);
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/sync/ExporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/ExporterTest.java
@@ -464,7 +464,7 @@ public class ExporterTest {
         when(consumer.getTypeId()).thenReturn(ctype.getId());
 
         when(ctc.getConsumerType(eq(consumer))).thenReturn(ctype);
-        when(ctc.find(eq(ctype.getId()))).thenReturn(ctype);
+        when(ctc.get(eq(ctype.getId()))).thenReturn(ctype);
 
         CandlepinQuery cqmock = mock(CandlepinQuery.class);
         when(cqmock.iterator()).thenReturn(Arrays.asList(new ConsumerType("system")).iterator());
@@ -517,7 +517,7 @@ public class ExporterTest {
         when(consumer.getName()).thenReturn("consumer_name");
         when(consumer.getTypeId()).thenReturn(ctype.getId());
         when(ctc.getConsumerType(eq(consumer))).thenReturn(ctype);
-        when(ctc.find(eq(ctype.getId()))).thenReturn(ctype);
+        when(ctc.get(eq(ctype.getId()))).thenReturn(ctype);
 
         DistributorVersion dv = new DistributorVersion("test-dist-ver");
         Set<DistributorVersionCapability> dvcSet = new HashSet<>();

--- a/server/src/test/java/org/candlepin/sync/ImporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/ImporterTest.java
@@ -182,7 +182,7 @@ public class ImporterTest {
         em.setExported(daybefore);
         em.setId("42");
         em.setType(ExporterMetadata.TYPE_SYSTEM);
-        when(emc.lookupByType(ExporterMetadata.TYPE_SYSTEM)).thenReturn(em);
+        when(emc.getByType(ExporterMetadata.TYPE_SYSTEM)).thenReturn(em);
         Importer i = new Importer(null, null, null, null, null, null,
             null, null, null, emc, null, null, i18n, null,
             null, su, null, this.mockSubReconciler, this.ec, this.translator);
@@ -207,7 +207,7 @@ public class ImporterTest {
         File actualmeta = createFile("meta.json", "0.0.3", new Date(),
             "test_user", "prefix");
         ExporterMetadataCurator emc = mock(ExporterMetadataCurator.class);
-        when(emc.lookupByType(ExporterMetadata.TYPE_SYSTEM)).thenReturn(null);
+        when(emc.getByType(ExporterMetadata.TYPE_SYSTEM)).thenReturn(null);
         Importer i = new Importer(null, null, null, null, null, null,
             null, null, null, emc, null, null, i18n,
             null, null, su, null, this.mockSubReconciler, this.ec, this.translator);
@@ -229,7 +229,7 @@ public class ImporterTest {
         em.setExported(getDateBeforeDays(3));
         em.setId("42");
         em.setType(ExporterMetadata.TYPE_SYSTEM);
-        when(emc.lookupByType(ExporterMetadata.TYPE_SYSTEM)).thenReturn(em);
+        when(emc.getByType(ExporterMetadata.TYPE_SYSTEM)).thenReturn(em);
         Importer i = new Importer(null, null, null, null, null, null,
             null, null, null, emc, null, null, i18n,
             null, null, su, null, this.mockSubReconciler, this.ec, this.translator);
@@ -258,7 +258,7 @@ public class ImporterTest {
         em.setExported(date); // exact same date = assumed same manifest
         em.setId("42");
         em.setType(ExporterMetadata.TYPE_SYSTEM);
-        when(emc.lookupByType(ExporterMetadata.TYPE_SYSTEM)).thenReturn(em);
+        when(emc.getByType(ExporterMetadata.TYPE_SYSTEM)).thenReturn(em);
         Importer i = new Importer(null, null, null, null, null, null,
             null, null, null, emc, null, null, i18n,
             null, null, su, null, this.mockSubReconciler, this.ec, this.translator);
@@ -306,7 +306,7 @@ public class ImporterTest {
         em.setExported(getDateBeforeDays(30));
         em.setId("42");
         em.setType(ExporterMetadata.TYPE_SYSTEM);
-        when(emc.lookupByType(ExporterMetadata.TYPE_SYSTEM)).thenReturn(em);
+        when(emc.getByType(ExporterMetadata.TYPE_SYSTEM)).thenReturn(em);
         Importer i = new Importer(null, null, null, null, null, null,
             null, null, null, emc, null, null, i18n,
             null, null, su, null, this.mockSubReconciler, this.ec, this.translator);
@@ -337,7 +337,7 @@ public class ImporterTest {
         File actualmeta = createFile("meta.json", "0.0.3", new Date(),
             "test_user", "prefix");
         ExporterMetadataCurator emc = mock(ExporterMetadataCurator.class);
-        when(emc.lookupByTypeAndOwner(ExporterMetadata.TYPE_PER_USER, null))
+        when(emc.getByTypeAndOwner(ExporterMetadata.TYPE_PER_USER, null))
             .thenReturn(null);
         Importer i = new Importer(null, null, null, null, null, null,
             null, null, null, emc, null, null, i18n,
@@ -578,15 +578,15 @@ public class ImporterTest {
         Owner owner = new Owner("admin", "Admin Owner");
 
         ExporterMetadataCurator emc = mock(ExporterMetadataCurator.class);
-        when(emc.lookupByTypeAndOwner("per_user", owner)).thenReturn(null);
+        when(emc.getByTypeAndOwner("per_user", owner)).thenReturn(null);
 
         ConsumerType stype = new ConsumerType(ConsumerTypeEnum.SYSTEM);
         stype.setId("test-ctype");
-        when(consumerTypeCurator.lookupByLabel(eq("system"))).thenReturn(stype);
-        when(consumerTypeCurator.find(eq(stype.getId()))).thenReturn(stype);
+        when(consumerTypeCurator.getByLabel(eq("system"))).thenReturn(stype);
+        when(consumerTypeCurator.get(eq(stype.getId()))).thenReturn(stype);
 
         OwnerCurator oc = mock(OwnerCurator.class);
-        when(oc.lookupWithUpstreamUuid(any(String.class))).thenReturn(null);
+        when(oc.getByUpstreamUuid(any(String.class))).thenReturn(null);
 
         PoolManager pm = mock(PoolManager.class);
         Refresher refresher = mock(Refresher.class);
@@ -618,8 +618,8 @@ public class ImporterTest {
 
         ConsumerType ctype = new ConsumerType(ConsumerTypeEnum.CANDLEPIN);
         ctype.setId("test-ctype");
-        when(consumerTypeCurator.lookupByLabel(eq("candlepin"))).thenReturn(ctype);
-        when(consumerTypeCurator.find(eq(ctype.getId()))).thenReturn(ctype);
+        when(consumerTypeCurator.getByLabel(eq("candlepin"))).thenReturn(ctype);
+        when(consumerTypeCurator.get(eq(ctype.getId()))).thenReturn(ctype);
 
         File consumerFile = new File(folder.getRoot(), "consumer.json");
         mapper.writeValue(consumerFile, consumerDTO);
@@ -733,8 +733,8 @@ public class ImporterTest {
         OwnerCurator oc = mock(OwnerCurator.class);
         ConsumerType type = new ConsumerType(ConsumerTypeEnum.CANDLEPIN);
         type.setId("test-ctype");
-        when(consumerTypeCurator.lookupByLabel(eq("candlepin"))).thenReturn(type);
-        when(consumerTypeCurator.find(eq(type.getId()))).thenReturn(type);
+        when(consumerTypeCurator.getByLabel(eq("candlepin"))).thenReturn(type);
+        when(consumerTypeCurator.get(eq(type.getId()))).thenReturn(type);
 
         Importer i = new Importer(consumerTypeCurator, null, null, oc,
             mock(IdentityCertificateCurator.class), null, null,
@@ -834,7 +834,7 @@ public class ImporterTest {
         //  is passed and then jump out instead of trying to fake the actual file
         //  processing.
         doThrow(new RuntimeException("Done with the test")).when(emc)
-            .lookupByTypeAndOwner(any(String.class), any(Owner.class));
+            .getByTypeAndOwner(any(String.class), any(Owner.class));
         OwnerCurator oc = mock(OwnerCurator.class);
         Owner owner = mock(Owner.class);
         ConflictOverrides co = mock(ConflictOverrides.class);


### PR DESCRIPTION
- Renamed the generic ID-based lookup "find" and "secureFind" to
  "get" and "secureGet" respectively
- Renamed methods using the "lookup" prefix to use a "get" prefix
- Refactored or removed a few methods which were made redundant
  either by this change or by other changes made over the years
- Added the new "getNaturalIdLoader" method to AbstractHibernateCurator
  to assist with fetching entities using their natural IDs