### PR TITLE
Remove toString call where it is not necessary.

### DIFF
--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -550,7 +550,7 @@ public class CandlepinPoolManager implements PoolManager {
          * send out the events. Create an event for each pool that could change,
          * even if we won't use them all.
          */
-        if (CollectionUtils.isEmpty(existingPools)) {
+        if (existingPools == null || existingPools.isEmpty()) {
             return new HashSet<>(0);
         }
 
@@ -617,10 +617,10 @@ public class CandlepinPoolManager implements PoolManager {
         // Process pool updates...
         for (PoolUpdate updatedPool : updatedPools) {
             Pool existingPool = updatedPool.getPool();
-            log.info("Pool changed: {}", updatedPool.toString());
+            log.debug("Pool changed: {}", updatedPool);
 
             if (existingPool == null || !existingPoolIds.contains(existingPool.getId())) {
-                log.info("Pool has already been deleted from the database.");
+                log.debug("Pool has already been deleted from the database.");
                 continue;
             }
 


### PR DESCRIPTION
The beauty of SLF4J style interpolation is that if the log level is
higher that the method requires, it will not call toString on the object
and therefore saves some time.  By calling toString on the object before
it is passed in as a parameter, we lose those gains.

---
Also drop a call to a very simple utility method that is getting hit a lot and demote the log level of the pool messages anyway.