### PR TITLE
[Intent] Dont filter pools based on SLA on auto-attach, but prioritize

### DIFF
--- a/server/spec/consumer_resource_spec.rb
+++ b/server/spec/consumer_resource_spec.rb
@@ -6,6 +6,7 @@ require 'rexml/document'
 describe 'Consumer Resource' do
 
   include CandlepinMethods
+  include AttributeHelper
 
   before(:each) do
     @owner1 = create_owner random_string('test_owner1')
@@ -772,7 +773,7 @@ describe 'Consumer Resource' do
     service_levels.length.should eq(0)
   end
 
-  it 'should allow a consumer dry run an autosubscribe based on service level' do
+  it 'should allow a consumer without existing entitlements to dry run an autoattach based on SLA but not filter on it' do
     product1 = create_product(random_string('product'),
       random_string('product'),
       {:attributes => {:support_level => 'VIP'},
@@ -797,23 +798,41 @@ describe 'Consumer Resource' do
     consumer = @cp.get_consumer(consumer['uuid'])
     consumer['serviceLevel'].should == 'VIP'
 
-    # dry run against the set service level
+    # dry run against the set service level:
+    # should return both pools because we no longer filter on consumer's sla
+    # (unless the consumer has existing entitlements, and in this case we don't).
     pools = @cp.autobind_dryrun(consumer['uuid'])
-    pools.length.should == 1
-    pool_id = pools.first.pool.id
-    pool = @cp.get_pool(pool_id)
+    pools.length.should == 2
+    pool1_id = pools[0].pool.id
+    pool2_id = pools[1].pool.id
+    pool = @cp.get_pool(pool1_id)
     pool.subscriptionId.should == pool1.subscriptionId
+    pool = @cp.get_pool(pool2_id)
+    pool.subscriptionId.should == pool2.subscriptionId
 
-    # dry run against the override service level
+    # dry run against the override service level:
+    # should return both pools because we no longer filter on the SLA override
+    # (unless the consumer has existing entitlements, and in this case we don't).
     pools = @cp.autobind_dryrun(consumer['uuid'], 'Ultra-VIP')
-    pools.length.should == 1
-    pool_id = pools.first.pool.id
-    pool = @cp.get_pool(pool_id)
+    pools.length.should == 2
+    pool1_id = pools[0].pool.id
+    pool2_id = pools[1].pool.id
+    pool = @cp.get_pool(pool1_id)
+    pool.subscriptionId.should == pool1.subscriptionId
+    pool = @cp.get_pool(pool2_id)
     pool.subscriptionId.should == pool2.subscriptionId
 
     # ensure the override use did not change the setting
     consumer = @cp.get_consumer(consumer['uuid'])
     consumer['serviceLevel'].should == 'VIP'
+
+    # dry run against 1) no consumer SLA 2) no override SLA 3) with owner default SLA:
+    # should return both pools because we no longer filter on the owner's default SLA.
+    # (unless the consumer has existing entitlements, and in this case we don't).
+    consumer_client.update_consumer({:serviceLevel => ''})
+    consumer = @cp.get_consumer(consumer['uuid'])
+    consumer['serviceLevel'].should == ''
+    @cp.update_owner(@owner1['key'], {:defaultServiceLevel => 'VIP'})
 
     # dry run with unknown level should return badrequest
     lambda do
@@ -822,10 +841,101 @@ describe 'Consumer Resource' do
 
     # dry run against the override service level should be case insensitive
     pools = @cp.autobind_dryrun(consumer['uuid'], 'Ultra-vip')
-    pools.length.should == 1
-    pool_id = pools.first.pool.id
-    pool = @cp.get_pool(pool_id)
+    pools.length.should == 2
+    pool1_id = pools[0].pool.id
+    pool2_id = pools[1].pool.id
+    pool = @cp.get_pool(pool1_id)
+    pool.subscriptionId.should == pool1.subscriptionId
+    pool = @cp.get_pool(pool2_id)
     pool.subscriptionId.should == pool2.subscriptionId
+  end
+
+  it "should allow a consumer dry run an autoattach based on SLA and filter on their existing entitlement SLAs" do
+    product1 = create_product(random_string('product'),
+      random_string('product'),
+      {:attributes => {:support_level => 'VIP'},
+      :owner => @owner1['key']})
+    product2 = create_product(random_string('product'),
+      random_string('product'),
+      {:attributes => {:support_level => 'Ultra-VIP'},
+      :owner => @owner1['key']})
+    product3 = create_product(random_string('product'),
+      random_string('product'),
+      {:attributes => {:support_level => 'Ultra-VIP'},
+      :owner => @owner1['key']})
+    product4 = create_product(random_string('product'),
+      random_string('product'),
+      {:attributes => {:support_level => 'Sub-Standard'},
+      :owner => @owner1['key']})
+    pool1 = create_pool_and_subscription(@owner1['key'], product1.id)
+    pool2 = create_pool_and_subscription(@owner1['key'], product2.id)
+    pool3 = create_pool_and_subscription(@owner1['key'], product3.id)
+    pool4 = create_pool_and_subscription(@owner1['key'], product4.id)
+
+    user_cp = user_client(@owner1, random_string('billy'))
+    consumer = user_cp.register(random_string('system'), :system, nil,
+      {}, nil, nil, [], [])
+    consumer_client = Candlepin.new(nil, nil, consumer['idCert']['cert'], consumer['idCert']['key'])
+    installed = [
+        {'productId' => product1.id, 'productName' => product1.name},
+        {'productId' => product2.id, 'productName' => product2.name},
+        {'productId' => product3.id, 'productName' => product3.name},
+        {'productId' => product4.id, 'productName' => product4.name}]
+
+    # We set the consumer's SLA as VIP
+    consumer_client.update_consumer({:serviceLevel => 'VIP',
+                                     :installedProducts => installed})
+
+    consumer = @cp.get_consumer(consumer['uuid'])
+    consumer['serviceLevel'].should == 'VIP'
+
+    # We explicitly attach to a pool with Ultra-VIP SLA
+    consumer_client.consume_pool(pool2.id, {:quantity => 1})
+
+    # dry run against the set service level:
+    # should return only one pool because we no longer filter on consumer's sla,
+    # but we do filter on the consumer's existing entitlements' SLA's, and in this case
+    # the consumer has an existing entitlement whose SLA is 'Ultra-VIP',
+    # so only 'Ultra-VIP' pools are eligible during autoattach (and the 'VIP' pool is not).
+    returned_pools = @cp.autobind_dryrun(consumer['uuid'])
+    returned_pools.length.should == 1
+    returned_pool_id = returned_pools.first.pool.id
+    returned_pool = @cp.get_pool(returned_pool_id)
+    returned_pool.subscriptionId.should == pool3.subscriptionId
+    expect(get_attribute_value(returned_pool['productAttributes'], 'support_level')).to eq('Ultra-VIP')
+
+    # dry run against the Override SLA:
+    # should return only one pool because we no longer filter on the override sla,
+    # but we do filter on the consumer's existing entitlements' SLA's, and in this case
+    # the consumer has an existing entitlement whose SLA is 'Ultra-VIP',
+    # so only 'Ultra-VIP' pools are eligible during autoattach (and the 'Sub-Standard' pool is not).
+    returned_pools = @cp.autobind_dryrun(consumer['uuid'], 'Sub-Standard')
+    returned_pools.length.should == 1
+    returned_pool_id = returned_pools.first.pool.id
+    returned_pool = @cp.get_pool(returned_pool_id)
+    returned_pool.subscriptionId.should == pool3.subscriptionId
+    expect(get_attribute_value(returned_pool['productAttributes'], 'support_level')).to eq('Ultra-VIP')
+
+    # Remove the consumer's SLA, to force subsequent autobinds to use the owner's default SLA
+    # and populate the owner's default SLA
+    consumer_client.update_consumer({:serviceLevel => ''})
+    consumer = @cp.get_consumer(consumer['uuid'])
+    consumer['serviceLevel'].should == ''
+    @cp.update_owner(@owner1['key'], {:defaultServiceLevel => 'Sub-Standard'})
+    current_owner = @cp.get_owner(@owner1['key'])
+    current_owner['defaultServiceLevel'].should == 'Sub-Standard'
+
+    # dry run against the owner's default SLA:
+    # should return only one pool because we no longer filter on the owner's default sla,
+    # but we do filter on the consumer's existing entitlements' SLA's, and in this case
+    # the consumer has an existing entitlement whose SLA is 'Ultra-VIP',
+    # so only 'Ultra-VIP' pools are eligible during autoattach (and the 'Sub-Standard' pool is not).
+    returned_pools = @cp.autobind_dryrun(consumer['uuid'])
+    returned_pools.length.should == 1
+    returned_pool_id = returned_pools.first.pool.id
+    returned_pool = @cp.get_pool(returned_pool_id)
+    returned_pool.subscriptionId.should == pool3.subscriptionId
+    expect(get_attribute_value(returned_pool['productAttributes'], 'support_level')).to eq('Ultra-VIP')
   end
 
   it 'should recognize support level exempt attribute' do
@@ -847,8 +957,8 @@ describe 'Consumer Resource' do
       {:attributes => {:support_level => 'LAYered'},
       :owner => @owner1['key']})
     pool1 = create_pool_and_subscription(@owner1['key'], product1.id)
-    create_pool_and_subscription(@owner1['key'], product2.id, 1, [], '', '', '', nil, nil, true)
-    create_pool_and_subscription(@owner1['key'], product3.id)
+    pool2 = create_pool_and_subscription(@owner1['key'], product2.id)
+    pool3 = create_pool_and_subscription(@owner1['key'], product3.id)
 
     user_cp = user_client(@owner1, random_string('billy'))
     consumer = user_cp.register(random_string('system'), :system, nil,
@@ -865,22 +975,28 @@ describe 'Consumer Resource' do
     consumer = @cp.get_consumer(consumer['uuid'])
     consumer['serviceLevel'].should == 'Ultra-VIP'
 
-    # dry run against the set service level
-    # should get only the exempt product that has subscription
+    # Dry run against the set service level:
+    # Should get pools of both the exempt product (product1) and the other installed product (product2), 
+    # because we no longer filter on the consumer's sla match (unless the consumer has existing entitlements),
+    # and exempt sla pools are always returned.
     pools = @cp.autobind_dryrun(consumer['uuid'])
-    pools.length.should == 1
-    pool_id = pools.first.pool.id
-    pool = @cp.get_pool(pool_id)
+    pools.length.should == 2
+    pool1_id = pools[0].pool.id
+    pool2_id = pools[1].pool.id
+    pool = @cp.get_pool(pool1_id)
     pool.subscriptionId.should == pool1.subscriptionId
+    pool = @cp.get_pool(pool2_id)
+    pool.subscriptionId.should == pool2.subscriptionId
 
     # this product should also get pulled, exempt overrides
     # based on name match
     create_pool_and_subscription(@owner1['key'], product4.id)
     pools = @cp.autobind_dryrun(consumer['uuid'])
-    pools.length.should == 2
+    pools.length.should == 3
 
-    # change service level to one that matches installed
-    # should get 3 pools
+    # changing consumer's service level to one that matches installed
+    # should have no effect because we are not filtering on it (unless the consumer has existing entitlements),
+    # and exempt sla pools are always returned.
     consumer_client.update_consumer({:serviceLevel => 'VIP'})
     pools = @cp.autobind_dryrun(consumer['uuid'])
     pools.length.should == 3

--- a/server/src/main/resources/rules/rules.js
+++ b/server/src/main/resources/rules/rules.js
@@ -1,4 +1,4 @@
-// Version: 5.26
+// Version: 5.27
 
 /*
  * Default Candlepin rule set.
@@ -324,7 +324,7 @@ function get_mock_ent_for_pool(pool, consumer) {
     };
 }
 
-function get_pool_priority(pool, consumer) {
+function get_pool_priority(pool, consumer, context) {
     var priority = 100;
 
     // use virt only if possible
@@ -341,6 +341,11 @@ function get_pool_priority(pool, consumer) {
     // Decrease the priority of shared pools slightly so that non-shared pools will get consumed first.
     if (pool.hasSharedAncestor) {
         priority -= 10;
+    }
+
+    // We no longer filter pools on SLA mismatch, but prioritize for match.
+    if(should_pool_be_prioritized_for_sla(context, pool)) {
+        priority += 700;
     }
 
     /*
@@ -380,6 +385,52 @@ function get_pool_priority(pool, consumer) {
     return priority;
 }
 
+/*
+ * Returns true if the following are all true:
+ * - the pool's SLA is non-null, non-empty and not in the exempt list.
+ * - at least one of these is non-null and non-empty: SLA override, consumer's SLA, owner's default SLA.
+ * - the pool's SLA matches either the SLA override, the consumer's SLA, or the owner's default SLA.
+ *
+ * False otherwise.
+ */
+function should_pool_be_prioritized_for_sla(context, pool) {
+    var poolSLA = pool.getProductAttribute('support_level');
+    var consumerSLA = get_consumer_sla(context);
+    if (!is_pool_sla_null_or_exempt(context, poolSLA) &&
+        consumerSLA && consumerSLA !== "" &&
+        Utils.equalsIgnoreCase(consumerSLA, poolSLA)) {
+        return true;
+    }
+    return false;
+}
+
+/*
+ * Returns true if the pool's SLA is null or empty, or is included in the exempt list; false otherwise.
+ */
+function is_pool_sla_null_or_exempt(context, poolSLA) {
+    if (!poolSLA || poolSLA === "") {
+        return true;
+    }
+
+    return isLevelExempt(poolSLA, context.exemptList);
+}
+
+/*
+ * Fetches the sla of the consumer, unless serviceLevelOverride is set, in which
+ * case we use that. If neither of those is set, use the owner's default sla.
+ * Order of priority is: service level override > consumer's service level > owner's default service level.
+ */
+function get_consumer_sla(context) {
+    log.debug("context.serviceLevelOverride: " + context.serviceLevelOverride);
+    var consumerSLA = context.serviceLevelOverride;
+    if (!consumerSLA || consumerSLA == "") {
+        consumerSLA = context.consumer.serviceLevel;
+            if (!consumerSLA || consumerSLA == "") {
+                consumerSLA = context.owner.defaultServiceLevel;
+            }
+    }
+    return consumerSLA;
+}
 
 /* Utility functions */
 function contains(a, obj) {
@@ -1869,7 +1920,7 @@ var Autobind = {
      * have to know if it's a stack, single entitlement, etc... It is either valid
      * or not, and provides products.
      */
-    create_entitlement_group: function(stackable, stack_id, installed_ids, consumer, attached_ents, consider_derived) {
+    create_entitlement_group: function(stackable, stack_id, installed_ids, consumer, attached_ents, consider_derived, context) {
         return {
             pools: [],
             stackable: stackable,
@@ -2114,6 +2165,7 @@ var Autobind = {
                 if (!this.stackable) {
                     return;
                 }
+
                 // Sort pools such that we preserve virt_only and host_requires if possible
                 this.pools.sort(this.compare_pools);
                 var temp = null;
@@ -2135,8 +2187,8 @@ var Autobind = {
              * Sort pools for pruning (helps us later with quantity as well)
              */
             compare_pools: function(pool0, pool1) {
-                var priority0 = get_pool_priority(pool0, consumer);
-                var priority1 = get_pool_priority(pool1, consumer);
+                var priority0 = get_pool_priority(pool0, consumer, context);
+                var priority1 = get_pool_priority(pool1, consumer, context);
 
                 // If two pools are still considered equal, select the pool that expires first
                 if (pool0.endDate > pool1.endDate) {
@@ -2170,7 +2222,7 @@ var Autobind = {
                     var total = 0;
                     for (var i=0; i < len; i++) {
                         var pool = this.pools[i];
-                        total += get_pool_priority(pool, consumer);
+                        total += get_pool_priority(pool, consumer, context);
                     }
                     this.average_priority = total/len;
                 }
@@ -2318,22 +2370,6 @@ var Autobind = {
     },
 
     /*
-     * Only use pools that match the consumer SLA or SLA override, if set
-     */
-    is_pool_sla_valid: function(context, pool, consumerSLA) {
-        var poolSLA = pool.getProductAttribute('support_level');
-        var poolSLAExempt = isLevelExempt(pool.getProductAttribute('support_level'), context.exemptList);
-
-        if (poolSLA && poolSLA != "" && !poolSLAExempt &&
-            consumerSLA && consumerSLA != "" &&
-            !Utils.equalsIgnoreCase(consumerSLA, poolSLA)) {
-            log.debug("Skipping pool " + pool.id + " since SLA does not match that of the consumer.");
-            return false;
-        }
-        return true;
-    },
-
-    /*
      * If the architecture does not match the consumer, this pool can never be valid
      */
     is_pool_arch_valid: function(context, pool, consumerArch) {
@@ -2359,6 +2395,76 @@ var Autobind = {
         return true;
     },
 
+    /*
+     * The pool is valid if any of these is true:
+     *  - The pool's SLA is null or in the exempt list.
+     *  - The consumer does not have any existing entitlements.
+     *  - The consumer has existing entitlements and one of them has a product that matches the pool SLA.
+     *
+     * The pool is invalid if the pool SLA is non-null, non-exempt, and the consumer has one or more existing
+     * entitlements, but none of their products' SLAs matches the pool's SLA.
+     */
+    is_pool_sla_valid: function(context, pool) {
+        var poolSLA = pool.getProductAttribute('support_level');
+
+        if (is_pool_sla_null_or_exempt(context, poolSLA)) {
+            return true;
+        }
+
+        var consumer_entitlement_slas = this.get_slas_of_existing_consumer_entitlements_from_compliance_status(context);
+        if (consumer_entitlement_slas <= 0) {
+            return true;
+        }
+
+        var is_valid = false;
+        for (i = 0 ; i < consumer_entitlement_slas.length ; i++) {
+            if (Utils.equalsIgnoreCase(poolSLA, consumer_entitlement_slas[i])) {
+                is_valid = true;
+                break;
+            }
+        }
+
+        if (!is_valid) {
+            log.debug("Skipping pool " + pool.id +
+            " since SLA is non-null, non-exempt, and does not match any of the consumer's entitlements' SLAs.");
+        }
+        return is_valid;
+    },
+
+    /*
+     * Traverses the ComplianceStatus object's product maps to find and return a list of
+     * the consumer's entitlements' SLAs.
+     */
+    get_slas_of_existing_consumer_entitlements_from_compliance_status: function(context) {
+        var listOfProductMaps = [];
+        listOfProductMaps.push(context.compliance.compliantProducts);
+        listOfProductMaps.push(context.compliance.partiallyCompliantProducts);
+        listOfProductMaps.push(context.compliance.partialStacks);
+
+        var sla_list = [];
+        listOfProductMaps.forEach(function(productMap) {
+            Object.keys(productMap).forEach(function(productId) {
+                var setOfEntitlements = productMap[productId];
+                setOfEntitlements.forEach(function(entitlement) {
+                    var sla = entitlement.pool.getProductAttribute('support_level');
+
+                    var exists = false;
+                    for (i = 0 ; i < sla_list.length ; i++) {
+                        if (Utils.equalsIgnoreCase(sla_list[i], sla)) {
+                            exists = true;
+                            break;
+                        }
+                    }
+
+                    if (!exists) {
+                        sla_list.push(sla);
+                    }
+                });
+            });
+        });
+        return sla_list;
+    },
+
     is_pool_not_empty: function(pool) {
         if (pool.currently_available > 0) {
             return true;
@@ -2367,25 +2473,8 @@ var Autobind = {
         return false;
     },
 
-    /*
-     * Gets the sla of the consumer, unless serviceLevelOverride is set, in which
-     * case we use that.
-     */
-    get_consumer_sla: function(context) {
-        log.debug("context.serviceLevelOverride: " + context.serviceLevelOverride);
-        var consumerSLA = context.serviceLevelOverride;
-        if (!consumerSLA || consumerSLA == "") {
-            consumerSLA = context.consumer.serviceLevel;
-                if (!consumerSLA || consumerSLA == "") {
-                    consumerSLA = context.owner.defaultServiceLevel;
-                }
-        }
-        return consumerSLA;
-    },
-
     // returns all pools that can be attached to this consumer
     get_valid_pools: function(context) {
-        var consumerSLA = this.get_consumer_sla(context);
         var isGuest = Utils.isGuest(context.consumer);
         var consumerArch = ARCH_FACT in context.consumer.facts ?
                 context.consumer.facts[ARCH_FACT] : null;
@@ -2403,7 +2492,7 @@ var Autobind = {
              */
             if (this.is_pool_arch_valid(context, pool, consumerArch) &&
                     this.is_pool_virt_valid(pool, isGuest) &&
-                    this.is_pool_sla_valid(context, pool, consumerSLA) &&
+                    this.is_pool_sla_valid(context, pool) &&
                     pool_not_empty) {
                 valid_pools.push(pool);
             }
@@ -2414,7 +2503,7 @@ var Autobind = {
     /*
      * Builds entitlement group objects that allow us to treat stacks and individual entitlements the same
      */
-    build_entitlement_groups: function(valid_pools, installed, consumer, attached_ents, consider_derived) {
+    build_entitlement_groups: function(valid_pools, installed, consumer, attached_ents, consider_derived, context) {
         var ent_groups = [];
         for (var i = 0; i < valid_pools.length; i++) {
             var pool = valid_pools[i];
@@ -2432,13 +2521,13 @@ var Autobind = {
                 }
                 // If the pool is stackable, and not part of an existing entitlement group, create a new group and add it
                 if (!found) {
-                    var new_ent_group = this.create_entitlement_group(true, stack_id, installed, consumer, attached_ents, consider_derived);
+                    var new_ent_group = this.create_entitlement_group(true, stack_id, installed, consumer, attached_ents, consider_derived, context);
                     new_ent_group.add_pool(pool);
                     ent_groups.push(new_ent_group);
                 }
             } else {
                 //if the entitlement is not stackable, create a new stack group for it
-                var new_ent_group = this.create_entitlement_group(false, "", installed, consumer, attached_ents, consider_derived);
+                var new_ent_group = this.create_entitlement_group(false, "", installed, consumer, attached_ents, consider_derived, context);
                 new_ent_group.add_pool(pool);
                 ent_groups.push(new_ent_group);
             }
@@ -2629,7 +2718,7 @@ var Autobind = {
                 installed.splice(installed.indexOf(prod), 1);
             }
         }
-        var ent_groups = this.build_entitlement_groups(valid_pools, installed, context.consumer, attached_ents, context.considerDerived);
+        var ent_groups = this.build_entitlement_groups(valid_pools, installed, context.consumer, attached_ents, context.considerDerived, context);
         log.debug("Total ent groups: " + ent_groups.length);
 
         var valid_groups = [];

--- a/server/src/main/resources/rules/rules.js
+++ b/server/src/main/resources/rules/rules.js
@@ -389,13 +389,23 @@ function get_pool_priority(pool, consumer, context) {
  * Returns true if the following are all true:
  * - the pool's SLA is non-null, non-empty and not in the exempt list.
  * - at least one of these is non-null and non-empty: SLA override, consumer's SLA, owner's default SLA.
- * - the pool's SLA matches either the SLA override, the consumer's SLA, or the owner's default SLA.
+ * - the pool's SLA matches either the SLA override, the consumer's SLA, or the owner's default SLA
+ *   (Order of priority is: SLA override > consumer's SLA > owner's default SLA.)
  *
  * False otherwise.
  */
 function should_pool_be_prioritized_for_sla(context, pool) {
     var poolSLA = pool.getProductAttribute('support_level');
-    var consumerSLA = get_consumer_sla(context);
+
+    log.debug("context.serviceLevelOverride: " + context.serviceLevelOverride);
+    var consumerSLA = context.serviceLevelOverride;
+    if (!consumerSLA || consumerSLA == "") {
+        consumerSLA = context.consumer.serviceLevel;
+            if (!consumerSLA || consumerSLA == "") {
+                consumerSLA = context.owner.defaultServiceLevel;
+            }
+    }
+
     if (!is_pool_sla_null_or_exempt(context, poolSLA) &&
         consumerSLA && consumerSLA !== "" &&
         Utils.equalsIgnoreCase(consumerSLA, poolSLA)) {
@@ -413,23 +423,6 @@ function is_pool_sla_null_or_exempt(context, poolSLA) {
     }
 
     return isLevelExempt(poolSLA, context.exemptList);
-}
-
-/*
- * Fetches the sla of the consumer, unless serviceLevelOverride is set, in which
- * case we use that. If neither of those is set, use the owner's default sla.
- * Order of priority is: service level override > consumer's service level > owner's default service level.
- */
-function get_consumer_sla(context) {
-    log.debug("context.serviceLevelOverride: " + context.serviceLevelOverride);
-    var consumerSLA = context.serviceLevelOverride;
-    if (!consumerSLA || consumerSLA == "") {
-        consumerSLA = context.consumer.serviceLevel;
-            if (!consumerSLA || consumerSLA == "") {
-                consumerSLA = context.owner.defaultServiceLevel;
-            }
-    }
-    return consumerSLA;
 }
 
 /* Utility functions */
@@ -2398,11 +2391,16 @@ var Autobind = {
     /*
      * The pool is valid if any of these is true:
      *  - The pool's SLA is null or in the exempt list.
-     *  - The consumer does not have any existing entitlements.
-     *  - The consumer has existing entitlements and one of them has a product that matches the pool SLA.
+     *  - The pool's SLA is non-null, non-exempt, and the consumer does not have any existing entitlements.
+     *  - The pool's SLA is non-null, non-exempt, and the consumer has existing entitlements,
+     *    but none of their products has an SLA.
+     *  - The pool's SLA is non-null, non-exempt, and the consumer has existing entitlements,
+     *    and at least one of them has a product with a non-null SLA that matches the pool SLA.
      *
-     * The pool is invalid if the pool SLA is non-null, non-exempt, and the consumer has one or more existing
-     * entitlements, but none of their products' SLAs matches the pool's SLA.
+     * The pool is invalid if this is true:
+     *  - The pool's SLA is non-null, non-exempt, and the consumer has existing entitlements,
+     *    and one or more of those have products with non-null SLAs,
+     *    but those SLAs do not match with the pool's SLA.
      */
     is_pool_sla_valid: function(context, pool) {
         var poolSLA = pool.getProductAttribute('support_level');
@@ -2412,7 +2410,7 @@ var Autobind = {
         }
 
         var consumer_entitlement_slas = this.get_slas_of_existing_consumer_entitlements_from_compliance_status(context);
-        if (consumer_entitlement_slas <= 0) {
+        if (consumer_entitlement_slas.length <= 0) {
             return true;
         }
 
@@ -2433,7 +2431,7 @@ var Autobind = {
 
     /*
      * Traverses the ComplianceStatus object's product maps to find and return a list of
-     * the consumer's entitlements' SLAs.
+     * the consumer's entitlements' SLAs. Null SLAs are not returned.
      */
     get_slas_of_existing_consumer_entitlements_from_compliance_status: function(context) {
         var listOfProductMaps = [];
@@ -2447,7 +2445,6 @@ var Autobind = {
                 var setOfEntitlements = productMap[productId];
                 setOfEntitlements.forEach(function(entitlement) {
                     var sla = entitlement.pool.getProductAttribute('support_level');
-
                     var exists = false;
                     for (i = 0 ; i < sla_list.length ; i++) {
                         if (Utils.equalsIgnoreCase(sla_list[i], sla)) {
@@ -2456,7 +2453,7 @@ var Autobind = {
                         }
                     }
 
-                    if (!exists) {
+                    if (!exists && sla) {
                         sla_list.push(sla);
                     }
                 });

--- a/server/src/test/java/org/candlepin/policy/AutobindRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/AutobindRulesTest.java
@@ -369,7 +369,7 @@ public class AutobindRulesTest {
      * This test assumes that the consumer does not have any existing entitlements.
      */
     @Test
-    public void ensureSelectBestPoolsDoesNotFilterPoolsBySLAWhenConsumerHasSLASet() {
+    public void selectBestPoolsDoesNotFilterPoolsBySLAWhenConsumerHasSLASet() {
         // Create Premium SLA prod
         String slaPremiumProdId = "premium-sla-product";
         Product slaPremiumProduct = TestUtil.createProduct(slaPremiumProdId, "Product with SLA Premium");
@@ -417,7 +417,7 @@ public class AutobindRulesTest {
      * This test assumes that the consumer does not have any existing entitlements.
      */
     @Test
-    public void ensureSelectBestPoolsDoesNotFilterPoolsBySLAWhenOrgHasDefaultSLASet() {
+    public void selectBestPoolsDoesNotFilterPoolsBySLAWhenOrgHasDefaultSLASet() {
         // Create Premium SLA prod
         String slaPremiumProdId = "premium-sla-product";
         Product slaPremiumProduct = TestUtil.createProduct(slaPremiumProdId, "Product with SLA Permium");
@@ -467,7 +467,7 @@ public class AutobindRulesTest {
      * This test assumes that the consumer does not have any existing entitlements.
      */
     @Test
-    public void ensureSelectBestPoolsDoesNotFilterPoolsBySLAWhenSLAOverrideIsSet() {
+    public void selectBestPoolsDoesNotFilterPoolsBySLAWhenSLAOverrideIsSet() {
         // Create Premium SLA prod
         String slaPremiumProdId = "premium-sla-product";
         Product slaPremiumProduct = TestUtil.createProduct(slaPremiumProdId, "Product with SLA Permium");
@@ -514,7 +514,7 @@ public class AutobindRulesTest {
     }
 
     @Test
-    public void ensureSelectBestPoolsDoesNotFilterPoolsBySLAWhenConsumerHasMatchingEntitlementSLAs() {
+    public void selectBestPoolsDoesNotFilterPoolsBySLAWhenConsumerHasNonNullMatchingEntitlementSLAs() {
         // Create Premium SLA prod
         String slaPremiumProdId = "premium-sla-product";
         Product slaPremiumProduct = TestUtil.createProduct(slaPremiumProdId, "Product with SLA Permium");
@@ -553,7 +553,8 @@ public class AutobindRulesTest {
     }
 
     @Test
-    public void ensureSelectBestPoolsFiltersPoolsBySLAWhenConsumerHasEntitlementSLAsThatDontMatch() {
+    @SuppressWarnings("checkstyle:LineLength")
+    public void selectBestPoolsFiltersPoolsBySLAWhenConsumerHasNonNullNonMatchingEntitlementSLAsAndConsumerSLAIsUsed() {
         // Create Premium SLA prod
         String slaPremiumProdId = "premium-sla-product";
         Product slaPremiumProduct = TestUtil.createProduct(slaPremiumProdId, "Product with SLA Permium");
@@ -583,7 +584,7 @@ public class AutobindRulesTest {
         // ^ A Standard SLA pool is not in the list of candidate pools.
 
         // The consumer has set their SLA to Premium, and also has an existing entitlement with Standard SLA
-        // which means the pool with Standard SLA SHOULD get filtered.
+        // which means the pool with Premium SLA SHOULD get filtered.
         consumer.setServiceLevel("Premium");
         Entitlement entitlementWithStandardSLA = new Entitlement();
         entitlementWithStandardSLA.setPool(slaStandardPool);
@@ -597,6 +598,179 @@ public class AutobindRulesTest {
         // The Premium SLA pool should get filtered because the customer had existing entitlements that
         // did not include one with a Premium SLA.
         assertFalse(bestPools.contains(new PoolQuantity(slaPremiumPool, 1)));
+        // Also, check pool with no sla is not filtered (as always)
+        assertTrue(bestPools.contains(new PoolQuantity(noSLAPool, 1)));
+    }
+
+    @Test
+    @SuppressWarnings("checkstyle:LineLength")
+    public void selectBestPoolsFiltersPoolsBySLAWhenConsumerWithSLAHasNonNullNonMatchingEntitlementSLAsAndOverrideSLAIsUsed() {
+        // Create Premium SLA prod
+        String slaPremiumProdId = "premium-sla-product";
+        Product slaPremiumProduct = TestUtil.createProduct(slaPremiumProdId, "Product with SLA Permium");
+        slaPremiumProduct.setAttribute(Product.Attributes.SUPPORT_LEVEL, "Premium");
+
+        Pool slaPremiumPool = TestUtil.createPool(owner, slaPremiumProduct);
+        slaPremiumPool.setId("pool-with-premium-sla");
+        slaPremiumPool.getProduct().setAttribute(Product.Attributes.SUPPORT_LEVEL, "Premium");
+
+        // Create Standard SLA Product
+        String slaStandardProdId = "standard-sla-product";
+        Product slaStandardProduct = TestUtil.createProduct(slaStandardProdId, "Product with SLA Standard");
+        slaStandardProduct.setAttribute(Product.Attributes.SUPPORT_LEVEL, "Standard");
+
+        Pool slaStandardPool = TestUtil.createPool(owner, slaStandardProduct);
+        slaStandardPool.setId("pool-with-standard-sla");
+        slaStandardPool.getProduct().setAttribute(Product.Attributes.SUPPORT_LEVEL, "Standard");
+
+        // Create Sub-Standard SLA Product
+        String slaSubStandardProdId = "sub-standard-sla-product";
+        Product slaSubStandardProduct = TestUtil.createProduct(slaSubStandardProdId, "Product with SLA Sub-Standard");
+        slaSubStandardProduct.setAttribute(Product.Attributes.SUPPORT_LEVEL, "Sub-Standard");
+
+        Pool slaSubStandardPool = TestUtil.createPool(owner, slaSubStandardProduct);
+        slaSubStandardPool.setId("pool-with-sub-standard-sla");
+        slaSubStandardPool.getProduct().setAttribute(Product.Attributes.SUPPORT_LEVEL, "Sub-Standard");
+
+        // Create a product with no SLA.
+        Product noSLAProduct = TestUtil.createProduct(productId, "A test product");
+        Pool noSLAPool = TestUtil.createPool(owner, noSLAProduct);
+        noSLAPool.setId("pool-1");
+
+        List<Pool> pools = new LinkedList<>();
+        pools.add(noSLAPool);
+        pools.add(slaPremiumPool);
+        pools.add(slaSubStandardPool);
+        // ^ A Standard SLA pool is not in the list of candidate pools.
+
+        // The consumer has set their SLA to Premium, but will be ignored because we specify an override SLA,
+        // and also the consumer has an existing entitlement with Standard SLA
+        // which means the candidate pools with Premium SLA and Sub-Standard SLA SHOULD BOTH get filtered.
+        consumer.setServiceLevel("Premium");
+        Entitlement entitlementWithStandardSLA = new Entitlement();
+        entitlementWithStandardSLA.setPool(slaStandardPool);
+        compliance.addPartiallyCompliantProduct("b4b4b4", entitlementWithStandardSLA);
+
+        String overrideSLA = "Sub-Standard";
+
+        List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
+            new String[]{ productId, slaStandardProdId},
+            pools, compliance, overrideSLA, new HashSet<>(), false);
+
+        assertEquals(1, bestPools.size());
+        // Both The Premium SLA and Sub-Standard SLA pools should get filtered
+        // because the customer had existing entitlements that
+        // did not include one with a Premium or Sub-Standard SLA.
+        assertFalse(bestPools.contains(new PoolQuantity(slaPremiumPool, 1)));
+        assertFalse(bestPools.contains(new PoolQuantity(slaSubStandardPool, 1)));
+        // Also, check pool with no sla is not filtered (as always)
+        assertTrue(bestPools.contains(new PoolQuantity(noSLAPool, 1)));
+    }
+
+    @Test
+    @SuppressWarnings("checkstyle:LineLength")
+    public void selectBestPoolsFiltersPoolsBySLAWhenConsumerWithSLAHasNonNullNonMatchingEntitlementSLAsAndOwnerDefaultSLAIsUsed() {
+        // Create Premium SLA prod
+        String slaPremiumProdId = "premium-sla-product";
+        Product slaPremiumProduct = TestUtil.createProduct(slaPremiumProdId, "Product with SLA Permium");
+        slaPremiumProduct.setAttribute(Product.Attributes.SUPPORT_LEVEL, "Premium");
+
+        Pool slaPremiumPool = TestUtil.createPool(owner, slaPremiumProduct);
+        slaPremiumPool.setId("pool-with-premium-sla");
+        slaPremiumPool.getProduct().setAttribute(Product.Attributes.SUPPORT_LEVEL, "Premium");
+
+        // Create Standard SLA Product
+        String slaStandardProdId = "standard-sla-product";
+        Product slaStandardProduct = TestUtil.createProduct(slaStandardProdId, "Product with SLA Standard");
+        slaStandardProduct.setAttribute(Product.Attributes.SUPPORT_LEVEL, "Standard");
+
+        Pool slaStandardPool = TestUtil.createPool(owner, slaStandardProduct);
+        slaStandardPool.setId("pool-with-standard-sla");
+        slaStandardPool.getProduct().setAttribute(Product.Attributes.SUPPORT_LEVEL, "Standard");
+
+        // Create a product with no SLA.
+        Product noSLAProduct = TestUtil.createProduct(productId, "A test product");
+        Pool noSLAPool = TestUtil.createPool(owner, noSLAProduct);
+        noSLAPool.setId("pool-1");
+
+        List<Pool> pools = new LinkedList<>();
+        pools.add(noSLAPool);
+        pools.add(slaPremiumPool);
+        // ^ A Standard SLA pool is not in the list of candidate pools.
+
+        // The consumer has set their SLA to nothing, so it will be ignored in favor of the
+        // owner default SLA which is set to Premium,
+        // but the consumer also has an existing entitlement with Standard SLA
+        // which means the candidate pool with Premium SLA SHOULD get filtered.
+        consumer.setServiceLevel("");
+        owner.setDefaultServiceLevel("Premium");
+        Entitlement entitlementWithStandardSLA = new Entitlement();
+        entitlementWithStandardSLA.setPool(slaStandardPool);
+        compliance.addPartiallyCompliantProduct("b4b4b4", entitlementWithStandardSLA);
+
+        List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
+            new String[]{ productId, slaStandardProdId},
+            pools, compliance, null, new HashSet<>(), false);
+
+        assertEquals(1, bestPools.size());
+        // The Premium SLA pool should get filtered because the customer had existing entitlements that
+        // did not include one with a Premium SLA.
+        assertFalse(bestPools.contains(new PoolQuantity(slaPremiumPool, 1)));
+        // Also, check pool with no sla is not filtered (as always)
+        assertTrue(bestPools.contains(new PoolQuantity(noSLAPool, 1)));
+    }
+
+    @Test
+    public void selectBestPoolsDoesNotFilterPoolsBySLAWhenConsumerHasOnlyNullEntitlementSLAs() {
+        // Create Premium SLA prod
+        String slaPremiumProdId = "premium-sla-product";
+        Product slaPremiumProduct = TestUtil.createProduct(slaPremiumProdId, "Product with SLA Permium");
+        slaPremiumProduct.setAttribute(Product.Attributes.SUPPORT_LEVEL, "Premium");
+
+        Pool slaPremiumPool = TestUtil.createPool(owner, slaPremiumProduct);
+        slaPremiumPool.setId("pool-with-premium-sla");
+        slaPremiumPool.getProduct().setAttribute(Product.Attributes.SUPPORT_LEVEL, "Premium");
+
+        // Create Standard SLA Product
+        String slaStandardProdId = "standard-sla-product";
+        Product slaStandardProduct = TestUtil.createProduct(slaStandardProdId, "Product with SLA Standard");
+        slaStandardProduct.setAttribute(Product.Attributes.SUPPORT_LEVEL, "Standard");
+
+        Pool slaStandardPool = TestUtil.createPool(owner, slaStandardProduct);
+        slaStandardPool.setId("pool-with-standard-sla");
+        slaStandardPool.getProduct().setAttribute(Product.Attributes.SUPPORT_LEVEL, "Standard");
+
+        // Create a product with no SLA.
+        Product noSLAProduct = TestUtil.createProduct(productId, "A test product");
+        Pool noSLAPool = TestUtil.createPool(owner, noSLAProduct);
+        noSLAPool.setId("pool-with-NO-sla-1");
+
+        // Create another product with no SLA.
+        String noSLAProdId2 = "no-sla-product2";
+        Product noSLAProduct2 = TestUtil.createProduct(noSLAProdId2, "A test product 2");
+        Pool noSLAPool2 = TestUtil.createPool(owner, noSLAProduct2);
+        noSLAPool2.setId("pool-with-NO-sla-2");
+
+        List<Pool> pools = new LinkedList<>();
+        pools.add(noSLAPool);
+        pools.add(slaPremiumPool);
+        pools.add(slaStandardPool);
+
+        // The consumer has set their SLA to Premium, and also has an existing entitlement with no SLA
+        // which means no pools should get filtered.
+        consumer.setServiceLevel("Premium");
+        Entitlement entitlementWithNoSLA = new Entitlement();
+        entitlementWithNoSLA.setPool(noSLAPool2);
+        compliance.addPartiallyCompliantProduct("b4b4b4", entitlementWithNoSLA);
+
+        List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
+            new String[]{ productId, slaStandardProdId, slaPremiumProdId },
+            pools, compliance, null, new HashSet<>(), false);
+
+        assertEquals(3, bestPools.size());
+        // Check that no pools were filtered, since the customer has an existing entitlement with a null SLA.
+        assertTrue(bestPools.contains(new PoolQuantity(slaPremiumPool, 1)));
+        assertTrue(bestPools.contains(new PoolQuantity(slaStandardPool, 1)));
         // Also, check pool with no sla is not filtered (as always)
         assertTrue(bestPools.contains(new PoolQuantity(noSLAPool, 1)));
     }


### PR DESCRIPTION
Pool filtering behaviour based on SLAs has changed and currently:

- A pool is not filtered if any of these is true:
    * The pool's SLA is null or empty, or in the exempt list.
    * The consumer does not have any existing entitlements.
    * The consumer has existing entitlements and one of them has a product that matches the pool SLA.

- A pool is filtered if the pool SLA is non-null, non-exempt,
and the consumer has one or more existing entitlements, but none of their SLAs matches the pool's SLA.

- Pools that are not filtered, will get prioritized (+700) if all of the following are true:
    * the pool's SLA is non-null, non-empty and not in the exempt list.
    * at least one of the following is non-null and non-empty: SLA override, consumer's SLA, owner's default SLA.
    * the pool's SLA matches either the SLA override, the consumer's SLA, or the owner's default SLA.

- Bumped rules.js minor version.