### PR TITLE
[M] 1569611: Manifest import no longer fails when product changes

### DIFF
--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -569,6 +569,16 @@ public class CandlepinPoolManager implements PoolManager {
         List<PoolUpdate> updatedPools = poolRules.updatePools(pool, existingPools, originalQuantity,
             changedProducts);
 
+        /*
+         * 1567922: Due to poolRules.updatePools call above, some fields of a product on a pool might change.
+         * Hibernate does not persist these changes yet, and when those pool changes result in
+         * revocation of entitlements later in this process, and the same pool is attempted to be locked
+         * due to it, we get an error.
+         * Temporarily we are resorting to flush the changes here, there will be an investigation later, at
+         * which time, this line of the comment could be replaced with a refactor.
+         */
+        poolCurator.flush();
+
         String virtLimit = pool.getProduct().getAttributeValue(Product.Attributes.VIRT_LIMIT);
         boolean createsSubPools = !StringUtils.isBlank(virtLimit) && !"0".equals(virtLimit);
 
@@ -600,7 +610,7 @@ public class CandlepinPoolManager implements PoolManager {
         List<PoolUpdate> updatedPools) {
 
         boolean flush = false;
-        Set<String> existingPoolIds = new HashSet<>();
+        Set<String> existingUndeletedPoolIds = new HashSet<>();
         Set<Pool> poolsToDelete = new HashSet<>();
         Set<Pool> poolsToRegenEnts = new HashSet<>();
         Set<String> entitlementsToRegen = new HashSet<>();
@@ -608,18 +618,18 @@ public class CandlepinPoolManager implements PoolManager {
         // Get our list of pool IDs so we can check which of them still exist in the DB...
         for (PoolUpdate update : updatedPools) {
             if (update != null && update.getPool() != null && update.getPool().getId() != null) {
-                existingPoolIds.add(update.getPool().getId());
+                existingUndeletedPoolIds.add(update.getPool().getId());
             }
         }
 
-        existingPoolIds = this.poolCurator.getExistingPoolIdsByIds(existingPoolIds);
+        existingUndeletedPoolIds = this.poolCurator.getExistingPoolIdsByIds(existingUndeletedPoolIds);
 
         // Process pool updates...
         for (PoolUpdate updatedPool : updatedPools) {
             Pool existingPool = updatedPool.getPool();
             log.debug("Pool changed: {}", updatedPool);
 
-            if (existingPool == null || !existingPoolIds.contains(existingPool.getId())) {
+            if (existingPool == null || !existingUndeletedPoolIds.contains(existingPool.getId())) {
                 log.debug("Pool has already been deleted from the database.");
                 continue;
             }
@@ -641,7 +651,12 @@ public class CandlepinPoolManager implements PoolManager {
                 RevocationOp revPlan = new RevocationOp(this.poolCurator, this.consumerTypeCurator,
                     Collections.singletonList(existingPool));
 
-                revPlan.execute(this);
+                Set<Pool> deletedPools = revPlan.execute(this);
+                if (deletedPools != null) {
+                    for (Pool pool : deletedPools) {
+                        existingUndeletedPoolIds.remove(pool.getId());
+                    }
+                }
             }
 
             // dates changed. regenerate all entitlement certificates
@@ -1737,8 +1752,8 @@ public class CandlepinPoolManager implements PoolManager {
     }
 
     @Override
-    public void revokeEntitlements(List<Entitlement> entsToRevoke) {
-        revokeEntitlements(entsToRevoke, null, true);
+    public Set<Pool> revokeEntitlements(List<Entitlement> entsToRevoke) {
+        return revokeEntitlements(entsToRevoke, null, true);
     }
 
     public void revokeEntitlements(List<Entitlement> entsToRevoke, Set<String> alreadyDeletedPools) {
@@ -1753,14 +1768,15 @@ public class CandlepinPoolManager implements PoolManager {
      * @param regenCertsAndStatuses if this revocation should also trigger regeneration of certificates
      * and recomputation of statuses. For performance reasons some callers might
      * choose to set this to false.
+     * @return the pools that are deleted as a consequence of revoking entitlements
      */
     @Transactional
     @Traceable
-    public void revokeEntitlements(List<Entitlement> entsToRevoke, Set<String> alreadyDeletedPools,
+    public Set<Pool> revokeEntitlements(List<Entitlement> entsToRevoke, Set<String> alreadyDeletedPools,
         boolean regenCertsAndStatuses) {
 
         if (CollectionUtils.isEmpty(entsToRevoke)) {
-            return;
+            return null;
         }
 
         log.debug("Starting batch revoke of {} entitlements", entsToRevoke.size());
@@ -1775,7 +1791,7 @@ public class CandlepinPoolManager implements PoolManager {
             log.trace("Additional pool IDs: {}", getPoolIds(poolsToDelete));
         }
 
-        List<Pool> poolsToLock = new ArrayList<>();
+        Set<Pool> poolsToLock = new HashSet<>();
         poolsToLock.addAll(poolsToDelete);
 
         for (Entitlement ent: entsToRevoke) {
@@ -1869,7 +1885,7 @@ public class CandlepinPoolManager implements PoolManager {
             log.info("Regeneration and status computation was not requested finishing batch revoke");
 
             sendDeletedEvents(entsToRevoke);
-            return;
+            return poolsToDelete;
         }
 
         log.info("Recomputing status for {} consumers.", consumerSortedEntitlements.size());
@@ -1887,6 +1903,7 @@ public class CandlepinPoolManager implements PoolManager {
         log.info("All statuses recomputed.");
 
         sendDeletedEvents(entsToRevoke);
+        return poolsToDelete;
     }
 
     private void sendDeletedEvents(List<Entitlement> entsToRevoke) {

--- a/server/src/main/java/org/candlepin/controller/PoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/PoolManager.java
@@ -144,7 +144,7 @@ public interface PoolManager {
     int revokeAllEntitlements(Consumer consumer);
     int revokeAllEntitlements(Consumer consumer, boolean regenCertsAndStatuses);
 
-    void revokeEntitlements(List<Entitlement> ents);
+    Set<Pool> revokeEntitlements(List<Entitlement> ents);
     void revokeEntitlement(Entitlement entitlement);
 
     Pool updatePoolQuantity(Pool pool, long adjust);

--- a/server/src/main/java/org/candlepin/model/Branding.java
+++ b/server/src/main/java/org/candlepin/model/Branding.java
@@ -66,6 +66,7 @@ public class Branding extends AbstractHibernateObject<Branding> {
     private String type;
 
     public Branding() {
+        // Intentionally left empty
     }
 
     public Branding(String productId, String type, String name) {
@@ -125,6 +126,7 @@ public class Branding extends AbstractHibernateObject<Branding> {
         if (this == anObject) {
             return true;
         }
+
         if (!(anObject instanceof Branding)) {
             return false;
         }
@@ -140,5 +142,11 @@ public class Branding extends AbstractHibernateObject<Branding> {
     public int hashCode() {
         return new HashCodeBuilder(129, 15).append(this.name)
             .append(this.productId).append(this.type).toHashCode();
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Branding [id: %s, name: %s, productId: %s, type: %s]",
+            this.getId(), this.getName(), this.getProductId(), this.getType());
     }
 }

--- a/server/src/main/java/org/candlepin/model/SourceSubscription.java
+++ b/server/src/main/java/org/candlepin/model/SourceSubscription.java
@@ -134,8 +134,8 @@ public class SourceSubscription extends AbstractHibernateObject<SourceSubscripti
 
     @Override
     public String toString() {
-        return String.format("SourceSubscription [subscriptionId: %s, subscriptionSubKey: %s]",
-            this.getSubscriptionId(), this.getSubscriptionSubKey());
+        return String.format("SourceSubscription [id: %s, subscriptionId: %s, subscriptionSubKey: %s]",
+            this.getId(), this.getSubscriptionId(), this.getSubscriptionSubKey());
     }
 
 


### PR DESCRIPTION
* When a product changes in a manifest resulting in entitlement revocation and subsequent deletion of entitlement derived pools,
  some pools that are deleted subsequently were attempted to being updated. This branch skips those deleted pools
* Some product changes resulted in creating brandings on a product, and when that pool was being locked, created an error since
  Hibernate had not flushed the brandings yet

## Verification steps
*  sudo systemctl stop tomcat
* dropdb -U candlepin  candlepin
* createdb -U candlepin  candlepin
* import db
  * psql -U candlepin -d candlepin -f candlepin_dump.sql 
* git checkout master
* ./server/bin/deploy 
*  fetch list of candlepin owners, so we can verify candlepin is working and we can use the owner key for later.

* import manifest from bug
* curl -X POST --header "Content-Type: multipart/form-data" -F "file=@manifest.zip"  -k -u admin:admin  "https://localhost:8443/candlepin/owners/{owner_key}/imports?force=SIGNATURE_CONFLICT&force=MANIFEST_SAME&force=MANIFEST_OLD&force=DISTRIBUTOR_CONFLICT"
* verify error Unable to find org.candlepin.model.Entitlement with id 8a38e08358
* git checkout vritant/1569611
* ./server/bin/deploy
* import manifest from bug
* curl -X POST --header "Content-Type: multipart/form-data" -F "file=@manifest.zip"  -k -u admin:admin  "https://localhost:8443/candlepin/owners/{owner_key}/imports?force=SIGNATURE_CONFLICT&force=MANIFEST_SAME&force=MANIFEST_OLD&force=DISTRIBUTOR_CONFLICT"
* verify successful import