### PR TITLE
[2.1] 1571354: Manifest import no longer fails when product changes

### DIFF
--- a/server/src/main/java/org/candlepin/controller/PoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/PoolManager.java
@@ -145,7 +145,7 @@ public interface PoolManager {
     int revokeAllEntitlements(Consumer consumer);
     int revokeAllEntitlements(Consumer consumer, boolean regenCertsAndStatuses);
 
-    void revokeEntitlements(List<Entitlement> ents);
+    Set<Pool> revokeEntitlements(List<Entitlement> ents);
     void revokeEntitlement(Entitlement entitlement);
 
     Pool updatePoolQuantity(Pool pool, long adjust);

--- a/server/src/main/java/org/candlepin/model/Branding.java
+++ b/server/src/main/java/org/candlepin/model/Branding.java
@@ -67,6 +67,7 @@ public class Branding extends AbstractHibernateObject {
     private String type;
 
     public Branding() {
+        // Intentionally left empty
     }
 
     public Branding(String productId, String type, String name) {
@@ -127,6 +128,7 @@ public class Branding extends AbstractHibernateObject {
         if (this == anObject) {
             return true;
         }
+
         if (!(anObject instanceof Branding)) {
             return false;
         }
@@ -142,5 +144,11 @@ public class Branding extends AbstractHibernateObject {
     public int hashCode() {
         return new HashCodeBuilder(129, 15).append(this.name)
             .append(this.productId).append(this.type).toHashCode();
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Branding [id: %s, name: %s, productId: %s, type: %s]",
+            this.getId(), this.getName(), this.getProductId(), this.getType());
     }
 }

--- a/server/src/main/java/org/candlepin/model/SourceSubscription.java
+++ b/server/src/main/java/org/candlepin/model/SourceSubscription.java
@@ -144,8 +144,8 @@ public class SourceSubscription extends AbstractHibernateObject {
 
     @Override
     public String toString() {
-        return String.format("SourceSubscription [subscriptionId: %s, subscriptionSubKey: %s]",
-            this.getSubscriptionId(), this.getSubscriptionSubKey());
+        return String.format("SourceSubscription [id: %s, subscriptionId: %s, subscriptionSubKey: %s]",
+            this.getId(), this.getSubscriptionId(), this.getSubscriptionSubKey());
     }
 
 


### PR DESCRIPTION
* When a product changes in a manifest resulting in entitlement revocation and subsequent deletion of entitlement derived pools,
  some pools that are deleted subsequently were attempted to being updated. This branch skips those deleted pools
* Some product changes resulted in creating brandings on a product, and when that pool was being locked, created an error since
  Hibernate had not flushed the brandings yet

## Verification steps
*  sudo systemctl stop tomcat
* dropdb -U candlepin  candlepin
* createdb -U candlepin  candlepin
* import db
  * psql -U candlepin -d candlepin -f candlepin_dump.sql 
* git checkout candlepin-2.1-HOTFIX
* ./server/bin/deploy 
*  fetch list of candlepin owners, so we can verify candlepin is working and we can use the owner key for later.

* import manifest from bug
* curl -X POST --header "Content-Type: multipart/form-data" -F "file=@manifest.zip"  -k -u admin:admin  "https://localhost:8443/candlepin/owners/{owner_key}/imports?force=SIGNATURE_CONFLICT&force=MANIFEST_SAME&force=MANIFEST_OLD&force=DISTRIBUTOR_CONFLICT"
* verify error Unable to find org.candlepin.model.Entitlement with id 8a38e08358
* git checkout vritant/1571354
* ./server/bin/deploy
* import manifest from bug
* curl -X POST --header "Content-Type: multipart/form-data" -F "file=@manifest.zip"  -k -u admin:admin  "https://localhost:8443/candlepin/owners/{owner_key}/imports?force=SIGNATURE_CONFLICT&force=MANIFEST_SAME&force=MANIFEST_OLD&force=DISTRIBUTOR_CONFLICT"
* verify successful import