### PR TITLE
ENT-432 Converted Owner.key to a hibernate @NaturalId

### DIFF
--- a/server/src/main/java/org/candlepin/model/Owner.java
+++ b/server/src/main/java/org/candlepin/model/Owner.java
@@ -29,6 +29,7 @@ import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.hibernate.annotations.GenericGenerator;
 
 import io.swagger.annotations.ApiModelProperty;
+import org.hibernate.annotations.NaturalId;
 
 import java.io.Serializable;
 import java.util.Date;
@@ -85,6 +86,7 @@ public class Owner extends AbstractHibernateObject<Owner>
     @Column(name = "account", nullable = false, unique = true)
     @Size(max = 255)
     @NotNull
+    @NaturalId
     private String key;
 
     @Column(nullable = false)

--- a/server/src/main/java/org/candlepin/model/OwnerCurator.java
+++ b/server/src/main/java/org/candlepin/model/OwnerCurator.java
@@ -95,14 +95,27 @@ public class OwnerCurator extends AbstractHibernateCurator<Owner> {
     }
 
     /**
+     * Fetches an owner by key securely by checking principal permissions.
+     *
+     * @param key owner's unique key to fetch.
+     * @return the owner whose key matches the one given.
+     */
+    @Transactional
+    public Owner getByKeySecure(String key) {
+        return (Owner) createSecureCriteria()
+            .add(Restrictions.eq("key", key))
+            .uniqueResult();
+    }
+
+    /**
+     * Fetches an owner by natural id (key). This method is non-secure.
+     *
      * @param key owner's unique key to fetch.
      * @return the owner whose key matches the one given.
      */
     @Transactional
     public Owner getByKey(String key) {
-        return (Owner) createSecureCriteria()
-            .add(Restrictions.eq("key", key))
-            .uniqueResult();
+        return this.currentSession().bySimpleNaturalId(Owner.class).load(key);
     }
 
     @Transactional

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -688,7 +688,14 @@ public class ConsumerResource {
         Consumer consumer = null;
         if (ownerKey != null && dto.getFact("system_uuid") != null &&
             !"true".equalsIgnoreCase(dto.getFact("virt.is_guest"))) {
+
             Owner owner = ownerCurator.getByKey(ownerKey);
+            if (!principal.canAccess(owner, SubResource.CONSUMERS, Access.CREATE)) {
+                throw new ForbiddenException(
+                    i18n.tr("User \"{0}\" does not have access to create consumers in org \"{1}\"",
+                    principal.getName(), owner.getKey()));
+            }
+
             if (owner != null) {
                 consumer = consumerCurator.getHypervisor(dto.getFact("system_uuid"), owner);
                 if (consumer != null) {
@@ -698,15 +705,6 @@ public class ConsumerResource {
                 }
             }
         }
-        if (consumer == null) {
-            consumer = new Consumer();
-        }
-
-        if (dto.getUuid() != null) {
-            consumer.setUuid(dto.getUuid());
-        }
-        consumer.setOwner(ownerCurator.getByKey(ownerKey));
-        populateEntity(consumer, dto);
 
         if (dto.getType() == null) {
             throw new BadRequestException(i18n.tr("Unit type must be specified."));

--- a/server/src/main/java/org/candlepin/resource/OwnerProductResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerProductResource.java
@@ -16,7 +16,6 @@ package org.candlepin.resource;
 
 import org.apache.commons.lang3.StringUtils;
 import org.candlepin.auth.Verify;
-import org.candlepin.common.auth.SecurityHole;
 import org.candlepin.common.config.Configuration;
 import org.candlepin.common.exceptions.BadRequestException;
 import org.candlepin.common.exceptions.ForbiddenException;
@@ -208,7 +207,6 @@ public class OwnerProductResource {
     @GET
     @Path("/{product_id}")
     @Produces(MediaType.APPLICATION_JSON)
-    @SecurityHole
     public ProductDTO getProduct(
         @Verify(Owner.class) @PathParam("owner_key") String ownerKey,
         @PathParam("product_id") String productId) {
@@ -224,7 +222,6 @@ public class OwnerProductResource {
     @GET
     @Path("/{product_id}/certificate")
     @Produces(MediaType.APPLICATION_JSON)
-    @SecurityHole
     @Transactional
     public ProductCertificateDTO getProductCertificate(
         @PathParam("owner_key") String ownerKey,

--- a/server/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -1689,7 +1689,6 @@ public class OwnerResource {
     @ApiResponses({ @ApiResponse(code = 404, message = "Owner not found"),
         @ApiResponse(code = 202, message = "") })
     public JobDetail refreshPools(
-        // TODO: Can we verify with autocreate?
         @PathParam("owner_key") String ownerKey,
         @QueryParam("auto_create_owner") @DefaultValue("false") Boolean autoCreateOwner,
         @QueryParam("lazy_regen") @DefaultValue("true") Boolean lazyRegen) {

--- a/server/src/main/java/org/candlepin/resteasy/filter/StoreFactory.java
+++ b/server/src/main/java/org/candlepin/resteasy/filter/StoreFactory.java
@@ -92,7 +92,7 @@ public class StoreFactory {
 
         @Override
         public Owner lookup(String key) {
-            return this.ownerCurator.getByKey(key);
+            return this.ownerCurator.getByKeySecure(key);
         }
 
         @Override

--- a/server/src/test/java/org/candlepin/auth/permissions/OwnerCuratorPermissionsTest.java
+++ b/server/src/test/java/org/candlepin/auth/permissions/OwnerCuratorPermissionsTest.java
@@ -80,10 +80,17 @@ public class OwnerCuratorPermissionsTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void testgetByKeyOwnerPermissionFiltering() {
+    public void testgetByKeySecureOwnerPermissionFiltering() {
+        assertEquals(owner1, ownerCurator.getByKeySecure(owner1.getKey()));
+        assertEquals(owner2, ownerCurator.getByKeySecure(owner2.getKey()));
+        assertNull(ownerCurator.getByKeySecure(owner3.getKey()));
+    }
+
+    @Test
+    public void testgetByKeyOwnerPermissionDoesNotFilter() {
         assertEquals(owner1, ownerCurator.getByKey(owner1.getKey()));
         assertEquals(owner2, ownerCurator.getByKey(owner2.getKey()));
-        assertNull(ownerCurator.getByKey(owner3.getKey()));
+        assertEquals(owner3, ownerCurator.getByKey(owner3.getKey()));
     }
 
 }


### PR DESCRIPTION
- OwnerCurator.getByKey now uses session.bySimpleNaturalId to fetch an owner, and the old version of that method is renamed to getByKeySecure.
- Added explicit access check in ConsumerResource.create API due to it being marked as @SecurityHole.
- Deleted two @SecurityHole annotations that were in conflict with @Verify annotations (these are mutually exclusive).
- Deleted a couple of unused methods from ResolverUtil.