### PR TITLE
[M] 1572669: Update liquibase checksums

### DIFF
--- a/server/src/main/resources/db/changelog/20130425102131-distributor-capabilities.xml
+++ b/server/src/main/resources/db/changelog/20130425102131-distributor-capabilities.xml
@@ -32,7 +32,11 @@
     </changeSet>
 
     <changeSet id="20130425102131-2" author="wpoteat" dbms="oracle,postgresql">
+        <validCheckSum>7:05836cb0a73b10e287483121604da65f</validCheckSum>
+        <validCheckSum>7:70cb19f5d0f1ff233849e52325c8437b</validCheckSum>
         <validCheckSum>7:99cf6849e828630689bead090ccca338</validCheckSum>
+        <validCheckSum>8:a437eb7d1a39dffa626dea56f1a2e49e</validCheckSum>
+        <validCheckSum>8:b9963ed36c2fe1c67f56d785e3c83bf1</validCheckSum>
 
         <createTable tableName="cp_dist_version">
             <column name="id" type="VARCHAR(32)">

--- a/server/src/main/resources/db/changelog/20130501152202-add-content-arch.xml
+++ b/server/src/main/resources/db/changelog/20130501152202-add-content-arch.xml
@@ -11,6 +11,11 @@
 
 
     <changeSet id="20130501152202-1" author="alikins" dbms="oracle,postgresql">
+        <validCheckSum>7:75a2f97f5bab86b5a9a2e2dbe7691846</validCheckSum>
+        <validCheckSum>7:9f23549e635ccba246d3932a9dc5a40d</validCheckSum>
+        <validCheckSum>7:a8a8479ea5703b60cf9ef21459bae983</validCheckSum>
+        <validCheckSum>8:10f008f90f3f4c11f178257c9b82b74a</validCheckSum>
+        <validCheckSum>8:9bde88c6c0b0e6b7adcc2c05cd69f1e2</validCheckSum>
         <comment>Add a cp_content_arch for content/arch mapping</comment>
         <createTable tableName="cp_arch">
 
@@ -27,6 +32,10 @@
 
     <changeSet id="20130501152202-2" author="alikins" dbms="oracle,postgresql">
         <validCheckSum>7:21a6dfe6c97700d58f1f8149007b7d7b</validCheckSum>
+        <validCheckSum>7:3b4602097ebfc5c75e3244fab603acbd</validCheckSum>
+        <validCheckSum>7:4b694f84dc22cb635c07172d6fa01f4c</validCheckSum>
+        <validCheckSum>8:e802d727014f0a83e6fc0301f3bf4aaf</validCheckSum>
+        <validCheckSum>8:fdc944d6f8749658e5a0c613cd374f6c</validCheckSum>
 
         <createTable tableName="cp_content_arch">
             <column name="content_id" type="VARCHAR(255)">

--- a/server/src/main/resources/db/changelog/20130722140547-add-cdn-table.xml
+++ b/server/src/main/resources/db/changelog/20130722140547-add-cdn-table.xml
@@ -10,6 +10,12 @@
     <include file="db/changelog/datatypes.xml"/>
 
     <changeSet id="20130722140547" author="wpoteat">
+        <validCheckSum>7:006ee3dba5d99df3da9c6f318815a610</validCheckSum>
+        <validCheckSum>7:483f4f799cb4955a143d3fb79c1506c6</validCheckSum>
+        <validCheckSum>7:51675f89ddff4bb5da44fdf2d214a1ab</validCheckSum>
+        <validCheckSum>8:1e8715fe9425746d1ec6ccb0d506c42c</validCheckSum>
+        <validCheckSum>8:7adafd93071bd44106818026ec83c1b6</validCheckSum>
+        <validCheckSum>8:ab847dff598b986fdf0e53cda5a3f80c</validCheckSum>
         <comment>CDN record</comment>
         <createTable tableName="cp_cdn">
             <column name="id" type="VARCHAR(32)">
@@ -40,6 +46,12 @@
     </changeSet>
 
     <changeSet author="wpoteat" id="20130722140547-2">
+        <validCheckSum>7:4ff292b0387562514b6238916e367b7d</validCheckSum>
+        <validCheckSum>7:9314a208d7c646475f64c09818a2e6ce</validCheckSum>
+        <validCheckSum>7:932b91625e84b50a9ffd38342e6dd698</validCheckSum>
+        <validCheckSum>8:4745fd585dc6909a41e86400d6dfdf2d</validCheckSum>
+        <validCheckSum>8:482e5b97251060f4b1b7bca01b818e07</validCheckSum>
+        <validCheckSum>8:6fffdbdb8cb5b7e358e8b43d1eef2b7a</validCheckSum>
         <createTable tableName="cp_cdn_certificate">
             <column name="id" type="VARCHAR(32)">
                 <constraints nullable="false" primaryKey="true" primaryKeyName="cp_cdn_certificate_pkey"/>

--- a/server/src/main/resources/db/changelog/20130912153356-create-import-upstream-consumer.xml
+++ b/server/src/main/resources/db/changelog/20130912153356-create-import-upstream-consumer.xml
@@ -10,7 +10,12 @@
     <include file="db/changelog/datatypes.xml"/>
 
     <changeSet id="20130912153356" author="wpoteat">
+        <validCheckSum>7:5cc2a94b3815daa27c2fa47718d4f499</validCheckSum>
         <validCheckSum>7:69e9ff14c6d2da8962d4870401700340</validCheckSum>
+        <validCheckSum>7:94ed4e585fc79be1e42740634465e4e4</validCheckSum>
+        <validCheckSum>8:65ed1119a70acd4b8975eb6b8968db5f</validCheckSum>
+        <validCheckSum>8:b95e028bdf52bc7b889cb89660124eb9</validCheckSum>
+        <validCheckSum>8:c0ebfd668ddf91c9d6afb39715629d7d</validCheckSum>
         <createTable tableName="cp_import_upstream_consumer">
             <column name="id" type="VARCHAR(32)">
                 <constraints nullable="false" primaryKey="true" primaryKeyName="cp_imp_upstream_cnsmr_pkey"/>

--- a/server/src/main/resources/db/changelog/20131002150608-consumer-content-override.xml
+++ b/server/src/main/resources/db/changelog/20131002150608-consumer-content-override.xml
@@ -10,7 +10,12 @@
     <include file="db/changelog/datatypes.xml"/>
 
     <changeSet id="20131002150608" author="wpoteat">
+        <validCheckSum>7:4fcc284aadf64caa405d12392422361e</validCheckSum>
+        <validCheckSum>7:a2f883a6e6023245798758e43b9aa0dd</validCheckSum>
         <validCheckSum>7:bef3100eb209f06cd08332a032e87c3f</validCheckSum>
+        <validCheckSum>8:10c4ffec7e7137a437a8551d9bbccfe1</validCheckSum>
+        <validCheckSum>8:a036fe270c0ee2c882c32efe15fc34aa</validCheckSum>
+        <validCheckSum>8:b5c16ffcba14ae901dd6b326c1230938</validCheckSum>
         <comment>Consumer content overrides</comment>
         <createTable tableName="cp_consumer_content_override">
             <column name="id" type="VARCHAR(32)">

--- a/server/src/main/resources/db/changelog/20140210083318-add-hypervisorid.xml
+++ b/server/src/main/resources/db/changelog/20140210083318-add-hypervisorid.xml
@@ -10,6 +10,12 @@
     <include file="db/changelog/datatypes.xml"/>
 
     <changeSet id="20140210083318-0" author="ckozak">
+        <validCheckSum>7:773aa718029078d9e68141229f80091a</validCheckSum>
+        <validCheckSum>7:898d5c32c76ff2b2014cfe357904a10a</validCheckSum>
+        <validCheckSum>7:d7d931282412415b930c924c5281fecd</validCheckSum>
+        <validCheckSum>8:0f9ab10fc0d8b75b8180f8b1fd559c07</validCheckSum>
+        <validCheckSum>8:a7b4cdcfe22f1bbd57fc42a178a718de</validCheckSum>
+        <validCheckSum>8:e9a607faa296b5c34a336acc6dfa4656</validCheckSum>
         <comment>Add hypervisorId</comment>
         <createTable tableName="cp_consumer_hypervisor">
             <column name="id" type="VARCHAR(32)">

--- a/server/src/main/resources/db/changelog/20140306150357-constrain-one-subpool-per-stack.xml
+++ b/server/src/main/resources/db/changelog/20140306150357-constrain-one-subpool-per-stack.xml
@@ -10,6 +10,12 @@
     <include file="db/changelog/datatypes.xml"/>
 
     <changeSet id="20140306150357-0" author="ckozak">
+        <validCheckSum>7:91d9151f61b108d92d5ad81163e56c71</validCheckSum>
+        <validCheckSum>7:d9ac0fb627e24719a716912ad4a3d156</validCheckSum>
+        <validCheckSum>7:dc60ea882d84442bd84f349d08f15144</validCheckSum>
+        <validCheckSum>8:6c3e4d59a0fa2902f7f401b15c93a546</validCheckSum>
+        <validCheckSum>8:7ea10bde79203b958a6fef50d4860f41</validCheckSum>
+        <validCheckSum>8:b946da32ce510c1b4913f7bb2f787da7</validCheckSum>
         <comment>Constrain one subpool per stack to avoid concurrency problems</comment>
 
         <createTable tableName="cp_pool_source_stack">

--- a/server/src/main/resources/db/changelog/20140313155734-create-branding.xml
+++ b/server/src/main/resources/db/changelog/20140313155734-create-branding.xml
@@ -10,6 +10,12 @@
     <include file="db/changelog/datatypes.xml"/>
 
     <changeSet id="20140313155734-1" author="dgoodwin">
+        <validCheckSum>7:158d98c02779a45c6a734b758febd2bf</validCheckSum>
+        <validCheckSum>7:54d90768d1359a612b561ecdf7313529</validCheckSum>
+        <validCheckSum>7:ec2335a6b45f46ba54d37e307b363e71</validCheckSum>
+        <validCheckSum>8:2f1db39170abdcf593bafd4ceae44b87</validCheckSum>
+        <validCheckSum>8:b1436cec6fea027bbdd7328c96158201</validCheckSum>
+        <validCheckSum>8:ef6b3ad62e6d8d8e14515165c091a505</validCheckSum>
         <comment>Create the branding table.</comment>
         <createTable tableName="cp_branding">
             <column name="id" type="VARCHAR(32)">

--- a/server/src/main/resources/db/changelog/20140317115036-index-facts-consumerid.xml
+++ b/server/src/main/resources/db/changelog/20140317115036-index-facts-consumerid.xml
@@ -8,8 +8,9 @@
 
 
     <changeSet id="20140317115036" author="ckozak">
-        <!-- This a valid state for this changeset; often appears this way in dumps from Satellite -->
+        <validCheckSum>7:33574c04acead7abc463faca77adb9f8</validCheckSum>
         <validCheckSum>7:ceb9b38d059a57332a2b9799299663fe</validCheckSum>
+        <validCheckSum>8:430cefe493aba0ec0784ba15aa919b58</validCheckSum>
 
         <comment>Index cp_consumer_facts on cp_consumer_id</comment>
         <createIndex indexName="consumer_fact_consumer_id_idx"

--- a/server/src/main/resources/db/changelog/20140408160212-add-pool-source-sub-table.xml
+++ b/server/src/main/resources/db/changelog/20140408160212-add-pool-source-sub-table.xml
@@ -10,6 +10,12 @@
     <include file="db/changelog/datatypes.xml"/>
 
     <changeSet id="20140408160212-0" author="ckozak">
+        <validCheckSum>7:8e70cea87f3971b9b7f50c9ae10c028d</validCheckSum>
+        <validCheckSum>7:978385cef948bba92700cecb359dde3a</validCheckSum>
+        <validCheckSum>7:e6a78ebe3c03b038c1413ea3637690d6</validCheckSum>
+        <validCheckSum>8:522a3f9fd70c7f59f1f10370ea6f5b56</validCheckSum>
+        <validCheckSum>8:732083ed7d41e2fcc15db69bc8aa1add</validCheckSum>
+        <validCheckSum>8:e459150e4bc443d4479c833c05f4d84d</validCheckSum>
         <comment>Create source subscription table</comment>
 
         <createTable tableName="cp_pool_source_sub">

--- a/server/src/main/resources/db/changelog/20150123105016-add-consumer-checkin-table.xml
+++ b/server/src/main/resources/db/changelog/20150123105016-add-consumer-checkin-table.xml
@@ -10,6 +10,12 @@
     <include file="db/changelog/datatypes.xml"/>
 
     <changeSet id="20150123105016-1" author="dgoodwin">
+        <validCheckSum>7:a9eed77a221e620c3ee501b3ee0fe79b</validCheckSum>
+        <validCheckSum>7:b1ec78ebeb49675f013951bd3aa23b7c</validCheckSum>
+        <validCheckSum>7:c99a09927da77f3ab79e990d465703c3</validCheckSum>
+        <validCheckSum>8:1dee9c3540fb37911003e2ba6d0b962e</validCheckSum>
+        <validCheckSum>8:2b82a53d8ef0a60ace30b325705cf961</validCheckSum>
+        <validCheckSum>8:bd946921ef2986f716ebb135013938e1</validCheckSum>
         <comment>Add consumer checkin table.</comment>
         <createTable tableName="cp_consumer_checkin">
 

--- a/server/src/main/resources/db/changelog/20150210094558-perorgproducts-phase-1.xml
+++ b/server/src/main/resources/db/changelog/20150210094558-perorgproducts-phase-1.xml
@@ -11,6 +11,12 @@
 
     <!-- cp2_products -->
     <changeSet id="20150210094558-01" author="crog">
+        <validCheckSum>7:3b5c6ab60babe2b14041b1e9355768eb</validCheckSum>
+        <validCheckSum>7:521255dcec24c26cd102a90e3e2a6a3c</validCheckSum>
+        <validCheckSum>7:6c56c1413ca32c71ada3853fe8b78490</validCheckSum>
+        <validCheckSum>8:2002795fb3d908f98c8dd520bfe32d92</validCheckSum>
+        <validCheckSum>8:f81658c53b38bbc2ecec915e742ac6fe</validCheckSum>
+        <validCheckSum>8:f9943a99c69749407633008b5b20d8d0</validCheckSum>
         <createTable tableName="cp2_products">
             <column name="uuid" type="varchar(32)">
                 <constraints primaryKey="true" primaryKeyName="cp2_products_pk"/>
@@ -93,6 +99,12 @@
 
     <!-- cp2_content -->
     <changeSet id="20150210094558-06" author="crog">
+        <validCheckSum>7:261f3361d263fcc0fd03ca6df110e82f</validCheckSum>
+        <validCheckSum>7:6d4b9b816ac3c17e67e8dc89c168164e</validCheckSum>
+        <validCheckSum>7:ba5d4d94e05c2542eaa6cadb2934444b</validCheckSum>
+        <validCheckSum>8:06fb37b1b3bf9a064adc5f016a07022a</validCheckSum>
+        <validCheckSum>8:e4232deafda37c711fcdac50376d2247</validCheckSum>
+        <validCheckSum>8:edbf8b23a52254856cdfaf24bbeb81ab</validCheckSum>
         <createTable tableName="cp2_content">
             <column name="uuid" type="varchar(32)">
                 <constraints primaryKey="true" primaryKeyName="cp2_content_pk"/>
@@ -170,6 +182,12 @@
 
     <!-- cp2_environment_content -->
     <changeSet id="20150210094558-10" author="crog">
+        <validCheckSum>7:b653132fefa3377dcbd7f6acca51ab36</validCheckSum>
+        <validCheckSum>7:d9ca85d0efaefa77bacc1bfbd94b1371</validCheckSum>
+        <validCheckSum>7:f8280ee48be35a7361829280037fc89f</validCheckSum>
+        <validCheckSum>8:6c10522bc78e7597aeb80838869e50ec</validCheckSum>
+        <validCheckSum>8:9ffd91eb69b2a05539b7b2aacb5dd4b6</validCheckSum>
+        <validCheckSum>8:d5f447c6162c26164ebfd8720ef8a0d8</validCheckSum>
         <createTable tableName="cp2_environment_content">
             <column name="id" type="varchar(32)">
                 <constraints primaryKey="true" primaryKeyName="cp2_environment_content_pk"/>
@@ -207,6 +225,12 @@
 
     <!-- cp2_installed_products -->
     <changeSet id="20150210094558-12" author="crog">
+        <validCheckSum>7:0e091ea99dc9dd997e2efadf0db4f988</validCheckSum>
+        <validCheckSum>7:c94b7a5eaab7269a8539ac09c2ba5c70</validCheckSum>
+        <validCheckSum>7:e6fb4be524be85359dce9d1016400388</validCheckSum>
+        <validCheckSum>8:6076c5a2371d88bfa8be13b12f6752db</validCheckSum>
+        <validCheckSum>8:bd790ff239d0ff173f02a3895232b8bc</validCheckSum>
+        <validCheckSum>8:c846433d74d537e0c59ad4e4937fcb46</validCheckSum>
         <createTable tableName="cp2_installed_products">
             <column name="id" type="varchar(32)">
                 <constraints primaryKey="true" primaryKeyName="cp2_installed_products_pk"/>
@@ -295,6 +319,12 @@
 
     <!-- cp2_product_attributes -->
     <changeSet id="20150210094558-18" author="crog">
+        <validCheckSum>7:3211d75204d019af23fc73b09e806f76</validCheckSum>
+        <validCheckSum>7:61a67e6bba4d6e860dca4cc01435e6b3</validCheckSum>
+        <validCheckSum>7:cb0d09e1d86fdde69470d11c0cfc166e</validCheckSum>
+        <validCheckSum>8:1289f3879a10f0c31ee579616f15fc76</validCheckSum>
+        <validCheckSum>8:7b3ff3d0fd4a0ba50bc696ce48bc58f9</validCheckSum>
+        <validCheckSum>8:8af7ebdb88dd20f8f2d8aa2de069ba65</validCheckSum>
         <createTable tableName="cp2_product_attributes">
             <column name="id" type="varchar(32)">
                 <constraints primaryKey="true" primaryKeyName="cp2_product_attributes_pk"/>
@@ -320,6 +350,12 @@
 
     <!-- cp2_product_certificates -->
     <changeSet id="20150210094558-19" author="crog">
+        <validCheckSum>7:45db9a72f519910f48c226943d315c2f</validCheckSum>
+        <validCheckSum>7:8d1fa50559873b9a57641971dd5946ab</validCheckSum>
+        <validCheckSum>7:efd42f929d8e7bcca98bc9972daa1eaa</validCheckSum>
+        <validCheckSum>8:17cbaa5cdde5d751c015128865da625e</validCheckSum>
+        <validCheckSum>8:491d6601d211b8a9dd7f982b737ea27d</validCheckSum>
+        <validCheckSum>8:c4db7e4e19ed09ae2d09a4b30c9477a1</validCheckSum>
         <createTable tableName="cp2_product_certificates">
             <column name="id" type="varchar(32)">
                 <constraints primaryKey="true" primaryKeyName="cp2_product_certificates_pk"/>
@@ -347,6 +383,12 @@
 
     <!-- cp2_product_content -->
     <changeSet id="20150210094558-20" author="crog">
+        <validCheckSum>7:11006e34c609f944943a1a1ded518f93</validCheckSum>
+        <validCheckSum>7:64c2e96eebb7b0219a08917ef46057a9</validCheckSum>
+        <validCheckSum>7:9b4f6922ffa2afb88e2be9f7e422452e</validCheckSum>
+        <validCheckSum>8:494b16b757a1f4c1ac92693be85b847a</validCheckSum>
+        <validCheckSum>8:7944400be7df32fa03c5ab68a1e8bf22</validCheckSum>
+        <validCheckSum>8:d6796720698ace24a36b4ef75c5c83d5</validCheckSum>
         <createTable tableName="cp2_product_content">
             <column name="product_uuid" type="varchar(32)">
                 <constraints
@@ -480,6 +522,12 @@
 
     <!-- cp2_pool_source_sub -->
     <changeSet id="20150210094558-33" author="crog">
+        <validCheckSum>7:191c60333258d3c40206bd52151f6873</validCheckSum>
+        <validCheckSum>7:21380b6acb1ec04519b40aecd4da5415</validCheckSum>
+        <validCheckSum>7:b1b2037cd3ee111accd28c419ad4d219</validCheckSum>
+        <validCheckSum>8:6208ec5fa82dcd0897530d4e1e6ad0cf</validCheckSum>
+        <validCheckSum>8:824bbcee945dbbb611755e0eb248d700</validCheckSum>
+        <validCheckSum>8:83c14e247d30927647c495c1519d765e</validCheckSum>
         <createTable tableName="cp2_pool_source_sub">
             <column name="id" type="varchar(32)">
                 <constraints primaryKey="true" primaryKeyName="cp2_pool_source_sub_pk"/>

--- a/server/src/main/resources/db/changelog/20150211111319-add-last-guest-update-table.xml
+++ b/server/src/main/resources/db/changelog/20150211111319-add-last-guest-update-table.xml
@@ -10,6 +10,12 @@
     <include file="db/changelog/datatypes.xml"/>
 
     <changeSet id="20150211111319-1" author="dgoodwin">
+        <validCheckSum>7:43a5396dcaa9c3dd6dbc41138e4b73ad</validCheckSum>
+        <validCheckSum>7:5b0f0f9c2016ebe7e605a03474d3706b</validCheckSum>
+        <validCheckSum>7:e527a46a648419347f2cd72acf3e2aec</validCheckSum>
+        <validCheckSum>8:1a30dbd7d465ae92ef395634ac91f7ad</validCheckSum>
+        <validCheckSum>8:4c32e67d69dc3ecbb6aed0421668c56b</validCheckSum>
+        <validCheckSum>8:93c0436f18c2337a723eeb008cf41987</validCheckSum>
         <comment>add last guest update table</comment>
 
         <!-- See http://www.liquibase.org/documentation/changes/index.html -->
@@ -36,9 +42,8 @@
     </changeSet>
 
     <changeSet id="20150211111319-2" author="dgoodwin">
-        <!-- Checksums for current state (top) and the state dated Feb 25, 2015 -->
-        <validCheckSum>7:25f5368fe0a7bce4784403b0dd79a5ed</validCheckSum>
         <validCheckSum>7:1cec9823accc46e660334425b7c5393b</validCheckSum>
+        <validCheckSum>8:fbefb0063913f7b1bcd799a5ec8235d5</validCheckSum>
 
         <comment>Populate guest ID checkins table with current values.</comment>
 

--- a/server/src/main/resources/db/changelog/20150316122833-add-entitlement-end-date-override.xml
+++ b/server/src/main/resources/db/changelog/20150316122833-add-entitlement-end-date-override.xml
@@ -10,6 +10,12 @@
     <include file="db/changelog/datatypes.xml"/>
 
     <changeSet id="20150316122833-1" author="dgoodwin">
+        <validCheckSum>7:427c7fad9fe2b2035f8e82aeeccee966</validCheckSum>
+        <validCheckSum>7:adf93b47681e5d3608e745ee9dde18ff</validCheckSum>
+        <validCheckSum>7:f192671aef38fc1879c4a1202274fbc8</validCheckSum>
+        <validCheckSum>8:213d247a9087b7a6734f1dd453327835</validCheckSum>
+        <validCheckSum>8:29524ce2e46c01c1bd55a20bac714d62</validCheckSum>
+        <validCheckSum>8:886a5fd0b4adfafadf07dbfbf19e22a0</validCheckSum>
         <comment>add entitlement end date override</comment>
         <!-- See http://www.liquibase.org/documentation/changes/index.html -->
         <addColumn tableName="cp_entitlement">

--- a/server/src/main/resources/db/changelog/20150820140403-revert-to-lastcheckin-column.xml
+++ b/server/src/main/resources/db/changelog/20150820140403-revert-to-lastcheckin-column.xml
@@ -10,6 +10,12 @@
     <include file="db/changelog/datatypes.xml"/>
 
     <changeSet id="20150820140403-1" author="dgoodwin">
+        <validCheckSum>7:316b7f97d051603e7c807ec2a12b5e0a</validCheckSum>
+        <validCheckSum>7:489efc048c93bc01b88dc88e5e6744ea</validCheckSum>
+        <validCheckSum>7:c39b5e252732b332557a1fc478044f93</validCheckSum>
+        <validCheckSum>8:3f03cb36c42dcb5c28b5601eb7284d85</validCheckSum>
+        <validCheckSum>8:590bfaaa11d0a4a6e9324d3d5c1ebb7a</validCheckSum>
+        <validCheckSum>8:cfbd6799af2ef2ce6892a4f0fbefde50</validCheckSum>
         <comment>revert to lastcheckin column</comment>
         <addColumn tableName="cp_consumer">
             <column name="lastcheckin" type="${timestamp.type}"/>

--- a/server/src/main/resources/db/changelog/20160419092221-add-db-file-storage.xml
+++ b/server/src/main/resources/db/changelog/20160419092221-add-db-file-storage.xml
@@ -16,6 +16,12 @@
     <property name="date.type" value="DATETIME" dbms="mysql"/>
 
     <changeSet id="20160419092221-1" author="mstead">
+        <validCheckSum>7:07aa73f9f3481fea2832f0e810673c25</validCheckSum>
+        <validCheckSum>7:08346f550770caed9ada2798ba73de55</validCheckSum>
+        <validCheckSum>7:8b59a9c4c9b7b3637f1d57e803117906</validCheckSum>
+        <validCheckSum>8:756fc94b83d004f24700f100d2b52fd4</validCheckSum>
+        <validCheckSum>8:7ec5b757d4db9429eba5c794392e8779</validCheckSum>
+        <validCheckSum>8:95c66aad2fedb93ebc076f8fc14543e9</validCheckSum>
         <comment>Add ManifestFileRecord object to track manifest data.</comment>
         <createTable tableName="cp_manifest_file_record">
             <column name="id" type="VARCHAR(32)">

--- a/server/src/main/resources/db/changelog/20161013145834-add-content-access-cert-column-to-consumer.xml
+++ b/server/src/main/resources/db/changelog/20161013145834-add-content-access-cert-column-to-consumer.xml
@@ -10,6 +10,12 @@
     <include file="db/changelog/datatypes.xml"/>
 
     <changeSet id="20161013145834-1" author="wpoteat">
+        <validCheckSum>7:26c6496e8df76f14cf3d585d06b1c7c6</validCheckSum>
+        <validCheckSum>7:ce5002991f3cb5fa4ed7dc31c97b70eb</validCheckSum>
+        <validCheckSum>7:d62c0661f81677585924fed7c86e6d76</validCheckSum>
+        <validCheckSum>8:1bef54fbfd88d043c2a4df389b284f78</validCheckSum>
+        <validCheckSum>8:73d44feaf877446697aa3e41dce6561e</validCheckSum>
+        <validCheckSum>8:73ea28468cd38d6cdcf78e32e10420fe</validCheckSum>
         <createTable tableName="cp_cont_access_cert">
             <column name="id" type="VARCHAR(32)">
                 <constraints nullable="false" primaryKey="true" primaryKeyName="cp_cont_access_cert_pkey"/>

--- a/server/src/main/resources/db/changelog/20161025103454-cleanup-ueber-certs-round2.xml
+++ b/server/src/main/resources/db/changelog/20161025103454-cleanup-ueber-certs-round2.xml
@@ -250,6 +250,8 @@
     <changeSet id="20161025103454-1" author="mstead">
         <validCheckSum>7:67265f7bbe46b62a789d326361adee32</validCheckSum>
         <validCheckSum>7:9b3c3db544862eaa6e7ff0cb9f9ef4b5</validCheckSum>
+        <validCheckSum>8:14b50077179cc361b889075c2b0806a2</validCheckSum>
+        <validCheckSum>8:c068dfb6b3bf42d4d0bfe5e1db14534d</validCheckSum>
 
         <comment>Clean out all ueber cert (debug cert) data to avoid manual cleanup.
                  This changeset will remove both the 0.9.54 (copied data) AND the

--- a/server/src/main/resources/db/changelog/20161109145238-add-owner-environment-content-access.xml
+++ b/server/src/main/resources/db/changelog/20161109145238-add-owner-environment-content-access.xml
@@ -10,8 +10,12 @@
     <include file="db/changelog/datatypes.xml"/>
 
     <changeSet id="20161109145238-1" author="wpoteat">
-        <validCheckSum>7:e7d90208e03c95b6b43ff73e4a6c441b</validCheckSum>
+        <validCheckSum>7:1dfdff5a21ccd08852ec458ea855f9d8</validCheckSum>
+        <validCheckSum>7:86907a72bb6a6107049aefc2e71c6fac</validCheckSum>
         <validCheckSum>7:bbc2d8aa1f2baa79d636c765a244fee8</validCheckSum>
+        <validCheckSum>8:069a1d7897dc0f357bb9d196d95a06e9</validCheckSum>
+        <validCheckSum>8:89dc37f3d2fe9e03b910b2c4d5b1fae1</validCheckSum>
+        <validCheckSum>8:c1ac41c03556dafe5294a69ea362e6cf</validCheckSum>
 
         <comment>add-owner-environment-content-access</comment>
         <createTable tableName="cp_owner_env_content_access">
@@ -38,6 +42,7 @@
     </changeSet>
     <changeSet author="wpoteat" id="20161109145238-02">
         <validCheckSum>7:f0088c7c4134a1161a75334886f85f48</validCheckSum>
+        <validCheckSum>8:cfd6dd3e7861f7e14a0fabae58f85054</validCheckSum>
         <!-- NOTE: in 2.1 constraintName was cp_owner_env_content_access_ukey -->
         <addUniqueConstraint columnNames="owner_id, environment_id" constraintName="cp_owner_ec_access_ukey" deferrable="false" disabled="false" initiallyDeferred="false" tableName="cp_owner_env_content_access"/>
     </changeSet>

--- a/server/src/main/resources/db/changelog/20170125112728-cleanup-uebercerts-round3-2-0.xml
+++ b/server/src/main/resources/db/changelog/20170125112728-cleanup-uebercerts-round3-2-0.xml
@@ -170,7 +170,10 @@
         value="delete c from cp_consumer c where name like 'ueber_cert_consumer';"/>
 
     <changeSet id="20170125112728-1" author="mstead">
+        <validCheckSum>7:96820607fe20a266dd38d33ad4468776</validCheckSum>
         <validCheckSum>7:ad63fc8bcde413c0f8b22331f7458d36</validCheckSum>
+        <validCheckSum>8:5aa5c36ef8dd2449e31506aab92543bd</validCheckSum>
+        <validCheckSum>8:e1c7033685e64abedb12ac0049c53fec</validCheckSum>
         <comment>Round 3 ueber cert data cleanup.</comment>
         <sql>${delete_ueber_certs_round3}</sql>
         <sql>${delete_pool_source_sub_round3}</sql>

--- a/server/src/main/resources/db/changelog/20170202093945-add-ueber-cert-to-owner.xml
+++ b/server/src/main/resources/db/changelog/20170202093945-add-ueber-cert-to-owner.xml
@@ -10,6 +10,12 @@
     <include file="db/changelog/datatypes.xml"/>
 
     <changeSet id="20170202093945-1" author="mstead">
+        <validCheckSum>7:79ac826bd4948a21511294f7e3b514ad</validCheckSum>
+        <validCheckSum>7:bf481d682e3b25ea7c24e51dbcaebdbf</validCheckSum>
+        <validCheckSum>7:d7233bc6784f5002e23443f379cefebb</validCheckSum>
+        <validCheckSum>8:06527b41b71a12eedbd4e2b83b79c9d3</validCheckSum>
+        <validCheckSum>8:19e8392cc21281d20b63a3e5a666b279</validCheckSum>
+        <validCheckSum>8:382cb843b4bd8a2f1405f90c87642353</validCheckSum>
         <comment>Create cp_ueber_cert table</comment>
         <createTable tableName="cp_ueber_cert">
             <column name="id" type="VARCHAR(32)">
@@ -60,6 +66,8 @@
     </changeSet>
 
     <changeSet id="20170202093945-3" author="mstead" dbms="oracle">
+        <validCheckSum>7:2fd5ee53d1ac8510b3168bf2265d6a0d</validCheckSum>
+        <validCheckSum>8:5873675b6c018690a89d017744ff8512</validCheckSum>
         <comment>Add indexes for the foreign keys in oracle.</comment>
 
         <!-- Oracle automatically creates an index for the unique constraint -->

--- a/server/src/main/resources/db/changelog/20170206114359-convert-quanity-consumed-exported-to-columns.xml
+++ b/server/src/main/resources/db/changelog/20170206114359-convert-quanity-consumed-exported-to-columns.xml
@@ -24,7 +24,10 @@
         0);"/>
 
     <changeSet id="20170206114359-1" author="wpoteat, crog, jiri" dbms="postgresql, oracle, mysql, hsqldb">
-        <validCheckSum>7:506efa873b8eb83ddc5971b6fb110753</validCheckSum>
+        <validCheckSum>7:248546ded951c8210448b83e2f167efe</validCheckSum>
+        <validCheckSum>7:be3fcc0546632846b17fe5cd4435c3bf</validCheckSum>
+        <validCheckSum>8:462a5b369ddd75b5625e2a3ecec343e6</validCheckSum>
+        <validCheckSum>8:b1c9653e27653b7f02f6997643b885b2</validCheckSum>
 
         <preConditions onFail="MARK_RAN">
             <not><columnExists tableName="cp_pool" columnName="quantity_exported"/></not>

--- a/server/src/main/resources/db/changelog/20170220102027-add-id-column-for-productcontent.xml
+++ b/server/src/main/resources/db/changelog/20170220102027-add-id-column-for-productcontent.xml
@@ -9,8 +9,8 @@
 
 
     <changeSet id="20170220102027-1" author="crog">
-        <!-- Original checksum of this changeset prior to adding the populating SQL -->
-        <validCheckSum>7:bb7e778ce1c3821e649eaa7699c51f8e</validCheckSum>
+        <validCheckSum>7:da9ac9b551583e7a0771e6e808b383c0</validCheckSum>
+        <validCheckSum>8:badd9607b42d12265c76b93f3db8f16c</validCheckSum>
 
         <!-- On MySQL/MariaDB, we need to drop *all* foreign keys before we can drop our primary key -->
         <dropAllForeignKeyConstraints baseTableName="cp2_product_content"/>

--- a/server/src/main/resources/db/changelog/20170224113816-add-productshare-table.xml
+++ b/server/src/main/resources/db/changelog/20170224113816-add-productshare-table.xml
@@ -10,6 +10,12 @@
     <include file="db/changelog/datatypes.xml"/>
 
     <changeSet id="20170224113816-1" author="awood">
+        <validCheckSum>7:016bbe196d32bdfc75c6cd9739a9ba36</validCheckSum>
+        <validCheckSum>7:71c4e5655cd7367735599132848156b9</validCheckSum>
+        <validCheckSum>7:fe517192b036eb166ce1de6ee3e05675</validCheckSum>
+        <validCheckSum>8:22c931934e0203dddfb89def470240b7</validCheckSum>
+        <validCheckSum>8:34fc02202cdd38c2948aa04e3c9e0c00</validCheckSum>
+        <validCheckSum>8:41e10c3c7a19c680e6ab84b611b0f1b4</validCheckSum>
         <comment>Add ProductShare table</comment>
         <createTable tableName="cp2_product_shares">
             <column name="id" type="varchar(32)">

--- a/server/src/main/resources/db/changelog/20170227140343-convert-consumer-entitlement-count-to-column.xml
+++ b/server/src/main/resources/db/changelog/20170227140343-convert-consumer-entitlement-count-to-column.xml
@@ -14,7 +14,10 @@
                 FROM cp_entitlement WHERE cp_entitlement.consumer_id = cp_consumer.id), 0);"/>
 
      <changeSet id="20170227140343-1" author="wpoteat, crog, jiri" dbms="postgresql, mysql, oracle, hsqldb">
-        <validCheckSum>7:124ba8236ee0308696be406ea2a5958a</validCheckSum>
+        <validCheckSum>7:90bafef558a7b01ec7bba9af76e75da4</validCheckSum>
+        <validCheckSum>7:e2516110fc76f234ff4316992e308778</validCheckSum>
+        <validCheckSum>8:32d1bea45d59f9f847d7503edb139f3d</validCheckSum>
+        <validCheckSum>8:82245c7c6047f5ed206c16c51eba7908</validCheckSum>
 
         <preConditions onFail="MARK_RAN">
             <not><columnExists tableName="cp_consumer" columnName="entitlement_count"/></not>

--- a/server/src/main/resources/db/changelog/20170301083925-update-revoked-cert-serial-data.xml
+++ b/server/src/main/resources/db/changelog/20170301083925-update-revoked-cert-serial-data.xml
@@ -13,8 +13,10 @@
     <property dbms="oracle" name="revoked_value" value="1"/>
 
     <changeSet id="20170301083925-1" author="mstead">
-        <validCheckSum>7:e5dc16a5b9672bbdf38bdac361c9d289</validCheckSum>
+        <validCheckSum>7:a33f4960c51f36dad5e4b5b83afff748</validCheckSum>
         <validCheckSum>7:f6ab674c256df2b2a99789e343daf40b</validCheckSum>
+        <validCheckSum>8:296b70a1645afe4681c50be187bf3ca2</validCheckSum>
+        <validCheckSum>8:de9d879b08886855a8eac379897c594a</validCheckSum>
 
         <comment>
             Calculate the value of the field for all known serials

--- a/server/src/main/resources/db/changelog/20170718095058-purge-orphaned-pools.xml
+++ b/server/src/main/resources/db/changelog/20170718095058-purge-orphaned-pools.xml
@@ -24,7 +24,12 @@
 
 
     <changeSet id="20170718095058-1" author="vrjain, crog">
-      <validCheckSum>7:5cf3a796a8dab98ed2114db716715bff</validCheckSum>
+      <validCheckSum>7:5494d3a96b8e4205ce7993d2c2b96e29</validCheckSum>
+      <validCheckSum>7:65a81a9ed61eca97c087f8518499e247</validCheckSum>
+      <validCheckSum>7:8850f008ea669aded02fe31c9538c134</validCheckSum>
+      <validCheckSum>8:01fffed045e8c0124bace18aa8ce5ac6</validCheckSum>
+      <validCheckSum>8:0d79b60dc1f5a189bdff9c7ffb381388</validCheckSum>
+      <validCheckSum>8:f5a809c22012bfccf3849f3c5a5744c8</validCheckSum>
 
       <comment>
         Purge orphaned pools

--- a/server/src/main/resources/db/changelog/20171020150559-add-index-to-cp-consumer-content-tags.xml
+++ b/server/src/main/resources/db/changelog/20171020150559-add-index-to-cp-consumer-content-tags.xml
@@ -7,7 +7,9 @@
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="20171020150559-1" author="awood" dbms="mysql,postgresql,hsqldb">
+        <validCheckSum>7:3079b8651ea5111832baec09b2add77e</validCheckSum>
         <validCheckSum>7:34b116c4ac1794421c8f955001fee798</validCheckSum>
+        <validCheckSum>8:f79e34dabbe6a42eb9c7b7aa7d52247b</validCheckSum>
 
         <comment>Add index to cp_consumer_content_tags</comment>
 


### PR DESCRIPTION
See #2008. I ran those scripts against candlepin-2.2.3-1:

    server/bin/check_liquibase_checksums --base candlepin-2.2.3-1 --fix

Use of the script catches and fixes any `validCheckSum` which does not
match the current checksum, and also catches and fixes any changeset
which has a different checksum between HEAD and candlepin-2.2.3-1 but
does not have `validCheckSum` specified (it should).

Some of those caught are for deployment against Oracle databases,
which we test far less often.

Then I ran similarly against candlepin-0.9.54-HOTFIX, but no changes
resulted.

I did a little bit of cleanup afterwards (mainly removing stale
comments).

Obsoletes #1986.