### PR TITLE
[2.3] 1582607: Added missing JsonFilter annotation to the DTOs

### DIFF
--- a/server/spec/filter_response_spec.rb
+++ b/server/spec/filter_response_spec.rb
@@ -39,7 +39,7 @@ describe 'Response JSON Filtering' do
     newdict = hash_diff(consumer_full, consumer_filtered)
     # There should only be one changed key
     newdict.keys.size.should == 2
-    # there should be no or facts href in the new response
+    # there should be no facts or href in the new response
     newdict["href"][1].should == nil
     newdict["facts"][1].should == nil
   end

--- a/server/src/main/java/org/candlepin/dto/CandlepinDTO.java
+++ b/server/src/main/java/org/candlepin/dto/CandlepinDTO.java
@@ -14,6 +14,7 @@
  */
 package org.candlepin.dto;
 
+import com.fasterxml.jackson.annotation.JsonFilter;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import java.io.Serializable;
@@ -43,6 +44,7 @@ import java.io.Serializable;
  *  DTO type extending this class; should be the name of the subclass
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonFilter("DTOFilter")
 public abstract class CandlepinDTO<T extends CandlepinDTO> implements Cloneable, Serializable {
     public static final long serialVersionUID = 1L;
 


### PR DESCRIPTION
- Added the missing @JsonFilter annotation to the CandlepinDTO
  class. This will re-enable the include/exclude filtering on DTOs