### PR TITLE
[M] 1584259: Detach consumers from persistence context to avoid OOM - ENT-583

### DIFF
--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -2296,8 +2296,7 @@ public class CandlepinPoolManager implements PoolManager {
 
                 // Recalculate status for affected consumers
                 for (List<String> subList : Lists.partition(consumers, 1000)) {
-                    for (String consumerId : subList) {
-                        Consumer consumer = consumerCurator.get(consumerId);
+                    for (Consumer consumer : this.consumerCurator.getConsumers(subList).list()) {
                         this.complianceRules.getStatus(consumer);
                         this.consumerCurator.detach(consumer);
                     }

--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -74,6 +74,7 @@ import org.candlepin.util.Util;
 import org.candlepin.util.Traceable;
 import org.candlepin.util.TraceableParam;
 
+import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import com.google.inject.persist.Transactional;
 
@@ -97,8 +98,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-
-
+import java.util.stream.Collectors;
 
 /**
  * PoolManager
@@ -2168,6 +2168,7 @@ public class CandlepinPoolManager implements PoolManager {
                 log.info("Revoking {} entitlements...", entitlements.size());
                 this.entitlementCurator.batchDelete(entitlements);
                 this.entitlementCurator.flush();
+                this.entitlementCurator.batchDetach(entitlements);
                 log.info("Entitlements successfully revoked");
             }
             else {
@@ -2282,17 +2283,26 @@ public class CandlepinPoolManager implements PoolManager {
                     this.enforcer.postUnbind(entitlement.getConsumer(), this, entitlement);
                 }
 
-                // Recalculate status for affected consumers
-                log.info("Recomputing status for {} consumers", consumerStackedEnts.size());
-                int i = 0;
-                for (Consumer consumer : consumerStackedEnts.keySet()) {
-                    this.complianceRules.getStatus(consumer);
+                /* Save the consumer IDs and then detach all the keys in the consumerStackEnts map.
+                 * Otherwise during the status calculations, the facts proxy objects objects will be resolved
+                 * and the memory use will grow linearly with the number of consumers instead of remaining
+                 * constant as we calculate the status of each consumer.  See BZ 1584259 */
+                List<String> consumers = consumerStackedEnts.keySet().stream()
+                    .map(Consumer::getId)
+                    .collect(Collectors.toList());
+                this.consumerCurator.batchDetach(consumerStackedEnts.keySet());
 
-                    if (++i % 1000 == 0) {
-                        this.consumerCurator.flush();
+                log.info("Recomputing status for {} consumers", consumers.size());
+
+                // Recalculate status for affected consumers
+                for (List<String> subList : Lists.partition(consumers, 1000)) {
+                    for (String consumerId : subList) {
+                        Consumer consumer = consumerCurator.get(consumerId);
+                        this.complianceRules.getStatus(consumer);
+                        this.consumerCurator.detach(consumer);
                     }
+                    this.consumerCurator.flush();
                 }
-                this.consumerCurator.flush();
 
                 log.info("All statuses recomputed");
             }

--- a/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
+++ b/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
@@ -548,6 +548,16 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
         }
     }
 
+    public void detach(E entity) {
+        getEntityManager().detach(entity);
+    }
+
+    public void batchDetach(Collection<E> entities) {
+        for (E entity : entities) {
+            detach(entity);
+        }
+    }
+
     @Transactional
     public void bulkDeleteTransactional(Collection<E> entities) {
         this.bulkDelete(entities);

--- a/server/src/main/java/org/candlepin/model/ConsumerCurator.java
+++ b/server/src/main/java/org/candlepin/model/ConsumerCurator.java
@@ -293,6 +293,28 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
         return (Consumer) criteria.uniqueResult();
     }
 
+    /**
+     * Fetches consumers with the specified IDs. If a consumer does not exist for a given ID, no
+     * matching consumer object will be returned, nor will an exception be thrown. As such, the
+     * number of consumer objects fetched may be lower than the number of consumer IDs provided.
+     *
+     * @param consumerIds
+     *  A collection of consumer IDs specifying the consumers to fetch
+     *
+     * @return
+     *  A query to fetch the consumers with the specified consumer IDs
+     */
+    public CandlepinQuery<Consumer> getConsumers(Collection<String> consumerIds) {
+        if (consumerIds != null && !consumerIds.isEmpty()) {
+            DetachedCriteria criteria = DetachedCriteria.forClass(Consumer.class)
+                .add(CPRestrictions.in("id", consumerIds));
+
+            return this.cpQueryFactory.<Consumer>buildQuery(this.currentSession(), criteria);
+        }
+
+        return this.cpQueryFactory.<Consumer>buildQuery();
+    }
+
     @SuppressWarnings("unchecked")
     @Transactional
     public CandlepinQuery<Consumer> listByOwner(Owner owner) {

--- a/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -1283,6 +1283,10 @@ public class PoolManagerTest {
         when(cqmock.list()).thenReturn(Collections.<Pool>emptyList());
         when(mockPoolCurator.getPoolsBySubscriptionIds(anyList())).thenReturn(cqmock);
 
+        CandlepinQuery<Consumer> cqmock2 = mock(CandlepinQuery.class);
+        when(cqmock2.list()).thenReturn(Collections.<Consumer>emptyList());
+        when(consumerCuratorMock.getConsumers(anyCollection())).thenReturn(cqmock2);
+
         this.manager.getRefresher(mockSubAdapter, mockOwnerAdapter).add(owner).run();
 
         verify(mockPoolCurator).batchDelete(eq(pools), anyCollectionOf(String.class));

--- a/server/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
@@ -190,16 +190,150 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
         return cSkuAndSubIdAndContract;
     }
 
+    private List<Consumer> getConsumersDirect() {
+        return this.getEntityManager()
+            .createQuery("select c from Consumer as c", Consumer.class)
+            .getResultList();
+    }
+
     @Test
     public void normalCreate() {
         Consumer consumer = new Consumer("testConsumer", "testUser", owner, ct);
         consumerCurator.create(consumer);
 
-        List<Consumer> results = this.getEntityManager()
-            .createQuery("select c from Consumer as c", Consumer.class)
-            .getResultList();
+        List<Consumer> results = this.getConsumersDirect();
 
         assertEquals(1, results.size());
+    }
+
+    @Test
+    public void testGetConsumersNoConsumers() {
+        List<Consumer> expected = this.getConsumersDirect();
+        assertTrue(expected.isEmpty());
+
+        List<String> cids = Arrays.asList("c1", "c2", "c3");
+        List<Consumer> actual = consumerCurator.getConsumers(cids).list();
+        assertTrue(actual.isEmpty());
+    }
+
+    @Test
+    public void testGetConsumersThreeConsumers() {
+        Consumer c1 = new Consumer("c1", "u1", owner, ct);
+        Consumer c2 = new Consumer("c2", "u1", owner, ct);
+        Consumer c3 = new Consumer("c3", "u1", owner, ct);
+        consumerCurator.create(c1);
+        consumerCurator.create(c2);
+        consumerCurator.create(c3);
+        consumerCurator.flush();
+
+        List<Consumer> expected = this.getConsumersDirect();
+        assertEquals(3, expected.size());
+        assertTrue(expected.contains(c1));
+        assertTrue(expected.contains(c2));
+        assertTrue(expected.contains(c3));
+
+        List<String> cids = Arrays.asList(c1.getId(), c2.getId(), c3.getId());
+        List<Consumer> actual = consumerCurator.getConsumers(cids).list();
+        assertEquals(3, actual.size());
+        assertTrue(actual.contains(c1));
+        assertTrue(actual.contains(c2));
+        assertTrue(actual.contains(c3));
+    }
+
+    @Test
+    public void testGetConsumersFetchThreeOfFiveConsumers() {
+        Consumer c1 = new Consumer("c1", "u1", owner, ct);
+        Consumer c2 = new Consumer("c2", "u1", owner, ct);
+        Consumer c3 = new Consumer("c3", "u1", owner, ct);
+        Consumer c4 = new Consumer("c4", "u1", owner, ct);
+        Consumer c5 = new Consumer("c5", "u1", owner, ct);
+        consumerCurator.create(c1);
+        consumerCurator.create(c2);
+        consumerCurator.create(c3);
+        consumerCurator.create(c4);
+        consumerCurator.create(c5);
+        consumerCurator.flush();
+
+        List<Consumer> expected = this.getConsumersDirect();
+        assertEquals(5, expected.size());
+        assertTrue(expected.contains(c1));
+        assertTrue(expected.contains(c2));
+        assertTrue(expected.contains(c3));
+        assertTrue(expected.contains(c4));
+        assertTrue(expected.contains(c5));
+
+        List<String> cids = Arrays.asList(c1.getId(), c3.getId(), c5.getId());
+        List<Consumer> actual = consumerCurator.getConsumers(cids).list();
+        assertEquals(3, actual.size());
+        assertTrue(actual.contains(c1));
+        assertTrue(actual.contains(c3));
+        assertTrue(actual.contains(c5));
+        assertFalse(actual.contains(c2));
+        assertFalse(actual.contains(c4));
+    }
+
+    @Test
+    public void testGetConsumersFetchLessThanRequested() {
+        Consumer c1 = new Consumer("c1", "u1", owner, ct);
+        Consumer c2 = new Consumer("c2", "u1", owner, ct);
+        Consumer c3 = new Consumer("c3", "u1", owner, ct);
+        consumerCurator.create(c1);
+        consumerCurator.create(c2);
+        consumerCurator.create(c3);
+        consumerCurator.flush();
+
+        List<Consumer> expected = this.getConsumersDirect();
+        assertEquals(3, expected.size());
+        assertTrue(expected.contains(c1));
+        assertTrue(expected.contains(c2));
+        assertTrue(expected.contains(c3));
+
+        List<String> cids = Arrays.asList(c1.getId(), c2.getId(), c3.getId(), "c4", "c5");
+        List<Consumer> actual = consumerCurator.getConsumers(cids).list();
+        assertEquals(3, actual.size());
+        assertTrue(actual.contains(c1));
+        assertTrue(actual.contains(c2));
+        assertTrue(actual.contains(c3));
+    }
+
+    @Test
+    public void testGetConsumersNullInput() {
+        Consumer c1 = new Consumer("c1", "u1", owner, ct);
+        Consumer c2 = new Consumer("c2", "u1", owner, ct);
+        Consumer c3 = new Consumer("c3", "u1", owner, ct);
+        consumerCurator.create(c1);
+        consumerCurator.create(c2);
+        consumerCurator.create(c3);
+        consumerCurator.flush();
+
+        List<Consumer> expected = this.getConsumersDirect();
+        assertEquals(3, expected.size());
+        assertTrue(expected.contains(c1));
+        assertTrue(expected.contains(c2));
+        assertTrue(expected.contains(c3));
+
+        List<Consumer> actual = consumerCurator.getConsumers(null).list();
+        assertEquals(0, actual.size());
+    }
+
+    @Test
+    public void testGetConsumersEmptyInput() {
+        Consumer c1 = new Consumer("c1", "u1", owner, ct);
+        Consumer c2 = new Consumer("c2", "u1", owner, ct);
+        Consumer c3 = new Consumer("c3", "u1", owner, ct);
+        consumerCurator.create(c1);
+        consumerCurator.create(c2);
+        consumerCurator.create(c3);
+        consumerCurator.flush();
+
+        List<Consumer> expected = this.getConsumersDirect();
+        assertEquals(3, expected.size());
+        assertTrue(expected.contains(c1));
+        assertTrue(expected.contains(c2));
+        assertTrue(expected.contains(c3));
+
+        List<Consumer> actual = consumerCurator.getConsumers(new LinkedList()).list();
+        assertEquals(0, actual.size());
     }
 
     @Test


### PR DESCRIPTION
Updating the status of a large number of consumers (roughly 10000) could
run the JVM out of memory due to all the consumers referenced in the
consumerStackedEnts map.  During status calculation, the consumer
facts are accessed and during those accesses, the Hibernate proxy object
is replaced by the actual map of facts.  The consumerStackedEnts map
would accordingly grow as each status was calculated.

This patch detaches several model objects as soon as we stop needing
them and most importantly, it detaches all the consumers in the
consumerStackedEnts map.  The consumers are then fetched again, the
status is updated, and then immediately detached to keep the persistence
context at roughly a constant size.