### PR TITLE
[2.4] 1571426: Two changes to make ActiveMQ clients more resilient (ENT-469):

### DIFF
--- a/server/src/main/java/org/candlepin/audit/ActiveMQContextListener.java
+++ b/server/src/main/java/org/candlepin/audit/ActiveMQContextListener.java
@@ -152,6 +152,8 @@ public class ActiveMQContextListener {
             config.setJournalBufferSize_AIO(largeMsgSize);
             config.setJournalBufferSize_NIO(largeMsgSize);
 
+            config.setConnectionTTLOverride(86400000L); // 24 hours
+
             activeMQServer = new EmbeddedActiveMQ();
             activeMQServer.setConfiguration(config);
         }
@@ -235,6 +237,8 @@ public class ActiveMQContextListener {
 
             ServerLocator locator = ActiveMQClient.createServerLocatorWithoutHA(
                 new TransportConfiguration(InVMConnectorFactory.class.getName()));
+
+            locator.setReconnectAttempts(-1);
 
             ClientSessionFactory factory =  locator.createSessionFactory();
             ClientSession session = factory.createSession(true, true);

--- a/server/src/main/java/org/candlepin/audit/EventSinkImpl.java
+++ b/server/src/main/java/org/candlepin/audit/EventSinkImpl.java
@@ -94,6 +94,7 @@ public class EventSinkImpl implements EventSink {
         ServerLocator locator = ActiveMQClient.createServerLocatorWithoutHA(
             new TransportConfiguration(InVMConnectorFactory.class.getName()));
         locator.setMinLargeMessageSize(largeMsgSize);
+        locator.setReconnectAttempts(-1);
         return locator.createSessionFactory();
     }
 


### PR DESCRIPTION
 * globally, connection TTL set to 24 hours
 * infinite number of reconnect attempts