### PR TITLE
[2.1] 1571425: Two changes to make HornetQ clients more resilient (ENT-469):

### DIFF
--- a/server/src/main/java/org/candlepin/audit/EventSinkImpl.java
+++ b/server/src/main/java/org/candlepin/audit/EventSinkImpl.java
@@ -99,6 +99,7 @@ public class EventSinkImpl implements EventSink {
         ServerLocator locator = HornetQClient.createServerLocatorWithoutHA(
             new TransportConfiguration(InVMConnectorFactory.class.getName()));
         locator.setMinLargeMessageSize(largeMsgSize);
+        locator.setReconnectAttempts(-1);
         return locator.createSessionFactory();
     }
 

--- a/server/src/main/java/org/candlepin/audit/HornetqContextListener.java
+++ b/server/src/main/java/org/candlepin/audit/HornetqContextListener.java
@@ -152,6 +152,8 @@ public class HornetqContextListener {
             config.setJournalBufferSize_AIO(largeMsgSize);
             config.setJournalBufferSize_NIO(largeMsgSize);
 
+            config.setConnectionTTLOverride(86400000L); // 24 hours
+
             hornetqServer = new EmbeddedHornetQ();
             hornetqServer.setConfiguration(config);
         }
@@ -235,6 +237,8 @@ public class HornetqContextListener {
 
             ServerLocator locator = HornetQClient.createServerLocatorWithoutHA(
                 new TransportConfiguration(InVMConnectorFactory.class.getName()));
+
+            locator.setReconnectAttempts(-1);
 
             ClientSessionFactory factory =  locator.createSessionFactory();
             ClientSession session = factory.createSession(true, true);


### PR DESCRIPTION
 * globally, connection TTL set to 24 hours
 * infinite number of reconnect attempts