### PR TITLE
[0.9.54]1571423: Two changes to make HornetQ clients more resilient (ENT-469):

### DIFF
--- a/server/src/main/java/org/candlepin/audit/HornetqContextListener.java
+++ b/server/src/main/java/org/candlepin/audit/HornetqContextListener.java
@@ -117,6 +117,8 @@ public class HornetqContextListener {
             settings.put("#", pagingConfig);
             config.setAddressesSettings(settings);
 
+            config.setConnectionTTLOverride(86400000L); // 24 hours
+
             hornetqServer = new HornetQServerImpl(config);
         }
         try {
@@ -184,6 +186,8 @@ public class HornetqContextListener {
 
             ServerLocator locator = HornetQClient.createServerLocatorWithoutHA(
                 new TransportConfiguration(InVMConnectorFactory.class.getName()));
+
+            locator.setReconnectAttempts(-1);
 
             ClientSessionFactory factory =  locator.createSessionFactory();
             ClientSession session = factory.createSession(true, true);

--- a/server/src/main/java/org/candlepin/audit/HornetqEventDispatcher.java
+++ b/server/src/main/java/org/candlepin/audit/HornetqEventDispatcher.java
@@ -72,6 +72,7 @@ public class HornetqEventDispatcher  {
         ServerLocator locator = HornetQClient.createServerLocatorWithoutHA(
             new TransportConfiguration(InVMConnectorFactory.class.getName()));
         locator.setMinLargeMessageSize(largeMsgSize);
+        locator.setReconnectAttempts(-1);
         return locator.createSessionFactory();
     }
 


### PR DESCRIPTION
 * globally, connection TTL set to 24 hours
 * infinite number of reconnect attempts