### PR TITLE
1510920: Allow consumer to cancel jobs started by consumer

### DIFF
--- a/server/src/main/java/org/candlepin/auth/ConsumerPrincipal.java
+++ b/server/src/main/java/org/candlepin/auth/ConsumerPrincipal.java
@@ -15,7 +15,7 @@
 package org.candlepin.auth;
 
 import org.candlepin.auth.permissions.AttachPermission;
-import org.candlepin.auth.permissions.CheckJobStatusPermission;
+import org.candlepin.auth.permissions.JobStatusPermission;
 import org.candlepin.auth.permissions.ConsumerEntitlementPermission;
 import org.candlepin.auth.permissions.ConsumerOrgHypervisorPermission;
 import org.candlepin.auth.permissions.ConsumerPermission;
@@ -53,7 +53,7 @@ public class ConsumerPrincipal extends Principal {
         addPermission(new ConsumerOrgHypervisorPermission(owner));
 
         // Allow consumers to check the status of their own jobs.
-        addPermission(new CheckJobStatusPermission(getData(), Arrays.asList(owner.getKey())));
+        addPermission(new JobStatusPermission(getData(), Arrays.asList(owner.getKey())));
     }
 
     public Consumer getConsumer() {

--- a/server/src/main/java/org/candlepin/auth/UserPrincipal.java
+++ b/server/src/main/java/org/candlepin/auth/UserPrincipal.java
@@ -14,7 +14,7 @@
  */
 package org.candlepin.auth;
 
-import org.candlepin.auth.permissions.CheckJobStatusPermission;
+import org.candlepin.auth.permissions.JobStatusPermission;
 import org.candlepin.auth.permissions.Permission;
 import org.candlepin.auth.permissions.UserUserPermission;
 import org.candlepin.model.Owner;
@@ -49,7 +49,7 @@ public class UserPrincipal extends Principal {
         addPermission(new UserUserPermission(username));
 
         // Allow users to check the status of their own jobs.
-        addPermission(new CheckJobStatusPermission(getData(), getOwnerKeys()));
+        addPermission(new JobStatusPermission(getData(), getOwnerKeys()));
     }
 
     public String getUsername() {


### PR DESCRIPTION
The permissions for JobResource were previously modified to allow a consumer to check
 the status of a job it started.  This scenario was introduced so that the virt-who
 process on a registered system could query for the job status. To assist the virt-who
 choreography, the consumer will be allowed to cancel its own jobs.