### PR TITLE
[M] Upgraded postgresql-jdbc driver to the latest ENT-521

### DIFF
--- a/buildfile
+++ b/buildfile
@@ -120,7 +120,7 @@ HIBERNATE = [group('hibernate-core', 'hibernate-entitymanager', 'hibernate-c3p0'
              'org.jboss.logging:jboss-logging:jar:3.3.0.Final'
              ] + JAVAX
 
-POSTGRESQL = 'postgresql:postgresql:jar:9.0-801.jdbc4'
+POSTGRESQL = 'org.postgresql:postgresql:jar:42.2.2'
 
 SWAGGER = [group('swagger-jaxrs', 'swagger-core','swagger-models','swagger-annotations',
                      :under => 'io.swagger',

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -127,7 +127,7 @@
     <com.fasterxml.jackson.dataformat-jackson-dataformat-yaml.version>2.9.4</com.fasterxml.jackson.dataformat-jackson-dataformat-yaml.version>
     <com.fasterxml.jackson.dataformat-jackson-dataformat-xml.version>2.9.4</com.fasterxml.jackson.dataformat-jackson-dataformat-xml.version>
     <org.candlepin-candlepin-common.version>2.0.3</org.candlepin-candlepin-common.version>
-    <postgresql-postgresql.version>9.0-801.jdbc4</postgresql-postgresql.version>
+    <org.postgresql-postgresql.version>42.2.2</org.postgresql-postgresql.version>
     <mysql-mysql-connector-java.version>5.1.26</mysql-mysql-connector-java.version>
     <org.jmock-jmock.version>2.5.1</org.jmock-jmock.version>
     <org.jmock-jmock-junit4.version>2.5.1</org.jmock-jmock-junit4.version>
@@ -1353,9 +1353,9 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>postgresql</groupId>
+      <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>${postgresql-postgresql.version}</version>
+      <version>${org.postgresql-postgresql.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>


### PR DESCRIPTION
BZ 1566200 occurs because of an issue with the postgres JDBC driver which causes some of the operations that liquibase executes against Postgres 9.6 to fail.

cpdb sets the classpath when running liquibase to the RPM installed version of the driver which causes the breakage.

The postgres driver will be updated for RHEL 7.5.z and 7.6 ( https://bugzilla.redhat.com/show_bug.cgi?id=1566200#c2 ) which will address the installer issue.

Candlepin runs on its own version of the driver which is included in the WAR. Although it is very old, it does not cause any issues during normal operation against postgres 9.6.

This PR updates the version of the driver to the latest ONLY in the master branch since it is really outdated, however, this in no way addresses the BZ. We will have to wait for the driver updates to hit RHEL 7 before we can close out the bug.