### PR TITLE
[2.4] Add a sleep to fix failing spec test against mysql

### DIFF
--- a/server/spec/import_excess_spec.rb
+++ b/server/spec/import_excess_spec.rb
@@ -36,6 +36,8 @@ describe 'Import Update', :serial => true do
     all_pools = @user.list_pools :owner => @import_owner.id
     all_pools.size.should == 3
 
+    # Sleep to create a gap between when the manifest was initially imported
+    sleep 1
     # Now lets import
     updated_export = @exporter.create_candlepin_export_update()
     @cp.import(@import_owner['key'], updated_export.export_filename)


### PR DESCRIPTION
Because of the lack of DATETIME precision in MySQL, it appears
this this test will fail randomly when an export and re-import
occur at just the right moment causing a 409 MANIFEST_SAME conflict
due to matching time.