### PR TITLE
[2.1 ENT-595] 1584716: Properly handle concurrent unregister requests

### DIFF
--- a/server/spec/consumer_resource_spec.rb
+++ b/server/spec/consumer_resource_spec.rb
@@ -1045,6 +1045,44 @@ describe 'Consumer Resource' do
     consumer_client.unbind_entitlement(ent2.id)
     @cp.get_consumer(consumer['uuid'])['entitlementCount'].should == 0
   end
+
+  it 'concurrent unregister should return 404 or 410 when consumer is deleted by another request' do
+    consumer = @user1.register(random_string("a_test_consumer"))
+    consumer_client = Candlepin.new(nil, nil, consumer['idCert']['cert'], consumer['idCert']['key'])
+
+    total_threads = 50
+    t_count = 0;
+    unexpected_exceptions = []
+    expected_exceptions = []
+    threads = []
+    total_threads.times do
+      t = Thread.new do
+        begin
+          @user1.unregister(consumer['uuid'])
+        rescue RestClient::ResourceNotFound => rnf
+          # Expected and OK.
+          expected_exceptions << rnf
+        rescue RestClient::Gone => gone
+          expected_exceptions << gone
+        rescue Exception => e
+          # Unexpected - report it.
+          unexpected_exceptions << e
+        end
+        t_count = t_count + 1
+      end
+      threads << t
+    end
+
+    threads.each { |thread| thread.join}
+    t_count.should == total_threads
+    unexpected_exceptions.should be_empty
+    expected_exceptions.should_not be_empty
+
+    # Note: 404 can be returned in cases where a request was made after the initial deletion.
+    #       With a large number of requests, we should expect 1 or more of each.
+    expected_exceptions.each { |e| e.should be_an(RestClient::Gone) | be_an(RestClient::ResourceNotFound) }
+  end
+
 end
 
 describe 'Consumer Resource Consumer Fact Filter Tests' do
@@ -1082,4 +1120,5 @@ describe 'Consumer Resource Consumer Fact Filter Tests' do
     consumers.length.should == 1
     consumers[0]['uuid'].should == odd_consumer['uuid']
   end
+
 end

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -32,6 +32,7 @@ import org.candlepin.common.config.Configuration;
 import org.candlepin.common.exceptions.BadRequestException;
 import org.candlepin.common.exceptions.CandlepinException;
 import org.candlepin.common.exceptions.ForbiddenException;
+import org.candlepin.common.exceptions.GoneException;
 import org.candlepin.common.exceptions.IseException;
 import org.candlepin.common.exceptions.NotFoundException;
 import org.candlepin.common.paging.Page;
@@ -138,6 +139,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+import javax.persistence.OptimisticLockException;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -1410,7 +1412,10 @@ public class ConsumerResource {
     }
 
     @ApiOperation(notes = "Removes a Consumer", value = "deleteConsumer")
-    @ApiResponses({ @ApiResponse(code = 403, message = ""), @ApiResponse(code = 404, message = "") })
+    @ApiResponses({
+        @ApiResponse(code = 403, message = "Invalid access rights to unregister the Consumer."),
+        @ApiResponse(code = 404, message = "Target consumer does not exist."),
+        @ApiResponse(code = 410, message = "Target consumer was already deleted.")})
     @DELETE
     @Produces(MediaType.APPLICATION_JSON)
     @Path("{consumer_uuid}")
@@ -1421,7 +1426,27 @@ public class ConsumerResource {
         log.debug("Deleting consumer_uuid {}", uuid);
 
         Consumer toDelete = consumerCurator.findByUuid(uuid);
-        this.consumerCurator.lock(toDelete);
+        // The consumer may have already been deleted if multiple requests come in at the same time.
+        // NOTE: The Verify on the Consumer class should handle cases where a 404 should be thrown
+        //       for a consumer that has never existed.
+        if (toDelete == null) {
+            throw new GoneException(i18n.tr("Consumer with UUID {0} was already deleted.", uuid));
+        }
+
+        try {
+            this.consumerCurator.lock(toDelete);
+        }
+        catch (OptimisticLockException e) {
+            DeletedConsumer deleted = deletedConsumerCurator.findByConsumerUuid(uuid);
+            if (deleted != null) {
+                log.debug("The consumer with UUID {} was deleted while waiting for lock.");
+                throw new GoneException(
+                    i18n.tr("Consumer with UUID {0} was already deleted.", uuid));
+            }
+            // Could have just been an update that caused the exception. In that case,
+            // just rethrow the exception.
+            throw e;
+        }
 
         try {
             // We're about to delete this consumer; no need to regen/dirty its dependent


### PR DESCRIPTION
Concurrent attempts to unregister a system will no longer
fail hard when concurrent registrations occur. If a Consumer
record is deleted before a lock is aquired, a GoneException
is thrown resulting in a 410 response.

**Testing**
This can be tested if you run the new spec test against the base branch and watch it fail.