### PR TITLE
[2.4] ENT-595 1584715: Properly handle concurrent unregister requests

### DIFF
--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -33,6 +33,7 @@ import org.candlepin.common.config.Configuration;
 import org.candlepin.common.exceptions.BadRequestException;
 import org.candlepin.common.exceptions.CandlepinException;
 import org.candlepin.common.exceptions.ForbiddenException;
+import org.candlepin.common.exceptions.GoneException;
 import org.candlepin.common.exceptions.IseException;
 import org.candlepin.common.exceptions.NotFoundException;
 import org.candlepin.common.paging.Page;
@@ -157,6 +158,7 @@ import java.util.Set;
 import java.util.regex.Pattern;
 
 import javax.inject.Provider;
+import javax.persistence.OptimisticLockException;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -1652,7 +1654,10 @@ public class ConsumerResource {
     }
 
     @ApiOperation(notes = "Removes a Consumer", value = "deleteConsumer")
-    @ApiResponses({ @ApiResponse(code = 403, message = ""), @ApiResponse(code = 404, message = "") })
+    @ApiResponses({
+        @ApiResponse(code = 403, message = "Invalid access rights to unregister the Consumer."),
+        @ApiResponse(code = 404, message = "Target consumer does not exist."),
+        @ApiResponse(code = 410, message = "Target consumer was already deleted.")})
     @DELETE
     @Produces(MediaType.APPLICATION_JSON)
     @Path("{consumer_uuid}")
@@ -1664,7 +1669,27 @@ public class ConsumerResource {
         log.debug("Deleting consumer_uuid {}", uuid);
 
         Consumer toDelete = consumerCurator.findByUuid(uuid);
-        this.consumerCurator.lock(toDelete);
+        // The consumer may have already been deleted if multiple requests come in at the same time.
+        // NOTE: The Verify on the Consumer class should handle cases where a 404 should be thrown
+        //       for a consumer that has never existed.
+        if (toDelete == null) {
+            throw new GoneException(i18n.tr("Consumer with UUID {0} was already deleted.", uuid));
+        }
+
+        try {
+            this.consumerCurator.lock(toDelete);
+        }
+        catch (OptimisticLockException e) {
+            DeletedConsumer deleted = deletedConsumerCurator.findByConsumerUuid(uuid);
+            if (deleted != null) {
+                log.debug("The consumer with UUID {} was deleted while waiting for lock.");
+                throw new GoneException(
+                    i18n.tr("Consumer with UUID {0} was already deleted.", uuid));
+            }
+            // Could have just been an update that caused the exception. In that case,
+            // just rethrow the exception.
+            throw e;
+        }
 
         try {
             // We're about to delete this consumer; no need to regen/dirty its dependent

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
@@ -34,6 +34,7 @@ import org.candlepin.auth.SubResource;
 import org.candlepin.auth.UserPrincipal;
 import org.candlepin.common.config.Configuration;
 import org.candlepin.common.exceptions.BadRequestException;
+import org.candlepin.common.exceptions.GoneException;
 import org.candlepin.common.exceptions.NotFoundException;
 import org.candlepin.config.CandlepinCommonTestConfig;
 import org.candlepin.controller.CandlepinPoolManager;
@@ -58,6 +59,8 @@ import org.candlepin.model.ConsumerInstalledProduct;
 import org.candlepin.model.ConsumerType;
 import org.candlepin.model.ConsumerType.ConsumerTypeEnum;
 import org.candlepin.model.ConsumerTypeCurator;
+import org.candlepin.model.DeletedConsumer;
+import org.candlepin.model.DeletedConsumerCurator;
 import org.candlepin.model.Entitlement;
 import org.candlepin.model.EntitlementCertificate;
 import org.candlepin.model.EntitlementCurator;
@@ -121,6 +124,7 @@ import java.util.Map;
 import java.util.Set;
 
 import javax.inject.Provider;
+import javax.persistence.OptimisticLockException;
 import javax.ws.rs.core.Response;
 
 
@@ -158,6 +162,7 @@ public class ConsumerResourceTest {
     @Mock private DefaultContentAccessCertServiceAdapter mockContentAccessCertService;
     @Mock private EventSink sink;
     @Mock private EnvironmentCurator mockEnvironmentCurator;
+    @Mock private DeletedConsumerCurator mockDeletedConsumerCurator;
 
     private GuestMigration testMigration;
     private Provider<GuestMigration> migrationProvider;
@@ -1013,6 +1018,66 @@ public class ConsumerResourceTest {
         cr.exportDataAsync(null, consumer.getUuid(), cdn.getLabel(), "prefix", cdn.getUrl(), extParams);
         verify(manifestManager).generateManifestAsync(eq(consumer.getUuid()), eq(owner.getKey()),
             eq(cdn.getLabel()), eq("prefix"), eq(cdn.getUrl()), any(Map.class));
+    }
+
+    @Test(expected = GoneException.class)
+    public void deleteConsumerThrowsGoneExceptionIfConsumerDoesNotExistOnInitialLookup() {
+        String targetConsumerUuid = "my-test-consumer";
+        when(mockConsumerCurator.findByUuid(eq(targetConsumerUuid))).thenReturn(null);
+
+        UserPrincipal uap = mock(UserPrincipal.class);
+        when(uap.canAccess(any(Object.class), any(SubResource.class), any(Access.class)))
+            .thenReturn(Boolean.TRUE);
+
+        ConsumerResource consumerResource = new ConsumerResource(
+            mockConsumerCurator, mockConsumerTypeCurator, null, null, null, null, null, null, i18n, null,
+            null, null, null, null, null, null, mockOwnerCurator, null, null, null,
+            mockDeletedConsumerCurator, null, null, this.config, null, null,
+            null, null, null, null, this.factValidator, null, consumerEnricher,
+            migrationProvider, translator);
+
+        consumerResource.deleteConsumer(targetConsumerUuid, uap);
+    }
+
+    @Test(expected = GoneException.class)
+    public void deleteConsuemrThrowsGoneExceptionWhenLockAquisitionFailsDueToConsumerAlreadyDeleted() {
+        Consumer consumer = createConsumer();
+        when(mockConsumerCurator.findByUuid(eq(consumer.getUuid()))).thenReturn(consumer);
+        when(mockConsumerCurator.lock(eq(consumer))).thenThrow(OptimisticLockException.class);
+        when(mockDeletedConsumerCurator.findByConsumerUuid(eq(consumer.getUuid())))
+            .thenReturn(new DeletedConsumer());
+
+        UserPrincipal uap = mock(UserPrincipal.class);
+        when(uap.canAccess(any(Object.class), any(SubResource.class), any(Access.class)))
+            .thenReturn(Boolean.TRUE);
+
+        ConsumerResource consumerResource = new ConsumerResource(
+            mockConsumerCurator, mockConsumerTypeCurator, null, null, null, null, null, null, i18n, null,
+            null, null, null, null, null, null, mockOwnerCurator, null, null, null,
+            mockDeletedConsumerCurator, null, null, this.config, null, null,
+            null, null, null, null, this.factValidator, null, consumerEnricher,
+            migrationProvider, translator);
+        consumerResource.deleteConsumer(consumer.getUuid(), uap);
+    }
+
+    @Test(expected = OptimisticLockException.class)
+    public void deleteConsuemrReThrowsOLEWhenLockAquisitionFailsWithoutConsumerHavingBeenDeleted() {
+        Consumer consumer = createConsumer();
+        when(mockConsumerCurator.findByUuid(eq(consumer.getUuid()))).thenReturn(consumer);
+        when(mockConsumerCurator.lock(eq(consumer))).thenThrow(OptimisticLockException.class);
+        when(mockDeletedConsumerCurator.findByConsumerUuid(eq(consumer.getUuid()))).thenReturn(null);
+
+        UserPrincipal uap = mock(UserPrincipal.class);
+        when(uap.canAccess(any(Object.class), any(SubResource.class), any(Access.class)))
+            .thenReturn(Boolean.TRUE);
+
+        ConsumerResource consumerResource = new ConsumerResource(
+            mockConsumerCurator, mockConsumerTypeCurator, null, null, null, null, null, null, i18n, null,
+            null, null, null, null, null, null, mockOwnerCurator, null, null, null,
+            mockDeletedConsumerCurator, null, null, this.config, null, null,
+            null, null, null, null, this.factValidator, null, consumerEnricher,
+            migrationProvider, translator);
+        consumerResource.deleteConsumer(consumer.getUuid(), uap);
     }
 
 }


### PR DESCRIPTION
Concurrent attempts to unregister a system will no longer
fail hard when concurrent registrations occur. If a Consumer
record is deleted before a lock is aquired, a GoneException
is thrown resulting in a 410 response.

**Testing**
This can be tested if you run the new spec test against the base branch and watch it fail.