### PR TITLE
[M] ENT-595 1582510: Properly handle concurrent unregister requests

### DIFF
--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
@@ -33,6 +33,7 @@ import org.candlepin.auth.SubResource;
 import org.candlepin.auth.UserPrincipal;
 import org.candlepin.common.config.Configuration;
 import org.candlepin.common.exceptions.BadRequestException;
+import org.candlepin.common.exceptions.GoneException;
 import org.candlepin.common.exceptions.NotFoundException;
 import org.candlepin.config.CandlepinCommonTestConfig;
 import org.candlepin.controller.CandlepinPoolManager;
@@ -57,6 +58,8 @@ import org.candlepin.model.ConsumerInstalledProduct;
 import org.candlepin.model.ConsumerType;
 import org.candlepin.model.ConsumerType.ConsumerTypeEnum;
 import org.candlepin.model.ConsumerTypeCurator;
+import org.candlepin.model.DeletedConsumer;
+import org.candlepin.model.DeletedConsumerCurator;
 import org.candlepin.model.Entitlement;
 import org.candlepin.model.EntitlementCertificate;
 import org.candlepin.model.EntitlementCurator;
@@ -121,6 +124,7 @@ import java.util.Map;
 import java.util.Set;
 
 import javax.inject.Provider;
+import javax.persistence.OptimisticLockException;
 import javax.ws.rs.core.Response;
 
 
@@ -164,6 +168,7 @@ public class ConsumerResourceTest {
     @Mock private ManifestManager mockManifestManager;
     @Mock private CdnCurator mockCdnCurator;
     @Mock private UserServiceAdapter userServiceAdapter;
+    @Mock private DeletedConsumerCurator mockDeletedConsumerCurator;
 
     private GuestMigration testMigration;
     private Provider<GuestMigration> migrationProvider;
@@ -208,7 +213,7 @@ public class ConsumerResourceTest {
             mockActivationKeyCurator,
             mockEntitler,
             mockComplianceRules,
-            null,
+            mockDeletedConsumerCurator,
             null,
             null,
             config,
@@ -828,6 +833,47 @@ public class ConsumerResourceTest {
             "prefix", cdn.getUrl(), extParams);
         verify(mockManifestManager).generateManifestAsync(eq(consumer.getUuid()), eq(owner),
             eq(cdn.getLabel()), eq("prefix"), eq(cdn.getUrl()), any(Map.class));
+    }
+
+    @Test(expected = GoneException.class)
+    public void deleteConsumerThrowsGoneExceptionIfConsumerDoesNotExistOnInitialLookup() {
+        String targetConsumerUuid = "my-test-consumer";
+        when(mockConsumerCurator.findByUuid(eq(targetConsumerUuid))).thenReturn(null);
+
+        UserPrincipal uap = mock(UserPrincipal.class);
+        when(uap.canAccess(any(Object.class), any(SubResource.class), any(Access.class)))
+            .thenReturn(Boolean.TRUE);
+
+        consumerResource.deleteConsumer(targetConsumerUuid, uap);
+    }
+
+    @Test(expected = GoneException.class)
+    public void deleteConsuemrThrowsGoneExceptionWhenLockAquisitionFailsDueToConsumerAlreadyDeleted() {
+        Consumer consumer = createConsumer();
+        when(mockConsumerCurator.findByUuid(eq(consumer.getUuid()))).thenReturn(consumer);
+        when(mockConsumerCurator.lock(eq(consumer))).thenThrow(OptimisticLockException.class);
+        when(mockDeletedConsumerCurator.findByConsumerUuid(eq(consumer.getUuid())))
+            .thenReturn(new DeletedConsumer());
+
+        UserPrincipal uap = mock(UserPrincipal.class);
+        when(uap.canAccess(any(Object.class), any(SubResource.class), any(Access.class)))
+            .thenReturn(Boolean.TRUE);
+
+        consumerResource.deleteConsumer(consumer.getUuid(), uap);
+    }
+
+    @Test(expected = OptimisticLockException.class)
+    public void deleteConsuemrReThrowsOLEWhenLockAquisitionFailsWithoutConsumerHavingBeenDeleted() {
+        Consumer consumer = createConsumer();
+        when(mockConsumerCurator.findByUuid(eq(consumer.getUuid()))).thenReturn(consumer);
+        when(mockConsumerCurator.lock(eq(consumer))).thenThrow(OptimisticLockException.class);
+        when(mockDeletedConsumerCurator.findByConsumerUuid(eq(consumer.getUuid()))).thenReturn(null);
+
+        UserPrincipal uap = mock(UserPrincipal.class);
+        when(uap.canAccess(any(Object.class), any(SubResource.class), any(Access.class)))
+            .thenReturn(Boolean.TRUE);
+
+        consumerResource.deleteConsumer(consumer.getUuid(), uap);
     }
 
 }


### PR DESCRIPTION
Concurrent attempts to unregister a system will no longer
fail hard when concurrent registrations occur. If a Consumer
record is deleted before a lock is aquired, a GoneException
is thrown resulting in a 410 response.

**Testing**
This can be tested if you run the new spec test against the base branch and watch it fail.