### PR TITLE
[M] ENT-617 Silence all hibernate deprecation warnings

### DIFF
--- a/server/src/main/resources/logback.xml
+++ b/server/src/main/resources/logback.xml
@@ -46,6 +46,9 @@
          our usage of Qpid -->
     <logger name="org.apache.qpid.transport.network.security.ssl.SSLUtil" level="ERROR"/>
 
+    <!-- Silence the hibernate deprecation warnings -->
+    <logger name="org.hibernate.orm.deprecation" level="DEBUG" additivity="false"/>
+
     <root level="WARN">
         <appender-ref ref="CandlepinAppender" />
         <appender-ref ref="ErrorAppender" />

--- a/server/src/test/resources/logback-test.xml
+++ b/server/src/test/resources/logback-test.xml
@@ -12,6 +12,9 @@
   <logger name="org.hibernate.id.UUIDHexGenerator" level="ERROR"/>
   <logger name="liquibase" level="ERROR"/>
 
+  <!-- Silence the hibernate deprecation warnings -->
+  <logger name="org.hibernate.orm.deprecation" level="DEBUG" additivity="false"/>
+  
 <!--
   <logger name="org.hibernate.SQL" level="DEBUG"/>
   <logger name="org.hibernate.type" level="TRACE"/>


### PR DESCRIPTION
After a hibernate upgrade, the log file is not getting
polluted with deprecation warnings due to our use of
the old Criteria API. This patch disables those warnings
so that the log file doesn't grow when deployed in production.

The warnings have also been silenced when running unit tests
as well so that the log file isn't polluted.