### PR TITLE
ENT-616: Update SubjectKeyIdentifierWriter for isolation [m]

### DIFF
--- a/server/src/main/java/org/candlepin/pki/SubjectKeyIdentifierWriter.java
+++ b/server/src/main/java/org/candlepin/pki/SubjectKeyIdentifierWriter.java
@@ -16,7 +16,6 @@ package org.candlepin.pki;
 
 import org.bouncycastle.asn1.ASN1Encoding;
 import org.bouncycastle.asn1.DEROctetString;
-import org.bouncycastle.cert.jcajce.JcaX509ExtensionUtils;
 
 import java.io.IOException;
 import java.security.KeyPair;
@@ -31,7 +30,7 @@ import java.util.Set;
  * extension so it may be necessary to hijack the extension as an alternative communications channel.
  */
 public interface SubjectKeyIdentifierWriter {
-     /**
+    /**
      * This method returns the SubjectKeyIdentifier extension that will be written into a certificate.
      *
      * @param clientKeyPair
@@ -40,14 +39,12 @@ public interface SubjectKeyIdentifierWriter {
      * @throws IOException thrown if error reading cert
      * @throws NoSuchAlgorithmException thrown if JcaX509ExtensionUtils can't be created
      */
-    default byte[] getSubjectKeyIdentifier(KeyPair clientKeyPair, Set<X509ExtensionWrapper> extensions)
-            throws IOException, NoSuchAlgorithmException {
-        return new JcaX509ExtensionUtils().createSubjectKeyIdentifier(clientKeyPair.getPublic()).getEncoded();
-    }
+    byte[] getSubjectKeyIdentifier(KeyPair clientKeyPair, Set<X509ExtensionWrapper> extensions)
+        throws IOException, NoSuchAlgorithmException;
 
-    default byte[] toOctetString(byte[] bytes_to_encode) throws IOException {
-        DEROctetString octetStr = new DEROctetString(bytes_to_encode);
-        return octetStr.getEncoded(ASN1Encoding.DER);
+    default byte[] toOctetString(byte[] bytesToEncode) throws IOException {
+        DEROctetString octetStr = new DEROctetString(bytesToEncode);
+        return octetStr.getEncoded();
     }
 
 }

--- a/server/src/main/java/org/candlepin/pki/SubjectKeyIdentifierWriter.java
+++ b/server/src/main/java/org/candlepin/pki/SubjectKeyIdentifierWriter.java
@@ -14,6 +14,10 @@
  */
 package org.candlepin.pki;
 
+import org.bouncycastle.asn1.ASN1Encoding;
+import org.bouncycastle.asn1.DEROctetString;
+import org.bouncycastle.cert.jcajce.JcaX509ExtensionUtils;
+
 import java.io.IOException;
 import java.security.KeyPair;
 import java.security.NoSuchAlgorithmException;
@@ -27,7 +31,7 @@ import java.util.Set;
  * extension so it may be necessary to hijack the extension as an alternative communications channel.
  */
 public interface SubjectKeyIdentifierWriter {
-    /**
+     /**
      * This method returns the SubjectKeyIdentifier extension that will be written into a certificate.
      *
      * @param clientKeyPair
@@ -36,6 +40,14 @@ public interface SubjectKeyIdentifierWriter {
      * @throws IOException thrown if error reading cert
      * @throws NoSuchAlgorithmException thrown if JcaX509ExtensionUtils can't be created
      */
-    byte[] getSubjectKeyIdentifier(KeyPair clientKeyPair, Set<X509ExtensionWrapper> extensions)
-        throws IOException, NoSuchAlgorithmException;
+    default byte[] getSubjectKeyIdentifier(KeyPair clientKeyPair, Set<X509ExtensionWrapper> extensions)
+            throws IOException, NoSuchAlgorithmException {
+        return new JcaX509ExtensionUtils().createSubjectKeyIdentifier(clientKeyPair.getPublic()).getEncoded();
+    }
+
+    default byte[] toOctetString(byte[] bytes_to_encode) throws IOException {
+        DEROctetString octetStr = new DEROctetString(bytes_to_encode);
+        return octetStr.getEncoded(ASN1Encoding.DER);
+    }
+
 }

--- a/server/src/main/java/org/candlepin/pki/impl/DefaultSubjectKeyIdentifierWriter.java
+++ b/server/src/main/java/org/candlepin/pki/impl/DefaultSubjectKeyIdentifierWriter.java
@@ -15,7 +15,14 @@
 package org.candlepin.pki.impl;
 
 import org.candlepin.pki.SubjectKeyIdentifierWriter;
+import org.candlepin.pki.X509ExtensionWrapper;
 
+import org.bouncycastle.cert.jcajce.JcaX509ExtensionUtils;
+
+import java.io.IOException;
+import java.security.KeyPair;
+import java.security.NoSuchAlgorithmException;
+import java.util.Set;
 
 /**
  * Default implementation of SubjectKeyIdentifierWriter.  This implementation is exactly what you might
@@ -24,4 +31,9 @@ import org.candlepin.pki.SubjectKeyIdentifierWriter;
  */
 public class DefaultSubjectKeyIdentifierWriter implements SubjectKeyIdentifierWriter {
 
+    @Override
+    public byte[] getSubjectKeyIdentifier(KeyPair clientKeyPair, Set<X509ExtensionWrapper> extensions)
+        throws IOException, NoSuchAlgorithmException {
+        return new JcaX509ExtensionUtils().createSubjectKeyIdentifier(clientKeyPair.getPublic()).getEncoded();
+    }
 }

--- a/server/src/main/java/org/candlepin/pki/impl/DefaultSubjectKeyIdentifierWriter.java
+++ b/server/src/main/java/org/candlepin/pki/impl/DefaultSubjectKeyIdentifierWriter.java
@@ -15,14 +15,7 @@
 package org.candlepin.pki.impl;
 
 import org.candlepin.pki.SubjectKeyIdentifierWriter;
-import org.candlepin.pki.X509ExtensionWrapper;
 
-import org.bouncycastle.cert.jcajce.JcaX509ExtensionUtils;
-
-import java.io.IOException;
-import java.security.KeyPair;
-import java.security.NoSuchAlgorithmException;
-import java.util.Set;
 
 /**
  * Default implementation of SubjectKeyIdentifierWriter.  This implementation is exactly what you might
@@ -31,9 +24,4 @@ import java.util.Set;
  */
 public class DefaultSubjectKeyIdentifierWriter implements SubjectKeyIdentifierWriter {
 
-    @Override
-    public byte[] getSubjectKeyIdentifier(KeyPair clientKeyPair, Set<X509ExtensionWrapper> extensions)
-        throws IOException, NoSuchAlgorithmException {
-        return new JcaX509ExtensionUtils().createSubjectKeyIdentifier(clientKeyPair.getPublic()).getEncoded();
-    }
 }

--- a/server/src/test/java/org/candlepin/pki/SubjectKeyIdentifierWriterTest.java
+++ b/server/src/test/java/org/candlepin/pki/SubjectKeyIdentifierWriterTest.java
@@ -1,0 +1,17 @@
+package org.candlepin.pki;
+
+import org.candlepin.pki.impl.DefaultSubjectKeyIdentifierWriter;
+import org.hsqldb.types.Charset;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class SubjectKeyIdentifierWriterTest {
+
+    @Test
+    public void testToOctetString() throws Exception{
+        DefaultSubjectKeyIdentifierWriter writer = new DefaultSubjectKeyIdentifierWriter();
+
+        byte[] foobar_in_asn1 = {0x4, 0x6, 0x66, 0x6f, 0x6f, 0x62, 0x61, 0x72};
+        assertArrayEquals(foobar_in_asn1, writer.toOctetString("foobar".getBytes("UTF-8")));
+    }
+}

--- a/server/src/test/java/org/candlepin/pki/SubjectKeyIdentifierWriterTest.java
+++ b/server/src/test/java/org/candlepin/pki/SubjectKeyIdentifierWriterTest.java
@@ -1,17 +1,32 @@
+/**
+ * Copyright (c) 2009 - 2018 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
 package org.candlepin.pki;
 
 import org.candlepin.pki.impl.DefaultSubjectKeyIdentifierWriter;
-import org.hsqldb.types.Charset;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
 public class SubjectKeyIdentifierWriterTest {
 
     @Test
-    public void testToOctetString() throws Exception{
+    public void testToOctetString() throws Exception {
         DefaultSubjectKeyIdentifierWriter writer = new DefaultSubjectKeyIdentifierWriter();
 
-        byte[] foobar_in_asn1 = {0x4, 0x6, 0x66, 0x6f, 0x6f, 0x62, 0x61, 0x72};
-        assertArrayEquals(foobar_in_asn1, writer.toOctetString("foobar".getBytes("UTF-8")));
+        // 0x04 is the DER tag for an octet string and 0x06 is the subsequent length of the octet string
+        byte[] foobarInAsn1 = {0x04, 0x06, 0x66, 0x6f, 0x6f, 0x62, 0x61, 0x72};
+        assertArrayEquals(foobarInAsn1, writer.toOctetString("foobar".getBytes("UTF-8")));
     }
 }


### PR DESCRIPTION
- add toOctetString default method
- keeps IT from having to use BouncyCastle directly
- moved getSubjectKeyidentifier to the interface