### PR TITLE
Switch hashing algorithms from SHA-256 to Murmur3 for compliance hash

### DIFF
--- a/server/src/main/java/org/candlepin/pki/SubjectKeyIdentifierWriter.java
+++ b/server/src/main/java/org/candlepin/pki/SubjectKeyIdentifierWriter.java
@@ -14,7 +14,6 @@
  */
 package org.candlepin.pki;
 
-import org.bouncycastle.asn1.ASN1Encoding;
 import org.bouncycastle.asn1.DEROctetString;
 
 import java.io.IOException;


### PR DESCRIPTION
Compliance hashes do not need to be cryptographically secure, so using
SHA-256 is overkill.  Murmur3 is slightly faster and results in modest
performance improvement (roughly 10%).

---
Running ExpiredPoolsJob on a DB with about 10,500 consumers that need status recalculations goes from 195s to 181s on my machine (give or take).