### PR TITLE
ENT-711: ENT-711: Update candlepin to use BouncyCastle 1.60.

### DIFF
--- a/buildfile
+++ b/buildfile
@@ -148,7 +148,7 @@ GETTEXT_COMMONS = 'com.googlecode.gettext-commons:gettext-commons:jar:0.9.8'
 
 BOUNCYCASTLE = group('bcpkix-jdk15on', 'bcprov-jdk15on',
                      :under => 'org.bouncycastle',
-                     :version => '1.59')
+                     :version => '1.60')
 
 SERVLET = 'javax.servlet:servlet-api:jar:2.5'
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -22,8 +22,8 @@
     <org.apache.mina-mina-core.version>1.0.1</org.apache.mina-mina-core.version>
     <org.apache.mina-mina-filter-ssl.version>1.0.1</org.apache.mina-mina-filter-ssl.version>
     <geronimo-spec-geronimo-spec-jms.version>1.1-rc4</geronimo-spec-geronimo-spec-jms.version>
-    <org.bouncycastle-bcpkix-jdk15on.version>1.59</org.bouncycastle-bcpkix-jdk15on.version>
-    <org.bouncycastle-bcprov-jdk15on.version>1.59</org.bouncycastle-bcprov-jdk15on.version>
+    <org.bouncycastle-bcpkix-jdk15on.version>1.60</org.bouncycastle-bcpkix-jdk15on.version>
+    <org.bouncycastle-bcprov-jdk15on.version>1.60</org.bouncycastle-bcprov-jdk15on.version>
     <com.google.guava-guava.version>13.0</com.google.guava-guava.version>
     <commons-codec-commons-codec.version>1.4</commons-codec-commons-codec.version>
     <commons-collections-commons-collections.version>3.2</commons-collections-commons-collections.version>


### PR DESCRIPTION
* Updated candlepin-2.1 to use BouncyCastle 1.60