### PR TITLE
Fix issue with intermittent rspec test failure.

### DIFF
--- a/server/spec/job_status_spec.rb
+++ b/server/spec/job_status_spec.rb
@@ -140,8 +140,22 @@ describe 'Job Status' do
   end
 
   it 'should allow user to cancel a job it initiated' do
+    @cp.set_scheduler_status(false)
     job = @user.autoheal_org(@owner['key'])
+    #make sure we see a job waiting to go
+    joblist = @cp.list_jobs(@owner['key'])
+    expect(joblist.find { |j| j['id'] == job['id'] }['state']).to eq('CREATED')
+
     @user.cancel_job(job['id'])
+    #make sure we see a job canceled
+    joblist = @cp.list_jobs(@owner['key'])
+    expect(joblist.find { |j| j['id'] == job['id'] }['state']).to eq('CANCELED')
+
+    @cp.set_scheduler_status(true)
+    sleep 1 #let the job queue drain..
+    #make sure job didn't flip to FINISHED
+    joblist = @cp.list_jobs(@owner['key'])
+    expect(joblist.find { |j| j['id'] == job['id'] }['state']).to eq('CANCELED')
   end
 
   it 'should not allow user to cancel a job it did not initiate' do


### PR DESCRIPTION
This test was originally just scheduling a job and then attempting to
cancel it.  Unfortunately, if the job ran fast enough, it would be
complete before the cancellation attempt landed and Candlepin would
return a 400 error.  This patch fixes the issue by pausing the
scheduler, scheduling a job, and then attempts to cancel it.  The patch
is based on a similar test elsewhere in the spec file.