### PR TITLE
[M] Adapter Refactor Work

### DIFF
--- a/buildfile
+++ b/buildfile
@@ -161,8 +161,8 @@ SERVLET = 'javax.servlet:servlet-api:jar:2.5'
 GUICE =  [group('guice-assistedinject', 'guice-multibindings',
                 'guice-servlet', 'guice-throwingproviders', 'guice-persist',
                 :under=>'com.google.inject.extensions',
-                :version=>'3.0'),
-           'com.google.inject:guice:jar:3.0',
+                :version=>'4.1.0'),
+           'com.google.inject:guice:jar:4.1.0',
            'aopalliance:aopalliance:jar:1.0',
            'javax.inject:javax.inject:jar:1']
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -33,12 +33,12 @@
     <org.slf4j-jcl-over-slf4j.version>1.7.12</org.slf4j-jcl-over-slf4j.version>
     <org.slf4j-log4j-over-slf4j.version>1.7.12</org.slf4j-log4j-over-slf4j.version>
     <org.slf4j-slf4j-api.version>1.7.25</org.slf4j-slf4j-api.version>
-    <com.google.inject.extensions-guice-assistedinject.version>3.0</com.google.inject.extensions-guice-assistedinject.version>
-    <com.google.inject.extensions-guice-multibindings.version>3.0</com.google.inject.extensions-guice-multibindings.version>
-    <com.google.inject.extensions-guice-servlet.version>3.0</com.google.inject.extensions-guice-servlet.version>
-    <com.google.inject.extensions-guice-throwingproviders.version>3.0</com.google.inject.extensions-guice-throwingproviders.version>
-    <com.google.inject.extensions-guice-persist.version>3.0</com.google.inject.extensions-guice-persist.version>
-    <com.google.inject-guice.version>3.0</com.google.inject-guice.version>
+    <com.google.inject.extensions-guice-assistedinject.version>4.1.0</com.google.inject.extensions-guice-assistedinject.version>
+    <com.google.inject.extensions-guice-multibindings.version>4.1.0</com.google.inject.extensions-guice-multibindings.version>
+    <com.google.inject.extensions-guice-servlet.version>4.1.0</com.google.inject.extensions-guice-servlet.version>
+    <com.google.inject.extensions-guice-throwingproviders.version>4.1.0</com.google.inject.extensions-guice-throwingproviders.version>
+    <com.google.inject.extensions-guice-persist.version>4.1.0</com.google.inject.extensions-guice-persist.version>
+    <com.google.inject-guice.version>4.1.0</com.google.inject-guice.version>
     <aopalliance-aopalliance.version>1.0</aopalliance-aopalliance.version>
     <javax.inject-javax.inject.version>1</javax.inject-javax.inject.version>
     <com.googlecode.gettext-commons-gettext-commons.version>0.9.8</com.googlecode.gettext-commons-gettext-commons.version>

--- a/server/bin/import_test_data.rb
+++ b/server/bin/import_test_data.rb
@@ -100,7 +100,12 @@ def create_role(cp, new_role)
 
   print "role_name: #{role_name}\n"
   perms.each do |perm|
-    print "\t owner: #{perm['owner']}\n"
+    # convert owner key to owner objects
+    if (perm['owner'].is_a? String)
+      perm['owner'] = { :key => perm['owner'] }
+    end
+
+    print "\t owner: #{perm['owner']['key']}\n"
     print "\t access: #{perm['access']}\n"
   end
 
@@ -108,9 +113,8 @@ def create_role(cp, new_role)
 
   users.each do |user|
     print "\t user: #{user['username']}\n"
-    cp.add_role_user(role['id'], user['username'])
+    cp.add_role_user(role['name'], user['username'])
   end
-
 end
 
 thread_pool = ThreadPool.new(5)

--- a/server/client/ruby/candlepin_api.rb
+++ b/server/client/ruby/candlepin_api.rb
@@ -393,43 +393,45 @@ class Candlepin
   # TODO: drop perms here too?
   def create_role(name, perms=nil)
     perms ||= []
+
     role = {
       :name => name,
       :permissions => perms,
     }
+
     post("/roles", {}, role)
   end
 
-  def update_role(role)
-    put("/roles/#{role['id']}", {}, role)
+  def update_role(role_name, role)
+    put("/roles/#{role_name}", {}, role)
   end
 
-  def delete_role(roleid)
-    delete("/roles/#{roleid}")
+  def delete_role(role_name)
+    delete("/roles/#{role_name}")
   end
 
-  def add_role_user(role_id, username)
-    post("/roles/#{role_id}/users/#{username}")
+  def add_role_user(role_name, username)
+    post("/roles/#{role_name}/users/#{username}")
   end
 
-  def delete_role_user(role_id, username)
-    delete("/roles/#{role_id}/users/#{username}")
+  def delete_role_user(role_name, username)
+    delete("/roles/#{role_name}/users/#{username}")
   end
 
-  def add_role_permission(role_id, permission)
-    post("/roles/#{role_id}/permissions", {}, permission)
+  def add_role_permission(role_name, permission)
+    post("/roles/#{role_name}/permissions", {}, permission)
   end
 
-  def delete_role_permission(role_id, permission_id)
-    delete("/roles/#{role_id}/permissions/#{permission_id}")
+  def delete_role_permission(role_name, permission_id)
+    delete("/roles/#{role_name}/permissions/#{permission_id}")
   end
 
   def list_roles
     get("/roles")
   end
 
-  def get_role(role_id)
-    get("/roles/#{role_id}")
+  def get_role(role_name)
+    get("/roles/#{role_name}")
   end
 
   def delete_user(username)

--- a/server/client/ruby/hostedtest_api.rb
+++ b/server/client/ruby/hostedtest_api.rb
@@ -3,10 +3,14 @@ module HostedTest
   @@hosted_mode = nil
   @@hostedtest_alive = nil
 
+  # FIXME: This is broken. There's no distiction between up and downstream data sources, which creates
+  # a lot of problems when it comes to product and content mapping. Hosted test resources should be
+  # entirely upstream, and not rely on, nor require, anything downstream for proper functionality.
+
   def is_hostedtest_alive?
     if @@hostedtest_alive.nil?
       begin
-        @@hostedtest_alive = @cp.get('/hostedtest/subscriptions/is_alive', {}, 'json', true)
+        @@hostedtest_alive = @cp.get('/hostedtest/alive', {}, 'text/plain', true)
       rescue RestClient::ResourceNotFound
         @@hostedttest_alive = false
       end
@@ -15,7 +19,6 @@ module HostedTest
   end
 
   def create_hostedtest_subscription(owner_key, product_id, quantity=1, params={})
-
     provided_products = params[:provided_products] || []
     start_date = params[:start_date] || DateTime.now
     end_date = params[:end_date] || start_date + 365
@@ -63,7 +66,8 @@ module HostedTest
   end
 
   def update_hostedtest_subscription(subscription)
-    return @cp.put("/hostedtest/subscriptions", {}, subscription)
+    id = subscription.id
+    return @cp.put("/hostedtest/subscriptions/#{id}", {}, subscription)
   end
 
   def get_all_hostedtest_subscriptions()
@@ -78,8 +82,8 @@ module HostedTest
     return @cp.delete("/hostedtest/subscriptions/#{id}", {}, nil, true)
   end
 
-  def delete_all_hostedtest_subscriptions()
-    @cp.delete('/hostedtest/subscriptions/', {}, nil, true)
+  def clear_upstream_data()
+    @cp.delete('/hostedtest', {}, nil, true)
   end
 
   def is_hosted?
@@ -109,7 +113,7 @@ module HostedTest
       content_ids.each do |id|
         data[id] = enabled
       end
-      @cp.post("/hostedtest/subscriptions/owners/#{owner_key}/products/#{product_id}/batch_content", {}, data)
+      @cp.post("/hostedtest/products/#{product_id}/batch_content", {}, data)
     else
       @cp.add_batch_content_to_product(owner_key, product_id, content_ids, true)
     end
@@ -117,7 +121,7 @@ module HostedTest
 
   def add_content_to_product(owner_key, product_id, content_id, enabled=true)
     if is_hosted?
-      @cp.post("/hostedtest/subscriptions/owners/#{owner_key}/products/#{product_id}/content/#{content_id}", {:enabled => enabled})
+      @cp.post("/hostedtest/products/#{product_id}/content/#{content_id}", {:enabled => enabled})
     else
       @cp.add_content_to_product(owner_key, product_id, content_id, true)
     end
@@ -125,16 +129,19 @@ module HostedTest
 
   def update_product(owner_key, product_id, params={})
     if is_hosted?
+      # FIXME: This is broken
+
       product = {
         :id => product_id
       }
+
       product[:name] = params[:name] if params[:name]
       product[:multiplier] = params[:multiplier] if params[:multiplier]
       product[:attributes] = params[:attributes] if params[:attributes]
       product[:dependentProductIds] = params[:dependentProductIds] if params[:dependentProductIds]
       product[:relies_on] = params[:relies_on] if params[:relies_on]
 
-      @cp.put("/hostedtest/subscriptions/owners/#{owner_key}/products/#{product_id}", {}, product)
+      @cp.put("/hostedtest/products/#{product_id}", {}, product)
     else
       @cp.update_product(owner_key, product_id, params)
     end
@@ -155,6 +162,7 @@ module HostedTest
     params[:order_number] = order_number
     params[:quantity] = quantity
     params[:provided_products] = provided_products
+
     pool = nil
     if is_hosted?
       ensure_hostedtest_resource
@@ -274,5 +282,201 @@ module HostedTest
       delete_all_hostedtest_subscriptions
     end
   end
+
+
+
+
+def create_upstream_subscription(subscription_id, owner_key, product_id, params = {})
+    start_date = params.delete(:start_date) || Date.today
+    end_date = params.delete(:end_date) || start_date + 365
+
+    # Define subscription with defaults & specified params
+    subscription = {
+      :startDate => start_date,
+      :endDate   => end_date,
+      :product =>  { :id => product_id },
+      :owner =>  { :key => owner_key },
+      :quantity => 1
+    }
+
+    # Merge, but convert some snake-case keys to camel case
+    keys = [:account_number, :contract_number, :order_number, :upstream_pool_id,
+      :provided_products, :derived_product, :derived_provided_products,
+      'account_number', 'contract_number', 'order_number', 'upstream_pool_id',
+      'provided_products', 'derived_product', 'derived_provided_products']
+
+    params.each do |key, value|
+      if keys.include?(key)
+        key = key.to_s.gsub!(/_(\w)/){$1.upcase}
+      end
+
+      subscription[key] = value
+    end
+
+    # Forcefully set identifier
+    subscription[:id] = subscription_id
+
+    return @cp.post('hostedtest/subscriptions', {}, subscription)
+  end
+
+  def list_upstream_subscriptions()
+    return @cp.get('/hostedtest/subscriptions')
+  end
+
+  def get_upstream_subscription(subscription_id)
+    return @cp.get("/hostedtest/subscriptions/#{subscription_id}")
+  end
+
+  def update_upstream_subscription(subscription_id, params = {})
+    subscription = {}
+
+    # Merge, but convert some snake-case keys to camel case
+    keys = ['account_number', 'contract_number', 'order_number', 'upstream_pool_id', 'start_date', 'end_date',
+      'provided_products', 'derived_product', 'derived_provided_products']
+
+    params.each do |key, value|
+      if keys.include?(key.to_s)
+        key = key.to_s.gsub!(/_(\w)/){$1.upcase}
+      end
+
+      subscription[key] = value
+    end
+
+    # Forcefully set identifier
+    subscription[:id] = subscription_id
+
+    return @cp.put("/hostedtest/subscriptions/#{subscription_id}", {}, subscription)
+  end
+
+  def delete_upstream_subscription(subscription_id)
+    return @cp.delete("/hostedtest/subscriptions/#{subscription_id}")
+  end
+
+  def create_upstream_product(product_id = nil, params = {})
+    # Generate an ID if one was not provided
+    if product_id.nil?
+      product_id = random_str('product')
+    end
+
+    # Create a product with some defaults for required fields
+    product = {
+      :multiplier => 1
+    }
+
+    # Merge provided params in
+    product.merge!(params)
+
+    # Forcefully set identifier and name (if absent)
+    product[:id] = product_id
+    product[:name] = product_id if !product[:name] && !product['name']
+
+    return @cp.post('hostedtest/products', {}, product)
+  end
+
+  def list_upstream_products()
+    return @cp.get('/hostedtest/products')
+  end
+
+  def get_upstream_product(product_id)
+    return @cp.get("/hostedtest/products/#{product_id}")
+  end
+
+  def update_upstream_product(product_id, params = {})
+    product = {}.merge(params)
+
+    # Forcefully set identifier
+    product[:id] = product_id
+
+    return @cp.put("/hostedtest/products/#{product_id}", {}, product)
+  end
+
+  def delete_upstream_product(product_id)
+    return @cp.delete("/hostedtest/products/#{product_id}")
+  end
+
+  def create_upstream_content(content_id = nil, params = {})
+    # Generate an ID if one was not provided
+    if content_id.nil?
+      content_id = random_str('content')
+    end
+
+    # Create a content with some defaults for required fields
+    content = {
+      :label => 'label',
+      :type => 'yum',
+      :vendor => 'vendor'
+    }
+
+    # Merge, but convert some snake-case keys to camel case
+    keys = ['content_url', 'gpg_url', 'modified_product_ids', 'metadata_expire', 'required_tags']
+
+    params.each do |key, value|
+      if keys.include?(key.to_s)
+        key = key.to_s.gsub!(/_(\w)/){$1.upcase}
+      end
+
+      content[key] = value
+    end
+
+    # Forcefully assign the ID and name (if absent)
+    content[:id] = content_id
+    content[:name] = content_id if !content[:name]
+
+    return @cp.post('hostedtest/content', {}, content)
+  end
+
+  def list_upstream_contents()
+    return @cp.get('/hostedtest/content')
+  end
+
+  def get_upstream_content(content_id)
+    return @cp.get("/hostedtest/content/#{content_id}")
+  end
+
+  def update_upstream_content(content_id, params = {})
+    content = {}
+
+    # Merge, but convert some snake-case keys to camel case
+    keys = ['content_url', 'gpg_url', 'modified_product_ids', 'metadata_expire', 'required_tags']
+
+    params.each do |key, value|
+      if keys.include?(key.to_s)
+        key = key.to_s.gsub!(/_(\w)/){$1.upcase}
+      end
+
+      content[key] = value
+    end
+
+    # Forcefully set identifier
+    content[:id] = content_id
+
+    return @cp.put("/hostedtest/content/#{content_id}", {}, content)
+  end
+
+  def delete_upstream_content(content_id)
+    return @cp.delete("/hostedtest/content/#{content_id}")
+  end
+
+  def add_batch_content_to_product_upstream(product_id, content_ids, enabled=true)
+    data = {}
+    content_ids.each do |id|
+      data[id] = enabled
+    end
+    @cp.post("/hostedtest/products/#{product_id}/content", {}, data)
+  end
+
+  def add_content_to_product_upstream(product_id, content_id, enabled = true)
+    @cp.post("/hostedtest/products/#{product_id}/content/#{content_id}", { :enabled => enabled })
+  end
+
+  def remove_batch_content_from_product_upstream(product_id, content_ids)
+    @cp.delete("/hostedtest/products/#{product_id}/content", {}, content_ids)
+  end
+
+  def remove_content_from_product_upstream(product_id, content_id)
+    @cp.delete("/hostedtest/products/#{product_id}/content/#{content_id}")
+  end
+
+
 
 end

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -38,12 +38,12 @@
     <commons-io-commons-io.version>1.4</commons-io-commons-io.version>
     <commons-lang-commons-lang.version>2.5</commons-lang-commons-lang.version>
     <com.googlecode.gettext-commons-gettext-commons.version>0.9.8</com.googlecode.gettext-commons-gettext-commons.version>
-    <com.google.inject.extensions-guice-assistedinject.version>3.0</com.google.inject.extensions-guice-assistedinject.version>
-    <com.google.inject.extensions-guice-multibindings.version>3.0</com.google.inject.extensions-guice-multibindings.version>
-    <com.google.inject.extensions-guice-servlet.version>3.0</com.google.inject.extensions-guice-servlet.version>
-    <com.google.inject.extensions-guice-throwingproviders.version>3.0</com.google.inject.extensions-guice-throwingproviders.version>
-    <com.google.inject.extensions-guice-persist.version>3.0</com.google.inject.extensions-guice-persist.version>
-    <com.google.inject-guice.version>3.0</com.google.inject-guice.version>
+    <com.google.inject.extensions-guice-assistedinject.version>4.1.0</com.google.inject.extensions-guice-assistedinject.version>
+    <com.google.inject.extensions-guice-multibindings.version>4.1.0</com.google.inject.extensions-guice-multibindings.version>
+    <com.google.inject.extensions-guice-servlet.version>4.1.0</com.google.inject.extensions-guice-servlet.version>
+    <com.google.inject.extensions-guice-throwingproviders.version>4.1.0</com.google.inject.extensions-guice-throwingproviders.version>
+    <com.google.inject.extensions-guice-persist.version>4.1.0</com.google.inject.extensions-guice-persist.version>
+    <com.google.inject-guice.version>4.1.0</com.google.inject-guice.version>
     <aopalliance-aopalliance.version>1.0</aopalliance-aopalliance.version>
     <javax.inject-javax.inject.version>1</javax.inject-javax.inject.version>
     <org.hibernate-hibernate-core.version>5.2.17.Final</org.hibernate-hibernate-core.version>

--- a/server/spec/candlepin_scenarios.rb
+++ b/server/spec/candlepin_scenarios.rb
@@ -166,7 +166,7 @@ module CandlepinMethods
     @users << user
 
     role = @cp.create_role(random_string('testrole'), perms)
-    @cp.add_role_user(role['id'], username)
+    @cp.add_role_user(role['name'], username)
 
     return Candlepin.new(username, password)
   end
@@ -181,7 +181,7 @@ module CandlepinMethods
     # Create a role for user to administer the given owner:
     perm = readonly ? 'READ_ONLY' : 'ALL'
     role = create_role(nil, owner['key'], perm)
-    @cp.add_role_user(role['id'], user['username'])
+    @cp.add_role_user(role['name'], user['username'])
     return user
   end
 

--- a/server/spec/client_v1_size_spec.rb
+++ b/server/spec/client_v1_size_spec.rb
@@ -8,27 +8,50 @@ describe 'Entitlement Certificate V1 Size' do
     @owner = create_owner random_string('test_owner')
     @content_list = create_batch_content(200)
 
-    @product1 = create_product(nil, nil, :attributes =>
-                {:version => '6.4',
-                 :warning_period => 15,
-                 :management_enabled => true,
-                 :virt_only => 'false',
-                 :support_level => 'standard',
-                 :support_type => 'excellent',})
+    @product1 = create_product(nil, nil, :attributes => {
+      :version => '6.4',
+      :warning_period => 15,
+      :management_enabled => true,
+      :virt_only => 'false',
+      :support_level => 'standard',
+      :support_type => 'excellent',
+    })
+
     @cp.add_content_to_product(@owner['key'], @product1.id, @content_list[0].id, true)
-    create_pool_and_subscription(@owner['key'], @product1.id, 10, [], '12345', '6789', 'order1')
-    @product2 = create_product(nil, nil, :attributes =>
-                {:version => '6.4',
-                 :warning_period => 15,
-                 :management_enabled => true,
-                 :virt_only => 'false',
-                 :support_level => 'standard',
-                 :support_type => 'excellent',})
+
+    @cp.create_pool(@owner['key'], @product1.id, {
+      :quantity => 10,
+      :provided_products => [],
+      :contract_number => '12345',
+      :account_number => '6789',
+      :order_number => 'order1',
+      :subscription_id => random_str('source_sub'),
+      :upstream_pool_id => random_str('upstream')
+    })
+
+    @product2 = create_product(nil, nil, :attributes => {
+      :version => '6.4',
+      :warning_period => 15,
+      :management_enabled => true,
+      :virt_only => 'false',
+      :support_level => 'standard',
+      :support_type => 'excellent',
+    })
+
     @cp.add_content_to_product(@owner['key'], @product2.id, @content_list[0].id, true)
-    create_pool_and_subscription(@owner['key'], @product2.id, 10, [], '12345', '6789', 'order1')
+
+    @cp.create_pool(@owner['key'], @product2.id, {
+      :quantity => 1,
+      :provided_products => [],
+      :contract_number => '12345',
+      :account_number => '6789',
+      :order_number => 'order1',
+      :subscription_id => random_str('source_sub'),
+      :upstream_pool_id => random_str('upstream')
+    })
+
     @user = user_client(@owner, random_string('billy'))
-    @system = consumer_client(@user, random_string('system1'), :system, nil,
-                {'system.certificate_version' => '1.0'})
+    @system = consumer_client(@user, random_string('system1'), :system, nil, {'system.certificate_version' => '1.0'})
   end
 
   after(:each) do
@@ -45,7 +68,7 @@ describe 'Entitlement Certificate V1 Size' do
     (1..10).each do |i|
       content_ids << @content_list[i].id
     end
-    add_batch_content_to_product(@owner['key'], @product1.id, content_ids, true)
+    @cp.add_batch_content_to_product(@owner['key'], @product1.id, content_ids, true)
     @cp.regenerate_entitlement_certificates_for_product(@product1.id)
     ent2 = @system.get_entitlement(ent1.id)
     ent2.certificates[0].serial.id.should_not == ent1.certificates[0].serial.id
@@ -56,7 +79,7 @@ describe 'Entitlement Certificate V1 Size' do
     (11..200).each do |i|
       content_ids.push(@content_list[i].id)
     end
-    add_batch_content_to_product(@owner['key'], @product1.id, content_ids, true)
+    @cp.add_batch_content_to_product(@owner['key'], @product1.id, content_ids, true)
     @cp.regenerate_entitlement_certificates_for_product(@product1.id)
     ent3 = @system.get_entitlement(ent1.id)
     ent3.certificates[0].serial.id.should == ent2.certificates[0].serial.id
@@ -73,13 +96,19 @@ describe 'Entitlement Certificate V1 Size' do
   end
 
   it 'will not allow an excessive content set to block others' do
-    @cp.refresh_pools(@owner['key'])
+    # @cp.refresh_pools(@owner['key'])
+
     ent1 = @system.consume_product(@product1.id)[0]
+    expect(ent1).to_not be_nil
+
     ent2 = @system.consume_product(@product2.id)[0]
+    expect(ent2).to_not be_nil
+
     (1..200).each do |i|
-      add_content_to_product(@owner['key'], @product1.id, @content_list[i].id, true)
+      @cp.add_content_to_product(@owner['key'], @product1.id, @content_list[i].id, true)
     end
-    add_content_to_product(@owner['key'], @product2.id, @content_list[1].id, true)
+
+    @cp.add_content_to_product(@owner['key'], @product2.id, @content_list[1].id, true)
     @cp.regenerate_entitlement_certificates_for_product(@product1.id)
     @cp.regenerate_entitlement_certificates_for_product(@product2.id)
 

--- a/server/spec/pool_resource_spec.rb
+++ b/server/spec/pool_resource_spec.rb
@@ -259,11 +259,15 @@ describe 'Pool Resource' do
         :type => 'type1', :name => 'branding1'}
       b2 = {:productId => 'prodid2',
         :type => 'type2', :name => 'branding2'}
+
       owner = create_owner random_string('some-owner')
       name = random_string("product-")
+
       product = create_product(name, name, :owner => owner['key'])
+
       created = create_pool_and_subscription(owner['key'], product.id, 11,
-        [], '', '', '', nil, nil, false, :branding => [b1,b2])
+        [], '', '', '', nil, nil, false, :branding => [b1, b2])
+
       pool = @cp.get_pool(created['id'])
       pool.quantity.should == 11
       pool.branding.size.should == 2

--- a/server/spec/refresh_pools_spec.rb
+++ b/server/spec/refresh_pools_spec.rb
@@ -4,8 +4,11 @@ require 'candlepin_scenarios'
 require 'rubygems'
 require 'rest_client'
 
+
 describe 'Refresh Pools' do
   include CandlepinMethods
+  include AttributeHelper
+  include CertificateMethods
   include VirtHelper
   include CertificateMethods
 
@@ -40,14 +43,11 @@ describe 'Refresh Pools' do
 
     # Create 6 subscriptions to different products
     6.times do |i|
-      name = random_string("product-#{i}")
-      product = create_product(name, name, :owner => owner['key'])
-
-      create_pool_and_subscription(owner['key'], product.id)
+      product = create_upstream_product(random_string("product-#{i}"))
+      create_upstream_subscription(random_string("sub-#{i}"), owner['key'], product.id)
     end
 
-    # @cp.refresh_pools(owner['key'])
-
+    @cp.refresh_pools(owner['key'])
     @cp.list_pools({:owner => owner.id}).length.should == 6
   end
 
@@ -56,10 +56,8 @@ describe 'Refresh Pools' do
 
     # Create 6 subscriptions to different products
     6.times do |i|
-      name = random_string("product-#{i}")
-      product = create_product(name, name, :owner => owner['key'])
-
-      create_pool_and_subscription(owner['key'], product.id)
+      product = create_upstream_product(random_string("product-#{i}"))
+      create_upstream_subscription(random_string("sub-#{i}"), owner['key'], product.id)
     end
 
     @cp.refresh_pools(owner['key'])
@@ -71,229 +69,584 @@ describe 'Refresh Pools' do
   end
 
   it 'detects changes in provided products' do
-    owner = create_owner random_string
-    product = create_product(random_string, random_string, :owner => owner['key'])
-    provided1 = create_product(random_string, random_string, :owner => owner['key'])
-    provided2 = create_product(random_string, random_string, :owner => owner['key'])
-    provided3 = create_product(random_string, random_string, :owner => owner['key'])
-    pool = create_pool_and_subscription(owner['key'], product.id, 500, [provided1.id, provided2.id])
+    owner_key = random_string('test_owner')
+    owner = create_owner(owner_key)
+
+    product = create_upstream_product(random_string('test_prod'))
+    provided = []
+
+    3.times do |i|
+      provided << create_upstream_product(random_string("provided-#{i}"))
+    end
+
+    sub = create_upstream_subscription(random_string('test_sub'), owner_key, product.id, {
+      :provided_products => provided[0..1]
+    })
+
+    @cp.refresh_pools(owner_key)
     pools = @cp.list_pools({:owner => owner.id})
-    pools.length.should == 1
-    pools[0].providedProducts.length.should == 2
-    # Remove the old provided products and add a new one:
-    sub = get_hostedtest_subscription(pool.subscriptionId)
-    sub.providedProducts = [@cp.get_product(owner['key'], provided3.id)]
-    update_hostedtest_subscription(sub)
-    @cp.refresh_pools(owner['key'])
+
+    expect(pools.length).to eq(1)
+    expect(pools[0].providedProducts.length).to eq(2)
+
+    provided_ids = provided[0..1].collect { |p| p.id }
+    pools[0].providedProducts.each do |p|
+      expect(provided_ids).to include(p.productId)
+      provided_ids.delete(p.productId)
+    end
+
+    # Remove the old provided products and add a new one...
+    sub.providedProducts = [provided[2]]
+    update_upstream_subscription(sub.id, sub)
+
+    @cp.refresh_pools(owner_key)
     pools = @cp.list_pools({:owner => owner.id})
-    pools[0].providedProducts.length.should == 1
+
+    expect(pools.length).to eq(1)
+    expect(pools[0].providedProducts.length).to eq(1)
+    expect(pools[0].providedProducts[0].productId).to eq(provided[2].id)
   end
 
   it 'deletes expired subscriptions\' pools and entitlements' do
-    owner = create_owner random_string
-    product = create_product(random_string, random_string, :owner => owner['key'])
-    pool = create_pool_and_subscription(owner['key'], product.id, 500, [])
+    owner_key = random_string('test_owner')
+    owner = create_owner(owner_key)
+
+    product = create_upstream_product(random_string('test_prod'))
+    sub = create_upstream_subscription(random_string('test_sub'), owner_key, product.id, { :quantity => 500 })
+
+    @cp.refresh_pools(owner_key)
     pools = @cp.list_pools({:owner => owner.id})
-    pools.length.should == 1
+    expect(pools.length).to eq(1)
 
-    user = user_client(owner, random_string("user"))
+    user = user_client(owner, random_string('test_user'))
+    consumer = consumer_client(user, random_string('test_consumer'))
+    entitlements = consumer.consume_pool(pools.first.id, {:quantity => 1})
+    expect(entitlements.length).to eq(1)
 
-    consumer_id = random_string("consumer")
-    consumer = consumer_client(user, consumer_id)
-    consumer.consume_pool(pools.first.id, {:quantity => 1}).size.should == 1
+    consumer = @cp.get_consumer(consumer.uuid)
+    expect(consumer.entitlementCount).to eq(1)
 
-    # Update the subscription to be expired so that pool, and entitlements are removed.
-    now = DateTime.now
-    sub = get_hostedtest_subscription(pool.subscriptionId)
-    sub.startDate = now - 20
-    sub.endDate = now - 10
-    update_hostedtest_subscription(sub)
-    @cp.refresh_pools(owner['key'])
-    @cp.list_pools({:owner => owner.id}).size.should == 0
-    @cp.get_consumer(consumer.uuid).entitlementCount.should == 0
+    # Update subscription such that it's expired, then refresh. The entitlements should be removed.
+    update_upstream_subscription(sub.id, {
+      :start_date => Date.today - 20,
+      :end_date => Date.today - 10
+    })
+    @cp.refresh_pools(owner_key)
+
+    pools = @cp.list_pools({:owner => owner.id})
+    consumer = @cp.get_consumer(consumer.uuid)
+
+    expect(pools.length).to eq(0)
+    expect(consumer.entitlementCount).to eq(0)
   end
 
   it 'regenerates entitlements' do
-    owner = create_owner random_string
-    product = create_product(random_string, random_string, :owner => owner['key'])
-    new_product = create_product(random_string, random_string, :owner => owner['key'])
-    pool = create_pool_and_subscription(owner['key'], product.id, 500, [])
+    owner_key = random_string('test_owner')
+    owner = create_owner(owner_key)
+
+    product1 = create_upstream_product(random_string('test_prod1'))
+    product2 = create_upstream_product(random_string('test_prod2'))
+    sub = create_upstream_subscription(random_string('test_sub'), owner_key, product1.id)
+
+    @cp.refresh_pools(owner_key)
     pools = @cp.list_pools({:owner => owner.id})
-    pools.length.should == 1
+    expect(pools.length).to eq(1)
 
-    user = user_client(owner, random_string("user"))
+    user = user_client(owner, random_string('test_user'))
+    consumer = consumer_client(user, random_string('test_consumer'))
+    entitlements = consumer.consume_pool(pools.first.id, {:quantity => 1})
+    expect(entitlements.length).to eq(1)
 
-    consumer_id = random_string("consumer")
-    consumer = consumer_client(user, consumer_id)
-    ents = consumer.consume_pool(pools.first.id, {:quantity => 1})
-    ents.size.should == 1
-    ent = ents[0]
-    old_cert = ent['certificates'][0]
+    consumer = @cp.get_consumer(consumer.uuid)
+    expect(consumer.entitlementCount).to eq(1)
+
+    entitlement = entitlements.first
+    old_cert = entitlement['certificates'].first
     old_serial = old_cert['serial']['serial']
 
-    # Change the product on subscription to trigger a regenerate:
-    sub = get_hostedtest_subscription(pool.subscriptionId)
-    sub['product'] = {'id' => new_product['id']}
-    update_hostedtest_subscription(sub)
-    @cp.refresh_pools(owner['key'], false, false, true)
-    ent = @cp.get_entitlement(ent['id'])
-    new_cert = ent['certificates'][0]
-    new_serial = new_cert['serial']['serial']
-    new_serial.should_not == old_serial
+    # Update the subscription's product to trigger an entitlement regeneration
+    update_upstream_subscription(sub.id, {
+      :product => { :id => product2.id }
+    })
+    @cp.refresh_pools(owner_key)
 
-    @cp.get_consumer(consumer.uuid).entitlementCount.should == 1
+    consumer = @cp.get_consumer(consumer.uuid)
+    expect(consumer.entitlementCount).to eq(1)
+
+    updated_ent = @cp.get_entitlement(entitlement['id'])
+    new_cert = updated_ent['certificates'].first
+    new_serial = new_cert['serial']['serial']
+
+    expect(new_serial).to_not eq(old_serial)
   end
 
   it 'handle derived products being removed' do
-   # 998317: is caused by refresh pools dying with an NPE
-   # this happens when subscriptions no longer have
-   # derived products resulting in a null during the refresh
-   # which we didn't handle in all cases.
+    # 998317: is caused by refresh pools dying with an NPE
+    # this happens when subscriptions no longer have
+    # derived products resulting in a null during the refresh
+    # which we didn't handle in all cases.
+    owner_key = random_string('test_owner')
+    owner = create_owner(owner_key)
 
-    owner = create_owner random_string
-    # create subscription with sub-pool data:
-    datacenter_product = create_product(nil, nil, {
+    datacenter_product = create_upstream_product(random_string('dc_prod'), {
       :attributes => {
         :virt_limit => "unlimited",
         :stacking_id => "stackme",
         :sockets => "2",
         'multi-entitlement' => "yes"
-      },
-      :owner => owner['key']
+      }
     })
-    derived_product = create_product(nil, nil, {
+
+    derived_product = create_upstream_product(random_string('derived_prod'), {
       :attributes => {
-          :cores => 2,
-          :sockets=>4
-      },
-      :owner => owner['key']
+        :cores => 2,
+        :sockets=>4
+      }
     })
-    eng_product = create_product('300', nil, :owner => owner['key'])
 
-    pool1 = create_pool_and_subscription(owner['key'], datacenter_product.id,
-      10, [], '', '', '', nil, nil, false,
-      {
-        :derived_product_id => derived_product['id'],
-        :derived_provided_products => ['300']
-      })
-    # extra unmapped guest pool will be labeled with provided product
-    pools = @cp.list_pools :owner => owner.id,
-      :product => datacenter_product.id
-    pools.size.should == 1
-    pools[0]['derivedProvidedProducts'].length.should == 1
+    derived_eng_product = create_upstream_product(random_string(nil, true))
 
-    # let's remove the derivedProducts - this simulates
-    # the scenario that caues the bug
-    sub1 = get_hostedtest_subscription(pool1.subscriptionId)
-    sub1['derivedProduct'] = nil
-    sub1['derivedProvidedProducts'] = nil
-    update_hostedtest_subscription(sub1)
+    eng_product = create_upstream_product(random_string('eng_prod'))
 
-    # this is the refresh we are actually testing
-    # it should succeed
-    @cp.refresh_pools(owner['key'])
+    sub = create_upstream_subscription(random_string('dc_sub'), owner_key, datacenter_product.id, {
+      :quantity => 10,
+      :derived_product => derived_product,
+      :derived_provided_products => [derived_eng_product]
+    })
 
-    # let's verify it removed them correctly
-    # extra unmapped pool now shows datacenter product
-    pools = @cp.list_pools :owner => owner.id, \
-      :product => datacenter_product.id
-    pools.length.should == 2
-    pools[0]['derivedProvidedProducts'].length.should == 0
+    @cp.refresh_pools(owner_key)
+    pools = @cp.list_pools({:owner => owner.id})
+    expect(pools.length).to eq(2) # We're expecting the base pool + a virt-only bonus pool for guests
+
+    # Swap pools if necessary
+    if pools[0].productId != datacenter_product.id
+      pools[0], pools[1] = pools[1], pools[0]
+    end
+
+    expect(pools.first).to have_key('derivedProvidedProducts')
+    expect(pools.first.derivedProvidedProducts.length).to eq(1)
+
+    update_upstream_subscription(sub.id, {
+      :derived_product => nil,
+      :derived_provided_products => []
+    })
+
+    @cp.refresh_pools(owner_key)
+
+    pools = @cp.list_pools :owner => owner.id, :product => datacenter_product.id
+    expect(pools.length).to eq(2)
+
+    # Swap pools if necessary
+    if pools[0].productId != datacenter_product.id
+      pools[0], pools[1] = pools[1], pools[0]
+    end
+
+    expect(pools.first).to have_key('derivedProvidedProducts')
+    expect(pools.first.derivedProvidedProducts.length).to eq(0)
   end
 
-  it 'can migrate subscription' do
-    # Create the initial owner and generate the pools.
-    owner1 = create_owner random_string('initial-owner')
-    name = random_string("product")
-    product1 = create_product(name, name, :owner => owner1['key'])
-    pool = create_pool_and_subscription(owner1['key'], product1.id)
-    owner1_pools = @cp.list_pools({:owner => owner1.id})
-    owner1_pools.length.should == 1
+  it 'can migrate subscriptions' do
+    owner_key1 = random_string('test_owner_1')
+    owner_key2 = random_string('test_owner_2')
+    owner1 = create_owner(owner_key1)
+    owner2 = create_owner(owner_key2)
 
-    # Create another owner and migrate the subscription
-    owner2 = create_owner random_string('migrated-owner')
-    product2 = create_product(name, name, :owner => owner2['key'])
+    product = create_upstream_product(random_string('test_prod'))
+    sub = create_upstream_subscription(random_string('test_sub'), owner_key1, product.id)
 
-    # migrate the subscription to another owner.
-    sub = get_hostedtest_subscription(pool.subscriptionId)
-    sub["owner"] = owner2
-    update_hostedtest_subscription(sub)
-    @cp.refresh_pools(owner1["key"])
-    @cp.refresh_pools(owner2["key"])
+    @cp.refresh_pools(owner_key1)
+    @cp.refresh_pools(owner_key2)
 
-    # Check that the pools are removed from the first owner
-    @cp.list_pools({:owner => owner1.id}).length.should == 0
-    @cp.list_pools({:owner => owner2.id}).length.should == 1
+    pools1 = @cp.list_pools({:owner => owner1.id})
+    pools2 = @cp.list_pools({:owner => owner2.id})
+    expect(pools1.length).to eq(1)
+    expect(pools2.length).to eq(0)
+
+    # Update sub to be owned by the second owner
+    update_upstream_subscription(sub.id, { :owner => { :key => owner_key2 }})
+
+    @cp.refresh_pools(owner_key1)
+    @cp.refresh_pools(owner_key2)
+
+    pools1 = @cp.list_pools({:owner => owner1.id})
+    pools2 = @cp.list_pools({:owner => owner2.id})
+    expect(pools1.length).to eq(0)
+    expect(pools2.length).to eq(1)
   end
 
   it 'removes pools from other owners when subscription is migrated' do
-    # Create the initial owner and generate the pools.
-    owner1 = create_owner random_string('initial-owner')
-    name = random_string("product")
-    product1 = create_product(name, name, :owner => owner1['key'])
-    pool = create_pool_and_subscription(owner1['key'], product1.id)
-    owner1_pools = @cp.list_pools({:owner => owner1.id})
-    owner1_pools.length.should == 1
+    owner_key1 = random_string('test_owner_1')
+    owner_key2 = random_string('test_owner_2')
+    owner1 = create_owner(owner_key1)
+    owner2 = create_owner(owner_key2)
 
-    # Create another owner and migrate the subscription
-    owner2 = create_owner random_string('migrated-owner')
-    product2 = create_product(name, name, :owner => owner2['key'])
+    product = create_upstream_product(random_string('test_prod'))
+    sub = create_upstream_subscription(random_string('test_sub'), owner_key1, product.id)
 
-    # migrate the subscription to another owner.
-    sub = get_hostedtest_subscription(pool.subscriptionId)
-    sub["owner"] = owner2
-    update_hostedtest_subscription(sub)
+    @cp.refresh_pools(owner_key1)
+    @cp.refresh_pools(owner_key2)
 
-    # Refresh the second owner so that the pools are updated.
-    @cp.refresh_pools(owner2["key"], true)
-    sleep 1
-    # Initial owner should have all pools removed.
-    @cp.list_pools({:owner => owner1.id}).length.should == 0
+    pools1 = @cp.list_pools({:owner => owner1.id})
+    pools2 = @cp.list_pools({:owner => owner2.id})
+    expect(pools1.length).to eq(1)
+    expect(pools2.length).to eq(0)
 
-    # Pools should now be created for the second owner since
-    # the subscription was migrated.
-    @cp.list_pools({:owner => owner2.id}).length.should == 1
+    # Update sub to be owned by the second owner
+    update_upstream_subscription(sub.id, { :owner => { :key => owner_key2 }})
+
+    @cp.refresh_pools(owner_key2)
+
+    pools1 = @cp.list_pools({:owner => owner1.id})
+    pools2 = @cp.list_pools({:owner => owner2.id})
+    expect(pools1.length).to eq(0)
+    expect(pools2.length).to eq(1)
   end
 
   # Testing bug #1150234:
   it 'can change attributes and revoke entitlements at same time' do
-    owner = create_owner random_string
-    user = user_client(owner, random_string('virt_user'))
-    product = create_product(
-      random_string,
-      random_string,
-      {
-        :attributes => {'multi-entitlement' => "yes"},
-        :owner => owner['key']
+    owner_key = random_string('test_owner')
+    owner = create_owner(owner_key)
+
+    product = create_upstream_product(random_string('multient_prod'), {
+      :attributes => {
+        'multi-entitlement' => 'yes'
       }
-    )
-    create_pool_and_subscription(owner['key'], product.id, 2)
+    })
 
-    user = user_client(owner, random_string("user"))
-    host = consumer_client(user, 'host', :system, nil)
+    sub = create_upstream_subscription(random_string('multient_sub'), owner_key, product.id, {
+      :quantity => 2
+    })
 
-    pools = @cp.list_pools({:owner => owner.id, :product => product.id})
-    pools.length.should == 1
-    # We'll consume quantity 2, later we will reduce the pool to 1 forcing a
-    # revoke of this entitlement:
-    @cp.consume_pool(pools[0]['id'], {:uuid => host.uuid, :quantity => 2})
-    @cp.refresh_pools(owner['key'], false, false, false)
+    user = user_client(owner, random_string('test_user'))
+    consumer_client = consumer_client(user, random_string('test_consumer'))
 
-    pool = @cp.list_pools({:owner => owner.id, :product => product.id})[0]
+    @cp.refresh_pools(owner_key)
+    pools = @cp.list_pools({:owner => owner.id})
+    expect(pools.length).to eq(1)
 
-    # Modify product attributes:
-    attrs = product['attributes']
-    attrs << {:name => 'newattribute', :value => 'something'}
-    update_product(owner['key'], product.id, :attributes => attrs)
+    # We'll consume quantity 2, later we will reduce the pool to 1 forcing revokation of this entitlement
+    entitlements = consumer_client.consume_pool(pools.first.id, { :quantity => 2 })
+    expect(entitlements.length).to eq(1)
 
-    # Reduce the subscription quantity:
-    sub = get_hostedtest_subscription(pool.subscriptionId)
-    sub['quantity'] = 1
-    update_hostedtest_subscription(sub)
+    # FIXME: This seems like a bug. Our entitlement count here should be 1, right?
+    consumer = @cp.get_consumer(consumer_client.uuid)
+    expect(consumer.entitlementCount).to eq(2)
 
-    @cp.refresh_pools(owner['key'], false, false, false)
-    pools = @cp.list_pools({:owner => owner.id, :product => product.id})
-    pools.length.should == 1
+    # Add a new attribute to the product
+    update_upstream_product(product.id, {
+      :attributes => {
+        'new_attrib' => 'new value',
+        'multi-entitlement' => 'yes'
+      }
+    })
+
+    # ...and reduce the quantity available on the subscription
+    update_upstream_subscription(sub.id, {
+      :quantity => 1
+    })
+
+    # Refresh pools for this org
+    @cp.refresh_pools(owner_key)
+
+    pools = @cp.list_pools({:owner => owner.id})
+    expect(pools.length).to eq(1)
+
+    # Verify the pool's product now contains the new attribute
+    expect(pools.first).to have_key('productAttributes')
+
+    attributes = normalize_attributes(pools.first.productAttributes)
+    expect(attributes).to eq({
+      'new_attrib' => 'new value',
+      'multi-entitlement' => 'yes'
+    })
+
+    # Verify that the entitlement was revoked
+    consumer = @cp.get_consumer(consumer_client.uuid)
+    expect(consumer.entitlementCount).to eq(0)
+
+    lambda do
+      @cp.get_entitlement(entitlements[0].id)
+    end.should raise_exception(RestClient::ResourceNotFound)
+  end
+
+  it 'regenerates entitlements when content for an entitled pool changes' do
+    owner_key = random_string('test_owner')
+    owner = create_owner(owner_key)
+
+    content_id = random_string('test_content')
+    content = create_upstream_content(content_id, { :label => 'test_label', :content_url => 'http://www.url.com' })
+
+    product_id = random_string(nil, true)
+    product = create_upstream_product(product_id)
+
+    add_content_to_product_upstream(product_id, content_id)
+
+    sub_id = random_string('test_subscription')
+    create_upstream_subscription(sub_id, owner_key, product_id)
+
+    @cp.refresh_pools(owner_key)
+    pools = @cp.list_pools({:owner => owner.id})
+    expect(pools.length).to eq(1)
+
+    # Verify the content exists in its initial state
+    ds_content = @cp.get_content(owner_key, content_id)
+    expect(ds_content).to_not be_nil
+    expect(ds_content.label).to eq('test_label')
+
+    # Consume the pool so we have an entitlement
+    user = user_client(owner, random_string('test_user'))
+    consumer_client = consumer_client(user, random_string('test_consumer'), :system, nil,
+      { 'system.certificate_version' => '3.0' })
+
+    entitlements = consumer_client.consume_pool(pools.first.id, { :quantity => 1 })
+    expect(entitlements.length).to eq(1)
+
+    consumer = @cp.get_consumer(consumer_client.uuid)
+    expect(consumer.entitlementCount).to eq(1)
+
+    entitlement = entitlements.first
+    ent_cert = entitlement['certificates'].first
+    ent_cert_serial = ent_cert['serial']['serial']
+
+    # Modify the content for this product/sub
+    update_upstream_content(content_id, { :label => 'updated_label' })
+
+    @cp.refresh_pools(owner_key)
+    pools = @cp.list_pools({:owner => owner.id})
+    expect(pools.length).to eq(1)
+
+    # Verify the content change has been pulled down
+    ds_content = @cp.get_content(owner_key, content_id)
+    expect(ds_content).to_not be_nil
+    expect(ds_content.label).to eq('updated_label')
+
+    # Verify the entitlement cert has changed as a result
+    updated_ent = @cp.get_entitlement(entitlement['id'])
+    updated_cert = updated_ent['certificates'].first
+    updated_cert_serial = updated_cert['serial']['serial']
+
+    expect(updated_cert_serial).to_not eq(ent_cert_serial)
+  end
+
+  it 'regenerates entitlements when products for an entitled pool changes' do
+    owner_key = random_string('test_owner')
+    owner = create_owner(owner_key)
+
+    content_id = random_string('test_content')
+    content = create_upstream_content(content_id, { :content_url => 'http://www.url.com' })
+
+    product_id = random_string(nil, true)
+    product = create_upstream_product(product_id, { :name => 'test_prod' })
+
+    add_content_to_product_upstream(product_id, content_id)
+
+    sub_id = random_string('test_subscription')
+    create_upstream_subscription(sub_id, owner_key, product_id)
+
+    @cp.refresh_pools(owner_key)
+    pools = @cp.list_pools({:owner => owner.id})
+    expect(pools.length).to eq(1)
+
+    # Verify the product exists in its initial state
+    ds_product = @cp.get_product(owner_key, product_id)
+    expect(ds_product).to_not be_nil
+    expect(ds_product.name).to eq('test_prod')
+
+    # Consume the pool so we have an entitlement
+    user = user_client(owner, random_string('test_user'))
+    consumer_client = consumer_client(user, random_string('test_consumer'), :system, nil,
+      { 'system.certificate_version' => '3.0' })
+
+    entitlements = consumer_client.consume_pool(pools.first.id, { :quantity => 1 })
+    expect(entitlements.length).to eq(1)
+
+    consumer = @cp.get_consumer(consumer_client.uuid)
+    expect(consumer.entitlementCount).to eq(1)
+
+    entitlement = entitlements.first
+    ent_cert = entitlement['certificates'].first
+    ent_cert_serial = ent_cert['serial']['serial']
+
+    # Modify the product for this sub
+    update_upstream_product(product_id, { :name => 'updated_name' })
+
+    @cp.refresh_pools(owner_key)
+    pools = @cp.list_pools({:owner => owner.id})
+    expect(pools.length).to eq(1)
+
+    # Verify the product change has been pulled down
+    ds_product = @cp.get_product(owner_key, product_id)
+    expect(ds_product).to_not be_nil
+    expect(ds_product.name).to eq('updated_name')
+
+    # Verify the entitlement cert has changed as a result
+    updated_ent = @cp.get_entitlement(entitlement['id'])
+    updated_cert = updated_ent['certificates'].first
+    updated_cert_serial = updated_cert['serial']['serial']
+
+    expect(updated_cert_serial).to_not eq(ent_cert_serial)
+  end
+
+  it 'regenerates entitlements when required products change' do
+    owner_key = random_string('test_owner')
+    owner = create_owner(owner_key)
+
+    sku_id1 = random_string('required_prod', true)
+    sku_id2 = random_string('dependent_prod', true)
+    sku_prod1 = create_upstream_product(sku_id1)
+    sku_prod2 = create_upstream_product(sku_id2)
+
+    eng_id1 = random_string(nil, true)
+    eng_id2 = random_string(nil, true)
+    eng_prod1 = create_upstream_product(eng_id1)
+    eng_prod2 = create_upstream_product(eng_id2)
+
+    content_id1 = random_string('test_content_1')
+    content1 = create_upstream_content(content_id1, { :content_url => 'http://www.url.com/c1' })
+
+    content_id2 = random_string('test_content_2')
+    content2 = create_upstream_content(content_id2, { :content_url => 'http://www.url.com/c2' })
+
+    content_id3 = random_string('test_content_3')
+    content3 = create_upstream_content(content_id3, { :content_url => 'http://www.url.com/c3' })
+
+    add_content_to_product_upstream(eng_id1, content_id1)
+    add_content_to_product_upstream(eng_id2, content_id2)
+    add_content_to_product_upstream(eng_id2, content_id3)
+
+    sub_id1 = random_string('test_subscription_1')
+    sub1 = create_upstream_subscription(sub_id1, owner_key, sku_id1, { :provided_products => [eng_prod1] })
+
+    sub_id2 = random_string('test_subscription_2')
+    sub2 = create_upstream_subscription(sub_id2, owner_key, sku_id2, { :provided_products => [eng_prod2] })
+
+    @cp.refresh_pools(owner_key)
+    pools = @cp.list_pools({:owner => owner.id})
+    expect(pools.length).to eq(2)
+
+    # Rearrange the pools if they're backward
+    if pools.first.productId == sku_id2
+      pools[0], pools[1] = pools[1], pools[0]
+    end
+
+    products = @cp.list_products_by_owner(owner_key)
+    expect(products.length).to eq(4)
+
+    content = @cp.list_content(owner_key)
+    expect(content.length).to eq(3)
+
+    # Consume both pools
+    user = user_client(owner, random_string('test_user'))
+    consumer_client = consumer_client(user, random_string('test_consumer'), :system, nil,
+      { 'system.certificate_version' => '3.0' })
+
+    pool_ents = []
+
+    entitlements = consumer_client.consume_pool(pools[0].id, { :quantity => 1 })
+    expect(entitlements.length).to eq(1)
+    pool_ents << entitlements.first
+
+    entitlements = consumer_client.consume_pool(pools[1].id, { :quantity => 1 })
+    expect(entitlements.length).to eq(1)
+    pool_ents << entitlements.first
+
+    entitlements = @cp.list_entitlements({ :uuid => consumer_client.uuid })
+    expect(entitlements.length).to eq(2)
+
+    payload1 = extract_payload(pool_ents[0].certificates.first['cert'])
+    payload2 = extract_payload(pool_ents[1].certificates.first['cert'])
+
+    # Verify the entitlements contains the products and content
+    expect(payload1).to have_key('products')
+    expect(payload1.products.length).to eq(1)
+    expect(payload1.products.first.id).to eq(eng_id1)
+    expect(payload1.products.first).to have_key('content')
+    expect(payload1.products.first.content.length).to eq(1)
+    expect(payload1.products.first.content.first.id).to eq(content1.id)
+    expect(payload1.products.first.content.first.path).to eq(content1.contentUrl)
+
+    expect(payload2).to have_key('products')
+    expect(payload2.products.length).to eq(1)
+    expect(payload2.products.first).to have_key('content')
+    expect(payload2.products.first.id).to eq(eng_id2)
+    expect(payload2.products.first.content.length).to eq(2)
+
+    if payload2.products.first.content[0].id == content2.id
+      expect(payload2.products.first.content[0].id).to eq(content2.id)
+      expect(payload2.products.first.content[0].path).to eq(content2.contentUrl)
+      expect(payload2.products.first.content[1].id).to eq(content3.id)
+      expect(payload2.products.first.content[1].path).to eq(content3.contentUrl)
+    else
+      expect(payload2.products.first.content[0].id).to eq(content3.id)
+      expect(payload2.products.first.content[0].path).to eq(content3.contentUrl)
+      expect(payload2.products.first.content[1].id).to eq(content2.id)
+      expect(payload2.products.first.content[1].path).to eq(content2.contentUrl)
+    end
+
+    ent_cert = pool_ents[1]['certificates'].first
+    ent_cert_serial = ent_cert['serial']['serial']
+
+    # Add a dependent product to content2 for a product the consumer is entitled to
+    update_upstream_content(content_id2, { :modified_product_ids => [eng_id1] })
+    @cp.refresh_pools(owner_key)
+
+    # Verify the content change has been pulled down
+    content = @cp.get_content(owner_key, content_id2)
+    expect(content.modifiedProductIds).to eq([eng_id1])
+
+    # Verify the entitlement has been regenerated
+    updated_ent = @cp.get_entitlement(pool_ents[1]['id'])
+    updated_cert = updated_ent['certificates'].first
+    updated_cert_serial = updated_cert['serial']['serial']
+
+    expect(updated_cert_serial).to_not eq(ent_cert_serial)
+
+    # Verify the content path is still present in the entitlement
+    payload = extract_payload(updated_ent['certificates'].first['cert'])
+
+    expect(payload).to have_key('products')
+    expect(payload.products.length).to eq(1)
+    expect(payload.products.first).to have_key('content')
+    expect(payload.products.first.id).to eq(eng_id2)
+    expect(payload.products.first.content.length).to eq(2)
+
+    if payload.products.first.content[0].id == content2.id
+      expect(payload.products.first.content[0].id).to eq(content2.id)
+      expect(payload.products.first.content[0].path).to eq(content2.contentUrl)
+      expect(payload.products.first.content[1].id).to eq(content3.id)
+      expect(payload.products.first.content[1].path).to eq(content3.contentUrl)
+    else
+      expect(payload.products.first.content[0].id).to eq(content3.id)
+      expect(payload.products.first.content[0].path).to eq(content3.contentUrl)
+      expect(payload.products.first.content[1].id).to eq(content2.id)
+      expect(payload.products.first.content[1].path).to eq(content2.contentUrl)
+    end
+
+    # Add a dependent product to content3 for a product the consumer is NOT entitled to
+    update_upstream_content(content_id3, { :modified_product_ids => ['fake_pid'] })
+    @cp.refresh_pools(owner_key)
+
+    # Verify the content change has been pulled down
+    content = @cp.get_content(owner_key, content_id3)
+    expect(content.modifiedProductIds).to eq(['fake_pid'])
+
+    # Verify the entitlement has been regenerated
+    updated_ent = @cp.get_entitlement(pool_ents[1]['id'])
+    updated_cert = updated_ent['certificates'].first
+    updated_cert_serial = updated_cert['serial']['serial']
+
+    expect(updated_cert_serial).to_not eq(ent_cert_serial)
+
+    # Verify the content path is still present in the entitlement
+    payload = extract_payload(updated_ent['certificates'].first['cert'])
+
+    expect(payload).to have_key('products')
+    expect(payload.products.length).to eq(1)
+    expect(payload.products.first).to have_key('content')
+    expect(payload.products.first.id).to eq(eng_id2)
+    expect(payload.products.first.content.length).to eq(1)
+    expect(payload.products.first.content.first.id).to eq(content2.id)
+    expect(payload.products.first.content.first.path).to eq(content2.contentUrl)
   end
 
   def concat_serials(normal_ent, bonus_ent)
@@ -303,95 +656,131 @@ describe 'Refresh Pools' do
   end
 
   def test_entitlement_regeneration
-    @owner = create_owner random_string('test_owner')
-    @product = create_product(nil, nil, :attributes =>
-                {:version => '6.4',
-                 :arch => 'i386, x86_64',
-                 :sockets => 4,
-                 :cores => 8,
-                 :ram => 16,
-                 :warning_period => 15,
-                 :management_enabled => true,
-                 :stacking_id => '8888',
-		 :virt_limit => "unlimited",
-		 :host_limited => "true",
-                 :virt_only => 'false',
-                 :support_level => 'standard',
-                 :support_type => 'excellent',})
+    owner_key = random_string('test_owner')
+    owner = create_owner(owner_key)
 
-    @provided_product = create_product(nil, nil, :attributes =>
-                {:version => '6.4',
-                 :arch => 'i386, x86_64',
-                 :sockets => 4,
-                 :cores => 8,
-                 :ram => 16,
-                 :warning_period => 15,
-                 :management_enabled => true,
-                 :stacking_id => '8888',
-                 :virt_only => 'false',
-                 :support_level => 'standard',
-                 :support_type => 'excellent',})
-
-    @derived_provided_product = create_product(nil, nil, :attributes =>
-                {:version => '6.4',
-                 :arch => 'i386, x86_64',
-                 :sockets => 4,
-                 :cores => 8,
-                 :ram => 16,
-                 :warning_period => 15,
-                 :management_enabled => true,
-                 :stacking_id => '8888',
-                 :virt_only => 'false',
-                 :support_level => 'standard',
-                 :support_type => 'excellent',})
-
-    @derived_product = create_product(nil, "derived product 1", {
+    product = create_upstream_product(random_string(nil, true), {
+      :name => random_string('prod', true),
       :attributes => {
-          :cores => 2,
-          :sockets => 4
+        :version => '6.4',
+        :arch => 'i386, x86_64',
+        :sockets => 4,
+        :cores => 8,
+        :ram => 16,
+        :warning_period => 15,
+        :management_enabled => true,
+        :stacking_id => '8888',
+        :virt_limit => "unlimited",
+        :host_limited => "true",
+        :virt_only => 'false',
+        :support_level => 'standard',
+        :support_type => 'excellent'
       }
     })
 
-    @content = create_content({:gpg_url => 'gpg_url',
-                               :content_url => '/content/dist/rhel/$releasever/$basearch/os',
-                               :metadata_expire => 6400,
-                               :required_tags => 'TAG1,TAG2',})
-
-    @content2 = create_content({:gpg_url => 'gpg_url',
-                               :content_url => '/content/dist/rhel/$releasever/$basearch/os',
-                               :metadata_expire => 6400,
-                               :required_tags => 'TAG1,TAG2',})
-
-    @content3 = create_content({:gpg_url => 'gpg_url',
-                               :content_url => '/content/dist/rhel/$releasever/$basearch/os',
-                               :metadata_expire => 6400,
-                               :required_tags => 'TAG1,TAG2',})
-
-    @cp.add_content_to_product(@owner['key'], @product.id, @content.id, false)
-    @cp.add_content_to_product(@owner['key'], @provided_product.id, @content2.id, false)
-    @cp.add_content_to_product(@owner['key'], @derived_provided_product.id, @content3.id, false)
-
-    @pool = create_pool_and_subscription(@owner['key'], @product.id, 10, [@provided_product.id],
-					 '12345', '6789', 'order1', nil, nil, false,
-					 {:derived_product_id => @derived_product['id'],
-                                          :derived_provided_products => [@derived_provided_product.id]
-                                         })
-    sub = get_hostedtest_subscription(@pool['subscriptionId'])
-
-    @bonus_pool = @cp.list_owner_pools(@owner['key']).select {|p| p['type'] == 'UNMAPPED_GUEST' }[0]
-
-    # create an entitlement with a product and content
-    @user = user_client(@owner, random_string('billy'))
-    @system = consumer_client(@user, random_string('system1'), :system, nil,
-                {'system.certificate_version' => '3.3',
-                 'uname.machine' => 'i386'})
-    @guest = consumer_client(@user, 'virty', :system, nil, {
-      'virt.is_guest' => true,
-      'system.certificate_version' => '3.3'
+    prov_product = create_upstream_product(random_string(nil, true), {
+      :name => random_string('prov_prod', true),
+      :attributes => {
+        :version => '6.4',
+        :arch => 'i386, x86_64',
+        :sockets => 4,
+        :cores => 8,
+        :ram => 16,
+        :warning_period => 15,
+        :management_enabled => true,
+        :stacking_id => '8888',
+        :virt_only => 'false',
+        :support_level => 'standard',
+        :support_type => 'excellent'
+      }
     })
 
-    entitlement = @system.consume_pool(@pool['id'], {:quantity => 1})[0]
-    bonus_entitlement = @guest.consume_pool(@bonus_pool['id'], {:quantity => 1})[0]
+    der_product = create_upstream_product(random_string(nil, true), {
+      :name => random_string('der_prod', true),
+      :attributes => {
+        :cores => 2,
+        :sockets => 4
+      }
+    })
+
+    der_prov_product = create_upstream_product(random_string(nil, true), {
+      :name => random_string('der_prov_prod', true),
+      :attributes => {
+        :version => '6.4',
+        :arch => 'i386, x86_64',
+        :sockets => 4,
+        :cores => 8,
+        :ram => 16,
+        :warning_period => 15,
+        :management_enabled => true,
+        :stacking_id => '8888',
+        :virt_only => 'false',
+        :support_level => 'standard',
+        :support_type => 'excellent'
+      }
+    })
+
+    content_id1 = random_string('test_content_1')
+    content1 = create_upstream_content(content_id1, {
+      :gpg_url => 'gpg_url',
+      :content_url => '/content/dist/rhel/$releasever/$basearch/os',
+      :metadata_expire => 6400,
+      :required_tags => 'TAG1,TAG2'
+    })
+
+    content_id2 = random_string('test_content_2')
+    content2 = create_upstream_content(content_id2, {
+      :gpg_url => 'gpg_url',
+      :content_url => '/content/dist/rhel/$releasever/$basearch/os',
+      :metadata_expire => 6400,
+      :required_tags => 'TAG1,TAG2'
+    })
+
+    content_id3 = random_string('test_content_3')
+    content3 = create_upstream_content(content_id3, {
+      :gpg_url => 'gpg_url',
+      :content_url => '/content/dist/rhel/$releasever/$basearch/os',
+      :metadata_expire => 6400,
+      :required_tags => 'TAG1,TAG2'
+    })
+
+    add_content_to_product_upstream(product.id, content_id1, false)
+    add_content_to_product_upstream(prov_product.id, content_id2, false)
+    add_content_to_product_upstream(der_prov_product.id, content_id3, false)
+
+    sub_id = random_string('test_subscription_1')
+    sub = create_upstream_subscription(sub_id, owner_key, product.id, {
+      :quantity => 10,
+      :contract_number => '12345',
+      :account_number => '6789',
+      :order_number => 'order1',
+      :provided_products => [prov_product],
+      :derived_product => der_product,
+      :derived_provided_products => [der_prov_product]
+    })
+
+    @cp.refresh_pools(owner_key)
+    pools = @cp.list_pools({:owner => owner.id})
+    expect(pools.length).to eq(2) # Expecting base pool + bonus pool
+
+    pool = pools.select {|p| p['type'] != 'UNMAPPED_GUEST' }[0]
+    bonus_pool = pools.select {|p| p['type'] == 'UNMAPPED_GUEST' }[0]
+
+
+    # create an entitlement with a product and content
+    user = user_client(owner, random_string('billy'))
+    system = consumer_client(user, random_string('system1'), :system, nil, {
+      'system.certificate_version' => '3.3',
+      'uname.machine' => 'i386'
+    })
+
+    guest = consumer_client(user, 'virty', :system, nil, {
+      'system.certificate_version' => '3.3',
+      'virt.is_guest' => true
+    })
+
+    entitlement = system.consume_pool(pool['id'], {:quantity => 1})[0]
+    bonus_entitlement = guest.consume_pool(bonus_pool['id'], {:quantity => 1})[0]
 
     json_body = extract_payload(entitlement['certificates'][0]['cert'])
     bonus_json_body = extract_payload(bonus_entitlement['certificates'][0]['cert'])
@@ -399,151 +788,193 @@ describe 'Refresh Pools' do
     serial_concat = concat_serials(entitlement, bonus_entitlement)
 
     # verify serial does not change on simple refresh
-    @cp.refresh_pools(@owner['key'], false, false, false)
+    @cp.refresh_pools(owner_key, false, false, false)
     entitlement =  @cp.get_entitlement(entitlement['id'])
     bonus_entitlement =  @cp.get_entitlement(bonus_entitlement['id'])
 
     concat_serials(entitlement, bonus_entitlement).should == serial_concat
 
-    # modify sub object, update upstream sub but dont refresh
-    sub = yield(sub, @owner)
-    update_pool_or_subscription(sub, false)
+    # Yield to encapsulating test, applying any change it may have made
+    sub = yield(owner, sub)
+    update_upstream_subscription(sub.id, sub)
 
     # verify serial does not change on content update request that does not regenerate cert
     entitlement =  @cp.get_entitlement(entitlement['id'])
     bonus_entitlement =  @cp.get_entitlement(bonus_entitlement['id'])
     concat_serials(entitlement, bonus_entitlement).should == serial_concat
+
     # this time when we refresh, serial should change
-    @cp.refresh_pools(@owner['key'], false, false, false)
+    @cp.refresh_pools(owner_key, false, false, false)
     entitlement =  @cp.get_entitlement(entitlement['id'])
     bonus_entitlement =  @cp.get_entitlement(bonus_entitlement['id'])
     concat_serials(entitlement, bonus_entitlement).should_not == serial_concat
     json_body = extract_payload(entitlement['certificates'][0]['cert'])
-    return json_body, @product
+
+    return json_body, product
   end
 
   it 'regenerates entitlements when modifiedProductIds of content change' do
-    test_entitlement_regeneration { |sub, owner|
-      prod_id_2 = random_string('modifying_prod')
-      create_product(prod_id_2, prod_id_2, {
-        :owner => owner['key']
-      })
-      sub['product']['productContent'][0]['content']['modifiedProductIds'] = [prod_id_2]
-      sub
+    test_entitlement_regeneration { |owner, subscription|
+      product_id2 = random_string(nil, true)
+      product2 = create_upstream_product(product_id2, { :name => 'test_prod_2' })
+
+      content = subscription['product']['productContent'].first['content']
+      content.modifiedProductIds = [product_id2]
+      update_upstream_content(content.id, content)
+
+      subscription
     }
   end
 
   it 'regenerates entitlements when modifiedProductIds of content of a provided product change' do
-    test_entitlement_regeneration { |sub, owner|
-      prod_id_2 = random_string('modifying_prod')
-      create_product(prod_id_2, prod_id_2, {
-        :owner => owner['key']
-      })
-      sub['providedProducts'][0]['productContent'][0]['content']['modifiedProductIds'] = [prod_id_2]
-      sub
+    test_entitlement_regeneration { |owner, subscription|
+      product_id2 = random_string(nil, true)
+      product2 = create_upstream_product(product_id2, { :name => 'test_prod_2' })
+
+      content = subscription['providedProducts'][0]['productContent'][0]['content']
+      content.modifiedProductIds = [product_id2]
+      update_upstream_content(content.id, content)
+
+      subscription
     }
   end
 
   it 'regenerates entitlements when modifiedProductIds of content of a derived provided product change' do
-    test_entitlement_regeneration { |sub, owner|
-      prod_id_2 = random_string('modifying_prod')
-      create_product(prod_id_2, prod_id_2, {
-        :owner => owner['key']
-      })
-      sub['derivedProvidedProducts'][0]['productContent'][0]['content']['modifiedProductIds'] = [prod_id_2]
-      sub
+    test_entitlement_regeneration { |owner, subscription|
+      product_id2 = random_string(nil, true)
+      product2 = create_upstream_product(product_id2, { :name => 'test_prod_2' })
+
+      content = subscription['derivedProvidedProducts'][0]['productContent'][0]['content']
+      content.modifiedProductIds = [product_id2]
+      update_upstream_content(content.id, content)
+
+      subscription
     }
   end
 
   it 'regenerates entitlements when provided product is added' do
-    pp_name = random_string('pp_name')
-    pp_id = random_string(nil, true)
-    json_body, main_product = test_entitlement_regeneration { |sub, owner|
-      pp = create_product(pp_id, pp_name, {:attributes =>
-                  {:version => '6.4',
-                   :arch => 'i386, x86_64',
-                   :sockets => 4,
-                   :cores => 8,
-                   :ram => 16,
-                   :warning_period => 15,
-                   :management_enabled => true,
-                   :stacking_id => '8888',
-                   :virt_only => 'false',
-                   :support_level => 'standard',
-                   :support_type => 'excellent',}, :owner => owner['key']})
-      pp_content = create_content({:gpg_url => 'gpg_url',
-                   :content_url => '/content/dist/rhel/$releasever/$basearch/os',
-                   :metadata_expire => 6400,
-                   :required_tags => 'TAG1,TAG2',})
-      pp['productContent'] = [{'content' => pp_content, 'enabled' => 'true'}]
-      sub['providedProducts'].push(pp)
-      sub
+    prov_product_id = random_string(nil, true)
+
+    json_body, main_product = test_entitlement_regeneration { |owner, subscription|
+      prov_product = create_upstream_product(prov_product_id, {
+        :name => 'test_prov_prod',
+        :version => '6.4',
+        :arch => 'i386, x86_64',
+        :sockets => 4,
+        :cores => 8,
+        :ram => 16,
+        :warning_period => 15,
+        :management_enabled => true,
+        :stacking_id => '8888',
+        :virt_only => 'false',
+        :support_level => 'standard',
+        :support_type => 'excellent'
+      })
+
+      content_id = random_string('test_content_')
+      content = create_upstream_content(content_id, {
+        :gpg_url => 'gpg_url',
+        :content_url => '/content/dist/rhel/$releasever/$basearch/os',
+        :metadata_expire => 6400,
+        :required_tags => 'TAG1,TAG2'
+      })
+
+      add_content_to_product_upstream(prov_product.id, content_id)
+
+      subscription['providedProducts'].push(prov_product)
+
+      subscription
     }
-    pp = json_body['products'].find {|p| p['id'] == pp_id}
-    pp['name'].should == pp_name
+
+    prov_product = json_body['products'].find {|p| p['id'] == prov_product_id}
+    expect(prov_product).to_not be_nil
   end
 
   it 'regenerates entitlements when provided product is removed' do
-    json_body, main_product = test_entitlement_regeneration { |sub, owner|
-      sub['providedProducts'] = []
-      sub
+    json_body, main_product = test_entitlement_regeneration { |owner, subscription|
+      subscription['providedProducts'] = []
+      subscription
     }
+
     json_body['products'].size.should == 1
   end
 
   it 'regenerates entitlements when label of a content changes' do
-    json_body, main_product = test_entitlement_regeneration { |sub, owner|
-      sub['product']['productContent'][0]['content']['label'] = 'shakeItOff'
-      sub
+    json_body, main_product = test_entitlement_regeneration { |owner, subscription|
+      content = subscription['product']['productContent'].first['content']
+      content.label = 'shakeItOff'
+      update_upstream_content(content.id, content)
+
+      subscription
     }
+
     product_json = json_body['products'].find {|p| p['id'] == main_product['id']}
     product_json['content'][0]['label'].should == 'shakeItOff'
   end
 
   it 'regenerates entitlements when releaseVer of a content changes' do
-    test_entitlement_regeneration { |sub|
-      sub['product']['productContent'][0]['content']['releaseVer'] = 'badBlood'
-      sub
+    test_entitlement_regeneration { |owner, subscription|
+      content = subscription['product']['productContent'].first['content']
+      content.releaseVer = 'badBlood'
+      update_upstream_content(content.id, content)
+
+      subscription
     }
+
     # releasever is not in json
   end
 
   it 'regenerates entitlements when vendor of a content changes' do
-    json_body, main_product = test_entitlement_regeneration { |sub|
-      sub['product']['productContent'][0]['content']['vendor'] = 'blankSpace'
-      sub
+    json_body, main_product = test_entitlement_regeneration { |owner, subscription|
+      content = subscription['product']['productContent'].first['content']
+      content.vendor = 'blankSpace'
+      update_upstream_content(content.id, content)
+
+      subscription
     }
+
     product_json = json_body['products'].find {|p| p['id'] == main_product['id']}
     product_json['content'][0]['vendor'].should == 'blankSpace'
   end
 
   it 'regenerates entitlements when adding a content' do
-    json_body, main_product = test_entitlement_regeneration { |sub|
-      productContent =
-        { "content"=>{ "created"=>"2017-11-24T13:41:39+0000",
-		       "updated"=>"2017-11-24T13:41:39+0000",
-		       "uuid"=>"theStroyOfUs",
-		       "id"=>"twentyTwo",
-		       "type"=>"yum",
-		       "label"=>"teardropsOnMyGuitar",
-		       "name"=>"swiftrocks",
-		       "vendor"=>"fifteen",
-		       "releaseVer"=>nil},
-          "enabled"=>true }
+    json_body, main_product = test_entitlement_regeneration { |owner, subscription|
+      product = subscription['product']
 
-      sub['product']['productContent'].push(productContent)
-      sub
+      content = create_upstream_content("twentyTwo", {
+        :type => "yum",
+        :label => "teardropsOnMyGuitar",
+        :name => "swiftrocks",
+        :vendor => "fifteen",
+        :releaseVer => nil
+      })
+
+      add_content_to_product_upstream(product.id, content.id)
+
+      # Need to return the updated, upstream subscription here so we don't risk clobbering the addition.
+      # We shouldn't, anyway, but there's no need to risk it unnecessarily.
+      get_upstream_subscription(subscription.id)
     }
+
     product_json = json_body['products'].find {|p| p['id'] == main_product['id']}
     content = product_json['content'].find {|c| c['id'] == 'twentyTwo'}
-    content['name'].should == 'swiftrocks'
+
+    expect(content).to_not be_nil
+    expect(content['name']).to eq('swiftrocks')
   end
 
-  it 'regenerates entitlements when deleting a content' do
-    json_body, main_product = test_entitlement_regeneration { |sub|
-      sub['product']['productContent'] = []
-      sub
+  it 'regenerates entitlements when deleting content' do
+    json_body, main_product = test_entitlement_regeneration { |owner, subscription|
+      product = subscription['product']
+      content = product['productContent'].first['content']
+
+      remove_content_from_product_upstream(product.id, content.id)
+
+      # Need to return the updated, upstream subscription here so we don't risk clobbering the removal.
+      # We shouldn't, anyway, but there's no need to risk it unnecessarily.
+      get_upstream_subscription(subscription.id)
     }
+
     product_json = json_body['products'].find {|p| p['id'] == main_product['id']}
     product_json['content'].should == []
   end

--- a/server/spec/role_resource_spec.rb
+++ b/server/spec/role_resource_spec.rb
@@ -24,20 +24,26 @@ describe 'Role Resource' do
       end.should raise_exception(RestClient::Forbidden)
   end
 
-
   it 'should update just the name' do
-    new_role = create_role('testrole', @test_owner['key'], 'ALL')
-    new_role['name'] = 'testroleupdated'
-    perm = {
-      :owner => @test_owner['key'],
-      :access => 'READ_ONLY',
-    }
-    new_role.permissions[0] = perm
+    role_name = random_string("test_role")
+    updated_name = "#{role_name}-updated"
 
-    @cp.update_role(new_role)
-    updatedrole = @cp.get_role(new_role['id'])
-    updatedrole['name'].should == 'testroleupdated'
-    updatedrole.permissions[0].access.should == 'ALL'
+    new_role = create_role(role_name, @test_owner['key'], 'ALL')
+    new_role['name'] = updated_name
+    # perm = {
+    #   :type => 'OWNER',
+    #   :owner => {:key => @test_owner['key']},
+    #   :access => 'READ_ONLY',
+    # }
+    # new_role.permissions[0] = perm
+
+    @cp.update_role(role_name, new_role)
+    updatedrole = @cp.get_role(new_role['name'])
+    expect(updatedrole['name']).to eq(updated_name)
+    # updatedrole.permissions[0].access.should == 'ALL'
+
+    # TODO: Figure out why whoever wrote this test expected it to not update the role's permissions after
+    # providing a new permission during the update.
   end
 
   it 'should delete roles' do
@@ -49,7 +55,7 @@ describe 'Role Resource' do
     role_name = random_string("role_to_delete")
     new_role = @cp.create_role(role_name, perms)
     @cp.list_roles().map { |i| i['name'] }.should include(role_name)
-    @cp.delete_role(new_role['id'])
+    @cp.delete_role(new_role['name'])
     @cp.list_roles().map { |i| i['name'] }.should_not include(role_name)
   end
 
@@ -57,42 +63,43 @@ describe 'Role Resource' do
     role = create_role(nil, @test_owner['key'], 'ALL')
     role['users'].size.should == 0
 
-    role = @cp.add_role_user(role['id'], @username)
+    role = @cp.add_role_user(role['name'], @username)
     role['users'].size.should == 1
 
-    role = @cp.get_role(role['id'])
+    role = @cp.get_role(role['name'])
     role['users'].size.should == 1
 
-    @cp.delete_role_user(role['id'], @username)
-    next_role = @cp.get_role(role['id'])
+    @cp.delete_role_user(role['name'], @username)
+    next_role = @cp.get_role(role['name'])
     next_role['users'].size.should == 0
   end
 
   it 'should add a new permission to a role, then delete the original permission' do
-
     perms = [{
       :type => 'OWNER',
       :owner => {:key => @test_owner['key']},
       :access => 'ALL',
     }]
+
     new_role = @cp.create_role(random_string('testrole'), perms)
     role_perm = new_role.permissions[0]
 
     perm = {
       :type => 'OWNER',
-      :owner => @test_owner['key'],
+      :owner => {:key => @test_owner['key']},
       :access => 'READ_ONLY',
     }
-    @cp.add_role_permission(new_role['id'], perm)
-    role = @cp.get_role(new_role['id'])
+
+    @cp.add_role_permission(new_role['name'], perm)
+    role = @cp.get_role(new_role['name'])
     role.permissions.size.should == 2
 
-    @cp.delete_role_permission(role['id'], role_perm['id'])
-    role = @cp.get_role(new_role['id'])
+    @cp.delete_role_permission(role['name'], role_perm['id'])
+    role = @cp.get_role(new_role['name'])
     role.permissions.size.should == 1
     role.permissions[0].access.should == 'READ_ONLY'
 
-    @cp.delete_role(new_role['id'])
+    @cp.delete_role(new_role['name'])
   end
 
 end

--- a/server/spec/spec_helper.rb
+++ b/server/spec/spec_helper.rb
@@ -15,7 +15,7 @@ module CleanupHooks
   end
 
   def cleanup_after
-    @roles.reverse_each { |r| @cp.delete_role r['id'] }
+    @roles.reverse_each { |r| @cp.delete_role r['name'] }
     @owners.reverse_each { |owner| @cp.delete_owner(owner['key'], true, true) }
     @users.reverse_each { |user| @cp.delete_user user['username'] }
     @dist_versions.reverse_each { |dist_version| @cp.delete_distributor_version dist_version['id'] }
@@ -28,7 +28,7 @@ module CleanupHooks
 
     if !@cp.get_status()['standalone']
       begin
-        @cp.delete('/hostedtest/subscriptions/', {}, nil, true)
+        @cp.delete('/hostedtest/', {}, nil, true)
       rescue RestClient::ResourceNotFound
         puts "skipping hostedtest cleanup"
       end

--- a/server/spec/system_admin_spec.rb
+++ b/server/spec/system_admin_spec.rb
@@ -141,6 +141,7 @@ describe 'System admins with read-only on org' do
         :owner => {:key => @owner['key']},
       }
     ]
+
     @username = random_string 'user'
     @user_cp = user_client_with_perms(@username, 'password', perms)
 

--- a/server/spec/user_resource_spec.rb
+++ b/server/spec/user_resource_spec.rb
@@ -68,7 +68,7 @@ describe 'User Resource' do
     }]
 
     new_role = @cp.create_role(random_string('testrole'), new_perm)
-    @cp.add_role_user(new_role['id'], alice)
+    @cp.add_role_user(new_role['name'], alice)
 
     #make sure we see the extra role
     roles = alice_cp.get_user_roles(alice)
@@ -77,7 +77,7 @@ describe 'User Resource' do
     bob = random_string 'user'
     bob_cp = user_client(@test_owner, bob)
 
-    @cp.add_role_user(new_role['id'], bob)
+    @cp.add_role_user(new_role['name'], bob)
     roles = bob_cp.get_user_roles(bob)
     roles.size.should == 2
     roles.each { |role|
@@ -85,7 +85,7 @@ describe 'User Resource' do
     }
 
     #admin should see both users on the role obj (note the different API call)
-    userlist = @cp.get_role(new_role['id'])['users']
+    userlist = @cp.get_role(new_role['name'])['users']
     userlist.select { |u| u['username'] == alice }.should_not be_empty
     userlist.select { |u| u['username'] == bob }.should_not be_empty
 

--- a/server/src/main/java/org/candlepin/auth/BasicAuth.java
+++ b/server/src/main/java/org/candlepin/auth/BasicAuth.java
@@ -14,6 +14,7 @@
  */
 package org.candlepin.auth;
 
+import org.candlepin.auth.permissions.PermissionFactory;
 import org.candlepin.common.exceptions.CandlepinException;
 import org.candlepin.common.exceptions.NotAuthorizedException;
 import org.candlepin.common.exceptions.ServiceUnavailableException;
@@ -38,8 +39,10 @@ public class BasicAuth extends UserAuth {
     private static Logger log = LoggerFactory.getLogger(BasicAuth.class);
 
     @Inject
-    BasicAuth(UserServiceAdapter userServiceAdapter, Provider<I18n> i18n) {
-        super(userServiceAdapter, i18n);
+    BasicAuth(UserServiceAdapter userServiceAdapter, Provider<I18n> i18nProvider,
+        PermissionFactory permissionFactory) {
+
+        super(userServiceAdapter, i18nProvider, permissionFactory);
     }
 
     @Override
@@ -68,7 +71,7 @@ public class BasicAuth extends UserAuth {
                     return principal;
                 }
                 else {
-                    throw new NotAuthorizedException(i18n.get().tr("Invalid Credentials"));
+                    throw new NotAuthorizedException(i18nProvider.get().tr("Invalid Credentials"));
                 }
             }
         }
@@ -82,7 +85,7 @@ public class BasicAuth extends UserAuth {
             if (log.isDebugEnabled()) {
                 log.debug("Error getting principal " + e);
             }
-            throw new ServiceUnavailableException(i18n.get().tr("Error contacting user service"));
+            throw new ServiceUnavailableException(i18nProvider.get().tr("Error contacting user service"));
         }
         return null;
     }

--- a/server/src/main/java/org/candlepin/auth/TrustedUserAuth.java
+++ b/server/src/main/java/org/candlepin/auth/TrustedUserAuth.java
@@ -14,6 +14,7 @@
  */
 package org.candlepin.auth;
 
+import org.candlepin.auth.permissions.PermissionFactory;
 import org.candlepin.common.resteasy.auth.AuthUtil;
 import org.candlepin.service.UserServiceAdapter;
 
@@ -31,15 +32,16 @@ import javax.inject.Provider;
  * This should be used only if the environment is known to be secure
  */
 public class TrustedUserAuth extends UserAuth {
+    private static Logger log = LoggerFactory.getLogger(TrustedUserAuth.class);
 
     public static final String USER_HEADER = "cp-user";
     public static final String LOOKUP_PERMISSIONS_HEADER = "cp-lookup-permissions";
 
-    private static Logger log = LoggerFactory.getLogger(TrustedUserAuth.class);
-
     @Inject
-    TrustedUserAuth(UserServiceAdapter userServiceAdaper, Provider<I18n> i18n) {
-        super(userServiceAdaper, i18n);
+    TrustedUserAuth(UserServiceAdapter userServiceAdaper, Provider<I18n> i18n,
+        PermissionFactory permissionFactory) {
+
+        super(userServiceAdaper, i18n, permissionFactory);
     }
 
     public Principal getPrincipal(HttpRequest httpRequest) {

--- a/server/src/main/java/org/candlepin/auth/UserPrincipal.java
+++ b/server/src/main/java/org/candlepin/auth/UserPrincipal.java
@@ -36,8 +36,7 @@ public class UserPrincipal extends Principal {
      *
      * @param username
      */
-    public UserPrincipal(String username, Collection<Permission> permissions,
-        Boolean admin) {
+    public UserPrincipal(String username, Collection<Permission> permissions, boolean admin) {
         this.username = username;
         this.admin = admin;
 
@@ -134,11 +133,7 @@ public class UserPrincipal extends Principal {
 
     @Override
     public boolean canAccess(Object target, SubResource subResource, Access access) {
-        if (this.admin) {
-            return true;
-        }
-
-        return super.canAccess(target, subResource, access);
+        return this.hasFullAccess() || super.canAccess(target, subResource, access);
     }
 
 }

--- a/server/src/main/java/org/candlepin/auth/permissions/ConsumerEntitlementPermission.java
+++ b/server/src/main/java/org/candlepin/auth/permissions/ConsumerEntitlementPermission.java
@@ -41,8 +41,7 @@ public class ConsumerEntitlementPermission extends TypedPermission<Entitlement> 
     }
 
     @Override
-    public boolean canAccessTarget(Entitlement target, SubResource subResource,
-        Access required) {
+    public boolean canAccessTarget(Entitlement target, SubResource subResource, Access required) {
         return target.getConsumer().getUuid().equals(consumer.getUuid());
     }
 

--- a/server/src/main/java/org/candlepin/auth/permissions/ConsumerOrgHypervisorPermission.java
+++ b/server/src/main/java/org/candlepin/auth/permissions/ConsumerOrgHypervisorPermission.java
@@ -21,6 +21,8 @@ import org.candlepin.model.Owner;
 import org.hibernate.criterion.Criterion;
 import org.hibernate.criterion.Restrictions;
 
+
+
 /**
  * ConsumerOrgHypervisorPermission
  * Permission allowing consumers to check in hypervisors for their owner.
@@ -42,8 +44,7 @@ public class ConsumerOrgHypervisorPermission extends TypedPermission<Owner> {
     }
 
     @Override
-    public boolean canAccessTarget(Owner target, SubResource subResource,
-        Access required) {
+    public boolean canAccessTarget(Owner target, SubResource subResource, Access required) {
         return subResource.equals(SubResource.HYPERVISOR) &&
             Access.READ_ONLY.provides(required) &&
             this.owner.getKey().equals(target.getKey());
@@ -54,6 +55,7 @@ public class ConsumerOrgHypervisorPermission extends TypedPermission<Owner> {
         if (entityClass.equals(Owner.class)) {
             return Restrictions.eq("key", owner.getKey());
         }
+
         return null;
     }
 

--- a/server/src/main/java/org/candlepin/auth/permissions/OwnerPermission.java
+++ b/server/src/main/java/org/candlepin/auth/permissions/OwnerPermission.java
@@ -47,12 +47,10 @@ public class OwnerPermission implements Permission, Serializable {
     }
 
     @Override
-    public boolean canAccess(Object target, SubResource subResource,
-        Access requiredAccess) {
+    public boolean canAccess(Object target, SubResource subResource, Access requiredAccess) {
         if (target instanceof Owned) {
             // First make sure the owner matches:
-            if (owner.getId().equals(((Owned) target).getOwnerId()) &&
-                access.provides(requiredAccess)) {
+            if (owner.getId().equals(((Owned) target).getOwnerId()) && access.provides(requiredAccess)) {
                 return true;
             }
         }

--- a/server/src/main/java/org/candlepin/auth/permissions/OwnerPoolsPermission.java
+++ b/server/src/main/java/org/candlepin/auth/permissions/OwnerPoolsPermission.java
@@ -25,7 +25,7 @@ import org.hibernate.criterion.Criterion;
  */
 public class OwnerPoolsPermission extends TypedPermission<Owner> {
 
-    private Owner owner;
+    private final Owner owner;
 
     public OwnerPoolsPermission(Owner owner) {
         this.owner = owner;
@@ -38,8 +38,7 @@ public class OwnerPoolsPermission extends TypedPermission<Owner> {
     }
 
     @Override
-    public boolean canAccessTarget(Owner target, SubResource subResource,
-        Access required) {
+    public boolean canAccessTarget(Owner target, SubResource subResource, Access required) {
         return target.getKey().equals(owner.getKey()) &&
             (subResource.equals(SubResource.POOLS) ||
                 subResource.equals(SubResource.SUBSCRIPTIONS)) &&

--- a/server/src/main/java/org/candlepin/auth/permissions/Permission.java
+++ b/server/src/main/java/org/candlepin/auth/permissions/Permission.java
@@ -20,6 +20,8 @@ import org.candlepin.model.Owner;
 
 import org.hibernate.criterion.Criterion;
 
+
+
 /**
  *
  */

--- a/server/src/main/java/org/candlepin/auth/permissions/PermissionFactory.java
+++ b/server/src/main/java/org/candlepin/auth/permissions/PermissionFactory.java
@@ -14,20 +14,34 @@
  */
 package org.candlepin.auth.permissions;
 
-import org.candlepin.model.PermissionBlueprint;
-import org.candlepin.model.User;
+import org.candlepin.auth.Access;
+import org.candlepin.model.Owner;
+import org.candlepin.model.OwnerCurator;
+import org.candlepin.service.model.PermissionBlueprintInfo;
+import org.candlepin.service.model.OwnerInfo;
+import org.candlepin.service.model.RoleInfo;
+import org.candlepin.service.model.UserInfo;
 
-import com.google.inject.Inject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import javax.inject.Singleton;
+import javax.inject.Inject;
+
+
 
 /**
- * PermissionFactory: Creates concrete Java permission classes based on the
- * permission blueprints from the database.
+ * PermissionFactory: Creates concrete Java permission classes based on the provided permission info
  */
+@Singleton
 public class PermissionFactory {
+    private static Logger log = LoggerFactory.getLogger(PermissionFactory.class);
 
     /**
      * PermissionType: Key used to determine which class to create.
@@ -37,45 +51,227 @@ public class PermissionFactory {
         OWNER_POOLS,
         USERNAME_CONSUMERS,
         USERNAME_CONSUMERS_ENTITLEMENTS,
-        ATTACH
+        ATTACH,
+        OWNER_HYPERVISORS
     }
+
+    /**
+     * Performs simple resolution of various entities needed by the permissions. A new instance
+     * should be created for each instance
+     *
+     * @deprecated
+     *  This is a temporary class used purely to perform fast resolution in lieu of a proper
+     *  resolution utility. It should not be carried forward any further than absolutely
+     *  necessary, and should be replaced by a proper resolver as soon as possible.
+     */
+    @Deprecated
+    protected static class Resolver {
+
+        protected OwnerCurator ownerCurator;
+        protected Map<String, Owner> ownerCache;
+
+        public Resolver(OwnerCurator ownerCurator) {
+            this.ownerCurator = ownerCurator;
+            this.ownerCache = new HashMap<>();
+        }
+
+        public Owner resolve(OwnerInfo oinfo) {
+            if (oinfo != null) {
+                // If it's already an Owner instance, just cast it.
+                if (oinfo instanceof Owner) {
+                    return (Owner) oinfo;
+                }
+
+                // Nope. Guess we need to resolve it...
+                Owner owner = this.ownerCache.get(oinfo.getKey());
+
+                if (owner == null) {
+                    owner = this.ownerCurator.getByKey(oinfo.getKey());
+
+                    if (owner == null) {
+                        throw new IllegalStateException("No such owner: " + oinfo.getKey());
+                    }
+
+                    ownerCache.put(owner.getKey(), owner);
+                    return owner;
+                }
+            }
+
+            return null;
+        }
+    }
+
+
+    /**
+     * Micro-interface used to create simple permission builders from a user and a permission
+     * blueprint.
+     */
+    @FunctionalInterface
+    public interface PermissionBuilder {
+        Permission build(UserInfo user, PermissionBlueprintInfo blueprint, Resolver resolver);
+    }
+
+    protected Map<String, PermissionBuilder> builders;
+
+    protected OwnerCurator ownerCurator;
 
     @Inject
-    public PermissionFactory() {
+    public PermissionFactory(OwnerCurator ownerCurator) {
+        this.ownerCurator = ownerCurator;
+
+        this.initBuilders();
     }
 
-    public List<Permission> createPermissions(User user,
-        Collection<PermissionBlueprint> dbPerms) {
-        List<Permission> perms = new LinkedList<>();
-        for (PermissionBlueprint hint : dbPerms) {
-            perms.add(createPermission(user, hint));
-        }
-        return perms;
+    /**
+     * Initializes the permission builders used by this factory.
+     */
+    @SuppressWarnings("checkstyle:indentation")
+    protected void initBuilders() {
+        this.builders = new HashMap<>();
+
+        this.builders.put(PermissionType.OWNER.name(),
+            (user, bp, r) -> new OwnerPermission(r.resolve(bp.getOwner()),
+                Access.valueOf(bp.getAccessLevel())));
+
+        this.builders.put(PermissionType.OWNER_POOLS.name(),
+            (user, bp, r) -> new OwnerPoolsPermission(r.resolve(bp.getOwner())));
+
+        this.builders.put(PermissionType.USERNAME_CONSUMERS.name(),
+            (user, bp, r) -> new UsernameConsumersPermission(user, r.resolve(bp.getOwner())));
+
+        // At the time of writing, no matching permission exists for USERNAME_CONSUMERS_ENTITLEMENTS
+
+        this.builders.put(PermissionType.ATTACH.name(),
+            (user, bp, r) -> new AttachPermission(r.resolve(bp.getOwner())));
+
+        this.builders.put(PermissionType.OWNER_HYPERVISORS.name(),
+            (user, bp, r) -> new ConsumerOrgHypervisorPermission(r.resolve(bp.getOwner())));
     }
 
-    public Permission createPermission(User user, PermissionBlueprint permBp) {
-        switch (permBp.getType()) {
-        // TODO: what if an entity isn't found?
-            case OWNER:
-                Permission p = new OwnerPermission(permBp.getOwner(),
-                    permBp.getAccess());
-                return p;
-
-            case USERNAME_CONSUMERS:
-                Permission usernamePerm = new UsernameConsumersPermission(user,
-                    permBp.getOwner());
-                return usernamePerm;
-
-            case OWNER_POOLS:
-                Permission ownerPools = new OwnerPoolsPermission(permBp.getOwner());
-                return ownerPools;
-
-            case ATTACH:
-                Permission attach = new AttachPermission(permBp.getOwner());
-                return attach;
-
-            default:
-                return null; // TODO
+    /**
+     * Converts the provided permission blueprint into a concrete permission for the given user.
+     *
+     * @param user
+     *  The user info of the user for which to create a permission
+     *
+     * @param blueprint
+     *  The permission blueprint to use to create the permission
+     *
+     * @throws IllegalArgumentException
+     *  if user is null
+     *
+     * @return
+     *  A concrete permission based on the provided user and permission blueprint
+     */
+    public Permission createPermission(UserInfo user, PermissionBlueprintInfo blueprint) {
+        if (user == null) {
+            throw new IllegalArgumentException("user is null");
         }
+
+        return this.createPermissionImpl(user, blueprint, new Resolver(this.ownerCurator));
+    }
+
+    /**
+     * Converts the provided permission info into concrete permissions for the given user. If the
+     * provided permission blueprints do not result in any explicit permissions for the given user,
+     * this method returns an empty collection.
+     *
+     * @param user
+     *  The user info of the user for which to create a permission
+     *
+     * @param blueprints
+     *  A collection of permission blueprints to use to create the concrete permissions
+     *
+     * @throws IllegalArgumentException
+     *  if user is null
+     *
+     * @return
+     *  A collection of concrete permissions based on the provided user and permission info
+     */
+    public Collection<Permission> createPermissions(UserInfo user,
+        Collection<? extends PermissionBlueprintInfo> blueprints) {
+
+        if (user == null) {
+            throw new IllegalArgumentException("user is null");
+        }
+
+        Set<Permission> translated = new HashSet<>();
+
+        if (blueprints != null) {
+            Resolver resolver = new Resolver(this.ownerCurator);
+
+            for (PermissionBlueprintInfo pbinfo : blueprints) {
+                Permission permission = this.createPermissionImpl(user, pbinfo, resolver);
+
+                if (permission != null) {
+                    translated.add(permission);
+                }
+            }
+        }
+
+        return translated;
+    }
+
+    /**
+     * Performs the work of permission creation for the given user and permission blueprint. Should
+     * only be called after the inputs have been validated elsewhere.
+     *
+     * @param user
+     *  The user info of the user for which to create a permission
+     *
+     * @param blueprint
+     *  The permission blueprint to use to create the permission
+     *
+     * @param resolver
+     *  The entity resolver to use during permission creation
+     *
+     * @return
+     *  A concrete permission based on the provided user and permission blueprint
+     */
+    private Permission createPermissionImpl(UserInfo user, PermissionBlueprintInfo blueprint,
+        Resolver resolver) {
+
+        if (blueprint != null) {
+            PermissionBuilder builder = this.builders.get(blueprint.getTypeName());
+            if (builder != null) {
+                return builder.build(user, blueprint, resolver);
+            }
+
+            log.warn("Unsupported permission type: {}", blueprint.getTypeName());
+        }
+
+        return null;
+    }
+
+    /**
+     * Builds a collection of permissions applicable to the user based on their roles and any
+     * explicitly granted access rights. If the user is not granted any special permissions, this
+     * method returns an empty collection.
+     *
+     * @param user
+     *  The user for which to build permissions
+     *
+     * @throws IllegalArgumentException
+     *  if user is null
+     *
+     * @return
+     *  a collection of permissions applicable to the provided user
+     */
+    public Collection<Permission> createUserPermissions(UserInfo user) {
+        if (user == null) {
+            throw new IllegalArgumentException("user is null");
+        }
+
+        Set<Permission> permissions = new HashSet<>();
+
+        if (user.getRoles() != null) {
+            for (RoleInfo role : user.getRoles()) {
+                if (role != null) {
+                    permissions.addAll(this.createPermissions(user, role.getPermissions()));
+                }
+            }
+        }
+
+        return permissions;
     }
 }

--- a/server/src/main/java/org/candlepin/auth/permissions/TypedPermission.java
+++ b/server/src/main/java/org/candlepin/auth/permissions/TypedPermission.java
@@ -30,13 +30,12 @@ public abstract class TypedPermission<T> implements Permission, Serializable {
 
     public abstract Class<T> getTargetType();
 
-    public abstract boolean canAccessTarget(T target, SubResource subResource,
-        Access action);
+    public abstract boolean canAccessTarget(T target, SubResource subResource, Access action);
 
     @Override
     public boolean canAccess(Object target, SubResource subResource, Access required) {
         if (this.getTargetType().isInstance(target)) {
-            return canAccessTarget((T) target, subResource, required);
+            return this.canAccessTarget((T) target, subResource, required);
         }
 
         return false;

--- a/server/src/main/java/org/candlepin/auth/permissions/UsernameConsumersPermission.java
+++ b/server/src/main/java/org/candlepin/auth/permissions/UsernameConsumersPermission.java
@@ -19,7 +19,7 @@ import org.candlepin.auth.SubResource;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.Entitlement;
 import org.candlepin.model.Owner;
-import org.candlepin.model.User;
+import org.candlepin.service.model.UserInfo;
 
 import org.hibernate.criterion.Criterion;
 import org.hibernate.criterion.Restrictions;
@@ -38,18 +38,17 @@ import java.io.Serializable;
 public class UsernameConsumersPermission implements Permission, Serializable {
     private static final long serialVersionUID = 571612156736570455L;
 
-    private final User user;
+    private final UserInfo user;
     private final Owner owner;
 
-    public UsernameConsumersPermission(User u, Owner o) {
-        this.user = u;
-        this.owner = o;
+    public UsernameConsumersPermission(UserInfo user, Owner owner) {
+        this.user = user;
+        this.owner = owner;
     }
 
 
     @Override
     public boolean canAccess(Object target, SubResource subResource, Access required) {
-
         // Implied full access to the relevant Consumers:
         if (target.getClass().equals(Consumer.class)) {
             return ((Consumer) target).getOwnerId().equals(owner.getId()) &&
@@ -62,8 +61,7 @@ public class UsernameConsumersPermission implements Permission, Serializable {
 
         // Implied create access to the owner's consumers collection, which includes
         // read as well:
-        if (target.getClass().equals(Owner.class) &&
-            subResource.equals(SubResource.CONSUMERS) &&
+        if (target.getClass().equals(Owner.class) && subResource.equals(SubResource.CONSUMERS) &&
             Access.CREATE.provides(required)) {
             return true;
         }
@@ -85,6 +83,7 @@ public class UsernameConsumersPermission implements Permission, Serializable {
         if (entityClass.equals(Consumer.class)) {
             return Restrictions.eq("username", user.getUsername());
         }
+
         return null;
     }
 

--- a/server/src/main/java/org/candlepin/controller/ImportedEntityCompiler.java
+++ b/server/src/main/java/org/candlepin/controller/ImportedEntityCompiler.java
@@ -1,0 +1,314 @@
+/**
+ * Copyright (c) 2009 - 2018 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.controller;
+
+import org.candlepin.service.model.SubscriptionInfo;
+import org.candlepin.service.model.ProductInfo;
+import org.candlepin.service.model.ProductContentInfo;
+import org.candlepin.service.model.ContentInfo;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+
+
+/**
+ * The ImportedEntityCompiler builds collections of subscriptions, products and content to import.
+ */
+public class ImportedEntityCompiler {
+    private static Logger log = LoggerFactory.getLogger(ImportedEntityCompiler.class);
+
+    protected Map<String, SubscriptionInfo> subscriptions;
+    protected Map<String, ProductInfo> products;
+    protected Map<String, ContentInfo> content;
+
+    /**
+     * Creates a new ImportedEntityCompiler
+     */
+
+    public ImportedEntityCompiler() {
+        this.subscriptions = new HashMap<>();
+        this.products = new HashMap<>();
+        this.content = new HashMap<>();
+    }
+
+    /**
+     * Adds the specified subscriptions to this entity compiler. If a given subscription has already
+     * been added, but differs from the existing version, a warning will be generated and the
+     * previous entry will be replaced. Products and content attached to the subscriptions will be
+     * mapped by this compiler. Null subscriptions will be silently ignored.
+     *
+     * @param subscriptions
+     *  The subscriptions to add to this compiler
+     *
+     * @throws IllegalArgumentException
+     *  if any provided subscription does not contain a valid subscription ID
+     */
+    public void addSubscriptions(SubscriptionInfo... subscriptions) {
+        this.addSubscriptions(Arrays.asList(subscriptions));
+    }
+
+    /**
+     * Adds the specified subscriptions to this entity compiler. If a given subscription has already
+     * been added, but differs from the existing version, a warning will be generated and the
+     * previous entry will be replaced. Products and content attached to the subscriptions will be
+     * mapped by this compiler. Null subscriptions will be silently ignored.
+     *
+     * @param subscriptions
+     *  The subscriptions to add to this compiler
+     *
+     * @throws IllegalArgumentException
+     *  if any provided subscription does not contain a valid subscription ID
+     */
+    public void addSubscriptions(Collection<? extends SubscriptionInfo> subscriptions) {
+        if (subscriptions != null) {
+            for (SubscriptionInfo subscription : subscriptions) {
+                if (subscription == null) {
+                    continue;
+                }
+
+                if (subscription.getId() == null || subscription.getId().isEmpty()) {
+                    String msg = String.format(
+                        "subscription does not contain a mappable Red Hat ID: %s", subscription);
+
+                    log.error(msg);
+                    throw new IllegalArgumentException(msg);
+                }
+
+                SubscriptionInfo existing = this.subscriptions.get(subscription.getId());
+                if (existing != null && !existing.equals(subscription)) {
+                    log.warn("Multiple versions of the same subscription received during refresh; " +
+                        "discarding previous: {} => {}, {}", subscription.getId(), existing, subscription);
+                }
+
+                this.subscriptions.put(subscription.getId(), subscription);
+
+                // Add any products attached to this subscription...
+                this.addProducts(subscription.getProduct());
+                this.addProducts(subscription.getDerivedProduct());
+                this.addProducts(subscription.getProvidedProducts());
+                this.addProducts(subscription.getDerivedProvidedProducts());
+            }
+        }
+    }
+
+    /**
+     * Adds the specified products to this entity compiler. If a given product has already
+     * been added, but differs from the existing version, a warning will be generated and the
+     * previous entry will be replaced. Content attached to the products will be mapped by this
+     * compiler. Null products will be silently ignored.
+     *
+     * @param products
+     *  The products to add to this compiler
+     *
+     * @throws IllegalArgumentException
+     *  if any provided product does not contain a valid product ID
+     */
+    public void addProducts(ProductInfo... products) {
+        this.addProducts(Arrays.asList(products));
+    }
+
+    /**
+     * Adds the specified products to this entity compiler. If a given product has already
+     * been added, but differs from the existing version, a warning will be generated and the
+     * previous entry will be replaced. Content attached to the products will be mapped by this
+     * compiler. Null products will be silently ignored.
+     *
+     * @param products
+     *  The products to add to this compiler
+     *
+     * @throws IllegalArgumentException
+     *  if any provided product does not contain a valid product ID
+     */
+    public void addProducts(Collection<? extends ProductInfo> products) {
+        if (products != null) {
+            for (ProductInfo product : products) {
+                if (product == null) {
+                    continue;
+                }
+
+                if (product.getId() == null || product.getId().isEmpty()) {
+                    String msg = String.format("product does not contain a mappable Red Hat ID: %s", product);
+
+                    log.error(msg);
+                    throw new IllegalArgumentException(msg);
+                }
+
+                ProductInfo existing = this.products.get(product.getId());
+                if (existing != null && !existing.equals(product)) {
+                    log.warn("Multiple versions of the same product received during refresh; " +
+                        "discarding previous: {} => {}, {}", product.getId(), existing, product);
+                }
+
+                log.debug("ADDING PRODUCT: {}", product);
+                this.products.put(product.getId(), product);
+
+                // Add any content attached to this product...
+                this.addProductContent(product.getProductContent());
+            }
+        }
+    }
+
+    /**
+     * Adds the specified content to this entity compiler. If a given content has already
+     * been added, but differs from the existing version, a warning will be generated and the
+     * previous entry will be replaced. Null content will be silently ignored.
+     *
+     * @param contents
+     *  The content to add to this compiler
+     *
+     * @throws IllegalArgumentException
+     *  if any provided content does not contain a valid content ID
+     */
+    public void addProductContent(ProductContentInfo... contents) {
+        this.addProductContent(Arrays.asList(contents));
+    }
+
+    /**
+     * Adds the specified content to this entity compiler. If a given content has already
+     * been added, but differs from the existing version, a warning will be generated and the
+     * previous entry will be replaced. Null content will be silently ignored.
+     *
+     * @param contents
+     *  The content to add to this compiler
+     *
+     * @throws IllegalArgumentException
+     *  if any provided content does not contain a valid content ID
+     */
+    public void addProductContent(Collection<? extends ProductContentInfo> contents) {
+        if (contents != null) {
+            for (ProductContentInfo container : contents) {
+                if (container == null) {
+                    continue;
+                }
+
+                ContentInfo content = container.getContent();
+
+                // Do some simple mapping validation
+                if (content == null) {
+                    String msg = "collection contains an incomplete product-content mapping";
+
+                    log.error(msg);
+                    throw new IllegalArgumentException(msg);
+                }
+
+                if (content.getId() == null || content.getId().isEmpty()) {
+                    String msg = String.format("content does not contain a mappable Red Hat ID: %s", content);
+
+                    log.error(msg);
+                    throw new IllegalArgumentException(msg);
+                }
+
+                ContentInfo existing = this.content.get(content.getId());
+                if (existing != null && !existing.equals(content)) {
+                    log.warn("Multiple versions of the same content received during refresh; " +
+                        "discarding previous: {} => {}, {}", content.getId(), existing, content);
+                }
+
+                this.content.put(content.getId(), content);
+            }
+        }
+    }
+
+    /**
+     * Adds the specified content to this entity compiler. If a given content has already
+     * been added, but differs from the existing version, a warning will be generated and the
+     * previous entry will be replaced. Null content will be silently ignored.
+     *
+     * @param contents
+     *  The content to add to this compiler
+     *
+     * @throws IllegalArgumentException
+     *  if any provided content does not contain a valid content ID
+     */
+    public void addContent(ContentInfo... contents) {
+        this.addContent(Arrays.asList(contents));
+    }
+
+    /**
+     * Adds the specified content to this entity compiler. If a given content has already
+     * been added, but differs from the existing version, a warning will be generated and the
+     * previous entry will be replaced. Null content will be silently ignored.
+     *
+     * @param contents
+     *  The content to add to this compiler
+     *
+     * @throws IllegalArgumentException
+     *  if any provided content does not contain a valid content ID
+     */
+    public void addContent(Collection<? extends ContentInfo> contents) {
+        if (contents != null) {
+            for (ContentInfo content : contents) {
+                if (content == null) {
+                    continue;
+                }
+
+                if (content.getId() == null || content.getId().isEmpty()) {
+                    String msg = String.format("content does not contain a mappable Red Hat ID: %s", content);
+
+                    log.error(msg);
+                    throw new IllegalArgumentException(msg);
+                }
+
+                ContentInfo existing = this.content.get(content.getId());
+                if (existing != null && !existing.equals(content)) {
+                    log.warn("Multiple versions of the same content received during refresh; " +
+                        "discarding previous: {} => {}, {}", content.getId(), existing, content);
+                }
+
+                this.content.put(content.getId(), content);
+            }
+        }
+    }
+
+    /**
+     * Fetches the compiled subscriptions, mapped by subscription ID. If no subscriptions have been
+     * added, this method returns an empty map.
+     *
+     * @return
+     *  A mapping of the compiled, imported subscriptions
+     */
+    public Map<String, ? extends SubscriptionInfo> getSubscriptions() {
+        return this.subscriptions;
+    }
+
+    /**
+     * Fetches the compiled products, mapped by product ID. If no products have been added, this
+     * method returns an empty map.
+     *
+     * @return
+     *  A mapping of the compiled, imported products
+     */
+    public Map<String, ? extends ProductInfo> getProducts() {
+        return this.products;
+    }
+
+    /**
+     * Fetches the compiled content, mapped by content ID. If no content have been
+     * added, this method returns an empty map.
+     *
+     * @return
+     *  A mapping of the compiled, imported content
+     */
+    public Map<String, ? extends ContentInfo> getContent() {
+        return this.content;
+    }
+
+}

--- a/server/src/main/java/org/candlepin/controller/PoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/PoolManager.java
@@ -32,6 +32,7 @@ import org.candlepin.policy.js.pool.PoolUpdate;
 import org.candlepin.resource.dto.AutobindData;
 import org.candlepin.service.OwnerServiceAdapter;
 import org.candlepin.service.SubscriptionServiceAdapter;
+import org.candlepin.service.model.SubscriptionInfo;
 
 import java.util.Collection;
 import java.util.Date;
@@ -52,7 +53,7 @@ public interface PoolManager {
      * @param sub
      * @return the newly created Pool(s)
      */
-    List<Pool> createAndEnrichPools(Subscription sub);
+    List<Pool> createAndEnrichPools(SubscriptionInfo sub);
 
     /**
      * Create any pools that need to be created for the given pool.
@@ -64,7 +65,7 @@ public interface PoolManager {
 
     Pool createAndEnrichPools(Pool pool, List<Pool> existingPools);
 
-    Pool convertToMasterPool(Subscription subscription);
+    Pool convertToMasterPool(SubscriptionInfo subscription);
 
     /**
      * Applies changes to the given pool to itself and any of its derived pools. This may result in

--- a/server/src/main/java/org/candlepin/dto/SimpleModelTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/SimpleModelTranslator.java
@@ -242,6 +242,8 @@ public class SimpleModelTranslator implements ModelTranslator {
 
         ObjectTranslator<I, O> translator = null;
 
+        // TODO: This is broken for finding nearest output. Output cannot be less specific than
+        // specified; it can only get more specific.
         Class outputKey = this.findNearestMappedClass(outputClass, this.translators.keySet());
         if (outputKey != null) {
             Map<Class, ObjectTranslator> inputMappings = this.translators.get(outputKey);

--- a/server/src/main/java/org/candlepin/dto/StandardTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/StandardTranslator.java
@@ -55,8 +55,10 @@ import org.candlepin.dto.api.v1.ImportUpstreamConsumerDTO;
 import org.candlepin.dto.api.v1.ImportUpstreamConsumerTranslator;
 import org.candlepin.dto.api.v1.JobStatusDTO;
 import org.candlepin.dto.api.v1.JobStatusTranslator;
+import org.candlepin.dto.api.v1.OwnerInfoTranslator;
 import org.candlepin.dto.api.v1.PermissionBlueprintDTO;
 import org.candlepin.dto.api.v1.PermissionBlueprintTranslator;
+import org.candlepin.dto.api.v1.PermissionBlueprintInfoTranslator;
 import org.candlepin.dto.api.v1.PoolQuantityDTO;
 import org.candlepin.dto.api.v1.PoolQuantityTranslator;
 import org.candlepin.dto.api.v1.ProductCertificateDTO;
@@ -65,12 +67,14 @@ import org.candlepin.dto.api.v1.ProductDTO;
 import org.candlepin.dto.api.v1.ProductTranslator;
 import org.candlepin.dto.api.v1.RoleDTO;
 import org.candlepin.dto.api.v1.RoleTranslator;
+import org.candlepin.dto.api.v1.RoleInfoTranslator;
 import org.candlepin.dto.api.v1.UeberCertificateDTO;
 import org.candlepin.dto.api.v1.UeberCertificateTranslator;
 import org.candlepin.dto.api.v1.UpstreamConsumerDTO;
 import org.candlepin.dto.api.v1.UpstreamConsumerTranslator;
 import org.candlepin.dto.api.v1.UserDTO;
 import org.candlepin.dto.api.v1.UserTranslator;
+import org.candlepin.dto.api.v1.UserInfoTranslator;
 import org.candlepin.dto.shim.ContentDTOTranslator;
 import org.candlepin.dto.shim.ContentDataTranslator;
 import org.candlepin.dto.shim.ProductDTOTranslator;
@@ -112,6 +116,10 @@ import org.candlepin.model.dto.ProductData;
 import org.candlepin.pinsetter.core.model.JobStatus;
 import org.candlepin.policy.js.compliance.ComplianceReason;
 import org.candlepin.policy.js.compliance.ComplianceStatus;
+import org.candlepin.service.model.OwnerInfo;
+import org.candlepin.service.model.PermissionBlueprintInfo;
+import org.candlepin.service.model.RoleInfo;
+import org.candlepin.service.model.UserInfo;
 
 import com.google.inject.Inject;
 
@@ -183,7 +191,12 @@ public class StandardTranslator extends SimpleModelTranslator {
             new org.candlepin.dto.api.v1.OwnerTranslator(),
             Owner.class, org.candlepin.dto.api.v1.OwnerDTO.class);
         this.registerTranslator(
+            new OwnerInfoTranslator(), OwnerInfo.class, org.candlepin.dto.api.v1.OwnerDTO.class);
+        this.registerTranslator(
             new PermissionBlueprintTranslator(), PermissionBlueprint.class, PermissionBlueprintDTO.class);
+        this.registerTranslator(
+            new PermissionBlueprintInfoTranslator(),
+            PermissionBlueprintInfo.class, PermissionBlueprintDTO.class);
         this.registerTranslator(
             new org.candlepin.dto.api.v1.PoolTranslator(),
             Pool.class, org.candlepin.dto.api.v1.PoolDTO.class);
@@ -196,11 +209,15 @@ public class StandardTranslator extends SimpleModelTranslator {
         this.registerTranslator(
             new RoleTranslator(), Role.class, RoleDTO.class);
         this.registerTranslator(
+            new RoleInfoTranslator(), RoleInfo.class, RoleDTO.class);
+        this.registerTranslator(
             new UeberCertificateTranslator(), UeberCertificate.class, UeberCertificateDTO.class);
         this.registerTranslator(
             new UpstreamConsumerTranslator(), UpstreamConsumer.class, UpstreamConsumerDTO.class);
         this.registerTranslator(
             new UserTranslator(), User.class, UserDTO.class);
+        this.registerTranslator(
+            new UserInfoTranslator(), UserInfo.class, UserDTO.class);
 
         // Event translators
         /////////////////////////////////////////////

--- a/server/src/main/java/org/candlepin/dto/api/v1/ActivationKeyDTO.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/ActivationKeyDTO.java
@@ -14,18 +14,21 @@
  */
 package org.candlepin.dto.api.v1;
 
+import org.candlepin.dto.TimestampedCandlepinDTO;
+import org.candlepin.jackson.SingleValueWrapSerializer;
+import org.candlepin.jackson.SingleValueWrapDeserializer;
+import org.candlepin.util.SetView;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
 import io.swagger.annotations.ApiModel;
+
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.candlepin.dto.TimestampedCandlepinDTO;
-import org.candlepin.jackson.SingleValueWrapSerializer;
-import org.candlepin.jackson.SingleValueWrapDeserializer;
-import org.candlepin.util.SetView;
 
 import java.util.Collection;
 import java.util.HashSet;

--- a/server/src/main/java/org/candlepin/dto/api/v1/ContentDTO.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/ContentDTO.java
@@ -16,6 +16,7 @@ package org.candlepin.dto.api.v1;
 
 import org.candlepin.dto.TimestampedCandlepinDTO;
 import org.candlepin.util.SetView;
+import org.candlepin.service.model.ContentInfo;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -59,7 +60,7 @@ import javax.xml.bind.annotation.XmlRootElement;
  */
 @ApiModel(parent = TimestampedCandlepinDTO.class, description = "DTO representing a certificate")
 @XmlRootElement
-public class ContentDTO extends TimestampedCandlepinDTO<ContentDTO> {
+public class ContentDTO extends TimestampedCandlepinDTO<ContentDTO> implements ContentInfo {
     public static final long serialVersionUID = 1L;
 
     @ApiModelProperty(example = "ff808081554a3e4101554a3e9033005d")
@@ -421,6 +422,14 @@ public class ContentDTO extends TimestampedCandlepinDTO<ContentDTO> {
      */
     public Collection<String> getModifiedProductIds() {
         return this.modifiedProductIds != null ? new SetView(this.modifiedProductIds) : null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Collection<String> getRequiredProductIds() {
+        return this.getModifiedProductIds();
     }
 
     /**

--- a/server/src/main/java/org/candlepin/dto/api/v1/ContentTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/ContentTranslator.java
@@ -67,7 +67,7 @@ public class ContentTranslator extends TimestampedEntityTranslator<Content, Cont
         destination.setRequiredTags(source.getRequiredTags());
         destination.setReleaseVersion(source.getReleaseVersion());
         destination.setGpgUrl(source.getGpgUrl());
-        destination.setMetadataExpiration(source.getMetadataExpire());
+        destination.setMetadataExpiration(source.getMetadataExpiration());
         destination.setModifiedProductIds(source.getModifiedProductIds());
         destination.setArches(source.getArches());
         destination.setLocked(source.isLocked());

--- a/server/src/main/java/org/candlepin/dto/api/v1/EventTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/EventTranslator.java
@@ -70,10 +70,11 @@ public class EventTranslator implements ObjectTranslator<Event, EventDTO> {
         destination.setPrincipalStore(source.getPrincipalStore());
         destination.setReferenceId(source.getReferenceId());
         destination.setTimestamp(source.getTimestamp());
-        destination.setType(source.getType() != null ? source.getType().toString() : null);
-        destination.setTarget(source.getTarget() != null ? source.getTarget().toString() : null);
+        destination.setType(source.getType() != null ? source.getType().name() : null);
+        destination.setTarget(source.getTarget() != null ? source.getTarget().name() : null);
         destination.setReferenceType(source.getReferenceType() != null ?
-            source.getReferenceType().toString() : null);
+            source.getReferenceType().name() :
+            null);
         destination.setEventData(source.getEventData());
 
         if (modelTranslator != null) {

--- a/server/src/main/java/org/candlepin/dto/api/v1/ImportRecordTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/ImportRecordTranslator.java
@@ -65,7 +65,7 @@ public class ImportRecordTranslator extends TimestampedEntityTranslator<ImportRe
         dest.setGeneratedDate(source.getGeneratedDate());
 
         ImportRecord.Status status = source.getStatus();
-        dest.setStatus(status != null ? status.toString() : null);
+        dest.setStatus(status != null ? status.name() : null);
 
         // Process nested objects if we have a ModelTranslator to use to the translation...
         if (translator != null) {

--- a/server/src/main/java/org/candlepin/dto/api/v1/JobStatusTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/JobStatusTranslator.java
@@ -64,7 +64,7 @@ public class JobStatusTranslator extends TimestampedEntityTranslator<JobStatus, 
             .setResultData(source.getResultData())
             .setStartTime(source.getStartTime())
             .setFinishTime(source.getFinishTime())
-            .setState(source.getState() != null ? source.getState().toString() : null)
+            .setState(source.getState() != null ? source.getState().name() : null)
             .setTargetId(source.getTargetId())
             .setTargetType(source.getTargetType())
             .setDone(source.isDone());

--- a/server/src/main/java/org/candlepin/dto/api/v1/OwnerDTO.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/OwnerDTO.java
@@ -15,6 +15,7 @@
 package org.candlepin.dto.api.v1;
 
 import org.candlepin.common.jackson.HateoasInclude;
+import org.candlepin.service.model.OwnerInfo;
 
 import com.fasterxml.jackson.annotation.JsonFilter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -40,7 +41,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @ApiModel(parent = TimestampedCandlepinDTO.class, description = "DTO representing an owner/organization")
 @JsonFilter("OwnerFilter")
-public class OwnerDTO extends TimestampedCandlepinDTO<OwnerDTO> implements LinkableDTO {
+public class OwnerDTO extends TimestampedCandlepinDTO<OwnerDTO> implements LinkableDTO, OwnerInfo {
     public static final long serialVersionUID = 1L;
 
     protected String id;
@@ -226,8 +227,6 @@ public class OwnerDTO extends TimestampedCandlepinDTO<OwnerDTO> implements Linka
     @Override
     @HateoasInclude
     public String getHref() {
-        // TODO: When/if we ever version our API, we should change this to use the owner ID rather
-        // than the key. We're really inconsistent with how we address owners.
         return this.key != null ? String.format("/owners/%s", this.key) : null;
     }
 

--- a/server/src/main/java/org/candlepin/dto/api/v1/OwnerInfoTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/OwnerInfoTranslator.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2009 - 2017 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.dto.api.v1;
+
+import org.candlepin.dto.ModelTranslator;
+import org.candlepin.dto.ObjectTranslator;
+import org.candlepin.service.model.OwnerInfo;
+
+
+
+/**
+ * The OwnerInfoTranslator provides translation from OwnerInfo service model objects to OwnerDTOs
+ */
+public class OwnerInfoTranslator implements ObjectTranslator<OwnerInfo, OwnerDTO> {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public OwnerDTO translate(OwnerInfo source) {
+        return this.translate(null, source);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public OwnerDTO translate(ModelTranslator translator, OwnerInfo source) {
+        return source != null ? this.populate(translator, source, new OwnerDTO()) : null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public OwnerDTO populate(OwnerInfo source, OwnerDTO destination) {
+        return this.populate(null, source, destination);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public OwnerDTO populate(ModelTranslator translator, OwnerInfo source, OwnerDTO dest) {
+        if (source == null) {
+            throw new IllegalArgumentException("source is null");
+        }
+
+        if (dest == null) {
+            throw new IllegalArgumentException("dest is null");
+        }
+
+        dest.setCreated(source.getCreated());
+        dest.setUpdated(source.getUpdated());
+
+        // Service model objects do not provide an ID
+        dest.setId(null);
+        dest.setKey(source.getKey());
+
+        // These fields are not present on the service model
+        dest.setDisplayName(null);
+        dest.setContentPrefix(null);
+        dest.setDefaultServiceLevel(null);
+        dest.setLogLevel(null);
+        dest.setAutobindDisabled(null);
+        dest.setContentAccessMode(null);
+        dest.setContentAccessModeList(null);
+        dest.setLastRefreshed(null);
+        dest.setParentOwner(null);
+        dest.setUpstreamConsumer(null);
+
+        return dest;
+    }
+
+}

--- a/server/src/main/java/org/candlepin/dto/api/v1/PermissionBlueprintDTO.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/PermissionBlueprintDTO.java
@@ -15,6 +15,9 @@
 package org.candlepin.dto.api.v1;
 
 import org.candlepin.dto.TimestampedCandlepinDTO;
+import org.candlepin.service.model.PermissionBlueprintInfo;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -44,7 +47,8 @@ import org.apache.commons.lang.builder.HashCodeBuilder;
  * </pre>
  */
 @ApiModel(parent = TimestampedCandlepinDTO.class, description = "User information for a given user")
-public class PermissionBlueprintDTO extends TimestampedCandlepinDTO<PermissionBlueprintDTO> {
+public class PermissionBlueprintDTO extends TimestampedCandlepinDTO<PermissionBlueprintDTO>
+    implements PermissionBlueprintInfo {
 
     @ApiModelProperty(required = true, example = "ff808081554a3e4101554a3e9033005d")
     protected String id;
@@ -147,6 +151,15 @@ public class PermissionBlueprintDTO extends TimestampedCandlepinDTO<PermissionBl
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    @JsonIgnore
+    public String getTypeName() {
+        return this.getType();
+    }
+
+    /**
      * Sets or clears the type for this permission.
      *
      * @param type
@@ -169,6 +182,15 @@ public class PermissionBlueprintDTO extends TimestampedCandlepinDTO<PermissionBl
      */
     public String getAccess() {
         return this.access;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @JsonIgnore
+    public String getAccessLevel() {
+        return this.getAccess();
     }
 
     /**

--- a/server/src/main/java/org/candlepin/dto/api/v1/PermissionBlueprintInfoTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/PermissionBlueprintInfoTranslator.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2009 - 2018 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.dto.api.v1;
+
+import org.candlepin.dto.ModelTranslator;
+import org.candlepin.dto.ObjectTranslator;
+import org.candlepin.service.model.PermissionBlueprintInfo;
+
+
+
+/**
+ * The PermissionBlueprintInfoTranslator provides translation from PermissionBlueprintInfo service
+ * model objects to PermissionBlueprintDTOs
+ */
+public class PermissionBlueprintInfoTranslator implements
+    ObjectTranslator<PermissionBlueprintInfo, PermissionBlueprintDTO> {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public PermissionBlueprintDTO translate(PermissionBlueprintInfo source) {
+        return this.translate(null, source);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public PermissionBlueprintDTO translate(ModelTranslator translator, PermissionBlueprintInfo source) {
+        return source != null ? this.populate(translator, source, new PermissionBlueprintDTO()) : null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public PermissionBlueprintDTO populate(PermissionBlueprintInfo source, PermissionBlueprintDTO dest) {
+        return this.populate(null, source, dest);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public PermissionBlueprintDTO populate(ModelTranslator translator, PermissionBlueprintInfo source,
+        PermissionBlueprintDTO dest) {
+
+        if (source == null) {
+            throw new IllegalArgumentException("source is null");
+        }
+
+        if (dest == null) {
+            throw new IllegalArgumentException("dest is null");
+        }
+
+        // Service model objects do not provide an ID
+        dest.setId(null);
+        dest.setType(source.getTypeName());
+        dest.setAccess(source.getAccessLevel());
+
+        if (translator != null) {
+            dest.setOwner(translator.translate(source.getOwner(), OwnerDTO.class));
+        }
+        else {
+            dest.setOwner(null);
+        }
+
+        return dest;
+    }
+
+}

--- a/server/src/main/java/org/candlepin/dto/api/v1/PermissionBlueprintTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/PermissionBlueprintTranslator.java
@@ -66,8 +66,8 @@ public class PermissionBlueprintTranslator extends
         Access access = source.getAccess();
 
         dest.setId(source.getId());
-        dest.setType(type != null ? type.toString() : null);
-        dest.setAccess(access != null ? access.toString() : null);
+        dest.setType(type != null ? type.name() : null);
+        dest.setAccess(access != null ? access.name() : null);
 
         if (translator != null) {
             dest.setOwner(translator.translate(source.getOwner(), OwnerDTO.class));

--- a/server/src/main/java/org/candlepin/dto/api/v1/PoolTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/PoolTranslator.java
@@ -65,7 +65,7 @@ public class PoolTranslator extends TimestampedEntityTranslator<Pool, PoolDTO> {
         dest = super.populate(modelTranslator, source, dest);
 
         dest.setId(source.getId());
-        dest.setType(source.getType().toString());
+        dest.setType(source.getType() != null ? source.getType().name() : null);
         dest.setActiveSubscription(source.getActiveSubscription());
         dest.setQuantity(source.getQuantity());
         dest.setStartDate(source.getStartDate());

--- a/server/src/main/java/org/candlepin/dto/api/v1/ProductDTO.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/ProductDTO.java
@@ -18,6 +18,8 @@ import org.candlepin.dto.CandlepinDTO;
 import org.candlepin.dto.TimestampedCandlepinDTO;
 import org.candlepin.jackson.CandlepinAttributeDeserializer;
 import org.candlepin.jackson.CandlepinLegacyAttributeSerializer;
+import org.candlepin.service.model.ProductInfo;
+import org.candlepin.service.model.ProductContentInfo;
 import org.candlepin.util.MapView;
 import org.candlepin.util.SetView;
 import org.candlepin.util.Util;
@@ -66,13 +68,15 @@ import javax.xml.bind.annotation.XmlTransient;
  */
 @ApiModel(parent = CandlepinDTO.class, description = "Product information for a given sku or product")
 @XmlRootElement
-public class ProductDTO extends TimestampedCandlepinDTO<ProductDTO> {
+public class ProductDTO extends TimestampedCandlepinDTO<ProductDTO> implements ProductInfo {
     public static final long serialVersionUID = 1L;
 
     /**
      * Join object DTO for joining products to content
      */
-    public static class ProductContentDTO extends CandlepinDTO<ProductContentDTO> {
+    public static class ProductContentDTO extends CandlepinDTO<ProductContentDTO>
+        implements ProductContentInfo {
+
         protected final ContentDTO content;
         protected Boolean enabled;
 

--- a/server/src/main/java/org/candlepin/dto/api/v1/RoleInfoTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/RoleInfoTranslator.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) 2009 - 2017 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.dto.api.v1;
+
+import org.candlepin.dto.ModelTranslator;
+import org.candlepin.dto.ObjectTranslator;
+import org.candlepin.service.model.PermissionBlueprintInfo;
+import org.candlepin.service.model.RoleInfo;
+import org.candlepin.service.model.UserInfo;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.stream.Collectors;
+
+
+
+/**
+ * The RoleInfoTranslator provides translation from Role model objects to
+ * RoleDTOs
+ */
+public class RoleInfoTranslator implements ObjectTranslator<RoleInfo, RoleDTO> {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public RoleDTO translate(RoleInfo source) {
+        return this.translate(null, source);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public RoleDTO translate(ModelTranslator translator, RoleInfo source) {
+        return source != null ? this.populate(translator, source, new RoleDTO()) : null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public RoleDTO populate(RoleInfo source, RoleDTO destination) {
+        return this.populate(null, source, destination);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @SuppressWarnings("checkstyle:indentation")
+    public RoleDTO populate(ModelTranslator translator, RoleInfo source, RoleDTO dest) {
+        if (source == null) {
+            throw new IllegalArgumentException("source is null");
+        }
+
+        if (dest == null) {
+            throw new IllegalArgumentException("dest is null");
+        }
+
+        dest.setCreated(source.getCreated());
+        dest.setUpdated(source.getUpdated());
+
+        // Service model objects don't provide an ID
+        dest.setId(null);
+        dest.setName(source.getName());
+
+        if (translator != null) {
+            // Users
+            Collection<? extends UserInfo> users = source.getUsers();
+
+            if (users != null) {
+                dest.setUsers(users.stream()
+                    .map(translator.getStreamMapper(UserInfo.class, UserDTO.class))
+                    .collect(Collectors.toList()));
+            }
+            else {
+                dest.setUsers(Collections.<UserDTO>emptyList());
+            }
+
+            // Permissions
+            Collection<? extends PermissionBlueprintInfo> permissions = source.getPermissions();
+
+            if (permissions != null) {
+                dest.setPermissions(permissions.stream()
+                    .map(translator.getStreamMapper(PermissionBlueprintInfo.class,
+                        PermissionBlueprintDTO.class))
+                    .collect(Collectors.toList()));
+            }
+            else {
+                dest.setPermissions(Collections.<PermissionBlueprintDTO>emptyList());
+            }
+        }
+        else {
+            dest.setUsers(Collections.<UserDTO>emptyList());
+            dest.setPermissions(Collections.<PermissionBlueprintDTO>emptyList());
+        }
+
+        return dest;
+    }
+
+}

--- a/server/src/main/java/org/candlepin/dto/api/v1/RoleTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/RoleTranslator.java
@@ -22,6 +22,7 @@ import org.candlepin.model.User;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.stream.Collectors;
 
 
 
@@ -66,22 +67,28 @@ public class RoleTranslator extends TimestampedEntityTranslator<Role, RoleDTO> {
         dest.setName(source.getName());
 
         if (translator != null) {
+            // Users
             Collection<User> users = source.getUsers();
-            dest.setUsers(Collections.<UserDTO>emptyList());
 
             if (users != null) {
-                for (User user : users) {
-                    dest.addUser(translator.translate(user, UserDTO.class));
-                }
+                dest.setUsers(users.stream()
+                    .map(translator.getStreamMapper(User.class, UserDTO.class))
+                    .collect(Collectors.toList()));
+            }
+            else {
+                dest.setUsers(Collections.<UserDTO>emptyList());
             }
 
+            // Permissions
             Collection<PermissionBlueprint> permissions = source.getPermissions();
-            dest.setPermissions(Collections.<PermissionBlueprintDTO>emptyList());
 
             if (permissions != null) {
-                for (PermissionBlueprint permission : permissions) {
-                    dest.addPermission(translator.translate(permission, PermissionBlueprintDTO.class));
-                }
+                dest.setPermissions(permissions.stream()
+                    .map(translator.getStreamMapper(PermissionBlueprint.class, PermissionBlueprintDTO.class))
+                    .collect(Collectors.toList()));
+            }
+            else {
+                dest.setPermissions(Collections.<PermissionBlueprintDTO>emptyList());
             }
         }
         else {

--- a/server/src/main/java/org/candlepin/dto/api/v1/UserInfoTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/UserInfoTranslator.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2009 - 2017 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.dto.api.v1;
+
+import org.candlepin.dto.ModelTranslator;
+import org.candlepin.dto.ObjectTranslator;
+import org.candlepin.service.model.UserInfo;
+
+
+
+/**
+ * The UserTranslator provides translation from UserInfo service model objects to UserDTOs
+ */
+public class UserInfoTranslator implements ObjectTranslator<UserInfo, UserDTO> {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public UserDTO translate(UserInfo source) {
+        return this.translate(null, source);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public UserDTO translate(ModelTranslator translator, UserInfo source) {
+        return source != null ? this.populate(translator, source, new UserDTO()) : null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public UserDTO populate(UserInfo source, UserDTO destination) {
+        return this.populate(null, source, destination);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public UserDTO populate(ModelTranslator translator, UserInfo source, UserDTO dest) {
+        if (source == null) {
+            throw new IllegalArgumentException("source is null");
+        }
+
+        if (dest == null) {
+            throw new IllegalArgumentException("dest is null");
+        }
+
+        dest.setCreated(source.getCreated());
+        dest.setUpdated(source.getUpdated());
+
+        // We don't have an ID from the adapters, so we'll just null it out.
+        dest.setId(null);
+
+        dest.setUsername(source.getUsername());
+        dest.setSuperAdmin(source.isSuperAdmin());
+
+        // The password field should never be set when populating from an entity
+        dest.setPassword(null);
+
+        return dest;
+    }
+}

--- a/server/src/main/java/org/candlepin/dto/manifest/v1/ContentDTO.java
+++ b/server/src/main/java/org/candlepin/dto/manifest/v1/ContentDTO.java
@@ -443,7 +443,7 @@ public class ContentDTO extends TimestampedCandlepinDTO<ContentDTO> {
      *  the metadata expiration of the content, or null if the metadata expiration has not yet been
      *  defined
      */
-    public Long getMetadataExpire() {
+    public Long getMetadataExpiration() {
         return this.metadataExpire;
     }
 
@@ -457,7 +457,7 @@ public class ContentDTO extends TimestampedCandlepinDTO<ContentDTO> {
      * @return
      *  a reference to this DTO
      */
-    public ContentDTO setMetadataExpire(Long metadataExpire) {
+    public ContentDTO setMetadataExpiration(Long metadataExpire) {
         this.metadataExpire = metadataExpire;
         return this;
     }
@@ -487,7 +487,7 @@ public class ContentDTO extends TimestampedCandlepinDTO<ContentDTO> {
                 .append(this.getRequiredTags(), that.getRequiredTags())
                 .append(this.getReleaseVersion(), that.getReleaseVersion())
                 .append(this.getGpgUrl(), that.getGpgUrl())
-                .append(this.getMetadataExpire(), that.getMetadataExpire())
+                .append(this.getMetadataExpiration(), that.getMetadataExpiration())
 
                 .append(this.getModifiedProductIds(), that.getModifiedProductIds())
                 .append(this.getArches(), that.getArches());
@@ -512,7 +512,7 @@ public class ContentDTO extends TimestampedCandlepinDTO<ContentDTO> {
             .append(this.getRequiredTags())
             .append(this.getReleaseVersion())
             .append(this.getGpgUrl())
-            .append(this.getMetadataExpire())
+            .append(this.getMetadataExpiration())
             .append(this.getModifiedProductIds())
             .append(this.getArches());
 
@@ -554,7 +554,7 @@ public class ContentDTO extends TimestampedCandlepinDTO<ContentDTO> {
         this.setRequiredTags(source.getRequiredTags());
         this.setReleaseVersion(source.getReleaseVersion());
         this.setGpgUrl(source.getGpgUrl());
-        this.setMetadataExpire(source.getMetadataExpire());
+        this.setMetadataExpiration(source.getMetadataExpiration());
         this.setModifiedProductIds(source.getModifiedProductIds());
         this.setArches(source.getArches());
 

--- a/server/src/main/java/org/candlepin/dto/manifest/v1/ContentTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/manifest/v1/ContentTranslator.java
@@ -58,7 +58,7 @@ public class ContentTranslator extends TimestampedEntityTranslator<Content, Cont
         destination = super.populate(translator, source, destination);
 
         destination.setUuid(source.getUuid());
-        destination.setMetadataExpire(source.getMetadataExpire());
+        destination.setMetadataExpiration(source.getMetadataExpiration());
         destination.setId(source.getId());
         destination.setType(source.getType());
         destination.setLabel(source.getLabel());

--- a/server/src/main/java/org/candlepin/dto/manifest/v1/PoolTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/manifest/v1/PoolTranslator.java
@@ -71,7 +71,7 @@ public class PoolTranslator implements ObjectTranslator<Pool, PoolDTO> {
         }
 
         dest.setId(source.getId());
-        dest.setType(source.getType().toString());
+        dest.setType(source.getType() != null ? source.getType().name() : null);
         dest.setActiveSubscription(source.getActiveSubscription());
         dest.setQuantity(source.getQuantity());
         dest.setStartDate(source.getStartDate());

--- a/server/src/main/java/org/candlepin/dto/shim/ContentDTOTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/shim/ContentDTOTranslator.java
@@ -80,7 +80,7 @@ public class ContentDTOTranslator implements ObjectTranslator<ContentDTO, Conten
         dest.setRequiredTags(source.getRequiredTags());
         dest.setReleaseVersion(source.getReleaseVersion());
         dest.setGpgUrl(source.getGpgUrl());
-        dest.setMetadataExpire(source.getMetadataExpire());
+        dest.setMetadataExpiration(source.getMetadataExpiration());
         dest.setArches(source.getArches());
         dest.setModifiedProductIds(source.getModifiedProductIds());
 

--- a/server/src/main/java/org/candlepin/dto/shim/ContentDataTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/shim/ContentDataTranslator.java
@@ -77,7 +77,7 @@ public class ContentDataTranslator implements ObjectTranslator<ContentData, Cont
         dest.setRequiredTags(source.getRequiredTags());
         dest.setReleaseVersion(source.getReleaseVersion());
         dest.setGpgUrl(source.getGpgUrl());
-        dest.setMetadataExpiration(source.getMetadataExpire());
+        dest.setMetadataExpiration(source.getMetadataExpiration());
         dest.setModifiedProductIds(source.getModifiedProductIds());
         dest.setArches(source.getArches());
         dest.setLocked(source.isLocked());

--- a/server/src/main/java/org/candlepin/hostedtest/HostedTestSubscriptionResource.java
+++ b/server/src/main/java/org/candlepin/hostedtest/HostedTestSubscriptionResource.java
@@ -14,23 +14,28 @@
  */
 package org.candlepin.hostedtest;
 
+import org.candlepin.common.exceptions.BadRequestException;
 import org.candlepin.common.exceptions.NotFoundException;
+import org.candlepin.common.exceptions.ConflictException;
 import org.candlepin.common.util.SuppressSwaggerCheck;
 import org.candlepin.controller.ProductManager;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.dto.api.v1.ContentDTO;
 import org.candlepin.dto.api.v1.ProductDTO;
-import org.candlepin.model.Content;
-import org.candlepin.model.Owner;
 import org.candlepin.model.OwnerContentCurator;
 import org.candlepin.model.OwnerCurator;
 import org.candlepin.model.OwnerProductCurator;
-import org.candlepin.model.Product;
 import org.candlepin.model.ProductContent;
 import org.candlepin.model.ProductCurator;
+import org.candlepin.model.dto.ContentData;
+import org.candlepin.model.dto.ProductContentData;
+import org.candlepin.model.dto.ProductData;
 import org.candlepin.model.dto.Subscription;
 import org.candlepin.resource.util.ResolverUtil;
 import org.candlepin.service.UniqueIdGenerator;
+import org.candlepin.service.model.ContentInfo;
+import org.candlepin.service.model.ProductInfo;
+import org.candlepin.service.model.SubscriptionInfo;
 
 import com.google.inject.persist.Transactional;
 
@@ -38,8 +43,7 @@ import org.xnap.commons.i18n.I18n;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -64,7 +68,7 @@ import javax.ws.rs.core.MediaType;
  * as the only purpose of this class is to support spec tests.
  */
 @SuppressSwaggerCheck
-@Path("/hostedtest/subscriptions")
+@Path("/hostedtest")
 public class HostedTestSubscriptionResource {
 
     @Inject
@@ -110,27 +114,125 @@ public class HostedTestSubscriptionResource {
     }
 
     /**
+     * Creates or updates all of the subobjects referenced by the given subscription.
+     *
+     * @deprecated
+     *  This method is a shim to work with the existing "hosted" spec tests that create
+     *  subscriptions and its subobjects from the raw JSON provided. In the future, this should be
+     *  more well-formed and require that objects are created explicitly rather than implicitly.
+     *
+     * @param subscription
+     *  The subscription for which to create or update subobjects.
+     */
+    @Deprecated
+    protected void createSubscriptionObjects(Subscription subscription) {
+        if (subscription == null) {
+            throw new IllegalArgumentException("subscription is null");
+        }
+
+        Map<String, ProductData> pmap = new HashMap<>();
+        Map<String, ContentData> cmap = new HashMap<>();
+
+        this.addProductsToMap(subscription.getProduct(), pmap);
+        this.addProductsToMap(subscription.getProvidedProducts(), pmap);
+        this.addProductsToMap(subscription.getDerivedProduct(), pmap);
+        this.addProductsToMap(subscription.getDerivedProvidedProducts(), pmap);
+
+        for (ProductData product : pmap.values()) {
+            this.addContentToMap(product.getProductContent(), cmap);
+        }
+
+        // Create content...
+        for (ContentData content : cmap.values()) {
+            if (this.adapter.getContent(content.getId()) != null) {
+                this.adapter.updateContent(content.getId(), content);
+            }
+            else {
+                this.adapter.createContent(content);
+            }
+        }
+
+        // Create products...
+        for (ProductData product : pmap.values()) {
+            if (this.adapter.getProduct(product.getId()) != null) {
+                this.adapter.updateProduct(product.getId(), product);
+            }
+            else {
+                this.adapter.createProduct(product);
+            }
+        }
+    }
+
+    private void addProductsToMap(ProductData product, Map<String, ProductData> pmap) {
+        if (product != null) {
+            if (product.getId() == null || product.getId().matches("\\A\\s*\\z")) {
+                throw new BadRequestException("product has a null or empty product ID: " + product);
+            }
+
+            pmap.put(product.getId(), product);
+        }
+    }
+
+    private void addProductsToMap(Collection<ProductData> products, Map<String, ProductData> pmap) {
+        if (products != null) {
+            for (ProductData product : products) {
+                if (product == null) {
+                    throw new BadRequestException("product collection contains a null product");
+                }
+
+                this.addProductsToMap(product, pmap);
+            }
+        }
+    }
+
+    private void addContentToMap(Collection<ProductContentData> content, Map<String, ContentData> cmap) {
+        if (content != null) {
+            for (ProductContentData pcdata : content) {
+                if (pcdata != null) {
+                    ContentData cdata = pcdata.getContent();
+
+                    if (cdata == null) {
+                        throw new BadRequestException("product contains a null content: " + pcdata);
+                    }
+
+                    if (cdata.getId() == null || cdata.getId().matches("\\A\\s*\\z")) {
+                        throw new BadRequestException("content has a null or empty content ID: " + cdata);
+                    }
+
+                    cmap.put(cdata.getId(), cdata);
+                }
+            }
+        }
+    }
+
+
+    /**
      * Creates a new subscription from the subscription JSON provided. Any UUID
      * provided in the JSON will be ignored when creating the new subscription.
      *
      * @param subscription
-     *        A Subscription object built from the JSON provided in the request
+     *  A Subscription object built from the JSON provided in the request
+     *
      * @return
-     *         The newly created Subscription object
+     *  The newly created Subscription object
      */
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    public Subscription createSubscription(
-        Subscription subscription,
-        @QueryParam("disable_resolution") Boolean disableResolution) {
-        if (subscription.getId() == null || subscription.getId().trim().length() == 0) {
+    @Path("/subscriptions")
+    public SubscriptionInfo createSubscription(Subscription subscription) {
+        // Generate an ID if necessary
+        if (subscription.getId() == null || subscription.getId().matches("\\A\\s*\\z")) {
             subscription.setId(this.idGenerator.generateId());
         }
-        if (disableResolution != null && disableResolution) {
-            return adapter.createSubscription(subscription);
-        }
-        return adapter.createSubscription(resolverUtil.resolveSubscriptionAndProduct(subscription));
+
+        // Create the subobjects first
+        this.createSubscriptionObjects(subscription);
+
+        // Create subscription object...
+        SubscriptionInfo sinfo = this.adapter.createSubscription(subscription);
+
+        return sinfo;
     }
 
     /**
@@ -141,8 +243,9 @@ public class HostedTestSubscriptionResource {
      */
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public List<Subscription> listSubscriptions() {
-        return adapter.getSubscriptions();
+    @Path("/subscriptions")
+    public Collection<? extends SubscriptionInfo> listSubscriptions() {
+        return this.adapter.getSubscriptions();
     }
 
     /**
@@ -156,16 +259,17 @@ public class HostedTestSubscriptionResource {
      *         could not be found
      */
     @GET
-    @Path("/{subscription_id}")
+    @Path("/subscriptions/{subscription_id}")
     @Produces(MediaType.APPLICATION_JSON)
-    public Subscription getSubscription(@PathParam("subscription_id") String subscriptionId) {
+    public SubscriptionInfo getSubscription(@PathParam("subscription_id") String subscriptionId) {
         return adapter.getSubscription(subscriptionId);
     }
 
     /**
      * Updates the specified subscription with the provided subscription data.
      *
-     * @param subscriptionNew
+     * @param subscriptionId the ID of the subscription to update
+     * @param subscription
      *        A Subscription object built from the JSON provided in the request;
      *        contains the data to use
      *        to update the specified subscription
@@ -175,8 +279,24 @@ public class HostedTestSubscriptionResource {
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    public Subscription updateSubscription(Subscription subscriptionNew) {
-        return adapter.updateSubscription(resolverUtil.resolveSubscription(subscriptionNew));
+    @Path("/subscriptions/{subscription_id}")
+    public SubscriptionInfo updateSubscription(
+        @PathParam("subscription_id") String subscriptionId,
+        Subscription subscription) {
+
+        if (subscription == null) {
+            throw new BadRequestException("no subscription data provided");
+        }
+
+        if (this.adapter.getSubscription(subscriptionId) == null) {
+            throw new NotFoundException("subscription does not yet exist: " + subscriptionId);
+        }
+
+        // Create/Update sub objects
+        this.createSubscriptionObjects(subscription);
+
+        // Update subscription
+        return this.adapter.updateSubscription(subscriptionId, subscription);
     }
 
     /**
@@ -189,133 +309,238 @@ public class HostedTestSubscriptionResource {
      *         otherwise
      */
     @DELETE
-    @Path("/{subscription_id}")
+    @Path("/subscriptions/{subscription_id}")
     @Produces(MediaType.APPLICATION_JSON)
     public boolean deleteSubscription(@PathParam("subscription_id") String subscriptionId) {
-        return adapter.deleteSubscription(subscriptionId);
+        return adapter.deleteSubscription(subscriptionId) != null;
     }
 
     /**
-     * Deletes all subscriptions.
+     * Deletes all data currently maintained by the backing adapter.
      */
     @DELETE
     @Produces(MediaType.APPLICATION_JSON)
-    public void deleteAllSubscriptions() {
-        adapter.deleteAllSubscriptions();
+    public void clearData() {
+        this.adapter.clearData();
     }
 
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    @Path("/owners/{owner_key}/products/{product_id}/batch_content")
+    @Path("/products/{product_id}/batch_content")
     @Transactional
-    public ProductDTO addBatchContent(
-        @PathParam("owner_key") String ownerKey,
+    public ProductInfo addContentToProduct(
         @PathParam("product_id") String productId,
         Map<String, Boolean> contentMap) {
 
-        Owner owner = this.getOwnerByKey(ownerKey);
-        Product product = this.fetchProduct(owner, productId);
-        Collection<ProductContent> productContent = new LinkedList<>();
+        ProductInfo pinfo = this.adapter.getProduct(productId);
 
-        ProductDTO pdto = this.translator.translate(product, ProductDTO.class);
+        if (pinfo == null) {
+            throw new NotFoundException("product not found: " + productId);
+        }
 
-        // Impl note:
-        // This is a wholely inefficient way of doing this. When we return to using ID-based linking
-        // and we're not linking the universe with our model, we can just attach the IDs directly
-        // without needing all this DTO conversion back and forth.
-        // Alternatively, we can shut off Hibernate's auto-commit junk and get in the habit of
-        // calling commit methods as necessary so we don't have to work with DTOs internally.
+        for (String contentId : contentMap.keySet()) {
+            if (this.adapter.getContent(contentId) == null) {
+                throw new NotFoundException("content not found: " + contentId);
+            }
+        }
 
-        boolean changed = false;
         for (Entry<String, Boolean> entry : contentMap.entrySet()) {
-            Content content = this.fetchContent(owner, entry.getKey());
+            String contentId = entry.getKey();
+
             boolean enabled = entry.getValue() != null ?
                 entry.getValue() :
                 ProductContent.DEFAULT_ENABLED_STATE;
 
-            ContentDTO cdto = this.translator.translate(content, ContentDTO.class);
-
-            changed |= pdto.addContent(cdto, enabled);
-            addContentToUpstreamSubscriptions(product, content, enabled);
+            this.adapter.addContentToProduct(productId, contentId, enabled);
         }
 
-        if (changed) {
-            product = this.productManager.updateProduct(pdto, owner, true);
-        }
-
-        return this.translator.translate(product, ProductDTO.class);
-    }
-
-    private void addContentToUpstreamSubscriptions(Product product, Content content, boolean enabled) {
-        List<Subscription> subs = adapter.getSubscriptions(product.toDTO());
-        for (Subscription sub: subs) {
-            if (sub.getProduct().getId().contentEquals(product.getId())) {
-                sub.getProduct().addContent(content, enabled);
-            }
-        }
+        return pinfo;
     }
 
     @POST
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.WILDCARD)
-    @Path("/owners/{owner_key}/products/{product_id}/content/{content_id}")
+    @Path("/products/{product_id}/content/{content_id}")
     @Transactional
-    public ProductDTO addContent(
-        @PathParam("owner_key") String ownerKey,
+    public ProductInfo addContentToProduct(
         @PathParam("product_id") String productId,
         @PathParam("content_id") String contentId,
         @QueryParam("enabled") Boolean enabled) {
 
         // Package the params up and pass it off to our batch method
         Map<String, Boolean> contentMap = Collections.singletonMap(contentId, enabled);
-        return this.addBatchContent(ownerKey, productId, contentMap);
+        return this.addContentToProduct(productId, contentMap);
     }
 
-    @PUT
-    @Path("/owners/{owner_key}/products/{product_id}")
+    @DELETE
+    @Path("/products/{product_id}/content")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public ProductInfo removeContentFromProduct(@PathParam("product_id") String productId,
+        Collection<String> contentIds) {
+
+        if (this.adapter.getProduct(productId) == null) {
+            throw new NotFoundException("product not found: " + productId);
+        }
+
+        if (contentIds != null) {
+            for (String contentId : contentIds) {
+                this.adapter.removeContentFromProduct(productId, contentId);
+            }
+        }
+
+        return this.adapter.getProduct(productId);
+    }
+
+    @DELETE
+    @Path("/products/{product_id}/content/{content_id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public ProductInfo removeContentFromProduct(@PathParam("product_id") String productId,
+        @PathParam("content_id") String contentId) {
+
+        return this.removeContentFromProduct(productId, Collections.<String>singletonList(contentId));
+    }
+
+    @GET
+    @Path("/products")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Transactional
+    public Collection<? extends ProductInfo> listProducts() {
+        return this.adapter.listProducts();
+    }
+
+    @GET
+    @Path("/products/{product_id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Transactional
+    public ProductInfo getProduct(@PathParam("product_id") String productId) {
+        ProductInfo pinfo = this.adapter.getProduct(productId);
+
+        if (pinfo == null) {
+            throw new NotFoundException("product does not exist: " + productId);
+        }
+
+        return pinfo;
+    }
+
+    @POST
+    @Path("/products")
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
     @Transactional
-    public ProductDTO updateProduct(
-        @PathParam("owner_key") String ownerKey,
+    public ProductInfo createProduct(ProductDTO product) {
+        if (product == null) {
+            throw new BadRequestException("product is null");
+        }
+
+        if (product.getId() == null || product.getId().isEmpty()) {
+            throw new BadRequestException("product lacks a product ID: " + product);
+        }
+
+        if (this.adapter.getProduct(product.getId()) != null) {
+            throw new ConflictException("product already exists: " + product.getId());
+        }
+
+        return this.adapter.createProduct(product);
+    }
+
+    @PUT
+    @Path("/products/{product_id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Transactional
+    public ProductInfo updateProduct(
         @PathParam("product_id") String productId,
         ProductDTO update) {
 
-        Owner owner = this.getOwnerByKey(ownerKey);
-        Product existing = this.fetchProduct(owner, productId);
-        Product updated = this.productManager.updateProduct(update, owner, true);
-
-        return this.translator.translate(updated, ProductDTO.class);
-    }
-
-    protected Product fetchProduct(Owner owner, String productId) {
-        Product product = this.ownerProductCurator.getProductById(owner, productId);
-
-        if (product == null) {
-            throw new NotFoundException(i18n.tr("Product with ID \"{0}\" could not be found.", productId));
+        if (update == null) {
+            throw new BadRequestException("product update is null");
         }
 
-        return product;
-    }
-
-    protected Owner getOwnerByKey(String key) {
-        Owner owner = this.ownerCurator.getByKey(key);
-
-        if (owner == null) {
-            throw new NotFoundException(i18n.tr("Owner with key \"{0}\" was not found.", key));
+        if (this.adapter.getProduct(productId) == null) {
+            throw new NotFoundException("product does not yet exist: " + productId);
         }
 
-        return owner;
+        return this.adapter.updateProduct(productId, update);
     }
 
-    protected Content fetchContent(Owner owner, String contentId) {
-        Content content = this.ownerContentCurator.getContentById(owner, contentId);
+    @DELETE
+    @Path("/products/{product_id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public boolean deleteProduct(@PathParam("product_id") String productId) {
+        return adapter.deleteProduct(productId) != null;
+    }
 
+
+    @GET
+    @Path("/content")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Transactional
+    public Collection<? extends ContentInfo> listContent() {
+        return this.adapter.listContent();
+    }
+
+    @GET
+    @Path("/content/{content_id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Transactional
+    public ContentInfo getContent(@PathParam("content_id") String contentId) {
+        ContentInfo cinfo = this.adapter.getContent(contentId);
+
+        if (cinfo == null) {
+            throw new NotFoundException("content does not exist: " + contentId);
+        }
+
+        return cinfo;
+    }
+
+    @POST
+    @Path("/content")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Transactional
+    public ContentInfo createContent(ContentDTO content) {
         if (content == null) {
-            throw new NotFoundException(i18n.tr("Content with ID \"{0}\" could not be found.", contentId));
+            throw new BadRequestException("content is null");
         }
 
-        return content;
+        if (content.getId() == null || content.getId().isEmpty()) {
+            throw new BadRequestException("content lacks a content ID: " + content);
+        }
+
+        if (this.adapter.getContent(content.getId()) != null) {
+            throw new ConflictException("content already exists: " + content.getId());
+        }
+
+        return this.adapter.createContent(content);
     }
+
+    @PUT
+    @Path("/content/{content_id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Transactional
+    public ContentInfo updateContent(
+        @PathParam("content_id") String contentId,
+        ContentDTO update) {
+
+        if (update == null) {
+            throw new BadRequestException("content update is null");
+        }
+
+        if (this.adapter.getContent(contentId) == null) {
+            throw new NotFoundException("content does not yet exist: " + contentId);
+        }
+
+        return this.adapter.updateContent(contentId, update);
+    }
+
+    @DELETE
+    @Path("/content/{content_id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public boolean deleteContent(@PathParam("content_id") String contentId) {
+        return adapter.deleteContent(contentId) != null;
+    }
+
 }

--- a/server/src/main/java/org/candlepin/hostedtest/HostedTestSubscriptionServiceAdapter.java
+++ b/server/src/main/java/org/candlepin/hostedtest/HostedTestSubscriptionServiceAdapter.java
@@ -14,21 +14,45 @@
  */
 package org.candlepin.hostedtest;
 
-import org.candlepin.model.Consumer;
+import org.candlepin.model.Branding;
+import org.candlepin.model.Cdn;
+import org.candlepin.model.CdnCertificate;
+import org.candlepin.model.CertificateSerial;
 import org.candlepin.model.Owner;
-import org.candlepin.model.dto.ProductContentData;
+import org.candlepin.model.ProductContent;
+import org.candlepin.model.SubscriptionsCertificate;
+import org.candlepin.model.dto.ContentData;
 import org.candlepin.model.dto.ProductData;
+import org.candlepin.model.dto.ProductContentData;
 import org.candlepin.model.dto.Subscription;
 import org.candlepin.service.SubscriptionServiceAdapter;
+import org.candlepin.service.model.BrandingInfo;
+import org.candlepin.service.model.CdnInfo;
+import org.candlepin.service.model.CertificateInfo;
+import org.candlepin.service.model.CertificateSerialInfo;
+import org.candlepin.service.model.ConsumerInfo;
+import org.candlepin.service.model.ContentInfo;
+import org.candlepin.service.model.OwnerInfo;
+import org.candlepin.service.model.ProductInfo;
+import org.candlepin.service.model.ProductContentInfo;
+import org.candlepin.service.model.SubscriptionInfo;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
-import java.util.List;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import javax.inject.Singleton;
 
 
 
@@ -38,146 +62,961 @@ import java.util.Map;
  * mode, while it is built with candlepin, it is not packaged in candlepin.war,
  * as the only purpose of this class is to support spec tests.
  */
+@Singleton
 public class HostedTestSubscriptionServiceAdapter implements SubscriptionServiceAdapter {
     private static Logger log = LoggerFactory.getLogger(HostedTestSubscriptionServiceAdapter.class);
 
-    private static Map<String, Subscription> idMap = new HashMap<>();
-    private static Map<String, List<Subscription>> ownerMap = new HashMap<>();
-    private static Map<String, List<Subscription>> productMap = new HashMap<>();
+    // Owner mapping. Owners are mapped using owner key to a simplified Owner object containing only
+    // a minimal set of data to be a valid OwnerInfo instance (likely just the key itself)
+    protected Map<String, Owner> ownerMap;
 
-    @Override
-    public List<Subscription> getSubscriptions(Owner owner) {
-        if (ownerMap.containsKey(owner.getKey())) {
-            return ownerMap.get(owner.getKey());
+    // Subscription mapping. Subscriptions themselves are mapped by subscription ID to DTO. Since
+    // we don't store owners (orgs) at this level, we just maintain a mapping of owner keys
+    // (account) to subscription IDs.
+    protected Map<String, Subscription> subscriptionMap;
+
+    // At the time of writing, upstream product and content data is global; no need to separate these
+    // by org. Mapped by RHID to DTO
+    protected Map<String, ProductData> productMap;
+    protected Map<String, ContentData> contentMap;
+
+    // These are used to provide reverse lookups from child objects back to their parents
+    protected Map<String, Set<String>> contentProductMap;
+    protected Map<String, Set<String>> productSubscriptionMap;
+
+    /**
+     * Creates a new HostedTestSubscriptionServiceAdapter instance
+     */
+    public HostedTestSubscriptionServiceAdapter() {
+        this.ownerMap = new HashMap<>();
+
+        this.subscriptionMap = new HashMap<>();
+
+        this.productMap = new HashMap<>();
+        this.contentMap = new HashMap<>();
+
+        this.contentProductMap = new HashMap<>();
+        this.productSubscriptionMap = new HashMap<>();
+    }
+
+
+
+    public SubscriptionInfo createSubscription(SubscriptionInfo sinfo) {
+        if (sinfo == null) {
+            throw new IllegalArgumentException("sinfo is null");
         }
-        return new ArrayList<>();
-    }
 
-    @Override
-    public List<String> getSubscriptionIds(Owner owner) {
-        List<String> ids = new ArrayList<>();
-        List<Subscription> subscriptions = ownerMap.get(owner.getKey());
-        if (subscriptions != null) {
-            for (Subscription subscription : subscriptions) {
-                ids.add(subscription.getId());
-            }
+        if (StringUtils.isBlank(sinfo.getId())) {
+            throw new IllegalArgumentException("subscription is lacking an identifier: " + sinfo);
         }
 
-        return ids;
-    }
-
-    @Override
-    public List<Subscription> getSubscriptions(ProductData product) {
-        if (productMap.containsKey(product.getId())) {
-            return productMap.get(product.getId());
+        if (this.subscriptionMap.containsKey(sinfo.getId())) {
+            throw new IllegalStateException("subscription already exists: " + sinfo.getId());
         }
-        return new ArrayList<>();
+
+        // TODO: Add any other subscription validation we want here
+
+        Subscription sdata = new Subscription();
+
+        sdata.setId(sinfo.getId());
+        sdata.setOwner(this.resolveOwner(sinfo.getOwner()));
+
+        sdata.setProduct(this.resolveProduct(sinfo.getProduct()));
+        sdata.setProvidedProducts(this.resolveProducts(sinfo.getProvidedProducts()));
+        sdata.setDerivedProduct(this.resolveProduct(sinfo.getDerivedProduct()));
+        sdata.setDerivedProvidedProducts(this.resolveProducts(sinfo.getDerivedProvidedProducts()));
+
+        sdata.setQuantity(sinfo.getQuantity());
+        sdata.setStartDate(sinfo.getStartDate());
+        sdata.setEndDate(sinfo.getEndDate());
+        sdata.setModified(sinfo.getLastModified());
+        sdata.setContractNumber(sinfo.getContractNumber());
+        sdata.setAccountNumber(sinfo.getAccountNumber());
+        sdata.setOrderNumber(sinfo.getOrderNumber());
+
+        sdata.setUpstreamPoolId(sinfo.getUpstreamPoolId());
+        sdata.setUpstreamEntitlementId(sinfo.getUpstreamEntitlementId());
+        sdata.setUpstreamConsumerId(sinfo.getUpstreamConsumerId());
+        sdata.setCertificate(this.convertSubscriptionCertificate(sinfo.getCertificate()));
+        sdata.setCdn(this.convertCdn(sinfo.getCdn()));
+        sdata.setBranding(this.resolveBranding(sinfo.getBranding()));
+
+        // Update mappings
+        this.subscriptionMap.put(sdata.getId(), sdata);
+        this.updateSubscriptionProductMappings(sdata);
+
+        return sdata;
     }
 
-    @Override
-    public Subscription getSubscription(String subscriptionId) {
-        return idMap.get(subscriptionId);
-    }
 
-    @Override
-    public List<Subscription> getSubscriptions() {
-        List<Subscription> result = new ArrayList<>();
-        for (String id : idMap.keySet()) {
-            result.add(idMap.get(id));
+    public SubscriptionInfo updateSubscription(String subscriptionId, SubscriptionInfo sinfo) {
+        if (subscriptionId == null) {
+            throw new IllegalArgumentException("subscriptionId is null");
         }
-        return result;
+
+        if (sinfo == null) {
+            throw new IllegalArgumentException("sinfo is null");
+        }
+
+        Subscription sdata = this.subscriptionMap.get(subscriptionId);
+
+        if (sdata == null) {
+            throw new IllegalStateException("subscription does not exist: " + subscriptionId);
+        }
+
+        // Apply updates...
+
+        // Do product resolution here
+        ProductData product = this.resolveProduct(sinfo.getProduct());
+        Collection<ProductData> providedProducts = this.resolveProducts(sinfo.getProvidedProducts());
+
+        ProductData dProduct = this.resolveProduct(sinfo.getDerivedProduct());
+        Collection<ProductData> dpProvidedProducts = this.resolveProducts(sinfo.getDerivedProvidedProducts());
+
+        // If they all resolved, set the products
+        if (product != null) {
+            sdata.setProduct(product);
+        }
+
+        if (providedProducts != null) {
+            sdata.setProvidedProducts(providedProducts);
+        }
+
+        sdata.setDerivedProduct(dProduct);
+
+        if (dpProvidedProducts != null) {
+            sdata.setDerivedProvidedProducts(dpProvidedProducts);
+        }
+
+        // Set the other "safe" properties here...
+        if (sinfo.getOwner() != null) {
+            sdata.setOwner(this.resolveOwner(sinfo.getOwner()));
+        }
+
+        if (sinfo.getQuantity() != null) {
+            sdata.setQuantity(sinfo.getQuantity());
+        }
+
+        if (sinfo.getStartDate() != null) {
+            sdata.setStartDate(sinfo.getStartDate());
+        }
+
+        if (sinfo.getEndDate() != null) {
+            sdata.setEndDate(sinfo.getEndDate());
+        }
+
+        if (sinfo.getLastModified() != null) {
+            sdata.setModified(sinfo.getLastModified());
+        }
+
+        if (sinfo.getContractNumber() != null) {
+            sdata.setContractNumber(sinfo.getContractNumber());
+        }
+
+        if (sinfo.getAccountNumber() != null) {
+            sdata.setAccountNumber(sinfo.getAccountNumber());
+        }
+
+        if (sinfo.getOrderNumber() != null) {
+            sdata.setOrderNumber(sinfo.getOrderNumber());
+        }
+
+        if (sinfo.getUpstreamPoolId() != null) {
+            sdata.setUpstreamPoolId(sinfo.getUpstreamPoolId());
+        }
+
+        if (sinfo.getUpstreamEntitlementId() != null) {
+            sdata.setUpstreamEntitlementId(sinfo.getUpstreamEntitlementId());
+        }
+
+        if (sinfo.getUpstreamConsumerId() != null) {
+            sdata.setUpstreamConsumerId(sinfo.getUpstreamConsumerId());
+        }
+
+        sdata.setCertificate(this.convertSubscriptionCertificate(sinfo.getCertificate()));
+
+        sdata.setCdn(this.convertCdn(sinfo.getCdn()));
+
+        if (sinfo.getBranding() != null) {
+            sdata.setBranding(this.resolveBranding(sinfo.getBranding()));
+        }
+
+        // Update mappings...
+        this.updateSubscriptionProductMappings(sdata);
+
+        return sdata;
     }
 
-    @Override
-    public boolean hasUnacceptedSubscriptionTerms(Owner owner) {
+    public SubscriptionInfo deleteSubscription(String subscriptionId) {
+        if (subscriptionId == null) {
+            throw new IllegalArgumentException("subscriptionId is null");
+        }
+
+        if (!this.subscriptionMap.containsKey(subscriptionId)) {
+            throw new IllegalStateException("subscription does not exist: " + subscriptionId);
+        }
+
+        Subscription sdata = this.subscriptionMap.remove(subscriptionId);
+
+        // Remove any product mappings to this subscription...
+        for (Set<String> sids : this.productSubscriptionMap.values()) {
+            sids.remove(subscriptionId);
+        }
+
+        return sdata;
+    }
+
+    public ProductInfo createProduct(ProductInfo pinfo) {
+        if (pinfo == null) {
+            throw new IllegalArgumentException("pinfo is null");
+        }
+
+        if (StringUtils.isBlank(pinfo.getId())) {
+            throw new IllegalArgumentException("product is lacking an identifier: " + pinfo);
+        }
+
+        if (this.productMap.containsKey(pinfo.getId())) {
+            throw new IllegalStateException("product already exists: " + pinfo.getId());
+        }
+
+        // TODO: Add any other product validation we want here
+
+        ProductData pdata = new ProductData();
+
+        pdata.setId(pinfo.getId());
+        pdata.setProductContent(this.resolveProductContent(pinfo.getProductContent()));
+        pdata.setName(pinfo.getName());
+        pdata.setMultiplier(pinfo.getMultiplier());
+        pdata.setAttributes(pinfo.getAttributes());
+        pdata.setDependentProductIds(pinfo.getDependentProductIds());
+        pdata.setCreated(new Date());
+        pdata.setUpdated(new Date());
+
+        // Create our mappings...
+        this.productMap.put(pdata.getId(), pdata);
+        this.productSubscriptionMap.put(pdata.getId(), new HashSet<>());
+
+        // Update content=>product mappings
+        this.updateProductContentMappings(pdata);
+
+        return pdata;
+    }
+
+    public ProductInfo updateProduct(String productId, ProductInfo pinfo) {
+        if (productId == null) {
+            throw new IllegalArgumentException("productId is null");
+        }
+
+        if (pinfo == null) {
+            throw new IllegalArgumentException("pinfo is null");
+        }
+
+        ProductData pdata = this.productMap.get(productId);
+
+        if (pdata == null) {
+            throw new IllegalStateException("product does not exist: " + productId);
+        }
+
+        // Apply updates...
+        // Don't allow changing the ID
+
+        Collection<ProductContentData> pcdata = this.resolveProductContent(pinfo.getProductContent());
+        if (pcdata != null) {
+            pdata.setProductContent(pcdata);
+        }
+
+        if (pinfo.getName() != null) {
+            pdata.setName(pinfo.getName());
+        }
+
+        if (pinfo.getMultiplier() != null) {
+            pdata.setMultiplier(pinfo.getMultiplier());
+        }
+
+        if (pinfo.getAttributes() != null) {
+            pdata.setAttributes(pinfo.getAttributes());
+        }
+
+        if (pinfo.getDependentProductIds() != null) {
+            pdata.setDependentProductIds(pinfo.getDependentProductIds());
+        }
+
+        // Update product=>content mappings
+        this.updateProductContentMappings(pdata);
+
+        pdata.setUpdated(new Date());
+
+        return pdata;
+    }
+
+    public ProductInfo deleteProduct(String productId) {
+        if (productId == null) {
+            throw new IllegalArgumentException("productId is null");
+        }
+
+        if (!this.productMap.containsKey(productId)) {
+            throw new IllegalStateException("Product does not exist: " + productId);
+        }
+
+        if (this.productSubscriptionMap.containsKey(productId) &&
+            !this.productSubscriptionMap.get(productId).isEmpty()) {
+
+            throw new IllegalStateException(
+                "Product is still referenced by one or more subscriptions: " + productId);
+        }
+
+        ProductData pdata = this.productMap.remove(productId);
+
+        // Update our mappings...
+        // Impl note: no need to update the subscriptions since we know none are using this product.
+        this.productSubscriptionMap.remove(productId);
+
+        // Update content=>product mappings to no longer reference this product
+        for (Set<String> pids : this.contentProductMap.values()) {
+            pids.remove(productId);
+        }
+
+        return pdata;
+    }
+
+    public Collection<? extends ProductInfo> listProducts() {
+        return this.productMap.values();
+    }
+
+    public ProductInfo getProduct(String productId) {
+        if (productId == null) {
+            throw new IllegalArgumentException("productId is null");
+        }
+
+        return this.productMap.get(productId);
+    }
+
+    public ContentInfo createContent(ContentInfo cinfo) {
+        if (cinfo == null) {
+            throw new IllegalArgumentException("cinfo is null");
+        }
+
+        if (StringUtils.isBlank(cinfo.getId())) {
+            throw new IllegalArgumentException("content is lacking an identifier: " + cinfo);
+        }
+
+        if (this.contentMap.containsKey(cinfo.getId())) {
+            throw new IllegalStateException("content already exists: " + cinfo.getId());
+        }
+
+        // TODO: Add any other content validation we want here
+
+        // Create a copy of the data so we're guaranteed to be detached from any other object
+        ContentData cdata = new ContentData();
+
+        cdata.setId(cinfo.getId());
+        cdata.setType(cinfo.getType());
+        cdata.setLabel(cinfo.getLabel());
+        cdata.setName(cinfo.getName());
+        cdata.setVendor(cinfo.getVendor());
+        cdata.setContentUrl(cinfo.getContentUrl());
+        cdata.setRequiredTags(cinfo.getRequiredTags());
+        cdata.setReleaseVersion(cinfo.getReleaseVersion());
+        cdata.setGpgUrl(cinfo.getGpgUrl());
+        cdata.setArches(cinfo.getArches());
+        cdata.setMetadataExpiration(cinfo.getMetadataExpiration());
+        cdata.setRequiredProductIds(cinfo.getRequiredProductIds());
+        cdata.setCreated(new Date());
+        cdata.setUpdated(new Date());
+
+        // Create our mappings...
+        this.contentMap.put(cdata.getId(), cdata);
+        this.contentProductMap.put(cdata.getId(), new HashSet<>());
+
+        return cdata;
+    }
+
+    public ContentInfo updateContent(String contentId, ContentInfo cinfo) {
+        if (contentId == null) {
+            throw new IllegalArgumentException("contentId is null");
+        }
+
+        if (cinfo == null) {
+            throw new IllegalArgumentException("cinfo is null");
+        }
+
+        ContentData cdata = this.contentMap.get(contentId);
+
+        if (cdata == null) {
+            throw new IllegalStateException("content does not exist: " + contentId);
+        }
+
+        // Don't allow changing the ID
+
+        if (cinfo.getType() != null) {
+            cdata.setType(cinfo.getType());
+        }
+
+        if (cinfo.getLabel() != null) {
+            cdata.setLabel(cinfo.getLabel());
+        }
+
+        if (cinfo.getName() != null) {
+            cdata.setName(cinfo.getName());
+        }
+
+        if (cinfo.getVendor() != null) {
+            cdata.setVendor(cinfo.getVendor());
+        }
+
+        if (cinfo.getContentUrl() != null) {
+            cdata.setContentUrl(cinfo.getContentUrl());
+        }
+
+        if (cinfo.getRequiredTags() != null) {
+            cdata.setRequiredTags(cinfo.getRequiredTags());
+        }
+
+        if (cinfo.getReleaseVersion() != null) {
+            cdata.setReleaseVersion(cinfo.getReleaseVersion());
+        }
+
+        if (cinfo.getGpgUrl() != null) {
+            cdata.setGpgUrl(cinfo.getGpgUrl());
+        }
+
+        if (cinfo.getArches() != null) {
+            cdata.setArches(cinfo.getArches());
+        }
+
+        if (cinfo.getMetadataExpiration() != null) {
+            cdata.setMetadataExpiration(cinfo.getMetadataExpiration());
+        }
+
+        if (cinfo.getRequiredProductIds() != null) {
+            cdata.setRequiredProductIds(cinfo.getRequiredProductIds());
+        }
+
+        cdata.setUpdated(new Date());
+
+        return cdata;
+    }
+
+    public ContentInfo deleteContent(String contentId) {
+        if (contentId == null) {
+            throw new IllegalArgumentException("contentId is null");
+        }
+
+        ContentData cdata = this.contentMap.remove(contentId);
+
+        if (cdata == null) {
+            throw new IllegalStateException("content does not exist: " + contentId);
+        }
+
+        // Update every product pointing to this content and update our mappings
+        for (String productId : this.contentProductMap.remove(contentId)) {
+            ProductData pdata = this.productMap.get(productId);
+            pdata.removeContent(contentId);
+        }
+
+        return cdata;
+    }
+
+    public Collection<? extends ContentInfo> listContent() {
+        return this.contentMap.values();
+    }
+
+    public ContentInfo getContent(String contentId) {
+        if (contentId == null) {
+            throw new IllegalArgumentException("contentId is null");
+        }
+
+        return this.contentMap.get(contentId);
+    }
+
+    public boolean addContentToProduct(String productId, String contentId, boolean enabled) {
+        if (productId == null) {
+            throw new IllegalArgumentException("productId is null");
+        }
+
+        if (contentId == null) {
+            throw new IllegalArgumentException("contentId is null");
+        }
+
+        ProductData pdata = this.productMap.get(productId);
+        if (pdata == null) {
+            throw new IllegalArgumentException("No such product: " + productId);
+        }
+
+        ContentData cdata = this.contentMap.get(contentId);
+        if (cdata == null) {
+            throw new IllegalArgumentException("No such content: " + contentId);
+        }
+
+        if (pdata.addContent(cdata, enabled)) {
+            this.updateProductContentMappings(pdata);
+            return true;
+        }
+
         return false;
     }
 
+    public boolean removeContentFromProduct(String productId, String contentId) {
+        if (productId == null) {
+            throw new IllegalArgumentException("productId is null");
+        }
+
+        if (contentId == null) {
+            throw new IllegalArgumentException("contentId is null");
+        }
+
+        ProductData pdata = this.productMap.get(productId);
+        if (pdata == null) {
+            throw new IllegalArgumentException("No such product: " + productId);
+        }
+
+        ContentData cdata = this.contentMap.get(contentId);
+        if (cdata == null) {
+            throw new IllegalArgumentException("No such content: " + contentId);
+        }
+
+        if (pdata.removeContent(contentId)) {
+            this.updateProductContentMappings(pdata);
+            return true;
+        }
+
+        return false;
+    }
+
+
+    protected void updateSubscriptionProductMappings(Subscription sdata) {
+        if (sdata == null) {
+            throw new IllegalArgumentException("sdata is null");
+        }
+
+        if (StringUtils.isBlank(sdata.getId())) {
+            throw new IllegalArgumentException("subscription lacks identifying information: " + sdata);
+        }
+
+        // Compile list of products this subscription uses...
+        Set<String> pids = new HashSet<>();
+
+        if (sdata.getProduct() != null && sdata.getProduct().getId() != null) {
+            pids.add(sdata.getProduct().getId());
+        }
+
+        if (sdata.getProvidedProducts() != null) {
+            for (ProductData pdata : sdata.getProvidedProducts()) {
+                if (pdata != null && pdata.getId() != null) {
+                    pids.add(pdata.getId());
+                }
+            }
+        }
+
+        if (sdata.getDerivedProduct() != null && sdata.getDerivedProduct().getId() != null) {
+            pids.add(sdata.getDerivedProduct().getId());
+        }
+
+        if (sdata.getDerivedProvidedProducts() != null) {
+            for (ProductData pdata : sdata.getDerivedProvidedProducts()) {
+                if (pdata != null && pdata.getId() != null) {
+                    pids.add(pdata.getId());
+                }
+            }
+        }
+
+        // Sanity check: Make sure every pid we're refrencing is one we're tracking. This shouldn't
+        // ever fail, but if it does, something very bad has happened.
+        for (String pid : pids) {
+            if (!this.productMap.containsKey(pid)) {
+                throw new IllegalStateException("unknown/unexpected product id: " + pid);
+            }
+
+            if (!this.productSubscriptionMap.containsKey(pid)) {
+                throw new IllegalStateException("product=>subscription map lacks table for product: " + pid);
+            }
+        }
+
+        // Step through our mapped products and either add the subscription or remove it depending
+        // on if the product ID exists in our compiled map
+        for (Map.Entry<String, Set<String>> entry : this.productSubscriptionMap.entrySet()) {
+            String pid = entry.getKey();
+            Set<String> sids = entry.getValue();
+
+            if (pids.contains(pid)) {
+                sids.add(sdata.getId());
+            }
+            else {
+                sids.remove(sdata.getId());
+            }
+        }
+    }
+
+    protected void updateProductContentMappings(ProductData pdata) {
+        if (pdata == null) {
+            throw new IllegalArgumentException("pdata is null");
+        }
+
+        if (StringUtils.isBlank(pdata.getId())) {
+            throw new IllegalArgumentException("product lacks identifying information: " + pdata);
+        }
+
+        // Compile list of content this product uses...
+        Set<String> cids = new HashSet<>();
+
+        if (pdata.getProductContent() != null) {
+            for (ProductContentData pcdata : pdata.getProductContent()) {
+                if (pcdata != null) {
+                    ContentData cdata = pcdata.getContent();
+
+                    if (cdata != null && cdata.getId() != null) {
+                        cids.add(cdata.getId());
+                    }
+                }
+            }
+        }
+
+        // Sanity check: Make sure every cid we're refrencing is one we're tracking. This shouldn't
+        // ever fail, but if it does, something very bad has happened.
+        for (String cid : cids) {
+            if (!this.contentMap.containsKey(cid)) {
+                throw new IllegalStateException("unknown/unexpected content id: " + cid);
+            }
+
+            if (!this.contentProductMap.containsKey(cid)) {
+                throw new IllegalStateException("content=>product map lacks table for content: " + cid);
+            }
+        }
+
+        // Step through our mapped content and either add the product or remove it depending
+        // on if the content ID exists in our compiled set
+        for (Map.Entry<String, Set<String>> entry : this.contentProductMap.entrySet()) {
+            String cid = entry.getKey();
+            Set<String> pids = entry.getValue();
+
+            if (cids.contains(cid)) {
+                pids.add(pdata.getId());
+            }
+            else {
+                pids.remove(pdata.getId());
+            }
+        }
+    }
+
+
+    protected Owner resolveOwner(OwnerInfo oinfo) {
+        if (oinfo == null || StringUtils.isBlank(oinfo.getKey())) {
+            throw new IllegalArgumentException("owner is null or lacks an owner key");
+        }
+
+        Owner owner = this.ownerMap.get(oinfo.getKey());
+
+        if (owner == null) {
+            owner = new Owner(oinfo.getKey());
+            this.ownerMap.put(owner.getKey(), owner);
+        }
+
+        return owner;
+    }
+
+    protected ProductData resolveProduct(ProductInfo pinfo) {
+        if (pinfo != null) {
+            if (StringUtils.isBlank(pinfo.getId())) {
+                throw new IllegalArgumentException("product lacks an identifier: " + pinfo);
+            }
+
+            ProductData pdata = this.productMap.get(pinfo.getId());
+            if (pdata == null) {
+                throw new IllegalStateException("product does not exist: " + pinfo.getId());
+            }
+
+            return pdata;
+        }
+
+        return null;
+    }
+
+    protected Collection<ProductData> resolveProducts(Collection<? extends ProductInfo> products) {
+        if (products != null) {
+            Map<String, ProductData> output = new HashMap<>();
+
+            for (ProductInfo pinfo : products) {
+                ProductData pdata = this.resolveProduct(pinfo);
+
+                if (pdata != null) {
+                    output.put(pdata.getId(), pdata);
+                }
+            }
+
+            return output.values();
+        }
+
+        return null;
+    }
+
+    protected Collection<ProductContentData> resolveProductContent(
+        Collection<? extends ProductContentInfo> productContent) {
+
+        if (productContent != null) {
+            Map<String, ProductContentData> output = new HashMap<>();
+
+            for (ProductContentInfo pcinfo : productContent) {
+                if (pcinfo != null) {
+                    ContentInfo cinfo = pcinfo.getContent();
+
+                    if (cinfo == null || StringUtils.isBlank(cinfo.getId())) {
+                        throw new IllegalArgumentException(
+                            "content is null or lacks an identifier: " + cinfo);
+                    }
+
+                    ContentData cdata = this.contentMap.get(cinfo.getId());
+
+                    if (cdata == null) {
+                        throw new IllegalStateException("content does not exist: " + cinfo.getId());
+                    }
+
+                    ProductContentData pcdata = new ProductContentData();
+                    pcdata.setContent(cdata);
+                    pcdata.setEnabled(pcinfo.isEnabled() != null ?
+                        pcinfo.isEnabled() :
+                        ProductContent.DEFAULT_ENABLED_STATE);
+
+                    output.put(cinfo.getId(), pcdata);
+                }
+            }
+
+            return output.values();
+        }
+
+        return null;
+    }
+
+    protected Set<Branding> resolveBranding(Collection<? extends BrandingInfo> branding) {
+        if (branding != null) {
+            Map<String, Branding> brandMap = new HashMap<>();
+
+            // We don't bother keeping cross-subscription references here, so the only thing
+            // we are really concerned with is making sure we don't end up with two brands
+            // for the same product.
+
+            for (BrandingInfo binfo : branding) {
+                // Silently ignore null refs
+                if (binfo != null) {
+                    if (binfo.getProductId() == null || binfo.getProductId().isEmpty()) {
+                        throw new IllegalArgumentException("Branding lacks a product ID: " + binfo);
+                    }
+
+                    Branding bdata = new Branding();
+
+                    bdata.setProductId(binfo.getProductId());
+                    bdata.setType(binfo.getType());
+                    bdata.setName(binfo.getName());
+
+                    brandMap.put(bdata.getProductId(), bdata);
+                }
+            }
+
+            return new HashSet<>(brandMap.values());
+        }
+
+        return null;
+    }
+
+    protected Cdn convertCdn(CdnInfo cinfo) {
+        if (cinfo != null) {
+            if (cinfo.getName() == null || cinfo.getName().isEmpty()) {
+                throw new IllegalArgumentException("Cdn lacks a name: " + cinfo);
+            }
+
+            Cdn cdata = new Cdn();
+
+            cdata.setName(cinfo.getName());
+            cdata.setLabel(cinfo.getLabel());
+            cdata.setUrl(cinfo.getUrl());
+            cdata.setCertificate(this.convertCdnCertificate(cinfo.getCertificate()));
+
+            return cdata;
+        }
+
+        return null;
+    }
+
+    protected CdnCertificate convertCdnCertificate(CertificateInfo cinfo) {
+        if (cinfo != null) {
+            CdnCertificate cert = new CdnCertificate();
+
+            cert.setKey(cinfo.getKey());
+            cert.setCert(cinfo.getCertificate());
+
+            if (cinfo.getSerial() != null) {
+                CertificateSerialInfo serialInfo = cinfo.getSerial();
+                CertificateSerial serial = new CertificateSerial();
+
+                serial.setSerial(serialInfo.getSerial());
+                serial.setRevoked(serialInfo.isRevoked());
+                serial.setCollected(serialInfo.isCollected());
+                serial.setExpiration(serialInfo.getExpiration());
+
+                cert.setSerial(serial);
+            }
+
+            return cert;
+        }
+
+        return null;
+    }
+
+    protected SubscriptionsCertificate convertSubscriptionCertificate(CertificateInfo cinfo) {
+        if (cinfo != null) {
+            SubscriptionsCertificate cert = new SubscriptionsCertificate();
+
+            cert.setKey(cinfo.getKey());
+            cert.setCert(cinfo.getCertificate());
+
+            if (cinfo.getSerial() != null) {
+                CertificateSerialInfo serialInfo = cinfo.getSerial();
+                CertificateSerial serial = new CertificateSerial();
+
+                serial.setSerial(serialInfo.getSerial());
+                serial.setRevoked(serialInfo.isRevoked());
+                serial.setCollected(serialInfo.isCollected());
+                serial.setExpiration(serialInfo.getExpiration());
+
+                cert.setSerial(serial);
+            }
+
+            return cert;
+        }
+
+        return null;
+    }
+
+
+
+    /**
+     * Clears all data for this service adapter
+     */
+    public void clearData() {
+        this.ownerMap.clear();
+        this.subscriptionMap.clear();
+        this.productMap.clear();
+        this.contentMap.clear();
+        this.contentProductMap.clear();
+        this.productSubscriptionMap.clear();
+    }
+
+
+
+    // Service adapter interface methods
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Collection<? extends SubscriptionInfo> getSubscriptions() {
+        return this.subscriptionMap.values();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SubscriptionInfo getSubscription(String subscriptionId) {
+        return this.subscriptionMap.get(subscriptionId);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Collection<? extends SubscriptionInfo> getSubscriptions(String ownerKey) {
+        if (ownerKey != null) {
+            return this.subscriptionMap.values()
+                .stream()
+                .filter(s -> s.getOwner() != null && ownerKey.equals(s.getOwner().getKey()))
+                .collect(Collectors.toList());
+        }
+
+        return Collections.emptyList();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Collection<String> getSubscriptionIds(String ownerKey) {
+        if (ownerKey != null) {
+            return this.subscriptionMap.values()
+                .stream()
+                .filter(s -> s.getOwner() != null && ownerKey.equals(s.getOwner().getKey()))
+                .map(s -> s.getId())
+                .collect(Collectors.toList());
+        }
+
+        return Collections.emptyList();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Collection<? extends SubscriptionInfo> getSubscriptionsByProductId(String productId) {
+        if (productId != null) {
+            Predicate<Subscription> predicate = sub -> {
+                if (sub.getProduct() != null && productId.equals(sub.getProduct().getId())) {
+                    return true;
+                }
+
+                if (sub.getProvidedProducts() != null) {
+                    for (ProductData product : sub.getProvidedProducts()) {
+                        if (product != null && productId.equals(product.getId())) {
+                            return true;
+                        }
+                    }
+                }
+
+                return false;
+            };
+
+            return this.subscriptionMap.values()
+                .stream()
+                .filter(predicate)
+                .collect(Collectors.toList());
+        }
+
+        return Collections.emptyList();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean hasUnacceptedSubscriptionTerms(String ownerKey) {
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void sendActivationEmail(String subscriptionId) {
         // method intentionally left blank
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
-    public boolean canActivateSubscription(Consumer consumer) {
+    public boolean canActivateSubscription(ConsumerInfo consumer) {
         return false;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
-    public void activateSubscription(Consumer consumer, String email, String emailLocale) {
+    public void activateSubscription(ConsumerInfo consumer, String email, String emailLocale) {
         // method intentionally left blank
     }
 
-    @Override
-    public Subscription createSubscription(Subscription s) {
-        idMap.put(s.getId(), s);
-        if (!ownerMap.containsKey(s.getOwner().getKey())) {
-            ownerMap.put(s.getOwner().getKey(), new ArrayList<>());
-        }
-        ownerMap.get(s.getOwner().getKey()).add(s);
-        if (!productMap.containsKey(s.getProduct().getId())) {
-            productMap.put(s.getProduct().getId(), new ArrayList<>());
-        }
-
-        this.clearUuids(s.getProduct());
-        this.clearUuids(s.getDerivedProduct());
-
-        if (CollectionUtils.isNotEmpty(s.getProvidedProducts())) {
-            for (ProductData pdata : s.getProvidedProducts()) {
-                this.clearUuids(pdata);
-            }
-        }
-
-        if (CollectionUtils.isNotEmpty(s.getDerivedProvidedProducts())) {
-            for (ProductData pdata : s.getDerivedProvidedProducts()) {
-                this.clearUuids(pdata);
-            }
-        }
-
-        productMap.get(s.getProduct().getId()).add(s);
-        return s;
-    }
-
-    private void clearUuids(ProductData pdata) {
-        if (pdata != null) {
-            pdata.setUuid(null);
-            if (pdata.getProductContent() != null) {
-                for (ProductContentData pcdata : pdata.getProductContent()) {
-                    if (pcdata.getContent() != null) {
-                        pcdata.getContent().setUuid(null);
-                    }
-                }
-            }
-        }
-    }
-
-    public Subscription updateSubscription(Subscription ss) {
-        deleteSubscription(ss.getId());
-        Subscription s = createSubscription(ss);
-        return s;
-    }
-
-    @Override
-    public void deleteSubscription(Subscription s) {
-        deleteSubscription(s.getId());
-    }
-
-    public boolean deleteSubscription(String id) {
-        if (idMap.containsKey(id)) {
-            Subscription s = idMap.remove(id);
-            ownerMap.get(s.getOwner().getKey()).remove(s);
-            productMap.get(s.getProduct().getId()).remove(s);
-            return true;
-        }
-        return false;
-    }
-
-    public void deleteAllSubscriptions() {
-        idMap.clear();
-        ownerMap.clear();
-        productMap.clear();
-    }
-
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public boolean isReadOnly() {
         return false;

--- a/server/src/main/java/org/candlepin/katello/KatelloUserServiceAdapter.java
+++ b/server/src/main/java/org/candlepin/katello/KatelloUserServiceAdapter.java
@@ -14,11 +14,15 @@
  */
 package org.candlepin.katello;
 
-import org.candlepin.model.Role;
-import org.candlepin.model.User;
 import org.candlepin.service.UserServiceAdapter;
+import org.candlepin.service.model.OwnerInfo;
+import org.candlepin.service.model.PermissionBlueprintInfo;
+import org.candlepin.service.model.RoleInfo;
+import org.candlepin.service.model.UserInfo;
 
-import java.util.List;
+import java.util.Collection;
+
+
 
 /**
  * KatelloUserServiceAdapter
@@ -31,68 +35,82 @@ import java.util.List;
 public class KatelloUserServiceAdapter implements UserServiceAdapter {
 
     @Override
-    public boolean validateUser(String username, String password)
-        throws Exception {
+    public boolean validateUser(String username, String password) throws Exception {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public User createUser(User user) {
+    public UserInfo createUser(UserInfo user) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public User updateUser(User user) {
+    public UserInfo updateUser(String username, UserInfo user) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void deleteUser(User user) {
+    public void deleteUser(String username) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public User findByLogin(String login) {
+    public UserInfo findByLogin(String username) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public List<User> listUsers() {
+    public Collection<? extends UserInfo> listUsers() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Role createRole(Role r) {
+    public Collection<? extends OwnerInfo> getAccessibleOwners(String username) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Role updateRole(Role r) {
+    public RoleInfo createRole(RoleInfo role) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void addUserToRole(Role role, User user) {
+    public RoleInfo updateRole(String roleName, RoleInfo role) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void removeUserFromRole(Role role, User user) {
+    public RoleInfo addUserToRole(String roleName, String username) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void deleteRole(String roleId) {
+    public RoleInfo removeUserFromRole(String roleName, String username) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Role getRole(String roleId) {
+    public RoleInfo addPermissionToRole(String roleName, PermissionBlueprintInfo permission) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public List<Role> listRoles() {
+    public RoleInfo removePermissionFromRole(String roleName, String permissionId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void deleteRole(String roleName) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RoleInfo getRole(String roleName) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Collection<? extends RoleInfo> listRoles() {
         throw new UnsupportedOperationException();
     }
 

--- a/server/src/main/java/org/candlepin/model/AbstractCertificate.java
+++ b/server/src/main/java/org/candlepin/model/AbstractCertificate.java
@@ -14,6 +14,8 @@
  */
 package org.candlepin.model;
 
+import org.candlepin.service.model.CertificateInfo;
+
 import javax.persistence.Column;
 import javax.persistence.MappedSuperclass;
 import javax.validation.constraints.NotNull;
@@ -29,7 +31,8 @@ import javax.xml.bind.annotation.XmlType;
  */
 @MappedSuperclass
 @XmlType(name = "Certificate")
-public abstract class AbstractCertificate<T extends AbstractCertificate> extends AbstractHibernateObject<T> {
+public abstract class AbstractCertificate<T extends AbstractCertificate> extends AbstractHibernateObject<T>
+    implements CertificateInfo {
 
     @Column(nullable = false, name = "privatekey")
     @NotNull
@@ -49,6 +52,10 @@ public abstract class AbstractCertificate<T extends AbstractCertificate> extends
         return key;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public String getKey() {
         return new String(key);
     }
@@ -69,6 +76,14 @@ public abstract class AbstractCertificate<T extends AbstractCertificate> extends
 
     public String getCert() {
         return new String(cert);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getCertificate() {
+        return this.getCert();
     }
 
     public void setCert(String cert) {

--- a/server/src/main/java/org/candlepin/model/Branding.java
+++ b/server/src/main/java/org/candlepin/model/Branding.java
@@ -14,6 +14,8 @@
  */
 package org.candlepin.model;
 
+import org.candlepin.service.model.BrandingInfo;
+
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.hibernate.annotations.GenericGenerator;
@@ -38,7 +40,7 @@ import javax.validation.constraints.Size;
  */
 @Entity
 @Table(name = Branding.DB_TABLE)
-public class Branding extends AbstractHibernateObject<Branding> {
+public class Branding extends AbstractHibernateObject<Branding> implements BrandingInfo {
 
     /** Name of the table backing this object in the database */
     public static final String DB_TABLE = "cp_branding";
@@ -89,6 +91,7 @@ public class Branding extends AbstractHibernateObject<Branding> {
      * client. Candlepin will always send down the brand mapping for a subscription, the
      * client is responsible for determining if it should be applied or not, and how.
      */
+    @Override
     public String getProductId() {
         return productId;
     }
@@ -100,6 +103,7 @@ public class Branding extends AbstractHibernateObject<Branding> {
     /**
      * @return The brand name to be applied.
      */
+    @Override
     public String getName() {
         return name;
     }
@@ -113,6 +117,7 @@ public class Branding extends AbstractHibernateObject<Branding> {
      * @return The type of this branding. (i.e. "OS") Clients use this value to determine
      * what action should be taken with the branding information.
      */
+    @Override
     public String getType() {
         return type;
     }

--- a/server/src/main/java/org/candlepin/model/Cdn.java
+++ b/server/src/main/java/org/candlepin/model/Cdn.java
@@ -14,6 +14,8 @@
  */
 package org.candlepin.model;
 
+import org.candlepin.service.model.CdnInfo;
+
 import org.hibernate.annotations.GenericGenerator;
 
 import javax.persistence.CascadeType;
@@ -31,6 +33,8 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 
+
+
 /**
  * Represents an Content Delivery Network
  */
@@ -38,7 +42,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @Entity
 @Table(name = Cdn.DB_TABLE, uniqueConstraints = {@UniqueConstraint(columnNames = {"label"})})
-public class Cdn extends AbstractHibernateObject {
+public class Cdn extends AbstractHibernateObject implements CdnInfo {
 
     /** Name of the table backing this object in the database */
     public static final String DB_TABLE = "cp_cdn";
@@ -97,6 +101,10 @@ public class Cdn extends AbstractHibernateObject {
         this.id = id;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public String getLabel() {
         return label;
     }
@@ -105,6 +113,10 @@ public class Cdn extends AbstractHibernateObject {
         this.label = label;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public String getName() {
         return name;
     }
@@ -113,6 +125,10 @@ public class Cdn extends AbstractHibernateObject {
         this.name = name;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public String getUrl() {
         return url;
     }
@@ -121,6 +137,10 @@ public class Cdn extends AbstractHibernateObject {
         this.url = url;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public CdnCertificate getCertificate() {
         return cert;
     }

--- a/server/src/main/java/org/candlepin/model/CertificateSerial.java
+++ b/server/src/main/java/org/candlepin/model/CertificateSerial.java
@@ -15,6 +15,10 @@
 package org.candlepin.model;
 
 import org.candlepin.util.Util;
+import org.candlepin.service.model.CertificateSerialInfo;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.math.BigInteger;
 import java.util.Date;
@@ -31,7 +35,8 @@ import javax.validation.constraints.NotNull;
  */
 @Entity
 @Table(name = CertificateSerial.DB_TABLE)
-public class CertificateSerial extends AbstractHibernateObject<CertificateSerial> {
+public class CertificateSerial extends AbstractHibernateObject<CertificateSerial>
+    implements CertificateSerialInfo {
 
     /** Name of the table backing this object in the database */
     public static final String DB_TABLE = "cp_cert_serial";
@@ -82,36 +87,39 @@ public class CertificateSerial extends AbstractHibernateObject<CertificateSerial
     }
 
     /**
-     * @return the revoked
+     * {@inheritDoc}
      */
-    public boolean isRevoked() {
+    @Override
+    public Boolean isRevoked() {
         return revoked;
     }
 
     /**
      * @param isRevoked whether or not this serial is revoked.
      */
-    public void setRevoked(boolean isRevoked) {
-        this.revoked = isRevoked;
+    public void setRevoked(Boolean isRevoked) {
+        this.revoked = isRevoked != null ? isRevoked : false;
     }
 
     /**
-     * @return the collected
+     * {@inheritDoc}
      */
-    public boolean isCollected() {
+    @Override
+    public Boolean isCollected() {
         return collected;
     }
 
     /**
      * @param collected the collected to set
      */
-    public void setCollected(boolean collected) {
-        this.collected = collected;
+    public void setCollected(Boolean collected) {
+        this.collected = collected != null ? collected : false;
     }
 
     /**
-     * @return the expiration
+     * {@inheritDoc}
      */
+    @Override
     public Date getExpiration() {
         return expiration;
     }
@@ -132,12 +140,22 @@ public class CertificateSerial extends AbstractHibernateObject<CertificateSerial
             this.getId(), this.getSerial(), date, this.isCollected(), this.isRevoked());
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public BigInteger getSerial() {
         return this.getId() != null ? BigInteger.valueOf(this.getId()) : null;
     }
 
+    @JsonProperty
     public void setSerial(Long serial) {
         this.id = serial;
+    }
+
+    @JsonIgnore
+    public void setSerial(BigInteger serial) {
+        this.setId(serial != null ? serial.longValueExact() : null);
     }
 
 }

--- a/server/src/main/java/org/candlepin/model/ConsumerCurator.java
+++ b/server/src/main/java/org/candlepin/model/ConsumerCurator.java
@@ -244,12 +244,24 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
      */
     @Transactional
     public Consumer findByUser(User user) {
+        return user != null ? this.findByUsername(user.getUsername()) : null;
+    }
+
+    /**
+     * Candlepin supports the notion of a user being a consumer. When in effect
+     * a consumer will exist in the system who is tied to a particular user.
+     *
+     * @param username the username to use to find a consumer
+     * @return Consumer for this user if one exists, null otherwise.
+     */
+    @Transactional
+    public Consumer findByUsername(String username) {
         ConsumerType person = consumerTypeCurator
             .getByLabel(ConsumerType.ConsumerTypeEnum.PERSON.getLabel());
 
         if (person != null) {
             return (Consumer) createSecureCriteria()
-                .add(Restrictions.eq("username", user.getUsername()))
+                .add(Restrictions.eq("username", username))
                 .add(Restrictions.eq("typeId", person.getId())).uniqueResult();
         }
 
@@ -406,7 +418,7 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
         // everywhere else, and just blindly copying everything over.
         existingConsumer.setFacts(updatedConsumer.getFacts());
         existingConsumer.setName(updatedConsumer.getName());
-        existingConsumer.setOwnerId(updatedConsumer.getOwnerId());
+        existingConsumer.setOwner(updatedConsumer.getOwner());
         existingConsumer.setTypeId(updatedConsumer.getTypeId());
         existingConsumer.setUuid(updatedConsumer.getUuid());
 
@@ -416,6 +428,7 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
 
         return existingConsumer;
     }
+
     /**
      * Modifies the last check in and persists the entity. Make sure that the data
      * is refreshed before using this method.

--- a/server/src/main/java/org/candlepin/model/Content.java
+++ b/server/src/main/java/org/candlepin/model/Content.java
@@ -15,6 +15,7 @@
 package org.candlepin.model;
 
 import org.candlepin.model.dto.ContentData;
+import org.candlepin.service.model.ContentInfo;
 import org.candlepin.util.SetView;
 import org.candlepin.util.Util;
 
@@ -57,7 +58,7 @@ import javax.xml.bind.annotation.XmlTransient;
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @Entity
 @Table(name = Content.DB_TABLE)
-public class Content extends AbstractHibernateObject implements SharedEntity, Cloneable {
+public class Content extends AbstractHibernateObject implements SharedEntity, Cloneable, ContentInfo {
 
     /** Name of the table backing this object in the database */
     public static final String DB_TABLE = "cp2_content";
@@ -205,7 +206,7 @@ public class Content extends AbstractHibernateObject implements SharedEntity, Cl
         this.setRequiredTags(source.getRequiredTags());
         this.setReleaseVersion(source.getReleaseVersion());
         this.setGpgUrl(source.getGpgUrl());
-        this.setMetadataExpire(source.getMetadataExpire());
+        this.setMetadataExpiration(source.getMetadataExpiration());
         this.setArches(source.getArches());
         this.setModifiedProductIds(source.getModifiedProductIds());
 
@@ -277,6 +278,7 @@ public class Content extends AbstractHibernateObject implements SharedEntity, Cl
      * @return
      *  this content's ID.
      */
+    @Override
     public String getId() {
         return this.id;
     }
@@ -292,6 +294,7 @@ public class Content extends AbstractHibernateObject implements SharedEntity, Cl
         this.id = id;
     }
 
+    @Override
     public String getType() {
         return type;
     }
@@ -300,6 +303,7 @@ public class Content extends AbstractHibernateObject implements SharedEntity, Cl
         this.type = type;
     }
 
+    @Override
     public String getLabel() {
         return label;
     }
@@ -308,6 +312,7 @@ public class Content extends AbstractHibernateObject implements SharedEntity, Cl
         this.label = label;
     }
 
+    @Override
     public String getName() {
         return name;
     }
@@ -316,6 +321,7 @@ public class Content extends AbstractHibernateObject implements SharedEntity, Cl
         this.name = name;
     }
 
+    @Override
     public String getVendor() {
         return vendor;
     }
@@ -324,6 +330,7 @@ public class Content extends AbstractHibernateObject implements SharedEntity, Cl
         this.vendor = vendor;
     }
 
+    @Override
     public String getContentUrl() {
         return contentUrl;
     }
@@ -336,6 +343,7 @@ public class Content extends AbstractHibernateObject implements SharedEntity, Cl
      * @return Comma separated list of tags this content set requires to be
      *         enabled.
      */
+    @Override
     public String getRequiredTags() {
         return requiredTags;
     }
@@ -351,6 +359,7 @@ public class Content extends AbstractHibernateObject implements SharedEntity, Cl
     /**
      * @return the releaseVer
      */
+    @Override
     public String getReleaseVersion() {
         return releaseVer;
     }
@@ -362,6 +371,7 @@ public class Content extends AbstractHibernateObject implements SharedEntity, Cl
         this.releaseVer = releaseVer;
     }
 
+    @Override
     public String getGpgUrl() {
         return gpgUrl;
     }
@@ -370,11 +380,12 @@ public class Content extends AbstractHibernateObject implements SharedEntity, Cl
         this.gpgUrl = gpgUrl;
     }
 
-    public Long getMetadataExpire() {
+    @Override
+    public Long getMetadataExpiration() {
         return metadataExpire;
     }
 
-    public void setMetadataExpire(Long metadataExpire) {
+    public void setMetadataExpiration(Long metadataExpire) {
         this.metadataExpire = metadataExpire;
     }
 
@@ -385,8 +396,16 @@ public class Content extends AbstractHibernateObject implements SharedEntity, Cl
      * @return
      *  the modified product IDs of the content
      */
-    public Set<String> getModifiedProductIds() {
+    public Collection<String> getModifiedProductIds() {
         return new SetView(this.modifiedProductIds);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Collection<String> getRequiredProductIds() {
+        return this.getModifiedProductIds();
     }
 
     /**
@@ -457,6 +476,7 @@ public class Content extends AbstractHibernateObject implements SharedEntity, Cl
         this.arches = arches;
     }
 
+    @Override
     public String getArches() {
         return arches;
     }
@@ -494,7 +514,6 @@ public class Content extends AbstractHibernateObject implements SharedEntity, Cl
                 .append(this.gpgUrl, that.gpgUrl)
                 .append(this.metadataExpire, that.metadataExpire)
                 .append(this.arches, that.arches)
-                .append(this.locked, that.locked)
                 .isEquals();
 
             if (equals) {
@@ -537,8 +556,7 @@ public class Content extends AbstractHibernateObject implements SharedEntity, Cl
             .append(this.releaseVer)
             .append(this.gpgUrl)
             .append(this.metadataExpire)
-            .append(this.arches)
-            .append(this.locked);
+            .append(this.arches);
 
         // Impl note:
         // We need to be certain that the hash code is calculated in a way that's order

--- a/server/src/main/java/org/candlepin/model/Owner.java
+++ b/server/src/main/java/org/candlepin/model/Owner.java
@@ -18,6 +18,7 @@ import org.candlepin.common.jackson.HateoasInclude;
 import org.candlepin.model.activationkeys.ActivationKey;
 import org.candlepin.resteasy.InfoProperty;
 import org.candlepin.service.ContentAccessCertServiceAdapter;
+import org.candlepin.service.model.OwnerInfo;
 
 import com.fasterxml.jackson.annotation.JsonFilter;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -65,7 +66,7 @@ import javax.xml.bind.annotation.XmlTransient;
 @Table(name = Owner.DB_TABLE)
 @JsonFilter("OwnerFilter")
 public class Owner extends AbstractHibernateObject<Owner>
-    implements Serializable, Linkable, Owned, Named, Eventful {
+    implements Serializable, Linkable, Owned, Named, Eventful, OwnerInfo {
 
     /** Name of the table backing this object in the database */
     public static final String DB_TABLE = "cp_owner";
@@ -283,12 +284,11 @@ public class Owner extends AbstractHibernateObject<Owner>
     /**
      * Add a consumer to this owner
      *
-     * @param c consumer for this owner.
+     * @param consumer consumer for this owner.
      */
-    public void addConsumer(Consumer c) {
-        c.setOwner(this);
-        this.consumers.add(c);
-
+    public void addConsumer(Consumer consumer) {
+        consumer.setOwner(this);
+        this.consumers.add(consumer);
     }
 
     /**

--- a/server/src/main/java/org/candlepin/model/PermissionBlueprint.java
+++ b/server/src/main/java/org/candlepin/model/PermissionBlueprint.java
@@ -16,6 +16,7 @@ package org.candlepin.model;
 
 import org.candlepin.auth.Access;
 import org.candlepin.auth.permissions.PermissionFactory.PermissionType;
+import org.candlepin.service.model.PermissionBlueprintInfo;
 
 import org.hibernate.annotations.ForeignKey;
 import org.hibernate.annotations.GenericGenerator;
@@ -33,6 +34,8 @@ import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
 import javax.xml.bind.annotation.XmlTransient;
 
+
+
 /**
  * A representation of a permission to be stored in the database. Used by the
  * PermissionFactory to determine which actual Java class to create, and any relevant
@@ -43,7 +46,7 @@ import javax.xml.bind.annotation.XmlTransient;
  */
 @Entity
 @Table(name = PermissionBlueprint.DB_TABLE)
-public class PermissionBlueprint extends AbstractHibernateObject {
+public class PermissionBlueprint extends AbstractHibernateObject implements PermissionBlueprintInfo {
 
     /** Name of the table backing this object in the database */
     public static final String DB_TABLE = "cp_permission";
@@ -101,13 +104,23 @@ public class PermissionBlueprint extends AbstractHibernateObject {
         return access;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @XmlTransient
+    public String getAccessLevel() {
+        Access access = this.getAccess();
+        return access != null ? access.name() : null;
+    }
+
     public void setAccess(Access access) {
         this.access = access;
     }
 
     @XmlTransient
     public Role getRole() {
-        return role;
+        return this.role;
     }
 
     public void setRole(Role role) {
@@ -119,6 +132,16 @@ public class PermissionBlueprint extends AbstractHibernateObject {
      */
     public PermissionType getType() {
         return type;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @XmlTransient
+    public String getTypeName() {
+        PermissionType type = this.getType();
+        return type != null ? type.name() : null;
     }
 
     public void setType(PermissionType type) {

--- a/server/src/main/java/org/candlepin/model/Pool.java
+++ b/server/src/main/java/org/candlepin/model/Pool.java
@@ -17,6 +17,7 @@ package org.candlepin.model;
 import org.candlepin.common.jackson.HateoasInclude;
 import org.candlepin.jackson.CandlepinAttributeDeserializer;
 import org.candlepin.jackson.CandlepinLegacyAttributeSerializer;
+import org.candlepin.service.model.SubscriptionInfo;
 import org.candlepin.util.DateSource;
 
 import com.fasterxml.jackson.annotation.JsonFilter;
@@ -80,7 +81,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 @Table(name = Pool.DB_TABLE)
 @JsonFilter("PoolFilter")
 public class Pool extends AbstractHibernateObject<Pool> implements Owned, Named, Comparable<Pool>,
-    Eventful {
+    Eventful, SubscriptionInfo {
 
     /** Name of the table backing this object in the database */
     public static final String DB_TABLE = "cp_pool";
@@ -476,6 +477,13 @@ public class Pool extends AbstractHibernateObject<Pool> implements Owned, Named,
      */
     public void setEndDate(Date endDate) {
         this.endDate = endDate;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public Date getLastModified() {
+        return this.getUpdated();
     }
 
     /**
@@ -1271,6 +1279,7 @@ public class Pool extends AbstractHibernateObject<Pool> implements Owned, Named,
         else if (hasAttribute(Attributes.DEVELOPMENT_POOL)) {
             return PoolType.DEVELOPMENT;
         }
+
         return PoolType.NORMAL;
     }
 

--- a/server/src/main/java/org/candlepin/model/Product.java
+++ b/server/src/main/java/org/candlepin/model/Product.java
@@ -17,6 +17,7 @@ package org.candlepin.model;
 import org.candlepin.jackson.CandlepinAttributeDeserializer;
 import org.candlepin.jackson.CandlepinLegacyAttributeSerializer;
 import org.candlepin.model.dto.ProductData;
+import org.candlepin.service.model.ProductInfo;
 import org.candlepin.util.ListView;
 import org.candlepin.util.MapView;
 import org.candlepin.util.SetView;
@@ -81,7 +82,9 @@ import javax.xml.bind.annotation.XmlTransient;
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @Entity
 @Table(name = Product.DB_TABLE)
-public class Product extends AbstractHibernateObject implements SharedEntity, Linkable, Cloneable, Eventful {
+public class Product extends AbstractHibernateObject implements SharedEntity, Linkable, Cloneable, Eventful,
+    ProductInfo {
+
     /** Name of the table backing this object in the database */
     public static final String DB_TABLE = "cp2_products";
 
@@ -1051,7 +1054,6 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
                 .append(this.id, that.id)
                 .append(this.name, that.name)
                 .append(this.multiplier, that.multiplier)
-                .append(this.locked, that.locked)
                 .append(this.attributes, that.attributes)
                 .isEquals();
 
@@ -1096,7 +1098,6 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
             .append(this.id)
             .append(this.name)
             .append(this.multiplier)
-            .append(this.locked)
             .append(this.attributes);
 
         // Impl note:

--- a/server/src/main/java/org/candlepin/model/ProductCertificate.java
+++ b/server/src/main/java/org/candlepin/model/ProductCertificate.java
@@ -76,4 +76,15 @@ public class ProductCertificate extends AbstractCertificate {
     public void setProduct(Product product) {
         this.product = product;
     }
+
+    /**
+     * Always returns null
+     *
+     * @return
+     *  null
+     */
+    @Override
+    public CertificateSerial getSerial() {
+        return null;
+    }
 }

--- a/server/src/main/java/org/candlepin/model/ProductCertificateCurator.java
+++ b/server/src/main/java/org/candlepin/model/ProductCertificateCurator.java
@@ -45,7 +45,6 @@ import javax.inject.Singleton;
 public class ProductCertificateCurator extends AbstractHibernateCurator<ProductCertificate> {
     private static Logger log = LoggerFactory.getLogger(ProductCertificateCurator.class);
 
-
     private PKIUtility pki;
     private X509ExtensionUtil extensionUtil;
 

--- a/server/src/main/java/org/candlepin/model/ProductContent.java
+++ b/server/src/main/java/org/candlepin/model/ProductContent.java
@@ -15,6 +15,7 @@
 package org.candlepin.model;
 
 import org.candlepin.model.dto.ProductContentData;
+import org.candlepin.service.model.ProductContentInfo;
 
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
@@ -39,7 +40,8 @@ import javax.xml.bind.annotation.XmlTransient;
  */
 @Entity
 @Table(name = ProductContent.DB_TABLE)
-public class ProductContent extends AbstractHibernateObject {
+public class ProductContent extends AbstractHibernateObject implements ProductContentInfo {
+
     /** Name of the table backing this object in the database */
     public static final String DB_TABLE = "cp2_product_content";
 
@@ -90,6 +92,7 @@ public class ProductContent extends AbstractHibernateObject {
     /**
      * @return the content
      */
+    @Override
     public Content getContent() {
         return content;
     }
@@ -119,7 +122,8 @@ public class ProductContent extends AbstractHibernateObject {
     /**
      * @return the enabled
      */
-    public boolean isEnabled() {
+    @Override
+    public Boolean isEnabled() {
         return enabled;
     }
 

--- a/server/src/main/java/org/candlepin/model/Role.java
+++ b/server/src/main/java/org/candlepin/model/Role.java
@@ -14,6 +14,8 @@
  */
 package org.candlepin.model;
 
+import org.candlepin.service.model.RoleInfo;
+
 import org.hibernate.annotations.ForeignKey;
 import org.hibernate.annotations.GenericGenerator;
 
@@ -38,7 +40,7 @@ import javax.validation.constraints.Size;
  */
 @Entity
 @Table(name = Role.DB_TABLE)
-public class Role extends AbstractHibernateObject implements Linkable {
+public class Role extends AbstractHibernateObject implements Linkable, RoleInfo {
 
     /** Name of the table backing this object in the database */
     public static final String DB_TABLE = "cp_role";
@@ -118,6 +120,18 @@ public class Role extends AbstractHibernateObject implements Linkable {
         this.users = users;
     }
 
+    public void clearUsers() {
+        Set<User> cleared = this.users;
+
+        if (cleared != null) {
+            this.users = new HashSet<>();
+
+            for (User user : cleared) {
+                user.removeRole(this);
+            }
+        }
+    }
+
     public void addUser(User u) {
         if (this.users.add(u)) {
             u.addRole(this);
@@ -130,6 +144,10 @@ public class Role extends AbstractHibernateObject implements Linkable {
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public Set<PermissionBlueprint> getPermissions() {
         return permissions;
     }
@@ -141,5 +159,9 @@ public class Role extends AbstractHibernateObject implements Linkable {
     public void addPermission(PermissionBlueprint p) {
         this.permissions.add(p);
         p.setRole(this);
+    }
+
+    public void clearPermissions() {
+        this.permissions.clear();
     }
 }

--- a/server/src/main/java/org/candlepin/model/UserCurator.java
+++ b/server/src/main/java/org/candlepin/model/UserCurator.java
@@ -14,11 +14,11 @@
  */
 package org.candlepin.model;
 
-import com.google.inject.persist.Transactional;
-
 import org.hibernate.criterion.Restrictions;
 
 import javax.inject.Singleton;
+
+
 
 /**
  *
@@ -44,20 +44,6 @@ public class UserCurator extends AbstractHibernateCurator<User> {
     public Long getUserCount() {
         return (Long) currentSession().createQuery("select count(*) from User").
             iterate().next();
-    }
-
-    @Transactional
-    public User update(User user) {
-        User existingUser = this.get(user.getId());
-        if (existingUser == null) {
-            return create(user);
-        }
-
-        existingUser.setHashedPassword(user.getHashedPassword());
-        existingUser.setSuperAdmin(user.isSuperAdmin());
-        existingUser.setUsername(user.getUsername());
-        this.save(existingUser);
-        return existingUser;
     }
 
 }

--- a/server/src/main/java/org/candlepin/model/dto/Content.java
+++ b/server/src/main/java/org/candlepin/model/dto/Content.java
@@ -110,7 +110,7 @@ public class Content {
     /**
      * @param metadataExpire
      */
-    public void setMetadataExpire(Long metadataExpire) {
+    public void setMetadataExpiration(Long metadataExpire) {
         this.metadataExpire = metadataExpire;
     }
 

--- a/server/src/main/java/org/candlepin/model/dto/ContentData.java
+++ b/server/src/main/java/org/candlepin/model/dto/ContentData.java
@@ -15,6 +15,7 @@
 package org.candlepin.model.dto;
 
 import org.candlepin.model.Content;
+import org.candlepin.service.model.ContentInfo;
 import org.candlepin.util.SetView;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -59,7 +60,7 @@ import javax.xml.bind.annotation.XmlTransient;
  */
 @ApiModel(parent = CandlepinDTO.class)
 @XmlRootElement
-public class ContentData extends CandlepinDTO {
+public class ContentData extends CandlepinDTO implements ContentInfo {
     public static final long serialVersionUID = 1L;
 
     @ApiModelProperty(example = "ff808081554a3e4101554a3e9033005d")
@@ -446,7 +447,7 @@ public class ContentData extends CandlepinDTO {
      *  the metadata expiration of the content, or null if the metadata expiration has not yet been
      *  defined
      */
-    public Long getMetadataExpire() {
+    public Long getMetadataExpiration() {
         return this.metadataExpire;
     }
 
@@ -460,7 +461,7 @@ public class ContentData extends CandlepinDTO {
      * @return
      *  a reference to this DTO
      */
-    public ContentData setMetadataExpire(Long metadataExpire) {
+    public ContentData setMetadataExpiration(Long metadataExpire) {
         this.metadataExpire = metadataExpire;
         return this;
     }
@@ -475,6 +476,14 @@ public class ContentData extends CandlepinDTO {
      */
     public Collection<String> getModifiedProductIds() {
         return this.modifiedProductIds != null ? new SetView(this.modifiedProductIds) : null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Collection<String> getRequiredProductIds() {
+        return this.getModifiedProductIds();
     }
 
     /**
@@ -526,7 +535,7 @@ public class ContentData extends CandlepinDTO {
      * existing modified product IDs will be cleared before assigning the given product IDs.
      *
      * @param modifiedProductIds
-     *  A collection of product IDs to be modified by the content content, or null to clear the
+     *  A collection of product IDs to be modified by the content, or null to clear the
      *  existing modified product IDs
      *
      * @return
@@ -548,6 +557,20 @@ public class ContentData extends CandlepinDTO {
         }
 
         return this;
+    }
+
+    /**
+     * New name for the old setModifiedProductIds method.
+     *
+     * @param requiredProductIds
+     *  A collection of product IDs to be required by the content, or null to clear the
+     *  existing required product IDs
+     *
+     * @return
+     *  a reference to this DTO
+     */
+    public ContentData setRequiredProductIds(Collection<String> requiredProductIds) {
+        return this.setModifiedProductIds(requiredProductIds);
     }
 
     /**
@@ -697,7 +720,7 @@ public class ContentData extends CandlepinDTO {
         this.requiredTags = source.getRequiredTags();
         this.releaseVer = source.getReleaseVersion();
         this.gpgUrl = source.getGpgUrl();
-        this.metadataExpire = source.getMetadataExpire();
+        this.metadataExpire = source.getMetadataExpiration();
         this.arches = source.getArches();
         this.locked = source.isLocked();
 
@@ -735,7 +758,7 @@ public class ContentData extends CandlepinDTO {
         this.requiredTags = source.getRequiredTags();
         this.releaseVer = source.getReleaseVersion();
         this.gpgUrl = source.getGpgUrl();
-        this.metadataExpire = source.getMetadataExpire();
+        this.metadataExpire = source.getMetadataExpiration();
         this.arches = source.getArches();
         this.locked = source.isLocked();
 

--- a/server/src/main/java/org/candlepin/model/dto/ProductContentData.java
+++ b/server/src/main/java/org/candlepin/model/dto/ProductContentData.java
@@ -16,6 +16,7 @@ package org.candlepin.model.dto;
 
 import org.candlepin.model.Content;
 import org.candlepin.model.ProductContent;
+import org.candlepin.service.model.ProductContentInfo;
 
 import io.swagger.annotations.ApiModel;
 
@@ -44,7 +45,7 @@ import javax.xml.bind.annotation.XmlRootElement;
  */
 @ApiModel(parent = CandlepinDTO.class)
 @XmlRootElement
-public class ProductContentData implements Cloneable, Serializable {
+public class ProductContentData implements Cloneable, Serializable, ProductContentInfo {
     public static final long serialVersionUID = 1L;
 
     private ContentData content;

--- a/server/src/main/java/org/candlepin/model/dto/ProductData.java
+++ b/server/src/main/java/org/candlepin/model/dto/ProductData.java
@@ -19,6 +19,7 @@ import org.candlepin.jackson.CandlepinLegacyAttributeSerializer;
 import org.candlepin.model.Content;
 import org.candlepin.model.Product;
 import org.candlepin.model.ProductContent;
+import org.candlepin.service.model.ProductInfo;
 import org.candlepin.util.MapView;
 import org.candlepin.util.SetView;
 
@@ -62,7 +63,7 @@ import javax.xml.bind.annotation.XmlTransient;
  */
 @ApiModel(parent = CandlepinDTO.class, description = "Product information for a given sku or product")
 @XmlRootElement
-public class ProductData extends CandlepinDTO {
+public class ProductData extends CandlepinDTO implements ProductInfo {
     public static final long serialVersionUID = 1L;
 
     @ApiModelProperty(example = "ff808081554a3e4101554a3e9033005d")

--- a/server/src/main/java/org/candlepin/model/dto/Subscription.java
+++ b/server/src/main/java/org/candlepin/model/dto/Subscription.java
@@ -24,6 +24,7 @@ import org.candlepin.model.Pool;
 import org.candlepin.model.Product;
 import org.candlepin.model.ProductCurator;
 import org.candlepin.model.SubscriptionsCertificate;
+import org.candlepin.service.model.SubscriptionInfo;
 
 import com.fasterxml.jackson.annotation.JsonFilter;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -55,7 +56,7 @@ import javax.xml.bind.annotation.XmlTransient;
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonFilter("DefaultFilter")
-public class Subscription extends CandlepinDTO implements Owned, Named, Eventful {
+public class Subscription extends CandlepinDTO implements Owned, Named, Eventful, SubscriptionInfo {
     private static Logger log = LoggerFactory.getLogger(Subscription.class);
 
     private String id;
@@ -243,6 +244,14 @@ public class Subscription extends CandlepinDTO implements Owned, Named, Eventful
      */
     public void setModified(Date modified) {
         this.modified = modified;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Date getLastModified() {
+        return this.getModified();
     }
 
     /**

--- a/server/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
@@ -26,7 +26,7 @@ import org.candlepin.model.Pool;
 import org.candlepin.model.Product;
 import org.candlepin.model.ProductCurator;
 import org.candlepin.model.SourceSubscription;
-import org.candlepin.model.dto.Subscription;
+import org.candlepin.service.model.SubscriptionInfo;
 
 import com.google.inject.Inject;
 
@@ -91,11 +91,11 @@ public class PoolRules {
         return result;
     }
 
-    public List<Pool> createAndEnrichPools(Subscription sub) {
+    public List<Pool> createAndEnrichPools(SubscriptionInfo sub) {
         return createAndEnrichPools(sub, new LinkedList<>());
     }
 
-    public List<Pool> createAndEnrichPools(Subscription sub, List<Pool> existingPools) {
+    public List<Pool> createAndEnrichPools(SubscriptionInfo sub, List<Pool> existingPools) {
         Pool pool = this.poolManager.convertToMasterPool(sub);
         return createAndEnrichPools(pool, existingPools);
     }

--- a/server/src/main/java/org/candlepin/resource/RoleResource.java
+++ b/server/src/main/java/org/candlepin/resource/RoleResource.java
@@ -15,14 +15,16 @@
 package org.candlepin.resource;
 
 import org.candlepin.auth.Access;
+import org.candlepin.common.exceptions.ConflictException;
 import org.candlepin.common.exceptions.NotFoundException;
-import org.candlepin.model.Owner;
+import org.candlepin.dto.ModelTranslator;
+import org.candlepin.dto.api.v1.RoleDTO;
+import org.candlepin.dto.api.v1.PermissionBlueprintDTO;
 import org.candlepin.model.OwnerCurator;
-import org.candlepin.model.PermissionBlueprint;
 import org.candlepin.model.PermissionBlueprintCurator;
-import org.candlepin.model.Role;
-import org.candlepin.model.User;
 import org.candlepin.service.UserServiceAdapter;
+import org.candlepin.service.model.RoleInfo;
+import org.candlepin.service.model.UserInfo;
 
 import com.google.inject.Inject;
 
@@ -30,9 +32,8 @@ import org.jboss.resteasy.annotations.providers.jaxb.Wrapped;
 import org.jboss.resteasy.spi.BadRequestException;
 import org.xnap.commons.i18n.I18n;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.Collection;
+import java.util.stream.Stream;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -51,6 +52,8 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 
+
+
 /**
  *
  */
@@ -62,14 +65,75 @@ public class RoleResource {
     private OwnerCurator ownerCurator;
     private PermissionBlueprintCurator permissionCurator;
     private I18n i18n;
+    private ModelTranslator modelTranslator;
 
     @Inject
     public RoleResource(UserServiceAdapter userService, OwnerCurator ownerCurator,
-        PermissionBlueprintCurator permCurator, I18n i18n) {
+        PermissionBlueprintCurator permCurator, I18n i18n, ModelTranslator modelTranslator) {
+
         this.userService = userService;
         this.ownerCurator = ownerCurator;
         this.i18n = i18n;
         this.permissionCurator = permCurator;
+        this.modelTranslator = modelTranslator;
+    }
+
+    /**
+     * Fetches the role for a given role name, or throws a NotFoundException if the specified role
+     * cannot be found.
+     *
+     * @param roleName
+     *  The name of the role to fetch
+     *
+     * @throws NotFoundException
+     *  if a role for the given role name cannot be found
+     *
+     * @throws BadRequestException
+     *  if the given role name is null or empty
+     *
+     * @return
+     *  The role for the given role name
+     */
+    protected RoleInfo fetchRoleByName(String roleName) {
+        if (roleName == null || roleName.isEmpty()) {
+            throw new BadRequestException(this.i18n.tr("role name is null or empty"));
+        }
+
+        RoleInfo role = this.userService.getRole(roleName);
+        if (role == null) {
+            throw new NotFoundException(this.i18n.tr("Role not found: {0}", roleName));
+        }
+
+        return role;
+    }
+
+    /**
+     * Fetches the user for a given username, or throws a NotFoundException if the username cannot
+     * be found.
+     *
+     * @param username
+     *  The username of the user to fetch
+     *
+     * @throws NotFoundException
+     *  if a user for the given username cannot be found
+     *
+     * @throws BadRequestException
+     *  if the given user is null or empty
+     *
+     * @return
+     *  The user for the given username
+     */
+    protected UserInfo fetchUserByUsername(String username) {
+        if (username == null || username.isEmpty()) {
+            throw new BadRequestException(this.i18n.tr("username is null or empty"));
+        }
+
+        UserInfo user = this.userService.findByLogin(username);
+        if (user == null) {
+            throw new NotFoundException(this.i18n.tr("User not found: {0}", username));
+        }
+
+        return user;
     }
 
     @ApiOperation(notes = "Creates a Role", value = "createRole")
@@ -77,20 +141,21 @@ public class RoleResource {
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    public Role createRole(@ApiParam(name = "role", required = true) Role role) {
-
-        // Attach actual owner objects to each incoming permission:
-        for (PermissionBlueprint p : role.getPermissions()) {
-            Owner temp = p.getOwner();
-            Owner actual = ownerCurator.getByKey(temp.getKey());
-            if (actual == null) {
-                throw new NotFoundException(i18n.tr("No such owner: {0}", temp.getKey()));
-            }
-            p.setOwner(actual);
+    public RoleDTO createRole(@ApiParam(name = "role", required = true) RoleDTO dto) {
+        if (dto == null) {
+            throw new BadRequestException(this.i18n.tr("role data is null or empty"));
         }
 
-        Role r = this.userService.createRole(role);
-        return r;
+        if (dto.getName() == null || dto.getName().isEmpty()) {
+            throw new BadRequestException(this.i18n.tr("role name not specified"));
+        }
+
+        if (this.userService.getRole(dto.getName()) != null) {
+            throw new ConflictException(this.i18n.tr("Role already exists: {0}", dto.getName()));
+        }
+
+        RoleInfo role = this.userService.createRole(dto);
+        return this.modelTranslator.translate(role, RoleDTO.class);
     }
 
     @ApiOperation(notes = "Updates a Role.  To avoid race conditions, we do not support " +
@@ -99,150 +164,124 @@ public class RoleResource {
         " permissions.", value = "updateRole")
     @ApiResponses({ @ApiResponse(code = 404, message = "") })
     @PUT
-    @Path("{role_id}")
+    @Path("{role_name}")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    public Role updateRole(@PathParam("role_id") String roleId,
-        @ApiParam(name = "role", required = true) Role role) {
-        //Only operate here if you only have 1 ID to pull,
-        //but if the user passes in an ID in the body of the JSON
-        //and that ID is NOT equal to what the ID in the URL is, then throw an error
-        if (role.getId() != null && !roleId.equals(role.getId())) {
-            throw new BadRequestException(i18n.tr("Role ID does not match path."));
-        }
-        Role existingRole = lookupRole(roleId);
-        existingRole.setName(role.getName());
-        return this.userService.updateRole(existingRole);
+    public RoleDTO updateRole(@PathParam("role_name") String roleName,
+        @ApiParam(name = "role", required = true) RoleDTO dto) {
+
+        // We don't actually need the role, but we do this for quick verification and better error
+        // generation
+        this.fetchRoleByName(roleName);
+
+        RoleInfo role = this.userService.updateRole(roleName, dto);
+        return this.modelTranslator.translate(role, RoleDTO.class);
     }
 
     @ApiOperation(notes = "Adds a Permission to a Role. Returns the updated Role.",
         value = "addRolePermission")
     @ApiResponses({ @ApiResponse(code = 404, message = ""), @ApiResponse(code = 400, message = "") })
     @POST
-    @Path("{role_id}/permissions")
+    @Path("{role_name}/permissions")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    public Role addRolePermission(@PathParam("role_id") String roleId,
-        @ApiParam(name = "permissionBlueprint", required = true) PermissionBlueprint permission) {
+    public RoleDTO addRolePermission(@PathParam("role_name") String roleName,
+        @ApiParam(name = "permissionBlueprint", required = true) PermissionBlueprintDTO permission) {
 
-        Role existingRole = lookupRole(roleId);
+        // Validate role name
+        this.fetchRoleByName(roleName);
 
         // Don't allow NONE permissions to be created, this is currently just for
         // internal use:
-        if (permission.getAccess().equals(Access.NONE)) {
+        if (Access.NONE.name().equals(permission.getAccess())) {
             throw new BadRequestException(i18n.tr("Access type NONE not supported."));
         }
 
-        // Attach actual owner objects to each incoming permission:
-        Owner temp = permission.getOwner();
-        Owner real = ownerCurator.getByKey(temp.getKey());
-        permission.setOwner(real);
-        existingRole.addPermission(permission);
-
-        Role r = this.userService.updateRole(existingRole);
-        return r;
+        RoleInfo role = this.userService.addPermissionToRole(roleName, permission);
+        return this.modelTranslator.translate(role, RoleDTO.class);
     }
 
     @ApiOperation(notes = "Removes a Permission from a Role. Returns the updated Role.",
         value = "removeRolePermission")
     @ApiResponses({ @ApiResponse(code = 404, message = "") })    @DELETE
-    @Path("{role_id}/permissions/{perm_id}")
+    @Path("{role_name}/permissions/{perm_id}")
     @Produces(MediaType.APPLICATION_JSON)
-    public Role removeRolePermission(@PathParam("role_id") String roleId,
+    public RoleDTO removeRolePermission(@PathParam("role_name") String roleName,
         @PathParam("perm_id") String permissionId) {
 
-        Role existingRole = lookupRole(roleId);
-        Set<PermissionBlueprint> picks = new HashSet<>();
-        boolean found = false;
-        PermissionBlueprint toRemove = null;
-        for (PermissionBlueprint op : existingRole.getPermissions()) {
-            if (!op.getId().equals(permissionId)) {
-                picks.add(op);
-            }
-            else {
-                found = true;
-                toRemove = op;
-            }
-        }
+        // Validate role name
+        this.fetchRoleByName(roleName);
 
-        if (!found) {
-            throw new NotFoundException(i18n.tr("No such permission: {0} in role: {1}",
-                permissionId, roleId));
-        }
-
-        existingRole.setPermissions(picks);
-        Role r = this.userService.updateRole(existingRole);
-        toRemove.setOwner(null);
-        permissionCurator.delete(toRemove);
-        return r;
-    }
-
-    private Role lookupRole(String roleId) {
-        Role role = userService.getRole(roleId);
-        if (role == null) {
-            throw new NotFoundException(i18n.tr("No such role: {0}", roleId));
-        }
-        return role;
-    }
-
-    private User lookupUser(String username) {
-        User user = userService.findByLogin(username);
-        if (user == null) {
-            throw new NotFoundException(i18n.tr("No such user: {0}", username));
-        }
-        return user;
+        RoleInfo role = this.userService.removePermissionFromRole(roleName, permissionId);
+        return this.modelTranslator.translate(role, RoleDTO.class);
     }
 
     @ApiOperation(notes = "Retrieves a single Role", value = "getRole")
     @GET
-    @Path("{role_id}")
+    @Path("{role_name}")
     @Produces(MediaType.APPLICATION_JSON)
-    public Role getRole(@PathParam("role_id") String roleId) {
-        return lookupRole(roleId);
+    public RoleDTO getRole(@PathParam("role_name") String roleName) {
+        RoleInfo role = this.fetchRoleByName(roleName);
+        return this.modelTranslator.translate(role, RoleDTO.class);
     }
 
     @ApiOperation(notes = "Removes a Role", value = "deleteRole")
     @DELETE
-    @Path("/{role_id}")
+    @Path("/{role_name}")
     @Produces(MediaType.WILDCARD)
-    public void deleteRole(@PathParam("role_id") String roleId) {
-        this.userService.deleteRole(roleId);
+    public void deleteRole(@PathParam("role_name") String roleName) {
+        // Validate role name
+        this.fetchRoleByName(roleName);
+
+        this.userService.deleteRole(roleName);
     }
 
     @ApiOperation(notes = "Adds a User to a Role", value = "addUser")
     @ApiResponses({ @ApiResponse(code = 404, message = "") })
     @POST
-    @Path("/{role_id}/users/{username}")
+    @Path("/{role_name}/users/{username}")
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.WILDCARD)
-    public Role addUser(@PathParam("role_id") String roleId,
+    public RoleDTO addUserToRole(@PathParam("role_name") String roleName,
         @PathParam("username") String username) {
-        Role role = lookupRole(roleId);
-        User user = lookupUser(username);
-        userService.addUserToRole(role, user);
-        return role;
+
+        // Validate role name
+        this.fetchRoleByName(roleName);
+
+        // Validate username
+        this.fetchUserByUsername(username);
+
+        RoleInfo role = this.userService.addUserToRole(roleName, username);
+        return this.modelTranslator.translate(role, RoleDTO.class);
     }
 
     @ApiOperation(notes = "Removes a User from a Role", value = "deleteUser")
     @ApiResponses({ @ApiResponse(code = 404, message = "") })
     @DELETE
-    @Path("/{role_id}/users/{username}")
+    @Path("/{role_name}/users/{username}")
     @Produces(MediaType.APPLICATION_JSON)
-    public Role deleteUser(@PathParam("role_id") String roleId,
+    public RoleDTO deleteUserFromRole(@PathParam("role_name") String roleName,
         @PathParam("username") String username) {
-        Role role = lookupRole(roleId);
-        User user = lookupUser(username);
-        userService.removeUserFromRole(role, user);
-        return role;
+
+        // Validate role name
+        this.fetchRoleByName(roleName);
+
+        // Validate username
+        this.fetchUserByUsername(username);
+
+        RoleInfo role = this.userService.removeUserFromRole(roleName, username);
+        return this.modelTranslator.translate(role, RoleDTO.class);
     }
 
     @ApiOperation(notes = "Retrieves a list of Roles", value = "getRoles")
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Wrapped(element = "roles")
-    public List<Role> getRoles() {
-        // TODO:  Add in filter options
-        return userService.listRoles();
+    public Stream<RoleDTO> getRoles() {
+        // TODO: Add in filter options
+
+        Collection<? extends RoleInfo> roles = this.userService.listRoles();
+        return roles.stream().map(this.modelTranslator.getStreamMapper(RoleInfo.class, RoleDTO.class));
     }
 
 }

--- a/server/src/main/java/org/candlepin/resource/UserResource.java
+++ b/server/src/main/java/org/candlepin/resource/UserResource.java
@@ -14,10 +14,7 @@
  */
 package org.candlepin.resource;
 
-
-import org.candlepin.auth.Access;
 import org.candlepin.auth.Principal;
-import org.candlepin.auth.SubResource;
 import org.candlepin.auth.Verify;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.dto.api.v1.OwnerDTO;
@@ -28,21 +25,20 @@ import org.candlepin.common.exceptions.BadRequestException;
 import org.candlepin.common.exceptions.NotFoundException;
 import org.candlepin.model.Owner;
 import org.candlepin.model.OwnerCurator;
-import org.candlepin.model.Role;
 import org.candlepin.model.User;
 import org.candlepin.service.UserServiceAdapter;
+import org.candlepin.service.model.OwnerInfo;
+import org.candlepin.service.model.RoleInfo;
+import org.candlepin.service.model.UserInfo;
 
 import com.google.inject.Inject;
 
 import org.xnap.commons.i18n.I18n;
 
 import java.util.Collection;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -105,12 +101,12 @@ public class UserResource {
      * @return
      *  The user for the given username
      */
-    protected User fetchUserByUsername(String username) {
+    protected UserInfo fetchUserByUsername(String username) {
         if (username == null || username.isEmpty()) {
             throw new BadRequestException(this.i18n.tr("username is null or empty"));
         }
 
-        User user = this.userService.findByLogin(username);
+        UserInfo user = this.userService.findByLogin(username);
         if (user == null) {
             throw new NotFoundException(this.i18n.tr("User not found: {0}", username));
         }
@@ -122,10 +118,10 @@ public class UserResource {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public Stream<UserDTO> list() {
-        Collection<User> users = userService.listUsers();
+        Collection<? extends UserInfo> users = userService.listUsers();
 
         return users != null ?
-            users.stream().map(this.modelTranslator.getStreamMapper(User.class, UserDTO.class)) :
+            users.stream().map(this.modelTranslator.getStreamMapper(UserInfo.class, UserDTO.class)) :
             null;
     }
 
@@ -148,23 +144,21 @@ public class UserResource {
     @Path("/{username}/roles")
     @Produces(MediaType.APPLICATION_JSON)
     public Stream<RoleDTO> getUserRoles(@PathParam("username") @Verify(User.class) String username) {
-        User user = this.fetchUserByUsername(username);
+        UserInfo user = this.fetchUserByUsername(username);
 
-        List<Role> roles = new LinkedList<>();
-        Set<User> s = new HashSet<>();
-        s.add(user);
+        Collection<? extends RoleInfo> roles = user.getRoles();
+        if (roles != null) {
+            UserDTO udto = this.modelTranslator.translate(user, UserDTO.class);
+            Set<UserDTO> users = Collections.singleton(udto);
 
-        for (Role r : user.getRoles()) {
-            // Copy onto a detached role object so we can omit users list, which could
-            // technically leak information here.
-            Role copy = new Role(r.getName());
-            copy.setId(r.getId());
-            copy.setPermissions(r.getPermissions());
-            copy.setUsers(s);
-            roles.add(copy);
+            // Make sure we clear/overwrite the collection of users with our singleton users set
+            // to avoid leaking role details about other users.
+            return roles.stream()
+                .map(this.modelTranslator.getStreamMapper(RoleInfo.class, RoleDTO.class))
+                .peek(e -> e.setUsers(users));
         }
 
-        return roles.stream().map(this.modelTranslator.getStreamMapper(Role.class, RoleDTO.class));
+        return Stream.<RoleDTO>empty();
     }
 
     @ApiOperation(notes = "Creates a User", value = "createUser")
@@ -183,25 +177,15 @@ public class UserResource {
             throw new BadRequestException(this.i18n.tr("user data is null or empty"));
         }
 
-        if (userService.findByLogin(dto.getUsername()) != null) {
-            throw new ConflictException(this.i18n.tr("User already exists: {0}", dto.getUsername()));
-        }
-
-        User user = new User();
-
         if (dto.getUsername() == null) {
             throw new BadRequestException(this.i18n.tr("Username not specified"));
         }
 
-        user.setUsername(dto.getUsername());
-
-        if (dto.getPassword() != null) {
-            user.setPassword(dto.getPassword());
+        if (this.userService.findByLogin(dto.getUsername()) != null) {
+            throw new ConflictException(this.i18n.tr("User already exists: {0}", dto.getUsername()));
         }
 
-        user.setSuperAdmin(dto.isSuperAdmin() != null ? dto.isSuperAdmin() : false);
-
-        return this.modelTranslator.translate(userService.createUser(user), UserDTO.class);
+        return this.modelTranslator.translate(userService.createUser(dto), UserDTO.class);
     }
 
     @ApiOperation(notes = "Updates a User", value = "updateUser")
@@ -214,23 +198,11 @@ public class UserResource {
         @PathParam("username") @Verify(User.class) String username,
         @ApiParam(name = "user", required = true) UserDTO dto) {
 
-        // Note, to change the username, the old username needs to be provided.
-        User user = this.fetchUserByUsername(username);
+        // We don't actually need the user, but we do this for quick verification and better error
+        // generation
+        UserInfo user = this.fetchUserByUsername(username);
 
-        // Apparently we allow anything to change here...???
-        if (dto.getUsername() != null) {
-            user.setUsername(dto.getUsername());
-        }
-
-        if (dto.getPassword() != null) {
-            user.setPassword(dto.getPassword());
-        }
-
-        if (dto.isSuperAdmin() != null) {
-            user.setSuperAdmin(dto.isSuperAdmin());
-        }
-
-        return this.modelTranslator.translate(userService.updateUser(user), UserDTO.class);
+        return this.modelTranslator.translate(userService.updateUser(username, dto), UserDTO.class);
     }
 
     @ApiOperation(notes = "Removes a User", value = "deleteUser")
@@ -239,9 +211,9 @@ public class UserResource {
     @Path("/{username}")
     @Produces(MediaType.APPLICATION_JSON)
     public void deleteUser(@PathParam("username") String username) {
-        User user = this.fetchUserByUsername(username);
+        UserInfo user = this.fetchUserByUsername(username);
 
-        userService.deleteUser(user);
+        userService.deleteUser(username);
     }
 
     @ApiOperation(notes = "Retrieve a list of owners the user can register systems to. " +
@@ -258,13 +230,42 @@ public class UserResource {
         @PathParam("username") @Verify(User.class) String username,
         @Context Principal principal) {
 
-        User user = userService.findByLogin(username);
+        // Fetch the user for a simple existence check. We don't actually need it.
+        UserInfo user = this.fetchUserByUsername(username);
 
-        Stream<Owner> stream = user.isSuperAdmin() ?
-            StreamSupport.stream(this.ownerCurator.listAll().spliterator(), false) :
-            user.getOwners(SubResource.CONSUMERS, Access.CREATE).stream();
+        Collection<? extends OwnerInfo> owners = this.userService.getAccessibleOwners(username);
 
-        return stream.map(this.modelTranslator.getStreamMapper(Owner.class, OwnerDTO.class));
+        if (owners != null) {
+            // If this ends up being a bottleneck, change this to do a bulk owner lookup
+
+            return owners.stream()
+                .map(this::resolveOwner)
+                .map(this.modelTranslator.getStreamMapper(Owner.class, OwnerDTO.class));
+        }
+
+        return null;
     }
+
+    protected Owner resolveOwner(OwnerInfo oinfo) {
+        if (oinfo != null) {
+            // This is a bit of an odd situation. Should we just pass through what the adapter gave us
+            // anyway?
+
+            if (oinfo.getKey() == null || oinfo.getKey().isEmpty()) {
+                throw new IllegalStateException("owner lacks identifying information: " + oinfo);
+            }
+
+            Owner owner = this.ownerCurator.getByKey(oinfo.getKey());
+            if (owner == null) {
+                owner = new Owner(oinfo.getKey());
+            }
+
+            return owner;
+        }
+
+        return null;
+    }
+
+
 
 }

--- a/server/src/main/java/org/candlepin/service/ContentAccessCertServiceAdapter.java
+++ b/server/src/main/java/org/candlepin/service/ContentAccessCertServiceAdapter.java
@@ -23,7 +23,14 @@ import java.util.Date;
 
 /**
  * Interface to the Certificate Service.
+ *
+ * @deprecated
+ *  This adapter is not implemented by anyone else and makes use of direct model objects. If the
+ *  adapter is still needed in the future, this interface should be redefined to no longer use
+ *  Candlepin-internal model objects, and minimize the number of adapter views or DTOs as input
+ *  parameters.
  */
+@Deprecated
 public interface ContentAccessCertServiceAdapter {
 
     // If we ever have a need for more modes, these should move to a proper enum

--- a/server/src/main/java/org/candlepin/service/ExportExtensionAdapter.java
+++ b/server/src/main/java/org/candlepin/service/ExportExtensionAdapter.java
@@ -14,11 +14,13 @@
  */
 package org.candlepin.service;
 
+import org.candlepin.service.model.ConsumerInfo;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.Map;
 
-import org.candlepin.model.Consumer;
+
 
 /**
  * <p>This adapter provides a hook for allowing the extension of what is
@@ -55,7 +57,7 @@ public interface ExportExtensionAdapter {
      * @param extensionData data passed via the ext query param when the initial request was made.
      * @throws IOException if there were any issues creating the extension files.
      */
-    void extendManifest(File extensionDir, Consumer targetConsumer, Map<String, String> extensionData)
+    void extendManifest(File extensionDir, ConsumerInfo targetConsumer, Map<String, String> extensionData)
         throws IOException;
 
 }

--- a/server/src/main/java/org/candlepin/service/ProductServiceAdapter.java
+++ b/server/src/main/java/org/candlepin/service/ProductServiceAdapter.java
@@ -14,9 +14,8 @@
  */
 package org.candlepin.service;
 
-import org.candlepin.model.Owner;
-import org.candlepin.model.ProductCertificate;
-import org.candlepin.model.dto.ProductData;
+import org.candlepin.service.model.CertificateInfo;
+import org.candlepin.service.model.ProductInfo;
 
 import java.util.Collection;
 
@@ -44,21 +43,22 @@ public interface ProductServiceAdapter {
      * If the ids param is null or empty, an empty list of products will be
      * returned.
      *
-     * @param owner the owner/org in which to search for products
+     * @param ownerKey the owner/org in which to search for products
      * @param ids list of product ids
      * @return list of products matching the given string IDs,
      *         empty list if none were found.
      */
-    Collection<ProductData> getProductsByIds(Owner owner, Collection<String> ids);
+    Collection<? extends ProductInfo> getProductsByIds(String ownerKey, Collection<String> ids);
 
     /**
      * Gets the certificate that defines the given product, creating one
      * if necessary. If the implementation does not support product certificates
      * for some reason, null can be returned instead of creating a new one.
      *
-     * @param owner the owner/org in which to search for products
+     * @param ownerKey the owner/org in which to search for products
      * @param productId the ID of the source product of the certificate
      * @return the stored or created {@link ProductCertificate}
      */
-    ProductCertificate getProductCertificate(Owner owner, String productId);
+    CertificateInfo getProductCertificate(String ownerKey, String productId);
+
 }

--- a/server/src/main/java/org/candlepin/service/SubscriptionServiceAdapter.java
+++ b/server/src/main/java/org/candlepin/service/SubscriptionServiceAdapter.java
@@ -14,12 +14,12 @@
  */
 package org.candlepin.service;
 
-import org.candlepin.model.Consumer;
-import org.candlepin.model.Owner;
-import org.candlepin.model.dto.ProductData;
-import org.candlepin.model.dto.Subscription;
+import org.candlepin.service.model.ConsumerInfo;
+import org.candlepin.service.model.SubscriptionInfo;
 
-import java.util.List;
+import java.util.Collection;
+
+
 
 /**
  * Subscription data may originate from a separate service outside Candlepin
@@ -31,40 +31,47 @@ import java.util.List;
 public interface SubscriptionServiceAdapter {
 
     /**
-     * List all subscriptions for the given owner.
-     * @param owner Owner of the subscriptions.
-     * @return all subscriptions for the given owner.
+     * Return all subscriptions.
+     * @return all subscriptions.
      */
-    List<Subscription> getSubscriptions(Owner owner);
-
-    /**
-     * List all active subscription ids for the given owner.
-     * @param owner Owner of the subscriptions.
-     * @return ids of all subscriptions for the given owner.
-     */
-    List<String> getSubscriptionIds(Owner owner);
+    Collection<? extends SubscriptionInfo> getSubscriptions();
 
     /**
      * Lookup a specific subscription.
      * @param subscriptionId id of the subscription to return.
      * @return Subscription whose id matches subscriptionId
      */
-    Subscription getSubscription(String subscriptionId);
+    SubscriptionInfo getSubscription(String subscriptionId);
 
     /**
-     * Return all subscriptions.
-     * @return all subscriptions.
+     * List all subscriptions for the given owner.
+     * @param ownerKey Owner of the subscriptions.
+     * @return all subscriptions for the given owner.
      */
-    List<Subscription> getSubscriptions();
+    Collection<? extends SubscriptionInfo> getSubscriptions(String ownerKey);
+
+    /**
+     * List all active subscription ids for the given owner.
+     * @param ownerKey Owner of the subscriptions.
+     * @return ids of all subscriptions for the given owner.
+     */
+    Collection<String> getSubscriptionIds(String ownerKey);
+
+    /**
+     * Search for all subscriptions that provide a given product.
+     *
+     * @param productId the main or provided product to look for.
+     * @return a list of subscriptions that provide this product.
+     */
+    Collection<? extends SubscriptionInfo> getSubscriptionsByProductId(String productId);
 
     /**
      * Checks to see if the customer has subscription terms that need to be accepted
-     * @param owner
+     * @param ownerKey
      * @return false if no subscriptions a runtime exception will a localized message
      * if there are terms to be accepted
      */
-    boolean hasUnacceptedSubscriptionTerms(Owner owner);
-
+    boolean hasUnacceptedSubscriptionTerms(String ownerKey);
 
     /**
      * A pool for a subscription id has been created. Send the activation email
@@ -74,14 +81,13 @@ public interface SubscriptionServiceAdapter {
      */
     void sendActivationEmail(String subscriptionId);
 
-
     /**
      * Can this consumer activate a subscription?
      *
      * @param consumer
      * @return <code>true</code> if and only if this consumer can activate a subscription
      */
-    boolean canActivateSubscription(Consumer consumer);
+    boolean canActivateSubscription(ConsumerInfo consumer);
 
     /**
      * Activate a subscription associated with the consumer
@@ -90,28 +96,7 @@ public interface SubscriptionServiceAdapter {
      * @param email the email address tied to this consumer
      * @param emailLocale the i18n locale for the email
      */
-    void activateSubscription(Consumer consumer, String email, String emailLocale);
-
-    /**
-     * Create the given subscription.
-     *
-     * Raise not implemented exception if you do not wish to support this
-     * in your subscription service.
-     *
-     * @param s Subscription to create.
-     * @return Newly created Subscription.
-     */
-    Subscription createSubscription(Subscription s);
-
-    /**
-     * Delete the given subscription.
-     *
-     * Raise not implemented exception if you do not wish to support this
-     * in your subscription service.
-     *
-     * @param s Subscription to destroy.
-     */
-    void deleteSubscription(Subscription s);
+    void activateSubscription(ConsumerInfo consumer, String email, String emailLocale);
 
     /**
      * Some subscription services are read-only. This allows us to avoid certain
@@ -123,12 +108,4 @@ public interface SubscriptionServiceAdapter {
      * @return Whether or not this service is read-only
      */
     boolean isReadOnly();
-
-    /**
-     * Search for all subscriptions that provide a given product.
-     *
-     * @param product the main or provided product to look for.
-     * @return a list of subscriptions that provide this product.
-     */
-    List<Subscription> getSubscriptions(ProductData product);
 }

--- a/server/src/main/java/org/candlepin/service/UserServiceAdapter.java
+++ b/server/src/main/java/org/candlepin/service/UserServiceAdapter.java
@@ -14,10 +14,14 @@
  */
 package org.candlepin.service;
 
-import org.candlepin.model.Role;
-import org.candlepin.model.User;
+import org.candlepin.service.model.OwnerInfo;
+import org.candlepin.service.model.PermissionBlueprintInfo;
+import org.candlepin.service.model.RoleInfo;
+import org.candlepin.service.model.UserInfo;
 
-import java.util.List;
+import java.util.Collection;
+
+
 
 /**
  * UserServiceAdapter
@@ -34,28 +38,44 @@ public interface UserServiceAdapter {
     boolean validateUser(String username, String password) throws Exception;
 
     // User life cycle
-    User createUser(User user);
+    UserInfo createUser(UserInfo user);
 
-    User updateUser(User user);
+    UserInfo updateUser(String username, UserInfo user);
 
-    void deleteUser(User user);
+    void deleteUser(String username);
 
-    User findByLogin(String login);
+    UserInfo findByLogin(String username);
 
-    List<User> listUsers();
+    Collection<? extends UserInfo> listUsers();
 
-    Role createRole(Role r);
+    /**
+     * Fetches a collection of owners to which the specified user is allowed to register.
+     *
+     * @param username
+     *  The username of the user to check
+     *
+     * @return
+     *  a collection of owners to which the user is allowed to register
+     */
+    Collection<? extends OwnerInfo> getAccessibleOwners(String username);
 
-    Role updateRole(Role r);
+    // Roles
+    RoleInfo createRole(RoleInfo role);
 
-    void addUserToRole(Role role, User user);
+    RoleInfo updateRole(String roleName, RoleInfo role);
 
-    void removeUserFromRole(Role role, User user);
+    RoleInfo addUserToRole(String roleName, String username);
 
-    void deleteRole(String roleId);
+    RoleInfo removeUserFromRole(String roleName, String username);
 
-    Role getRole(String roleId);
+    RoleInfo addPermissionToRole(String roleName, PermissionBlueprintInfo permission);
 
-    List<Role> listRoles();
+    RoleInfo removePermissionFromRole(String roleName, String permissionId);
+
+    void deleteRole(String roleName);
+
+    RoleInfo getRole(String roleName);
+
+    Collection<? extends RoleInfo> listRoles();
 
 }

--- a/server/src/main/java/org/candlepin/service/impl/BaseEntitlementCertServiceAdapter.java
+++ b/server/src/main/java/org/candlepin/service/impl/BaseEntitlementCertServiceAdapter.java
@@ -12,13 +12,16 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.service;
+package org.candlepin.service.impl;
 
 import org.candlepin.model.Consumer;
 import org.candlepin.model.EntitlementCertificate;
 import org.candlepin.model.EntitlementCertificateCurator;
+import org.candlepin.service.EntitlementCertServiceAdapter;
 
 import java.util.List;
+
+
 
 /**
  * BaseEntitlementCertServiceAdapter
@@ -26,8 +29,7 @@ import java.util.List;
  * Shared base class for all entitlement cert service adapters. Because we store the
  * certs in most cases, some functionality is common to all.
  */
-public abstract class BaseEntitlementCertServiceAdapter implements
-    EntitlementCertServiceAdapter {
+public abstract class BaseEntitlementCertServiceAdapter implements EntitlementCertServiceAdapter {
 
     protected EntitlementCertificateCurator entCertCurator;
 

--- a/server/src/main/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapter.java
+++ b/server/src/main/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapter.java
@@ -41,7 +41,6 @@ import org.candlepin.model.ProductCurator;
 import org.candlepin.pki.PKIUtility;
 import org.candlepin.pki.X509ByteExtensionWrapper;
 import org.candlepin.pki.X509ExtensionWrapper;
-import org.candlepin.service.BaseEntitlementCertServiceAdapter;
 import org.candlepin.util.CertificateSizeException;
 import org.candlepin.util.OIDUtil;
 import org.candlepin.util.Util;

--- a/server/src/main/java/org/candlepin/service/impl/DefaultExportExtensionAdapter.java
+++ b/server/src/main/java/org/candlepin/service/impl/DefaultExportExtensionAdapter.java
@@ -14,23 +14,26 @@
  */
 package org.candlepin.service.impl;
 
+import org.candlepin.service.model.ConsumerInfo;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.Map;
 
-import org.candlepin.model.Consumer;
 import org.candlepin.service.ExportExtensionAdapter;
+
+
 
 /**
  * The default implementation of the {@link ExportExtensionAdapter}. This adapter adds
  * nothing to the manifest.
- *
  */
 public class DefaultExportExtensionAdapter implements ExportExtensionAdapter {
 
     @Override
-    public void extendManifest(File extensionDir, Consumer targetConsumer, Map<String, String> extensionData)
+    public void extendManifest(File extensionDir, ConsumerInfo consumer, Map<String, String> extensionData)
         throws IOException {
+
         // The default implementation does nothing.
     }
 

--- a/server/src/main/java/org/candlepin/service/impl/DefaultProductServiceAdapter.java
+++ b/server/src/main/java/org/candlepin/service/impl/DefaultProductServiceAdapter.java
@@ -15,21 +15,18 @@
 package org.candlepin.service.impl;
 
 import org.candlepin.model.ContentCurator;
-import org.candlepin.model.Owner;
 import org.candlepin.model.OwnerProductCurator;
 import org.candlepin.model.Product;
-import org.candlepin.model.ProductCertificate;
 import org.candlepin.model.ProductCertificateCurator;
-import org.candlepin.model.ResultIterator;
-import org.candlepin.model.dto.ProductData;
 import org.candlepin.service.ProductServiceAdapter;
 import org.candlepin.service.UniqueIdGenerator;
+import org.candlepin.service.model.CertificateInfo;
+import org.candlepin.service.model.ProductInfo;
 
 import com.google.inject.Inject;
 import com.google.inject.persist.Transactional;
 
 import java.util.Collection;
-import java.util.LinkedList;
 
 
 
@@ -51,29 +48,18 @@ public class DefaultProductServiceAdapter implements ProductServiceAdapter {
     }
 
     @Override
-    public ProductCertificate getProductCertificate(Owner owner, String productId) {
+    public CertificateInfo getProductCertificate(String ownerKey, String productId) {
         // for product cert storage/generation - not sure if this should go in
         // a separate service?
-        Product entity = this.ownerProductCurator.getProductById(owner, productId);
+
+        Product entity = this.ownerProductCurator.getProductByIdUsingOwnerKey(ownerKey, productId);
         return entity != null ? this.prodCertCurator.getCertForProduct(entity) : null;
     }
 
     @Override
     @Transactional
-    public Collection<ProductData> getProductsByIds(Owner owner, Collection<String> ids) {
-        Collection<ProductData> productData = new LinkedList<>();
-
-        ResultIterator<Product> iterator = this.ownerProductCurator
-            .getProductsByIds(owner, ids)
-            .iterate(0, true);
-
-        while (iterator.hasNext()) {
-            productData.add(iterator.next().toDTO());
-        }
-
-        iterator.close();
-
-        return productData;
+    public Collection<? extends ProductInfo> getProductsByIds(String ownerKey, Collection<String> ids) {
+        return this.ownerProductCurator.getProductsByIdsUsingOwnerKey(ownerKey, ids).list();
     }
 
 }

--- a/server/src/main/java/org/candlepin/service/impl/DefaultUserServiceAdapter.java
+++ b/server/src/main/java/org/candlepin/service/impl/DefaultUserServiceAdapter.java
@@ -14,74 +14,187 @@
  */
 package org.candlepin.service.impl;
 
+import org.candlepin.auth.Access;
+import org.candlepin.auth.SubResource;
+import org.candlepin.auth.permissions.Permission;
+import org.candlepin.auth.permissions.PermissionFactory;
+import org.candlepin.auth.permissions.PermissionFactory.PermissionType;
+import org.candlepin.model.Owner;
+import org.candlepin.model.OwnerCurator;
 import org.candlepin.model.PermissionBlueprint;
+import org.candlepin.model.PermissionBlueprintCurator;
 import org.candlepin.model.Role;
 import org.candlepin.model.RoleCurator;
 import org.candlepin.model.User;
 import org.candlepin.model.UserCurator;
 import org.candlepin.service.UserServiceAdapter;
+import org.candlepin.service.model.OwnerInfo;
+import org.candlepin.service.model.PermissionBlueprintInfo;
+import org.candlepin.service.model.RoleInfo;
+import org.candlepin.service.model.UserInfo;
 import org.candlepin.util.Util;
 
 import com.google.inject.Inject;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+
+
 
 /**
  * A {@link UserServiceAdapter} implementation backed by a {@link UserCurator}
  * for user creation and persistence.
  */
 public class DefaultUserServiceAdapter implements UserServiceAdapter {
+    private static Logger log = LoggerFactory.getLogger(DefaultUserServiceAdapter.class);
 
     private UserCurator userCurator;
     private RoleCurator roleCurator;
+    private PermissionBlueprintCurator permissionCurator;
+    private OwnerCurator ownerCurator;
+    private PermissionFactory permissionFactory;
 
     @Inject
-    public DefaultUserServiceAdapter(UserCurator userCurator, RoleCurator roleCurator) {
+    public DefaultUserServiceAdapter(UserCurator userCurator, RoleCurator roleCurator,
+        PermissionBlueprintCurator permissionCurator, OwnerCurator ownerCurator,
+        PermissionFactory permissionFactory) {
+
         this.userCurator = userCurator;
         this.roleCurator = roleCurator;
+        this.permissionCurator = permissionCurator;
+        this.ownerCurator = ownerCurator;
+        this.permissionFactory = permissionFactory;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
-    public User createUser(User user) {
-        return this.userCurator.create(user);
+    public UserInfo createUser(UserInfo user) {
+        if (user == null) {
+            throw new IllegalArgumentException("user is null");
+        }
+
+        if (user.getUsername() == null || user.getUsername().isEmpty()) {
+            throw new IllegalArgumentException("Username is null or empty");
+        }
+
+        if (this.userCurator.findByLogin(user.getUsername()) != null) {
+            throw new IllegalStateException("User already exists: " + user.getUsername());
+        }
+
+        User entity = new User();
+
+        entity.setUsername(user.getUsername());
+        entity.setHashedPassword(user.getHashedPassword());
+        entity.setSuperAdmin(user.isSuperAdmin() != null ? user.isSuperAdmin() : false);
+
+        // Convert roles
+        if (user.getRoles() != null) {
+            for (RoleInfo role : user.getRoles()) {
+                // If this ends up being a bottleneck, we can optimize this a tad by bulking this lookup
+                Role roleEntity = this.roleCurator.getByName(role.getName());
+
+                if (roleEntity == null) {
+                    throw new IllegalStateException("Role does not exist: " + role.getName());
+                }
+
+                entity.addRole(roleEntity);
+            }
+        }
+
+        entity = this.userCurator.create(entity);
+
+        return entity;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
-    public User updateUser(User user) {
-        return userCurator.update(user);
+    public UserInfo updateUser(String username, UserInfo user) {
+        if (user == null) {
+            throw new IllegalArgumentException("user is null");
+        }
+
+        if (username == null || username.isEmpty()) {
+            throw new IllegalArgumentException("username is null or empty");
+        }
+
+        User entity = this.userCurator.findByLogin(username);
+        if (entity == null) {
+            throw new IllegalStateException("User does not exist: " + username);
+        }
+
+        // If the username is changing, verify that the new username isn't already in use
+        if (user.getUsername() != null && !username.equals(user.getUsername()) &&
+            this.userCurator.findByLogin(user.getUsername()) != null) {
+
+            throw new IllegalStateException("Username already in use: " + user.getUsername());
+        }
+
+        // Check if the inbound entity is not the same instance we would update here. If it is,
+        // we have nothing to do, so we'll just skip everything.
+        if (entity != user) {
+            Set<Role> roles = null;
+
+            // Convert roles
+            if (user.getRoles() != null) {
+                roles = new HashSet<>();
+
+                for (RoleInfo role : user.getRoles()) {
+                    // If this ends up being a bottleneck, we can optimize this a tad by bulking this lookup
+                    Role roleEntity = this.roleCurator.getByName(role.getName());
+
+                    if (roleEntity == null) {
+                        throw new IllegalStateException("Role does not exist: " + role.getName());
+                    }
+
+                    roles.add(roleEntity);
+                }
+            }
+
+            // If our sub-objects validated, set the rest of the properties now
+            if (user.getUsername() != null) {
+                entity.setUsername(user.getUsername());
+            }
+
+            if (user.getHashedPassword() != null) {
+                entity.setHashedPassword(user.getHashedPassword());
+            }
+
+            if (user.isSuperAdmin() != null) {
+                entity.setSuperAdmin(user.isSuperAdmin());
+            }
+
+            if (roles != null) {
+                entity.clearRoles();
+                for (Role role : roles) {
+                    entity.addRole(role);
+                }
+            }
+        }
+
+        return this.userCurator.merge(entity);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
-    public List<User> listUsers() {
+    public List<? extends UserInfo> listUsers() {
         return this.userCurator.listAll().list();
     }
 
-
-    @Override
-    public List<Role> listRoles() {
-        return roleCurator.listAll().list();
-    }
-
-    @Override
-    public Role createRole(Role role) {
-        Set<User> actualUsers = new HashSet<>();
-
-        for (User user : role.getUsers()) {
-            User actualUser = findByLogin(user.getUsername());
-            actualUsers.add(actualUser);
-        }
-        role.setUsers(actualUsers);
-
-        for (PermissionBlueprint permission : role.getPermissions()) {
-            permission.setRole(role);
-        }
-
-        this.roleCurator.create(role);
-        return role;
-    }
-
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public boolean validateUser(String username, String password) {
         User user = this.userCurator.findByLogin(username);
@@ -94,51 +207,374 @@ public class DefaultUserServiceAdapter implements UserServiceAdapter {
         return false;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
-    public void deleteUser(User user) {
-        for (Role r : user.getRoles()) {
-            user.removeRole(r);
+    public void deleteUser(String username) {
+        User entity = this.userCurator.findByLogin(username);
+
+        if (entity != null) {
+            entity.clearRoles();
+            this.userCurator.delete(entity);
         }
-        userCurator.delete(user);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
-    public User findByLogin(String login) {
+    public UserInfo findByLogin(String login) {
         return userCurator.findByLogin(login);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
-    public void deleteRole(String roleId) {
-        Role r = roleCurator.get(roleId);
-        roleCurator.delete(r);
+    public Collection<? extends OwnerInfo> getAccessibleOwners(String username) {
+        if (username == null) {
+            throw new IllegalArgumentException("username is null");
+        }
+
+        User entity = this.userCurator.findByLogin(username);
+        if (entity == null) {
+            throw new IllegalStateException("User does not exist: " + username);
+        }
+
+        if (entity.isSuperAdmin() != null && entity.isSuperAdmin()) {
+            // Super admins can see everything
+            return this.ownerCurator.listAll().list();
+        }
+        else {
+            // We need to pair this down to just accessible owners...
+            Collection<Permission> permissions = this.permissionFactory.createUserPermissions(entity);
+            Set<OwnerInfo> owners = new HashSet<>();
+
+            for (Permission permission : permissions) {
+                if (permission.canAccess(permission.getOwner(), SubResource.CONSUMERS, Access.CREATE)) {
+                    owners.add(permission.getOwner());
+                }
+            }
+
+            return owners;
+        }
     }
 
-    @Override
-    public Role updateRole(Role r) {
-//        Set<OwnerPermission> newPermissions = new HashSet<OwnerPermission>();
-//        for (OwnerPermission incomingPerm : r.getPermissions()) {
-//            newPermissions.add(this.permCurator.findOrCreate(
-//                incomingPerm.getOwner(), incomingPerm.getAccess()));
-//        }
-//        r.getPermissions().clear();
-//        r.getPermissions().addAll(newPermissions);
-        return roleCurator.merge(r);
+    /**
+     * Resolves the owner represented by a given OwnerInfo instance. If the owner cannot be
+     * resolved, this method throws an exception.
+     *
+     * @throws IllegalStateException
+     *  if the provided OwnerInfo does not represent a valid owner
+     *
+     * @return
+     *  The Owner instance represented by the provided OwnerInfo
+     */
+    private Owner resolveOwnerInfo(OwnerInfo ownerInfo) {
+        if (ownerInfo != null) {
+            Owner owner = this.ownerCurator.getByKey(ownerInfo.getKey());
+
+            if (owner == null) {
+                throw new IllegalStateException("No such owner: " + ownerInfo.getKey());
+            }
+
+            return owner;
+        }
+
+        return null;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
-    public Role getRole(String roleId) {
-        return roleCurator.get(roleId);
+    public RoleInfo createRole(RoleInfo role) {
+        if (role == null) {
+            throw new IllegalArgumentException("role is null");
+        }
+
+        if (role.getName() == null || role.getName().isEmpty()) {
+            throw new IllegalArgumentException("Role name is null or empty");
+        }
+
+        if (this.roleCurator.getByName(role.getName()) != null) {
+            throw new IllegalStateException("Role already exists: " + role.getName());
+        }
+
+        Role entity = new Role();
+
+        entity.setName(role.getName());
+
+        if (role.getUsers() != null) {
+            for (UserInfo user : role.getUsers()) {
+                User userEntity = this.userCurator.findByLogin(user.getUsername());
+
+                if (userEntity == null) {
+                    throw new IllegalStateException("User does not exist: " + user.getUsername());
+                }
+
+                entity.addUser(userEntity);
+            }
+        }
+
+        if (role.getPermissions() != null) {
+            for (PermissionBlueprintInfo permission : role.getPermissions()) {
+                PermissionBlueprint pentity = new PermissionBlueprint(null, null, null);
+
+                if (permission.getOwner() == null) {
+                    throw new IllegalArgumentException("Permission does not define an owner: " + permission);
+                }
+
+                pentity.setOwner(this.resolveOwnerInfo(permission.getOwner()));
+
+                pentity.setType(permission.getTypeName() != null ?
+                    PermissionType.valueOf(permission.getTypeName()) :
+                    null);
+
+                pentity.setAccess(permission.getAccessLevel() != null ?
+                    Access.valueOf(permission.getAccessLevel()) :
+                    null);
+
+                entity.addPermission(pentity);
+
+                log.debug("CREATE -- PERMISSION ROLE: {}", pentity.getRole());
+            }
+        }
+
+        return this.roleCurator.create(entity);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
-    public void addUserToRole(Role role, User user) {
-        role.addUser(user);
-        roleCurator.merge(role);
+    public RoleInfo updateRole(String roleName, RoleInfo role) {
+        if (role == null) {
+            throw new IllegalArgumentException("role is null");
+        }
+
+        if (roleName == null || roleName.isEmpty()) {
+            throw new IllegalArgumentException("Role name is null or empty");
+        }
+
+        Role entity = this.roleCurator.getByName(roleName);
+        if (entity == null) {
+            throw new IllegalStateException("Role does not exist: " + roleName);
+        }
+
+        // If the role name is changing, verify that the new role name isn't already in use
+        if (role.getName() != null && !roleName.equals(role.getName()) &&
+            this.roleCurator.getByName(role.getName()) != null) {
+
+            throw new IllegalStateException("Role name already in use: " + role.getName());
+        }
+
+        // Check if the inbound entity is not the same instance we would update here. If it is,
+        // we have nothing to do, so we'll just skip everything.
+        if (entity != role) {
+            Set<User> users = null;
+            Set<PermissionBlueprint> permissions = null;
+
+            if (role.getUsers() != null) {
+                users = new HashSet<>();
+
+                for (UserInfo user : role.getUsers()) {
+                    User userEntity = this.userCurator.findByLogin(user.getUsername());
+
+                    if (userEntity == null) {
+                        throw new IllegalStateException("User does not exist: " + user.getUsername());
+                    }
+
+                    users.add(userEntity);
+                }
+            }
+
+            if (role.getPermissions() != null) {
+                permissions = new HashSet<>();
+
+                for (PermissionBlueprintInfo permission : role.getPermissions()) {
+                    PermissionBlueprint pentity = new PermissionBlueprint(null, null, null);
+
+                    if (permission.getOwner() == null) {
+                        throw new IllegalArgumentException("Permission does not define an owner: " +
+                            permission);
+                    }
+
+                    pentity.setOwner(this.resolveOwnerInfo(permission.getOwner()));
+
+                    pentity.setType(permission.getTypeName() != null ?
+                        PermissionType.valueOf(permission.getTypeName()) :
+                        null);
+
+                    pentity.setAccess(permission.getAccessLevel() != null ?
+                        Access.valueOf(permission.getAccessLevel()) :
+                        null);
+
+                    permissions.add(pentity);
+                }
+            }
+
+            // If everything validated, update the entity now:
+            if (role.getName() != null) {
+                entity.setName(role.getName());
+            }
+
+            if (users != null) {
+                entity.clearUsers();
+                for (User user : users) {
+                    entity.addUser(user);
+                }
+            }
+
+            if (permissions != null) {
+                entity.clearPermissions();
+                for (PermissionBlueprint permission : permissions) {
+                    entity.addPermission(permission);
+                }
+
+                // Impl note: Orphan removal should handle the cleanup of the old permissions for us
+            }
+        }
+
+        return this.roleCurator.merge(entity);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
-    public void removeUserFromRole(Role role, User user) {
-        role.removeUser(user);
-        roleCurator.merge(role);
+    public RoleInfo addUserToRole(String roleName, String username) {
+        Role roleEntity = this.roleCurator.getByName(roleName);
+        if (roleEntity == null) {
+            throw new IllegalStateException("Role does not exist: " + roleName);
+        }
+
+        User userEntity = this.userCurator.findByLogin(username);
+        if (userEntity == null) {
+            throw new IllegalStateException("User does not exist: " + username);
+        }
+
+        roleEntity.addUser(userEntity);
+        return this.roleCurator.merge(roleEntity);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public RoleInfo removeUserFromRole(String roleName, String username) {
+        Role roleEntity = this.roleCurator.getByName(roleName);
+        if (roleEntity == null) {
+            throw new IllegalStateException("Role does not exist: " + roleName);
+        }
+
+        User userEntity = this.userCurator.findByLogin(username);
+        if (userEntity == null) {
+            throw new IllegalStateException("User does not exist: " + username);
+        }
+
+        roleEntity.removeUser(userEntity);
+        return this.roleCurator.merge(roleEntity);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public RoleInfo addPermissionToRole(String roleName, PermissionBlueprintInfo permission) {
+        Role roleEntity = this.roleCurator.getByName(roleName);
+        if (roleEntity == null) {
+            throw new IllegalStateException("Role does not exist: " + roleName);
+        }
+
+        PermissionBlueprint pentity = new PermissionBlueprint(null, null, null);
+
+        if (permission.getOwner() == null) {
+            throw new IllegalArgumentException("Permission does not define an owner: " +
+                permission);
+        }
+
+        pentity.setOwner(this.resolveOwnerInfo(permission.getOwner()));
+        pentity.setType(PermissionType.valueOf(permission.getTypeName()));
+
+        if (permission.getAccessLevel() != null) {
+            pentity.setAccess(Access.valueOf(permission.getAccessLevel()));
+        }
+
+        roleEntity.addPermission(pentity);
+
+        return this.roleCurator.merge(roleEntity);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public RoleInfo removePermissionFromRole(String roleName, String permissionId) {
+        Role roleEntity = this.roleCurator.getByName(roleName);
+        if (roleEntity == null) {
+            throw new IllegalStateException("Role does not exist: " + roleName);
+        }
+
+        if (permissionId == null) {
+            throw new IllegalArgumentException("permissionId is null");
+        }
+
+        if (roleEntity.getPermissions() != null) {
+            boolean removed = false;
+
+            Set<PermissionBlueprint> permissions = roleEntity.getPermissions();
+            Iterator<PermissionBlueprint> iterator = permissions.iterator();
+
+            while (iterator.hasNext()) {
+                PermissionBlueprint permission = iterator.next();
+
+                if (permissionId.equals(permission.getId())) {
+                    iterator.remove();
+
+                    permission.setRole(null);
+                    this.permissionCurator.delete(permission);
+
+                    removed = true;
+                }
+            }
+
+            if (removed) {
+                roleEntity.setPermissions(permissions);
+                roleEntity = this.roleCurator.merge(roleEntity);
+            }
+        }
+
+        return roleEntity;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void deleteRole(String role) {
+        Role entity = this.roleCurator.getByName(role);
+
+        if (entity != null) {
+            entity.clearUsers();
+            this.roleCurator.delete(entity);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public RoleInfo getRole(String roleName) {
+        return this.roleCurator.getByName(roleName);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<? extends RoleInfo> listRoles() {
+        return this.roleCurator.listAll().list();
     }
 }

--- a/server/src/main/java/org/candlepin/service/impl/ImportSubscriptionServiceAdapter.java
+++ b/server/src/main/java/org/candlepin/service/impl/ImportSubscriptionServiceAdapter.java
@@ -16,16 +16,18 @@
 package org.candlepin.service.impl;
 
 import org.candlepin.common.exceptions.ServiceUnavailableException;
-import org.candlepin.model.Consumer;
-import org.candlepin.model.Owner;
-import org.candlepin.model.dto.ProductData;
 import org.candlepin.model.dto.Subscription;
 import org.candlepin.service.SubscriptionServiceAdapter;
+import org.candlepin.service.model.ConsumerInfo;
+import org.candlepin.service.model.ProductInfo;
+import org.candlepin.service.model.SubscriptionInfo;
+
 import org.xnap.commons.i18n.I18n;
 
 import com.google.inject.Inject;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -54,39 +56,52 @@ public class ImportSubscriptionServiceAdapter implements SubscriptionServiceAdap
     }
 
     @Override
-    public List<Subscription> getSubscriptions(Owner owner) {
+    public Collection<? extends SubscriptionInfo> getSubscriptions() {
         return subscriptions;
     }
 
     @Override
-    public List<String> getSubscriptionIds(Owner owner) {
-        return new ArrayList<>(subsBySubId.keySet());
-    }
-
-    @Override
-    public Subscription getSubscription(String subscriptionId) {
+    public SubscriptionInfo getSubscription(String subscriptionId) {
         return this.subsBySubId.get(subscriptionId);
     }
 
     @Override
-    public List<Subscription> getSubscriptions() {
+    public Collection<? extends SubscriptionInfo> getSubscriptions(String ownerKey) {
         return subscriptions;
     }
 
     @Override
-    public void activateSubscription(Consumer consumer, String email, String emailLocale) {
+    public Collection<String> getSubscriptionIds(String ownerKey) {
+        return new ArrayList<>(subsBySubId.keySet());
+    }
+
+    @Override
+    public Collection<? extends SubscriptionInfo> getSubscriptionsByProductId(String productId) {
+        List<SubscriptionInfo> subs = new LinkedList<>();
+
+        if (productId != null) {
+            for (SubscriptionInfo sub : this.subscriptions) {
+                if (productId.equals(sub.getProduct().getId())) {
+                    subs.add(sub);
+                    continue;
+                }
+
+                for (ProductInfo p : sub.getProvidedProducts()) {
+                    if (productId.equals(p.getId())) {
+                        subs.add(sub);
+                        break;
+                    }
+                }
+            }
+        }
+
+        return subs;
+    }
+
+    @Override
+    public void activateSubscription(ConsumerInfo consumer, String email, String emailLocale) {
         throw new ServiceUnavailableException(
                 i18n.tr("Standalone candlepin does not support redeeming a subscription."));
-    }
-
-    @Override
-    public Subscription createSubscription(Subscription s) {
-        return s;
-    }
-
-    @Override
-    public void deleteSubscription(Subscription s) {
-        // no op for now.
     }
 
     @Override
@@ -95,7 +110,7 @@ public class ImportSubscriptionServiceAdapter implements SubscriptionServiceAdap
     }
 
     @Override
-    public boolean hasUnacceptedSubscriptionTerms(Owner owner) {
+    public boolean hasUnacceptedSubscriptionTerms(String ownerKey) {
         return false;
     }
 
@@ -105,29 +120,8 @@ public class ImportSubscriptionServiceAdapter implements SubscriptionServiceAdap
     }
 
     @Override
-    public boolean canActivateSubscription(Consumer consumer) {
+    public boolean canActivateSubscription(ConsumerInfo consumer) {
         return false;
-    }
-
-    @Override
-    public List<Subscription> getSubscriptions(ProductData product) {
-
-        List<Subscription> subs = new LinkedList<>();
-
-        for (Subscription sub : this.subscriptions) {
-            if (product.getUuid().equals(sub.getProduct().getUuid())) {
-                subs.add(sub);
-                continue;
-            }
-
-            for (ProductData p : sub.getProvidedProducts()) {
-                if (product.getUuid().equals(p.getUuid())) {
-                    subs.add(sub);
-                    break;
-                }
-            }
-        }
-        return subs;
     }
 
 }

--- a/server/src/main/java/org/candlepin/service/model/BrandingInfo.java
+++ b/server/src/main/java/org/candlepin/service/model/BrandingInfo.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2009 - 2018 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.model;
+
+
+
+/**
+ * The BrandingInfo represents a minimal set of branding information used by the service adapters.
+ *
+ * Data which is not set or does not change should be represented by null values. To explicitly
+ * clear a value, an empty string or non-null "empty" value should be used instead.
+ */
+public interface BrandingInfo {
+
+    /**
+     * Fetches the name of this branding instance. If the name has not been set, this method
+     * returns null.
+     *
+     * @return
+     *  The name of the branding instance, or null if the name has not been set
+     */
+    String getName();
+
+    /**
+     * Fetches the type of this branding instance. If the type has not been set, this method
+     * returns null.
+     *
+     * @return
+     *  The type of the branding instance, or null if the type has not been set
+     */
+    String getType();
+
+    /**
+     * Fetches the product ID of the product affected by this branding instance. If the product ID
+     * has not been set, this method returns null.
+     *
+     * @return
+     *  The product ID of the product affected by this branding instance, or null if the product ID
+     *  has not been set
+     */
+    String getProductId();
+
+}

--- a/server/src/main/java/org/candlepin/service/model/CdnInfo.java
+++ b/server/src/main/java/org/candlepin/service/model/CdnInfo.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2009 - 2018 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.model;
+
+
+
+/**
+ * The CdnInfo represents a minimal set of CDN information used by the service adapters.
+ *
+ * Data which is not set or does not change should be represented by null values. To explicitly
+ * clear a value, an empty string or non-null "empty" value should be used instead.
+ */
+public interface CdnInfo {
+
+    /**
+     * Fetches the name of this CDN. If the name has not been set, this method returns null.
+     *
+     * @return
+     *  The name of the CDN, or null if the name has not been set
+     */
+    String getName();
+
+    /**
+     * Fetches the label of this CDN. If the label has not been set, this method returns null.
+     *
+     * @return
+     *  The label of the CDN, or null if the label has not been set
+     */
+    String getLabel();
+
+    /**
+     * Fetches the URL of this CDN. If the URL has not been set, this method returns null.
+     *
+     * @return
+     *  The URL of the CDN, or null if the URL has not been set
+     */
+    String getUrl();
+
+    /**
+     * Fetches the certificate info associated with this CDN. If this CDN has no associated
+     * certificate, this method returns null.
+     * <p></p>
+     * <strong>Note:</strong> Due to the nature of this field, null is always treated as
+     * "no value" rather than "no change."
+     *
+     * @return
+     *  The certificate info associated with this CDN, or null if this CDN does not have a
+     *  certificate
+     */
+    CertificateInfo getCertificate();
+
+}

--- a/server/src/main/java/org/candlepin/service/model/CertificateInfo.java
+++ b/server/src/main/java/org/candlepin/service/model/CertificateInfo.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2009 - 2018 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.model;
+
+
+
+/**
+ * The CertificateInfo represents a minimal set of certificate information used by the service
+ * adapters.
+ *
+ * Data which is not set or does not change should be represented by null values. To explicitly
+ * clear a value, an empty string or non-null "empty" value should be used instead.
+ */
+public interface CertificateInfo {
+
+    /**
+     * Fetches the serial of this certificate. If the serial has not been set, this method returns
+     * null.
+     *
+     * @deprecated
+     *  This method may be refactored or removed entirely when the backing certificate model is
+     *  reexamined and potentially normalized. This method should be properly implemented, but
+     *  building functionality around it is not advised.
+     *
+     * @return
+     *  the serial of this certificate, or null if the serial has not been set
+     */
+    @Deprecated
+    CertificateSerialInfo getSerial();
+
+    /**
+     * Fetches this certificate's key as PEM-encoded string. If the key has not been set, this
+     * method returns null.
+     *
+     * @return
+     *  the key for this certificate, or null if the key has not been set
+     */
+    String getKey();
+
+    /**
+     * Fetches a PEM-encoded x509 certificate as a string. If the certificate has not been set, this
+     * method returns null.
+     *
+     * @return
+     *  a PEM-encoded x509 certificate, or null if the certificate has not been set
+     */
+    String getCertificate();
+
+}

--- a/server/src/main/java/org/candlepin/service/model/CertificateSerialInfo.java
+++ b/server/src/main/java/org/candlepin/service/model/CertificateSerialInfo.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2009 - 2018 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.model;
+
+import java.math.BigInteger;
+import java.util.Date;
+
+
+
+/**
+ * The CertificateSerialInfo represents a minimal set of certificate information used by the service
+ * adapters.
+ *
+ * Data which is not set or does not change should be represented by null values. To explicitly
+ * clear a value, an empty string or non-null "empty" value should be used instead.
+ *
+ * @deprecated
+ *  This class may be refactored or removed entirely when the backing certificate model is
+ *  reexamined and potentially normalized. This class should be properly implemented, but
+ *  building functionality around it is not advised.
+ */
+@Deprecated
+public interface CertificateSerialInfo {
+
+    /**
+     * Fetches the serial of the linking certificate. If the serial has not been set, this method
+     * returns null.
+     *
+     * @return
+     *  the serial of the linking certificate, or null if the serial has not been set
+     */
+    BigInteger getSerial();
+
+    /**
+     * Checks if the linking certificate(s) has/have been revoked. If the revocation flag has not
+     * been set, this method returns null.
+     *
+     * @return
+     *  true if the linking certificate(s) has/have been revoked, or null if the revocation flag has
+     *  not been set
+     */
+    Boolean isRevoked();
+
+    /**
+     * Checks if the linking certificate(s) has/have been collected. If the collected flag has not
+     * been set, this method returns null.
+     *
+     * @return
+     *  true if the linking certificate(s) has/have been collected, or null if the collected flag
+     *  has not been set
+     */
+    Boolean isCollected();
+
+    /**
+     * Fetches the expiration date/time of the linking certificate(s). If the expiration has not
+     * been set, this method returns null.
+     *
+     * @return
+     *  the expiration of the linking certificate(s), or null if the expiration has not been set
+     */
+    Date getExpiration();
+
+}

--- a/server/src/main/java/org/candlepin/service/model/ConsumerInfo.java
+++ b/server/src/main/java/org/candlepin/service/model/ConsumerInfo.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2009 - 2018 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.model;
+
+import java.util.Map;
+
+
+
+/**
+ * The ConsumerInfo represents a minimal set of consumer information used by the service adapters.
+ *
+ * Data which is not set or does not change should be represented by null values. To explicitly
+ * clear a value, an empty string or non-null "empty" value should be used instead.
+ */
+public interface ConsumerInfo {
+
+    // /**
+    //  * Fetches the ID of this consumer. If the ID has not yet been generated or set, this method
+    //  * returns null.
+    //  *
+    //  * @return
+    //  *  The ID of this consumer, or null if the ID has not been set
+    //  */
+    // public String getId();
+
+    /**
+     * Fetches the UUID of this consumer. If the UUID has not yet been set, this method returns
+     * null.
+     *
+     * @return
+     *  The UUID of this consumer, or null if the UUID has not been set
+     */
+    String getUuid();
+
+    /**
+     * Fetches the username of this consumer. If the username has not yet been set, this method
+     * returns null.
+     *
+     * @return
+     *  The username of this consumer, or null if the username has not been set
+     */
+    String getUsername();
+
+    /**
+     * Fetches the owner of this consumer. If the owner has not been set, this method returns
+     * null.
+     *
+     * @return
+     *  The owner of this consumer, or null if the owner has not been set
+     */
+    OwnerInfo getOwner();
+
+    /**
+     * Fetches this consumer's facts. If the facts have not been set, this method returns null. If
+     * the consumer has no facts, this method returns an empty map.
+     *
+     * @return
+     *  The facts for this consumer, or null if the facts have not been set
+     */
+    Map<String, String> getFacts();
+
+}

--- a/server/src/main/java/org/candlepin/service/model/ContentInfo.java
+++ b/server/src/main/java/org/candlepin/service/model/ContentInfo.java
@@ -1,0 +1,156 @@
+/**
+ * Copyright (c) 2009 - 2018 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.model;
+
+import java.util.Collection;
+import java.util.Date;
+
+
+
+/**
+ * The ContentInfo represents a minimal set of owner/organization information used by the service
+ * adapters.
+ *
+ * Data which is not set or does not change should be represented by null values. To explicitly
+ * clear a value, an empty string or non-null "empty" value should be used instead.
+ */
+public interface ContentInfo {
+
+    /**
+     * Fetches the Red Hat ID of this content. If the ID has not yet been set, this method returns
+     * null.
+     *
+     * @return
+     *  the Red Hat ID of this content, or null if the ID has not been set
+     */
+    String getId();
+
+    /**
+     * Fetches the type of this content. If the type has not yet been set, this method returns null.
+     *
+     * @return
+     *  the type of this content, or null if the type has not been set
+     */
+    String getType();
+
+    /**
+     * Fetches the label of this content. If the label has not yet been set, this method returns
+     * null.
+     *
+     * @return
+     *  the label of this content, or null if the label has not been set
+     */
+    String getLabel();
+
+    /**
+     * Fetches the name of this content. If the name has not yet been set, this method returns null.
+     *
+     * @return
+     *  the name of this content, or null if the name has not been set
+     */
+    String getName();
+
+    /**
+     * Fetches the vendor of this content. If the vendor has not yet been set, this method returns
+     * null.
+     *
+     * @return
+     *  the vendor of this content, or null if the vendor has not been set
+     */
+    String getVendor();
+
+    /**
+     * Fetches the name of this content. If the name has not yet been set, this method returns null.
+     *
+     * @return
+     *  the name of this content, or null if the name has not been set
+     */
+    String getContentUrl();
+
+    /**
+     * Fetches the required tags of this content. If the tags have not yet been set, this method
+     * returns null.
+     *
+     * @return
+     *  the required tags of this content, or null if the tags have not been set
+     */
+    String getRequiredTags();
+
+    /**
+     * Fetches the release version of this content. If the version has not yet been set, this
+     * method returns null.
+     *
+     * @return
+     *  the release version of this content, or null if the version has not been set
+     */
+    String getReleaseVersion();
+
+    /**
+     * Fetches the URL of the GPG key for this content. If the URL has not yet been set, this method
+     * returns null.
+     *
+     * @return
+     *  the URL of the GPG key for this content, or null if the URL has not been set
+     */
+    String getGpgUrl();
+
+    /**
+     * Fetches the supported architectures for this content. If the arches have not yet been set,
+     * this method returns null.
+     *
+     * @return
+     *  the supported architectures of this content, or null if the arches have not been set
+     */
+    String getArches();
+
+    /**
+     * Fetches the expiration date of this content's metadata as a timestamp from the Unix epoch. If
+     * the metadata expiration has not yet been set, this method returns null.
+     *
+     * @return
+     *  the expiration date of this content's metadata, or null if the metadata expiration has not
+     *  been set
+     */
+    Long getMetadataExpiration();
+
+    /**
+     * Fetches a collection of product IDs required by this content. If the required products have
+     * not yet been set, this method returns null. If this content has no required products, this
+     * method returns an empty collection.
+     *
+     * @return
+     *  a collection of product IDs required by this content, or null if the required products have
+     *  not been set
+     */
+    Collection<String> getRequiredProductIds();
+
+    /**
+     * Fetches the date this content was created. If the creation date has not been set, this method
+     * returns null.
+     *
+     * @return
+     *  the creation date for this content, or null if the creation date has not been set
+     */
+    Date getCreated();
+
+    /**
+     * Fetches the date this content was last updated. If the update date has not been set, this
+     * method returns null.
+     *
+     * @return
+     *  the last update date for this content, or null if the last update date has not been set
+     */
+    Date getUpdated();
+}

--- a/server/src/main/java/org/candlepin/service/model/OwnerInfo.java
+++ b/server/src/main/java/org/candlepin/service/model/OwnerInfo.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2009 - 2018 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.model;
+
+import java.util.Date;
+
+
+
+/**
+ * The OwnerInfo represents a minimal set of owner/organization information used by the service
+ * adapters.
+ *
+ * Data which is not set or does not change should be represented by null values. To explicitly
+ * clear a value, an empty string or non-null "empty" value should be used instead.
+ */
+public interface OwnerInfo {
+
+    /**
+     * Fetches the key of this owner. If the key has not been set, this method returns null.
+     *
+     * @return
+     *  The key of the owner, or null if the key has not been set
+     */
+    String getKey();
+
+    /**
+     * Fetches the date this owner was created. If the creation date has not been set, this method
+     * returns null.
+     *
+     * @return
+     *  the creation date for this owner, or null if the creation date has not been set
+     */
+    Date getCreated();
+
+    /**
+     * Fetches the date this owner was last updated. If the update date has not been set, this
+     * method returns null.
+     *
+     * @return
+     *  the last update date for this owner, or null if the last update date has not been set
+     */
+    Date getUpdated();
+
+}

--- a/server/src/main/java/org/candlepin/service/model/PermissionBlueprintInfo.java
+++ b/server/src/main/java/org/candlepin/service/model/PermissionBlueprintInfo.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2009 - 2018 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.model;
+
+
+
+/**
+ * The PermissionBlueprintInfo represents a minimal set of permission blueprint information used by
+ * the service adapters and UAC infrastructure to build proper permissions on demand.
+ *
+ * Data which is not set or does not change should be represented by null values. To explicitly
+ * clear a value, an empty string or non-null "empty" value should be used instead.
+ */
+public interface PermissionBlueprintInfo {
+
+    // /**
+    //  * Fetches the ID of this role. If the ID has not yet been set, this method returns null.
+    //  *
+    //  * @return
+    //  *  The ID of this role, or null if the ID has not been set
+    //  */
+    // String getId();
+
+    /**
+     * Fetches the owner for which this permission applies. If the owner has not yet been set, this
+     * method returns null.
+     *
+     * @return
+     *  The owner for this permission, or null if the owner has not been set
+     */
+    OwnerInfo getOwner();
+
+    /**
+     * Fetches the permission's type as a string. If the type has not yet been defined, this method
+     * returns null.
+     *
+     * @return
+     *  The permission's type, or null if the type has not been set
+     */
+    String getTypeName();
+
+    /**
+     * Fetches the access provided by this permission. If the access has not yet been set, this
+     * method returns null.
+     *
+     * @return
+     *  The access provided by this permission, or null if the access has not been set
+     */
+    String getAccessLevel();
+
+}

--- a/server/src/main/java/org/candlepin/service/model/ProductContentInfo.java
+++ b/server/src/main/java/org/candlepin/service/model/ProductContentInfo.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2009 - 2018 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.model;
+
+
+
+/**
+ * The ProductContentInfo represents a minimal set of product-content joining information used by
+ * the service adapters.
+ *
+ * Data which is not set or does not change should be represented by null values. To explicitly
+ * clear a value, an empty string or non-null "empty" value should be used instead.
+ */
+public interface ProductContentInfo {
+
+    /**
+     * Fetches the content associated with the parent product. If the content has not been set,
+     * this method returns null.
+     *
+     * @return
+     *  the content associated with the parent product, or null if the content has not been set
+     */
+    ContentInfo getContent();
+
+    /**
+     * Checks whether or not the associated content is enabled. If the enabled flag has not yet
+     * been set, this method returns null.
+     *
+     * @return
+     *  whether or not the associated content is enabled, or null if the enabled flag has not been
+     *  set
+     */
+    Boolean isEnabled();
+
+}

--- a/server/src/main/java/org/candlepin/service/model/ProductInfo.java
+++ b/server/src/main/java/org/candlepin/service/model/ProductInfo.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2009 - 2018 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.model;
+
+import java.util.Collection;
+import java.util.Date;
+import java.util.Map;
+
+
+
+/**
+ * The ProductInfo represents a minimal set of owner/organization information used by the service
+ * adapters.
+ *
+ * Data which is not set or does not change should be represented by null values. To explicitly
+ * clear a value, an empty string or non-null "empty" value should be used instead.
+ */
+public interface ProductInfo {
+
+    /**
+     * Fetches the Red Hat ID of this product. If the ID has not yet been set, this method returns
+     * null.
+     *
+     * @return
+     *  the Red Hat ID of this product, or null if the ID has not been set
+     */
+    String getId();
+
+    /**
+     * Fetches the name of this product. If the name has not yet been set, this method returns null.
+     *
+     * @return
+     *  the name of this product, or null if the name has not been set
+     */
+    String getName();
+
+    /**
+     * Fetches the multiplier for this product. If the multiplier has not yet been set, this method
+     * returns null.
+     *
+     * @return
+     *  the multiplier for this product, or null if the multiplier has not been set
+     */
+    Long getMultiplier();
+
+    /**
+     * Fetches a collection of IDs of products dependent on this product. If the dependent products
+     * have not yet been set, this method returns null. If this product has no dependent products,
+     * this method returns an empty collection.
+     *
+     * @return
+     *  a collection of IDs of products dependent on this, or null if the dependent products have
+     *  not been set
+     */
+    Collection<String> getDependentProductIds();
+
+    /**
+     * Fetches the attributes of this product. If the attributes have not yet been set, this method
+     * returns null. If this product does not have any attributes, this method returns an empty
+     * map.
+     *
+     * @return
+     *  the attributes of this product, or null if the attributes have not been set
+     */
+    Map<String, String> getAttributes();
+
+    /**
+     * Fetches the value of the given attribute for this product. If the product's attributes have
+     * not been set, or the specific attribute is not defined, this method returns null.
+     *
+     * @param key
+     *  The key of the attribute for which to fetch the value
+     *
+     * @return
+     *  the value of the given attribute, or null if the attribute has not been set
+     */
+    String getAttributeValue(String key);
+
+    /**
+     * Fetches a collection of this product's content. If the content has not yet been set, this
+     * method returns null. If this product does not have any content, this method returns an empty
+     * collection.
+     *
+     * @return
+     *  the content of this product, or null if the content has not been set
+     */
+    Collection<? extends ProductContentInfo> getProductContent();
+
+    /**
+     * Fetches the date this product was created. If the creation date has not been set, this method
+     * returns null.
+     *
+     * @return
+     *  the creation date for this product, or null if the creation date has not been set
+     */
+    Date getCreated();
+
+    /**
+     * Fetches the date this product was last updated. If the update date has not been set, this
+     * method returns null.
+     *
+     * @return
+     *  the last update date for this product, or null if the last update date has not been set
+     */
+    Date getUpdated();
+}

--- a/server/src/main/java/org/candlepin/service/model/RoleInfo.java
+++ b/server/src/main/java/org/candlepin/service/model/RoleInfo.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2009 - 2018 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.model;
+
+import java.util.Collection;
+import java.util.Date;
+
+
+
+/**
+ * The RoleInfo represents a minimal set of role information used by the service adapters.
+ *
+ * Data which is not set or does not change should be represented by null values. To explicitly
+ * clear a value, an empty string or non-null "empty" value should be used instead.
+ */
+public interface RoleInfo {
+
+    // /**
+    //  * Fetches the ID of this role. If the ID has not yet been set, this method returns null.
+    //  *
+    //  * @return
+    //  *  The ID of this role, or null if the ID has not been set
+    //  */
+    // String getId();
+
+    /**
+     * Fetches the date this role was created. If the creation date has not been set, this method
+     * returns null.
+     *
+     * @return
+     *  the creation date for this role, or null if the creation date has not been set
+     */
+    Date getCreated();
+
+    /**
+     * Fetches the date this role was last updated. If the update date has not been set, this method
+     * returns null.
+     *
+     * @return
+     *  the last update date for this role, or null if the last update date has not been set
+     */
+    Date getUpdated();
+
+    /**
+     * Fetches the name of this role. If the name has not yet been set, this method returns null.
+     *
+     * @return
+     *  The name of this role, or null if the name has not been set
+     */
+    String getName();
+
+    /**
+     * Fetches the users currently assigned to this role. If the users have not yet been set, this
+     * method returns null. If this role is not currently assigned to any users, this method returns
+     * an empty collection.
+     *
+     * @return
+     *  The users assigned to this role, or null if the users have not been set
+     */
+    Collection<? extends UserInfo> getUsers();
+
+    /**
+     * Fetches the permission blueprints currently provided by this role. If the blueprints have not
+     * yet been set, this method returns null. If this role currently does not provide any
+     * permission blueprints, this method returns an empty collection.
+     *
+     * @return
+     *  The permission blueprints provided by this role, or null if the blueprints have not been set
+     */
+    Collection<? extends PermissionBlueprintInfo> getPermissions();
+
+}

--- a/server/src/main/java/org/candlepin/service/model/SubscriptionInfo.java
+++ b/server/src/main/java/org/candlepin/service/model/SubscriptionInfo.java
@@ -1,0 +1,221 @@
+/**
+ * Copyright (c) 2009 - 2018 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.model;
+
+import java.util.Collection;
+import java.util.Date;
+
+
+
+/**
+ * The SubscriptionInfo represents a minimal set of subscription information used by the
+ * service adapters.
+ *
+ * Data which is not set or does not change should be represented by null values. To explicitly
+ * clear a value, an empty string or non-null "empty" value should be used instead.
+ */
+public interface SubscriptionInfo {
+
+    /**
+     * Fetches the ID of this subscription. If the ID has not yet been set, this method returns
+     * null.
+     *
+     * @return
+     *  The ID of this subscription, or null if the ID has not been set
+     */
+    String getId();
+
+    /**
+     * Fetches the owner of this subscription. If the owner has not yet been set, this method
+     * returns null.
+     *
+     * @return
+     *  The owner of this subscription, or null if the owner has not been set
+     */
+    OwnerInfo getOwner();
+
+    /**
+     * Fetches the marketing product (SKU) for this subscription. If the marketing product has not
+     * yet been set, this method returns null.
+     *
+     * @return
+     *  The marketing product for this subscription, or null if the product has not been set
+     */
+    ProductInfo getProduct();
+
+    /**
+     * Fetches a collection of engineering products this subscription provides. If the provided
+     * products have not yet been set, this method returns null. If this subscription does not
+     * provide any engineering products, this method returns an empty collection.
+     *
+     * @return
+     *  A collection of engineering products provided by this subscription, or null if the provided
+     *  products have not been set
+     */
+    Collection<? extends ProductInfo> getProvidedProducts();
+
+    /**
+     * Fetches the derived marketing product (SKU) provided to guests of hosts consuming this
+     * subscription. If the derived product has not been set, this method returns null.
+     * <p></p>
+     * <strong>Note:</strong> Due to the nature of this field, null is always treated as
+     * "no value" rather than "no change."
+     *
+     * @return
+     *  The derived marketing product for this subscription, or null if the derived product has not
+     *  been set
+     */
+    ProductInfo getDerivedProduct();
+
+    /**
+     * Fetches a collection of derived engineering products provided to guests of hosts consuming
+     * this subscription. If the derived provided products have not been set, this method returns
+     * null. If this subscription does not provide any derived products, this method returns an
+     * empty collection.
+     *
+     * @return
+     *  A collection of engineering products provided by this subscription, or null if the derived
+     *  provided products have not been set
+     */
+    Collection<? extends ProductInfo> getDerivedProvidedProducts();
+
+    /**
+     * Fetches the quantity of this subscription. If the quantity has not yet been set, this method
+     * returns null.
+     *
+     * @return
+     *  The quantity of this subscription, or null if the quantity has not been set
+     */
+    Long getQuantity();
+
+    /**
+     * Fetches the date this subscription becomes active. If the start date has not yet been set,
+     * this method returns null.
+     *
+     * @return
+     *  The start date of this subscription, or null if the start date has not been set
+     */
+    Date getStartDate();
+
+    /**
+     * Fetches the date this subscription becomes inactive. If the end date has not yet been set,
+     * this method returns null.
+     *
+     * @return
+     *  The end date of this subscription, or null if the end date has not been set
+     */
+    Date getEndDate();
+
+    /**
+     * Fetches the date of the last modification to this subscription. If the last modified date has
+     * not yet been set, this method returns null.
+     *
+     * @return
+     *  The last modified date of this subscription, or null if the last modified date has not been
+     *  set
+     */
+    Date getLastModified();
+
+    /**
+     * Fetches the contract number for this subscription. If the contract number has not yet been
+     * set, this method returns null.
+     *
+     * @return
+     *  The contract number for this subscription, or null if the contract number has not been set
+     */
+    String getContractNumber();
+
+    /**
+     * Fetches the account number for this subscription. If the account number has not yet been set,
+     * this method returns null.
+     *
+     * @return
+     *  The account number for this subscription, or null if the account number has not been set
+     */
+    String getAccountNumber();
+
+    /**
+     * Fetches the order number for this subscription. If the order number has not yet been set,
+     * this method returns null.
+     *
+     * @return
+     *  The order number for this subscription, or null if the order number has not been set
+     */
+    String getOrderNumber();
+
+    /**
+     * Fetches the upstream pool ID of this subscription. If the upstream pool ID has not yet been
+     * set, this method returns null.
+     *
+     * @return
+     *  The upstream pool ID of this subscription, or null if the upstream pool ID has not been set
+     */
+    String getUpstreamPoolId();
+
+    /**
+     * Fetches the upstream entitlement ID of this subscription. If the upstream entitlement ID has
+     * not yet been set, this method returns null.
+     *
+     * @return
+     *  The upstream entitlement ID of this subscription, or null if the upstream entitlement ID has
+     *  not been set
+     */
+    String getUpstreamEntitlementId();
+
+    /**
+     * Fetches the upstream consumer ID of this subscription. If the upstream consumer ID has not
+     * yet been set, this method returns null.
+     *
+     * @return
+     *  The upstream consumer ID of this subscription, or null if the upstream consumer ID has not
+     *  been set
+     */
+    String getUpstreamConsumerId();
+
+    /**
+     * Fetches the CDN for this subscription. If the CDN has not been set, this method returns null.
+     * <p></p>
+     * <strong>Note:</strong> Due to the nature of this field, null is always treated as
+     * "no value" rather than "no change."
+     *
+     * @return
+     *  The CDN for this subscription, or null if the CDN has not been set
+     */
+    CdnInfo getCdn();
+
+    /**
+     * Fetches the branding associated with this subscription. If the branding has not been set,
+     * this method returns null. If this subscription does not have any custom branding, this method
+     * returns an empty collection.
+     *
+     * @return
+     *  A collection of custom branding associated with this subscription, or null if the branding
+     *  has not been set
+     */
+    Collection<? extends BrandingInfo> getBranding();
+
+    /**
+     * Fetches the certificate for this subscription. If the certificate has not been set, this
+     * method returns null.
+     * <p></p>
+     * <strong>Note:</strong> Due to the nature of this field, null is always treated as
+     * "no value" rather than "no change."
+     *
+     * @return
+     *  The certificate for this subscription, or null if the certificate has not been set
+     */
+    CertificateInfo getCertificate();
+
+}

--- a/server/src/main/java/org/candlepin/service/model/UserInfo.java
+++ b/server/src/main/java/org/candlepin/service/model/UserInfo.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2009 - 2018 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.model;
+
+import java.util.Collection;
+import java.util.Date;
+
+
+
+/**
+ * The UserInfo represents a minimal set of owner/organization information used by the service
+ * adapters.
+ *
+ * Data which is not set or does not change should be represented by null values. To explicitly
+ * clear a value, an empty string or non-null "empty" value should be used instead.
+ */
+public interface UserInfo {
+
+    // /**
+    //  * Fetches the ID of this user. If the ID has not yet been set, this method returns null.
+    //  *
+    //  * @return
+    //  *  The ID of this user, or null if the ID has not been set
+    //  */
+    // String getId();
+
+    /**
+     * Fetches the date this user was created. If the creation date has not been set, this method
+     * returns null.
+     *
+     * @return
+     *  the creation date for this user, or null if the creation date has not been set
+     */
+    Date getCreated();
+
+    /**
+     * Fetches the date this user was last updated. If the update date has not been set, this method
+     * returns null.
+     *
+     * @return
+     *  the last update date for this user, or null if the last update date has not been set
+     */
+    Date getUpdated();
+
+    /**
+     * Fetches the username of this user. If the username has not yet been set, this method returns
+     * null.
+     *
+     * @return
+     *  The username of this user, or null if the username has not been set
+     */
+    String getUsername();
+
+    /**
+     * Fetches the hashed password for this user. If the password has not yet been set, this method
+     * returns null.
+     *
+     * @return
+     *  The hashed password for this user, or null if the password has not been set
+     */
+    String getHashedPassword();
+
+    /**
+     * Checks if this user is a super admin. If the super admin flag has not yet been set, this
+     * method returns null. If the user is not a super admin, this method returns false.
+     *
+     * @return
+     *  The super admin flag for this user, or null if the super admin flag has not been set
+     */
+    Boolean isSuperAdmin();
+
+    /**
+     * Fetches a collection of roles for this user. If the roles have not yet been set, this method
+     * returns null. If this user does not have any roles, this method returns an empty collection.
+     *
+     * @return
+     *  A collection of roles for this user, or null if the roles have not been set
+     */
+    Collection<? extends RoleInfo> getRoles();
+
+    // /**
+    //  * Fetches a collection of permissions for this user, including permissions provided by roles
+    //  * assigned to this user. If the permissions have not yet been set, and this user does not have
+    //  * any roles, this method returns null. If the user does not have any permissions, nor any
+    //  * role-provided permissions, this method returns an empty collection.
+    //  *
+    //  * @deprecated
+    //  *  UserInfo returned by the service adapters should use roles instead of raw permissions and
+    //  *  let Candlepin build its permission objects internally. This method may be removed or
+    //  *  refactored in the future.
+    //  *
+    //  * @return
+    //  *  A collection of permissions for this user, or null if the permissions and roles have not
+    //  *  been set
+    //  */
+    // @Deprecated
+    // Collection<Permission> getPermissions();
+
+}

--- a/server/src/main/java/org/candlepin/sync/Exporter.java
+++ b/server/src/main/java/org/candlepin/sync/Exporter.java
@@ -35,7 +35,6 @@ import org.candlepin.model.Owner;
 import org.candlepin.model.OwnerCurator;
 import org.candlepin.model.Pool;
 import org.candlepin.model.Product;
-import org.candlepin.model.ProductCertificate;
 import org.candlepin.model.ResultIterator;
 import org.candlepin.model.ProductCurator;
 import org.candlepin.pki.PKIUtility;
@@ -43,6 +42,7 @@ import org.candlepin.policy.js.export.ExportRules;
 import org.candlepin.service.EntitlementCertServiceAdapter;
 import org.candlepin.service.ExportExtensionAdapter;
 import org.candlepin.service.ProductServiceAdapter;
+import org.candlepin.service.model.CertificateInfo;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Inject;
@@ -537,9 +537,8 @@ public class Exporter {
             // Real products have a numeric id.
             if (StringUtils.isNumeric(product.getId())) {
                 Owner owner = ownerCurator.findOwnerById(consumer.getOwnerId());
-                ProductCertificate cert = productAdapter.getProductCertificate(
-                    owner, product.getId()
-                );
+
+                CertificateInfo cert = productAdapter.getProductCertificate(owner.getKey(), product.getId());
 
                 // XXX: not all product adapters implement getProductCertificate,
                 // so just skip over this if we get null back

--- a/server/src/main/java/org/candlepin/sync/Importer.java
+++ b/server/src/main/java/org/candlepin/sync/Importer.java
@@ -586,6 +586,7 @@ public class Importer {
         final String contentAccessMode = StringUtils.isEmpty(consumer.getContentAccessMode()) ?
             ContentAccessCertServiceAdapter.DEFAULT_CONTENT_ACCESS_MODE :
             consumer.getContentAccessMode();
+
         SubscriptionServiceAdapter subAdapter = new ImportSubscriptionServiceAdapter(importSubs);
         OwnerServiceAdapter ownerAdapter = new OwnerServiceAdapter() {
             @Override

--- a/server/src/main/java/org/candlepin/sync/ProductCertExporter.java
+++ b/server/src/main/java/org/candlepin/sync/ProductCertExporter.java
@@ -15,6 +15,7 @@
 package org.candlepin.sync;
 
 import org.candlepin.model.ProductCertificate;
+import org.candlepin.service.model.CertificateInfo;
 
 import java.io.FileWriter;
 import java.io.IOException;
@@ -24,9 +25,12 @@ import java.io.IOException;
  */
 public class ProductCertExporter {
 
-    public void export(FileWriter writer, ProductCertificate productCert)
-        throws IOException {
+    public void export(FileWriter writer, ProductCertificate productCert) throws IOException {
         writer.write(productCert.getCert());
+    }
+
+    public void export(FileWriter writer, CertificateInfo productCert) throws IOException {
+        writer.write(productCert.getCertificate());
     }
 
 }

--- a/server/src/main/java/org/candlepin/sync/ProductImporter.java
+++ b/server/src/main/java/org/candlepin/sync/ProductImporter.java
@@ -72,7 +72,7 @@ public class ProductImporter {
                 //
                 // We know this is a standalone server due to the fact that import is
                 // being used, so there is no need to guard this behavior.
-                content.setMetadataExpire(1L);
+                content.setMetadataExpiration(1L);
             }
         }
 

--- a/server/src/main/java/org/candlepin/util/X509ExtensionUtil.java
+++ b/server/src/main/java/org/candlepin/util/X509ExtensionUtil.java
@@ -275,10 +275,10 @@ public class X509ExtensionUtil  extends X509Util{
                 (enabled) ? "1" : "0"));
 
             // Include metadata expiry if specified on the content:
-            if (pc.getContent().getMetadataExpire() != null) {
+            if (pc.getContent().getMetadataExpiration() != null) {
                 toReturn.add(new X509ExtensionWrapper(contentOid + "." +
                     OIDUtil.CHANNEL_FAMILY_OIDS.get(OIDUtil.CF_METADATA_EXPIRE),
-                    false, pc.getContent().getMetadataExpire().toString()));
+                    false, pc.getContent().getMetadataExpiration().toString()));
             }
 
             // Include required tags if specified on the content set:

--- a/server/src/main/java/org/candlepin/util/X509Util.java
+++ b/server/src/main/java/org/candlepin/util/X509Util.java
@@ -25,6 +25,7 @@ import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -94,7 +95,7 @@ public abstract class X509Util {
             boolean include = true;
             if (pc.getContent().getModifiedProductIds().size() > 0) {
                 include = false;
-                Set<String> prodIds = pc.getContent().getModifiedProductIds();
+                Collection<String> prodIds = pc.getContent().getModifiedProductIds();
                 // If consumer has an entitlement to just one of the modified products,
                 // we will include this content set:
                 for (String prodId : prodIds) {

--- a/server/src/main/java/org/candlepin/util/X509V3ExtensionUtil.java
+++ b/server/src/main/java/org/candlepin/util/X509V3ExtensionUtil.java
@@ -47,6 +47,7 @@ import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -415,8 +416,8 @@ public class X509V3ExtensionUtil extends X509Util {
             }
 
             // Include metadata expiry if specified on the content
-            if (pc.getContent().getMetadataExpire() != null) {
-                content.setMetadataExpire(pc.getContent().getMetadataExpire());
+            if (pc.getContent().getMetadataExpiration() != null) {
+                content.setMetadataExpiration(pc.getContent().getMetadataExpiration());
             }
 
             // Include required tags if specified on the content set
@@ -450,7 +451,7 @@ public class X509V3ExtensionUtil extends X509Util {
             boolean include = true;
             if (pc.getContent().getModifiedProductIds().size() > 0) {
                 include = false;
-                Set<String> prodIds = pc.getContent().getModifiedProductIds();
+                Collection<String> prodIds = pc.getContent().getModifiedProductIds();
                 // If consumer has an entitlement to just one of the modified products,
                 // we will include this content set
                 for (String prodId : prodIds) {

--- a/server/src/test/java/org/candlepin/auth/BasicAuthViaUserServiceTest.java
+++ b/server/src/test/java/org/candlepin/auth/BasicAuthViaUserServiceTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.when;
 
 import org.candlepin.auth.permissions.OwnerPermission;
+import org.candlepin.auth.permissions.PermissionFactory;
 import org.candlepin.common.exceptions.NotAuthorizedException;
 import org.candlepin.model.Owner;
 import org.candlepin.model.User;
@@ -55,6 +56,7 @@ public class BasicAuthViaUserServiceTest {
     @Mock private UserServiceAdapter userService;
     @Mock private Injector injector;
     @Mock private Provider<I18n> mockI18n;
+    @Mock private PermissionFactory mockPermissionFactory;
     private BasicAuth auth;
 
     @Before
@@ -72,7 +74,8 @@ public class BasicAuthViaUserServiceTest {
 
         I18n i18n = I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK);
         when(mockI18n.get()).thenReturn(i18n);
-        this.auth = new BasicAuth(userService, mockI18n);
+
+        this.auth = new BasicAuth(userService, mockI18n, mockPermissionFactory);
     }
 
     /**

--- a/server/src/test/java/org/candlepin/auth/ConsumerPrincipalTest.java
+++ b/server/src/test/java/org/candlepin/auth/ConsumerPrincipalTest.java
@@ -42,6 +42,7 @@ public class ConsumerPrincipalTest {
     public void init() {
         o = mock(Owner.class);
         when(o.getKey()).thenReturn("donaldduck");
+        when(o.getId()).thenReturn("dd-owner-id");
 
         consumer = mock(Consumer.class);
         when(consumer.getUuid()).thenReturn("consumer-uuid");
@@ -93,7 +94,10 @@ public class ConsumerPrincipalTest {
         ConsumerType ctype = new ConsumerType(ConsumerType.ConsumerTypeEnum.SYSTEM);
         ctype.setId("test-ctype");
 
-        Consumer c = new Consumer("Test Consumer", "test-consumer", new Owner("o1"), ctype);
+        Owner newOwner = new Owner("o1");
+        newOwner.setId("o1-id");
+
+        Consumer c = new Consumer("Test Consumer", "test-consumer", newOwner, ctype);
         ConsumerPrincipal cp = new ConsumerPrincipal(c, o);
         assertFalse(principal.equals(cp));
     }

--- a/server/src/test/java/org/candlepin/auth/SSLCertTest.java
+++ b/server/src/test/java/org/candlepin/auth/SSLCertTest.java
@@ -22,13 +22,11 @@ import org.junit.Test;
 import java.security.cert.CertPath;
 import java.security.cert.CertPathValidator;
 import java.security.cert.CertPathValidatorException;
-import java.security.cert.Certificate;
 import java.security.cert.CertificateFactory;
 import java.security.cert.PKIXParameters;
 import java.security.cert.TrustAnchor;
 import java.security.cert.X509Certificate;
 import java.util.Collections;
-import java.util.LinkedList;
 
 /**
  * some useful sources of certificate-related information:
@@ -52,19 +50,16 @@ public class SSLCertTest {
     public void setUp() throws Exception {
         certificateFactory = CertificateFactory.getInstance("X.509");
 
-        certificatePath = (X509Certificate) certificateFactory
-            .generateCertificate(getClass()
-                .getResourceAsStream("certchain.crt"));
+        certificatePath = (X509Certificate) certificateFactory.generateCertificate(
+            getClass().getResourceAsStream("certchain.crt"));
 
-        selfSignedCertificate = (X509Certificate) certificateFactory
-            .generateCertificate(getClass().getResourceAsStream(
-                "selfsigned.crt"));
+        selfSignedCertificate = (X509Certificate) certificateFactory.generateCertificate(
+            getClass().getResourceAsStream("selfsigned.crt"));
 
-        caCertificate = (X509Certificate) certificateFactory
-            .generateCertificate(getClass().getResourceAsStream("ca.crt"));
+        caCertificate = (X509Certificate) certificateFactory.generateCertificate(
+            getClass().getResourceAsStream("ca.crt"));
 
-        TrustAnchor anchor = new TrustAnchor(caCertificate,
-            null);
+        TrustAnchor anchor = new TrustAnchor(caCertificate, null);
         PKIXparams = new PKIXParameters(Collections.singleton(anchor));
         PKIXparams.setRevocationEnabled(false);
     }
@@ -73,17 +68,12 @@ public class SSLCertTest {
     @Test
     public void validCertificateShouldPassVerification() throws Exception {
         CertPathValidator cpv = CertPathValidator.getInstance("PKIX");
-        CertPath cp = certificateFactory
-            .generateCertPath(new LinkedList<Certificate>() {
-                {
-                    add(certificatePath);
-                }
-            });
+        CertPath cp = certificateFactory.generateCertPath(Collections.singletonList(certificatePath));
+
         // PKIXCertPathValidatorResult result = (PKIXCertPathValidatorResult)
         cpv.validate(cp, PKIXparams);
 
-        assertEquals(
-            "CN=Robert Paulson, OU=org unit, O=org, L=Halifax, ST=NS, C=CA",
+        assertEquals("CN=Robert Paulson, OU=org unit, O=org, L=Halifax, ST=NS, C=CA",
             certificatePath.getSubjectDN().getName());
     }
 
@@ -91,12 +81,8 @@ public class SSLCertTest {
     @Test(expected = CertPathValidatorException.class)
     public void invalidCertificateShouldFailVerification() throws Exception {
         CertPathValidator cpv = CertPathValidator.getInstance("PKIX");
-        CertPath cp = certificateFactory
-            .generateCertPath(new LinkedList<Certificate>() {
-                {
-                    add(selfSignedCertificate);
-                }
-            });
+        CertPath cp = certificateFactory.generateCertPath(Collections.singletonList(selfSignedCertificate));
+
         //PKIXCertPathValidatorResult result = (PKIXCertPathValidatorResult)
         cpv.validate(cp, PKIXparams);
     }

--- a/server/src/test/java/org/candlepin/auth/TrustedUserAuthTest.java
+++ b/server/src/test/java/org/candlepin/auth/TrustedUserAuthTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.*;
 import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 
+import org.candlepin.auth.permissions.PermissionFactory;
 import org.candlepin.model.User;
 import org.candlepin.service.UserServiceAdapter;
 
@@ -45,6 +46,7 @@ public class TrustedUserAuthTest {
     @Mock private HttpHeaders mockHeaders;
     @Mock private UserServiceAdapter userService;
     @Mock private Provider<I18n> mockI18n;
+    @Mock private PermissionFactory mockPermissionFactory;
     private TrustedUserAuth auth;
 
     private static final String USERNAME = "myusername";
@@ -64,7 +66,8 @@ public class TrustedUserAuthTest {
         when(request.getHttpHeaders()).thenReturn(mockHeaders);
         I18n i18n = I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK);
         when(mockI18n.get()).thenReturn(i18n);
-        this.auth = new TrustedUserAuth(userService, mockI18n);
+
+        this.auth = new TrustedUserAuth(userService, mockI18n, mockPermissionFactory);
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/controller/CdnManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/CdnManagerTest.java
@@ -23,7 +23,6 @@ import org.candlepin.model.Owner;
 import org.candlepin.model.Pool;
 import org.candlepin.model.Product;
 import org.candlepin.test.DatabaseTestFixture;
-import org.candlepin.test.TestUtil;
 import org.junit.Test;
 
 import java.util.Date;
@@ -67,8 +66,7 @@ public class CdnManagerTest extends DatabaseTestFixture {
     public void deleteCdnUpdatesPoolAssociation() {
         Cdn cdn = createCdn("MyTestCdn");
 
-        Owner owner = TestUtil.createOwner();
-        ownerCurator.create(owner);
+        Owner owner = this.createOwner();
 
         Product product = createProduct(owner);
         Pool pool = createPool(owner, product);

--- a/server/src/test/java/org/candlepin/controller/ProductManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/ProductManagerTest.java
@@ -104,8 +104,9 @@ public class ProductManagerTest extends DatabaseTestFixture {
     public void testUpdateProductNoChange() {
         Owner owner = this.createOwner("test-owner", "Test Owner");
         Product product = this.createProduct("p1", "prod1", owner);
+        ProductDTO dto = this.modelTranslator.translate(product, ProductDTO.class);
 
-        Product output = this.productManager.updateProduct(product.toDTO(), owner, true);
+        Product output = this.productManager.updateProduct(dto, owner, true);
 
         assertEquals(output.getUuid(), product.getUuid());
         assertEquals(output, product);

--- a/server/src/test/java/org/candlepin/dto/api/v1/ContentTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/ContentTranslatorTest.java
@@ -61,7 +61,7 @@ public class ContentTranslatorTest extends
         source.setRequiredTags("test_value");
         source.setReleaseVersion("test_value");
         source.setGpgUrl("test_value");
-        source.setMetadataExpire(1234L);
+        source.setMetadataExpiration(1234L);
         source.setModifiedProductIds(Arrays.asList("1", "2", "3"));
         source.setArches("test_value");
         source.setLocked(Boolean.TRUE);
@@ -91,7 +91,7 @@ public class ContentTranslatorTest extends
             assertEquals(source.getRequiredTags(), dto.getRequiredTags());
             assertEquals(source.getReleaseVersion(), dto.getReleaseVersion());
             assertEquals(source.getGpgUrl(), dto.getGpgUrl());
-            assertEquals(source.getMetadataExpire(), dto.getMetadataExpiration());
+            assertEquals(source.getMetadataExpiration(), dto.getMetadataExpiration());
             assertEquals(source.getModifiedProductIds(), dto.getModifiedProductIds());
             assertEquals(source.getArches(), dto.getArches());
             assertEquals(source.isLocked(), dto.isLocked());

--- a/server/src/test/java/org/candlepin/dto/api/v1/OwnerInfoTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/OwnerInfoTranslatorTest.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2009 - 2017 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.dto.api.v1;
+
+import org.candlepin.dto.AbstractTranslatorTest;
+import org.candlepin.dto.ModelTranslator;
+import org.candlepin.model.Owner;
+import org.candlepin.service.model.OwnerInfo;
+
+import static org.junit.Assert.*;
+
+import junitparams.JUnitParamsRunner;
+
+import org.junit.runner.RunWith;
+
+import java.util.Date;
+
+
+
+/**
+ * Test suite for the OwnerInfoTranslator class
+ */
+@RunWith(JUnitParamsRunner.class)
+public class OwnerInfoTranslatorTest extends
+    AbstractTranslatorTest<OwnerInfo, OwnerDTO, OwnerInfoTranslator> {
+
+    protected OwnerInfoTranslator translator = new OwnerInfoTranslator();
+
+    protected UpstreamConsumerTranslatorTest upstreamConsumerTranslatorTest =
+        new UpstreamConsumerTranslatorTest();
+
+    @Override
+    protected void initModelTranslator(ModelTranslator modelTranslator) {
+        this.upstreamConsumerTranslatorTest.initModelTranslator(modelTranslator);
+
+        modelTranslator.registerTranslator(this.translator, OwnerInfo.class, OwnerDTO.class);
+    }
+
+    @Override
+    protected OwnerInfoTranslator initObjectTranslator() {
+        return this.translator;
+    }
+
+    @Override
+    protected OwnerInfo initSourceObject() {
+        // Owner is an OwnerInfo implementation
+        Owner parent = null;
+
+        for (int i = 0; i < 3; ++i) {
+            Owner owner = new Owner();
+
+            owner.setId("owner_id-" + i);
+            owner.setKey("owner_key-" + i);
+            owner.setDisplayName("owner_name-" + i);
+            owner.setParentOwner(parent);
+            owner.setContentPrefix("content_prefix-" + i);
+            owner.setDefaultServiceLevel("service_level-" + i);
+            owner.setUpstreamConsumer(this.upstreamConsumerTranslatorTest.initSourceObject());
+            owner.setLogLevel("log_level-" + i);
+            owner.setAutobindDisabled(true);
+            owner.setContentAccessModeList(String.format("cam%1$d-a,cam%1$d-b,cam%1$d-c", i));
+            owner.setContentAccessMode(String.format("cam%d-b", i));
+            owner.setLastRefreshed(new Date());
+
+            parent = owner;
+        }
+
+        return parent;
+    }
+
+    @Override
+    protected OwnerDTO initDestinationObject() {
+        // Nothing fancy to do here.
+        return new OwnerDTO();
+    }
+
+    @Override
+    protected void verifyOutput(OwnerInfo source, OwnerDTO dest, boolean childrenGenerated) {
+        if (source != null) {
+            assertNull(dest.getId());
+            assertEquals(source.getKey(), dest.getKey());
+            assertNull(dest.getDisplayName());
+            assertNull(dest.getContentPrefix());
+            assertNull(dest.getDefaultServiceLevel());
+            assertNull(dest.getLogLevel());
+            assertNull(dest.isAutobindDisabled());
+            assertNull(dest.getContentAccessMode());
+            assertNull(dest.getContentAccessModeList());
+            assertNull(dest.getLastRefreshed());
+            assertNull(dest.getParentOwner());
+            assertNull(dest.getUpstreamConsumer());
+        }
+        else {
+            assertNull(dest);
+        }
+    }
+}

--- a/server/src/test/java/org/candlepin/dto/api/v1/PermissionBlueprintInfoTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/PermissionBlueprintInfoTranslatorTest.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2009 - 2018 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.dto.api.v1;
+
+import static org.junit.Assert.*;
+
+import org.candlepin.auth.Access;
+import org.candlepin.auth.permissions.PermissionFactory.PermissionType;
+import org.candlepin.dto.AbstractTranslatorTest;
+import org.candlepin.dto.ModelTranslator;
+import org.candlepin.model.Owner;
+import org.candlepin.model.PermissionBlueprint;
+import org.candlepin.service.model.PermissionBlueprintInfo;
+
+
+
+/**
+ * Test suite for the EntitlementTranslator class.
+ */
+public class PermissionBlueprintInfoTranslatorTest extends
+    AbstractTranslatorTest<PermissionBlueprintInfo, PermissionBlueprintDTO,
+    PermissionBlueprintInfoTranslator> {
+
+    protected PermissionBlueprintInfoTranslator translator = new PermissionBlueprintInfoTranslator();
+
+    protected OwnerInfoTranslatorTest ownerTranslatorTest = new OwnerInfoTranslatorTest();
+
+    @Override
+    protected void initModelTranslator(ModelTranslator modelTranslator) {
+        this.ownerTranslatorTest.initModelTranslator(modelTranslator);
+
+        modelTranslator.registerTranslator(this.translator, PermissionBlueprintInfo.class,
+            PermissionBlueprintDTO.class);
+    }
+
+    @Override
+    protected PermissionBlueprintInfoTranslator initObjectTranslator() {
+        return this.translator;
+    }
+
+    @Override
+    protected PermissionBlueprintInfo initSourceObject() {
+        // PermissionBlueprint is a PermissionBlueprintInfo implementation
+        PermissionBlueprint source = new PermissionBlueprint(
+            PermissionType.OWNER, (Owner) this.ownerTranslatorTest.initSourceObject(), Access.ALL);
+
+        source.setId("ent-id");
+
+        return source;
+    }
+
+    @Override
+    protected PermissionBlueprintDTO initDestinationObject() {
+        return new PermissionBlueprintDTO();
+    }
+
+    @Override
+    protected void verifyOutput(PermissionBlueprintInfo source, PermissionBlueprintDTO dest,
+        boolean childrenGenerated) {
+
+        if (source != null) {
+            // Service model objects do not provide an ID
+            assertNull(dest.getId());
+            assertEquals(source.getTypeName(), dest.getType());
+            assertEquals(source.getAccessLevel(), dest.getAccess());
+
+            if (childrenGenerated) {
+                this.ownerTranslatorTest.verifyOutput(source.getOwner(), dest.getOwner(), true);
+            }
+            else {
+                assertNull(dest.getOwner());
+            }
+        }
+        else {
+            assertNull(dest);
+        }
+    }
+}

--- a/server/src/test/java/org/candlepin/dto/api/v1/RoleDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/RoleDTOTest.java
@@ -46,6 +46,7 @@ public class RoleDTOTest extends AbstractDTOTest<RoleDTO> {
         for (int i = 0; i < 5; ++i) {
             UserDTO user = new UserDTO();
             user.setId("test-user-" + i);
+            user.setUsername(user.getId());
 
             PermissionBlueprintDTO permission = new PermissionBlueprintDTO();
             permission.setId("test-perm-" + i);
@@ -86,9 +87,11 @@ public class RoleDTOTest extends AbstractDTOTest<RoleDTO> {
 
         UserDTO user1 = new UserDTO();
         user1.setId("test-user-1");
+        user1.setUsername(user1.getId());
 
         UserDTO user2 = new UserDTO();
         user2.setId("test-user-2");
+        user2.setUsername(user2.getId());
 
         Collection<UserDTO> users = dto.getUsers();
         assertNull(users);
@@ -118,6 +121,7 @@ public class RoleDTOTest extends AbstractDTOTest<RoleDTO> {
 
         UserDTO user = new UserDTO();
         user.setId("test-user");
+        user.setUsername(user.getId());
 
         Collection<UserDTO> users = dto.getUsers();
         assertNull(users);
@@ -196,6 +200,7 @@ public class RoleDTOTest extends AbstractDTOTest<RoleDTO> {
 
         UserDTO user = new UserDTO();
         user.setId("test-user");
+        user.setUsername(user.getId());
 
         Collection<UserDTO> users = dto.getUsers();
         assertNull(users);
@@ -265,6 +270,7 @@ public class RoleDTOTest extends AbstractDTOTest<RoleDTO> {
 
         UserDTO user = new UserDTO();
         user.setId("test-user");
+        user.setUsername(user.getId());
 
         Collection<UserDTO> users = dto.getUsers();
         assertNull(users);

--- a/server/src/test/java/org/candlepin/dto/api/v1/RoleInfoTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/RoleInfoTranslatorTest.java
@@ -1,0 +1,153 @@
+/**
+ * Copyright (c) 2009 - 2017 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.dto.api.v1;
+
+import static org.junit.Assert.*;
+
+import org.candlepin.dto.AbstractTranslatorTest;
+import org.candlepin.dto.ModelTranslator;
+import org.candlepin.model.PermissionBlueprint;
+import org.candlepin.model.Role;
+import org.candlepin.model.User;
+import org.candlepin.service.model.PermissionBlueprintInfo;
+import org.candlepin.service.model.RoleInfo;
+import org.candlepin.service.model.UserInfo;
+
+import org.apache.commons.lang.builder.EqualsBuilder;
+
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
+
+
+
+/**
+ * Test suite for the EntitlementTranslator class.
+ */
+public class RoleInfoTranslatorTest extends AbstractTranslatorTest<RoleInfo, RoleDTO, RoleInfoTranslator> {
+
+    protected RoleInfoTranslator translator = new RoleInfoTranslator();
+
+    protected PermissionBlueprintInfoTranslatorTest permTranslatorTest =
+        new PermissionBlueprintInfoTranslatorTest();
+
+    protected UserInfoTranslatorTest userTranslatorTest = new UserInfoTranslatorTest();
+
+    @Override
+    protected void initModelTranslator(ModelTranslator modelTranslator) {
+        this.userTranslatorTest.initModelTranslator(modelTranslator);
+        this.permTranslatorTest.initModelTranslator(modelTranslator);
+
+        modelTranslator.registerTranslator(this.translator, RoleInfo.class, RoleDTO.class);
+    }
+
+    @Override
+    protected RoleInfoTranslator initObjectTranslator() {
+        return this.translator;
+    }
+
+    @Override
+    protected RoleInfo initSourceObject() {
+        // Role is a RoleInfo
+        Role source = new Role();
+
+        Set<User> users = new HashSet<>();
+        Set<PermissionBlueprint> permissions = new HashSet<>();
+
+        for (int i = 0; i < 5; ++i) {
+            User user = (User) this.userTranslatorTest.initSourceObject();
+            user.setId("test-user-" + i);
+
+            PermissionBlueprint permission = (PermissionBlueprint) this.permTranslatorTest.initSourceObject();
+            permission.setId("test-perm-" + i);
+
+            users.add(user);
+            permissions.add(permission);
+        }
+
+        source.setId("test-role-id");
+        source.setName("test-role-name");
+        source.setUsers(users);
+        source.setPermissions(permissions);
+
+        source.setCreated(new Date());
+        source.setUpdated(new Date());
+
+        return source;
+    }
+
+    @Override
+    protected RoleDTO initDestinationObject() {
+        return new RoleDTO();
+    }
+
+    @Override
+    protected void verifyOutput(RoleInfo source, RoleDTO dest, boolean childrenGenerated) {
+        if (source != null) {
+            // Service model objects don't provide IDs
+            assertNull(dest.getId());
+
+            assertEquals(source.getName(), dest.getName());
+
+            if (childrenGenerated) {
+                // Verify users
+                for (UserInfo user : source.getUsers()) {
+                    for (UserDTO userDto : dest.getUsers()) {
+                        assertNotNull(user.getUsername());
+                        assertNotNull(userDto.getUsername());
+
+                        if (user.getUsername().equals(userDto.getUsername())) {
+                            this.userTranslatorTest.verifyOutput(user, userDto, childrenGenerated);
+                        }
+                    }
+                }
+
+                // Verify permissions
+                int matches = 0;
+                for (PermissionBlueprintInfo pinfo : source.getPermissions()) {
+                    for (PermissionBlueprintDTO pdto : dest.getPermissions()) {
+                        // Since we don't have an ID to use for comparison, we have to just
+                        // compare all fields and hope for the best.
+
+                        String piOwnerKey = pinfo.getOwner() != null ? pinfo.getOwner().getKey() : null;
+                        String pdOwnerKey = pdto.getOwner() != null ? pdto.getOwner().getKey() : null;
+
+                        EqualsBuilder builder = new EqualsBuilder()
+                            .append(pinfo.getTypeName(), pdto.getTypeName())
+                            .append(pinfo.getAccessLevel(), pdto.getAccessLevel())
+                            .append(piOwnerKey, pdOwnerKey);
+
+                        if (builder.isEquals()) {
+                            ++matches;
+                            break;
+                        }
+                    }
+                }
+
+                assertEquals("Permission object mismatch", matches, source.getPermissions().size());
+            }
+            else {
+                assertNotNull(dest.getUsers());
+                assertTrue(dest.getUsers().isEmpty());
+
+                assertNotNull(dest.getPermissions());
+                assertTrue(dest.getPermissions().isEmpty());
+            }
+        }
+        else {
+            assertNull(dest);
+        }
+    }
+}

--- a/server/src/test/java/org/candlepin/dto/api/v1/UserDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/UserDTOTest.java
@@ -14,7 +14,12 @@
  */
 package org.candlepin.dto.api.v1;
 
+import static org.junit.Assert.*;
+
 import org.candlepin.dto.AbstractDTOTest;
+import org.candlepin.util.Util;
+
+import org.junit.Test;
 
 import java.util.Date;
 import java.util.HashMap;
@@ -35,7 +40,7 @@ public class UserDTOTest extends AbstractDTOTest<UserDTO> {
         this.values = new HashMap<>();
         this.values.put("Id", "test-id");
         this.values.put("Username", "test-username");
-        this.values.put("Password", "test-password");
+        this.values.put("HashedPassword", "test-password-hash");
         this.values.put("SuperAdmin", true);
         this.values.put("Created", new Date());
         this.values.put("Updated", new Date());
@@ -56,5 +61,33 @@ public class UserDTOTest extends AbstractDTOTest<UserDTO> {
     protected Object getOutputValueForAccessor(String field, Object input) {
         // Nothing to do here
         return input;
+    }
+
+    @Test
+    public void testPasswordHashing() {
+        UserDTO dto = new UserDTO();
+        assertNull(dto.getHashedPassword());
+
+        String password = "my_password";
+        String hashed = Util.hash(password);
+
+        // This should result in a hashed password
+        dto.setPassword(password);
+
+        assertEquals(hashed, dto.getHashedPassword());
+    }
+
+    @Test
+    public void testPasswordReset() {
+        UserDTO dto = new UserDTO();
+        assertNull(dto.getHashedPassword());
+
+        String password = "my_password";
+
+        dto.setPassword(password);
+        assertNotNull(dto.getHashedPassword());
+
+        dto.setPassword(null);
+        assertNull(dto.getHashedPassword());
     }
 }

--- a/server/src/test/java/org/candlepin/dto/api/v1/UserInfoTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/UserInfoTranslatorTest.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2009 - 2018 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.dto.api.v1;
+
+import org.candlepin.dto.AbstractTranslatorTest;
+import org.candlepin.dto.ModelTranslator;
+import org.candlepin.model.User;
+import org.candlepin.service.model.UserInfo;
+
+import static org.junit.Assert.*;
+
+import junitparams.JUnitParamsRunner;
+
+import org.junit.runner.RunWith;
+
+
+
+/**
+ * Test suite for the UserInfoTranslator class
+ */
+@RunWith(JUnitParamsRunner.class)
+public class UserInfoTranslatorTest extends AbstractTranslatorTest<UserInfo, UserDTO, UserInfoTranslator> {
+
+    protected UserInfoTranslator translator = new UserInfoTranslator();
+
+    @Override
+    protected void initModelTranslator(ModelTranslator modelTranslator) {
+        modelTranslator.registerTranslator(this.translator, UserInfo.class, UserDTO.class);
+    }
+
+    @Override
+    protected UserInfoTranslator initObjectTranslator() {
+        return this.translator;
+    }
+
+    @Override
+    protected UserInfo initSourceObject() {
+        // Impl note: Users are UserInfo implementations
+        User user = new User();
+
+        user.setId("user_id");
+        user.setUsername("user_username");
+        user.setPassword("user_password");
+        user.setSuperAdmin(true);
+
+        return user;
+    }
+
+    @Override
+    protected UserDTO initDestinationObject() {
+        // Nothing fancy to do here.
+        return new UserDTO();
+    }
+
+    @Override
+    protected void verifyOutput(UserInfo source, UserDTO dest, boolean childrenGenerated) {
+        if (source != null) {
+            // This DTO does not have any nested objects, so we don't need to worry about the
+            // childrenGenerated flag
+
+            assertNull(dest.getId());
+
+            assertEquals(source.getUsername(), dest.getUsername());
+            assertEquals(source.isSuperAdmin(), dest.isSuperAdmin());
+
+            // Under no circumstance should we be copying over the password field on translation.
+            // This should always be null on the DTO.
+            assertNull(dest.getHashedPassword());
+        }
+        else {
+            assertNull(dest);
+        }
+    }
+}

--- a/server/src/test/java/org/candlepin/dto/api/v1/UserTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/UserTranslatorTest.java
@@ -76,7 +76,7 @@ public class UserTranslatorTest extends AbstractTranslatorTest<User, UserDTO, Us
             // Under no circumstance should we be copying over the password field on translation.
             // This should always be null on the DTO.
             assertNotNull(source.getPassword());
-            assertNull(dest.getPassword());
+            assertNull(dest.getHashedPassword());
         }
         else {
             assertNull(dest);

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/ContentDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/ContentDTOTest.java
@@ -41,7 +41,7 @@ public class ContentDTOTest extends AbstractDTOTest<ContentDTO> {
         this.values = new HashMap<>();
         this.values.put("Id", "test_value");
         this.values.put("Uuid", "test_value");
-        this.values.put("MetadataExpire", 3L);
+        this.values.put("MetadataExpiration", 3L);
         this.values.put("Type", "test_value");
         this.values.put("Label", "test_value");
         this.values.put("Name", "test_value");

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/ContentTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/ContentTranslatorTest.java
@@ -52,7 +52,7 @@ public class ContentTranslatorTest extends
         Content source = new Content();
 
         source.setUuid("test_value");
-        source.setMetadataExpire(3L);
+        source.setMetadataExpiration(3L);
         source.setId("test_value");
         source.setType("test_value");
         source.setLabel("test_value");
@@ -81,7 +81,7 @@ public class ContentTranslatorTest extends
             // childrenGenerated flag
 
             assertEquals(source.getUuid(), dto.getUuid());
-            assertEquals(source.getMetadataExpire(), dto.getMetadataExpire());
+            assertEquals(source.getMetadataExpiration(), dto.getMetadataExpiration());
             assertEquals(source.getId(), dto.getId());
             assertEquals(source.getType(), dto.getType());
             assertEquals(source.getLabel(), dto.getLabel());

--- a/server/src/test/java/org/candlepin/dto/rules/v1/ConsumerTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/rules/v1/ConsumerTranslatorTest.java
@@ -132,7 +132,7 @@ public class ConsumerTranslatorTest extends
             if (childrenGenerated) {
                 ConsumerType ctype = this.mockConsumerTypeCurator.getConsumerType(source);
 
-                assertEquals(source.getOwnerId(), dest.getOwner().getId());
+                assertEquals(source.getOwnerId(), dest.getOwner() != null ? dest.getOwner().getId() : null);
                 this.consumerTypeTranslatorTest.verifyOutput(ctype, dest.getType(), true);
 
                 if (source.getInstalledProducts() != null) {

--- a/server/src/test/java/org/candlepin/dto/shim/ContentDTOTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/shim/ContentDTOTranslatorTest.java
@@ -62,7 +62,7 @@ public class ContentDTOTranslatorTest extends
         source.setRequiredTags("test_value");
         source.setReleaseVersion("test_value");
         source.setGpgUrl("test_value");
-        source.setMetadataExpire(1234L);
+        source.setMetadataExpiration(1234L);
         source.setModifiedProductIds(Arrays.asList("1", "2", "3"));
         source.setArches("test_value");
 
@@ -91,7 +91,7 @@ public class ContentDTOTranslatorTest extends
             assertEquals(source.getRequiredTags(), dto.getRequiredTags());
             assertEquals(source.getReleaseVersion(), dto.getReleaseVersion());
             assertEquals(source.getGpgUrl(), dto.getGpgUrl());
-            assertEquals(source.getMetadataExpire(), dto.getMetadataExpire());
+            assertEquals(source.getMetadataExpiration(), dto.getMetadataExpiration());
             assertEquals(source.getModifiedProductIds(), dto.getModifiedProductIds());
             assertEquals(source.getArches(), dto.getArches());
         }

--- a/server/src/test/java/org/candlepin/dto/shim/ContentDataTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/shim/ContentDataTranslatorTest.java
@@ -62,7 +62,7 @@ public class ContentDataTranslatorTest extends
         source.setRequiredTags("test_value");
         source.setReleaseVersion("test_value");
         source.setGpgUrl("test_value");
-        source.setMetadataExpire(1234L);
+        source.setMetadataExpiration(1234L);
         source.setModifiedProductIds(Arrays.asList("1", "2", "3"));
         source.setArches("test_value");
         source.setLocked(Boolean.TRUE);
@@ -92,7 +92,7 @@ public class ContentDataTranslatorTest extends
             assertEquals(source.getRequiredTags(), dto.getRequiredTags());
             assertEquals(source.getReleaseVersion(), dto.getReleaseVersion());
             assertEquals(source.getGpgUrl(), dto.getGpgUrl());
-            assertEquals(source.getMetadataExpire(), dto.getMetadataExpiration());
+            assertEquals(source.getMetadataExpiration(), dto.getMetadataExpiration());
             assertEquals(source.getModifiedProductIds(), dto.getModifiedProductIds());
             assertEquals(source.getArches(), dto.getArches());
             assertEquals(source.isLocked(), dto.isLocked());

--- a/server/src/test/java/org/candlepin/katello/KatelloUserServiceAdapterTest.java
+++ b/server/src/test/java/org/candlepin/katello/KatelloUserServiceAdapterTest.java
@@ -48,13 +48,12 @@ public class KatelloUserServiceAdapterTest {
     @Test(expected = UnsupportedOperationException.class)
     public void updateUser() throws Exception {
         User user = mock(User.class);
-        kusa.updateUser(user);
+        kusa.updateUser("username", user);
     }
 
     @Test(expected = UnsupportedOperationException.class)
     public void deleteUser() throws Exception {
-        User user = mock(User.class);
-        kusa.deleteUser(user);
+        kusa.deleteUser("username");
     }
 
     @Test(expected = UnsupportedOperationException.class)
@@ -76,7 +75,7 @@ public class KatelloUserServiceAdapterTest {
     @Test(expected = UnsupportedOperationException.class)
     public void updateRole() throws Exception {
         Role r = mock(Role.class);
-        kusa.updateRole(r);
+        kusa.updateRole("role name", r);
     }
 
     @Test(expected = UnsupportedOperationException.class)
@@ -86,16 +85,12 @@ public class KatelloUserServiceAdapterTest {
 
     @Test(expected = UnsupportedOperationException.class)
     public void addUserToRole() throws Exception {
-        Role r = mock(Role.class);
-        User user = mock(User.class);
-        kusa.addUserToRole(r, user);
+        kusa.addUserToRole("role name", "username");
     }
 
     @Test(expected = UnsupportedOperationException.class)
     public void removeUserFromRole() throws Exception {
-        Role r = mock(Role.class);
-        User user = mock(User.class);
-        kusa.removeUserFromRole(r, user);
+        kusa.removeUserFromRole("role name", "username");
     }
 
     @Test(expected = UnsupportedOperationException.class)

--- a/server/src/test/java/org/candlepin/model/CertificateTest.java
+++ b/server/src/test/java/org/candlepin/model/CertificateTest.java
@@ -64,8 +64,7 @@ public class CertificateTest extends DatabaseTestFixture {
 
         SubscriptionsCertificate certificate = createSubCert("key", "cert");
         certificateCurator.create(certificate);
-        SubscriptionsCertificate lookedUp = certificateCurator.get(certificate
-            .getId());
+        SubscriptionsCertificate lookedUp = certificateCurator.get(certificate.getId());
 
         assertNotNull(lookedUp);
         assertEquals(certificate.getId(), lookedUp.getId());

--- a/server/src/test/java/org/candlepin/model/ColumnarResultIteratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ColumnarResultIteratorTest.java
@@ -17,7 +17,6 @@ package org.candlepin.model;
 import static org.junit.Assert.*;
 
 import org.candlepin.test.DatabaseTestFixture;
-import org.candlepin.test.TestUtil;
 
 import org.hibernate.ScrollMode;
 import org.hibernate.Session;
@@ -43,7 +42,7 @@ public class ColumnarResultIteratorTest extends DatabaseTestFixture {
 
     @Test
     public void testHasNextWithElements() {
-        this.ownerCurator.create(TestUtil.createOwner());
+        this.createOwner();
         Query query = this.session.createQuery("SELECT o FROM Owner o");
 
         ColumnarResultIterator<Owner> iterator = new ColumnarResultIterator<>(
@@ -80,12 +79,9 @@ public class ColumnarResultIteratorTest extends DatabaseTestFixture {
 
     @Test
     public void testNextWithElements() {
-        Owner owner1 = TestUtil.createOwner();
-        Owner owner2 = TestUtil.createOwner();
-        Owner owner3 = TestUtil.createOwner();
-        this.ownerCurator.create(owner1);
-        this.ownerCurator.create(owner2);
-        this.ownerCurator.create(owner3);
+        Owner owner1 = this.createOwner();
+        Owner owner2 = this.createOwner();
+        Owner owner3 = this.createOwner();
 
         Query query = this.session.createQuery("SELECT o FROM Owner o");
 
@@ -133,7 +129,7 @@ public class ColumnarResultIteratorTest extends DatabaseTestFixture {
 
     @Test(expected = UnsupportedOperationException.class)
     public void testRemoveAlwaysFails() {
-        this.ownerCurator.create(TestUtil.createOwner());
+        this.createOwner();
         Query query = this.session.createQuery("SELECT o FROM Owner o");
 
         ColumnarResultIterator<Owner> iterator = new ColumnarResultIterator<>(

--- a/server/src/test/java/org/candlepin/model/ContentCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ContentCuratorTest.java
@@ -54,7 +54,7 @@ public class ContentCuratorTest extends DatabaseTestFixture {
 
         updates.setRequiredTags("required-tags");
         updates.setReleaseVersion("releaseVer");
-        updates.setMetadataExpire(new Long(1));
+        updates.setMetadataExpiration(new Long(1));
         updates.setModifiedProductIds(new HashSet<String>() { { add("productIdOne"); } });
     }
 
@@ -74,7 +74,7 @@ public class ContentCuratorTest extends DatabaseTestFixture {
         assertEquals(toBeUpdated.getContentUrl(), updates.getContentUrl());
         assertEquals(toBeUpdated.getRequiredTags(), updates.getRequiredTags());
         assertEquals(toBeUpdated.getReleaseVersion(), updates.getReleaseVersion());
-        assertEquals(toBeUpdated.getMetadataExpire(), updates.getMetadataExpire());
+        assertEquals(toBeUpdated.getMetadataExpiration(), updates.getMetadataExpiration());
         assertEquals(toBeUpdated.getModifiedProductIds(), updates.getModifiedProductIds());
         assertEquals(toBeUpdated.getArches(), updates.getArches());
     }

--- a/server/src/test/java/org/candlepin/model/ContentTest.java
+++ b/server/src/test/java/org/candlepin/model/ContentTest.java
@@ -53,14 +53,14 @@ public class ContentTest extends DatabaseTestFixture {
 
         content.setModifiedProductIds(modifiedProductIds);
         Long metadataExpire = new Long(60 * 60 * 24);
-        content.setMetadataExpire(metadataExpire);
+        content.setMetadataExpiration(metadataExpire);
 
         contentCurator.create(content);
 
         Content lookedUp = contentCurator.get(content.getUuid());
         assertEquals(content.getContentUrl(), lookedUp.getContentUrl());
         assertThat(lookedUp.getModifiedProductIds(), hasItem("ProductB"));
-        assertEquals(metadataExpire, lookedUp.getMetadataExpire());
+        assertEquals(metadataExpire, lookedUp.getMetadataExpiration());
     }
 
     @Test
@@ -101,21 +101,6 @@ public class ContentTest extends DatabaseTestFixture {
         assertEquals(newName, content.getName());
     }
 
-    @Test
-    public void testLockStateAffectsEquality() {
-        Owner owner = new Owner("Example-Corporation");
-        Content c1 = TestUtil.createContent("test_content-1");
-        Content c2 = TestUtil.createContent("test_content-1");
-
-        assertEquals(c1, c2);
-
-        c2.setLocked(true);
-        assertNotEquals(c1, c2);
-
-        c1.setLocked(true);
-        assertEquals(c1, c2);
-    }
-
     protected Object[][] getValuesForEqualityAndReplication() {
         return new Object[][] {
             new Object[] { "Id", "test_value", "alt_value" },
@@ -127,10 +112,10 @@ public class ContentTest extends DatabaseTestFixture {
             new Object[] { "RequiredTags", "test_value", "alt_value" },
             new Object[] { "ReleaseVersion", "test_value", "alt_value" },
             new Object[] { "GpgUrl", "test_value", "alt_value" },
-            new Object[] { "MetadataExpire", 1234L, 5678L },
+            new Object[] { "MetadataExpiration", 1234L, 5678L },
             new Object[] { "ModifiedProductIds", Arrays.asList("1", "2", "3"), Arrays.asList("4", "5", "6") },
-            new Object[] { "Arches", "test_value", "alt_value" },
-            new Object[] { "Locked", Boolean.TRUE, Boolean.FALSE }
+            new Object[] { "Arches", "test_value", "alt_value" }
+            // new Object[] { "Locked", Boolean.TRUE, Boolean.FALSE }
         };
     }
 

--- a/server/src/test/java/org/candlepin/model/JobCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/JobCuratorTest.java
@@ -296,6 +296,8 @@ public class JobCuratorTest extends DatabaseTestFixture {
     @Test
     public void findByPrincipalNameRestrictsConsumerToOwnJobs() {
         Owner owner = new Owner("ducks");
+        owner.setId("duck-owner");
+
         Consumer consumer = TestUtil.createConsumer(owner);
 
         JobStatus job = newJobStatus().principalName(consumer.getUuid()).owner(owner.getKey()).create();

--- a/server/src/test/java/org/candlepin/model/OwnerContentCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/OwnerContentCuratorTest.java
@@ -305,7 +305,7 @@ public class OwnerContentCuratorTest extends DatabaseTestFixture {
 
     @Test(expected = IllegalStateException.class)
     public void testMapContentToOwnerUnmappedOwner() {
-        Owner owner = TestUtil.createOwner();
+        Owner owner = new Owner("unmapped");
         Content content = this.createContent();
 
         this.ownerContentCurator.mapContentToOwner(content, owner);

--- a/server/src/test/java/org/candlepin/model/OwnerProductCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/OwnerProductCuratorTest.java
@@ -308,7 +308,7 @@ public class OwnerProductCuratorTest extends DatabaseTestFixture {
 
     @Test(expected = IllegalStateException.class)
     public void testMapProductToOwnerUnmappedOwner() {
-        Owner owner = TestUtil.createOwner();
+        Owner owner = new Owner("unmapped");
         Product product = this.createProduct();
 
         this.ownerProductCurator.mapProductToOwner(product, owner);

--- a/server/src/test/java/org/candlepin/model/OwnerTest.java
+++ b/server/src/test/java/org/candlepin/model/OwnerTest.java
@@ -36,6 +36,7 @@ public class OwnerTest extends DatabaseTestFixture {
         String prefix = "PhredPrefix";
 
         Owner o = TestUtil.createOwner(ownerName);
+        o.setId(null);
         o.setContentPrefix(prefix);
         ownerCurator.create(o);
 

--- a/server/src/test/java/org/candlepin/model/ProductTest.java
+++ b/server/src/test/java/org/candlepin/model/ProductTest.java
@@ -40,21 +40,6 @@ import javax.inject.Inject;
 public class ProductTest extends DatabaseTestFixture {
     @Inject private OwnerCurator ownerCurator;
 
-    @Test
-    public void testLockStateAffectsEquality() {
-        Owner owner = new Owner("Example-Corporation");
-        Product p1 = new Product("test-prod", "test-prod-name", "variant", "1.0.0", "x86", "type");
-        Product p2 = new Product("test-prod", "test-prod-name", "variant", "1.0.0", "x86", "type");
-
-        assertEquals(p1, p2);
-
-        p2.setLocked(true);
-        assertNotEquals(p1, p2);
-
-        p1.setLocked(true);
-        assertEquals(p1, p2);
-    }
-
     protected Object[][] getValuesForEqualityAndReplication() {
         Map<String, String> attributes1 = new HashMap<>();
         attributes1.put("a1", "v1");
@@ -99,7 +84,7 @@ public class ProductTest extends DatabaseTestFixture {
             new Object[] { "ProductContent", productContent1, productContent2 },
             new Object[] { "DependentProductIds", Arrays.asList("1", "2", "3"), Arrays.asList("4", "5") },
             // new Object[] { "Href", "test_value", null },
-            new Object[] { "Locked", Boolean.TRUE, false }
+            // new Object[] { "Locked", Boolean.TRUE, false }
         };
     }
 

--- a/server/src/test/java/org/candlepin/model/RowResultIteratorTest.java
+++ b/server/src/test/java/org/candlepin/model/RowResultIteratorTest.java
@@ -17,7 +17,6 @@ package org.candlepin.model;
 import static org.junit.Assert.*;
 
 import org.candlepin.test.DatabaseTestFixture;
-import org.candlepin.test.TestUtil;
 
 import org.hibernate.ScrollMode;
 import org.hibernate.Session;
@@ -43,7 +42,7 @@ public class RowResultIteratorTest extends DatabaseTestFixture {
 
     @Test
     public void testHasNextWithElements() {
-        this.ownerCurator.create(TestUtil.createOwner());
+        this.createOwner();
         Query query = this.session.createQuery("SELECT o FROM Owner o");
 
         RowResultIterator iterator = new RowResultIterator(query.scroll(ScrollMode.FORWARD_ONLY));
@@ -72,12 +71,9 @@ public class RowResultIteratorTest extends DatabaseTestFixture {
 
     @Test
     public void testNextWithElements() {
-        Owner owner1 = TestUtil.createOwner();
-        Owner owner2 = TestUtil.createOwner();
-        Owner owner3 = TestUtil.createOwner();
-        this.ownerCurator.create(owner1);
-        this.ownerCurator.create(owner2);
-        this.ownerCurator.create(owner3);
+        Owner owner1 = this.createOwner();
+        Owner owner2 = this.createOwner();
+        Owner owner3 = this.createOwner();
 
         Query query = this.session.createQuery("SELECT o FROM Owner o");
 
@@ -117,7 +113,7 @@ public class RowResultIteratorTest extends DatabaseTestFixture {
 
     @Test(expected = UnsupportedOperationException.class)
     public void testRemoveAlwaysFails() {
-        this.ownerCurator.create(TestUtil.createOwner());
+        this.createOwner();
         Query query = this.session.createQuery("SELECT o FROM Owner o");
 
         RowResultIterator iterator = new RowResultIterator(query.scroll(ScrollMode.FORWARD_ONLY));

--- a/server/src/test/java/org/candlepin/model/UserTest.java
+++ b/server/src/test/java/org/candlepin/model/UserTest.java
@@ -16,15 +16,11 @@ package org.candlepin.model;
 
 import static org.junit.Assert.assertEquals;
 
-import org.candlepin.auth.Access;
-import org.candlepin.auth.SubResource;
-import org.candlepin.auth.permissions.Permission;
 import org.candlepin.test.DatabaseTestFixture;
 
-import org.hibernate.criterion.Criterion;
 import org.junit.Test;
 
-import java.util.Set;
+
 
 public class UserTest extends DatabaseTestFixture {
 
@@ -44,114 +40,4 @@ public class UserTest extends DatabaseTestFixture {
         assertEquals(hashedPassword, lookedUp.getHashedPassword());
     }
 
-    @Test
-    public void testGetOwners() {
-        String username = "TESTUSER";
-        String password = "sekretpassword";
-        Owner owner1 = new Owner("owner1", "owner one");
-        Owner owner2 = new Owner("owner2", "owner two");
-        User user = new User(username, password);
-
-        Set<Owner> owners = user.getOwners(null, Access.ALL);
-        assertEquals(0, owners.size());
-        user.addPermissions(new TestPermission(owner1));
-        user.addPermissions(new TestPermission(owner2));
-
-        // Adding the new permissions should give us access
-        // to both new owners
-        owners = user.getOwners(null, Access.ALL);
-        assertEquals(2, owners.size());
-    }
-
-    @Test
-    public void testGetOwnersCoversCreateConsumers() {
-        String username = "TESTUSER";
-        String password = "sekretpassword";
-        Owner owner1 = new Owner("owner1", "owner one");
-        Owner owner2 = new Owner("owner2", "owner two");
-        User user = new User(username, password);
-
-        Set<Owner> owners = user.getOwners(null, Access.ALL);
-        assertEquals(0, owners.size());
-        user.addPermissions(new TestPermission(owner1));
-        user.addPermissions(new TestPermission(owner2));
-
-        // This is the check we do in API call, make sure owner admins show up as
-        // having perms to create consumers as well:
-        owners = user.getOwners(SubResource.CONSUMERS, Access.CREATE);
-        assertEquals(2, owners.size());
-    }
-
-    @Test
-    public void testGetOwnersNonOwnerPerm() {
-        String username = "TESTUSER";
-        String password = "sekretpassword";
-        Owner owner1 = new Owner("owner1", "owner one");
-        Owner owner2 = new Owner("owner2", "owner two");
-        User user = new User(username, password);
-
-        Set<Owner> owners = user.getOwners(null, Access.ALL);
-        assertEquals(0, owners.size());
-        user.addPermissions(new OtherPermission(owner1));
-        user.addPermissions(new OtherPermission(owner2));
-
-        // Adding the new permissions should not give us access
-        // to either of the new owners
-        owners = user.getOwners(null, Access.ALL);
-        assertEquals(0, owners.size());
-    }
-
-    private class TestPermission implements Permission {
-
-        private Owner owner;
-
-        public TestPermission(Owner o) {
-            owner = o;
-        }
-
-        @Override
-        public boolean canAccess(Object target, SubResource subResource,
-            Access access) {
-            if (target instanceof Owner) {
-                Owner targetOwner = (Owner) target;
-                return targetOwner.getKey().equals(this.getOwner().getKey());
-            }
-            return false;
-        }
-
-        @Override
-        public Criterion getCriteriaRestrictions(Class entityClass) {
-            return null;
-        }
-
-        @Override
-        public Owner getOwner() {
-            return owner;
-        }
-    }
-
-    private class OtherPermission implements Permission {
-
-        private Owner owner;
-
-        public OtherPermission(Owner o) {
-            owner = o;
-        }
-
-        @Override
-        public boolean canAccess(Object target, SubResource subResource,
-            Access access) {
-            return false;
-        }
-
-        @Override
-        public Criterion getCriteriaRestrictions(Class entityClass) {
-            return null;
-        }
-
-        @Override
-        public Owner getOwner() {
-            return owner;
-        }
-    }
 }

--- a/server/src/test/java/org/candlepin/model/dto/ContentDataTest.java
+++ b/server/src/test/java/org/candlepin/model/dto/ContentDataTest.java
@@ -223,17 +223,17 @@ public class ContentDataTest {
     }
 
     @Test
-    public void testGetSetMetadataExpire() {
+    public void testGetSetMetadataExpiration() {
         ContentData dto = new ContentData();
         Long input = 12345L;
 
-        Long output = dto.getMetadataExpire();
+        Long output = dto.getMetadataExpiration();
         assertNull(output);
 
-        ContentData output2 = dto.setMetadataExpire(input);
+        ContentData output2 = dto.setMetadataExpiration(input);
         assertSame(output2, dto);
 
-        output = dto.getMetadataExpire();
+        output = dto.getMetadataExpiration();
         assertEquals(input, output);
     }
 
@@ -365,10 +365,10 @@ public class ContentDataTest {
             new Object[] { "RequiredTags", "test_value", "alt_value" },
             new Object[] { "ReleaseVersion", "test_value", "alt_value" },
             new Object[] { "GpgUrl", "test_value", "alt_value" },
-            new Object[] { "MetadataExpire", 1234L, 5678L },
+            new Object[] { "MetadataExpiration", 1234L, 5678L },
             new Object[] { "ModifiedProductIds", Arrays.asList("1", "2", "3"), Arrays.asList("4", "5", "6") },
             new Object[] { "Arches", "test_value", "alt_value" },
-            new Object[] { "Locked", Boolean.TRUE, Boolean.FALSE }
+            new Object[] { "Locked", Boolean.TRUE, false }
         };
     }
 
@@ -473,7 +473,12 @@ public class ContentDataTest {
 
         // Verify only the specified field was set
         for (Method method : ContentData.class.getDeclaredMethods()) {
-            if (method.getName().matches("^(get|is)\\w+")) {
+            if (method.getName().matches("^(get|is)\\w+") &&
+                !method.getName().equals("getRequiredProductIds")) {
+
+                // The getRequiredProductIds method is a special case that would require large architectural
+                // changes to these tests to handle properly. Basically, it's just another
+
                 Object output = method.invoke(base, null);
 
                 if (method.getName().equals(accessor.getName())) {
@@ -504,7 +509,7 @@ public class ContentDataTest {
             new Object[] { "RequiredTags", "test_value", null },
             new Object[] { "ReleaseVersion", "test_value", null },
             new Object[] { "GpgUrl", "test_value", null },
-            new Object[] { "MetadataExpire", 1234L, null },
+            new Object[] { "MetadataExpiration", 1234L, null },
             new Object[] { "ModifiedProductIds", Arrays.asList("1", "2", "3"), Arrays.asList() },
             new Object[] { "Arches", "test_value", null },
             new Object[] { "Locked", Boolean.TRUE, false }

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/EntitleByProductsJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/EntitleByProductsJobTest.java
@@ -57,6 +57,7 @@ public class EntitleByProductsJobTest extends BaseJobTest {
         ConsumerType ctype = new ConsumerType("system");
         ctype.setId("test-ctype");
         owner = new Owner("test-owner");
+        owner.setId("test-owner-id");
         consumer = new Consumer("Test Consumer", "test-consumer", owner, ctype);
         consumer.setUuid(consumerUuid);
         e = mock(Entitler.class);

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/EntitlerJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/EntitlerJobTest.java
@@ -58,7 +58,7 @@ import java.util.Locale;
 /**
  * EntitlerJobTest
  */
-public class EntitlerJobTest extends BaseJobTest{
+public class EntitlerJobTest extends BaseJobTest {
 
     private String consumerUuid;
     private Consumer consumer;
@@ -74,7 +74,10 @@ public class EntitlerJobTest extends BaseJobTest{
 
         ConsumerType ctype = new ConsumerType("system");
         ctype.setId("test-ctype");
+
         owner = new Owner("test-owner");
+        owner.setId("test-owner-id");
+
         consumer = new Consumer("Test Consumer", "test-consumer", owner, ctype);
         consumer.setUuid(consumerUuid);
         e = mock(Entitler.class);

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/UndoImportsJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/UndoImportsJobTest.java
@@ -133,6 +133,9 @@ public class UndoImportsJobTest extends DatabaseTestFixture {
         // Create owner w/upstream consumer
         Owner owner1 = TestUtil.createOwner();
         Owner owner2 = TestUtil.createOwner();
+        owner1.setId(null);
+        owner2.setId(null);
+
         ConsumerType type = this.createConsumerType();
         UpstreamConsumer uc1 = new UpstreamConsumer("uc1", null, type, "uc1");
         UpstreamConsumer uc2 = new UpstreamConsumer("uc2", null, type, "uc2");

--- a/server/src/test/java/org/candlepin/policy/js/compliance/hash/ComplianceStatusHasherTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/compliance/hash/ComplianceStatusHasherTest.java
@@ -47,6 +47,8 @@ public class ComplianceStatusHasherTest {
     @Before
     public void setUp() throws Exception {
         owner = new Owner("test-owner", "Test Owner");
+        owner.setId("test-owner-id");
+
         Consumer consumer = createConsumer(owner);
         status = createInitialStatus(consumer);
         initialHash = generateHash(status, consumer);

--- a/server/src/test/java/org/candlepin/policy/js/entitlement/EntitlementRulesTestFixture.java
+++ b/server/src/test/java/org/candlepin/policy/js/entitlement/EntitlementRulesTestFixture.java
@@ -148,7 +148,7 @@ public class EntitlementRulesTestFixture {
             translator
         );
 
-        owner = new Owner();
+        owner = TestUtil.createOwner();
 
         consumerType = this.mockConsumerType(new ConsumerType(ConsumerTypeEnum.SYSTEM));
         consumer = new Consumer("test consumer", "test user", owner, consumerType);

--- a/server/src/test/java/org/candlepin/policy/js/quantity/QuantityRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/quantity/QuantityRulesTest.java
@@ -106,7 +106,7 @@ public class QuantityRulesTest {
         quantityRules = new QuantityRules(provider.get(), new RulesObjectMapper(
             new ProductCachedSerializationModule(productCurator)), translator);
 
-        owner = new Owner("Test Owner " + TestUtil.randomInt());
+        owner = TestUtil.createOwner();
         product = TestUtil.createProduct();
         pool = TestUtil.createPool(owner, product);
         pool.setId("fakepoolid");

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
@@ -73,6 +73,7 @@ import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Calendar;
 import java.util.HashSet;
 import java.util.List;
@@ -141,7 +142,9 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
         ownerAdminRole.addUser(someuser);
         roleCurator.create(ownerAdminRole);
 
-        List<Permission> perms = permFactory.createPermissions(someuser, ownerAdminRole.getPermissions());
+        Collection<Permission> perms = permFactory.createPermissions(someuser,
+            ownerAdminRole.getPermissions());
+
         principal = new UserPrincipal(USER_NAME, perms, false);
         setupPrincipal(principal);
 

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
@@ -380,7 +380,7 @@ public class ConsumerResourceTest {
         CandlepinPoolManager poolManager = new CandlepinPoolManager(
             null, null, null, this.config, null, null, mockEntitlementCurator,
             mockConsumerCurator, mockConsumerTypeCurator, null, null, null, null, mockActivationKeyRules,
-            null, null, null, null, null, null, null, null, null, null
+            null, null, null, null, null, null, null, null, null, null, null
         );
         ConsumerResource consumerResource = new ConsumerResource(
             mockConsumerCurator, mockConsumerTypeCurator, null, null, null, mockEntitlementCurator, null,
@@ -490,7 +490,7 @@ public class ConsumerResourceTest {
         Consumer c = createConsumer(o);
         String[] prodIds = {"notthere"};
 
-        when(mockSubscriptionServiceAdapter.hasUnacceptedSubscriptionTerms(eq(o))).thenReturn(false);
+        when(mockSubscriptionServiceAdapter.hasUnacceptedSubscriptionTerms(eq(o.getKey()))).thenReturn(false);
         when(mockConsumerCurator.verifyAndLookupConsumerWithEntitlements(eq("fakeConsumer"))).thenReturn(c);
         when(mockEntitler.bindByProducts(any(AutobindData.class))).thenReturn(null);
         when(mockOwnerCurator.findOwnerById(eq(o.getId()))).thenReturn(o);
@@ -511,7 +511,7 @@ public class ConsumerResourceTest {
 
         when(mockOwnerCurator.findOwnerById(eq(o.getId()))).thenReturn(o);
         when(cip.getProductId()).thenReturn("product-foo");
-        when(mockSubscriptionServiceAdapter.hasUnacceptedSubscriptionTerms(eq(o))).thenReturn(false);
+        when(mockSubscriptionServiceAdapter.hasUnacceptedSubscriptionTerms(eq(o.getKey()))).thenReturn(false);
         when(cc.verifyAndLookupConsumerWithEntitlements(eq(c.getUuid()))).thenReturn(c);
 
         String dtStr = "2011-09-26T18:10:50.184081+00:00";

--- a/server/src/test/java/org/candlepin/resource/EntitlementResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/EntitlementResourceTest.java
@@ -93,6 +93,7 @@ public class EntitlementResourceTest {
             poolManager, i18n, entitler, entRules, messageTranslator, modelTranslator);
 
         owner = new Owner("admin");
+        owner.setId("admin-id");
 
         ConsumerType ctype = TestUtil.createConsumerType();
         this.mockConsumerType(ctype);

--- a/server/src/test/java/org/candlepin/resource/GuestIdResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/GuestIdResourceTest.java
@@ -105,7 +105,7 @@ public class GuestIdResourceTest {
             this.ownerCurator);
 
         i18n = I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK);
-        owner = new Owner("test-owner", "Test Owner");
+        owner = TestUtil.createOwner();
         ct = new ConsumerType(ConsumerTypeEnum.SYSTEM);
         ct.setId("test-system-ctype");
 

--- a/server/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
@@ -259,14 +259,16 @@ public class HypervisorResourceTest {
     @SuppressWarnings({ "rawtypes", "unchecked", "deprecation" })
     @Test
     public void hypervisorCheckInUpdatesGuestIdsWhenHostConsumerExists() throws Exception {
-        Owner owner = new Owner("owner-id", "Owner Id");
+        Owner owner = new Owner("owner-key-1", "Owner Name 1");
+        owner.setId("owner-id-1");
 
         Map<String, List<GuestIdDTO>> hostGuestMap = new HashMap<>();
         String hypervisorId = "test-host";
         hostGuestMap.put(hypervisorId, new ArrayList(Arrays.asList(TestUtil.createGuestIdDTO("GUEST_B"))));
 
-        Owner o = new Owner("owner-id", "Owner ID");
-        o.setId("owner-id");
+        Owner o = new Owner("owner-key-2", "Owner Name 2");
+        o.setId("owner-id-2");
+
         Consumer existing = new Consumer();
         existing.setUuid("test-host");
         existing.setName("test-host-name");
@@ -291,7 +293,7 @@ public class HypervisorResourceTest {
         HypervisorConsumerDTO c1 = updated.get(0);
         assertEquals("test-host", c1.getUuid());
         assertEquals("test-host-name", c1.getName());
-        assertEquals("owner-id", c1.getOwner().getKey());
+        assertEquals("owner-key-1", c1.getOwner().getKey());
 
         assertEquals(1, existing.getGuestIds().size());
         assertEquals("GUEST_B", existing.getGuestIds().get(0).getGuestId());
@@ -301,6 +303,7 @@ public class HypervisorResourceTest {
     @Test
     public void hypervisorCheckInReportsFailuresOnCreateFailure() throws Exception {
         Owner owner = new Owner("admin");
+        owner.setId("admin-id");
 
         Map<String, List<GuestIdDTO>> hostGuestMap = new HashMap<>();
         String expectedHostVirtId = "test-host-id";
@@ -337,6 +340,7 @@ public class HypervisorResourceTest {
     @Test
     public void checkInCreatesNoNewConsumerWhenCreateIsFalse() throws Exception {
         Owner owner = new Owner("admin");
+        owner.setId("admin-id");
 
         Map<String, List<GuestIdDTO>> hostGuestMap = new HashMap<>();
         hostGuestMap.put("test-host", new ArrayList(Arrays.asList(TestUtil.createGuestIdDTO("GUEST_A"),
@@ -376,7 +380,7 @@ public class HypervisorResourceTest {
     @Test
     public void ensureEmptyHypervisorIdsAreIgnored() throws Exception {
         Owner owner = new Owner("admin");
-        owner.setId("test-id");
+        owner.setId("admin-id");
 
         Map<String, List<GuestIdDTO>> hostGuestMap = new HashMap<>();
         hostGuestMap.put("", new ArrayList(Arrays.asList(TestUtil.createGuestIdDTO("GUEST_A"),
@@ -476,6 +480,7 @@ public class HypervisorResourceTest {
     @Test
     public void ensureFailureWhenAutobindIsDisabledOnOwner() {
         Owner owner = new Owner("test_admin");
+        owner.setId("admin-id");
         owner.setAutobindDisabled(true);
 
         Map<String, List<GuestIdDTO>> hostGuestMap = new HashMap<>();

--- a/server/src/test/java/org/candlepin/resource/UserResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/UserResourceTest.java
@@ -70,14 +70,14 @@ public class UserResourceTest extends DatabaseTestFixture {
         assertEquals(dto.isSuperAdmin(), output.isSuperAdmin());
 
         // We better not be exposing this, ever.
-        assertNull(output.getPassword());
+        assertNull(output.getHashedPassword());
 
         // Verify we actually created a user
         existing = this.userCurator.findByLogin(dto.getUsername());
 
         assertNotNull(existing);
         assertEquals(dto.getUsername(), existing.getUsername());
-        assertEquals(Util.hash(dto.getPassword()), existing.getPassword());
+        assertEquals(dto.getHashedPassword(), existing.getHashedPassword());
         assertEquals(dto.isSuperAdmin(), existing.isSuperAdmin());
     }
 
@@ -106,7 +106,7 @@ public class UserResourceTest extends DatabaseTestFixture {
         assertEquals(output.isSuperAdmin(), user.isSuperAdmin());
 
         // We better not be exposing this, ever.
-        assertNull(output.getPassword());
+        assertNull(output.getHashedPassword());
     }
 
     @Test(expected = NotFoundException.class)
@@ -164,7 +164,7 @@ public class UserResourceTest extends DatabaseTestFixture {
             assertTrue(user.getUsername().startsWith("test-user-"));
 
             // This better be null
-            assertNull(user.getPassword());
+            assertNull(user.getHashedPassword());
 
             assertTrue(user.isSuperAdmin());
         }
@@ -281,7 +281,7 @@ public class UserResourceTest extends DatabaseTestFixture {
         assertFalse(result.isSuperAdmin());
 
         // Output should always be null here, so we'll use the direct object to verify
-        assertNull(result.getPassword());
+        assertNull(result.getHashedPassword());
 
         user = this.userCurator.get(user.getId());
         assertNotNull(user);
@@ -306,7 +306,7 @@ public class UserResourceTest extends DatabaseTestFixture {
         assertFalse(result.isSuperAdmin());
 
         // Output should always be null here, so we'll use the direct object to verify
-        assertNull(result.getPassword());
+        assertNull(result.getHashedPassword());
 
         user = this.userCurator.get(user.getId());
         assertNotNull(user);
@@ -331,7 +331,7 @@ public class UserResourceTest extends DatabaseTestFixture {
         assertTrue(result.isSuperAdmin());
 
         // Output should always be null here, so we'll use the direct object to verify
-        assertNull(result.getPassword());
+        assertNull(result.getHashedPassword());
 
         user = this.userCurator.get(user.getId());
         assertNotNull(user);

--- a/server/src/test/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapterTest.java
+++ b/server/src/test/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapterTest.java
@@ -241,24 +241,24 @@ public class DefaultEntitlementCertServiceAdapterTest {
 
         content = createContent(CONTENT_NAME, CONTENT_ID, CONTENT_LABEL,
             CONTENT_TYPE, CONTENT_VENDOR, CONTENT_URL, CONTENT_GPG_URL, ARCH_LABEL);
-        content.setMetadataExpire(CONTENT_METADATA_EXPIRE);
+        content.setMetadataExpiration(CONTENT_METADATA_EXPIRE);
         content.setRequiredTags(REQUIRED_TAGS);
 
         kickstartContent = createContent(CONTENT_NAME, CONTENT_ID_KICKSTART,
             CONTENT_LABEL, CONTENT_TYPE_KICKSTART, CONTENT_VENDOR, CONTENT_URL,
             CONTENT_GPG_URL, ARCH_LABEL);
-        kickstartContent.setMetadataExpire(CONTENT_METADATA_EXPIRE);
+        kickstartContent.setMetadataExpiration(CONTENT_METADATA_EXPIRE);
         kickstartContent.setRequiredTags(REQUIRED_TAGS);
 
         fileContent = createContent(CONTENT_NAME, CONTENT_ID_FILE, CONTENT_LABEL,
             CONTENT_TYPE_FILE, CONTENT_VENDOR, CONTENT_URL, CONTENT_GPG_URL, ARCH_LABEL);
-        fileContent.setMetadataExpire(CONTENT_METADATA_EXPIRE);
+        fileContent.setMetadataExpiration(CONTENT_METADATA_EXPIRE);
         fileContent.setRequiredTags(REQUIRED_TAGS);
 
         unknownTypeContent = createContent(CONTENT_NAME, CONTENT_ID_UNKNOWN, CONTENT_LABEL,
             CONTENT_TYPE_UNKNOWN, CONTENT_VENDOR, CONTENT_URL_UNKNOWN_TYPE,
             CONTENT_GPG_URL, ARCH_LABEL);
-        unknownTypeContent.setMetadataExpire(CONTENT_METADATA_EXPIRE);
+        unknownTypeContent.setMetadataExpiration(CONTENT_METADATA_EXPIRE);
         unknownTypeContent.setRequiredTags(REQUIRED_TAGS);
 
         String emptyArches = "";
@@ -516,7 +516,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
         assertTrue(encodedContent.containsKey(CONTENT_METADATA_EXPIRE.toString()));
 
         // Nullify this, and make sure it's not there.
-        content.setMetadataExpire(null);
+        content.setMetadataExpiration(null);
         contentExtensions = extensionUtil.contentExtensions(
             product.getProductContent(), "", new HashMap<>(), entitlement.getConsumer(), product);
         encodedContent = getEncodedContent(contentExtensions);

--- a/server/src/test/java/org/candlepin/service/impl/ProductCertCreationTest.java
+++ b/server/src/test/java/org/candlepin/service/impl/ProductCertCreationTest.java
@@ -14,21 +14,24 @@
  */
 package org.candlepin.service.impl;
 
+import static org.junit.Assert.*;
+
 import org.candlepin.model.Product;
-import org.candlepin.model.ProductCertificate;
 import org.candlepin.model.Owner;
 import org.candlepin.pki.CertificateReader;
 import org.candlepin.service.ProductServiceAdapter;
+import org.candlepin.service.model.CertificateInfo;
 import org.candlepin.test.DatabaseTestFixture;
 import org.candlepin.test.TestUtil;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Module;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import javax.inject.Inject;
+
+
 
 /**
  * DefaultProductServiceAdapterTest
@@ -43,16 +46,16 @@ public class ProductCertCreationTest extends DatabaseTestFixture {
 
     @Test
     public void hasCert() {
-        ProductCertificate cert = createDummyCert();
+        CertificateInfo cert = createDummyCert();
 
-        Assert.assertTrue(cert.getCert().length() > 0);
+        assertTrue(cert.getCertificate().length() > 0);
     }
 
     @Test
     public void hasKey() {
-        ProductCertificate cert = createDummyCert();
+        CertificateInfo cert = createDummyCert();
 
-        Assert.assertTrue(cert.getKey().length() > 0);
+        assertTrue(cert.getKey().length() > 0);
     }
 
     @Test
@@ -60,8 +63,10 @@ public class ProductCertCreationTest extends DatabaseTestFixture {
         Owner owner = TestUtil.createOwner("Example-Corporation");
         Product product = this.createProduct("50", "Test Product", "Standard", "1", "x86_64", "Base");
 
-        ProductCertificate cert = this.createCert(owner, product);
-        Assert.assertEquals(product, cert.getProduct());
+        CertificateInfo cert = this.createCert(owner, product);
+        assertNotNull(cert);
+        assertNotNull(cert.getKey());
+        assertNotNull(cert.getCertificate());
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -72,18 +77,23 @@ public class ProductCertCreationTest extends DatabaseTestFixture {
         createCert(owner, product);
     }
 
-    private ProductCertificate createDummyCert() {
+    private CertificateInfo createDummyCert() {
         Owner owner = TestUtil.createOwner("Example-Corporation");
         Product product = this.createProduct("50", "Test Product", "Standard", "1", "x86_64", "Base");
         return createCert(owner, product);
     }
 
-    private ProductCertificate createCert(Owner owner, Product product) {
+    private CertificateInfo createCert(Owner owner, Product product) {
+        owner.setId(null);
+        product.setUuid(null);
+
         this.ownerCurator.create(owner);
         this.productCurator.create(product);
         this.ownerProductCurator.mapProductToOwner(product, owner);
 
-        return this.productAdapter.getProductCertificate(owner, product.getId());
+        CertificateInfo out = this.productAdapter.getProductCertificate(owner.getKey(), product.getId());
+
+        return out;
     }
 
     private Product createProduct(String productId, String name, String variant, String version, String arch,

--- a/server/src/test/java/org/candlepin/service/impl/stub/StubEntitlementCertServiceAdapter.java
+++ b/server/src/test/java/org/candlepin/service/impl/stub/StubEntitlementCertServiceAdapter.java
@@ -23,7 +23,7 @@ import org.candlepin.model.EntitlementCertificateCurator;
 import org.candlepin.model.Pool;
 import org.candlepin.model.PoolQuantity;
 import org.candlepin.model.Product;
-import org.candlepin.service.BaseEntitlementCertServiceAdapter;
+import org.candlepin.service.impl.BaseEntitlementCertServiceAdapter;
 
 import com.google.inject.Inject;
 

--- a/server/src/test/java/org/candlepin/sync/EntitlementImporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/EntitlementImporterTest.java
@@ -95,6 +95,8 @@ public class EntitlementImporterTest {
     @Before
     public void init() {
         this.owner = new Owner();
+        this.owner.setId("test-owner-id");
+
         this.translator = new StandardTranslator(mockConsumerTypeCurator,
             mockEnvironmentCurator,
             ownerCurator);
@@ -140,8 +142,7 @@ public class EntitlementImporterTest {
         derivedProvidedProducts.add(new Product(derivedProvided1));
 
         Pool pool = TestUtil.createPool(
-            owner, parentProduct, new HashSet<>(), derivedProduct, new HashSet<>(), 3
-        );
+            owner, parentProduct, new HashSet<>(), derivedProduct, new HashSet<>(), 3);
 
         pool.setProvidedProducts(providedProducts);
         pool.setDerivedProvidedProducts(derivedProvidedProducts);
@@ -197,11 +198,11 @@ public class EntitlementImporterTest {
         for (Product p : products) {
             productsById.put(p.getId(), this.translator.translate(p, ProductDTO.class));
         }
+
         return productsById;
     }
 
-    protected EntitlementCertificate createEntitlementCertificate(String key,
-        String cert) {
+    protected EntitlementCertificate createEntitlementCertificate(String key, String cert) {
         EntitlementCertificate toReturn = new EntitlementCertificate();
         CertificateSerial certSerial = new CertificateSerial(new Date());
         certSerial.setCollected(true);
@@ -210,6 +211,7 @@ public class EntitlementImporterTest {
         toReturn.setKeyAsBytes(key.getBytes());
         toReturn.setCertAsBytes(cert.getBytes());
         toReturn.setSerial(certSerial);
+
         return toReturn;
     }
 }

--- a/server/src/test/java/org/candlepin/sync/ExporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/ExporterTest.java
@@ -89,6 +89,10 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
 
+// TODO: FIXME: Rewrite this test to not be so reliant upon mocks. It's making things incredibly brittle and
+// wasting dev time tracking down non-issues when a mock silently fails because the implementation changes.
+
+
 /**
  * ExporterTest
  */
@@ -238,7 +242,7 @@ public class ExporterTest {
         when(pki.getSHA256WithRSAHash(any(InputStream.class))).thenReturn("signature".getBytes());
         when(rc.getRules()).thenReturn(mrules);
         when(consumer.getEntitlements()).thenReturn(entitlements);
-        when(psa.getProductCertificate(any(Owner.class), any(String.class))).thenReturn(pcert);
+        when(psa.getProductCertificate(any(String.class), any(String.class))).thenReturn(pcert);
         when(pprov.get()).thenReturn(principal);
         when(principal.getUsername()).thenReturn("testUser");
         idcert.setSerial(new CertificateSerial(10L, new Date()));
@@ -262,6 +266,9 @@ public class ExporterTest {
         when(emptyIteratorMock.iterator()).thenReturn(Arrays.asList().iterator());
         when(cdnc.listAll()).thenReturn(emptyIteratorMock);
         when(ctc.listAll()).thenReturn(emptyIteratorMock);
+
+        when(consumer.getOwnerId()).thenReturn(owner.getId());
+        when(oc.findOwnerById(eq(owner.getId()))).thenReturn(owner);
 
         // FINALLY test this badboy
         Exporter e = new Exporter(ctc, oc, me, ce, cte, re, ece, ecsa, pe, psa,

--- a/server/src/test/java/org/candlepin/sync/ProductImporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/ProductImporterTest.java
@@ -108,7 +108,7 @@ public class ProductImporterTest {
         ContentDTO c = created.getProductContent().iterator().next().getContent();
 
         // Metadata expiry should be overridden to 0 on import:
-        assertEquals(new Long(1), c.getMetadataExpire());
+        assertEquals(new Long(1), c.getMetadataExpiration());
     }
 
     @Test
@@ -126,7 +126,7 @@ public class ProductImporterTest {
     // Returns the Content object added
     private Content addContentTo(Product product) {
         Content content = TestUtil.createContent("100130", "content_name");
-        content.setMetadataExpire(1000L);
+        content.setMetadataExpiration(1000L);
 
         product.addContent(content, true);
 
@@ -137,7 +137,7 @@ public class ProductImporterTest {
     private Content addNoVendorContentTo(Product product) {
         Content content = TestUtil.createContent("100130", "name");
         content.setVendor("");
-        content.setMetadataExpire(1000L);
+        content.setMetadataExpiration(1000L);
 
         product.addContent(content, true);
 

--- a/server/src/test/java/org/candlepin/test/DatabaseTestFixture.java
+++ b/server/src/test/java/org/candlepin/test/DatabaseTestFixture.java
@@ -23,6 +23,7 @@ import org.candlepin.auth.Principal;
 import org.candlepin.auth.UserPrincipal;
 import org.candlepin.auth.permissions.OwnerPermission;
 import org.candlepin.auth.permissions.Permission;
+import org.candlepin.auth.permissions.PermissionFactory;
 import org.candlepin.auth.permissions.PermissionFactory.PermissionType;
 import org.candlepin.common.config.Configuration;
 import org.candlepin.config.CandlepinCommonTestConfig;
@@ -155,6 +156,8 @@ public class DatabaseTestFixture {
     @Inject protected PoolCurator poolCurator;
     @Inject protected RoleCurator roleCurator;
     @Inject protected UserCurator userCurator;
+
+    @Inject protected PermissionFactory permissionFactory;
 
     @Inject protected ResourceLocatorMap locatorMap;
     @Inject protected ModelTranslator modelTranslator;
@@ -523,6 +526,8 @@ public class DatabaseTestFixture {
 
     protected Owner createOwner(String key, String name) {
         Owner owner = TestUtil.createOwner(key, name);
+        owner.setId(null);
+
         this.ownerCurator.create(owner);
 
         return owner;

--- a/server/src/test/java/org/candlepin/test/TestUtil.java
+++ b/server/src/test/java/org/candlepin/test/TestUtil.java
@@ -86,6 +86,7 @@ public class TestUtil {
 
     public static Owner createOwner(String key, String name) {
         Owner owner = new Owner(key, name);
+        owner.setId(key + "-id");
         return owner;
     }
 
@@ -128,7 +129,7 @@ public class TestUtil {
      * @return Consumer
      */
     public static Consumer createConsumer() {
-        return createConsumer(createConsumerType(), new Owner("Test Owner " + randomInt()));
+        return createConsumer(createConsumerType(), createOwner("Test Owner " + randomInt()));
     }
 
     public static Consumer createDistributor() {
@@ -214,7 +215,7 @@ public class TestUtil {
             content.setRequiredTags(dto.getRequiredTags());
             content.setReleaseVersion(dto.getReleaseVersion());
             content.setGpgUrl(dto.getGpgUrl());
-            content.setMetadataExpire(dto.getMetadataExpiration());
+            content.setMetadataExpiration(dto.getMetadataExpiration());
             content.setModifiedProductIds(dto.getModifiedProductIds());
             content.setArches(dto.getArches());
             content.setLocked(dto.isLocked());
@@ -237,7 +238,7 @@ public class TestUtil {
             content.setRequiredTags(cdata.getRequiredTags());
             content.setReleaseVersion(cdata.getReleaseVersion());
             content.setGpgUrl(cdata.getGpgUrl());
-            content.setMetadataExpire(cdata.getMetadataExpire());
+            content.setMetadataExpiration(cdata.getMetadataExpiration());
             content.setModifiedProductIds(cdata.getModifiedProductIds());
             content.setArches(cdata.getArches());
             content.setLocked(cdata.isLocked());


### PR DESCRIPTION
 Several updates and changes to the service adapters

- Several methods in the service adapters have been changed to
  avoid passing full objects through where an object ID or key
  will suffice
- Added the new model subpackage for the service adapters. The
  new service model interfaces provide an interface any object
  passing through the adapter must implement; allowing a complete
  separation from the API or DTO models for data hitting the
  adapters
- Updated the RoleResource to use DTOs for its input and output
- Codified the expected behavior of role and user update objects
  when presented with subobjects
- Codified the expected behavior of the User.getPermissions
  method
- Renamed all remaining instances of get/setMetadataExpire to
  get/setMetadataExpiration
- Updated the KatelloUserServiceAdapter and DefaultUserServiceAdapter
  in accordance with the UserServiceAdapter changes
- Made various corrections to code which were passing objects into
  the adapters where it now expects string-based keys or IDs
- Refactored the PermissionFactory class to work with the service
  adapter model
- Updated the UserAuth class work with the the service adapter model
- Updated the hosted test infrastructure to use the new service
  model
- Refactored the hosted test subscription adapter and resource to
  keep its own copies of products and content and no longer create
  downstream/local copies instead
- Removed the requirement for a local instance of a product/content
  before updating or linking them from the hosted test resource
- Added the ImportedEntityCompiler which gathers entities from various
  sources and compiles them into single, de-duplicated, validated
  collections for easier importing
- Updated the Entitler and CandlepinPoolManager to use the new
  ImportedEntityCompiler
- Updated several classes to reference the service adapter model
  when interacting with data originating from the adapters
- Refactored the PermissionFactory a bit; it should now be injected
  rather than directly instantiated, and will perform a temporary
  form of entity resolution internally
- User no longer provides permissions directly, nor does it provide
  the getAccessibleOwners utility method, as this required a lot of
  unnecessary churn to function, wasn't widely used and belongs
  elsewhere
- Removed the getId methods from the service model interfaces, as
  external data sources should not be expected to have our internal
  DB IDs for the model objects
- Changed Consumer.getOwner to lazily pull the owner using the
  owner ID field rather than using a transient reference
- Updated all tests in accordance with the changes above
- Fixed several failing tests in accordance with the changes above
- Updated standalone tests to work with the new service model
  and surrounding changes
- Added new translators to convert unknown service model objects
  to API DTOs
- Updated spec tests in accordance with the adapter changes
- Extended the API operations allowed by the hosted test
  endpoints
- Changed how RoleDTO manages its users and permissions
  internally
- Changed how Consumer references owner and owner ID