### PR TITLE
[2.4] 1618391: Manifest import no longer fails when product changes ENT-787

### DIFF
--- a/server/src/main/java/org/candlepin/controller/PoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/PoolManager.java
@@ -146,7 +146,7 @@ public interface PoolManager {
     int revokeAllEntitlements(Consumer consumer);
     int revokeAllEntitlements(Consumer consumer, boolean regenCertsAndStatuses);
 
-    void revokeEntitlements(List<Entitlement> ents);
+    Set<Pool> revokeEntitlements(List<Entitlement> ents);
     void revokeEntitlement(Entitlement entitlement);
 
     Pool updatePoolQuantity(Pool pool, long adjust);

--- a/server/src/main/java/org/candlepin/model/Branding.java
+++ b/server/src/main/java/org/candlepin/model/Branding.java
@@ -66,6 +66,7 @@ public class Branding extends AbstractHibernateObject<Branding> {
     private String type;
 
     public Branding() {
+        // Intentionally left empty
     }
 
     public Branding(String productId, String type, String name) {
@@ -125,6 +126,7 @@ public class Branding extends AbstractHibernateObject<Branding> {
         if (this == anObject) {
             return true;
         }
+
         if (!(anObject instanceof Branding)) {
             return false;
         }
@@ -140,5 +142,11 @@ public class Branding extends AbstractHibernateObject<Branding> {
     public int hashCode() {
         return new HashCodeBuilder(129, 15).append(this.name)
             .append(this.productId).append(this.type).toHashCode();
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Branding [id: %s, name: %s, productId: %s, type: %s]",
+            this.getId(), this.getName(), this.getProductId(), this.getType());
     }
 }

--- a/server/src/main/java/org/candlepin/model/SourceSubscription.java
+++ b/server/src/main/java/org/candlepin/model/SourceSubscription.java
@@ -134,8 +134,8 @@ public class SourceSubscription extends AbstractHibernateObject<SourceSubscripti
 
     @Override
     public String toString() {
-        return String.format("SourceSubscription [subscriptionId: %s, subscriptionSubKey: %s]",
-            this.getSubscriptionId(), this.getSubscriptionSubKey());
+        return String.format("SourceSubscription [id: %s, subscriptionId: %s, subscriptionSubKey: %s]",
+            this.getId(), this.getSubscriptionId(), this.getSubscriptionSubKey());
     }
 
 


### PR DESCRIPTION
Cherry-picked and then resolved conflicts.

* When a product changes in a manfiest resulting in entitlement revocation and subsequent deletion of entitlement derived pools,
  some pools that are deleted subsequently were attempted to being updated. This branch skips those deleted pools
* Some product changes resulted in creating brandings on a product, and when that pool was being locked, created an error since
  Hibernate had not flushed the brandings yet