### PR TITLE
[M] Updated gen-certs for compatibility with Tomcat 8.5+

### DIFF
--- a/server/bin/deploy
+++ b/server/bin/deploy
@@ -80,6 +80,7 @@ update_keystore() {
         if [ ! -L "$CONTAINER_CONF_DIR/keystore" -a "$(readlink $CONTAINER_CONF_DIR/keystore)" != "/etc/candlepin/certs/keystore" ]; then
           warn_msg "Using existing keystore"
         fi
+
         local candlepin_fp="$(fp_pkcs12 "/etc/candlepin/certs/keystore" "tomcat" "password")"
         local tomcat_fp="$(fp_pkcs12 "$CONTAINER_CONF_DIR/keystore" "tomcat" "password")"
         if [ "$candlepin_fp" != "$tomcat_fp" ]; then

--- a/server/bin/gen-certs
+++ b/server/bin/gen-certs
@@ -61,6 +61,10 @@ else
     $SUDO openssl req -new -x509 -days $CA_CERT_DAYS -key $CA_KEY -out $CA_CERT -subj "/CN=$HOSTNAME/C=US/L=Raleigh/"
     $SUDO su -c "echo -n "password" > $KEYSTORE_PASSWORD"
     $SUDO openssl pkcs12 -export -in $CA_CERT -inkey $CA_KEY -out $KEYSTORE -name tomcat -CAfile $CA_CERT -caname root -chain -password file:$KEYSTORE_PASSWORD
+
+    # Tomcat 8.5+ requires the cert be separate from the key when used as both a keystore and a trust store
+    $SUDO keytool -keystore $KEYSTORE -noprompt -importcert -storepass:file $KEYSTORE_PASSWORD -alias candlepin_ca -file $CA_CERT
+
     $SUDO cp $CA_REDHAT_CERT $CA_UPSTREAM_CERT
     $SUDO chmod a+r $KEYSTORE
 fi


### PR DESCRIPTION
- gen-certs will now add an explicit entry for the candlepin_ca
  cert for compatibility with Tomcat 8.5+ when using the same
  file as both a keystore and trust store