### PR TITLE
ENT-113 Replace @JsonIgnoreProperties with ObjectMapper config:

### DIFF
--- a/server/src/main/java/org/candlepin/dto/CandlepinDTO.java
+++ b/server/src/main/java/org/candlepin/dto/CandlepinDTO.java
@@ -15,7 +15,6 @@
 package org.candlepin.dto;
 
 import com.fasterxml.jackson.annotation.JsonFilter;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import java.io.Serializable;
 
@@ -43,7 +42,6 @@ import java.io.Serializable;
  * @param <T>
  *  DTO type extending this class; should be the name of the subclass
  */
-@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonFilter("DTOFilter")
 public abstract class CandlepinDTO<T extends CandlepinDTO> implements Cloneable, Serializable {
     public static final long serialVersionUID = 1L;

--- a/server/src/main/java/org/candlepin/dto/manifest/v1/ConsumerDTO.java
+++ b/server/src/main/java/org/candlepin/dto/manifest/v1/ConsumerDTO.java
@@ -14,7 +14,6 @@
  */
 package org.candlepin.dto.manifest.v1;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.candlepin.dto.CandlepinDTO;
 
 import org.apache.commons.lang.builder.EqualsBuilder;
@@ -24,7 +23,6 @@ import org.apache.commons.lang.builder.HashCodeBuilder;
 /**
  * A DTO representation of the Consumer entity as used by the manifest import/export API.
  */
-@JsonIgnoreProperties(ignoreUnknown = false)
 public class ConsumerDTO extends CandlepinDTO<ConsumerDTO> {
     public static final long serialVersionUID = 1L;
 

--- a/server/src/main/java/org/candlepin/model/AbstractHibernateObject.java
+++ b/server/src/main/java/org/candlepin/model/AbstractHibernateObject.java
@@ -17,7 +17,6 @@ package org.candlepin.model;
 import org.candlepin.model.dto.CandlepinDTO;
 
 import com.fasterxml.jackson.annotation.JsonFilter;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
@@ -41,7 +40,6 @@ import javax.xml.bind.annotation.XmlType;
  */
 @MappedSuperclass
 @XmlType(name = "CandlepinObject")
-@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonFilter("DefaultFilter")
 public abstract class AbstractHibernateObject<T extends AbstractHibernateObject>
     implements Persisted, Serializable, TimestampedEntity<T> {

--- a/server/src/main/java/org/candlepin/model/ImportUpstreamConsumer.java
+++ b/server/src/main/java/org/candlepin/model/ImportUpstreamConsumer.java
@@ -17,7 +17,6 @@ package org.candlepin.model;
 import org.candlepin.common.jackson.HateoasInclude;
 
 import com.fasterxml.jackson.annotation.JsonFilter;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import org.hibernate.annotations.ForeignKey;
 import org.hibernate.annotations.GenericGenerator;
@@ -42,7 +41,6 @@ import javax.xml.bind.annotation.XmlRootElement;
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @Entity
 @Table(name = ImportUpstreamConsumer.DB_TABLE)
-@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonFilter("ApiHateoas")
 public class ImportUpstreamConsumer extends AbstractHibernateObject {
 

--- a/server/src/main/java/org/candlepin/model/dto/CandlepinDTO.java
+++ b/server/src/main/java/org/candlepin/model/dto/CandlepinDTO.java
@@ -17,7 +17,6 @@ package org.candlepin.model.dto;
 import org.candlepin.model.AbstractHibernateObject;
 
 import com.fasterxml.jackson.annotation.JsonFilter;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import java.util.Date;
 import java.io.Serializable;
@@ -27,7 +26,6 @@ import java.io.Serializable;
 /**
  * The CandlepinDTO class provides common properties and functionality common to many DTOs.
  */
-@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonFilter("DefaultFilter")
 public abstract class CandlepinDTO implements Cloneable, Serializable {
     public static final long serialVersionUID = 1L;

--- a/server/src/main/java/org/candlepin/model/dto/Subscription.java
+++ b/server/src/main/java/org/candlepin/model/dto/Subscription.java
@@ -27,7 +27,6 @@ import org.candlepin.model.SubscriptionsCertificate;
 import org.candlepin.service.model.SubscriptionInfo;
 
 import com.fasterxml.jackson.annotation.JsonFilter;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.builder.EqualsBuilder;
@@ -54,7 +53,6 @@ import javax.xml.bind.annotation.XmlTransient;
  */
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonFilter("DefaultFilter")
 public class Subscription extends CandlepinDTO implements Owned, Named, Eventful, SubscriptionInfo {
     private static Logger log = LoggerFactory.getLogger(Subscription.class);

--- a/server/src/main/java/org/candlepin/resteasy/JsonProvider.java
+++ b/server/src/main/java/org/candlepin/resteasy/JsonProvider.java
@@ -14,6 +14,7 @@
  */
 package org.candlepin.resteasy;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import org.candlepin.common.config.Configuration;
 import org.candlepin.common.jackson.DynamicPropertyFilter;
 import org.candlepin.common.jackson.HateoasBeanPropertyFilter;
@@ -77,6 +78,7 @@ public class JsonProvider extends JacksonJsonProvider {
         dateModule.addSerializer(Date.class, new DateSerializer());
         mapper.registerModule(dateModule);
         mapper.registerModule(productCachedModules);
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         configureHateoasObjectMapper(mapper, indentJson);
         setMapper(mapper);
     }

--- a/server/src/test/java/org/candlepin/model/PoolTest.java
+++ b/server/src/test/java/org/candlepin/model/PoolTest.java
@@ -16,6 +16,7 @@ package org.candlepin.model;
 
 import static org.junit.Assert.*;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import org.candlepin.common.jackson.DynamicPropertyFilter;
 import org.candlepin.common.jackson.HateoasBeanPropertyFilter;
 import org.candlepin.controller.CandlepinPoolManager;
@@ -89,6 +90,7 @@ public class PoolTest extends DatabaseTestFixture {
         filterProvider = filterProvider.addFilter("OwnerFilter", new HateoasBeanPropertyFilter());
         filterProvider.setDefaultFilter(new DynamicPropertyFilter());
         this.mapper.setFilters(filterProvider);
+        this.mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
         beginTransaction();
 


### PR DESCRIPTION
- Removed all @JsonIgnoreProperties(ignoreUnknown) annotations from DTOs/models.
- Configured the API json provider's ObjectMapper to not fail during deserialization when unknown properties are encountered.