### PR TITLE
[M] Removed the v1 DTO shims from manifest import and export (ENT-334)

### DIFF
--- a/server/spec/import_warning_spec.rb
+++ b/server/spec/import_warning_spec.rb
@@ -47,6 +47,10 @@ describe 'Import Warning', :serial => true do
     fileText = File.read(entitlement_file)
     entitlement = JSON.parse(fileText)
     entitlement['pool']['endDate'] = (Date.today - 1).strftime
+
+    # Update the entitlement's date for consistency
+    entitlement['endDate'] = entitlement['pool']['endDate']
+
     File.write(entitlement_file, entitlement.to_json)
 
     # create a consumer_export.zip from scratch with the updated file

--- a/server/src/main/java/org/candlepin/audit/EventBuilder.java
+++ b/server/src/main/java/org/candlepin/audit/EventBuilder.java
@@ -86,6 +86,9 @@ public class EventBuilder {
                 event.setTargetName(((Named) entity).getName());
             }
 
+            // TODO: FIXME:
+            // This is entirely useless. Our owner APIs expect the owner key, not the ID, so
+            // providing the ID does very little for event consumers.
             if (entity instanceof Owned) {
                 String ownerId = ((Owned) entity).getOwnerId();
 

--- a/server/src/main/java/org/candlepin/audit/EventFactory.java
+++ b/server/src/main/java/org/candlepin/audit/EventFactory.java
@@ -29,9 +29,9 @@ import org.candlepin.model.Owner;
 import org.candlepin.model.Pool;
 import org.candlepin.model.Rules;
 import org.candlepin.model.activationkeys.ActivationKey;
-import org.candlepin.model.dto.Subscription;
 import org.candlepin.policy.js.compliance.ComplianceReason;
 import org.candlepin.policy.js.compliance.ComplianceStatus;
+import org.candlepin.dto.manifest.v1.SubscriptionDTO;
 import com.fasterxml.jackson.databind.AnnotationIntrospector;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.introspect.AnnotationIntrospectorPair;
@@ -209,7 +209,7 @@ public class EventFactory {
             .buildEvent();
     }
 
-    public Event subscriptionExpired(Subscription subscription) {
+    public Event subscriptionExpired(SubscriptionDTO subscription) {
         return getEventBuilder(Target.SUBSCRIPTION, Type.EXPIRED)
              .setEventData(subscription)
              .buildEvent();

--- a/server/src/main/java/org/candlepin/audit/EventSink.java
+++ b/server/src/main/java/org/candlepin/audit/EventSink.java
@@ -19,7 +19,7 @@ import org.candlepin.model.Owner;
 import org.candlepin.model.Pool;
 import org.candlepin.model.Rules;
 import org.candlepin.model.activationkeys.ActivationKey;
-import org.candlepin.model.dto.Subscription;
+import org.candlepin.dto.manifest.v1.SubscriptionDTO;
 import org.candlepin.policy.js.compliance.ComplianceStatus;
 
 import java.util.List;
@@ -51,7 +51,7 @@ public interface EventSink {
 
     void emitActivationKeyCreated(ActivationKey key);
 
-    void emitSubscriptionExpired(Subscription subscription);
+    void emitSubscriptionExpired(SubscriptionDTO subscription);
 
     void emitRulesModified(Rules oldRules, Rules newRules);
 

--- a/server/src/main/java/org/candlepin/audit/EventSinkImpl.java
+++ b/server/src/main/java/org/candlepin/audit/EventSinkImpl.java
@@ -22,7 +22,7 @@ import org.candlepin.model.Owner;
 import org.candlepin.model.Pool;
 import org.candlepin.model.Rules;
 import org.candlepin.model.activationkeys.ActivationKey;
-import org.candlepin.model.dto.Subscription;
+import org.candlepin.dto.manifest.v1.SubscriptionDTO;
 import org.candlepin.policy.js.compliance.ComplianceStatus;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -253,7 +253,7 @@ public class EventSinkImpl implements EventSink {
         queueEvent(e);
     }
 
-    public void emitSubscriptionExpired(Subscription subscription) {
+    public void emitSubscriptionExpired(SubscriptionDTO subscription) {
         Event e = eventFactory.subscriptionExpired(subscription);
         queueEvent(e);
     }

--- a/server/src/main/java/org/candlepin/audit/NoopEventSinkImpl.java
+++ b/server/src/main/java/org/candlepin/audit/NoopEventSinkImpl.java
@@ -19,7 +19,7 @@ import org.candlepin.model.Owner;
 import org.candlepin.model.Pool;
 import org.candlepin.model.Rules;
 import org.candlepin.model.activationkeys.ActivationKey;
-import org.candlepin.model.dto.Subscription;
+import org.candlepin.dto.manifest.v1.SubscriptionDTO;
 import org.candlepin.policy.js.compliance.ComplianceStatus;
 
 import org.slf4j.Logger;
@@ -93,7 +93,7 @@ public class NoopEventSinkImpl implements EventSink {
     }
 
     @Override
-    public void emitSubscriptionExpired(Subscription subscription) {
+    public void emitSubscriptionExpired(SubscriptionDTO subscription) {
         log.debug("emitSubscriptionExpired:" + subscription);
     }
 

--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -853,7 +853,10 @@ public class CandlepinPoolManager implements PoolManager {
                         CertificateSerialInfo serialInfo = certInfo.getSerial();
                         CertificateSerial serial = new CertificateSerial();
 
-                        serial.setSerial(serialInfo.getSerial());
+                        // Impl note:
+                        // We don't set the ID or serial here, as we generate the ID automagically,
+                        // and the serial is currently implemented as an alias for the ID.
+
                         serial.setRevoked(serialInfo.isRevoked());
                         serial.setCollected(serialInfo.isCollected());
                         serial.setExpiration(serialInfo.getExpiration());
@@ -884,7 +887,10 @@ public class CandlepinPoolManager implements PoolManager {
                 CertificateSerialInfo serialInfo = certInfo.getSerial();
                 CertificateSerial serial = new CertificateSerial();
 
-                serial.setSerial(serialInfo.getSerial());
+                // Impl note:
+                // We don't set the ID or serial here, as we generate the ID automagically, and the
+                // serial is currently implemented as an alias for the ID.
+
                 serial.setRevoked(serialInfo.isRevoked());
                 serial.setCollected(serialInfo.isCollected());
                 serial.setExpiration(serialInfo.getExpiration());

--- a/server/src/main/java/org/candlepin/controller/ImportedEntityCompiler.java
+++ b/server/src/main/java/org/candlepin/controller/ImportedEntityCompiler.java
@@ -157,7 +157,6 @@ public class ImportedEntityCompiler {
                         "discarding previous: {} => {}, {}", product.getId(), existing, product);
                 }
 
-                log.debug("ADDING PRODUCT: {}", product);
                 this.products.put(product.getId(), product);
 
                 // Add any content attached to this product...

--- a/server/src/main/java/org/candlepin/dto/api/v1/PoolDTO.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/PoolDTO.java
@@ -1074,6 +1074,7 @@ public class PoolDTO extends TimestampedCandlepinDTO<PoolDTO> implements Linkabl
         else {
             this.providedProducts = null;
         }
+
         return this;
     }
 

--- a/server/src/main/java/org/candlepin/dto/manifest/v1/BrandingDTO.java
+++ b/server/src/main/java/org/candlepin/dto/manifest/v1/BrandingDTO.java
@@ -14,9 +14,11 @@
  */
 package org.candlepin.dto.manifest.v1;
 
+import org.candlepin.dto.TimestampedCandlepinDTO;
+import org.candlepin.service.model.BrandingInfo;
+
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.candlepin.dto.TimestampedCandlepinDTO;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -28,7 +30,7 @@ import javax.xml.bind.annotation.XmlAccessorType;
  * for the manifest import/export framework.
  */
 @XmlAccessorType(XmlAccessType.PROPERTY)
-public class BrandingDTO extends TimestampedCandlepinDTO<BrandingDTO> {
+public class BrandingDTO extends TimestampedCandlepinDTO<BrandingDTO> implements BrandingInfo {
 
     public static final long serialVersionUID = 1L;
 

--- a/server/src/main/java/org/candlepin/dto/manifest/v1/CdnDTO.java
+++ b/server/src/main/java/org/candlepin/dto/manifest/v1/CdnDTO.java
@@ -14,22 +14,26 @@
  */
 package org.candlepin.dto.manifest.v1;
 
+import org.candlepin.dto.TimestampedCandlepinDTO;
+import org.candlepin.service.model.CdnInfo;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.candlepin.dto.TimestampedCandlepinDTO;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
+
+
 
 /**
  * A DTO representation of the Cdn entity as used by the manifest import/export framework.
  */
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.PROPERTY)
-public class CdnDTO extends TimestampedCandlepinDTO<CdnDTO> {
+public class CdnDTO extends TimestampedCandlepinDTO<CdnDTO> implements CdnInfo {
     public static final long serialVersionUID = 1L;
 
     private String id;

--- a/server/src/main/java/org/candlepin/dto/manifest/v1/CertificateDTO.java
+++ b/server/src/main/java/org/candlepin/dto/manifest/v1/CertificateDTO.java
@@ -17,13 +17,17 @@ package org.candlepin.dto.manifest.v1;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.candlepin.dto.TimestampedCandlepinDTO;
+import org.candlepin.service.model.CertificateInfo;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 
 
 /**
  * The CertificateDTO is a DTO representing most Candlepin certificates
  * as used by the manifest import/export framework.
  */
-public class CertificateDTO extends TimestampedCandlepinDTO<CertificateDTO> {
+public class CertificateDTO extends TimestampedCandlepinDTO<CertificateDTO> implements CertificateInfo {
     public static final long serialVersionUID = 1L;
 
     protected String id;
@@ -67,11 +71,13 @@ public class CertificateDTO extends TimestampedCandlepinDTO<CertificateDTO> {
         return this;
     }
 
-    public String getCert() {
+    @Override
+    @JsonProperty("cert")
+    public String getCertificate() {
         return this.cert;
     }
 
-    public CertificateDTO setCert(String cert) {
+    public CertificateDTO setCertificate(String cert) {
         this.cert = cert;
         return this;
     }
@@ -111,7 +117,7 @@ public class CertificateDTO extends TimestampedCandlepinDTO<CertificateDTO> {
             EqualsBuilder builder = new EqualsBuilder()
                 .append(this.getId(), that.getId())
                 .append(this.getKey(), that.getKey())
-                .append(this.getCert(), that.getCert())
+                .append(this.getCertificate(), that.getCertificate())
                 .append(this.getSerial(), that.getSerial());
 
             return builder.isEquals();
@@ -129,7 +135,7 @@ public class CertificateDTO extends TimestampedCandlepinDTO<CertificateDTO> {
             .append(super.hashCode())
             .append(this.getId())
             .append(this.getKey())
-            .append(this.getCert())
+            .append(this.getCertificate())
             .append(this.getSerial());
 
         return builder.toHashCode();
@@ -157,7 +163,7 @@ public class CertificateDTO extends TimestampedCandlepinDTO<CertificateDTO> {
 
         this.setId(source.getId());
         this.setKey(source.getKey());
-        this.setCert(source.getCert());
+        this.setCertificate(source.getCertificate());
         this.setSerial(source.getSerial());
 
         return this;

--- a/server/src/main/java/org/candlepin/dto/manifest/v1/CertificateSerialDTO.java
+++ b/server/src/main/java/org/candlepin/dto/manifest/v1/CertificateSerialDTO.java
@@ -17,6 +17,7 @@ package org.candlepin.dto.manifest.v1;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.candlepin.dto.TimestampedCandlepinDTO;
+import org.candlepin.service.model.CertificateSerialInfo;
 
 import java.math.BigInteger;
 import java.util.Date;
@@ -25,7 +26,9 @@ import java.util.Date;
 /**
  * A DTO representation of the CertificateSerial entity as used by the manifest import/export framework.
  */
-public class CertificateSerialDTO extends TimestampedCandlepinDTO<CertificateSerialDTO> {
+public class CertificateSerialDTO extends TimestampedCandlepinDTO<CertificateSerialDTO>
+    implements CertificateSerialInfo {
+
     public static final long serialVersionUID = 1L;
 
     protected Long id;

--- a/server/src/main/java/org/candlepin/dto/manifest/v1/CertificateTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/manifest/v1/CertificateTranslator.java
@@ -59,7 +59,7 @@ public class CertificateTranslator extends TimestampedEntityTranslator<Certifica
 
         dest.setId(source.getId());
         dest.setKey(source.getKey());
-        dest.setCert(source.getCert());
+        dest.setCertificate(source.getCert());
 
         if (translator != null) {
             dest.setSerial(translator.translate(source.getSerial(), CertificateSerialDTO.class));

--- a/server/src/main/java/org/candlepin/dto/manifest/v1/ContentDTO.java
+++ b/server/src/main/java/org/candlepin/dto/manifest/v1/ContentDTO.java
@@ -15,7 +15,10 @@
 package org.candlepin.dto.manifest.v1;
 
 import org.candlepin.dto.TimestampedCandlepinDTO;
+import org.candlepin.service.model.ContentInfo;
 import org.candlepin.util.SetView;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
@@ -32,7 +35,7 @@ import javax.xml.bind.annotation.XmlRootElement;
  * DTO representing the content data exposed to the manifest import/export framework.
  */
 @XmlRootElement
-public class ContentDTO extends TimestampedCandlepinDTO<ContentDTO> {
+public class ContentDTO extends TimestampedCandlepinDTO<ContentDTO> implements ContentInfo {
     public static final long serialVersionUID = 1L;
 
     protected String id;
@@ -44,7 +47,7 @@ public class ContentDTO extends TimestampedCandlepinDTO<ContentDTO> {
     protected String requiredTags;
     protected String releaseVer;
     protected String gpgUrl;
-    protected Set<String> modifiedProductIds;
+    protected Set<String> requiredProductIds;
     protected String arches;
     protected Long metadataExpire;
     protected String uuid;
@@ -326,15 +329,11 @@ public class ContentDTO extends TimestampedCandlepinDTO<ContentDTO> {
     }
 
     /**
-     * Retrieves the collection of IDs representing products that are modified by this content. If
-     * the modified product IDs have not yet been defined, this method returns null.
-     *
-     * @return
-     *  the modified product IDs of the content, or null if the modified product IDs have not yet
-     *  been defined
+     * {@inheritDoc}
      */
-    public Collection<String> getModifiedProductIds() {
-        return this.modifiedProductIds != null ? new SetView(this.modifiedProductIds) : null;
+    @Override
+    public Collection<String> getRequiredProductIds() {
+        return this.requiredProductIds != null ? new SetView(this.requiredProductIds) : null;
     }
 
     /**
@@ -347,16 +346,16 @@ public class ContentDTO extends TimestampedCandlepinDTO<ContentDTO> {
      * @return
      *  true if the product ID was added successfully; false otherwise
      */
-    public boolean addModifiedProductId(String productId) {
+    public boolean addRequiredProductId(String productId) {
         if (productId == null) {
             throw new IllegalArgumentException("productId is null");
         }
 
-        if (this.modifiedProductIds == null) {
-            this.modifiedProductIds = new HashSet<String>();
+        if (this.requiredProductIds == null) {
+            this.requiredProductIds = new HashSet<String>();
         }
 
-        return this.modifiedProductIds.add(productId);
+        return this.requiredProductIds.add(productId);
     }
 
     /**
@@ -373,38 +372,39 @@ public class ContentDTO extends TimestampedCandlepinDTO<ContentDTO> {
      * @return
      *  true if the product ID was removed successfully; false otherwise
      */
-    public boolean removeModifiedProductId(String productId) {
+    public boolean removeRequiredProductId(String productId) {
         if (productId == null) {
             throw new IllegalArgumentException("productId is null");
         }
 
-        return this.modifiedProductIds != null ? this.modifiedProductIds.remove(productId) : false;
+        return this.requiredProductIds != null ? this.requiredProductIds.remove(productId) : false;
     }
 
     /**
      * Sets the modified product IDs for the content represented by this DTO. Any previously
      * existing modified product IDs will be cleared before assigning the given product IDs.
      *
-     * @param modifiedProductIds
+     * @param requiredProductIds
      *  A collection of product IDs to be modified by the content content, or null to clear the
      *  existing modified product IDs
      *
      * @return
      *  a reference to this DTO
      */
-    public ContentDTO setModifiedProductIds(Collection<String> modifiedProductIds) {
-        if (modifiedProductIds != null) {
-            if (this.modifiedProductIds == null) {
-                this.modifiedProductIds = new HashSet<String>();
+    @JsonProperty("modifiedProductIds")
+    public ContentDTO setRequiredProductIds(Collection<String> requiredProductIds) {
+        if (requiredProductIds != null) {
+            if (this.requiredProductIds == null) {
+                this.requiredProductIds = new HashSet<String>();
             }
             else {
-                this.modifiedProductIds.clear();
+                this.requiredProductIds.clear();
             }
 
-            this.modifiedProductIds.addAll(modifiedProductIds);
+            this.requiredProductIds.addAll(requiredProductIds);
         }
         else {
-            this.modifiedProductIds = null;
+            this.requiredProductIds = null;
         }
 
         return this;
@@ -489,7 +489,7 @@ public class ContentDTO extends TimestampedCandlepinDTO<ContentDTO> {
                 .append(this.getGpgUrl(), that.getGpgUrl())
                 .append(this.getMetadataExpiration(), that.getMetadataExpiration())
 
-                .append(this.getModifiedProductIds(), that.getModifiedProductIds())
+                .append(this.getRequiredProductIds(), that.getRequiredProductIds())
                 .append(this.getArches(), that.getArches());
 
             return builder.isEquals();
@@ -513,7 +513,7 @@ public class ContentDTO extends TimestampedCandlepinDTO<ContentDTO> {
             .append(this.getReleaseVersion())
             .append(this.getGpgUrl())
             .append(this.getMetadataExpiration())
-            .append(this.getModifiedProductIds())
+            .append(this.getRequiredProductIds())
             .append(this.getArches());
 
         return builder.toHashCode();
@@ -523,7 +523,7 @@ public class ContentDTO extends TimestampedCandlepinDTO<ContentDTO> {
     public ContentDTO clone() {
         ContentDTO copy = super.clone();
 
-        copy.setModifiedProductIds(this.getModifiedProductIds());
+        copy.setRequiredProductIds(this.getRequiredProductIds());
 
         return copy;
     }
@@ -555,7 +555,7 @@ public class ContentDTO extends TimestampedCandlepinDTO<ContentDTO> {
         this.setReleaseVersion(source.getReleaseVersion());
         this.setGpgUrl(source.getGpgUrl());
         this.setMetadataExpiration(source.getMetadataExpiration());
-        this.setModifiedProductIds(source.getModifiedProductIds());
+        this.setRequiredProductIds(source.getRequiredProductIds());
         this.setArches(source.getArches());
 
         return this;

--- a/server/src/main/java/org/candlepin/dto/manifest/v1/ContentTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/manifest/v1/ContentTranslator.java
@@ -68,7 +68,7 @@ public class ContentTranslator extends TimestampedEntityTranslator<Content, Cont
         destination.setRequiredTags(source.getRequiredTags());
         destination.setReleaseVersion(source.getReleaseVersion());
         destination.setGpgUrl(source.getGpgUrl());
-        destination.setModifiedProductIds(source.getModifiedProductIds());
+        destination.setRequiredProductIds(source.getModifiedProductIds());
         destination.setArches(source.getArches());
 
         return destination;

--- a/server/src/main/java/org/candlepin/dto/manifest/v1/EntitlementDTO.java
+++ b/server/src/main/java/org/candlepin/dto/manifest/v1/EntitlementDTO.java
@@ -283,7 +283,7 @@ public class EntitlementDTO extends TimestampedCandlepinDTO<EntitlementDTO> {
         return certificate == null || certificate.getSerial() == null ||
             certificate.getId() == null || certificate.getId().isEmpty() ||
             certificate.getKey() == null || certificate.getKey().isEmpty() ||
-            certificate.getCert() == null || certificate.getCert().isEmpty();
+            certificate.getCertificate() == null || certificate.getCertificate().isEmpty();
     }
 
     /**

--- a/server/src/main/java/org/candlepin/dto/manifest/v1/OwnerDTO.java
+++ b/server/src/main/java/org/candlepin/dto/manifest/v1/OwnerDTO.java
@@ -15,6 +15,8 @@
 package org.candlepin.dto.manifest.v1;
 
 import org.candlepin.common.jackson.HateoasInclude;
+import org.candlepin.dto.TimestampedCandlepinDTO;
+import org.candlepin.service.model.OwnerInfo;
 
 import com.fasterxml.jackson.annotation.JsonFilter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -22,12 +24,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.candlepin.dto.TimestampedCandlepinDTO;
 
 import java.util.Date;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
+
+
 
 /**
  * A DTO representation of the Owner entity as used by the manifest import/export mechanism.
@@ -35,7 +38,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @JsonFilter("OwnerFilter")
-public class OwnerDTO extends TimestampedCandlepinDTO<OwnerDTO> {
+public class OwnerDTO extends TimestampedCandlepinDTO<OwnerDTO> implements OwnerInfo {
     public static final long serialVersionUID = 1L;
 
     protected String id;

--- a/server/src/main/java/org/candlepin/dto/manifest/v1/ProductDTO.java
+++ b/server/src/main/java/org/candlepin/dto/manifest/v1/ProductDTO.java
@@ -18,6 +18,8 @@ import org.candlepin.dto.CandlepinDTO;
 import org.candlepin.dto.TimestampedCandlepinDTO;
 import org.candlepin.jackson.CandlepinAttributeDeserializer;
 import org.candlepin.jackson.CandlepinLegacyAttributeSerializer;
+import org.candlepin.service.model.ProductInfo;
+import org.candlepin.service.model.ProductContentInfo;
 import org.candlepin.util.MapView;
 import org.candlepin.util.SetView;
 import org.candlepin.util.Util;
@@ -46,13 +48,15 @@ import javax.xml.bind.annotation.XmlRootElement;
  * DTO representing the product data exposed to the manifest import/export framework.
  */
 @XmlRootElement
-public class ProductDTO extends TimestampedCandlepinDTO<ProductDTO> {
+public class ProductDTO extends TimestampedCandlepinDTO<ProductDTO> implements ProductInfo {
     public static final long serialVersionUID = 1L;
 
     /**
      * Join object DTO for joining products to content
      */
-    public static class ProductContentDTO extends CandlepinDTO<ProductContentDTO> {
+    public static class ProductContentDTO extends CandlepinDTO<ProductContentDTO>
+        implements ProductContentInfo {
+
         protected final ContentDTO content;
         protected Boolean enabled;
 

--- a/server/src/main/java/org/candlepin/dto/manifest/v1/SubscriptionDTO.java
+++ b/server/src/main/java/org/candlepin/dto/manifest/v1/SubscriptionDTO.java
@@ -1,0 +1,842 @@
+/**
+ * Copyright (c) 2009 - 2017 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.dto.manifest.v1;
+
+import org.candlepin.dto.CandlepinDTO;
+import org.candlepin.model.Eventful;
+import org.candlepin.model.Named;
+import org.candlepin.model.Owned;
+import org.candlepin.service.model.SubscriptionInfo;
+import org.candlepin.util.ListView;
+import org.candlepin.util.Util;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+
+
+/**
+ * A DTO representation of a subscription generated from an entitlement during import.
+ *
+ * <strong>WARNING</strong>: The Eventful, Named and Owned interfaces are only implemented as a
+ * temporary requirement to be compatible with the event framework. Once the event framework has
+ * been updated, these interfaces should be dropped from this object.
+ */
+@XmlRootElement(name = "subscription")
+@XmlAccessorType(XmlAccessType.PROPERTY)
+public class SubscriptionDTO extends CandlepinDTO<SubscriptionDTO> implements SubscriptionInfo,
+    Eventful, Named, Owned {
+
+    public static final long serialVersionUID = 1L;
+
+    private String id;
+    private OwnerDTO owner;
+
+    private ProductDTO product;
+    private List<ProductDTO> providedProducts;
+    private ProductDTO derivedProduct;
+    private List<ProductDTO> derivedProvidedProducts;
+
+    private Long quantity;
+
+    private Date startDate;
+    private Date endDate;
+    private Date lastModifiedDate;
+
+    private String contractNumber;
+    private String accountNumber;
+    private String orderNumber;
+    private String upstreamPoolId;
+    private String upstreamEntitlementId;
+    private String upstreamConsumerId;
+
+    private CdnDTO cdn;
+    private List<BrandingDTO> branding;
+    private CertificateDTO certificate;
+
+
+    /**
+     * Initializes a new SubscriptionDTO instance with null values.
+     */
+    public SubscriptionDTO() {
+        // Intentionally left empty
+    }
+
+    /**
+     * Initializes a new SubscriptionDTO instance which is a shallow copy of the provided
+     * source entity.
+     *
+     * @param source
+     *  The source entity to copy
+     */
+    public SubscriptionDTO(SubscriptionDTO source) {
+        super(source);
+    }
+
+    /**
+     * Provided for compatibility with the Named interface for use with the eventing framework
+     *
+     * @deprecated
+     *  This will be removed upon reworking the event framework
+     *
+     * @return
+     *  The name of the product associated with this subscription
+     */
+    @Override
+    @Deprecated
+    @JsonIgnore
+    public String getName() {
+        return this.getProduct() != null ? this.getProduct().getName() : null;
+    }
+
+    /**
+     * Provided for compatibility with the Owned interface for use with the eventing framework
+     *
+     * @deprecated
+     *  This will be removed upon reworking the event framework
+     *
+     * @return
+     *  The ID of the owner associated with this subscription
+     */
+    @Override
+    @Deprecated
+    @JsonIgnore
+    public String getOwnerId() {
+        return this.getOwner() != null ? this.getOwner().getId() : null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Sets or clears the database ID for this subscription.
+     *
+     * @param id
+     *  The new database ID for this subscription, or null to clear the ID
+     *
+     * @return
+     *  a reference to this SubscriptionDTO
+     */
+    public SubscriptionDTO setId(String id) {
+        this.id = id;
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public OwnerDTO getOwner() {
+        return owner;
+    }
+
+    /**
+     * Sets or clears the owner this subscription.
+     *
+     * @param owner
+     *  The new owner this subscription, or null to clear the owner
+     *
+     * @return
+     *  a reference to this SubscriptionDTO
+     */
+    public SubscriptionDTO setOwner(OwnerDTO owner) {
+        this.owner = owner;
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ProductDTO getProduct() {
+        return this.product;
+    }
+
+    /**
+     * Sets or clears the product of this subscription.
+     *
+     * @param product
+     *  The new product of this subscription, or null to clear the product
+     *
+     * @return
+     *  a reference to this SubscriptionDTO
+     */
+    public SubscriptionDTO setProduct(ProductDTO product) {
+        this.product = product;
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Collection<ProductDTO> getProvidedProducts() {
+        return this.providedProducts != null ? new ListView<>(this.providedProducts) : null;
+    }
+
+    /**
+     * Sets or clears the products provided by this subscription.
+     *
+     * @param products
+     *  A collection of products to set as the provided products of this subscription, or null to
+     *  indicate no change in provided products
+     *
+     * @return
+     *  a reference to this SubscriptionDTO
+     */
+    public SubscriptionDTO setProvidedProducts(Collection<? extends ProductDTO> products) {
+        if (products != null) {
+            if (this.providedProducts == null) {
+                this.providedProducts = new ArrayList(products.size());
+            }
+
+            this.providedProducts.clear();
+
+            for (ProductDTO product : products) {
+                if (product == null || product.getId() == null || product.getId().isEmpty()) {
+                    throw new IllegalArgumentException("products contains a null or incomplete product");
+                }
+
+                this.providedProducts.add(product);
+            }
+        }
+        else {
+            this.providedProducts = null;
+        }
+
+        return this;
+    }
+
+    // TODO: Add other CRUD operations here as need dictates
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ProductDTO getDerivedProduct() {
+        return this.derivedProduct;
+    }
+
+    /**
+     * Sets or clears the product provided by subscriptions derived from this subscription.
+     *
+     * @param product
+     *  The new derived product of this subscription, or null to clear the derived product
+     *
+     * @return
+     *  a reference to this SubscriptionDTO
+     */
+    public SubscriptionDTO setDerivedProduct(ProductDTO product) {
+        this.derivedProduct = product;
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Collection<ProductDTO> getDerivedProvidedProducts() {
+        return this.derivedProvidedProducts != null ? new ListView<>(this.derivedProvidedProducts) : null;
+    }
+
+    /**
+     * Sets or clears the products provided by subscriptions derived from this subscription.
+     *
+     * @param products
+     *  A collection of products to set as the derived provided products of this subscription, or
+     *  null to indicate no change in derived provided products
+     *
+     * @return
+     *  a reference to this SubscriptionDTO
+     */
+    public SubscriptionDTO setDerivedProvidedProducts(Collection<? extends ProductDTO> products) {
+        if (products != null) {
+            if (this.derivedProvidedProducts == null) {
+                this.derivedProvidedProducts = new ArrayList(Math.max(10, products.size()));
+            }
+
+            this.derivedProvidedProducts.clear();
+
+            for (ProductDTO product : products) {
+                if (product == null || product.getId() == null || product.getId().isEmpty()) {
+                    throw new IllegalArgumentException("products contains a null or incomplete product");
+                }
+
+                this.derivedProvidedProducts.add(product);
+            }
+        }
+        else {
+            this.derivedProvidedProducts = null;
+        }
+
+        return this;
+    }
+
+    // TODO: Add other CRUD operations here as need dictates
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Long getQuantity() {
+        return quantity;
+    }
+
+    /**
+     * Sets or clears the provided quantity of this subscription
+     *
+     * @param quantity
+     *  The provided quantity of this subscription, or null to clear the quantity
+     *
+     * @return
+     *  a reference to this SubscriptionDTO
+     */
+    public SubscriptionDTO setQuantity(Long quantity) {
+        this.quantity = quantity;
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Date getStartDate() {
+        return this.startDate;
+    }
+
+    /**
+     * Sets or clears the start date of this subscription
+     *
+     * @param date
+     *  The start date of this subscription, or null to clear the start date
+     *
+     * @return
+     *  a reference to this SubscriptionDTO
+     */
+    public SubscriptionDTO setStartDate(Date date) {
+        this.startDate = date;
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Date getEndDate() {
+        return this.endDate;
+    }
+
+    /**
+     * Sets or clears the end date of this subscription
+     *
+     * @param date
+     *  The end date of this subscription, or null to clear the end date
+     *
+     * @return
+     *  a reference to this SubscriptionDTO
+     */
+    public SubscriptionDTO setEndDate(Date date) {
+        this.endDate = date;
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Date getLastModified() {
+        return this.lastModifiedDate;
+    }
+
+    /**
+     * Sets or clears the last modified date of this subscription
+     *
+     * @param date
+     *  The last modified date of this subscription, or null to clear the last modified date
+     *
+     * @return
+     *  a reference to this SubscriptionDTO
+     */
+    public SubscriptionDTO setLastModified(Date date) {
+        this.lastModifiedDate = date;
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getContractNumber() {
+        return this.contractNumber;
+    }
+
+    /**
+     * Sets or clears the contract number of this subscription
+     *
+     * @param contractNumber
+     *  The contract number of this subscription, or null to clear the contract number
+     *
+     * @return
+     *  a reference to this SubscriptionDTO
+     */
+    public SubscriptionDTO setContractNumber(String contractNumber) {
+        this.contractNumber = contractNumber;
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getAccountNumber() {
+        return this.accountNumber;
+    }
+
+    /**
+     * Sets or clears the account number of this subscription
+     *
+     * @param accountNumber
+     *  The account number of this subscription, or null to clear the account number
+     *
+     * @return
+     *  a reference to this SubscriptionDTO
+     */
+    public SubscriptionDTO setAccountNumber(String accountNumber) {
+        this.accountNumber = accountNumber;
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getOrderNumber() {
+        return this.orderNumber;
+    }
+
+    /**
+     * Sets or clears the order number of this subscription
+     *
+     * @param orderNumber
+     *  The order number of this subscription, or null to clear the order number
+     *
+     * @return
+     *  a reference to this SubscriptionDTO
+     */
+    public SubscriptionDTO setOrderNumber(String orderNumber) {
+        this.orderNumber = orderNumber;
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getUpstreamPoolId() {
+        return this.upstreamPoolId;
+    }
+
+    /**
+     * Sets or clears the upstream pool ID of this subscription
+     *
+     * @param upstreamPoolId
+     *  The upstream pool ID of this subscription, or null to clear the upstream pool ID
+     *
+     * @return
+     *  a reference to this SubscriptionDTO
+     */
+    public SubscriptionDTO setUpstreamPoolId(String upstreamPoolId) {
+        this.upstreamPoolId = upstreamPoolId;
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getUpstreamEntitlementId() {
+        return this.upstreamEntitlementId;
+    }
+
+    /**
+     * Sets or clears the upstream entitlement ID of this subscription
+     *
+     * @param upstreamEntitlementId
+     *  The upstream entitlement ID of this subscription, or null to clear the upstream entitlement ID
+     *
+     * @return
+     *  a reference to this SubscriptionDTO
+     */
+    public SubscriptionDTO setUpstreamEntitlementId(String upstreamEntitlementId) {
+        this.upstreamEntitlementId = upstreamEntitlementId;
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getUpstreamConsumerId() {
+        return this.upstreamConsumerId;
+    }
+
+    /**
+     * Sets or clears the upstream consumer ID of this subscription
+     *
+     * @param upstreamConsumerId
+     *  The upstream consumer ID of this subscription, or null to clear the upstream consumer ID
+     *
+     * @return
+     *  a reference to this SubscriptionDTO
+     */
+    public SubscriptionDTO setUpstreamConsumerId(String upstreamConsumerId) {
+        this.upstreamConsumerId = upstreamConsumerId;
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CdnDTO getCdn() {
+        return this.cdn;
+    }
+
+    /**
+     * Sets or clears the CDN of this subscription
+     *
+     * @param cdn
+     *  The CDN of this subscription, or null to clear the CDN
+     *
+     * @return
+     *  a reference to this SubscriptionDTO
+     */
+    public SubscriptionDTO setCdn(CdnDTO cdn) {
+        this.cdn = cdn;
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Collection<BrandingDTO> getBranding() {
+        return this.branding != null ? new ListView<>(this.branding) : null;
+    }
+
+    /**
+     * Sets or clears the branding information for products provided by subscriptions.
+     *
+     * @param branding
+     *  A collection of branding instances to set as the branding for products provided by this
+     *  subscription, or null to indicate no change in branding
+     *
+     * @return
+     *  a reference to this SubscriptionDTO
+     */
+    public SubscriptionDTO setBranding(Collection<? extends BrandingDTO> branding) {
+        if (branding != null) {
+            if (this.branding == null) {
+                this.branding = new ArrayList(Math.max(10, branding.size()));
+            }
+
+            this.branding.clear();
+
+            for (BrandingDTO bdata : branding) {
+                if (bdata == null || bdata.getProductId() == null || bdata.getProductId().isEmpty()) {
+                    throw new IllegalArgumentException(
+                        "branding contains a null or incomplete branding instance");
+                }
+
+                this.branding.add(bdata);
+            }
+        }
+        else {
+            this.branding = null;
+        }
+
+        return this;
+    }
+
+
+    // TODO: Add other CRUD operations here as need dictates
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CertificateDTO getCertificate() {
+        return this.certificate;
+    }
+
+    /**
+     * Sets or clears the certificate of this subscription
+     *
+     * @param certificate
+     *  The certificate of this subscription, or null to clear the certificate
+     *
+     * @return
+     *  a reference to this SubscriptionDTO
+     */
+    public SubscriptionDTO setCertificate(CertificateDTO certificate) {
+        this.certificate = certificate;
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        ProductDTO product = this.getProduct();
+
+        String pid = product != null ? product.getId() : null;
+        String pname = product != null ? product.getName() : null;
+
+        return String.format("SubscriptionDTO [id: %s, product id: %s, product name: %s, quantity: %s]",
+            this.getId(), pid, pname, this.getQuantity());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        }
+
+        if (obj instanceof SubscriptionDTO) {
+            SubscriptionDTO that = (SubscriptionDTO) obj;
+
+            // We are not interested in making sure nested objects are equal; we're only
+            // concerned with the reference to such an object.
+            String thisOwnerId = this.getOwner() != null ? this.getOwner().getId() : null;
+            String thatOwnerId = that.getOwner() != null ? that.getOwner().getId() : null;
+
+            String thisProductId = this.getProduct() != null ? this.getProduct().getId() : null;
+            String thatProductId = that.getProduct() != null ? that.getProduct().getId() : null;
+
+            String thisDerivedProductId =
+                this.getDerivedProduct() != null ? this.getDerivedProduct().getId() : null;
+            String thatDerivedProductId =
+                that.getDerivedProduct() != null ? that.getDerivedProduct().getId() : null;
+
+            String thisCdnId = this.getCdn() != null ? this.getCdn().getId() : null;
+            String thatCdnId = that.getCdn() != null ? that.getCdn().getId() : null;
+
+            String thisCertificateId =
+                this.getCertificate() != null ? this.getCertificate().getId() : null;
+            String thatCertificateId =
+                that.getCertificate() != null ? that.getCertificate().getId() : null;
+
+            EqualsBuilder builder = new EqualsBuilder()
+                .append(this.getId(), that.getId())
+                .append(thisOwnerId, thatOwnerId)
+                .append(thisProductId, thatProductId)
+                .append(thisDerivedProductId, thatDerivedProductId)
+                .append(this.getQuantity(), that.getQuantity())
+                .append(this.getStartDate(), that.getStartDate())
+                .append(this.getEndDate(), that.getEndDate())
+                .append(this.getLastModified(), that.getLastModified())
+                .append(this.getContractNumber(), that.getContractNumber())
+                .append(this.getAccountNumber(), that.getAccountNumber())
+                .append(this.getOrderNumber(), that.getOrderNumber())
+                .append(this.getUpstreamPoolId(), that.getUpstreamPoolId())
+                .append(this.getUpstreamEntitlementId(), that.getUpstreamEntitlementId())
+                .append(this.getUpstreamConsumerId(), that.getUpstreamConsumerId())
+                .append(thisCdnId, thatCdnId)
+                .append(thisCertificateId, thatCertificateId);
+
+            boolean equals = builder.isEquals();
+
+            equals = equals &&
+                Util.collectionsAreEqual(this.getProvidedProducts(), that.getProvidedProducts(),
+                    (lhs, rhs) -> (lhs == rhs || (lhs != null && rhs != null &&
+                        lhs.getId() != null && lhs.getId().equals(rhs.getId()))) ? 0 : 1);
+
+            equals = equals &&
+                Util.collectionsAreEqual(this.getDerivedProvidedProducts(), that.getDerivedProvidedProducts(),
+                    (lhs, rhs) -> (lhs == rhs || (lhs != null && rhs != null &&
+                        lhs.getId() != null && lhs.getId().equals(rhs.getId()))) ? 0 : 1);
+
+            equals = equals &&
+                Util.collectionsAreEqual(this.getBranding(), that.getBranding(),
+                    (lhs, rhs) -> (lhs == rhs || (lhs != null && rhs != null &&
+                        lhs.getId() != null && lhs.getId().equals(rhs.getId()))) ? 0 : 1);
+
+            return equals;
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        // Like with the equals method, we are not interested in hashing nested objects; we're only
+        // concerned with the reference to such an object.
+        String thisOwnerId = this.getOwner() != null ? this.getOwner().getId() : null;
+        String thisProductId = this.getProduct() != null ? this.getProduct().getId() : null;
+        String thisDerivedProductId =
+            this.getDerivedProduct() != null ? this.getDerivedProduct().getId() : null;
+
+        String thisCdnId = this.getCdn() != null ? this.getCdn().getId() : null;
+        String thisCertificateId = this.getCertificate() != null ? this.getCertificate().getId() : null;
+
+        int ppAccumulator = 0;
+        int dppAccumulator = 0;
+        int bAccumulator = 0;
+
+        Collection<ProductDTO> products = this.getProvidedProducts();
+        if (products != null) {
+            for (ProductDTO product : products) {
+                ppAccumulator = ppAccumulator * 17 +
+                    (product != null && product.getId() != null ? product.getId().hashCode() : 0);
+            }
+        }
+
+        products = this.getDerivedProvidedProducts();
+        if (products != null) {
+            for (ProductDTO product : products) {
+                dppAccumulator = dppAccumulator * 17 +
+                    (product != null && product.getId() != null ? product.getId().hashCode() : 0);
+            }
+        }
+
+        Collection<BrandingDTO> branding = this.getBranding();
+        if (branding != null) {
+            for (BrandingDTO bdata : branding) {
+                bAccumulator = bAccumulator * 17 +
+                    (bdata != null && bdata.getId() != null ? bdata.getId().hashCode() : 0);
+            }
+        }
+
+        HashCodeBuilder builder = new HashCodeBuilder(37, 7)
+            .append(this.getId())
+            .append(thisOwnerId)
+            .append(thisProductId)
+            .append(thisDerivedProductId)
+            .append(this.getQuantity())
+            .append(this.getStartDate())
+            .append(this.getEndDate())
+            .append(this.getLastModified())
+            .append(this.getContractNumber())
+            .append(this.getAccountNumber())
+            .append(this.getOrderNumber())
+            .append(this.getUpstreamPoolId())
+            .append(this.getUpstreamEntitlementId())
+            .append(this.getUpstreamConsumerId())
+            .append(thisCdnId)
+            .append(thisCertificateId)
+            .append(ppAccumulator)
+            .append(dppAccumulator)
+            .append(bAccumulator);
+
+        return builder.toHashCode();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SubscriptionDTO clone() {
+        SubscriptionDTO copy = super.clone();
+
+        OwnerDTO owner = this.getOwner();
+        copy.setOwner(owner != null ? owner.clone() : null);
+
+        ProductDTO product = this.getProduct();
+        copy.setProduct(product != null ? product.clone() : null);
+
+        ProductDTO derivedProduct = this.getDerivedProduct();
+        copy.setDerivedProduct(derivedProduct != null ? derivedProduct.clone() : null);
+
+        copy.setProvidedProducts(this.getProvidedProducts());
+        copy.setDerivedProvidedProducts(this.getDerivedProvidedProducts());
+
+        Date endDate = this.getEndDate();
+        copy.setEndDate(endDate != null ? (Date) endDate.clone() : null);
+
+        Date startDate = this.getStartDate();
+        copy.setStartDate(startDate != null ? (Date) startDate.clone() : null);
+
+        Date lastModified = this.getLastModified();
+        copy.setLastModified(lastModified != null ? (Date) lastModified.clone() : null);
+
+        CdnDTO cdn = this.getCdn();
+        copy.setCdn(cdn != null ? cdn.clone() : null);
+
+        CertificateDTO certificate = this.getCertificate();
+        copy.setCertificate(certificate != null ? certificate.clone() : null);
+
+        copy.setBranding(this.getBranding());
+
+        return copy;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SubscriptionDTO populate(SubscriptionDTO source) {
+        super.populate(source);
+
+        this.setId(source.getId());
+        this.setOwner(source.getOwner());
+
+        this.setProduct(source.getProduct());
+        this.setProvidedProducts(source.getProvidedProducts());
+        this.setDerivedProduct(source.getDerivedProduct());
+        this.setDerivedProvidedProducts(source.getDerivedProvidedProducts());
+
+        this.setQuantity(source.getQuantity());
+
+        this.setStartDate(source.getStartDate());
+        this.setEndDate(source.getEndDate());
+        this.setLastModified(source.getLastModified());
+
+        this.setContractNumber(source.getContractNumber());
+        this.setAccountNumber(source.getAccountNumber());
+        this.setOrderNumber(source.getOrderNumber());
+        this.setUpstreamPoolId(source.getUpstreamPoolId());
+        this.setUpstreamEntitlementId(source.getUpstreamEntitlementId());
+        this.setUpstreamConsumerId(source.getUpstreamConsumerId());
+
+        this.setCdn(source.getCdn());
+        this.setBranding(source.getBranding());
+        this.setCertificate(source.getCertificate());
+
+        return this;
+    }
+}

--- a/server/src/main/java/org/candlepin/dto/shim/ContentDTOTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/shim/ContentDTOTranslator.java
@@ -82,7 +82,7 @@ public class ContentDTOTranslator implements ObjectTranslator<ContentDTO, Conten
         dest.setGpgUrl(source.getGpgUrl());
         dest.setMetadataExpiration(source.getMetadataExpiration());
         dest.setArches(source.getArches());
-        dest.setModifiedProductIds(source.getModifiedProductIds());
+        dest.setModifiedProductIds(source.getRequiredProductIds());
 
         // We manually set this to false since it is not included in the exported data.
         dest.setLocked(false);

--- a/server/src/main/java/org/candlepin/service/impl/ImportSubscriptionServiceAdapter.java
+++ b/server/src/main/java/org/candlepin/service/impl/ImportSubscriptionServiceAdapter.java
@@ -16,11 +16,10 @@
 package org.candlepin.service.impl;
 
 import org.candlepin.common.exceptions.ServiceUnavailableException;
-import org.candlepin.model.dto.Subscription;
+import org.candlepin.dto.manifest.v1.ProductDTO;
+import org.candlepin.dto.manifest.v1.SubscriptionDTO;
 import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.service.model.ConsumerInfo;
-import org.candlepin.service.model.ProductInfo;
-import org.candlepin.service.model.SubscriptionInfo;
 
 import org.xnap.commons.i18n.I18n;
 
@@ -40,33 +39,33 @@ import java.util.Map;
  */
 public class ImportSubscriptionServiceAdapter implements SubscriptionServiceAdapter {
 
-    private List<Subscription> subscriptions;
-    private Map<String, Subscription> subsBySubId = new HashMap<>();
+    private List<SubscriptionDTO> subscriptions;
+    private Map<String, SubscriptionDTO> subsBySubId = new HashMap<>();
     @Inject private I18n i18n;
 
     public ImportSubscriptionServiceAdapter() {
         this(new LinkedList<>());
     }
 
-    public ImportSubscriptionServiceAdapter(List<Subscription> subs) {
+    public ImportSubscriptionServiceAdapter(List<SubscriptionDTO> subs) {
         this.subscriptions = subs;
-        for (Subscription sub : this.subscriptions) {
+        for (SubscriptionDTO sub : this.subscriptions) {
             subsBySubId.put(sub.getId(), sub);
         }
     }
 
     @Override
-    public Collection<? extends SubscriptionInfo> getSubscriptions() {
+    public Collection<SubscriptionDTO> getSubscriptions() {
         return subscriptions;
     }
 
     @Override
-    public SubscriptionInfo getSubscription(String subscriptionId) {
+    public SubscriptionDTO getSubscription(String subscriptionId) {
         return this.subsBySubId.get(subscriptionId);
     }
 
     @Override
-    public Collection<? extends SubscriptionInfo> getSubscriptions(String ownerKey) {
+    public Collection<? extends SubscriptionDTO> getSubscriptions(String ownerKey) {
         return subscriptions;
     }
 
@@ -76,17 +75,17 @@ public class ImportSubscriptionServiceAdapter implements SubscriptionServiceAdap
     }
 
     @Override
-    public Collection<? extends SubscriptionInfo> getSubscriptionsByProductId(String productId) {
-        List<SubscriptionInfo> subs = new LinkedList<>();
+    public Collection<? extends SubscriptionDTO> getSubscriptionsByProductId(String productId) {
+        List<SubscriptionDTO> subs = new LinkedList<>();
 
         if (productId != null) {
-            for (SubscriptionInfo sub : this.subscriptions) {
+            for (SubscriptionDTO sub : this.subscriptions) {
                 if (productId.equals(sub.getProduct().getId())) {
                     subs.add(sub);
                     continue;
                 }
 
-                for (ProductInfo p : sub.getProvidedProducts()) {
+                for (ProductDTO p : sub.getProvidedProducts()) {
                     if (productId.equals(p.getId())) {
                         subs.add(sub);
                         break;

--- a/server/src/main/java/org/candlepin/sync/EntitlementImporter.java
+++ b/server/src/main/java/org/candlepin/sync/EntitlementImporter.java
@@ -14,31 +14,21 @@
  */
 package org.candlepin.sync;
 
-import org.candlepin.common.exceptions.BadRequestException;
-import org.candlepin.common.exceptions.NotFoundException;
 import org.candlepin.dto.ModelTranslator;
-import org.candlepin.dto.manifest.v1.BrandingDTO;
+import org.candlepin.dto.manifest.v1.CdnDTO;
 import org.candlepin.dto.manifest.v1.CertificateDTO;
 import org.candlepin.dto.manifest.v1.EntitlementDTO;
 import org.candlepin.dto.manifest.v1.OwnerDTO;
 import org.candlepin.dto.manifest.v1.PoolDTO;
+import org.candlepin.dto.manifest.v1.PoolDTO.ProvidedProductDTO;
 import org.candlepin.dto.manifest.v1.ProductDTO;
-import org.candlepin.model.Branding;
+import org.candlepin.dto.manifest.v1.SubscriptionDTO;
 import org.candlepin.model.Cdn;
 import org.candlepin.model.CdnCurator;
-import org.candlepin.model.CertificateSerial;
 import org.candlepin.model.CertificateSerialCurator;
-import org.candlepin.model.Entitlement;
-import org.candlepin.model.EntitlementCertificate;
 import org.candlepin.model.EntitlementCurator;
 import org.candlepin.model.Owner;
-import org.candlepin.model.Pool;
 import org.candlepin.model.ProductCurator;
-import org.candlepin.model.ProvidedProduct;
-import org.candlepin.model.SourceStack;
-import org.candlepin.model.SubscriptionsCertificate;
-import org.candlepin.model.dto.ProductData;
-import org.candlepin.model.dto.Subscription;
 import org.candlepin.util.Util;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -50,10 +40,12 @@ import org.xnap.commons.i18n.I18n;
 
 import java.io.IOException;
 import java.io.Reader;
-import java.util.Collections;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+
+
 
 /**
  * EntitlementImporter - turn an upstream Entitlement into a local subscription
@@ -79,15 +71,13 @@ public class EntitlementImporter {
         this.translator = translator;
     }
 
-    public Subscription importObject(ObjectMapper mapper, Reader reader, Owner owner,
+    public SubscriptionDTO importObject(ObjectMapper mapper, Reader reader, Owner owner,
         Map<String, ProductDTO> productsById, String consumerUuid, Meta meta)
         throws IOException, SyncDataFormatException {
 
-        EntitlementDTO entitlementDTO = mapper.readValue(reader, EntitlementDTO.class);
-        Entitlement entitlement = new Entitlement();
-        populateEntity(entitlement, entitlementDTO);
+        EntitlementDTO entitlement = mapper.readValue(reader, EntitlementDTO.class);
 
-        Subscription subscription = new Subscription();
+        SubscriptionDTO subscription = new SubscriptionDTO();
 
         log.debug("Building subscription for owner: {}", owner);
         log.debug("Using pool from entitlement: {}", entitlement.getPool());
@@ -102,7 +92,7 @@ public class EntitlementImporter {
         subscription.setUpstreamEntitlementId(entitlement.getId());
         subscription.setUpstreamConsumerId(consumerUuid);
 
-        subscription.setOwner(owner);
+        subscription.setOwner(this.translator.translate(owner, OwnerDTO.class));
 
         subscription.setStartDate(entitlement.getStartDate());
         subscription.setEndDate(entitlement.getEndDate());
@@ -113,414 +103,35 @@ public class EntitlementImporter {
 
         subscription.setQuantity(entitlement.getQuantity().longValue());
 
-        for (Branding b : entitlement.getPool().getBranding()) {
-            subscription.getBranding().add(new Branding(b.getProductId(), b.getType(), b.getName()));
-        }
+        subscription.setBranding(entitlement.getPool().getBranding());
 
+        // This is a bit of an odd duck. We shouldn't be checking this here, but instead at the point
+        // where we actually import it for use.
         String cdnLabel = meta.getCdnLabel();
         if (!StringUtils.isBlank(cdnLabel)) {
             Cdn cdn = cdnCurator.getByLabel(cdnLabel);
             if (cdn != null) {
-                subscription.setCdn(cdn);
+                subscription.setCdn(this.translator.translate(cdn, CdnDTO.class));
             }
         }
 
-        ProductDTO productDTO = this.findProduct(productsById, entitlement.getPool().getProductId());
-        subscription.setProduct(this.translator.translate(productDTO, ProductData.class));
+        this.associateProducts(productsById, entitlement.getPool(), subscription);
 
-        // Add any sub product data to the subscription.
-        if (entitlement.getPool().getDerivedProductId() != null) {
-            productDTO = this.findProduct(productsById, entitlement.getPool().getDerivedProductId());
-            subscription.setDerivedProduct(this.translator.translate(productDTO, ProductData.class));
+        Collection<CertificateDTO> certs = entitlement.getCertificates();
+        if (certs != null && !certs.isEmpty()) {
+            if (certs.size() > 1) {
+                log.error("More than one entitlement certificate found for subscription; using first: {}",
+                    subscription);
+            }
+
+            subscription.setCertificate(certs.iterator().next());
         }
-
-        associateProvidedProducts(productsById, entitlement, subscription);
-
-        Set<EntitlementCertificate> certs = entitlement.getCertificates();
-
-        // subscriptions have one cert
-        int entcnt = 0;
-        for (EntitlementCertificate cert : certs) {
-            ++entcnt;
-
-            CertificateSerial cs = new CertificateSerial();
-            cs.setCollected(cert.getSerial().isCollected());
-            cs.setExpiration(cert.getSerial().getExpiration());
-            cs.setUpdated(cert.getSerial().getUpdated());
-            cs.setCreated(cert.getSerial().getCreated());
-
-            SubscriptionsCertificate sc = new SubscriptionsCertificate();
-            sc.setKey(cert.getKey());
-            sc.setCertAsBytes(cert.getCertAsBytes());
-            sc.setSerial(cs);
-
-            subscription.setCertificate(sc);
-        }
-
-        if (entcnt > 1) {
-            log.error("More than one entitlement cert found for subscription");
+        else {
+            log.error("No entitlement certificate found for subscription: {}", subscription);
         }
 
         return subscription;
     }
-
-
-    /**
-     * Populates the specified entity with data from the provided DTO.
-     *
-     * @param entity
-     *  The entity instance to populate
-     *
-     * @param dto
-     *  The DTO containing the data with which to populate the entity
-     *
-     * @throws IllegalArgumentException
-     *  if either entity or dto are null
-     */
-    @SuppressWarnings("checkstyle:methodlength")
-    private void populateEntity(Entitlement entity, EntitlementDTO dto) {
-        if (entity == null) {
-            throw new IllegalArgumentException("the entitlement model entity is null");
-        }
-
-        if (dto == null) {
-            throw new IllegalArgumentException("the entitlement dto is null");
-        }
-
-        if (dto.getId() != null) {
-            entity.setId(dto.getId());
-        }
-
-        if (dto.getQuantity() != null) {
-            entity.setQuantity(dto.getQuantity());
-        }
-
-        if (dto.getUpdated() != null) {
-            entity.setUpdated(dto.getUpdated());
-        }
-
-        if (dto.getCreated() != null) {
-            entity.setCreated(dto.getCreated());
-        }
-
-        if (dto.getStartDate() != null) {
-            entity.setStartDate(dto.getStartDate());
-        }
-
-        if (dto.getEndDate() != null) {
-            entity.setEndDate(dto.getEndDate());
-        }
-
-        if (dto.getPool() != null) {
-            PoolDTO poolDTO = dto.getPool();
-            Pool poolEntity = new Pool();
-
-            if (poolDTO.getId() != null) {
-                poolEntity.setId(poolDTO.getId());
-            }
-
-            if (poolDTO.getQuantity() != null) {
-                poolEntity.setQuantity(poolDTO.getQuantity());
-            }
-
-            if (poolDTO.isActiveSubscription() != null) {
-                poolEntity.setActiveSubscription(poolDTO.isActiveSubscription());
-            }
-
-            if (poolDTO.getRestrictedToUsername() != null) {
-                poolEntity.setRestrictedToUsername(poolDTO.getRestrictedToUsername());
-            }
-
-            if (poolDTO.getConsumed() != null) {
-                poolEntity.setConsumed(poolDTO.getConsumed());
-            }
-
-            if (poolDTO.getExported() != null) {
-                poolEntity.setExported(poolDTO.getExported());
-            }
-
-            if (poolDTO.getStackId() != null && poolDTO.getSourceStackId() != null) {
-                SourceStack sourceStack = new SourceStack();
-                sourceStack.setId(poolDTO.getStackId());
-                sourceStack.setSourceStackId(poolDTO.getSourceStackId());
-                poolEntity.setSourceStack(sourceStack);
-            }
-
-            if (poolDTO.getProductId() != null) {
-                poolEntity.setProductId(poolDTO.getProductId());
-            }
-
-            if (poolDTO.getDerivedProductId() != null) {
-                poolEntity.setDerivedProductId(poolDTO.getDerivedProductId());
-            }
-
-            if (poolDTO.getStartDate() != null) {
-                poolEntity.setStartDate(poolDTO.getStartDate());
-            }
-
-            if (poolDTO.getEndDate() != null) {
-                poolEntity.setEndDate(poolDTO.getEndDate());
-            }
-
-            if (poolDTO.getCreated() != null) {
-                poolEntity.setCreated(poolDTO.getCreated());
-            }
-
-            if (poolDTO.getUpdated() != null) {
-                poolEntity.setUpdated(poolDTO.getUpdated());
-            }
-
-            if (poolDTO.getAccountNumber() != null) {
-                poolEntity.setAccountNumber(poolDTO.getAccountNumber());
-            }
-
-            if (poolDTO.getOrderNumber() != null) {
-                poolEntity.setOrderNumber(poolDTO.getOrderNumber());
-            }
-
-            if (poolDTO.getContractNumber() != null) {
-                poolEntity.setContractNumber(poolDTO.getContractNumber());
-            }
-
-            if (poolDTO.getOwner() != null) {
-                Owner ownerEntity = new Owner();
-                populateEntity(ownerEntity, poolDTO.getOwner());
-
-                poolEntity.setOwner(ownerEntity);
-            }
-
-            if (poolDTO.getUpstreamPoolId() != null) {
-                poolEntity.setUpstreamPoolId(poolDTO.getUpstreamPoolId());
-            }
-
-            if (poolDTO.getUpstreamConsumerId() != null) {
-                poolEntity.setUpstreamConsumerId(poolDTO.getUpstreamConsumerId());
-            }
-
-            if (poolDTO.getUpstreamEntitlementId() != null) {
-                poolEntity.setUpstreamEntitlementId(poolDTO.getUpstreamEntitlementId());
-            }
-
-            if (poolDTO.getSourceEntitlement() != null) {
-                EntitlementDTO sourceEntitlementDTO = poolDTO.getSourceEntitlement();
-                poolEntity.setSourceEntitlement(findEntitlement(sourceEntitlementDTO.getId()));
-            }
-
-            if (poolDTO.getSubscriptionSubKey() != null) {
-                poolEntity.setSubscriptionSubKey(poolDTO.getSubscriptionSubKey());
-            }
-
-            if (poolDTO.getSubscriptionId() != null) {
-                poolEntity.setSubscriptionId(poolDTO.getSubscriptionId());
-            }
-
-            if (poolDTO.getAttributes() != null) {
-                if (poolDTO.getAttributes().isEmpty()) {
-                    poolEntity.setAttributes(Collections.emptyMap());
-                }
-                else {
-                    poolEntity.setAttributes(poolDTO.getAttributes());
-                }
-            }
-
-            if (poolDTO.getCalculatedAttributes() != null) {
-                if (poolDTO.getCalculatedAttributes().isEmpty()) {
-                    poolEntity.setCalculatedAttributes(Collections.emptyMap());
-                }
-                else {
-                    poolEntity.setCalculatedAttributes(poolDTO.getCalculatedAttributes());
-                }
-            }
-
-            if (poolDTO.getProductAttributes() != null) {
-                if (poolDTO.getProductAttributes().isEmpty()) {
-                    poolEntity.setProductAttributes(Collections.emptyMap());
-                }
-                else {
-                    poolEntity.setProductAttributes(poolDTO.getProductAttributes());
-                }
-            }
-
-            if (poolDTO.getDerivedProductAttributes() != null) {
-                if (poolDTO.getDerivedProductAttributes().isEmpty()) {
-                    poolEntity.setDerivedProductAttributes(Collections.emptyMap());
-                }
-                else {
-                    poolEntity.setDerivedProductAttributes(poolDTO.getDerivedProductAttributes());
-                }
-            }
-
-            if (poolDTO.getBranding() != null) {
-                if (poolDTO.getBranding().isEmpty()) {
-                    poolEntity.setBranding(Collections.emptySet());
-                }
-                else {
-                    Set<Branding> branding = new HashSet<>();
-                    for (BrandingDTO brandingDTO : poolDTO.getBranding()) {
-                        if (brandingDTO != null) {
-                            Branding brandingEntity = new Branding(
-                                brandingDTO.getProductId(),
-                                brandingDTO.getType(),
-                                brandingDTO.getName());
-                            brandingEntity.setId(brandingDTO.getId());
-                            brandingEntity.setCreated(brandingDTO.getCreated());
-                            brandingEntity.setUpdated(brandingDTO.getUpdated());
-                            branding.add(brandingEntity);
-                        }
-                    }
-                    poolEntity.setBranding(branding);
-                }
-            }
-
-            if (poolDTO.getProvidedProducts() != null) {
-                if (poolDTO.getProvidedProducts().isEmpty()) {
-                    poolEntity.setProvidedProductDtos(Collections.emptySet());
-                }
-                else {
-                    Set<ProvidedProduct> providedProducts = new HashSet<>();
-                    for (PoolDTO.ProvidedProductDTO ppDTO : poolDTO.getProvidedProducts()) {
-                        if (ppDTO != null) {
-                            ProvidedProduct providedProduct = new ProvidedProduct();
-                            providedProduct.setProductId(ppDTO.getProductId());
-                            providedProduct.setProductName(ppDTO.getProductName());
-                            providedProducts.add(providedProduct);
-                        }
-                    }
-                    poolEntity.setProvidedProductDtos(providedProducts);
-                }
-            }
-
-            if (poolDTO.getDerivedProvidedProducts() != null) {
-                if (poolDTO.getDerivedProvidedProducts().isEmpty()) {
-                    poolEntity.setDerivedProvidedProductDtos(Collections.emptySet());
-                }
-                else {
-                    Set<ProvidedProduct> derivedProvidedProducts = new HashSet<>();
-                    for (PoolDTO.ProvidedProductDTO dppDTO : poolDTO.getDerivedProvidedProducts()) {
-                        if (dppDTO != null) {
-                            ProvidedProduct derivedProvidedProduct = new ProvidedProduct();
-                            derivedProvidedProduct.setProductId(dppDTO.getProductId());
-                            derivedProvidedProduct.setProductName(dppDTO.getProductName());
-                            derivedProvidedProducts.add(derivedProvidedProduct);
-                        }
-                    }
-                    poolEntity.setDerivedProvidedProductDtos(derivedProvidedProducts);
-                }
-            }
-
-            entity.setPool(poolEntity);
-        }
-
-        if (dto.getCertificates() != null) {
-            if (dto.getCertificates().isEmpty()) {
-                entity.setCertificates(Collections.emptySet());
-            }
-            else {
-                Set<EntitlementCertificate> entityCerts = new HashSet<>();
-                for (CertificateDTO dtoCert : dto.getCertificates()) {
-                    if (dtoCert != null) {
-                        EntitlementCertificate entityCert = new EntitlementCertificate();
-                        ImporterUtils.populateEntity(entityCert, dtoCert);
-                        entityCert.setId(dtoCert.getId());
-                        entityCerts.add(entityCert);
-                    }
-                }
-                entity.setCertificates(entityCerts);
-            }
-        }
-    }
-
-
-    /**
-     * Populates the specified entity with data from the provided DTO.
-     * This method does not set the upstreamConsumer field.
-     *
-     * @param entity
-     *  The entity instance to populate
-     *
-     * @param dto
-     *  The DTO containing the data with which to populate the entity
-     *
-     * @throws IllegalArgumentException
-     *  if either entity or dto are null
-     */
-    protected void populateEntity(Owner entity, OwnerDTO dto) {
-        if (entity == null) {
-            throw new IllegalArgumentException("the owner model entity is null");
-        }
-
-        if (dto == null) {
-            throw new IllegalArgumentException("the owner dto is null");
-        }
-
-        if (dto.getId() != null) {
-            entity.setId(dto.getId());
-        }
-
-        if (dto.getDisplayName() != null) {
-            entity.setDisplayName(dto.getDisplayName());
-        }
-
-        if (dto.getKey() != null) {
-            entity.setKey(dto.getKey());
-        }
-
-        if (dto.getLastRefreshed() != null) {
-            entity.setLastRefreshed(dto.getLastRefreshed());
-        }
-
-        if (dto.getContentAccessMode() != null) {
-            entity.setContentAccessMode(dto.getContentAccessMode());
-        }
-
-        if (dto.getContentAccessModeList() != null) {
-            entity.setContentAccessModeList(dto.getContentAccessModeList());
-        }
-
-        if (dto.getCreated() != null) {
-            entity.setCreated(dto.getCreated());
-        }
-
-        if (dto.getUpdated() != null) {
-            entity.setUpdated(dto.getUpdated());
-        }
-
-        if (dto.getParentOwner() != null) {
-            OwnerDTO pdto = dto.getParentOwner();
-            Owner parent = new Owner();
-
-            if (pdto.getId() != null) {
-                parent.setId(pdto.getId());
-            }
-
-            if (pdto.getDisplayName() != null) {
-                parent.setDisplayName(pdto.getDisplayName());
-            }
-
-            if (pdto.getKey() != null) {
-                parent.setKey(pdto.getKey());
-            }
-
-            entity.setParentOwner(parent);
-        }
-
-        if (dto.getContentPrefix() != null) {
-            entity.setContentPrefix(dto.getContentPrefix());
-        }
-
-        if (dto.getDefaultServiceLevel() != null) {
-            entity.setDefaultServiceLevel(dto.getDefaultServiceLevel());
-        }
-
-        if (dto.getLogLevel() != null) {
-            entity.setLogLevel(dto.getLogLevel());
-        }
-
-        if (dto.isAutobindDisabled() != null) {
-            entity.setAutobindDisabled(dto.isAutobindDisabled());
-        }
-    }
-
 
     /*
      * Transfer associations to provided and derived provided products over to the
@@ -538,29 +149,46 @@ public class EntitlementImporter {
      * collections on pool which keeps the API/manifest JSON identical to what it was
      * before. On import we load into these transient collections, and here we transfer
      * to the actual persisted location.
+     *
+     * @param productsById
+     *  A mapping of product IDs to product DTOs being present in the imported manifest
+     *
+     * @param upstreamPoolDTO
+     *  A PoolDTO instance representing the upstream pool containing the collections of provided
+     *  products and derived provided product references to set on the subscription
+     *
+     * @param subscription
+     *  The SubscriptionDTO instance to update
      */
-    public void associateProvidedProducts(Map<String, ProductDTO> productsById, Entitlement entitlement,
-        Subscription subscription)
-        throws SyncDataFormatException {
+    public void associateProducts(Map<String, ProductDTO> productsById, PoolDTO upstreamPoolDTO,
+        SubscriptionDTO subscription) throws SyncDataFormatException {
 
-        // Associate main provided products:
-        Set<ProductData> providedProducts = new HashSet<>();
-        entitlement.getPool().populateAllTransientProvidedProducts(productCurator);
-        for (ProvidedProduct providedProduct : entitlement.getPool().getProvidedProductDtos()) {
-            ProductDTO productDTO = this.findProduct(productsById, providedProduct.getProductId());
-            providedProducts.add(this.translator.translate(productDTO, ProductData.class));
+        // Product
+        ProductDTO productDTO = this.findProduct(productsById, upstreamPoolDTO.getProductId());
+        subscription.setProduct(productDTO);
+
+        // Provided products
+        Set<ProductDTO> providedProducts = new HashSet<>();
+        for (ProvidedProductDTO pp : upstreamPoolDTO.getProvidedProducts()) {
+            productDTO = this.findProduct(productsById, pp.getProductId());
+            providedProducts.add(productDTO);
         }
         subscription.setProvidedProducts(providedProducts);
+        log.debug("Subscription has {} provided products.", providedProducts.size());
 
-        // Associate derived provided products:
-        Set<ProductData> derivedProvidedProducts = new HashSet<>();
-        for (ProvidedProduct pp : entitlement.getPool().getDerivedProvidedProductDtos()) {
-            ProductDTO productDTO = this.findProduct(productsById, pp.getProductId());
-            derivedProvidedProducts.add(this.translator.translate(productDTO, ProductData.class));
+        // Derived product
+        if (upstreamPoolDTO.getDerivedProductId() != null) {
+            productDTO = this.findProduct(productsById, upstreamPoolDTO.getDerivedProductId());
+            subscription.setDerivedProduct(productDTO);
+        }
+
+        // Derived provided products
+        Set<ProductDTO> derivedProvidedProducts = new HashSet<>();
+        for (ProvidedProductDTO pp : upstreamPoolDTO.getDerivedProvidedProducts()) {
+            productDTO = this.findProduct(productsById, pp.getProductId());
+            derivedProvidedProducts.add(productDTO);
         }
         subscription.setDerivedProvidedProducts(derivedProvidedProducts);
-
-        log.debug("Subscription has {} provided products.", derivedProvidedProducts.size());
         log.debug("Subscription has {} derived provided products.", derivedProvidedProducts.size());
     }
 
@@ -573,36 +201,5 @@ public class EntitlementImporter {
         }
 
         return product;
-    }
-
-    /**
-     * Returns the entitlement object that is identified by the given id, if it is found in the system.
-     * Otherwise, it throws a NotFoundException.
-     *
-     * @param entitlementId the id of the entitlement we are searching for.
-     *
-     * @return the entitlement that was found in the system based on the given id.
-     *
-     * @throws NotFoundException
-     *  if the entitlement with the given id was not found in the system.
-     *
-     * @throws BadRequestException
-     *  if the given Entitlement id is null or empty.
-     */
-    private Entitlement findEntitlement(String entitlementId) {
-        Entitlement entitlement = null;
-        if (entitlementId != null && !entitlementId.isEmpty()) {
-            entitlement = entitlementCurator.get(entitlementId);
-        }
-        else {
-            throw new BadRequestException(i18n.tr("Entitlement id is null or empty."));
-        }
-
-        if (entitlement == null) {
-            throw new NotFoundException(
-                    i18n.tr("Entitlement with id {0} could not be found.", entitlementId));
-        }
-
-        return entitlement;
     }
 }

--- a/server/src/main/java/org/candlepin/sync/ImporterUtils.java
+++ b/server/src/main/java/org/candlepin/sync/ImporterUtils.java
@@ -54,7 +54,7 @@ class ImporterUtils {
         }
 
         entity.setKey(dto.getKey());
-        entity.setCert(dto.getCert());
+        entity.setCert(dto.getCertificate());
         entity.setUpdated(dto.getUpdated());
         entity.setCreated(dto.getCreated());
 

--- a/server/src/test/java/org/candlepin/controller/PoolManagerFunctionalTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerFunctionalTest.java
@@ -24,6 +24,10 @@ import org.candlepin.audit.Event;
 import org.candlepin.audit.EventSink;
 import org.candlepin.common.paging.Page;
 import org.candlepin.common.paging.PageRequest;
+import org.candlepin.dto.manifest.v1.BrandingDTO;
+import org.candlepin.dto.manifest.v1.OwnerDTO;
+import org.candlepin.dto.manifest.v1.ProductDTO;
+import org.candlepin.dto.manifest.v1.SubscriptionDTO;
 import org.candlepin.model.Branding;
 import org.candlepin.model.CertificateSerial;
 import org.candlepin.model.Consumer;
@@ -38,7 +42,6 @@ import org.candlepin.model.Pool;
 import org.candlepin.model.PoolFilterBuilder;
 import org.candlepin.model.Product;
 import org.candlepin.model.activationkeys.ActivationKey;
-import org.candlepin.model.dto.Subscription;
 import org.candlepin.policy.EntitlementRefusedException;
 import org.candlepin.policy.js.entitlement.Enforcer;
 import org.candlepin.policy.js.entitlement.EntitlementRules;
@@ -93,7 +96,7 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
     private Product provisioning;
     private Product socketLimitedProduct;
 
-    private Subscription sub4;
+    private SubscriptionDTO sub4;
 
     private ConsumerType systemType;
 
@@ -139,39 +142,56 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
         productCurator.create(monitoring);
         productCurator.create(provisioning);
 
-        List<Subscription> subscriptions = new LinkedList<>();
-
+        List<SubscriptionDTO> subscriptions = new LinkedList<>();
         ImportSubscriptionServiceAdapter subAdapter = new ImportSubscriptionServiceAdapter(subscriptions);
 
-        Subscription sub1 = TestUtil.createSubscription(o, virtHost, new HashSet<>());
+        SubscriptionDTO sub1 = new SubscriptionDTO();
         sub1.setId(Util.generateDbUUID());
+        sub1.setOwner(this.modelTranslator.translate(o, OwnerDTO.class));
+        sub1.setProduct(this.modelTranslator.translate(virtHost, ProductDTO.class));
         sub1.setQuantity(5L);
         sub1.setStartDate(new Date());
         sub1.setEndDate(TestUtil.createDate(3020, 12, 12));
-        sub1.setModified(new Date());
+        sub1.setLastModified(new Date());
 
-        Subscription sub2 = TestUtil.createSubscription(o, virtHostPlatform, new HashSet<>());
+        SubscriptionDTO sub2 = new SubscriptionDTO();
         sub2.setId(Util.generateDbUUID());
+        sub2.setOwner(this.modelTranslator.translate(o, OwnerDTO.class));
+        sub2.setProduct(this.modelTranslator.translate(virtHostPlatform, ProductDTO.class));
         sub2.setQuantity(5L);
         sub2.setStartDate(new Date());
         sub2.setEndDate(TestUtil.createDate(3020, 12, 12));
-        sub2.setModified(new Date());
+        sub2.setLastModified(new Date());
 
-        Subscription sub3 = TestUtil.createSubscription(o, monitoring, new HashSet<>());
+        SubscriptionDTO sub3 = new SubscriptionDTO();
         sub3.setId(Util.generateDbUUID());
+        sub3.setOwner(this.modelTranslator.translate(o, OwnerDTO.class));
+        sub3.setProduct(this.modelTranslator.translate(monitoring, ProductDTO.class));
         sub3.setQuantity(5L);
         sub3.setStartDate(new Date());
         sub3.setEndDate(TestUtil.createDate(3020, 12, 12));
-        sub3.setModified(new Date());
+        sub3.setLastModified(new Date());
 
-        sub4 = TestUtil.createSubscription(o, provisioning, new HashSet<>());
+        sub4 = new SubscriptionDTO();
         sub4.setId(Util.generateDbUUID());
+        sub4.setOwner(this.modelTranslator.translate(o, OwnerDTO.class));
+        sub4.setProduct(this.modelTranslator.translate(provisioning, ProductDTO.class));
         sub4.setQuantity(5L);
         sub4.setStartDate(new Date());
         sub4.setEndDate(TestUtil.createDate(3020, 12, 12));
-        sub4.setModified(new Date());
-        sub4.getBranding().add(new Branding("product1", "type1", "branding1"));
-        sub4.getBranding().add(new Branding("product2", "type2", "branding2"));
+        sub4.setLastModified(new Date());
+
+        BrandingDTO brand1 = new BrandingDTO();
+        brand1.setName("branding1");
+        brand1.setType("type1");
+        brand1.setProductId("product1");
+
+        BrandingDTO brand2 = new BrandingDTO();
+        brand2.setName("branding2");
+        brand2.setType("type2");
+        brand2.setProductId("product2");
+
+        sub4.setBranding(Arrays.asList(brand1, brand2));
 
         subscriptions.add(sub1);
         subscriptions.add(sub2);
@@ -336,14 +356,16 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
         productCurator.create(modifier);
         this.ownerContentCurator.mapContentToOwner(content, this.o);
 
-        List<Subscription> subscriptions = new LinkedList<>();
+        List<SubscriptionDTO> subscriptions = new LinkedList<>();
         ImportSubscriptionServiceAdapter subAdapter = new ImportSubscriptionServiceAdapter(subscriptions);
 
-        Subscription sub = TestUtil.createSubscription(o, modifier, new HashSet<>());
+        SubscriptionDTO sub = new SubscriptionDTO();
         sub.setQuantity(5L);
+        sub.setOwner(this.modelTranslator.translate(o, OwnerDTO.class));
+        sub.setProduct(this.modelTranslator.translate(modifier, ProductDTO.class));
         sub.setStartDate(new Date());
         sub.setEndDate(TestUtil.createDate(3020, 12, 12));
-        sub.setModified(new Date());
+        sub.setLastModified(new Date());
 
         sub.setId(Util.generateDbUUID());
 
@@ -384,16 +406,17 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
         productCurator.create(product1);
         productCurator.create(product2);
 
-        List<Subscription> subscriptions = new LinkedList<>();
-        ImportSubscriptionServiceAdapter subAdapter
-            = new ImportSubscriptionServiceAdapter(subscriptions);
+        List<SubscriptionDTO> subscriptions = new LinkedList<>();
+        ImportSubscriptionServiceAdapter subAdapter = new ImportSubscriptionServiceAdapter(subscriptions);
 
-        Subscription subscription = TestUtil.createSubscription(o, product1, new HashSet<>());
+        SubscriptionDTO subscription = new SubscriptionDTO();
         subscription.setId(Util.generateDbUUID());
+        subscription.setOwner(this.modelTranslator.translate(o, OwnerDTO.class));
+        subscription.setProduct(this.modelTranslator.translate(product1, ProductDTO.class));
         subscription.setQuantity(5L);
         subscription.setStartDate(new Date());
         subscription.setEndDate(TestUtil.createDate(3020, 12, 12));
-        subscription.setModified(new Date());
+        subscription.setLastModified(new Date());
 
         subscriptions.add(subscription);
 
@@ -404,7 +427,7 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
         assertEquals(1, pools.size());
 
         // now alter the product behind the sub, and make sure the pool is also updated
-        subscription.setProduct(product2.toDTO());
+        subscription.setProduct(this.modelTranslator.translate(product2, ProductDTO.class));
 
         // set up initial pool
         poolManager.getRefresher(subAdapter, ownerAdapter).add(o).run();

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/CertificateDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/CertificateDTOTest.java
@@ -40,7 +40,7 @@ public class CertificateDTOTest extends AbstractDTOTest<CertificateDTO> {
         this.values = new HashMap<>();
         this.values.put("Id", "test-id");
         this.values.put("Key", "test-key");
-        this.values.put("Cert", "test-cert");
+        this.values.put("Certificate", "test-cert");
         this.values.put("Serial", serial);
         this.values.put("Created", new Date());
         this.values.put("Updated", new Date());

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/CertificateTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/CertificateTranslatorTest.java
@@ -79,7 +79,7 @@ public class CertificateTranslatorTest extends
         if (source != null) {
             assertEquals(source.getId(), dest.getId());
             assertEquals(source.getKey(), dest.getKey());
-            assertEquals(source.getCert(), dest.getCert());
+            assertEquals(source.getCert(), dest.getCertificate());
             assertEquals(source.getUpdated(), dest.getUpdated());
             assertEquals(source.getCreated(), dest.getCreated());
 

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/ContentDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/ContentDTOTest.java
@@ -50,7 +50,7 @@ public class ContentDTOTest extends AbstractDTOTest<ContentDTO> {
         this.values.put("RequiredTags", "test_value");
         this.values.put("ReleaseVersion", "test_value");
         this.values.put("GpgUrl", "test_value");
-        this.values.put("ModifiedProductIds", Arrays.asList("1", "2", "3"));
+        this.values.put("RequiredProductIds", Arrays.asList("1", "2", "3"));
         this.values.put("Arches", "test_value");
         this.values.put("Created", new Date());
         this.values.put("Updated", new Date());
@@ -74,60 +74,60 @@ public class ContentDTOTest extends AbstractDTOTest<ContentDTO> {
     }
 
     @Test
-    public void testAddModifiedProducts() {
+    public void testAddRequiredProducts() {
         ContentDTO dto = new ContentDTO();
-        dto.setModifiedProductIds(Arrays.asList("1", "2"));
-        assertEquals(new HashSet<>(Arrays.asList("1", "2")), dto.getModifiedProductIds());
+        dto.setRequiredProductIds(Arrays.asList("1", "2"));
+        assertEquals(new HashSet<>(Arrays.asList("1", "2")), dto.getRequiredProductIds());
 
-        dto.addModifiedProductId("3");
-        assertEquals(new HashSet<>(Arrays.asList("1", "2", "3")), dto.getModifiedProductIds());
+        dto.addRequiredProductId("3");
+        assertEquals(new HashSet<>(Arrays.asList("1", "2", "3")), dto.getRequiredProductIds());
     }
 
     @Test
-    public void testAddModifiedProductsNoChange() {
+    public void testAddRequiredProductsNoChange() {
         ContentDTO dto = new ContentDTO();
-        dto.setModifiedProductIds(Arrays.asList("1", "2"));
-        assertEquals(new HashSet<>(Arrays.asList("1", "2")), dto.getModifiedProductIds());
+        dto.setRequiredProductIds(Arrays.asList("1", "2"));
+        assertEquals(new HashSet<>(Arrays.asList("1", "2")), dto.getRequiredProductIds());
 
-        dto.addModifiedProductId("2");
-        assertEquals(new HashSet<>(Arrays.asList("1", "2")), dto.getModifiedProductIds());
+        dto.addRequiredProductId("2");
+        assertEquals(new HashSet<>(Arrays.asList("1", "2")), dto.getRequiredProductIds());
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testAddModifiedProductsWithNullValue() {
+    public void testAddRequiredProductsWithNullValue() {
         ContentDTO dto = new ContentDTO();
-        dto.setModifiedProductIds(Arrays.asList("1", "2"));
-        assertEquals(new HashSet<>(Arrays.asList("1", "2")), dto.getModifiedProductIds());
+        dto.setRequiredProductIds(Arrays.asList("1", "2"));
+        assertEquals(new HashSet<>(Arrays.asList("1", "2")), dto.getRequiredProductIds());
 
-        dto.addModifiedProductId(null);
+        dto.addRequiredProductId(null);
     }
 
     @Test
-    public void testRemoveModifiedProducts() {
+    public void testRemoveRequiredProducts() {
         ContentDTO dto = new ContentDTO();
-        dto.setModifiedProductIds(Arrays.asList("1", "2"));
-        assertEquals(new HashSet<>(Arrays.asList("1", "2")), dto.getModifiedProductIds());
+        dto.setRequiredProductIds(Arrays.asList("1", "2"));
+        assertEquals(new HashSet<>(Arrays.asList("1", "2")), dto.getRequiredProductIds());
 
-        dto.removeModifiedProductId("3");
-        assertEquals(new HashSet<>(Arrays.asList("1", "2")), dto.getModifiedProductIds());
+        dto.removeRequiredProductId("3");
+        assertEquals(new HashSet<>(Arrays.asList("1", "2")), dto.getRequiredProductIds());
     }
 
     @Test
-    public void testRemoveModifiedProductsNoChange() {
+    public void testRemoveRequiredProductsNoChange() {
         ContentDTO dto = new ContentDTO();
-        dto.setModifiedProductIds(Arrays.asList("1", "2"));
-        assertEquals(new HashSet<>(Arrays.asList("1", "2")), dto.getModifiedProductIds());
+        dto.setRequiredProductIds(Arrays.asList("1", "2"));
+        assertEquals(new HashSet<>(Arrays.asList("1", "2")), dto.getRequiredProductIds());
 
-        dto.removeModifiedProductId("3");
-        assertEquals(new HashSet<>(Arrays.asList("1", "2")), dto.getModifiedProductIds());
+        dto.removeRequiredProductId("3");
+        assertEquals(new HashSet<>(Arrays.asList("1", "2")), dto.getRequiredProductIds());
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testRemoveModifiedProductsWithNullValue() {
+    public void testRemoveRequiredProductsWithNullValue() {
         ContentDTO dto = new ContentDTO();
-        dto.setModifiedProductIds(Arrays.asList("1", "2"));
-        assertEquals(new HashSet<>(Arrays.asList("1", "2")), dto.getModifiedProductIds());
+        dto.setRequiredProductIds(Arrays.asList("1", "2"));
+        assertEquals(new HashSet<>(Arrays.asList("1", "2")), dto.getRequiredProductIds());
 
-        dto.removeModifiedProductId(null);
+        dto.removeRequiredProductId(null);
     }
 }

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/ContentTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/ContentTranslatorTest.java
@@ -91,7 +91,7 @@ public class ContentTranslatorTest extends
             assertEquals(source.getRequiredTags(), dto.getRequiredTags());
             assertEquals(source.getReleaseVersion(), dto.getReleaseVersion());
             assertEquals(source.getGpgUrl(), dto.getGpgUrl());
-            assertEquals(source.getModifiedProductIds(), dto.getModifiedProductIds());
+            assertEquals(source.getModifiedProductIds(), dto.getRequiredProductIds());
             assertEquals(source.getArches(), dto.getArches());
         }
         else {

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/EntitlementDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/EntitlementDTOTest.java
@@ -66,7 +66,7 @@ public class EntitlementDTOTest  extends AbstractDTOTest<EntitlementDTO> {
         CertificateDTO certificate = new CertificateDTO();
         certificate.setId("cert-id");
         certificate.setKey("cert-key");
-        certificate.setCert("cert");
+        certificate.setCertificate("cert");
         certificate.setSerial(new CertificateSerialDTO());
         certs.add(certificate);
 
@@ -107,7 +107,7 @@ public class EntitlementDTOTest  extends AbstractDTOTest<EntitlementDTO> {
         CertificateDTO certDTO = new CertificateDTO();
         certDTO.setId("cert-id-1");
         certDTO.setKey("cert-key-1");
-        certDTO.setCert("cert-cert-1");
+        certDTO.setCertificate("cert-cert-1");
         certDTO.setSerial(new CertificateSerialDTO());
         assertTrue(dto.addCertificate(certDTO));
     }
@@ -119,14 +119,14 @@ public class EntitlementDTOTest  extends AbstractDTOTest<EntitlementDTO> {
         CertificateDTO certDTO = new CertificateDTO();
         certDTO.setId("cert-id-2");
         certDTO.setKey("cert-key-2");
-        certDTO.setCert("cert-cert-2");
+        certDTO.setCertificate("cert-cert-2");
         certDTO.setSerial(new CertificateSerialDTO());
         assertTrue(dto.addCertificate(certDTO));
 
         CertificateDTO certDTO2 = new CertificateDTO();
         certDTO2.setId("cert-id-2");
         certDTO2.setKey("cert-key-2");
-        certDTO2.setCert("cert-cert-2");
+        certDTO2.setCertificate("cert-cert-2");
         certDTO2.setSerial(new CertificateSerialDTO());
         assertFalse(dto.addCertificate(certDTO2));
     }
@@ -144,7 +144,7 @@ public class EntitlementDTOTest  extends AbstractDTOTest<EntitlementDTO> {
         CertificateDTO certDTO = new CertificateDTO();
         certDTO.setId("");
         certDTO.setKey("cert-key-3");
-        certDTO.setCert("cert-cert-3");
+        certDTO.setCertificate("cert-cert-3");
         certDTO.setSerial(new CertificateSerialDTO());
         dto.addCertificate(certDTO);
     }
@@ -156,7 +156,7 @@ public class EntitlementDTOTest  extends AbstractDTOTest<EntitlementDTO> {
         CertificateDTO certDTO = new CertificateDTO();
         certDTO.setId("cert-id-4");
         certDTO.setKey("");
-        certDTO.setCert("cert-cert-4");
+        certDTO.setCertificate("cert-cert-4");
         certDTO.setSerial(new CertificateSerialDTO());
         dto.addCertificate(certDTO);
     }
@@ -168,7 +168,7 @@ public class EntitlementDTOTest  extends AbstractDTOTest<EntitlementDTO> {
         CertificateDTO certDTO = new CertificateDTO();
         certDTO.setId("cert-id-5");
         certDTO.setKey("cert-key-5");
-        certDTO.setCert("");
+        certDTO.setCertificate("");
         certDTO.setSerial(new CertificateSerialDTO());
         dto.addCertificate(certDTO);
     }
@@ -180,7 +180,7 @@ public class EntitlementDTOTest  extends AbstractDTOTest<EntitlementDTO> {
         CertificateDTO certDTO = new CertificateDTO();
         certDTO.setId("cert-id-6");
         certDTO.setKey("cert-key-6");
-        certDTO.setCert("cert-cert-6");
+        certDTO.setCertificate("cert-cert-6");
         certDTO.setSerial(null);
         dto.addCertificate(certDTO);
     }

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/PoolDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/PoolDTOTest.java
@@ -65,7 +65,7 @@ public class PoolDTOTest extends AbstractDTOTest<PoolDTO> {
         CertificateDTO cert = new CertificateDTO();
         cert.setId("cert-id");
         cert.setKey("cert-key");
-        cert.setCert("cert-cert");
+        cert.setCertificate("cert-cert");
         cert.setSerial(new CertificateSerialDTO());
 
         this.values = new HashMap<>();

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/SubscriptionDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/SubscriptionDTOTest.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright (c) 2009 - 2017 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.dto.manifest.v1;
+
+import org.candlepin.dto.AbstractDTOTest;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+
+
+/**
+ * Test suite for the SubscriptionDTO class
+ */
+public class SubscriptionDTOTest extends AbstractDTOTest<SubscriptionDTO> {
+
+    protected Map<String, Object> values;
+
+    public SubscriptionDTOTest() {
+        super(SubscriptionDTO.class);
+
+        OwnerDTO owner = new OwnerDTO();
+        owner.setId("owner_id");
+        owner.setKey("owner_key");
+
+        ProductDTO product = new ProductDTO();
+        product.setId("product_id");
+        product.setName("product_name");
+
+        ProductDTO derivedProduct = new ProductDTO();
+        derivedProduct.setId("derived_product_id");
+        derivedProduct.setName("derived_product_name");
+
+        List<ProductDTO> providedProducts = new ArrayList<>();
+        for (int i = 0; i < 5; ++i) {
+            ProductDTO pp = new ProductDTO();
+            pp.setId("provided_product_id-" + i);
+            pp.setName("provided_product_name-" + i);
+
+            providedProducts.add(pp);
+        }
+
+        List<ProductDTO> derivedProvidedProducts = new ArrayList<>();
+        for (int i = 0; i < 5; ++i) {
+            ProductDTO dpp = new ProductDTO();
+            dpp.setId("derived_provided_product_id-" + i);
+            dpp.setName("derived_provided_product_name-" + i);
+
+            derivedProvidedProducts.add(dpp);
+        }
+
+        CdnDTO cdn = new CdnDTO();
+        cdn.setId("cdn_id");
+        cdn.setName("cdn_name");
+
+        List<BrandingDTO> branding = new ArrayList<>();
+        for (int i = 0; i < 5; ++i) {
+            BrandingDTO brand = new BrandingDTO();
+            brand.setId("branding_id-" + i);
+            brand.setProductId("branded_product_id-" + i);
+            brand.setName("branding_name-" + i);
+
+            branding.add(brand);
+        }
+
+        CertificateDTO cert = new CertificateDTO();
+        cert.setId("certificate_id");
+
+
+        this.values = new HashMap<>();
+        this.values.put("Id", "test-id");
+        this.values.put("Owner", owner);
+
+        this.values.put("Product", product);
+        this.values.put("ProvidedProducts", providedProducts);
+        this.values.put("DerivedProduct", derivedProduct);
+        this.values.put("DerivedProvidedProducts", derivedProvidedProducts);
+
+        this.values.put("Quantity", 50L);
+
+        this.values.put("StartDate", new Date(System.currentTimeMillis() - 100000));
+        this.values.put("EndDate", new Date(System.currentTimeMillis() + 100000));
+        this.values.put("LastModified", new Date(System.currentTimeMillis() - 40000));
+
+        this.values.put("ContractNumber", "contract_number");
+        this.values.put("AccountNumber", "account_number");
+        this.values.put("OrderNumber", "order_number");
+        this.values.put("UpstreamPoolId", "upstream_pool_id");
+        this.values.put("UpstreamEntitlementId", "upstream_entitlement_id");
+        this.values.put("UpstreamConsumerId", "upstream_consumer_id");
+
+        this.values.put("Cdn", cdn);
+        this.values.put("Branding", branding);
+        this.values.put("Certificate", cert);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected Object getInputValueForMutator(String field) {
+        return this.values.get(field);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected Object getOutputValueForAccessor(String field, Object input) {
+        // Nothing to do here
+        return input;
+    }
+}

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/UpstreamConsumerDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/UpstreamConsumerDTOTest.java
@@ -40,7 +40,7 @@ public class UpstreamConsumerDTOTest extends AbstractDTOTest<UpstreamConsumerDTO
         CertificateDTO cert = new CertificateDTO();
         cert.setId("123");
         cert.setKey("cert_key");
-        cert.setCert("cert_cert");
+        cert.setCertificate("cert_cert");
         cert.setSerial(new CertificateSerialDTO());
 
         this.values = new HashMap<>();

--- a/server/src/test/java/org/candlepin/dto/shim/ContentDTOTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/shim/ContentDTOTranslatorTest.java
@@ -63,7 +63,7 @@ public class ContentDTOTranslatorTest extends
         source.setReleaseVersion("test_value");
         source.setGpgUrl("test_value");
         source.setMetadataExpiration(1234L);
-        source.setModifiedProductIds(Arrays.asList("1", "2", "3"));
+        source.setRequiredProductIds(Arrays.asList("1", "2", "3"));
         source.setArches("test_value");
 
         return source;
@@ -92,7 +92,7 @@ public class ContentDTOTranslatorTest extends
             assertEquals(source.getReleaseVersion(), dto.getReleaseVersion());
             assertEquals(source.getGpgUrl(), dto.getGpgUrl());
             assertEquals(source.getMetadataExpiration(), dto.getMetadataExpiration());
-            assertEquals(source.getModifiedProductIds(), dto.getModifiedProductIds());
+            assertEquals(source.getRequiredProductIds(), dto.getModifiedProductIds());
             assertEquals(source.getArches(), dto.getArches());
         }
         else {

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceVirtEntitlementTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceVirtEntitlementTest.java
@@ -20,12 +20,14 @@ import org.candlepin.common.config.Configuration;
 import org.candlepin.config.CandlepinCommonTestConfig;
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.controller.PoolManager;
+import org.candlepin.dto.manifest.v1.OwnerDTO;
+import org.candlepin.dto.manifest.v1.ProductDTO;
+import org.candlepin.dto.manifest.v1.SubscriptionDTO;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerType;
 import org.candlepin.model.Owner;
 import org.candlepin.model.Pool;
 import org.candlepin.model.Product;
-import org.candlepin.model.dto.Subscription;
 import org.candlepin.policy.js.entitlement.Enforcer;
 import org.candlepin.policy.js.entitlement.EntitlementRules;
 import org.candlepin.service.OwnerServiceAdapter;
@@ -42,10 +44,11 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 
 import javax.inject.Inject;
+
+
 
 /**
  * ConsumerResourceVirtEntitlementTest
@@ -75,7 +78,7 @@ public class ConsumerResourceVirtEntitlementTest extends DatabaseTestFixture {
 
     @Before
     public void setUp() {
-        List<Subscription> subscriptions = new ArrayList<>();
+        List<SubscriptionDTO> subscriptions = new ArrayList<>();
         subAdapter = new ImportSubscriptionServiceAdapter(subscriptions);
 
         manifestType = consumerTypeCurator.create(
@@ -97,12 +100,14 @@ public class ConsumerResourceVirtEntitlementTest extends DatabaseTestFixture {
         productLimit.setAttribute(Pool.Attributes.MULTI_ENTITLEMENT, "yes");
         productLimit = this.createProduct(productLimit, owner);
 
-        Subscription limitSub = TestUtil.createSubscription(owner, productLimit, new HashSet<>());
+        SubscriptionDTO limitSub = new SubscriptionDTO();
         limitSub.setId(Util.generateDbUUID());
+        limitSub.setOwner(this.modelTranslator.translate(owner, OwnerDTO.class));
+        limitSub.setProduct(this.modelTranslator.translate(productLimit, ProductDTO.class));
         limitSub.setQuantity(10L);
         limitSub.setStartDate(TestUtil.createDate(2010, 1, 1));
         limitSub.setEndDate(TestUtil.createDate(2020, 1, 1));
-        limitSub.setModified(TestUtil.createDate(2000, 1, 1));
+        limitSub.setLastModified(TestUtil.createDate(2000, 1, 1));
         subscriptions.add(limitSub);
 
         limitPools = poolManager.createAndEnrichPools(limitSub);
@@ -113,12 +118,14 @@ public class ConsumerResourceVirtEntitlementTest extends DatabaseTestFixture {
         productUnlimit.setAttribute(Pool.Attributes.MULTI_ENTITLEMENT, "yes");
         productUnlimit = this.createProduct(productUnlimit, owner);
 
-        Subscription unlimitSub = TestUtil.createSubscription(owner, productUnlimit, new HashSet<>());
+        SubscriptionDTO unlimitSub = new SubscriptionDTO();
         unlimitSub.setId(Util.generateDbUUID());
+        unlimitSub.setOwner(this.modelTranslator.translate(owner, OwnerDTO.class));
+        unlimitSub.setProduct(this.modelTranslator.translate(productUnlimit, ProductDTO.class));
         unlimitSub.setQuantity(10L);
         unlimitSub.setStartDate(TestUtil.createDate(2010, 1, 1));
         unlimitSub.setEndDate(TestUtil.createDate(2020, 1, 1));
-        unlimitSub.setModified(TestUtil.createDate(2000, 1, 1));
+        unlimitSub.setLastModified(TestUtil.createDate(2000, 1, 1));
         subscriptions.add(unlimitSub);
 
         unlimitPools = poolManager.createAndEnrichPools(unlimitSub);

--- a/server/src/test/java/org/candlepin/resource/OwnerResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/OwnerResourceTest.java
@@ -51,6 +51,8 @@ import org.candlepin.dto.api.v1.PoolDTO;
 import org.candlepin.dto.api.v1.SystemPurposeAttributesDTO;
 import org.candlepin.dto.api.v1.UeberCertificateDTO;
 import org.candlepin.dto.api.v1.UpstreamConsumerDTO;
+import org.candlepin.dto.manifest.v1.ProductDTO;
+import org.candlepin.dto.manifest.v1.SubscriptionDTO;
 import org.candlepin.model.CandlepinQuery;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerCurator;
@@ -184,16 +186,21 @@ public class OwnerResourceTest extends DatabaseTestFixture {
     public void testRefreshPoolsWithNewSubscriptions() {
         Product prod = this.createProduct(owner);
 
-        List<Subscription> subscriptions = new LinkedList<>();
+        List<SubscriptionDTO> subscriptions = new LinkedList<>();
         ImportSubscriptionServiceAdapter subAdapter = new ImportSubscriptionServiceAdapter(subscriptions);
         OwnerServiceAdapter ownerAdapter = new DefaultOwnerServiceAdapter(this.ownerCurator, this.i18n);
 
-        Subscription sub = TestUtil.createSubscription(owner, prod, new HashSet<>());
+        org.candlepin.dto.manifest.v1.OwnerDTO ownerDto =
+            this.modelTranslator.translate(owner, org.candlepin.dto.manifest.v1.OwnerDTO.class);
+
+        SubscriptionDTO sub = new SubscriptionDTO();
         sub.setId(Util.generateDbUUID());
+        sub.setOwner(ownerDto);
+        sub.setProduct(this.modelTranslator.translate(prod, ProductDTO.class));
         sub.setQuantity(2000L);
         sub.setStartDate(TestUtil.createDate(2010, 2, 9));
         sub.setEndDate(TestUtil.createDate(3000, 2, 9));
-        sub.setModified(TestUtil.createDate(2010, 2, 12));
+        sub.setLastModified(TestUtil.createDate(2010, 2, 12));
         subscriptions.add(sub);
 
         // Trigger the refresh:
@@ -215,16 +222,21 @@ public class OwnerResourceTest extends DatabaseTestFixture {
             TestUtil.createDate(2009, 11, 30),
             TestUtil.createDate(2015, 11, 30));
 
-        List<Subscription> subscriptions = new LinkedList<>();
+        List<SubscriptionDTO> subscriptions = new LinkedList<>();
         ImportSubscriptionServiceAdapter subAdapter = new ImportSubscriptionServiceAdapter(subscriptions);
         OwnerServiceAdapter ownerAdapter = new DefaultOwnerServiceAdapter(this.ownerCurator, this.i18n);
 
-        Subscription sub = TestUtil.createSubscription(owner, prod, new HashSet<>());
+        org.candlepin.dto.manifest.v1.OwnerDTO ownerDto =
+            this.modelTranslator.translate(owner, org.candlepin.dto.manifest.v1.OwnerDTO.class);
+
+        SubscriptionDTO sub = new SubscriptionDTO();
         sub.setId(Util.generateDbUUID());
+        sub.setOwner(ownerDto);
+        sub.setProduct(this.modelTranslator.translate(prod, ProductDTO.class));
         sub.setQuantity(2000L);
         sub.setStartDate(TestUtil.createDate(2010, 2, 9));
         sub.setEndDate(TestUtil.createDate(3000, 2, 9));
-        sub.setModified(TestUtil.createDate(2010, 2, 12));
+        sub.setLastModified(TestUtil.createDate(2010, 2, 12));
         subscriptions.add(sub);
 
         assertTrue(pool.getQuantity() < sub.getQuantity());
@@ -247,16 +259,21 @@ public class OwnerResourceTest extends DatabaseTestFixture {
     public void testRefreshPoolsWithRemovedSubscriptions() {
         Product prod = this.createProduct(owner);
 
-        List<Subscription> subscriptions = new LinkedList<>();
+        List<SubscriptionDTO> subscriptions = new LinkedList<>();
         ImportSubscriptionServiceAdapter subAdapter = new ImportSubscriptionServiceAdapter(subscriptions);
         OwnerServiceAdapter ownerAdapter = new DefaultOwnerServiceAdapter(this.ownerCurator, this.i18n);
 
-        Subscription sub = TestUtil.createSubscription(owner, prod, new HashSet<>());
+        org.candlepin.dto.manifest.v1.OwnerDTO ownerDto =
+            this.modelTranslator.translate(owner, org.candlepin.dto.manifest.v1.OwnerDTO.class);
+
+        SubscriptionDTO sub = new SubscriptionDTO();
         sub.setId(Util.generateDbUUID());
+        sub.setOwner(ownerDto);
+        sub.setProduct(this.modelTranslator.translate(prod, ProductDTO.class));
         sub.setQuantity(2000L);
         sub.setStartDate(TestUtil.createDate(2010, 2, 9));
         sub.setEndDate(TestUtil.createDate(3000, 2, 9));
-        sub.setModified(TestUtil.createDate(2010, 2, 12));
+        sub.setLastModified(TestUtil.createDate(2010, 2, 12));
 
         // This line is only present as a result of a (temporary?) fix for BZ 1452694. Once a
         // better fix has been implemented, the upstream pool ID can be removed.
@@ -285,24 +302,31 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         Product prod = this.createProduct(owner);
         Product prod2 = this.createProduct(owner);
 
-        List<Subscription> subscriptions = new LinkedList<>();
+        List<SubscriptionDTO> subscriptions = new LinkedList<>();
         ImportSubscriptionServiceAdapter subAdapter = new ImportSubscriptionServiceAdapter(subscriptions);
         OwnerServiceAdapter ownerAdapter = new DefaultOwnerServiceAdapter(this.ownerCurator, this.i18n);
 
-        Subscription sub = TestUtil.createSubscription(owner, prod, new HashSet<>());
+        org.candlepin.dto.manifest.v1.OwnerDTO ownerDto =
+            this.modelTranslator.translate(owner, org.candlepin.dto.manifest.v1.OwnerDTO.class);
+
+        SubscriptionDTO sub = new SubscriptionDTO();
         sub.setId(Util.generateDbUUID());
+        sub.setOwner(ownerDto);
+        sub.setProduct(this.modelTranslator.translate(prod, ProductDTO.class));
         sub.setQuantity(2000L);
         sub.setStartDate(TestUtil.createDate(2010, 2, 9));
         sub.setEndDate(TestUtil.createDate(3000, 2, 9));
-        sub.setModified(TestUtil.createDate(2010, 2, 12));
+        sub.setLastModified(TestUtil.createDate(2010, 2, 12));
         subscriptions.add(sub);
 
-        Subscription sub2 = TestUtil.createSubscription(owner, prod2, new HashSet<>());
+        SubscriptionDTO sub2 = new SubscriptionDTO();
         sub2.setId(Util.generateDbUUID());
+        sub2.setOwner(ownerDto);
+        sub2.setProduct(this.modelTranslator.translate(prod2, ProductDTO.class));
         sub2.setQuantity(800L);
         sub2.setStartDate(TestUtil.createDate(2010, 2, 9));
         sub2.setEndDate(TestUtil.createDate(3000, 2, 9));
-        sub2.setModified(TestUtil.createDate(2010, 2, 12));
+        sub2.setLastModified(TestUtil.createDate(2010, 2, 12));
         subscriptions.add(sub2);
 
         // Trigger the refresh:
@@ -320,16 +344,21 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         productCurator.merge(prod);
         config.setProperty(ConfigProperties.STANDALONE, "false");
 
-        List<Subscription> subscriptions = new LinkedList<>();
+        List<SubscriptionDTO> subscriptions = new LinkedList<>();
         ImportSubscriptionServiceAdapter subAdapter = new ImportSubscriptionServiceAdapter(subscriptions);
         OwnerServiceAdapter ownerAdapter = new DefaultOwnerServiceAdapter(this.ownerCurator, this.i18n);
 
-        Subscription sub = TestUtil.createSubscription(owner, prod, new HashSet<>());
+        org.candlepin.dto.manifest.v1.OwnerDTO ownerDto =
+            this.modelTranslator.translate(owner, org.candlepin.dto.manifest.v1.OwnerDTO.class);
+
+        SubscriptionDTO sub = new SubscriptionDTO();
         sub.setId(Util.generateDbUUID());
+        sub.setOwner(ownerDto);
+        sub.setProduct(this.modelTranslator.translate(prod, ProductDTO.class));
         sub.setQuantity(2000L);
         sub.setStartDate(TestUtil.createDate(2010, 2, 9));
         sub.setEndDate(TestUtil.createDate(3000, 2, 9));
-        sub.setModified(TestUtil.createDate(2010, 2, 12));
+        sub.setLastModified(TestUtil.createDate(2010, 2, 12));
         subscriptions.add(sub);
 
         // Trigger the refresh:
@@ -375,16 +404,21 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         productCurator.merge(prod);
         config.setProperty(ConfigProperties.STANDALONE, "false");
 
-        List<Subscription> subscriptions = new LinkedList<>();
+        List<SubscriptionDTO> subscriptions = new LinkedList<>();
         ImportSubscriptionServiceAdapter subAdapter = new ImportSubscriptionServiceAdapter(subscriptions);
         OwnerServiceAdapter ownerAdapter = new DefaultOwnerServiceAdapter(this.ownerCurator, this.i18n);
 
-        Subscription sub = TestUtil.createSubscription(owner, prod, new HashSet<>());
+        org.candlepin.dto.manifest.v1.OwnerDTO ownerDto =
+            this.modelTranslator.translate(owner, org.candlepin.dto.manifest.v1.OwnerDTO.class);
+
+        SubscriptionDTO sub = new SubscriptionDTO();
         sub.setId(Util.generateDbUUID());
+        sub.setOwner(ownerDto);
+        sub.setProduct(this.modelTranslator.translate(prod, ProductDTO.class));
         sub.setQuantity(2000L);
         sub.setStartDate(TestUtil.createDate(2010, 2, 9));
         sub.setEndDate(TestUtil.createDate(3000, 2, 9));
-        sub.setModified(TestUtil.createDate(2010, 2, 12));
+        sub.setLastModified(TestUtil.createDate(2010, 2, 12));
         subscriptions.add(sub);
 
         // Trigger the refresh:
@@ -968,21 +1002,24 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         key = ownerres.createActivationKey(owner.getKey(), key);
     }
 
-    private Pool doTestEntitlementsRevocationCommon(long subQ, int e1, int e2)
-        throws ParseException {
-
+    private Pool doTestEntitlementsRevocationCommon(long subQ, int e1, int e2) throws ParseException {
         Product prod = this.createProduct(owner);
 
-        List<Subscription> subscriptions = new LinkedList<>();
+        List<SubscriptionDTO> subscriptions = new LinkedList<>();
         ImportSubscriptionServiceAdapter subAdapter = new ImportSubscriptionServiceAdapter(subscriptions);
         OwnerServiceAdapter ownerAdapter = new DefaultOwnerServiceAdapter(this.ownerCurator, this.i18n);
 
-        Subscription sub = TestUtil.createSubscription(owner, prod, new HashSet<>());
+        org.candlepin.dto.manifest.v1.OwnerDTO ownerDto =
+            this.modelTranslator.translate(owner, org.candlepin.dto.manifest.v1.OwnerDTO.class);
+
+        SubscriptionDTO sub = new SubscriptionDTO();
         sub.setId(Util.generateDbUUID());
+        sub.setOwner(ownerDto);
+        sub.setProduct(this.modelTranslator.translate(prod, ProductDTO.class));
         sub.setQuantity(1000L);
         sub.setStartDate(TestUtil.createDate(2009, 11, 30));
         sub.setEndDate(TestUtil.createDate(Calendar.getInstance().get(Calendar.YEAR) + 10, 10, 30));
-        sub.setModified(TestUtil.createDate(2015, 11, 30));
+        sub.setLastModified(TestUtil.createDate(2015, 11, 30));
         subscriptions.add(sub);
 
         List<Pool> pools = poolManager.createAndEnrichPools(sub);
@@ -1126,7 +1163,6 @@ public class OwnerResourceTest extends DatabaseTestFixture {
 
     @Test(expected = ConflictException.class)
     public void testConflictOnDelete() {
-
         Owner o = mock(Owner.class);
         OwnerCurator oc = mock(OwnerCurator.class);
         ProductCurator pc = mock(ProductCurator.class);
@@ -1180,24 +1216,31 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         prod2.setAttribute(Product.Attributes.SUPPORT_LEVEL, "standard");
         productCurator.merge(prod2);
 
-        List<Subscription> subscriptions = new LinkedList<>();
+        List<SubscriptionDTO> subscriptions = new LinkedList<>();
         ImportSubscriptionServiceAdapter subAdapter = new ImportSubscriptionServiceAdapter(subscriptions);
         OwnerServiceAdapter ownerAdapter = new DefaultOwnerServiceAdapter(this.ownerCurator, this.i18n);
 
-        Subscription sub1 = TestUtil.createSubscription(owner, prod1, new HashSet<>());
+        org.candlepin.dto.manifest.v1.OwnerDTO ownerDto =
+            this.modelTranslator.translate(owner, org.candlepin.dto.manifest.v1.OwnerDTO.class);
+
+        SubscriptionDTO sub1 = new SubscriptionDTO();
         sub1.setId(Util.generateDbUUID());
+        sub1.setOwner(ownerDto);
+        sub1.setProduct(this.modelTranslator.translate(prod1, ProductDTO.class));
         sub1.setQuantity(2000L);
         sub1.setStartDate(TestUtil.createDate(2010, 2, 9));
         sub1.setEndDate(TestUtil.createDate(3000, 2, 9));
-        sub1.setModified(TestUtil.createDate(2010, 2, 12));
+        sub1.setLastModified(TestUtil.createDate(2010, 2, 12));
         subscriptions.add(sub1);
 
-        Subscription sub2 = TestUtil.createSubscription(owner, prod2, new HashSet<>());
+        SubscriptionDTO sub2 = new SubscriptionDTO();
         sub2.setId(Util.generateDbUUID());
+        sub2.setOwner(ownerDto);
+        sub2.setProduct(this.modelTranslator.translate(prod2, ProductDTO.class));
         sub2.setQuantity(2000L);
         sub2.setStartDate(TestUtil.createDate(2010, 2, 9));
         sub2.setEndDate(TestUtil.createDate(3000, 2, 9));
-        sub2.setModified(TestUtil.createDate(2010, 2, 12));
+        sub2.setLastModified(TestUtil.createDate(2010, 2, 12));
         subscriptions.add(sub2);
 
         // Trigger the refresh:

--- a/server/src/test/java/org/candlepin/sync/EntitlementImporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/EntitlementImporterTest.java
@@ -23,9 +23,11 @@ import static org.mockito.Mockito.when;
 import org.candlepin.audit.EventSink;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.dto.StandardTranslator;
+import org.candlepin.dto.manifest.v1.CertificateSerialDTO;
 import org.candlepin.dto.manifest.v1.ConsumerDTO;
 import org.candlepin.dto.manifest.v1.EntitlementDTO;
 import org.candlepin.dto.manifest.v1.ProductDTO;
+import org.candlepin.dto.manifest.v1.SubscriptionDTO;
 import org.candlepin.model.Cdn;
 import org.candlepin.model.CdnCurator;
 import org.candlepin.model.CertificateSerial;
@@ -42,7 +44,6 @@ import org.candlepin.model.OwnerCurator;
 import org.candlepin.model.Pool;
 import org.candlepin.model.Product;
 import org.candlepin.model.ProductCurator;
-import org.candlepin.model.dto.Subscription;
 import org.candlepin.test.TestUtil;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -158,14 +159,14 @@ public class EntitlementImporterTest {
         Map<String, ProductDTO> productsById = buildProductCache(
             parentProduct, provided1, derivedProduct, derivedProvided1);
 
-        Subscription sub = importer.importObject(om, reader, owner,
-            productsById, consumerDTO.getUuid(), meta);
+        SubscriptionDTO sub = importer.importObject(
+            om, reader, owner, productsById, consumerDTO.getUuid(), meta);
 
         assertEquals(pool.getId(), sub.getUpstreamPoolId());
         assertEquals(consumer.getUuid(), sub.getUpstreamConsumerId());
         assertEquals(ent.getId(), sub.getUpstreamEntitlementId());
 
-        assertEquals(owner, sub.getOwner());
+        assertEquals(owner.getKey(), sub.getOwner().getKey());
         assertEquals(ent.getStartDate(), sub.getStartDate());
         assertEquals(ent.getEndDate(), sub.getEndDate());
 
@@ -175,16 +176,16 @@ public class EntitlementImporterTest {
 
         assertEquals(ent.getQuantity().intValue(), sub.getQuantity().intValue());
 
-        assertEquals(parentProduct.toDTO(), sub.getProduct());
+        assertEquals(parentProduct.getId(), sub.getProduct().getId());
         assertEquals(providedProducts.size(), sub.getProvidedProducts().size());
         assertEquals(provided1.getId(), sub.getProvidedProducts().iterator().next().getId());
 
-        assertEquals(derivedProduct.toDTO(), sub.getDerivedProduct());
+        assertEquals(derivedProduct.getId(), sub.getDerivedProduct().getId());
         assertEquals(1, sub.getDerivedProvidedProducts().size());
         assertEquals(derivedProvided1.getId(), sub.getDerivedProvidedProducts().iterator().next().getId());
 
         assertNotNull(sub.getCertificate());
-        CertificateSerial serial = sub.getCertificate().getSerial();
+        CertificateSerialDTO serial = sub.getCertificate().getSerial();
         assertEquals(cert.getSerial().isCollected(), serial.isCollected());
         assertEquals(cert.getSerial().getExpiration(), serial.getExpiration());
         assertEquals(cert.getSerial().getCreated(), serial.getCreated());

--- a/server/src/test/java/org/candlepin/sync/ImporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/ImporterTest.java
@@ -30,6 +30,7 @@ import org.candlepin.dto.StandardTranslator;
 import org.candlepin.dto.manifest.v1.ConsumerDTO;
 import org.candlepin.dto.manifest.v1.ConsumerTypeDTO;
 import org.candlepin.dto.manifest.v1.OwnerDTO;
+import org.candlepin.dto.manifest.v1.SubscriptionDTO;
 import org.candlepin.jackson.ProductCachedSerializationModule;
 import org.candlepin.model.CertificateSerialCurator;
 import org.candlepin.model.ConsumerType;
@@ -656,7 +657,7 @@ public class ImporterTest {
         Importer i = new Importer(consumerTypeCurator, pc, ri, oc, null, null, pm,
             null, config, emc, null, null, i18n,
             null, null, su, null, this.mockSubReconciler, this.ec, this.translator);
-        List<Subscription> subscriptions = i.importObjects(owner, importFiles, co);
+        List<SubscriptionDTO> subscriptions = i.importObjects(owner, importFiles, co);
 
         assertEquals(1, subscriptions.size());
         assertEquals("prodId", subscriptions.get(0).getProduct().getId());
@@ -880,8 +881,8 @@ public class ImporterTest {
 
         Meta meta = new Meta("1.0", new Date(), "test-user", "candlepin", "testcdn");
 
-        List<Subscription> subscriptions = new ArrayList<>();
-        Subscription subscription = new Subscription();
+        List<SubscriptionDTO> subscriptions = new ArrayList<>();
+        SubscriptionDTO subscription = new SubscriptionDTO();
         subscriptions.add(subscription);
 
         Map<String, Object> data = new HashMap<>();
@@ -969,13 +970,13 @@ public class ImporterTest {
             null, null, su, importRecordCurator, this.mockSubReconciler, this.ec, this.translator);
 
         Map<String, Object> data = new HashMap<>();
-        List<Subscription> subscriptions = new ArrayList<>();
-        Subscription subscription1 = new Subscription();
+        List<SubscriptionDTO> subscriptions = new ArrayList<>();
+        SubscriptionDTO subscription1 = new SubscriptionDTO();
         //expires tomorrow
         subscription1.setEndDate(new Date((new Date()).getTime() + (1000 * 60 * 60 * 24)));
         subscriptions.add(subscription1);
 
-        Subscription subscription2 = new Subscription();
+        SubscriptionDTO subscription2 = new SubscriptionDTO();
         //expires yesterday
         subscription2.setEndDate(new Date((new Date()).getTime() - (1000 * 60 * 60 * 24)));
         subscriptions.add(subscription2);
@@ -1002,13 +1003,13 @@ public class ImporterTest {
             null, null, su, importRecordCurator, this.mockSubReconciler, this.ec, this.translator);
 
         Map<String, Object> data = new HashMap<>();
-        data.put("subscriptions", new ArrayList<Subscription>());
+        data.put("subscriptions", new ArrayList<SubscriptionDTO>());
 
         ImportRecord record = importer.recordImportSuccess(owner, data, new ConflictOverrides(), "test.zip");
         assertEquals(ImportRecord.Status.SUCCESS_WITH_WARNING, record.getStatus());
         assertEquals(owner.getKey() + " file imported successfully." +
             "No active subscriptions found in the file.", record.getStatusMessage());
-        verify(eventSinkMock, never()).emitSubscriptionExpired(any(Subscription.class));
+        verify(eventSinkMock, never()).emitSubscriptionExpired(any(SubscriptionDTO.class));
         verify(importRecordCurator).create(eq(record));
     }
 

--- a/server/src/test/java/org/candlepin/sync/ImporterUtilsTest.java
+++ b/server/src/test/java/org/candlepin/sync/ImporterUtilsTest.java
@@ -37,7 +37,7 @@ public class ImporterUtilsTest {
     @Before
     public void setUp() {
         certDTO = new CertificateDTO();
-        certDTO.setCert("test-cert");
+        certDTO.setCertificate("test-cert");
         certDTO.setKey("test-key");
         certDTO.setUpdated(new Date());
         certDTO.setCreated(new Date());
@@ -57,7 +57,7 @@ public class ImporterUtilsTest {
 
         ImporterUtils.populateEntity(certEntity, certDTO);
 
-        assertEquals(certDTO.getCert(), certEntity.getCert());
+        assertEquals(certDTO.getCertificate(), certEntity.getCert());
         assertEquals(certDTO.getKey(), certEntity.getKey());
         assertEquals(certDTO.getUpdated(), certEntity.getUpdated());
         assertEquals(certDTO.getCreated(), certEntity.getCreated());

--- a/server/src/test/java/org/candlepin/test/TestUtil.java
+++ b/server/src/test/java/org/candlepin/test/TestUtil.java
@@ -284,10 +284,7 @@ public class TestUtil {
 
     public static Product createProduct() {
         int random = randomInt();
-        return createProduct(
-            String.valueOf(random),
-            "test-product-" + random
-        );
+        return createProduct(String.valueOf(random), "test-product-" + random);
     }
 
     public static Product createProduct(ProductDTO dto) {


### PR DESCRIPTION
- Added the new SubscriptionDTO object to act as a full
  representation of a pool during manifest import
- EntitlementImporter no longer uses the Subscription class,
  nor attempts to validate its products, entitlements and
  other DTOs against existing model entities
- Optimized out some unnecessary sorting and collection
  conversion in SubscriptionReconciler
- Updated several tests to use the new manifest DTOs rather
  than the old DTO shims