### PR TITLE
[2.4] 1624447: Do not set connection-ttl-override ENT-823

### DIFF
--- a/server/src/main/java/org/candlepin/audit/ActiveMQContextListener.java
+++ b/server/src/main/java/org/candlepin/audit/ActiveMQContextListener.java
@@ -152,8 +152,6 @@ public class ActiveMQContextListener {
             config.setJournalBufferSize_AIO(largeMsgSize);
             config.setJournalBufferSize_NIO(largeMsgSize);
 
-            config.setConnectionTTLOverride(86400000L); // 24 hours
-
             activeMQServer = new EmbeddedActiveMQ();
             activeMQServer.setConfiguration(config);
         }


### PR DESCRIPTION
Unnecessary since this version of Artemis does not timeout invm
connections.

Note that to test this, it's best to deploy a version with the value of
the connection-ttl-override set lower in order to speed up reproduction
of the original issue. For example, `60000L` will show an issue in a
minute. `60000L` was the default value for non-invm connections anyway.

(See https://github.com/candlepin/candlepin/blob/40ad86a3b7de87de2cd9b9dc38f9d5b4439b8616/server/src/main/java/org/candlepin/audit/ActiveMQContextListener.java#L141)

Before: "AMQ119014" appears in logs; after: no such error in logs.