### PR TITLE
[2.4] 1628595: Update epoch on Java requirement [ ENT-881 ]

### DIFF
--- a/server/candlepin.spec.tmpl
+++ b/server/candlepin.spec.tmpl
@@ -43,7 +43,7 @@ BuildArch: noarch
 
 BuildRequires: selinux-policy-doc
 
-Requires: java >= 0:1.8.0
+Requires: java >= 1:1.8.0
 Requires: wget
 Requires: %{tomcat}
 Requires: liquibase >= 0:3.0.0


### PR DESCRIPTION
See note about epoch at https://fedora-java.github.io/howto/latest/#_jvm