### PR TITLE
[2.4] 1631590: Added limits to the size of link headers (ENT-893)

### DIFF
--- a/common/src/main/java/org/candlepin/common/resteasy/filter/LinkTooLongException.java
+++ b/common/src/main/java/org/candlepin/common/resteasy/filter/LinkTooLongException.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2009 - 2018 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.common.resteasy.filter;
+
+
+
+/**
+ * Thrown when a link would be too long to fit into a response header
+ */
+public class LinkTooLongException extends RuntimeException {
+    public LinkTooLongException(String link) {
+        super(link);
+    }
+}


### PR DESCRIPTION
- LinkHeaderResponseFilter no longer adds link headers if any link
  would be larger than 1024 characters; but instead issues a
  warning with the offending link