### PR TITLE
[M] Fixed an issue with object desync during pool cleanup

### DIFF
--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -83,7 +83,7 @@ import org.candlepin.util.Traceable;
 import org.candlepin.util.TraceableParam;
 import org.candlepin.util.Util;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
 import com.google.inject.persist.Transactional;
 
@@ -2336,23 +2336,21 @@ public class CandlepinPoolManager implements PoolManager {
                     this.enforcer.postUnbind(entitlement.getConsumer(), this, entitlement);
                 }
 
-                /* Save the consumer IDs and then detach all the keys in the consumerStackEnts map.
-                 * Otherwise during the status calculations, the facts proxy objects objects will be resolved
-                 * and the memory use will grow linearly with the number of consumers instead of remaining
-                 * constant as we calculate the status of each consumer.  See BZ 1584259 */
-                List<String> consumers = consumerStackedEnts.keySet().stream()
-                    .map(Consumer::getId)
-                    .collect(Collectors.toList());
-                this.consumerCurator.batchDetach(consumerStackedEnts.keySet());
-
-                log.info("Recomputing status for {} consumers", consumers.size());
+                log.info("Recomputing status for {} consumers", consumerStackedEnts.keySet().size());
 
                 // Recalculate status for affected consumers
-                for (List<String> subList : Lists.partition(consumers, 1000)) {
-                    for (Consumer consumer : this.consumerCurator.getConsumers(subList).list()) {
+                for (List<Consumer> subList : Iterables.partition(consumerStackedEnts.keySet(), 1000)) {
+                    for (Consumer consumer : subList) {
                         this.complianceRules.getStatus(consumer);
                         this.systemPurposeComplianceRules.getStatus(consumer, consumer.getEntitlements(),
                             null, true, true);
+
+                        // Detach the consumer object (and its children that receive cascaded detaches),
+                        // otherwise during the status calculations, the facts proxy objects objects will be
+                        // resolved and the memory use will grow linearly with the number of consumers
+                        // instead of remaining constant as we calculate the status of each consumer.
+                        //
+                        // See BZ 1584259 for details
                         this.consumerCurator.detach(consumer);
                     }
                     this.consumerCurator.flush();


### PR DESCRIPTION
- Fixed an issue where consumer instances could become desync'd
  during CPM.deletePools while recalculating compliance status
  for consumers in some cases, leading to an EntityExistsException