### PR TITLE
Fix reference error in js rules

### DIFF
--- a/server/src/main/resources/rules/rules.js
+++ b/server/src/main/resources/rules/rules.js
@@ -1043,11 +1043,11 @@ var CoverageCalculator = {
                 var supportedRoles = complianceTracker.enforces(prodAttr) ? complianceTracker.getAccumulatedValue(prodAttr) : [];
                 var consumerRole = consumer.role != null ? consumer.role : "";
                 if (!contains(supportedRoles, consumerRole)) {
-                    log.debug("  System addons not covered by: " + supportedAddOns);
+                    log.debug("  System role not covered by: " + supportedRoles);
                     return StatusReasonGenerator.buildReason(prodAttr.toUpperCase(),
                         complianceTracker.type,
                         complianceTracker.id,
-                        consumeRole,
+                        consumerRole,
                         supportedRoles);
                 }
                 log.debug("  System role is covered.");


### PR DESCRIPTION
I was testing syspurpose and have a product set up with these attributes:

```
candlepin=# select * from cp2_product_attributes where product_uuid = '4028f9356533d3030165352e61e20001';                                                                                                         
  name  |          value           |           product_uuid
--------+--------------------------+----------------------------------
 role   | Test Role                | 4028f9356533d3030165352e61e20001
 usage  | Development              | 4028f9356533d3030165352e61e20001
 addons | Test Addon1, Test Addon2 | 4028f9356533d3030165352e61e20001
 arch   | ALL                      | 4028f9356533d3030165352e61e20001
(4 rows)
```

Upon attaching the product to a newly registered system I'm getting this error:

```
2018-10-17 16:12:12,406 [thread=http-bio-8443-exec-3] [req=1e34d51b-18f8-4a55-8526-5c8526ce8fb4, org=Default_Organization, csid=d8ed81f1] ERROR org.candlepin.common.exceptions.mappers.CandlepinExceptionMapper - Runtime Error ReferenceError: "supportedAddOns" is not defined. (rules#1046) at org.mozilla.javascript.ScriptRuntime.constructError:3,785                                                                          
org.mozilla.javascript.EcmaError: ReferenceError: "supportedAddOns" is not defined. (rules#1046)                                                                                                                   
        at org.mozilla.javascript.ScriptRuntime.constructError(ScriptRuntime.java:3785)                                                                                                                            
        at org.mozilla.javascript.ScriptRuntime.constructError(ScriptRuntime.java:3763)                                                                                                                            
        at org.mozilla.javascript.ScriptRuntime.notFoundError(ScriptRuntime.java:3848)                                                                                                                             
        at org.mozilla.javascript.ScriptRuntime.nameOrFunction(ScriptRuntime.java:1847)                                                                                                                            
        at org.mozilla.javascript.ScriptRuntime.name(ScriptRuntime.java:1786)                                                                                                                                      
        at org.mozilla.javascript.gen.rules_1._c_anonymous_66(rules:1046)                                                                                                                                          
        at org.mozilla.javascript.gen.rules_1.call(rules)                                                                                                                                                          
        at org.mozilla.javascript.optimizer.OptRuntime.callN(OptRuntime.java:86)                                                                                                                                   
        at org.mozilla.javascript.gen.rules_1._c_anonymous_70(rules:1157)                                                                                                                                          
        at org.mozilla.javascript.gen.rules_1.call(rules)                                                                                                                                                          
        at org.mozilla.javascript.optimizer.OptRuntime.callN(OptRuntime.java:86)                                                                                                                                   
        at org.mozilla.javascript.gen.rules_1._c_anonymous_69(rules:1121)                                                                                                                                          
        at org.mozilla.javascript.gen.rules_1.call(rules)                                                                                                                                                          
        at org.mozilla.javascript.optimizer.OptRuntime.callN(OptRuntime.java:86)                                                                                                                                   
        at org.mozilla.javascript.gen.rules_1._c_anonymous_198(rules:3696)                                                                                                                                         
        at org.mozilla.javascript.gen.rules_1.call(rules)                                                                                                                                                          
        at org.mozilla.javascript.optimizer.OptRuntime.callN(OptRuntime.java:86)                                                                                                                                   
        at org.mozilla.javascript.gen.rules_1._c_anonymous_189(rules:3549)                                                                                                                                         
        at org.mozilla.javascript.gen.rules_1.call(rules)                                                                                                                                                          
        at org.mozilla.javascript.optimizer.OptRuntime.callN(OptRuntime.java:86)                                                                                                                                   
        at org.mozilla.javascript.gen.rules_1._c_anonymous_180(rules:3227)                                                                                                                                         
        at org.mozilla.javascript.gen.rules_1.call(rules)                                                                                                                                                          
        at org.mozilla.javascript.ContextFactory.doTopCall(ContextFactory.java:426)                                                                                                                                
        at org.mozilla.javascript.ScriptRuntime.doTopCall(ScriptRuntime.java:3178)                                                                                                                                 
        at org.mozilla.javascript.gen.rules_1.call(rules)                                                                                                                                                          
        at org.candlepin.policy.js.JsRunner.invokeMethod(JsRunner.java:100)                                                                                                                                        
        at org.candlepin.policy.js.JsRunner.invokeMethod(JsRunner.java:112)                                                                                                                                        
        at org.candlepin.policy.js.JsRunner.runJsFunction(JsRunner.java:140)                                                                                                                                       
        at org.candlepin.policy.js.compliance.ComplianceRules.getStatus(ComplianceRules.java:196)                                                                                                                  
        at org.candlepin.bind.ComplianceOp.preProcess(ComplianceOp.java:64)                                                                                                                                        
        at org.candlepin.bind.BindChain.preProcess(BindChain.java:69)                                                                                                                                              
        at org.candlepin.bind.BindChain.run(BindChain.java:108) 
```

I haven't tested this, but I think it's pretty straightforward for someone who has their environment set up to do so.