### PR TITLE
ENT-884 Reuse Objectmappers when possible:

### DIFF
--- a/server/src/main/java/org/candlepin/audit/ActivationListener.java
+++ b/server/src/main/java/org/candlepin/audit/ActivationListener.java
@@ -14,15 +14,12 @@
  */
 package org.candlepin.audit;
 
+import com.google.inject.name.Named;
 import org.candlepin.service.SubscriptionServiceAdapter;
 
 import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.databind.AnnotationIntrospector;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.introspect.AnnotationIntrospectorPair;
-import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
-import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
 import com.google.inject.Inject;
 
 import org.slf4j.Logger;
@@ -39,13 +36,10 @@ public class ActivationListener implements EventListener {
     private ObjectMapper mapper;
 
     @Inject
-    public ActivationListener(SubscriptionServiceAdapter subService) {
+    public ActivationListener(SubscriptionServiceAdapter subService,
+        @Named("ActivationListenerObjectMapper") ObjectMapper objectMapper) {
+        this.mapper = objectMapper;
         this.subscriptionService = subService;
-        mapper = new ObjectMapper();
-        AnnotationIntrospector primary = new JacksonAnnotationIntrospector();
-        AnnotationIntrospector secondary = new JaxbAnnotationIntrospector(mapper.getTypeFactory());
-        AnnotationIntrospector pair = new AnnotationIntrospectorPair(primary, secondary);
-        mapper.setAnnotationIntrospector(pair);
     }
 
     @Override

--- a/server/src/main/java/org/candlepin/audit/Event.java
+++ b/server/src/main/java/org/candlepin/audit/Event.java
@@ -14,12 +14,15 @@
  */
 package org.candlepin.audit;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.candlepin.auth.Principal;
 import org.candlepin.auth.PrincipalData;
 import org.candlepin.model.Persisted;
 import org.candlepin.util.Util;
 
 import org.hibernate.annotations.GenericGenerator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Date;
 
@@ -48,6 +51,8 @@ import javax.xml.bind.annotation.XmlTransient;
 @XmlRootElement(namespace = "http://fedorahosted.org/candlepin/Event")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 public class Event implements Persisted {
+
+    private static final Logger log = LoggerFactory.getLogger(Event.class);
 
     /** Name of the table backing this object in the database */
     public static final String DB_TABLE = "cp_event";
@@ -155,7 +160,13 @@ public class Event implements Persisted {
         this.targetName = targetName;
 
         // TODO: toString good enough? Need something better?
-        this.principalStore = Util.toJson(principal.getData());
+        try {
+            this.principalStore = Util.toJson(principal.getData());
+        }
+        catch (JsonProcessingException e) {
+            log.error("Error while building JSON for event.", e);
+            this.principalStore = "";
+        }
         this.ownerId = ownerId;
 
         this.entityId = entityId;
@@ -199,7 +210,13 @@ public class Event implements Persisted {
     }
 
     public void setPrincipal(PrincipalData principal) {
-        this.principalStore = Util.toJson(principal);
+        try {
+            this.principalStore = Util.toJson(principal);
+        }
+        catch (JsonProcessingException e) {
+            log.error("Error while building JSON for principal.", e);
+            this.principalStore = "";
+        }
     }
 
     public Date getTimestamp() {

--- a/server/src/main/java/org/candlepin/audit/EventBuilder.java
+++ b/server/src/main/java/org/candlepin/audit/EventBuilder.java
@@ -14,6 +14,7 @@
  */
 package org.candlepin.audit;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.candlepin.audit.Event.Target;
 import org.candlepin.audit.Event.Type;
 import org.candlepin.common.exceptions.IseException;
@@ -25,9 +26,7 @@ import org.candlepin.model.Named;
 import org.candlepin.model.Owned;
 import org.candlepin.model.Pool;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
+import org.candlepin.util.Util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,13 +42,9 @@ public class EventBuilder {
 
     private static final Logger log = LoggerFactory.getLogger(EventBuilder.class);
 
-    private final ObjectMapper mapper;
-
     private Event event;
 
     public EventBuilder(EventFactory factory, Target target, Type type) {
-        this.mapper = new ObjectMapper();
-
         event = new Event(type, target, null, factory.principalProvider.get(),
                 null, null, null, null, null, null);
     }
@@ -122,11 +117,11 @@ public class EventBuilder {
                 eventData.put("subscriptionId", ((Pool) entity).getSubscriptionId());
 
                 try {
-                    event.setEventData(mapper.writeValueAsString(eventData));
+                    event.setEventData(Util.toJson(eventData));
                 }
                 catch (JsonProcessingException e) {
                     log.error("Error while building JSON for pool.created event.", e);
-                    throw new IseException("Error while building JSON for pool.created event.");
+                    throw new IseException("Error while building JSON for pool.created event.", e);
                 }
             }
         }

--- a/server/src/main/java/org/candlepin/auth/Principal.java
+++ b/server/src/main/java/org/candlepin/auth/Principal.java
@@ -14,6 +14,7 @@
  */
 package org.candlepin.auth;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.candlepin.auth.permissions.Permission;
 import org.candlepin.util.Util;
 
@@ -120,7 +121,13 @@ public abstract class Principal implements Serializable, java.security.Principal
 
     @Override
     public String toString() {
-        return Util.toJson(this.getData());
+        try {
+            return Util.toJson(this.getData());
+        }
+        catch (JsonProcessingException e) {
+            log.error("Error while building JSON for principal.", e);
+            return "";
+        }
     }
 
 }

--- a/server/src/main/java/org/candlepin/hibernate/ResultDataUserType.java
+++ b/server/src/main/java/org/candlepin/hibernate/ResultDataUserType.java
@@ -63,11 +63,11 @@ public class ResultDataUserType implements UserType, DynamicParameterizedType {
     private static final Logger log = LoggerFactory.getLogger(ResultDataUserType.class);
     public static final String JSON_CLASS = "jsonClass";
 
-    private ObjectMapper mapper;
+    private static ObjectMapper mapper = configureObjectMapper();
     private Class<?> jsonClass;
 
-    public ResultDataUserType() {
-        mapper = new ObjectMapper();
+    private static ObjectMapper configureObjectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
 
         Hibernate5Module hbm = new Hibernate5Module();
         hbm.enable(Hibernate5Module.Feature.FORCE_LAZY_LOADING);
@@ -83,6 +83,8 @@ public class ResultDataUserType implements UserType, DynamicParameterizedType {
         // We're not going to want any of the JSON filters like DynamicPropertyFilter that we apply elsewhere
         filterProvider.setFailOnUnknownId(false);
         mapper.setFilterProvider(filterProvider);
+
+        return mapper;
     }
 
     @Override

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/HypervisorUpdateJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/HypervisorUpdateJob.java
@@ -16,8 +16,8 @@ package org.candlepin.pinsetter.tasks;
 
 import static org.quartz.JobBuilder.*;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.name.Named;
 import org.candlepin.auth.Principal;
 import org.candlepin.common.exceptions.BadRequestException;
 import org.candlepin.common.filter.LoggingFilter;
@@ -83,9 +83,7 @@ public class HypervisorUpdateJob extends KingpinJob {
 
     private static Logger log = LoggerFactory.getLogger(HypervisorUpdateJob.class);
 
-    // Reuse this instance of ObjectMapper since they are expensive to create.
-    private static ObjectMapper mapper = configureObjectMapper();
-
+    private ObjectMapper mapper;
     private OwnerCurator ownerCurator;
     private ConsumerCurator consumerCurator;
     private ConsumerResource consumerResource;
@@ -104,7 +102,8 @@ public class HypervisorUpdateJob extends KingpinJob {
     @Inject
     public HypervisorUpdateJob(OwnerCurator ownerCurator, ConsumerCurator consumerCurator,
         ConsumerTypeCurator consumerTypeCurator, ConsumerResource consumerResource, I18n i18n,
-        SubscriptionServiceAdapter subAdapter, ComplianceRules complianceRules, ModelTranslator translator) {
+        SubscriptionServiceAdapter subAdapter, ComplianceRules complianceRules, ModelTranslator translator,
+        @Named("HypervisorUpdateJobObjectMapper") ObjectMapper objectMapper) {
         this.ownerCurator = ownerCurator;
         this.consumerCurator = consumerCurator;
         this.consumerResource = consumerResource;
@@ -113,6 +112,7 @@ public class HypervisorUpdateJob extends KingpinJob {
         this.complianceRules = complianceRules;
         this.translator = translator;
         this.hypervisorType = consumerTypeCurator.getByLabel(ConsumerTypeEnum.HYPERVISOR.getLabel(), true);
+        this.mapper = objectMapper;
     }
 
     public static JobStatus scheduleJob(JobCurator jobCurator, Scheduler scheduler, JobDetail detail,
@@ -519,11 +519,5 @@ public class HypervisorUpdateJob extends KingpinJob {
         consumerCurator.updateLastCheckin(consumer, now);
         consumer.setLastCheckin(now);
         return consumer;
-    }
-
-    private static ObjectMapper configureObjectMapper() {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        return mapper;
     }
 }

--- a/server/src/main/java/org/candlepin/util/Util.java
+++ b/server/src/main/java/org/candlepin/util/Util.java
@@ -14,6 +14,7 @@
  */
 package org.candlepin.util;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.candlepin.model.CuratorException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -361,15 +362,9 @@ public class Util {
         return new String(Hex.encodeHex(sha1hash));
     }
 
-    public static String toJson(Object anObject) {
-        String output = "";
-        try {
-            output = mapper.writeValueAsString(anObject);
-        }
-        catch (Exception e) {
-            log.error("Could no serialize the object to json " + anObject, e);
-        }
-        return output;
+
+    public static String toJson(Object anObject) throws JsonProcessingException {
+        return mapper.writeValueAsString(anObject);
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })

--- a/server/src/main/java/org/candlepin/util/X509V3ExtensionUtil.java
+++ b/server/src/main/java/org/candlepin/util/X509V3ExtensionUtil.java
@@ -14,6 +14,7 @@
  */
 package org.candlepin.util;
 
+import com.google.inject.name.Named;
 import org.candlepin.common.config.Configuration;
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.model.Branding;
@@ -31,9 +32,6 @@ import org.candlepin.model.dto.TinySubscription;
 import org.candlepin.pki.X509ByteExtensionWrapper;
 import org.candlepin.pki.X509ExtensionWrapper;
 
-import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Collections2;
 import com.google.inject.Inject;
@@ -67,6 +65,7 @@ import java.util.zip.InflaterOutputStream;
 public class X509V3ExtensionUtil extends X509Util {
 
     private static Logger log = LoggerFactory.getLogger(X509V3ExtensionUtil.class);
+    private ObjectMapper mapper;
     private Configuration config;
     private EntitlementCurator entCurator;
     private String thisVersion = "3.3";
@@ -77,10 +76,13 @@ public class X509V3ExtensionUtil extends X509Util {
     private static boolean treeDebug = false;
 
     @Inject
-    public X509V3ExtensionUtil(Configuration config, EntitlementCurator entCurator) {
+    public X509V3ExtensionUtil(Configuration config, EntitlementCurator entCurator,
+        @Named("X509V3ExtensionUtilObjectMapper") ObjectMapper objectMapper) {
+
         // Output everything in UTC
         this.config = config;
         this.entCurator = entCurator;
+        this.mapper = objectMapper;
     }
 
     public Set<X509ExtensionWrapper> getExtensions() {
@@ -841,13 +843,10 @@ public class X509V3ExtensionUtil extends X509Util {
         return "";
     }
 
-    public static String toJson(Object anObject) {
+    private String toJson(Object anObject) {
         String output = "";
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-        mapper.setVisibility(PropertyAccessor.FIELD, Visibility.ANY);
         try {
-            output = mapper.writeValueAsString(anObject);
+            output = this.mapper.writeValueAsString(anObject);
         }
         catch (Exception e) {
             log.error("Could no serialize the object to json " + anObject, e);

--- a/server/src/test/java/org/candlepin/audit/AMQPBusPublisherTest.java
+++ b/server/src/test/java/org/candlepin/audit/AMQPBusPublisherTest.java
@@ -61,7 +61,7 @@ public class AMQPBusPublisherTest {
         PrincipalProvider pp = mock(PrincipalProvider.class);
         when(pp.get()).thenReturn(TestUtil.createPrincipal("admin", null, null));
 
-        EventFactory factory = new EventFactory(pp);
+        EventFactory factory = new EventFactory(pp, new ObjectMapper());
         Consumer c = TestUtil.createConsumer();
         Event e = factory.consumerCreated(c);
 
@@ -77,7 +77,7 @@ public class AMQPBusPublisherTest {
         PrincipalProvider pp = mock(PrincipalProvider.class);
         when(pp.get()).thenReturn(TestUtil.createPrincipal("admin", null, null));
 
-        EventFactory factory = new EventFactory(pp);
+        EventFactory factory = new EventFactory(pp, mapper);
         Consumer c = TestUtil.createConsumer();
         Event e = factory.consumerCreated(c);
 

--- a/server/src/test/java/org/candlepin/audit/ActivationListenerTest.java
+++ b/server/src/test/java/org/candlepin/audit/ActivationListenerTest.java
@@ -14,6 +14,7 @@
  */
 package org.candlepin.audit;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.service.impl.ImportSubscriptionServiceAdapter;
 import org.junit.Before;
@@ -29,7 +30,7 @@ public class ActivationListenerTest {
     @Before
     public void init() {
         subscriptionService = mock(ImportSubscriptionServiceAdapter.class);
-        listener = new ActivationListener(subscriptionService);
+        listener = new ActivationListener(subscriptionService, new ObjectMapper());
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/audit/EventBuilderTest.java
+++ b/server/src/test/java/org/candlepin/audit/EventBuilderTest.java
@@ -14,6 +14,7 @@
  */
 package org.candlepin.audit;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.candlepin.auth.Principal;
 import org.candlepin.common.exceptions.IseException;
 import org.candlepin.guice.PrincipalProvider;
@@ -40,7 +41,7 @@ public class EventBuilderTest {
     public void init() throws Exception {
         principalProvider = mock(PrincipalProvider.class);
         Principal principal = mock(Principal.class);
-        factory = new EventFactory(principalProvider);
+        factory = new EventFactory(principalProvider, new ObjectMapper());
         when(principalProvider.get()).thenReturn(principal);
     }
 

--- a/server/src/test/java/org/candlepin/audit/EventFactoryTest.java
+++ b/server/src/test/java/org/candlepin/audit/EventFactoryTest.java
@@ -17,6 +17,7 @@ package org.candlepin.audit;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.candlepin.auth.Principal;
 import org.candlepin.guice.PrincipalProvider;
 import org.candlepin.model.Consumer;
@@ -45,7 +46,7 @@ public class EventFactoryTest {
         principalProvider = mock(PrincipalProvider.class);
         Principal principal = mock(Principal.class);
         when(principalProvider.get()).thenReturn(principal);
-        eventFactory = new EventFactory(principalProvider);
+        eventFactory = new EventFactory(principalProvider, new ObjectMapper());
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/audit/EventSinkImplTest.java
+++ b/server/src/test/java/org/candlepin/audit/EventSinkImplTest.java
@@ -83,7 +83,7 @@ public class EventSinkImplTest {
 
     @Before
     public void init() throws Exception {
-        this.factory = new EventFactory(mockPrincipalProvider);
+        this.factory = new EventFactory(mockPrincipalProvider, mapper);
         this.principal = TestUtil.createOwnerPrincipal();
         eventFilter = new EventFilter(new CandlepinCommonTestConfig());
         when(mockPrincipalProvider.get()).thenReturn(this.principal);

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/HypervisorUpdateJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/HypervisorUpdateJobTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.*;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.candlepin.auth.Principal;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.dto.StandardTranslator;
@@ -71,6 +72,7 @@ public class HypervisorUpdateJobTest extends BaseJobTest {
     private Principal principal;
     private String hypervisorJson;
 
+    private ObjectMapper objectMapper;
     private OwnerCurator ownerCurator;
     private ConsumerCurator consumerCurator;
     private ConsumerResource consumerResource;
@@ -101,6 +103,7 @@ public class HypervisorUpdateJobTest extends BaseJobTest {
         subAdapter = mock(SubscriptionServiceAdapter.class);
         complianceRules = mock(ComplianceRules.class);
         environmentCurator = mock(EnvironmentCurator.class);
+        objectMapper = new ObjectMapper();
         when(owner.getId()).thenReturn("joe");
 
         ConsumerType ctype = new ConsumerType(ConsumerTypeEnum.HYPERVISOR);
@@ -148,7 +151,8 @@ public class HypervisorUpdateJobTest extends BaseJobTest {
             any(HypervisorUpdateJob.HypervisorList.class))).thenReturn(new VirtConsumerMap());
 
         HypervisorUpdateJob job = new HypervisorUpdateJob(ownerCurator, consumerCurator,
-            consumerTypeCurator, consumerResource, i18n, subAdapter, complianceRules, translator);
+            consumerTypeCurator, consumerResource, i18n, subAdapter, complianceRules, translator,
+            objectMapper);
         injector.injectMembers(job);
         job.execute(ctx);
         verify(consumerCurator).create(any(Consumer.class), eq(false));
@@ -167,7 +171,7 @@ public class HypervisorUpdateJobTest extends BaseJobTest {
             any(HypervisorUpdateJob.HypervisorList.class))).thenReturn(new VirtConsumerMap());
 
         HypervisorUpdateJob job = new HypervisorUpdateJob(ownerCurator, consumerCurator, consumerTypeCurator,
-            consumerResource, i18n, subAdapter, complianceRules, translator);
+            consumerResource, i18n, subAdapter, complianceRules, translator, objectMapper);
         injector.injectMembers(job);
         job.execute(ctx);
         ArgumentCaptor<Consumer> argument = ArgumentCaptor.forClass(Consumer.class);
@@ -194,7 +198,7 @@ public class HypervisorUpdateJobTest extends BaseJobTest {
         when(ctx.getMergedJobDataMap()).thenReturn(detail.getJobDataMap());
 
         HypervisorUpdateJob job = new HypervisorUpdateJob(ownerCurator, consumerCurator, consumerTypeCurator,
-            consumerResource, i18n, subAdapter, complianceRules, translator);
+            consumerResource, i18n, subAdapter, complianceRules, translator, objectMapper);
         injector.injectMembers(job);
         job.execute(ctx);
         verify(consumerResource).checkForFactsUpdate(any(Consumer.class), any(Consumer.class));
@@ -221,7 +225,7 @@ public class HypervisorUpdateJobTest extends BaseJobTest {
         when(ctx.getMergedJobDataMap()).thenReturn(detail.getJobDataMap());
 
         HypervisorUpdateJob job = new HypervisorUpdateJob(ownerCurator, consumerCurator, consumerTypeCurator,
-            consumerResource, i18n, subAdapter, complianceRules, translator);
+            consumerResource, i18n, subAdapter, complianceRules, translator, objectMapper);
         injector.injectMembers(job);
         job.execute(ctx);
         assertEquals("updateReporterId", hypervisor.getHypervisorId().getReporterId());
@@ -256,7 +260,7 @@ public class HypervisorUpdateJobTest extends BaseJobTest {
         when(ctx.getMergedJobDataMap()).thenReturn(detail.getJobDataMap());
 
         HypervisorUpdateJob job = new HypervisorUpdateJob(ownerCurator, consumerCurator, consumerTypeCurator,
-            consumerResource, i18n, subAdapter, complianceRules, translator);
+            consumerResource, i18n, subAdapter, complianceRules, translator, objectMapper);
         injector.injectMembers(job);
         job.execute(ctx);
 
@@ -285,7 +289,7 @@ public class HypervisorUpdateJobTest extends BaseJobTest {
             any(HypervisorUpdateJob.HypervisorList.class))).thenReturn(new VirtConsumerMap());
 
         HypervisorUpdateJob job = new HypervisorUpdateJob(ownerCurator, consumerCurator, consumerTypeCurator,
-            consumerResource, i18n, subAdapter, complianceRules, translator);
+            consumerResource, i18n, subAdapter, complianceRules, translator, objectMapper);
         injector.injectMembers(job);
         job.execute(ctx);
         verify(consumerResource, never()).createConsumerFromDTO(any(ConsumerDTO.class),
@@ -314,7 +318,7 @@ public class HypervisorUpdateJobTest extends BaseJobTest {
             .thenReturn(new VirtConsumerMap());
 
         HypervisorUpdateJob job = new HypervisorUpdateJob(ownerCurator, consumerCurator, consumerTypeCurator,
-            consumerResource, i18n, subAdapter, complianceRules, translator);
+            consumerResource, i18n, subAdapter, complianceRules, translator, objectMapper);
         injector.injectMembers(job);
         job.execute(ctx);
     }
@@ -329,7 +333,8 @@ public class HypervisorUpdateJobTest extends BaseJobTest {
         JobStatus preExistingJobStatus = new JobStatus();
         preExistingJobStatus.setState(JobState.WAITING);
         HypervisorUpdateJob job = new HypervisorUpdateJob(ownerCurator, consumerCurator,
-            consumerTypeCurator, consumerResource, i18n, subAdapter, complianceRules, translator);
+            consumerTypeCurator, consumerResource, i18n, subAdapter, complianceRules, translator,
+            objectMapper);
         JobStatus newlyScheduledJobStatus = new JobStatus();
 
         JobCurator jobCurator = mock(JobCurator.class);
@@ -372,7 +377,8 @@ public class HypervisorUpdateJobTest extends BaseJobTest {
             .thenReturn(new VirtConsumerMap());
 
         HypervisorUpdateJob job = new HypervisorUpdateJob(ownerCurator, consumerCurator,
-            consumerTypeCurator, consumerResource, i18n, subAdapter, complianceRules, translator);
+            consumerTypeCurator, consumerResource, i18n, subAdapter, complianceRules, translator,
+            objectMapper);
         injector.injectMembers(job);
 
         try {

--- a/server/src/test/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapterTest.java
+++ b/server/src/test/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapterTest.java
@@ -21,6 +21,8 @@ import static org.mockito.Matchers.argThat;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.name.Named;
 import org.candlepin.TestingModules;
 import org.candlepin.common.config.Configuration;
 import org.candlepin.model.CertificateSerial;
@@ -141,6 +143,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
     @Inject private PKIUtility realPKI;
     @Inject private Configuration config;
     @Inject private X509ExtensionUtil extensionUtil;
+    @Inject @Named("X509V3ExtensionUtilObjectMapper") private ObjectMapper mapper;
 
     @Mock private Configuration mockConfig;
     @Mock private X509V3ExtensionUtil mockV3extensionUtil;
@@ -216,7 +219,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
         );
         injector.injectMembers(this);
 
-        v3extensionUtil = new X509V3ExtensionUtil(config, entCurator);
+        v3extensionUtil = new X509V3ExtensionUtil(config, entCurator, mapper);
         certServiceAdapter = new DefaultEntitlementCertServiceAdapter(
             mockedPKI, extensionUtil, v3extensionUtil,
             mock(EntitlementCertificateCurator.class),

--- a/server/src/test/java/org/candlepin/util/UtilTest.java
+++ b/server/src/test/java/org/candlepin/util/UtilTest.java
@@ -17,6 +17,7 @@ package org.candlepin.util;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.commons.codec.binary.Base64;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -432,7 +433,7 @@ public class UtilTest {
     }
 
     @Test
-    public void json() {
+    public void json() throws JsonProcessingException {
         String test = "I Love JSON";
         String json = Util.toJson(test);
         String result = (String) Util.fromJson(json, String.class);

--- a/server/src/test/java/org/candlepin/util/X509V3ExtensionUtilTest.java
+++ b/server/src/test/java/org/candlepin/util/X509V3ExtensionUtilTest.java
@@ -17,6 +17,7 @@ package org.candlepin.util;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.candlepin.common.config.Configuration;
 import org.candlepin.model.Branding;
 import org.candlepin.model.Consumer;
@@ -55,7 +56,7 @@ public class X509V3ExtensionUtilTest {
     public void init() {
         config = mock(Configuration.class);
         ec = mock(EntitlementCurator.class);
-        util = new X509V3ExtensionUtil(config, ec);
+        util = new X509V3ExtensionUtil(config, ec, new ObjectMapper());
     }
 
     @Test


### PR DESCRIPTION
* Changed all ObjectMapper instance references to static ones
* Changed SyncUtils to a singleton to make sure the ObjectMapper its
wrapping is reused instead of recreated