### PR TITLE
[M] 1650635: Fix addons & roles compliance mismatch in rules (ENT-930)

### DIFF
--- a/server/spec/autobind_spec.rb
+++ b/server/spec/autobind_spec.rb
@@ -255,7 +255,7 @@ describe 'Autobind On Owner' do
     status['compliantAddOns']['addon1'][0]['pool']['id'].should == p1.id
   end
 
-  it 'should attach more than on addon pool when needed' do
+  it 'should attach more than one addon pool when needed' do
     product1 = create_product(random_string('product'),
                               random_string('product'),
                               {:attributes => {:addons => "addon1"},

--- a/server/src/main/java/org/candlepin/policy/js/compliance/ComplianceReason.java
+++ b/server/src/main/java/org/candlepin/policy/js/compliance/ComplianceReason.java
@@ -76,6 +76,12 @@ public class ComplianceReason {
 
         /** TODO: Fill this in */
         public static final String STORAGE_BAND = "STORAGE_BAND";
+
+        /** Key for specifying the role of the system is not covered */
+        public static final String ROLES = "ROLES";
+
+        /** Key for specifying an addon of the system is not covered */
+        public static final String ADDONS = "ADDONS";
     }
 
     private String key;

--- a/server/src/main/java/org/candlepin/policy/js/compliance/StatusReasonMessageGenerator.java
+++ b/server/src/main/java/org/candlepin/policy/js/compliance/StatusReasonMessageGenerator.java
@@ -69,6 +69,10 @@ public class StatusReasonMessageGenerator {
             " For more information, please see https://access.redhat.com/solutions/1592573"));
         REASON_MESSAGES.put(ComplianceReason.ReasonKeys.STORAGE_BAND,
             I18n.marktr("Only supports {1}TB of {2}TB of storage."));
+        REASON_MESSAGES.put(ComplianceReason.ReasonKeys.ROLES,
+            I18n.marktr("Supports role(s) {1} but the system has {2}."));
+        REASON_MESSAGES.put(ComplianceReason.ReasonKeys.ADDONS,
+            I18n.marktr("Supports addon(s) {1} but the system has {2}."));
         DEFAULT_REASON_MESSAGE =
             I18n.marktr("{0} COVERAGE PROBLEM.  Supports {1} of {2}");
     }


### PR DESCRIPTION
Fixes a few things on the back of previous work
to make roles & addons behave similarly to products
in terms of compliance:

- Fix deserialization error by providing a non-compliance reason
of addons and roles in the form of CSV for the whole pool stack,
instead of in the form of an array.
- Alter rules' use of product attribute name from 'role' to 'roles'
as agreed with IT.
- Check for role/addon compliance against each separate value in the
CSV of the role/addon product attribute strings.
- Added proper Compliance Reason output strings for role/addon
mismatch to show to the user.
- Added spec tests that check mismatched role/addons does not
result to failure and the proper reasons are returned.