### PR TITLE
[2.5] 1634451: Fixed an issue with syspurpose changes not updating status (ENT-908)

### DIFF
--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -1348,7 +1348,7 @@ public class ConsumerResource {
 
             // this should update compliance on toUpdate, but not call the curator
             complianceRules.getStatus(toUpdate, null, false, false);
-            systemPurposeComplianceRules.getStatus(toUpdate, toUpdate.getEntitlements(), null, false, false);
+            systemPurposeComplianceRules.getStatus(toUpdate, toUpdate.getEntitlements(), null, false, true);
 
             Event event = eventBuilder.setEventData(toUpdate).buildEvent();
             sink.queueEvent(event);


### PR DESCRIPTION
- Fixed an issue with changes to system purpose not causing the
  syspurpose compliance status hash to be updated, events
  generated, nor system purpose status to be retained.