### PR TITLE
Reconnect to Artemis broker when connection goes down

### DIFF
--- a/server/src/main/java/org/candlepin/audit/ActiveMQConnection.java
+++ b/server/src/main/java/org/candlepin/audit/ActiveMQConnection.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2009 - 2016 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.audit;
+
+import org.apache.activemq.artemis.api.core.ActiveMQException;
+import org.apache.activemq.artemis.api.core.client.ClientSession;
+import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
+import org.apache.activemq.artemis.api.core.client.ServerLocator;
+import org.candlepin.common.config.Configuration;
+import org.candlepin.config.ConfigProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An abstract base class representing a connection to the message bus.
+ */
+public abstract class ActiveMQConnection {
+
+    private static Logger log = LoggerFactory.getLogger(ActiveMQConnection.class);
+
+    protected ServerLocator locator;
+    protected String serverUrl;
+    protected ClientSessionFactory factory;
+
+
+    public ActiveMQConnection(Configuration config) {
+        serverUrl = config.getProperty(ConfigProperties.ACTIVEMQ_BROKER_URL);
+    }
+
+    /**
+     * Creates an instance of a ServerLocator that is configured with the connection
+     * details of the target broker. Called on the first invocation of getFactory().
+     *
+     * @return a fully configured ServerLocator from which a ClientSessionFactory can be created.
+     * @throws Exception thrown when an error occurs while creating the locator.
+     */
+    abstract ServerLocator initLocator() throws Exception;
+
+    /**
+     * Creates an instance of a ClientSessionFactory from the provided locator.
+     * Called on the first invocation of getFactory().
+     *
+     * @param locator the ServerLocator to be used to create the session factory.
+     * @return the ClientSessionFactory representing the connection to the broker.
+     * @throws Exception when an error occurs creating the session factory.
+     */
+    abstract ClientSessionFactory initClientSessionFactory(ServerLocator locator) throws Exception;
+
+    /**
+     * Creates a new instance of a client session.
+     *
+     * @return
+     * @throws ActiveMQException
+     */
+    abstract ClientSession createClientSession() throws ActiveMQException;
+
+    /**
+     * Gets the single ClientSessionFactory instance that represents the connection to the broker.
+     * The initial connection to the broker will be made on the first invocation of this method.
+     *
+     * @return the single connection factory instance.
+     */
+    synchronized ClientSessionFactory getFactory() {
+        try {
+            if (this.locator == null) {
+                this.locator = initLocator();
+            }
+            if (this.factory == null || this.factory.isClosed()) {
+                this.factory = initClientSessionFactory(this.locator);
+            }
+        }
+        catch (Exception e) {
+            log.error("Unable to create connection to message bus.", e);
+            throw new RuntimeException(e);
+        }
+        return this.factory;
+    }
+
+    public boolean isClosed() {
+        try {
+            return this.factory == null || this.factory.isClosed();
+        }
+        catch (Exception e) {
+            return true;
+        }
+    }
+
+    public void close() {
+        if (!isClosed()) {
+            this.factory.close();
+        }
+    }
+}

--- a/server/src/main/java/org/candlepin/audit/ActiveMQStatus.java
+++ b/server/src/main/java/org/candlepin/audit/ActiveMQStatus.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+ * Copyright (c) 2009 - 2016 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -16,29 +16,25 @@
 package org.candlepin.audit;
 
 /**
- * Represents the status of the connection to the Qpid broker.
+ * Represents the status of the connection to the ActiveMQ broker.
  */
-public enum QpidStatus {
-    /**
-     * Qpid is up and running.
-     */
-    CONNECTED,
+public enum ActiveMQStatus {
 
     /**
-     * Qpid is up but the exchange is flow stopped.
-     */
-
-    FLOW_STOPPED,
-
-    /**
-     * Qpid is down.
+     * The broker instance is down and
      */
     DOWN,
 
     /**
-     * The status of Qpid is currently unknown. This state should only be set on
+     * The broker instance is online and available for new connections.
+     */
+    CONNECTED,
+
+    /**
+     * The broker status is currently unknown. This state should only be set on
      * candlepin startup and should be updated accordingly when the candlepin
      * context is loaded and all listeners have been registered.
      */
     UNKNOWN
+
 }

--- a/server/src/main/java/org/candlepin/audit/EventMessageReceiver.java
+++ b/server/src/main/java/org/candlepin/audit/EventMessageReceiver.java
@@ -17,7 +17,6 @@ package org.candlepin.audit;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
-import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,9 +29,9 @@ public class EventMessageReceiver extends MessageReceiver {
 
     private static Logger log = LoggerFactory.getLogger(EventMessageReceiver.class);
 
-    public EventMessageReceiver(EventListener listener, ClientSessionFactory sessionFactory,
+    public EventMessageReceiver(EventListener listener, ActiveMQConnection connection,
         ObjectMapper mapper) throws ActiveMQException {
-        super(listener, sessionFactory, mapper);
+        super(listener, connection, mapper);
     }
 
     @Override

--- a/server/src/main/java/org/candlepin/audit/EventSink.java
+++ b/server/src/main/java/org/candlepin/audit/EventSink.java
@@ -30,8 +30,6 @@ import java.util.List;
  */
 public interface EventSink {
 
-    void initialize() throws Exception;
-
     void queueEvent(Event event);
 
     void sendEvents();

--- a/server/src/main/java/org/candlepin/audit/EventSinkConnection.java
+++ b/server/src/main/java/org/candlepin/audit/EventSinkConnection.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2009 - 2016 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.audit;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import org.apache.activemq.artemis.api.core.ActiveMQException;
+import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
+import org.apache.activemq.artemis.api.core.client.ClientSession;
+import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
+import org.apache.activemq.artemis.api.core.client.ServerLocator;
+import org.candlepin.common.config.Configuration;
+import org.candlepin.config.ConfigProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An ActiveMQ connection that is configured for the EventSink. This connection will
+ * will continuously attempt reconnects to the broker if the connection is lost. This
+ * is to ensure that message sends can survive while a broker is restarted so long as
+ * candlepin remains up.
+ *
+ * NOTE: This is legacy behavior and could likely be better supported by JTA in the
+ *       future.
+ */
+@Singleton
+public class EventSinkConnection extends ActiveMQConnection {
+    private static Logger log = LoggerFactory.getLogger(EventSinkConnection.class);
+    private int largeMessageSize;
+
+    @Inject
+    public EventSinkConnection(Configuration config) {
+        super(config);
+        this.largeMessageSize = config.getInt(ConfigProperties.ACTIVEMQ_LARGE_MSG_SIZE);
+    }
+
+    @Override
+    ServerLocator initLocator() throws Exception {
+        ServerLocator locator = ActiveMQClient.createServerLocator(serverUrl);
+        locator.setMinLargeMessageSize(this.largeMessageSize);
+        locator.setReconnectAttempts(-1);
+        return locator;
+    }
+
+    @Override
+    ClientSessionFactory initClientSessionFactory(ServerLocator locator) throws Exception {
+        return locator.createSessionFactory();
+    }
+
+    @Override
+    ClientSession createClientSession() throws ActiveMQException {
+        return getFactory().createTransactedSession();
+    }
+
+}

--- a/server/src/main/java/org/candlepin/audit/EventSinkImpl.java
+++ b/server/src/main/java/org/candlepin/audit/EventSinkImpl.java
@@ -15,8 +15,8 @@
 package org.candlepin.audit;
 
 import org.candlepin.common.config.Configuration;
-import org.candlepin.config.ConfigProperties;
 import org.candlepin.controller.ModeManager;
+import org.candlepin.guice.CandlepinRequestScoped;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.Owner;
 import org.candlepin.model.Pool;
@@ -27,16 +27,12 @@ import org.candlepin.policy.SystemPurposeComplianceStatus;
 import org.candlepin.policy.js.compliance.ComplianceStatus;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.inject.Singleton;
 
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.SimpleString;
-import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
 import org.apache.activemq.artemis.api.core.client.ClientProducer;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
-import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
-import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,110 +44,42 @@ import javax.inject.Inject;
 /**
  * EventSink - Queues events to be sent after request/job completes, and handles actual
  * sending of events on successful job or API request, as well as rollback if either fails.
+ *
+ * An single instance of this object will be created per request/job.
  */
-@Singleton
+@CandlepinRequestScoped
 public class EventSinkImpl implements EventSink {
     private static Logger log = LoggerFactory.getLogger(EventSinkImpl.class);
 
     private EventFactory eventFactory;
-    private ClientSessionFactory factory;
-    private Configuration config;
     private ObjectMapper mapper;
     private EventFilter eventFilter;
-    private int largeMsgSize;
     private ModeManager modeManager;
+    private Configuration config;
 
-    /*
-     * Important use of ThreadLocal here, each Tomcat/Quartz thread gets it's own session
-     * which is reused across invocations. Sessions must have commit or rollback called
-     * on them per request/job. This is handled in EventFilter for the API, and KingpinJob
-     * for quartz jobs.
-     */
-    private ThreadLocal<ClientSession> sessions = new ThreadLocal<>();
-    private ThreadLocal<ClientProducer> producers = new ThreadLocal<>();
+    private EventSinkConnection connection;
+    private EventMessageSender messageSender;
 
     @Inject
     public EventSinkImpl(EventFilter eventFilter, EventFactory eventFactory,
-        ObjectMapper mapper, Configuration config, ModeManager modeManager) {
-
+        ObjectMapper mapper, Configuration config, EventSinkConnection connection,
+        ModeManager modeManager) throws ActiveMQException {
         this.eventFactory = eventFactory;
-        this.config = config;
         this.mapper = mapper;
         this.eventFilter = eventFilter;
-        this.largeMsgSize = config.getInt(ConfigProperties.ACTIVEMQ_LARGE_MSG_SIZE);
         this.modeManager = modeManager;
+        this.config = config;
+        this.connection = connection;
     }
 
-    /**
-     * Initializes the Singleton from the ContextListener not from the ctor.
-     * @throws Exception thrown if there's a problem creating the session factory.
-     */
-    @Override
-    public void initialize() throws Exception {
-        if (this.factory == null) {
-            this.factory = createClientSessionFactory();
-        }
-
-        log.info("EventSink Initialized");
-    }
-
-    protected ClientSessionFactory createClientSessionFactory() throws Exception {
-        String serverUrl = config.getProperty(ConfigProperties.ACTIVEMQ_BROKER_URL);
-        ServerLocator locator = ActiveMQClient.createServerLocator(serverUrl);
-        locator.setMinLargeMessageSize(largeMsgSize);
-        locator.setReconnectAttempts(-1);
-        return locator.createSessionFactory();
-    }
-
-    protected ClientSession getClientSession() {
-        ClientSession session = sessions.get();
-        if (session == null || session.isClosed()) {
-            try {
-                /*
-                 * Use a transacted ActiveMQ session, events will not be dispatched until
-                 * commit() is called on it, and a call to rollback() will revert any queued
-                 * messages safely and the session is then ready to start over the next time
-                 * the thread is used.
-                 */
-                session = this.factory.createTransactedSession();
-                this.sessions.set(session);
-
-                log.debug("Created new ActiveMQ session: {}", System.identityHashCode(session));
-            }
-            catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        }
-
-        return session;
-    }
-
-    protected ClientProducer getClientProducer() {
-        ClientProducer producer = producers.get();
-        if (producer == null || producer.isClosed()) {
-            try {
-                ClientSession session = this.getClientSession();
-
-                producer = session.createProducer(MessageAddress.DEFAULT_EVENT_MESSAGE_ADDRESS);
-                this.producers.set(producer);
-
-                log.debug("Created new ActiveMQ producer: {}", System.identityHashCode(producer));
-            }
-            catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        }
-
-        return producer;
-    }
-
+    // FIXME This method really does not belong here. It should probably be moved
+    //       to its own class.
     @Override
     public List<QueueStatus> getQueueInfo() {
         List<QueueStatus> results = new LinkedList<>();
-        try {
-            ClientSession session = getClientSession();
-            session.start();
 
+        try (ClientSession session = this.connection.createClientSession()) {
+            session.start();
             for (String listenerClassName : ActiveMQContextListener.getActiveMQListeners(config)) {
                 String queueName = "event." + listenerClassName;
                 long msgCount = session.queueQuery(new SimpleString(queueName)).getMessageCount();
@@ -159,9 +87,8 @@ public class EventSinkImpl implements EventSink {
             }
         }
         catch (Exception e) {
-            log.error("Error looking up ActiveMQ queue info", e);
+            log.error("Error looking up ActiveMQ queue info: ", e);
         }
-
         return results;
     }
 
@@ -187,13 +114,12 @@ public class EventSinkImpl implements EventSink {
         log.debug("Queuing event: {}", event);
 
         try {
-            ClientSession session = getClientSession();
-            ClientMessage message = session.createMessage(true);
-            String eventString = mapper.writeValueAsString(event);
-            message.getBodyBuffer().writeString(eventString);
-
-            // NOTE: not actually send until we commit the session.
-            getClientProducer().send(message);
+            // Lazily initialize the message sender when the first
+            // message gets queued.
+            if (messageSender == null) {
+                messageSender = new EventMessageSender(this.connection);
+            }
+            messageSender.queueMessage(mapper.writeValueAsString(event));
         }
         catch (Exception e) {
             log.error("Error while trying to send event", e);
@@ -207,28 +133,24 @@ public class EventSinkImpl implements EventSink {
      */
     @Override
     public void sendEvents() {
-        log.debug("Committing ActiveMQ transaction");
-
-        try (ClientSession session = this.getClientSession()) {
-            session.commit();
+        if (!hasQueuedMessages()) {
+            log.debug("No events to send.");
+            return;
         }
-        catch (Exception e) {
-            // This would be pretty bad, but we always try not to let event errors
-            // interfere with the operation of the overall application.
-            log.error("Error committing ActiveMQ transaction", e);
-        }
+        messageSender.sendMessages();
     }
 
     @Override
     public void rollback() {
-        log.warn("Rolling back ActiveMQ transaction");
+        if (!hasQueuedMessages()) {
+            log.debug("No events to roll back.");
+            return;
+        }
+        messageSender.cancelMessages();
+    }
 
-        try (ClientSession session = this.getClientSession()) {
-            session.rollback();
-        }
-        catch (ActiveMQException e) {
-            log.error("Error rolling back ActiveMQ transaction", e);
-        }
+    private boolean hasQueuedMessages() {
+        return messageSender != null;
     }
 
     public void emitConsumerCreated(Consumer newConsumer) {
@@ -289,5 +211,64 @@ public class EventSinkImpl implements EventSink {
     @Override
     public void emitCompliance(Consumer consumer, SystemPurposeComplianceStatus compliance) {
         queueEvent(eventFactory.complianceCreated(consumer, compliance));
+    }
+
+    /**
+     * An internal class responsible for encapsulating a single session to the
+     * event message broker.
+     */
+    private class EventMessageSender {
+
+        private ActiveMQConnection connection;
+        private ClientSession session;
+        private ClientProducer producer;
+
+        public EventMessageSender(ActiveMQConnection connection) {
+            try {
+                /*
+                 * Uses a transacted ActiveMQ session, events will not be dispatched until
+                 * commit() is called on it, and a call to rollback() will revert any queued
+                 * messages safely and the session is then ready to start over the next time
+                 * the thread is used.
+                 */
+                session = connection.createClientSession();
+                producer = session.createProducer(MessageAddress.DEFAULT_EVENT_MESSAGE_ADDRESS);
+            }
+            catch (ActiveMQException e) {
+                throw new RuntimeException(e);
+            }
+            log.debug("Created new message sender.");
+        }
+
+        public void queueMessage(String eventString) throws ActiveMQException {
+            ClientMessage message = session.createMessage(true);
+            message.getBodyBuffer().writeString(eventString);
+
+            // NOTE: not actually sent until we commit the session.
+            producer.send(message);
+        }
+
+        public void sendMessages() {
+            log.debug("Committing ActiveMQ transaction.");
+            try (ClientSession toClose = session) {
+                toClose.commit();
+            }
+            catch (Exception e) {
+                // This would be pretty bad, but we always try not to let event errors
+                // interfere with the operation of the overall application.
+                log.error("Error committing ActiveMQ transaction", e);
+            }
+        }
+
+        public void cancelMessages() {
+            log.warn("Rolling back ActiveMQ transaction.");
+            try (ClientSession toClose = session) {
+                toClose.rollback();
+            }
+            catch (ActiveMQException e) {
+                log.error("Error rolling back ActiveMQ transaction", e);
+            }
+        }
+
     }
 }

--- a/server/src/main/java/org/candlepin/audit/EventSource.java
+++ b/server/src/main/java/org/candlepin/audit/EventSource.java
@@ -17,10 +17,8 @@ package org.candlepin.audit;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Inject;
 
-import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
-import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
-import org.candlepin.common.config.Configuration;
-import org.candlepin.config.ConfigProperties;
+import com.google.inject.Singleton;
+import org.candlepin.controller.ActiveMQStatusListener;
 import org.candlepin.controller.QpidStatusListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,46 +29,33 @@ import java.util.List;
 /**
  * EventSource
  */
-public class EventSource implements QpidStatusListener {
+@Singleton
+public class EventSource implements QpidStatusListener, ActiveMQStatusListener {
     private static  Logger log = LoggerFactory.getLogger(EventSource.class);
 
-    private ClientSessionFactory factory;
     private ObjectMapper mapper;
+    private EventSourceConnection connection;
     private List<MessageReceiver> messageReceivers = new LinkedList<>();
 
 
     @Inject
-    public EventSource(ObjectMapper mapper, Configuration config) {
+    public EventSource(EventSourceConnection connection, ObjectMapper mapper) {
+        this.connection = connection;
         this.mapper = mapper;
-
-        try {
-            factory =  createSessionFactory(config);
-        }
-        catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    /**
-     * @return new instance of {@link ClientSessionFactory}
-     * @throws Exception
-     */
-    protected ClientSessionFactory createSessionFactory(Configuration config) throws Exception {
-        String serverUrl = config.getProperty(ConfigProperties.ACTIVEMQ_BROKER_URL);
-        return ActiveMQClient.createServerLocator(serverUrl).createSessionFactory();
     }
 
     protected void shutDown() {
         closeEventReceivers();
-        factory.close();
+        this.connection.close();
     }
 
     void registerListener(EventListener listener) throws Exception {
+        log.debug("Registering event listener for queue: {}", EventSource.getQueueName(listener));
         if (listener.requiresQpid()) {
-            this.messageReceivers.add(new QpidEventMessageReceiver(listener, factory, mapper));
+            this.messageReceivers.add(new QpidEventMessageReceiver(listener, this.connection, mapper));
         }
         else {
-            this.messageReceivers.add(new EventMessageReceiver(listener, factory, mapper));
+            this.messageReceivers.add(new EventMessageReceiver(listener, this.connection, mapper));
         }
     }
 
@@ -81,7 +66,6 @@ public class EventSource implements QpidStatusListener {
     @Override
     public void onStatusUpdate(QpidStatus oldStatus, QpidStatus newStatus) {
         if (newStatus.equals(oldStatus)) {
-            log.debug("Status has not changed.");
             return;
         }
 
@@ -91,18 +75,54 @@ public class EventSource implements QpidStatusListener {
                 continue;
             }
 
-            if (QpidStatus.FLOW_STOPPED.equals(newStatus) || QpidStatus.DOWN.equals(newStatus)) {
-                log.debug("Stopping session for EventReciever.");
-                receiver.stopSession();
+            switch (newStatus) {
+                case FLOW_STOPPED:
+                case DOWN:
+                    receiver.pause();
+                    break;
+                case CONNECTED:
+                    receiver.resume();
+                    break;
+                default:
+                    // do nothing
             }
-            else if (QpidStatus.CONNECTED.equals(newStatus)) {
-                log.debug("Starting session for EventReciever.");
-                receiver.startSession();
-            }
+        }
+    }
+
+    /**
+     * Called when the ActiveMQStatusMonitor determines that the connection to the
+     * ActiveMQ broker has changed.
+     *
+     * @param oldStatus the old status of the broker.
+     * @param newStatus the current status of the broker.
+     */
+    @Override
+    public void onStatusUpdate(ActiveMQStatus oldStatus, ActiveMQStatus newStatus) {
+        log.debug("ActiveMQ status has been updated: {}:{}", oldStatus, newStatus);
+        if (ActiveMQStatus.DOWN.equals(newStatus) && !ActiveMQStatus.DOWN.equals(oldStatus)) {
+            log.info("Shutting down all message receivers because the broker went down.");
+            shutDown();
+        }
+        else if (ActiveMQStatus.CONNECTED.equals(newStatus) && !ActiveMQStatus.CONNECTED.equals(oldStatus)) {
+            log.info("Connecting to message broker and initializing all message listeners.");
+
+            // Attempt a shutdown to be sure that all resources are cleared.
+            shutDown();
+
+            this.messageReceivers.forEach(receiver -> {
+                try {
+                    receiver.connect();
+                }
+                catch (Exception e) {
+                    log.warn("Unable to reconnect message listeners. Messages will not be received: {}",
+                        receiver.getQueueAddress(), e);
+                }
+            });
         }
     }
 
     public static String getQueueName(EventListener listener) {
         return MessageAddress.EVENT_ADDRESS_PREFIX + "." + listener.getClass().getCanonicalName();
     }
+
 }

--- a/server/src/main/java/org/candlepin/audit/EventSourceConnection.java
+++ b/server/src/main/java/org/candlepin/audit/EventSourceConnection.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2009 - 2016 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.audit;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import org.apache.activemq.artemis.api.core.ActiveMQException;
+import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
+import org.apache.activemq.artemis.api.core.client.ClientSession;
+import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
+import org.apache.activemq.artemis.api.core.client.ServerLocator;
+import org.candlepin.common.config.Configuration;
+import org.candlepin.controller.ActiveMQStatusMonitor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An ActiveMQ connection specifically configured for candlepin's EventSource. This is a basic
+ * connection that will be notified as soon as the broker goes down and will be monitored by
+ * the ActiveMQStatusMonitor.
+ */
+@Singleton
+public class EventSourceConnection extends ActiveMQConnection {
+
+    private static Logger log = LoggerFactory.getLogger(EventSourceConnection.class);
+    private ActiveMQStatusMonitor monitor;
+
+    @Inject
+    public EventSourceConnection(ActiveMQStatusMonitor monitor, Configuration config) {
+        super(config);
+        this.monitor = monitor;
+    }
+
+    @Override
+    ServerLocator initLocator() throws Exception {
+        return ActiveMQClient.createServerLocator(serverUrl);
+    }
+
+    @Override
+    ClientSessionFactory initClientSessionFactory(ServerLocator locator) throws Exception {
+        ClientSessionFactory factory = locator.createSessionFactory();
+        factory.getConnection().addCloseListener(this.monitor);
+        return factory;
+    }
+
+    @Override
+    ClientSession createClientSession() throws ActiveMQException {
+        // The client session is created without auto-acking enabled. This means
+        // that the client handlers will have to manage the session themselves.
+        // The session management will be done by each individual ListenerWrapper.
+        //
+        // A message ack batch size of 0 is specified to prevent duplicate messages
+        // if the server goes down before the batch ack size is reached.
+        return getFactory().createSession(false, false, 0);
+    }
+
+}

--- a/server/src/main/java/org/candlepin/audit/MessageReceiver.java
+++ b/server/src/main/java/org/candlepin/audit/MessageReceiver.java
@@ -19,7 +19,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.client.ClientConsumer;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
-import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.MessageHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,6 +31,8 @@ public abstract class MessageReceiver implements MessageHandler {
 
     private static Logger log = LoggerFactory.getLogger(MessageReceiver.class);
 
+    private ActiveMQConnection connection;
+
     protected ClientSession session;
     protected ObjectMapper mapper;
     protected EventListener listener;
@@ -40,50 +41,48 @@ public abstract class MessageReceiver implements MessageHandler {
 
     protected abstract String getQueueAddress();
 
-    public MessageReceiver(EventListener listener, ClientSessionFactory sessionFactory,
+    public MessageReceiver(EventListener listener, ActiveMQConnection connection,
         ObjectMapper mapper) throws ActiveMQException {
+        this.connection = connection;
         this.mapper = mapper;
         this.listener = listener;
-
-        queueName = EventSource.getQueueName(listener);
-        log.debug("registering listener for {}", queueName);
-
-        // The client session is created without auto-acking enabled. This means
-        // that the client handlers will have to manage the session themselves.
-        // The session management will be done by each individual ListenerWrapper.
-        //
-        // A message ack batch size of 0 is specified to prevent duplicate messages
-        // if the server goes down before the batch ack size is reached.
-        session = sessionFactory.createSession(false, false, 0);
-
-        consumer = session.createConsumer(queueName);
-        consumer.setMessageHandler(this);
-        session.start();
+        this.queueName = EventSource.getQueueName(listener);
     }
 
     public boolean requiresQpid() {
         return this.listener.requiresQpid();
     }
 
-    public void stopSession() {
+    /**
+     * Pause message consumption for this receiver.
+     */
+    public void pause() {
         try {
+            log.debug("Pausing message consumption for: {}.", listener);
             this.consumer.close();
         }
         catch (ActiveMQException e) {
-            log.warn("QpidEventMessageReceiver could not stop client consumer.", e);
+            log.warn("Message receiver could not stop client consumer.", e);
         }
     }
 
-    public void startSession() {
+    /**
+     * Resume message consumption for this receiver.
+     */
+    public void resume() {
+        if (session.isClosed()) {
+            log.warn("MessageReceiver was unable to resume message consumption. Artemis DOWN!");
+            return;
+        }
         try {
             if (this.consumer.isClosed()) {
-                log.debug("### Recreating the ActiveMQ client for {}.", listener);
+                log.debug("Resuming message consumption for {}.", listener);
                 this.consumer = session.createConsumer(queueName);
                 this.consumer.setMessageHandler(this);
             }
         }
         catch (ActiveMQException e) {
-            log.warn("QpidEventMessageReceiver could not start client session.", e);
+            log.warn("MessageReceiver could not start client session.", e);
         }
     }
 
@@ -92,18 +91,32 @@ public abstract class MessageReceiver implements MessageHandler {
      */
     public void close() {
         log.debug("Shutting down message receiver for {}.", listener);
-        try {
-            this.session.stop();
-        }
-        catch (ActiveMQException e) {
-            log.warn("QpidEventMessageReceiver could not stop client session.", e);
+        if (session != null && !session.isClosed()) {
+
+            try {
+                this.session.stop();
+            }
+            catch (ActiveMQException e) {
+                log.warn("MessageReceiver could not stop client session.", e);
+            }
+
+            try {
+                this.session.close();
+            }
+            catch (ActiveMQException e) {
+                log.warn("Error closing client session.", e);
+            }
         }
 
-        try {
-            this.session.close();
-        }
-        catch (ActiveMQException e) {
-            log.warn("Error closing client session.", e);
+    }
+
+    public void connect() throws ActiveMQException {
+        if (session == null || session.isClosed()) {
+            session = this.connection.createClientSession();
+
+            consumer = session.createConsumer(queueName);
+            consumer.setMessageHandler(this);
+            session.start();
         }
     }
 }

--- a/server/src/main/java/org/candlepin/audit/NoopEventSinkImpl.java
+++ b/server/src/main/java/org/candlepin/audit/NoopEventSinkImpl.java
@@ -119,11 +119,6 @@ public class NoopEventSinkImpl implements EventSink {
     }
 
     @Override
-    public void initialize() throws Exception {
-
-    }
-
-    @Override
     public List<QueueStatus> getQueueInfo() {
         return null;
     }

--- a/server/src/main/java/org/candlepin/audit/QpidEventMessageReceiver.java
+++ b/server/src/main/java/org/candlepin/audit/QpidEventMessageReceiver.java
@@ -17,7 +17,6 @@ package org.candlepin.audit;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
-import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,9 +29,9 @@ public class QpidEventMessageReceiver extends MessageReceiver {
     private static final String AMQ_ORIG_ADDRESS = "_AMQ_ORIG_ADDRESS";
     private static final String AMQ_ORIG_MSG_ID = "_AMQ_ORIG_MESSAGE_ID";
 
-    public QpidEventMessageReceiver(EventListener listener, ClientSessionFactory sessionFactory,
+    public QpidEventMessageReceiver(EventListener listener, ActiveMQConnection connection,
         ObjectMapper mapper) throws ActiveMQException {
-        super(listener, sessionFactory, mapper);
+        super(listener, connection, mapper);
     }
 
     /**

--- a/server/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/server/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -84,6 +84,13 @@ public class ConfigProperties {
      */
     public static final String ACTIVEMQ_LARGE_MSG_SIZE = "candlepin.audit.hornetq.large_msg_size";
 
+    /**
+     * The interval (in milliseconds) at which the ActiveMQStatusMonitor will check the connection state
+     * once the connection has dropped.
+     */
+    public static final String ACTIVEMQ_CONNECTION_MONITOR_INTERVAL =
+        "candlepin.audit.hornetq.monitor.interval";
+
     public static final String AUDIT_LISTENERS = "candlepin.audit.listeners";
     public static final String AUDIT_LOG_FILE = "candlepin.audit.log_file";
     /**
@@ -280,6 +287,7 @@ public class ConfigProperties {
             // By default use the broker.xml file that is packaged in the war.
             this.put(ACTIVEMQ_SERVER_CONFIG_PATH, "");
             this.put(ACTIVEMQ_LARGE_MSG_SIZE, Integer.toString(100 * 1024));
+            this.put(ACTIVEMQ_CONNECTION_MONITOR_INTERVAL, "5000"); // milliseconds
 
             this.put(AUDIT_LISTENERS,
                 "org.candlepin.audit.DatabaseListener," +

--- a/server/src/main/java/org/candlepin/controller/ActiveMQStatusListener.java
+++ b/server/src/main/java/org/candlepin/controller/ActiveMQStatusListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+ * Copyright (c) 2009 - 2016 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,33 +12,22 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
+package org.candlepin.controller;
 
-package org.candlepin.audit;
+import org.candlepin.audit.ActiveMQStatus;
 
 /**
- * Represents the status of the connection to the Qpid broker.
+ * An interface for Objects that wish to be notified about ActiveMQ broker
+ * status changes.
  */
-public enum QpidStatus {
-    /**
-     * Qpid is up and running.
-     */
-    CONNECTED,
+public interface ActiveMQStatusListener {
 
     /**
-     * Qpid is up but the exchange is flow stopped.
+     * Called each time the ActiveMQStatusListener checks the status of the broker.
+     *
+     * @param oldStatus the old status of the broker.
+     * @param newStatus the current status of the broker.
      */
+    void onStatusUpdate(ActiveMQStatus oldStatus, ActiveMQStatus newStatus);
 
-    FLOW_STOPPED,
-
-    /**
-     * Qpid is down.
-     */
-    DOWN,
-
-    /**
-     * The status of Qpid is currently unknown. This state should only be set on
-     * candlepin startup and should be updated accordingly when the candlepin
-     * context is loaded and all listeners have been registered.
-     */
-    UNKNOWN
 }

--- a/server/src/main/java/org/candlepin/controller/ActiveMQStatusMonitor.java
+++ b/server/src/main/java/org/candlepin/controller/ActiveMQStatusMonitor.java
@@ -1,0 +1,147 @@
+/**
+ * Copyright (c) 2009 - 2016 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.controller;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
+import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
+import org.apache.activemq.artemis.api.core.client.ServerLocator;
+import org.apache.activemq.artemis.core.remoting.CloseListener;
+import org.candlepin.audit.ActiveMQStatus;
+import org.candlepin.common.config.Configuration;
+import org.candlepin.config.ConfigProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Monitors the status of the ActiveMQ connection and notifies listeners when
+ * there are issues with the connection.
+ */
+@Singleton
+public class ActiveMQStatusMonitor implements Runnable, CloseListener {
+
+    private static Logger log = LoggerFactory.getLogger(ActiveMQStatusMonitor.class);
+
+    private Configuration config;
+    private long monitorInterval;
+    private List<ActiveMQStatusListener> registeredListeners;
+    private ActiveMQStatus lastReported;
+    private ScheduledExecutorService executorService;
+    private Future<?> future = null;
+    private final Object lock = new Object();
+
+    @Inject
+    public ActiveMQStatusMonitor(Configuration config) {
+        this.config = config;
+        this.monitorInterval = config.getLong(ConfigProperties.ACTIVEMQ_CONNECTION_MONITOR_INTERVAL);
+        this.registeredListeners = new LinkedList<>();
+        executorService = Executors.newSingleThreadScheduledExecutor();
+        this.lastReported = ActiveMQStatus.UNKNOWN;
+    }
+
+    /**
+     * Checks the status of the connection to the broker and starts the monitor
+     * if it is down.
+     */
+    public void initialize() {
+        ActiveMQStatus current = testConnection() ? ActiveMQStatus.CONNECTED : ActiveMQStatus.DOWN;
+        notifyListeners(current);
+
+        // If the connection is currently down, start monitoring the connection
+        // so that candlepin will be notified when it comes back up.
+        if (ActiveMQStatus.DOWN.equals(current)) {
+            monitorConnection();
+        }
+    }
+
+    public void registerListener(ActiveMQStatusListener listener) {
+        this.registeredListeners.add(listener);
+    }
+
+    @Override
+    public void connectionClosed() {
+        notifyListeners(ActiveMQStatus.DOWN);
+        monitorConnection();
+    }
+
+    private void monitorConnection() {
+        // Since there can be multiple connections reporting that they have closed,
+        // ensure that we only start one monitoring task.
+        synchronized (lock) {
+            if (future == null || future.isDone() || future.isCancelled()) {
+                log.info("Scheduling connection retries.");
+                future = executorService.scheduleAtFixedRate(this, 1, monitorInterval, TimeUnit.MILLISECONDS);
+            }
+            else {
+                log.info("Monitor already running.");
+            }
+        }
+    }
+
+    @Override
+    public void run() {
+        log.debug("Checking status of the ActiveMQ broker.");
+        if (testConnection()) {
+            notifyListeners(ActiveMQStatus.CONNECTED);
+            future.cancel(false);
+        }
+    }
+
+    protected boolean testConnection() {
+        ServerLocator locator = null;
+        ClientSessionFactory factory = null;
+        try {
+            String serverUrl = config.getProperty(ConfigProperties.ACTIVEMQ_BROKER_URL);
+            locator = ActiveMQClient.createServerLocator(serverUrl);
+            locator.createSessionFactory();
+            log.info("Connection to ActiveMQ is available.");
+            return true;
+        }
+        catch (Exception e) {
+            log.debug("Connection to ActiveMQ is unavailable.", e);
+            return false;
+        }
+        finally {
+            if (factory != null) {
+                factory.close();
+            }
+            if (locator != null) {
+                locator.close();
+            }
+        }
+    }
+
+    private void notifyListeners(ActiveMQStatus newStatus) {
+        log.debug("Notifying listeners of new status: {}", newStatus);
+        this.registeredListeners.forEach(listener -> {
+            try {
+                listener.onStatusUpdate(lastReported, newStatus);
+            }
+            catch (Exception e) {
+                // If the listener throws an exception, log it and move on to the next.
+                log.error("Unable to notify listener about new status: {}", listener.getClass(), e);
+            }
+        });
+        lastReported = newStatus;
+    }
+}

--- a/server/src/main/java/org/candlepin/controller/ModeManager.java
+++ b/server/src/main/java/org/candlepin/controller/ModeManager.java
@@ -32,9 +32,9 @@ public interface ModeManager {
     /**
      * Enters a mode m. Reason should be a machine readable enumeration
      * @param m new Mode into which Candlepin should enter
-     * @param reason why is Candlepin entering this mode?
+     * @param reasons why is Candlepin entering this mode?
      */
-    void enterMode(Mode m, Reason reason);
+    void enterMode(Mode m, Reason ... reasons);
     /**
      * Checks if Candlepin is in suspend mode. In case it is, this method
      * will throw an error. This method is useful to quickly fail requests

--- a/server/src/main/java/org/candlepin/controller/ModeManagerImpl.java
+++ b/server/src/main/java/org/candlepin/controller/ModeManagerImpl.java
@@ -60,7 +60,7 @@ public class ModeManagerImpl implements ModeManager {
     }
 
     @Override
-    public void enterMode(Mode m, Reason reason) {
+    public void enterMode(Mode m, Reason ... reasons) {
         /**
          * When suspend mode is disabled, the Candlepin should never get into Suspend Mode.
          * Candlepin is starting always in NORMAL mode, so disalowing the transition here should
@@ -74,22 +74,22 @@ public class ModeManagerImpl implements ModeManager {
             return;
         }
 
-        if (reason == null) {
+        if (reasons == null || reasons.length == 0) {
             String noReasonErrorString = "No reason supplied when trying to change CandlepinModeChange.";
             log.error(noReasonErrorString);
             throw new IllegalArgumentException(noReasonErrorString);
         }
-        log.info("Entering new mode {} for reason {}", m, reason);
+        log.info("Entering new mode {} for the following reasons: {}", m, reasons);
 
         Mode previousMode = cpMode.getMode();
         if (previousMode != m) {
             fireModeChangeEvent(m);
         }
         if (m.equals(Mode.SUSPEND)) {
-            log.warn("Candlepin is entering suspend mode for the following reason: {}", reason);
+            log.warn("Candlepin is entering suspend mode for the following reasons: {}", reasons);
         }
 
-        cpMode = new CandlepinModeChange(new Date(), m, reason);
+        cpMode = new CandlepinModeChange(new Date(), m, reasons);
     }
 
     @Override

--- a/server/src/main/java/org/candlepin/controller/QpidStatusMonitor.java
+++ b/server/src/main/java/org/candlepin/controller/QpidStatusMonitor.java
@@ -61,7 +61,7 @@ public class QpidStatusMonitor implements Runnable {
                 defaultDelay);
             delay = defaultDelay;
         }
-        this.lastStatus = QpidStatus.DOWN;
+        this.lastStatus = QpidStatus.UNKNOWN;
     }
 
     /**

--- a/server/src/main/java/org/candlepin/hostedtest/AdapterOverrideModule.java
+++ b/server/src/main/java/org/candlepin/hostedtest/AdapterOverrideModule.java
@@ -35,7 +35,7 @@ public class AdapterOverrideModule extends AbstractModule {
 
         bind(SubscriptionServiceAdapter.class).to(HostedTestSubscriptionServiceAdapter.class)
                 .asEagerSingleton();
-        bind(HostedTestSubscriptionResource.class).asEagerSingleton();
+        bind(HostedTestSubscriptionResource.class);
     }
 
 }

--- a/server/src/main/java/org/candlepin/hostedtest/HostedTestSubscriptionResource.java
+++ b/server/src/main/java/org/candlepin/hostedtest/HostedTestSubscriptionResource.java
@@ -18,28 +18,19 @@ import org.candlepin.common.exceptions.BadRequestException;
 import org.candlepin.common.exceptions.NotFoundException;
 import org.candlepin.common.exceptions.ConflictException;
 import org.candlepin.common.util.SuppressSwaggerCheck;
-import org.candlepin.controller.ProductManager;
-import org.candlepin.dto.ModelTranslator;
 import org.candlepin.dto.api.v1.ContentDTO;
 import org.candlepin.dto.api.v1.ProductDTO;
-import org.candlepin.model.OwnerContentCurator;
-import org.candlepin.model.OwnerCurator;
-import org.candlepin.model.OwnerProductCurator;
 import org.candlepin.model.ProductContent;
-import org.candlepin.model.ProductCurator;
 import org.candlepin.model.dto.ContentData;
 import org.candlepin.model.dto.ProductContentData;
 import org.candlepin.model.dto.ProductData;
 import org.candlepin.model.dto.Subscription;
-import org.candlepin.resource.util.ResolverUtil;
 import org.candlepin.service.UniqueIdGenerator;
 import org.candlepin.service.model.ContentInfo;
 import org.candlepin.service.model.ProductInfo;
 import org.candlepin.service.model.SubscriptionInfo;
 
 import com.google.inject.persist.Transactional;
-
-import org.xnap.commons.i18n.I18n;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -76,30 +67,6 @@ public class HostedTestSubscriptionResource {
 
     @Inject
     private UniqueIdGenerator idGenerator;
-
-    @Inject
-    private ResolverUtil resolverUtil;
-
-    @Inject
-    private ProductManager productManager;
-
-    @Inject
-    private ProductCurator productCurator;
-
-    @Inject
-    private OwnerContentCurator ownerContentCurator;
-
-    @Inject
-    private OwnerCurator ownerCurator;
-
-    @Inject
-    private OwnerProductCurator ownerProductCurator;
-
-    @Inject
-    private I18n i18n;
-
-    @Inject
-    private ModelTranslator translator;
 
     /**
      * API to check if resource is alive

--- a/server/src/main/java/org/candlepin/hostedtest/HostedTestSubscriptionServiceAdapter.java
+++ b/server/src/main/java/org/candlepin/hostedtest/HostedTestSubscriptionServiceAdapter.java
@@ -49,9 +49,11 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import javax.inject.Inject;
 import javax.inject.Singleton;
 
 
@@ -87,16 +89,17 @@ public class HostedTestSubscriptionServiceAdapter implements SubscriptionService
     /**
      * Creates a new HostedTestSubscriptionServiceAdapter instance
      */
+    @Inject
     public HostedTestSubscriptionServiceAdapter() {
-        this.ownerMap = new HashMap<>();
+        this.ownerMap = new ConcurrentHashMap<>();
 
-        this.subscriptionMap = new HashMap<>();
+        this.subscriptionMap = new ConcurrentHashMap();
 
-        this.productMap = new HashMap<>();
-        this.contentMap = new HashMap<>();
+        this.productMap = new ConcurrentHashMap();
+        this.contentMap = new ConcurrentHashMap();
 
-        this.contentProductMap = new HashMap<>();
-        this.productSubscriptionMap = new HashMap<>();
+        this.contentProductMap = new ConcurrentHashMap();
+        this.productSubscriptionMap = new ConcurrentHashMap();
     }
 
 

--- a/server/src/main/java/org/candlepin/model/CandlepinModeChange.java
+++ b/server/src/main/java/org/candlepin/model/CandlepinModeChange.java
@@ -15,7 +15,10 @@
 package org.candlepin.model;
 
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Class representing candlepins mode, (NORMAL || SUSPEND),
@@ -24,7 +27,7 @@ import java.util.Date;
 public class CandlepinModeChange implements Serializable {
     private static final long serialVersionUID = -7059065874812188168L;
     private final Mode mode;
-    private final Reason reason;
+    private final Set<Reason> reasons;
     private final Date changeTime;
 
     /**
@@ -45,29 +48,38 @@ public class CandlepinModeChange implements Serializable {
          */
         STARTUP,
         /**
-         * When Qpid broker isn't available, Candlepin must enter
-         * Suspend mode
+         * The Qpid broker has gone down and is not available.
          */
         QPID_DOWN,
         /**
-         * Qpid comes back up
+         * The Qpid broker has come online and is available.
          */
         QPID_UP,
         /**
          * Qpid is overloaded to a point where its not possible to
          * send messages to it
          */
-        QPID_FLOW_STOPPED
+        QPID_FLOW_STOPPED,
+
+        /**
+         * The ActiveMQ broker has come online and is available.
+         */
+        ACTIVEMQ_UP,
+
+        /**
+         * The ActiveMQ broker has gone down and is not available.
+         */
+        ACTIVEMQ_DOWN
     }
 
-    public CandlepinModeChange(Date changeTime, Mode mode, Reason reason) {
+    public CandlepinModeChange(Date changeTime, Mode mode, Reason ... reasons) {
         this.mode = mode;
         this.changeTime = changeTime;
-        this.reason = reason;
+        this.reasons = reasons != null ? new HashSet<>(Arrays.asList(reasons)) : new HashSet<>();
     }
 
-    public Reason getReason() {
-        return reason;
+    public Set<Reason> getReasons() {
+        return reasons;
     }
 
     public Mode getMode() {
@@ -80,7 +92,7 @@ public class CandlepinModeChange implements Serializable {
 
     @Override
     public String toString() {
-        return "CandlepinModeChange [mode=" + mode + ", reason=" + reason + ", changeTime=" +
+        return "CandlepinModeChange [mode=" + mode + ", reasons=" + reasons + ", changeTime=" +
             changeTime + "]";
     }
 

--- a/server/src/main/java/org/candlepin/resource/StatusResource.java
+++ b/server/src/main/java/org/candlepin/resource/StatusResource.java
@@ -37,6 +37,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 
 import java.util.Date;
+import java.util.Iterator;
 import java.util.Map;
 
 import javax.ws.rs.GET;
@@ -137,7 +138,9 @@ public class StatusResource {
 
         CandlepinModeChange modeChange = modeManager.getLastCandlepinModeChange();
         CandlepinModeChange.Mode mode = modeChange.getMode();
-        CandlepinModeChange.Reason modeChangeReason = modeChange.getReason();
+
+        Iterator<CandlepinModeChange.Reason> reasonItr = modeChange.getReasons().iterator();
+        CandlepinModeChange.Reason modeChangeReason = reasonItr.hasNext() ? reasonItr.next() : null;
 
         if (mode != CandlepinModeChange.Mode.NORMAL) {
             good = false;

--- a/server/src/test/java/org/candlepin/audit/EventSourceTest.java
+++ b/server/src/test/java/org/candlepin/audit/EventSourceTest.java
@@ -23,7 +23,9 @@ import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.client.ClientConsumer;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
+import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.candlepin.common.config.Configuration;
+import org.candlepin.controller.ActiveMQStatusMonitor;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -39,15 +41,25 @@ public class EventSourceTest {
     @Mock private ClientSessionFactory clientSessionFactory;
 
     @Test
-    public void registeringNewListenerCreatesNewSessionAndStartsIt() throws Exception {
-        ClientSession clientSession = mock(ClientSession.class);
-        EventSource source = createEventSourceStubbedWithFactoryCreation();
-        when(clientSessionFactory.createSession(eq(false), eq(false), eq(0))).thenReturn(clientSession);
-        when(clientSession.createConsumer(any(String.class))).thenReturn(mock(ClientConsumer.class));
-
+    public void eventSourceDoesNotConnectEventReceiversUntilNotifiedConnectionEstablished() throws Exception {
+        EventSourceConnection connection = createConnection();
+        EventSource source = new EventSource(connection, new ObjectMapper());
         source.registerListener(mock(EventListener.class));
+
+        // Should not attempt to create a client session.
+        verifyZeroInteractions(clientSessionFactory);
+
+        ClientSession session = mock(ClientSession.class);
+        when(clientSessionFactory.createSession(eq(false), eq(false), eq(0))).thenReturn(session);
+        when(session.createConsumer(any(String.class))).thenReturn(mock(ClientConsumer.class));
+
+        // Simulate connection notification.
+        source.onStatusUpdate(ActiveMQStatus.UNKNOWN, ActiveMQStatus.CONNECTED);
         verify(clientSessionFactory).createSession(eq(false), eq(false), eq(0));
-        verify(clientSession).start();
+        verify(session).createConsumer(any(String.class));
+        verify(session, times(1)).start();
+        verify(session, never()).stop();
+
     }
 
     @Test
@@ -55,14 +67,13 @@ public class EventSourceTest {
         ClientSession session1 = mock(ClientSession.class);
         ClientSession session2 = mock(ClientSession.class);
 
-        EventSource eventSource = createEventSourceStubbedWithFactoryCreation();
         when(clientSessionFactory.createSession(eq(false), eq(false), eq(0)))
             .thenReturn(session1).thenReturn(session2);
         when(session1.createConsumer(any(String.class))).thenReturn(mock(ClientConsumer.class));
         when(session2.createConsumer(any(String.class))).thenReturn(mock(ClientConsumer.class));
 
-        eventSource.registerListener(mock(EventListener.class));
-        eventSource.registerListener(mock(EventListener.class));
+        EventSource eventSource = createEventSourceStubbedWithFactoryCreation(
+            mock(EventListener.class), mock(EventListener.class));
         eventSource.shutDown();
 
         // Verify that all client sessions were stopped and closed.
@@ -80,12 +91,11 @@ public class EventSourceTest {
     public void shouldStopAndCloseSessionOnShutdownWhenExceptionThrownOnStop() throws Exception {
         ClientSession session = mock(ClientSession.class);
 
-        EventSource eventSource = createEventSourceStubbedWithFactoryCreation();
         when(clientSessionFactory.createSession(eq(false), eq(false), eq(0))).thenReturn(session);
         when(session.createConsumer(any(String.class))).thenReturn(mock(ClientConsumer.class));
         doThrow(new ActiveMQException("Forced")).when(session).stop();
 
-        eventSource.registerListener(mock(EventListener.class));
+        EventSource eventSource = createEventSourceStubbedWithFactoryCreation(mock(EventListener.class));
         eventSource.shutDown();
 
         // Verify that close was at least still called.
@@ -99,12 +109,11 @@ public class EventSourceTest {
     public void shouldStopAndCloseSessionOnShutdownWhenExceptionThrownOnClose() throws Exception {
         ClientSession session = mock(ClientSession.class);
 
-        EventSource eventSource = createEventSourceStubbedWithFactoryCreation();
         when(clientSessionFactory.createSession(eq(false), eq(false), eq(0))).thenReturn(session);
         when(session.createConsumer(any(String.class))).thenReturn(mock(ClientConsumer.class));
         doThrow(new ActiveMQException("Forced")).when(session).close();
 
-        eventSource.registerListener(mock(EventListener.class));
+        EventSource eventSource = createEventSourceStubbedWithFactoryCreation(mock(EventListener.class));
         eventSource.shutDown();
 
         // Verify that stop was at least still called.
@@ -117,16 +126,17 @@ public class EventSourceTest {
     @Test
     public void eventSourceDoesNothingWhenQpidStatusDoesntChange() throws Exception {
         ClientSession session = mock(ClientSession.class);
-        EventSource eventSource = createEventSourceStubbedWithFactoryCreation();
         when(clientSessionFactory.createSession(eq(false), eq(false), eq(0))).thenReturn(session);
         when(session.createConsumer(any(String.class))).thenReturn(mock(ClientConsumer.class));
 
         EventListener listener = mock(EventListener.class);
         when(listener.requiresQpid()).thenReturn(true);
+
+        EventSource eventSource = createEventSourceStubbedWithFactoryCreation(listener);
         eventSource.registerListener(listener);
 
         eventSource.onStatusUpdate(QpidStatus.DOWN, QpidStatus.DOWN);
-        // Start was called only on construction
+        // Start was called only during setup.
         verify(session, times(1)).start();
         verify(session, never()).stop();
     }
@@ -134,7 +144,6 @@ public class EventSourceTest {
     @Test
     public void eventSourceClosesEventReceiverClientConsumerWhenQpidGoesDown() throws Exception {
         ClientSession session = mock(ClientSession.class);
-        EventSource eventSource = createEventSourceStubbedWithFactoryCreation();
         when(clientSessionFactory.createSession(eq(false), eq(false), eq(0))).thenReturn(session);
 
         ClientConsumer consumer = mock(ClientConsumer.class);
@@ -142,7 +151,8 @@ public class EventSourceTest {
 
         EventListener listener = mock(EventListener.class);
         when(listener.requiresQpid()).thenReturn(true);
-        eventSource.registerListener(listener);
+
+        EventSource eventSource = createEventSourceStubbedWithFactoryCreation(listener);
 
         eventSource.onStatusUpdate(QpidStatus.CONNECTED, QpidStatus.DOWN);
         // Start was called only on construction
@@ -154,7 +164,6 @@ public class EventSourceTest {
     @Test
     public void eventSourceCreatesNewEventReceiverClientSessionWhenQpidComesUp() throws Exception {
         ClientSession session = mock(ClientSession.class);
-        EventSource eventSource = createEventSourceStubbedWithFactoryCreation();
         when(clientSessionFactory.createSession(eq(false), eq(false), eq(0))).thenReturn(session);
 
         // Initially created before qpid goes down.
@@ -167,10 +176,11 @@ public class EventSourceTest {
 
         EventListener listener = mock(EventListener.class);
         when(listener.requiresQpid()).thenReturn(true);
-        eventSource.registerListener(listener);
 
+        EventSource eventSource = createEventSourceStubbedWithFactoryCreation(listener);
         eventSource.onStatusUpdate(QpidStatus.DOWN, QpidStatus.CONNECTED);
-        // Start was called only on construction
+
+        // Start was called only during setup.
         verify(session, times(1)).start();
         verify(session, never()).stop();
         verify(session, times(2)).createConsumer(any(String.class));
@@ -180,16 +190,16 @@ public class EventSourceTest {
     public void eventSourceDoesNothingWithEventReceiverClientSessionWhenListenerDoesntRequireQpid()
         throws Exception {
         ClientSession session = mock(ClientSession.class);
-        EventSource eventSource = createEventSourceStubbedWithFactoryCreation();
         when(clientSessionFactory.createSession(eq(false), eq(false), eq(0))).thenReturn(session);
         when(session.createConsumer(any(String.class))).thenReturn(mock(ClientConsumer.class));
 
         EventListener listener = mock(EventListener.class);
         when(listener.requiresQpid()).thenReturn(false);
-        eventSource.registerListener(listener);
 
+        EventSource eventSource = createEventSourceStubbedWithFactoryCreation(listener);
         eventSource.onStatusUpdate(QpidStatus.DOWN, QpidStatus.CONNECTED);
-        // Start was called only on construction
+
+        // Start was called only during setup.
         verify(session, times(1)).start();
         verify(session, never()).stop();
     }
@@ -199,11 +209,31 @@ public class EventSourceTest {
      *
      * @return the new EventSource
      */
-    private EventSource createEventSourceStubbedWithFactoryCreation() {
-        return new EventSource(new ObjectMapper(), mock(Configuration.class)) {
-            protected ClientSessionFactory createSessionFactory(Configuration config) {
+    private EventSource createEventSourceStubbedWithFactoryCreation(EventListener ... listeners)
+        throws Exception {
+        EventSourceConnection connection = createConnection();
+        EventSource source = new EventSource(connection, new ObjectMapper());
+
+        for (EventListener listener : listeners) {
+            source.registerListener(listener);
+        }
+
+        // Listener client sessions are not created until the source has been notified
+        // that the connection can be made. Simulate this.
+        source.onStatusUpdate(ActiveMQStatus.UNKNOWN, ActiveMQStatus.CONNECTED);
+        return source;
+    }
+
+    private EventSourceConnection createConnection() {
+        return new EventSourceConnection(mock(ActiveMQStatusMonitor.class), mock(Configuration.class)) {
+
+            @Override
+            ClientSessionFactory getFactory() {
+                this.locator = mock(ServerLocator.class);
+                this.factory = clientSessionFactory;
                 return clientSessionFactory;
             }
+
         };
     }
 

--- a/server/src/test/java/org/candlepin/audit/QpidConnectionTest.java
+++ b/server/src/test/java/org/candlepin/audit/QpidConnectionTest.java
@@ -83,6 +83,15 @@ public class QpidConnectionTest {
     }
 
     @Test
+    public void connectionIsMadeWhenUpdatingFromUnknownState() throws Exception {
+        connection.onStatusUpdate(QpidStatus.UNKNOWN, QpidStatus.CONNECTED);
+
+        verify(connection, never()).closeConnection();
+        verify(connection, never()).close();
+        verify(connection, times(1)).connect();
+    }
+
+    @Test
     public void connectionIsReconnectedWhenQpidConnectedStatusIsReportedAndQpidWasPreviouslyDown()
         throws Exception {
         connection.onStatusUpdate(QpidStatus.DOWN, QpidStatus.CONNECTED);

--- a/server/src/test/java/org/candlepin/audit/QpidEventMessageReceiverTest.java
+++ b/server/src/test/java/org/candlepin/audit/QpidEventMessageReceiverTest.java
@@ -16,7 +16,6 @@ package org.candlepin.audit;
 
 import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
-import static org.junit.Assert.fail;
 
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -29,6 +28,8 @@ import org.apache.activemq.artemis.api.core.client.ClientMessage;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.candlepin.auth.PrincipalData;
+import org.candlepin.common.config.Configuration;
+import org.candlepin.controller.ActiveMQStatusMonitor;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -52,28 +53,32 @@ public class QpidEventMessageReceiverTest {
     @Spy private ObjectMapper mapper = new ObjectMapper();
     @Spy private ActiveMQBuffer activeMQBuffer = ActiveMQBuffers.fixedBuffer(1000);
 
+    private EventSourceConnection connection;
+    private QpidEventMessageReceiver receiver;
+
     @Before
     public void init() throws Exception {
         when(clientMessage.getBodyBuffer()).thenReturn(activeMQBuffer);
         when(clientSessionFactory.createSession(eq(false), eq(false), eq(0))).thenReturn(clientSession);
         when(clientSession.createConsumer(anyString())).thenReturn(clientConsumer);
-    }
 
-    @Test(expected = ActiveMQException.class)
-    public void shouldThrowActiveMQExceptionWhenSessionCreateFailsDuringEventSourceCreation()
-        throws Exception {
-        doThrow(new ActiveMQException()).when(clientSession).start();
+        this.connection = new EventSourceConnection(mock(ActiveMQStatusMonitor.class),
+            mock(Configuration.class)) {
 
-        new QpidEventMessageReceiver(eventListener, clientSessionFactory, new ObjectMapper());
-        fail("Should have thrown ActiveMQException");
+            @Override
+            ClientSessionFactory getFactory() {
+                return clientSessionFactory;
+            }
+        };
+
+        receiver = new QpidEventMessageReceiver(eventListener, this.connection, new ObjectMapper());
+        // Calling connect will initialize the ClientSession
+        receiver.connect();
     }
 
     @Test
     public void shouldCreateNewConsumer()
         throws Exception {
-        QpidEventMessageReceiver receiver = new QpidEventMessageReceiver(eventListener, clientSessionFactory,
-            new ObjectMapper());
-
         verify(clientSession).createConsumer(anyString());
         verify(clientConsumer).setMessageHandler(eq(receiver));
         verify(clientSession).start();
@@ -81,12 +86,12 @@ public class QpidEventMessageReceiverTest {
 
     @Test
     public void whenMapperReadThrowsExceptionThenMessageShouldBeAckedAndSessionRolledBack() throws Exception {
-        QpidEventMessageReceiver receiver = new QpidEventMessageReceiver(eventListener, clientSessionFactory,
-            mapper);
         doReturn("test123").when(activeMQBuffer).readString();
         doThrow(new JsonMappingException("Induced exception"))
             .when(mapper).readValue(anyString(), eq(Event.class));
+
         receiver.onMessage(clientMessage);
+
         verify(clientMessage).acknowledge();
         verifyZeroInteractions(eventListener);
         verify(clientSession).rollback();
@@ -96,12 +101,12 @@ public class QpidEventMessageReceiverTest {
     @Test
     public void whenMsgAcknowledgeThrowsExceptionSessionIsRolledBack()
         throws Exception {
-        QpidEventMessageReceiver receiver = new QpidEventMessageReceiver(eventListener, clientSessionFactory,
-            mapper);
         doReturn(eventJson()).when(activeMQBuffer).readString();
         doThrow(new ActiveMQException(ActiveMQExceptionType.DISCONNECTED, "Induced exception for testing"))
             .when(clientMessage).acknowledge();
+
         receiver.onMessage(clientMessage);
+
         verify(clientSession).rollback();
         verify(clientSession, never()).commit();
     }
@@ -109,10 +114,10 @@ public class QpidEventMessageReceiverTest {
     @Test
     public void whenProperClientMsgPassedThenOnMessageShouldSucceed()
         throws Exception {
-        QpidEventMessageReceiver receiver = new QpidEventMessageReceiver(eventListener, clientSessionFactory,
-            mapper);
         doReturn(eventJson()).when(activeMQBuffer).readString();
+
         receiver.onMessage(clientMessage);
+
         verify(eventListener).onEvent(any(Event.class));
         verify(clientMessage).acknowledge();
         verify(clientSession).commit();
@@ -121,11 +126,11 @@ public class QpidEventMessageReceiverTest {
 
     @Test
     public void sessionIsRolledBackWhenAnyExceptionIsThrownFromEventListener() throws Exception {
-        QpidEventMessageReceiver receiver = new QpidEventMessageReceiver(eventListener, clientSessionFactory,
-            mapper);
         doReturn(eventJson()).when(activeMQBuffer).readString();
         doThrow(new RuntimeException("Forced")).when(eventListener).onEvent(any(Event.class));
+
         receiver.onMessage(clientMessage);
+
         verify(clientMessage).acknowledge();
         verify(clientSession).rollback();
         verify(clientSession, never()).commit();
@@ -133,11 +138,11 @@ public class QpidEventMessageReceiverTest {
 
     @Test
     public void noRollbackOccursWhenQpidConnectionExceptionIsThrownFromListener() throws Exception {
-        QpidEventMessageReceiver receiver = new QpidEventMessageReceiver(eventListener, clientSessionFactory,
-            mapper);
         doReturn(eventJson()).when(activeMQBuffer).readString();
         doThrow(new QpidConnectionException("Forced")).when(eventListener).onEvent(any(Event.class));
+
         receiver.onMessage(clientMessage);
+
         verify(clientMessage, never()).acknowledge();
         verify(clientSession, never()).rollback();
         verify(clientSession, never()).commit();

--- a/server/src/test/java/org/candlepin/controller/ActiveMQStatusMonitorTest.java
+++ b/server/src/test/java/org/candlepin/controller/ActiveMQStatusMonitorTest.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2009 - 2016 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.controller;
+
+import org.candlepin.audit.ActiveMQStatus;
+import org.candlepin.common.config.Configuration;
+import org.candlepin.config.ConfigProperties;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ActiveMQStatusMonitorTest {
+
+    @Mock private Configuration config;
+
+    @Before
+    public void setup() {
+        when(config.getLong(ConfigProperties.ACTIVEMQ_CONNECTION_MONITOR_INTERVAL)).thenReturn(500L);
+    }
+
+    @Test
+    public void monitorNotifiesListenersOfConnectionChanges() throws Exception {
+        TestingListener listener = new TestingListener();
+        TestingMonitor monitor = new TestingMonitor(config);
+        monitor.registerListener(listener);
+
+        // Connection at this point is Ok. Close the connection to start the
+        // connection monitoring thread.
+        monitor.setConnectionOk(false);
+        monitor.connectionClosed();
+
+        // Sleep for a second to allow the monitoring thread to report a failure
+        // before changing the connection state.
+        Thread.sleep(1000);
+
+        // Set the connection state and then sleep again to allow the thread to report
+        // the connection.
+        monitor.setConnectionOk(true);
+        Thread.sleep(1000);
+
+        // Assert that both states were reported.
+        assertTrue(listener.getReported().contains(ActiveMQStatus.DOWN));
+        assertTrue(listener.getReported().contains(ActiveMQStatus.CONNECTED));
+
+        // Check that the listener had received the correct states. Only the last reported
+        // state should have been CONNECTED as the monitor is shut down once a connection
+        // is reported.
+        Iterator<ActiveMQStatus> iter = listener.getReported().iterator();
+        while (iter.hasNext()) {
+            ActiveMQStatus next = iter.next();
+            // Only the last should be connected.
+            if (iter.hasNext()) {
+                assertEquals(ActiveMQStatus.DOWN, next);
+            }
+            else {
+                assertEquals(ActiveMQStatus.CONNECTED, next);
+            }
+        }
+    }
+
+    private class TestingMonitor extends ActiveMQStatusMonitor {
+        private boolean connectionOk;
+
+        public TestingMonitor(Configuration config) {
+            super(config);
+            this.connectionOk = true;
+        }
+
+        @Override
+        public boolean testConnection() {
+            return connectionOk;
+        }
+
+        public void setConnectionOk(boolean ok) {
+            this.connectionOk = ok;
+        }
+
+    }
+
+    private class TestingListener implements ActiveMQStatusListener {
+        private List<ActiveMQStatus> reported = new LinkedList<>();
+
+        @Override
+        public void onStatusUpdate(ActiveMQStatus oldStatus, ActiveMQStatus newStatus) {
+            reported.add(newStatus);
+        }
+
+        public List<ActiveMQStatus> getReported() {
+            return this.reported;
+        }
+    }
+}

--- a/server/src/test/java/org/candlepin/controller/ModeManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/ModeManagerTest.java
@@ -57,10 +57,26 @@ public class ModeManagerTest {
         sleep(1);
         modeManager.enterMode(mode, testReason);
         assertEquals(mode, modeManager.getLastCandlepinModeChange().getMode());
-        assertEquals(testReason, modeManager.getLastCandlepinModeChange().getReason());
+        assertEquals(1, modeManager.getLastCandlepinModeChange().getReasons().size());
+        assertTrue(modeManager.getLastCandlepinModeChange().getReasons().contains(testReason));
         assertTrue(previousTime.before(modeManager.getLastCandlepinModeChange().getChangeTime()));
     }
 
+    @Test
+    public void testEnterModeWithMultipleReasons() throws InterruptedException {
+        Date previousTime = modeManager.getLastCandlepinModeChange().getChangeTime();
+        Mode mode = Mode.SUSPEND;
+        sleep(1);
+
+        // Using this two reasons for testing purposes, but does not make sense
+        // in the context of candlepin -- this is Ok.
+        modeManager.enterMode(mode, testReason, Reason.QPID_UP);
+        assertEquals(mode, modeManager.getLastCandlepinModeChange().getMode());
+        assertEquals(2, modeManager.getLastCandlepinModeChange().getReasons().size());
+        assertTrue(modeManager.getLastCandlepinModeChange().getReasons().contains(testReason));
+        assertTrue(modeManager.getLastCandlepinModeChange().getReasons().contains(Reason.QPID_UP));
+        assertTrue(previousTime.before(modeManager.getLastCandlepinModeChange().getChangeTime()));
+    }
     @Test(expected = IllegalArgumentException.class)
     public void testEnterModeNeedsReason() {
         modeManager.enterMode(Mode.NORMAL, null);

--- a/server/src/test/java/org/candlepin/controller/QpidStatusMonitorTest.java
+++ b/server/src/test/java/org/candlepin/controller/QpidStatusMonitorTest.java
@@ -75,8 +75,9 @@ public class QpidStatusMonitorTest {
             .thenReturn(QpidStatus.FLOW_STOPPED)
             .thenReturn(QpidStatus.DOWN);
 
+
         monitor.run();
-        verify(listener, times(1)).onStatusUpdate(eq(QpidStatus.DOWN), eq(QpidStatus.CONNECTED));
+        verify(listener, times(1)).onStatusUpdate(eq(QpidStatus.UNKNOWN), eq(QpidStatus.CONNECTED));
 
         monitor.run();
         verify(listener, times(1)).onStatusUpdate(eq(QpidStatus.CONNECTED), eq(QpidStatus.FLOW_STOPPED));

--- a/server/src/test/java/org/candlepin/controller/SuspendModeTransitionerTest.java
+++ b/server/src/test/java/org/candlepin/controller/SuspendModeTransitionerTest.java
@@ -14,11 +14,16 @@
  */
 package org.candlepin.controller;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
 
+import org.candlepin.audit.ActiveMQStatus;
 import org.candlepin.audit.QpidStatus;
 import org.candlepin.cache.CandlepinCache;
 import org.candlepin.cache.StatusCache;
+import org.candlepin.common.config.Configuration;
+import org.candlepin.config.ConfigProperties;
 import org.candlepin.model.CandlepinModeChange;
 import org.candlepin.model.CandlepinModeChange.Mode;
 import org.candlepin.model.CandlepinModeChange.Reason;
@@ -28,84 +33,175 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.xnap.commons.i18n.I18n;
+import org.xnap.commons.i18n.I18nFactory;
 
-import java.util.Date;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
 
 
 @RunWith(MockitoJUnitRunner.class)
 public class SuspendModeTransitionerTest {
-    @Mock private ModeManager modeManager;
+
     @Mock private CandlepinCache candlepinCache;
     @Mock private StatusCache cache;
+    @Mock private Configuration config;
 
+    private ModeManager modeManager;
     private SuspendModeTransitioner transitioner;
-    private CandlepinModeChange startupModeChange;
-    private CandlepinModeChange downModeChange;
-    private CandlepinModeChange normalModeChange;
 
     @Before
     public void setUp() {
         when(candlepinCache.getStatusCache()).thenReturn(cache);
+        when(config.getBoolean(eq(ConfigProperties.SUSPEND_MODE_ENABLED))).thenReturn(true);
+
+        I18n i18n = I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK);
+        modeManager = new ModeManagerImpl(config, i18n);
+
         transitioner = new SuspendModeTransitioner(candlepinCache);
         transitioner.setModeManager(modeManager);
-        startupModeChange = new CandlepinModeChange(new Date(), Mode.NORMAL, Reason.STARTUP);
-        downModeChange = new CandlepinModeChange(new Date(), Mode.SUSPEND, Reason.QPID_DOWN);
-        normalModeChange = new CandlepinModeChange(new Date(), Mode.NORMAL, Reason.QPID_UP);
     }
 
     @Test
-    public void normalConnected() {
-        when(modeManager.getLastCandlepinModeChange()).thenReturn(startupModeChange);
+    public void unchangedStatusUpdateDoesNotTransitionAtAll() {
+        // Verify initial state.
+        assertMode(Mode.NORMAL, Reason.STARTUP);
+
+        // Nothing changed.
+        transitioner.onStatusUpdate(QpidStatus.CONNECTED, QpidStatus.CONNECTED);
+        assertMode(Mode.NORMAL, Reason.STARTUP);
+
+        // Nothing changed.
+        transitioner.onStatusUpdate(ActiveMQStatus.CONNECTED, ActiveMQStatus.CONNECTED);
+        assertMode(Mode.NORMAL, Reason.STARTUP);
+    }
+
+    @Test
+    public void transitionFromNormalModeToQpidDown() {
+        transitioner.onStatusUpdate(QpidStatus.CONNECTED, QpidStatus.DOWN);
+        assertMode(Mode.SUSPEND, Reason.QPID_DOWN);
+    }
+
+    @Test
+    public void transitionFromNormalModeToAMQDown() {
+        transitioner.onStatusUpdate(ActiveMQStatus.CONNECTED, ActiveMQStatus.DOWN);
+        assertMode(Mode.SUSPEND, Reason.ACTIVEMQ_DOWN);
+    }
+
+    @Test
+    public void transitionFromNormalModeToQpidAndAMQDown() throws Exception {
+        transitionFromNormalModeToQpidDown();
+
+        // Bring AMQ down.
+        transitioner.onStatusUpdate(ActiveMQStatus.CONNECTED, ActiveMQStatus.DOWN);
+        assertMode(Mode.SUSPEND, Reason.ACTIVEMQ_DOWN, Reason.QPID_DOWN);
+    }
+
+    @Test
+    public void transitionToNormalModeWhenQpidComesUp() throws Exception {
+        modeManager.enterMode(Mode.SUSPEND, Reason.QPID_DOWN);
 
         transitioner.onStatusUpdate(QpidStatus.DOWN, QpidStatus.CONNECTED);
-
-        verify(modeManager, times(1)).getLastCandlepinModeChange();
-        verifyNoMoreInteractions(modeManager);
+        assertMode(Mode.NORMAL, Reason.QPID_UP);
     }
 
     @Test
-    public void stillDisconnected() {
-        when(modeManager.getLastCandlepinModeChange()).thenReturn(downModeChange);
+    public void transitionToNormalModeWhenAMQComesUp() throws Exception {
+        modeManager.enterMode(Mode.SUSPEND, Reason.ACTIVEMQ_DOWN);
 
-        transitioner.onStatusUpdate(QpidStatus.CONNECTED, QpidStatus.DOWN);
-
-        verify(modeManager, times(1)).getLastCandlepinModeChange();
-        verifyNoMoreInteractions(modeManager);
+        transitioner.onStatusUpdate(ActiveMQStatus.DOWN, ActiveMQStatus.CONNECTED);
+        assertMode(Mode.NORMAL, Reason.ACTIVEMQ_UP);
     }
 
-
     @Test
-    public void transitionFromDownToConnected() throws Exception {
-        when(modeManager.getLastCandlepinModeChange()).thenReturn(downModeChange);
+    public void transitionToNormalModeWhenQpidThenAMQComesUp() throws Exception {
+        modeManager.enterMode(Mode.SUSPEND, Reason.QPID_DOWN, Reason.ACTIVEMQ_DOWN);
 
         transitioner.onStatusUpdate(QpidStatus.DOWN, QpidStatus.CONNECTED);
+        assertMode(Mode.SUSPEND, Reason.ACTIVEMQ_DOWN);
 
-        verify(modeManager, times(1)).getLastCandlepinModeChange();
-        verify(modeManager, times(1)).enterMode(Mode.NORMAL, Reason.QPID_UP);
-        verifyNoMoreInteractions(modeManager);
+        transitioner.onStatusUpdate(ActiveMQStatus.DOWN, ActiveMQStatus.CONNECTED);
+        assertMode(Mode.NORMAL, Reason.ACTIVEMQ_UP);
     }
 
     @Test
-    public void transitionFromConnectedToDown() throws Exception {
-        when(modeManager.getLastCandlepinModeChange()).thenReturn(normalModeChange);
+    public void transitionToNormalModeWhenAMQThenQpidComesUp() throws Exception {
+        modeManager.enterMode(Mode.SUSPEND, Reason.QPID_DOWN, Reason.ACTIVEMQ_DOWN);
 
-        transitioner.onStatusUpdate(QpidStatus.CONNECTED, QpidStatus.DOWN);
+        transitioner.onStatusUpdate(ActiveMQStatus.DOWN, ActiveMQStatus.CONNECTED);
+        assertMode(Mode.SUSPEND, Reason.QPID_DOWN);
 
-        verify(modeManager, times(1)).getLastCandlepinModeChange();
-        verify(modeManager, times(1)).enterMode(Mode.SUSPEND, Reason.QPID_DOWN);
-        verifyNoMoreInteractions(modeManager);
+        transitioner.onStatusUpdate(QpidStatus.DOWN, QpidStatus.CONNECTED);
+        assertMode(Mode.NORMAL, Reason.QPID_UP);
     }
 
     @Test
-    public void transitionFromConnectedToFlowStopped()
-        throws Exception {
-        when(modeManager.getLastCandlepinModeChange()).thenReturn(normalModeChange);
-
+    public void transitionToSuspendModeWhenQpidBecomesFlowStopped() throws Exception {
+        modeManager.enterMode(Mode.NORMAL, Reason.STARTUP);
         transitioner.onStatusUpdate(QpidStatus.CONNECTED, QpidStatus.FLOW_STOPPED);
-
-        verify(modeManager, times(1)).getLastCandlepinModeChange();
-        verify(modeManager, times(1)).enterMode(Mode.SUSPEND, Reason.QPID_FLOW_STOPPED);
-        verifyNoMoreInteractions(modeManager);
+        assertMode(Mode.SUSPEND, Reason.QPID_FLOW_STOPPED);
     }
 
+    @Test
+    public void remainInSuspendModeWhenQpidComesUpButIsInFlowStopped() {
+        modeManager.enterMode(Mode.SUSPEND, Reason.QPID_DOWN);
+        transitioner.onStatusUpdate(QpidStatus.DOWN, QpidStatus.FLOW_STOPPED);
+        assertMode(Mode.SUSPEND, Reason.QPID_FLOW_STOPPED);
+    }
+
+    @Test
+    public void remainInSuspendModeWhenQpidIsFlowStoppedAndThenGoesDown() {
+        modeManager.enterMode(Mode.SUSPEND, Reason.QPID_FLOW_STOPPED);
+        transitioner.onStatusUpdate(QpidStatus.FLOW_STOPPED, QpidStatus.DOWN);
+        assertMode(Mode.SUSPEND, Reason.QPID_DOWN);
+    }
+
+
+    @Test
+    public void transitionToSuspendModeWhenAMQGoesDown() throws Exception {
+        modeManager.enterMode(Mode.NORMAL, Reason.ACTIVEMQ_UP);
+        transitioner.onStatusUpdate(ActiveMQStatus.CONNECTED, ActiveMQStatus.DOWN);
+        assertMode(Mode.SUSPEND, Reason.ACTIVEMQ_DOWN);
+    }
+
+    @Test
+    public void transitionToNormalModeWhenAMQComesBackUp() throws Exception {
+        modeManager.enterMode(Mode.SUSPEND, Reason.ACTIVEMQ_DOWN);
+        transitioner.onStatusUpdate(ActiveMQStatus.DOWN, ActiveMQStatus.CONNECTED);
+        assertMode(Mode.NORMAL, Reason.ACTIVEMQ_UP);
+    }
+
+    @Test
+    public void remainInSuspendModeWhenAMQComesUpWhileQpidRemainsDown() throws Exception {
+        modeManager.enterMode(Mode.SUSPEND, Reason.QPID_DOWN, Reason.ACTIVEMQ_DOWN);
+        transitioner.onStatusUpdate(ActiveMQStatus.DOWN, ActiveMQStatus.CONNECTED);
+        assertMode(Mode.SUSPEND, Reason.QPID_DOWN);
+    }
+
+    @Test
+    public void remainInSuspendModeWhenQpidComesUpWhileAMQRemainsDown() throws Exception {
+        modeManager.enterMode(Mode.SUSPEND, Reason.QPID_DOWN, Reason.ACTIVEMQ_DOWN);
+        transitioner.onStatusUpdate(QpidStatus.DOWN, QpidStatus.CONNECTED);
+        assertMode(Mode.SUSPEND, Reason.ACTIVEMQ_DOWN);
+    }
+
+    @Test
+    public void remainInSuspendModeWhenQpidIsFlowStoppedAndAMQComesUp() throws Exception {
+        modeManager.enterMode(Mode.SUSPEND, Reason.QPID_FLOW_STOPPED, Reason.ACTIVEMQ_DOWN);
+        transitioner.onStatusUpdate(ActiveMQStatus.DOWN, ActiveMQStatus.CONNECTED);
+        assertMode(Mode.SUSPEND, Reason.QPID_FLOW_STOPPED);
+    }
+
+    private List<Reason> reasons(Reason ... reasons) {
+        return reasons != null ? Arrays.asList(reasons) : new ArrayList<>();
+    }
+
+    private void assertMode(Mode expectedMode, Reason ... expectedReasons) {
+        CandlepinModeChange lastChange = modeManager.getLastCandlepinModeChange();
+        assertEquals(expectedMode, lastChange.getMode());
+        assertEquals(expectedReasons.length, lastChange.getReasons().size());
+        assertTrue(lastChange.getReasons().containsAll(Arrays.asList(expectedReasons)));
+    }
 }


### PR DESCRIPTION
* Created an ActiveMQConnectionMonitor that listens for connection drops
  and will run a connection monitor and notify listeners when the connection
  is re-established.
* EventSource will now listen for connection drops
  and will re-establish connections to Artemis when
  the connection is reported by the monitor as being
  up.
* Candlepin will now enter suspend mode when the ActiveMQ (Artemis) broker
  is down.
* Suspend mode transitioner now based on reasons since there could be multiple
  reasons reported as to why candlepin is in suspend mode. Only the initial
  reason will be shown in the /status response (API V1).
* EventSink will no longer attempt to send/rollback when no session exists
  which supresses the ActiveMQ rollback exceptions when no messages are sent
  during a particular request.
* Removed the use of ThreadLocal in the EventSink for Sessions and Producers
  - A single instance of the EventSink is now created per request and has a
    single ClientSession and Producer.


# Testing

1. Deploy candlepin with an external broker plus qpid
```bash
$ bin/deploy -gtaqb
```

2. Tail the logs in a separate console.

3. Shut down artemis
```bash
$ sudo systemctl stop artemis
```

4. Check the candlepin status and it should have entered suspend mode.
```bash
$ curl -k https://localhost:8443/candlepin/status
```

5. Try registering a consumer. It should fail because of suspend mode.
```bash
curl -k -u admin:admin -X POST -H "Content-Type: application/json" -d '{"type":{"label":"system"}, "name":"my_test_system", "facts":{}, "installedProducts":[], "contentTags":[]}' https://localhost:8443/candlepin/consumers?owner=admin
```

6. Restart Artemis, wait for candlepin to come out of suspend mode and attempt to register a consumer again. This time it should succeed.
```bash
$ sudo systemctl start artemis
```

7. Shut down qpidd and wait for suspend mode to be entered. Then shut down artemis. The logs should show that candlepin is in suspend mode for 2 reasons: qpidd and artemis are down. Candlepin status will only reflect the last state causing suspend mode (didn't want to change the API at this point).
```bash
$ sudo systemctl stop qpidd
$ sudo systemctl stop artemis
$ curl -k https://localhost:8443/candlepin/status
```

8. Start qpid and candlepin will remain in suspend mode.
```bash
$ sudo systemctl start qpidd
$ curl -k https://localhost:8443/candlepin/status
```

9. Start artemis and candlepin will return to Normal mode.
```bash
$ sudo systemctl start artemis
$ curl -k https://localhost:8443/candlepin/status
```

10. Register another system to ensure that all connections have been re-established.
```bash
curl -k -u admin:admin -X POST -H "Content-Type: application/json" -d '{"type":{"label":"system"}, "name":"my_test_system_2", "facts":{}, "installedProducts":[], "contentTags":[]}' https://localhost:8443/candlepin/consumers?owner=admin
```

NOTE: You can check the artemis console to make sure that messages are flowing.
http://localhost:8161/console

### Additional Testing
When candlepin is started without qpid and/or artemis started, candlepin should start Ok and should be in suspend mode.

Check it with by curling the candlepin status.