### PR TITLE
Add support for running rspec tests via Gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,48 +59,9 @@ path to `checks.xml` and drop the result into `.checkstyle` in your Eclipse
 project directory.
 
 ## Spec Tests
-* `buildr rspec` runs RSpec tests serially
-* `buildr rspec:parallel` runs RSpec tests in parallel when possible
-* `buildr rspec:failures` runs the tests that failed on the last run
-* `buildr rspec:my_spec_name:my_test_name` runs `my_test_name` in the
-  `my_spec_name` file
-
-The spec tests are our integration tests.  You can run them serially with
-`buildr rspec`.  If you want to speed things up use `buildr rspec:parallel`.
-That task will run *most* of the tests in parallel.  A few must still be run
-serially to prevent errors (generally import tests are run serially).
-
-You can run specific tests by appending items to the `rspec` task name.  For
-example, `buildr rspec:vcpu,consumer` will run any spec file that begins with
-"vcpu" or "consumer".  You can exclude tests with a minus sign in front of the
-identifier.  E.g. `buildr rspec:-vcpu` will run all spec files that do not
-begin with "vcpu".
-
-Additionally, you can provide either line numbers or test names to the task.
-For example, `buildr rspec:vcpu:62,41` will run the tests on line 62 and 41 of
-the vcpu spec file.  Likewise, `buildr rspec:vcpu,consumer:consumer` will run
-all tests in the vcpu and consumer specs that have the word "consumer" in the
-test name.
-
-The general syntax is
-
-```
-rspec:test_name[,test_name ...][:signifier[,signifier ...]]
-```
-
-where the signifier is either a string or an integer.
-
-Please note that if you need to use a phrase to single out a test, you will
-need to quote the task name: `buildr "rspec:vcpu:should be valid"` to prevent
-the shell from interfering.  Also note that any phrase or line number you
-specify will be applied to *all* tests.  So `buildr rspec:vcpu,consumer:62`
-will only run tests that begin on line 62 in either the vcpu or consumer specs.
-This is a limitation of RSpec itself.
-
-When you run RSpec, failed tests are recorded in `target/rspec.failures`.  You
-can then use the `rspec:failures` task to just run failed tests which will then
-update the list of failures again.  Thus, you can keep running `rspec:failures`
-until the list is empty.
+* `./gradlew rspec` runs RSpec tests serially
+* `./gradlew rspec --spec <my_spec_name> -- test 'my_test_name'` 
+runs `my_test_name` in the `my_spec_name` file. 
 
 ## Liquibase
 * `buildr "changeset:my changeset name"`

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -1,3 +1,4 @@
+import org.gradle.api.tasks.options.Option
 
 apply plugin: 'war'
 apply plugin: Gettext
@@ -47,6 +48,60 @@ configurations {
         extendsFrom(core_testing, jukito, liquibase_slf4j)
     }
 }
+
+class Rspec extends DefaultTask {
+
+    Rspec() {
+        description = 'Run ruby based spec tests'
+        group = 'Verification'
+    }
+
+    @Input
+    String test = ""
+
+    @Input
+    String spec = ""
+
+    @Option(option = 'spec', description = 'The name of the spec file to search. Example: "core_and_ram"')
+    void setSpec(final String specfile_name) {
+        this.spec = specfile_name
+    }
+
+    @Option(option = 'test', description = 'Set the name of the spec test to run')
+    void setTest(final String test_name) {
+        this.test = test_name
+    }
+
+    @TaskAction
+    runRspec() {
+        def rspec_args = [
+                "--format", "documentation",
+                "--require", "${project.rootDir}/tasks/failure_formatter",
+                "--format", "ModifiedRSpec::FailuresFormatter",
+                "-I", "${project.getProjectDir()}/client/ruby"
+        ]
+
+        // Use --pattern to match the name of the spec file for the spec argument
+        if (spec){
+            rspec_args.add("--pattern")
+            rspec_args.add("**/${spec}*_spec.rb")
+        }
+
+        // use -e to match the name of a specific test within the matched spec files
+        if (test){
+            rspec_args.add("-e")
+            rspec_args.add(test)
+        }
+
+        project.exec {
+            executable 'rspec'
+            args rspec_args
+            workingDir project.getProjectDir()
+        }
+    }
+}
+
+task rspec(type: Rspec)
 
 dependencies {
 

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -76,6 +76,7 @@ class Rspec extends DefaultTask {
     runRspec() {
         def rspec_args = [
                 "--format", "documentation",
+                "--force-color",
                 "--require", "${project.rootDir}/tasks/failure_formatter",
                 "--format", "ModifiedRSpec::FailuresFormatter",
                 "-I", "${project.getProjectDir()}/client/ruby"


### PR DESCRIPTION
Enable running the rspec tests.

This assumes that the ruby environment is set up separately and 'rspec' can be run from the command line. 

Supports specifying the spec file name using the -- spec option. 
Supports specifying the test name using the --test option. 