### PR TITLE
[M] 1633829: Fixed StaleStateException during dirty entitlement regeneration

### DIFF
--- a/server/spec/entitlement_certificate_spec.rb
+++ b/server/spec/entitlement_certificate_spec.rb
@@ -43,10 +43,13 @@ describe 'Entitlement Certificate' do
     @system.regenerate_entitlement_certificates()
 
     new_certs = @system.list_certificates()
-    old_certs.size.should == new_certs.size
+
+    expect(new_certs.size).to eq(old_certs.size)
+
     old_ids = old_certs.map { |cert| cert['serial']['id']}
     new_ids = new_certs.map { |cert| cert['serial']['id']}
-    (old_ids & new_ids).size.should == 0
+
+    expect((old_ids & new_ids).size).to eq(0)
   end
 
   it 'can regenerate certificate by entitlement id' do

--- a/server/src/main/java/org/candlepin/bind/HandleCertificatesOp.java
+++ b/server/src/main/java/org/candlepin/bind/HandleCertificatesOp.java
@@ -92,7 +92,7 @@ public class HandleCertificatesOp implements BindOperation {
         Map<String, Entitlement> ents = context.getEntitlementMap();
         for (Entitlement ent: ents.values()) {
             EntitlementCertificate cert = certs.get(ent.getPool().getId());
-            ent.getCertificates().add(cert);
+            ent.addCertificate(cert);
             cert.setEntitlement(ent);
         }
         ecCurator.saveAll(certs.values(), false, false);

--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -2408,18 +2408,27 @@ public class CandlepinPoolManager implements PoolManager {
 
     @Override
     public void regenerateDirtyEntitlements(Consumer consumer) {
-        this.regenerateDirtyEntitlements(this.entitlementCurator.listDirty(consumer));
+        if (consumer != null) {
+            this.ecGenerator.regenerateCertificatesOf(this.entitlementCurator.listDirty(consumer), false);
+        }
     }
 
     @Override
     public void regenerateDirtyEntitlements(Iterable<Entitlement> entitlements) {
         if (entitlements != null) {
+            Map<String, Entitlement> dirty = new HashMap<>();
+
             for (Entitlement entitlement : entitlements) {
-                if (entitlement.isDirty()) {
+                if (entitlement.isDirty() && !dirty.containsKey(entitlement.getId())) {
                     log.info("Found dirty entitlement to regenerate: {}", entitlement);
-                    this.ecGenerator.regenerateCertificatesOf(entitlement, false);
+
+                    // Store the entitlement for later processing
+                    dirty.put(entitlement.getId(), entitlement);
                 }
             }
+
+            // Regenerate the dirty entitlements we found...
+            this.ecGenerator.regenerateCertificatesOf(dirty.values(), false);
         }
     }
 

--- a/server/src/main/java/org/candlepin/controller/EntitlementCertificateGenerator.java
+++ b/server/src/main/java/org/candlepin/controller/EntitlementCertificateGenerator.java
@@ -40,7 +40,9 @@ import com.google.inject.persist.Transactional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -144,7 +146,6 @@ public class EntitlementCertificateGenerator {
      */
     @Transactional
     public EntitlementCertificate generateEntitlementCertificate(Pool pool, Entitlement entitlement) {
-
         Map<String, Product> products = new HashMap<>();
         Map<String, Entitlement> entitlements = new HashMap<>();
         Map<String, PoolQuantity> poolQuantities = new HashMap<>();
@@ -158,7 +159,36 @@ public class EntitlementCertificateGenerator {
     }
 
     /**
-     * Regenerates the certificates for the specified entitlement.
+     * Generates a new entitlement certificate for the given entitlement and pool.
+     *
+     * @param pool
+     *  The pool for which to generate an entitlement certificate
+     *
+     * @param entitlement
+     *  The entitlement to use when generating the certificate
+     *
+     * @return
+     *  The newly generate entitlement certificate
+     */
+    @Transactional
+    public EntitlementCertificate generateEntitlementCertificate(Pool pool, Entitlement entitlement,
+        boolean updateEntitlement) {
+
+        Map<String, Product> products = new HashMap<>();
+        Map<String, Entitlement> entitlements = new HashMap<>();
+        Map<String, PoolQuantity> poolQuantities = new HashMap<>();
+
+        products.put(pool.getId(), pool.getProduct());
+        entitlements.put(pool.getId(), entitlement);
+        poolQuantities.put(pool.getId(), new PoolQuantity(pool, entitlement.getQuantity()));
+
+        return this.generateEntitlementCertificates(entitlement.getConsumer(),
+            products, poolQuantities, entitlements, updateEntitlement).get(pool.getId());
+    }
+
+    /**
+     * Regenerates the certificates for the specified entitlement. If the lazy parameter is set,
+     * this method only marks the entitlement dirty for later certificate regeneration.
      *
      * @param entitlement
      *  The entitlement for which to regenerate certificates
@@ -169,48 +199,15 @@ public class EntitlementCertificateGenerator {
      */
     @Transactional
     public void regenerateCertificatesOf(Entitlement entitlement, boolean lazy) {
-
-        if (lazy) {
-            log.info("Marking certificates dirty for entitlement: {}", entitlement);
-            entitlement.setDirty(true);
-            return;
-        }
-
-        log.debug("Revoking entitlementCertificates of: {}", entitlement);
-
-        Entitlement tempE = new Entitlement();
-        tempE.setCertificates(entitlement.getCertificates());
-        entitlement.setCertificates(null);
-
-        // below call creates new certificates and saves it to the backend.
-        try {
-            EntitlementCertificate generated = this.generateEntitlementCertificate(
-                entitlement.getPool(), entitlement
-            );
-
-            entitlement.setDirty(false);
-            this.entitlementCurator.merge(entitlement);
-            for (EntitlementCertificate ec : tempE.getCertificates()) {
-                log.debug("Deleting entitlementCertificate: #{}", ec.getId());
-                this.entitlementCertificateCurator.delete(ec);
-            }
-
-            // send entitlement changed event.
-            this.eventSink.queueEvent(this.eventFactory.entitlementChanged(entitlement));
-            log.debug("Generated entitlementCertificate: #{}", generated.getId());
-        }
-        catch (CertificateSizeException cse) {
-            entitlement.setCertificates(tempE.getCertificates());
-            log.warn("The certificate cannot be regenerated at this time: {}", cse.getMessage());
-        }
+        this.regenerateCertificatesOf(Arrays.asList(entitlement), lazy);
     }
 
     /**
-     * Regenerates the certificates for the specified entitlements. This method is a utility method
-     * which individually regenerates certificates for each entitlement in the provided collection.
+     * Regenerates the certificates for the specified entitlements. If the lazy parameter is set,
+     * this method only marks the entitlements dirty for later certificate regeneration.
      *
      * @param entitlements
-     *  An iterable collection of entitlements for which to regenerate certificates
+     *  The entitlements for which to regenerate certificates
      *
      * @param lazy
      *  Whether or not to generate the certificate immediately, or mark it dirty and allow it to be
@@ -218,8 +215,59 @@ public class EntitlementCertificateGenerator {
      */
     @Transactional
     public void regenerateCertificatesOf(Iterable<Entitlement> entitlements, boolean lazy) {
-        for (Entitlement entitlement : entitlements) {
-            this.regenerateCertificatesOf(entitlement, lazy);
+        if (lazy) {
+            this.regenerateCertificatesLazyImpl(entitlements);
+        }
+        else {
+            this.regenerateCertificatesImpl(entitlements);
+        }
+    }
+
+    /**
+     * Marks the specified entitlements for regeneration without actually updating them.
+     */
+    private void regenerateCertificatesLazyImpl(Iterable<Entitlement> entitlements) {
+        if (entitlements != null) {
+            for (Entitlement entitlement : entitlements) {
+                entitlement.setDirty(true);
+            }
+        }
+    }
+
+    /**
+     * Regenerates the certificates for the specified entitlements.
+     */
+    private void regenerateCertificatesImpl(Iterable<Entitlement> entitlements) {
+        if (entitlements != null) {
+            Set<String> entIds = new HashSet<>();
+
+            for (Entitlement entitlement : entitlements) {
+                try {
+                    // Generate new cert
+                    EntitlementCertificate generated = this.generateEntitlementCertificate(
+                        entitlement.getPool(), entitlement, false);
+
+                    // Apply to the entitlement
+                    entitlement.setDirty(false);
+                    entitlement.setCertificates(Collections.singleton(generated));
+
+                    // send entitlement changed event.
+                    this.eventSink.queueEvent(this.eventFactory.entitlementChanged(entitlement));
+
+                    entIds.add(entitlement.getId());
+                }
+                catch (CertificateSizeException cse) {
+                    // Uh oh... do nothing for now.
+                    log.warn("The certificate cannot be regenerated at this time: {}", cse.getMessage());
+                }
+            }
+
+            // Clear the old certs before we save so we don't end up in a weird state
+            int count = this.entitlementCertificateCurator.deleteByEntitlementIds(entIds);
+            log.debug("{} old entitlement certificates deleted", count);
+
+            // Save everything
+            this.entitlementCurator.saveOrUpdateAll(entitlements, false, false);
         }
     }
 

--- a/server/src/main/java/org/candlepin/controller/ManifestManager.java
+++ b/server/src/main/java/org/candlepin/controller/ManifestManager.java
@@ -140,9 +140,11 @@ public class ManifestManager {
         log.info("Exporting consumer {}", consumerUuid);
 
         Consumer consumer = validateConsumerForExport(consumerUuid, cdnLabel);
-        poolManager.regenerateDirtyEntitlements(entitlementCurator.listByConsumer(consumer));
+        poolManager.regenerateDirtyEntitlements(consumer);
+
         File export = exporter.getFullExport(consumer, cdnLabel, webUrl, apiUrl, extensionData);
         sink.queueEvent(eventFactory.exportCreated(consumer));
+
         return export;
     }
 
@@ -390,9 +392,9 @@ public class ManifestManager {
      */
     public File generateEntitlementArchive(Consumer consumer, Set<Long> serials)
         throws ExportCreationException {
+
         log.debug("Getting client certificate zip file for consumer: {}", consumer.getUuid());
-        poolManager.regenerateDirtyEntitlements(
-            entitlementCurator.listByConsumer(consumer));
+        poolManager.regenerateDirtyEntitlements(consumer);
 
         return exporter.getEntitlementExport(consumer, serials);
     }

--- a/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
+++ b/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
@@ -23,8 +23,6 @@ import org.candlepin.common.paging.PageRequest;
 import org.candlepin.config.DatabaseConfigFactory;
 import org.candlepin.guice.PrincipalProvider;
 
-import org.apache.commons.collections.CollectionUtils;
-
 import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
@@ -722,8 +720,8 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
         return entities;
     }
 
-    public Collection<E> saveOrUpdateAll(Collection<E> entities, boolean flush, boolean evict) {
-        if (CollectionUtils.isNotEmpty(entities)) {
+    public Iterable<E> saveOrUpdateAll(Iterable<E> entities, boolean flush, boolean evict) {
+        if (entities != null) {
             try {
                 Session session = this.currentSession();
                 EntityManager em = this.getEntityManager();

--- a/server/src/main/java/org/candlepin/model/Entitlement.java
+++ b/server/src/main/java/org/candlepin/model/Entitlement.java
@@ -276,16 +276,24 @@ public class Entitlement extends AbstractHibernateObject<Entitlement>
     }
 
     public void setCertificates(Set<EntitlementCertificate> certificates) {
-        this.certificates.clear();
+        this.certificates = new HashSet<>();
 
         if (certificates != null) {
-            this.certificates.addAll(certificates);
+            for (EntitlementCertificate cert : certificates) {
+                this.addCertificate(cert);
+            }
         }
     }
 
     public void addCertificate(EntitlementCertificate certificate) {
-        certificate.setEntitlement(this);
-        certificates.add(certificate);
+        if (certificate != null) {
+            certificate.setEntitlement(this);
+            certificates.add(certificate);
+        }
+    }
+
+    public boolean removeCertificate(EntitlementCertificate certificate) {
+        return this.certificates.remove(certificate);
     }
 
     @Override

--- a/server/src/main/java/org/candlepin/model/EntitlementCertificate.java
+++ b/server/src/main/java/org/candlepin/model/EntitlementCertificate.java
@@ -99,4 +99,16 @@ public class EntitlementCertificate extends RevocableCertificate<EntitlementCert
         }
         return false;
     }
+
+    @Override
+    public String toString() {
+        Entitlement entitlement = this.getEntitlement();
+        String entitlementId = entitlement != null ? entitlement.getId() : null;
+
+        CertificateSerial serial = this.getSerial();
+        Long serialId = serial != null ? serial.getId() : null;
+
+        return String.format("EntitlementCertificate [id: %s, entitlement: %s, serial: %s]",
+            this.getId(), entitlementId, serialId);
+    }
 }

--- a/server/src/main/java/org/candlepin/model/EntitlementCertificateCurator.java
+++ b/server/src/main/java/org/candlepin/model/EntitlementCertificateCurator.java
@@ -19,10 +19,17 @@ import com.google.inject.persist.Transactional;
 
 import org.hibernate.criterion.Restrictions;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import javax.inject.Singleton;
+import javax.persistence.Query;
 
 
 
@@ -31,6 +38,7 @@ import javax.inject.Singleton;
  */
 @Singleton
 public class EntitlementCertificateCurator extends AbstractHibernateCurator<EntitlementCertificate> {
+    private static Logger log = LoggerFactory.getLogger(EntitlementCertificateCurator.class);
 
     @Inject
     public EntitlementCertificateCurator() {
@@ -62,7 +70,84 @@ public class EntitlementCertificateCurator extends AbstractHibernateCurator<Enti
     public void delete(EntitlementCertificate cert) {
         // make sure to delete it! else get ready to face
         // javax.persistence.EntityNotFoundException('deleted entity passed to persist')
-        cert.getEntitlement().getCertificates().remove(cert);
+        cert.getEntitlement().removeCertificate(cert);
         super.delete(cert);
+    }
+
+    /**
+     * Deletes any existing entitlement certificates for the specified entitlements.
+     *
+     * @param entitlementIds
+     *  A collection of IDs of the entitlements for which to delete certificates
+     *
+     * @return
+     *  the number of entitlement certificates deleted
+     */
+    public int deleteByEntitlementIds(String... entitlementIds) {
+        return entitlementIds != null ? this.deleteByEntitlementIds(Arrays.asList(entitlementIds)) : 0;
+    }
+
+    /**
+     * Deletes any existing entitlement certificates for the specified entitlements.
+     *
+     * @param entitlementIds
+     *  A collection of IDs of the entitlements for which to delete certificates
+     *
+     * @return
+     *  the number of entitlement certificates deleted
+     */
+    @Transactional
+    public int deleteByEntitlementIds(Iterable<String> entitlementIds) {
+        int removed = 0;
+        int revoked = 0;
+
+        if (entitlementIds != null) {
+            Set<String> certIds = new HashSet<>();
+            Set<Long> serials = new HashSet<>();
+
+            String sjpql = "SELECT ec.id, ec.serial.id FROM EntitlementCertificate ec " +
+                "WHERE ec.entitlement.id IN :entids";
+            Query selector = this.getEntityManager().createQuery(sjpql);
+
+            // Impl note:
+            // If we don't set the flush mode here, we will trigger inserts on any pending new
+            // entitlement certificates, on top of potentially catching certs we don't intend
+            // to pick up.
+            selector.setFlushMode(javax.persistence.FlushModeType.COMMIT);
+
+            String rjpql = "DELETE FROM EntitlementCertificate ec WHERE ec.id IN :ecids";
+            Query remover = this.getEntityManager().createQuery(rjpql);
+
+            // Get certificate and serial IDs...
+            for (List<String> block : this.partition(entitlementIds)) {
+                selector.setParameter("entids", block);
+
+                for (Object[] ids : (List<Object[]>) selector.getResultList()) {
+                    certIds.add((String) ids[0]);
+                    serials.add((Long) ids[1]);
+                }
+            }
+
+            // Delete the old entitlement certificates
+            for (List<String> block : this.partition(certIds)) {
+                remover.setParameter("ecids", block);
+                removed += remover.executeUpdate();
+            }
+
+            log.debug("{} entitlement certificates removed", removed);
+
+            // Mark the serials as revoked so they get picked up and added to the CRL later
+            String ujpql = "UPDATE CertificateSerial cs SET cs.revoked = true WHERE cs.id IN :csids";
+            Query updater = this.getEntityManager().createQuery(ujpql);
+
+            for (List<Long> block : this.partition(serials)) {
+                updater.setParameter("csids", block);
+                revoked += updater.executeUpdate();
+            }
+
+            log.debug("{} certificate serials revoked", revoked);
+        }
+
+        return removed;
     }
 }

--- a/server/src/main/java/org/candlepin/service/EntitlementCertServiceAdapter.java
+++ b/server/src/main/java/org/candlepin/service/EntitlementCertServiceAdapter.java
@@ -45,7 +45,7 @@ public interface EntitlementCertServiceAdapter {
         throws GeneralSecurityException, IOException;
 
     /**
-     * Generate an entitlement certificate, used to grant access to some
+     * Generate entitlement certificates, used to grant access to some
      * content.
      * End date specified explicitly to allow for flexible termination policies.
      * The Map keys are used to associate the entitlement with its product and

--- a/server/src/main/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapter.java
+++ b/server/src/main/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapter.java
@@ -147,6 +147,7 @@ public class DefaultEntitlementCertServiceAdapter extends BaseEntitlementCertSer
         Map<String, PoolQuantity> poolQuantities, Map<String, Entitlement> entitlements,
         Map<String, Product> products, boolean save)
         throws GeneralSecurityException, IOException {
+
         return doEntitlementCertGeneration(consumer, products, poolQuantities, entitlements, save);
     }
 
@@ -446,6 +447,8 @@ public class DefaultEntitlementCertServiceAdapter extends BaseEntitlementCertSer
             serialMap.put(entry.getKey(), new CertificateSerial(entry.getValue().getPool().getEndDate()));
         }
 
+        log.debug("WE HAVE {} POOL QUANTITIES TO LOOP THROUGH", poolQuantities.size());
+
         Map<String, EntitlementCertificate> entitlementCerts = new HashMap<>();
         for (Entry<String, PoolQuantity> entry : poolQuantities.entrySet()) {
             Pool pool = entry.getValue().getPool();
@@ -536,10 +539,11 @@ public class DefaultEntitlementCertServiceAdapter extends BaseEntitlementCertSer
                 throw new RuntimeException(
                     "Entitlement certificate not found for entitlement during cert generation");
             }
+
             nextCert.setSerial(nextSerial);
             if (save) {
                 Entitlement ent = entitlements.get(entry.getKey());
-                ent.getCertificates().add(nextCert);
+                ent.addCertificate(nextCert);
             }
         }
 

--- a/server/src/test/java/org/candlepin/controller/EntitlementCertificateGeneratorTest.java
+++ b/server/src/test/java/org/candlepin/controller/EntitlementCertificateGeneratorTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyMapOf;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -143,7 +144,7 @@ public class EntitlementCertificateGeneratorTest {
         poolQuantities.put("Taylor", new PoolQuantity(pool, 1));
         ecGenerator.generateEntitlementCertificates(consumer, products, poolQuantities, entitlements, true);
         verify(mockEntCertAdapter).generateEntitlementCerts(eq(consumer), eq(poolQuantities), eq
-            (entitlements), eq(products), eq(true));
+            (entitlements), eq(products), anyBoolean());
     }
 
     @Test
@@ -257,7 +258,7 @@ public class EntitlementCertificateGeneratorTest {
         when(cqmock.iterator()).thenReturn(entitlements.iterator());
         when(this.mockEntitlementCurator.listByEnvironment(environment)).thenReturn(cqmock);
         when(this.mockEntCertAdapter.generateEntitlementCerts(any(Consumer.class), any(Map.class),
-            any(Map.class), any(Map.class), eq(true))).thenReturn(ecMap);
+            any(Map.class), any(Map.class), anyBoolean())).thenReturn(ecMap);
 
         this.ecGenerator.regenerateCertificatesOf(environment, Arrays.asList("c1", "c2", "c4"), false);
 
@@ -267,7 +268,7 @@ public class EntitlementCertificateGeneratorTest {
 
         verify(this.mockEntCertAdapter, times(2)).generateEntitlementCerts(any(Consumer.class),
             this.poolQuantityMapCaptor.capture(), this.entMapCaptor.capture(), this.productMapCaptor
-            .capture(), eq(true));
+            .capture(), eq(false));
 
         verify(this.mockEventSink, times(2)).queueEvent(any(Event.class));
     }
@@ -310,7 +311,7 @@ public class EntitlementCertificateGeneratorTest {
         when(this.mockPoolCurator.listAvailableEntitlementPools(any(Consumer.class), eq(owner),
             eq(product.getId()), any(Date.class))).thenReturn(Arrays.asList(pool));
         when(this.mockEntCertAdapter.generateEntitlementCerts(any(Consumer.class), any(Map.class),
-            any(Map.class), any(Map.class), eq(true))).thenReturn(ecMap);
+            any(Map.class), any(Map.class), anyBoolean())).thenReturn(ecMap);
 
         this.ecGenerator.regenerateCertificatesOf(owner, product.getId(), false);
 
@@ -318,7 +319,7 @@ public class EntitlementCertificateGeneratorTest {
 
         verify(this.mockEntCertAdapter, times(1)).generateEntitlementCerts(any(Consumer.class),
             this.poolQuantityMapCaptor.capture(), this.entMapCaptor.capture(),
-            this.productMapCaptor.capture(), eq(true));
+            this.productMapCaptor.capture(), eq(false));
 
         verify(this.mockEventSink, times(1)).queueEvent(any(Event.class));
     }
@@ -353,7 +354,7 @@ public class EntitlementCertificateGeneratorTest {
         when(this.mockEntCertAdapter.generateEntitlementCerts(
             any(Consumer.class), anyMapOf(String.class, PoolQuantity.class),
             anyMapOf(String.class, Entitlement.class),
-            anyMapOf(String.class, Product.class), eq(true))).thenReturn(entCerts);
+            anyMapOf(String.class, Product.class), anyBoolean())).thenReturn(entCerts);
 
         Consumer consumer = TestUtil.createConsumer(owner);
         Entitlement entitlement = new Entitlement(pool, consumer, owner, 1);
@@ -364,7 +365,7 @@ public class EntitlementCertificateGeneratorTest {
 
         verify(this.mockEntCertAdapter).generateEntitlementCerts(eq(consumer),
             this.poolQuantityMapCaptor.capture(), this.entMapCaptor.capture(), this.productMapCaptor
-            .capture(), eq(true));
+            .capture(), eq(false));
 
         assertEquals(entitlement, this.entMapCaptor.getValue().get(pool.getId()));
         assertEquals(product, this.productMapCaptor.getValue().get(pool.getId()));
@@ -411,7 +412,7 @@ public class EntitlementCertificateGeneratorTest {
 
         when(this.mockEntitlementCurator.get(eq(entitlement.getId()))).thenReturn(entitlement);
         when(this.mockEntCertAdapter.generateEntitlementCerts(any(Consumer.class), any(Map.class),
-            any(Map.class), any(Map.class), eq(true))).thenReturn(ecMap);
+            any(Map.class), any(Map.class), anyBoolean())).thenReturn(ecMap);
 
         this.ecGenerator.regenerateCertificatesByEntitlementIds(entitlements, false);
 
@@ -419,7 +420,7 @@ public class EntitlementCertificateGeneratorTest {
 
         verify(this.mockEntCertAdapter, times(1)).generateEntitlementCerts(any(Consumer.class),
             this.poolQuantityMapCaptor.capture(), this.entMapCaptor.capture(), this.productMapCaptor
-            .capture(), eq(true));
+            .capture(), eq(false));
 
         verify(this.mockEventSink, times(1)).queueEvent(any(Event.class));
     }

--- a/server/src/test/java/org/candlepin/controller/ManifestManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/ManifestManagerTest.java
@@ -144,7 +144,6 @@ public class ManifestManagerTest {
 
         manager.generateManifest(consumer.getUuid(), cdn.getLabel(), webAppPrefix, apiUrl, extData);
 
-        verify(poolManager).regenerateDirtyEntitlements(eq(ents));
         verify(exporter).getFullExport(eq(consumer), eq(cdn.getLabel()), eq(webAppPrefix), eq(apiUrl),
             eq(extData));
     }
@@ -216,7 +215,6 @@ public class ManifestManagerTest {
             extData);
         assertEquals(manifestFile, result);
 
-        verify(entitlementCurator).listByConsumer(eq(consumer));
         verify(exporter).getFullExport(eq(consumer), eq(cdn.getLabel()), eq(webAppPrefix), eq(apiUrl),
             eq(extData));
 

--- a/server/src/test/java/org/candlepin/model/EntitlementCertificateCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/EntitlementCertificateCuratorTest.java
@@ -1,0 +1,199 @@
+/**
+ * Copyright (c) 2009 - 2018 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.model;
+
+import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.*;
+
+import org.candlepin.test.DatabaseTestFixture;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.Date;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+
+
+/**
+ * Test suite for the EntitlementCertificateCurator class
+ */
+public class EntitlementCertificateCuratorTest extends DatabaseTestFixture {
+
+    private Owner owner;
+    private Consumer consumer;
+    private Product product;
+    private Pool pool;
+
+    @Before
+    public void setup() {
+        this.owner = this.createOwner();
+        this.consumer = this.createConsumer(this.owner);
+        this.product = this.createProduct(this.owner);
+        this.pool = this.createPool(this.owner, this.product);
+    }
+
+    @Test
+    public void testDeleteSingleCertBySingleEntitlementId() {
+        Entitlement ent1 = this.createEntitlement(this.owner, this.consumer, this.pool);
+        Entitlement ent2 = this.createEntitlement(this.owner, this.consumer, this.pool);
+
+        EntitlementCertificate cert1 = this.createEntitlementCertificate(ent1, "key1", "cert1");
+        EntitlementCertificate cert2a = this.createEntitlementCertificate(ent2, "key2a", "cert2a");
+        EntitlementCertificate cert2b = this.createEntitlementCertificate(ent2, "key2b", "cert2b");
+
+        // Verify initial state
+        assertNotNull(ent1.getId());
+        assertNotNull(ent2.getId());
+        assertNotEquals(ent1.getId(), ent2.getId());
+
+        assertNotNull(cert1.getId());
+        assertNotNull(cert2a.getId());
+        assertNotNull(cert2b.getId());
+
+        this.entitlementCertificateCurator.clear();
+
+        // Verify that we can fetch all three certs generally
+        Collection<EntitlementCertificate> certs = this.entitlementCertificateCurator.listAll().list();
+        assertNotNull(certs);
+        assertEquals(3, certs.size());
+
+        this.entitlementCertificateCurator.clear();
+
+        // Delete certs for ent1, verify we have one cert remaining
+        int count = this.entitlementCertificateCurator.deleteByEntitlementIds(ent1.getId());
+        assertEquals(1, count);
+
+        // Verify state after deletion
+        certs = this.entitlementCertificateCurator.listAll().list();
+        assertNotNull(certs);
+        assertEquals(2, certs.size());
+
+        ent1 = this.entitlementCurator.get(ent1.getId());
+        assertNotNull(ent1);
+        assertNotNull(ent1.getCertificates());
+        assertEquals(0, ent1.getCertificates().size());
+
+        ent2 = this.entitlementCurator.get(ent2.getId());
+        assertNotNull(ent2);
+        assertNotNull(ent2.getCertificates());
+        assertEquals(2, ent2.getCertificates().size());
+
+        Set<String> remaining = ent2.getCertificates().stream()
+            .map(c -> c.getId())
+            .collect(Collectors.toSet());
+
+        assertTrue(remaining.contains(cert2a.getId()));
+        assertTrue(remaining.contains(cert2b.getId()));
+    }
+
+    @Test
+    public void testDeleteMultipleCertsBySingleEntitlementId() {
+        Entitlement ent1 = this.createEntitlement(this.owner, this.consumer, this.pool);
+        Entitlement ent2 = this.createEntitlement(this.owner, this.consumer, this.pool);
+
+        EntitlementCertificate cert1 = this.createEntitlementCertificate(ent1, "key1", "cert1");
+        EntitlementCertificate cert2a = this.createEntitlementCertificate(ent2, "key2a", "cert2a");
+        EntitlementCertificate cert2b = this.createEntitlementCertificate(ent2, "key2b", "cert2b");
+
+        // Verify initial state
+        assertNotNull(ent1.getId());
+        assertNotNull(ent2.getId());
+        assertNotEquals(ent1.getId(), ent2.getId());
+
+        assertNotNull(cert1.getId());
+        assertNotNull(cert2a.getId());
+        assertNotNull(cert2b.getId());
+
+        this.entitlementCertificateCurator.clear();
+
+        // Verify that we can fetch all three certs generally
+        Collection<EntitlementCertificate> certs = this.entitlementCertificateCurator.listAll().list();
+        assertNotNull(certs);
+        assertEquals(3, certs.size());
+
+        this.entitlementCertificateCurator.clear();
+
+        // Delete certs for ent1, verify we have one cert remaining
+        int count = this.entitlementCertificateCurator.deleteByEntitlementIds(ent2.getId());
+        assertEquals(2, count);
+
+        // Verify state after deletion
+        certs = this.entitlementCertificateCurator.listAll().list();
+        assertNotNull(certs);
+        assertEquals(1, certs.size());
+
+        ent1 = this.entitlementCurator.get(ent1.getId());
+        assertNotNull(ent1);
+        assertNotNull(ent1.getCertificates());
+        assertEquals(1, ent1.getCertificates().size());
+
+        Set<String> remaining = ent1.getCertificates().stream()
+            .map(c -> c.getId())
+            .collect(Collectors.toSet());
+
+        assertTrue(remaining.contains(cert1.getId()));
+
+        ent2 = this.entitlementCurator.get(ent2.getId());
+        assertNotNull(ent2);
+        assertNotNull(ent2.getCertificates());
+        assertEquals(0, ent2.getCertificates().size());
+
+    }
+
+    @Test
+    public void testDeleteDoesntAffectUnsavedCerts() {
+        Entitlement ent1 = this.createEntitlement(this.owner, this.consumer, this.pool);
+        EntitlementCertificate cert1 = this.createEntitlementCertificate(ent1, "key1", "cert1");
+
+        // Verify initial state
+        assertNotNull(ent1.getId());
+        assertNotNull(cert1.getId());
+
+        // Create a new, unsaved cert
+        EntitlementCertificate certN = new EntitlementCertificate();
+        CertificateSerial certSerial = new CertificateSerial(new Date());
+        this.certSerialCurator.create(certSerial);
+
+        certN.setKeyAsBytes("keyN".getBytes());
+        certN.setCertAsBytes("certN".getBytes());
+        certN.setSerial(certSerial);
+
+        ent1.addCertificate(certN);
+
+        // Delete existing certs for ent1, without affecting the new, unsaved cert.
+        int count = this.entitlementCertificateCurator.deleteByEntitlementIds(ent1.getId());
+        assertEquals(1, count);
+
+        // Merge the changes on entitlement; we should end up with the entitlement only having the
+        // new cert
+        ent1 = this.entitlementCurator.merge(ent1);
+        this.entitlementCurator.clear();
+
+        ent1 = this.entitlementCurator.get(ent1.getId());
+        assertNotNull(ent1);
+        assertNotNull(ent1.getCertificates());
+        assertEquals(1, ent1.getCertificates().size());
+
+        // Verify the serial on the remaining cert is what we expect it to be
+        EntitlementCertificate remaining = ent1.getCertificates().iterator().next();
+        CertificateSerial remSerial = remaining.getSerial();
+
+        assertEquals(certSerial.getId(), remSerial.getId());
+    }
+
+}

--- a/server/src/test/java/org/candlepin/test/DatabaseTestFixture.java
+++ b/server/src/test/java/org/candlepin/test/DatabaseTestFixture.java
@@ -448,6 +448,10 @@ public class DatabaseTestFixture {
         return this.consumerTypeCurator.create(ctype);
     }
 
+    protected Entitlement createEntitlement(Owner owner, Consumer consumer, Pool pool) {
+        return this.createEntitlement(owner, consumer, pool, null);
+    }
+
     protected Entitlement createEntitlement(Owner owner, Consumer consumer, Pool pool,
         EntitlementCertificate cert) {
 
@@ -465,24 +469,39 @@ public class DatabaseTestFixture {
 
         if (cert != null) {
             cert.setEntitlement(entitlement);
-            entitlement.getCertificates().add(cert);
+            entitlement.addCertificate(cert);
 
             this.entitlementCertificateCurator.merge(cert);
-            this.entitlementCurator.merge(entitlement);
+            entitlement = this.entitlementCurator.merge(entitlement);
         }
 
         return entitlement;
     }
 
     protected EntitlementCertificate createEntitlementCertificate(String key, String cert) {
-        EntitlementCertificate toReturn = new EntitlementCertificate();
-        CertificateSerial certSerial = new CertificateSerial(new Date());
-        certSerialCurator.create(certSerial);
-        toReturn.setKeyAsBytes(key.getBytes());
-        toReturn.setCertAsBytes(cert.getBytes());
-        toReturn.setSerial(certSerial);
+        return this.createEntitlementCertificate(null, key, cert);
+    }
 
-        return toReturn;
+    protected EntitlementCertificate createEntitlementCertificate(Entitlement entitlement, String key,
+        String cert) {
+
+        EntitlementCertificate entcert = new EntitlementCertificate();
+        CertificateSerial certSerial = new CertificateSerial(new Date());
+        this.certSerialCurator.create(certSerial);
+
+        entcert.setKeyAsBytes(key.getBytes());
+        entcert.setCertAsBytes(cert.getBytes());
+        entcert.setSerial(certSerial);
+
+        if (entitlement != null) {
+            entcert.setEntitlement(entitlement);
+            entitlement.addCertificate(entcert);
+
+            entcert = this.entitlementCertificateCurator.create(entcert);
+            this.entitlementCurator.merge(entitlement);
+        }
+
+        return entcert;
     }
 
     protected Environment createEnvironment(Owner owner, String id) {


### PR DESCRIPTION
- Fixed an issue that could cause StaleStateExceptions to occur when
  regenerating certificates for the same consumer multiple times in
  parallel