### PR TITLE
[2.3] 1642624: Remove service level checking for consumers [ENT-929]

### DIFF
--- a/server/spec/consumer_resource_spec.rb
+++ b/server/spec/consumer_resource_spec.rb
@@ -732,11 +732,6 @@ describe 'Consumer Resource' do
     consumer = @cp.get_consumer(consumer['uuid'])
     consumer['serviceLevel'].should == 'VIP'
 
-    # Should not be able to set service level to one not available by org
-    lambda do
-        consumer_client.update_consumer({:serviceLevel => 'Ultra-VIP'})
-    end.should raise_exception(RestClient::BadRequest)
-
     # The service level should be case insensitive
     consumer_client.update_consumer({:serviceLevel => ''})
     consumer = @cp.get_consumer(consumer['uuid'])
@@ -745,11 +740,6 @@ describe 'Consumer Resource' do
     consumer_client.update_consumer({:serviceLevel => 'vip'})
     consumer = @cp.get_consumer(consumer['uuid'])
     consumer['serviceLevel'].should == 'vip'
-
-   # Cannot assign exempt level to consumer
-    lambda do
-        consumer_client.update_consumer({:serviceLevel => 'Layered'})
-    end.should raise_exception(RestClient::BadRequest)
 
   end
 
@@ -833,11 +823,6 @@ describe 'Consumer Resource' do
     consumer = @cp.get_consumer(consumer['uuid'])
     consumer['serviceLevel'].should == ''
     @cp.update_owner(@owner1['key'], {:defaultServiceLevel => 'VIP'})
-
-    # dry run with unknown level should return badrequest
-    lambda do
-        @cp.autobind_dryrun(consumer['uuid'], 'Standard').length.should == 0
-    end.should raise_exception(RestClient::BadRequest)
 
     # dry run against the override service level should be case insensitive
     pools = @cp.autobind_dryrun(consumer['uuid'], 'Ultra-vip')

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -821,7 +821,8 @@ public class ConsumerResource {
         logNewConsumerDebugInfo(consumerToCreate, keys, type);
 
         validateContentAccessMode(consumerToCreate, owner);
-        consumerBindUtil.validateServiceLevel(owner.getId(), consumerToCreate.getServiceLevel());
+        // BZ 1618398 Remove validation check on consumer service level
+        // consumerBindUtil.validateServiceLevel(owner.getId(), consumerToCreate.getServiceLevel());
 
         try {
             Date createdDate = consumerToCreate.getCreated();
@@ -1465,7 +1466,8 @@ public class ConsumerResource {
         String level = updated.getServiceLevel();
         if (level != null && !level.equals(toUpdate.getServiceLevel())) {
             log.info("   Updating consumer service level setting.");
-            consumerBindUtil.validateServiceLevel(toUpdate.getOwnerId(), level);
+            // BZ 1618398 Remove validation check on consumer service level
+            // consumerBindUtil.validateServiceLevel(toUpdate.getOwnerId(), level);
             toUpdate.setServiceLevel(level);
             changesMade = true;
         }
@@ -2153,7 +2155,8 @@ public class ConsumerResource {
         List<PoolQuantity> dryRunPools = new ArrayList<>();
 
         try {
-            consumerBindUtil.validateServiceLevel(consumer.getOwnerId(), serviceLevel);
+            // BZ 1618398 Remove validation check on consumer service level
+            // consumerBindUtil.validateServiceLevel(consumer.getOwnerId(), serviceLevel);
             dryRunPools = entitler.getDryRun(consumer, owner, serviceLevel);
         }
         catch (ForbiddenException fe) {


### PR DESCRIPTION
This is a patch of https://github.com/candlepin/candlepin/pull/2131 for the 2.3-HOTFIX branch.