### PR TITLE
1556930: Index to make hypervisor uuid lookup faster

### DIFF
--- a/server/src/main/resources/db/changelog/20181116110941-virt-fact-index.xml
+++ b/server/src/main/resources/db/changelog/20181116110941-virt-fact-index.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="20181116110941-1" author="wpoteat" dbms="postgresql">
+        <comment>virt-fact-index</comment>
+        <createIndex indexName="cp_consumer_fact_mapkey_idx" tableName="cp_consumer_facts" unique="false">
+            <column name="mapkey"/>
+            <column name="element"/>
+        </createIndex>
+        <modifySql>
+            <append value=" WHERE mapkey='virt.uuid'"/>
+        </modifySql>
+    </changeSet>
+
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/server/src/main/resources/db/changelog/changelog-create.xml
+++ b/server/src/main/resources/db/changelog/changelog-create.xml
@@ -1227,4 +1227,5 @@
     <include file="db/changelog/20180329144902-change-cp-event-dot-consumer-id-to-consumer-uuid.xml"/>
     <include file="db/changelog/20180820091431-revert-share-fields.xml"/>
     <include file="db/changelog/20180430101420-add-intent-fields-to-consumer.xml"/>
+    <include file="db/changelog/20181116110941-virt-fact-index.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-testing.xml
+++ b/server/src/main/resources/db/changelog/changelog-testing.xml
@@ -2319,4 +2319,5 @@
     <include file="db/changelog/20180329144902-change-cp-event-dot-consumer-id-to-consumer-uuid.xml"/>
     <include file="db/changelog/20180820091431-revert-share-fields.xml"/>
     <include file="db/changelog/20180430101420-add-intent-fields-to-consumer.xml"/>
+    <include file="db/changelog/20181116110941-virt-fact-index.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-update.xml
+++ b/server/src/main/resources/db/changelog/changelog-update.xml
@@ -136,4 +136,5 @@
     <include file="db/changelog/20180329144902-change-cp-event-dot-consumer-id-to-consumer-uuid.xml"/>
     <include file="db/changelog/20180820091431-revert-share-fields.xml"/>
     <include file="db/changelog/20180430101420-add-intent-fields-to-consumer.xml"/>
+    <include file="db/changelog/20181116110941-virt-fact-index.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
Postgres allows the condition to better focus the index.
MySql does not, so the index will need to be broader.