### PR TITLE
[2.5] 1640688: Fix incorrect partial compliance status on consumers

### DIFF
--- a/server/spec/system_purpose_compliance_spec.rb
+++ b/server/spec/system_purpose_compliance_spec.rb
@@ -51,6 +51,70 @@ describe 'System purpose compliance' do
       status['compliantRole']['myrole'][0]['pool']['id'].should == p.id
   end
 
+  it 'should be valid for any SLA when consumer has null SLA' do
+      product = create_product(random_string('product'),
+                              random_string('product'),
+                              {:attributes => {:support_level => 'mysla'},
+                               :owner => @owner2['key']})
+      p = create_pool_and_subscription(@owner2['key'], product.id)
+      consumer = @user2.register(
+          random_string('systempurpose'), :system, nil, {}, nil, @owner2['key'], [], [], nil, [],
+          nil, [], nil, nil, nil, nil, nil, 0, nil, nil, nil, nil, nil)
+      status = @user2.get_purpose_compliance(consumer['uuid'])
+      @user2.consume_pool(p.id, params={:uuid=>consumer.uuid})
+      status = @user2.get_purpose_compliance(consumer['uuid'])
+      expect(status['status']).to eq('valid')
+      expect(status['compliantSLA']).to be_empty
+  end
+
+  it 'should be valid for any usage when consumer has null usage' do
+      product = create_product(random_string('product'),
+                              random_string('product'),
+                              {:attributes => {:usage => 'myusage'},
+                               :owner => @owner2['key']})
+      p = create_pool_and_subscription(@owner2['key'], product.id)
+      consumer = @user2.register(
+          random_string('systempurpose'), :system, nil, {}, nil, @owner2['key'], [], [], nil, [],
+          nil, [], nil, nil, nil, nil, nil, 0, nil, nil, nil, nil, nil)
+      status = @user2.get_purpose_compliance(consumer['uuid'])
+      @user2.consume_pool(p.id, params={:uuid=>consumer.uuid})
+      status = @user2.get_purpose_compliance(consumer['uuid'])
+      expect(status['status']).to eq('valid')
+      expect(status['compliantUsage']).to be_empty
+  end
+
+  it 'should be valid for any role when consumer has null role' do
+      product = create_product(random_string('product'),
+                              random_string('product'),
+                              {:attributes => {:roles => 'myrole'},
+                               :owner => @owner2['key']})
+      p = create_pool_and_subscription(@owner2['key'], product.id)
+      consumer = @user2.register(
+          random_string('systempurpose'), :system, nil, {}, nil, @owner2['key'], [], [], nil, [],
+          nil, [], nil, nil, nil, nil, nil, 0, nil, nil, nil, nil, nil)
+      status = @user2.get_purpose_compliance(consumer['uuid'])
+      @user2.consume_pool(p.id, params={:uuid=>consumer.uuid})
+      status = @user2.get_purpose_compliance(consumer['uuid'])
+      expect(status['status']).to eq('valid')
+      expect(status['compliantRole']).to be_empty
+  end
+
+  it 'should be valid for any addons when consumer has null addons' do
+      product = create_product(random_string('product'),
+                              random_string('product'),
+                              {:attributes => {:addons => 'myaddon,myotheraddon'},
+                               :owner => @owner2['key']})
+      p = create_pool_and_subscription(@owner2['key'], product.id)
+      consumer = @user2.register(
+          random_string('systempurpose'), :system, nil, {}, nil, @owner2['key'], [], [], nil, [],
+          nil, [], nil, nil, nil, nil, nil, 0, nil, nil, nil, nil, nil)
+      status = @user2.get_purpose_compliance(consumer['uuid'])
+      @user2.consume_pool(p.id, params={:uuid=>consumer.uuid})
+      status = @user2.get_purpose_compliance(consumer['uuid'])
+      expect(status['status']).to eq('valid')
+      expect(status['compliantAddOns']).to be_empty
+  end
+
   it 'should be invalid for unsatisfied usage' do
       consumer = @user2.register(
           random_string('systempurpose'), :system, nil, {}, nil, @owner2['key'], [], [], nil, [],

--- a/server/src/main/java/org/candlepin/policy/SystemPurposeComplianceRules.java
+++ b/server/src/main/java/org/candlepin/policy/SystemPurposeComplianceRules.java
@@ -98,7 +98,6 @@ public class SystemPurposeComplianceRules {
             .collect(Collectors.toSet());
 
         for (Entitlement entitlement : entitlements) {
-
             String unsatisfedRole = consumer.getRole();
             Set<String> unsatisfiedAddons = new HashSet<>(consumer.getAddOns());
             String preferredSla = consumer.getServiceLevel();
@@ -140,9 +139,10 @@ public class SystemPurposeComplianceRules {
                 }
                 unsatisfiedAddons.removeAll(addonsFound);
 
-                if (product.hasAttribute(Product.Attributes.SUPPORT_LEVEL)) {
+                if (StringUtils.isNotEmpty(preferredSla) &&
+                    product.hasAttribute(Product.Attributes.SUPPORT_LEVEL)) {
                     String sla = product.getAttributeValue(Product.Attributes.SUPPORT_LEVEL);
-                    if (StringUtils.isNotEmpty(preferredSla) && sla.equalsIgnoreCase(preferredSla)) {
+                    if (sla.equalsIgnoreCase(preferredSla)) {
                         status.addCompliantSLA(sla, entitlement);
                     }
                     else {
@@ -150,9 +150,10 @@ public class SystemPurposeComplianceRules {
                     }
                 }
 
-                if (product.hasAttribute(Product.Attributes.USAGE)) {
+                if (StringUtils.isNotEmpty(preferredUsage) &&
+                    product.hasAttribute(Product.Attributes.USAGE)) {
                     String usage = product.getAttributeValue(Product.Attributes.USAGE);
-                    if (StringUtils.isNotEmpty(preferredUsage) && usage.equalsIgnoreCase(preferredUsage)) {
+                    if (usage.equalsIgnoreCase(preferredUsage)) {
                         status.addCompliantUsage(usage, entitlement);
                     }
                     else {

--- a/server/src/main/resources/rules/rules.js
+++ b/server/src/main/resources/rules/rules.js
@@ -1029,11 +1029,16 @@ var CoverageCalculator = {
                 }
                 if (!anyCoverage) {
                     log.debug("  System addons not covered by: " + supportedAddOns);
+                    // The ComplianceReasonDTO expects the "attributes" field to be a Map<String, String>.
+                    // add-ons can be an array and if leave it as such, Jackson won't be able to
+                    // deserialize the JSON it receives from the rules into a ComplianceReasonDTO.
+                    var joinedConsumerAddOns = consumerAddOns.join(', ');
+                    var joinedSupportedAddOns = supportedAddOns.join(', ');
                     return StatusReasonGenerator.buildReason(prodAttr.toUpperCase(),
                         complianceTracker.type,
                         complianceTracker.id,
-                        consumerAddOns,
-                        supportedAddOns);
+                        joinedConsumerAddOns,
+                        joinedSupportedAddOns);
                 }
                 log.debug("  System addons is covered.");
                 return null;


### PR DESCRIPTION
If a consumer does not specify a syspurpose attribute (role, usage,
etc.), do not mark them partially compliant if they attach to a pool
that provides that attribute.

This commit also fixes a Jackson error that I discovered while writing
the test cases.  Jackson was attempting to deserialize compliance reason
JSON to a Map<String, String> when the JSON had arrays as the values
instead.