### PR TITLE
1588101: dynamicly filter activation key's pools subfields [ENT-972]

### DIFF
--- a/server/src/main/java/org/candlepin/dto/api/v1/ActivationKeyDTO.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/ActivationKeyDTO.java
@@ -14,6 +14,7 @@
  */
 package org.candlepin.dto.api.v1;
 
+import org.candlepin.dto.CandlepinDTO;
 import org.candlepin.dto.TimestampedCandlepinDTO;
 import org.candlepin.jackson.SingleValueWrapSerializer;
 import org.candlepin.jackson.SingleValueWrapDeserializer;
@@ -48,7 +49,7 @@ public class ActivationKeyDTO extends TimestampedCandlepinDTO<ActivationKeyDTO> 
     /**
      * Join object DTO for joining the activation key to pools
      */
-    public static class ActivationKeyPoolDTO {
+    public static class ActivationKeyPoolDTO extends CandlepinDTO<ActivationKeyPoolDTO> {
         protected final String poolId;
         protected final Long quantity;
 

--- a/server/src/main/java/org/candlepin/dto/api/v1/EventDTO.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/EventDTO.java
@@ -42,7 +42,7 @@ public class EventDTO extends CandlepinDTO<EventDTO> {
     /**
      * Internal DTO object for PrincipalData.
      */
-    public static class PrincipalDataDTO {
+    public static class PrincipalDataDTO extends CandlepinDTO<PrincipalDataDTO> {
         private final String type;
         private final String name;
 


### PR DESCRIPTION
- Now using ?includes=pools.poolId or ?includes=pools.quantity on the
GET /owners/{owner_key}/activation_keys API will only show the requested subfield,
instead of the whole pools field.
- Also similarly fixed: using ?include=principal.name or
?include=principal.type on the GET /owners/{owner_key}/events API.
- By extending `CandlepinDTO`, which has a `@JsonFilter("DTOFilter")` on it, like all other
DTO classes, forces jackson to serialize properties of these classes using filters (even though
the `DTOFilter` does not exist, the default filter (`DynamicPropertyFilter`) will be used).