### PR TITLE
Allow tomcat to read the candlepin CA cert

### DIFF
--- a/server/selinux/candlepin.te
+++ b/server/selinux/candlepin.te
@@ -75,10 +75,12 @@ miscfiles_read_localization(candlepin_t)
 
 require {
     type candlepin_etc_certs_ca_cert_r_t;
+    type cgroup_t;
     type httpd_t;
     type tomcat_t;
     type postgresql_port_t;
     class file { read getattr open };
+    class dir search;
 }
 
 # for httpd/katello, access to the candlepin ca certs
@@ -87,6 +89,9 @@ allow httpd_t candlepin_etc_certs_ca_cert_r_t: file { read getattr open };
 allow httpd_t candlepin_etc_certs_rw_t:dir search;
 
 # allow tomcat to access candlepin ca certs, etc.
+allow tomcat_t cgroup_t:dir search;
+allow tomcat_t cgroup_t:file { getattr open read };
+allow tomcat_t candlepin_etc_certs_ca_cert_r_t: file { read getattr open };
 allow tomcat_t candlepin_etc_certs_rw_t:dir { list_dir_perms };
 allow tomcat_t candlepin_etc_certs_rw_t:file { read_file_perms };
 allow tomcat_t candlepin_etc_rw_t:dir { list_dir_perms };


### PR DESCRIPTION
In our Katello deployment we have recently moved the candlepin CA cert and key to live under /etc/candlepin/certs and I noticed that when using selinux the app just doesn't work - /candlepin/status gives a 404

I found some denials in audit.log:

```
[root@nightly-test certs]# audit2allow -a

#============= tomcat_t ==============
allow tomcat_t candlepin_etc_certs_ca_cert_r_t:file { getattr open read };
allow tomcat_t cgroup_t:dir search;
allow tomcat_t cgroup_t:file { getattr open read };
```

I applied these and everything seems to work fine, and I think I've translated these in the proper way to the policy in this repo.