### PR TITLE
Use MariaDB JDBC connector. [ENT-986]

### DIFF
--- a/bin/bash_functions
+++ b/bin/bash_functions
@@ -171,6 +171,11 @@ init_mysql_jdbc() {
     JDBC_JAR="/usr/share/java/mysql-connector-java.jar"
     JDBC_URL="jdbc:mysql://$db_host/$db_name"
 
+    # Change once the mariadb-java-client RPM is available in EPEL
+    # JDBC_DRIVER="org.mariadb.jdbc.Driver"
+    # JDBC_JAR="/usr/lib/java/mariadb-java-client.jar"
+    # JDBC_URL="jdbc:mariadb://$db_host/$db_name"
+
     local isolation_level=$(mysql -h $db_host $db_name  --user=$db_user --password="$password"  -e 'select @@global.tx_isolation')
     local READ_COMMITTED="READ-COMMITTED"
     if [[ $isolation_level != *$READ_COMMITTED* ]]; then

--- a/buildfile
+++ b/buildfile
@@ -135,9 +135,9 @@ SWAGGER = [group('swagger-jaxrs', 'swagger-core','swagger-models','swagger-annot
                   :version => JACKSON_VERSION)
          ]
 
-MYSQL = 'mysql:mysql-connector-java:jar:5.1.26'
+MARIADB = 'org.mariadb.jdbc:mariadb-java-client:jar:2.3.0'
 
-DB = [POSTGRESQL, MYSQL]
+DB = [POSTGRESQL, MARIADB]
 
 HSQLDB = 'org.hsqldb:hsqldb:jar:2.3.2'
 HSQLDB_OLD = 'org.hsqldb:hsqldb:jar:1.8.0.10'

--- a/docker/candlepin-base/setup-devel-env.sh
+++ b/docker/candlepin-base/setup-devel-env.sh
@@ -75,11 +75,12 @@ curl -O https://raw.githubusercontent.com/rvm/rvm/master/binscripts/rvm-installe
 gpg2 --verify rvm-installer.asc && bash rvm-installer stable
 source /etc/profile.d/rvm.sh || true
 
-rvm install 2.0.0
-rvm use --default 2.0.0
+rvm install 2.5.3
+rvm use --default 2.5.3
 set -v
 
 # Install all ruby deps
+gem update --system
 gem install bundler
 bundle install
 

--- a/docker/candlepin-base/setup-devel-env.sh
+++ b/docker/candlepin-base/setup-devel-env.sh
@@ -24,6 +24,7 @@ PACKAGES=(
     liquibase
     mariadb
     mysql-connector-java
+    mariadb-java-client
     openssl
     postgresql
     postgresql-jdbc

--- a/docker/docker-compose-mysql.yml
+++ b/docker/docker-compose-mysql.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   db:
-    image: mariadb:10.0
+    image: mariadb:10.2
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: password

--- a/docker/mysql.cnf
+++ b/docker/mysql.cnf
@@ -1,4 +1,16 @@
+[client]
+default-character-set=utf8mb4
+
+[mysql]
+default-character-set=utf8mb4
+
 [mysqld]
 symbolic-links=0
 transaction-isolation=READ-COMMITTED
-
+# MySQL/MariaDB "utf8" charset only supports characters up to three bytes wide
+# (i.e. no emojis).  To get full unicode support, we need to use "utf8mb4"
+# See https://mathiasbynens.be/notes/mysql-utf8mb4
+init-connect='SET NAMES utf8mb4'
+collation-server=utf8mb4_unicode_ci
+character-set-server=utf8mb4
+character-set-client-handshake=FALSE

--- a/profiles.yaml
+++ b/profiles.yaml
@@ -27,10 +27,10 @@ development:
 
 mysql:
   static: &mysql_static
-    driver_class: "com.mysql.jdbc.Driver"
-    dialect: "org.hibernate.dialect.MySQL5InnoDBDialect"
+    driver_class: "org.mariadb.jdbc.Driver"
+    dialect: "org.hibernate.dialect.MariaDBDialect"
     quartz_driver: "org.quartz.impl.jdbcjobstore.StdJDBCDelegate"
   server:
     <<: *common_server
     <<: *mysql_static
-    jdbc_url: "jdbc:mysql://$DB_HOST/$DB_NAME"
+    jdbc_url: "jdbc:mariadb://$DB_HOST/$DB_NAME"

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -132,7 +132,7 @@
     <com.fasterxml.jackson.dataformat-jackson-dataformat-xml.version>2.9.4</com.fasterxml.jackson.dataformat-jackson-dataformat-xml.version>
     <org.candlepin-candlepin-common.version>2.0.3</org.candlepin-candlepin-common.version>
     <org.postgresql-postgresql.version>42.2.2</org.postgresql-postgresql.version>
-    <mysql-mysql-connector-java.version>5.1.26</mysql-mysql-connector-java.version>
+    <org.mariadb.jdbc-mariadb-java-client.version>2.3.0</org.mariadb.jdbc-mariadb-java-client.version>
     <org.jmock-jmock.version>2.5.1</org.jmock-jmock.version>
     <org.jmock-jmock-junit4.version>2.5.1</org.jmock-jmock-junit4.version>
   </properties>
@@ -1412,9 +1412,9 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>mysql</groupId>
-      <artifactId>mysql-connector-java</artifactId>
-      <version>${mysql-mysql-connector-java.version}</version>
+      <groupId>org.mariadb.jdbc</groupId>
+      <artifactId>mariadb-java-client</artifactId>
+      <version>${org.mariadb.jdbc-mariadb-java-client.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>

--- a/server/spec/owner_resource_spec.rb
+++ b/server/spec/owner_resource_spec.rb
@@ -301,7 +301,7 @@ describe 'Owner Resource' do
   end
 
   it 'should allow unicode owner creation' do
-    create_owner random_string('☠pirate org yarr☠')
+    create_owner random_string('Ακμή корпорация')
   end
 
   it "lets owners show service levels" do

--- a/server/src/main/java/org/candlepin/config/DatabaseConfigFactory.java
+++ b/server/src/main/java/org/candlepin/config/DatabaseConfigFactory.java
@@ -56,7 +56,8 @@ public class DatabaseConfigFactory {
      */
     public enum SupportedDatabase {
         POSTGRESQL("postgresql", POSTGRESQL_CONFIG),
-        MYSQL("mysql", MYSQL_CONFIG);
+        MYSQL("mysql", MYSQL_CONFIG),
+        MARIADB("mariadb", MYSQL_CONFIG);
 
         private final String label;
         private final Map<String, String> settings;

--- a/server/src/main/java/org/candlepin/guice/CandlepinContextListener.java
+++ b/server/src/main/java/org/candlepin/guice/CandlepinContextListener.java
@@ -266,6 +266,10 @@ public class CandlepinContextListener extends GuiceResteasyBootstrapServletConte
             dialect, DatabaseConfigFactory.SupportedDatabase.MYSQL.getLabel())) {
             return DatabaseConfigFactory.SupportedDatabase.MYSQL;
         }
+        if (StringUtils
+            .containsIgnoreCase(dialect, DatabaseConfigFactory.SupportedDatabase.MARIADB.getLabel())) {
+            return DatabaseConfigFactory.SupportedDatabase.MARIADB;
+        }
         return DatabaseConfigFactory.SupportedDatabase.POSTGRESQL;
     }
 


### PR DESCRIPTION
This commit leaves Liquibase still using the MySQL JDBC connector because the `mariadb-java-client` RPM isn't packaged in EPEL.  We can still use the JAR file in the deployed WAR though.