### PR TITLE
[M] ( ENT-894 ) 1658291: Enter suspend mode when Qpid queue loses exchange and/or binding

### DIFF
--- a/server/src/main/java/org/candlepin/audit/EventSource.java
+++ b/server/src/main/java/org/candlepin/audit/EventSource.java
@@ -31,12 +31,11 @@ import java.util.List;
  */
 @Singleton
 public class EventSource implements QpidStatusListener, ActiveMQStatusListener {
-    private static  Logger log = LoggerFactory.getLogger(EventSource.class);
+    private static Logger log = LoggerFactory.getLogger(EventSource.class);
 
     private ObjectMapper mapper;
     private EventSourceConnection connection;
     private List<MessageReceiver> messageReceivers = new LinkedList<>();
-
 
     @Inject
     public EventSource(EventSourceConnection connection, ObjectMapper mapper) {
@@ -77,6 +76,8 @@ public class EventSource implements QpidStatusListener, ActiveMQStatusListener {
 
             switch (newStatus) {
                 case FLOW_STOPPED:
+                case MISSING_BINDING:
+                case MISSING_EXCHANGE:
                 case DOWN:
                     receiver.pause();
                     break;

--- a/server/src/main/java/org/candlepin/audit/QpidConnection.java
+++ b/server/src/main/java/org/candlepin/audit/QpidConnection.java
@@ -85,10 +85,13 @@ public class QpidConnection implements QpidStatusListener {
     private Configuration candlepinConfig;
 
     protected boolean isFlowStopped = false;
+    protected boolean isMissingBinding = false;
+    protected boolean exchangeMissing = false;
 
     @Inject
     public QpidConnection(QpidConfigBuilder config, Configuration candlepinConfiguration) {
         try {
+            this.producerMap = new HashMap<>();
             this.config = config;
             this.candlepinConfig = candlepinConfiguration;
             this.producerMap = new HashMap<>();
@@ -120,6 +123,14 @@ public class QpidConnection implements QpidStatusListener {
             throw new QpidConnectionException("Message not sent: No connection to Qpid.");
         }
 
+        if (this.exchangeMissing) {
+            throw new QpidConnectionException("Message not sent: Qpid queue has no exchange.");
+        }
+
+        if (this.isMissingBinding) {
+            throw new QpidConnectionException("Message not sent: Qpid queue's exchange has no bindings.");
+        }
+
         if (this.isFlowStopped) {
             throw new QpidConnectionException("Message not sent: Qpid queue is FLOW_STOPPED.");
         }
@@ -130,6 +141,9 @@ public class QpidConnection implements QpidStatusListener {
             if (m != null) {
                 TopicPublisher tp = m.get(type);
                 tp.send(session.createTextMessage(msg));
+            }
+            else {
+                log.warn("Publisher did not exist! Message will not be sent!");
             }
         }
         catch (JMSException jmse) {
@@ -147,6 +161,8 @@ public class QpidConnection implements QpidStatusListener {
      * @throws Exception errors during connecting to the Broker
      */
     public synchronized void connect() throws Exception {
+        ctx = createInitialContext();
+        connectionFactory = createConnectionFactory();
         connection = newConnection();
         log.debug("creating topic session");
         session = createTopicSession();
@@ -154,6 +170,7 @@ public class QpidConnection implements QpidStatusListener {
         Map<Target, Map<Type, TopicPublisher>> pm = new HashMap<>();
         buildAllTopicPublishers(pm);
         producerMap = pm;
+        connection.start();
     }
 
     /**
@@ -253,34 +270,64 @@ public class QpidConnection implements QpidStatusListener {
      */
     @Override
     public void onStatusUpdate(QpidStatus oldStatus, QpidStatus newStatus) {
-        // When the status changes to CONNECTED, rebuild the connection to Qpid.
-        // Since the connection went down, the JMS objects are stale, it is necessary
-        // to recreate them.
-        //
-        // NOTE: We do not shut down the connection when FLOW_STOPPED is detected as there is no
-        //       need to. Message sends are just blocked in that case as the connection is fine.
-        if (QpidStatus.CONNECTED.equals(newStatus) &&
-            (QpidStatus.DOWN.equals(oldStatus) || QpidStatus.UNKNOWN.equals(oldStatus))) {
-            log.info("Attempting to connect to QPID");
-            try {
-                connect();
-            }
-            catch (Exception e) {
-                throw new RuntimeException("Unable to connect to Qpid.", e);
-            }
-        }
-        else if (QpidStatus.DOWN.equals(newStatus) && !QpidStatus.DOWN.equals(oldStatus)) {
-            // If the connection changes to DOWN, close the existing connection to
-            // ensure that we don't leave a stale one open.
-            log.debug("Connection to Qpid was lost. Closing current connection.");
-            closeConnection();
-        }
 
         // Qpid queue is in flow_stopped and will not accept any new messages
         // until it catches up. Set the state so that we can use it to prevent
         // sending messages until the state goes back to connected.
         this.isFlowStopped = QpidStatus.FLOW_STOPPED.equals(newStatus);
         log.debug("Qpid is flow stopped: {}", this.isFlowStopped);
+
+        // Qpid queue is missing its exchange.
+        this.exchangeMissing = QpidStatus.MISSING_EXCHANGE.equals(newStatus);
+
+        // Qpid queue's exchange is missing a binding.
+        this.isMissingBinding = QpidStatus.MISSING_BINDING.equals(newStatus);
+
+        switch (newStatus) {
+            // When the status changes to CONNECTED, rebuild the connection to Qpid.
+            // Since the connection went down, the JMS objects are stale, it is necessary
+            // to recreate them.
+            //
+            // NOTE: We do not shut down the connection when FLOW_STOPPED is detected as there is no
+            //       need to. Message sends are just blocked in that case as the connection is fine.
+            case CONNECTED:
+                if (QpidStatus.DOWN.equals(oldStatus) ||
+                    QpidStatus.UNKNOWN.equals(oldStatus) ||
+                    QpidStatus.MISSING_BINDING.equals(oldStatus) ||
+                    QpidStatus.MISSING_EXCHANGE.equals(oldStatus)) {
+                    log.info("Attempting to connect to QPID due to status change: {} --> {}",
+                        oldStatus, newStatus);
+                    try {
+                        connect();
+                    }
+                    catch (Exception e) {
+                        throw new RuntimeException("Unable to connect to Qpid.", e);
+                    }
+                }
+                break;
+            case DOWN:
+                if (!QpidStatus.DOWN.equals(oldStatus)) {
+                    // If the connection changes to DOWN, close the existing connection to
+                    // ensure that we don't leave a stale one open.
+                    log.warn("Connection to Qpid was lost! Cleaning up current connection!");
+                    closeConnection();
+                }
+                break;
+            case MISSING_BINDING:
+                if (!QpidStatus.MISSING_BINDING.equals(oldStatus)) {
+                    log.warn("Closing connection to Qpid since the binding is missing!");
+                    closeConnection();
+                }
+                break;
+            case MISSING_EXCHANGE:
+                if (!QpidStatus.MISSING_EXCHANGE.equals(oldStatus)) {
+                    log.warn("Shutting down connection to Qpid since the exchange is missing!");
+                    closeConnection();
+                }
+                break;
+            default:
+                // Nothing to do.
+        }
     }
 
     /**

--- a/server/src/main/java/org/candlepin/audit/QpidConnection.java
+++ b/server/src/main/java/org/candlepin/audit/QpidConnection.java
@@ -91,7 +91,6 @@ public class QpidConnection implements QpidStatusListener {
     @Inject
     public QpidConnection(QpidConfigBuilder config, Configuration candlepinConfiguration) {
         try {
-            this.producerMap = new HashMap<>();
             this.config = config;
             this.candlepinConfig = candlepinConfiguration;
             this.producerMap = new HashMap<>();

--- a/server/src/main/java/org/candlepin/audit/QpidStatus.java
+++ b/server/src/main/java/org/candlepin/audit/QpidStatus.java
@@ -31,6 +31,16 @@ public enum QpidStatus {
     FLOW_STOPPED,
 
     /**
+     * Qpid is up but is missing the appropriate exchange.
+     */
+    MISSING_EXCHANGE,
+
+    /**
+     * Qpid is up but the queue's exchange has no bindings.
+     */
+    MISSING_BINDING,
+
+    /**
      * Qpid is down.
      */
     DOWN,
@@ -41,4 +51,5 @@ public enum QpidStatus {
      * context is loaded and all listeners have been registered.
      */
     UNKNOWN
+
 }

--- a/server/src/main/java/org/candlepin/controller/SuspendModeTransitioner.java
+++ b/server/src/main/java/org/candlepin/controller/SuspendModeTransitioner.java
@@ -87,6 +87,12 @@ public class SuspendModeTransitioner implements QpidStatusListener, ActiveMQStat
         else if (QpidStatus.FLOW_STOPPED.equals(newStatus)) {
             reason = Reason.QPID_FLOW_STOPPED;
         }
+        else if (QpidStatus.MISSING_EXCHANGE.equals(newStatus)) {
+            reason = Reason.QPID_MISSING_EXCHANGE;
+        }
+        else if (QpidStatus.MISSING_BINDING.equals(newStatus)) {
+            reason = Reason.QPID_MISSING_BINDING;
+        }
         else {
             String msg = String.format("Could not transition candlepin mode: Unknown Qpid status: %s",
                 newStatus);
@@ -143,6 +149,7 @@ public class SuspendModeTransitioner implements QpidStatusListener, ActiveMQStat
      */
     private synchronized void transitionAppropriately(Reason reason) {
         log.debug("Attempting to transition to appropriate Mode");
+
         CandlepinModeChange lastModeChange = modeManager.getLastCandlepinModeChange();
 
         if (lastModeChange.getReasons().contains(reason)) {
@@ -159,6 +166,8 @@ public class SuspendModeTransitioner implements QpidStatusListener, ActiveMQStat
                     break;
                 case QPID_FLOW_STOPPED:
                 case QPID_DOWN:
+                case QPID_MISSING_BINDING:
+                case QPID_MISSING_EXCHANGE:
                     resetQpidReasons(lastReasons, reason);
                     break;
                 case ACTIVEMQ_UP:
@@ -185,6 +194,8 @@ public class SuspendModeTransitioner implements QpidStatusListener, ActiveMQStat
         else if (lastModeChange.getMode() == Mode.NORMAL) {
             switch (reason) {
                 case QPID_FLOW_STOPPED:
+                case QPID_MISSING_BINDING:
+                case QPID_MISSING_EXCHANGE:
                 case QPID_DOWN:
                 case ACTIVEMQ_DOWN:
                     log.debug("Will need to transition Candlepin into SUSPEND Mode: {}", reason);
@@ -210,7 +221,12 @@ public class SuspendModeTransitioner implements QpidStatusListener, ActiveMQStat
     }
 
     private void resetQpidReasons(Set<Reason> reasons, Reason ... keep) {
-        List<Reason> allAMQ = Arrays.asList(Reason.QPID_UP, Reason.QPID_DOWN, Reason.QPID_FLOW_STOPPED);
+        List<Reason> allAMQ = Arrays.asList(
+            Reason.QPID_UP,
+            Reason.QPID_DOWN,
+            Reason.QPID_FLOW_STOPPED,
+            Reason.QPID_MISSING_BINDING,
+            Reason.QPID_MISSING_EXCHANGE);
         resetReasonGroup(reasons, allAMQ, keep);
     }
 

--- a/server/src/main/java/org/candlepin/model/CandlepinModeChange.java
+++ b/server/src/main/java/org/candlepin/model/CandlepinModeChange.java
@@ -69,7 +69,16 @@ public class CandlepinModeChange implements Serializable {
         /**
          * The ActiveMQ broker has gone down and is not available.
          */
-        ACTIVEMQ_DOWN
+        ACTIVEMQ_DOWN,
+
+        /**
+         * Qpid event queue is missing the appropriate exchange.
+         */
+        QPID_MISSING_EXCHANGE,
+        /**
+         * Qpid event queue's exchange has no bindings.
+         */
+        QPID_MISSING_BINDING
     }
 
     public CandlepinModeChange(Date changeTime, Mode mode, Reason ... reasons) {
@@ -95,6 +104,5 @@ public class CandlepinModeChange implements Serializable {
         return "CandlepinModeChange [mode=" + mode + ", reasons=" + reasons + ", changeTime=" +
             changeTime + "]";
     }
-
 
 }

--- a/server/src/test/java/org/candlepin/audit/EventSourceTest.java
+++ b/server/src/test/java/org/candlepin/audit/EventSourceTest.java
@@ -155,10 +155,12 @@ public class EventSourceTest {
         EventSource eventSource = createEventSourceStubbedWithFactoryCreation(listener);
 
         eventSource.onStatusUpdate(QpidStatus.CONNECTED, QpidStatus.DOWN);
+
         // Start was called only on construction
         verify(session, times(1)).start();
         verify(consumer).close();
         verify(session, never()).stop();
+
     }
 
     @Test
@@ -201,6 +203,48 @@ public class EventSourceTest {
 
         // Start was called only during setup.
         verify(session, times(1)).start();
+        verify(session, never()).stop();
+    }
+
+    @Test
+    public void eventSourceClosesEventReceiverClientConsumerWhenQpidExchangeMissing() throws Exception {
+        ClientSession session = mock(ClientSession.class);
+        when(clientSessionFactory.createSession(eq(false), eq(false), eq(0))).thenReturn(session);
+
+        ClientConsumer consumer = mock(ClientConsumer.class);
+        when(session.createConsumer(any(String.class))).thenReturn(consumer);
+
+        EventListener listener = mock(EventListener.class);
+        when(listener.requiresQpid()).thenReturn(true);
+
+        EventSource eventSource = createEventSourceStubbedWithFactoryCreation(listener);
+
+        eventSource.onStatusUpdate(QpidStatus.CONNECTED, QpidStatus.MISSING_EXCHANGE);
+
+        // Start was called only on construction
+        verify(session, times(1)).start();
+        verify(consumer).close();
+        verify(session, never()).stop();
+    }
+
+    @Test
+    public void eventSourceClosesEventReceiverClientConsumerWhenQpidBindingMissing() throws Exception {
+        ClientSession session = mock(ClientSession.class);
+        when(clientSessionFactory.createSession(eq(false), eq(false), eq(0))).thenReturn(session);
+
+        ClientConsumer consumer = mock(ClientConsumer.class);
+        when(session.createConsumer(any(String.class))).thenReturn(consumer);
+
+        EventListener listener = mock(EventListener.class);
+        when(listener.requiresQpid()).thenReturn(true);
+
+        EventSource eventSource = createEventSourceStubbedWithFactoryCreation(listener);
+
+        eventSource.onStatusUpdate(QpidStatus.CONNECTED, QpidStatus.MISSING_BINDING);
+
+        // Start was called only on construction
+        verify(session, times(1)).start();
+        verify(consumer).close();
         verify(session, never()).stop();
     }
 

--- a/server/src/test/java/org/candlepin/audit/QpidConnectionTest.java
+++ b/server/src/test/java/org/candlepin/audit/QpidConnectionTest.java
@@ -102,6 +102,26 @@ public class QpidConnectionTest {
     }
 
     @Test
+    public void connectionIsReconnectedWhenQpidConnectedStatusIsReportedAndQpidHadNoExchange()
+        throws Exception {
+        connection.onStatusUpdate(QpidStatus.MISSING_EXCHANGE, QpidStatus.CONNECTED);
+
+        verify(connection, never()).closeConnection();
+        verify(connection, never()).close();
+        verify(connection, times(1)).connect();
+    }
+
+    @Test
+    public void connectionIsReconnectedWhenQpidConnectedStatusIsReportedAndQpidHadNoExchangeBinding()
+        throws Exception {
+        connection.onStatusUpdate(QpidStatus.MISSING_BINDING, QpidStatus.CONNECTED);
+
+        verify(connection, never()).closeConnection();
+        verify(connection, never()).close();
+        verify(connection, times(1)).connect();
+    }
+
+    @Test
     public void connectedToFlowStoppedDoesNotRequireDisconnect() throws Exception {
         connection.onStatusUpdate(QpidStatus.CONNECTED, QpidStatus.FLOW_STOPPED);
 
@@ -142,6 +162,72 @@ public class QpidConnectionTest {
 
         connection.onStatusUpdate(QpidStatus.DOWN, QpidStatus.FLOW_STOPPED);
         assertTrue(connection.isFlowStopped());
+
+        connection.onStatusUpdate(QpidStatus.FLOW_STOPPED, QpidStatus.MISSING_EXCHANGE);
+        assertFalse(connection.isFlowStopped());
+
+        connection.onStatusUpdate(QpidStatus.FLOW_STOPPED, QpidStatus.MISSING_BINDING);
+        assertFalse(connection.isFlowStopped());
+    }
+
+    @Test
+    public void checkMissingExchangeValueOnStateChange() throws Exception {
+        // Force connection so that the producer map is initialized.
+        connection.connect();
+
+        connection.onStatusUpdate(QpidStatus.CONNECTED, QpidStatus.CONNECTED);
+        assertFalse(connection.isMissingExchange());
+
+        connection.onStatusUpdate(QpidStatus.CONNECTED, QpidStatus.MISSING_EXCHANGE);
+        assertTrue(connection.isMissingExchange());
+
+        connection.onStatusUpdate(QpidStatus.MISSING_EXCHANGE, QpidStatus.MISSING_EXCHANGE);
+        assertTrue(connection.isMissingExchange());
+
+        connection.onStatusUpdate(QpidStatus.MISSING_EXCHANGE, QpidStatus.CONNECTED);
+        assertFalse(connection.isMissingExchange());
+
+        connection.onStatusUpdate(QpidStatus.MISSING_EXCHANGE, QpidStatus.DOWN);
+        assertFalse(connection.isMissingExchange());
+
+        connection.onStatusUpdate(QpidStatus.DOWN, QpidStatus.MISSING_EXCHANGE);
+        assertTrue(connection.isMissingExchange());
+
+        connection.onStatusUpdate(QpidStatus.MISSING_EXCHANGE, QpidStatus.FLOW_STOPPED);
+        assertFalse(connection.isMissingExchange());
+
+        connection.onStatusUpdate(QpidStatus.MISSING_EXCHANGE, QpidStatus.MISSING_BINDING);
+        assertFalse(connection.isMissingExchange());
+    }
+
+    @Test
+    public void checkMissingBindingValueOnStateChange() throws Exception {
+        // Force connection so that the producer map is initialized.
+        connection.connect();
+
+        connection.onStatusUpdate(QpidStatus.CONNECTED, QpidStatus.CONNECTED);
+        assertFalse(connection.isMissingBinding());
+
+        connection.onStatusUpdate(QpidStatus.CONNECTED, QpidStatus.MISSING_BINDING);
+        assertTrue(connection.isMissingBinding());
+
+        connection.onStatusUpdate(QpidStatus.MISSING_BINDING, QpidStatus.MISSING_BINDING);
+        assertTrue(connection.isMissingBinding());
+
+        connection.onStatusUpdate(QpidStatus.MISSING_BINDING, QpidStatus.CONNECTED);
+        assertFalse(connection.isMissingBinding());
+
+        connection.onStatusUpdate(QpidStatus.MISSING_BINDING, QpidStatus.DOWN);
+        assertFalse(connection.isMissingBinding());
+
+        connection.onStatusUpdate(QpidStatus.DOWN, QpidStatus.MISSING_BINDING);
+        assertTrue(connection.isMissingBinding());
+
+        connection.onStatusUpdate(QpidStatus.MISSING_BINDING, QpidStatus.FLOW_STOPPED);
+        assertFalse(connection.isMissingBinding());
+
+        connection.onStatusUpdate(QpidStatus.MISSING_BINDING, QpidStatus.MISSING_EXCHANGE);
+        assertFalse(connection.isMissingBinding());
     }
 
     @Test
@@ -159,6 +245,37 @@ public class QpidConnectionTest {
         verify(connection, atMost(1)).connect();
     }
 
+    @Test
+    public void connectionIsClosedWhenExchangeIsLost()
+        throws Exception {
+        // Force connection so that the producer map is initialized.
+        connection.connect();
+
+        connection.onStatusUpdate(QpidStatus.CONNECTED, QpidStatus.MISSING_EXCHANGE);
+
+        // Initial connection.
+        verify(connection, times(1)).connect();
+        // Expect the connection to be closed.
+        verify(connection, times(1)).closeConnection();
+        // Don't expect a hard close where the session factory is also closed.
+        verify(connection, never()).close();
+    }
+
+    @Test
+    public void connectionIsClosedWhenBindingIsMissing()
+        throws Exception {
+        // Force connection so that the producer map is initialized.
+        connection.connect();
+
+        connection.onStatusUpdate(QpidStatus.CONNECTED, QpidStatus.MISSING_BINDING);
+
+        // Initial connection.
+        verify(connection, times(1)).connect();
+        // Expect the connection to be closed.
+        verify(connection, times(1)).closeConnection();
+        // Don't expect a hard close where the session factory is also closed.
+        verify(connection, never()).close();
+    }
 
     /**
      * A stubbed test class to avoid trying to configure and make an actual
@@ -192,6 +309,14 @@ public class QpidConnectionTest {
 
         public boolean isFlowStopped() {
             return this.isFlowStopped;
+        }
+
+        public boolean isMissingExchange() {
+            return this.exchangeMissing;
+        }
+
+        public boolean isMissingBinding() {
+            return this.isMissingBinding;
         }
     }
 }

--- a/server/src/test/java/org/candlepin/controller/SuspendModeTransitionerTest.java
+++ b/server/src/test/java/org/candlepin/controller/SuspendModeTransitionerTest.java
@@ -194,6 +194,34 @@ public class SuspendModeTransitionerTest {
         assertMode(Mode.SUSPEND, Reason.QPID_FLOW_STOPPED);
     }
 
+    @Test
+    public void transitionFromConnectedToMissingExchange() throws Exception {
+        modeManager.enterMode(Mode.NORMAL, Reason.QPID_UP);
+        transitioner.onStatusUpdate(QpidStatus.CONNECTED, QpidStatus.MISSING_EXCHANGE);
+        assertMode(Mode.SUSPEND, Reason.QPID_MISSING_EXCHANGE);
+    }
+
+    @Test
+    public void transitionFromConnectedToMissingBinding() {
+        modeManager.enterMode(Mode.NORMAL, Reason.QPID_UP);
+        transitioner.onStatusUpdate(QpidStatus.CONNECTED, QpidStatus.MISSING_BINDING);
+        assertMode(Mode.SUSPEND, Reason.QPID_MISSING_BINDING);
+    }
+
+    @Test
+    public void transitionFromAMQDownToMissingBinding() {
+        modeManager.enterMode(Mode.SUSPEND, Reason.ACTIVEMQ_DOWN);
+        transitioner.onStatusUpdate(QpidStatus.CONNECTED, QpidStatus.MISSING_BINDING);
+        assertMode(Mode.SUSPEND, Reason.QPID_MISSING_BINDING, Reason.ACTIVEMQ_DOWN);
+    }
+
+    @Test
+    public void transitionFromAMQDownToMissingExchange() {
+        modeManager.enterMode(Mode.SUSPEND, Reason.ACTIVEMQ_DOWN);
+        transitioner.onStatusUpdate(QpidStatus.CONNECTED, QpidStatus.MISSING_EXCHANGE);
+        assertMode(Mode.SUSPEND, Reason.QPID_MISSING_EXCHANGE, Reason.ACTIVEMQ_DOWN);
+    }
+
     private List<Reason> reasons(Reason ... reasons) {
         return reasons != null ? Arrays.asList(reasons) : new ArrayList<>();
     }
@@ -204,4 +232,5 @@ public class SuspendModeTransitionerTest {
         assertEquals(expectedReasons.length, lastChange.getReasons().size());
         assertTrue(lastChange.getReasons().containsAll(Arrays.asList(expectedReasons)));
     }
+
 }


### PR DESCRIPTION
When Qpid's 'event' exchange does not exist, or the exchange does not
have at least 1 binding, candlepin will enter suspend mode until these
issues have been addressed.

# How To Test

**NOTE:** All commands should be run from the _server_ directory under your candlepin checkout.

## Scenario 1: Message Recovery

1. Deploy candlepin with AMQP (Qpid)  support and test data
```bash
$ bin/deploy -gtaq
```

2. Make note of the current message count after deployment.
```bash
$ sudo qpid-stat --ssl-certificate=bin/qpid/keys/candlepin.crt --ssl-key bin/qpid/keys/candlepin.key -b amqps://localhost:5671 -q allmsg
```

3. Delete the  event exchange and immediately attempt to register your system.

**Note:** The system registration command should execute successfully. If you get a suspend mode error then you'll need to re-add the exchange and binding (step X - Y) and start again from step 2. This can occur if the exchange was deleted just before the QpidStatusMonitor runs.
```bash
$ sudo qpid-config --ssl-certificate=bin/qpid/keys/candlepin.crt --ssl-key bin/qpid/keys/candlepin.key -b amqps://localhost:5671 del exchange event && sudo subscription-manager register --user admin --pass admin --org admin
```

4. Check the message count again to make sure that no messages made it to Qpid.
```bash
$ sudo qpid-stat --ssl-certificate=bin/qpid/keys/candlepin.crt --ssl-key bin/qpid/keys/candlepin.key -b amqps://localhost:5671 -q allmsg
```

5. Check the candlepin status to make sure that candlepin went into suspend mode due to SUSPEND | QPID_MISSING_EXCHANGE.
```bash
$ curl -k https://localhost:8443/candlepin/status
```

6. Re-create the event exchange.
```bash
$ sudo qpid-config --ssl-certificate=bin/qpid/keys/candlepin.crt --ssl-key bin/qpid/keys/candlepin.key -b amqps://localhost:5671 add exchange topic event --durable
```

7. Wait at least 10 seconds for the QpidStatusMonitor to run and check that the status now transitions to SUSPEND | MISSING_BINDING. At least one exchange binding must exist before candlepin will come out of this state.
```bash
$ curl -k https://localhost:8443/candlepin/status
```

8. Re-create the exchange binding.
```bash
$ sudo qpid-config --ssl-certificate=bin/qpid/keys/candlepin.crt --ssl-key bin/qpid/keys/candlepin.key -b amqps://localhost:5671 bind event allmsg '#'
```

9. Wait for the monitor to run and ensure that candlepin leave's suspend mode - NORMAL | QPID_UP
```bash
$ curl -k https://localhost:8443/candlepin/status
```

10. As soon as candlepin leaves suspend mode, the Artemis message consumers should again be active and the messages that should have been sent due to the registration should get delivered to Qpid. Check the message count again and there should now be **2** additional messages in the Qpid queue.
```bash
$ sudo qpid-stat --ssl-certificate=bin/qpid/keys/candlepin.crt --ssl-key bin/qpid/keys/candlepin.key -b amqps://localhost:5671 -q allmsg
```

## Scenario 2: Requests Are Blocked Due To Suspend Mode

1. Make note of the current message count.
```bash
$ sudo qpid-stat --ssl-certificate=bin/qpid/keys/candlepin.crt --ssl-key bin/qpid/keys/candlepin.key -b amqps://localhost:5671 -q allmsg
```

2. Delete the event exchange. Ensure that candlepin enters suspend mode due to MISSING_EXCHANGE.
```bash
$ sudo qpid-config --ssl-certificate=bin/qpid/keys/candlepin.crt --ssl-key bin/qpid/keys/candlepin.key -b amqps://localhost:5671 del exchange event

$ curl -k https://localhost:8443/candlepin/status
```

3. Attempt to register the system. You should get an error that candlepin was in suspend mode. No messages should have made it to qpid.
```bash
$ sudo subscription-manager register --user admin --pass admin --org admin

$ sudo qpid-stat --ssl-certificate=bin/qpid/keys/candlepin.crt --ssl-key bin/qpid/keys/candlepin.key -b amqps://localhost:5671 -q allmsg
```

4. Re-create the exchange. Candlepin should remain in suspend mode because of MISSING_BINDING.
```bash
$ sudo qpid-config --ssl-certificate=bin/qpid/keys/candlepin.crt --ssl-key bin/qpid/keys/candlepin.key -b amqps://localhost:5671 add exchange topic event --durable

$ curl -k https://localhost:8443/candlepin/status
```

5. Attempt to register the system. You should get an error that candlepin was in suspend mode. No messages should have made it to candlepin.
```bash
$ sudo subscription-manager register --user admin --pass admin --org admin

$ sudo qpid-stat --ssl-certificate=bin/qpid/keys/candlepin.crt --ssl-key bin/qpid/keys/candlepin.key -b amqps://localhost:5671 -q allmsg
```

6. Add the binding. Candlepin should return to NORMAL mode.
```bash
$ sudo qpid-config --ssl-certificate=bin/qpid/keys/candlepin.crt --ssl-key bin/qpid/keys/candlepin.key -b amqps://localhost:5671 bind event allmsg '#'

$ curl -k https://localhost:8443/candlepin/status
```

7. You should now be able to register the system.
```
$ sudo subscription-manager register --user admin --pass admin --org admin
```

8. Verify that **2** messages made it to candlepin.
```bash
$ sudo qpid-stat --ssl-certificate=bin/qpid/keys/candlepin.crt --ssl-key bin/qpid/keys/candlepin.key -b amqps://localhost:5671 -q allmsg
```