### PR TITLE
[2.5] ( ENT-894 ) 1658289: Enter suspend mode when Qpid queue loses exchange and/or binding

### DIFF
--- a/server/src/main/java/org/candlepin/audit/EventSource.java
+++ b/server/src/main/java/org/candlepin/audit/EventSource.java
@@ -32,12 +32,11 @@ import java.util.List;
  * EventSource
  */
 public class EventSource implements QpidStatusListener {
-    private static  Logger log = LoggerFactory.getLogger(EventSource.class);
+    private static Logger log = LoggerFactory.getLogger(EventSource.class);
 
     private ClientSessionFactory factory;
     private ObjectMapper mapper;
     private List<MessageReceiver> messageReceivers = new LinkedList<>();
-
 
     @Inject
     public EventSource(ObjectMapper mapper) {
@@ -91,7 +90,10 @@ public class EventSource implements QpidStatusListener {
                 continue;
             }
 
-            if (QpidStatus.FLOW_STOPPED.equals(newStatus) || QpidStatus.DOWN.equals(newStatus)) {
+            if (QpidStatus.FLOW_STOPPED.equals(newStatus) ||
+                QpidStatus.MISSING_BINDING.equals(newStatus) ||
+                QpidStatus.MISSING_EXCHANGE.equals(newStatus) ||
+                QpidStatus.DOWN.equals(newStatus)) {
                 log.debug("Stopping session for EventReciever.");
                 receiver.stopSession();
             }

--- a/server/src/main/java/org/candlepin/audit/QpidStatus.java
+++ b/server/src/main/java/org/candlepin/audit/QpidStatus.java
@@ -31,5 +31,15 @@ public enum QpidStatus {
     /**
      * Qpid is down.
      */
-    DOWN
+    DOWN,
+
+    /**
+     * Qpid is up but is missing the appropriate exchange.
+     */
+    MISSING_EXCHANGE,
+
+    /**
+     * Qpid is up but the queue's exchange has no bindings.
+     */
+    MISSING_BINDING
 }

--- a/server/src/main/java/org/candlepin/model/CandlepinModeChange.java
+++ b/server/src/main/java/org/candlepin/model/CandlepinModeChange.java
@@ -57,7 +57,15 @@ public class CandlepinModeChange implements Serializable {
          * Qpid is overloaded to a point where its not possible to
          * send messages to it
          */
-        QPID_FLOW_STOPPED
+        QPID_FLOW_STOPPED,
+        /**
+         * Qpid event queue is missing the appropriate exchange.
+         */
+        QPID_MISSING_EXCHANGE,
+        /**
+         * Qpid event queue's exchange has no bindings.
+         */
+        QPID_MISSING_BINDING
     }
 
     public CandlepinModeChange(Date changeTime, Mode mode, Reason reason) {

--- a/server/src/test/java/org/candlepin/controller/SuspendModeTransitionerTest.java
+++ b/server/src/test/java/org/candlepin/controller/SuspendModeTransitionerTest.java
@@ -108,4 +108,26 @@ public class SuspendModeTransitionerTest {
         verifyNoMoreInteractions(modeManager);
     }
 
+    @Test
+    public void transitionFromConnectedToMissingExchange() throws Exception {
+        when(modeManager.getLastCandlepinModeChange()).thenReturn(normalModeChange);
+
+        transitioner.onStatusUpdate(QpidStatus.CONNECTED, QpidStatus.MISSING_EXCHANGE);
+
+        verify(modeManager, times(1)).getLastCandlepinModeChange();
+        verify(modeManager, times(1)).enterMode(Mode.SUSPEND, Reason.QPID_MISSING_EXCHANGE);
+        verifyNoMoreInteractions(modeManager);
+    }
+
+    @Test
+    public void transitionFromConnectedToMissingBinding() {
+        when(modeManager.getLastCandlepinModeChange()).thenReturn(normalModeChange);
+
+        transitioner.onStatusUpdate(QpidStatus.CONNECTED, QpidStatus.MISSING_BINDING);
+
+        verify(modeManager, times(1)).getLastCandlepinModeChange();
+        verify(modeManager, times(1)).enterMode(Mode.SUSPEND, Reason.QPID_MISSING_BINDING);
+        verifyNoMoreInteractions(modeManager);
+    }
+
 }


### PR DESCRIPTION
When Qpid's 'event' exchange does not exist, or the exchange does not
have at least 1 binding, candlepin will enter suspend mode until these
issues have been addressed.

# How To Test

**NOTE:** All commands should be run from the _server_ directory under your candlepin checkout.

## Scenario 1: Message Recovery

1. Deploy candlepin with AMQP (Qpid)  support and test data
```bash
$ bin/deploy -gtaq
```

2. Make note of the current message count after deployment.
```bash
$ sudo qpid-stat --ssl-certificate=bin/qpid/keys/candlepin.crt --ssl-key bin/qpid/keys/candlepin.key -b amqps://localhost:5671 -q allmsg
```

3. Delete the  event exchange and immediately attempt to register your system.

**Note:** The system registration command should execute successfully. If you get a suspend mode error then you'll need to re-add the exchange and binding (step X - Y) and start again from step 2. This can occur if the exchange was deleted just before the QpidStatusMonitor runs.
```bash
$ sudo qpid-config --ssl-certificate=bin/qpid/keys/candlepin.crt --ssl-key bin/qpid/keys/candlepin.key -b amqps://localhost:5671 del exchange event && sudo subscription-manager register --user admin --pass admin --org admin
```

4. Check the message count again to make sure that no messages made it to Qpid.
```bash
$ sudo qpid-stat --ssl-certificate=bin/qpid/keys/candlepin.crt --ssl-key bin/qpid/keys/candlepin.key -b amqps://localhost:5671 -q allmsg
```

5. Check the candlepin status to make sure that candlepin went into suspend mode due to SUSPEND | QPID_MISSING_EXCHANGE.
```bash
$ curl -k https://localhost:8443/candlepin/status
```

6. Re-create the event exchange.
```bash
$ sudo qpid-config --ssl-certificate=bin/qpid/keys/candlepin.crt --ssl-key bin/qpid/keys/candlepin.key -b amqps://localhost:5671 add exchange topic event --durable
```

7. Wait at least 10 seconds for the QpidStatusMonitor to run and check that the status now transitions to SUSPEND | MISSING_BINDING. At least one exchange binding must exist before candlepin will come out of this state.
```bash
$ curl -k https://localhost:8443/candlepin/status
```

8. Re-create the exchange binding.
```bash
$ sudo qpid-config --ssl-certificate=bin/qpid/keys/candlepin.crt --ssl-key bin/qpid/keys/candlepin.key -b amqps://localhost:5671 bind event allmsg '#'
```

9. Wait for the monitor to run and ensure that candlepin leave's suspend mode - NORMAL | QPID_UP
```bash
$ curl -k https://localhost:8443/candlepin/status
```

10. As soon as candlepin leaves suspend mode, the Artemis message consumers should again be active and the messages that should have been sent due to the registration should get delivered to Qpid. Check the message count again and there should now be **2** additional messages in the Qpid queue.
```bash
$ sudo qpid-stat --ssl-certificate=bin/qpid/keys/candlepin.crt --ssl-key bin/qpid/keys/candlepin.key -b amqps://localhost:5671 -q allmsg
```

## Scenario 2: Requests Are Blocked Due To Suspend Mode

1. Make note of the current message count.
```bash
$ sudo qpid-stat --ssl-certificate=bin/qpid/keys/candlepin.crt --ssl-key bin/qpid/keys/candlepin.key -b amqps://localhost:5671 -q allmsg
```

2. Delete the event exchange. Ensure that candlepin enters suspend mode due to MISSING_EXCHANGE.
```bash
$ sudo qpid-config --ssl-certificate=bin/qpid/keys/candlepin.crt --ssl-key bin/qpid/keys/candlepin.key -b amqps://localhost:5671 del exchange event

$ curl -k https://localhost:8443/candlepin/status
```

3. Attempt to register the system. You should get an error that candlepin was in suspend mode. No messages should have made it to qpid.
```bash
$ sudo subscription-manager register --user admin --pass admin --org admin

$ sudo qpid-stat --ssl-certificate=bin/qpid/keys/candlepin.crt --ssl-key bin/qpid/keys/candlepin.key -b amqps://localhost:5671 -q allmsg
```

4. Re-create the exchange. Candlepin should remain in suspend mode because of MISSING_BINDING.
```bash
$ sudo qpid-config --ssl-certificate=bin/qpid/keys/candlepin.crt --ssl-key bin/qpid/keys/candlepin.key -b amqps://localhost:5671 add exchange topic event --durable

$ curl -k https://localhost:8443/candlepin/status
```

5. Attempt to register the system. You should get an error that candlepin was in suspend mode. No messages should have made it to candlepin.
```bash
$ sudo subscription-manager register --user admin --pass admin --org admin

$ sudo qpid-stat --ssl-certificate=bin/qpid/keys/candlepin.crt --ssl-key bin/qpid/keys/candlepin.key -b amqps://localhost:5671 -q allmsg
```

6. Add the binding. Candlepin should return to NORMAL mode.
```bash
$ sudo qpid-config --ssl-certificate=bin/qpid/keys/candlepin.crt --ssl-key bin/qpid/keys/candlepin.key -b amqps://localhost:5671 bind event allmsg '#'

$ curl -k https://localhost:8443/candlepin/status
```

7. You should now be able to register the system.
```
$ sudo subscription-manager register --user admin --pass admin --org admin
```

8. Verify that **2** messages made it to candlepin.
```bash
$ sudo qpid-stat --ssl-certificate=bin/qpid/keys/candlepin.crt --ssl-key bin/qpid/keys/candlepin.key -b amqps://localhost:5671 -q allmsg
```