### PR TITLE
[2.3] 1660532: Maintain backwards compatibility in rules for system purpose ( ENT-1023 )

### DIFF
--- a/server/src/main/resources/rules/rules.js
+++ b/server/src/main/resources/rules/rules.js
@@ -1,4 +1,4 @@
-// Version: 5.30
+// Version: 5.31
 
 /*
  * Default Candlepin rule set.
@@ -351,6 +351,24 @@ function createActivationKey(key) {
 }
 
 function createConsumer(consumer, compliance) {
+
+    /*
+     * Add the default consumer system purpose data so that we can be backwards compatible
+     * with older versions of candlepin. By doing this, we avoid errors when attributes
+     * are undefined vs null.
+     */
+    if (!consumer.addOns) {
+        // Defaulting the addOns consumer data.
+        consumer.addOns = [];
+    }
+
+    if (!consumer.role) {
+        consumer.role = null;
+    }
+
+    if (!consumer.usage) {
+        consumer.usage = null;
+    }
 
     consumer.contextCompliance = compliance;
 


### PR DESCRIPTION
Set the system purpose defaults in the rules file in order
to be backwards compatible with older candlepins when the
updated rules is brought in via a manifest import/refresh.