### PR TITLE
Use gpg2 for rvm

### DIFF
--- a/docker/candlepin-base/setup-devel-env.sh
+++ b/docker/candlepin-base/setup-devel-env.sh
@@ -66,12 +66,12 @@ git clone https://github.com/candlepin/candlepin.git /candlepin
 cd /candlepin
 
 # Setup and install rvm, ruby and pals
-gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 # turning off verbose mode, rvm is nuts with this
 set +v
 curl -O https://raw.githubusercontent.com/rvm/rvm/master/binscripts/rvm-installer
 curl -O https://raw.githubusercontent.com/rvm/rvm/master/binscripts/rvm-installer.asc
-gpg --verify rvm-installer.asc && bash rvm-installer stable
+gpg2 --verify rvm-installer.asc && bash rvm-installer stable
 source /etc/profile.d/rvm.sh || true
 
 rvm install 2.0.0


### PR DESCRIPTION
For some reason using gpg (vs. gpg2) doesn't work anymore.