### PR TITLE
1482942: Remove unnecessary deleted consumer checks

### DIFF
--- a/server/src/main/java/org/candlepin/auth/SSLAuth.java
+++ b/server/src/main/java/org/candlepin/auth/SSLAuth.java
@@ -49,6 +49,7 @@ public class SSLAuth extends ConsumerAuth {
         super(consumerCurator, ownerCurator, deletedConsumerCurator, i18nProvider);
     }
 
+    @Override
     public Principal getPrincipal(HttpRequest httpRequest) {
         X509Certificate[] certs = (X509Certificate[]) httpRequest.getAttribute(CERTIFICATES_ATTR);
 

--- a/server/src/main/java/org/candlepin/auth/TrustedConsumerAuth.java
+++ b/server/src/main/java/org/candlepin/auth/TrustedConsumerAuth.java
@@ -42,6 +42,7 @@ public class TrustedConsumerAuth extends ConsumerAuth {
         super(consumerCurator, ownerCurator, deletedConsumerCurator, i18nProvider);
     }
 
+    @Override
     public Principal getPrincipal(HttpRequest httpRequest) {
         ConsumerPrincipal principal = null;
 

--- a/server/src/test/java/org/candlepin/auth/SSLAuthTest.java
+++ b/server/src/test/java/org/candlepin/auth/SSLAuthTest.java
@@ -55,7 +55,7 @@ public class SSLAuthTest {
         this.auth = new SSLAuth(this.consumerCurator,
             this.ownerCurator,
             this.deletedConsumerCurator,
-            i18nProvider);
+            this.i18nProvider);
     }
 
     /**
@@ -115,7 +115,6 @@ public class SSLAuthTest {
         when(this.consumerCurator.findByUuid("235-8")).thenReturn(null);
         assertNull(this.auth.getPrincipal(httpRequest));
     }
-
 
     private void mockCert(String dn) {
         X509Certificate idCert =  mock(X509Certificate.class);


### PR DESCRIPTION
 - Remove unnecessary deleted consumer check from ConsumerAuth.createPrincipal. This check is done by ConsumerStore.lookup
 - Refactor ConsumerStore.lookup so that the deleted consumer check is run only when the consumer was not found
