### PR TITLE
1620226: Perform CRL generation without exceeding memory and maxing CPU

### DIFF
--- a/server/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/server/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -260,6 +260,14 @@ public class ConfigProperties {
     public static final String CRL_NEXT_UPDATE_DELTA = "candlepin.crl.nextupdate.delta_days";
     public static final String CRL_FILE_PATH = "candlepin.crl.file";
 
+    /**
+     * The number of uncollected and expired cert serials will be processed at a time while updating
+     * the CRL file. It is important to note that both uncollected and expired serials will be batched
+     * at the specified amount.
+     *
+     */
+    public static final String CRL_SERIAL_BATCH_SIZE = "candlepin.crl.update_serial_batch_size";
+
     public static final String IDENTITY_CERT_YEAR_ADDENDUM = "candlepin.identityCert.yr.addendum";
     /**
      * Identity certificate expiry threshold in days
@@ -316,6 +324,7 @@ public class ConfigProperties {
             this.put(PRETTY_PRINT, "false");
             this.put(CRL_FILE_PATH, "/var/lib/candlepin/candlepin-crl.crl");
             this.put(CRL_NEXT_UPDATE_DELTA, "1");
+            this.put(CRL_SERIAL_BATCH_SIZE, "1000000");
 
             this.put(SYNC_WORK_DIR, "/var/cache/candlepin/sync");
             this.put(CONSUMER_FACTS_MATCHER, ".*");

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/CertificateRevocationListTask.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/CertificateRevocationListTask.java
@@ -64,6 +64,7 @@ public class CertificateRevocationListTask extends KingpinJob {
         if (filePath == null) {
             throw new JobExecutionException("Invalid " + ConfigProperties.CRL_FILE_PATH, false);
         }
+
         try {
             File crlFile = new File(filePath);
             this.crlFileUtil.syncCRLWithDB(crlFile);

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/CertificateRevocationListTaskTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/CertificateRevocationListTaskTest.java
@@ -63,7 +63,6 @@ public class CertificateRevocationListTaskTest extends BaseJobTest {
     @Test
     public void execute() throws Exception {
         when(config.getString(ConfigProperties.CRL_FILE_PATH)).thenReturn("/tmp/test.crl");
-        when(crlFileUtil.syncCRLWithDB(any(File.class))).thenReturn(true);
 
         JobExecutionContext context = mock(JobExecutionContext.class);
         task.execute(context);

--- a/server/src/test/java/org/candlepin/util/CrlFileUtilTest.java
+++ b/server/src/test/java/org/candlepin/util/CrlFileUtilTest.java
@@ -18,6 +18,7 @@ import static org.candlepin.test.MatchesPattern.*;
 import static org.junit.Assert.*;
 
 import org.candlepin.TestingModules;
+import org.candlepin.common.config.Configuration;
 import org.candlepin.model.CertificateSerialCurator;
 import org.candlepin.pki.CertificateReader;
 import org.candlepin.pki.PKIUtility;
@@ -61,6 +62,7 @@ public class CrlFileUtilTest {
     @Inject private CertificateReader certificateReader;
     @Inject private PKIUtility pkiUtility;
     @Mock private CertificateSerialCurator certSerialCurator;
+    @Mock private Configuration config;
     private File temp;
     private Set<BigInteger> initialEntry;
 
@@ -73,7 +75,8 @@ public class CrlFileUtilTest {
         );
         injector.injectMembers(this);
 
-        this.cfu = new CrlFileUtil(this.certificateReader, this.pkiUtility, this.certSerialCurator);
+        this.cfu = new CrlFileUtil(this.certificateReader, this.pkiUtility, this.certSerialCurator,
+            this.config);
         this.temp = File.createTempFile("cp_test_crl-", ".pem");
         this.initialEntry = new HashSet<>();
         this.initialEntry.add(BigInteger.ONE);


### PR DESCRIPTION
Using a HashSet instead of an ArrayList to store the serials improves
the performance of .contains when checking if an entry in the CRL file
should be removed due to expiry.

Batch lookup/process fetched serials to keep the memory footprint down
and to allow garbage collection of the serials earlier. The number of
records per batch can be configured via the candlepin config file.

NOTE: Due to the way the CRL generation framework works, when batching
the serial processing, we end up re-scanning the crl num_serials/batch_size times.
This isn't ideal, but we will make due until we make the move to generating
a plain text serial file.

## Testing

1. Deploy candlepin from the master branch.
2. Stop tomcat, drop the candlepin DB and replace it with one loaded with millions of cert serials:
```bash
$ wget http://file.rdu.redhat.com/mstead/pr/1620226/db-with-lots-of-serials-for-crl-testing.tar.gz
$ sudo systemctl stop tomcat
$ tar xvzf db-with-lots-of-serials-for-crl-testing.tar.gz
$ dropdb -U candlepin candlepin && createdb -U candlepin candlepin && psql -U candlepin candlepin < lots-of-serials-for-crl-gen-testing.sql
```
3. Restart tomcat and manually run the CRL job. It won't take long before OOM exception is thrown.
```bash
$ sudo systemctl start tomcat
$ curl -k -u admin:admin  -X POST https://localhost:8443/candlepin/jobs/schedule/CertificateRevocationListTask
```
4. Set up logging so that you can track the progress of the job.
```bash
log4j.logger.org.candlepin.util.CrlFileUtil=DEBUG
```
5. Deploy candlepin from this PR's branch against the same database.
```bash
$ bin/deploy
```
6. In a separate terminal, tail the candlepin log so that you can see what's going on.
```bash
# Generally I tail the log just to get the job id, then use grep to narrow to just that job.
tail -f /var/log/candlepin/candlepin.log
# once the job is running, re-tail and use grep.
tail -f /var/log/candlepin/candlepin.log | grep <YOUR_JOB_ID>
```

7. In a separate terminal, use 'top' to monitor tomcat's cpu and memory usage.
```bash
top | grep tomcat
```

8. Run the CRL job again. It will take about 1h - 1h20m to fully complete. Memory usage shouldn't rise more than a couple Gig and CPU should only go to 100% in bursts.
```bash
curl -k -u admin:admin  -X POST https://localhost:8443/candlepin/jobs/schedule/CertificateRevocationListTask
```
