### PR TITLE
[M] 1623491: Get syspurpose attributes an owner's consumers [ENT-821]

### DIFF
--- a/server/client/ruby/candlepin_api.rb
+++ b/server/client/ruby/candlepin_api.rb
@@ -295,6 +295,10 @@ class Candlepin
     get("/owners/#{owner}/system_purpose")
   end
 
+  def get_owner_consumers_syspurpose(owner)
+    get("/owners/#{owner}/consumers_system_purpose")
+  end
+
   def get_owner_hypervisors(owner, hypervisor_ids = [])
     url = "/owners/#{owner}/hypervisors"
     params = {

--- a/server/spec/owner_resource_spec.rb
+++ b/server/spec/owner_resource_spec.rb
@@ -5,6 +5,7 @@ require 'candlepin_scenarios'
 require 'rubygems'
 require 'rest_client'
 require 'time'
+require 'json'
 
 describe 'Owner Resource' do
   include CandlepinMethods
@@ -589,7 +590,7 @@ describe 'Owner Resource' do
     # output for owners, so we don't need to verify their presence.
   end
 
-  it 'accepts system purpose attributes' do
+  it 'lists system purpose attributes of its products' do
     owner_key = random_string("owner")
     @cp.create_owner(owner_key)
 
@@ -608,6 +609,51 @@ describe 'Owner Resource' do
     expect(res["systemPurposeAttributes"]["addons"]).to include("addon1")
     expect(res["systemPurposeAttributes"]["addons"]).to include("addon2")
     expect(res["systemPurposeAttributes"]["support_level"]).to include("mysla")
+  end
+
+  it 'lists system purpose attributes of its consumers' do
+    owner1_key = random_string("owner1")
+    owner1 = @cp.create_owner(owner1_key)
+
+    username1 = random_string("user1")
+    user1 = user_client(owner1, username1)
+
+    consumer1 = user1.register(random_string('consumer1'), :system, nil, {}, random_string('consumer1'), owner1_key,
+      [], [], nil, [], nil, [], nil, nil, nil, nil, nil, nil, nil, 'sla1', 'common_role', 'usage1', ['addon1'])
+    consumer2 = user1.register(random_string('consumer2'), :system, nil, {}, random_string('consumer2'), owner1_key,
+      [], [], nil, [], nil, [], nil, nil, nil, nil, nil, nil, nil, 'sla2', 'common_role', 'usage2', ['addon2'])
+    consumer3 = user1.register(random_string('consumer3'), :system, nil, {}, random_string('consumer3'), owner1_key,
+      [], [], nil, [], nil, [], nil, nil, nil, nil, nil, nil, nil, nil, nil, 'usage3', ['', nil])
+    consumer4 = user1.register(random_string('consumer4'), :system, nil, {}, random_string('consumer4'), owner1_key,
+      [], [], nil, [], nil, [], nil, nil, nil, nil, nil, nil, nil, nil, '', 'usage4', nil)
+
+    user1.list_owner_consumers(owner1_key).length.should == 4
+
+    res = @cp.get_owner_consumers_syspurpose(owner1_key)
+    expect(res["owner"]["key"]).to eq(owner1_key)
+    expect(res["systemPurposeAttributes"]["usage"]).to include("usage1")
+    expect(res["systemPurposeAttributes"]["usage"]).to include("usage2")
+    expect(res["systemPurposeAttributes"]["usage"]).to include("usage3")
+    expect(res["systemPurposeAttributes"]["usage"]).to include("usage4")
+
+    expect(res["systemPurposeAttributes"]["addons"]).to include("addon1")
+    expect(res["systemPurposeAttributes"]["addons"]).to include("addon2")
+    # Make sure to filter null & empty addons.
+    expect(res["systemPurposeAttributes"]["addons"]).to_not include(nil)
+    expect(res["systemPurposeAttributes"]["addons"]).to_not include("")
+
+    expect(res["systemPurposeAttributes"]["support_level"]).to include("sla1")
+    expect(res["systemPurposeAttributes"]["support_level"]).to include("sla2")
+    # Empty serviceLevel means no serviceLevel, so we have to make sure those are filtered those out.
+    expect(res["systemPurposeAttributes"]["support_level"]).to_not include("")
+
+    expect(res["systemPurposeAttributes"]["roles"]).to include("common_role")
+    # Make sure to filter null null & empty roles.
+    expect(res["systemPurposeAttributes"]["roles"]).to_not include(nil)
+    expect(res["systemPurposeAttributes"]["roles"]).to_not include("")
+    # Even though 2 consumers have both specified the 'common_role', output should be deduplicated
+    # and only include one instance of each unique value.
+    res["systemPurposeAttributes"]["roles"].length.should == 1
   end
 end
 

--- a/server/src/main/java/org/candlepin/dto/api/v1/SystemPurposeAttributesDTO.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/SystemPurposeAttributesDTO.java
@@ -36,13 +36,13 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 
 /**
- * DTO representation of the system purpose attributes available across the set of products belonging to an
- * owner
+ * DTO representation of the system purpose attributes available across the set of products or consumers
+ * belonging to an owner
  */
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @ApiModel(parent = TimestampedCandlepinDTO.class, description = "DTO representing the system purpose " +
-    "attributes available across the set of products belonging to an owner")
+    "attributes available across the set of products or consumers belonging to an owner")
 public class SystemPurposeAttributesDTO extends CandlepinDTO<SystemPurposeAttributesDTO> {
     private static final long serialVersionUID = 1L;
 

--- a/server/src/main/java/org/candlepin/model/ConsumerCurator.java
+++ b/server/src/main/java/org/candlepin/model/ConsumerCurator.java
@@ -328,6 +328,88 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
         return this.cpQueryFactory.<Consumer>buildQuery();
     }
 
+    /**
+     * Fetches all unique role attribute values set by all the consumers of the specified owner.
+     *
+     * @param owner
+     *  The owner the consumers belong to.
+     * @return
+     *  A list of the all the distinct values of the role attribute that the consumers belonging to the
+     *  specified owner have set.
+     */
+    @SuppressWarnings("unchecked")
+    @Transactional
+    public List<String> getDistinctSyspurposeRolesByOwner(Owner owner) {
+        return this.createSecureCriteria()
+            .add(Restrictions.eq("ownerId", owner.getId()))
+            .add(Restrictions.neOrIsNotNull("role", ""))
+            .setProjection(Projections.property("role"))
+            .setResultTransformer(Criteria.DISTINCT_ROOT_ENTITY)
+            .list();
+    }
+
+    /**
+     * Fetches all unique usage attribute values set by all the consumers of the specified owner.
+     *
+     * @param owner
+     *  The owner the consumers belong to.
+     * @return
+     *  A list of the all the distinct values of the usage attribute that the consumers belonging to the
+     *  specified owner have set.
+     */
+    @SuppressWarnings("unchecked")
+    @Transactional
+    public List<String> getDistinctSyspurposeUsageByOwner(Owner owner) {
+        return this.createSecureCriteria()
+            .add(Restrictions.eq("ownerId", owner.getId()))
+            .add(Restrictions.neOrIsNotNull("usage", ""))
+            .setProjection(Projections.property("usage"))
+            .setResultTransformer(Criteria.DISTINCT_ROOT_ENTITY)
+            .list();
+    }
+
+    /**
+     * Fetches all unique serviceLevel attribute values set by all the consumers of the specified owner.
+     *
+     * @param owner
+     *  The owner the consumers belong to.
+     * @return
+     *  A list of the all the distinct values of the serviceLevel attribute that the consumers belonging
+     *  to the specified owner have set.
+     */
+    @SuppressWarnings("unchecked")
+    @Transactional
+    public List<String> getDistinctSyspurposeServicelevelByOwner(Owner owner) {
+        return this.createSecureCriteria()
+            .add(Restrictions.eq("ownerId", owner.getId()))
+            .add(Restrictions.neOrIsNotNull("serviceLevel", ""))
+            .setProjection(Projections.property("serviceLevel"))
+            .setResultTransformer(Criteria.DISTINCT_ROOT_ENTITY)
+            .list();
+    }
+
+    /**
+     * Fetches all unique addon attribute values set by all the consumers of the specified owner.
+     *
+     * @param owner
+     *  The owner the consumers belong to.
+     * @return
+     *  A list of the all the distinct values of the addon attribute that the consumers belonging
+     *  to the specified owner have set.
+     */
+    @SuppressWarnings("unchecked")
+    @Transactional
+    public List<String> getDistinctSyspurposeAddonsByOwner(Owner owner) {
+        String sql = "SELECT DISTINCT add_on FROM cp_sp_add_on, cp_consumer " +
+            "WHERE cp_consumer.id = cp_sp_add_on.consumer_id " +
+            "AND cp_consumer.owner_id = :ownerid " +
+            "AND add_on IS NOT NULL " +
+            "AND add_on != ''";
+        Query query = this.currentSession().createSQLQuery(sql);
+        query.setParameter("ownerid", owner.getId());
+        return query.list();
+    }
+
     @SuppressWarnings("unchecked")
     @Transactional
     public CandlepinQuery<Consumer> listByOwner(Owner owner) {

--- a/server/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -2093,6 +2093,35 @@ public class OwnerResource {
         return dto;
     }
 
+    @ApiOperation(notes = "Retrieves an aggregate of the system purpose settings of the owner's consumers",
+        value = "getConsumersSyspurpose")
+    @ApiResponses({@ApiResponse(code = 404, message = "Owner not found")})
+    @GET
+    @Path("{owner_key}/consumers_system_purpose")
+    @Produces(MediaType.APPLICATION_JSON)
+    public SystemPurposeAttributesDTO getConsumersSyspurpose(
+        @PathParam("owner_key") @Verify(Owner.class) String ownerKey) {
+        Owner owner = findOwnerByKey(ownerKey);
+        List<String> consumerRoles = this.consumerCurator.getDistinctSyspurposeRolesByOwner(owner);
+        List<String> consumerUsages = this.consumerCurator.getDistinctSyspurposeUsageByOwner(owner);
+        List<String> consumerSLAs = this.consumerCurator.getDistinctSyspurposeServicelevelByOwner(owner);
+        List<String> consumerAddons = this.consumerCurator.getDistinctSyspurposeAddonsByOwner(owner);
+
+        Map<String, Set<String>> dtoMap = new HashMap<>();
+        Arrays.stream(SystemPurposeAttributeType.values())
+            .forEach(x -> dtoMap.put(x.toString(), new LinkedHashSet<>()));
+
+        dtoMap.get(SystemPurposeAttributeType.ROLES.toString()).addAll(consumerRoles);
+        dtoMap.get(SystemPurposeAttributeType.USAGE.toString()).addAll(consumerUsages);
+        dtoMap.get(SystemPurposeAttributeType.SERVICE_LEVEL.toString()).addAll(consumerSLAs);
+        dtoMap.get(SystemPurposeAttributeType.ADDONS.toString()).addAll(consumerAddons);
+
+        SystemPurposeAttributesDTO dto = new SystemPurposeAttributesDTO();
+        dto.setOwner(translator.translate(owner, OwnerDTO.class));
+        dto.setSystemPurposeAttributes(dtoMap);
+        return dto;
+    }
+
     /**
      * Creates an Ueber Entitlement Certificate
      *

--- a/server/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
@@ -339,6 +339,210 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
     }
 
     @Test
+    public void testGetDistinctSyspurposeRolesByOwnerReturnsAllRoles() {
+        Consumer c1 = new Consumer("c1", "u1", owner, ct);
+        c1.setRole("role1");
+        Consumer c2 = new Consumer("c2", "u1", owner, ct);
+        c2.setRole("role2");
+        Consumer c3 = new Consumer("c3", "u1", owner, ct);
+        c3.setRole("common_role");
+        Consumer c4 = new Consumer("c3", "u1", owner, ct);
+        c3.setRole("common_role");
+
+        consumerCurator.create(c1);
+        consumerCurator.create(c2);
+        consumerCurator.create(c3);
+        consumerCurator.create(c4);
+        consumerCurator.flush();
+
+        List<String> result = consumerCurator.getDistinctSyspurposeRolesByOwner(owner);
+
+        // Make sure 'common_role' is not duplicated in the result
+        assertEquals(3, result.size());
+        assertTrue(result.contains("role1"));
+        assertTrue(result.contains("role2"));
+        assertTrue(result.contains("common_role"));
+    }
+
+    @Test
+    public void testGetDistinctSyspurposeRolesByOwnerDoesNotReturnNullOrEmpty() {
+        Consumer c1 = new Consumer("c1", "u1", owner, ct);
+        c1.setRole("role1");
+        Consumer c2 = new Consumer("c2", "u1", owner, ct);
+        c2.setRole("");
+        Consumer c3 = new Consumer("c3", "u1", owner, ct);
+        c3.setRole(null);
+
+        consumerCurator.create(c1);
+        consumerCurator.create(c2);
+        consumerCurator.create(c3);
+        consumerCurator.flush();
+
+        List<String> result = consumerCurator.getDistinctSyspurposeRolesByOwner(owner);
+
+        // Make sure the result does not contain null or empty roles.
+        assertEquals(1, result.size());
+        assertTrue(result.contains("role1"));
+        assertFalse(result.contains(""));
+        assertFalse(result.contains(null));
+    }
+
+    @Test
+    public void testGetDistinctSyspurposeUsageByOwnerReturnsAllUsages() {
+        Consumer c1 = new Consumer("c1", "u1", owner, ct);
+        c1.setUsage("usage1");
+        Consumer c2 = new Consumer("c2", "u1", owner, ct);
+        c2.setUsage("usage2");
+        Consumer c3 = new Consumer("c3", "u1", owner, ct);
+        c3.setUsage("common_usage");
+        Consumer c4 = new Consumer("c3", "u1", owner, ct);
+        c3.setUsage("common_usage");
+
+        consumerCurator.create(c1);
+        consumerCurator.create(c2);
+        consumerCurator.create(c3);
+        consumerCurator.create(c4);
+        consumerCurator.flush();
+
+        List<String> result = consumerCurator.getDistinctSyspurposeUsageByOwner(owner);
+
+        // Make sure 'common_usage' is not duplicated in the result
+        assertEquals(3, result.size());
+        assertTrue(result.contains("usage1"));
+        assertTrue(result.contains("usage2"));
+        assertTrue(result.contains("common_usage"));
+    }
+
+    @Test
+    public void testGetDistinctSyspurposeUsageByOwnerDoesNotReturnNullOrEmpty() {
+        Consumer c1 = new Consumer("c1", "u1", owner, ct);
+        c1.setUsage("usage1");
+        Consumer c2 = new Consumer("c2", "u1", owner, ct);
+        c2.setUsage("");
+        Consumer c3 = new Consumer("c3", "u1", owner, ct);
+        c3.setUsage(null);
+
+        consumerCurator.create(c1);
+        consumerCurator.create(c2);
+        consumerCurator.create(c3);
+        consumerCurator.flush();
+
+        List<String> result = consumerCurator.getDistinctSyspurposeUsageByOwner(owner);
+
+        // Make sure the result does not contain null or empty usages.
+        assertEquals(1, result.size());
+        assertTrue(result.contains("usage1"));
+        assertFalse(result.contains(""));
+        assertFalse(result.contains(null));
+    }
+
+    @Test
+    public void testGetDistinctSyspurposeServiceLevelByOwnerReturnsAllServiceLevels() {
+        Consumer c1 = new Consumer("c1", "u1", owner, ct);
+        c1.setServiceLevel("sla1");
+        Consumer c2 = new Consumer("c2", "u1", owner, ct);
+        c2.setServiceLevel("sla2");
+        Consumer c3 = new Consumer("c3", "u1", owner, ct);
+        c3.setServiceLevel("common_sla");
+        Consumer c4 = new Consumer("c3", "u1", owner, ct);
+        c3.setServiceLevel("common_sla");
+
+        consumerCurator.create(c1);
+        consumerCurator.create(c2);
+        consumerCurator.create(c3);
+        consumerCurator.create(c4);
+        consumerCurator.flush();
+
+        List<String> result = consumerCurator.getDistinctSyspurposeServicelevelByOwner(owner);
+
+        // Make sure 'common_sla' is not duplicated in the result
+        assertEquals(3, result.size());
+        assertTrue(result.contains("sla1"));
+        assertTrue(result.contains("sla2"));
+        assertTrue(result.contains("common_sla"));
+    }
+
+    @Test
+    public void testGetDistinctSyspurposeServiceLevelByOwnerDoesNotReturnNullOrEmpty() {
+        Consumer c1 = new Consumer("c1", "u1", owner, ct);
+        c1.setServiceLevel("sla1");
+        Consumer c2 = new Consumer("c2", "u1", owner, ct);
+        c2.setServiceLevel("");
+        Consumer c3 = new Consumer("c3", "u1", owner, ct);
+        c3.setServiceLevel(null);
+
+        consumerCurator.create(c1);
+        consumerCurator.create(c2);
+        consumerCurator.create(c3);
+        consumerCurator.flush();
+
+        List<String> result = consumerCurator.getDistinctSyspurposeServicelevelByOwner(owner);
+
+        // Make sure the result does not contain null or empty SLAs.
+        assertEquals(1, result.size());
+        assertTrue(result.contains("sla1"));
+        assertFalse(result.contains(""));
+        assertFalse(result.contains(null));
+    }
+
+    @Test
+    public void testGetDistinctSyspurposeAddonsByOwnerReturnsAllAddons() {
+        Consumer c1 = new Consumer("c1", "u1", owner, ct);
+        Set<String> addons = new HashSet<>();
+        addons.add("addon1");
+        c1.setAddOns(addons);
+        Consumer c2 = new Consumer("c2", "u1", owner, ct);
+        Set<String> addons2 = new HashSet<>();
+        addons.add("addon2");
+        addons.add("common_addon");
+        c2.setAddOns(addons2);
+        Consumer c3 = new Consumer("c3", "u1", owner, ct);
+        Set<String> addons3 = new HashSet<>();
+        addons.add("addon3");
+        addons.add("common_addon");
+        c3.setAddOns(addons3);
+
+        consumerCurator.create(c1);
+        consumerCurator.create(c2);
+        consumerCurator.create(c3);
+        consumerCurator.flush();
+
+        List<String> result = consumerCurator.getDistinctSyspurposeAddonsByOwner(owner);
+
+        // Make sure 'common_addon' is not duplicated in the result
+        assertEquals(4, result.size());
+        assertTrue(result.contains("addon1"));
+        assertTrue(result.contains("addon2"));
+        assertTrue(result.contains("addon3"));
+        assertTrue(result.contains("common_addon"));
+    }
+
+    @Test
+    public void testGetDistinctSyspurposeAddonsByOwnerDoesNotReturnNullOrEmpty() {
+        Consumer c1 = new Consumer("c1", "u1", owner, ct);
+        Set<String> addons = new HashSet<>();
+        addons.add("addon1");
+        c1.setAddOns(addons);
+        Consumer c2 = new Consumer("c2", "u1", owner, ct);
+        Set<String> addons2 = new HashSet<>();
+        addons.add(null);
+        addons.add("");
+        c2.setAddOns(addons2);
+
+        consumerCurator.create(c1);
+        consumerCurator.create(c2);
+        consumerCurator.flush();
+
+        List<String> result = consumerCurator.getDistinctSyspurposeAddonsByOwner(owner);
+
+        // Make sure the result does not contain null or empty addons.
+        assertEquals(1, result.size());
+        assertTrue(result.contains("addon1"));
+        assertFalse(result.contains(""));
+        assertFalse(result.contains(null));
+    }
+
+    @Test
     public void addGuestConsumers() {
         Consumer consumer = new Consumer("hostConsumer", "testUser", owner, ct);
         consumerCurator.create(consumer);

--- a/server/src/test/java/org/candlepin/resource/OwnerResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/OwnerResourceTest.java
@@ -1736,7 +1736,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void testReturnSysPurposeValuesForOwner() throws Exception {
+    public void testReturnProductSysPurposeValuesForOwner() throws Exception {
         Owner owner = TestUtil.createOwner();
         OwnerCurator oc = mock(OwnerCurator.class);
         OwnerProductCurator opc = mock(OwnerProductCurator.class);
@@ -1780,4 +1780,65 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         assertEquals(expectedUsage, usage);
     }
 
+    @Test
+    public void testReturnConsumerSysPurposeValuesForOwner() throws Exception {
+        Owner owner = TestUtil.createOwner();
+        OwnerCurator oc = mock(OwnerCurator.class);
+        ConsumerCurator cc = mock(ConsumerCurator.class);
+
+        OwnerResource resource = new OwnerResource(oc, null, null, cc, null, null, null, null, null, null,
+            null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null,
+            null, null, null, this.modelTranslator
+        );
+
+        when(oc.getByKey(eq(owner.getKey()))).thenReturn(owner);
+
+        List<String> mockRoles = new ArrayList<>();
+        mockRoles.add("role1");
+        mockRoles.add("role2");
+        mockRoles.add("role3");
+
+        List<String> mockUsages = new ArrayList<>();
+        mockUsages.add("usage1");
+        mockUsages.add("usage2");
+        mockUsages.add("usage3");
+
+        List<String> mockSLAs = new ArrayList<>();
+        mockSLAs.add("sla1");
+        mockSLAs.add("sla2");
+        mockSLAs.add("sla3");
+
+        List<String> mockAddons = new ArrayList<>();
+        mockAddons.add("addon1");
+        mockAddons.add("addon2");
+        mockAddons.add("addon3");
+
+        when(cc.getDistinctSyspurposeRolesByOwner(eq(owner))).thenReturn(mockRoles);
+        when(cc.getDistinctSyspurposeServicelevelByOwner(eq(owner))).thenReturn(mockSLAs);
+        when(cc.getDistinctSyspurposeUsageByOwner(eq(owner))).thenReturn(mockUsages);
+        when(cc.getDistinctSyspurposeAddonsByOwner(eq(owner))).thenReturn(mockAddons);
+
+        SystemPurposeAttributesDTO result = resource.getConsumersSyspurpose(owner.getKey());
+
+        assertEquals(modelTranslator.translate(owner, OwnerDTO.class), result.getOwner());
+        Set<String> addons =
+            result.getSystemPurposeAttributes().get(SystemPurposeAttributeType.ADDONS.toString());
+        Set<String> expectedAddOns = new HashSet<>(Arrays.asList("addon1", "addon2", "addon3"));
+        assertEquals(expectedAddOns, addons);
+
+        Set<String> usage =
+            result.getSystemPurposeAttributes().get(SystemPurposeAttributeType.USAGE.toString());
+        Set<String> expectedUsage = new HashSet<>(Arrays.asList("usage1", "usage2", "usage3"));
+        assertEquals(expectedUsage, usage);
+
+        Set<String> roles =
+            result.getSystemPurposeAttributes().get(SystemPurposeAttributeType.ROLES.toString());
+        Set<String> expectedRoles = new HashSet<>(Arrays.asList("role1", "role2", "role3"));
+        assertEquals(expectedRoles, roles);
+
+        Set<String> serviceLevelAgreements =
+            result.getSystemPurposeAttributes().get(SystemPurposeAttributeType.SERVICE_LEVEL.toString());
+        Set<String> expectedSLAs = new HashSet<>(Arrays.asList("sla1", "sla2", "sla3"));
+        assertEquals(expectedSLAs, serviceLevelAgreements);
+    }
 }


### PR DESCRIPTION
- Created new API /owners/{owner_key}/consumers_system_purpose used
to retrieve an aggregate of all the syspurpose attributes that the
owner's consumers have specified.