### PR TITLE
[F] Moved the amqp management  and message sending out of JobManager [ENT-1090]

### DIFF
--- a/server/src/main/java/org/candlepin/async/JobMessage.java
+++ b/server/src/main/java/org/candlepin/async/JobMessage.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.async;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+
+
+/**
+ * The JobMessage class represents a message to be sent between Candlepin's job management system
+ * and the messaging system connecting various Candlepin nodes or compatible systems.
+ */
+public class JobMessage {
+    private String jobId;
+    private String jobKey;
+
+    @JsonCreator
+    public JobMessage(String jobId, String jobKey) {
+        // Impl note:
+        // While in most cases I would aggressively check for nulls or empty strings and throw an
+        // exception, we don't want to do so here, as such exceptions get messy with how
+        // deserialization works, making debugging much harder than it needs to be.
+        //
+        // Instead, we should verify that the values aren't null immediately after creation in
+        // the area that is about to be using or handing off the job message instance. This will
+        // allow for cleaner debugging in the event something goes sideways.
+
+        this.jobId = jobId;
+        this.jobKey = jobKey;
+    }
+
+    /**
+     * Fetches the ID of the job represented by this message
+     *
+     * @return
+     *  The ID of the job represented by this message, or null if the ID is not available
+     */
+    public String getJobId() {
+        return this.jobId;
+    }
+
+    /**
+     * Fetches the job key for the job represented by this message
+     *
+     * @return
+     *  The job key for the job represented by this method, or null if the job key is not available
+     */
+    public String getJobKey() {
+        return this.jobKey;
+    }
+}

--- a/server/src/main/java/org/candlepin/async/JobMessageDispatcher.java
+++ b/server/src/main/java/org/candlepin/async/JobMessageDispatcher.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.async;
+
+
+
+/**
+ * The JobMessageDispatcher interface defines a method for sending a job message to another
+ * queue or underlying messaging system.
+ */
+public interface JobMessageDispatcher {
+
+    /**
+     * Sends a job message to the backing message bus. If the message cannot be sent, this method
+     * should throw an exception.
+     *
+     * @param jobMessage
+     *  The JobMessage to send
+     *
+     * @throws Exception
+     *  if the message cannot be sent for any reason
+     */
+    void sendJobMessage(JobMessage jobMessage) throws Exception;
+
+}

--- a/server/src/main/java/org/candlepin/async/impl/ActiveMQSessionFactory.java
+++ b/server/src/main/java/org/candlepin/async/impl/ActiveMQSessionFactory.java
@@ -1,0 +1,193 @@
+/**
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.async.impl;
+
+import org.candlepin.common.config.Configuration;
+import org.candlepin.config.ConfigProperties;
+
+import org.apache.activemq.artemis.api.core.ActiveMQException;
+import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
+import org.apache.activemq.artemis.api.core.client.ClientSession;
+import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
+import org.apache.activemq.artemis.api.core.client.ServerLocator;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+
+
+/**
+ * The ActiveMQSessionFactory provides initialization and management of both egress and ingress
+ * session factories, as well as a method for fetching sessions configured for each.
+ */
+@Singleton
+public class ActiveMQSessionFactory {
+    private static Logger log = LoggerFactory.getLogger(ActiveMQSessionFactory.class);
+
+    /**
+     * Manages a session factory and session generation, recreating and reopening the factory as
+     * necessary.
+     */
+    private static class SessionManager {
+        private final ServerLocator locator;
+
+        private ClientSessionFactory sessionFactory;
+
+        /**
+         * Creates a new SessionManager instance using the provided locator to create the session
+         * factories
+         *
+         * @param locator
+         *  The locator to use for creating session factories
+         */
+        public SessionManager(ServerLocator locator) {
+            if (locator == null) {
+                throw new IllegalArgumentException("locator is null");
+            }
+
+            this.locator = locator;
+        }
+
+        /**
+         * Fetches the current session factory, initializing a new instance as necessary. This should
+         * almost certainly not be used by any method other than getClientSession.
+         *
+         * @throws ActiveMQException
+         *  if an exception occurs while spinning up the ActiveMQ client session factory
+         *
+         * @return
+         *  the ClientSessionFactory instance for this job manager
+         */
+        public ClientSessionFactory getClientSessionFactory() throws Exception {
+            if (this.sessionFactory == null || this.sessionFactory.isClosed()) {
+                log.debug("Creating new ActiveMQ client session factory...");
+
+                this.sessionFactory = locator.createSessionFactory();
+                log.debug("Created new ActiveMQ client session factory: {}", this.sessionFactory);
+            }
+
+            return this.sessionFactory;
+        }
+
+        /**
+         * Fetches the current client session, creating and intializing a new instance as necessary.
+         *
+         * @return
+         *  the current ClientSession instance for this job manager
+         */
+        public ClientSession getClientSession() throws Exception {
+            log.debug("Creating new ActiveMQ session...");
+
+            ClientSessionFactory csf = this.getClientSessionFactory();
+            ClientSession session = csf.createSession();
+
+            log.debug("Created new ActiveMQ session: {}", session);
+
+            return session;
+        }
+    }
+
+
+    private Configuration config;
+
+    private SessionManager ingressSessionManager;
+    private SessionManager egressSessionManager;
+
+
+    /**
+     * Creates a new ActiveMQSessionFactory using the specified Candlepin configuration.
+     *
+     * @param config
+     *  The Candlepin configuration to use for configuring this session factory
+     */
+    @Inject
+    public ActiveMQSessionFactory(Configuration config) {
+        this.config = config;
+    }
+
+
+    /**
+     * Fetches the ingress session manager, creating a new instance as necessary.
+     *
+     * @return
+     *  a SessionManager for sessions configured for receiving messages
+     */
+    protected SessionManager getIngressSessionManager() throws Exception {
+        if (this.ingressSessionManager == null) {
+            // TODO:
+            // This needs to be updated such that it's properly configured for whatever
+            // workaround we need on the receiving side of things. If it looks like the
+            // egress configuration, something is probably broken.
+
+            ServerLocator locator = ActiveMQClient.createServerLocator(
+                this.config.getProperty(ConfigProperties.ACTIVEMQ_BROKER_URL));
+
+            // TODO: Maybe make this a bit more defensive and skip setting the property if it's
+            // not present in the configuration rather than crashing out?
+            locator.setMinLargeMessageSize(this.config.getInt(ConfigProperties.ACTIVEMQ_LARGE_MSG_SIZE));
+
+            this.ingressSessionManager = new SessionManager(locator);
+        }
+
+        return this.ingressSessionManager;
+    }
+
+    /**
+     * Fetches the egress session manager, creating a new instance as necessary.
+     *
+     * @return
+     *  a SessionManager for sessions configured for sending messages
+     */
+    protected SessionManager getEgressSessionManager() throws Exception {
+        if (this.egressSessionManager == null) {
+            ServerLocator locator = ActiveMQClient.createServerLocator(
+                this.config.getProperty(ConfigProperties.ACTIVEMQ_BROKER_URL));
+
+            // TODO: Maybe make this a bit more defensive and skip setting the property if it's
+            // not present in the configuration rather than crashing out?
+            locator.setMinLargeMessageSize(this.config.getInt(ConfigProperties.ACTIVEMQ_LARGE_MSG_SIZE));
+
+            this.egressSessionManager = new SessionManager(locator);
+        }
+
+        return this.egressSessionManager;
+    }
+
+    /**
+     * Fetches a new ingress session, configured for receiving messages.
+     *
+     * @return
+     *  a ClientSession instance configured for receiving messages
+     */
+    public ClientSession getIngressSession() throws Exception {
+        SessionManager manager = this.getIngressSessionManager();
+        return manager.getClientSession();
+    }
+
+    /**
+     * Fetches a new egress session, configured for sending messages.
+     *
+     * @return
+     *  a ClientSession instance configured for sending messages
+     */
+    public ClientSession getEgressSession() throws Exception {
+        SessionManager manager = this.getEgressSessionManager();
+        return manager.getClientSession();
+    }
+
+}

--- a/server/src/main/java/org/candlepin/async/impl/ArtemisJobMessageDispatcher.java
+++ b/server/src/main/java/org/candlepin/async/impl/ArtemisJobMessageDispatcher.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.async.impl;
+
+import org.candlepin.async.JobMessage;
+import org.candlepin.async.JobMessageDispatcher;
+import org.candlepin.audit.MessageAddress;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.apache.activemq.artemis.api.core.client.ClientMessage;
+import org.apache.activemq.artemis.api.core.client.ClientProducer;
+import org.apache.activemq.artemis.api.core.client.ClientSession;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+
+
+
+/**
+ * The ArtemisJobMessageDispatcher is a job message dispatcher implementation that uses Artemis
+ * to distribute job messages using a single message queue.
+ */
+public class ArtemisJobMessageDispatcher implements JobMessageDispatcher {
+    private static Logger log = LoggerFactory.getLogger(ArtemisJobMessageDispatcher.class);
+
+    private ActiveMQSessionFactory sessionFactory;
+    private ClientSession session;
+    private ClientProducer producer;
+
+    private ObjectMapper objMapper;
+
+
+    /**
+     * Creates a new message dispatcher
+     *
+     * @param sessionFactory
+     *  The session factory to use for creating sessions
+     *
+     * @param objMapper
+     *  The ObjectMapper to use for serializing and deserializing messages
+     */
+    @Inject
+    public ArtemisJobMessageDispatcher(ActiveMQSessionFactory sessionFactory, ObjectMapper objMapper) {
+        this.sessionFactory = sessionFactory;
+        this.objMapper = objMapper;
+    }
+
+    /**
+     * Fetches the current client session, creating and intializing a new instance as necessary.
+     *
+     * @return
+     *  the current ClientSession instance for this job manager
+     */
+    protected ClientSession getClientSession() throws Exception {
+        if (this.session == null || this.session.isClosed()) {
+            log.debug("Creating new ActiveMQ session for sending async job messages...");
+
+            this.session = this.sessionFactory.getEgressSession();
+
+            log.debug("Created new ActiveMQ session: {}", this.session);
+        }
+
+        return this.session;
+    }
+
+    /**
+     * Fetches the current client producer, creating and initializing a new instance as necessary.
+     *
+     * @return
+     *  the current ClientProducer instance for this job manager
+     */
+    protected ClientProducer getClientProducer() throws Exception {
+        if (this.producer == null || this.producer.isClosed()) {
+            log.debug("Creating new ActiveMQ producer for async job messages...");
+
+            ClientSession session = this.getClientSession();
+            this.producer = session.createProducer();
+
+            log.debug("Created new ActiveMQ producer: {}", this.producer);
+        }
+
+        return this.producer;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void sendJobMessage(JobMessage jobMessage) throws Exception {
+        ClientSession session = this.getClientSession();
+        ClientMessage message = session.createMessage(true);
+        message.putStringProperty("job_key", jobMessage.getJobKey());
+
+        String eventString = this.objMapper.writeValueAsString(message);
+        message.getBodyBuffer().writeString(eventString);
+
+        log.debug("Sending message to {}: {}", MessageAddress.JOB_MESSAGE_ADDRESS, eventString);
+
+        ClientProducer producer = this.getClientProducer();
+        producer.send(MessageAddress.JOB_MESSAGE_ADDRESS, message);
+    }
+
+}

--- a/server/src/main/java/org/candlepin/audit/EventSource.java
+++ b/server/src/main/java/org/candlepin/audit/EventSource.java
@@ -31,7 +31,7 @@ import java.util.List;
  */
 @Singleton
 public class EventSource implements QpidStatusListener, ActiveMQStatusListener {
-    private static  Logger log = LoggerFactory.getLogger(EventSource.class);
+    private static Logger log = LoggerFactory.getLogger(EventSource.class);
 
     private ObjectMapper mapper;
     private EventSourceConnection connection;

--- a/server/src/main/java/org/candlepin/audit/MessageReceiver.java
+++ b/server/src/main/java/org/candlepin/audit/MessageReceiver.java
@@ -41,8 +41,9 @@ public abstract class MessageReceiver implements MessageHandler {
 
     protected abstract String getQueueAddress();
 
-    public MessageReceiver(EventListener listener, ActiveMQConnection connection,
-        ObjectMapper mapper) throws ActiveMQException {
+    public MessageReceiver(EventListener listener, ActiveMQConnection connection, ObjectMapper mapper)
+        throws ActiveMQException {
+
         this.connection = connection;
         this.mapper = mapper;
         this.listener = listener;


### PR DESCRIPTION
- Added a new interface, JobMessageDispatcher, to allow for multiple
  implementations of the message sending backend without needing to
  modify JobManager itself
- Moved the AMQP broker connection management out of the JobManager
  and into the new ArtemisJobMessageDispatcher class