### PR TITLE
[gradle] Move the rspec custom task to buildSrc

### DIFF
--- a/buildSrc/src/main/groovy/Rspec.groovy
+++ b/buildSrc/src/main/groovy/Rspec.groovy
@@ -1,0 +1,73 @@
+/*
+ *  Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ *  This software is licensed to you under the GNU General Public License,
+ *  version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ *  implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ *  FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ *  along with this software; if not, see
+ *  http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ *  Red Hat trademarks are not licensed under GPLv2. No permission is
+ *  granted to use or replicate Red Hat trademarks that are incorporated
+ *  in this software or its documentation.
+ */
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.options.Option
+
+
+class Rspec extends DefaultTask {
+
+    Rspec() {
+        description = 'Run ruby based spec tests'
+        group = 'Verification'
+    }
+
+    @Input
+    String test = ""
+
+    @Input
+    String spec = ""
+
+    @Option(option = 'spec', description = 'The name of the spec file to search. Example: "core_and_ram"')
+    void setSpec(final String specfile_name) {
+        this.spec = specfile_name
+    }
+
+    @Option(option = 'test', description = 'Set the name of the spec test to run')
+    void setTest(final String test_name) {
+        this.test = test_name
+    }
+
+    @TaskAction
+    runRspec() {
+        def rspec_args = [
+                "--format", "documentation",
+                "--force-color",
+                "--require", "${project.rootDir}/tasks/failure_formatter",
+                "--format", "ModifiedRSpec::FailuresFormatter",
+                "-I", "${project.getProjectDir()}/client/ruby"
+        ]
+
+        // Use --pattern to match the name of the spec file for the spec argument
+        if (spec){
+            rspec_args.add("--pattern")
+            rspec_args.add("**/${spec}*_spec.rb")
+        }
+
+        // use -e to match the name of a specific test within the matched spec files
+        if (test){
+            rspec_args.add("-e")
+            rspec_args.add(test)
+        }
+
+        project.exec {
+            executable 'rspec'
+            args rspec_args
+            workingDir project.getProjectDir()
+        }
+    }
+}

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -1,6 +1,4 @@
 import groovy.text.GStringTemplateEngine
-import org.gradle.api.tasks.options.Option
-import org.apache.tools.ant.filters.ReplaceTokens
 
 apply plugin: 'war'
 apply plugin: Gettext
@@ -56,59 +54,6 @@ configurations {
     }
     testCompile {
         extendsFrom(core_testing, jukito, liquibase_slf4j)
-    }
-}
-
-class Rspec extends DefaultTask {
-
-    Rspec() {
-        description = 'Run ruby based spec tests'
-        group = 'Verification'
-    }
-
-    @Input
-    String test = ""
-
-    @Input
-    String spec = ""
-
-    @Option(option = 'spec', description = 'The name of the spec file to search. Example: "core_and_ram"')
-    void setSpec(final String specfile_name) {
-        this.spec = specfile_name
-    }
-
-    @Option(option = 'test', description = 'Set the name of the spec test to run')
-    void setTest(final String test_name) {
-        this.test = test_name
-    }
-
-    @TaskAction
-    runRspec() {
-        def rspec_args = [
-                "--format", "documentation",
-                "--force-color",
-                "--require", "${project.rootDir}/tasks/failure_formatter",
-                "--format", "ModifiedRSpec::FailuresFormatter",
-                "-I", "${project.getProjectDir()}/client/ruby"
-        ]
-
-        // Use --pattern to match the name of the spec file for the spec argument
-        if (spec){
-            rspec_args.add("--pattern")
-            rspec_args.add("**/${spec}*_spec.rb")
-        }
-
-        // use -e to match the name of a specific test within the matched spec files
-        if (test){
-            rspec_args.add("-e")
-            rspec_args.add(test)
-        }
-
-        project.exec {
-            executable 'rspec'
-            args rspec_args
-            workingDir project.getProjectDir()
-        }
     }
 }
 


### PR DESCRIPTION
In order to optimize compile time move the Rspec custom task class to buildSrc so that it will be compiled once & then cached between build runs.