### PR TITLE
1520502: Move to syslog/journald[ENT-397]

### DIFF
--- a/server/bin/update-server-xml.py
+++ b/server/bin/update-server-xml.py
@@ -339,6 +339,7 @@ class AccessValveEditor(AbstractBaseEditor):
             ("directory", "/var/log/candlepin/"),
             ("prefix", "access"),
             ("rotatable", "false"),
+            ("checkExists", "true"),
             ("suffix", ".log"),
             ("pattern", '%h %l %u %t "%r" %s %b "" "%{user-agent}i sm/%{x-subscription-manager-version}i" "req_time=%T,req=%{requestUuid}r"'),
             ("resolveHosts", "false"),

--- a/server/conf/logrotate.conf
+++ b/server/conf/logrotate.conf
@@ -1,5 +1,6 @@
+#1520502: Only access.log requires logrotate. Other logs are rotated by logback
 #1344469: cant use * here cause not all logs in this folder will be owned by tomcat
-/var/log/candlepin/access.log /var/log/candlepin/audit.log /var/log/candlepin/candlepin.log /var/log/candlepin/error.log {
+/var/log/candlepin/access.log {
 # logrotate 3.8 requires the su directive,
 # where as prior versions do not recognize it.
 #LOGROTATE-3.8#    su tomcat tomcat
@@ -7,6 +8,9 @@
     daily
     rotate 52
     compress
+    dateext
+    dateyesterday
+    dateformat -%Y-%m-%d
     missingok
     create 0644 tomcat tomcat
 }

--- a/server/src/main/java/org/candlepin/audit/LoggingListener.java
+++ b/server/src/main/java/org/candlepin/audit/LoggingListener.java
@@ -14,22 +14,9 @@
  */
 package org.candlepin.audit;
 
-import org.candlepin.common.config.Configuration;
-import org.candlepin.config.ConfigProperties;
-
-import com.google.inject.Inject;
-
-import org.slf4j.LoggerFactory;
-
 import ch.qos.logback.classic.Logger;
-import ch.qos.logback.classic.LoggerContext;
-import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.FileAppender;
-
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.TimeZone;
+import com.google.inject.Inject;
+import org.slf4j.LoggerFactory;
 
 /**
  * LoggingListener
@@ -40,52 +27,26 @@ import java.util.TimeZone;
  * See http://slf4j.org/faq.html#when
  */
 public class LoggingListener implements EventListener {
+
     private static Logger auditLog;
 
-    private final DateFormat df;
-
     @Inject
-    public LoggingListener(Configuration config) {
-        LoggerContext lc = (LoggerContext) LoggerFactory.getILoggerFactory();
-        auditLog = lc.getLogger(LoggingListener.class.getCanonicalName() + ".AuditLog");
-
-        PatternLayoutEncoder encoder = new PatternLayoutEncoder();
-        encoder.setContext(lc);
-        encoder.setPattern("%m");
-        encoder.start();
-
-        FileAppender<ILoggingEvent> appender = new FileAppender<>();
-        appender.setFile(config.getString(ConfigProperties.AUDIT_LOG_FILE));
-        appender.setEncoder(encoder);
-        appender.setName("AUDITLOG");
-        appender.setContext(lc);
-        appender.start();
-
-        auditLog.addAppender(appender);
-        // Keep these messages in audit.log only
-        auditLog.setAdditive(false);
-
-        TimeZone tz = TimeZone.getDefault();
-        // Format for ISO8601 to match our other logging:
-        df = new SimpleDateFormat("yyyy-MM-dd' 'HH:mm:ssZ");
-        df.setTimeZone(tz);
+    public LoggingListener() {
+        auditLog = (Logger) LoggerFactory
+            .getLogger(LoggingListener.class.getCanonicalName() + ".AuditLog");
     }
 
     @Override
-    @SuppressWarnings("checkstyle:indentation")
     public void onEvent(Event e) {
         auditLog.info(
-            "{} principalType={} principal={} target={} entityId={} type={} owner={} eventData={}\n",
-            new Object[] {
-                df.format(e.getTimestamp()),
-                e.getPrincipal().getType(),
-                e.getPrincipal().getName(),
-                e.getTarget(),
-                e.getEntityId(),
-                e.getType(),
-                e.getOwnerId(),
-                e.getEventData()}
-        );
+            "principalType={} principal={} target={} entityId={} type={} owner={} eventData={}\n",
+            e.getPrincipal().getType(),
+            e.getPrincipal().getName(),
+            e.getTarget(),
+            e.getEntityId(),
+            e.getType(),
+            e.getOwnerId(),
+            e.getEventData());
     }
 
     @Override

--- a/server/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/server/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -17,6 +17,7 @@ package org.candlepin.config;
 
 import static org.candlepin.common.config.ConfigurationPrefixes.JPA_CONFIG_PREFIX;
 
+import org.candlepin.common.config.Configuration;
 import org.candlepin.pinsetter.tasks.ActiveEntitlementJob;
 import org.candlepin.pinsetter.tasks.CancelJobJob;
 import org.candlepin.pinsetter.tasks.CertificateRevocationListTask;
@@ -36,7 +37,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Defines a map of default properties used to prepopulate the {@link Config}.
+ * Defines a map of default properties used to prepopulate the {@link Configuration}.
  * Also holds static keys for config lookup.
  */
 public class ConfigProperties {
@@ -92,7 +93,6 @@ public class ConfigProperties {
         "candlepin.audit.hornetq.monitor.interval";
 
     public static final String AUDIT_LISTENERS = "candlepin.audit.listeners";
-    public static final String AUDIT_LOG_FILE = "candlepin.audit.log_file";
     /**
      * Enables audit event filtering. See documentation of EventFilter
      */
@@ -301,7 +301,6 @@ public class ConfigProperties {
                 "org.candlepin.audit.DatabaseListener," +
                 "org.candlepin.audit.LoggingListener," +
                 "org.candlepin.audit.ActivationListener");
-            this.put(AUDIT_LOG_FILE, "/var/log/candlepin/audit.log");
             this.put(AUDIT_FILTER_ENABLED, "false");
 
             /**

--- a/server/src/main/resources/logback.xml
+++ b/server/src/main/resources/logback.xml
@@ -2,14 +2,23 @@
 <configuration>
     <contextName>candlepin</contextName>
 
+    <property name="LOG_DIR" value="/var/log/candlepin" />
+    <property name="ARCHIVED_LOG_DIR" value="${LOG_DIR}" />
+    <!--Daily rollover-->
+    <property name="ROLLING_PATTERN" value="%d{yyyy-MM-dd}" />
+    <!--Archive old logs-->
+    <property name="ROLLING_FORMAT" value="gz" />
+    <!--Keep 52 days of history-->
+    <property name="MAX_HISTORY" value="52" />
+
     <turboFilter class="org.candlepin.logging.LoggerAndMDCFilter">
         <key>orgLogLevel</key>
         <topLogger>org.candlepin</topLogger>
         <OnMatch>ACCEPT</OnMatch>
     </turboFilter>
 
-    <appender name="CandlepinAppender" class="ch.qos.logback.core.FileAppender">
-        <file>/var/log/candlepin/candlepin.log</file>
+    <appender name="CandlepinAppender" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_DIR}/candlepin.log</file>
         <encoder>
             <pattern>%d{ISO8601} [thread=%thread] [%X{requestType}=%X{requestUuid}, org=%X{org}, csid=%X{csid}] %-5p %c - %m%n</pattern>
         </encoder>
@@ -26,20 +35,50 @@
             <OnMatch>DENY</OnMatch>
         </filter>
         -->
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${ARCHIVED_LOG_DIR}/candlepin.log-${ROLLING_PATTERN}.${ROLLING_FORMAT}</fileNamePattern>
+            <maxHistory>${MAX_HISTORY}</maxHistory>
+        </rollingPolicy>
     </appender>
 
-    <appender name="ErrorAppender" class="ch.qos.logback.core.FileAppender">
-        <file>/var/log/candlepin/error.log</file>
+    <appender name="AUDITLOG" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_DIR}/audit.log</file>
+        <encoder>
+            <pattern>%d{ISO8601} %m</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${ARCHIVED_LOG_DIR}/audit.log-${ROLLING_PATTERN}.${ROLLING_FORMAT}</fileNamePattern>
+            <maxHistory>${MAX_HISTORY}</maxHistory>
+        </rollingPolicy>
+    </appender>
+
+    <appender name="ErrorAppender" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_DIR}/error.log</file>
         <encoder>
             <pattern>%d{ISO8601} [thread=%thread] [%X{requestType}=%X{requestUuid}, org=%X{org}, csid=%X{csid}] %-5p %c - %m%n</pattern>
         </encoder>
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
             <level>WARN</level>
         </filter>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${ARCHIVED_LOG_DIR}/error.log-${ROLLING_PATTERN}.${ROLLING_FORMAT}</fileNamePattern>
+            <maxHistory>${MAX_HISTORY}</maxHistory>
+        </rollingPolicy>
+    </appender>
+
+    <appender name="SyslogAppender" class="ch.qos.logback.classic.net.SyslogAppender">
+        <syslogHost>localhost</syslogHost>
+        <facility>DAEMON</facility>
+        <suffixPattern>[%thread] %logger %msg</suffixPattern>
     </appender>
 
     <logger name="org.candlepin" level="INFO"/>
-     
+
+    <!-- Keep these messages in audit.log only-->
+    <logger name="org.candlepin.audit.LoggingListener.AuditLog" level="INFO" additivity="false">
+        <appender-ref ref="AUDITLOG" />
+    </logger>
+
     <!-- With each attempt to connect Qpid, we get a warning message: 
           Exception received while trying to verify hostname 
          We decide to silence this in logs because it shouldn't have any significance to
@@ -51,6 +90,7 @@
 
     <root level="WARN">
         <appender-ref ref="CandlepinAppender" />
+        <appender-ref ref="SyslogAppender" />
         <appender-ref ref="ErrorAppender" />
     </root>
 </configuration>


### PR DESCRIPTION
Candlepin root logger now  logs to the syslog. All log files (access.log, audit.log, candlepin.log and error.log) are rotated daily. Old log files are rotated in a format "${filename}.log-${YYYY-MM-dd}.gz"

- Configure Candlepin to log into the syslog
- Replace logrotate with Logback rolling for audit.log, candlepin.log and error.log
- Remove unused property AUDIT_LOG_FILE from ConfigProperties
- Fix rotation of Tomcat's access.log