### PR TITLE
[2.4] 1668454: Fix problems with CPM.deletePools with large datasets

### DIFF
--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -2155,9 +2155,19 @@ public class CandlepinPoolManager implements PoolManager {
             // Fetch entitlements (uggh).
             // TODO: Stop doing this. Update the bits below to not use the entities directly and
             // do the updates via queries.
-            Collection<Entitlement> entitlements = !entitlementIds.isEmpty() ?
-                this.entitlementCurator.listAllByIds(entitlementIds).list() :
-                Collections.<Entitlement>emptySet();
+            // Impl note: we have to fetch these in blocks to guard against the case where we're
+            // attempting to fetch more entitlements than the parameter limit allows (~32k).
+            Set<Entitlement> entitlements = new HashSet<>();
+
+            if (!entitlementIds.isEmpty()) {
+                log.debug("IN BLOCK SIZE: {}", this.entitlementCurator.getInBlockSize());
+                Iterable<List<String>> blocks =
+                    Iterables.partition(entitlementIds, this.entitlementCurator.getInBlockSize());
+
+                for (List<String> block : blocks) {
+                    entitlements.addAll(this.entitlementCurator.listAllByIds(block).list());
+                }
+            }
 
             // Mark remaining dependent entitlements dirty for this consumer
             this.entitlementCurator.markDependentEntitlementsDirty(entitlementIds);

--- a/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -1280,10 +1280,13 @@ public class PoolManagerTest {
         when(cqmock2.list()).thenReturn(Collections.<Consumer>emptyList());
         when(consumerCuratorMock.getConsumers(anyCollection())).thenReturn(cqmock2);
 
+        // Any positive value is acceptable here
+        when(entitlementCurator.getInBlockSize()).thenReturn(50);
+
         this.manager.getRefresher(mockSubAdapter, mockOwnerAdapter).add(owner).run();
 
         verify(mockPoolCurator).batchDelete(eq(pools), anyCollectionOf(String.class));
-        verify(entitlementCurator).batchDelete(eq(poolEntitlements));
+        verify(entitlementCurator).batchDelete(eq(new HashSet<Entitlement>(poolEntitlements)));
     }
 
     private List<Pool> createPoolsWithSourceEntitlement(Entitlement e, Product p) {


### PR DESCRIPTION
- Fixed several queries which would fail when presented with large
  collections of inputs
- Reduced the chunk size of the cleanupExpiredPools operation to
  avoid hitting additional query size limits elsewhere