### PR TITLE
[M] 1650992: Increased certificate key size to 4096 bits (ENT-1069)

### DIFF
--- a/server/src/main/java/org/candlepin/pki/impl/ProviderBasedPKIUtility.java
+++ b/server/src/main/java/org/candlepin/pki/impl/ProviderBasedPKIUtility.java
@@ -65,7 +65,7 @@ public abstract class ProviderBasedPKIUtility implements PKIUtility {
     private static Logger log = LoggerFactory.getLogger(ProviderBasedPKIUtility.class);
 
     // TODO : configurable?
-    public static final int RSA_KEY_SIZE = 2048;
+    public static final int RSA_KEY_SIZE = 4096;
 
     protected CertificateReader reader;
     protected SubjectKeyIdentifierWriter subjectKeyWriter;


### PR DESCRIPTION
Testing notes:
Several rspec tests cover the CRL functionality, specifically the cert_revocation_spec, but also the client_v1_size_spec. At one point I saw failures in the CRL processing (unexpected EOL), but after regenerating a new CRL, no amount of switching between 2048- and 4096-bit builds could re-trigger them. May be unrelated, but something to be aware of while testing.

Additionally, it's important to verify that subscription manager can perform various actions against this branch, including status, register and attach; both with a newly registered system and a system that was already registered against CP with a 2048-bit key size.

When this branch is confirmed safe, the other two PRs will go up for the 2.5 and 2.3 branches.