### PR TITLE
[2.5] 1674419: changed the possible syspurpose status states

### DIFF
--- a/server/spec/autobind_spec.rb
+++ b/server/spec/autobind_spec.rb
@@ -143,7 +143,7 @@ describe 'Autobind On Owner' do
         random_string('systempurpose'), :system, nil, {}, nil, owner_key, [], installed, nil, [],
         nil, [], nil, nil, nil, nil, nil, 0, nil, nil, nil, nil, ['addon1'])
     status = @cp.get_purpose_compliance(consumer['uuid'])
-    status['status'].should == 'invalid'
+    status['status'].should == 'mismatched'
     status['nonCompliantAddOns'].include?('addon1').should == true
 
     @cp.consume_product(nil, {:uuid => consumer.uuid})
@@ -151,7 +151,7 @@ describe 'Autobind On Owner' do
     entitlements.size.should == 2
     # print ("entitlements: " + entitlements.inspect())
     status = @cp.get_purpose_compliance(consumer.uuid)
-    status['status'].should == 'valid'
+    status['status'].should == 'matched'
     status['nonCompliantAddOns'].size.should == 0
     status['compliantAddOns']['addon1'][0]['pool']['id'].should == p1.id
   end
@@ -174,7 +174,7 @@ describe 'Autobind On Owner' do
         random_string('systempurpose'), :system, nil, {}, nil, owner_key, [], installed, nil, [],
         nil, [], nil, nil, nil, nil, nil, 0, nil, nil, 'role1', nil, [])
     status = @cp.get_purpose_compliance(consumer['uuid'])
-    status['status'].should == 'invalid'
+    status['status'].should == 'mismatched'
     status['nonCompliantRole'].include?('role1').should == true
 
     @cp.consume_product(nil, {:uuid => consumer.uuid})
@@ -182,7 +182,7 @@ describe 'Autobind On Owner' do
     entitlements.size.should == 2
     # print ("entitlements: " + entitlements.inspect())
     status = @cp.get_purpose_compliance(consumer.uuid)
-    status['status'].should == 'valid'
+    status['status'].should == 'matched'
     status['nonCompliantRole'].should be_nil
     status['compliantRole']['role1'][0]['pool']['id'].should == p1.id
   end
@@ -208,7 +208,7 @@ describe 'Autobind On Owner' do
         random_string('systempurpose'), :system, nil, {}, nil, owner_key, [], installed, nil, [],
         nil, [], nil, nil, nil, nil, nil, 0, nil, nil, 'role1', nil, [])
     status = @cp.get_purpose_compliance(consumer['uuid'])
-    status['status'].should == 'invalid'
+    status['status'].should == 'mismatched'
     status['nonCompliantRole'].include?('role1').should == true
 
     @cp.consume_product(nil, {:uuid => consumer.uuid})
@@ -216,7 +216,7 @@ describe 'Autobind On Owner' do
     entitlements.size.should == 1
     # print ("entitlements: " + entitlements.inspect())
     status = @cp.get_purpose_compliance(consumer.uuid)
-    status['status'].should == 'valid'
+    status['status'].should == 'matched'
     status['nonCompliantRole'].should be_nil
     status['compliantRole']['role1'][0]['pool']['id'].should == p1.id
   end
@@ -242,7 +242,7 @@ describe 'Autobind On Owner' do
         random_string('systempurpose'), :system, nil, {}, nil, owner_key, [], installed, nil, [],
         nil, [], nil, nil, nil, nil, nil, 0, nil, nil, nil, nil, ['addon1'])
     status = @cp.get_purpose_compliance(consumer['uuid'])
-    status['status'].should == 'invalid'
+    status['status'].should == 'mismatched'
     status['nonCompliantAddOns'].include?('addon1').should == true
 
     @cp.consume_product(nil, {:uuid => consumer.uuid})
@@ -250,7 +250,7 @@ describe 'Autobind On Owner' do
     entitlements.size.should == 1
     # print ("entitlements: " + entitlements.inspect())
     status = @cp.get_purpose_compliance(consumer.uuid)
-    status['status'].should == 'valid'
+    status['status'].should == 'matched'
     status['nonCompliantAddOns'].size.should == 0
     status['compliantAddOns']['addon1'][0]['pool']['id'].should == p1.id
   end
@@ -274,7 +274,7 @@ describe 'Autobind On Owner' do
         random_string('systempurpose'), :system, nil, {}, nil, owner_key, [], installed, nil, [],
         nil, [], nil, nil, nil, nil, nil, 0, nil, nil, nil, nil, ['addon1','addon2'])
     status = @cp.get_purpose_compliance(consumer['uuid'])
-    status['status'].should == 'invalid'
+    status['status'].should == 'mismatched'
     status['nonCompliantAddOns'].include?('addon1').should == true
 
     @cp.consume_product(nil, {:uuid => consumer.uuid})
@@ -282,7 +282,7 @@ describe 'Autobind On Owner' do
     entitlements.size.should == 2
     # print ("entitlements: " + entitlements.inspect())
     status = @cp.get_purpose_compliance(consumer.uuid)
-    status['status'].should == 'valid'
+    status['status'].should == 'matched'
     status['nonCompliantAddOns'].size.should == 0
     status['compliantAddOns']['addon1'][0]['pool']['id'].should == p1.id
     status['compliantAddOns']['addon2'][0]['pool']['id'].should == p2.id
@@ -309,7 +309,7 @@ describe 'Autobind On Owner' do
         random_string('systempurpose'), :system, nil, {}, nil, owner_key, [], installed, nil, [],
         nil, [], nil, nil, nil, nil, nil, 0, nil, nil, nil, "my_usage", [])
     status = @cp.get_purpose_compliance(consumer['uuid'])
-    status['status'].should == 'invalid'
+    status['status'].should == 'mismatched'
     status['nonCompliantUsage'].include?('my_usage').should == true
 
     @cp.consume_product(nil, {:uuid => consumer.uuid})
@@ -318,7 +318,7 @@ describe 'Autobind On Owner' do
     entitlements[0].pool.id.should == p1.id
 
     status = @cp.get_purpose_compliance(consumer.uuid)
-    status['status'].should == 'valid'
+    status['status'].should == 'matched'
     status['nonCompliantUsage'].should be_nil
     status['compliantUsage']['my_usage'][0]['pool']['id'].should == p1.id
   end
@@ -342,7 +342,7 @@ describe 'Autobind On Owner' do
         nil, [], nil, nil, nil, nil, nil, 0, nil, nil, "provided_role", nil, [])
 
     status = @cp.get_purpose_compliance(consumer['uuid'])
-    status['status'].should == 'invalid'
+    status['status'].should == 'mismatched'
     status['nonCompliantRole'].include?('provided_role').should == true
 
     @cp.consume_product(nil, {:uuid => consumer.uuid})
@@ -351,7 +351,7 @@ describe 'Autobind On Owner' do
     entitlements[0].pool.id.should == p1.id
 
     status = @cp.get_purpose_compliance(consumer.uuid)
-    status['status'].should == 'valid'
+    status['status'].should == 'matched'
     status['nonCompliantRole'].should be_nil
     status['compliantRole']['provided_role'][0]['pool']['id'].should == p1.id
   end
@@ -375,7 +375,7 @@ describe 'Autobind On Owner' do
         nil, [], nil, nil, nil, nil, nil, 0, nil, nil, nil, nil, ["provided_addon", "random_addon"])
 
     status = @cp.get_purpose_compliance(consumer['uuid'])
-    status['status'].should == 'invalid'
+    status['status'].should == 'mismatched'
     status['nonCompliantAddOns'].include?('provided_addon').should == true
     status['nonCompliantAddOns'].include?('random_addon').should == true
 
@@ -385,7 +385,7 @@ describe 'Autobind On Owner' do
     entitlements[0].pool.id.should == p1.id
 
     status = @cp.get_purpose_compliance(consumer.uuid)
-    status['status'].should == 'partial'
+    status['status'].should == 'mismatched'
     status['nonCompliantAddOns'].include?('random_addon').should == true
     status['compliantAddOns']['provided_addon'][0]['pool']['id'].should == p1.id
   end
@@ -409,7 +409,7 @@ describe 'Autobind On Owner' do
         nil, [], nil, nil, nil, nil, nil, 0, nil, nil, nil, "provided_usage", [])
 
     status = @cp.get_purpose_compliance(consumer['uuid'])
-    status['status'].should == 'invalid'
+    status['status'].should == 'mismatched'
     status['nonCompliantUsage'].include?('provided_usage').should == true
 
     @cp.consume_product(nil, {:uuid => consumer.uuid})
@@ -417,7 +417,7 @@ describe 'Autobind On Owner' do
     entitlements.size.should == 0
 
     status = @cp.get_purpose_compliance(consumer.uuid)
-    status['status'].should == 'invalid'
+    status['status'].should == 'mismatched'
     status['nonCompliantUsage'].include?('provided_usage').should == true
   end
 
@@ -440,7 +440,7 @@ describe 'Autobind On Owner' do
         nil, [], nil, nil, nil, nil, nil, 0, nil, "provided_sla", nil, nil, [])
 
     status = @cp.get_purpose_compliance(consumer['uuid'])
-    status['status'].should == 'invalid'
+    status['status'].should == 'mismatched'
     status['nonCompliantSLA'].include?('provided_sla').should == true
 
     @cp.consume_product(nil, {:uuid => consumer.uuid})
@@ -448,7 +448,7 @@ describe 'Autobind On Owner' do
     entitlements.size.should == 0
 
     status = @cp.get_purpose_compliance(consumer.uuid)
-    status['status'].should == 'invalid'
+    status['status'].should == 'mismatched'
     status['nonCompliantSLA'].include?('provided_sla').should == true
   end
 
@@ -497,7 +497,7 @@ describe 'Autobind On Owner' do
             "provided_sla", "provided_role", "provided_usage", ["provided_addon", "another_addon"])
 
     status = @cp.get_purpose_compliance(consumer['uuid'])
-    status['status'].should == 'invalid'
+    status['status'].should == 'mismatched'
     status['nonCompliantSLA'].include?('provided_sla').should == true
     status['nonCompliantUsage'].include?('provided_usage').should == true
     status['nonCompliantRole'].include?('provided_role').should == true
@@ -527,7 +527,7 @@ describe 'Autobind On Owner' do
     end
 
     status = @cp.get_purpose_compliance(consumer.uuid)
-    status['status'].should == 'invalid'
+    status['status'].should == 'mismatched'
     status['nonCompliantSLA'].include?('provided_sla').should == true
     status['nonCompliantUsage'].include?('provided_usage').should == true
     status['nonCompliantAddOns'].include?('another_addon').should == true

--- a/server/src/main/java/org/candlepin/dto/api/v1/SystemPurposeComplianceStatusDTO.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/SystemPurposeComplianceStatusDTO.java
@@ -50,8 +50,6 @@ public class SystemPurposeComplianceStatusDTO extends CandlepinDTO<SystemPurpose
     protected Map<String, Set<EntitlementDTO>> compliantAddOns;
     protected Map<String, Set<EntitlementDTO>> compliantSLA;
     protected Map<String, Set<EntitlementDTO>> compliantUsage;
-    protected Map<String, Set<EntitlementDTO>> nonPreferredSLA;
-    protected Map<String, Set<EntitlementDTO>> nonPreferredUsage;
 
     protected Set<String> reasons;
 
@@ -233,48 +231,6 @@ public class SystemPurposeComplianceStatusDTO extends CandlepinDTO<SystemPurpose
         return this;
     }
 
-    public Map<String, Set<EntitlementDTO>> getNonPreferredSLA() {
-        return getMapOfSets(nonPreferredSLA);
-    }
-
-    public SystemPurposeComplianceStatusDTO setNonPreferredSLA(
-        Map<String, Set<EntitlementDTO>> nonPreferredSLA) {
-        if (nonPreferredSLA != null) {
-            if (this.nonPreferredSLA == null) {
-                this.nonPreferredSLA = new HashMap<>();
-            }
-
-            this.nonPreferredSLA.clear();
-            this.nonPreferredSLA.putAll(nonPreferredSLA);
-        }
-        else {
-            this.nonPreferredSLA = null;
-        }
-
-        return this;
-    }
-
-    public Map<String, Set<EntitlementDTO>> getNonPreferredUsage() {
-        return getMapOfSets(nonPreferredUsage);
-    }
-
-    public SystemPurposeComplianceStatusDTO setNonPreferredUsage(
-        Map<String, Set<EntitlementDTO>> nonPreferredUsage) {
-        if (nonPreferredUsage != null) {
-            if (this.nonPreferredUsage == null) {
-                this.nonPreferredUsage = new HashMap<>();
-            }
-
-            this.nonPreferredUsage.clear();
-            this.nonPreferredUsage.putAll(nonPreferredUsage);
-        }
-        else {
-            this.nonPreferredUsage = null;
-        }
-
-        return this;
-    }
-
     public Set<String> getReasons() {
         return this.reasons != null ? new SetView(this.reasons) : null;
     }
@@ -323,9 +279,6 @@ public class SystemPurposeComplianceStatusDTO extends CandlepinDTO<SystemPurpose
             equals = equals && this.compareMapContents(this.getCompliantAddOns(), that.getCompliantAddOns());
             equals = equals && this.compareMapContents(this.getCompliantSLA(), that.getCompliantSLA());
             equals = equals && this.compareMapContents(this.getCompliantUsage(), that.getCompliantUsage());
-            equals = equals && this.compareMapContents(this.getNonPreferredSLA(), that.getNonPreferredSLA());
-            equals = equals && this.compareMapContents(this.getNonPreferredUsage(),
-                that.getNonPreferredUsage());
 
             return equals;
         }
@@ -397,8 +350,6 @@ public class SystemPurposeComplianceStatusDTO extends CandlepinDTO<SystemPurpose
         int compliantAddOnsHash = this.buildMapHash(this.getCompliantAddOns());
         int compliantUsageHash = this.buildMapHash(this.getCompliantUsage());
         int compliantSLAHash = this.buildMapHash(this.getCompliantSLA());
-        int nonPreferredSLAHash = this.buildMapHash(this.getNonPreferredSLA());
-        int nonPreferredUsageHash = this.buildMapHash(this.getNonPreferredUsage());
 
         HashCodeBuilder builder = new HashCodeBuilder(7, 17)
             .append(this.getStatus())
@@ -408,8 +359,6 @@ public class SystemPurposeComplianceStatusDTO extends CandlepinDTO<SystemPurpose
             .append(compliantAddOnsHash)
             .append(compliantUsageHash)
             .append(compliantSLAHash)
-            .append(nonPreferredSLAHash)
-            .append(nonPreferredUsageHash)
             .append(this.getNonCompliantRole())
             .append(this.getNonCompliantAddOns())
             .append(this.getNonCompliantUsage())
@@ -473,18 +422,6 @@ public class SystemPurposeComplianceStatusDTO extends CandlepinDTO<SystemPurpose
             copy.setCompliantSLA(compliantSLAMap);
         }
 
-        Map<String, Set<EntitlementDTO>> nonPreferredSLAMap = this.getNonPreferredSLA();
-        copy.setNonPreferredSLA(null);
-        if (nonPreferredSLAMap != null) {
-            copy.setNonPreferredSLA(nonPreferredSLAMap);
-        }
-
-        Map<String, Set<EntitlementDTO>> nonPreferredUsageMap = this.getNonPreferredUsage();
-        copy.setNonPreferredUsage(null);
-        if (nonPreferredUsageMap != null) {
-            copy.setNonPreferredUsage(nonPreferredUsageMap);
-        }
-
         Set<String> nonCompliantAddOns = this.getNonCompliantAddOns();
         copy.setNonCompliantAddOns(null);
         if (nonCompliantAddOns != null) {
@@ -515,8 +452,6 @@ public class SystemPurposeComplianceStatusDTO extends CandlepinDTO<SystemPurpose
             this.setCompliantAddOns(source.getCompliantAddOns());
             this.setCompliantUsage(source.getCompliantUsage());
             this.setCompliantSLA(source.getCompliantSLA());
-            this.setNonPreferredSLA(source.getNonPreferredSLA());
-            this.setNonPreferredUsage(source.getNonPreferredUsage());
             this.setNonCompliantRole(source.getNonCompliantRole());
             this.setNonCompliantAddOns(source.getNonCompliantAddOns());
             this.setNonCompliantUsage(source.getNonCompliantUsage());

--- a/server/src/main/java/org/candlepin/dto/api/v1/SystemPurposeComplianceStatusTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/SystemPurposeComplianceStatusTranslator.java
@@ -95,8 +95,6 @@ public class SystemPurposeComplianceStatusTranslator implements
             Map<String, Set<Entitlement>> compliantAddOns = source.getCompliantAddOns();
             Map<String, Set<Entitlement>> compliantUsage = source.getCompliantUsage();
             Map<String, Set<Entitlement>> compliantSLA = source.getCompliantSLA();
-            Map<String, Set<Entitlement>> nonPreferredSLA = source.getNonPreferredSLA();
-            Map<String, Set<Entitlement>> nonPreferredUsage = source.getNonPreferredUsage();
 
             if (compliantRole != null) {
                 compliantRole.values().forEach(entitlements::addAll);
@@ -114,14 +112,6 @@ public class SystemPurposeComplianceStatusTranslator implements
                 compliantSLA.values().forEach(entitlements::addAll);
             }
 
-            if (nonPreferredSLA != null) {
-                nonPreferredSLA.values().forEach(entitlements::addAll);
-            }
-
-            if (nonPreferredUsage != null) {
-                nonPreferredUsage.values().forEach(entitlements::addAll);
-            }
-
             // TODO: Use the bulk translation once available
             for (Entitlement entitlement : entitlements) {
                 EntitlementDTO dto = translator.translate(entitlement, EntitlementDTO.class);
@@ -136,16 +126,12 @@ public class SystemPurposeComplianceStatusTranslator implements
             destination.setCompliantAddOns(this.translateEntitlementMap(compliantAddOns, translated));
             destination.setCompliantUsage(this.translateEntitlementMap(compliantUsage, translated));
             destination.setCompliantSLA(this.translateEntitlementMap(compliantSLA, translated));
-            destination.setNonPreferredSLA(this.translateEntitlementMap(nonPreferredSLA, translated));
-            destination.setNonPreferredUsage(this.translateEntitlementMap(nonPreferredUsage, translated));
         }
         else {
             destination.setCompliantRole(null);
             destination.setCompliantAddOns(null);
             destination.setCompliantUsage(null);
             destination.setCompliantSLA(null);
-            destination.setNonPreferredSLA(null);
-            destination.setNonPreferredUsage(null);
         }
 
         return destination;

--- a/server/src/main/java/org/candlepin/policy/SystemPurposeComplianceRules.java
+++ b/server/src/main/java/org/candlepin/policy/SystemPurposeComplianceRules.java
@@ -145,9 +145,6 @@ public class SystemPurposeComplianceRules {
                     if (sla.equalsIgnoreCase(preferredSla)) {
                         status.addCompliantSLA(sla, entitlement);
                     }
-                    else {
-                        status.addNonPreferredSLA(preferredSla, sla, entitlement);
-                    }
                 }
 
                 if (StringUtils.isNotEmpty(preferredUsage) &&
@@ -155,9 +152,6 @@ public class SystemPurposeComplianceRules {
                     String usage = product.getAttributeValue(Product.Attributes.USAGE);
                     if (usage.equalsIgnoreCase(preferredUsage)) {
                         status.addCompliantUsage(usage, entitlement);
-                    }
-                    else {
-                        status.addNonPreferredUsage(preferredUsage, usage, entitlement);
                     }
                 }
             }

--- a/server/src/main/java/org/candlepin/policy/js/compliance/hash/ComplianceStatusHasher.java
+++ b/server/src/main/java/org/candlepin/policy/js/compliance/hash/ComplianceStatusHasher.java
@@ -48,9 +48,7 @@ public class ComplianceStatusHasher extends Hasher {
         putCollection(status.getCompliantAddOns().keySet(), HashableStringGenerators.STRING);
         putCollection(status.getNonCompliantAddOns(), HashableStringGenerators.STRING);
         putCollection(status.getCompliantSLA().keySet() , HashableStringGenerators.STRING);
-        putCollection(status.getNonPreferredSLA().keySet() , HashableStringGenerators.STRING);
         putCollection(status.getCompliantUsage().keySet() , HashableStringGenerators.STRING);
-        putCollection(status.getNonPreferredUsage().keySet() , HashableStringGenerators.STRING);
         putObject(consumer, HashableStringGenerators.CONSUMER);
     }
 

--- a/server/src/test/java/org/candlepin/dto/api/v1/SystemPurposeComplianceStatusDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/SystemPurposeComplianceStatusDTOTest.java
@@ -72,8 +72,6 @@ public class SystemPurposeComplianceStatusDTOTest extends AbstractDTOTest<System
         this.values.put("CompliantAddOns", compliantAddOns);
         this.values.put("CompliantUsage", compliantUsage);
         this.values.put("CompliantSLA", compliantSLA);
-        this.values.put("NonPreferredSLA", nonPreferredSLA);
-        this.values.put("NonPreferredUsage", nonPreferredUsage);
         this.values.put("Reasons", reasons);
     }
 

--- a/server/src/test/java/org/candlepin/dto/api/v1/SystemPurposeComplianceStatusTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/SystemPurposeComplianceStatusTranslatorTest.java
@@ -87,8 +87,6 @@ public class SystemPurposeComplianceStatusTranslatorTest extends
             source.addCompliantAddOn("a" + i, this.generateEntitlement("addOn", i));
             source.addCompliantUsage("u" + i, this.generateEntitlement("usage", i));
             source.addCompliantSLA("a" + i, this.generateEntitlement("SLA", i));
-            source.addNonPreferredUsage("npu" + i, "anpu" + i, this.generateEntitlement("nonPrefSLA", i));
-            source.addNonPreferredSLA("nps" + i, "anps" + i, this.generateEntitlement("nonPrefUsage", i));
         }
 
         source.setDate(new Date());
@@ -131,16 +129,12 @@ public class SystemPurposeComplianceStatusTranslatorTest extends
                 this.compareEntitlementMaps(source.getCompliantAddOns(), dest.getCompliantAddOns());
                 this.compareEntitlementMaps(source.getCompliantUsage(), dest.getCompliantUsage());
                 this.compareEntitlementMaps(source.getCompliantSLA(), dest.getCompliantSLA());
-                this.compareEntitlementMaps(source.getNonPreferredSLA(), dest.getNonPreferredSLA());
-                this.compareEntitlementMaps(source.getNonPreferredUsage(), dest.getNonPreferredUsage());
             }
             else {
                 assertNull(dest.getCompliantRole());
                 assertNull(dest.getCompliantAddOns());
                 assertNull(dest.getCompliantUsage());
                 assertNull(dest.getCompliantSLA());
-                assertNull(dest.getNonPreferredSLA());
-                assertNull(dest.getNonPreferredUsage());
             }
         }
         else {


### PR DESCRIPTION
- Now the syspurpose status states will be 'matched', 'mismatched' and
  'not specified', instead of 'valid', 'invalid' and 'partial'
- Scenarios of mixed SLAs/Usages that would previously fall under the
  'partial' category, will now be 'matched'. Scenarios of multiple
  addons that are not all satisfied, that would previously fall under
  the 'partial' category, will now be 'mismatched'
- Also, an additional reason will not be added for each pool that has a
  mismatched sla or usage. Only one general mismatch reason is sent now