### PR TITLE
[2.5] 1674544: Added input partitioning to select ConsumerCurator methods

### DIFF
--- a/server/src/main/java/org/candlepin/resteasy/filter/EntityStore.java
+++ b/server/src/main/java/org/candlepin/resteasy/filter/EntityStore.java
@@ -18,7 +18,6 @@ import org.candlepin.model.Owner;
 import org.candlepin.model.Persisted;
 
 import java.util.Collection;
-import java.util.List;
 
 /**
  * Classes implementing EntityStore are used to look up the Owner for a particular
@@ -28,6 +27,6 @@ import java.util.List;
  */
 interface EntityStore<E extends Persisted> {
     E lookup(String key);
-    List<E> lookup(Collection<String> keys);
+    Collection<E> lookup(Collection<String> keys);
     Owner getOwner(E entity);
 }

--- a/server/src/main/java/org/candlepin/resteasy/filter/StoreFactory.java
+++ b/server/src/main/java/org/candlepin/resteasy/filter/StoreFactory.java
@@ -141,11 +141,11 @@ public class StoreFactory {
         }
 
         @Override
-        public List<Consumer> lookup(Collection<String> keys) {
+        public Collection<Consumer> lookup(Collection<String> keys) {
             // Do not look for deleted consumers because we do not want to throw
             // an exception and reject the whole request just because one of
             // the requested items is deleted.
-            return consumerCurator.findByUuids(keys).list();
+            return consumerCurator.findByUuids(keys);
         }
 
         @Override

--- a/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -1301,9 +1301,7 @@ public class PoolManagerTest {
         when(cqmock.list()).thenReturn(Collections.<Pool>emptyList());
         when(mockPoolCurator.getPoolsBySubscriptionIds(anyList())).thenReturn(cqmock);
 
-        CandlepinQuery<Consumer> cqmock2 = mock(CandlepinQuery.class);
-        when(cqmock2.list()).thenReturn(Collections.<Consumer>emptyList());
-        when(consumerCuratorMock.getConsumers(anyCollection())).thenReturn(cqmock2);
+        when(consumerCuratorMock.getConsumers(anyCollection())).thenReturn(Collections.<Consumer>emptyList());
 
         // Any positive value is acceptable here
         when(entitlementCurator.getInBlockSize()).thenReturn(50);

--- a/server/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
@@ -13,13 +13,9 @@
  * in this software or its documentation.
  */
 package org.candlepin.model;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 import org.candlepin.common.config.Configuration;
 import org.candlepin.common.exceptions.NotFoundException;
@@ -44,6 +40,7 @@ import java.lang.reflect.Field;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -178,8 +175,7 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
 
     private Consumer createConsumerAndBindItToProduct(Owner o, Product product, String subId) {
         Consumer c = createConsumer(o);
-        Pool p = createPool(o, product, 1L, subId,
-            "subsSubKey", Util.yesterday(), Util.tomorrow());
+        Pool p = createPool(o, product, 1L, subId, "subsSubKey", Util.yesterday(), Util.tomorrow());
         createEntitlement(o, c, p, null);
         return c;
     }
@@ -214,7 +210,7 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
         assertTrue(expected.isEmpty());
 
         List<String> cids = Arrays.asList("c1", "c2", "c3");
-        List<Consumer> actual = consumerCurator.getConsumers(cids).list();
+        Collection<Consumer> actual = consumerCurator.getConsumers(cids);
         assertTrue(actual.isEmpty());
     }
 
@@ -235,7 +231,7 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
         assertTrue(expected.contains(c3));
 
         List<String> cids = Arrays.asList(c1.getId(), c2.getId(), c3.getId());
-        List<Consumer> actual = consumerCurator.getConsumers(cids).list();
+        Collection<Consumer> actual = consumerCurator.getConsumers(cids);
         assertEquals(3, actual.size());
         assertTrue(actual.contains(c1));
         assertTrue(actual.contains(c2));
@@ -265,7 +261,7 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
         assertTrue(expected.contains(c5));
 
         List<String> cids = Arrays.asList(c1.getId(), c3.getId(), c5.getId());
-        List<Consumer> actual = consumerCurator.getConsumers(cids).list();
+        Collection<Consumer> actual = consumerCurator.getConsumers(cids);
         assertEquals(3, actual.size());
         assertTrue(actual.contains(c1));
         assertTrue(actual.contains(c3));
@@ -275,7 +271,7 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void testGetConsumersFetchLessThanRequested() {
+    public void testGetConsumersFetchFewerThanRequested() {
         Consumer c1 = new Consumer("c1", "u1", owner, ct);
         Consumer c2 = new Consumer("c2", "u1", owner, ct);
         Consumer c3 = new Consumer("c3", "u1", owner, ct);
@@ -291,7 +287,7 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
         assertTrue(expected.contains(c3));
 
         List<String> cids = Arrays.asList(c1.getId(), c2.getId(), c3.getId(), "c4", "c5");
-        List<Consumer> actual = consumerCurator.getConsumers(cids).list();
+        Collection<Consumer> actual = consumerCurator.getConsumers(cids);
         assertEquals(3, actual.size());
         assertTrue(actual.contains(c1));
         assertTrue(actual.contains(c2));
@@ -314,8 +310,53 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
         assertTrue(expected.contains(c2));
         assertTrue(expected.contains(c3));
 
-        List<Consumer> actual = consumerCurator.getConsumers(null).list();
+        Collection<Consumer> actual = consumerCurator.getConsumers(null);
         assertEquals(0, actual.size());
+    }
+
+    @Test
+    public void testGetConsumerInputPartioning() {
+        int partitionBlockSize = 5;
+
+        ConsumerCurator curator = Mockito.spy(consumerCurator);
+        when(curator.getInBlockSize()).thenReturn(partitionBlockSize);
+
+        Map<String, Consumer> consumers = new HashMap<>();
+
+        // Create a pile of consumers
+        for (int i = 0; i < partitionBlockSize * 5; ++i) {
+            Consumer consumer = new Consumer("consumer-" + i, "user-" + i, owner, ct);
+            consumer.setUuid("uuid-" + i);
+
+            curator.create(consumer);
+
+            consumers.put(consumer.getUuid(), consumer);
+        }
+
+        curator.flush();
+
+        Set<String> input = new HashSet<>();
+        Set<Consumer> expected = new HashSet<>();
+        for (int i = 0; i < partitionBlockSize * 10; ++i) {
+            Consumer consumer = consumers.get("uuid-" + i);
+
+            if (consumer != null) {
+                expected.add(consumer);
+                input.add(consumer.getId());
+            }
+            else {
+                input.add("id-" + i);
+            }
+        }
+
+        // Verify we can successfully fetch all of the requested consumers
+        Collection<Consumer> output = curator.getConsumers(input);
+
+        assertEquals(output.size(), expected.size());
+
+        for (Consumer consumer : expected) {
+            assertTrue(output.contains(consumer));
+        }
     }
 
     @Test
@@ -334,7 +375,7 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
         assertTrue(expected.contains(c2));
         assertTrue(expected.contains(c3));
 
-        List<Consumer> actual = consumerCurator.getConsumers(new LinkedList()).list();
+        Collection<Consumer> actual = consumerCurator.getConsumers(new LinkedList());
         assertEquals(0, actual.size());
     }
 
@@ -788,10 +829,50 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
         consumer3.setUuid("3");
         consumer3 = consumerCurator.create(consumer3);
 
-        List<Consumer> results = consumerCurator.findByUuids(Arrays.asList("1", "2")).list();
+        Collection<Consumer> results = consumerCurator.findByUuids(Arrays.asList("1", "2"));
         assertTrue(results.contains(consumer));
         assertTrue(results.contains(consumer2));
         assertFalse(results.contains(consumer3));
+    }
+
+    @Test
+    public void testFindByUuidsInputPartioning() {
+        int partitionBlockSize = 5;
+
+        ConsumerCurator curator = Mockito.spy(consumerCurator);
+        when(curator.getInBlockSize()).thenReturn(partitionBlockSize);
+
+        Map<String, Consumer> consumers = new HashMap<>();
+
+        // Create a pile of consumers
+        for (int i = 0; i < partitionBlockSize * 5; ++i) {
+            Consumer consumer = new Consumer("consumer-" + i, "user-" + i, owner, ct);
+            consumer.setUuid("uuid-" + i);
+
+            curator.create(consumer);
+
+            consumers.put(consumer.getUuid(), consumer);
+        }
+
+        curator.flush();
+
+        Set<String> input = new HashSet<>();
+        Set<Consumer> expected = new HashSet<>();
+        for (int i = 0; i < partitionBlockSize * 3 + 1; ++i) {
+            Consumer consumer = consumers.get("uuid-" + i);
+
+            input.add(consumer.getUuid());
+            expected.add(consumer);
+        }
+
+        // Verify we can successfully fetch all of the requested consumers
+        Collection<Consumer> output = curator.findByUuids(input);
+
+        assertEquals(output.size(), expected.size());
+
+        for (Consumer consumer : expected) {
+            assertTrue(output.contains(consumer));
+        }
     }
 
     @Test
@@ -811,11 +892,51 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
         consumer3.setUuid("3");
         consumer3 = consumerCurator.create(consumer3);
 
-        List<Consumer> results = consumerCurator
-            .findByUuidsAndOwner(Arrays.asList("2"), owner2.getId()).list();
+        Collection<Consumer> results = consumerCurator
+            .findByUuidsAndOwner(Arrays.asList("2"), owner2.getId());
         assertTrue(results.contains(consumer2));
         assertFalse(results.contains(consumer));
         assertFalse(results.contains(consumer3));
+    }
+
+    @Test
+    public void testFindByUuidsAndOwnerInputPartioning() {
+        int partitionBlockSize = 5;
+
+        ConsumerCurator curator = Mockito.spy(consumerCurator);
+        when(curator.getInBlockSize()).thenReturn(partitionBlockSize);
+
+        Map<String, Consumer> consumers = new HashMap<>();
+
+        // Create a pile of consumers
+        for (int i = 0; i < partitionBlockSize * 5; ++i) {
+            Consumer consumer = new Consumer("consumer-" + i, "user-" + i, owner, ct);
+            consumer.setUuid("uuid-" + i);
+
+            curator.create(consumer);
+
+            consumers.put(consumer.getUuid(), consumer);
+        }
+
+        curator.flush();
+
+        Set<String> input = new HashSet<>();
+        Set<Consumer> expected = new HashSet<>();
+        for (int i = 0; i < partitionBlockSize * 3 + 1; ++i) {
+            Consumer consumer = consumers.get("uuid-" + i);
+
+            input.add(consumer.getUuid());
+            expected.add(consumer);
+        }
+
+        // Verify we can successfully fetch all of the requested consumers
+        Collection<Consumer> output = curator.findByUuidsAndOwner(input, owner.getId());
+
+        assertEquals(output.size(), expected.size());
+
+        for (Consumer consumer : expected) {
+            assertTrue(output.contains(consumer));
+        }
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
@@ -634,14 +634,10 @@ public class ConsumerResourceTest {
         consumers.add(c);
         consumers.add(c2);
 
-        CandlepinQuery cqmock = mock(CandlepinQuery.class);
-        when(cqmock.list()).thenReturn(consumers);
-        when(cqmock.iterator()).thenReturn(consumers.iterator());
-
         List<String> uuids = new ArrayList<>();
         uuids.add(c.getUuid());
         uuids.add(c2.getUuid());
-        when(mockConsumerCurator.findByUuids(eq(uuids))).thenReturn(cqmock);
+        when(mockConsumerCurator.findByUuids(eq(uuids))).thenReturn(consumers);
 
         ComplianceStatus status = new ComplianceStatus();
         when(mockComplianceRules.getStatus(any(Consumer.class), any(Date.class)))


### PR DESCRIPTION
- Added input partioning to ConsumerCurator.getConsumers, .findByUuids,
  and .findByUuidsAndOwner. This will avoid hitting the query
  parameter limit with large consumer sets.