### PR TITLE
[2.4] 1674546: Added input partitioning to select ConsumerCurator methods

### DIFF
--- a/server/src/main/java/org/candlepin/model/ConsumerCurator.java
+++ b/server/src/main/java/org/candlepin/model/ConsumerCurator.java
@@ -267,20 +267,38 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
     }
 
     @Transactional
-    public CandlepinQuery<Consumer> findByUuids(Collection<String> uuids) {
-        DetachedCriteria criteria = this.createSecureDetachedCriteria()
-            .add(Restrictions.in("uuid", uuids));
+    public Collection<Consumer> findByUuids(Collection<String> uuids) {
+        Set<Consumer> consumers = new HashSet<>();
 
-        return this.cpQueryFactory.<Consumer>buildQuery(this.currentSession(), criteria);
+        for (List<String> block : this.partition(uuids)) {
+            // Unfortunately, this needs to be a secure criteria due to the contexts in which this
+            // is called.
+            Criteria criteria = this.createSecureCriteria()
+                .add(Restrictions.in("uuid", block));
+
+            consumers.addAll(criteria.list());
+        }
+
+        return consumers;
     }
 
     @Transactional
-    public CandlepinQuery<Consumer> findByUuidsAndOwner(Collection<String> uuids, String ownerId) {
-        DetachedCriteria criteria = DetachedCriteria.forClass(Consumer.class)
-            .add(Restrictions.eq("ownerId", ownerId))
-            .add(Restrictions.in("uuid", uuids));
+    public Collection<Consumer> findByUuidsAndOwner(Collection<String> uuids, String ownerId) {
+        Set<Consumer> consumers = new HashSet<>();
 
-        return this.cpQueryFactory.<Consumer>buildQuery(this.currentSession(), criteria);
+        javax.persistence.Query query = this.getEntityManager()
+            .createQuery("SELECT c FROM Consumer c WHERE c.ownerId = :oid AND c.uuid IN (:uuids)")
+            .setParameter("oid", ownerId);
+
+        if (uuids != null && !uuids.isEmpty()) {
+            for (List<String> block : this.partition(uuids)) {
+                query.setParameter("uuids", block);
+
+                consumers.addAll(query.getResultList());
+            }
+        }
+
+        return consumers;
     }
 
     // NOTE: This is a giant hack that is for use *only* by SSLAuth in order
@@ -304,16 +322,28 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
      * @return
      *  A query to fetch the consumers with the specified consumer IDs
      */
-    public CandlepinQuery<Consumer> getConsumers(Collection<String> consumerIds) {
+    public Collection<Consumer> getConsumers(Collection<String> consumerIds) {
         if (consumerIds != null && !consumerIds.isEmpty()) {
-            DetachedCriteria criteria = DetachedCriteria.forClass(Consumer.class)
-                .add(CPRestrictions.in("id", consumerIds));
+            List<String> cids;
 
-            return this.cpQueryFactory.<Consumer>buildQuery(this.currentSession(), criteria);
+            // Unfortunately multiLoad does not accept a generic collection, so we need to cast it
+            // or convert it as necessary.
+            if (consumerIds instanceof List) {
+                cids = (List<String>) consumerIds;
+            }
+            else {
+                cids = new ArrayList(consumerIds);
+            }
+
+            return this.currentSession()
+                .byMultipleIds(this.entityType())
+                .enableSessionCheck(true)
+                .multiLoad(cids);
         }
 
-        return this.cpQueryFactory.<Consumer>buildQuery();
+        return Collections.emptyList();
     }
+
 
     @SuppressWarnings("unchecked")
     @Transactional

--- a/server/src/main/java/org/candlepin/resteasy/filter/EntityStore.java
+++ b/server/src/main/java/org/candlepin/resteasy/filter/EntityStore.java
@@ -18,7 +18,6 @@ import org.candlepin.model.Owner;
 import org.candlepin.model.Persisted;
 
 import java.util.Collection;
-import java.util.List;
 
 /**
  * Classes implementing EntityStore are used to look up the Owner for a particular
@@ -28,6 +27,6 @@ import java.util.List;
  */
 interface EntityStore<E extends Persisted> {
     E lookup(String key);
-    List<E> lookup(Collection<String> keys);
+    Collection<E> lookup(Collection<String> keys);
     Owner getOwner(E entity);
 }

--- a/server/src/main/java/org/candlepin/resteasy/filter/StoreFactory.java
+++ b/server/src/main/java/org/candlepin/resteasy/filter/StoreFactory.java
@@ -141,11 +141,11 @@ public class StoreFactory {
         }
 
         @Override
-        public List<Consumer> lookup(Collection<String> keys) {
+        public Collection<Consumer> lookup(Collection<String> keys) {
             // Do not look for deleted consumers because we do not want to throw
             // an exception and reject the whole request just because one of
             // the requested items is deleted.
-            return consumerCurator.findByUuids(keys).list();
+            return consumerCurator.findByUuids(keys);
         }
 
         @Override

--- a/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -1276,9 +1276,7 @@ public class PoolManagerTest {
         when(cqmock.list()).thenReturn(Collections.<Pool>emptyList());
         when(mockPoolCurator.getPoolsBySubscriptionIds(anyList())).thenReturn(cqmock);
 
-        CandlepinQuery<Consumer> cqmock2 = mock(CandlepinQuery.class);
-        when(cqmock2.list()).thenReturn(Collections.<Consumer>emptyList());
-        when(consumerCuratorMock.getConsumers(anyCollection())).thenReturn(cqmock2);
+        when(consumerCuratorMock.getConsumers(anyCollection())).thenReturn(Collections.<Consumer>emptyList());
 
         // Any positive value is acceptable here
         when(entitlementCurator.getInBlockSize()).thenReturn(50);

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
@@ -776,14 +776,10 @@ public class ConsumerResourceTest {
         consumers.add(c);
         consumers.add(c2);
 
-        CandlepinQuery cqmock = mock(CandlepinQuery.class);
-        when(cqmock.list()).thenReturn(consumers);
-        when(cqmock.iterator()).thenReturn(consumers.iterator());
-
         List<String> uuids = new ArrayList<>();
         uuids.add(c.getUuid());
         uuids.add(c2.getUuid());
-        when(mockConsumerCurator.findByUuids(eq(uuids))).thenReturn(cqmock);
+        when(mockConsumerCurator.findByUuids(eq(uuids))).thenReturn(consumers);
 
         ComplianceStatus status = new ComplianceStatus();
         when(mockComplianceRules.getStatus(any(Consumer.class), any(Date.class)))


### PR DESCRIPTION
- Added input partioning to ConsumerCurator.getConsumers, .findByUuids,
  and .findByUuidsAndOwner. This will avoid hitting the query
  parameter limit with large consumer sets.