### PR TITLE
1659345: Hypervisor reconciliation uses different attribute

### DIFF
--- a/server/spec/hypervisor_check_in_spec.rb
+++ b/server/spec/hypervisor_check_in_spec.rb
@@ -984,7 +984,7 @@ describe 'Hypervisor Resource', :type => :virt do
     result = virtwho.hypervisor_check_in(owner['key'], hostguestmapping)
     result.should_not be_nil
 
-    test_host = user.register("test-host", :system, nil, {"system_uuid" => "test-uuid", "virt.is_guest"=>"false"}, nil, owner['key'])
+    test_host = user.register("test-host", :system, nil, {"dmi.system.uuid" => "test-uuid", "virt.is_guest"=>"false"}, nil, owner['key'])
 
     @cp.list_consumers({:owner=>owner['key']}).length.should == 2
     test_host = @cp.get_consumer(test_host['uuid'])
@@ -1003,7 +1003,7 @@ describe 'Hypervisor Resource', :type => :virt do
     result_data.created.size.should == 1
     hypervisor_uuid = result_data.created[0]
 
-    test_host = user.register("test-host", :system, nil, {"system_uuid" => "test-uuid", "virt.is_guest"=>"false"}, nil, owner['key'])
+    test_host = user.register("test-host", :system, nil, {"dmi.system.uuid" => "test-uuid", "virt.is_guest"=>"false"}, nil, owner['key'])
 
     @cp.list_consumers({:owner=>owner['key']}).length.should == 1
     test_host = @cp.get_consumer(test_host['uuid'])
@@ -1015,7 +1015,7 @@ describe 'Hypervisor Resource', :type => :virt do
     owner = create_owner random_string('owner')
     user = user_client(owner, random_string('user'))
 
-    test_host = user.register("test-host", :system, nil, {"system_uuid" => "test-uuid", "virt.is_guest"=>"false"}, nil, owner['key'])
+    test_host = user.register("test-host", :system, nil, {"dmi.system.uuid" => "test-uuid", "virt.is_guest"=>"false"}, nil, owner['key'])
 
     virtwho = create_virtwho_client(user)
     host_hyp_id = "test-uuid"
@@ -1034,7 +1034,7 @@ describe 'Hypervisor Resource', :type => :virt do
     owner = create_owner random_string('owner')
     user = user_client(owner, random_string('user'))
 
-    test_host = user.register("test-host", :system, nil, {"system_uuid" => "test-uuid", "virt.is_guest"=>"false"}, nil, owner['key'])
+    test_host = user.register("test-host", :system, nil, {"dmi.system.uuid" => "test-uuid", "virt.is_guest"=>"false"}, nil, owner['key'])
 
     host_hyp_id = "test-uuid"
     guests = ['g1', 'g2']

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -595,13 +595,13 @@ public class ConsumerResource {
         }
 
         if (dto.getHypervisorId() == null &&
-            dto.getFact("system_uuid") != null &&
+            dto.getFact("dmi.system.uuid") != null &&
             !"true".equals(dto.getFact("virt.is_guest")) &&
             entity.getOwnerId() != null) {
             HypervisorId hypervisorId = new HypervisorId(
                 entity,
                 ownerCurator.findOwnerById(entity.getOwnerId()),
-                dto.getFact("system_uuid"));
+                dto.getFact("dmi.system.uuid"));
             entity.setHypervisorId(hypervisorId);
         }
 
@@ -705,11 +705,11 @@ public class ConsumerResource {
 
         // fix for duplicate hypervisor/consumer problem
         Consumer consumer = null;
-        if (ownerKey != null && dto.getFact("system_uuid") != null &&
+        if (ownerKey != null && dto.getFact("dmi.system.uuid") != null &&
             !"true".equalsIgnoreCase(dto.getFact("virt.is_guest"))) {
             Owner owner = ownerCurator.lookupByKey(ownerKey);
             if (owner != null) {
-                consumer = consumerCurator.getHypervisor(dto.getFact("system_uuid"), owner);
+                consumer = consumerCurator.getHypervisor(dto.getFact("dmi.system.uuid"), owner);
                 if (consumer != null) {
                     consumer.setIdCert(generateIdCert(consumer, false));
                     this.updateConsumer(consumer.getUuid(), dto, principal);


### PR DESCRIPTION
I initially attempted to back port all the changes Vritant had made in this area. There were too many changes necessary for that to work.

I instead updated it to use the properly named attribute.