### PR TITLE
[M] Addressed issues surrounding locking with unmanaged entities

### DIFF
--- a/server/src/main/java/org/candlepin/controller/OwnerManager.java
+++ b/server/src/main/java/org/candlepin/controller/OwnerManager.java
@@ -223,12 +223,15 @@ public class OwnerManager {
         }
 
         // Lock the owner
-        owner = ownerCurator.lockAndLoad(owner);
+        Owner locked = ownerCurator.lockAndLoad(owner);
+        if (locked == null) {
+            throw new IllegalStateException("Unable to obtain exclusive lock on owner: " + owner);
+        }
 
         // Fetch the upstream list and mode
-        String upstreamList = adapter.getContentAccessModeList(owner.getKey());
-        String upstreamMode = adapter.getContentAccessMode(owner.getKey());
-        String currentMode = owner.getContentAccessMode();
+        String upstreamList = adapter.getContentAccessModeList(locked.getKey());
+        String upstreamMode = adapter.getContentAccessMode(locked.getKey());
+        String currentMode = locked.getContentAccessMode();
 
         // This shouldn't happen, but in the event our upstream source is having issues, let's
         // not put ourselves in a bad state as well.
@@ -264,18 +267,18 @@ public class OwnerManager {
         }
 
         // Set new values
-        owner.setContentAccessModeList(upstreamList);
+        locked.setContentAccessModeList(upstreamList);
 
         // If the content access mode changed, we'll need to update it and refresh the access certs
         if (!StringUtils.isEmpty(currentMode) ? !currentMode.equals(upstreamMode) :
             !StringUtils.isEmpty(upstreamMode)) {
 
-            owner.setContentAccessMode(upstreamMode);
+            locked.setContentAccessMode(upstreamMode);
 
-            ownerCurator.merge(owner);
+            ownerCurator.merge(locked);
             ownerCurator.flush();
 
-            this.refreshOwnerForContentAccess(owner);
+            this.refreshOwnerForContentAccess(locked);
         }
     }
 
@@ -288,15 +291,18 @@ public class OwnerManager {
     @Transactional
     public void refreshOwnerForContentAccess(Owner owner) {
         // we need to update the owner's consumers if the content access mode has changed
-        owner = ownerCurator.lockAndLoad(owner);
+        Owner locked = ownerCurator.lockAndLoad(owner);
+        if (locked == null) {
+            throw new IllegalStateException("Unable to obtain exclusive lock for owner: " + owner);
+        }
 
-        String cam = owner.getContentAccessMode();
+        String cam = locked.getContentAccessMode();
         if (ContentAccessCertServiceAdapter.ENTITLEMENT_ACCESS_MODE.equals(cam)) {
-            contentAccessCertCurator.deleteForOwner(owner);
+            contentAccessCertCurator.deleteForOwner(locked);
         }
 
         // removed cached versions of content access cert data
-        ownerEnvContentAccessCurator.removeAllForOwner(owner.getId());
+        ownerEnvContentAccessCurator.removeAllForOwner(locked.getId());
         ownerCurator.flush();
     }
 

--- a/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
+++ b/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
@@ -28,21 +28,25 @@ import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.persist.Transactional;
 
+import org.hibernate.CacheMode;
 import org.hibernate.Criteria;
 import org.hibernate.NaturalIdLoadAccess;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
+import org.hibernate.LockOptions;
+import org.hibernate.LockMode;
 import org.hibernate.criterion.Criterion;
 import org.hibernate.criterion.DetachedCriteria;
 import org.hibernate.criterion.Order;
 import org.hibernate.criterion.Projection;
 import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
+import org.hibernate.engine.spi.EntityEntry;
 import org.hibernate.engine.spi.EntityKey;
 import org.hibernate.engine.spi.PersistenceContext;
+import org.hibernate.engine.spi.Status;
 import org.hibernate.internal.CriteriaImpl;
 import org.hibernate.internal.SessionImpl;
-import org.hibernate.jpa.AvailableSettings;
 import org.hibernate.metadata.ClassMetadata;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.query.NativeQuery;
@@ -63,20 +67,11 @@ import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
-import javax.persistence.CacheRetrieveMode;
-import javax.persistence.CacheStoreMode;
 import javax.persistence.EntityManager;
-import javax.persistence.FlushModeType;
 import javax.persistence.LockModeType;
 import javax.persistence.NonUniqueResultException;
-import javax.persistence.NoResultException;
 import javax.persistence.OptimisticLockException;
 import javax.persistence.TypedQuery;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.Root;
-import javax.persistence.criteria.ParameterExpression;
-import javax.persistence.criteria.Path;
 
 
 
@@ -902,9 +897,9 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
         SessionImpl session = (SessionImpl) this.currentSession();
         ClassMetadata metadata = session.getSessionFactory().getClassMetadata(this.entityType);
 
-        if (metadata == null || !metadata.hasIdentifierProperty()) {
+        if (metadata == null || !metadata.hasIdentifierProperty() || !metadata.isMutable()) {
             throw new UnsupportedOperationException(
-                "lockAndLoad only supports entities with database identifiers");
+                "lockAndLoad only supports mutable entities with database identifiers");
         }
 
         return this.lockAndLoadById(this.entityType, metadata.getIdentifier(entity, session));
@@ -939,9 +934,9 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
         final SessionImpl session = (SessionImpl) this.currentSession();
         final ClassMetadata metadata = session.getSessionFactory().getClassMetadata(this.entityType);
 
-        if (metadata == null || !metadata.hasIdentifierProperty()) {
+        if (metadata == null || !metadata.hasIdentifierProperty() || !metadata.isMutable()) {
             throw new UnsupportedOperationException(
-                "lockAndLoad only supports entities with database identifiers");
+                "lockAndLoad only supports mutable entities with database identifiers");
         }
 
         Iterable<Serializable> iterable = new Iterable<Serializable>() {
@@ -1013,9 +1008,9 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
 
         // Get the entity's metadata so we can ask Hibernate for the name of its identifier
         // and check if it's already in the session cache without doing a database lookup
-        if (metadata == null || !metadata.hasIdentifierProperty()) {
+        if (metadata == null || !metadata.hasIdentifierProperty() || !metadata.isMutable()) {
             throw new UnsupportedOperationException(
-                "lockAndLoad only supports entities with database identifiers");
+                "lockAndLoad only supports mutable entities with database identifiers");
         }
 
         // Fetch the entity persister and session context so we can check the session cache for an
@@ -1030,47 +1025,23 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
 
         if (entity == null) {
             // The entity isn't in the local session, we'll need to query for it
-
-            String idName = metadata.getIdentifierPropertyName();
-            if (idName == null) {
-                // This shouldn't happen.
-                throw new RuntimeException("Unable to fetch identifier property name");
-            }
-
-            // Impl note:
-            // We're building the query here using JPA Criteria to avoid fiddling with string
-            // building and, potentially, erroneously using the class name as the entity name.
-            // Additionally, using a query (as opposed to the .find and .load methods) lets us set
-            // the flush, cache and lock modes for the entity we're attempting to fetch.
-            CriteriaBuilder builder = entityManager.getCriteriaBuilder();
-            CriteriaQuery<E> query = builder.createQuery(entityClass);
-            Root<E> root = query.from(entityClass);
-            Path<Serializable> target = root.<Serializable>get(idName);
-            ParameterExpression<Serializable> param = builder.parameter(Serializable.class);
-
-            query.select(root).where(builder.equal(target, param));
-
-            // Note that it's critical here to set both modes, as Hibernate is wildly inconsistent
-            // (and non-standard) in which properties it actually accepts when processing its own
-            // config objects. The cache mode combination specified below ends up being evaluated
-            // by Hibernate down to a CacheMode.REFRESH.
-            try {
-                entity = entityManager.createQuery(query)
-                    .setFlushMode(FlushModeType.COMMIT)
-                    .setHint(AvailableSettings.SHARED_CACHE_RETRIEVE_MODE, CacheRetrieveMode.BYPASS)
-                    .setHint(AvailableSettings.SHARED_CACHE_STORE_MODE, CacheStoreMode.REFRESH)
-                    .setLockMode(LockModeType.PESSIMISTIC_WRITE)
-                    .setParameter(param, id)
-                    .getSingleResult();
-            }
-            catch (NoResultException exception) {
-                // No entity found matching the ID. We don't define this as an error case, so we're
-                // going to silently discard the exception.
-            }
+            entity = ((Session) session).byId(entityClass)
+                .with(new LockOptions(LockMode.PESSIMISTIC_WRITE))
+                .with(CacheMode.REFRESH)
+                .load(id);
         }
         else {
-            // It's already available locally. Issue a refresh with a lock.
-            entityManager.refresh(entity, LockModeType.PESSIMISTIC_WRITE);
+            EntityEntry entry = context.getEntry(entity);
+
+            // Make sure the entry hasn't been deleted or otherwise removed.
+            if (entry.isExistsInDatabase() && entry.getStatus() != Status.DELETED &&
+                entry.getStatus() != Status.GONE) {
+
+                entityManager.refresh(entity, LockModeType.PESSIMISTIC_WRITE);
+            }
+            else {
+                entity = null; // It's not in the DB yet/anymore. Nothing to lock or refresh here.
+            }
         }
 
         return entity;
@@ -1133,9 +1104,9 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
             SessionImpl session = (SessionImpl) this.currentSession();
             ClassMetadata metadata = session.getFactory().getClassMetadata(entityClass);
 
-            if (metadata == null || !metadata.hasIdentifierProperty()) {
+            if (metadata == null || !metadata.hasIdentifierProperty() || !metadata.isMutable()) {
                 throw new UnsupportedOperationException(
-                    "lockAndLoad only supports entities with database identifiers");
+                    "lockAndLoad only supports mutable entities with database identifiers");
             }
 
             EntityPersister persister = session.getFactory().getEntityPersister(metadata.getEntityName());
@@ -1153,7 +1124,14 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
                     E entity = (E) context.getEntity(key);
 
                     if (entity != null) {
-                        entitySet.put(id, entity);
+                        EntityEntry entry = context.getEntry(entity);
+
+                        // Make sure the entry hasn't been deleted or otherwise removed.
+                        if (entry.isExistsInDatabase() && entry.getStatus() != Status.DELETED &&
+                            entry.getStatus() != Status.GONE) {
+
+                            entitySet.put(id, entity);
+                        }
                     }
                     else {
                         idSet.add(id);
@@ -1175,43 +1153,15 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
                 }
             }
 
-            // Build a query to fetch the remaining entities
+            // Fetch the remaining entities from the DB
             if (idSet.size() > 0) {
-                // Get the entity's metadata so we can ask Hibernate for the name of its identifier
-                String idName = metadata.getIdentifierPropertyName();
-                if (idName == null) {
-                    // This shouldn't happen.
-                    throw new RuntimeException("Unable to fetch identifier property name");
-                }
-
-                // Impl note:
-                // We're building the query here using JPA Criteria to avoid fiddling with string
-                // building and, potentially, erroneously using the class name as the entity name.
-                // Additionally, using a query (as opposed to the .find and .load methods) lets us set
-                // the flush, cache and lock modes for the entity we're attempting to fetch.
-                CriteriaBuilder builder = entityManager.getCriteriaBuilder();
-                CriteriaQuery<E> query = builder.createQuery(entityClass);
-                Root<E> root = query.from(entityClass);
-                Path<Serializable> target = root.<Serializable>get(idName);
-                ParameterExpression<List> param = builder.parameter(List.class);
-
-                query.select(root).where(target.in(param));
-
-                // Note that it's critical here to set both modes, as Hibernate is wildly inconsistent
-                // (and non-standard) in which properties it actually accepts when processing its own
-                // config objects. The cache mode combination specified below ends up being evaluated
-                // by Hibernate down to a CacheMode.REFRESH.
-                TypedQuery<E> executable = entityManager.createQuery(query)
-                    .setFlushMode(FlushModeType.COMMIT)
-                    .setHint(AvailableSettings.SHARED_CACHE_RETRIEVE_MODE, CacheRetrieveMode.BYPASS)
-                    .setHint(AvailableSettings.SHARED_CACHE_STORE_MODE, CacheStoreMode.REFRESH)
-                    .setLockMode(LockModeType.PESSIMISTIC_WRITE);
-
-                // Step through the query in blocks
-                for (List<Serializable> block : Iterables.partition(idSet, getBatchBlockSize())) {
-                    executable.setParameter(param, block);
-                    result.addAll(executable.getResultList());
-                }
+                result.addAll(((Session) session)
+                    .byMultipleIds(this.entityType())
+                    .with(new LockOptions(LockMode.PESSIMISTIC_WRITE))
+                    .with(CacheMode.REFRESH)
+                    .enableSessionCheck(false)
+                    .enableOrderedReturn(false)
+                    .multiLoad(new ArrayList(idSet)));
             }
         }
 

--- a/server/src/test/java/org/candlepin/test/DatabaseTestFixture.java
+++ b/server/src/test/java/org/candlepin/test/DatabaseTestFixture.java
@@ -83,6 +83,7 @@ import com.google.inject.Module;
 import com.google.inject.persist.PersistFilter;
 import com.google.inject.util.Modules;
 
+import org.hibernate.Session;
 import org.hibernate.cfg.beanvalidation.BeanValidationEventListener;
 import org.hibernate.event.service.spi.EventListenerRegistry;
 import org.hibernate.event.spi.EventType;
@@ -302,6 +303,10 @@ public class DatabaseTestFixture {
 
     protected EntityManager getEntityManager() {
         return this.getEntityManagerProvider().get();
+    }
+
+    protected Session getCurrentSession() {
+        return (Session) this.getEntityManager().getDelegate();
     }
 
     /**


### PR DESCRIPTION
- Fixed a couple bugs with AbstractHibernateCurator.lockAndLoad
  not properly handling entities which have been deleted or
  created, but not yet flushed
- lockAndLoad now throws an exception if provided an entity which
  is immutable
- Removed the JPA criteria query building in favor of Hibernate's
  native MultiIdentifierLoadAccess entity fetching
- Updated several unit tests in accordance with the above changes,
  and added new tests for the created and deleted cases