### PR TITLE
[2.3] 1679286: Addressed issues surrounding locking with unmanaged entities

### DIFF
--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -1156,10 +1156,14 @@ public class CandlepinPoolManager implements PoolManager {
     public List<Entitlement> entitleByProductsForHost(Consumer guest, Consumer host, Date entitleDate,
         Collection<String> possiblePools) throws EntitlementRefusedException {
 
-        host = consumerCurator.lockAndLoad(host);
+        Consumer locked = consumerCurator.lockAndLoad(host);
+        if (locked == null) {
+            throw new IllegalStateException("Unable to obtain exclusive lock on host: " + host);
+        }
+
         List<Entitlement> entitlements = new LinkedList<>();
-        if (!host.getOwnerId().equals(guest.getOwnerId())) {
-            log.debug("Host {} and guest {} have different owners", host.getUuid(), guest.getUuid());
+        if (!locked.getOwnerId().equals(guest.getOwnerId())) {
+            log.debug("Host {} and guest {} have different owners", locked.getUuid(), guest.getUuid());
             return entitlements;
         }
         // Use the current date if one wasn't provided:
@@ -1167,16 +1171,16 @@ public class CandlepinPoolManager implements PoolManager {
             entitleDate = new Date();
         }
 
-        List<PoolQuantity> bestPools = getBestPoolsForHost(guest, host, entitleDate, host.getOwnerId(), null,
-            possiblePools);
+        List<PoolQuantity> bestPools = getBestPoolsForHost(guest, locked, entitleDate, locked.getOwnerId(),
+            null, possiblePools);
 
         if (bestPools == null) {
-            log.info("No entitlements for host: {}", host.getUuid());
+            log.info("No entitlements for host: {}", locked.getUuid());
             return null;
         }
 
         // now make the entitlements
-        return entitleByPools(host, convertToMap(bestPools));
+        return entitleByPools(locked, convertToMap(bestPools));
     }
 
     /**
@@ -1627,8 +1631,12 @@ public class CandlepinPoolManager implements PoolManager {
         /*
          * Grab an exclusive lock on the consumer to prevent deadlock.
          */
-        consumer = consumerCurator.lockAndLoad(consumer);
-        ConsumerType ctype = this.consumerTypeCurator.getConsumerType(consumer);
+        Consumer locked = consumerCurator.lockAndLoad(consumer);
+        if (locked == null) {
+            throw new IllegalStateException("Unable to obtain exclusive lock on consumer: " + consumer);
+        }
+
+        ConsumerType ctype = this.consumerTypeCurator.getConsumerType(locked);
 
         // Persist the entitlement after it has been updated.
         log.info("Processing entitlement and persisting.");
@@ -1640,20 +1648,20 @@ public class CandlepinPoolManager implements PoolManager {
             pool.setExported(pool.getExported() + change);
         }
         poolCurator.merge(pool);
-        consumer.setEntitlementCount(consumer.getEntitlementCount() + change);
+        locked.setEntitlementCount(locked.getEntitlementCount() + change);
 
         Map<String, Entitlement> entMap = new HashMap<>();
         entMap.put(pool.getId(), entitlement);
         Map<String, PoolQuantity> poolQuantityMap = new HashMap<>();
         poolQuantityMap.put(pool.getId(), new PoolQuantity(pool, change));
 
-        Owner owner = ownerCurator.find(consumer.getOwnerId());
+        Owner owner = ownerCurator.find(locked.getOwnerId());
 
         // the only thing we do here is decrement bonus pool quantity
-        enforcer.postEntitlement(this, consumer, owner, entMap, new ArrayList<>(), true, poolQuantityMap);
+        enforcer.postEntitlement(this, locked, owner, entMap, new ArrayList<>(), true, poolQuantityMap);
 
         // we might have changed the bonus pool quantities, revoke ents if needed.
-        checkBonusPoolQuantities(consumer.getOwnerId(), entMap);
+        checkBonusPoolQuantities(locked.getOwnerId(), entMap);
 
         // if shared ents, update shared pool quantity
         if (ctype != null && ctype.isType(ConsumerTypeEnum.SHARE)) {
@@ -1674,10 +1682,10 @@ public class CandlepinPoolManager implements PoolManager {
          * all consumer's entitlement count are updated though, so we need to update irrespective
          * of the consumer type.
          */
-        complianceRules.getStatus(consumer, null, false, false);
+        complianceRules.getStatus(locked, null, false, false);
         // Note: a quantity change should *not* need a system purpose compliance recalculation. if that is
         // not true any more, we should update that here.
-        consumerCurator.update(consumer);
+        consumerCurator.update(locked);
         poolCurator.flush();
 
         return entitlement;
@@ -1845,6 +1853,10 @@ public class CandlepinPoolManager implements PoolManager {
             }
         }
 
+        // Impl note: this will refresh pools backed by the DB, but not those newly created or deleted. Since
+        // we're operating on a list of existing entities, not expecting to pull from the DB and don't care
+        // about anything that was deleted, we can safely ignore the output here and continue working with
+        // the existing list.
         poolCurator.lockAndLoad(poolsToLock);
         log.info("Batch revoking {} entitlements", entsToRevoke.size());
         entsToRevoke = new ArrayList<>(entsToRevoke);
@@ -2363,13 +2375,17 @@ public class CandlepinPoolManager implements PoolManager {
      */
     @Override
     public Pool updatePoolQuantity(Pool pool, long adjust) {
-        pool = poolCurator.lockAndLoad(pool);
-        long newCount = pool.getQuantity() + adjust;
+        Pool locked = poolCurator.lockAndLoad(pool);
+        if (locked == null) {
+            throw new IllegalStateException("Unable to obtain exclusive lock on pool: " + pool);
+        }
+
+        long newCount = locked.getQuantity() + adjust;
         if (newCount < 0) {
             newCount = 0;
         }
-        pool.setQuantity(newCount);
-        return poolCurator.merge(pool);
+        locked.setQuantity(newCount);
+        return poolCurator.merge(locked);
     }
 
     /**

--- a/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
+++ b/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
@@ -28,21 +28,25 @@ import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.persist.Transactional;
 
+import org.hibernate.CacheMode;
 import org.hibernate.Criteria;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.SQLQuery;
+import org.hibernate.LockOptions;
+import org.hibernate.LockMode;
 import org.hibernate.criterion.Criterion;
 import org.hibernate.criterion.DetachedCriteria;
 import org.hibernate.criterion.Order;
 import org.hibernate.criterion.Projection;
 import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
+import org.hibernate.engine.spi.EntityEntry;
 import org.hibernate.engine.spi.EntityKey;
 import org.hibernate.engine.spi.PersistenceContext;
+import org.hibernate.engine.spi.Status;
 import org.hibernate.internal.CriteriaImpl;
 import org.hibernate.internal.SessionImpl;
-import org.hibernate.jpa.AvailableSettings;
 import org.hibernate.metadata.ClassMetadata;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.transform.ResultTransformer;
@@ -62,20 +66,11 @@ import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
-import javax.persistence.CacheRetrieveMode;
-import javax.persistence.CacheStoreMode;
 import javax.persistence.EntityManager;
-import javax.persistence.FlushModeType;
 import javax.persistence.LockModeType;
 import javax.persistence.NonUniqueResultException;
-import javax.persistence.NoResultException;
 import javax.persistence.OptimisticLockException;
 import javax.persistence.TypedQuery;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.Root;
-import javax.persistence.criteria.ParameterExpression;
-import javax.persistence.criteria.Path;
 
 
 
@@ -873,9 +868,9 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
         SessionImpl session = (SessionImpl) this.currentSession();
         ClassMetadata metadata = session.getSessionFactory().getClassMetadata(this.entityType);
 
-        if (metadata == null || !metadata.hasIdentifierProperty()) {
+        if (metadata == null || !metadata.hasIdentifierProperty() || !metadata.isMutable()) {
             throw new UnsupportedOperationException(
-                "lockAndLoad only supports entities with database identifiers");
+                "lockAndLoad only supports mutable entities with database identifiers");
         }
 
         return this.lockAndLoadById(this.entityType, metadata.getIdentifier(entity, session));
@@ -910,9 +905,9 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
         final SessionImpl session = (SessionImpl) this.currentSession();
         final ClassMetadata metadata = session.getSessionFactory().getClassMetadata(this.entityType);
 
-        if (metadata == null || !metadata.hasIdentifierProperty()) {
+        if (metadata == null || !metadata.hasIdentifierProperty() || !metadata.isMutable()) {
             throw new UnsupportedOperationException(
-                "lockAndLoad only supports entities with database identifiers");
+                "lockAndLoad only supports mutable entities with database identifiers");
         }
 
         Iterable<Serializable> iterable = new Iterable<Serializable>() {
@@ -984,9 +979,9 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
 
         // Get the entity's metadata so we can ask Hibernate for the name of its identifier
         // and check if it's already in the session cache without doing a database lookup
-        if (metadata == null || !metadata.hasIdentifierProperty()) {
+        if (metadata == null || !metadata.hasIdentifierProperty() || !metadata.isMutable()) {
             throw new UnsupportedOperationException(
-                "lockAndLoad only supports entities with database identifiers");
+                "lockAndLoad only supports mutable entities with database identifiers");
         }
 
         // Fetch the entity persister and session context so we can check the session cache for an
@@ -1001,47 +996,23 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
 
         if (entity == null) {
             // The entity isn't in the local session, we'll need to query for it
-
-            String idName = metadata.getIdentifierPropertyName();
-            if (idName == null) {
-                // This shouldn't happen.
-                throw new RuntimeException("Unable to fetch identifier property name");
-            }
-
-            // Impl note:
-            // We're building the query here using JPA Criteria to avoid fiddling with string
-            // building and, potentially, erroneously using the class name as the entity name.
-            // Additionally, using a query (as opposed to the .find and .load methods) lets us set
-            // the flush, cache and lock modes for the entity we're attempting to fetch.
-            CriteriaBuilder builder = entityManager.getCriteriaBuilder();
-            CriteriaQuery<E> query = builder.createQuery(entityClass);
-            Root<E> root = query.from(entityClass);
-            Path<Serializable> target = root.<Serializable>get(idName);
-            ParameterExpression<Serializable> param = builder.parameter(Serializable.class);
-
-            query.select(root).where(builder.equal(target, param));
-
-            // Note that it's critical here to set both modes, as Hibernate is wildly inconsistent
-            // (and non-standard) in which properties it actually accepts when processing its own
-            // config objects. The cache mode combination specified below ends up being evaluated
-            // by Hibernate down to a CacheMode.REFRESH.
-            try {
-                entity = entityManager.createQuery(query)
-                    .setFlushMode(FlushModeType.COMMIT)
-                    .setHint(AvailableSettings.SHARED_CACHE_RETRIEVE_MODE, CacheRetrieveMode.BYPASS)
-                    .setHint(AvailableSettings.SHARED_CACHE_STORE_MODE, CacheStoreMode.REFRESH)
-                    .setLockMode(LockModeType.PESSIMISTIC_WRITE)
-                    .setParameter(param, id)
-                    .getSingleResult();
-            }
-            catch (NoResultException exception) {
-                // No entity found matching the ID. We don't define this as an error case, so we're
-                // going to silently discard the exception.
-            }
+            entity = ((Session) session).byId(entityClass)
+                .with(new LockOptions(LockMode.PESSIMISTIC_WRITE))
+                .with(CacheMode.REFRESH)
+                .load(id);
         }
         else {
-            // It's already available locally. Issue a refresh with a lock.
-            entityManager.refresh(entity, LockModeType.PESSIMISTIC_WRITE);
+            EntityEntry entry = context.getEntry(entity);
+
+            // Make sure the entry hasn't been deleted or otherwise removed.
+            if (entry.isExistsInDatabase() && entry.getStatus() != Status.DELETED &&
+                entry.getStatus() != Status.GONE) {
+
+                entityManager.refresh(entity, LockModeType.PESSIMISTIC_WRITE);
+            }
+            else {
+                entity = null; // It's not in the DB yet/anymore. Nothing to lock or refresh here.
+            }
         }
 
         return entity;
@@ -1104,9 +1075,9 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
             SessionImpl session = (SessionImpl) this.currentSession();
             ClassMetadata metadata = session.getFactory().getClassMetadata(entityClass);
 
-            if (metadata == null || !metadata.hasIdentifierProperty()) {
+            if (metadata == null || !metadata.hasIdentifierProperty() || !metadata.isMutable()) {
                 throw new UnsupportedOperationException(
-                    "lockAndLoad only supports entities with database identifiers");
+                    "lockAndLoad only supports mutable entities with database identifiers");
             }
 
             EntityPersister persister = session.getFactory().getEntityPersister(metadata.getEntityName());
@@ -1124,7 +1095,14 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
                     E entity = (E) context.getEntity(key);
 
                     if (entity != null) {
-                        entitySet.put(id, entity);
+                        EntityEntry entry = context.getEntry(entity);
+
+                        // Make sure the entry hasn't been deleted or otherwise removed.
+                        if (entry.isExistsInDatabase() && entry.getStatus() != Status.DELETED &&
+                            entry.getStatus() != Status.GONE) {
+
+                            entitySet.put(id, entity);
+                        }
                     }
                     else {
                         idSet.add(id);
@@ -1146,43 +1124,14 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
                 }
             }
 
-            // Build a query to fetch the remaining entities
+            // Fetch the remaining entities from the DB
             if (idSet.size() > 0) {
-                // Get the entity's metadata so we can ask Hibernate for the name of its identifier
-                String idName = metadata.getIdentifierPropertyName();
-                if (idName == null) {
-                    // This shouldn't happen.
-                    throw new RuntimeException("Unable to fetch identifier property name");
-                }
-
-                // Impl note:
-                // We're building the query here using JPA Criteria to avoid fiddling with string
-                // building and, potentially, erroneously using the class name as the entity name.
-                // Additionally, using a query (as opposed to the .find and .load methods) lets us set
-                // the flush, cache and lock modes for the entity we're attempting to fetch.
-                CriteriaBuilder builder = entityManager.getCriteriaBuilder();
-                CriteriaQuery<E> query = builder.createQuery(entityClass);
-                Root<E> root = query.from(entityClass);
-                Path<Serializable> target = root.<Serializable>get(idName);
-                ParameterExpression<List> param = builder.parameter(List.class);
-
-                query.select(root).where(target.in(param));
-
-                // Note that it's critical here to set both modes, as Hibernate is wildly inconsistent
-                // (and non-standard) in which properties it actually accepts when processing its own
-                // config objects. The cache mode combination specified below ends up being evaluated
-                // by Hibernate down to a CacheMode.REFRESH.
-                TypedQuery<E> executable = entityManager.createQuery(query)
-                    .setFlushMode(FlushModeType.COMMIT)
-                    .setHint(AvailableSettings.SHARED_CACHE_RETRIEVE_MODE, CacheRetrieveMode.BYPASS)
-                    .setHint(AvailableSettings.SHARED_CACHE_STORE_MODE, CacheStoreMode.REFRESH)
-                    .setLockMode(LockModeType.PESSIMISTIC_WRITE);
-
-                // Step through the query in blocks
-                for (List<Serializable> block : Iterables.partition(idSet, getBatchBlockSize())) {
-                    executable.setParameter(param, block);
-                    result.addAll(executable.getResultList());
-                }
+                result.addAll(((Session) session)
+                    .byMultipleIds(this.entityType())
+                    .with(new LockOptions(LockMode.PESSIMISTIC_WRITE))
+                    .with(CacheMode.REFRESH)
+                    .enableSessionCheck(false)
+                    .multiLoad(new ArrayList(idSet)));
             }
         }
 

--- a/server/src/test/java/org/candlepin/model/AbstractHibernateCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/AbstractHibernateCuratorTest.java
@@ -67,28 +67,29 @@ public class AbstractHibernateCuratorTest extends DatabaseTestFixture {
         }
     }
 
+    AbstractHibernateCurator<Owner> testOwnerCurator;
     AbstractHibernateCurator<Content> testContentCurator;
 
     @Before
     public void setup() {
+        this.testOwnerCurator = new TestHibernateCurator<>(Owner.class);
         this.testContentCurator = new TestHibernateCurator<>(Content.class);
+        this.injectMembers(this.testOwnerCurator);
         this.injectMembers(this.testContentCurator);
     }
 
     @Test
     public void testBulkSQLUpdate() throws Exception {
-        Owner owner = this.createOwner();
-
-        Content c1 = this.createContent("c1", "content 1", owner);
-        Content c2 = this.createContent("c2", "content 2", owner);
-        Content c3 = this.createContent("c3", "content 3", owner);
+        Cdn c1 = this.createCdn("c1", "http://url1.com");
+        Cdn c2 = this.createCdn("c2", "http://url2.com");
+        Cdn c3 = this.createCdn("c3", "http://url3.com");
 
         Map<Object, Object> values = new HashMap<>();
-        values.put("content 1", "update 1");
-        values.put("content 2", "update 2");
+        values.put("c1", "c1updated");
+        values.put("c2", "c2updated");
         values.put("content ?", "should not exist");
 
-        int result = this.testContentCurator.bulkSQLUpdate(Content.DB_TABLE, "name", values, null);
+        int result = this.cdnCurator.bulkSQLUpdate(Cdn.DB_TABLE, "name", values, null);
 
         // Note:
         // This looks like it should be 2, and technically that's what's happening here, but with
@@ -96,11 +97,13 @@ public class AbstractHibernateCuratorTest extends DatabaseTestFixture {
         // themselves.
         assertEquals(3, result);
 
-        testContentCurator.refresh(c1, c2, c3);
+        this.getEntityManager().refresh(c1);
+        this.getEntityManager().refresh(c2);
+        this.getEntityManager().refresh(c3);
 
-        assertEquals("update 1", c1.getName());
-        assertEquals("update 2", c2.getName());
-        assertEquals("content 3", c3.getName());
+        assertEquals("c1updated", c1.getName());
+        assertEquals("c2updated", c2.getName());
+        assertEquals("c3", c3.getName());
     }
 
     @Test
@@ -350,50 +353,92 @@ public class AbstractHibernateCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void testLockAndLoadSingleEntityRefresh() {
-        Owner owner = this.createOwner();
-        Content content = this.createContent("c1", "content-1", owner);
+        Owner owner = this.createOwner("owner_key-1", "owner-1");
 
         // Verify that we're getting an equal entity back out
-        Content output = this.testContentCurator.lockAndLoad(content);
-        assertEquals(content, output);
+        Owner output = this.testOwnerCurator.lockAndLoad(owner);
+        assertEquals(owner, output);
     }
 
     @Test
     public void testLockAndLoadSingleEntityRevertsPropertyChange() {
-        Owner owner = this.createOwner();
-        Content content = this.createContent("c1", "content-1", owner);
+        Owner owner = this.createOwner("owner_key-1", "owner-1");
 
         // Verify that lockAndLoad's refresh reverts our name change
-        content.setName("changed_name");
-        this.testContentCurator.lockAndLoad(content);
-        assertEquals("content-1", content.getName());
+        owner.setDisplayName("changed_name");
+        this.testOwnerCurator.lockAndLoad(owner);
+        assertEquals("owner-1", owner.getDisplayName());
     }
 
     @Test
     public void testLockAndLoadSingleEntityRevertsUnflushedMerge() {
-        Owner owner = this.createOwner();
-        Content content = this.createContent("c1", "content-1", owner);
+        Owner owner = this.createOwner("owner_key-1", "owner-1");
 
         // Verify that even a pending merge will be reverted
-        content.setName("changed_name");
-        testContentCurator.merge(content);
-        this.testContentCurator.lockAndLoad(content);
-        assertEquals("content-1", content.getName());
+        owner.setDisplayName("changed_name");
+        testOwnerCurator.merge(owner);
+        this.testOwnerCurator.lockAndLoad(owner);
+        assertEquals("owner-1", owner.getDisplayName());
     }
 
     @Test
     public void testLockAndLoadSingleEntityRefreshIgnoresEvicted() {
-        Owner owner = this.createOwner();
-        Content content = this.createContent("c1", "content-1", owner);
+        Owner owner = this.createOwner("owner_key-1", "owner-1");
 
         // Verify evicted/detached elements aren't affected
-        content.setName("detached");
-        testContentCurator.evict(content);
-        Content output = this.testContentCurator.lockAndLoad(content);
-        assertNotEquals(content, output);
-        assertEquals("content-1", output.getName());
-        assertEquals("detached", content.getName());
+        owner.setDisplayName("detached");
+        testOwnerCurator.evict(owner);
+        Owner output = this.testOwnerCurator.lockAndLoad(owner);
+        assertNotEquals(owner, output);
+        assertEquals("owner-1", output.getName());
+        assertEquals("detached", owner.getDisplayName());
     }
+
+    @Test
+    public void testLockAndLoadSingleEntityRefreshHandlesDeleted() {
+        Owner owner = this.createOwner("owner_key-1", "owner-1");
+
+        // Verify evicted/detached elements aren't affected
+        owner.setDisplayName("deleted");
+        testOwnerCurator.delete(owner);
+
+        Owner output = this.testOwnerCurator.lockAndLoad(owner);
+        assertNull(output);
+    }
+
+    @Test
+    public void testLockAndLoadSingleEntityRefreshHandlesUnflushedCreation() {
+        Owner owner = new Owner("owner_key-1", "owner-1");
+        this.getEntityManager().persist(owner);
+
+        // Verify newly created, but not yet flushed objects don't cause problems here
+        Owner output = this.testOwnerCurator.lockAndLoad(owner);
+
+        // It's not backed by the DB yet, so this should return null
+        assertNull(output);
+    }
+
+    /**
+     * At the time of writing, we have no means of actually addressing this scenario, so the
+     * test will always fail. As such, we'll comment it out and hopefully come up with a way
+     * to fix it some day.
+     */
+    // @Test
+    // public void testLockAndLoadSingleEntityRefreshIgnoresDeletedViaSQL() {
+    //     Owner owner = this.createOwner("owner_key-1", "owner-1");
+
+    //     int count = testOwnerCurator.getEntityManager()
+    //         .createNativeQuery("DELETE FROM cp_owner WHERE displayname=:name")
+    //         .setParameter("name", owner.getDisplayName())
+    //         .executeUpdate();
+
+    //     assertEquals(1, count);
+
+    //     Owner output = this.testOwnerCurator.lockAndLoad(owner);
+    //     assertNull(output);
+
+    //     assertEquals("detached", owner.getDisplayName());
+    // }
 
     @Test
     public void testLockAndLoadSingleEntityRefreshRetainsFlushedChanged() {
@@ -410,111 +455,114 @@ public class AbstractHibernateCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void testLockAndLoadSingleEntityByIdRefresh() {
-        Owner owner = this.createOwner();
-        Content content = this.createContent("c1", "content-1", owner);
+        Owner owner = this.createOwner("owner_key-1", "owner-1");
 
         // Verify that we're getting an equal entity back out
-        Content output = this.testContentCurator.lockAndLoadById(content.getUuid());
-        assertEquals(content, output);
+        Owner output = this.testOwnerCurator.lockAndLoadById(owner.getId());
+        assertEquals(owner, output);
     }
 
     @Test
     public void testLockAndLoadSingleEntityByIdRevertsPropertyChange() {
-        Owner owner = this.createOwner();
-        Content content = this.createContent("c1", "content-1", owner);
+        Owner owner = this.createOwner("owner_key-1", "owner-1");
 
         // Verify that lockAndLoad's refresh reverts our name change
-        content.setName("changed_name");
-        this.testContentCurator.lockAndLoadById(content.getUuid());
-        assertEquals("content-1", content.getName());
+        owner.setDisplayName("changed_name");
+        this.testOwnerCurator.lockAndLoadById(owner.getId());
+        assertEquals("owner-1", owner.getDisplayName());
     }
 
     @Test
     public void testLockAndLoadSingleEntityByIdRevertsUnflushedMerge() {
-        Owner owner = this.createOwner();
-        Content content = this.createContent("c1", "content-1", owner);
+        Owner owner = this.createOwner("owner_key-1", "owner-1");
 
         // Verify that even a pending merge will be reverted
-        content.setName("changed_name");
-        testContentCurator.merge(content);
-        this.testContentCurator.lockAndLoadById(content.getUuid());
-        assertEquals("content-1", content.getName());
+        owner.setDisplayName("changed_name");
+        testOwnerCurator.merge(owner);
+        this.testOwnerCurator.lockAndLoadById(owner.getId());
+        assertEquals("owner-1", owner.getDisplayName());
     }
 
     @Test
     public void testLockAndLoadSingleEntityByIdRefreshIgnoresEvicted() {
-        Owner owner = this.createOwner();
-        Content content = this.createContent("c1", "content-1", owner);
+        Owner owner = this.createOwner("owner_key-1", "owner-1");
 
         // Verify evicted/detached elements aren't affected
-        content.setName("detached");
-        testContentCurator.evict(content);
-        Content output = this.testContentCurator.lockAndLoadById(content.getUuid());
+        owner.setDisplayName("detached");
+        testOwnerCurator.evict(owner);
+        Owner output = this.testOwnerCurator.lockAndLoadById(owner.getId());
         assertNotNull(output);
-        assertNotEquals(content, output);
-        assertEquals("content-1", output.getName());
-        assertEquals("detached", content.getName());
+        assertNotEquals(owner, output);
+        assertEquals("owner-1", output.getName());
+        assertEquals("detached", owner.getDisplayName());
+    }
+
+    @Test
+    public void testLockAndLoadSingleEntityByIdRefreshHandlesDeleted() {
+        Owner owner = this.createOwner("owner_key-1", "owner-1");
+
+        // Verify evicted/detached elements aren't affected
+        owner.setDisplayName("deleted");
+        testOwnerCurator.delete(owner);
+
+        Owner output = this.testOwnerCurator.lockAndLoadById(owner.getId());
+        assertNull(output);
     }
 
     @Test
     public void testLockAndLoadSingleEntityByIdRefreshRetainsFlushedChanged() {
-        Owner owner = this.createOwner();
-        Content content = this.createContent("c1", "content-1", owner);
+        Owner owner = this.createOwner("fooOwner", "displayName");
+        owner.setDisplayName("changed_name");
 
         // Verify that a flush will make the change persistent
-        content.setName("changed_name");
-        testContentCurator.merge(content);
-        testContentCurator.flush();
-        this.testContentCurator.lockAndLoadById(content.getUuid());
-        assertEquals("changed_name", content.getName());
+        testOwnerCurator.merge(owner);
+        testOwnerCurator.flush();
+        this.testOwnerCurator.lockAndLoadById(owner.getId());
+        assertEquals("changed_name", owner.getDisplayName());
     }
 
     @Test
     public void testLockAndLoadSingleEntityByClassAndIdRefresh() {
-        Owner owner = this.createOwner();
-        Content content = this.createContent("c1", "content-1", owner);
+        Owner owner = this.createOwner("owner_key-1", "owner-1");
 
         // Verify that we're getting an equal entity back out
-        Content output = this.testContentCurator.lockAndLoadById(Content.class, content.getUuid());
-        assertEquals(content, output);
+        Owner output = this.testOwnerCurator.lockAndLoadById(Owner.class, owner.getId());
+        assertEquals(owner, output);
     }
 
     @Test
     public void testLockAndLoadSingleEntityByClassAndIdRevertsPropertyChange() {
-        Owner owner = this.createOwner();
-        Content content = this.createContent("c1", "content-1", owner);
+        Owner owner = this.createOwner("owner_key-1", "owner-1");
 
         // Verify that lockAndLoad's refresh reverts our name change
-        content.setName("changed_name");
-        this.testContentCurator.lockAndLoadById(Content.class, content.getUuid());
-        assertEquals("content-1", content.getName());
+        owner.setDisplayName("changed_name");
+        this.testOwnerCurator.lockAndLoadById(Owner.class, owner.getId());
+        assertEquals("owner-1", owner.getDisplayName());
     }
 
     @Test
     public void testLockAndLoadSingleEntityByClassAndIdRevertsUnflushedMerge() {
-        Owner owner = this.createOwner();
-        Content content = this.createContent("c1", "content-1", owner);
+        Owner owner = this.createOwner("owner_key-1", "owner-1");
 
         // Verify that even a pending merge will be reverted
-        content.setName("changed_name");
-        testContentCurator.merge(content);
-        this.testContentCurator.lockAndLoadById(Content.class, content.getUuid());
-        assertEquals("content-1", content.getName());
+        owner.setDisplayName("changed_name");
+        testOwnerCurator.merge(owner);
+        this.testOwnerCurator.lockAndLoadById(Owner.class, owner.getId());
+        assertEquals("owner-1", owner.getDisplayName());
     }
 
     @Test
     public void testLockAndLoadSingleEntityByClassAndIdRefreshIgnoresEvicted() {
-        Owner owner = this.createOwner();
-        Content content = this.createContent("c1", "content-1", owner);
+        Owner owner = this.createOwner("owner_key-1", "owner-1");
 
         // Verify evicted/detached elements aren't affected
-        content.setName("detached");
-        testContentCurator.evict(content);
-        Content output = this.testContentCurator.lockAndLoadById(Content.class, content.getUuid());
+        owner.setDisplayName("detached");
+        testOwnerCurator.evict(owner);
+        Owner output = this.testOwnerCurator.lockAndLoadById(Owner.class, owner.getId());
         assertNotNull(output);
-        assertNotEquals(content, output);
-        assertEquals("content-1", output.getName());
-        assertEquals("detached", content.getName());
+        assertNotEquals(owner, output);
+        assertEquals("owner-1", output.getDisplayName());
+        assertEquals("detached", owner.getDisplayName());
     }
 
     @Test
@@ -523,35 +571,34 @@ public class AbstractHibernateCuratorTest extends DatabaseTestFixture {
         Content content = this.createContent("c1", "content-1", owner);
 
         // Verify that a flush will make the change persistent
-        content.setName("changed_name");
-        testContentCurator.merge(content);
-        testContentCurator.flush();
-        this.testContentCurator.lockAndLoadById(Content.class, content.getUuid());
-        assertEquals("changed_name", content.getName());
+        owner.setDisplayName("changed_name");
+        testOwnerCurator.merge(owner);
+        testOwnerCurator.flush();
+        this.testOwnerCurator.lockAndLoadById(Owner.class, owner.getId());
+        assertEquals("changed_name", owner.getDisplayName());
     }
 
     @Test
     public void testLockAndLoadMultiEntity() {
-        Owner owner = this.createOwner();
-        Content content1 = this.createContent("c1", "content-1", owner);
-        Content content2 = this.createContent("c2", "content-2", owner);
-        Content content3 = this.createContent("c3", "content-3", owner);
+        Owner owner1 = this.createOwner("owner_key-1", "owner-1");
+        Owner owner2 = this.createOwner("owner_key-2", "owner-2");
+        Owner owner3 = this.createOwner("owner_key-3", "owner-3");
 
         // Verify we're getting the correct number of entities out
-        Collection<Content> input = Arrays.asList(content1, content2, content3);
-        Collection<Content> output = this.testContentCurator.lockAndLoad(input);
+        Collection<Owner> input = Arrays.asList(owner1, owner2, owner3);
+        Collection<Owner> output = this.testOwnerCurator.lockAndLoad(input);
 
         assertEquals(3, output.size());
 
         // Note: the instances may be different here, but as long as they're equal (including UUID),
         // we're okay.
-        for (Content expected : input) {
+        for (Owner expected : input) {
             boolean found = false;
 
-            for (Content content : output) {
-                if (expected.equals(content)) {
+            for (Owner owner : output) {
+                if (expected.equals(owner)) {
                     assertFalse(found);
-                    assertEquals(expected.getUuid(), content.getUuid());
+                    assertEquals(expected.getId(), owner.getId());
                     found = true;
 
                     // We don't break here because we're verifying we didn't receive any duplicates.
@@ -564,51 +611,49 @@ public class AbstractHibernateCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void testLockAndLoadMultiEntityRefreshRevertsPropertyChange() {
-        Owner owner = this.createOwner();
-        Content content1 = this.createContent("c1", "content-1", owner);
-        Content content2 = this.createContent("c2", "content-2", owner);
-        Content content3 = this.createContent("c3", "content-3", owner);
+        Owner owner1 = this.createOwner("owner_key-1", "owner-1");
+        Owner owner2 = this.createOwner("owner_key-2", "owner-2");
+        Owner owner3 = this.createOwner("owner_key-3", "owner-3");
 
         // Verify that lockAndLoad's refresh reverts our name changes only where applicable
-        content1.setName("name change 1");
-        content2.setName("name change 2");
-        content3.setName("name change 3");
+        owner1.setDisplayName("name change 1");
+        owner2.setDisplayName("name change 2");
+        owner3.setDisplayName("name change 3");
 
-        Collection<Content> output = this.testContentCurator.lockAndLoad(Arrays.asList(content1, content3));
+        Collection<Owner> output = this.testOwnerCurator.lockAndLoad(Arrays.asList(owner1, owner3));
 
         assertEquals(2, output.size());
-        assertTrue(output.contains(content1));
-        assertFalse(output.contains(content2));
-        assertTrue(output.contains(content3));
-        assertEquals("content-1", content1.getName());
-        assertEquals("name change 2", content2.getName());
-        assertEquals("content-3", content3.getName());
+        assertTrue(output.contains(owner1));
+        assertFalse(output.contains(owner2));
+        assertTrue(output.contains(owner3));
+        assertEquals("owner-1", owner1.getDisplayName());
+        assertEquals("name change 2", owner2.getDisplayName());
+        assertEquals("owner-3", owner3.getDisplayName());
     }
 
     @Test
     public void testLockAndLoadMultiEntityRefreshRevertsUnflushedMerge() {
-        Owner owner = this.createOwner();
-        Content content1 = this.createContent("c1", "content-1", owner);
-        Content content2 = this.createContent("c2", "content-2", owner);
-        Content content3 = this.createContent("c3", "content-3", owner);
+        Owner owner1 = this.createOwner("owner_key-1", "owner-1");
+        Owner owner2 = this.createOwner("owner_key-2", "owner-2");
+        Owner owner3 = this.createOwner("owner_key-3", "owner-3");
 
         // Verify that even a pending merge will be reverted
-        content1.setName("name change 1");
-        content2.setName("name change 2");
-        content3.setName("name change 3");
-        this.testContentCurator.merge(content1);
-        this.testContentCurator.merge(content2);
-        this.testContentCurator.merge(content3);
+        owner1.setDisplayName("name change 1");
+        owner2.setDisplayName("name change 2");
+        owner3.setDisplayName("name change 3");
+        this.testOwnerCurator.merge(owner1);
+        this.testOwnerCurator.merge(owner2);
+        this.testOwnerCurator.merge(owner3);
 
-        Collection<Content> output = this.testContentCurator.lockAndLoad(Arrays.asList(content1, content3));
+        Collection<Owner> output = this.testOwnerCurator.lockAndLoad(Arrays.asList(owner1, owner3));
 
         assertEquals(2, output.size());
-        assertTrue(output.contains(content1));
-        assertFalse(output.contains(content2));
-        assertTrue(output.contains(content3));
-        assertEquals("content-1", content1.getName());
-        assertEquals("name change 2", content2.getName());
-        assertEquals("content-3", content3.getName());
+        assertTrue(output.contains(owner1));
+        assertFalse(output.contains(owner2));
+        assertTrue(output.contains(owner3));
+        assertEquals("owner-1", owner1.getDisplayName());
+        assertEquals("name change 2", owner2.getDisplayName());
+        assertEquals("owner-3", owner3.getDisplayName());
     }
 
     @Test
@@ -640,56 +685,102 @@ public class AbstractHibernateCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void testLockAndLoadMultiEntityRefreshIgnoresEvicted() {
-        Owner owner = this.createOwner();
-        Content content1 = this.createContent("c1", "content-1", owner);
-        Content content2 = this.createContent("c2", "content-2", owner);
-        Content content3 = this.createContent("c3", "content-3", owner);
+        Owner owner1 = this.createOwner("owner_key-1", "owner-1");
+        Owner owner2 = this.createOwner("owner_key-2", "owner-2");
+        Owner owner3 = this.createOwner("owner_key-3", "owner-3");
 
         // Verify evicted/detached elements aren't affected
-        content1.setName("name change 1");
-        content2.setName("name change 2");
-        content3.setName("name change 3");
-        this.testContentCurator.evict(content1);
-        this.testContentCurator.evict(content2);
-        this.testContentCurator.evict(content3);
+        owner1.setDisplayName("name change 1");
+        owner2.setDisplayName("name change 2");
+        owner3.setDisplayName("name change 3");
+        this.testOwnerCurator.evict(owner1);
+        this.testOwnerCurator.evict(owner2);
+        this.testOwnerCurator.evict(owner3);
 
-        Collection<Content> output = this.testContentCurator.lockAndLoad(Arrays.asList(content1, content3));
+        Collection<Owner> output = this.testOwnerCurator.lockAndLoad(Arrays.asList(owner1, owner3));
 
         assertEquals(2, output.size());
-        assertFalse(output.contains(content1));
-        assertFalse(output.contains(content2));
-        assertFalse(output.contains(content3));
-        assertEquals("name change 1", content1.getName());
-        assertEquals("name change 2", content2.getName());
-        assertEquals("name change 3", content3.getName());
+        assertFalse(output.contains(owner1));
+        assertFalse(output.contains(owner2));
+        assertFalse(output.contains(owner3));
+        assertEquals("name change 1", owner1.getDisplayName());
+        assertEquals("name change 2", owner2.getDisplayName());
+        assertEquals("name change 3", owner3.getDisplayName());
 
-        for (Content entity : output) {
-            assertTrue(entity.getName().matches("content-\\d"));
+        for (Owner entity : output) {
+            assertTrue(entity.getDisplayName().matches("owner-\\d"));
         }
     }
 
     @Test
+    public void testLockAndLoadMultiEntityRefreshIgnoresDeleted() {
+        Owner owner1 = this.createOwner("owner_key-1", "owner-1");
+        Owner owner2 = this.createOwner("owner_key-2", "owner-2");
+        Owner owner3 = this.createOwner("owner_key-3", "owner-3");
+
+        // Verify deleted elements aren't affected
+        owner1.setDisplayName("name change 1");
+        owner2.setDisplayName("name change 2");
+        owner3.setDisplayName("name change 3");
+        this.testOwnerCurator.delete(owner3);
+
+        Collection<Owner> output = this.testOwnerCurator.lockAndLoad(Arrays.asList(owner1, owner3));
+
+        assertEquals(1, output.size());
+        assertTrue(output.contains(owner1));
+        assertFalse(output.contains(owner2));
+        assertFalse(output.contains(owner3));
+        assertEquals("owner-1", owner1.getDisplayName());
+        assertEquals("name change 2", owner2.getDisplayName());
+        assertEquals("name change 3", owner3.getDisplayName());
+
+        assertEquals(owner1, output.iterator().next());
+    }
+
+    @Test
+    public void testLockAndLoadMultiEntityRefreshIgnoresCreated() {
+        Owner owner1 = this.createOwner("owner_key-1", "owner-1");
+        Owner owner2 = this.createOwner("owner_key-2", "owner-2");
+        Owner owner3 = new Owner("owner_key-3", "owner-3");
+
+        owner1.setDisplayName("name change 1");
+        owner2.setDisplayName("name change 2");
+        owner3.setDisplayName("name change 3");
+
+        Collection<Owner> output = this.testOwnerCurator.lockAndLoad(Arrays.asList(owner1, owner3));
+
+        assertEquals(1, output.size());
+        assertTrue(output.contains(owner1));
+        assertFalse(output.contains(owner2));
+        assertFalse(output.contains(owner3));
+        assertEquals("owner-1", owner1.getDisplayName());
+        assertEquals("name change 2", owner2.getDisplayName());
+        assertEquals("name change 3", owner3.getDisplayName());
+
+        assertEquals(owner1, output.iterator().next());
+    }
+
+    @Test
     public void testLockAndLoadMultiEntityByIds() {
-        Owner owner = this.createOwner();
-        Content content1 = this.createContent("c1", "content-1", owner);
-        Content content2 = this.createContent("c2", "content-2", owner);
-        Content content3 = this.createContent("c3", "content-3", owner);
+        Owner owner1 = this.createOwner("owner_key-1", "owner-1");
+        Owner owner2 = this.createOwner("owner_key-2", "owner-2");
+        Owner owner3 = this.createOwner("owner_key-3", "owner-3");
 
         // Verify we're getting the correct number of entities out
-        Collection<String> input = Arrays.asList(content1.getUuid(), content2.getUuid(), content3.getUuid());
-        Collection<Content> output = this.testContentCurator.lockAndLoadByIds(input);
+        Collection<String> input = Arrays.asList(owner1.getId(), owner2.getId(), owner3.getId());
+        Collection<Owner> output = this.testOwnerCurator.lockAndLoadByIds(input);
 
         assertEquals(3, output.size());
 
         // Note: the instances may be different here, but as long as they're equal (including UUID),
         // we're okay.
-        for (Content expected : Arrays.asList(content1, content2, content3)) {
+        for (Owner expected : Arrays.asList(owner1, owner2, owner3)) {
             boolean found = false;
 
-            for (Content content : output) {
-                if (expected.equals(content)) {
+            for (Owner owner : output) {
+                if (expected.equals(owner)) {
                     assertFalse(found);
-                    assertEquals(expected.getUuid(), content.getUuid());
+                    assertEquals(expected.getId(), owner.getId());
                     found = true;
 
                     // We don't break here because we're verifying we didn't receive any duplicates.
@@ -702,53 +793,51 @@ public class AbstractHibernateCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void testLockAndLoadMultiEntityByIdsRefreshRevertsPropertyChange() {
-        Owner owner = this.createOwner();
-        Content content1 = this.createContent("c1", "content-1", owner);
-        Content content2 = this.createContent("c2", "content-2", owner);
-        Content content3 = this.createContent("c3", "content-3", owner);
+        Owner owner1 = this.createOwner("owner_key-1", "owner-1");
+        Owner owner2 = this.createOwner("owner_key-2", "owner-2");
+        Owner owner3 = this.createOwner("owner_key-3", "owner-3");
 
         // Verify that lockAndLoad's refresh reverts our name changes only where applicable
-        content1.setName("name change 1");
-        content2.setName("name change 2");
-        content3.setName("name change 3");
+        owner1.setDisplayName("name change 1");
+        owner2.setDisplayName("name change 2");
+        owner3.setDisplayName("name change 3");
 
-        Collection<String> input = Arrays.asList(content1.getUuid(), content3.getUuid());
-        Collection<Content> output = this.testContentCurator.lockAndLoadByIds(input);
+        Collection<String> input = Arrays.asList(owner1.getId(), owner3.getId());
+        Collection<Owner> output = this.testOwnerCurator.lockAndLoadByIds(input);
 
         assertEquals(2, output.size());
-        assertTrue(output.contains(content1));
-        assertFalse(output.contains(content2));
-        assertTrue(output.contains(content3));
-        assertEquals("content-1", content1.getName());
-        assertEquals("name change 2", content2.getName());
-        assertEquals("content-3", content3.getName());
+        assertTrue(output.contains(owner1));
+        assertFalse(output.contains(owner2));
+        assertTrue(output.contains(owner3));
+        assertEquals("owner-1", owner1.getDisplayName());
+        assertEquals("name change 2", owner2.getDisplayName());
+        assertEquals("owner-3", owner3.getDisplayName());
     }
 
     @Test
     public void testLockAndLoadMultiEntityByIdsRefreshRevertsUnflushedMerge() {
-        Owner owner = this.createOwner();
-        Content content1 = this.createContent("c1", "content-1", owner);
-        Content content2 = this.createContent("c2", "content-2", owner);
-        Content content3 = this.createContent("c3", "content-3", owner);
+        Owner owner1 = this.createOwner("owner_key-1", "owner-1");
+        Owner owner2 = this.createOwner("owner_key-2", "owner-2");
+        Owner owner3 = this.createOwner("owner_key-3", "owner-3");
 
         // Verify that even a pending merge will be reverted
-        content1.setName("name change 1");
-        content2.setName("name change 2");
-        content3.setName("name change 3");
-        this.testContentCurator.merge(content1);
-        this.testContentCurator.merge(content2);
-        this.testContentCurator.merge(content3);
+        owner1.setDisplayName("name change 1");
+        owner2.setDisplayName("name change 2");
+        owner3.setDisplayName("name change 3");
+        this.testOwnerCurator.merge(owner1);
+        this.testOwnerCurator.merge(owner2);
+        this.testOwnerCurator.merge(owner3);
 
-        Collection<String> input = Arrays.asList(content1.getUuid(), content3.getUuid());
-        Collection<Content> output = this.testContentCurator.lockAndLoadByIds(input);
+        Collection<String> input = Arrays.asList(owner1.getId(), owner3.getId());
+        Collection<Owner> output = this.testOwnerCurator.lockAndLoadByIds(input);
 
         assertEquals(2, output.size());
-        assertTrue(output.contains(content1));
-        assertFalse(output.contains(content2));
-        assertTrue(output.contains(content3));
-        assertEquals("content-1", content1.getName());
-        assertEquals("name change 2", content2.getName());
-        assertEquals("content-3", content3.getName());
+        assertTrue(output.contains(owner1));
+        assertFalse(output.contains(owner2));
+        assertTrue(output.contains(owner3));
+        assertEquals("owner-1", owner1.getDisplayName());
+        assertEquals("name change 2", owner2.getDisplayName());
+        assertEquals("owner-3", owner3.getDisplayName());
     }
 
     @Test
@@ -781,59 +870,55 @@ public class AbstractHibernateCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void testLockAndLoadMultiEntityByIdsRefreshIgnoresEvicted() {
-        Owner owner = this.createOwner();
-        Content content1 = this.createContent("c1", "content-1", owner);
-        Content content2 = this.createContent("c2", "content-2", owner);
-        Content content3 = this.createContent("c3", "content-3", owner);
+        Owner owner1 = this.createOwner("owner_key-1", "owner-1");
+        Owner owner2 = this.createOwner("owner_key-2", "owner-2");
+        Owner owner3 = this.createOwner("owner_key-3", "owner-3");
 
         // Verify evicted/detached elements aren't affected
-        content1.setName("name change 1");
-        content2.setName("name change 2");
-        content3.setName("name change 3");
-        this.testContentCurator.evict(content1);
-        this.testContentCurator.evict(content2);
-        this.testContentCurator.evict(content3);
+        owner1.setDisplayName("name change 1");
+        owner2.setDisplayName("name change 2");
+        owner3.setDisplayName("name change 3");
+        this.testOwnerCurator.evict(owner1);
+        this.testOwnerCurator.evict(owner2);
+        this.testOwnerCurator.evict(owner3);
 
-        Collection<String> input = Arrays.asList(content1.getUuid(), content3.getUuid());
-        Collection<Content> output = this.testContentCurator.lockAndLoadByIds(input);
+        Collection<String> input = Arrays.asList(owner1.getId(), owner3.getId());
+        Collection<Owner> output = this.testOwnerCurator.lockAndLoadByIds(input);
 
         assertEquals(2, output.size());
-        assertFalse(output.contains(content1));
-        assertFalse(output.contains(content2));
-        assertFalse(output.contains(content3));
-        assertEquals("name change 1", content1.getName());
-        assertEquals("name change 2", content2.getName());
-        assertEquals("name change 3", content3.getName());
+        assertFalse(output.contains(owner1));
+        assertFalse(output.contains(owner2));
+        assertFalse(output.contains(owner3));
+        assertEquals("name change 1", owner1.getDisplayName());
+        assertEquals("name change 2", owner2.getDisplayName());
+        assertEquals("name change 3", owner3.getDisplayName());
 
-        for (Content entity : output) {
-            assertTrue(entity.getName().matches("content-\\d"));
+        for (Owner entity : output) {
+            assertTrue(entity.getDisplayName().matches("owner-\\d"));
         }
     }
 
-
-
     @Test
     public void testLockAndLoadMultiEntityByClassAndIds() {
-        Owner owner = this.createOwner();
-        Content content1 = this.createContent("c1", "content-1", owner);
-        Content content2 = this.createContent("c2", "content-2", owner);
-        Content content3 = this.createContent("c3", "content-3", owner);
+        Owner owner1 = this.createOwner("owner_key-1", "owner-1");
+        Owner owner2 = this.createOwner("owner_key-2", "owner-2");
+        Owner owner3 = this.createOwner("owner_key-3", "owner-3");
 
         // Verify we're getting the correct number of entities out
-        Collection<String> input = Arrays.asList(content1.getUuid(), content2.getUuid(), content3.getUuid());
-        Collection<Content> output = this.testContentCurator.lockAndLoadByIds(Content.class, input);
+        Collection<String> input = Arrays.asList(owner1.getId(), owner2.getId(), owner3.getId());
+        Collection<Owner> output = this.testOwnerCurator.lockAndLoadByIds(Owner.class, input);
 
         assertEquals(3, output.size());
 
         // Note: the instances may be different here, but as long as they're equal (including UUID),
         // we're okay.
-        for (Content expected : Arrays.asList(content1, content2, content3)) {
+        for (Owner expected : Arrays.asList(owner1, owner2, owner3)) {
             boolean found = false;
 
-            for (Content content : output) {
-                if (expected.equals(content)) {
+            for (Owner owner : output) {
+                if (expected.equals(owner)) {
                     assertFalse(found);
-                    assertEquals(expected.getUuid(), content.getUuid());
+                    assertEquals(expected.getId(), owner.getId());
                     found = true;
 
                     // We don't break here because we're verifying we didn't receive any duplicates.
@@ -846,53 +931,51 @@ public class AbstractHibernateCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void testLockAndLoadMultiEntityByClassAndIdsRefreshRevertsPropertyChange() {
-        Owner owner = this.createOwner();
-        Content content1 = this.createContent("c1", "content-1", owner);
-        Content content2 = this.createContent("c2", "content-2", owner);
-        Content content3 = this.createContent("c3", "content-3", owner);
+        Owner owner1 = this.createOwner("owner_key-1", "owner-1");
+        Owner owner2 = this.createOwner("owner_key-2", "owner-2");
+        Owner owner3 = this.createOwner("owner_key-3", "owner-3");
 
         // Verify that lockAndLoad's refresh reverts our name changes only where applicable
-        content1.setName("name change 1");
-        content2.setName("name change 2");
-        content3.setName("name change 3");
+        owner1.setDisplayName("name change 1");
+        owner2.setDisplayName("name change 2");
+        owner3.setDisplayName("name change 3");
 
-        Collection<String> input = Arrays.asList(content1.getUuid(), content3.getUuid());
-        Collection<Content> output = this.testContentCurator.lockAndLoadByIds(Content.class, input);
+        Collection<String> input = Arrays.asList(owner1.getId(), owner3.getId());
+        Collection<Owner> output = this.testOwnerCurator.lockAndLoadByIds(Owner.class, input);
 
         assertEquals(2, output.size());
-        assertTrue(output.contains(content1));
-        assertFalse(output.contains(content2));
-        assertTrue(output.contains(content3));
-        assertEquals("content-1", content1.getName());
-        assertEquals("name change 2", content2.getName());
-        assertEquals("content-3", content3.getName());
+        assertTrue(output.contains(owner1));
+        assertFalse(output.contains(owner2));
+        assertTrue(output.contains(owner3));
+        assertEquals("owner-1", owner1.getDisplayName());
+        assertEquals("name change 2", owner2.getDisplayName());
+        assertEquals("owner-3", owner3.getDisplayName());
     }
 
     @Test
     public void testLockAndLoadMultiEntityByClassAndIdsRefreshRevertsUnflushedMerge() {
-        Owner owner = this.createOwner();
-        Content content1 = this.createContent("c1", "content-1", owner);
-        Content content2 = this.createContent("c2", "content-2", owner);
-        Content content3 = this.createContent("c3", "content-3", owner);
+        Owner owner1 = this.createOwner("owner_key-1", "owner-1");
+        Owner owner2 = this.createOwner("owner_key-2", "owner-2");
+        Owner owner3 = this.createOwner("owner_key-3", "owner-3");
 
         // Verify that even a pending merge will be reverted
-        content1.setName("name change 1");
-        content2.setName("name change 2");
-        content3.setName("name change 3");
-        this.testContentCurator.merge(content1);
-        this.testContentCurator.merge(content2);
-        this.testContentCurator.merge(content3);
+        owner1.setDisplayName("name change 1");
+        owner2.setDisplayName("name change 2");
+        owner3.setDisplayName("name change 3");
+        this.testOwnerCurator.merge(owner1);
+        this.testOwnerCurator.merge(owner2);
+        this.testOwnerCurator.merge(owner3);
 
-        Collection<String> input = Arrays.asList(content1.getUuid(), content3.getUuid());
-        Collection<Content> output = this.testContentCurator.lockAndLoadByIds(Content.class, input);
+        Collection<String> input = Arrays.asList(owner1.getId(), owner3.getId());
+        Collection<Owner> output = this.testOwnerCurator.lockAndLoadByIds(Owner.class, input);
 
         assertEquals(2, output.size());
-        assertTrue(output.contains(content1));
-        assertFalse(output.contains(content2));
-        assertTrue(output.contains(content3));
-        assertEquals("content-1", content1.getName());
-        assertEquals("name change 2", content2.getName());
-        assertEquals("content-3", content3.getName());
+        assertTrue(output.contains(owner1));
+        assertFalse(output.contains(owner2));
+        assertTrue(output.contains(owner3));
+        assertEquals("owner-1", owner1.getDisplayName());
+        assertEquals("name change 2", owner2.getDisplayName());
+        assertEquals("owner-3", owner3.getDisplayName());
     }
 
     @Test
@@ -925,32 +1008,31 @@ public class AbstractHibernateCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void testLockAndLoadMultiEntityByClassAndIdsRefreshIgnoresEvicted() {
-        Owner owner = this.createOwner();
-        Content content1 = this.createContent("c1", "content-1", owner);
-        Content content2 = this.createContent("c2", "content-2", owner);
-        Content content3 = this.createContent("c3", "content-3", owner);
+        Owner owner1 = this.createOwner("owner_key-1", "owner-1");
+        Owner owner2 = this.createOwner("owner_key-2", "owner-2");
+        Owner owner3 = this.createOwner("owner_key-3", "owner-3");
 
         // Verify evicted/detached elements aren't affected
-        content1.setName("name change 1");
-        content2.setName("name change 2");
-        content3.setName("name change 3");
-        this.testContentCurator.evict(content1);
-        this.testContentCurator.evict(content2);
-        this.testContentCurator.evict(content3);
+        owner1.setDisplayName("name change 1");
+        owner2.setDisplayName("name change 2");
+        owner3.setDisplayName("name change 3");
+        this.testOwnerCurator.evict(owner1);
+        this.testOwnerCurator.evict(owner2);
+        this.testOwnerCurator.evict(owner3);
 
-        Collection<String> input = Arrays.asList(content1.getUuid(), content3.getUuid());
-        Collection<Content> output = this.testContentCurator.lockAndLoadByIds(Content.class, input);
+        Collection<String> input = Arrays.asList(owner1.getId(), owner3.getId());
+        Collection<Owner> output = this.testOwnerCurator.lockAndLoadByIds(Owner.class, input);
 
         assertEquals(2, output.size());
-        assertFalse(output.contains(content1));
-        assertFalse(output.contains(content2));
-        assertFalse(output.contains(content3));
-        assertEquals("name change 1", content1.getName());
-        assertEquals("name change 2", content2.getName());
-        assertEquals("name change 3", content3.getName());
+        assertFalse(output.contains(owner1));
+        assertFalse(output.contains(owner2));
+        assertFalse(output.contains(owner3));
+        assertEquals("name change 1", owner1.getName());
+        assertEquals("name change 2", owner2.getName());
+        assertEquals("name change 3", owner3.getName());
 
-        for (Content entity : output) {
-            assertTrue(entity.getName().matches("content-\\d"));
+        for (Owner entity : output) {
+            assertTrue(entity.getName().matches("owner-\\d"));
         }
     }
 }

--- a/server/src/test/java/org/candlepin/test/DatabaseTestFixture.java
+++ b/server/src/test/java/org/candlepin/test/DatabaseTestFixture.java
@@ -82,6 +82,7 @@ import com.google.inject.Module;
 import com.google.inject.persist.PersistFilter;
 import com.google.inject.util.Modules;
 
+import org.hibernate.Session;
 import org.hibernate.cfg.beanvalidation.BeanValidationEventListener;
 import org.hibernate.ejb.HibernateEntityManagerFactory;
 import org.hibernate.event.service.spi.EventListenerRegistry;
@@ -302,6 +303,10 @@ public class DatabaseTestFixture {
 
     protected EntityManager getEntityManager() {
         return this.getEntityManagerProvider().get();
+    }
+
+    protected Session getCurrentSession() {
+        return (Session) this.getEntityManager().getDelegate();
     }
 
     /**


### PR DESCRIPTION
- Fixed a couple bugs with AbstractHibernateCurator.lockAndLoad
  not properly handling entities which have been deleted or
  created, but not yet flushed
- lockAndLoad now throws an exception if provided an entity which
  is immutable
- Removed the JPA criteria query building in favor of Hibernate's
  native MultiIdentifierLoadAccess entity fetching
- Updated several unit tests in accordance with the above changes,
  and added new tests for the created and deleted cases