### PR TITLE
Execute Jobs When Message Is Received From Artemis[ENT-1089]

### DIFF
--- a/server/src/main/java/org/candlepin/async/temp/TestJob1.java
+++ b/server/src/main/java/org/candlepin/async/temp/TestJob1.java
@@ -21,6 +21,8 @@ import org.candlepin.async.JobManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.concurrent.TimeUnit;
+
 
 /**
  * A basic AsyncJob implementation that we can build out to manually test the
@@ -50,7 +52,26 @@ public class TestJob1 implements AsyncJob {
     @Override
     public String execute(JobExecutionContext jdata) throws JobExecutionException {
         // TODO Finish this implementation once we work on the bits that actually execute the job.
+        log.info("TestJob1 has been started!");
+        final boolean forceFailure = jdata.getJobData().getAsBoolean("force_failure");
+        final boolean sleep = jdata.getJobData().getAsBoolean("sleep");
+        if (sleep) {
+            sleep();
+        }
+        if (forceFailure) {
+            throw new JobExecutionException("Forced failure!");
+        }
         log.info("TestJob1 has been executed!");
         return null;
+    }
+
+    private void sleep() {
+        try {
+            TimeUnit.SECONDS.sleep(10);
+        }
+        catch (Exception e) {
+            log.info("TestJob1 has been interrupted!");
+            Thread.currentThread().interrupt();
+        }
     }
 }

--- a/server/src/main/java/org/candlepin/model/AsyncJobStatus.java
+++ b/server/src/main/java/org/candlepin/model/AsyncJobStatus.java
@@ -129,6 +129,8 @@ public class AsyncJobStatus extends AbstractHibernateObject implements JobExecut
     @Column(name = "job_result")
     @Type(type = "org.candlepin.hibernate.JsonSerializedDataType")
     private Object jobResult;
+    @Column(name = "job_exec_source")
+    private String jobExecSource;
 
 
     /**
@@ -543,6 +545,36 @@ public class AsyncJobStatus extends AbstractHibernateObject implements JobExecut
      */
     public AsyncJobStatus setJobResult(Object resultData) {
         this.jobResult = resultData;
+        return this;
+    }
+
+    /**
+     * Fetches the execution source of this job. If the source has not yet been
+     * set, this method returns null.
+     *
+     * @return The execution source of this job status, or null if the source
+     * has not been set
+     */
+    public String getJobExecSource() {
+        return jobExecSource;
+    }
+
+    /**
+     * Sets the execution source of this job. If the source is null or empty,
+     * any existing origin will be cleared.
+     *
+     * @param execSource The execution source to set to this job status, or null
+     * to clear it
+     *
+     * @return this job status instance
+     */
+    public AsyncJobStatus setJobExecSource(final String execSource) {
+        if (execSource == null || execSource.isEmpty()) {
+            this.jobExecSource = null;
+        }
+        else {
+            this.jobExecSource = execSource;
+        }
         return this;
     }
 

--- a/server/src/main/resources/db/changelog/20190222103500-add-async-job-exec-source.xml
+++ b/server/src/main/resources/db/changelog/20190222103500-add-async-job-exec-source.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="20190222103500-1" author="ojanus">
+        <comment>add-async-job-exec-source</comment>
+        <addColumn tableName="cp2_async_jobs">
+            <column name="job_exec_source" type="varchar(255)"/>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/server/src/main/resources/db/changelog/changelog-create.xml
+++ b/server/src/main/resources/db/changelog/changelog-create.xml
@@ -1228,4 +1228,5 @@
     <include file="db/changelog/20180820091431-revert-share-fields.xml"/>
     <include file="db/changelog/20180430101420-add-intent-fields-to-consumer.xml"/>
     <include file="db/changelog/20181121151738-add-async-job-tables.xml"/>
+    <include file="db/changelog/20190222103500-add-async-job-exec-source.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-testing.xml
+++ b/server/src/main/resources/db/changelog/changelog-testing.xml
@@ -2320,4 +2320,5 @@
     <include file="db/changelog/20180820091431-revert-share-fields.xml"/>
     <include file="db/changelog/20180430101420-add-intent-fields-to-consumer.xml"/>
     <include file="db/changelog/20181121151738-add-async-job-tables.xml"/>
+    <include file="db/changelog/20190222103500-add-async-job-exec-source.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-update.xml
+++ b/server/src/main/resources/db/changelog/changelog-update.xml
@@ -137,4 +137,5 @@
     <include file="db/changelog/20180820091431-revert-share-fields.xml"/>
     <include file="db/changelog/20180430101420-add-intent-fields-to-consumer.xml"/>
     <include file="db/changelog/20181121151738-add-async-job-tables.xml"/>
+    <include file="db/changelog/20190222103500-add-async-job-exec-source.xml"/>
 </databaseChangeLog>

--- a/server/src/test/java/org/candlepin/async/JobManagerTest.java
+++ b/server/src/test/java/org/candlepin/async/JobManagerTest.java
@@ -1,0 +1,307 @@
+/**
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.async;
+
+import com.google.inject.Injector;
+import com.google.inject.persist.UnitOfWork;
+import org.candlepin.async.temp.TestJob1;
+import org.candlepin.audit.EventSink;
+import org.candlepin.guice.CandlepinRequestScope;
+import org.candlepin.guice.PrincipalProvider;
+import org.candlepin.model.AsyncJobStatus;
+import org.candlepin.model.AsyncJobStatusCurator;
+import org.candlepin.pinsetter.core.model.JobStatus;
+import org.hamcrest.core.StringContains;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.InOrder;
+import org.slf4j.MDC;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class JobManagerTest {
+
+    private static final String JOB_ID = "jobId";
+    private static final String JOB_KEY = TestJob1.getJobKey();
+    private static final String REQUEST_TYPE_KEY = "requestType";
+    private static final String REQUEST_UUID_KEY = "requestUuid";
+    private static final String ORG_KEY = "org";
+    private static final String ORG_LOG_LEVEL_KEY = "orgLogLevel";
+    private static final String OWNER_ID = "ownerId";
+    private static final String OWNER_LOG_LEVEL = "ownerLogLevel";
+    private static final String REQUEST_UUID = "requestUuid";
+    private static final String REQUEST_TYPE = "job";
+
+    private AsyncJobStatusCurator jobCurator;
+    private PrincipalProvider principalProvider;
+    private CandlepinRequestScope scope;
+    private JobMessageDispatcher dispatcher;
+    private Injector injector;
+    private EventSink eventSink;
+    private UnitOfWork uow;
+
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Before
+    public void setUp() {
+        this.jobCurator = mock(AsyncJobStatusCurator.class);
+        this.principalProvider = mock(PrincipalProvider.class);
+        this.scope = mock(CandlepinRequestScope.class);
+        this.dispatcher = mock(JobMessageDispatcher.class);
+        this.injector = mock(Injector.class);
+        this.eventSink = mock(EventSink.class);
+        this.uow = mock(UnitOfWork.class);
+
+        doReturn(this.eventSink).when(this.injector).getInstance(EventSink.class);
+        doReturn(this.jobCurator).when(this.injector).getInstance(AsyncJobStatusCurator.class);
+        doReturn(this.uow).when(this.injector).getInstance(UnitOfWork.class);
+    }
+
+    @Test
+    public void jobShouldFailWhenJobStatusIsNotFound()
+        throws PreJobExecutionException, JobExecutionException {
+        doReturn(null).when(jobCurator).get(anyString());
+        final JobManager manager = createJobManager();
+
+        thrown.expect(PreJobExecutionException.class);
+        thrown.expectMessage(StringContains.containsString("not found"));
+
+        manager.executeJob(new JobMessage(JOB_ID, JOB_KEY));
+    }
+
+    @Test
+    public void jobShouldFailWhenJobWasCancelled() throws PreJobExecutionException, JobExecutionException {
+        doReturn(new AsyncJobStatus().setState(AsyncJobStatus.JobState.CANCELED))
+            .when(jobCurator).get(anyString());
+        final JobManager manager = createJobManager();
+
+        thrown.expect(PreJobExecutionException.class);
+        thrown.expectMessage(StringContains.containsString("CANCELLED"));
+
+        manager.executeJob(new JobMessage(JOB_ID, JOB_KEY));
+    }
+
+
+    @Test
+    public void shouldFailWhenJobCouldNotBeConstructed()
+        throws PreJobExecutionException, JobExecutionException {
+        doReturn(new AsyncJobStatus().setState(AsyncJobStatus.JobState.QUEUED))
+            .when(jobCurator).get(anyString());
+        final JobManager manager = createJobManager();
+
+        thrown.expect(PreJobExecutionException.class);
+        thrown.expectMessage(StringContains.containsString("could not be created"));
+
+        manager.executeJob(new JobMessage(JOB_ID, JOB_KEY));
+    }
+
+    @Test
+    public void jobShouldBeExecuted() throws PreJobExecutionException, JobExecutionException {
+        final AsyncJob spy = mock(AsyncJob.class);
+        doReturn(spy).when(injector).getInstance(TestJob1.class);
+        doReturn(new AsyncJobStatus().setState(AsyncJobStatus.JobState.QUEUED))
+            .when(jobCurator).get(anyString());
+        final JobManager manager = createJobManager();
+
+        manager.executeJob(new JobMessage(JOB_ID, JOB_KEY));
+
+        verify(spy).execute(any());
+    }
+
+    @Test
+    public void shouldSetupDMC() throws JobExecutionException, PreJobExecutionException {
+        final AsyncJobStatus status = mock(AsyncJobStatus.class);
+        final Map<String, Object> map = new HashMap<>();
+        map.put(REQUEST_UUID_KEY, REQUEST_UUID);
+        map.put(JobStatus.OWNER_ID, OWNER_ID);
+        map.put(JobStatus.OWNER_LOG_LEVEL, OWNER_LOG_LEVEL);
+        doReturn(new JobDataMap(map)).when(status).getJobData();
+        doReturn(mock(AsyncJob.class)).when(injector).getInstance(TestJob1.class);
+        doReturn(status).when(jobCurator).get(JOB_ID);
+        final JobManager manager = createJobManager();
+
+        manager.executeJob(new JobMessage(JOB_ID, JOB_KEY));
+
+        assertEquals(REQUEST_TYPE, MDC.get(REQUEST_TYPE_KEY));
+        assertEquals(REQUEST_UUID, MDC.get(REQUEST_UUID_KEY));
+        assertEquals(OWNER_ID, MDC.get(ORG_KEY));
+        assertEquals(OWNER_LOG_LEVEL, MDC.get(ORG_LOG_LEVEL_KEY));
+    }
+
+    @Test
+    public void shouldSendEvents() throws JobExecutionException, PreJobExecutionException {
+        doReturn(mock(AsyncJob.class)).when(injector).getInstance(TestJob1.class);
+        doReturn(new AsyncJobStatus().setState(AsyncJobStatus.JobState.QUEUED))
+            .when(jobCurator).get(anyString());
+        final JobManager manager = createJobManager();
+
+        manager.executeJob(new JobMessage(JOB_ID, JOB_KEY));
+
+        verify(this.eventSink).sendEvents();
+    }
+
+    @Test
+    public void shouldRollbackEventsOfFailedJob() {
+        final AsyncJob job = jdata -> {
+            throw new JobExecutionException();
+        };
+        doReturn(job).when(injector).getInstance(TestJob1.class);
+        doReturn(new AsyncJobStatus().setState(AsyncJobStatus.JobState.QUEUED))
+            .when(jobCurator).get(anyString());
+        final JobManager manager = createJobManager();
+
+        try {
+            manager.executeJob(new JobMessage(JOB_ID, JOB_KEY));
+            fail("Should not happen");
+        }
+        catch (PreJobExecutionException | JobExecutionException e) {
+            verify(this.eventSink).rollback();
+        }
+    }
+
+    @Test
+    public void successfulJobShouldEndAsCompleted() throws JobExecutionException, PreJobExecutionException {
+        final StateCollectingStatus status = new StateCollectingStatus();
+        doReturn(mock(AsyncJob.class)).when(injector).getInstance(TestJob1.class);
+        doReturn(new AsyncJobStatus().setState(AsyncJobStatus.JobState.QUEUED))
+            .when(jobCurator).get(anyString());
+        doReturn(status).when(this.jobCurator).get(JOB_ID);
+        final JobManager manager = createJobManager();
+
+        manager.executeJob(new JobMessage(JOB_ID, JOB_KEY));
+
+        assertTrue(status.containsAll(
+            AsyncJobStatus.JobState.RUNNING,
+            AsyncJobStatus.JobState.COMPLETED));
+    }
+
+    @Test
+    public void shouldSetJobExecSource() throws PreJobExecutionException, JobExecutionException {
+        final AsyncJobStatus status = new AsyncJobStatus();
+        doReturn(mock(AsyncJob.class)).when(injector).getInstance(TestJob1.class);
+        doReturn(new AsyncJobStatus().setState(AsyncJobStatus.JobState.QUEUED))
+            .when(jobCurator).get(anyString());
+        doReturn(status).when(this.jobCurator).get(JOB_ID);
+        final JobManager manager = createJobManager();
+
+        manager.executeJob(new JobMessage(JOB_ID, JOB_KEY));
+
+        final String execSource = status.getJobExecSource();
+        assertFalse(execSource == null || execSource.isEmpty());
+    }
+
+    @Test
+    public void failedJobShouldEndAsFailed() throws PreJobExecutionException {
+        final StateCollectingStatus status = new StateCollectingStatus();
+        final AsyncJob mock = jdata -> {
+            throw new JobExecutionException();
+        };
+        doReturn(mock).when(injector).getInstance(TestJob1.class);
+        doReturn(status).when(this.jobCurator).get(JOB_ID);
+        final JobManager manager = createJobManager();
+
+        try {
+            manager.executeJob(new JobMessage(JOB_ID, JOB_KEY));
+            fail("Should not happen");
+        }
+        catch (JobExecutionException e) {
+            assertTrue(status.containsAll(
+                AsyncJobStatus.JobState.RUNNING,
+                AsyncJobStatus.JobState.FAILED));
+        }
+    }
+
+    @Test
+    public void shouldSurroundJobExecutionWithUnitOfWork()
+        throws JobExecutionException, PreJobExecutionException {
+        final AsyncJob job = mock(AsyncJob.class);
+        doReturn(job).when(injector).getInstance(TestJob1.class);
+        doReturn(new AsyncJobStatus().setState(AsyncJobStatus.JobState.QUEUED))
+            .when(jobCurator).get(anyString());
+        final InOrder inOrder = inOrder(uow, job, uow);
+        final JobManager manager = createJobManager();
+
+        manager.executeJob(new JobMessage(JOB_ID, JOB_KEY));
+
+        inOrder.verify(uow).begin();
+        inOrder.verify(job).execute(any());
+        inOrder.verify(uow).end();
+    }
+
+    @Test
+    public void shouldProperlyEndUnitOfWorkOfFailedJobs()
+        throws JobExecutionException, PreJobExecutionException {
+        final AsyncJob job = mock(AsyncJob.class);
+        doReturn(job).when(injector).getInstance(TestJob1.class);
+        doReturn(new AsyncJobStatus().setState(AsyncJobStatus.JobState.QUEUED))
+            .when(jobCurator).get(anyString());
+        doThrow(new JobExecutionException()).when(job).execute(any());
+        final InOrder inOrder = inOrder(uow, job, uow);
+        final JobManager manager = createJobManager();
+
+        try {
+            manager.executeJob(new JobMessage(JOB_ID, JOB_KEY));
+            fail("Must not happen!");
+        }
+        catch (JobExecutionException e) {
+            inOrder.verify(uow).begin();
+            inOrder.verify(job).execute(any());
+            inOrder.verify(uow).end();
+        }
+    }
+
+    private JobManager createJobManager() {
+        return new JobManager(
+            jobCurator, dispatcher, principalProvider, scope, injector);
+    }
+
+    private static class StateCollectingStatus extends AsyncJobStatus {
+
+        private final List<JobState> states = new ArrayList<>();
+
+        @Override
+        public AsyncJobStatus setState(final JobState state) {
+            super.setState(state);
+            this.states.add(state);
+            return this;
+        }
+
+        public boolean containsAll(JobState... states) {
+            return new HashSet<>(this.states).containsAll(Arrays.asList(states));
+        }
+    }
+
+}


### PR DESCRIPTION
- Implement construction of job from job key
- Update job state during execution(QUEUED->RUNNING->COMPLETED/FAILED)
- Handle job execution transactions
- Setup MDC for job logging
- Update TestJob1 so that it can sleep/fail according to the given parameters
- Add job_exec_source column to the cp2_async_jobs table