### PR TITLE
Adjust candlepin spec to account for removal of policyhelp from selin…

### DIFF
--- a/server/candlepin.spec.tmpl
+++ b/server/candlepin.spec.tmpl
@@ -73,13 +73,9 @@ Summary:        SELinux policy module supporting candlepin
 Group:          System Environment/Base
 BuildRequires:  checkpolicy
 BuildRequires:  selinux-policy-devel
-BuildRequires:  /usr/share/selinux/devel/policyhelp
 BuildRequires:  hardlink
 
-%{!?_selinux_policy_version: %global _selinux_policy_version %(sed -e 's,.*selinux-policy-\\([^/]*\\)/.*,\\1,' /usr/share/selinux/devel/policyhelp 2>/dev/null)}
-%if "%{_selinux_policy_version}" != ""
-Requires:      selinux-policy >= %{_selinux_policy_version}
-%endif
+Requires:	selinux-policy >= %{_selinux_policy_version}
 Requires:       %{name} = %{version}-%{release}
 Requires(post):   /usr/sbin/semodule
 Requires(post):   /sbin/restorecon


### PR DESCRIPTION
…x-policy

All newer version of selinx-policy will no longer contain `/usr/share/selinux/devel/policyhelp` as it was taken removed for [this BZ](https://bugzilla.redhat.com/show_bug.cgi?id=1498429). Specifically it seems it's not needed anymore because of [comment 2](https://bugzilla.redhat.com/show_bug.cgi?id=1498429#c2). Following this logic, I do not think these parts are needed anymore, but I also acknowledge I'm somewhat out of my depth here and would love comment and review. 