### PR TITLE
1650992: Change default key size to 4096 bits.

### DIFF
--- a/server/src/main/java/org/candlepin/pki/impl/ProviderBasedPKIUtility.java
+++ b/server/src/main/java/org/candlepin/pki/impl/ProviderBasedPKIUtility.java
@@ -64,8 +64,7 @@ import java.util.Set;
 public abstract class ProviderBasedPKIUtility implements PKIUtility {
     private static Logger log = LoggerFactory.getLogger(ProviderBasedPKIUtility.class);
 
-    // TODO : configurable?
-    public static final int RSA_KEY_SIZE = 2048;
+    public static final int RSA_KEY_SIZE = 4096;
 
     protected CertificateReader reader;
     protected SubjectKeyIdentifierWriter subjectKeyWriter;


### PR DESCRIPTION
Simply converting Candlepin to issue 4098 bit (up from 2046) keys
doesn't present any problems that I see. The major issue (that I can
see) is that once a key is generated for a client, that's the key
Candlepin is going to use for the foreseeable future. Clients will have
to re-register if they want a larger key. There's nothing we can do
about that though.  The CRL generation code has specific allowances for
changing the key size, but that would only be relevant if Candlepin
restarted with a brand new server key.

Starting to issue 4096 bit keys to new clients seems like about the
extent of what we can do for future-proofing without the user tearing up
a bunch of existing stuff in their deployment.

---

I want to test this **irrespective** of the crypto policy settings.  4096-bit keys are what we should be using anyway and in my experience, setting `update-crypto-policies --set FUTURE` on a system is going to have **a lot** of side-effects that will be more related to deployment (e.g. supported ciphers) than actual Candlepin functionality.  The bug asks us to adjust the key size, so that's what this PR does.  Pursuing issues with a FUTURE crypto-policy is a wild goose chase if you ask me.