### PR TITLE
Update Checkstyle DTDs links[2.3]

### DIFF
--- a/project_conf/checks.xml
+++ b/project_conf/checks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
-  "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-  "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+    "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+    "https://checkstyle.org/dtds/configuration_1_3.dtd">
 
 <!--
 


### PR DESCRIPTION
Checkstyle DTDs on puppycrawl site were deprecated some time ago and are now removed.
- Change configuration DTD link to "https://checkstyle.org/dtds/configuration_1_3.dtd"
- Change suppressions DTD link to "https://checkstyle.org/dtds/suppressions_1_2.dtd"

For more information see the following issues:
- https://github.com/checkstyle/checkstyle/issues/1571
- https://github.com/checkstyle/checkstyle/issues/6478