### PR TITLE
Added ability to create testing yum/dnf repositories.

### DIFF
--- a/server/bin/create_test_repos.py
+++ b/server/bin/create_test_repos.py
@@ -1,0 +1,469 @@
+#!/usr/bin/env python
+
+"""
+This script is used for generating testing RPM repositories
+"""
+
+import sys
+import os
+import json
+import string
+import subprocess
+import shutil
+import tempfile
+import requests
+
+
+RPM_SPEC_FILE_TEMPLATE = """
+Summary:        ${Name} package
+Name:           ${name}
+Version:        ${version}
+Release:        ${release}
+License:        GPL License
+Packager:       Jiri Hnidek <jhnidek redhat com>
+Vendor:         Red Hat
+Group:          Networking/Daemons
+URL:            http://www.tricky-testing-animals.org/
+BuildArch:      noarch
+ 
+%%description
+This is a ${name} package.
+ 
+%%files
+ 
+%%changelog
+* Fri Mar 1 2019 Jiri Hnidek <jhnidek redhat com> 0
+- ${name}
+"""
+
+GPG_NAME_REAL = "candlepin"
+
+GPG_NAME_EMAIL = "noreply@candlepinproject.org"
+
+GPG_BATCH_GEN_SCRIPT_CONTENT = """
+Key-Type: 1
+Key-Length: 2048
+Subkey-Type: 1
+Subkey-Length: 2048
+Name-Real: %s
+Name-Email: %s
+Expire-Date: 0
+%%no-protection
+%%transient-key
+%%commit
+""" % (GPG_NAME_REAL, GPG_NAME_EMAIL)
+
+GPG_EXPORTED_CANDLEPIN_KEY = os.path.expanduser("~") + "/RPM-GPG-KEY-candlepin"
+
+RPMMACROS_CONTENT = """
+%%_signature gpg
+%%_gpg_name %s
+""" % GPG_NAME_REAL
+
+RPMBUILD_ROOT_DIR = os.path.expanduser("~") + "/rpmbuild"
+
+REPO_ROOT_DIR = "/var/lib/tomcat/webapps/ROOT"
+
+CANLDEPIN_SERVER_BASE_URL = "https://localhost:8443/candlepin/"
+
+CANDLEPIN_USER = 'admin'
+CANDLEPIN_PASS = 'admin'
+
+
+def run_command(command, verbose=False):
+    """
+    Try to run command in own process
+    """
+
+    # Run command in subprocess
+    process = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+
+    # Print output of command
+    if verbose is True:
+        for line in process.stdout.readlines():
+            print line
+
+    # Wait for result of process
+    ret = process.wait()
+
+    return ret
+
+
+def read_test_data(filename):
+    """
+    Try to read test data from json file.
+    """
+    try:
+        with open(filename) as fp:
+            try:
+                data = json.load(fp)
+            except ValueError as err:
+                print("Unable to read file %s with test data: %s" % (filename, str(err)))
+                return None
+    except IOError as err:
+        print("Unable to read file: %s with test data: %s" % (filename, str(err)))
+        return None
+    return data
+
+
+def get_repo_definitions(test_data):
+    """
+    Get list of repositories from test_data
+    """
+
+    if test_data is None:
+        return []
+
+    try:
+        repo_definitions = test_data['content']
+    except KeyError as err:
+        print('Info: Test data does not include any global definition of repositories')
+        repo_definitions = []
+
+    # There can be also some content specific for owners
+    try:
+        owners = test_data['owners']
+    except KeyError as err:
+        return repo_definitions
+    
+    for owner in owners:
+        try:
+            owner_content = owner['content']
+        except KeyError as err:
+            continue
+        else:
+            repo_definitions.extend(owner_content)
+    
+    return repo_definitions
+
+
+def add_packages_to_repo(packages_list, repo_path, repository):
+    """
+    This function tries to add list of packages to the repository
+    """
+    for pkg_name in packages_list:
+        print("\tAdding package %s" % pkg_name)
+        pkg_file_name = pkg_name + '-1-0.noarch.rpm'
+        src_pkg_file_path = RPMBUILD_ROOT_DIR + '/RPMS/noarch/' + pkg_file_name
+        dst_pkg_file_path = repo_path + '/RPMS/' + pkg_file_name
+        shutil.copyfile(src_pkg_file_path, dst_pkg_file_path)
+
+
+def generate_repositories(repo_definitions):
+    """
+    This function tries to generate yum repositories with some dummy packages
+    """
+    if repo_definitions is None:
+        return None
+
+    # Make sure that root directory of repositories exist
+    try:
+        if not os.path.exists(REPO_ROOT_DIR):
+            os.makedirs(REPO_ROOT_DIR)
+    except OSError as err:
+        print("Unable to create directory: %s, %s" % (REPO_ROOT_DIR, str(err)))
+        return None
+
+    for repo in repo_definitions:
+        repo_path = REPO_ROOT_DIR + repo['content_url']
+        print("creating repository %s in %s" % (repo['name'], repo_path ))
+        if not os.path.exists(repo_path + '/RPMS'):
+            os.makedirs(repo_path + '/RPMS')
+
+        add_packages_to_repo(repo['packages'], repo_path, repo)
+
+        # Create repository with RPM packages
+        run_command('createrepo %s' % repo_path)
+
+        # Try to create temporary product on candlepin server
+        ret = create_repo_product(repo)
+        if ret is None:
+            continue
+
+        # Try to get product certificate from candlepin server and add it to repository
+        cert = get_productid_cert(repo)
+        if cert is not None:
+            # Note: the cert has to have name 'productid', because modifyrepo
+            # command creates new record in repomd.xml according name of file
+            with open('productid', 'w') as fp:
+                fp.write(cert)
+            # This command add productid certificate to repository
+            run_command('modifyrepo productid %s/repodata' % repo_path)
+            # Remove temporary cert file
+            os.remove('productid')
+
+        # Remove temporary product from candelpin server
+        remove_repo_product(repo)
+
+
+def get_productid_cert(content, owner='admin'):
+    """
+    This function tries to get product-id certificate for given repository (content)
+    """
+    product_id = content['id']
+
+    try:
+        r = requests.get(
+            CANLDEPIN_SERVER_BASE_URL + 'owners/' + owner + '/products/' + str(product_id) + '/certificate',
+            auth=(CANDLEPIN_USER, CANDLEPIN_PASS),
+            verify=False)
+    except Exception as err:
+        print('Error: %s' % str(err))
+        return None
+
+    if r.status_code != 200:
+        return None
+
+    json_data = r.json()
+
+    try:
+        cert = json_data['cert']
+    except KeyError:
+        return None
+
+    return cert
+
+
+def create_repo_product(content, owner="admin"):
+    """
+    This function tries to create temporary product for getting product-id certificate.
+    We need to create certificate with id that contains only one content and id of
+    product is equal to id of content.
+    """
+
+    # Name and ID have to be in specification of content
+    name = content['name']
+    product_id = content['id']
+    # Other attributes are optional in definition of content and have default values
+    arches = content.get('arches', 'noarch')
+    version = content.get('version', '1.0')
+
+    request_data = {
+        'name': name,
+        'id': product_id,
+        'arch': arches,
+        'version': version,
+        'content': [product_id, True]
+    }
+
+    try:
+        r = requests.post(
+            CANLDEPIN_SERVER_BASE_URL + 'owners/' + owner + '/products',
+            json=request_data,
+            auth=(CANDLEPIN_USER, CANDLEPIN_PASS),
+            verify=False)
+    except Exception as err:
+        print('Error: %s' % str(err))
+        return None
+
+    return r
+
+
+def remove_repo_product(content, owner='admin'):
+    """
+    This function tries to remove temporary products from candlepin server
+    """
+    product_id = content['id']
+
+    try:
+        r = requests.delete(
+            CANLDEPIN_SERVER_BASE_URL + 'owners/' + owner + '/products/' + str(product_id),
+            auth=(CANDLEPIN_USER, CANDLEPIN_PASS),
+            verify=False)
+    except Exception as err:
+        print('Error: %s' % str(err))
+        return None
+
+    return r
+
+
+def get_package_definitions(test_data):
+    """
+    Try to get list of package definitions from test_data
+    """
+    if test_data is None:
+        return None
+
+    try:
+        package_definitions = test_data['packages']
+    except KeyError as err:
+        print('Test data does not include any definition of packages')
+        return None
+    
+    return package_definitions
+
+
+def create_dummy_package(package):
+    """
+    This function tries to create dummy RPM package
+    """
+    name = package['name']
+    version = package.get('version', '1')
+    release = package.get('release', '0')
+    arch = package.get('arch', 'noarch')
+
+    print("creating RPM %s" % name)
+
+    # Create content of spec file
+    template = string.Template(RPM_SPEC_FILE_TEMPLATE)
+    d = {'name': name, 'Name': name[0].upper() + name[1:], 'version': version, 'release': release}
+    rpm_spec_content = template.substitute(d)
+
+    # Path to spec file
+    spec_file_path = RPMBUILD_ROOT_DIR + '/SPECS/' + name + '.spec'
+
+    # Save content of spec file to real file
+    with open(spec_file_path, 'w') as fp:
+        fp.write(rpm_spec_content)
+
+    # Generate RPM package using rpmbuild
+    run_command('rpmbuild -bb %s' % spec_file_path)
+
+    rpm_file_path = RPMBUILD_ROOT_DIR + '/RPMS/' + arch + '/' + name + '-' + version + '-' + release + '.' + arch + '.rpm'
+
+    # Resign RPM package with GPG key
+    # Note: GPG is interesting software requiring passphrase and it's almost impossible to avoid
+    # using of passphrase on Centos7. For this reason packages will be without GPG signatures.
+    #
+    #run_command('rpm --resign %s' % rpm_file_path)
+    
+
+def generate_packages(package_definitions):
+    """
+    This function tries to generate dummy packages from the list of package definitions
+    """
+
+    if package_definitions is None:
+        return None
+
+    rpmbuild_sub_dirs = ["BUILD", "RPMS", "SOURCES", "SPECS", "SRPMS"]
+
+    # Make root dir for rpmbuild (~/rpmbuild)
+    if not os.path.exists(RPMBUILD_ROOT_DIR):
+        os.makedirs(RPMBUILD_ROOT_DIR)
+
+    # Make all remaining subdirs for rpmbuild
+    for subdir in rpmbuild_sub_dirs:
+        subdir_path = RPMBUILD_ROOT_DIR + '/' + subdir
+        if not os.path.exists(subdir_path):
+            os.makedirs(subdir_path)
+
+    for pkg in package_definitions:
+        create_dummy_package(pkg)
+
+
+def create_gpg_batch_gen_script():
+    """
+    This function tries to create temporary script file for creating gpg key.
+    This function returns path to script file and path to temporary directory
+    """ 
+
+    # Create temporary directory first
+    temp_dir_path = tempfile.mkdtemp()
+
+    script_path = temp_dir_path + "/gpg_batch_gen_script"
+
+    with open(script_path, "w") as fp:
+        fp.write(GPG_BATCH_GEN_SCRIPT_CONTENT)
+
+    return script_path, temp_dir_path
+
+
+def does_gpg_key_exist():
+    """
+    This function tries to check if GPG for signing RPM packages already exist
+    """
+
+    key_id = '"%s <%s>"' % (GPG_NAME_REAL, GPG_NAME_EMAIL)
+
+    # Try to get list of GPG key with given key ID
+    return run_command('gpg --list-keys %s' % key_id)
+
+
+def create_gpg_key():
+    """
+    This function tries to create gpg key used for signing of RPM packages
+    """
+
+    # Note: you can completely remove all generated/exported keys using:
+    #
+    # gpg --delete-secret-key "candlepin <noreply@candlepinproject.org>"
+    # gpg --delete-key "candlepin <noreply@candlepinproject.org>"
+    #
+    # rpm -q gpg-pubkey --qf '%{NAME}-%{VERSION}-%{RELEASE}\t%{SUMMARY}\n' | grep candlepin
+    # Look at output and notice id
+    #
+    # rpm -e gpg-pubkey-12345678-90abcdef
+
+    script_path, temp_dir_path = create_gpg_batch_gen_script()
+    
+    # Generate GPG key for signing RPM packages
+    ret = run_command('gpg --batch --gen-key %s' % script_path)
+
+    # Remove temporary directory containing script for generating GPG key
+    shutil.rmtree(temp_dir_path)
+
+    # Export gpg key
+    ret += run_command('gpg --export -a %s > %s' % (GPG_NAME_REAL, GPG_EXPORTED_CANDLEPIN_KEY))
+
+    # Copy exported GPG key to default path
+    ret += run_command('cp %s /etc/pki/rpm-gpg/' % GPG_EXPORTED_CANDLEPIN_KEY)
+
+    # Import GPG key to rpm db
+    ret += run_command('rpm --import %s' % GPG_EXPORTED_CANDLEPIN_KEY)
+
+    return ret
+
+
+def modify_rpmmacros():
+    """
+    This function tries to modify ~/.rpmmacros
+    """
+    rpmmacros_path = os.path.expanduser("~") + '/.rpmmacros'
+    if not os.path.isfile(rpmmacros_path):
+        with open(rpmmacros_path, "w") as fp:
+            fp.write(RPMMACROS_CONTENT)
+    else:
+        # TODO: check for macros and add them to the rpmmacros in needed
+        pass
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("Error: syntax %s test_data.json" % sys.argv[0])
+    else:
+        test_data = read_test_data(sys.argv[1])
+
+        # When GPG is used, then add following line to most of
+        # definitions of content (test_data.json)
+        #
+        # "gpg_url": "/foo/path/never/gpg"
+
+        # It is not reliable to use GPG for automatic testing
+        # gpg_exists = does_gpg_key_exist()
+
+        # if gpg_exists != 0:
+        #     print("")
+        #     print("Creating GPG key...")
+        #     print(GPG_BATCH_GEN_SCRIPT_CONTENT)
+        #     create_gpg_key()
+
+        modify_rpmmacros()
+
+        print("")
+        print("Creating packages...")
+
+        package_definitions = get_package_definitions(test_data)
+
+        generate_packages(package_definitions)
+
+        print("")
+        print("Creating repositories...")
+
+        repo_definitions = get_repo_definitions(test_data)
+
+        generate_repositories(repo_definitions)
+            
+
+if __name__ == '__main__':
+    main()

--- a/server/bin/data_generator.rb
+++ b/server/bin/data_generator.rb
@@ -105,7 +105,7 @@ class UnmappedProductContentGenerator < PoolGenerator
       :name => self.generate_content_name,
       :id => self.generate_content_id,
       :content_url => "/foo/path/always",
-      :gpg_url => "/foo/path/always/gpg",
+      :gpg_url => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
     }
 
     products << {
@@ -128,7 +128,7 @@ class SimplePoolGenerator < PoolGenerator
       :name => self.generate_content_name,
       :id => self.generate_content_id,
       :content_url => "/foo/path/always",
-      :gpg_url => "/foo/path/always/gpg",
+      :gpg_url => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
     }
 
     eng_product = {
@@ -204,7 +204,7 @@ class SharedObjectPoolGenerator < PoolGenerator
           :name => self.generate_content_name + " (shared)",
           :id => self.generate_content_id,
           :content_url => "/foo/path/always",
-          :gpg_url => "/foo/path/always/gpg",
+          :gpg_url => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
         }
 
         content_name = self.generate_content_name + " (shared, tagged)"
@@ -215,7 +215,7 @@ class SharedObjectPoolGenerator < PoolGenerator
           :type => "yum",
           :vendor => "test-vendor",
           :content_url => "/foo/path/always",
-          :gpg_url => "/foo/path/always/gpg",
+          :gpg_url => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
           :required_tags => "TAG1,TAG2"
         }
 
@@ -342,7 +342,7 @@ class VDCPoolGenerator < PoolGenerator
         :type => "yum",
         :vendor => "test-vendor",
         :content_url => "/foo/path",
-        :gpg_url => "/foo/path/gpg/",
+        :gpg_url => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
         :metadata_expire => 0
       }
 
@@ -354,7 +354,7 @@ class VDCPoolGenerator < PoolGenerator
         :type => "yum",
         :vendor => "test-vendor",
         :content_url => "http://example.com/awesomeos-modifier",
-        :gpg_url => "http://example.com/awesomeos-modifier/gpg",
+        :gpg_url => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
         :modified_products => [base_product_id]
       }
 

--- a/server/bin/deploy
+++ b/server/bin/deploy
@@ -101,9 +101,10 @@ create_test_repos() {
     fi
     $SUDO chown -R tomcat:tomcat "${REPOS}"
     echo ""
-    echo "Run this command on registered system to use created repositories:"
+    echo "Run following commands on registered system to use created repositories:"
     echo ""
     echo "    subscription-manager config --rhsm.baseurl=http://<ip_of_this_server>:8080"
+    echo "    curl http://<ip_of_this_server>:8080/RPM-GPG-KEY-candlepin > /etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin"
     echo ""
 }
 

--- a/server/bin/deploy
+++ b/server/bin/deploy
@@ -92,6 +92,21 @@ upload_products() {
   fi
 }
 
+create_test_repos() {
+    if [ ! -d "${REPOS}" ]; then
+        $SUDO mkdir "${REPOS}"
+    fi
+    if [ "$TESTREPO" = "1" ]; then
+        $SUDO $SELF_DIR/create_test_repos.py $SELF_DIR/test_data.json
+    fi
+    $SUDO chown -R tomcat:tomcat "${REPOS}"
+    echo ""
+    echo "Run this command on registered system to use created repositories:"
+    echo ""
+    echo "    subscription-manager config --rhsm.baseurl=http://<ip_of_this_server>:8080"
+    echo ""
+}
+
 create_var_lib_candlepin() {
     $SUDO mkdir -p /var/lib/candlepin
     $SUDO chown tomcat:tomcat /var/lib/candlepin
@@ -132,6 +147,7 @@ usage: deploy [options]
 OPTIONS:
   -f          force cert regeneration
   -g          generate database
+  -r          generate test repositories
   -q          Qpid enabled. Also deploys 'allmsg' queue used by spec tests
   -t          import test data
   -T          import minimal test data, some owners, users, and roles
@@ -186,7 +202,7 @@ init
 
 DBUSER="candlepin"
 
-while getopts ":fqgtTHolmavbd:" opt; do
+while getopts ":fqgtTrHolmavbd:" opt; do
     case $opt in
         f  ) FORCECERT="1" ;;
         g  ) GENDB="1";;
@@ -194,6 +210,7 @@ while getopts ":fqgtTHolmavbd:" opt; do
         q  ) QPID="qpid";;
         t  ) TESTDATA="1";;
         T  ) TESTDATA="MIN";;
+        r  ) TESTREPO="1";;
         l  ) LOGDRIVER="logdriver";;
         m  ) USE_MYSQL="1";;
         a  ) AUTOCONF="1";;
@@ -252,7 +269,7 @@ fi
 DEPLOY="$TC_HOME/webapps/candlepin.war"
 CLEAN="$TC_HOME/webapps/candlepin/"
 
-
+REPOS="$TC_HOME/webapps/ROOT"
 
 
 
@@ -376,4 +393,6 @@ echo
 initialize_cp
 
 upload_products
+create_test_repos
+
 notify

--- a/server/bin/test_data.json
+++ b/server/bin/test_data.json
@@ -381,7 +381,7 @@
                     "label": "admin-content-label",
                     "type": "yum",
                     "vendor": "test-vendor",
-                    "content_url": "/admin/foo/path/common",
+                    "content_url": "/foo/admin/path/common",
                     "gpg_url": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
                     "metadata_expire": 0,
                     "packages": ["fluffy-snake"]
@@ -392,7 +392,7 @@
                     "label": "admin-tagged-content",
                     "type": "yum",
                     "vendor": "test-vendor",
-                    "content_url": "/admin/foo/path/always",
+                    "content_url": "/foo//adminpath/always",
                     "gpg_url": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
                     "required_tags": "TAG1,TAG2",
                     "packages": ["tricky-frog"]
@@ -403,7 +403,7 @@
                     "label": "admin-never-enabled-content",
                     "type": "yum",
                     "vendor": "test-vendor",
-                    "content_url": "/admin/foo/path/never",
+                    "content_url": "/foo/admin/path/never",
                     "gpg_url": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
                     "metadata_expire": 600,
                     "packages": ["lazy-fox"]

--- a/server/bin/test_data.json
+++ b/server/bin/test_data.json
@@ -392,7 +392,7 @@
                     "label": "admin-tagged-content",
                     "type": "yum",
                     "vendor": "test-vendor",
-                    "content_url": "/foo//adminpath/always",
+                    "content_url": "/foo/admin/path/always",
                     "gpg_url": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
                     "required_tags": "TAG1,TAG2",
                     "packages": ["tricky-frog"]

--- a/server/bin/test_data.json
+++ b/server/bin/test_data.json
@@ -41,7 +41,8 @@
         },
         {
             "name": "slow-eagle",
-            "version": "1"
+            "version": "1",
+            "release": "07"
         },
         {
             "name": "cool-mouse",
@@ -71,7 +72,8 @@
             "label": "never-enabled-content",
             "type": "yum",
             "vendor": "test-vendor",
-            "content_url": "/foo/path/never",
+            "content_url": "/foo/path/never_enabled",
+            "gpg_url": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
             "metadata_expire": 600,
             "packages": ["tricky-frog", "slow-eagle", "white-lion"]
         },
@@ -81,8 +83,8 @@
             "label": "tagged-content",
             "type": "yum",
             "vendor": "test-vendor",
-            "content_url": "/foo/path/always",
-
+            "content_url": "/foo/path/tagged",
+            "gpg_url": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
             "required_tags": "TAG1,TAG2",
             "packages": ["lazy-fox", "white-lion", "fluffy-snake"]
         },
@@ -92,7 +94,8 @@
             "label": "content-label",
             "type": "yum",
             "vendor": "test-vendor",
-            "content_url": "/foo/path",
+            "content_url": "/foo/path/common",
+            "gpg_url": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
             "metadata_expire": 0,
             "packages": ["jumping-snail", "cool-mouse"]
         },
@@ -102,7 +105,7 @@
             "label": "content-label-no-gpg",
             "type": "yum",
             "vendor": "test-vendor",
-            "content_url": "/foo/path/no",
+            "content_url": "/foo/path/no_gpg",
             "metadata_expire": 0,
             "packages": ["slow-eagle", "schrodingers-kitten"]
         },
@@ -112,7 +115,7 @@
             "label": "content-label-empty-gpg",
             "type": "yum",
             "vendor": "test-vendor",
-            "content_url": "/foo/path/empty",
+            "content_url": "/foo/path/empty_gpg",
             "gpg_url": "",
             "metadata_expire": 0,
             "packages": ["cool-mouse", "lazy-fox"]
@@ -124,6 +127,7 @@
             "type": "yum",
             "vendor": "test-vendor",
             "content_url": "/example.com/awesomeos-modifier",
+            "gpg_url": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
             "modified_products": ["37060", "27060"],
             "packages": ["awesome-pig"]
         },
@@ -134,6 +138,7 @@
             "type": "yum",
             "vendor": "Red Hat",
             "content_url": "/path/to/generic/awesomeos",
+            "gpg_url": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
             "metadata_expire": 3600,
             "packages": ["awesome-rabbit"]
         },
@@ -144,6 +149,7 @@
             "type": "yum",
             "vendor": "Red Hat",
             "content_url": "/path/to/awesomeos/x86",
+            "gpg_url": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
             "metadata_expire": 3600,
             "packages": ["awesome-goat"]
         },
@@ -154,6 +160,7 @@
             "type": "yum",
             "vendor": "Red Hat",
             "content_url": "/path/to/awesomeos/i386",
+            "gpg_url": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
             "metadata_expire": 3600,
             "packages": ["awesome-sheep"]
         },
@@ -164,6 +171,7 @@
             "type": "yum",
             "vendor": "Red Hat",
             "content_url": "/path/to/awesomeos/i686",
+            "gpg_url": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
             "metadata_expire": 3600,
             "packages": ["awesome-chicken"]
         },
@@ -174,6 +182,7 @@
             "type": "yum",
             "vendor": "Red Hat",
             "content_url": "/path/to/awesomeos/x86_64",
+            "gpg_url": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
             "metadata_expire": 3600,
             "packages": ["awesome-sheep", "awesome-chicken"]
         },
@@ -184,6 +193,7 @@
             "type": "yum",
             "vendor": "Red Hat",
             "content_url": "/path/to/awesomeos/ia64",
+            "gpg_url": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
             "metadata_expire": 3600,
             "packages": ["awesome-rabbit", "awesome-rabbit"]
         },
@@ -194,6 +204,7 @@
             "type": "yum",
             "vendor": "Red Hat",
             "content_url": "/path/to/awesomeos/ppc64",
+            "gpg_url": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
             "metadata_expire": 3600,
             "packages": ["awesome-chicken", "awesome-sheep"]
         },
@@ -204,6 +215,7 @@
             "type": "yum",
             "vendor": "Red Hat",
             "content_url": "/path/to/awesomeos/ppc",
+            "gpg_url": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
             "metadata_expire": 3600,
             "packages": ["awesome-chicken", "awesome-sheep", "awesome-rabbit"]
         },
@@ -214,6 +226,7 @@
             "type": "yum",
             "vendor": "Red Hat",
             "content_url": "/path/to/awesomeos/s390x",
+            "gpg_url": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
             "metadata_expire": 3600,
             "packages": ["awesome-cow", "awesome-pig"]
         },
@@ -224,6 +237,7 @@
             "type": "yum",
             "vendor": "Red Hat",
             "content_url": "/path/to/awesomeos/all",
+            "gpg_url": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
             "metadata_expire": 3600,
             "packages": ["awesome-chicken", "awesome-rabbit", "awesome-sheep", "awesome-cow"]
         },
@@ -234,6 +248,7 @@
             "type": "yum",
             "vendor": "Red Hat",
             "content_url": "/path/to/awesomeos/i386_content",
+            "gpg_url": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
             "arches": "i386",
             "metadata_expire": 3600,
             "packages": ["awesome-sheep"]
@@ -245,6 +260,7 @@
             "type": "yum",
             "vendor": "Red Hat",
             "content_url": "/path/to/awesomeos/x86_64_i368_content",
+            "gpg_url": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
             "arches": "x86_64,i386",
             "metadata_expire": 3600,
             "packages": ["awesome-cow"]
@@ -256,6 +272,7 @@
             "type": "yum",
             "vendor": "Red Hat",
             "content_url": "/path/to/awesomeos/x86_64_content",
+            "gpg_url": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
             "arches": "x86_64",
             "metadata_expire": 3600,
             "packages": ["awesome-rabbit"]
@@ -267,6 +284,7 @@
             "type": "yum",
             "vendor": "Red Hat",
             "content_url": "/path/to/awesomeos/s390x_content",
+            "gpg_url": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
             "arches": "s390x",
             "metadata_expire": 3600,
             "packages": ["awesome-pig"]
@@ -278,6 +296,7 @@
             "type": "yum",
             "vendor": "Red Hat",
             "content_url": "/path/to/awesomeos/ppc64_content",
+            "gpg_url": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
             "arches": "ppc64",
             "metadata_expire": 3600,
             "packages": ["awesome-pig", "awesome-sheep"]
@@ -289,6 +308,7 @@
             "type": "yum",
             "vendor": "Red Hat",
             "content_url": "/path/to/awesomeos/ppc_content",
+            "gpg_url": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
             "arches": "ppc",
             "metadata_expire": 3600,
             "packages": ["awesome-sheep", "awesome-rabbit"]
@@ -300,6 +320,7 @@
             "type": "yum",
             "vendor": "Red Hat",
             "content_url": "/path/to/awesomeos/i64_content",
+            "gpg_url": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
             "arches": "ia64",
             "metadata_expire": 3600,
             "packages": ["awesome-sheep", "awesome-cow"]
@@ -311,6 +332,7 @@
             "type": "yum",
             "vendor": "Red Hat",
             "content_url": "/path/to/awesomeos-server-scalable-fs",
+            "gpg_url": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
             "metadata_expire": 3600,
             "modified_products": ["37060"],
             "packages": ["awesome-sheep", "schrodingers-kitten"]
@@ -322,6 +344,7 @@
             "type": "yum",
             "vendor": "Red Hat",
             "content_url": "/path/to/awesomeos-workstation-scalable-fs",
+            "gpg_url": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
             "metadata_expire": 3600,
             "modified_products": ["27060"],
             "packages": ["awesome-sheep", "jumping-snail"]
@@ -333,6 +356,7 @@
             "type": "containerImage",
             "vendor": "Red Hat",
             "content_url": "/path/to/awesomeos-docker-images",
+            "gpg_url": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
             "packages": ["awesome-sheep", "flying-fish"]
         },
         {
@@ -342,6 +366,7 @@
             "type": "ostree",
             "vendor": "Red Hat",
             "content_url": "/path/to/awesomeos-ostree",
+            "gpg_url": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
             "packages": ["awesome-sheep", "fluffy-snake"]
         }
     ],
@@ -356,7 +381,8 @@
                     "label": "admin-content-label",
                     "type": "yum",
                     "vendor": "test-vendor",
-                    "content_url": "/admin/foo/path",
+                    "content_url": "/admin/foo/path/common",
+                    "gpg_url": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
                     "metadata_expire": 0,
                     "packages": ["fluffy-snake"]
                 },
@@ -367,6 +393,7 @@
                     "type": "yum",
                     "vendor": "test-vendor",
                     "content_url": "/admin/foo/path/always",
+                    "gpg_url": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
                     "required_tags": "TAG1,TAG2",
                     "packages": ["tricky-frog"]
                 },
@@ -377,6 +404,7 @@
                     "type": "yum",
                     "vendor": "test-vendor",
                     "content_url": "/admin/foo/path/never",
+                    "gpg_url": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
                     "metadata_expire": 600,
                     "packages": ["lazy-fox"]
                 }
@@ -465,7 +493,8 @@
                     "label": "snowy-content-label",
                     "type": "yum",
                     "vendor": "test-vendor",
-                    "content_url": "/snowy/foo/path",
+                    "content_url": "/snowy/foo/path/common",
+                    "gpg_url": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
                     "metadata_expire": 0,
                     "packages": ["slow-eagle"]
                 },
@@ -476,6 +505,7 @@
                     "type": "yum",
                     "vendor": "test-vendor",
                     "content_url": "/snowy/foo/path/always",
+                    "gpg_url": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
                     "required_tags": "TAG1,TAG2",
                     "packages": ["jumping-snail"]
                 },
@@ -486,6 +516,7 @@
                     "type": "yum",
                     "vendor": "test-vendor",
                     "content_url": "/snowy/foo/path/never",
+                    "gpg_url": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
                     "metadata_expire": 600,
                     "packages": ["tricky-frog"]
                 }

--- a/server/bin/test_data.json
+++ b/server/bin/test_data.json
@@ -1,4 +1,69 @@
 {
+    "packages": [
+        {
+            "name": "tricky-frog",
+            "version": "1"
+        },
+        {
+            "name": "lazy-fox",
+            "version": "1"
+        },
+        {
+            "name": "awesome-pig",
+            "version": "1"
+        },
+        {
+            "name": "awesome-cow",
+            "version": "1"
+        },
+        {
+            "name": "awesome-chicken",
+            "version": "1"
+        },
+        {
+            "name": "awesome-sheep",
+            "version": "2"
+        },
+        {
+            "name": "awesome-goat",
+            "version": "3",
+            "release": "14"
+        },
+        {
+            "name": "awesome-rabbit",
+            "version": "6",
+            "release": "626"
+        },
+        {
+            "name": "schrodingers-kitten",
+            "version": "2",
+            "release": "71"
+        },
+        {
+            "name": "slow-eagle",
+            "version": "1"
+        },
+        {
+            "name": "cool-mouse",
+            "version": "1"
+        },
+        {
+            "name": "flying-fish",
+            "version": "1"
+        },
+        {
+            "name": "white-lion",
+            "version": "1"
+        },
+        {
+            "name": "jumping-snail",
+            "version": "1"
+        },
+        {
+            "name": "fluffy-snake",
+            "version": "1"
+        }
+    ],
     "content": [
         {
             "name": "never-enabled-content",
@@ -7,8 +72,8 @@
             "type": "yum",
             "vendor": "test-vendor",
             "content_url": "/foo/path/never",
-            "gpg_url": "/foo/path/never/gpg",
-            "metadata_expire": 600
+            "metadata_expire": 600,
+            "packages": ["tricky-frog", "slow-eagle", "white-lion"]
         },
         {
             "name": "tagged-content",
@@ -17,8 +82,9 @@
             "type": "yum",
             "vendor": "test-vendor",
             "content_url": "/foo/path/always",
-            "gpg_url": "/foo/path/always/gpg",
-            "required_tags": "TAG1,TAG2"
+
+            "required_tags": "TAG1,TAG2",
+            "packages": ["lazy-fox", "white-lion", "fluffy-snake"]
         },
         {
             "name": "content",
@@ -27,8 +93,8 @@
             "type": "yum",
             "vendor": "test-vendor",
             "content_url": "/foo/path",
-            "gpg_url": "/foo/path/gpg/",
-            "metadata_expire": 0
+            "metadata_expire": 0,
+            "packages": ["jumping-snail", "cool-mouse"]
         },
         {
             "name": "content-nogpg",
@@ -36,8 +102,9 @@
             "label": "content-label-no-gpg",
             "type": "yum",
             "vendor": "test-vendor",
-            "content_url": "/foo/path",
-            "metadata_expire": 0
+            "content_url": "/foo/path/no",
+            "metadata_expire": 0,
+            "packages": ["slow-eagle", "schrodingers-kitten"]
         },
         {
             "name": "content-emptygpg",
@@ -45,9 +112,10 @@
             "label": "content-label-empty-gpg",
             "type": "yum",
             "vendor": "test-vendor",
-            "content_url": "/foo/path",
+            "content_url": "/foo/path/empty",
             "gpg_url": "",
-            "metadata_expire": 0
+            "metadata_expire": 0,
+            "packages": ["cool-mouse", "lazy-fox"]
         },
         {
             "name": "awesomeos-modifier",
@@ -55,9 +123,9 @@
             "label": "awesomeos-modifier",
             "type": "yum",
             "vendor": "test-vendor",
-            "content_url": "http://example.com/awesomeos-modifier",
-            "gpg_url": "http://example.com/awesomeos-modifier/gpg",
-            "modified_products": ["37060", "27060"]
+            "content_url": "/example.com/awesomeos-modifier",
+            "modified_products": ["37060", "27060"],
+            "packages": ["awesome-pig"]
         },
         {
             "name": "awesomeos",
@@ -65,9 +133,9 @@
             "label": "awesomeos",
             "type": "yum",
             "vendor": "Red Hat",
-            "content_url": "/path/to/$basearch/$releasever/awesomeos",
-            "gpg_url": "/path/to/awesomeos/gpg/",
-            "metadata_expire": 3600
+            "content_url": "/path/to/generic/awesomeos",
+            "metadata_expire": 3600,
+            "packages": ["awesome-rabbit"]
         },
         {
             "name": "awesomeos-x86",
@@ -75,9 +143,9 @@
             "label": "awesomeos-x86",
             "type": "yum",
             "vendor": "Red Hat",
-            "content_url": "/path/to/awesomeos/$releasever/x86",
-            "gpg_url": "/path/to/awesomeos/gpg/",
-            "metadata_expire": 3600
+            "content_url": "/path/to/awesomeos/x86",
+            "metadata_expire": 3600,
+            "packages": ["awesome-goat"]
         },
         {
             "name": "awesomeos-i386",
@@ -86,8 +154,8 @@
             "type": "yum",
             "vendor": "Red Hat",
             "content_url": "/path/to/awesomeos/i386",
-            "gpg_url": "/path/to/awesomeos/gpg/",
-            "metadata_expire": 3600
+            "metadata_expire": 3600,
+            "packages": ["awesome-sheep"]
         },
         {
             "name": "awesomeos-i686",
@@ -96,8 +164,8 @@
             "type": "yum",
             "vendor": "Red Hat",
             "content_url": "/path/to/awesomeos/i686",
-            "gpg_url": "/path/to/awesomeos/gpg/",
-            "metadata_expire": 3600
+            "metadata_expire": 3600,
+            "packages": ["awesome-chicken"]
         },
         {
             "name": "awesomeos-x86_64",
@@ -106,8 +174,8 @@
             "type": "yum",
             "vendor": "Red Hat",
             "content_url": "/path/to/awesomeos/x86_64",
-            "gpg_url": "/path/to/awesomeos/gpg/",
-            "metadata_expire": 3600
+            "metadata_expire": 3600,
+            "packages": ["awesome-sheep", "awesome-chicken"]
         },
         {
             "name": "awesomeos-ia64",
@@ -116,8 +184,8 @@
             "type": "yum",
             "vendor": "Red Hat",
             "content_url": "/path/to/awesomeos/ia64",
-            "gpg_url": "/path/to/awesomeos/gpg/",
-            "metadata_expire": 3600
+            "metadata_expire": 3600,
+            "packages": ["awesome-rabbit", "awesome-rabbit"]
         },
         {
             "name": "awesomeos-ppc64",
@@ -126,8 +194,8 @@
             "type": "yum",
             "vendor": "Red Hat",
             "content_url": "/path/to/awesomeos/ppc64",
-            "gpg_url": "/path/to/awesomeos/gpg/",
-            "metadata_expire": 3600
+            "metadata_expire": 3600,
+            "packages": ["awesome-chicken", "awesome-sheep"]
         },
         {
             "name": "awesomeos-ppc",
@@ -136,8 +204,8 @@
             "type": "yum",
             "vendor": "Red Hat",
             "content_url": "/path/to/awesomeos/ppc",
-            "gpg_url": "/path/to/awesomeos/gpg/",
-            "metadata_expire": 3600
+            "metadata_expire": 3600,
+            "packages": ["awesome-chicken", "awesome-sheep", "awesome-rabbit"]
         },
         {
             "name": "awesomeos-s390x",
@@ -146,8 +214,8 @@
             "type": "yum",
             "vendor": "Red Hat",
             "content_url": "/path/to/awesomeos/s390x",
-            "gpg_url": "/path/to/awesomeos/gpg/",
-            "metadata_expire": 3600
+            "metadata_expire": 3600,
+            "packages": ["awesome-cow", "awesome-pig"]
         },
         {
             "name": "awesomeos-all",
@@ -156,8 +224,8 @@
             "type": "yum",
             "vendor": "Red Hat",
             "content_url": "/path/to/awesomeos/all",
-            "gpg_url": "/path/to/awesomeos/gpg/",
-            "metadata_expire": 3600
+            "metadata_expire": 3600,
+            "packages": ["awesome-chicken", "awesome-rabbit", "awesome-sheep", "awesome-cow"]
         },
         {
             "name": "awesomeos-i386-only-content",
@@ -165,10 +233,10 @@
             "label": "awesomeos-i386-only-content",
             "type": "yum",
             "vendor": "Red Hat",
-            "content_url": "/path/to/awesomeos/all",
-            "gpg_url": "/path/to/awesomeos/gpg/",
+            "content_url": "/path/to/awesomeos/i386_content",
             "arches": "i386",
-            "metadata_expire": 3600
+            "metadata_expire": 3600,
+            "packages": ["awesome-sheep"]
         },
         {
             "name": "awesomeos-x86_64-i386-content",
@@ -176,10 +244,10 @@
             "label": "awesomeos-x86_64-i386-content",
             "type": "yum",
             "vendor": "Red Hat",
-            "content_url": "/path/to/awesomeos/all",
-            "gpg_url": "/path/to/awesomeos/gpg/",
+            "content_url": "/path/to/awesomeos/x86_64_i368_content",
             "arches": "x86_64,i386",
-            "metadata_expire": 3600
+            "metadata_expire": 3600,
+            "packages": ["awesome-cow"]
         },
         {
             "name": "awesomeos-x86_64-only-content",
@@ -187,10 +255,10 @@
             "label": "awesomeos-x86_64-only-content",
             "type": "yum",
             "vendor": "Red Hat",
-            "content_url": "/path/to/awesomeos/all",
-            "gpg_url": "/path/to/awesomeos/gpg/",
+            "content_url": "/path/to/awesomeos/x86_64_content",
             "arches": "x86_64",
-            "metadata_expire": 3600
+            "metadata_expire": 3600,
+            "packages": ["awesome-rabbit"]
         },
         {
             "name": "awesomeos-s390x-only-content",
@@ -198,10 +266,10 @@
             "label": "awesomeos-s390x-only-content",
             "type": "yum",
             "vendor": "Red Hat",
-            "content_url": "/path/to/awesomeos/all",
-            "gpg_url": "/path/to/awesomeos/gpg/",
+            "content_url": "/path/to/awesomeos/s390x_content",
             "arches": "s390x",
-            "metadata_expire": 3600
+            "metadata_expire": 3600,
+            "packages": ["awesome-pig"]
         },
         {
             "name": "awesomeos-ppc64-only-content",
@@ -209,10 +277,10 @@
             "label": "awesomeos-ppc64-only-content",
             "type": "yum",
             "vendor": "Red Hat",
-            "content_url": "/path/to/awesomeos/all",
-            "gpg_url": "/path/to/awesomeos/gpg/",
+            "content_url": "/path/to/awesomeos/ppc64_content",
             "arches": "ppc64",
-            "metadata_expire": 3600
+            "metadata_expire": 3600,
+            "packages": ["awesome-pig", "awesome-sheep"]
         },
         {
             "name": "awesomeos-ppc-only-content",
@@ -220,10 +288,10 @@
             "label": "awesomeos-ppc-only-content",
             "type": "yum",
             "vendor": "Red Hat",
-            "content_url": "/path/to/awesomeos/all",
-            "gpg_url": "/path/to/awesomeos/gpg/",
+            "content_url": "/path/to/awesomeos/ppc_content",
             "arches": "ppc",
-            "metadata_expire": 3600
+            "metadata_expire": 3600,
+            "packages": ["awesome-sheep", "awesome-rabbit"]
         },
         {
             "name": "awesomeos-ia64-only-content",
@@ -231,10 +299,10 @@
             "label": "awesomeos-ia64-only-content",
             "type": "yum",
             "vendor": "Red Hat",
-            "content_url": "/path/to/awesomeos/all",
-            "gpg_url": "/path/to/awesomeos/gpg/",
+            "content_url": "/path/to/awesomeos/i64_content",
             "arches": "ia64",
-            "metadata_expire": 3600
+            "metadata_expire": 3600,
+            "packages": ["awesome-sheep", "awesome-cow"]
         },
         {
             "name": "awesomeos-server-scalable-fs",
@@ -243,9 +311,9 @@
             "type": "yum",
             "vendor": "Red Hat",
             "content_url": "/path/to/awesomeos-server-scalable-fs",
-            "gpg_url": "/path/to/awesomeos/gpg/",
             "metadata_expire": 3600,
-            "modified_products": ["37060"]
+            "modified_products": ["37060"],
+            "packages": ["awesome-sheep", "schrodingers-kitten"]
         },
         {
             "name": "awesomeos-workstation-scalable-fs",
@@ -254,9 +322,9 @@
             "type": "yum",
             "vendor": "Red Hat",
             "content_url": "/path/to/awesomeos-workstation-scalable-fs",
-            "gpg_url": "/path/to/awesomeos/gpg/",
             "metadata_expire": 3600,
-            "modified_products": ["27060"]
+            "modified_products": ["27060"],
+            "packages": ["awesome-sheep", "jumping-snail"]
         },
         {
             "name": "awesomeos-docker-images",
@@ -265,7 +333,7 @@
             "type": "containerImage",
             "vendor": "Red Hat",
             "content_url": "/path/to/awesomeos-docker-images",
-            "gpg_url": "/path/to/awesomeos/gpg/"
+            "packages": ["awesome-sheep", "flying-fish"]
         },
         {
             "name": "awesomeos-ostree",
@@ -274,7 +342,7 @@
             "type": "ostree",
             "vendor": "Red Hat",
             "content_url": "/path/to/awesomeos-ostree",
-            "gpg_url": "/path/to/awesomeos/gpg/"
+            "packages": ["awesome-sheep", "fluffy-snake"]
         }
     ],
     "owners": [
@@ -289,8 +357,8 @@
                     "type": "yum",
                     "vendor": "test-vendor",
                     "content_url": "/admin/foo/path",
-                    "gpg_url": "/admin/foo/path/gpg/",
-                    "metadata_expire": 0
+                    "metadata_expire": 0,
+                    "packages": ["fluffy-snake"]
                 },
                 {
                     "name": "admin-tagged-content",
@@ -299,8 +367,8 @@
                     "type": "yum",
                     "vendor": "test-vendor",
                     "content_url": "/admin/foo/path/always",
-                    "gpg_url": "/admin/foo/path/always/gpg",
-                    "required_tags": "TAG1,TAG2"
+                    "required_tags": "TAG1,TAG2",
+                    "packages": ["tricky-frog"]
                 },
                 {
                     "name": "admin-never-enabled-content",
@@ -309,8 +377,8 @@
                     "type": "yum",
                     "vendor": "test-vendor",
                     "content_url": "/admin/foo/path/never",
-                    "gpg_url": "/admin/foo/path/never/gpg",
-                    "metadata_expire": 600
+                    "metadata_expire": 600,
+                    "packages": ["lazy-fox"]
                 }
             ],
             "products": [
@@ -398,8 +466,8 @@
                     "type": "yum",
                     "vendor": "test-vendor",
                     "content_url": "/snowy/foo/path",
-                    "gpg_url": "/snowy/foo/path/gpg/",
-                    "metadata_expire": 0
+                    "metadata_expire": 0,
+                    "packages": ["slow-eagle"]
                 },
                 {
                     "name": "snowy-tagged-content",
@@ -408,8 +476,8 @@
                     "type": "yum",
                     "vendor": "test-vendor",
                     "content_url": "/snowy/foo/path/always",
-                    "gpg_url": "/snowy/foo/path/always/gpg",
-                    "required_tags": "TAG1,TAG2"
+                    "required_tags": "TAG1,TAG2",
+                    "packages": ["jumping-snail"]
                 },
                 {
                     "name": "snowy-never-enabled-content",
@@ -418,8 +486,8 @@
                     "type": "yum",
                     "vendor": "test-vendor",
                     "content_url": "/snowy/foo/path/never",
-                    "gpg_url": "/snowy/foo/path/never/gpg",
-                    "metadata_expire": 600
+                    "metadata_expire": 600,
+                    "packages": ["tricky-frog"]
                 }
             ],
             "products": [


### PR DESCRIPTION
* Repositories are created according definition of 'content' in
  test_data.json
* Added definitions of dummy packages to test_data.json
  - Dummy packages are empty packages without any content (no files)
  - No dependencies on anything
  - Easy to test on any platform (RHEL, CentOS 6/7, Fedora, ...)
* Product certificate is created from temporary product using REST API
  - Temporary product contains only one contet and ID of temporary
    product is the same as ID of content
  - Certitifate for temporary product is downloaded
  - Temporary product is removed
* Python script for creating testing repos also contains functions
  for creating GPG keys and signing keys, but it is not used ATM
* It requires more packages on the system running candlepin (https://github.com/candlepin/ansible-role-candlepin will be updated according these requirements):
    - createrepo
    - rpm-build
    - rpm-sign
    - python-requests
    - expect
* To test new option run: `./server/bin/deploy -gtar` on the candlepin server
* Generated RPMs are signed with GPG key
* GPG key has to be protected by passphrase, because rpmsing
  tries to read passphrase despite key is not protected by
  any passphrase
* Tool called expect is used to "type" secret passphrase
* Generated RPMs are cached in rpmbuild directory
* Modified some paths in products
* Modified gpg_url to:
   "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin"
* It is not possible to use: "gpg_url": "/RPM-GPG-KEY-candlepin",
  because subscription-manager generate following
  gpgkey: http://ip_addr:8080/RPM-GPG-KEY-candlepin
  in redhat.repo and yum/dnf/pkcon/microdnf are not willing
  to download GPG key using http. It is allowed to use only
  https protocol.
* GPG key has to be downloaded and installed on registered
  system to be able to install signed RPMs. Note: yum and dnf
  allow to install RPMs without gpg sign, when --nogpgcheck
  is used, but pkcon nor microdnf do not have such option
* Added hint to final message of the deploy script how to
  install GPG key on registered system