### PR TITLE
Added support for unique job constraints during job queuing (ENT-844)

### DIFF
--- a/server/src/main/java/org/candlepin/async/JobInitializationException.java
+++ b/server/src/main/java/org/candlepin/async/JobInitializationException.java
@@ -14,8 +14,10 @@
  */
 package org.candlepin.async;
 
+
+
 /**
- * The PreJobExecutionException represents an error that occurs before a job is
+ * The JobInitializationException represents an error that occurs before a job is
  * actually executed by the JobManager. The JobManager should throw this exeception
  * anytime that a job is invalid and can not be run. The JobMessageReceiver will
  * discard the associated job message when it encounters this exception, so it should
@@ -27,14 +29,14 @@ package org.candlepin.async;
  *         - Job was determined cancelled before execution.
  * </pre>
  */
-public class PreJobExecutionException extends Exception {
+public class JobInitializationException extends Exception {
 
     /**
      * Create an instance of this exception with the specified message.
      *
      * @param message a message describing the cause of the exception.
      */
-    public PreJobExecutionException(String message) {
+    public JobInitializationException(String message) {
         super(message);
     }
 }

--- a/server/src/main/java/org/candlepin/async/JobMessageReceiver.java
+++ b/server/src/main/java/org/candlepin/async/JobMessageReceiver.java
@@ -81,7 +81,7 @@ public class JobMessageReceiver extends MessageReceiver {
             // Finally commit the session so that the message is taken out of the queue.
             session.commit();
         }
-        catch (PreJobExecutionException pjee) {
+        catch (JobInitializationException jie) {
             // Expected when:
             //   * Job status could not be found
             //   * Job was determined cancelled before execution.
@@ -89,7 +89,7 @@ public class JobMessageReceiver extends MessageReceiver {
                 session.commit();
             }
             catch (ActiveMQException amqe) {
-                log.error("Unable to commit job message after receiving PreJobExecutionException.", amqe);
+                log.error("Unable to commit job message after receiving JobInitializationException.", amqe);
                 // Nothing we can do. The job will be lost.
             }
         }

--- a/server/src/main/java/org/candlepin/async/temp/AsyncJobResource.java
+++ b/server/src/main/java/org/candlepin/async/temp/AsyncJobResource.java
@@ -72,14 +72,42 @@ public class AsyncJobResource {
         @QueryParam("sleep") @DefaultValue("false") Boolean sleep, @QueryParam("persist")
         @DefaultValue("false") Boolean persist) {
 
-        return jobManager.queueJob(new JobBuilder()
-            .setJobKey("TEST_JOB1")
+        // for (int j = 0; j < 10000; ++j) {
+        //     JobBuilder builder = new JobBuilder()
+        //         .setJobKey("TEST_JOB-" + j)
+        //         .setJobGroup("async")
+        //         .setJobName("Test Job " + j)
+        //         .setJobArgument("force_failure", forceFailure)
+        //         .setJobArgument("sleep", sleep)
+        //         .setJobArgument("persist", persist);
+
+        //     // Add a ton of random constraints for performance testing
+        //     for (int i = 0; i < 100; ++i) {
+        //         builder.setUniqueConstraint("constraint-" + i, "value-" + i);
+        //     }
+
+        //     jobManager.queueJob(builder);
+        // }
+
+        // return null;
+
+
+        JobBuilder builder = new JobBuilder()
+            .setJobKey("TEST_JOB")
             .setJobGroup("async")
-            .setJobName("Test Job 1")
+            .setJobName("Test Job")
             .setJobArgument("force_failure", forceFailure)
             .setJobArgument("sleep", sleep)
-            .setJobArgument("persist", persist)
-        );
+            .setJobArgument("persist", persist);
+
+        // Add a ton of random constraints for performance testing
+        for (int i = 0; i < 100; ++i) {
+            builder.setUniqueConstraint("constraint-" + i, "value-" + i);
+        }
+
+        return jobManager.queueJob(builder);
+
+
 
     }
 

--- a/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
+++ b/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
@@ -86,7 +86,7 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
     private static Logger log = LoggerFactory.getLogger(AbstractHibernateCurator.class);
 
     @Inject protected CandlepinQueryFactory cpQueryFactory;
-    @Inject protected Provider<EntityManager> entityManager;
+    @Inject protected Provider<EntityManager> emProvider;
     @Inject protected Provider<I18n> i18nProvider;
     @Inject protected Configuration config;
     @Inject private PrincipalProvider principalProvider;
@@ -588,8 +588,12 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
         }
     }
 
+    public EntityManager getEntityManager() {
+        return this.emProvider.get();
+    }
+
     public Session currentSession() {
-        return (Session) entityManager.get().getDelegate();
+        return (Session) this.getEntityManager().getDelegate();
     }
 
     public Session openSession() {
@@ -597,9 +601,6 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
         return factory.openSession();
     }
 
-    public EntityManager getEntityManager() {
-        return entityManager.get();
-    }
 
     /**
      * Fetches the natural ID loader for this entity. This loader can be used and reused to

--- a/server/src/main/resources/db/changelog/20181121151738-add-async-job-tables.xml
+++ b/server/src/main/resources/db/changelog/20181121151738-add-async-job-tables.xml
@@ -24,6 +24,7 @@
             <column name="origin" type="varchar(255)"/>
             <column name="principal" type="varchar(255)"/>
             <column name="correlation_id" type="varchar(255)"/>
+            <column name="constraint_hash" type="varchar(64)"/>
 
             <column name="state" type="int"/>
             <column name="attempts" type="int"/>
@@ -37,26 +38,20 @@
     </changeSet>
 
     <changeSet id="20181121151738-2" author="crog">
-        <createTable tableName="cp2_async_job_constraints">
-            <column name="job_id" type="varchar(255)">
-                <constraints
-                    nullable="false"
-                    foreignKeyName="cp2_async_job_constraints_fk1"
-                    references="cp2_async_jobs(id)"
-                    deleteCascade="true"
-                />
-            </column>
+        <createIndex tableName="cp2_async_jobs"
+            indexName="cp2_async_jobs_idx1" unique="false">
+            <column name="name"/>
+        </createIndex>
 
-            <column name="key" type="varchar(255)"/>
-            <column name="value" type="varchar(255)"/>
-        </createTable>
-    </changeSet>
+        <createIndex tableName="cp2_async_jobs"
+            indexName="cp2_async_jobs_idx2" unique="false">
+            <column name="constraint_hash"/>
+        </createIndex>
 
-    <changeSet id="20181121151738-3" author="crog">
-        <addPrimaryKey tableName="cp2_async_job_constraints"
-            columnNames="job_id,key"
-            constraintName="cp2_async_job_constraints_pk"
-        />
+        <createIndex tableName="cp2_async_jobs"
+            indexName="cp2_async_jobs_idx3" unique="false">
+            <column name="state"/>
+        </createIndex>
     </changeSet>
 
 </databaseChangeLog>

--- a/server/src/test/java/org/candlepin/model/AsyncJobStatusCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/AsyncJobStatusCuratorTest.java
@@ -1,0 +1,168 @@
+/**
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.model;
+
+import static org.junit.Assert.*;
+
+import org.candlepin.test.DatabaseTestFixture;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.inject.Inject;
+
+
+/**
+ * Test suite for the ConsumerTypeCurator
+ */
+public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
+
+    @Inject private AsyncJobStatusCurator asyncJobCurator;
+
+    public AsyncJobStatus createJobStatus(String name, String group, String constraintHash,
+        AsyncJobStatus.JobState state) {
+
+        AsyncJobStatus status = new AsyncJobStatus()
+            .setName(name)
+            .setGroup(group)
+            .setUniqueConstraintHash(constraintHash)
+            .setState(state);
+
+        return this.asyncJobCurator.create(status);
+    }
+
+    @Test
+    public void testFindJobsByConstraintsReturnsEmptyWithNoName() {
+        for (int i = 0; i < 3; ++i) {
+            this.createJobStatus("job_name-" + i, "job_group-" + i, "constraint-" + i,
+                AsyncJobStatus.JobState.values()[i]);
+        }
+
+        for (int i = 0; i < 3; ++i) {
+            Collection<AsyncJobStatus> fetched = this.asyncJobCurator.findJobsByConstraints(null,
+                "job_group-" + i, Arrays.asList(AsyncJobStatus.JobState.values()[i]), "constraint-" + i);
+
+            assertNotNull(fetched);
+            assertEquals(0, fetched.size());
+        }
+    }
+
+    @Test
+    public void testFindJobsByConstraintsReturnsEmptyWithNoConstraint() {
+        for (int i = 0; i < 3; ++i) {
+            this.createJobStatus("job_name-" + i, "job_group-" + i, "constraint-" + i,
+                AsyncJobStatus.JobState.values()[i]);
+        }
+
+        for (int i = 0; i < 3; ++i) {
+            Collection<AsyncJobStatus> fetched = this.asyncJobCurator.findJobsByConstraints("job_group-" + i,
+                "job_group-" + i, Arrays.asList(AsyncJobStatus.JobState.values()[i]), null);
+
+            assertNotNull(fetched);
+            assertEquals(0, fetched.size());
+        }
+    }
+
+    @Test
+    public void testFindJobsByConstraintsRestrictsByNameAndConstraints() {
+        for (int i = 0; i < 3; ++i) {
+            this.createJobStatus("job_name-" + i, "job_group-" + i, "constraint-" + i,
+                AsyncJobStatus.JobState.values()[i]);
+        }
+
+        for (int i = 0; i < 3; ++i) {
+            Collection<AsyncJobStatus> fetched = this.asyncJobCurator.findJobsByConstraints("job_name-" + i,
+                null, null, "constraint-" + i);
+
+            assertNotNull("Job lookup returned null for simple test " + i, fetched);
+            assertEquals("Job lookup returned null for simple test " + i, 1, fetched.size());
+
+            AsyncJobStatus actual = fetched.iterator().next();
+            assertEquals("job_name-" + i, actual.getName());
+            assertEquals("constraint-" + i, actual.getUniqueConstraintHash());
+        }
+    }
+
+    @Test
+    public void testFindJobsByConstraintsRestrictsByNameConstraintsAndGroup() {
+        Map<Integer, AsyncJobStatus> jobs = new HashMap<>();
+
+        for (int i = 0; i < 5; ++i) {
+            jobs.put(i, this.createJobStatus("job_name", "job_group-" + i, "constraint",
+                AsyncJobStatus.JobState.values()[i]));
+        }
+
+        for (int i = 0; i < 5; ++i) {
+            Collection<AsyncJobStatus> fetched = this.asyncJobCurator.findJobsByConstraints("job_name",
+                "job_group-" + i, null, "constraint");
+
+            assertNotNull("Job lookup returned null for group test " + i, fetched);
+            assertEquals("Failed to fetch job for group test " + i, 1, fetched.size());
+
+            AsyncJobStatus expected = jobs.get(i);
+            AsyncJobStatus actual = fetched.iterator().next();
+
+            assertEquals("Job equality test failed for group test " + i, expected.getId(), actual.getId());
+        }
+    }
+
+    @Test
+    public void testFindJobsByConstraintsRestrictsByNameConstraintsAndState() {
+        Map<Integer, AsyncJobStatus> jobs = new HashMap<>();
+
+        for (int i = 0; i < 5; ++i) {
+            jobs.put(i, this.createJobStatus("job_name", "job_group", "constraint",
+                AsyncJobStatus.JobState.values()[i]));
+        }
+
+        for (int i = 0; i < 5; ++i) {
+            Collection<AsyncJobStatus> fetched = this.asyncJobCurator.findJobsByConstraints("job_name",
+                "job_group", Arrays.asList(AsyncJobStatus.JobState.values()[i]), "constraint");
+
+            assertNotNull("Job lookup returned null for state test " + i, fetched);
+            assertEquals("Failed to fetch job for state test " + i, 1, fetched.size());
+
+            AsyncJobStatus expected = jobs.get(i);
+            AsyncJobStatus actual = fetched.iterator().next();
+
+            assertEquals("Job equality test failed for state test " + i, expected.getId(), actual.getId());
+        }
+    }
+
+    @Test
+    public void testFindJobsByConstraintsRestrictsByNameConstraintsAndStates() {
+        Map<Integer, AsyncJobStatus> jobs = new HashMap<>();
+
+        for (int i = 0; i < 5; ++i) {
+            jobs.put(i, this.createJobStatus("job_name", "job_group", "constraint",
+                AsyncJobStatus.JobState.values()[i]));
+        }
+
+        Collection<AsyncJobStatus> fetched = this.asyncJobCurator.findJobsByConstraints("job_name",
+            "job_group", Arrays.asList(AsyncJobStatus.JobState.values()), "constraint");
+
+        assertNotNull(fetched);
+        assertEquals(5, fetched.size());
+
+        for (AsyncJobStatus job : jobs.values()) {
+            assertTrue(fetched.contains(job));
+        }
+    }
+
+}


### PR DESCRIPTION
- JobManager.queueJob will now check for matching jobs using the
  incoming job's unique constraints, and will return any existing
  active job(s) rather than queuing the new job if one is found
- Renamed PreJobExecutionException to JobInitializationException
- Removed the async job constraints table in favor of a single
  varchar field on the async job status for a hash of the
  constraints
- Added additional indexes on the async job status table to
  improve the querying performance for job lookups