### PR TITLE
Update deploy and cpdb to use CP-provided Liquibase[ENT-1209]

### DIFF
--- a/server/bin/deploy
+++ b/server/bin/deploy
@@ -9,7 +9,7 @@ prepare_classpath() {
     rm -rf ${CP_EXTRACT_DIR}/*
     cd ${CP_EXTRACT_DIR}
     # Workspace might not be cleaned up
-    jar xf $(find /vagrant/server/target -name 'candlepin*.war' | head -n 1)
+    jar xf $(find ${PROJECT_DIR}/target -name 'candlepin*.war' | head -n 1)
     chmod -R 744 ${CP_EXTRACT_DIR}
     cd -
     export CP_LIQUIBASE_CLASSPATH="${CP_EXTRACT_DIR}/WEB-INF/lib"

--- a/server/bin/deploy
+++ b/server/bin/deploy
@@ -2,6 +2,18 @@
 
 APP_DB_NAME="candlepin"
 MAX_STARTUP_WAIT_TIME=30
+CP_EXTRACT_DIR=/var/tmp/candlepin
+
+prepare_classpath() {
+    mkdir -p ${CP_EXTRACT_DIR}
+    rm -rf ${CP_EXTRACT_DIR}/*
+    cd ${CP_EXTRACT_DIR}
+    # Workspace might not be cleaned up
+    jar xf $(find /vagrant/server/target -name 'candlepin*.war' | head -n 1)
+    chmod -R 744 ${CP_EXTRACT_DIR}
+    cd -
+    export CP_LIQUIBASE_CLASSPATH="${CP_EXTRACT_DIR}/WEB-INF/lib"
+}
 
 gendb() {
     if [ "$USE_MYSQL" == "1" ]; then
@@ -29,8 +41,10 @@ gendb() {
         CHANGELOG="changelog-update.xml"
     fi
 
+    prepare_classpath
+
     info_msg "$MESSAGE"
-    LQCOMMAND="liquibase --driver=${JDBC_DRIVER} --classpath=$PROJECT_DIR/src/main/resources/:target/classes/:${JDBC_JAR} --changeLogFile=db/changelog/$CHANGELOG --url=${JDBC_URL} --username=candlepin"
+    LQCOMMAND="${PROJECT_DIR}/bin/liquibase.sh --driver=${JDBC_DRIVER} --classpath=$PROJECT_DIR/src/main/resources/:target/classes/:${JDBC_JAR} --changeLogFile=db/changelog/$CHANGELOG --url=${JDBC_URL} --username=candlepin"
     if [ -n "$DBPASSWORD" ] ; then
         LQCOMMAND="$LQCOMMAND --password=$DBPASSWORD "
     fi

--- a/server/bin/liquibase.sh
+++ b/server/bin/liquibase.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# Source functions library
+_prefer_jre="true"
+. /usr/share/java-utils/java-functions
+
+# Source system prefs
+if [ -f /etc/java/liquibase.conf ] ; then
+  . /etc/java/liquibase.conf
+fi
+
+# Source user prefs
+if [ -f $HOME/.liquibaserc ] ; then
+  . $HOME/.liquibaserc
+fi
+
+# Configuration
+MAIN_CLASS=liquibase.integration.commandline.Main
+BASE_FLAGS=""
+BASE_OPTIONS=""
+
+CP_CLASSPATH=${CP_LIQUIBASE_CLASSPATH:-/var/lib/tomcat/webapps/candlepin/WEB-INF/lib}
+CLASSPATH=$(JARS=("$CP_CLASSPATH"/*.jar); IFS=:; echo "${JARS[*]}")
+
+# Set parameters
+set_jvm
+set_flags ${BASE_FLAGS}
+set_options ${BASE_OPTIONS}
+
+# Let's start
+run "$@"
+
+exit 0

--- a/server/candlepin.spec.tmpl
+++ b/server/candlepin.spec.tmpl
@@ -45,10 +45,8 @@ Requires: tomcat >= 0:7.0.0
 %else
 Requires: pki-servlet-container >= 0:7.0.0
 %endif
-Requires: liquibase >= 0:3.0.0
 Requires: jss
-# Need JDBC driver for cpdb
-Requires: postgresql-jdbc
+Requires: javapackages-tools
 
 %description
 Candlepin is an open source entitlement management system.

--- a/server/code/setup/cpdb
+++ b/server/code/setup/cpdb
@@ -19,8 +19,9 @@
 from __future__ import print_function
 from optparse import OptionParser
 
-import sys
+import glob
 import os
+import sys
 
 try:
     from commands import getstatusoutput
@@ -34,6 +35,7 @@ else:
 
 JBOSS_CLASSPATH = "/var/lib/jbossas/server/production/deploy/candlepin.war/WEB-INF/classes/"
 TOMCAT_CLASSPATH = "/var/lib/" + TOMCAT + "/webapps/candlepin/WEB-INF/classes/"
+JAR_PATH = "/var/lib/" + TOMCAT + "/webapps/candlepin/WEB-INF/lib/"
 
 def run_command(command):
     (status, output) = getstatusoutput(command)
@@ -79,7 +81,7 @@ class DbSetup(object):
 
     def _run_liquibase(self, changelog_path):
         # Figure out what to append to the classpath for liquibase:
-        classpath = self.jdbc_jar
+        classpath = ":".join(glob.glob(JAR_PATH + "*postgresql*.jar"))
 
         if os.path.exists('target/classes'):
             classpath = "%s:%s" % (classpath, 'target/classes/')
@@ -106,7 +108,7 @@ class DbSetup(object):
 
         print(liquibase_options)
 
-        output = run_command("liquibase %s migrate -Dcommunity=%s" % (liquibase_options, self.community))
+        output = run_command("/usr/share/candlepin/liquibase.sh %s migrate -Dcommunity=%s" % (liquibase_options, self.community))
         print(output)
 
 
@@ -115,7 +117,6 @@ class PostgresqlSetup(DbSetup):
         super(PostgresqlSetup, self).__init__(username, password, db, community, verbose)
         self.host = host
         self.port = port
-        self.jdbc_jar = "/usr/share/java/postgresql-jdbc.jar"
         self.driver_class = "org.postgresql.Driver"
 
         # Adjust the jdbc URL for correct deployment:


### PR DESCRIPTION
- Add custom script for running CP-provided Liquibase
- Update deploy and cpdb to use the new script instead of locally installed Liquibase
- Remove postgresql-jdbc from candlepin.spec.tmpl