### PR TITLE
[2.3] 1664789: Change default key size to 4096 bits.

### DIFF
--- a/server/src/main/java/org/candlepin/pki/PKIUtility.java
+++ b/server/src/main/java/org/candlepin/pki/PKIUtility.java
@@ -54,8 +54,7 @@ import java.util.Set;
 public abstract class PKIUtility {
     private static Logger log = LoggerFactory.getLogger(PKIUtility.class);
 
-    // TODO : configurable?
-    public static final int RSA_KEY_SIZE = 2048;
+    public static final int RSA_KEY_SIZE = 4096;
     public static final String SIGNATURE_ALGO = "SHA256WithRSA";
 
     protected CertificateReader reader;


### PR DESCRIPTION
Simply converting Candlepin to issue 4098 bit (up from 2046) keys
doesn't present any problems that I see. The major issue (that I can
see) is that once a key is generated for a client, that's the key
Candlepin is going to use for the foreseeable future. Clients will have
to re-register if they want a larger key. There's nothing we can do
about that though.  The CRL generation code has specific allowances for
changing the key size, but that would only be relevant if Candlepin
restarted with a brand new server key.

Starting to issue 4096 bit keys to new clients seems like about the
extent of what we can do for future-proofing without the user tearing up
a bunch of existing stuff in their deployment.