### PR TITLE
Syspurose Status filter on date fixes

### DIFF
--- a/server/spec/owner_resource_spec.rb
+++ b/server/spec/owner_resource_spec.rb
@@ -623,7 +623,7 @@ describe 'Owner Resource' do
     consumer2 = user1.register(random_string('consumer2'), :system, nil, {}, random_string('consumer2'), owner1_key,
       [], [], nil, [], nil, [], nil, nil, nil, nil, nil, nil, nil, 'sla2', 'common_role', 'usage2', ['addon2'])
     consumer3 = user1.register(random_string('consumer3'), :system, nil, {}, random_string('consumer3'), owner1_key,
-      [], [], nil, [], nil, [], nil, nil, nil, nil, nil, nil, nil, nil, nil, 'usage3', ['', nil])
+      [], [], nil, [], nil, [], nil, nil, nil, nil, nil, nil, nil, nil, nil, 'usage3', [''])
     consumer4 = user1.register(random_string('consumer4'), :system, nil, {}, random_string('consumer4'), owner1_key,
       [], [], nil, [], nil, [], nil, nil, nil, nil, nil, nil, nil, nil, '', 'usage4', nil)
 

--- a/server/src/main/java/org/candlepin/bind/ComplianceOp.java
+++ b/server/src/main/java/org/candlepin/bind/ComplianceOp.java
@@ -73,7 +73,6 @@ public class ComplianceOp implements BindOperation {
             consumer,
             consumer.getEntitlements(),
             entitlementMap.values(),
-            false,
             false);
 
         for (Map.Entry<String, Entitlement> entry: entitlementMap.entrySet()) {

--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -1970,7 +1970,7 @@ public class CandlepinPoolManager implements PoolManager {
             }
 
             complianceRules.getStatus(consumer);
-            systemPurposeComplianceRules.getStatus(consumer, consumer.getEntitlements(), null, true, true);
+            systemPurposeComplianceRules.getStatus(consumer, consumer.getEntitlements(), null, true);
         }
 
         consumerCurator.flush();
@@ -2371,7 +2371,7 @@ public class CandlepinPoolManager implements PoolManager {
                     for (Consumer consumer : subList) {
                         this.complianceRules.getStatus(consumer);
                         this.systemPurposeComplianceRules.getStatus(consumer, consumer.getEntitlements(),
-                            null, true, true);
+                            null, true);
 
                         // Detach the consumer object (and its children that receive cascaded detaches),
                         // otherwise during the status calculations, the facts proxy objects objects will be

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/ActiveEntitlementJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/ActiveEntitlementJob.java
@@ -53,7 +53,7 @@ public class ActiveEntitlementJob extends KingpinJob {
         for (String id : ids) {
             Consumer c = consumerCurator.get(id);
             complianceRules.getStatus(c);
-            systemPurposeComplianceRules.getStatus(c, c.getEntitlements(), null, true, true);
+            systemPurposeComplianceRules.getStatus(c, c.getEntitlements(), null, true);
         }
     }
 }

--- a/server/src/main/java/org/candlepin/policy/SystemPurposeComplianceRules.java
+++ b/server/src/main/java/org/candlepin/policy/SystemPurposeComplianceRules.java
@@ -17,6 +17,7 @@ package org.candlepin.policy;
 import org.candlepin.audit.EventSink;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerCurator;
+import org.candlepin.model.ConsumerType;
 import org.candlepin.model.ConsumerTypeCurator;
 import org.candlepin.model.Entitlement;
 import org.candlepin.model.EntitlementCurator;
@@ -35,6 +36,7 @@ import org.xnap.commons.i18n.I18n;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -71,19 +73,47 @@ public class SystemPurposeComplianceRules {
     }
 
     /**
-     * Check compliance status for a consumer on a specific date.
+     * Check system purpose compliance status for a consumer for the current date.
      *
-     * @param consumer Consumer to check.
-     * @param updateConsumer whether or not to use consumerCurator.update
-     *        (also expensive)
-     * @return Compliance status.
+     * @param consumer The consumer to check.
+     * @param existingEntitlements The consumer's existing entitlements.
+     * @param newEntitlements New entitlements of the consumer.
+     * @param updateConsumer Whether or not to use consumerCurator.update
+     *
+     * @return The system purpose compliance status currently.
      */
-    @SuppressWarnings("checkstyle:indentation")
     public SystemPurposeComplianceStatus getStatus(Consumer consumer,
         Collection<Entitlement> existingEntitlements, Collection<Entitlement> newEntitlements,
-        boolean updateConsumer, boolean currentCompliance) {
+        boolean updateConsumer) {
+
+        return getStatus(consumer, existingEntitlements, newEntitlements,
+            null, updateConsumer);
+    }
+
+    /**
+     * Check system purpose compliance status for a consumer on a specific date.
+     *
+     * @param consumer The consumer to check.
+     * @param existingEntitlements The consumer's existing entitlements.
+     * @param newEntitlements New entitlements of the consumer.
+     * @param date The date to check compliance status for.
+     * @param updateConsumer Whether or not to use consumerCurator.update
+     *
+     * @return The system purpose compliance status for the given date.
+     */
+    @SuppressWarnings({"checkstyle:indentation", "checkstyle:methodlength"})
+    public SystemPurposeComplianceStatus getStatus(Consumer consumer,
+        Collection<Entitlement> existingEntitlements, Collection<Entitlement> newEntitlements,
+        Date date, boolean updateConsumer) {
 
         SystemPurposeComplianceStatus status = new SystemPurposeComplianceStatus(i18n);
+
+        // Do not calculate compliance status for distributors. It is prohibitively
+        // expensive and meaningless
+        ConsumerType ctype = this.consumerTypeCurator.getConsumerType(consumer);
+        if (ctype != null && (ctype.isManifest())) {
+            return status;
+        }
 
         if (consumer.getOwner().getContentAccessMode().equals(
             ContentAccessCertServiceAdapter.ORG_ENV_ACCESS_MODE)) {
@@ -104,6 +134,18 @@ public class SystemPurposeComplianceRules {
             existingEntitlements.stream(),
             newEntitlements.stream())
             .collect(Collectors.toSet());
+
+        // If we're calculating status for the current date, apply this change to the consumer & emit event.
+        boolean currentCompliance = false;
+        if (date == null) {
+            currentCompliance = true;
+            date = new Date();
+        }
+
+        // Filter the entitlements based on the given date.
+        Date finalDate = date;
+        entitlements.removeIf(element -> finalDate.compareTo(element.getStartDate()) < 0 ||
+            finalDate.compareTo(element.getEndDate()) > 0);
 
         for (Entitlement entitlement : entitlements) {
             String unsatisfedRole = consumer.getRole();

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -818,11 +818,10 @@ public class ConsumerResource {
                 consumerBindUtil.handleActivationKeys(consumerToCreate, keys, owner.isAutobindDisabled());
             }
 
-            // Don't allow complianceRules to update entitlementStatus, because we're about to perform
-            // an update unconditionally.
+            // This should update compliance on consumerToCreate, but not call the curator
             complianceRules.getStatus(consumerToCreate, null, false, false);
             systemPurposeComplianceRules.getStatus(consumerToCreate, consumerToCreate.getEntitlements(),
-                null, false, false);
+                null, false);
             consumerCurator.update(consumerToCreate);
 
             log.info("Consumer {} created in org {}",
@@ -1342,7 +1341,7 @@ public class ConsumerResource {
 
             // this should update compliance on toUpdate, but not call the curator
             complianceRules.getStatus(toUpdate, null, false, false);
-            systemPurposeComplianceRules.getStatus(toUpdate, toUpdate.getEntitlements(), null, false, true);
+            systemPurposeComplianceRules.getStatus(toUpdate, toUpdate.getEntitlements(), null, false);
 
             Event event = eventBuilder.setEventData(toUpdate).buildEvent();
             sink.queueEvent(event);
@@ -2645,9 +2644,8 @@ public class ConsumerResource {
         SystemPurposeComplianceStatus status = null;
         Consumer consumer = consumerCurator.verifyAndLookupConsumer(uuid);
         Date date = ResourceDateParser.parseDateString(onDate);
-        date = date != null ? date : new Date();
-        List<Entitlement> entitlements = entitlementCurator.listByConsumerAndDate(consumer, date).list();
-        status = this.systemPurposeComplianceRules.getStatus(consumer, entitlements, null, true, true);
+        status = this.systemPurposeComplianceRules.getStatus(consumer, consumer.getEntitlements(), null,
+            date, true);
 
         return this.translator.translate(status, SystemPurposeComplianceStatusDTO.class);
     }


### PR DESCRIPTION
- Now the syspurpose status is calculated & persisted during
consumer creation.
- Now the syspurpose status is calculated & persisted correctly
during a bind operation (consumed entitlements are filtered by
their valid date).
- Now the syspurpose status will not be recalculated & persisted
during a status call with specified on_date.
- Removed redundant db call when filtering entitlements
with a specified date for the syspurpose status calculation.
- Do not calculate syspurpose status for distributors.