### PR TITLE
[2.3] 1644707: RevocationOp no longer refreshes pools while locking (ENT-1221)

### DIFF
--- a/server/src/main/java/org/candlepin/controller/RevocationOp.java
+++ b/server/src/main/java/org/candlepin/controller/RevocationOp.java
@@ -92,7 +92,7 @@ public class RevocationOp {
         if (overflowing.isEmpty()) {
             return;
         }
-        overflowing = poolCurator.lockAndLoad(overflowing);
+        overflowing = poolCurator.lock(overflowing);
         for (Pool pool : overflowing) {
             poolNewConsumed.put(pool, pool.getConsumed());
             List<Pool> shared = poolCurator.listSharedPoolsOf(pool);

--- a/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
+++ b/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
@@ -802,6 +802,37 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
     }
 
     /**
+     * Locks a collection of entities with a pessimisitic write lock. Note that none of the entities
+     * will be refreshed as a result of a call to this method. If an entity needs to be locked and
+     * refreshed, used the lockAndLoad method family instead.
+     *
+     * @param entities
+     *  A collection of entities to lock
+     *
+     * @return
+     *  the provided collection of now-locked entities
+     */
+    public Collection<E> lock(Iterable<E> entities) {
+        Map<Serializable, E> entityMap = new TreeMap<>();
+
+        SessionImpl session = (SessionImpl) this.currentSession();
+        ClassMetadata metadata = session.getSessionFactory().getClassMetadata(this.entityType);
+
+        // Step through and toss all the entities into our TreeMap, which orders its entries using
+        // the natural order of the key. This will ensure that we have our entity collection sorted
+        // by entity ID, which should help avoid deadlock by having a deterministic locking order.
+        for (E entity : entities) {
+            entityMap.put(metadata.getIdentifier(entity, session), entity);
+        }
+
+        for (E entity : entityMap.values()) {
+            this.lock(entity);
+        }
+
+        return entityMap.values();
+    }
+
+    /**
      * Locks the specified entity with a pessimistic write lock. Note that the entity will not be
      * refreshed as a result of a call to this method. If the entity needs to be locked and
      * refreshed, use the lockAndLoad method family instead.

--- a/server/src/main/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapter.java
+++ b/server/src/main/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapter.java
@@ -448,8 +448,6 @@ public class DefaultEntitlementCertServiceAdapter extends BaseEntitlementCertSer
             serialMap.put(entry.getKey(), new CertificateSerial(entry.getValue().getPool().getEndDate()));
         }
 
-        log.debug("WE HAVE {} POOL QUANTITIES TO LOOP THROUGH", poolQuantities.size());
-
         Map<String, EntitlementCertificate> entitlementCerts = new HashMap<>();
         for (Entry<String, PoolQuantity> entry : poolQuantities.entrySet()) {
             Pool pool = entry.getValue().getPool();

--- a/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -1892,7 +1892,7 @@ public class PoolManagerTest {
         assertEquals(1, derivedPool.getEntitlements().size());
 
         Collection<Pool> overPools = Collections.singletonList(derivedPool);
-        when(mockPoolCurator.lockAndLoad(any(Collection.class))).thenReturn(overPools);
+        when(mockPoolCurator.lock(any(Collection.class))).thenReturn(overPools);
         when(mockPoolCurator.lockAndLoad(pool)).thenReturn(pool);
         when(enforcerMock.update(any(Consumer.class), any(Entitlement.class), any(Integer.class)))
             .thenReturn(new ValidationResult());
@@ -1973,7 +1973,7 @@ public class PoolManagerTest {
         when(mockPoolCurator.retrieveOrderedEntitlementsOf(eq(Arrays.asList(derivedPool3)))).thenReturn(
             new ArrayList<>());
         Collection<Pool> overPools = new ArrayList<Pool>(){{ add(derivedPool); add(derivedPool2); }};
-        when(mockPoolCurator.lockAndLoad(any(Collection.class))).thenReturn(overPools);
+        when(mockPoolCurator.lock(any(Collection.class))).thenReturn(overPools);
         when(mockPoolCurator.lockAndLoad(eq(derivedPool))).thenReturn(derivedPool);
         when(mockPoolCurator.lockAndLoad(eq(derivedPool2))).thenReturn(derivedPool2);
         when(mockPoolCurator.lockAndLoad(eq(derivedPool3))).thenReturn(derivedPool3);


### PR DESCRIPTION
- RevocationOp no longer uses lockAndLoad to both lock and refresh
  pools, instead only using lock and leaving pools in their current
  state
- Added additional trace output during refresh
- Removed an extraneous output line from the class
  DefaultEntitlementCertServiceAdapter