### PR TITLE
[2.4.8] Added additional tests to verify import functionality

### DIFF
--- a/buildfile
+++ b/buildfile
@@ -119,7 +119,7 @@ HIBERNATE = [group('hibernate-core', 'hibernate-entitymanager', 'hibernate-c3p0'
               'org.jboss.logging:jboss-logging:jar:3.3.0.Final'
              ] + JAVAX
 
-POSTGRESQL = 'postgresql:postgresql:jar:9.0-801.jdbc4'
+POSTGRESQL = 'org.postgresql:postgresql:jar:42.2.2'
 
 SWAGGER = [group('swagger-jaxrs', 'swagger-core','swagger-models','swagger-annotations',
                      :under => 'io.swagger',

--- a/server/spec/import_spec.rb
+++ b/server/spec/import_spec.rb
@@ -19,7 +19,7 @@ describe 'Import Test Group:', :serial => true do
       @cp = Candlepin.new('admin', 'admin')
       skip("candlepin running in hosted mode") if is_hosted?
 
-      @cp_export = StandardExporter.new
+      @cp_export = async ? AsyncStandardExporter.new : StandardExporter.new
       @cp_export.create_candlepin_export()
       @cp_export_file = @cp_export.export_filename
       @cp_correlation_id = "a7b79f6d-63ca-40d8-8bfb-f255041f4e3a"

--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -74,6 +74,7 @@ import org.candlepin.util.Traceable;
 import org.candlepin.util.TraceableParam;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
 import com.google.inject.persist.Transactional;
 


### PR DESCRIPTION
- Added an additional pair of spec tests to verify
  content access mode can be exported and imported
  as the only change in a manifest
- Fixed an oversight in the import spec tests that
  was using a non-async export operation during
  async tests