### PR TITLE
[2.4] Added additional tests to verify import functionality

### DIFF
--- a/server/spec/import_spec.rb
+++ b/server/spec/import_spec.rb
@@ -19,7 +19,7 @@ describe 'Import Test Group:', :serial => true do
       @cp = Candlepin.new('admin', 'admin')
       skip("candlepin running in hosted mode") if is_hosted?
 
-      @cp_export = StandardExporter.new
+      @cp_export = async ? AsyncStandardExporter.new : StandardExporter.new
       @cp_export.create_candlepin_export()
       @cp_export_file = @cp_export.export_filename
       @cp_correlation_id = "a7b79f6d-63ca-40d8-8bfb-f255041f4e3a"


### PR DESCRIPTION
- Added an additional pair of spec tests to verify
  content access mode can be exported and imported
  as the only change in a manifest
- Fixed an oversight in the import spec tests that
  was using a non-async export operation during
  async tests