### PR TITLE
[M] 1644707: Entitlement revocation no longer refreshes pools while locking

### DIFF
--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -70,6 +70,7 @@ import org.candlepin.policy.js.entitlement.Enforcer.CallerType;
 import org.candlepin.policy.js.pool.PoolRules;
 import org.candlepin.policy.js.pool.PoolUpdate;
 import org.candlepin.resource.dto.AutobindData;
+import org.candlepin.resteasy.JsonProvider;
 import org.candlepin.service.OwnerServiceAdapter;
 import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.service.model.BrandingInfo;
@@ -87,11 +88,15 @@ import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
 import com.google.inject.persist.Transactional;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.StringUtils;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import org.xnap.commons.i18n.I18n;
 
 import java.util.ArrayList;
@@ -108,6 +113,10 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import javax.ws.rs.core.MediaType;
+
+
 
 /**
  * PoolManager
@@ -144,6 +153,8 @@ public class CandlepinPoolManager implements PoolManager {
     private PinsetterKernel pinsetterKernel;
     private OwnerManager ownerManager;
     private BindChainFactory bindChainFactory;
+
+    @Inject protected JsonProvider jsonProvider;
 
     /**
      * @param poolCurator
@@ -231,6 +242,22 @@ public class CandlepinPoolManager implements PoolManager {
         Map<String, ? extends SubscriptionInfo> subscriptionMap = compiler.getSubscriptions();
         Map<String, ? extends ProductInfo> productMap = compiler.getProducts();
         Map<String, ? extends ContentInfo> contentMap = compiler.getContent();
+
+        // If trace output is enabled, dump some JSON representing the subscriptions we received so
+        // we can simulate this in a testing environment.
+        if (log.isTraceEnabled() || "TRACE".equalsIgnoreCase(owner.getLogLevel())) {
+            try {
+                ObjectMapper mapper = this.jsonProvider
+                    .locateMapper(Object.class, MediaType.APPLICATION_JSON_TYPE);
+
+                log.trace("Received {} subscriptions from upstream:", subscriptionMap.size());
+                log.trace(mapper.writeValueAsString(subscriptionMap.values()));
+                log.trace("Finished outputting upstream subscriptions");
+            }
+            catch (Exception e) {
+                log.trace("Exception occurred while outputting upstream subscriptions", e);
+            }
+        }
 
         // Persist content changes
         log.debug("Importing {} content...", contentMap.size());
@@ -615,7 +642,7 @@ public class CandlepinPoolManager implements PoolManager {
         List<Entitlement> entitlementsToRevoke = new ArrayList<>();
 
         // Impl note: this may remove pools which are not backed by the DB.
-        overflowing = poolCurator.lockAndLoad(overflowing);
+        overflowing = poolCurator.lock(overflowing);
 
         List<Entitlement> overFlowingEnts = this.poolCurator.retrieveOrderedEntitlementsOf(overflowing);
         Map<String, List<Entitlement>> entMap = new HashMap<>();
@@ -1883,6 +1910,8 @@ public class CandlepinPoolManager implements PoolManager {
         // we're operating on a list of existing entities, not expecting to pull from the DB and don't care
         // about anything that was deleted, we can safely ignore the output here and continue working with
         // the existing list.
+        // TODO: This is dangerous (thanks to Hibernate quirks)! We should update this to use explicit locks
+        // and refreshes on entities where we know the state.
         poolCurator.lockAndLoad(poolsToLock);
         log.info("Batch revoking {} entitlements", entsToRevoke.size());
         entsToRevoke = new ArrayList<>(entsToRevoke);

--- a/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
+++ b/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
@@ -831,6 +831,37 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
     }
 
     /**
+     * Locks a collection of entities with a pessimisitic write lock. Note that none of the entities
+     * will be refreshed as a result of a call to this method. If an entity needs to be locked and
+     * refreshed, used the lockAndLoad method family instead.
+     *
+     * @param entities
+     *  A collection of entities to lock
+     *
+     * @return
+     *  the provided collection of now-locked entities
+     */
+    public Collection<E> lock(Iterable<E> entities) {
+        Map<Serializable, E> entityMap = new TreeMap<>();
+
+        SessionImpl session = (SessionImpl) this.currentSession();
+        ClassMetadata metadata = session.getSessionFactory().getClassMetadata(this.entityType);
+
+        // Step through and toss all the entities into our TreeMap, which orders its entries using
+        // the natural order of the key. This will ensure that we have our entity collection sorted
+        // by entity ID, which should help avoid deadlock by having a deterministic locking order.
+        for (E entity : entities) {
+            entityMap.put(metadata.getIdentifier(entity, session), entity);
+        }
+
+        for (E entity : entityMap.values()) {
+            this.lock(entity);
+        }
+
+        return entityMap.values();
+    }
+
+    /**
      * Locks the specified entity with a pessimistic write lock. Note that the entity will not be
      * refreshed as a result of a call to this method. If the entity needs to be locked and
      * refreshed, use the lockAndLoad method family instead.

--- a/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -1911,7 +1911,7 @@ public class PoolManagerTest {
         assertEquals(1, derivedPool.getEntitlements().size());
 
         Collection<Pool> overPools = Collections.singletonList(derivedPool);
-        when(mockPoolCurator.lockAndLoad(any(Collection.class))).thenReturn(overPools);
+        when(mockPoolCurator.lock(any(Collection.class))).thenReturn(overPools);
         when(mockPoolCurator.lockAndLoad(pool)).thenReturn(pool);
         when(enforcerMock.update(any(Consumer.class), any(Entitlement.class), any(Integer.class)))
             .thenReturn(new ValidationResult());
@@ -1992,7 +1992,7 @@ public class PoolManagerTest {
         when(mockPoolCurator.retrieveOrderedEntitlementsOf(eq(Arrays.asList(derivedPool, derivedPool2))))
             .thenReturn(Arrays.asList(derivedEnt, derivedEnt2, derivedEnt3));
         Collection<Pool> overPools = new ArrayList<Pool>(){{ add(derivedPool); add(derivedPool2); }};
-        when(mockPoolCurator.lockAndLoad(any(Collection.class))).thenReturn(overPools);
+        when(mockPoolCurator.lock(any(Collection.class))).thenReturn(overPools);
         when(mockPoolCurator.lockAndLoad(eq(derivedPool))).thenReturn(derivedPool);
         when(mockPoolCurator.lockAndLoad(eq(derivedPool2))).thenReturn(derivedPool2);
         when(mockPoolCurator.lockAndLoad(eq(derivedPool3))).thenReturn(derivedPool3);


### PR DESCRIPTION
- Entitlement revocation no longer uses lockAndLoad to both lock and
  refresh pools, instead only using lock and leaving pools in their
  current state
- Added additional trace output during refresh
- Removed an extraneous output line from the class
  DefaultEntitlementCertServiceAdapter