### PR TITLE
[2.4] 1679287: RevocationOp no longer refreshes pools while locking

### DIFF
--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -67,6 +67,7 @@ import org.candlepin.policy.js.entitlement.Enforcer.CallerType;
 import org.candlepin.policy.js.pool.PoolRules;
 import org.candlepin.policy.js.pool.PoolUpdate;
 import org.candlepin.resource.dto.AutobindData;
+import org.candlepin.resteasy.JsonProvider;
 import org.candlepin.service.OwnerServiceAdapter;
 import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.util.Util;
@@ -77,11 +78,15 @@ import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
 import com.google.inject.persist.Transactional;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.StringUtils;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import org.xnap.commons.i18n.I18n;
 
 import java.util.ArrayList;
@@ -97,6 +102,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+
+import javax.ws.rs.core.MediaType;
 
 
 
@@ -133,6 +140,8 @@ public class CandlepinPoolManager implements PoolManager {
     private PinsetterKernel pinsetterKernel;
     private OwnerManager ownerManager;
     private BindChainFactory bindChainFactory;
+
+    @Inject protected JsonProvider jsonProvider;
 
     /**
      * @param poolCurator
@@ -216,6 +225,22 @@ public class CandlepinPoolManager implements PoolManager {
         // duplicate inbound data
         log.debug("Fetching subscriptions from adapter...");
         List<Subscription> subscriptions = subAdapter.getSubscriptions(owner);
+
+        // If trace output is enabled, dump some JSON representing the subscriptions we received so
+        // we can simulate this in a testing environment.
+        if (log.isTraceEnabled() || "TRACE".equalsIgnoreCase(owner.getLogLevel())) {
+            try {
+                ObjectMapper mapper = this.jsonProvider
+                    .locateMapper(Object.class, MediaType.APPLICATION_JSON_TYPE);
+
+                log.trace("Received {} subscriptions from upstream:", subscriptions.size());
+                log.trace(mapper.writeValueAsString(subscriptions));
+                log.trace("Finished outputting upstream subscriptions");
+            }
+            catch (Exception e) {
+                log.trace("Exception occurred while outputting upstream subscriptions", e);
+            }
+        }
 
         log.debug("Done. Processing subscriptions...");
         for (Subscription subscription : subscriptions) {
@@ -1822,6 +1847,8 @@ public class CandlepinPoolManager implements PoolManager {
         // we're operating on a list of existing entities, not expecting to pull from the DB and don't care
         // about anything that was deleted, we can safely ignore the output here and continue working with
         // the existing list.
+        // TODO: This is dangerous (thanks to Hibernate quirks)! We should update this to use explicit locks
+        // and refreshes on entities where we know the state.
         poolCurator.lockAndLoad(poolsToLock);
         log.info("Batch revoking {} entitlements", entsToRevoke.size());
         entsToRevoke = new ArrayList<>(entsToRevoke);

--- a/server/src/main/java/org/candlepin/controller/RevocationOp.java
+++ b/server/src/main/java/org/candlepin/controller/RevocationOp.java
@@ -92,7 +92,7 @@ public class RevocationOp {
         if (overflowing.isEmpty()) {
             return null;
         }
-        overflowing = poolCurator.lockAndLoad(overflowing);
+        overflowing = poolCurator.lock(overflowing);
         for (Pool pool : overflowing) {
             poolNewConsumed.put(pool, pool.getConsumed());
             List<Pool> shared = poolCurator.listSharedPoolsOf(pool);

--- a/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -1895,7 +1895,7 @@ public class PoolManagerTest {
         assertEquals(1, derivedPool.getEntitlements().size());
 
         Collection<Pool> overPools = Collections.singletonList(derivedPool);
-        when(mockPoolCurator.lockAndLoad(any(Collection.class))).thenReturn(overPools);
+        when(mockPoolCurator.lock(any(Collection.class))).thenReturn(overPools);
         when(mockPoolCurator.lockAndLoad(pool)).thenReturn(pool);
         when(enforcerMock.update(any(Consumer.class), any(Entitlement.class), any(Integer.class)))
             .thenReturn(new ValidationResult());
@@ -1976,7 +1976,7 @@ public class PoolManagerTest {
         when(mockPoolCurator.retrieveOrderedEntitlementsOf(eq(Arrays.asList(derivedPool3)))).thenReturn(
             new ArrayList<>());
         Collection<Pool> overPools = new ArrayList<Pool>(){{ add(derivedPool); add(derivedPool2); }};
-        when(mockPoolCurator.lockAndLoad(any(Collection.class))).thenReturn(overPools);
+        when(mockPoolCurator.lock(any(Collection.class))).thenReturn(overPools);
         when(mockPoolCurator.lockAndLoad(eq(derivedPool))).thenReturn(derivedPool);
         when(mockPoolCurator.lockAndLoad(eq(derivedPool2))).thenReturn(derivedPool2);
         when(mockPoolCurator.lockAndLoad(eq(derivedPool3))).thenReturn(derivedPool3);


### PR DESCRIPTION
- RevocationOp no longer uses lockAndLoad to both lock and refresh
  pools, instead only using lock and leaving pools in their current
  state
- Added additional trace output during refresh
- Removed an extraneous output line from the class
  DefaultEntitlementCertServiceAdapter