### PR TITLE
[F] Added support for retry-on-failure to the async job system

### DIFF
--- a/server/src/main/java/org/candlepin/async/JobBuilder.java
+++ b/server/src/main/java/org/candlepin/async/JobBuilder.java
@@ -33,8 +33,6 @@ public class JobBuilder {
     private int retries;
     private boolean logJobExecution;
 
-
-
     /**
      * Creates an empty JobBuilder
      */
@@ -57,7 +55,6 @@ public class JobBuilder {
 
         return builder.setJobKey(jobKey);
     }
-
 
     /**
      * Sets the key for the job class to handle execution of this job. If the key does represent a
@@ -301,20 +298,16 @@ public class JobBuilder {
     // dump all of the fields in the log line for any job that has it. Would be an easy, generic way
     // to add logging info to the jobs in a way that's not unique to any particular job.
 
-
-
+    //      JobBuilder builder = new JobBuilder()
+    //          .forTask(runnable job class or key here)
+    //          .setName("my_task")
+    //          .setTaskArgument("key", "value")
+    //          .setTaskArgument("key2", "value2")
+    //          .addUniqueRestriction("owner", owner_id_here)
+    //          .addUniqueRestriction("product", product_id_here)
+    //          .addTaskMetadata("correlation_id", cid)
+    //          .setRetryCount(3)
+    //
+    //      jobManager.queueJob(builder);
 
 }
-        //      JobBuilder builder = new JobBuilder()
-        //          .forTask(runnable job class or key here)
-        //          .setName("my_task")
-        //          .setTaskArgument("key", "value")
-        //          .setTaskArgument("key2", "value2")
-        //          .addUniqueRestriction("owner", owner_id_here)
-        //          .addUniqueRestriction("product", product_id_here)
-        //          .addTaskMetadata("correlation_id", cid)
-        //          .setRetryCount(3)
-        //
-        //      jobManager.queueJob(builder);
-
-

--- a/server/src/main/java/org/candlepin/async/JobException.java
+++ b/server/src/main/java/org/candlepin/async/JobException.java
@@ -22,12 +22,27 @@ package org.candlepin.async;
  */
 public class JobException extends Exception {
 
+    protected final boolean terminal;
+
     /**
      * Constructs a new exception with null as its detail message. The cause is not initialized,
      * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
      */
     public JobException() {
+        this(false);
+    }
+
+    /**
+     * Constructs a new exception with null as its detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     *
+     * @param terminal
+     *  whether or not the exception is terminal or non-recoverable and the job should not be
+     *  retried.
+     */
+    public JobException(boolean terminal) {
         super();
+        this.terminal = terminal;
     }
 
     /**
@@ -39,7 +54,24 @@ public class JobException extends Exception {
      *  method.
      */
     public JobException(String message) {
+        this(message, false);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     *
+     * @param terminal
+     *  whether or not the exception is terminal or non-recoverable and the job should not be
+     *  retried.
+     */
+    public JobException(String message, boolean terminal) {
         super(message);
+        this.terminal = terminal;
     }
 
     /**
@@ -53,7 +85,26 @@ public class JobException extends Exception {
      *  value is permitted, and indicates that the cause is nonexistent or unknown.
      */
     public JobException(Throwable cause) {
+        this(cause, false);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of
+     * <tt>(cause == null ? null : cause.toString())</tt> (which typically contains the and
+     * detail message of cause). This constructor is useful for exceptions that are little more
+     * than wrappers for other throwables (for example, PrivilegedActionException).
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     *
+     * @param terminal
+     *  whether or not the exception is terminal or non-recoverable and the job should not be
+     *  retried.
+     */
+    public JobException(Throwable cause, boolean terminal) {
         super(cause);
+        this.terminal = terminal;
     }
 
     /**
@@ -71,7 +122,41 @@ public class JobException extends Exception {
      *  value is permitted, and indicates that the cause is nonexistent or unknown.
      */
     public JobException(String message, Throwable cause) {
+        this(message, cause, false);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p></p>
+     * Note that the detail message associated with cause is not automatically incorporated in this
+     * exception's detail message.
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     *
+     * @param terminal
+     *  whether or not the exception is terminal or non-recoverable and the job should not be
+     *  retried.
+     */
+    public JobException(String message, Throwable cause, boolean terminal) {
         super(message, cause);
+        this.terminal = terminal;
+    }
+
+    /**
+     * Checks if this exception represents a terminal, or non-recoverable exception, indicating the
+     * job should not be retried.
+     *
+     * @return
+     *  true if the exception is a terminal exception; false otherwise
+     */
+    public boolean isTerminal() {
+        return this.terminal;
     }
 
 }

--- a/server/src/main/java/org/candlepin/async/JobException.java
+++ b/server/src/main/java/org/candlepin/async/JobException.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.async;
+
+
+
+/**
+ * The JobException represents the class of unexpected errors that may occur within the job
+ * system.
+ */
+public class JobException extends Exception {
+
+    /**
+     * Constructs a new exception with null as its detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     */
+    public JobException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     */
+    public JobException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of
+     * <tt>(cause == null ? null : cause.toString())</tt> (which typically contains the and
+     * detail message of cause). This constructor is useful for exceptions that are little more
+     * than wrappers for other throwables (for example, PrivilegedActionException).
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public JobException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p></p>
+     * Note that the detail message associated with cause is not automatically incorporated in this
+     * exception's detail message.
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public JobException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/server/src/main/java/org/candlepin/async/JobExecutionException.java
+++ b/server/src/main/java/org/candlepin/async/JobExecutionException.java
@@ -21,14 +21,29 @@ package org.candlepin.async;
  * job. This exception may be thrown manually by the job itself, or generated if a runtime
  * exception bubbles up to the job management framework.
  */
-public class JobExecutionException extends Exception {
+public class JobExecutionException extends JobException {
+
+    protected final boolean terminal;
 
     /**
      * Constructs a new exception with null as its detail message. The cause is not initialized,
      * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
      */
     public JobExecutionException() {
+        this(false);
+    }
+
+    /**
+     * Constructs a new exception with null as its detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     *
+     * @param terminal
+     *  whether or not the exception is terminal or non-recoverable and the job should not be
+     *  retried.
+     */
+    public JobExecutionException(boolean terminal) {
         super();
+        this.terminal = terminal;
     }
 
     /**
@@ -40,7 +55,24 @@ public class JobExecutionException extends Exception {
      *  method.
      */
     public JobExecutionException(String message) {
+        this(message, false);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     *
+     * @param terminal
+     *  whether or not the exception is terminal or non-recoverable and the job should not be
+     *  retried.
+     */
+    public JobExecutionException(String message, boolean terminal) {
         super(message);
+        this.terminal = terminal;
     }
 
     /**
@@ -54,7 +86,26 @@ public class JobExecutionException extends Exception {
      *  value is permitted, and indicates that the cause is nonexistent or unknown.
      */
     public JobExecutionException(Throwable cause) {
+        this(cause, false);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of
+     * <tt>(cause == null ? null : cause.toString())</tt> (which typically contains the and
+     * detail message of cause). This constructor is useful for exceptions that are little more
+     * than wrappers for other throwables (for example, PrivilegedActionException).
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     *
+     * @param terminal
+     *  whether or not the exception is terminal or non-recoverable and the job should not be
+     *  retried.
+     */
+    public JobExecutionException(Throwable cause, boolean terminal) {
         super(cause);
+        this.terminal = terminal;
     }
 
     /**
@@ -72,7 +123,41 @@ public class JobExecutionException extends Exception {
      *  value is permitted, and indicates that the cause is nonexistent or unknown.
      */
     public JobExecutionException(String message, Throwable cause) {
+        this(message, cause, false);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p></p>
+     * Note that the detail message associated with cause is not automatically incorporated in this
+     * exception's detail message.
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     *
+     * @param terminal
+     *  whether or not the exception is terminal or non-recoverable and the job should not be
+     *  retried.
+     */
+    public JobExecutionException(String message, Throwable cause, boolean terminal) {
         super(message, cause);
+        this.terminal = terminal;
+    }
+
+    /**
+     * Checks if this exception represents a terminal, or non-recoverable exception, indicating the
+     * job should not be retried.
+     *
+     * @return
+     *  true if the exception is a terminal exception; false otherwise
+     */
+    public boolean isTerminal() {
+        return this.terminal;
     }
 
 }

--- a/server/src/main/java/org/candlepin/async/JobExecutionException.java
+++ b/server/src/main/java/org/candlepin/async/JobExecutionException.java
@@ -23,14 +23,12 @@ package org.candlepin.async;
  */
 public class JobExecutionException extends JobException {
 
-    protected final boolean terminal;
-
     /**
      * Constructs a new exception with null as its detail message. The cause is not initialized,
      * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
      */
     public JobExecutionException() {
-        this(false);
+        super(false);
     }
 
     /**
@@ -42,8 +40,7 @@ public class JobExecutionException extends JobException {
      *  retried.
      */
     public JobExecutionException(boolean terminal) {
-        super();
-        this.terminal = terminal;
+        super(terminal);
     }
 
     /**
@@ -55,7 +52,7 @@ public class JobExecutionException extends JobException {
      *  method.
      */
     public JobExecutionException(String message) {
-        this(message, false);
+        super(message, false);
     }
 
     /**
@@ -71,8 +68,7 @@ public class JobExecutionException extends JobException {
      *  retried.
      */
     public JobExecutionException(String message, boolean terminal) {
-        super(message);
-        this.terminal = terminal;
+        super(message, terminal);
     }
 
     /**
@@ -86,7 +82,7 @@ public class JobExecutionException extends JobException {
      *  value is permitted, and indicates that the cause is nonexistent or unknown.
      */
     public JobExecutionException(Throwable cause) {
-        this(cause, false);
+        super(cause, false);
     }
 
     /**
@@ -104,8 +100,7 @@ public class JobExecutionException extends JobException {
      *  retried.
      */
     public JobExecutionException(Throwable cause, boolean terminal) {
-        super(cause);
-        this.terminal = terminal;
+        super(cause, terminal);
     }
 
     /**
@@ -123,7 +118,7 @@ public class JobExecutionException extends JobException {
      *  value is permitted, and indicates that the cause is nonexistent or unknown.
      */
     public JobExecutionException(String message, Throwable cause) {
-        this(message, cause, false);
+        super(message, cause, false);
     }
 
     /**
@@ -145,19 +140,7 @@ public class JobExecutionException extends JobException {
      *  retried.
      */
     public JobExecutionException(String message, Throwable cause, boolean terminal) {
-        super(message, cause);
-        this.terminal = terminal;
-    }
-
-    /**
-     * Checks if this exception represents a terminal, or non-recoverable exception, indicating the
-     * job should not be retried.
-     *
-     * @return
-     *  true if the exception is a terminal exception; false otherwise
-     */
-    public boolean isTerminal() {
-        return this.terminal;
+        super(message, cause, terminal);
     }
 
 }

--- a/server/src/main/java/org/candlepin/async/JobInitializationException.java
+++ b/server/src/main/java/org/candlepin/async/JobInitializationException.java
@@ -30,11 +30,122 @@ package org.candlepin.async;
 public class JobInitializationException extends JobException {
 
     /**
-     * Create an instance of this exception with the specified message.
+     * Constructs a new exception with null as its detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     */
+    public JobInitializationException() {
+        super(false);
+    }
+
+    /**
+     * Constructs a new exception with null as its detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
      *
-     * @param message a message describing the cause of the exception.
+     * @param terminal
+     *  whether or not the exception is terminal or non-recoverable and the job should not be
+     *  retried.
+     */
+    public JobInitializationException(boolean terminal) {
+        super(terminal);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
      */
     public JobInitializationException(String message) {
-        super(message);
+        super(message, false);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     *
+     * @param terminal
+     *  whether or not the exception is terminal or non-recoverable and the job should not be
+     *  retried.
+     */
+    public JobInitializationException(String message, boolean terminal) {
+        super(message, terminal);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of
+     * <tt>(cause == null ? null : cause.toString())</tt> (which typically contains the and
+     * detail message of cause). This constructor is useful for exceptions that are little more
+     * than wrappers for other throwables (for example, PrivilegedActionException).
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public JobInitializationException(Throwable cause) {
+        super(cause, false);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of
+     * <tt>(cause == null ? null : cause.toString())</tt> (which typically contains the and
+     * detail message of cause). This constructor is useful for exceptions that are little more
+     * than wrappers for other throwables (for example, PrivilegedActionException).
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     *
+     * @param terminal
+     *  whether or not the exception is terminal or non-recoverable and the job should not be
+     *  retried.
+     */
+    public JobInitializationException(Throwable cause, boolean terminal) {
+        super(cause, terminal);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p></p>
+     * Note that the detail message associated with cause is not automatically incorporated in this
+     * exception's detail message.
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public JobInitializationException(String message, Throwable cause) {
+        super(message, cause, false);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p></p>
+     * Note that the detail message associated with cause is not automatically incorporated in this
+     * exception's detail message.
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     *
+     * @param terminal
+     *  whether or not the exception is terminal or non-recoverable and the job should not be
+     *  retried.
+     */
+    public JobInitializationException(String message, Throwable cause, boolean terminal) {
+        super(message, cause, terminal);
     }
 }

--- a/server/src/main/java/org/candlepin/async/JobInitializationException.java
+++ b/server/src/main/java/org/candlepin/async/JobInitializationException.java
@@ -15,7 +15,7 @@
 package org.candlepin.async;
 
 /**
- * The PreJobExecutionException represents an error that occurs before a job is
+ * The JobInitializationException represents an error that occurs before a job is
  * actually executed by the JobManager. The JobManager should throw this exeception
  * anytime that a job is invalid and can not be run. The JobMessageReceiver will
  * discard the associated job message when it encounters this exception, so it should
@@ -27,14 +27,14 @@ package org.candlepin.async;
  *         - Job was determined cancelled before execution.
  * </pre>
  */
-public class PreJobExecutionException extends Exception {
+public class JobInitializationException extends JobException {
 
     /**
      * Create an instance of this exception with the specified message.
      *
      * @param message a message describing the cause of the exception.
      */
-    public PreJobExecutionException(String message) {
+    public JobInitializationException(String message) {
         super(message);
     }
 }

--- a/server/src/main/java/org/candlepin/async/JobMessage.java
+++ b/server/src/main/java/org/candlepin/async/JobMessage.java
@@ -63,6 +63,6 @@ public class JobMessage {
 
     @Override
     public String toString() {
-        return String.format("[%s]: %s", this.jobKey, this.jobId);
+        return String.format("JobMessage [id: %s, key: %s]", this.jobKey, this.jobId);
     }
 }

--- a/server/src/main/java/org/candlepin/async/JobMessageDispatchException.java
+++ b/server/src/main/java/org/candlepin/async/JobMessageDispatchException.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.async;
+
+
+
+/**
+ * The JobMessageDispatchException represents the class of unexpected errors that may occur while
+ * dispatching jobs to the underlying message dispatcher.
+ */
+public class JobMessageDispatchException extends JobException {
+
+    /**
+     * Constructs a new exception with null as its detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     */
+    public JobMessageDispatchException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     */
+    public JobMessageDispatchException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of
+     * <tt>(cause == null ? null : cause.toString())</tt> (which typically contains the and
+     * detail message of cause). This constructor is useful for exceptions that are little more
+     * than wrappers for other throwables (for example, PrivilegedActionException).
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public JobMessageDispatchException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p></p>
+     * Note that the detail message associated with cause is not automatically incorporated in this
+     * exception's detail message.
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public JobMessageDispatchException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/server/src/main/java/org/candlepin/async/JobMessageDispatcher.java
+++ b/server/src/main/java/org/candlepin/async/JobMessageDispatcher.java
@@ -29,9 +29,9 @@ public interface JobMessageDispatcher {
      * @param jobMessage
      *  The JobMessage to send
      *
-     * @throws Exception
+     * @throws JobMessageDispatchException
      *  if the message cannot be sent for any reason
      */
-    void sendJobMessage(JobMessage jobMessage) throws Exception;
+    void sendJobMessage(JobMessage jobMessage) throws JobMessageDispatchException;
 
 }

--- a/server/src/main/java/org/candlepin/async/JobMessageReceiver.java
+++ b/server/src/main/java/org/candlepin/async/JobMessageReceiver.java
@@ -16,15 +16,21 @@
 package org.candlepin.async;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.client.ClientConsumer;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
+
 import org.candlepin.async.impl.ActiveMQSessionFactory;
 import org.candlepin.audit.MessageReceiver;
 import org.candlepin.model.AsyncJobStatus;
+import org.candlepin.model.AsyncJobStatus.JobState;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+
 
 /**
  * Responsible for receiving async job messages from the Artemis job queue.
@@ -38,9 +44,17 @@ public class JobMessageReceiver extends MessageReceiver {
     private ClientConsumer consumer;
     private String msgFilter;
 
+    // Variable we use to track whether or not we have work pending to commit or rollback. Since
+    // the AMQP docs aren't clear on the expected behavior of consecutive commits and/or rollbacks,
+    // we're taking the safe route and avoiding using either if no work is pending.
+    // Note that this will fail if a given instance is shared between multiple threads/queues.
+    private boolean amqpWorkPending;
+
     public JobMessageReceiver(String msgFilter, JobManager manager, ActiveMQSessionFactory sessionFactory,
         ObjectMapper mapper) {
+
         super(JOB_QUEUE_NAME, sessionFactory, mapper);
+
         this.manager = manager;
         this.msgFilter = msgFilter;
     }
@@ -77,10 +91,75 @@ public class JobMessageReceiver extends MessageReceiver {
 
             // Execute the job
             AsyncJobStatus jobStatus = manager.executeJob(jobMessage);
+
+            // We didn't fail! Commit the message
+            this.commitSession();
+        }
+        catch (JobExecutionException e) {
+            // The job failed during execution; retry logic within JobManager will handle this
+            // case for us. We need not handle it any further.
+            this.commitSession();
+        }
+        catch (JobStateManagementException e) {
+            // The JobManager failed to update the job's state. Depending on the intended state,
+            // we may or may not want to commit the message.
+
+            JobState intendedState = e.getIntendedState();
+
+            if (intendedState != null && !intendedState.isTerminal()) {
+                log.error("Job processing failed; rolling back job message to retry later: {}", body);
+                // The intended state is non-terminal (likely fail-with-retry), so we'll rollback
+                // to allow the message to be redelivered so the job can be re-attempted.
+                this.rollbackSession();
+            }
+            else {
+                log.error("Job processing failed terminally; committing job message as acknowledged: {}",
+                    body);
+
+                // The state is unknown or terminal. We don't want to redeliver the message as
+                // the job was intended to be put in a "completed" state.
+
+                // TODO: We need to move the message to a dead-letter queue or some such so we can
+                // clean up the old job once the DB is playing nice again. While the job will be
+                // processed correctly, we're going to have a desync'd status in the database.
+                this.commitSession();
+            }
+        }
+        catch (JobMessageDispatchException e) {
+            // The JobManager failed to send a message to Artemis. This is pretty bad since there's
+            // a very high possibility we're going to fail to either commit or rollback here. The
+            // good news, is that since this is happening during execution, we know the state is
+            // FAIL-WITH-RETRY, as that's the only reason a message would be sent (and fail).
+            // We'll attempt to rollback to let the message be redelivered, since that's what we
+            // want anyway.
+
+            log.error("Failed to dispatch job message during job execution; rolling back job message " +
+                "to retry later: {}", body);
+
+            this.rollbackSession();
         }
         catch (JobException e) {
-            // The job failed; we're going to assume the job manager has handled everything
-            // and ignore it here.
+            // The job failed in some other, unexpected way. This is generally very bad, but we can
+            // recover somewhat gracefully here. If the failure is terminal, we can commit the
+            // message and not bother retry. Otherwise, we need to retry the message and let it
+            // resync itself.
+
+            // Terminal errors here will likely result in some state desync that will need to be
+            // sorted out by some kind of cleanup/reaper job. To facilitate that, we need to move
+            // the message to a dead-letter queue for semi-manual cleanup once things are back in
+            // working order.
+
+            if (e.isTerminal()) {
+                log.error("Job processing failed terminally; committing job message as acknowledged: {}",
+                    body);
+
+                // TODO: Move the message to another queue for cleanup/resync later
+                this.commitSession();
+            }
+            else {
+                log.error("Job processing failed; rolling back job message to retry later: {}", body);
+                this.rollbackSession();
+            }
         }
         catch (Exception e) {
             // Once a job actually executes, the failure should be recorded in the job's status
@@ -97,26 +176,45 @@ public class JobMessageReceiver extends MessageReceiver {
             // If debugging is enabled log a more in depth message.
             log.debug("Unable to process message. Rolling back client session.\n{}", body, e);
 
-            try {
-                // Roll back the session so that the message remains on the queue.
-                session.rollback();
-            }
-            catch (ActiveMQException amqe) {
-                log.error("Unable to roll back client session.", amqe);
-            }
-        }
-        finally {
-            // Finally commit the session so that the message is taken out of the queue.
-            // We're always committing here since retry logic will fire off a new message rather
-            // than attempting to redeliver this one.
-
-            try {
-                session.commit();
-            }
-            catch (ActiveMQException amqe) {
-                log.error("Unable to commit client session", amqe);
-            }
+            this.rollbackSession();
         }
     }
 
+    /**
+     * Commits the session if work is pending. If no work is pending, this method immediately
+     * returns.
+     *
+     * @return
+     *  true if there was pending work that was committed successfully; false otherwise
+     */
+    private boolean commitSession() {
+        try {
+            this.session.commit();
+            return true;
+        }
+        catch (ActiveMQException amqe) {
+            log.error("Unable to commit client session", amqe);
+        }
+
+        return false;
+    }
+
+    /**
+     * Rolls back the session if work is pending. If no work is pending, this method immediately
+     * returns.
+     *
+     * @return
+     *  true if there was pending work that was rolled back successfully; false otherwise
+     */
+    private boolean rollbackSession() {
+        try {
+            this.session.rollback();
+            return true;
+        }
+        catch (ActiveMQException amqe) {
+            log.error("Unable to roll back client session.", amqe);
+        }
+
+        return false;
+    }
 }

--- a/server/src/main/java/org/candlepin/async/JobStateManagementException.java
+++ b/server/src/main/java/org/candlepin/async/JobStateManagementException.java
@@ -1,0 +1,273 @@
+/**
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.async;
+
+import org.candlepin.model.AsyncJobStatus;
+import org.candlepin.model.AsyncJobStatus.JobState;
+
+
+
+/**
+ * The JobStateManagementException represents an unexpected error that occurred while attempting to
+ * update a given job's state. The job is now in an unexpected, bad state and some recovery should
+ * be attempted to correct it.
+ */
+public class JobStateManagementException extends JobException {
+
+    protected final AsyncJobStatus status;
+    protected final JobState initialState;
+    protected final JobState intendedState;
+
+
+    /**
+     * Constructs a new exception with null as its detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     *
+     * @param status
+     *  The AsyncJobStatus instance being updated at the time of failure
+     *
+     * @param initialState
+     *  The initial state of the job status before any changes were made leading to the exception
+     *
+     * @param intendedState
+     *  The intended state the job status was transitioning to at the time of the exception
+     */
+    public JobStateManagementException(AsyncJobStatus status, JobState initialState, JobState intendedState) {
+        this(status, initialState, intendedState, null, null, false);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     *
+     * @param status
+     *  The AsyncJobStatus instance being updated at the time of failure
+     *
+     * @param initialState
+     *  The initial state of the job status before any changes were made leading to the exception
+     *
+     * @param intendedState
+     *  The intended state the job status was transitioning to at the time of the exception
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     */
+    public JobStateManagementException(AsyncJobStatus status, JobState initialState, JobState intendedState,
+        String message) {
+
+        this(status, initialState, intendedState, null, null, false);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of
+     * <tt>(cause == null ? null : cause.toString())</tt> (which typically contains the and
+     * detail message of cause). This constructor is useful for exceptions that are little more
+     * than wrappers for other throwables (for example, PrivilegedActionException).
+     *
+     * @param status
+     *  The AsyncJobStatus instance being updated at the time of failure
+     *
+     * @param initialState
+     *  The initial state of the job status before any changes were made leading to the exception
+     *
+     * @param intendedState
+     *  The intended state the job status was transitioning to at the time of the exception
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public JobStateManagementException(AsyncJobStatus status, JobState initialState, JobState intendedState,
+        Throwable cause) {
+
+        this(status, initialState, intendedState, null, null, false);
+    }
+
+    /**
+     * Constructs a new exception with null as its detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     *
+     * @param status
+     *  The AsyncJobStatus instance being updated at the time of failure
+     *
+     * @param initialState
+     *  The initial state of the job status before any changes were made leading to the exception
+     *
+     * @param intendedState
+     *  The intended state the job status was transitioning to at the time of the exception
+     *
+     * @param terminal
+     *  whether or not the exception is terminal or non-recoverable and the job should not be
+     *  retried and any associated job messages should be discarded
+     */
+    public JobStateManagementException(AsyncJobStatus status, JobState initialState, JobState intendedState,
+        boolean terminal) {
+
+        this(status, initialState, intendedState, null, null, false);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p></p>
+     * Note that the detail message associated with cause is not automatically incorporated in this
+     * exception's detail message.
+     *
+     * @param status
+     *  The AsyncJobStatus instance being updated at the time of failure
+     *
+     * @param initialState
+     *  The initial state of the job status before any changes were made leading to the exception
+     *
+     * @param intendedState
+     *  The intended state the job status was transitioning to at the time of the exception
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public JobStateManagementException(AsyncJobStatus status, JobState initialState, JobState intendedState,
+        String message, Throwable cause) {
+
+        this(status, initialState, intendedState, null, null, false);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     *
+     * @param status
+     *  The AsyncJobStatus instance being updated at the time of failure
+     *
+     * @param initialState
+     *  The initial state of the job status before any changes were made leading to the exception
+     *
+     * @param intendedState
+     *  The intended state the job status was transitioning to at the time of the exception
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     *
+     * @param terminal
+     *  whether or not the exception is terminal or non-recoverable and the job should not be
+     *  retried and any associated job messages should be discarded
+     */
+    public JobStateManagementException(AsyncJobStatus status, JobState initialState, JobState intendedState,
+        String message, boolean terminal) {
+
+        this(status, initialState, intendedState, null, null, false);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of
+     * <tt>(cause == null ? null : cause.toString())</tt> (which typically contains the and
+     * detail message of cause). This constructor is useful for exceptions that are little more
+     * than wrappers for other throwables (for example, PrivilegedActionException).
+     *
+     * @param status
+     *  The AsyncJobStatus instance being updated at the time of failure
+     *
+     * @param initialState
+     *  The initial state of the job status before any changes were made leading to the exception
+     *
+     * @param intendedState
+     *  The intended state the job status was transitioning to at the time of the exception
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     *
+     * @param terminal
+     *  whether or not the exception is terminal or non-recoverable and the job should not be
+     *  retried and any associated job messages should be discarded
+     */
+    public JobStateManagementException(AsyncJobStatus status, JobState initialState, JobState intendedState,
+        Throwable cause, boolean terminal) {
+
+        this(status, initialState, intendedState, null, null, false);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p></p>
+     * Note that the detail message associated with cause is not automatically incorporated in this
+     * exception's detail message.
+     *
+     * @param status
+     *  The AsyncJobStatus instance being updated at the time of failure
+     *
+     * @param initialState
+     *  The initial state of the job status before any changes were made leading to the exception
+     *
+     * @param intendedState
+     *  The intended state the job status was transitioning to at the time of the exception
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     *
+     * @param terminal
+     *  whether or not the exception is terminal or non-recoverable and the job should not be
+     *  retried and any associated job messages should be discarded
+     */
+    public JobStateManagementException(AsyncJobStatus status, JobState initialState, JobState intendedState,
+        String message, Throwable cause, boolean terminal) {
+
+        super(message, cause, terminal);
+
+        this.status = status;
+        this.initialState = initialState;
+        this.intendedState = intendedState;
+    }
+
+    /**
+     * Fetches the job status instance that failed to have its state updated properly.
+     *
+     * @return
+     *  the AsyncJobStatus instance that failed to update
+     */
+    public AsyncJobStatus getJobStatus() {
+        return this.status;
+    }
+
+    /**
+     * Fetches the initial state of the job status before the most recent state change was attempted.
+     *
+     * @return
+     *  the initial state of the AsyncJobStatus instance before the update failed
+     */
+    public JobState getInitialState() {
+        return this.initialState;
+    }
+
+    /**
+     * Fetches the intended final state of the job status before the failure occurred.
+     *
+     * @return
+     *  the intended final state of the AsyncJobStatus instance before the update failed
+     */
+    public JobState getIntendedState() {
+        return this.intendedState;
+    }
+}

--- a/server/src/test/java/org/candlepin/async/JobManagerTest.java
+++ b/server/src/test/java/org/candlepin/async/JobManagerTest.java
@@ -21,272 +21,49 @@ import org.candlepin.audit.EventSink;
 import org.candlepin.guice.CandlepinRequestScope;
 import org.candlepin.guice.PrincipalProvider;
 import org.candlepin.model.AsyncJobStatus;
+import org.candlepin.model.AsyncJobStatus.JobState;
 import org.candlepin.model.AsyncJobStatusCurator;
 import org.candlepin.pinsetter.core.model.JobStatus;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+
 import org.hamcrest.core.StringContains;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
 import org.mockito.InOrder;
 import org.slf4j.MDC;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
+
+import static org.mockito.AdditionalAnswers.returnsFirstArg;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
+
+
+@RunWith(JUnitParamsRunner.class)
 public class JobManagerTest {
-
-    private static final String JOB_ID = "jobId";
-    private static final String JOB_KEY = TestJob1.getJobKey();
-    private static final String REQUEST_TYPE_KEY = "requestType";
-    private static final String REQUEST_UUID_KEY = "requestUuid";
-    private static final String ORG_KEY = "org";
-    private static final String ORG_LOG_LEVEL_KEY = "orgLogLevel";
-    private static final String OWNER_ID = "ownerId";
-    private static final String OWNER_LOG_LEVEL = "ownerLogLevel";
-    private static final String REQUEST_UUID = "requestUuid";
-    private static final String REQUEST_TYPE = "job";
-
-    private AsyncJobStatusCurator jobCurator;
-    private PrincipalProvider principalProvider;
-    private CandlepinRequestScope scope;
-    private JobMessageDispatcher dispatcher;
-    private Injector injector;
-    private EventSink eventSink;
-    private UnitOfWork uow;
-
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
-
-    @Before
-    public void setUp() {
-        this.jobCurator = mock(AsyncJobStatusCurator.class);
-        this.principalProvider = mock(PrincipalProvider.class);
-        this.scope = mock(CandlepinRequestScope.class);
-        this.dispatcher = mock(JobMessageDispatcher.class);
-        this.injector = mock(Injector.class);
-        this.eventSink = mock(EventSink.class);
-        this.uow = mock(UnitOfWork.class);
-
-        doReturn(this.eventSink).when(this.injector).getInstance(EventSink.class);
-        doReturn(this.jobCurator).when(this.injector).getInstance(AsyncJobStatusCurator.class);
-        doReturn(this.uow).when(this.injector).getInstance(UnitOfWork.class);
-    }
-
-    @Test
-    public void jobShouldFailWhenJobStatusIsNotFound()
-        throws PreJobExecutionException, JobExecutionException {
-        doReturn(null).when(jobCurator).get(anyString());
-        final JobManager manager = createJobManager();
-
-        thrown.expect(PreJobExecutionException.class);
-        thrown.expectMessage(StringContains.containsString("not found"));
-
-        manager.executeJob(new JobMessage(JOB_ID, JOB_KEY));
-    }
-
-    @Test
-    public void jobShouldFailWhenJobWasCancelled() throws PreJobExecutionException, JobExecutionException {
-        doReturn(new AsyncJobStatus().setState(AsyncJobStatus.JobState.CANCELED))
-            .when(jobCurator).get(anyString());
-        final JobManager manager = createJobManager();
-
-        thrown.expect(PreJobExecutionException.class);
-        thrown.expectMessage(StringContains.containsString("CANCELLED"));
-
-        manager.executeJob(new JobMessage(JOB_ID, JOB_KEY));
-    }
-
-
-    @Test
-    public void shouldFailWhenJobCouldNotBeConstructed()
-        throws PreJobExecutionException, JobExecutionException {
-        doReturn(new AsyncJobStatus().setState(AsyncJobStatus.JobState.QUEUED))
-            .when(jobCurator).get(anyString());
-        final JobManager manager = createJobManager();
-
-        thrown.expect(PreJobExecutionException.class);
-        thrown.expectMessage(StringContains.containsString("could not be created"));
-
-        manager.executeJob(new JobMessage(JOB_ID, JOB_KEY));
-    }
-
-    @Test
-    public void jobShouldBeExecuted() throws PreJobExecutionException, JobExecutionException {
-        final AsyncJob spy = mock(AsyncJob.class);
-        doReturn(spy).when(injector).getInstance(TestJob1.class);
-        doReturn(new AsyncJobStatus().setState(AsyncJobStatus.JobState.QUEUED))
-            .when(jobCurator).get(anyString());
-        final JobManager manager = createJobManager();
-
-        manager.executeJob(new JobMessage(JOB_ID, JOB_KEY));
-
-        verify(spy).execute(any());
-    }
-
-    @Test
-    public void shouldSetupDMC() throws JobExecutionException, PreJobExecutionException {
-        final AsyncJobStatus status = mock(AsyncJobStatus.class);
-        final Map<String, Object> map = new HashMap<>();
-        map.put(REQUEST_UUID_KEY, REQUEST_UUID);
-        map.put(JobStatus.OWNER_ID, OWNER_ID);
-        map.put(JobStatus.OWNER_LOG_LEVEL, OWNER_LOG_LEVEL);
-        doReturn(new JobDataMap(map)).when(status).getJobData();
-        doReturn(mock(AsyncJob.class)).when(injector).getInstance(TestJob1.class);
-        doReturn(status).when(jobCurator).get(JOB_ID);
-        final JobManager manager = createJobManager();
-
-        manager.executeJob(new JobMessage(JOB_ID, JOB_KEY));
-
-        assertEquals(REQUEST_TYPE, MDC.get(REQUEST_TYPE_KEY));
-        assertEquals(REQUEST_UUID, MDC.get(REQUEST_UUID_KEY));
-        assertEquals(OWNER_ID, MDC.get(ORG_KEY));
-        assertEquals(OWNER_LOG_LEVEL, MDC.get(ORG_LOG_LEVEL_KEY));
-    }
-
-    @Test
-    public void shouldSendEvents() throws JobExecutionException, PreJobExecutionException {
-        doReturn(mock(AsyncJob.class)).when(injector).getInstance(TestJob1.class);
-        doReturn(new AsyncJobStatus().setState(AsyncJobStatus.JobState.QUEUED))
-            .when(jobCurator).get(anyString());
-        final JobManager manager = createJobManager();
-
-        manager.executeJob(new JobMessage(JOB_ID, JOB_KEY));
-
-        verify(this.eventSink).sendEvents();
-    }
-
-    @Test
-    public void shouldRollbackEventsOfFailedJob() {
-        final AsyncJob job = jdata -> {
-            throw new JobExecutionException();
-        };
-        doReturn(job).when(injector).getInstance(TestJob1.class);
-        doReturn(new AsyncJobStatus().setState(AsyncJobStatus.JobState.QUEUED))
-            .when(jobCurator).get(anyString());
-        final JobManager manager = createJobManager();
-
-        try {
-            manager.executeJob(new JobMessage(JOB_ID, JOB_KEY));
-            fail("Should not happen");
-        }
-        catch (PreJobExecutionException | JobExecutionException e) {
-            verify(this.eventSink).rollback();
-        }
-    }
-
-    @Test
-    public void successfulJobShouldEndAsCompleted() throws JobExecutionException, PreJobExecutionException {
-        final StateCollectingStatus status = new StateCollectingStatus();
-        doReturn(mock(AsyncJob.class)).when(injector).getInstance(TestJob1.class);
-        doReturn(new AsyncJobStatus().setState(AsyncJobStatus.JobState.QUEUED))
-            .when(jobCurator).get(anyString());
-        doReturn(status).when(this.jobCurator).get(JOB_ID);
-        final JobManager manager = createJobManager();
-
-        manager.executeJob(new JobMessage(JOB_ID, JOB_KEY));
-
-        assertTrue(status.containsAll(
-            AsyncJobStatus.JobState.RUNNING,
-            AsyncJobStatus.JobState.COMPLETED));
-    }
-
-    @Test
-    public void shouldSetJobExecSource() throws PreJobExecutionException, JobExecutionException {
-        final AsyncJobStatus status = new AsyncJobStatus();
-        doReturn(mock(AsyncJob.class)).when(injector).getInstance(TestJob1.class);
-        doReturn(new AsyncJobStatus().setState(AsyncJobStatus.JobState.QUEUED))
-            .when(jobCurator).get(anyString());
-        doReturn(status).when(this.jobCurator).get(JOB_ID);
-        final JobManager manager = createJobManager();
-
-        manager.executeJob(new JobMessage(JOB_ID, JOB_KEY));
-
-        final String execSource = status.getJobExecSource();
-        assertFalse(execSource == null || execSource.isEmpty());
-    }
-
-    @Test
-    public void failedJobShouldEndAsFailed() throws PreJobExecutionException {
-        final StateCollectingStatus status = new StateCollectingStatus();
-        final AsyncJob mock = jdata -> {
-            throw new JobExecutionException();
-        };
-        doReturn(mock).when(injector).getInstance(TestJob1.class);
-        doReturn(status).when(this.jobCurator).get(JOB_ID);
-        final JobManager manager = createJobManager();
-
-        try {
-            manager.executeJob(new JobMessage(JOB_ID, JOB_KEY));
-            fail("Should not happen");
-        }
-        catch (JobExecutionException e) {
-            assertTrue(status.containsAll(
-                AsyncJobStatus.JobState.RUNNING,
-                AsyncJobStatus.JobState.FAILED));
-        }
-    }
-
-    @Test
-    public void shouldSurroundJobExecutionWithUnitOfWork()
-        throws JobExecutionException, PreJobExecutionException {
-        final AsyncJob job = mock(AsyncJob.class);
-        doReturn(job).when(injector).getInstance(TestJob1.class);
-        doReturn(new AsyncJobStatus().setState(AsyncJobStatus.JobState.QUEUED))
-            .when(jobCurator).get(anyString());
-        final InOrder inOrder = inOrder(uow, job, uow);
-        final JobManager manager = createJobManager();
-
-        manager.executeJob(new JobMessage(JOB_ID, JOB_KEY));
-
-        inOrder.verify(uow).begin();
-        inOrder.verify(job).execute(any());
-        inOrder.verify(uow).end();
-    }
-
-    @Test
-    public void shouldProperlyEndUnitOfWorkOfFailedJobs()
-        throws JobExecutionException, PreJobExecutionException {
-        final AsyncJob job = mock(AsyncJob.class);
-        doReturn(job).when(injector).getInstance(TestJob1.class);
-        doReturn(new AsyncJobStatus().setState(AsyncJobStatus.JobState.QUEUED))
-            .when(jobCurator).get(anyString());
-        doThrow(new JobExecutionException()).when(job).execute(any());
-        final InOrder inOrder = inOrder(uow, job, uow);
-        final JobManager manager = createJobManager();
-
-        try {
-            manager.executeJob(new JobMessage(JOB_ID, JOB_KEY));
-            fail("Must not happen!");
-        }
-        catch (JobExecutionException e) {
-            inOrder.verify(uow).begin();
-            inOrder.verify(job).execute(any());
-            inOrder.verify(uow).end();
-        }
-    }
-
-    private JobManager createJobManager() {
-        return new JobManager(
-            jobCurator, dispatcher, principalProvider, scope, injector);
-    }
 
     private static class StateCollectingStatus extends AsyncJobStatus {
 
@@ -304,4 +81,483 @@ public class JobManagerTest {
         }
     }
 
+    /**
+     * A JobMessageDispatcher implementation that collects the messages sent for verification
+     */
+    private static class CollectingJobMessageDispatcher implements JobMessageDispatcher {
+        private List<JobMessage> messages = new ArrayList<>();
+
+        @Override
+        public void sendJobMessage(JobMessage jobMessage) throws Exception {
+            this.messages.add(jobMessage);
+        }
+
+        public List<JobMessage> getSentMessages() {
+            return this.messages;
+        }
+    }
+
+
+    private static final String JOB_ID = "jobId";
+    private static final String JOB_KEY = TestJob1.getJobKey();
+    private static final String REQUEST_TYPE_KEY = "requestType";
+    private static final String REQUEST_UUID_KEY = "requestUuid";
+    private static final String ORG_KEY = "org";
+    private static final String ORG_LOG_LEVEL_KEY = "orgLogLevel";
+    private static final String OWNER_ID = "ownerId";
+    private static final String OWNER_LOG_LEVEL = "ownerLogLevel";
+    private static final String REQUEST_UUID = "requestUuid";
+    private static final String REQUEST_TYPE = "job";
+
+    private AsyncJobStatusCurator jobCurator;
+    private PrincipalProvider principalProvider;
+    private CandlepinRequestScope scope;
+    private CollectingJobMessageDispatcher dispatcher;
+    private Injector injector;
+    private EventSink eventSink;
+    private UnitOfWork uow;
+
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Before
+    public void setUp() {
+        this.jobCurator = mock(AsyncJobStatusCurator.class);
+        this.principalProvider = mock(PrincipalProvider.class);
+        this.scope = mock(CandlepinRequestScope.class);
+        this.dispatcher = new CollectingJobMessageDispatcher();
+        this.injector = mock(Injector.class);
+        this.eventSink = mock(EventSink.class);
+        this.uow = mock(UnitOfWork.class);
+
+        doReturn(this.eventSink).when(this.injector).getInstance(EventSink.class);
+        doReturn(this.jobCurator).when(this.injector).getInstance(AsyncJobStatusCurator.class);
+        doReturn(this.uow).when(this.injector).getInstance(UnitOfWork.class);
+        doAnswer(returnsFirstArg()).when(this.jobCurator).merge(any(AsyncJobStatus.class));
+    }
+
+    private JobManager createJobManager() {
+        return new JobManager(
+            jobCurator, dispatcher, principalProvider, scope, injector);
+    }
+
+    @Test
+    public void jobShouldFailWhenJobStatusIsNotFound() throws JobException {
+        doReturn(null).when(jobCurator).get(anyString());
+        final JobManager manager = createJobManager();
+
+        thrown.expect(JobInitializationException.class);
+        thrown.expectMessage(StringContains.containsString("Unable to find"));
+
+        manager.executeJob(new JobMessage(JOB_ID, JOB_KEY));
+    }
+
+    public Object[] getTerminalJobStates() {
+        List<JobState> states = new ArrayList<>();
+
+        for (JobState state : JobState.values()) {
+            if (state.isTerminal()) {
+                states.add(state);
+            }
+        }
+
+        return states.toArray();
+    }
+
+    @Test
+    @Parameters(method = "getTerminalJobStates")
+    public void jobShouldFailWhenJobStateIsTerminal(JobState state) throws JobException {
+        doReturn(new AsyncJobStatus().setState(state)).when(jobCurator).get(anyString());
+        final JobManager manager = createJobManager();
+
+        thrown.expect(JobInitializationException.class);
+        thrown.expectMessage(StringContains.containsString("unknown or terminal state"));
+
+        manager.executeJob(new JobMessage(JOB_ID, JOB_KEY));
+    }
+
+    @Test
+    public void shouldFailWhenJobCouldNotBeConstructed() throws JobException {
+        doReturn(new AsyncJobStatus().setState(JobState.QUEUED))
+            .when(jobCurator).get(anyString());
+        final JobManager manager = createJobManager();
+
+        thrown.expect(JobInitializationException.class);
+        thrown.expectMessage(StringContains.containsString("Unable to instantiate"));
+
+        manager.executeJob(new JobMessage(JOB_ID, JOB_KEY));
+    }
+
+    @Test
+    public void jobShouldBeExecuted() throws JobException {
+        final AsyncJob spy = mock(AsyncJob.class);
+        doReturn(spy).when(injector).getInstance(TestJob1.class);
+        doReturn(new AsyncJobStatus().setState(JobState.QUEUED))
+            .when(jobCurator).get(anyString());
+        final JobManager manager = createJobManager();
+
+        manager.executeJob(new JobMessage(JOB_ID, JOB_KEY));
+
+        verify(spy).execute(any());
+    }
+
+    @Test
+    public void shouldSetupDMC() throws JobException {
+        final Map<String, Object> map = new HashMap<>();
+        map.put(REQUEST_UUID_KEY, REQUEST_UUID);
+        map.put(JobStatus.OWNER_ID, OWNER_ID);
+        map.put(JobStatus.OWNER_LOG_LEVEL, OWNER_LOG_LEVEL);
+
+        final AsyncJobStatus status = new AsyncJobStatus()
+            .setJobData(map);
+
+        doReturn(mock(AsyncJob.class)).when(injector).getInstance(TestJob1.class);
+        doReturn(status).when(jobCurator).get(JOB_ID);
+        final JobManager manager = createJobManager();
+
+        manager.executeJob(new JobMessage(JOB_ID, JOB_KEY));
+
+        assertEquals(REQUEST_TYPE, MDC.get(REQUEST_TYPE_KEY));
+        assertEquals(REQUEST_UUID, MDC.get(REQUEST_UUID_KEY));
+        assertEquals(OWNER_ID, MDC.get(ORG_KEY));
+        assertEquals(OWNER_LOG_LEVEL, MDC.get(ORG_LOG_LEVEL_KEY));
+    }
+
+    @Test
+    public void shouldSendEvents() throws JobException {
+        doReturn(mock(AsyncJob.class)).when(injector).getInstance(TestJob1.class);
+        doReturn(new AsyncJobStatus().setState(JobState.QUEUED))
+            .when(jobCurator).get(anyString());
+        final JobManager manager = createJobManager();
+
+        manager.executeJob(new JobMessage(JOB_ID, JOB_KEY));
+
+        verify(this.eventSink).sendEvents();
+    }
+
+    @Test
+    public void shouldRollbackEventsOfFailedJob() {
+        final AsyncJob job = jdata -> {
+            throw new JobExecutionException();
+        };
+        doReturn(job).when(injector).getInstance(TestJob1.class);
+        doReturn(new AsyncJobStatus().setState(JobState.QUEUED))
+            .when(jobCurator).get(anyString());
+        final JobManager manager = createJobManager();
+
+        try {
+            manager.executeJob(new JobMessage(JOB_ID, JOB_KEY));
+            fail("Should not happen");
+        }
+        catch (JobException e) {
+            verify(this.eventSink).rollback();
+        }
+    }
+
+    @Test
+    public void successfulJobShouldEndAsCompleted() throws JobException {
+        final StateCollectingStatus status = new StateCollectingStatus();
+        doReturn(mock(AsyncJob.class)).when(injector).getInstance(TestJob1.class);
+        doReturn(new AsyncJobStatus().setState(JobState.QUEUED))
+            .when(jobCurator).get(anyString());
+        doReturn(status).when(this.jobCurator).get(JOB_ID);
+
+
+        final JobManager manager = createJobManager();
+
+        manager.executeJob(new JobMessage(JOB_ID, JOB_KEY));
+
+        assertTrue(status.containsAll(
+            JobState.RUNNING,
+            JobState.COMPLETED));
+    }
+
+    @Test
+    public void shouldSetJobExecSource() throws JobException {
+        final AsyncJobStatus status = new AsyncJobStatus();
+        doReturn(mock(AsyncJob.class)).when(injector).getInstance(TestJob1.class);
+        doReturn(new AsyncJobStatus().setState(JobState.QUEUED))
+            .when(jobCurator).get(anyString());
+        doReturn(status).when(this.jobCurator).get(JOB_ID);
+        final JobManager manager = createJobManager();
+
+        manager.executeJob(new JobMessage(JOB_ID, JOB_KEY));
+
+        final String execSource = status.getJobExecSource();
+        assertFalse(execSource == null || execSource.isEmpty());
+    }
+
+    @Test
+    public void failedJobShouldEndAsFailed() throws JobInitializationException {
+        final StateCollectingStatus status = new StateCollectingStatus();
+        final AsyncJob mock = jdata -> {
+            throw new JobExecutionException();
+        };
+        doReturn(mock).when(injector).getInstance(TestJob1.class);
+        doReturn(status).when(this.jobCurator).get(JOB_ID);
+        final JobManager manager = createJobManager();
+
+        try {
+            manager.executeJob(new JobMessage(JOB_ID, JOB_KEY));
+            fail("Should not happen");
+        }
+        catch (JobException e) {
+            assertTrue(status.containsAll(
+                JobState.RUNNING,
+                JobState.FAILED));
+        }
+    }
+
+    @Test
+    public void shouldSurroundJobExecutionWithUnitOfWork() throws JobException {
+        final AsyncJob job = mock(AsyncJob.class);
+        doReturn(job).when(injector).getInstance(TestJob1.class);
+        doReturn(new AsyncJobStatus().setState(JobState.QUEUED))
+            .when(jobCurator).get(anyString());
+        final InOrder inOrder = inOrder(uow, job, uow);
+        final JobManager manager = createJobManager();
+
+        manager.executeJob(new JobMessage(JOB_ID, JOB_KEY));
+
+        inOrder.verify(uow).begin();
+        inOrder.verify(job).execute(any());
+        inOrder.verify(uow).end();
+    }
+
+    @Test
+    public void shouldProperlyEndUnitOfWorkOfFailedJobs() throws JobException {
+        final AsyncJob job = mock(AsyncJob.class);
+        doReturn(job).when(injector).getInstance(TestJob1.class);
+        doReturn(new AsyncJobStatus().setState(JobState.QUEUED))
+            .when(jobCurator).get(anyString());
+        doThrow(new JobExecutionException()).when(job).execute(any());
+        final InOrder inOrder = inOrder(uow, job, uow);
+        final JobManager manager = createJobManager();
+
+        try {
+            manager.executeJob(new JobMessage(JOB_ID, JOB_KEY));
+            fail("Must not happen!");
+        }
+        catch (JobExecutionException e) {
+            inOrder.verify(uow).begin();
+            inOrder.verify(job).execute(any());
+            inOrder.verify(uow).end();
+        }
+    }
+
+    @Test
+    public void testStartTimeIsSetOnExecution() throws JobException {
+        AsyncJob job = jdata -> { return null; };
+        AsyncJobStatus status = new AsyncJobStatus()
+            .setState(JobState.QUEUED);
+
+        doReturn(job).when(this.injector).getInstance(TestJob1.class);
+        doReturn(status).when(this.jobCurator).get(anyString());
+
+        assertNull(status.getStartTime());
+        Date start = new Date();
+
+        JobManager manager = this.createJobManager();
+        manager.executeJob(new JobMessage(JOB_ID, JOB_KEY));
+
+        Date end = new Date();
+
+        assertNotNull(status.getStartTime());
+        assertTrue(start.compareTo(status.getStartTime()) <= 0);
+        assertTrue(end.compareTo(status.getStartTime()) >= 0);
+    }
+
+    @Test
+    public void testEndTimeIsSetOnExecution() throws JobException {
+        AsyncJob job = jdata -> { return null; };
+        AsyncJobStatus status = new AsyncJobStatus()
+            .setState(JobState.QUEUED);
+
+        doReturn(job).when(this.injector).getInstance(TestJob1.class);
+        doReturn(status).when(this.jobCurator).get(anyString());
+
+        assertNull(status.getEndTime());
+        Date start = new Date();
+
+        JobManager manager = this.createJobManager();
+        manager.executeJob(new JobMessage(JOB_ID, JOB_KEY));
+
+        Date end = new Date();
+
+        assertNotNull(status.getEndTime());
+        assertTrue(start.compareTo(status.getEndTime()) <= 0);
+        assertTrue(end.compareTo(status.getEndTime()) >= 0);
+    }
+
+    @Test
+    public void testEndTimeIsSetOnExecutionFailure() {
+        AsyncJob job = jdata -> { throw new JobExecutionException("kaboom"); };
+        AsyncJobStatus status = new AsyncJobStatus()
+            .setState(JobState.QUEUED);
+
+        doReturn(job).when(this.injector).getInstance(TestJob1.class);
+        doReturn(status).when(this.jobCurator).get(anyString());
+
+        assertNull(status.getEndTime());
+        Date start = new Date();
+
+        try {
+            JobManager manager = this.createJobManager();
+            manager.executeJob(new JobMessage(JOB_ID, JOB_KEY));
+
+            fail("Expected exception was not thrown by JobManager.executeJob");
+        }
+        catch (JobException e) {
+            // This is expected
+            assertEquals("kaboom", e.getMessage());
+        }
+
+        Date end = new Date();
+
+        assertNotNull(status.getEndTime());
+        assertTrue(start.compareTo(status.getEndTime()) <= 0);
+        assertTrue(end.compareTo(status.getEndTime()) >= 0);
+    }
+
+    @Test
+    public void testAttemptCountIsIncrementedOnExecution() throws JobException {
+        AsyncJob job = jdata -> { return null; };
+        AsyncJobStatus status = new AsyncJobStatus()
+            .setState(JobState.QUEUED);
+
+        doReturn(job).when(this.injector).getInstance(TestJob1.class);
+        doReturn(status).when(this.jobCurator).get(anyString());
+
+        assertEquals(0, status.getAttempts());
+
+        JobManager manager = this.createJobManager();
+        manager.executeJob(new JobMessage(JOB_ID, JOB_KEY));
+
+        assertEquals(1, status.getAttempts());
+    }
+
+    @Test
+    public void testAttemptCountRemainsIncrementedOnExecutionFailure() throws JobException {
+        AsyncJob job = jdata -> { throw new JobExecutionException("kaboom"); };
+        AsyncJobStatus status = new AsyncJobStatus()
+            .setState(JobState.QUEUED);
+
+        doReturn(job).when(this.injector).getInstance(TestJob1.class);
+        doReturn(status).when(this.jobCurator).get(anyString());
+
+        assertEquals(0, status.getAttempts());
+
+        try {
+            JobManager manager = this.createJobManager();
+            manager.executeJob(new JobMessage(JOB_ID, JOB_KEY));
+
+            fail("Expected exception was not thrown by JobManager.executeJob");
+        }
+        catch (JobException e) {
+            // This is expected
+            assertEquals("kaboom", e.getMessage());
+        }
+
+        assertEquals(1, status.getAttempts());
+    }
+
+    @Test
+    public void testFailingWithRetryGeneratesNewJobMessage() {
+        AsyncJob job = jdata -> { throw new JobExecutionException("kaboom"); };
+        AsyncJobStatus status = spy(new AsyncJobStatus()
+            .setJobKey(JOB_KEY)
+            .setState(JobState.QUEUED)
+            .setMaxAttempts(3));
+
+        // TODO: Stop doing this when we stop relying on Hibernate to generate the ID for us
+        doReturn(JOB_ID).when(status).getId();
+
+        doReturn(job).when(this.injector).getInstance(TestJob1.class);
+        doReturn(status).when(this.jobCurator).get(anyString());
+
+        assertEquals(0, this.dispatcher.getSentMessages().size());
+
+        try {
+            JobManager manager = this.createJobManager();
+            manager.executeJob(new JobMessage(JOB_ID, JOB_KEY));
+
+            fail("Expected exception was not thrown by JobManager.executeJob");
+        }
+        catch (JobException e) {
+            // This is expected
+            assertEquals("kaboom", e.getMessage());
+        }
+
+        assertEquals(1, this.dispatcher.getSentMessages().size());
+
+        JobMessage message = this.dispatcher.getSentMessages().get(0);
+        assertEquals(JOB_ID, message.getJobId());
+        assertEquals(JOB_KEY, message.getJobKey());
+
+        assertEquals(JobState.FAILED_WITH_RETRY, status.getState());
+    }
+
+    @Test
+    public void testFailingWithRetryDoesNotRetryWhenAttemptsExhaused() {
+        AsyncJob job = jdata -> { throw new JobExecutionException("kaboom"); };
+        AsyncJobStatus status = spy(new AsyncJobStatus()
+            .setJobKey(JOB_KEY)
+            .setState(JobState.QUEUED)
+            .incrementAttempts()
+            .setMaxAttempts(2));
+
+        // TODO: Stop doing this when we stop relying on Hibernate to generate the ID for us
+        doReturn(JOB_ID).when(status).getId();
+
+        doReturn(job).when(this.injector).getInstance(TestJob1.class);
+        doReturn(status).when(this.jobCurator).get(anyString());
+
+        assertEquals(0, this.dispatcher.getSentMessages().size());
+
+        try {
+            JobManager manager = this.createJobManager();
+            manager.executeJob(new JobMessage(JOB_ID, JOB_KEY));
+
+            fail("Expected exception was not thrown by JobManager.executeJob");
+        }
+        catch (JobException e) {
+            // This is expected
+            assertEquals("kaboom", e.getMessage());
+        }
+
+        assertEquals(0, this.dispatcher.getSentMessages().size());
+        assertEquals(JobState.FAILED, status.getState());
+    }
+
+    @Test
+    public void testFailingWithRetryDoesNotRetryOnTerminalFailure() {
+        AsyncJob job = jdata -> { throw new JobExecutionException("kaboom", true); };
+        AsyncJobStatus status = spy(new AsyncJobStatus()
+            .setJobKey(JOB_KEY)
+            .setState(JobState.QUEUED)
+            .setMaxAttempts(3));
+
+        // TODO: Stop doing this when we stop relying on Hibernate to generate the ID for us
+        doReturn(JOB_ID).when(status).getId();
+
+        doReturn(job).when(this.injector).getInstance(TestJob1.class);
+        doReturn(status).when(this.jobCurator).get(anyString());
+
+        assertEquals(0, this.dispatcher.getSentMessages().size());
+
+        try {
+            JobManager manager = this.createJobManager();
+            manager.executeJob(new JobMessage(JOB_ID, JOB_KEY));
+
+            fail("Expected exception was not thrown by JobManager.executeJob");
+        }
+        catch (JobException e) {
+            // This is expected
+            assertEquals("kaboom", e.getMessage());
+        }
+
+        assertEquals(0, this.dispatcher.getSentMessages().size());
+        assertEquals(JobState.FAILED, status.getState());
+    }
 }

--- a/server/src/test/java/org/candlepin/async/JobMessageReceiverTest.java
+++ b/server/src/test/java/org/candlepin/async/JobMessageReceiverTest.java
@@ -1,0 +1,213 @@
+/**
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.async;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
+
+import org.candlepin.async.impl.ActiveMQSessionFactory;
+import org.candlepin.model.AsyncJobStatus;
+import org.candlepin.model.AsyncJobStatus.JobState;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
+import org.apache.activemq.artemis.api.core.ActiveMQBuffers;
+import org.apache.activemq.artemis.api.core.client.ClientConsumer;
+import org.apache.activemq.artemis.api.core.client.ClientMessage;
+import org.apache.activemq.artemis.api.core.client.ClientSession;
+
+import org.junit.Before;
+import org.junit.Test;
+
+
+
+public class JobMessageReceiverTest {
+
+    private String filter;
+    private JobManager jobManager;
+    private ObjectMapper objMapper;
+
+    private ActiveMQSessionFactory sessionFactory;
+    private ClientSession session;
+    private ClientConsumer consumer;
+
+    @Before
+    public void setUp() throws Exception {
+        this.filter = "test filter";
+        this.jobManager = mock(JobManager.class);
+        this.objMapper = new ObjectMapper();
+
+        // Prep the session factory...
+        this.sessionFactory = mock(ActiveMQSessionFactory.class);
+        this.session = mock(ClientSession.class);
+        this.consumer = mock(ClientConsumer.class);
+
+        doReturn(this.session).when(this.sessionFactory).getIngressSession(anyBoolean());
+        doReturn(this.consumer).when(this.session).createConsumer(anyString(), anyString());
+    }
+
+    public JobMessageReceiver buildJobMessageReceiver() {
+        try {
+            JobMessageReceiver receiver = new JobMessageReceiver(this.filter, this.jobManager,
+                this.sessionFactory, this.objMapper);
+
+            receiver.initialize();
+
+            return receiver;
+        }
+        catch (Exception e) {
+            throw new RuntimeException("Unexpected exception occurred while building JobMessageReceiver", e);
+        }
+    }
+
+    public ClientMessage buildClientMessage(String jobId, String jobKey) {
+        try {
+            String body = String.format("{ \"jobId\": \"%s\", \"jobKey\": \"%s\" }", jobId, jobKey);
+
+            ClientMessage message = mock(ClientMessage.class);
+            ActiveMQBuffer buffer = ActiveMQBuffers.dynamicBuffer(body.length());
+            buffer.writeString(body);
+
+            doReturn(buffer).when(message).getBodyBuffer();
+            // Mock more of this thing here as necessary. Yeesh...
+
+            return message;
+        }
+        catch (Exception e) {
+            throw new RuntimeException("Unexpected exception occurred while building ClientMessage", e);
+        }
+    }
+
+    @Test
+    public void testMessageAckAndSessionCommitOnSuccess() throws Exception {
+        ClientMessage message = this.buildClientMessage("test_id", "test_key");
+        JobMessageReceiver receiver = this.buildJobMessageReceiver();
+
+        receiver.onMessage(message);
+
+        verify(message, times(1)).acknowledge();
+        verify(this.session, times(1)).commit();
+        verify(this.session, never()).rollback();
+    }
+
+    @Test
+    public void testMessageCommitOnJobExecutionException() throws Exception {
+        ClientMessage message = this.buildClientMessage("test_id", "test_key");
+        JobMessageReceiver receiver = this.buildJobMessageReceiver();
+
+        doThrow(new JobExecutionException()).when(this.jobManager).executeJob(any());
+
+        receiver.onMessage(message);
+
+        verify(message, times(1)).acknowledge();
+        verify(this.session, times(1)).commit();
+        verify(this.session, never()).rollback();
+    }
+
+    @Test
+    public void testMessageCommitOnTerminalJobStateManagementException() throws Exception {
+        ClientMessage message = this.buildClientMessage("test_id", "test_key");
+        JobMessageReceiver receiver = this.buildJobMessageReceiver();
+
+        JobStateManagementException exception = new JobStateManagementException(new AsyncJobStatus(),
+            JobState.RUNNING, JobState.FAILED, true);
+
+        doThrow(exception).when(this.jobManager).executeJob(any());
+
+        receiver.onMessage(message);
+
+        verify(message, times(1)).acknowledge();
+        verify(this.session, times(1)).commit();
+        verify(this.session, never()).rollback();
+    }
+
+    @Test
+    public void testMessageRollbackOnNonTerminalJobStateManagementException() throws Exception {
+        ClientMessage message = this.buildClientMessage("test_id", "test_key");
+        JobMessageReceiver receiver = this.buildJobMessageReceiver();
+
+        JobStateManagementException exception = new JobStateManagementException(new AsyncJobStatus(),
+            JobState.RUNNING, JobState.FAILED_WITH_RETRY, false);
+
+        doThrow(exception).when(this.jobManager).executeJob(any());
+
+        receiver.onMessage(message);
+
+        verify(message, times(1)).acknowledge();
+        verify(this.session, never()).commit();
+        verify(this.session, times(1)).rollback();
+    }
+
+    @Test
+    public void testMessageRollbackOnMessageDispatchException() throws Exception {
+        ClientMessage message = this.buildClientMessage("test_id", "test_key");
+        JobMessageReceiver receiver = this.buildJobMessageReceiver();
+
+        doThrow(new JobMessageDispatchException()).when(this.jobManager).executeJob(any());
+
+        receiver.onMessage(message);
+
+        verify(message, times(1)).acknowledge();
+        verify(this.session, never()).commit();
+        verify(this.session, times(1)).rollback();
+    }
+
+    @Test
+    public void testMessageCommitOnTerminalJobException() throws Exception {
+        ClientMessage message = this.buildClientMessage("test_id", "test_key");
+        JobMessageReceiver receiver = this.buildJobMessageReceiver();
+
+        doThrow(new JobException(true)).when(this.jobManager).executeJob(any());
+
+        receiver.onMessage(message);
+
+        verify(message, times(1)).acknowledge();
+        verify(this.session, times(1)).commit();
+        verify(this.session, never()).rollback();
+    }
+
+    @Test
+    public void testMessageRollbackOnNonTerminalJobException() throws Exception {
+        ClientMessage message = this.buildClientMessage("test_id", "test_key");
+        JobMessageReceiver receiver = this.buildJobMessageReceiver();
+
+        doThrow(new JobException(false)).when(this.jobManager).executeJob(any());
+
+        receiver.onMessage(message);
+
+        verify(message, times(1)).acknowledge();
+        verify(this.session, never()).commit();
+        verify(this.session, times(1)).rollback();
+    }
+
+    @Test
+    public void testMessageRollbackOnMessageProcessingException() throws Exception {
+        ClientMessage message = this.buildClientMessage("test_id", "test_key");
+
+        this.objMapper = mock(ObjectMapper.class);
+        doThrow(new RuntimeException("kaboom")).when(this.objMapper).readValue(anyString(), any(Class.class));
+
+        JobMessageReceiver receiver = this.buildJobMessageReceiver();
+
+        receiver.onMessage(message);
+
+        verify(message, times(1)).acknowledge();
+        verify(this.session, never()).commit();
+        verify(this.session, times(1)).rollback();
+    }
+
+}


### PR DESCRIPTION
- The JobManager will now retry jobs that fail during execution
  if they have been configured to run more than once and the
  failure is not flagged as a terminal failure
- Executed jobs now have their run attempt counter and start
  and end times properly set
- Updated log and exception output messages to improve clarity
  and conform to existing message formats
- Renamed PreJobExecutionException to JobInitializationException
- JobInitializationException and JobExecutionException are now
  both subclasses of JobException
- JobExecutionException can now be flagged as a "terminal"
  exception, indicating that it should not be retried, even if
  the job has been configured to retry and has not yet exceeded
  its attempt limit
- Removed some of the exception handling from JobMessageReciever,
  as this is now performed by the JobManager
- JobMessageReceiver now only rolls back AMQP messages when the
  message parsing and processing fails. Once job execution begins,
  any message receive is acknowledged and pulled from the queue.