### PR TITLE
1591315: Less confusing warnings, when golden ticket is used; ENT-671

### DIFF
--- a/server/src/main/java/org/candlepin/resource/util/ConsumerBindUtil.java
+++ b/server/src/main/java/org/candlepin/resource/util/ConsumerBindUtil.java
@@ -82,6 +82,7 @@ public class ConsumerBindUtil {
         // Process activation keys.
 
         boolean listSuccess = false;
+        boolean isCAModeEnabledForAny = false;
         for (ActivationKey key : keys) {
             boolean keySuccess = true;
             handleActivationKeyOverrides(consumer, key.getContentOverrides());
@@ -89,8 +90,11 @@ public class ConsumerBindUtil {
             keySuccess &= handleActivationKeyServiceLevel(consumer, key.getServiceLevel(), key.getOwner());
             if (key.isAutoAttach() != null && key.isAutoAttach()) {
                 if (autoattachDisabledForOwner || key.getOwner().isContentAccessEnabled()) {
-                    String caMessage = key.getOwner().isContentAccessEnabled() ?
-                        " because of the content access mode setting" : "";
+                    String caMessage = "";
+                    if (key.getOwner().isContentAccessEnabled()) {
+                        caMessage = " because of the content access mode setting";
+                        isCAModeEnabledForAny = true;
+                    }
                     log.warn(
                         "Auto-attach is disabled for owner{}. Skipping auto-attach for consumer/key: {}/{}",
                         caMessage, consumer.getUuid(), key.getName());
@@ -104,7 +108,7 @@ public class ConsumerBindUtil {
             }
             listSuccess |= keySuccess;
         }
-        if (!listSuccess) {
+        if (!listSuccess && !isCAModeEnabledForAny) {
             throw new BadRequestException(
                 i18n.tr("None of the subscriptions on the activation key were available for attaching."));
         }


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1591315
* This BZ bug report was originaly opened against sub-man and most
  of issues were really related to sub-man. These issues were
  fixed in: https://github.com/candlepin/subscription-manager/pull/2056
* It was necessary to fix only one case in candlepin server.
* When system is registererd with activation key,  auto-attch is false
  and subscriptions attached that cover installed products but all
  pools associated with the key are exhausted/consumed, then no
  exception should not be raised, when golden ticket is used.