### PR TITLE
[2.5] 1694728: Added index on column key_id in cp_content_override

### DIFF
--- a/server/src/main/resources/db/changelog/20190401093722-add-content-override-index.xml
+++ b/server/src/main/resources/db/changelog/20190401093722-add-content-override-index.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="20190401093722-1" author="crog">
+        <comment>add content override index</comment>
+
+        <createIndex indexName="cp_content_override_idx1" tableName="cp_content_override" unique="false">
+            <column name="key_id"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/server/src/main/resources/db/changelog/changelog-create.xml
+++ b/server/src/main/resources/db/changelog/changelog-create.xml
@@ -1228,4 +1228,5 @@
     <include file="db/changelog/20180820091431-revert-share-fields.xml"/>
     <include file="db/changelog/20180430101420-add-intent-fields-to-consumer.xml"/>
     <include file="db/changelog/20181116110941-virt-fact-index.xml"/>
+    <include file="db/changelog/20190401093722-add-content-override-index.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-testing.xml
+++ b/server/src/main/resources/db/changelog/changelog-testing.xml
@@ -2028,7 +2028,7 @@
     </changeSet>
     <changeSet author="awood" id="1413225753032-290">
         <comment>
-             Add the default quartz lock columns. 
+             Add the default quartz lock columns.
         </comment>
         <insert tableName="QRTZ_LOCKS">
             <column name="LOCK_NAME" value="TRIGGER_ACCESS"/>
@@ -2320,4 +2320,5 @@
     <include file="db/changelog/20180820091431-revert-share-fields.xml"/>
     <include file="db/changelog/20180430101420-add-intent-fields-to-consumer.xml"/>
     <include file="db/changelog/20181116110941-virt-fact-index.xml"/>
+    <include file="db/changelog/20190401093722-add-content-override-index.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-update.xml
+++ b/server/src/main/resources/db/changelog/changelog-update.xml
@@ -137,4 +137,5 @@
     <include file="db/changelog/20180820091431-revert-share-fields.xml"/>
     <include file="db/changelog/20180430101420-add-intent-fields-to-consumer.xml"/>
     <include file="db/changelog/20181116110941-virt-fact-index.xml"/>
+    <include file="db/changelog/20190401093722-add-content-override-index.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
- Added an index on the key_id column in the table cp_content_override
  to reduce query time when fetching activation key details