### PR TITLE
[2.3] 1679286: Removed AHC.lockAndLoad to address quirks with refresh (ENT-1245)

### DIFF
--- a/server/src/main/java/org/candlepin/bind/BindContext.java
+++ b/server/src/main/java/org/candlepin/bind/BindContext.java
@@ -125,7 +125,8 @@ public class BindContext {
      * locks the pools and replaces the existing entities in poolQuantities.
      */
     public void lockPools() {
-        Collection<Pool> pools = poolCurator.lockAndLoadByIds(poolQuantities.keySet());
+        Collection<Pool> pools = poolCurator.lockAndLoad(poolQuantities.keySet());
+        this.poolCurator.refresh(pools);
         for (Pool pool: pools) {
             poolQuantities.get(pool.getId()).setPool(pool);
         }
@@ -133,7 +134,7 @@ public class BindContext {
 
     public Consumer getLockedConsumer() {
         if (lockedConsumer == null) {
-            lockedConsumer = consumerCurator.lockAndLoad(consumer);
+            lockedConsumer = consumerCurator.lock(consumer);
         }
 
         return lockedConsumer;

--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -1181,14 +1181,11 @@ public class CandlepinPoolManager implements PoolManager {
     public List<Entitlement> entitleByProductsForHost(Consumer guest, Consumer host, Date entitleDate,
         Collection<String> possiblePools) throws EntitlementRefusedException {
 
-        Consumer locked = consumerCurator.lockAndLoad(host);
-        if (locked == null) {
-            throw new IllegalStateException("Unable to obtain exclusive lock on host: " + host);
-        }
+        this.consumerCurator.lock(host);
 
         List<Entitlement> entitlements = new LinkedList<>();
-        if (!locked.getOwnerId().equals(guest.getOwnerId())) {
-            log.debug("Host {} and guest {} have different owners", locked.getUuid(), guest.getUuid());
+        if (!host.getOwnerId().equals(guest.getOwnerId())) {
+            log.debug("Host {} and guest {} have different owners", host.getUuid(), guest.getUuid());
             return entitlements;
         }
         // Use the current date if one wasn't provided:
@@ -1196,16 +1193,16 @@ public class CandlepinPoolManager implements PoolManager {
             entitleDate = new Date();
         }
 
-        List<PoolQuantity> bestPools = getBestPoolsForHost(guest, locked, entitleDate, locked.getOwnerId(),
+        List<PoolQuantity> bestPools = getBestPoolsForHost(guest, host, entitleDate, host.getOwnerId(),
             null, possiblePools);
 
         if (bestPools == null) {
-            log.info("No entitlements for host: {}", locked.getUuid());
+            log.info("No entitlements for host: {}", host.getUuid());
             return null;
         }
 
         // now make the entitlements
-        return entitleByPools(locked, convertToMap(bestPools));
+        return entitleByPools(host, convertToMap(bestPools));
     }
 
     /**
@@ -1636,10 +1633,8 @@ public class CandlepinPoolManager implements PoolManager {
         // before starting this process.
         log.debug("Updating entitlement, Locking pool: {}", entitlement.getPool().getId());
 
-        Pool pool = poolCurator.lockAndLoad(entitlement.getPool());
-        if (pool == null) {
-            throw new RuntimeException("Unable to lock pool for entitlement: " + entitlement);
-        }
+        Pool pool = this.poolCurator.lock(entitlement.getPool());
+        this.poolCurator.refresh(pool);
 
         log.debug("Locked pool: {} consumed: {}", pool, pool.getConsumed());
 
@@ -1653,15 +1648,11 @@ public class CandlepinPoolManager implements PoolManager {
             throw new EntitlementRefusedException(errorMap);
         }
 
-        /*
-         * Grab an exclusive lock on the consumer to prevent deadlock.
-         */
-        Consumer locked = consumerCurator.lockAndLoad(consumer);
-        if (locked == null) {
-            throw new IllegalStateException("Unable to obtain exclusive lock on consumer: " + consumer);
-        }
 
-        ConsumerType ctype = this.consumerTypeCurator.getConsumerType(locked);
+        // Grab an exclusive lock on the consumer to prevent deadlock.
+        this.consumerCurator.lock(consumer);
+
+        ConsumerType ctype = this.consumerTypeCurator.getConsumerType(consumer);
 
         // Persist the entitlement after it has been updated.
         log.info("Processing entitlement and persisting.");
@@ -1673,20 +1664,20 @@ public class CandlepinPoolManager implements PoolManager {
             pool.setExported(pool.getExported() + change);
         }
         poolCurator.merge(pool);
-        locked.setEntitlementCount(locked.getEntitlementCount() + change);
+        consumer.setEntitlementCount(consumer.getEntitlementCount() + change);
 
         Map<String, Entitlement> entMap = new HashMap<>();
         entMap.put(pool.getId(), entitlement);
         Map<String, PoolQuantity> poolQuantityMap = new HashMap<>();
         poolQuantityMap.put(pool.getId(), new PoolQuantity(pool, change));
 
-        Owner owner = ownerCurator.find(locked.getOwnerId());
+        Owner owner = ownerCurator.find(consumer.getOwnerId());
 
         // the only thing we do here is decrement bonus pool quantity
-        enforcer.postEntitlement(this, locked, owner, entMap, new ArrayList<>(), true, poolQuantityMap);
+        enforcer.postEntitlement(this, consumer, owner, entMap, new ArrayList<>(), true, poolQuantityMap);
 
         // we might have changed the bonus pool quantities, revoke ents if needed.
-        checkBonusPoolQuantities(locked.getOwnerId(), entMap);
+        checkBonusPoolQuantities(consumer.getOwnerId(), entMap);
 
         // if shared ents, update shared pool quantity
         if (ctype != null && ctype.isType(ConsumerTypeEnum.SHARE)) {
@@ -1707,10 +1698,10 @@ public class CandlepinPoolManager implements PoolManager {
          * all consumer's entitlement count are updated though, so we need to update irrespective
          * of the consumer type.
          */
-        complianceRules.getStatus(locked, null, false, false);
+        complianceRules.getStatus(consumer, null, false, false);
         // Note: a quantity change should *not* need a system purpose compliance recalculation. if that is
         // not true any more, we should update that here.
-        consumerCurator.update(locked);
+        consumerCurator.update(consumer);
         poolCurator.flush();
 
         return entitlement;
@@ -1878,13 +1869,9 @@ public class CandlepinPoolManager implements PoolManager {
             }
         }
 
-        // Impl note: this will refresh pools backed by the DB, but not those newly created or deleted. Since
-        // we're operating on a list of existing entities, not expecting to pull from the DB and don't care
-        // about anything that was deleted, we can safely ignore the output here and continue working with
-        // the existing list.
-        // TODO: This is dangerous (thanks to Hibernate quirks)! We should update this to use explicit locks
-        // and refreshes on entities where we know the state.
-        poolCurator.lockAndLoad(poolsToLock);
+        this.poolCurator.lock(poolsToLock);
+        this.poolCurator.refresh(poolsToLock);
+
         log.info("Batch revoking {} entitlements", entsToRevoke.size());
         entsToRevoke = new ArrayList<>(entsToRevoke);
 
@@ -2200,7 +2187,7 @@ public class CandlepinPoolManager implements PoolManager {
         }
 
         // Lock pools we're going to delete (also, fetch them for event generation/slow deletes)
-        pools = this.poolCurator.lockAndLoadByIds(poolIds);
+        pools = this.poolCurator.lockAndLoad(poolIds);
 
         if (!pools.isEmpty()) {
             log.info("Locked {} pools for deletion...", pools.size());
@@ -2402,17 +2389,16 @@ public class CandlepinPoolManager implements PoolManager {
      */
     @Override
     public Pool updatePoolQuantity(Pool pool, long adjust) {
-        Pool locked = poolCurator.lockAndLoad(pool);
-        if (locked == null) {
-            throw new IllegalStateException("Unable to obtain exclusive lock on pool: " + pool);
-        }
+        this.poolCurator.lock(pool);
+        this.poolCurator.refresh(pool);
 
-        long newCount = locked.getQuantity() + adjust;
+        long newCount = pool.getQuantity() + adjust;
         if (newCount < 0) {
             newCount = 0;
         }
-        locked.setQuantity(newCount);
-        return poolCurator.merge(locked);
+
+        pool.setQuantity(newCount);
+        return poolCurator.merge(pool);
     }
 
     /**
@@ -2425,7 +2411,7 @@ public class CandlepinPoolManager implements PoolManager {
      */
     @Override
     public Pool setPoolQuantity(Pool pool, long set) {
-        pool = poolCurator.lockAndLoad(pool);
+        this.poolCurator.lock(pool);
         pool.setQuantity(set);
         return poolCurator.merge(pool);
     }

--- a/server/src/main/java/org/candlepin/controller/RevocationOp.java
+++ b/server/src/main/java/org/candlepin/controller/RevocationOp.java
@@ -89,9 +89,11 @@ public class RevocationOp {
                 overflowing.add(pool);
             }
         }
+
         if (overflowing.isEmpty()) {
             return;
         }
+
         overflowing = poolCurator.lock(overflowing);
         for (Pool pool : overflowing) {
             poolNewConsumed.put(pool, pool.getConsumed());
@@ -104,8 +106,10 @@ public class RevocationOp {
             // we then start revoking the existing entitlements
             determineExcessEntitlements(pool);
         }
+
         // revoke the entitlements amassed above
         poolManager.revokeEntitlements(new ArrayList<>(entitlementsToRevoke));
+
         // here is where we actually change the source entitlement quantities for the shared pools.
         // We have to wait until we get here so that share pool entitlements we want revoked are gone
         for (Entitlement entitlement : shareEntitlementsToAdjust.keySet()) {

--- a/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
+++ b/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
@@ -28,7 +28,6 @@ import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.persist.Transactional;
 
-import org.hibernate.CacheMode;
 import org.hibernate.Criteria;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
@@ -41,27 +40,20 @@ import org.hibernate.criterion.Order;
 import org.hibernate.criterion.Projection;
 import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
-import org.hibernate.engine.spi.EntityEntry;
-import org.hibernate.engine.spi.EntityKey;
-import org.hibernate.engine.spi.PersistenceContext;
-import org.hibernate.engine.spi.Status;
 import org.hibernate.internal.CriteriaImpl;
 import org.hibernate.internal.SessionImpl;
 import org.hibernate.metadata.ClassMetadata;
-import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.transform.ResultTransformer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xnap.commons.i18n.I18n;
 
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
@@ -715,13 +707,19 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
         return entities;
     }
 
-    public void refresh(E... entities) {
+    public void refresh(Iterable<E> entities) {
         if (entities != null) {
             EntityManager manager = this.getEntityManager();
 
             for (E entity : entities) {
                 manager.refresh(entity);
             }
+        }
+    }
+
+    public void refresh(E... entities) {
+        if (entities != null) {
+            this.refresh(Arrays.asList(entities));
         }
     }
 
@@ -832,6 +830,10 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
         return entityMap.values();
     }
 
+    public Collection<E> lock(E... entities) {
+        return entities != null ? this.lock(Arrays.asList(entities)) : null;
+    }
+
     /**
      * Locks the specified entity with a pessimistic write lock. Note that the entity will not be
      * refreshed as a result of a call to this method. If the entity needs to be locked and
@@ -881,102 +883,18 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
     }
 
     /**
-     * Refreshes/reloads the given entity and locks it using a pessimistic write lock.
-     *
-     * @param entity
-     *  The entity to lock and load
-     *
-     * @return
-     *  The locked entity
-     */
-    public E lockAndLoad(E entity) {
-        if (entity == null) {
-            throw new IllegalArgumentException("entity is null");
-        }
-
-        // Pull the entity's metadata and identifier, just in case we were passed a detached
-        // entity or some such.
-        SessionImpl session = (SessionImpl) this.currentSession();
-        ClassMetadata metadata = session.getSessionFactory().getClassMetadata(this.entityType);
-
-        if (metadata == null || !metadata.hasIdentifierProperty() || !metadata.isMutable()) {
-            throw new UnsupportedOperationException(
-                "lockAndLoad only supports mutable entities with database identifiers");
-        }
-
-        return this.lockAndLoadById(this.entityType, metadata.getIdentifier(entity, session));
-    }
-
-    /**
-     * Locks the given collection of entities, reloading them as necessary.
-     *
-     * @param entities
-     *  A collection of entities to lock
-     *
-     * @throws RuntimeException
-     *  If this method is called for a curator handling an entity type that is not a subclass of
-     *  the AbstractHibernateObject class.
-     *
-     * @return
-     *  The collection of locked entities
-     */
-    public Collection<E> lockAndLoad(Iterable<E> entities) {
-        // Impl note:
-        // We're going to take advantage of some blackbox knowledge of how LockAndLoadByIds works to
-        // minimize the amount of extra loops we need to do. We can pass a custom iterable which
-        // fetches the entity's ID on the call to "next" and pass that through to LockAndLoadByIds.
-
-        if (entities == null) {
-            return Collections.<E>emptyList();
-        }
-
-        // We redeclare the collection here so we don't require the final modifier in subclass
-        // definitions
-        final Iterable<E> entityCollection = entities;
-        final SessionImpl session = (SessionImpl) this.currentSession();
-        final ClassMetadata metadata = session.getSessionFactory().getClassMetadata(this.entityType);
-
-        if (metadata == null || !metadata.hasIdentifierProperty() || !metadata.isMutable()) {
-            throw new UnsupportedOperationException(
-                "lockAndLoad only supports mutable entities with database identifiers");
-        }
-
-        Iterable<Serializable> iterable = new Iterable<Serializable>() {
-            @Override
-            public Iterator<Serializable> iterator() {
-                return new Iterator<Serializable>() {
-                    private Iterator<E> entityIterator;
-
-                    /* initializer */ {
-                        this.entityIterator = entityCollection.iterator();
-                    }
-
-                    @Override
-                    public boolean hasNext() {
-                        return this.entityIterator.hasNext();
-                    }
-
-                    @Override
-                    public Serializable next() {
-                        E next = this.entityIterator.next();
-                        return next != null ? metadata.getIdentifier(next, session) : null;
-                    }
-
-                    @Override
-                    public void remove() {
-                        this.entityIterator.remove();
-                    }
-                };
-            }
-        };
-
-        return this.lockAndLoadByIds(this.entityType, iterable);
-    }
-
-    /**
      * Loads an entity with a pessimistic lock using the specified ID. If the entity has already
-     * been loaded, it will be refreshed with the lock instead. If a  matching entity could not be
+     * been loaded, it will be refreshed with the lock instead. If a matching entity could not be
      * found, this method returns null.
+     * <p></p>
+     * <strong>Note:</strong> There is no guarantee that the entity returned by this method will be
+     * loaded from the database at the time it is called. Due to various caching mechanisms, it's
+     * possible that an existing entity will be returned in its current state, including any
+     * pending, uncommitted changes or operations. As such, the only guarantees this method
+     * provides is that if a non-null value is returned, it will be a locked instance of the entity.
+     * Any desired refresh or resynchronization behavior must be done by the caller after this
+     * method returns.
+     *
      *
      * @param id
      *  The id of the entity to load/refresh and lock
@@ -984,14 +902,22 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
      * @return
      *  A locked entity instance, or null if a matching entity could not be found
      */
-    public E lockAndLoadById(Serializable id) {
-        return this.lockAndLoadById(this.entityType, id);
+    public E lockAndLoad(Serializable id) {
+        return this.lockAndLoad(this.entityType, id);
     }
 
     /**
      * Loads an entity with a pessimistic lock using the specified entity class and ID. If the
-     * entity has already been loaded, it will be refreshed with the lock instead. If a  matching
+     * entity has already been loaded, it will be refreshed with the lock instead. If a matching
      * entity could not be found, this method returns null.
+     * <p></p>
+     * <strong>Note:</strong> There is no guarantee that the entity returned by this method will be
+     * loaded from the database at the time it is called. Due to various caching mechanisms, it's
+     * possible that an existing entity will be returned in its current state, including any
+     * pending, uncommitted changes or operations. As such, the only guarantees this method
+     * provides is that if a non-null value is returned, it will be a locked instance of the entity.
+     * Any desired refresh or resynchronization behavior must be done by the caller after this
+     * method returns.
      *
      * @param entityClass
      *  The class representing the type of entity to fetch (i.e. Pool.class or Product.class)
@@ -1003,55 +929,24 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
      *  A locked entity instance, or null if a matching entity could not be found
      */
     @SuppressWarnings("unchecked")
-    protected E lockAndLoadById(Class<E> entityClass, Serializable id) {
-        EntityManager entityManager = this.getEntityManager();
-        SessionImpl session = (SessionImpl) this.currentSession();
-        ClassMetadata metadata = session.getFactory().getClassMetadata(entityClass);
-
-        // Get the entity's metadata so we can ask Hibernate for the name of its identifier
-        // and check if it's already in the session cache without doing a database lookup
-        if (metadata == null || !metadata.hasIdentifierProperty() || !metadata.isMutable()) {
-            throw new UnsupportedOperationException(
-                "lockAndLoad only supports mutable entities with database identifiers");
-        }
-
-        // Fetch the entity persister and session context so we can check the session cache for an
-        // entity before hitting the database.
-        EntityPersister persister = session.getFactory().getEntityPersister(metadata.getEntityName());
-        PersistenceContext context = session.getPersistenceContext();
-
-        // Lookup whether or not we have an entity with a given ID in the current session's cache.
-        // See the notes in lockAndLoadByIds for details as to why we're going about it this way.
-        EntityKey key = session.generateEntityKey(id, persister);
-        E entity = (E) context.getEntity(key);
-
-        if (entity == null) {
-            // The entity isn't in the local session, we'll need to query for it
-            entity = ((Session) session).byId(entityClass)
-                .with(new LockOptions(LockMode.PESSIMISTIC_WRITE))
-                .with(CacheMode.REFRESH)
-                .load(id);
-        }
-        else {
-            EntityEntry entry = context.getEntry(entity);
-
-            // Make sure the entry hasn't been deleted or otherwise removed.
-            if (entry.isExistsInDatabase() && entry.getStatus() != Status.DELETED &&
-                entry.getStatus() != Status.GONE) {
-
-                entityManager.refresh(entity, LockModeType.PESSIMISTIC_WRITE);
-            }
-            else {
-                entity = null; // It's not in the DB yet/anymore. Nothing to lock or refresh here.
-            }
-        }
-
-        return entity;
+    protected E lockAndLoad(Class<E> entityClass, Serializable id) {
+        return this.currentSession()
+            .byId(entityClass)
+            .with(new LockOptions(LockMode.PESSIMISTIC_WRITE))
+            .load(id);
     }
 
     /**
      * Loads the entities represented by the given IDs with a pessimistic write lock. If no
      * entities were found with the given IDs, this method returns an empty collection.
+     * <p></p>
+     * <strong>Note:</strong> There is no guarantee that the entities returned by this method will
+     * be loaded from the database at the time it is called. Due to various caching mechanisms, it's
+     * possible that an existing entity will be returned in its current state, including any
+     * pending, uncommitted changes or operations. As such, the only guarantees this method
+     * provides is that if a non-null value is returned, it will be a locked instance of the entity.
+     * Any desired refresh or resynchronization behavior must be done by the caller after this
+     * method returns.
      *
      * @param ids
      *  A collection of entity IDs to use to load and lock the represented entities
@@ -1059,8 +954,8 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
      * @return
      *  A collection of locked entities represented by the given IDs
      */
-    public Collection<E> lockAndLoadByIds(Iterable<? extends Serializable> ids) {
-        return this.lockAndLoadByIds(this.entityType, ids);
+    public Collection<E> lockAndLoad(Iterable<? extends Serializable> ids) {
+        return this.lockAndLoad(this.entityType, ids);
     }
 
     /**
@@ -1070,13 +965,13 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
      * is loaded for every ID provided. It is possible for the output collection to be smaller than
      * the provided set of IDs.
      * <p></p>
-     * Depending on the session state when this method is called, this method may perform a refresh
-     * on each entity individually rather than performing a bulk lookup. This is due to a current
-     * limitation in Hibernate that forces use of the L1 cache when executing a query. To avoid
-     * this bottleneck, before calling this method, the caller should either evict the target
-     * entities from the session -- using session.evict or session.clear -- or use this method to
-     * perform the initial lookup straight away. Entities which are not already in the session
-     * cache will be fetched and locked in bulk, rather than refreshed and locked individually.
+     * <strong>Note:</strong> There is no guarantee that the entities returned by this method will
+     * be loaded from the database at the time it is called. Due to various caching mechanisms, it's
+     * possible that an existing entity will be returned in its current state, including any
+     * pending, uncommitted changes or operations. As such, the only guarantees this method
+     * provides is that if a non-null value is returned, it will be a locked instance of the entity.
+     * Any desired refresh or resynchronization behavior must be done by the caller after this
+     * method returns.
      *
      * @param entityClass
      *  The class representing the type of the entity to load (i.e. Pool.class or Product.class)
@@ -1087,87 +982,23 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
      * @return
      *  A collection of locked entities matching the given values
      */
-    protected Collection<E> lockAndLoadByIds(Class<E> entityClass, Iterable<? extends Serializable> ids) {
-        // The lockAndLoadById(s) methods work in two separate stages. The first stage determines
-        // whether or not an entity associated with a given ID is present in Hibernate's L1 cache.
-        // If it is, we need to fetch it from the cache and perform an explicit refresh operation
-        // for that entity. Otherwise, if it is not present, we can do a normal(ish) query to fetch
-        // it, and any other non-present entities.
-        //
-        // Unfortunately, there isn't a single, concise method for performing such a lookup.
-        // Instead, we need to check with the persistence context and determine whether or not it
-        // has an entity associated with a given entity key, which we generate using the session
-        // and entity persister. It's convoluted, but necessary to get consistently correct
-        // behavior from these methods.
-        List<E> result = new ArrayList<>();
-
-        if (ids != null && ids.iterator().hasNext()) {
-            EntityManager entityManager = this.getEntityManager();
-            SessionImpl session = (SessionImpl) this.currentSession();
-            ClassMetadata metadata = session.getFactory().getClassMetadata(entityClass);
-
-            if (metadata == null || !metadata.hasIdentifierProperty() || !metadata.isMutable()) {
-                throw new UnsupportedOperationException(
-                    "lockAndLoad only supports mutable entities with database identifiers");
-            }
-
-            EntityPersister persister = session.getFactory().getEntityPersister(metadata.getEntityName());
-            PersistenceContext context = session.getPersistenceContext();
-
-            SortedSet<Serializable> idSet = new TreeSet<>();
-            SortedMap<Serializable, E> entitySet = new TreeMap<>();
-
-            // Step through the collection of IDs and figure out which entities we have to refresh,
-            // and which we need to lookup.
-            for (Serializable id : ids) {
-                // Make sure we don't doubly load/lock anything
-                if (id != null && !idSet.contains(id) && !entitySet.containsKey(id)) {
-                    EntityKey key = session.generateEntityKey(id, persister);
-                    E entity = (E) context.getEntity(key);
-
-                    if (entity != null) {
-                        EntityEntry entry = context.getEntry(entity);
-
-                        // Make sure the entry hasn't been deleted or otherwise removed.
-                        if (entry.isExistsInDatabase() && entry.getStatus() != Status.DELETED &&
-                            entry.getStatus() != Status.GONE) {
-
-                            entitySet.put(id, entity);
-                        }
-                    }
-                    else {
-                        idSet.add(id);
-                    }
-                }
-            }
-
-            // First address the slow (and hopefully smaller) part of the lookup and refresh the
-            // entities that exist
-
-            // TODO: Maybe add a debug warning here to call out situations where our existing
-            // entity size is larger than our absent entity size. Those are areas where we may be
-            // reloading entities unnecessarily and could be optimized to avoid doing extraneous
-            // work.
-            if (entitySet.size() > 0) {
-                for (E entity : entitySet.values()) {
-                    entityManager.refresh(entity, LockModeType.PESSIMISTIC_WRITE);
-                    result.add(entity);
-                }
-            }
-
-            // Fetch the remaining entities from the DB
-            if (idSet.size() > 0) {
-                result.addAll(((Session) session)
-                    .byMultipleIds(this.entityType())
-                    .with(new LockOptions(LockMode.PESSIMISTIC_WRITE))
-                    .with(CacheMode.REFRESH)
-                    .enableSessionCheck(false)
-                    .multiLoad(new ArrayList(idSet)));
-            }
+    protected Collection<E> lockAndLoad(Class<E> entityClass, Iterable<? extends Serializable> ids) {
+        // Sort and de-duplicate the provided collection of IDs so we have a deterministic locking
+        // order for the entities (helps avoid deadlock)
+        SortedSet<Serializable> idSet = new TreeSet<>();
+        for (Serializable id : ids) {
+            idSet.add(id);
         }
 
-        // Should we be returning a view of the list, rather than the fully mutable list here?
-        return result;
+        // Fetch the entities from the DB...
+        if (idSet.size() > 0) {
+            return this.currentSession()
+                .byMultipleIds(entityClass)
+                .with(new LockOptions(LockMode.PESSIMISTIC_WRITE))
+                .multiLoad(new ArrayList(idSet));
+        }
+
+        return new ArrayList<E>();
     }
 
     /**

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/UndoImportsJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/UndoImportsJob.java
@@ -102,7 +102,7 @@ public class UndoImportsJob extends UniqueByEntityJob {
             JobDataMap map = context.getMergedJobDataMap();
             String ownerId = map.getString(JobStatus.TARGET_ID);
             String ownerKey = map.getString(JobStatus.OWNER_ID);
-            Owner owner = this.ownerCurator.lockAndLoadById(ownerId);
+            Owner owner = this.ownerCurator.lockAndLoad(ownerId);
             Boolean lazy = map.getBoolean(LAZY_REGEN);
             Principal principal = (Principal) map.get(PinsetterJobListener.PRINCIPAL_KEY);
 

--- a/server/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
@@ -527,7 +527,6 @@ public class PoolRules {
         else {
             for (Branding b : pool.getBranding()) {
                 if (!existingPool.getBranding().contains(b)) {
-                    syncBranding(pool, existingPool);
                     brandingChanged = true;
                     break;
                 }
@@ -537,6 +536,7 @@ public class PoolRules {
         if (brandingChanged) {
             syncBranding(pool, existingPool);
         }
+
         return brandingChanged;
     }
 

--- a/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -16,6 +16,7 @@ package org.candlepin.controller;
 
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
+import static org.mockito.AdditionalAnswers.returnsFirstArg;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyCollection;
@@ -218,13 +219,8 @@ public class PoolManagerTest {
         when(complianceRules.getStatus(any(Consumer.class), any(Date.class))).thenReturn(
             dummyComplianceStatus);
 
-        when(consumerCuratorMock.lockAndLoad(any(Consumer.class))).thenAnswer(new Answer<Consumer>() {
-            @Override
-            public Consumer answer(InvocationOnMock invocation) throws Throwable {
-                Object[] args = invocation.getArguments();
-                return (Consumer) args[0];
-            }
-        });
+        doAnswer(returnsFirstArg()).when(this.consumerCuratorMock).lock(any(Consumer.class));
+        doAnswer(returnsFirstArg()).when(this.mockPoolCurator).lock(any(Pool.class));
     }
 
     protected ConsumerType mockConsumerType(ConsumerType ctype) {
@@ -366,7 +362,7 @@ public class PoolManagerTest {
         pool.setId("test-id");
         pools.add(pool);
 
-        when(mockPoolCurator.lockAndLoadByIds(any(Iterable.class))).thenReturn(pools);
+        when(mockPoolCurator.lockAndLoad(any(Iterable.class))).thenReturn(pools);
 
         doNothing().when(mockPoolCurator).batchDelete(eq(pools), anySetOf(String.class));
         manager.deletePools(pools);
@@ -1242,7 +1238,7 @@ public class PoolManagerTest {
         p.setConsumed(1L);
         pools.add(p);
 
-        when(mockPoolCurator.lockAndLoadByIds(anyCollection())).thenReturn(pools);
+        when(mockPoolCurator.lockAndLoad(anyCollection())).thenReturn(pools);
 
         mockPoolsList(pools);
 
@@ -1334,7 +1330,7 @@ public class PoolManagerTest {
         manager.cleanupExpiredPools();
 
         // And the pool should be deleted:
-        when(mockPoolCurator.lockAndLoadByIds(anyCollection())).thenReturn(pools);
+        when(mockPoolCurator.lockAndLoad(anyCollection())).thenReturn(pools);
     }
 
     @Test
@@ -1343,7 +1339,7 @@ public class PoolManagerTest {
         p.setSubscriptionId("subid");
         List<Pool> pools = Arrays.asList(p);
 
-        when(mockPoolCurator.lockAndLoadByIds(anyCollection())).thenReturn(pools);
+        when(mockPoolCurator.lockAndLoad(anyCollection())).thenReturn(pools);
         when(mockPoolCurator.listExpiredPools(anyInt())).thenReturn(pools);
         when(mockPoolCurator.entitlementsIn(p)).thenReturn(new ArrayList<>(p.getEntitlements()));
         Subscription sub = new Subscription();

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/UndoImportsJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/UndoImportsJobTest.java
@@ -247,7 +247,7 @@ public class UndoImportsJobTest extends DatabaseTestFixture {
     @Test
     public void handleException() throws JobExecutionException {
         // the real thing we want to handle
-        doThrow(new NullPointerException()).when(this.ownerCurator).lockAndLoadById(anyString());
+        doThrow(new NullPointerException()).when(this.ownerCurator).lockAndLoad(anyString());
 
         try {
             this.undoImportsJob.execute(this.jobContext);
@@ -263,7 +263,7 @@ public class UndoImportsJobTest extends DatabaseTestFixture {
     @Test
     public void refireOnWrappedSQLException() throws JobExecutionException {
         RuntimeException e = new RuntimeException("uh oh", new SQLException("not good"));
-        doThrow(e).when(this.ownerCurator).lockAndLoadById(anyString());
+        doThrow(e).when(this.ownerCurator).lockAndLoad(anyString());
 
         try {
             this.undoImportsJob.execute(this.jobContext);
@@ -280,7 +280,7 @@ public class UndoImportsJobTest extends DatabaseTestFixture {
     public void refireOnMultiLayerWrappedSQLException() throws JobExecutionException {
         RuntimeException e = new RuntimeException("uh oh", new SQLException("not good"));
         RuntimeException e2 = new RuntimeException("trouble!", e);
-        doThrow(e2).when(this.ownerCurator).lockAndLoadById(anyString());
+        doThrow(e2).when(this.ownerCurator).lockAndLoad(anyString());
 
         try {
             this.undoImportsJob.execute(this.jobContext);
@@ -294,7 +294,7 @@ public class UndoImportsJobTest extends DatabaseTestFixture {
     @Test
     public void noRefireOnRegularRuntimeException() throws JobExecutionException {
         RuntimeException e = new RuntimeException("uh oh", new NullPointerException());
-        doThrow(e).when(this.ownerCurator).lockAndLoadById(anyString());
+        doThrow(e).when(this.ownerCurator).lockAndLoad(anyString());
 
         try {
             this.undoImportsJob.execute(this.jobContext);


### PR DESCRIPTION
- Entirely removed AbstractHibernateCurator.lockAndLoadById(s), as
  they were becoming increasingly resource intensive and difficult to
  maintain attempting to cover every possible edgecase that can occur
  with regards to entity state. No replacement will be added, due to
  the high risk involved with hidden/generic refresh behavior.
- AHC.lockAndLoad no longer attempts to bypass the cache or perform
  individual refreshes on the entities it returns
- Updated several places where lockAndLoad's behavior was being
  expected such that the callers now perform explicit refreshes where
  it is necessary to do so
- Added additional overloads for refresh and lock to address new
  usages
