### PR TITLE
1691897: Candlepin should use cores as a default if vcpu is not set & cores is. [ENT-1229]

### DIFF
--- a/server/spec/compliance_reasons_spec.rb
+++ b/server/spec/compliance_reasons_spec.rb
@@ -34,7 +34,59 @@ describe 'Single Entitlement Compliance Reasons' do
                  :support_type => 'excellent',})
     @product1_pool = create_pool_and_subscription(@owner['key'], @product1.id, 100, [], '1888', '1234')
 
+    # Create a stackable product limiting by socket.
+    @prod3 = random_string("Product3")
+    @socket_product = create_product(nil, @prod3, :attributes => {
+        :version => '6.4',
+        :cores => 2,
+        :sockets => 1,
+        :instance_multiplier => 2,
+        :stacking_id => @prod3,
+        :'multi-entitlement' => 'yes',
+        :warning_period => 15,
+        :management_enabled => true,
+        :support_level => 'standard',
+        :support_type => 'excellent',})
+    @socket_pool = create_pool_and_subscription(@owner['key'], @socket_product.id, 5, [], '1888', '1234')
+
     @user = user_client(@owner, random_string('test-user'))
+  end
+
+  # the actual test:
+  it 'should be partially compliant when using cores if vcpu is not available' do
+    system = consumer_client(@user, random_string('system1'), :system, nil,
+                             {'system.certificate_version' => '3.2',
+                              # Simulate 8 sockets as would be returned from system fact
+                              'cpu.core(s)_per_socket'=> '1',
+                              'cpu.cpu(s)'=> '8',
+                              'cpu.cpu_socket(s)'=> '8',
+                              'virt.is_guest'=> 'true'
+                             })
+    installed = [
+        {'productId' => @socket_product.id, 'productName' => @socket_product.name}
+    ]
+    system.update_consumer({:installedProducts => installed})
+
+    entitlements = system.consume_pool(@socket_pool.id, {:quantity => 1})
+    entitlements.should_not == nil
+    entitlements.size.should == 1
+
+    compliance_status = system.get_compliance(consumer_id=system.uuid)
+    compliance_status['status'].should == 'partial'
+    compliance_status['compliant'].should == false
+    compliance_status.should have_key('reasons')
+
+    expected_has = "8"
+    expected_covered = "4"
+    expected_message = "Only supports %s of %s vCPUs." % [expected_covered,
+                                                          expected_has]
+
+    reasons = compliance_status['reasons']
+    reasons.size.should == 1
+    assert_reason(reasons[0], 'VCPU', expected_message, {'stack_id' => @prod3,
+                                                         'covered' => expected_covered,
+                                                         'has' => expected_has,
+                                                         'name' => @socket_product.name})
   end
 
   it 'reports products not covered' do

--- a/server/spec/pool_resource_spec.rb
+++ b/server/spec/pool_resource_spec.rb
@@ -243,6 +243,9 @@ describe 'Pool Resource' do
 
     pools = @cp.list_pools
 
+    # Wait for events to arrive
+    sleep 1
+
     events = @cp.list_owner_events(owner['key'])
     pool_created_events = events.find_all { |event| event['target'] == 'POOL' && event['type'] == 'CREATED' }
     pool_created_events.size.should eq(6)

--- a/server/spec/vcpu_spec.rb
+++ b/server/spec/vcpu_spec.rb
@@ -11,7 +11,7 @@ describe 'vCPU Limiting' do
     @vcpu_product = create_product(nil, random_string("Product1"), :attributes =>
                 {:version => '6.4',
                  :vcpu => 8,
-                 :cores => 2,
+                 :cores => 8,
                  :sockets => 1,
                  :warning_period => 15,
                  :management_enabled => true,
@@ -22,7 +22,7 @@ describe 'vCPU Limiting' do
     @vcpu_stackable_prod = create_product(nil, random_string("Product2"), :attributes =>
                 {:version => '6.4',
                  :vcpu => 8,
-                 :cores => 2,
+                 :cores => 8,
                  :sockets => 1,
                  :warning_period => 15,
                  :management_enabled => true,

--- a/server/src/main/resources/rules/rules.js
+++ b/server/src/main/resources/rules/rules.js
@@ -1,4 +1,4 @@
-// Version: 5.35
+// Version: 5.37
 
 /*
  * Default Candlepin rule set.
@@ -161,7 +161,7 @@ function getComplianceAttributes(consumer) {
  * Model object related functions.
  */
 
-function createPool(pool) {
+function createPool(pool, consumer) {
 
     // Lazily initialized arrays of provided product IDs. Includes the pool's
     // main productId.
@@ -313,6 +313,21 @@ function createPool(pool) {
         }
         return poolSet;
     };
+
+    // When pool is missing vcpu and consumer is virtual, pool should use cores
+    // instead so we calculate calculate vcpu based on cores and sockets
+    pool.calculateVcpu = function (consumer) {
+        if (Utils.isGuest(consumer) && !this.hasAttribute(VCPU_ATTRIBUTE) && this.hasAttribute(CORES_ATTRIBUTE)) {
+            pool.attributes.push({
+                name: VCPU_ATTRIBUTE,
+                value: parseInt(this.getAttribute(CORES_ATTRIBUTE)) * 2
+            });
+        }
+    };
+
+    if (consumer != null) {
+        pool.calculateVcpu(consumer);
+    }
 
     return pool;
 }
@@ -1582,19 +1597,19 @@ var Entitlement = {
         context = JSON.parse(json_context);
 
         if ("pool" in context) {
-            context.pool = createPool(context.pool);
+            context.pool = createPool(context.pool, context.consumer);
         }
 
         if ("pools" in context) {
             for (var i = 0; i < context.pools.length; i++) {
-                context.pools[i] = createPool(context.pools[i]);
+                context.pools[i] = createPool(context.pools[i], context.consumer);
             }
         }
 
         if ("poolQuantities" in context) {
             context.pools = [];
             for (var i = 0; i < context.poolQuantities.length; i++) {
-                context.pools[i] = createPool(context.poolQuantities[i].pool);
+                context.pools[i] = createPool(context.poolQuantities[i].pool, context.consumer);
                 context.pools[i].quantityRequested = context.poolQuantities[i].quantity;
             }
         }
@@ -2595,13 +2610,13 @@ var Autobind = {
             for (var key in nextMap) {
                 var ents = nextMap[key];
                 for (var entIdx = 0; entIdx < ents.length; entIdx++) {
-                    ents[entIdx].pool = createPool(ents[entIdx].pool);
+                    ents[entIdx].pool = createPool(ents[entIdx].pool, context.consumer);
                 }
             }
         }
 
         for (var i = 0; i < context.pools.length; i++) {
-            context.pools[i] = createPool(context.pools[i]);
+            context.pools[i] = createPool(context.pools[i], context.consumer);
             var pool = context.pools[i];
             if (pool.quantity == -1) {
                 // In the unlimited case, we need at most the number required to cover the system
@@ -3188,11 +3203,11 @@ var Compliance = {
         // Add some methods to the various Pool objects:
         for (var k = 0; k < ((context.entitlements) ? context.entitlements.length : 0); k++) {
             var e = context.entitlements[k];
-            e.pool = createPool(e.pool);
+            e.pool = createPool(e.pool, context.consumer);
         }
 
         if ("entitlement" in context) {
-            context.entitlement.pool = createPool(context.entitlement.pool);
+            context.entitlement.pool = createPool(context.entitlement.pool, context.consumer);
         }
 
         // Older candlepins don't send this value, assume they need to calculate compliantUntil
@@ -3689,21 +3704,22 @@ var Quantity = {
         context = JSON.parse(json_context);
 
         if ("pool" in context) {
-            context.pool = createPool(context.pool);
+            context.pool = createPool(context.pool, context.consumer);
         }
 
         if ("pools" in context) {
             for (var i = 0; i < context.pools.length; i++) {
-                context.pools[i] = createPool(context.pools[i]);
+                context.pools[i] = createPool(context.pools[i], context.consumer);
             }
         }
 
         if ("validEntitlements" in context) {
             for (var i = 0; i < context.validEntitlements.length; i++) {
                 var e = context.validEntitlements[i];
-                e.pool = createPool(e.pool);
+                e.pool = createPool(e.pool, context.consumer);
             }
         }
+
         return context;
     },
 

--- a/server/src/test/java/org/candlepin/policy/AutobindRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/AutobindRulesTest.java
@@ -138,7 +138,6 @@ public class AutobindRulesTest {
         activeGuestAttrs.put("active", "1");
     }
 
-
     @Test
     public void testFindBestWithSingleProductSinglePoolReturnsProvidedPool() {
         Product product = TestUtil.createProduct(productId, "A test product");
@@ -153,6 +152,32 @@ public class AutobindRulesTest {
             false);
 
         assertEquals(1, bestPools.size());
+    }
+
+    @Test
+    public void singleProductSinglePoolShouldFindBestWithCorrectQuantity() {
+        final Product product = TestUtil.createProduct(productId, "A test product");
+        product.setAttribute("stacking_id", productId);
+        product.setAttribute("multi-entitlement", "yes");
+        product.setAttribute("instance_multiplier", "2");
+        product.setAttribute("cores", "2");
+        product.setAttribute("sockets", "1");
+        final Pool pool = TestUtil.createPool(owner, product);
+        pool.setId("DEAD-BEEF");
+        final List<Pool> pools = new LinkedList<>();
+        pools.add(pool);
+
+        consumer.setFact("virt.is_guest", "true");
+        consumer.setFact("cpu.cpu(s)", "8");
+        consumer.setFact("cpu.cpu_socket(s)", "8");
+        consumer.setFact("cpu.core(s)_per_socket", "1");
+
+        final List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
+            new String[]{ productId }, pools, compliance, null, new HashSet<>(),
+            false);
+
+        assertEquals(1, bestPools.size());
+        assertEquals(2, bestPools.get(0).getQuantity().intValue());
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/policy/js/quantity/QuantityRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/quantity/QuantityRulesTest.java
@@ -14,11 +14,7 @@
  */
 package org.candlepin.policy.js.quantity;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.when;
-
+import com.google.inject.Provider;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.dto.StandardTranslator;
 import org.candlepin.dto.rules.v1.SuggestedQuantityDTO;
@@ -42,9 +38,6 @@ import org.candlepin.policy.js.JsRunnerRequestCache;
 import org.candlepin.policy.js.RulesObjectMapper;
 import org.candlepin.test.TestUtil;
 import org.candlepin.util.Util;
-
-import com.google.inject.Provider;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -59,6 +52,11 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
 
 /**
  * QuantityRulesTest
@@ -223,6 +221,20 @@ public class QuantityRulesTest {
     }
 
     @Test
+    public void shouldUseCoresIfNoVcpu() {
+        consumer.setFact(IS_VIRT, "true");
+        consumer.setFact(SOCKET_FACT, "1");
+        consumer.setFact(CORES_FACT, "8");
+        pool.getProduct().setAttribute(CORES_ATTRIBUTE, "2");
+        pool.getProduct().setAttribute(SOCKET_ATTRIBUTE, "1");
+
+        final SuggestedQuantityDTO suggested = quantityRules
+            .getSuggestedQuantity(pool, consumer, new Date());
+
+        assertEquals(new Long(2), suggested.getSuggested());
+    }
+
+    @Test
     public void testVirtUses1IfNoVcpu() {
         // Ensure that we start this test with no entitlements.
         consumer.getEntitlements().clear();
@@ -267,7 +279,7 @@ public class QuantityRulesTest {
     public void testUnlimitedQuantity() {
         consumer.setFact(SOCKET_FACT, "8");
         pool.getProduct().setAttribute(SOCKET_ATTRIBUTE, "2");
-        pool.setQuantity(new Long(-1));
+        pool.setQuantity(-1L);
         SuggestedQuantityDTO suggested =
             quantityRules.getSuggestedQuantity(pool, consumer, new Date());
         assertEquals(new Long(4), suggested.getSuggested());
@@ -574,7 +586,7 @@ public class QuantityRulesTest {
 
         pool.getProduct().setAttribute(GUEST_LIMIT_ATTRIBUTE, "4");
         pool.getProduct().setAttribute(SOCKET_ATTRIBUTE, "2");
-        pool.setQuantity(new Long(-1));
+        pool.setQuantity(-1L);
         SuggestedQuantityDTO suggested = quantityRules.getSuggestedQuantity(pool, consumer, new Date());
         assertEquals(new Long(4), suggested.getSuggested());
     }


### PR DESCRIPTION
- Update rules so that pool uses cores for virtual consumers when the vcpu of pool is not set.
- Fix spec test products so that its number of vcpus corresponds to the number of its cores