### PR TITLE
[2.3] Improved hosted test adapter separation

### DIFF
--- a/server/spec/client_v1_size_spec.rb
+++ b/server/spec/client_v1_size_spec.rb
@@ -8,27 +8,50 @@ describe 'Entitlement Certificate V1 Size' do
     @owner = create_owner random_string('test_owner')
     @content_list = create_batch_content(200)
 
-    @product1 = create_product(nil, nil, :attributes =>
-                {:version => '6.4',
-                 :warning_period => 15,
-                 :management_enabled => true,
-                 :virt_only => 'false',
-                 :support_level => 'standard',
-                 :support_type => 'excellent',})
+    @product1 = create_product(nil, nil, :attributes => {
+      :version => '6.4',
+      :warning_period => 15,
+      :management_enabled => true,
+      :virt_only => 'false',
+      :support_level => 'standard',
+      :support_type => 'excellent',
+    })
+
     @cp.add_content_to_product(@owner['key'], @product1.id, @content_list[0].id, true)
-    create_pool_and_subscription(@owner['key'], @product1.id, 10, [], '12345', '6789', 'order1')
-    @product2 = create_product(nil, nil, :attributes =>
-                {:version => '6.4',
-                 :warning_period => 15,
-                 :management_enabled => true,
-                 :virt_only => 'false',
-                 :support_level => 'standard',
-                 :support_type => 'excellent',})
+
+    @cp.create_pool(@owner['key'], @product1.id, {
+      :quantity => 10,
+      :provided_products => [],
+      :contract_number => '12345',
+      :account_number => '6789',
+      :order_number => 'order1',
+      :subscription_id => random_str('source_sub'),
+      :upstream_pool_id => random_str('upstream')
+    })
+
+    @product2 = create_product(nil, nil, :attributes => {
+      :version => '6.4',
+      :warning_period => 15,
+      :management_enabled => true,
+      :virt_only => 'false',
+      :support_level => 'standard',
+      :support_type => 'excellent',
+    })
+
     @cp.add_content_to_product(@owner['key'], @product2.id, @content_list[0].id, true)
-    create_pool_and_subscription(@owner['key'], @product2.id, 10, [], '12345', '6789', 'order1')
+
+    @cp.create_pool(@owner['key'], @product2.id, {
+      :quantity => 1,
+      :provided_products => [],
+      :contract_number => '12345',
+      :account_number => '6789',
+      :order_number => 'order1',
+      :subscription_id => random_str('source_sub'),
+      :upstream_pool_id => random_str('upstream')
+    })
+
     @user = user_client(@owner, random_string('billy'))
-    @system = consumer_client(@user, random_string('system1'), :system, nil,
-                {'system.certificate_version' => '1.0'})
+    @system = consumer_client(@user, random_string('system1'), :system, nil, {'system.certificate_version' => '1.0'})
   end
 
   after(:each) do
@@ -45,7 +68,7 @@ describe 'Entitlement Certificate V1 Size' do
     (1..10).each do |i|
       content_ids << @content_list[i].id
     end
-    add_batch_content_to_product(@owner['key'], @product1.id, content_ids, true)
+    @cp.add_batch_content_to_product(@owner['key'], @product1.id, content_ids, true)
     @cp.regenerate_entitlement_certificates_for_product(@product1.id)
     ent2 = @system.get_entitlement(ent1.id)
     ent2.certificates[0].serial.id.should_not == ent1.certificates[0].serial.id
@@ -56,7 +79,7 @@ describe 'Entitlement Certificate V1 Size' do
     (11..200).each do |i|
       content_ids.push(@content_list[i].id)
     end
-    add_batch_content_to_product(@owner['key'], @product1.id, content_ids, true)
+    @cp.add_batch_content_to_product(@owner['key'], @product1.id, content_ids, true)
     @cp.regenerate_entitlement_certificates_for_product(@product1.id)
     ent3 = @system.get_entitlement(ent1.id)
     ent3.certificates[0].serial.id.should == ent2.certificates[0].serial.id
@@ -73,13 +96,19 @@ describe 'Entitlement Certificate V1 Size' do
   end
 
   it 'will not allow an excessive content set to block others' do
-    @cp.refresh_pools(@owner['key'])
+    # @cp.refresh_pools(@owner['key'])
+
     ent1 = @system.consume_product(@product1.id)[0]
+    expect(ent1).to_not be_nil
+
     ent2 = @system.consume_product(@product2.id)[0]
+    expect(ent2).to_not be_nil
+
     (1..200).each do |i|
-      add_content_to_product(@owner['key'], @product1.id, @content_list[i].id, true)
+      @cp.add_content_to_product(@owner['key'], @product1.id, @content_list[i].id, true)
     end
-    add_content_to_product(@owner['key'], @product2.id, @content_list[1].id, true)
+
+    @cp.add_content_to_product(@owner['key'], @product2.id, @content_list[1].id, true)
     @cp.regenerate_entitlement_certificates_for_product(@product1.id)
     @cp.regenerate_entitlement_certificates_for_product(@product2.id)
 

--- a/server/spec/pool_resource_spec.rb
+++ b/server/spec/pool_resource_spec.rb
@@ -166,7 +166,7 @@ describe 'Pool Resource' do
     product = create_product(nil, nil,
       {
         :attributes => {:virt_limit => '10'},
-	:owner => owner1['key']
+  :owner => owner1['key']
       }
     )
 
@@ -259,11 +259,15 @@ describe 'Pool Resource' do
         :type => 'type1', :name => 'branding1'}
       b2 = {:productId => 'prodid2',
         :type => 'type2', :name => 'branding2'}
+
       owner = create_owner random_string('some-owner')
       name = random_string("product-")
+
       product = create_product(name, name, :owner => owner['key'])
+
       created = create_pool_and_subscription(owner['key'], product.id, 11,
-        [], '', '', '', nil, nil, false, :branding => [b1,b2])
+        [], '', '', '', nil, nil, false, :branding => [b1, b2])
+
       pool = @cp.get_pool(created['id'])
       pool.quantity.should == 11
       pool.branding.size.should == 2

--- a/server/spec/refresh_pools_spec.rb
+++ b/server/spec/refresh_pools_spec.rb
@@ -4,8 +4,11 @@ require 'candlepin_scenarios'
 require 'rubygems'
 require 'rest_client'
 
+
 describe 'Refresh Pools' do
   include CandlepinMethods
+  include AttributeHelper
+  include CertificateMethods
   include VirtHelper
   include CertificateMethods
 
@@ -40,14 +43,11 @@ describe 'Refresh Pools' do
 
     # Create 6 subscriptions to different products
     6.times do |i|
-      name = random_string("product-#{i}")
-      product = create_product(name, name, :owner => owner['key'])
-
-      create_pool_and_subscription(owner['key'], product.id)
+      product = create_upstream_product(random_string("product-#{i}"))
+      create_upstream_subscription(random_string("sub-#{i}"), owner['key'], product.id)
     end
 
-    # @cp.refresh_pools(owner['key'])
-
+    @cp.refresh_pools(owner['key'])
     @cp.list_pools({:owner => owner.id}).length.should == 6
   end
 
@@ -56,10 +56,8 @@ describe 'Refresh Pools' do
 
     # Create 6 subscriptions to different products
     6.times do |i|
-      name = random_string("product-#{i}")
-      product = create_product(name, name, :owner => owner['key'])
-
-      create_pool_and_subscription(owner['key'], product.id)
+      product = create_upstream_product(random_string("product-#{i}"))
+      create_upstream_subscription(random_string("sub-#{i}"), owner['key'], product.id)
     end
 
     @cp.refresh_pools(owner['key'])
@@ -71,229 +69,777 @@ describe 'Refresh Pools' do
   end
 
   it 'detects changes in provided products' do
-    owner = create_owner random_string
-    product = create_product(random_string, random_string, :owner => owner['key'])
-    provided1 = create_product(random_string, random_string, :owner => owner['key'])
-    provided2 = create_product(random_string, random_string, :owner => owner['key'])
-    provided3 = create_product(random_string, random_string, :owner => owner['key'])
-    pool = create_pool_and_subscription(owner['key'], product.id, 500, [provided1.id, provided2.id])
+    owner_key = random_string('test_owner')
+    owner = create_owner(owner_key)
+
+    product = create_upstream_product(random_string('test_prod'))
+    provided = []
+
+    3.times do |i|
+      provided << create_upstream_product(random_string("provided-#{i}"))
+    end
+
+    sub = create_upstream_subscription(random_string('test_sub'), owner_key, product.id, {
+      :provided_products => provided[0..1]
+    })
+
+    @cp.refresh_pools(owner_key)
     pools = @cp.list_pools({:owner => owner.id})
-    pools.length.should == 1
-    pools[0].providedProducts.length.should == 2
-    # Remove the old provided products and add a new one:
-    sub = get_hostedtest_subscription(pool.subscriptionId)
-    sub.providedProducts = [@cp.get_product(owner['key'], provided3.id)]
-    update_hostedtest_subscription(sub)
-    @cp.refresh_pools(owner['key'])
+
+    expect(pools.length).to eq(1)
+    expect(pools[0].providedProducts.length).to eq(2)
+
+    provided_ids = provided[0..1].collect { |p| p.id }
+    pools[0].providedProducts.each do |p|
+      expect(provided_ids).to include(p.productId)
+      provided_ids.delete(p.productId)
+    end
+
+    # Remove the old provided products and add a new one...
+    sub.providedProducts = [provided[2]]
+    update_upstream_subscription(sub.id, sub)
+
+    @cp.refresh_pools(owner_key)
     pools = @cp.list_pools({:owner => owner.id})
-    pools[0].providedProducts.length.should == 1
+
+    expect(pools.length).to eq(1)
+    expect(pools[0].providedProducts.length).to eq(1)
+    expect(pools[0].providedProducts[0].productId).to eq(provided[2].id)
   end
 
   it 'deletes expired subscriptions\' pools and entitlements' do
-    owner = create_owner random_string
-    product = create_product(random_string, random_string, :owner => owner['key'])
-    pool = create_pool_and_subscription(owner['key'], product.id, 500, [])
+    owner_key = random_string('test_owner')
+    owner = create_owner(owner_key)
+
+    product = create_upstream_product(random_string('test_prod'))
+    sub = create_upstream_subscription(random_string('test_sub'), owner_key, product.id, { :quantity => 500 })
+
+    @cp.refresh_pools(owner_key)
     pools = @cp.list_pools({:owner => owner.id})
-    pools.length.should == 1
+    expect(pools.length).to eq(1)
 
-    user = user_client(owner, random_string("user"))
+    user = user_client(owner, random_string('test_user'))
+    consumer = consumer_client(user, random_string('test_consumer'))
+    entitlements = consumer.consume_pool(pools.first.id, {:quantity => 1})
+    expect(entitlements.length).to eq(1)
 
-    consumer_id = random_string("consumer")
-    consumer = consumer_client(user, consumer_id)
-    consumer.consume_pool(pools.first.id, {:quantity => 1}).size.should == 1
+    consumer = @cp.get_consumer(consumer.uuid)
+    expect(consumer.entitlementCount).to eq(1)
 
-    # Update the subscription to be expired so that pool, and entitlements are removed.
-    now = DateTime.now
-    sub = get_hostedtest_subscription(pool.subscriptionId)
-    sub.startDate = now - 20
-    sub.endDate = now - 10
-    update_hostedtest_subscription(sub)
-    @cp.refresh_pools(owner['key'])
-    @cp.list_pools({:owner => owner.id}).size.should == 0
-    @cp.get_consumer(consumer.uuid).entitlementCount.should == 0
+    # Update subscription such that it's expired, then refresh. The entitlements should be removed.
+    update_upstream_subscription(sub.id, {
+      :start_date => Date.today - 20,
+      :end_date => Date.today - 10
+    })
+    @cp.refresh_pools(owner_key)
+
+    pools = @cp.list_pools({:owner => owner.id})
+    consumer = @cp.get_consumer(consumer.uuid)
+
+    expect(pools.length).to eq(0)
+    expect(consumer.entitlementCount).to eq(0)
   end
 
   it 'regenerates entitlements' do
-    owner = create_owner random_string
-    product = create_product(random_string, random_string, :owner => owner['key'])
-    new_product = create_product(random_string, random_string, :owner => owner['key'])
-    pool = create_pool_and_subscription(owner['key'], product.id, 500, [])
+    owner_key = random_string('test_owner')
+    owner = create_owner(owner_key)
+
+    product1 = create_upstream_product(random_string('test_prod1'))
+    product2 = create_upstream_product(random_string('test_prod2'))
+    sub = create_upstream_subscription(random_string('test_sub'), owner_key, product1.id)
+
+    @cp.refresh_pools(owner_key)
     pools = @cp.list_pools({:owner => owner.id})
-    pools.length.should == 1
+    expect(pools.length).to eq(1)
 
-    user = user_client(owner, random_string("user"))
+    user = user_client(owner, random_string('test_user'))
+    consumer = consumer_client(user, random_string('test_consumer'))
+    entitlements = consumer.consume_pool(pools.first.id, {:quantity => 1})
+    expect(entitlements.length).to eq(1)
 
-    consumer_id = random_string("consumer")
-    consumer = consumer_client(user, consumer_id)
-    ents = consumer.consume_pool(pools.first.id, {:quantity => 1})
-    ents.size.should == 1
-    ent = ents[0]
-    old_cert = ent['certificates'][0]
+    consumer = @cp.get_consumer(consumer.uuid)
+    expect(consumer.entitlementCount).to eq(1)
+
+    entitlement = entitlements.first
+    old_cert = entitlement['certificates'].first
     old_serial = old_cert['serial']['serial']
 
-    # Change the product on subscription to trigger a regenerate:
-    sub = get_hostedtest_subscription(pool.subscriptionId)
-    sub['product'] = {'id' => new_product['id']}
-    update_hostedtest_subscription(sub)
-    @cp.refresh_pools(owner['key'], false, false, true)
-    ent = @cp.get_entitlement(ent['id'])
-    new_cert = ent['certificates'][0]
-    new_serial = new_cert['serial']['serial']
-    new_serial.should_not == old_serial
+    # Update the subscription's product to trigger an entitlement regeneration
+    update_upstream_subscription(sub.id, {
+      :product => { :id => product2.id }
+    })
+    @cp.refresh_pools(owner_key)
 
-    @cp.get_consumer(consumer.uuid).entitlementCount.should == 1
+    consumer = @cp.get_consumer(consumer.uuid)
+    expect(consumer.entitlementCount).to eq(1)
+
+    updated_ent = @cp.get_entitlement(entitlement['id'])
+    new_cert = updated_ent['certificates'].first
+    new_serial = new_cert['serial']['serial']
+
+    expect(new_serial).to_not eq(old_serial)
   end
 
   it 'handle derived products being removed' do
-   # 998317: is caused by refresh pools dying with an NPE
-   # this happens when subscriptions no longer have
-   # derived products resulting in a null during the refresh
-   # which we didn't handle in all cases.
+    # 998317: is caused by refresh pools dying with an NPE
+    # this happens when subscriptions no longer have
+    # derived products resulting in a null during the refresh
+    # which we didn't handle in all cases.
+    owner_key = random_string('test_owner')
+    owner = create_owner(owner_key)
 
-    owner = create_owner random_string
-    # create subscription with sub-pool data:
-    datacenter_product = create_product(nil, nil, {
+    datacenter_product = create_upstream_product(random_string('dc_prod'), {
       :attributes => {
         :virt_limit => "unlimited",
         :stacking_id => "stackme",
         :sockets => "2",
         'multi-entitlement' => "yes"
-      },
-      :owner => owner['key']
+      }
     })
-    derived_product = create_product(nil, nil, {
+
+    derived_product = create_upstream_product(random_string('derived_prod'), {
       :attributes => {
-          :cores => 2,
-          :sockets=>4
-      },
-      :owner => owner['key']
+        :cores => 2,
+        :sockets=>4
+      }
     })
-    eng_product = create_product('300', nil, :owner => owner['key'])
 
-    pool1 = create_pool_and_subscription(owner['key'], datacenter_product.id,
-      10, [], '', '', '', nil, nil, false,
-      {
-        :derived_product_id => derived_product['id'],
-        :derived_provided_products => ['300']
-      })
-    # extra unmapped guest pool will be labeled with provided product
-    pools = @cp.list_pools :owner => owner.id,
-      :product => datacenter_product.id
-    pools.size.should == 1
-    pools[0]['derivedProvidedProducts'].length.should == 1
+    derived_eng_product = create_upstream_product(random_string(nil, true))
 
-    # let's remove the derivedProducts - this simulates
-    # the scenario that caues the bug
-    sub1 = get_hostedtest_subscription(pool1.subscriptionId)
-    sub1['derivedProduct'] = nil
-    sub1['derivedProvidedProducts'] = nil
-    update_hostedtest_subscription(sub1)
+    eng_product = create_upstream_product(random_string('eng_prod'))
 
-    # this is the refresh we are actually testing
-    # it should succeed
-    @cp.refresh_pools(owner['key'])
+    sub = create_upstream_subscription(random_string('dc_sub'), owner_key, datacenter_product.id, {
+      :quantity => 10,
+      :derived_product => derived_product,
+      :derived_provided_products => [derived_eng_product]
+    })
 
-    # let's verify it removed them correctly
-    # extra unmapped pool now shows datacenter product
-    pools = @cp.list_pools :owner => owner.id, \
-      :product => datacenter_product.id
-    pools.length.should == 2
-    pools[0]['derivedProvidedProducts'].length.should == 0
+    @cp.refresh_pools(owner_key)
+    pools = @cp.list_pools({:owner => owner.id})
+    expect(pools.length).to eq(2) # We're expecting the base pool + a virt-only bonus pool for guests
+
+    # Swap pools if necessary
+    if pools[0].productId != datacenter_product.id
+      pools[0], pools[1] = pools[1], pools[0]
+    end
+
+    expect(pools.first).to have_key('derivedProvidedProducts')
+    expect(pools.first.derivedProvidedProducts.length).to eq(1)
+
+    update_upstream_subscription(sub.id, {
+      :derived_product => nil,
+      :derived_provided_products => []
+    })
+
+    @cp.refresh_pools(owner_key)
+
+    pools = @cp.list_pools :owner => owner.id, :product => datacenter_product.id
+    expect(pools.length).to eq(2)
+
+    # Swap pools if necessary
+    if pools[0].productId != datacenter_product.id
+      pools[0], pools[1] = pools[1], pools[0]
+    end
+
+    expect(pools.first).to have_key('derivedProvidedProducts')
+    expect(pools.first.derivedProvidedProducts.length).to eq(0)
   end
 
-  it 'can migrate subscription' do
-    # Create the initial owner and generate the pools.
-    owner1 = create_owner random_string('initial-owner')
-    name = random_string("product")
-    product1 = create_product(name, name, :owner => owner1['key'])
-    pool = create_pool_and_subscription(owner1['key'], product1.id)
-    owner1_pools = @cp.list_pools({:owner => owner1.id})
-    owner1_pools.length.should == 1
+  it 'can migrate subscriptions' do
+    owner_key1 = random_string('test_owner_1')
+    owner_key2 = random_string('test_owner_2')
+    owner1 = create_owner(owner_key1)
+    owner2 = create_owner(owner_key2)
 
-    # Create another owner and migrate the subscription
-    owner2 = create_owner random_string('migrated-owner')
-    product2 = create_product(name, name, :owner => owner2['key'])
+    product = create_upstream_product(random_string('test_prod'))
+    sub = create_upstream_subscription(random_string('test_sub'), owner_key1, product.id)
 
-    # migrate the subscription to another owner.
-    sub = get_hostedtest_subscription(pool.subscriptionId)
-    sub["owner"] = owner2
-    update_hostedtest_subscription(sub)
-    @cp.refresh_pools(owner1["key"])
-    @cp.refresh_pools(owner2["key"])
+    @cp.refresh_pools(owner_key1)
+    @cp.refresh_pools(owner_key2)
 
-    # Check that the pools are removed from the first owner
-    @cp.list_pools({:owner => owner1.id}).length.should == 0
-    @cp.list_pools({:owner => owner2.id}).length.should == 1
+    pools1 = @cp.list_pools({:owner => owner1.id})
+    pools2 = @cp.list_pools({:owner => owner2.id})
+    expect(pools1.length).to eq(1)
+    expect(pools2.length).to eq(0)
+
+    # Update sub to be owned by the second owner
+    update_upstream_subscription(sub.id, { :owner => { :key => owner_key2 }})
+
+    @cp.refresh_pools(owner_key1)
+    @cp.refresh_pools(owner_key2)
+
+    pools1 = @cp.list_pools({:owner => owner1.id})
+    pools2 = @cp.list_pools({:owner => owner2.id})
+    expect(pools1.length).to eq(0)
+    expect(pools2.length).to eq(1)
   end
 
   it 'removes pools from other owners when subscription is migrated' do
-    # Create the initial owner and generate the pools.
-    owner1 = create_owner random_string('initial-owner')
-    name = random_string("product")
-    product1 = create_product(name, name, :owner => owner1['key'])
-    pool = create_pool_and_subscription(owner1['key'], product1.id)
-    owner1_pools = @cp.list_pools({:owner => owner1.id})
-    owner1_pools.length.should == 1
+    owner_key1 = random_string('test_owner_1')
+    owner_key2 = random_string('test_owner_2')
+    owner1 = create_owner(owner_key1)
+    owner2 = create_owner(owner_key2)
 
-    # Create another owner and migrate the subscription
-    owner2 = create_owner random_string('migrated-owner')
-    product2 = create_product(name, name, :owner => owner2['key'])
+    product = create_upstream_product(random_string('test_prod'))
+    sub = create_upstream_subscription(random_string('test_sub'), owner_key1, product.id)
 
-    # migrate the subscription to another owner.
-    sub = get_hostedtest_subscription(pool.subscriptionId)
-    sub["owner"] = owner2
-    update_hostedtest_subscription(sub)
+    @cp.refresh_pools(owner_key1)
+    @cp.refresh_pools(owner_key2)
 
-    # Refresh the second owner so that the pools are updated.
-    @cp.refresh_pools(owner2["key"], true)
-    sleep 1
-    # Initial owner should have all pools removed.
-    @cp.list_pools({:owner => owner1.id}).length.should == 0
+    pools1 = @cp.list_pools({:owner => owner1.id})
+    pools2 = @cp.list_pools({:owner => owner2.id})
+    expect(pools1.length).to eq(1)
+    expect(pools2.length).to eq(0)
 
-    # Pools should now be created for the second owner since
-    # the subscription was migrated.
-    @cp.list_pools({:owner => owner2.id}).length.should == 1
+    # Update sub to be owned by the second owner
+    update_upstream_subscription(sub.id, { :owner => { :key => owner_key2 }})
+
+    @cp.refresh_pools(owner_key2)
+
+    pools1 = @cp.list_pools({:owner => owner1.id})
+    pools2 = @cp.list_pools({:owner => owner2.id})
+    expect(pools1.length).to eq(0)
+    expect(pools2.length).to eq(1)
   end
 
   # Testing bug #1150234:
   it 'can change attributes and revoke entitlements at same time' do
-    owner = create_owner random_string
-    user = user_client(owner, random_string('virt_user'))
-    product = create_product(
-      random_string,
-      random_string,
-      {
-        :attributes => {'multi-entitlement' => "yes"},
-        :owner => owner['key']
+    owner_key = random_string('test_owner')
+    owner = create_owner(owner_key)
+
+    product = create_upstream_product(random_string('multient_prod'), {
+      :attributes => {
+        'multi-entitlement' => 'yes'
       }
-    )
-    create_pool_and_subscription(owner['key'], product.id, 2)
+    })
 
-    user = user_client(owner, random_string("user"))
-    host = consumer_client(user, 'host', :system, nil)
+    sub = create_upstream_subscription(random_string('multient_sub'), owner_key, product.id, {
+      :quantity => 2
+    })
 
-    pools = @cp.list_pools({:owner => owner.id, :product => product.id})
-    pools.length.should == 1
-    # We'll consume quantity 2, later we will reduce the pool to 1 forcing a
-    # revoke of this entitlement:
-    @cp.consume_pool(pools[0]['id'], {:uuid => host.uuid, :quantity => 2})
-    @cp.refresh_pools(owner['key'], false, false, false)
+    user = user_client(owner, random_string('test_user'))
+    consumer_client = consumer_client(user, random_string('test_consumer'))
 
-    pool = @cp.list_pools({:owner => owner.id, :product => product.id})[0]
+    @cp.refresh_pools(owner_key)
+    pools = @cp.list_pools({:owner => owner.id})
+    expect(pools.length).to eq(1)
 
-    # Modify product attributes:
-    attrs = product['attributes']
-    attrs << {:name => 'newattribute', :value => 'something'}
-    update_product(owner['key'], product.id, :attributes => attrs)
+    # We'll consume quantity 2, later we will reduce the pool to 1 forcing revokation of this entitlement
+    entitlements = consumer_client.consume_pool(pools.first.id, { :quantity => 2 })
+    expect(entitlements.length).to eq(1)
 
-    # Reduce the subscription quantity:
-    sub = get_hostedtest_subscription(pool.subscriptionId)
-    sub['quantity'] = 1
-    update_hostedtest_subscription(sub)
+    # FIXME: This seems like a bug. Our entitlement count here should be 1, right?
+    consumer = @cp.get_consumer(consumer_client.uuid)
+    expect(consumer.entitlementCount).to eq(2)
 
-    @cp.refresh_pools(owner['key'], false, false, false)
-    pools = @cp.list_pools({:owner => owner.id, :product => product.id})
-    pools.length.should == 1
+    # Add a new attribute to the product
+    update_upstream_product(product.id, {
+      :attributes => {
+        'new_attrib' => 'new value',
+        'multi-entitlement' => 'yes'
+      }
+    })
+
+    # ...and reduce the quantity available on the subscription
+    update_upstream_subscription(sub.id, {
+      :quantity => 1
+    })
+
+    # Refresh pools for this org
+    @cp.refresh_pools(owner_key)
+
+    pools = @cp.list_pools({:owner => owner.id})
+    expect(pools.length).to eq(1)
+
+    # Verify the pool's product now contains the new attribute
+    expect(pools.first).to have_key('productAttributes')
+
+    attributes = normalize_attributes(pools.first.productAttributes)
+    expect(attributes).to eq({
+      'new_attrib' => 'new value',
+      'multi-entitlement' => 'yes'
+    })
+
+    # Verify that the entitlement was revoked
+    consumer = @cp.get_consumer(consumer_client.uuid)
+    expect(consumer.entitlementCount).to eq(0)
+
+    lambda do
+      @cp.get_entitlement(entitlements[0].id)
+    end.should raise_exception(RestClient::ResourceNotFound)
+  end
+
+  it 'regenerates entitlements when content for an entitled pool changes' do
+    owner_key = random_string('test_owner')
+    owner = create_owner(owner_key)
+
+    content_id = random_string('test_content')
+    content = create_upstream_content(content_id, { :label => 'test_label', :content_url => 'http://www.url.com' })
+
+    product_id = random_string(nil, true)
+    product = create_upstream_product(product_id)
+
+    add_content_to_product_upstream(product_id, content_id)
+
+    sub_id = random_string('test_subscription')
+    create_upstream_subscription(sub_id, owner_key, product_id)
+
+    @cp.refresh_pools(owner_key)
+    pools = @cp.list_pools({:owner => owner.id})
+    expect(pools.length).to eq(1)
+
+    # Verify the content exists in its initial state
+    ds_content = @cp.get_content(owner_key, content_id)
+    expect(ds_content).to_not be_nil
+    expect(ds_content.label).to eq('test_label')
+
+    # Consume the pool so we have an entitlement
+    user = user_client(owner, random_string('test_user'))
+    consumer_client = consumer_client(user, random_string('test_consumer'), :system, nil,
+      { 'system.certificate_version' => '3.0' })
+
+    entitlements = consumer_client.consume_pool(pools.first.id, { :quantity => 1 })
+    expect(entitlements.length).to eq(1)
+
+    consumer = @cp.get_consumer(consumer_client.uuid)
+    expect(consumer.entitlementCount).to eq(1)
+
+    entitlement = entitlements.first
+    ent_cert = entitlement['certificates'].first
+    ent_cert_serial = ent_cert['serial']['serial']
+
+    # Modify the content for this product/sub
+    update_upstream_content(content_id, { :label => 'updated_label' })
+
+    @cp.refresh_pools(owner_key)
+    pools = @cp.list_pools({:owner => owner.id})
+    expect(pools.length).to eq(1)
+
+    # Verify the content change has been pulled down
+    ds_content = @cp.get_content(owner_key, content_id)
+    expect(ds_content).to_not be_nil
+    expect(ds_content.label).to eq('updated_label')
+
+    # Verify the entitlement cert has changed as a result
+    updated_ent = @cp.get_entitlement(entitlement['id'])
+    updated_cert = updated_ent['certificates'].first
+    updated_cert_serial = updated_cert['serial']['serial']
+
+    expect(updated_cert_serial).to_not eq(ent_cert_serial)
+  end
+
+  it 'regenerates entitlements when products for an entitled pool changes' do
+    owner_key = random_string('test_owner')
+    owner = create_owner(owner_key)
+
+    content_id = random_string('test_content')
+    content = create_upstream_content(content_id, { :content_url => 'http://www.url.com' })
+
+    product_id = random_string(nil, true)
+    product = create_upstream_product(product_id, { :name => 'test_prod' })
+
+    add_content_to_product_upstream(product_id, content_id)
+
+    sub_id = random_string('test_subscription')
+    create_upstream_subscription(sub_id, owner_key, product_id)
+
+    @cp.refresh_pools(owner_key)
+    pools = @cp.list_pools({:owner => owner.id})
+    expect(pools.length).to eq(1)
+
+    # Verify the product exists in its initial state
+    ds_product = @cp.get_product(owner_key, product_id)
+    expect(ds_product).to_not be_nil
+    expect(ds_product.name).to eq('test_prod')
+
+    # Consume the pool so we have an entitlement
+    user = user_client(owner, random_string('test_user'))
+    consumer_client = consumer_client(user, random_string('test_consumer'), :system, nil,
+      { 'system.certificate_version' => '3.0' })
+
+    entitlements = consumer_client.consume_pool(pools.first.id, { :quantity => 1 })
+    expect(entitlements.length).to eq(1)
+
+    consumer = @cp.get_consumer(consumer_client.uuid)
+    expect(consumer.entitlementCount).to eq(1)
+
+    entitlement = entitlements.first
+    ent_cert = entitlement['certificates'].first
+    ent_cert_serial = ent_cert['serial']['serial']
+
+    # Modify the product for this sub
+    update_upstream_product(product_id, { :name => 'updated_name' })
+
+    @cp.refresh_pools(owner_key)
+    pools = @cp.list_pools({:owner => owner.id})
+    expect(pools.length).to eq(1)
+
+    # Verify the product change has been pulled down
+    ds_product = @cp.get_product(owner_key, product_id)
+    expect(ds_product).to_not be_nil
+    expect(ds_product.name).to eq('updated_name')
+
+    # Verify the entitlement cert has changed as a result
+    updated_ent = @cp.get_entitlement(entitlement['id'])
+    updated_cert = updated_ent['certificates'].first
+    updated_cert_serial = updated_cert['serial']['serial']
+
+    expect(updated_cert_serial).to_not eq(ent_cert_serial)
+  end
+
+  it 'regenerates entitlements when required products change' do
+    owner_key = random_string('test_owner')
+    owner = create_owner(owner_key)
+
+    sku_id1 = random_string('required_prod', true)
+    sku_id2 = random_string('dependent_prod', true)
+    sku_prod1 = create_upstream_product(sku_id1)
+    sku_prod2 = create_upstream_product(sku_id2)
+
+    eng_id1 = random_string(nil, true)
+    eng_id2 = random_string(nil, true)
+    eng_prod1 = create_upstream_product(eng_id1)
+    eng_prod2 = create_upstream_product(eng_id2)
+
+    content_id1 = random_string('test_content_1')
+    content1 = create_upstream_content(content_id1, { :content_url => 'http://www.url.com/c1' })
+
+    content_id2 = random_string('test_content_2')
+    content2 = create_upstream_content(content_id2, { :content_url => 'http://www.url.com/c2' })
+
+    content_id3 = random_string('test_content_3')
+    content3 = create_upstream_content(content_id3, { :content_url => 'http://www.url.com/c3' })
+
+    add_content_to_product_upstream(eng_id1, content_id1)
+    add_content_to_product_upstream(eng_id2, content_id2)
+    add_content_to_product_upstream(eng_id2, content_id3)
+
+    sub_id1 = random_string('test_subscription_1')
+    sub1 = create_upstream_subscription(sub_id1, owner_key, sku_id1, { :provided_products => [eng_prod1] })
+
+    sub_id2 = random_string('test_subscription_2')
+    sub2 = create_upstream_subscription(sub_id2, owner_key, sku_id2, { :provided_products => [eng_prod2] })
+
+    @cp.refresh_pools(owner_key)
+    pools = @cp.list_pools({:owner => owner.id})
+    expect(pools.length).to eq(2)
+
+    # Rearrange the pools if they're backward
+    if pools.first.productId == sku_id2
+      pools[0], pools[1] = pools[1], pools[0]
+    end
+
+    products = @cp.list_products_by_owner(owner_key)
+    expect(products.length).to eq(4)
+
+    content = @cp.list_content(owner_key)
+    expect(content.length).to eq(3)
+
+    # Consume both pools
+    user = user_client(owner, random_string('test_user'))
+    consumer_client = consumer_client(user, random_string('test_consumer'), :system, nil,
+      { 'system.certificate_version' => '3.0' })
+
+    pool_ents = []
+
+    entitlements = consumer_client.consume_pool(pools[0].id, { :quantity => 1 })
+    expect(entitlements.length).to eq(1)
+    pool_ents << entitlements.first
+
+    entitlements = consumer_client.consume_pool(pools[1].id, { :quantity => 1 })
+    expect(entitlements.length).to eq(1)
+    pool_ents << entitlements.first
+
+    entitlements = @cp.list_entitlements({ :uuid => consumer_client.uuid })
+    expect(entitlements.length).to eq(2)
+
+    payload1 = extract_payload(pool_ents[0].certificates.first['cert'])
+    payload2 = extract_payload(pool_ents[1].certificates.first['cert'])
+
+    # Verify the entitlements contains the products and content
+    expect(payload1).to have_key('products')
+    expect(payload1.products.length).to eq(1)
+    expect(payload1.products.first.id).to eq(eng_id1)
+    expect(payload1.products.first).to have_key('content')
+    expect(payload1.products.first.content.length).to eq(1)
+    expect(payload1.products.first.content.first.id).to eq(content1.id)
+    expect(payload1.products.first.content.first.path).to eq(content1.contentUrl)
+
+    expect(payload2).to have_key('products')
+    expect(payload2.products.length).to eq(1)
+    expect(payload2.products.first).to have_key('content')
+    expect(payload2.products.first.id).to eq(eng_id2)
+    expect(payload2.products.first.content.length).to eq(2)
+
+    if payload2.products.first.content[0].id == content2.id
+      expect(payload2.products.first.content[0].id).to eq(content2.id)
+      expect(payload2.products.first.content[0].path).to eq(content2.contentUrl)
+      expect(payload2.products.first.content[1].id).to eq(content3.id)
+      expect(payload2.products.first.content[1].path).to eq(content3.contentUrl)
+    else
+      expect(payload2.products.first.content[0].id).to eq(content3.id)
+      expect(payload2.products.first.content[0].path).to eq(content3.contentUrl)
+      expect(payload2.products.first.content[1].id).to eq(content2.id)
+      expect(payload2.products.first.content[1].path).to eq(content2.contentUrl)
+    end
+
+    ent_cert = pool_ents[1]['certificates'].first
+    ent_cert_serial = ent_cert['serial']['serial']
+
+    # Add a dependent product to content2 for a product the consumer is entitled to
+    update_upstream_content(content_id2, { :modified_product_ids => [eng_id1] })
+    @cp.refresh_pools(owner_key)
+
+    # Verify the content change has been pulled down
+    content = @cp.get_content(owner_key, content_id2)
+    expect(content.modifiedProductIds).to eq([eng_id1])
+
+    # Verify the entitlement has been regenerated
+    updated_ent = @cp.get_entitlement(pool_ents[1]['id'])
+    updated_cert = updated_ent['certificates'].first
+    updated_cert_serial = updated_cert['serial']['serial']
+
+    expect(updated_cert_serial).to_not eq(ent_cert_serial)
+
+    # Verify the content path is still present in the entitlement
+    payload = extract_payload(updated_ent['certificates'].first['cert'])
+
+    expect(payload).to have_key('products')
+    expect(payload.products.length).to eq(1)
+    expect(payload.products.first).to have_key('content')
+    expect(payload.products.first.id).to eq(eng_id2)
+    expect(payload.products.first.content.length).to eq(2)
+
+    if payload.products.first.content[0].id == content2.id
+      expect(payload.products.first.content[0].id).to eq(content2.id)
+      expect(payload.products.first.content[0].path).to eq(content2.contentUrl)
+      expect(payload.products.first.content[1].id).to eq(content3.id)
+      expect(payload.products.first.content[1].path).to eq(content3.contentUrl)
+    else
+      expect(payload.products.first.content[0].id).to eq(content3.id)
+      expect(payload.products.first.content[0].path).to eq(content3.contentUrl)
+      expect(payload.products.first.content[1].id).to eq(content2.id)
+      expect(payload.products.first.content[1].path).to eq(content2.contentUrl)
+    end
+
+    # Add a dependent product to content3 for a product the consumer is NOT entitled to
+    update_upstream_content(content_id3, { :modified_product_ids => ['fake_pid'] })
+    @cp.refresh_pools(owner_key)
+
+    # Verify the content change has been pulled down
+    content = @cp.get_content(owner_key, content_id3)
+    expect(content.modifiedProductIds).to eq(['fake_pid'])
+
+    # Verify the entitlement has been regenerated
+    updated_ent = @cp.get_entitlement(pool_ents[1]['id'])
+    updated_cert = updated_ent['certificates'].first
+    updated_cert_serial = updated_cert['serial']['serial']
+
+    expect(updated_cert_serial).to_not eq(ent_cert_serial)
+
+    # Verify the content path is still present in the entitlement
+    payload = extract_payload(updated_ent['certificates'].first['cert'])
+
+    expect(payload).to have_key('products')
+    expect(payload.products.length).to eq(1)
+    expect(payload.products.first).to have_key('content')
+    expect(payload.products.first.id).to eq(eng_id2)
+    expect(payload.products.first.content.length).to eq(1)
+    expect(payload.products.first.content.first.id).to eq(content2.id)
+    expect(payload.products.first.content.first.path).to eq(content2.contentUrl)
+  end
+
+  it 'invalidates entitlements when pool quantity is reduced' do
+    owner_key = random_string('test_owner')
+    owner = create_owner(owner_key)
+
+    content_id = random_string('test_content')
+    content = create_upstream_content(content_id, { :content_url => 'http://www.url.com' })
+
+    product_id = random_string(nil, true)
+    product = create_upstream_product(product_id, { :name => 'test_prod' })
+
+    add_content_to_product_upstream(product_id, content_id)
+
+    sub_id = random_string('test_subscription')
+    create_upstream_subscription(sub_id, owner_key, product_id, {:quantity => 5})
+
+    @cp.refresh_pools(owner_key)
+    pools = @cp.list_pools({:owner => owner.id})
+    expect(pools.length).to eq(1)
+    expect(pools.first.quantity).to eq(5)
+
+    # Verify the product exists in its initial state
+    ds_product = @cp.get_product(owner_key, product_id)
+    expect(ds_product).to_not be_nil
+    expect(ds_product.name).to eq('test_prod')
+
+    # Consume the pool multiple times so we have entitlements to revoke
+    5.times do |i|
+      user = user_client(owner, random_string('test_user'))
+      consumer_client = consumer_client(user, random_string('test_consumer'), :system, nil,
+        { 'system.certificate_version' => '3.0' })
+
+      entitlements = consumer_client.consume_pool(pools.first.id, { :quantity => 1 })
+      expect(entitlements.length).to eq(1)
+
+      consumer = @cp.get_consumer(consumer_client.uuid)
+      expect(consumer.entitlementCount).to eq(1)
+    end
+
+    # Verify the entitlement count for this pool
+    entitlements = @cp.list_pool_entitlements(pools.first.id)
+    expect(entitlements.length).to eq(5)
+
+    # Modify the subscription upstream
+    update_upstream_subscription(sub_id, {:quantity => 1})
+
+    @cp.refresh_pools(owner_key)
+    pools = @cp.list_pools({:owner => owner.id})
+    expect(pools.length).to eq(1)
+    expect(pools.first.quantity).to eq(1)
+
+    # Verify the entitlement count has changed
+    entitlements = @cp.list_pool_entitlements(pools.first.id)
+    expect(entitlements.length).to eq(1)
+  end
+
+  it 'invalidates bonus pool entitlements when master pool quantity is reduced' do
+    owner_key = random_string('test_owner')
+    owner = create_owner(owner_key)
+
+    content_id = random_string('test_content')
+    content = create_upstream_content(content_id, { :content_url => 'http://www.url.com' })
+
+    product_id = random_string(nil, true)
+    product = create_upstream_product(product_id, { :name => 'test_prod', :attributes => { "virt_limit" => "1" } })
+
+    add_content_to_product_upstream(product_id, content_id)
+
+    sub_id = random_string('test_subscription')
+    create_upstream_subscription(sub_id, owner_key, product_id, {:quantity => 5})
+
+    @cp.refresh_pools(owner_key)
+    pools = @cp.list_pools({:owner => owner.id})
+    expect(pools.length).to eq(2) # pool + bonus pool
+
+    # Swap if the order isn't our expected order
+    pools[0], pools[1] = pools[1], pools[0] if pools.first.type == "BONUS"
+
+    expect(pools.first.quantity).to eq(5)
+    expect(pools.last.quantity).to eq(5)
+
+    # Verify the product exists in its initial state
+    ds_product = @cp.get_product(owner_key, product_id)
+    expect(ds_product).to_not be_nil
+    expect(ds_product.name).to eq('test_prod')
+
+    # Consume the pool multiple times so we have entitlements to revoke
+    5.times do |i|
+      user = user_client(owner, random_string('test_user'))
+      consumer_client = consumer_client(user, random_string('test_consumer'), :system, nil,
+        { 'system.certificate_version' => '3.0', 'virt.is_guest' => true})
+
+      entitlements = consumer_client.consume_pool(pools.last.id, { :quantity => 1 })
+      expect(entitlements.length).to eq(1)
+
+      consumer = @cp.get_consumer(consumer_client.uuid)
+      expect(consumer.entitlementCount).to eq(1)
+    end
+
+    # Verify the entitlement count for this pool
+    entitlements = @cp.list_pool_entitlements(pools.first.id)
+    expect(entitlements.length).to eq(0)
+    entitlements = @cp.list_pool_entitlements(pools.last.id)
+    expect(entitlements.length).to eq(5)
+
+    # Modify the subscription upstream
+    update_upstream_subscription(sub_id, {:quantity => 1})
+
+    @cp.refresh_pools(owner_key)
+    pools = @cp.list_pools({:owner => owner.id})
+    expect(pools.length).to eq(2) # pool + bonus pool
+
+    # Swap if the order isn't our expected order
+    pools[0], pools[1] = pools[1], pools[0] if pools.first.type == "BONUS"
+
+    expect(pools.first.quantity).to eq(1)
+    expect(pools.last.quantity).to eq(1)
+
+    # Verify the entitlement count has changed
+    entitlements = @cp.list_pool_entitlements(pools.first.id)
+    expect(entitlements.length).to eq(0)
+    entitlements = @cp.list_pool_entitlements(pools.last.id)
+    expect(entitlements.length).to eq(1)
+  end
+
+  it 'invalidates bonus pool entitlements when bonus pool quantity is reduced' do
+    owner_key = random_string('test_owner')
+    owner = create_owner(owner_key)
+
+    content_id = random_string('test_content')
+    content = create_upstream_content(content_id, { :content_url => 'http://www.url.com' })
+
+    product_id = random_string(nil, true)
+    product = create_upstream_product(product_id, { :name => 'test_prod', :attributes => { "virt_limit" => "5" } })
+
+    add_content_to_product_upstream(product_id, content_id)
+
+    sub_id = random_string('test_subscription')
+    create_upstream_subscription(sub_id, owner_key, product_id, {:quantity => 1})
+
+    @cp.refresh_pools(owner_key)
+    pools = @cp.list_pools({:owner => owner.id})
+    expect(pools.length).to eq(2) # pool + bonus pool
+
+    # Swap if the order isn't our expected order
+    pools[0], pools[1] = pools[1], pools[0] if pools.first.type == "BONUS"
+
+    expect(pools.first.quantity).to eq(1)
+    expect(pools.last.quantity).to eq(5)
+
+    # Verify the product exists in its initial state
+    ds_product = @cp.get_product(owner_key, product_id)
+    expect(ds_product).to_not be_nil
+    expect(ds_product.name).to eq('test_prod')
+
+    # Consume the pool multiple times so we have entitlements to revoke
+    5.times do |i|
+      user = user_client(owner, random_string('test_user'))
+      consumer_client = consumer_client(user, random_string('test_consumer'), :system, nil,
+        { 'system.certificate_version' => '3.0', 'virt.is_guest' => true})
+
+      entitlements = consumer_client.consume_pool(pools.last.id, { :quantity => 1 })
+      expect(entitlements.length).to eq(1)
+
+      consumer = @cp.get_consumer(consumer_client.uuid)
+      expect(consumer.entitlementCount).to eq(1)
+    end
+
+    # Verify the entitlement count for this pool
+    entitlements = @cp.list_pool_entitlements(pools.first.id)
+    expect(entitlements.length).to eq(0)
+    entitlements = @cp.list_pool_entitlements(pools.last.id)
+    expect(entitlements.length).to eq(5)
+
+    # Modify the subscription upstream
+    update_upstream_product(product.id, { :attributes => { "virt_limit" => "1" } })
+
+    @cp.refresh_pools(owner_key)
+    pools = @cp.list_pools({:owner => owner.id})
+    expect(pools.length).to eq(2) # pool + bonus pool
+
+    # Swap if the order isn't our expected order
+    pools[0], pools[1] = pools[1], pools[0] if pools.first.type == "BONUS"
+
+    expect(pools.first.quantity).to eq(1)
+    expect(pools.last.quantity).to eq(1)
+
+    # Verify the entitlement count has changed
+    entitlements = @cp.list_pool_entitlements(pools.first.id)
+    expect(entitlements.length).to eq(0)
+    entitlements = @cp.list_pool_entitlements(pools.last.id)
+    expect(entitlements.length).to eq(1)
   end
 
   def concat_serials(normal_ent, bonus_ent)
@@ -303,95 +849,131 @@ describe 'Refresh Pools' do
   end
 
   def test_entitlement_regeneration
-    @owner = create_owner random_string('test_owner')
-    @product = create_product(nil, nil, :attributes =>
-                {:version => '6.4',
-                 :arch => 'i386, x86_64',
-                 :sockets => 4,
-                 :cores => 8,
-                 :ram => 16,
-                 :warning_period => 15,
-                 :management_enabled => true,
-                 :stacking_id => '8888',
-		 :virt_limit => "unlimited",
-		 :host_limited => "true",
-                 :virt_only => 'false',
-                 :support_level => 'standard',
-                 :support_type => 'excellent',})
+    owner_key = random_string('test_owner')
+    owner = create_owner(owner_key)
 
-    @provided_product = create_product(nil, nil, :attributes =>
-                {:version => '6.4',
-                 :arch => 'i386, x86_64',
-                 :sockets => 4,
-                 :cores => 8,
-                 :ram => 16,
-                 :warning_period => 15,
-                 :management_enabled => true,
-                 :stacking_id => '8888',
-                 :virt_only => 'false',
-                 :support_level => 'standard',
-                 :support_type => 'excellent',})
-
-    @derived_provided_product = create_product(nil, nil, :attributes =>
-                {:version => '6.4',
-                 :arch => 'i386, x86_64',
-                 :sockets => 4,
-                 :cores => 8,
-                 :ram => 16,
-                 :warning_period => 15,
-                 :management_enabled => true,
-                 :stacking_id => '8888',
-                 :virt_only => 'false',
-                 :support_level => 'standard',
-                 :support_type => 'excellent',})
-
-    @derived_product = create_product(nil, "derived product 1", {
+    product = create_upstream_product(random_string(nil, true), {
+      :name => random_string('prod', true),
       :attributes => {
-          :cores => 2,
-          :sockets => 4
+        :version => '6.4',
+        :arch => 'i386, x86_64',
+        :sockets => 4,
+        :cores => 8,
+        :ram => 16,
+        :warning_period => 15,
+        :management_enabled => true,
+        :stacking_id => '8888',
+        :virt_limit => "unlimited",
+        :host_limited => "true",
+        :virt_only => 'false',
+        :support_level => 'standard',
+        :support_type => 'excellent'
       }
     })
 
-    @content = create_content({:gpg_url => 'gpg_url',
-                               :content_url => '/content/dist/rhel/$releasever/$basearch/os',
-                               :metadata_expire => 6400,
-                               :required_tags => 'TAG1,TAG2',})
-
-    @content2 = create_content({:gpg_url => 'gpg_url',
-                               :content_url => '/content/dist/rhel/$releasever/$basearch/os',
-                               :metadata_expire => 6400,
-                               :required_tags => 'TAG1,TAG2',})
-
-    @content3 = create_content({:gpg_url => 'gpg_url',
-                               :content_url => '/content/dist/rhel/$releasever/$basearch/os',
-                               :metadata_expire => 6400,
-                               :required_tags => 'TAG1,TAG2',})
-
-    @cp.add_content_to_product(@owner['key'], @product.id, @content.id, false)
-    @cp.add_content_to_product(@owner['key'], @provided_product.id, @content2.id, false)
-    @cp.add_content_to_product(@owner['key'], @derived_provided_product.id, @content3.id, false)
-
-    @pool = create_pool_and_subscription(@owner['key'], @product.id, 10, [@provided_product.id],
-					 '12345', '6789', 'order1', nil, nil, false,
-					 {:derived_product_id => @derived_product['id'],
-                                          :derived_provided_products => [@derived_provided_product.id]
-                                         })
-    sub = get_hostedtest_subscription(@pool['subscriptionId'])
-
-    @bonus_pool = @cp.list_owner_pools(@owner['key']).select {|p| p['type'] == 'UNMAPPED_GUEST' }[0]
-
-    # create an entitlement with a product and content
-    @user = user_client(@owner, random_string('billy'))
-    @system = consumer_client(@user, random_string('system1'), :system, nil,
-                {'system.certificate_version' => '3.3',
-                 'uname.machine' => 'i386'})
-    @guest = consumer_client(@user, 'virty', :system, nil, {
-      'virt.is_guest' => true,
-      'system.certificate_version' => '3.3'
+    prov_product = create_upstream_product(random_string(nil, true), {
+      :name => random_string('prov_prod', true),
+      :attributes => {
+        :version => '6.4',
+        :arch => 'i386, x86_64',
+        :sockets => 4,
+        :cores => 8,
+        :ram => 16,
+        :warning_period => 15,
+        :management_enabled => true,
+        :stacking_id => '8888',
+        :virt_only => 'false',
+        :support_level => 'standard',
+        :support_type => 'excellent'
+      }
     })
 
-    entitlement = @system.consume_pool(@pool['id'], {:quantity => 1})[0]
-    bonus_entitlement = @guest.consume_pool(@bonus_pool['id'], {:quantity => 1})[0]
+    der_product = create_upstream_product(random_string(nil, true), {
+      :name => random_string('der_prod', true),
+      :attributes => {
+        :cores => 2,
+        :sockets => 4
+      }
+    })
+
+    der_prov_product = create_upstream_product(random_string(nil, true), {
+      :name => random_string('der_prov_prod', true),
+      :attributes => {
+        :version => '6.4',
+        :arch => 'i386, x86_64',
+        :sockets => 4,
+        :cores => 8,
+        :ram => 16,
+        :warning_period => 15,
+        :management_enabled => true,
+        :stacking_id => '8888',
+        :virt_only => 'false',
+        :support_level => 'standard',
+        :support_type => 'excellent'
+      }
+    })
+
+    content_id1 = random_string('test_content_1')
+    content1 = create_upstream_content(content_id1, {
+      :gpg_url => 'gpg_url',
+      :content_url => '/content/dist/rhel/$releasever/$basearch/os',
+      :metadata_expire => 6400,
+      :required_tags => 'TAG1,TAG2'
+    })
+
+    content_id2 = random_string('test_content_2')
+    content2 = create_upstream_content(content_id2, {
+      :gpg_url => 'gpg_url',
+      :content_url => '/content/dist/rhel/$releasever/$basearch/os',
+      :metadata_expire => 6400,
+      :required_tags => 'TAG1,TAG2'
+    })
+
+    content_id3 = random_string('test_content_3')
+    content3 = create_upstream_content(content_id3, {
+      :gpg_url => 'gpg_url',
+      :content_url => '/content/dist/rhel/$releasever/$basearch/os',
+      :metadata_expire => 6400,
+      :required_tags => 'TAG1,TAG2'
+    })
+
+    add_content_to_product_upstream(product.id, content_id1, false)
+    add_content_to_product_upstream(prov_product.id, content_id2, false)
+    add_content_to_product_upstream(der_prov_product.id, content_id3, false)
+
+    sub_id = random_string('test_subscription_1')
+    sub = create_upstream_subscription(sub_id, owner_key, product.id, {
+      :quantity => 10,
+      :contract_number => '12345',
+      :account_number => '6789',
+      :order_number => 'order1',
+      :provided_products => [prov_product],
+      :derived_product => der_product,
+      :derived_provided_products => [der_prov_product]
+    })
+
+    @cp.refresh_pools(owner_key)
+    pools = @cp.list_pools({:owner => owner.id})
+    expect(pools.length).to eq(2) # Expecting base pool + bonus pool
+
+    pool = pools.select {|p| p['type'] != 'UNMAPPED_GUEST' }[0]
+    bonus_pool = pools.select {|p| p['type'] == 'UNMAPPED_GUEST' }[0]
+
+
+    # create an entitlement with a product and content
+    user = user_client(owner, random_string('billy'))
+    system = consumer_client(user, random_string('system1'), :system, nil, {
+      'system.certificate_version' => '3.3',
+      'uname.machine' => 'i386'
+    })
+
+    guest = consumer_client(user, 'virty', :system, nil, {
+      'system.certificate_version' => '3.3',
+      'virt.is_guest' => true
+    })
+
+    entitlement = system.consume_pool(pool['id'], {:quantity => 1})[0]
+    bonus_entitlement = guest.consume_pool(bonus_pool['id'], {:quantity => 1})[0]
 
     json_body = extract_payload(entitlement['certificates'][0]['cert'])
     bonus_json_body = extract_payload(bonus_entitlement['certificates'][0]['cert'])
@@ -399,151 +981,193 @@ describe 'Refresh Pools' do
     serial_concat = concat_serials(entitlement, bonus_entitlement)
 
     # verify serial does not change on simple refresh
-    @cp.refresh_pools(@owner['key'], false, false, false)
+    @cp.refresh_pools(owner_key, false, false, false)
     entitlement =  @cp.get_entitlement(entitlement['id'])
     bonus_entitlement =  @cp.get_entitlement(bonus_entitlement['id'])
 
     concat_serials(entitlement, bonus_entitlement).should == serial_concat
 
-    # modify sub object, update upstream sub but dont refresh
-    sub = yield(sub, @owner)
-    update_pool_or_subscription(sub, false)
+    # Yield to encapsulating test, applying any change it may have made
+    sub = yield(owner, sub)
+    update_upstream_subscription(sub.id, sub)
 
     # verify serial does not change on content update request that does not regenerate cert
     entitlement =  @cp.get_entitlement(entitlement['id'])
     bonus_entitlement =  @cp.get_entitlement(bonus_entitlement['id'])
     concat_serials(entitlement, bonus_entitlement).should == serial_concat
+
     # this time when we refresh, serial should change
-    @cp.refresh_pools(@owner['key'], false, false, false)
+    @cp.refresh_pools(owner_key, false, false, false)
     entitlement =  @cp.get_entitlement(entitlement['id'])
     bonus_entitlement =  @cp.get_entitlement(bonus_entitlement['id'])
     concat_serials(entitlement, bonus_entitlement).should_not == serial_concat
     json_body = extract_payload(entitlement['certificates'][0]['cert'])
-    return json_body, @product
+
+    return json_body, product
   end
 
   it 'regenerates entitlements when modifiedProductIds of content change' do
-    test_entitlement_regeneration { |sub, owner|
-      prod_id_2 = random_string('modifying_prod')
-      create_product(prod_id_2, prod_id_2, {
-        :owner => owner['key']
-      })
-      sub['product']['productContent'][0]['content']['modifiedProductIds'] = [prod_id_2]
-      sub
+    test_entitlement_regeneration { |owner, subscription|
+      product_id2 = random_string(nil, true)
+      product2 = create_upstream_product(product_id2, { :name => 'test_prod_2' })
+
+      content = subscription['product']['productContent'].first['content']
+      content.modifiedProductIds = [product_id2]
+      update_upstream_content(content.id, content)
+
+      subscription
     }
   end
 
   it 'regenerates entitlements when modifiedProductIds of content of a provided product change' do
-    test_entitlement_regeneration { |sub, owner|
-      prod_id_2 = random_string('modifying_prod')
-      create_product(prod_id_2, prod_id_2, {
-        :owner => owner['key']
-      })
-      sub['providedProducts'][0]['productContent'][0]['content']['modifiedProductIds'] = [prod_id_2]
-      sub
+    test_entitlement_regeneration { |owner, subscription|
+      product_id2 = random_string(nil, true)
+      product2 = create_upstream_product(product_id2, { :name => 'test_prod_2' })
+
+      content = subscription['providedProducts'][0]['productContent'][0]['content']
+      content.modifiedProductIds = [product_id2]
+      update_upstream_content(content.id, content)
+
+      subscription
     }
   end
 
   it 'regenerates entitlements when modifiedProductIds of content of a derived provided product change' do
-    test_entitlement_regeneration { |sub, owner|
-      prod_id_2 = random_string('modifying_prod')
-      create_product(prod_id_2, prod_id_2, {
-        :owner => owner['key']
-      })
-      sub['derivedProvidedProducts'][0]['productContent'][0]['content']['modifiedProductIds'] = [prod_id_2]
-      sub
+    test_entitlement_regeneration { |owner, subscription|
+      product_id2 = random_string(nil, true)
+      product2 = create_upstream_product(product_id2, { :name => 'test_prod_2' })
+
+      content = subscription['derivedProvidedProducts'][0]['productContent'][0]['content']
+      content.modifiedProductIds = [product_id2]
+      update_upstream_content(content.id, content)
+
+      subscription
     }
   end
 
   it 'regenerates entitlements when provided product is added' do
-    pp_name = random_string('pp_name')
-    pp_id = random_string(nil, true)
-    json_body, main_product = test_entitlement_regeneration { |sub, owner|
-      pp = create_product(pp_id, pp_name, {:attributes =>
-                  {:version => '6.4',
-                   :arch => 'i386, x86_64',
-                   :sockets => 4,
-                   :cores => 8,
-                   :ram => 16,
-                   :warning_period => 15,
-                   :management_enabled => true,
-                   :stacking_id => '8888',
-                   :virt_only => 'false',
-                   :support_level => 'standard',
-                   :support_type => 'excellent',}, :owner => owner['key']})
-      pp_content = create_content({:gpg_url => 'gpg_url',
-                   :content_url => '/content/dist/rhel/$releasever/$basearch/os',
-                   :metadata_expire => 6400,
-                   :required_tags => 'TAG1,TAG2',})
-      pp['productContent'] = [{'content' => pp_content, 'enabled' => 'true'}]
-      sub['providedProducts'].push(pp)
-      sub
+    prov_product_id = random_string(nil, true)
+
+    json_body, main_product = test_entitlement_regeneration { |owner, subscription|
+      prov_product = create_upstream_product(prov_product_id, {
+        :name => 'test_prov_prod',
+        :version => '6.4',
+        :arch => 'i386, x86_64',
+        :sockets => 4,
+        :cores => 8,
+        :ram => 16,
+        :warning_period => 15,
+        :management_enabled => true,
+        :stacking_id => '8888',
+        :virt_only => 'false',
+        :support_level => 'standard',
+        :support_type => 'excellent'
+      })
+
+      content_id = random_string('test_content_')
+      content = create_upstream_content(content_id, {
+        :gpg_url => 'gpg_url',
+        :content_url => '/content/dist/rhel/$releasever/$basearch/os',
+        :metadata_expire => 6400,
+        :required_tags => 'TAG1,TAG2'
+      })
+
+      add_content_to_product_upstream(prov_product.id, content_id)
+
+      subscription['providedProducts'].push(prov_product)
+
+      subscription
     }
-    pp = json_body['products'].find {|p| p['id'] == pp_id}
-    pp['name'].should == pp_name
+
+    prov_product = json_body['products'].find {|p| p['id'] == prov_product_id}
+    expect(prov_product).to_not be_nil
   end
 
   it 'regenerates entitlements when provided product is removed' do
-    json_body, main_product = test_entitlement_regeneration { |sub, owner|
-      sub['providedProducts'] = []
-      sub
+    json_body, main_product = test_entitlement_regeneration { |owner, subscription|
+      subscription['providedProducts'] = []
+      subscription
     }
+
     json_body['products'].size.should == 1
   end
 
   it 'regenerates entitlements when label of a content changes' do
-    json_body, main_product = test_entitlement_regeneration { |sub, owner|
-      sub['product']['productContent'][0]['content']['label'] = 'shakeItOff'
-      sub
+    json_body, main_product = test_entitlement_regeneration { |owner, subscription|
+      content = subscription['product']['productContent'].first['content']
+      content.label = 'shakeItOff'
+      update_upstream_content(content.id, content)
+
+      subscription
     }
+
     product_json = json_body['products'].find {|p| p['id'] == main_product['id']}
     product_json['content'][0]['label'].should == 'shakeItOff'
   end
 
   it 'regenerates entitlements when releaseVer of a content changes' do
-    test_entitlement_regeneration { |sub|
-      sub['product']['productContent'][0]['content']['releaseVer'] = 'badBlood'
-      sub
+    test_entitlement_regeneration { |owner, subscription|
+      content = subscription['product']['productContent'].first['content']
+      content.releaseVer = 'badBlood'
+      update_upstream_content(content.id, content)
+
+      subscription
     }
+
     # releasever is not in json
   end
 
   it 'regenerates entitlements when vendor of a content changes' do
-    json_body, main_product = test_entitlement_regeneration { |sub|
-      sub['product']['productContent'][0]['content']['vendor'] = 'blankSpace'
-      sub
+    json_body, main_product = test_entitlement_regeneration { |owner, subscription|
+      content = subscription['product']['productContent'].first['content']
+      content.vendor = 'blankSpace'
+      update_upstream_content(content.id, content)
+
+      subscription
     }
+
     product_json = json_body['products'].find {|p| p['id'] == main_product['id']}
     product_json['content'][0]['vendor'].should == 'blankSpace'
   end
 
   it 'regenerates entitlements when adding a content' do
-    json_body, main_product = test_entitlement_regeneration { |sub|
-      productContent =
-        { "content"=>{ "created"=>"2017-11-24T13:41:39+0000",
-		       "updated"=>"2017-11-24T13:41:39+0000",
-		       "uuid"=>"theStroyOfUs",
-		       "id"=>"twentyTwo",
-		       "type"=>"yum",
-		       "label"=>"teardropsOnMyGuitar",
-		       "name"=>"swiftrocks",
-		       "vendor"=>"fifteen",
-		       "releaseVer"=>nil},
-          "enabled"=>true }
+    json_body, main_product = test_entitlement_regeneration { |owner, subscription|
+      product = subscription['product']
 
-      sub['product']['productContent'].push(productContent)
-      sub
+      content = create_upstream_content("twentyTwo", {
+        :type => "yum",
+        :label => "teardropsOnMyGuitar",
+        :name => "swiftrocks",
+        :vendor => "fifteen",
+        :releaseVer => nil
+      })
+
+      add_content_to_product_upstream(product.id, content.id)
+
+      # Need to return the updated, upstream subscription here so we don't risk clobbering the addition.
+      # We shouldn't, anyway, but there's no need to risk it unnecessarily.
+      get_upstream_subscription(subscription.id)
     }
+
     product_json = json_body['products'].find {|p| p['id'] == main_product['id']}
     content = product_json['content'].find {|c| c['id'] == 'twentyTwo'}
-    content['name'].should == 'swiftrocks'
+
+    expect(content).to_not be_nil
+    expect(content['name']).to eq('swiftrocks')
   end
 
-  it 'regenerates entitlements when deleting a content' do
-    json_body, main_product = test_entitlement_regeneration { |sub|
-      sub['product']['productContent'] = []
-      sub
+  it 'regenerates entitlements when deleting content' do
+    json_body, main_product = test_entitlement_regeneration { |owner, subscription|
+      product = subscription['product']
+      content = product['productContent'].first['content']
+
+      remove_content_from_product_upstream(product.id, content.id)
+
+      # Need to return the updated, upstream subscription here so we don't risk clobbering the removal.
+      # We shouldn't, anyway, but there's no need to risk it unnecessarily.
+      get_upstream_subscription(subscription.id)
     }
+
     product_json = json_body['products'].find {|p| p['id'] == main_product['id']}
     product_json['content'].should == []
   end

--- a/server/spec/spec_helper.rb
+++ b/server/spec/spec_helper.rb
@@ -28,7 +28,7 @@ module CleanupHooks
 
     if !@cp.get_status()['standalone']
       begin
-        @cp.delete('/hostedtest/subscriptions/', {}, nil, true)
+        @cp.delete('/hostedtest/', {}, nil, true)
       rescue RestClient::ResourceNotFound
         puts "skipping hostedtest cleanup"
       end

--- a/server/src/main/java/org/candlepin/hostedtest/HostedTestSubscriptionServiceAdapter.java
+++ b/server/src/main/java/org/candlepin/hostedtest/HostedTestSubscriptionServiceAdapter.java
@@ -14,21 +14,41 @@
  */
 package org.candlepin.hostedtest;
 
+import org.candlepin.model.Branding;
+import org.candlepin.model.Cdn;
+import org.candlepin.model.CdnCertificate;
+import org.candlepin.model.CertificateSerial;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.Owner;
-import org.candlepin.model.dto.ProductContentData;
+import org.candlepin.model.ProductContent;
+import org.candlepin.model.SubscriptionsCertificate;
+import org.candlepin.model.dto.ContentData;
 import org.candlepin.model.dto.ProductData;
+import org.candlepin.model.dto.ProductContentData;
 import org.candlepin.model.dto.Subscription;
 import org.candlepin.service.SubscriptionServiceAdapter;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
+import java.math.BigInteger;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
 
 
 
@@ -38,146 +58,977 @@ import java.util.Map;
  * mode, while it is built with candlepin, it is not packaged in candlepin.war,
  * as the only purpose of this class is to support spec tests.
  */
+@Singleton
 public class HostedTestSubscriptionServiceAdapter implements SubscriptionServiceAdapter {
     private static Logger log = LoggerFactory.getLogger(HostedTestSubscriptionServiceAdapter.class);
 
-    private static Map<String, Subscription> idMap = new HashMap<>();
-    private static Map<String, List<Subscription>> ownerMap = new HashMap<>();
-    private static Map<String, List<Subscription>> productMap = new HashMap<>();
+    // Owner mapping. Owners are mapped using owner key to a simplified Owner object containing only
+    // a minimal set of data to be a valid OwnerInfo instance (likely just the key itself)
+    protected Map<String, Owner> ownerMap;
 
-    @Override
-    public List<Subscription> getSubscriptions(Owner owner) {
-        if (ownerMap.containsKey(owner.getKey())) {
-            return ownerMap.get(owner.getKey());
+    // Subscription mapping. Subscriptions themselves are mapped by subscription ID to DTO. Since
+    // we don't store owners (orgs) at this level, we just maintain a mapping of owner keys
+    // (account) to subscription IDs.
+    protected Map<String, Subscription> subscriptionMap;
+
+    // At the time of writing, upstream product and content data is global; no need to separate these
+    // by org. Mapped by RHID to DTO
+    protected Map<String, ProductData> productMap;
+    protected Map<String, ContentData> contentMap;
+
+    // These are used to provide reverse lookups from child objects back to their parents
+    protected Map<String, Set<String>> contentProductMap;
+    protected Map<String, Set<String>> productSubscriptionMap;
+
+    /**
+     * Creates a new HostedTestSubscriptionServiceAdapter instance
+     */
+    @Inject
+    public HostedTestSubscriptionServiceAdapter() {
+        this.ownerMap = new ConcurrentHashMap<>();
+
+        this.subscriptionMap = new ConcurrentHashMap();
+
+        this.productMap = new ConcurrentHashMap();
+        this.contentMap = new ConcurrentHashMap();
+
+        this.contentProductMap = new ConcurrentHashMap();
+        this.productSubscriptionMap = new ConcurrentHashMap();
+    }
+
+
+
+    public Subscription createSubscription(Subscription sinfo) {
+        if (sinfo == null) {
+            throw new IllegalArgumentException("sinfo is null");
         }
-        return new ArrayList<>();
+
+        if (StringUtils.isBlank(sinfo.getId())) {
+            throw new IllegalArgumentException("subscription is lacking an identifier: " + sinfo);
+        }
+
+        if (this.subscriptionMap.containsKey(sinfo.getId())) {
+            throw new IllegalStateException("subscription already exists: " + sinfo.getId());
+        }
+
+        // TODO: Add any other subscription validation we want here
+
+        Subscription sdata = new Subscription();
+
+        sdata.setId(sinfo.getId());
+        sdata.setOwner(this.resolveOwner(sinfo.getOwner()));
+
+        sdata.setProduct(this.resolveProduct(sinfo.getProduct()));
+        sdata.setProvidedProducts(this.resolveProducts(sinfo.getProvidedProducts()));
+        sdata.setDerivedProduct(this.resolveProduct(sinfo.getDerivedProduct()));
+        sdata.setDerivedProvidedProducts(this.resolveProducts(sinfo.getDerivedProvidedProducts()));
+
+        sdata.setQuantity(sinfo.getQuantity());
+        sdata.setStartDate(sinfo.getStartDate());
+        sdata.setEndDate(sinfo.getEndDate());
+        sdata.setModified(sinfo.getModified());
+        sdata.setContractNumber(sinfo.getContractNumber());
+        sdata.setAccountNumber(sinfo.getAccountNumber());
+        sdata.setOrderNumber(sinfo.getOrderNumber());
+
+        sdata.setUpstreamPoolId(sinfo.getUpstreamPoolId());
+        sdata.setUpstreamEntitlementId(sinfo.getUpstreamEntitlementId());
+        sdata.setUpstreamConsumerId(sinfo.getUpstreamConsumerId());
+        sdata.setCertificate(this.convertSubscriptionCertificate(sinfo.getCertificate()));
+        sdata.setCdn(this.convertCdn(sinfo.getCdn()));
+        sdata.setBranding(this.resolveBranding(sinfo.getBranding()));
+
+        // Update mappings
+        this.subscriptionMap.put(sdata.getId(), sdata);
+        this.updateSubscriptionProductMappings(sdata);
+
+        return sdata;
+    }
+
+
+    public Subscription updateSubscription(String subscriptionId, Subscription sinfo) {
+        if (subscriptionId == null) {
+            throw new IllegalArgumentException("subscriptionId is null");
+        }
+
+        if (sinfo == null) {
+            throw new IllegalArgumentException("sinfo is null");
+        }
+
+        Subscription sdata = this.subscriptionMap.get(subscriptionId);
+
+        if (sdata == null) {
+            throw new IllegalStateException("subscription does not exist: " + subscriptionId);
+        }
+
+        // Apply updates...
+
+        // Do product resolution here
+        ProductData product = this.resolveProduct(sinfo.getProduct());
+        Collection<ProductData> providedProducts = this.resolveProducts(sinfo.getProvidedProducts());
+
+        ProductData dProduct = this.resolveProduct(sinfo.getDerivedProduct());
+        Collection<ProductData> dpProvidedProducts = this.resolveProducts(sinfo.getDerivedProvidedProducts());
+
+        // If they all resolved, set the products
+        if (product != null) {
+            sdata.setProduct(product);
+        }
+
+        if (providedProducts != null) {
+            sdata.setProvidedProducts(providedProducts);
+        }
+
+        sdata.setDerivedProduct(dProduct);
+
+        if (dpProvidedProducts != null) {
+            sdata.setDerivedProvidedProducts(dpProvidedProducts);
+        }
+
+        // Set the other "safe" properties here...
+        if (sinfo.getOwner() != null) {
+            sdata.setOwner(this.resolveOwner(sinfo.getOwner()));
+        }
+
+        if (sinfo.getQuantity() != null) {
+            sdata.setQuantity(sinfo.getQuantity());
+        }
+
+        if (sinfo.getStartDate() != null) {
+            sdata.setStartDate(sinfo.getStartDate());
+        }
+
+        if (sinfo.getEndDate() != null) {
+            sdata.setEndDate(sinfo.getEndDate());
+        }
+
+        if (sinfo.getModified() != null) {
+            sdata.setModified(sinfo.getModified());
+        }
+
+        if (sinfo.getContractNumber() != null) {
+            sdata.setContractNumber(sinfo.getContractNumber());
+        }
+
+        if (sinfo.getAccountNumber() != null) {
+            sdata.setAccountNumber(sinfo.getAccountNumber());
+        }
+
+        if (sinfo.getOrderNumber() != null) {
+            sdata.setOrderNumber(sinfo.getOrderNumber());
+        }
+
+        if (sinfo.getUpstreamPoolId() != null) {
+            sdata.setUpstreamPoolId(sinfo.getUpstreamPoolId());
+        }
+
+        if (sinfo.getUpstreamEntitlementId() != null) {
+            sdata.setUpstreamEntitlementId(sinfo.getUpstreamEntitlementId());
+        }
+
+        if (sinfo.getUpstreamConsumerId() != null) {
+            sdata.setUpstreamConsumerId(sinfo.getUpstreamConsumerId());
+        }
+
+        sdata.setCertificate(this.convertSubscriptionCertificate(sinfo.getCertificate()));
+
+        sdata.setCdn(this.convertCdn(sinfo.getCdn()));
+
+        if (sinfo.getBranding() != null) {
+            sdata.setBranding(this.resolveBranding(sinfo.getBranding()));
+        }
+
+        // Update mappings...
+        this.updateSubscriptionProductMappings(sdata);
+
+        return sdata;
     }
 
     @Override
-    public List<String> getSubscriptionIds(Owner owner) {
-        List<String> ids = new ArrayList<>();
-        List<Subscription> subscriptions = ownerMap.get(owner.getKey());
-        if (subscriptions != null) {
-            for (Subscription subscription : subscriptions) {
-                ids.add(subscription.getId());
+    public void deleteSubscription(Subscription subscription) {
+        if (subscription != null) {
+            this.deleteSubscription(subscription.getId());
+        }
+    }
+
+    public Subscription deleteSubscription(String subscriptionId) {
+        if (subscriptionId == null) {
+            throw new IllegalArgumentException("subscriptionId is null");
+        }
+
+        if (!this.subscriptionMap.containsKey(subscriptionId)) {
+            throw new IllegalStateException("subscription does not exist: " + subscriptionId);
+        }
+
+        Subscription sdata = this.subscriptionMap.remove(subscriptionId);
+
+        // Remove any product mappings to this subscription...
+        for (Set<String> sids : this.productSubscriptionMap.values()) {
+            sids.remove(subscriptionId);
+        }
+
+        return sdata;
+    }
+
+    public ProductData createProduct(ProductData pinfo) {
+        if (pinfo == null) {
+            throw new IllegalArgumentException("pinfo is null");
+        }
+
+        if (StringUtils.isBlank(pinfo.getId())) {
+            throw new IllegalArgumentException("product is lacking an identifier: " + pinfo);
+        }
+
+        if (this.productMap.containsKey(pinfo.getId())) {
+            throw new IllegalStateException("product already exists: " + pinfo.getId());
+        }
+
+        // TODO: Add any other product validation we want here
+
+        ProductData pdata = new ProductData();
+
+        pdata.setId(pinfo.getId());
+        pdata.setProductContent(this.resolveProductContent(pinfo.getProductContent()));
+        pdata.setName(pinfo.getName());
+        pdata.setMultiplier(pinfo.getMultiplier());
+        pdata.setAttributes(pinfo.getAttributes());
+        pdata.setDependentProductIds(pinfo.getDependentProductIds());
+        pdata.setCreated(new Date());
+        pdata.setUpdated(new Date());
+
+        // Create our mappings...
+        this.productMap.put(pdata.getId(), pdata);
+        this.productSubscriptionMap.put(pdata.getId(), new HashSet<>());
+
+        // Update content=>product mappings
+        this.updateProductContentMappings(pdata);
+
+        return pdata;
+    }
+
+    public ProductData updateProduct(String productId, ProductData pinfo) {
+        if (productId == null) {
+            throw new IllegalArgumentException("productId is null");
+        }
+
+        if (pinfo == null) {
+            throw new IllegalArgumentException("pinfo is null");
+        }
+
+        ProductData pdata = this.productMap.get(productId);
+
+        if (pdata == null) {
+            throw new IllegalStateException("product does not exist: " + productId);
+        }
+
+        // Apply updates...
+        // Don't allow changing the ID
+
+        Collection<ProductContentData> pcdata = this.resolveProductContent(pinfo.getProductContent());
+        if (pcdata != null) {
+            pdata.setProductContent(pcdata);
+        }
+
+        if (pinfo.getName() != null) {
+            pdata.setName(pinfo.getName());
+        }
+
+        if (pinfo.getMultiplier() != null) {
+            pdata.setMultiplier(pinfo.getMultiplier());
+        }
+
+        if (pinfo.getAttributes() != null) {
+            pdata.setAttributes(pinfo.getAttributes());
+        }
+
+        if (pinfo.getDependentProductIds() != null) {
+            pdata.setDependentProductIds(pinfo.getDependentProductIds());
+        }
+
+        // Update product=>content mappings
+        this.updateProductContentMappings(pdata);
+
+        pdata.setUpdated(new Date());
+
+        return pdata;
+    }
+
+    public ProductData deleteProduct(String productId) {
+        if (productId == null) {
+            throw new IllegalArgumentException("productId is null");
+        }
+
+        if (!this.productMap.containsKey(productId)) {
+            throw new IllegalStateException("Product does not exist: " + productId);
+        }
+
+        if (this.productSubscriptionMap.containsKey(productId) &&
+            !this.productSubscriptionMap.get(productId).isEmpty()) {
+
+            throw new IllegalStateException(
+                "Product is still referenced by one or more subscriptions: " + productId);
+        }
+
+        ProductData pdata = this.productMap.remove(productId);
+
+        // Update our mappings...
+        // Impl note: no need to update the subscriptions since we know none are using this product.
+        this.productSubscriptionMap.remove(productId);
+
+        // Update content=>product mappings to no longer reference this product
+        for (Set<String> pids : this.contentProductMap.values()) {
+            pids.remove(productId);
+        }
+
+        return pdata;
+    }
+
+    public Collection<? extends ProductData> listProducts() {
+        return this.productMap.values();
+    }
+
+    public ProductData getProduct(String productId) {
+        if (productId == null) {
+            throw new IllegalArgumentException("productId is null");
+        }
+
+        return this.productMap.get(productId);
+    }
+
+    public ContentData createContent(ContentData cinfo) {
+        if (cinfo == null) {
+            throw new IllegalArgumentException("cinfo is null");
+        }
+
+        if (StringUtils.isBlank(cinfo.getId())) {
+            throw new IllegalArgumentException("content is lacking an identifier: " + cinfo);
+        }
+
+        if (this.contentMap.containsKey(cinfo.getId())) {
+            throw new IllegalStateException("content already exists: " + cinfo.getId());
+        }
+
+        // TODO: Add any other content validation we want here
+
+        // Create a copy of the data so we're guaranteed to be detached from any other object
+        ContentData cdata = new ContentData();
+
+        cdata.setId(cinfo.getId());
+        cdata.setType(cinfo.getType());
+        cdata.setLabel(cinfo.getLabel());
+        cdata.setName(cinfo.getName());
+        cdata.setVendor(cinfo.getVendor());
+        cdata.setContentUrl(cinfo.getContentUrl());
+        cdata.setRequiredTags(cinfo.getRequiredTags());
+        cdata.setReleaseVersion(cinfo.getReleaseVersion());
+        cdata.setGpgUrl(cinfo.getGpgUrl());
+        cdata.setArches(cinfo.getArches());
+        cdata.setMetadataExpire(cinfo.getMetadataExpire());
+        cdata.setModifiedProductIds(cinfo.getModifiedProductIds());
+        cdata.setCreated(new Date());
+        cdata.setUpdated(new Date());
+
+        // Create our mappings...
+        this.contentMap.put(cdata.getId(), cdata);
+        this.contentProductMap.put(cdata.getId(), new HashSet<>());
+
+        return cdata;
+    }
+
+    public ContentData updateContent(String contentId, ContentData cinfo) {
+        if (contentId == null) {
+            throw new IllegalArgumentException("contentId is null");
+        }
+
+        if (cinfo == null) {
+            throw new IllegalArgumentException("cinfo is null");
+        }
+
+        ContentData cdata = this.contentMap.get(contentId);
+
+        if (cdata == null) {
+            throw new IllegalStateException("content does not exist: " + contentId);
+        }
+
+        // Don't allow changing the ID
+
+        if (cinfo.getType() != null) {
+            cdata.setType(cinfo.getType());
+        }
+
+        if (cinfo.getLabel() != null) {
+            cdata.setLabel(cinfo.getLabel());
+        }
+
+        if (cinfo.getName() != null) {
+            cdata.setName(cinfo.getName());
+        }
+
+        if (cinfo.getVendor() != null) {
+            cdata.setVendor(cinfo.getVendor());
+        }
+
+        if (cinfo.getContentUrl() != null) {
+            cdata.setContentUrl(cinfo.getContentUrl());
+        }
+
+        if (cinfo.getRequiredTags() != null) {
+            cdata.setRequiredTags(cinfo.getRequiredTags());
+        }
+
+        if (cinfo.getReleaseVersion() != null) {
+            cdata.setReleaseVersion(cinfo.getReleaseVersion());
+        }
+
+        if (cinfo.getGpgUrl() != null) {
+            cdata.setGpgUrl(cinfo.getGpgUrl());
+        }
+
+        if (cinfo.getArches() != null) {
+            cdata.setArches(cinfo.getArches());
+        }
+
+        if (cinfo.getMetadataExpire() != null) {
+            cdata.setMetadataExpire(cinfo.getMetadataExpire());
+        }
+
+        if (cinfo.getModifiedProductIds() != null) {
+            cdata.setModifiedProductIds(cinfo.getModifiedProductIds());
+        }
+
+        cdata.setUpdated(new Date());
+
+        return cdata;
+    }
+
+    public ContentData deleteContent(String contentId) {
+        if (contentId == null) {
+            throw new IllegalArgumentException("contentId is null");
+        }
+
+        ContentData cdata = this.contentMap.remove(contentId);
+
+        if (cdata == null) {
+            throw new IllegalStateException("content does not exist: " + contentId);
+        }
+
+        // Update every product pointing to this content and update our mappings
+        for (String productId : this.contentProductMap.remove(contentId)) {
+            ProductData pdata = this.productMap.get(productId);
+            pdata.removeContent(contentId);
+        }
+
+        return cdata;
+    }
+
+    public Collection<? extends ContentData> listContent() {
+        return this.contentMap.values();
+    }
+
+    public ContentData getContent(String contentId) {
+        if (contentId == null) {
+            throw new IllegalArgumentException("contentId is null");
+        }
+
+        return this.contentMap.get(contentId);
+    }
+
+    public boolean addContentToProduct(String productId, String contentId, boolean enabled) {
+        if (productId == null) {
+            throw new IllegalArgumentException("productId is null");
+        }
+
+        if (contentId == null) {
+            throw new IllegalArgumentException("contentId is null");
+        }
+
+        ProductData pdata = this.productMap.get(productId);
+        if (pdata == null) {
+            throw new IllegalArgumentException("No such product: " + productId);
+        }
+
+        ContentData cdata = this.contentMap.get(contentId);
+        if (cdata == null) {
+            throw new IllegalArgumentException("No such content: " + contentId);
+        }
+
+        if (pdata.addContent(cdata, enabled)) {
+            this.updateProductContentMappings(pdata);
+            return true;
+        }
+
+        return false;
+    }
+
+    public boolean removeContentFromProduct(String productId, String contentId) {
+        if (productId == null) {
+            throw new IllegalArgumentException("productId is null");
+        }
+
+        if (contentId == null) {
+            throw new IllegalArgumentException("contentId is null");
+        }
+
+        ProductData pdata = this.productMap.get(productId);
+        if (pdata == null) {
+            throw new IllegalArgumentException("No such product: " + productId);
+        }
+
+        ContentData cdata = this.contentMap.get(contentId);
+        if (cdata == null) {
+            throw new IllegalArgumentException("No such content: " + contentId);
+        }
+
+        if (pdata.removeContent(contentId)) {
+            this.updateProductContentMappings(pdata);
+            return true;
+        }
+
+        return false;
+    }
+
+
+    protected void updateSubscriptionProductMappings(Subscription sdata) {
+        if (sdata == null) {
+            throw new IllegalArgumentException("sdata is null");
+        }
+
+        if (StringUtils.isBlank(sdata.getId())) {
+            throw new IllegalArgumentException("subscription lacks identifying information: " + sdata);
+        }
+
+        // Compile list of products this subscription uses...
+        Set<String> pids = new HashSet<>();
+
+        if (sdata.getProduct() != null && sdata.getProduct().getId() != null) {
+            pids.add(sdata.getProduct().getId());
+        }
+
+        if (sdata.getProvidedProducts() != null) {
+            for (ProductData pdata : sdata.getProvidedProducts()) {
+                if (pdata != null && pdata.getId() != null) {
+                    pids.add(pdata.getId());
+                }
             }
         }
 
-        return ids;
-    }
-
-    @Override
-    public List<Subscription> getSubscriptions(ProductData product) {
-        if (productMap.containsKey(product.getId())) {
-            return productMap.get(product.getId());
+        if (sdata.getDerivedProduct() != null && sdata.getDerivedProduct().getId() != null) {
+            pids.add(sdata.getDerivedProduct().getId());
         }
-        return new ArrayList<>();
+
+        if (sdata.getDerivedProvidedProducts() != null) {
+            for (ProductData pdata : sdata.getDerivedProvidedProducts()) {
+                if (pdata != null && pdata.getId() != null) {
+                    pids.add(pdata.getId());
+                }
+            }
+        }
+
+        // Sanity check: Make sure every pid we're refrencing is one we're tracking. This shouldn't
+        // ever fail, but if it does, something very bad has happened.
+        for (String pid : pids) {
+            if (!this.productMap.containsKey(pid)) {
+                throw new IllegalStateException("unknown/unexpected product id: " + pid);
+            }
+
+            if (!this.productSubscriptionMap.containsKey(pid)) {
+                throw new IllegalStateException("product=>subscription map lacks table for product: " + pid);
+            }
+        }
+
+        // Step through our mapped products and either add the subscription or remove it depending
+        // on if the product ID exists in our compiled map
+        for (Map.Entry<String, Set<String>> entry : this.productSubscriptionMap.entrySet()) {
+            String pid = entry.getKey();
+            Set<String> sids = entry.getValue();
+
+            if (pids.contains(pid)) {
+                sids.add(sdata.getId());
+            }
+            else {
+                sids.remove(sdata.getId());
+            }
+        }
     }
 
-    @Override
-    public Subscription getSubscription(String subscriptionId) {
-        return idMap.get(subscriptionId);
+    protected void updateProductContentMappings(ProductData pdata) {
+        if (pdata == null) {
+            throw new IllegalArgumentException("pdata is null");
+        }
+
+        if (StringUtils.isBlank(pdata.getId())) {
+            throw new IllegalArgumentException("product lacks identifying information: " + pdata);
+        }
+
+        // Compile list of content this product uses...
+        Set<String> cids = new HashSet<>();
+
+        if (pdata.getProductContent() != null) {
+            for (ProductContentData pcdata : pdata.getProductContent()) {
+                if (pcdata != null) {
+                    ContentData cdata = pcdata.getContent();
+
+                    if (cdata != null && cdata.getId() != null) {
+                        cids.add(cdata.getId());
+                    }
+                }
+            }
+        }
+
+        // Sanity check: Make sure every cid we're refrencing is one we're tracking. This shouldn't
+        // ever fail, but if it does, something very bad has happened.
+        for (String cid : cids) {
+            if (!this.contentMap.containsKey(cid)) {
+                throw new IllegalStateException("unknown/unexpected content id: " + cid);
+            }
+
+            if (!this.contentProductMap.containsKey(cid)) {
+                throw new IllegalStateException("content=>product map lacks table for content: " + cid);
+            }
+        }
+
+        // Step through our mapped content and either add the product or remove it depending
+        // on if the content ID exists in our compiled set
+        for (Map.Entry<String, Set<String>> entry : this.contentProductMap.entrySet()) {
+            String cid = entry.getKey();
+            Set<String> pids = entry.getValue();
+
+            if (cids.contains(cid)) {
+                pids.add(pdata.getId());
+            }
+            else {
+                pids.remove(pdata.getId());
+            }
+        }
     }
 
+
+    protected Owner resolveOwner(Owner oinfo) {
+        if (oinfo == null || StringUtils.isBlank(oinfo.getKey())) {
+            throw new IllegalArgumentException("owner is null or lacks an owner key");
+        }
+
+        Owner owner = this.ownerMap.get(oinfo.getKey());
+
+        if (owner == null) {
+            owner = new Owner(oinfo.getKey());
+            this.ownerMap.put(owner.getKey(), owner);
+        }
+
+        return owner;
+    }
+
+    protected ProductData resolveProduct(ProductData pinfo) {
+        if (pinfo != null) {
+            if (StringUtils.isBlank(pinfo.getId())) {
+                throw new IllegalArgumentException("product lacks an identifier: " + pinfo);
+            }
+
+            ProductData pdata = this.productMap.get(pinfo.getId());
+            if (pdata == null) {
+                throw new IllegalStateException("product does not exist: " + pinfo.getId());
+            }
+
+            return pdata;
+        }
+
+        return null;
+    }
+
+    protected Collection<ProductData> resolveProducts(Collection<? extends ProductData> products) {
+        if (products != null) {
+            Map<String, ProductData> output = new HashMap<>();
+
+            for (ProductData pinfo : products) {
+                ProductData pdata = this.resolveProduct(pinfo);
+
+                if (pdata != null) {
+                    output.put(pdata.getId(), pdata);
+                }
+            }
+
+            return output.values();
+        }
+
+        return null;
+    }
+
+    protected Collection<ProductContentData> resolveProductContent(
+        Collection<? extends ProductContentData> productContent) {
+
+        if (productContent != null) {
+            Map<String, ProductContentData> output = new HashMap<>();
+
+            for (ProductContentData pcinfo : productContent) {
+                if (pcinfo != null) {
+                    ContentData cinfo = pcinfo.getContent();
+
+                    if (cinfo == null || StringUtils.isBlank(cinfo.getId())) {
+                        throw new IllegalArgumentException(
+                            "content is null or lacks an identifier: " + cinfo);
+                    }
+
+                    ContentData cdata = this.contentMap.get(cinfo.getId());
+
+                    if (cdata == null) {
+                        throw new IllegalStateException("content does not exist: " + cinfo.getId());
+                    }
+
+                    ProductContentData pcdata = new ProductContentData();
+                    pcdata.setContent(cdata);
+                    pcdata.setEnabled(pcinfo.isEnabled() != null ?
+                        pcinfo.isEnabled() :
+                        ProductContent.DEFAULT_ENABLED_STATE);
+
+                    output.put(cinfo.getId(), pcdata);
+                }
+            }
+
+            return output.values();
+        }
+
+        return null;
+    }
+
+    protected Set<Branding> resolveBranding(Collection<? extends Branding> branding) {
+        if (branding != null) {
+            Map<String, Branding> brandMap = new HashMap<>();
+
+            // We don't bother keeping cross-subscription references here, so the only thing
+            // we are really concerned with is making sure we don't end up with two brands
+            // for the same product.
+
+            for (Branding binfo : branding) {
+                // Silently ignore null refs
+                if (binfo != null) {
+                    if (binfo.getProductId() == null || binfo.getProductId().isEmpty()) {
+                        throw new IllegalArgumentException("Branding lacks a product ID: " + binfo);
+                    }
+
+                    Branding bdata = new Branding();
+
+                    bdata.setProductId(binfo.getProductId());
+                    bdata.setType(binfo.getType());
+                    bdata.setName(binfo.getName());
+
+                    brandMap.put(bdata.getProductId(), bdata);
+                }
+            }
+
+            return new HashSet<>(brandMap.values());
+        }
+
+        return null;
+    }
+
+    protected Cdn convertCdn(Cdn cinfo) {
+        if (cinfo != null) {
+            if (cinfo.getName() == null || cinfo.getName().isEmpty()) {
+                throw new IllegalArgumentException("Cdn lacks a name: " + cinfo);
+            }
+
+            Cdn cdata = new Cdn();
+
+            cdata.setName(cinfo.getName());
+            cdata.setLabel(cinfo.getLabel());
+            cdata.setUrl(cinfo.getUrl());
+            cdata.setCertificate(this.convertCdnCertificate(cinfo.getCertificate()));
+
+            return cdata;
+        }
+
+        return null;
+    }
+
+    protected CdnCertificate convertCdnCertificate(CdnCertificate cinfo) {
+        if (cinfo != null) {
+            CdnCertificate cert = new CdnCertificate();
+
+            cert.setKey(cinfo.getKey());
+            cert.setCert(cinfo.getCert());
+
+            if (cinfo.getSerial() != null) {
+                CertificateSerial serialInfo = cinfo.getSerial();
+                CertificateSerial serial = new CertificateSerial();
+
+                BigInteger bigSerial = serialInfo.getSerial();
+                serial.setSerial(bigSerial != null ? bigSerial.longValue() : 0L);
+                serial.setRevoked(serialInfo.isRevoked());
+                serial.setCollected(serialInfo.isCollected());
+                serial.setExpiration(serialInfo.getExpiration());
+
+                cert.setSerial(serial);
+            }
+
+            return cert;
+        }
+
+        return null;
+    }
+
+    protected SubscriptionsCertificate convertSubscriptionCertificate(SubscriptionsCertificate cinfo) {
+        if (cinfo != null) {
+            SubscriptionsCertificate cert = new SubscriptionsCertificate();
+
+            cert.setKey(cinfo.getKey());
+            cert.setCert(cinfo.getCert());
+
+            if (cinfo.getSerial() != null) {
+                CertificateSerial serialInfo = cinfo.getSerial();
+                CertificateSerial serial = new CertificateSerial();
+
+                BigInteger bigSerial = serialInfo.getSerial();
+                serial.setSerial(bigSerial != null ? bigSerial.longValue() : 0L);
+                serial.setRevoked(serialInfo.isRevoked());
+                serial.setCollected(serialInfo.isCollected());
+                serial.setExpiration(serialInfo.getExpiration());
+
+                cert.setSerial(serial);
+            }
+
+            return cert;
+        }
+
+        return null;
+    }
+
+
+
+    /**
+     * Clears all data for this service adapter
+     */
+    public void clearData() {
+        this.ownerMap.clear();
+        this.subscriptionMap.clear();
+        this.productMap.clear();
+        this.contentMap.clear();
+        this.contentProductMap.clear();
+        this.productSubscriptionMap.clear();
+    }
+
+
+
+    // Service adapter interface methods
+
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public List<Subscription> getSubscriptions() {
-        List<Subscription> result = new ArrayList<>();
-        for (String id : idMap.keySet()) {
-            result.add(idMap.get(id));
-        }
-        return result;
+        return new LinkedList(this.subscriptionMap.values());
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Subscription getSubscription(String subscriptionId) {
+        return this.subscriptionMap.get(subscriptionId);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<Subscription> getSubscriptions(Owner owner) {
+        String ownerKey = owner != null ? owner.getKey() : null;
+
+        if (ownerKey != null) {
+            return this.subscriptionMap.values()
+                .stream()
+                .filter(s -> s.getOwner() != null && ownerKey.equals(s.getOwner().getKey()))
+                .collect(Collectors.toList());
+        }
+
+        return Collections.emptyList();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<String> getSubscriptionIds(Owner owner) {
+        String ownerKey = owner != null ? owner.getKey() : null;
+
+        if (ownerKey != null) {
+            return this.subscriptionMap.values()
+                .stream()
+                .filter(s -> s.getOwner() != null && ownerKey.equals(s.getOwner().getKey()))
+                .map(s -> s.getId())
+                .collect(Collectors.toList());
+        }
+
+        return Collections.emptyList();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<Subscription> getSubscriptions(ProductData pdata) {
+        String productId = pdata != null ? pdata.getId() : null;
+
+        if (productId != null) {
+            Predicate<Subscription> predicate = sub -> {
+                if (sub.getProduct() != null && productId.equals(sub.getProduct().getId())) {
+                    return true;
+                }
+
+                if (sub.getProvidedProducts() != null) {
+                    for (ProductData product : sub.getProvidedProducts()) {
+                        if (product != null && productId.equals(product.getId())) {
+                            return true;
+                        }
+                    }
+                }
+
+                return false;
+            };
+
+            return this.subscriptionMap.values()
+                .stream()
+                .filter(predicate)
+                .collect(Collectors.toList());
+        }
+
+        return Collections.emptyList();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public boolean hasUnacceptedSubscriptionTerms(Owner owner) {
         return false;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void sendActivationEmail(String subscriptionId) {
         // method intentionally left blank
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public boolean canActivateSubscription(Consumer consumer) {
         return false;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void activateSubscription(Consumer consumer, String email, String emailLocale) {
         // method intentionally left blank
     }
 
-    @Override
-    public Subscription createSubscription(Subscription s) {
-        idMap.put(s.getId(), s);
-        if (!ownerMap.containsKey(s.getOwner().getKey())) {
-            ownerMap.put(s.getOwner().getKey(), new ArrayList<>());
-        }
-        ownerMap.get(s.getOwner().getKey()).add(s);
-        if (!productMap.containsKey(s.getProduct().getId())) {
-            productMap.put(s.getProduct().getId(), new ArrayList<>());
-        }
-
-        this.clearUuids(s.getProduct());
-        this.clearUuids(s.getDerivedProduct());
-
-        if (CollectionUtils.isNotEmpty(s.getProvidedProducts())) {
-            for (ProductData pdata : s.getProvidedProducts()) {
-                this.clearUuids(pdata);
-            }
-        }
-
-        if (CollectionUtils.isNotEmpty(s.getDerivedProvidedProducts())) {
-            for (ProductData pdata : s.getDerivedProvidedProducts()) {
-                this.clearUuids(pdata);
-            }
-        }
-
-        productMap.get(s.getProduct().getId()).add(s);
-        return s;
-    }
-
-    private void clearUuids(ProductData pdata) {
-        if (pdata != null) {
-            pdata.setUuid(null);
-            if (pdata.getProductContent() != null) {
-                for (ProductContentData pcdata : pdata.getProductContent()) {
-                    if (pcdata.getContent() != null) {
-                        pcdata.getContent().setUuid(null);
-                    }
-                }
-            }
-        }
-    }
-
-    public Subscription updateSubscription(Subscription ss) {
-        deleteSubscription(ss.getId());
-        Subscription s = createSubscription(ss);
-        return s;
-    }
-
-    @Override
-    public void deleteSubscription(Subscription s) {
-        deleteSubscription(s.getId());
-    }
-
-    public boolean deleteSubscription(String id) {
-        if (idMap.containsKey(id)) {
-            Subscription s = idMap.remove(id);
-            ownerMap.get(s.getOwner().getKey()).remove(s);
-            productMap.get(s.getProduct().getId()).remove(s);
-            return true;
-        }
-        return false;
-    }
-
-    public void deleteAllSubscriptions() {
-        idMap.clear();
-        ownerMap.clear();
-        productMap.clear();
-    }
-
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public boolean isReadOnly() {
         return false;


### PR DESCRIPTION
- The HostedTestSubscriptionResource and ServiceAdapter are now
  completely isolated from the locally managed products and
  content
- Updated the hosted test API to allow for directly updating
  products, content and subscriptions independently from their
  downstream counterparts
- Updated several spec tests to utilize the separation between
  up and downstream product/content definitions