### PR TITLE
Do not share one content with several products.

### DIFF
--- a/server/bin/create_test_repos.py
+++ b/server/bin/create_test_repos.py
@@ -129,6 +129,34 @@ def read_test_data(filename):
     return data
 
 
+def find_content(content_definitions, content_id):
+    """
+    Try to find content with specified content_id
+    """
+
+    for content in content_definitions:
+        if content['id'] == content_id:
+            return content
+
+    return None
+
+
+def create_repo_definition(product, content):
+    """
+    Create definition of repository from definition of content. Note: Definitions of
+    content are shared between several products in test data.
+    """
+    repo_definition = {
+        'name': product['id'] + '-' + content['name'],
+        'product_id': product['id'],
+        'type': content['type'],
+        'content_url': os.path.join(content['content_url'], product['id']),
+        'gpg_url': content.get('gpg_url', ""),
+        'packages': content.get('packages', [])
+    }
+    return repo_definition
+
+
 def get_repo_definitions(test_data):
     """
     Get list of repositories from test_data
@@ -137,11 +165,26 @@ def get_repo_definitions(test_data):
     if test_data is None:
         return []
 
+    repo_definitions = []
+
     try:
-        repo_definitions = test_data['content']
+        content_definitions = test_data['content']
     except KeyError as err:
-        print('Info: Test data does not include any global definition of repositories')
-        repo_definitions = []
+        print('Info: Test data does not include any global definition of content')
+        content_definitions = []
+
+    # There can be some "global" definitions of content shared between several products
+    content_definitions = test_data.get('content', [])
+    for product in test_data['products']:
+        product_contents = product.get('content', [])
+        for prod_cont in product_contents:
+            content_id = prod_cont[0]
+            content = find_content(content_definitions, content_id)
+            if content is None:
+                print("Info: unable to find content_id: %s in definition of product: %s" % (content_id, product['name']))
+                continue
+            repo = create_repo_definition(product, content)
+            repo_definitions.append(repo)
 
     # There can be also some content specific for owners
     try:
@@ -151,11 +194,27 @@ def get_repo_definitions(test_data):
     
     for owner in owners:
         try:
-            owner_content = owner['content']
+            owner_contents = owner['content']
         except KeyError as err:
             continue
-        else:
-            repo_definitions.extend(owner_content)
+
+        try:
+            owner_products = owner['products']
+        except KeyError as err:
+            continue
+
+        for product in owner_products:
+            owners_repos = []
+            product_contents = product.get('content', [])
+            for prod_cont in product_contents:
+                content_id = prod_cont[0]
+                content = find_content(owner_contents, content_id)
+                if content is None:
+                    print("Info: unable to find content_id: %s in definition of product: %s" % (content_id, product['name']))
+                    continue
+                repo = create_repo_definition(product, content)
+                owners_repos.append(repo)
+            repo_definitions.extend(owners_repos)
     
     return repo_definitions
 
@@ -264,11 +323,6 @@ def generate_repositories(repo_definitions, package_definitions):
         # Create repository with RPM packages
         run_command('createrepo_c %s' % repo_path)
 
-        # Try to create temporary product on candlepin server
-        ret = create_repo_product(repo)
-        if ret is None:
-            continue
-
         # Try to get product certificate from candlepin server and add it to repository
         cert = get_productid_cert(repo)
         if cert is not None:
@@ -280,9 +334,6 @@ def generate_repositories(repo_definitions, package_definitions):
             run_command('modifyrepo_c productid %s/repodata' % repo_path)
             # Remove temporary cert file
             os.remove('productid')
-
-        # Remove temporary product from candelpin server
-        #remove_repo_product(repo)
 
     # Copy exported file to root of repositories
     gpg_key_path = os.path.join(REPO_ROOT_DIR, "RPM-GPG-KEY-candlepin")
@@ -296,11 +347,11 @@ def generate_repositories(repo_definitions, package_definitions):
     owner_names = get_owners()
     generate_symlinks_for_owners(owner_names)
 
-def get_productid_cert(content, owner='admin'):
+def get_productid_cert(repo_definition, owner='admin'):
     """
-    This function tries to get product-id certificate for given repository (content)
+    This function tries to get product-id certificate for given repository
     """
-    product_id = content['id']
+    product_id = repo_definition['product_id']
 
     try:
         r = requests.get(
@@ -322,82 +373,6 @@ def get_productid_cert(content, owner='admin'):
         return None
 
     return cert
-
-
-def create_repo_product(content, owner="admin"):
-    """
-    This function tries to create temporary product for getting product-id certificate.
-    We need to create certificate with id that contains only one content and id of
-    product is equal to id of content.
-    """
-
-    # Name and ID have to be in specification of content
-    name = content['name']
-    content_id = product_id = content['id']
-    # Other attributes are optional in definition of content and have default values
-    arches = content.get('arches', 'noarch')
-    version = content.get('version', '1.0')
-
-    request_data = {
-        'name': name,
-        'id': product_id,
-        'multiplier': 1,
-        'attributes': {
-            'arch': arches,
-            'version': version,
-            'variant': 'ALL',
-            'type': 'SVC'
-        },
-        'dependentProductIds': [],
-        'reliesOn': []
-    }
-
-    # Create product itself
-    try:
-        r = requests.post(
-            CANLDEPIN_SERVER_BASE_URL + 'owners/' + owner + '/products',
-            json=request_data,
-            auth=(CANDLEPIN_USER, CANDLEPIN_PASS),
-            verify=False)
-    except Exception as err:
-        print('Error: %s' % str(err))
-        return None
-
-    request_data = {
-        'enabled': True
-    }
-
-    # Add content to this product
-    try:
-        r = requests.post(
-            CANLDEPIN_SERVER_BASE_URL + 'owners/' + owner + '/products/' + str(product_id) + '/content/' + str(content_id),
-            json=request_data,
-            auth=(CANDLEPIN_USER, CANDLEPIN_PASS),
-            verify=False
-            )
-    except Exception as err:
-        print('Error: %s' % str(err))
-        return None
-
-    return r
-
-
-def remove_repo_product(content, owner='admin'):
-    """
-    This function tries to remove temporary products from candlepin server
-    """
-    product_id = content['id']
-
-    try:
-        r = requests.delete(
-            CANLDEPIN_SERVER_BASE_URL + 'owners/' + owner + '/products/' + str(product_id),
-            auth=(CANDLEPIN_USER, CANDLEPIN_PASS),
-            verify=False)
-    except Exception as err:
-        print('Error: %s' % str(err))
-        return None
-
-    return r
 
 
 def get_package_definitions(test_data):

--- a/server/bin/import_test_data.rb
+++ b/server/bin/import_test_data.rb
@@ -125,7 +125,7 @@ thread_pool.shutdown
 
 
 def create_content(cp, owner, product, content)
-  print "#{owner['name']}/#{product['id']}/#{content['name']}\n"
+  print "\t content: #{owner['name']}/#{content['name']}/#{product['id']}\n"
 
   params = {}
   modified_products = content['modified_products'] || []

--- a/server/bin/test_data.json
+++ b/server/bin/test_data.json
@@ -357,7 +357,7 @@
             "vendor": "Red Hat",
             "content_url": "/path/to/awesomeos-docker-images",
             "gpg_url": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
-            "packages": ["awesome-sheep", "flying-fish"]
+            "packages": []
         },
         {
             "name": "awesomeos-ostree",
@@ -367,7 +367,7 @@
             "vendor": "Red Hat",
             "content_url": "/path/to/awesomeos-ostree",
             "gpg_url": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
-            "packages": ["awesome-sheep", "fluffy-snake"]
+            "packages": []
         }
     ],
     "owners": [
@@ -815,7 +815,7 @@
     ],
     "products": [
         {
-            "name": "Clustering Bits",
+            "name": "Clustering Bits (no content)",
             "id": "37065",
             "attributes": {
                     "sockets": 2,
@@ -824,7 +824,7 @@
             "content": []
         },
         {
-            "name": "Load Balancing Bits",
+            "name": "Load Balancing Bits (no content)",
             "id": "37070",
             "attributes": {
                 "sockets": 2,
@@ -834,7 +834,7 @@
             "content": []
         },
         {
-            "name": "Shared Storage Bits",
+            "name": "Shared Storage Bits (no content)",
             "id": "37067",
             "attributes": {
                 "sockets": 2,
@@ -844,7 +844,7 @@
             "content": []
         },
         {
-            "name": "Large File Support Bits",
+            "name": "Large File Support Bits (no content)",
             "id": "37068",
             "attributes": {
                 "sockets": 2,
@@ -854,7 +854,7 @@
             "content": []
         },
         {
-            "name": "Management Bits",
+            "name": "Management Bits (no content)",
             "id": "37069",
             "attributes": {
                 "sockets": 2,
@@ -864,7 +864,7 @@
             "content": []
         },
         {
-            "name": "Shared File System Bits",
+            "name": "Shared File System Bits (no content)",
             "id": "88888",
             "attributes": {
                 "sockets": 1,
@@ -891,7 +891,7 @@
             ]
         },
         {
-            "name": "Awesome Hypervisor Bits",
+            "name": "Awesome Hypervisor Bits (no content)",
             "id": "98121",
             "version": "6.1",
             "attributes": {
@@ -1021,7 +1021,7 @@
             }
         },
         {
-            "name": "Awesome OS Server Basic (dc-virt)",
+            "name": "Awesome OS Server Basic (dc-virt, no content)",
             "id": "awesomeos-server-basic-vdc",
             "type": "MKT",
             "version": "0.1",
@@ -1393,7 +1393,7 @@
             ]
         },
         {
-            "name": "Awesome OS for All Arch (excpt for x86_64 content)",
+            "name": "Awesome OS for All Arch (except for x86_64 content)",
             "id": "awesomeos-all-no-86_64-cont",
             "version": "3.11",
             "arch": "ALL",
@@ -1718,7 +1718,7 @@
             }
         },
         {
-            "name": "Awesome OS Super Hypervisor",
+            "name": "Awesome OS Super Hypervisor (no content)",
             "id": "awesomeos-super-hypervisor",
             "version": "6.1",
             "type": "MKT",

--- a/server/bin/test_data.json
+++ b/server/bin/test_data.json
@@ -63,6 +63,14 @@
         {
             "name": "fluffy-snake",
             "version": "1"
+        },
+        {
+            "name": "awesome-dummy-docker-conf",
+            "version": "1"
+        },
+        {
+            "name": "awesome-dummy-ostree-conf",
+            "version": "1"
         }
     ],
     "content": [
@@ -357,7 +365,7 @@
             "vendor": "Red Hat",
             "content_url": "/path/to/awesomeos-docker-images",
             "gpg_url": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
-            "packages": []
+            "packages": ["awesome-dummy-docker-conf"]
         },
         {
             "name": "awesomeos-ostree",
@@ -367,7 +375,7 @@
             "vendor": "Red Hat",
             "content_url": "/path/to/awesomeos-ostree",
             "gpg_url": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
-            "packages": []
+            "packages": ["awesome-dummy-ostree-conf"]
         }
     ],
     "owners": [

--- a/server/bin/test_data.json
+++ b/server/bin/test_data.json
@@ -71,6 +71,10 @@
         {
             "name": "awesome-dummy-ostree-conf",
             "version": "1"
+        },
+        {
+            "name": "awesome-dummy-deb",
+            "version": "1"
         }
     ],
     "content": [
@@ -376,6 +380,16 @@
             "content_url": "/path/to/awesomeos-ostree",
             "gpg_url": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
             "packages": ["awesome-dummy-ostree-conf"]
+        },
+        {
+            "name": "awesomeos-deb",
+            "id": 3901,
+            "label": "awesomeos-deb",
+            "type": "deb",
+            "vendor": "Foo Vendor",
+            "content_url": "/path/to/awesomeos-deb",
+            "gpg_url": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
+            "packages": ["awesome-dummy-deb"]
         }
     ],
     "owners": [
@@ -907,8 +921,7 @@
                 "vcpu": 4,
                 "warning_period": 30
             },
-            "content": [
-            ]
+            "content": []
         },
         {
             "name": "Awesome OS Instance Server Bits",
@@ -988,6 +1001,21 @@
             "type": "MKT",
             "provided_products": [
                 "37080"
+            ]
+        },
+        {
+            "name": "Awesome OS Debian Bits",
+            "id": "38070",
+            "content": [
+                [3901, true]
+            ]
+        },
+        {
+            "name": "Awesome OS Debian Bits",
+            "id": "awesomeos-debian",
+            "type": "MKT",
+            "provided_products": [
+                "38070"
             ]
         },
         {
@@ -1927,17 +1955,16 @@
             ]
         },
         {
-            "name": "Multi-Attribute Limited Product",
+            "name": "Multi-Attribute Limited Product (no content)",
             "id": "900",
             "version": "1.0",
             "arch": "x86_64",
             "attributes": {
             },
-            "content": [
-            ]
+            "content": []
         },
         {
-            "name": "Multi-Attribute Stackable (2 sockets)",
+            "name": "Multi-Attribute Stackable (2 sockets, no content)",
             "id": "sock2-multiattr",
             "type": "MKT",
             "attributes": {
@@ -1953,7 +1980,7 @@
             ]
         },
         {
-            "name": "Multi-Attribute Stackable (4 cores)",
+            "name": "Multi-Attribute Stackable (4 cores, no content)",
             "id": "cores4-multiattr",
             "type": "MKT",
             "attributes": {
@@ -1968,7 +1995,7 @@
             ]
         },
         {
-            "name": "Multi-Attribute Stackable (2 GB)",
+            "name": "Multi-Attribute Stackable (2 GB, no content)",
             "id": "ram2-multiattr",
             "type": "MKT",
             "attributes": {
@@ -1983,7 +2010,7 @@
             ]
         },
         {
-            "name": "Multi-Attribute Stackable (2 GB, 2 Cores)",
+            "name": "Multi-Attribute Stackable (2 GB, 2 Cores, no content)",
             "id": "2cores-2ram-multiattr",
             "type": "MKT",
             "attributes": {
@@ -1999,7 +2026,7 @@
             ]
         },
         {
-            "name": "Multi-Attribute Stackable (16 cores, 4 sockets, 8GB RAM)",
+            "name": "Multi-Attribute Stackable (16 cores, 4 sockets, 8GB RAM, no content)",
             "id": "sock-core-ram-multiattr",
             "type": "MKT",
             "attributes": {
@@ -2017,7 +2044,7 @@
             ]
         },
         {
-            "name": "Multi-Attribute (non-stackable) (6 cores, 8GB)",
+            "name": "Multi-Attribute (non-stackable) (6 cores, 8GB, no content)",
             "id": "non-stacked-6core8ram-multiattr",
             "type": "MKT",
             "attributes": {
@@ -2031,7 +2058,7 @@
             ]
         },
         {
-            "name": "Multi-Attribute (non-stackable) (24 cores, 6 sockets, 8GB RAM)",
+            "name": "Multi-Attribute (non-stackable) (24 cores, 6 sockets, 8GB RAM, no content)",
             "id": "non-stacked-multiattr",
             "type": "MKT",
             "attributes": {
@@ -2047,7 +2074,7 @@
             ]
         },
         {
-            "name": "Multi-Attribute (multi-entitlement only) (8 cores, 4GB)",
+            "name": "Multi-Attribute (multi-entitlement only) (8 cores, 4GB, no content)",
             "id": "non-stacked-8core4ram-multiattr",
             "type": "MKT",
             "attributes": {
@@ -2068,11 +2095,10 @@
             "arch": "x86_64",
             "attributes": {
             },
-            "content": [
-            ]
+            "content": []
         },
         {
-            "name": "Storage Limited (256 TB)",
+            "name": "Storage Limited (256 TB, no content)",
             "id": "storage-limited-256",
             "type": "MKT",
             "multiplier": 256,
@@ -2089,7 +2115,7 @@
             ]
         },
         {
-            "name": "Development SKU Product",
+            "name": "Development SKU Product, no content",
             "id": "dev-sku-product",
             "type": "MKT",
             "skip_pools": "true",


### PR DESCRIPTION
* When some content_id is shared with some product, then modificated
  duplicity of the content is created. ID of content is:
    str(product_id) + str(content_id)
* No temporary products and product certificates are installed
* Modificated a little bit some names of products without any content.
  It helps with testing.
* Definition of content is automatically modified as is illustrated in this snippet:

```json
{
    "contents": [
        {
            "name": "${product_id}-never-enabled-content",
            "id": "${product_id} + 100",
            "label": "${product_id}-never-enabled-content",
            "type": "yum",
            "vendor": "test-vendor",
            "content_url": "/foo/path/never_enabled/${product_id}",
            "gpg_url": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
            "metadata_expire": 600,
            "packages": ["tricky-frog", "slow-eagle", "white-lion"]
        },
    ],
    "products": [
            {
            "name": "Awesome OS Server Bits",
            "id": "37060",
            "version": "6.1",
            "attributes": {
                "sockets": 2,
                "vcpu": 4,
                "warning_period": 30,
                "brand_type": "OS"
            },
            "content": [
                [1111, false],
                [100, false],
            ]
        },
    ]
}
```