### PR TITLE
Cleanup after ENT-849

### DIFF
--- a/server/src/main/java/org/candlepin/async/JobManager.java
+++ b/server/src/main/java/org/candlepin/async/JobManager.java
@@ -587,7 +587,7 @@ public class JobManager {
             return;
         }
         final String principalJson = jobData.getAsString(AsyncJobStatus.PRINCIPAL_KEY);
-        final PrincipalData principal = (PrincipalData) Util.fromJson(principalJson, PrincipalData.class);
+        final PrincipalData principal = Util.fromJson(principalJson, PrincipalData.class);
         ResteasyProviderFactory.pushContext(
             Principal.class,
             new UserPrincipal(principal.getName(), Collections.emptyList(), false));

--- a/server/src/main/java/org/candlepin/async/tasks/ExportJob.java
+++ b/server/src/main/java/org/candlepin/async/tasks/ExportJob.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.async.tasks;
+
+import com.google.inject.Inject;
+import org.apache.log4j.MDC;
+import org.candlepin.async.AsyncJob;
+import org.candlepin.async.JobBuilder;
+import org.candlepin.async.JobDataMap;
+import org.candlepin.async.JobExecutionContext;
+import org.candlepin.async.JobExecutionException;
+import org.candlepin.async.JobManager;
+import org.candlepin.common.filter.LoggingFilter;
+import org.candlepin.controller.ManifestManager;
+import org.candlepin.model.Consumer;
+import org.candlepin.model.Owner;
+import org.candlepin.pinsetter.core.model.JobStatus;
+import org.candlepin.sync.ExportResult;
+import org.candlepin.util.Util;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+/**
+ * A job that generates a compressed file representation of a Consumer. Once the job
+ * has completed, its result data will contain the details of the newly created file
+ * that can be used to download the file.
+ *
+ * @see ExportResult
+ */
+public class ExportJob implements AsyncJob {
+
+    protected static final String CDN_LABEL = "cdn_label";
+    protected static final String WEBAPP_PREFIX = "webapp_prefix";
+    protected static final String API_URL = "api_url";
+    protected static final String EXTENSION_DATA = "extension_data";
+
+    private static final String JOB_KEY = "EXPORT_JOB";
+
+    // Register the job with the JobManager
+    static {
+        JobManager.registerJob(JOB_KEY, ExportJob.class);
+    }
+
+    // NOTE: In order the get the above static block to run when candlepin is initialized,
+    //       we need to wrap the static key access in this method. When 'static final'
+    //       is used, the static block isn't run due to the way java processes them.
+    //
+    //       'public static String' can be used but checkstyle warns against this.
+    // TODO Are we Ok with this?
+    public static String getJobKey() {
+        return JOB_KEY;
+    }
+
+    private static Logger log = LoggerFactory.getLogger(ExportJob.class);
+
+    private ManifestManager manifestManager;
+
+    @Inject
+    public ExportJob(ManifestManager manifestManager) {
+        this.manifestManager = manifestManager;
+    }
+
+    @Override
+    public Object execute(final JobExecutionContext jdata) throws JobExecutionException {
+        final JobDataMap map = jdata.getJobData();
+        final String consumerUuid = map.getAsString(JobStatus.TARGET_ID);
+        final String cdnLabel = map.getAsString(CDN_LABEL);
+        final String webAppPrefix = map.getAsString(WEBAPP_PREFIX);
+        final String apiUrl = map.getAsString(API_URL);
+        final Map<String, String> extensionData = (Map<String, String>) map.get(EXTENSION_DATA);
+
+        log.info("Starting async export for {}", consumerUuid);
+        try {
+            final ExportResult result = manifestManager.generateAndStoreManifest(
+                consumerUuid, cdnLabel, webAppPrefix, apiUrl, extensionData);
+            log.info("Async export complete.");
+            return result;
+        }
+        catch (Exception e) {
+            throw new JobExecutionException(e.getMessage(), e, false);
+        }
+    }
+
+    /**
+     * Schedules the generation of a consumer export. This job starts immediately.
+     *
+     * @param consumer the target consumer
+     * @param cdnLabel the cdn label
+     * @param webAppPrefix the web app prefix
+     * @param apiUrl the api url
+     * @return a JobDetail representing the job to be started.
+     */
+    public static JobBuilder scheduleExport(
+        final Consumer consumer,
+        final Owner owner,
+        final String cdnLabel,
+        final String webAppPrefix,
+        final String apiUrl,
+        final Map<String, String> extensionData
+    ) {
+        return JobBuilder.forJob(JOB_KEY)
+            .setJobGroup("async")
+            .setJobName("export_" + Util.generateUUID())
+            .setJobArgument(JobStatus.OWNER_ID, owner.getKey())
+            .setJobArgument(JobStatus.OWNER_LOG_LEVEL, owner.getLogLevel())
+            .setJobArgument(JobStatus.TARGET_TYPE, JobStatus.TargetType.CONSUMER)
+            .setJobArgument(JobStatus.TARGET_ID, consumer.getUuid())
+            .setJobArgument(CDN_LABEL, cdnLabel)
+            .setJobArgument(WEBAPP_PREFIX, webAppPrefix)
+            .setJobArgument(API_URL, apiUrl)
+            .setJobArgument(EXTENSION_DATA, extensionData)
+            .setJobArgument(JobStatus.CORRELATION_ID, MDC.get(LoggingFilter.CSID_KEY));
+    }
+}

--- a/server/src/main/java/org/candlepin/audit/Event.java
+++ b/server/src/main/java/org/candlepin/audit/Event.java
@@ -205,7 +205,7 @@ public class Event implements Persisted {
     }
 
     public PrincipalData getPrincipal() {
-        return (PrincipalData) Util.fromJson(this.principalStore,
+        return Util.fromJson(this.principalStore,
             PrincipalData.class);
     }
 

--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -1253,7 +1253,7 @@ public class CandlepinPoolManager implements PoolManager {
      * @param guest whose products we want to provide
      * @param host to bind entitlements to
      * @param entitleDate
-     * @param owner
+     * @param ownerId
      * @param serviceLevelOverride
      * @return PoolQuantity list to attempt to attach
      * @throws EntitlementRefusedException if unable to bind

--- a/server/src/main/java/org/candlepin/controller/ManifestManager.java
+++ b/server/src/main/java/org/candlepin/controller/ManifestManager.java
@@ -42,6 +42,8 @@ import org.candlepin.model.ImportRecord;
 import org.candlepin.pinsetter.tasks.ExportJob;
 import org.candlepin.pinsetter.tasks.ImportJob;
 import org.candlepin.model.Owner;
+import org.candlepin.pinsetter.tasks.ManifestCleanerJob;
+import org.candlepin.service.ExportExtensionAdapter;
 import org.candlepin.sync.ConflictOverrides;
 import org.candlepin.sync.ExportCreationException;
 import org.candlepin.sync.ExportResult;
@@ -402,7 +404,7 @@ public class ManifestManager {
     /**
      * Stores the specified manifest import file via the {@link ManifestFileService}.
      *
-     * @param the manifest import {@link File} to store
+     * @param importFile the manifest import {@link File} to store
      * @return the id of the stored manifest file.
      */
     @Transactional

--- a/server/src/main/java/org/candlepin/model/AsyncJobStatus.java
+++ b/server/src/main/java/org/candlepin/model/AsyncJobStatus.java
@@ -53,6 +53,7 @@ public class AsyncJobStatus extends AbstractHibernateObject implements JobExecut
 
     /** Name of the table backing this object in the database */
     public static final String DB_TABLE = "cp2_async_jobs";
+    public static final String PRINCIPAL_KEY = "principal_key";
 
     /** Enum of job states; terminal states represent states at which the job will no longer change */
     public enum JobState {

--- a/server/src/main/java/org/candlepin/sync/Exporter.java
+++ b/server/src/main/java/org/candlepin/sync/Exporter.java
@@ -150,10 +150,6 @@ public class Exporter {
         this.translator = translator;
     }
 
-    public File getFullExport(Consumer consumer) throws ExportCreationException {
-        return getFullExport(consumer, null, null, null, new HashMap<>());
-    }
-
     /**
      * Creates a manifest archive for the target {@link Consumer}.
      *
@@ -286,13 +282,6 @@ public class Exporter {
         return archive;
     }
 
-
-
-    /**
-     * @param out
-     * @param exportDir
-     * @throws IOException
-     */
     private void addFilesToArchive(ZipOutputStream out, int charsToDropFromName,
         File directory) throws IOException {
         for (File file : directory.listFiles()) {

--- a/server/src/main/java/org/candlepin/util/Util.java
+++ b/server/src/main/java/org/candlepin/util/Util.java
@@ -15,15 +15,13 @@
 package org.candlepin.util;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import org.candlepin.model.CuratorException;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.collections.Closure;
 import org.apache.commons.collections.ClosureUtils;
 import org.apache.commons.lang.StringUtils;
+import org.candlepin.model.CuratorException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,7 +38,6 @@ import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.Comparator;
@@ -57,9 +54,6 @@ import java.util.UUID;
  */
 public class Util {
 
-    /**
-     *
-     */
     public static final String UTC_STR = "UTC";
     private static Logger log = LoggerFactory.getLogger(Util.class);
     private static ObjectMapper mapper = new ObjectMapper();
@@ -95,18 +89,6 @@ public class Util {
         return generateUUID().replace("-", "");
     }
 
-    public static <T> List<T> subList(List<T> parentList, int start, int end) {
-        List<T> l = new ArrayList<>();
-        for (int i = start; i < end; i++) {
-            l.add(parentList.get(i));
-        }
-        return l;
-    }
-
-    public static <T> List<T> subList(List<T> parentList, int size) {
-        return subList(parentList, 0, size - 1);
-    }
-
     public static <T> Set<T> asSet(T... values) {
         Set<T> output = new HashSet<>(values.length);
 
@@ -115,13 +97,6 @@ public class Util {
         }
 
         return output;
-    }
-
-    public static Date getFutureDate(int years) {
-        Calendar future = Calendar.getInstance();
-        future.setTime(new Date());
-        future.set(Calendar.YEAR, future.get(Calendar.YEAR) + years);
-        return future.getTime();
     }
 
     public static Date tomorrow() {
@@ -154,30 +129,6 @@ public class Util {
         return calendar.getTime();
     }
 
-    public static Date hoursAgo(int hours) {
-        Calendar calendar = Calendar.getInstance();
-        calendar.add(Calendar.HOUR, hours * -1);
-        return calendar.getTime();
-    }
-
-    public static Date addToFields(int day, int month, int yr) {
-        Calendar calendar = Calendar.getInstance();
-        calendar.add(Calendar.DAY_OF_MONTH, day);
-        calendar.add(Calendar.MONTH, month);
-        calendar.add(Calendar.YEAR, yr);
-        return calendar.getTime();
-    }
-
-    public static Date setToMidnight(Date dt) {
-        Calendar cal = Calendar.getInstance();
-        cal.setTime(dt);
-        cal.set(Calendar.MINUTE, 0);
-        cal.set(Calendar.SECOND, 0);
-        cal.set(Calendar.HOUR_OF_DAY, 0);
-        cal.set(Calendar.MILLISECOND, 0);
-        return cal.getTime();
-    }
-
     public static Date toDate(String dt) {
         SimpleDateFormat fmt = new SimpleDateFormat("MM/dd/yyyy");
         try {
@@ -193,13 +144,6 @@ public class Util {
             throw new IllegalArgumentException(message);
         }
         return value;
-    }
-
-    public static String defaultIfEmpty(String str, String def) {
-        if (str == null || str.trim().length() == 0) {
-            return def;
-        }
-        return str;
     }
 
     public static boolean equals(String str, String str1) {
@@ -239,7 +183,7 @@ public class Util {
     }
 
     public static String capitalize(String str) {
-        char [] chars = str.toCharArray();
+        char[] chars = str.toCharArray();
         chars[0] = Character.toUpperCase(chars[0]);
         return new String(chars);
     }
@@ -295,7 +239,7 @@ public class Util {
         return Math.abs(rnd);
     }
 
-    public static String toBase64(byte [] data) {
+    public static String toBase64(byte[] data) {
         try {
             // to be thread-safe, we should create it from the static method
             // If we don't specify the line separator, it will use CRLF
@@ -370,9 +314,8 @@ public class Util {
         return mapper.writeValueAsString(anObject);
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
-    public static Object fromJson(String json, Class clazz) {
-        Object output = null;
+    public static <T> T fromJson(String json, Class<T> clazz) {
+        T output = null;
         try {
             output = mapper.readValue(json, clazz);
         }

--- a/server/src/test/java/org/candlepin/async/tasks/ExportJobTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/ExportJobTest.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.async.tasks;
+
+import org.candlepin.async.JobBuilder;
+import org.candlepin.async.JobDataMap;
+import org.candlepin.async.JobExecutionContext;
+import org.candlepin.controller.ManifestManager;
+import org.candlepin.model.Consumer;
+import org.candlepin.model.Owner;
+import org.candlepin.pinsetter.core.model.JobStatus;
+import org.candlepin.pinsetter.tasks.BaseJobTest;
+import org.candlepin.sync.ExportResult;
+import org.candlepin.test.TestUtil;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ExportJobTest extends BaseJobTest {
+
+    private static final String CDN_LABEL = "cdn-label";
+    private static final String WEBAPP_PREFIX = "webapp-prefix";
+    private static final String API_URL = "url";
+
+    @Mock
+    private ManifestManager manifestManager;
+    @Mock
+    private JobExecutionContext ctx;
+    private ExportJob job;
+
+    @Before
+    public void setupTest() {
+        super.init();
+        job = new ExportJob(manifestManager);
+        injector.injectMembers(job);
+    }
+
+    @Test
+    public void checkJobDetail() {
+        final Owner owner = TestUtil.createOwner();
+        owner.setId(TestUtil.randomString());
+        final Consumer distributor = TestUtil.createDistributor(owner);
+
+        final Map<String, String> extData = new HashMap<>();
+        extData.put("version", "sat-6.2");
+
+        final JobBuilder detail = ExportJob.scheduleExport(
+            distributor, owner, CDN_LABEL, WEBAPP_PREFIX, API_URL, extData);
+        final Map<String, Object> dataMap = detail.getJobArguments();
+
+        assertEquals(dataMap.get(JobStatus.OWNER_ID), owner.getKey());
+        assertEquals(dataMap.get(JobStatus.TARGET_ID), distributor.getUuid());
+        assertEquals(dataMap.get(JobStatus.TARGET_TYPE), JobStatus.TargetType.CONSUMER);
+        assertEquals(dataMap.get(ExportJob.CDN_LABEL), CDN_LABEL);
+        assertEquals(dataMap.get(ExportJob.WEBAPP_PREFIX), WEBAPP_PREFIX);
+        assertEquals(dataMap.get(ExportJob.API_URL), API_URL);
+        assertEquals(dataMap.get(ExportJob.EXTENSION_DATA), extData);
+    }
+
+    @Test
+    public void ensureJobSuccess() throws Exception {
+        final Owner owner = TestUtil.createOwner();
+        owner.setId(TestUtil.randomString());
+        final Consumer distributor = TestUtil.createDistributor(owner);
+        final String manifestId = "1234";
+        final Map<String, String> extData = new HashMap<>();
+        final ExportResult result = new ExportResult(distributor.getUuid(), manifestId);
+        doReturn(result).when(manifestManager).generateAndStoreManifest(
+            eq(distributor.getUuid()),
+            eq(CDN_LABEL),
+            eq(WEBAPP_PREFIX),
+            eq(API_URL),
+            eq(extData));
+        final JobBuilder detail = ExportJob.scheduleExport(
+            distributor, owner, CDN_LABEL, WEBAPP_PREFIX, API_URL, extData);
+        when(ctx.getJobData()).thenReturn(new JobDataMap(detail.getJobArguments()));
+
+        final Object actualResult = job.execute(ctx);
+
+        assertEquals(result, actualResult);
+        verify(manifestManager).generateAndStoreManifest(
+            eq(distributor.getUuid()),
+            eq(CDN_LABEL),
+            eq(WEBAPP_PREFIX),
+            eq(API_URL),
+            eq(extData));
+
+    }
+
+}

--- a/server/src/test/java/org/candlepin/sync/ExporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/ExporterTest.java
@@ -274,7 +274,7 @@ public class ExporterTest {
             pce, ec, ee, pki, config, exportRules, pprov, dvc, dve, cdnc, cdne, pc, su,
             exportExtensionAdapter, translator);
 
-        File export = e.getFullExport(consumer);
+        File export = e.getFullExport(consumer, null, null, null, new HashMap<>());
 
         // VERIFY
         assertNotNull(export);
@@ -329,7 +329,7 @@ public class ExporterTest {
             pce, ec, ee, pki, config, exportRules, pprov, dvc, dve, cdnc, cdne, pc, su,
             exportExtensionAdapter, translator);
 
-        e.getFullExport(consumer);
+        e.getFullExport(consumer, null, null, null, new HashMap<>());
     }
 
     @Test
@@ -370,7 +370,7 @@ public class ExporterTest {
         Exporter e = new Exporter(ctc, oc, me, ce, cte, re, ece, ecsa, pe, psa,
             pce, ec, ee, pki, config, exportRules, pprov, dvc, dve, cdnc, cdne, pc, su,
             exportExtensionAdapter, translator);
-        File export = e.getFullExport(consumer);
+        File export = e.getFullExport(consumer, null, null, null, new HashMap<>());
 
         // VERIFY
         assertNotNull(export);
@@ -422,7 +422,7 @@ public class ExporterTest {
         Exporter e = new Exporter(ctc, oc, me, ce, cte, re, ece, ecsa, pe, psa,
             pce, ec, ee, pki, config, exportRules, pprov, dvc, dve, cdnc, cdne, pc, su,
             exportExtensionAdapter, translator);
-        File export = e.getFullExport(consumer);
+        File export = e.getFullExport(consumer, null, null, null, new HashMap<>());
 
         // VERIFY
         assertNotNull(export);
@@ -480,7 +480,7 @@ public class ExporterTest {
         Exporter e = new Exporter(ctc, oc, me, ce, cte, re, ece, ecsa, pe, psa,
             pce, ec, ee, pki, config, exportRules, pprov, dvc, dve, cdnc, cdne, pc, su,
             exportExtensionAdapter, translator);
-        File export = e.getFullExport(consumer);
+        File export = e.getFullExport(consumer, null, null, null, new HashMap<>());
 
         verifyContent(export, "export/consumer.json", new VerifyConsumer("consumer.json"));
     }
@@ -544,7 +544,7 @@ public class ExporterTest {
         Exporter e = new Exporter(ctc, oc, me, ce, cte, re, ece, ecsa, pe, psa,
             pce, ec, ee, pki, config, exportRules, pprov, dvc, dve, cdnc, cdne, pc, su,
             exportExtensionAdapter, translator);
-        File export = e.getFullExport(consumer);
+        File export = e.getFullExport(consumer, null, null, null, new HashMap<>());
 
         verifyContent(export, "export/distributor_version/test-dist-ver.json",
             new VerifyDistributorVersion("test-dist-ver.json"));

--- a/server/src/test/java/org/candlepin/util/UtilTest.java
+++ b/server/src/test/java/org/candlepin/util/UtilTest.java
@@ -14,22 +14,17 @@
  */
 package org.candlepin.util;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import org.apache.commons.codec.binary.Base64;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.mockito.ArgumentCaptor;
-import org.slf4j.LoggerFactory;
-
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.Appender;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.commons.codec.binary.Base64;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -37,14 +32,23 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
 import java.text.SimpleDateFormat;
-import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.TimeZone;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 
 /**
@@ -67,71 +71,6 @@ public class UtilTest {
     @Test
     public void testRandomUUIDS() {
         assertNotSame(Util.generateUUID(), Util.generateUUID());
-    }
-
-    @Test
-    @SuppressWarnings("unchecked")
-    public void subListStartEnd() {
-        String[] strs = {"a", "b", "c", "d"};
-        List<String> strings = Arrays.asList(strs);
-        List<String> sub = Util.subList(strings, 1, 3);
-        assertNotNull(sub);
-        assertEquals(2, sub.size());
-        assertEquals("b", sub.get(0));
-        assertEquals("c", sub.get(1));
-    }
-
-    @Test(expected = ArrayIndexOutOfBoundsException.class)
-    @SuppressWarnings("unchecked")
-    public void subListInvalidStart() {
-        String[] strs = {"a", "b", "c", "d"};
-        List<String> strings = Arrays.asList(strs);
-        Util.subList(strings, -1, 3);
-    }
-
-    @Test(expected = ArrayIndexOutOfBoundsException.class)
-    @SuppressWarnings("unchecked")
-    public void subListInvalidEnd() {
-        String[] strs = {"a", "b", "c", "d"};
-        List<String> strings = Arrays.asList(strs);
-        Util.subList(strings, 1, 10);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void subListNull() {
-        Util.subList(null, 0, 10);
-    }
-
-    @Test
-    @SuppressWarnings("unchecked")
-    public void subListSize() {
-        String[] strs = {"a", "b", "c", "d"};
-        List<String> strings = Arrays.asList(strs);
-        List<String> sub = Util.subList(strings, 3);
-        assertNotNull(sub);
-        assertEquals(2, sub.size());
-        assertEquals("a", sub.get(0));
-        assertEquals("b", sub.get(1));
-    }
-
-    @Test
-    @SuppressWarnings("unchecked")
-    public void subListBadSize() {
-        String[] strs = {"a", "b", "c", "d"};
-        List<String> strings = Arrays.asList(strs);
-        List<String> sub = Util.subList(strings, -3);
-        assertNotNull(sub);
-        assertEquals(0, sub.size());
-    }
-
-    @Test
-    public void futureDate() {
-        Calendar c = Calendar.getInstance();
-        c.setTime(new Date());
-        int curyear = c.get(Calendar.YEAR);
-
-        c.setTime(Util.getFutureDate(5));
-        assertFalse(curyear == c.get(Calendar.YEAR));
     }
 
     @Test
@@ -214,63 +153,6 @@ public class UtilTest {
     }
 
     @Test
-    public void hoursAgoSubtractsHoursFromCurrentTime() {
-        Calendar c = Calendar.getInstance();
-        int expectedMinute = c.get(Calendar.MINUTE);
-
-        c.add(Calendar.HOUR_OF_DAY, -26);
-        int expectedDay = c.get(Calendar.DATE);
-        int expectedHour = c.get(Calendar.HOUR_OF_DAY);
-
-        c.setTime(Util.hoursAgo(26));
-        assertEquals(expectedDay, c.get(Calendar.DATE));
-        assertEquals(expectedHour, c.get(Calendar.HOUR_OF_DAY));
-        assertEquals(expectedMinute, c.get(Calendar.MINUTE));
-    }
-
-    @Ignore("This will fail on the last day of each month, or any time after July!")
-    @Test
-    public void addToFields() {
-        Calendar c = Calendar.getInstance();
-        c.setTime(new Date());
-        int curday = c.get(Calendar.DAY_OF_MONTH);
-        int curmonth = c.get(Calendar.MONTH);
-        int curyear = c.get(Calendar.YEAR);
-
-        c.setTime(Util.addToFields(1, 5, 10));
-        assertEquals(curday + 1, c.get(Calendar.DAY_OF_MONTH));
-        assertEquals(curmonth + 5, c.get(Calendar.MONTH));
-        assertEquals(curyear + 10, c.get(Calendar.YEAR));
-
-        // TODO: figure out how to do negatives
-//        c.setTime(Util.addToFields(-40, -13, -99));
-//        assertEquals(curday - 40, c.get(Calendar.DAY_OF_MONTH));
-//        assertEquals(curmonth - 13, c.get(Calendar.MONTH));
-//        assertEquals(curyear - 99, c.get(Calendar.YEAR));
-    }
-
-    @Test
-    public void testSetToMidnight() {
-        Date now = new Date();
-        Date midnight = Util.setToMidnight(now);
-        assertFalse(now.equals(midnight));
-
-        Calendar cal = Calendar.getInstance();
-        cal.setTime(midnight);
-        assertEquals(0, cal.get(Calendar.HOUR_OF_DAY));
-        assertEquals(0, cal.get(Calendar.MINUTE));
-        assertEquals(0, cal.get(Calendar.SECOND));
-        assertEquals(TimeZone.getDefault(), cal.getTimeZone());
-
-        Date stillmidnight = Util.setToMidnight(midnight);
-        cal.setTime(stillmidnight);
-        assertEquals(0, cal.get(Calendar.HOUR_OF_DAY));
-        assertEquals(0, cal.get(Calendar.MINUTE));
-        assertEquals(0, cal.get(Calendar.SECOND));
-        assertEquals(TimeZone.getDefault(), cal.getTimeZone());
-    }
-
-    @Test
     public void toDate() {
         Calendar c = Calendar.getInstance();
         c.setTime(Util.toDate("03/17/2011"));
@@ -321,21 +203,6 @@ public class UtilTest {
         Integer daone = Util.assertNotNull(one, "shouldn't see this");
         assertNotNull(daone);
         assertEquals(one, daone);
-    }
-
-    @Test
-    public void returnDefaultIfNull() {
-        assertEquals("default", Util.defaultIfEmpty(null, "default"));
-    }
-
-    @Test
-    public void returnDefaultIfEmpty() {
-        assertEquals("default", Util.defaultIfEmpty("", "default"));
-    }
-
-    @Test
-    public void returnString() {
-        assertEquals("returnme", Util.defaultIfEmpty("returnme", "default"));
     }
 
     @Test
@@ -436,7 +303,7 @@ public class UtilTest {
     public void json() throws JsonProcessingException {
         String test = "I Love JSON";
         String json = Util.toJson(test);
-        String result = (String) Util.fromJson(json, String.class);
+        String result = Util.fromJson(json, String.class);
         assertEquals(result, test);
     }
 


### PR DESCRIPTION
Cleanup of some dead code and minor issues I found during ENT-849. Please review [ENT-849](https://github.com/candlepin/candlepin/pull/2309) first.
    
- Fix JavaDoc issues with missing qualifiers
- Remove dead code from Exporter
- Make Util.fromJson generic
- Remove redundant casts
- Remove dead code from Util
