### PR TITLE
[F] Added basic support for scheduling jobs (ENT-857)

### DIFF
--- a/buildfile
+++ b/buildfile
@@ -177,7 +177,7 @@ OAUTH= [group('oauth',
               :under => 'net.oauth.core',
               :version => '20100527')]
 
-QUARTZ = 'org.quartz-scheduler:quartz:jar:2.2.1'
+QUARTZ = 'org.quartz-scheduler:quartz:jar:2.2.2'
 
 ACTIVEMQ = [group('artemis-server',
                   'artemis-core-client',

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -101,7 +101,7 @@
     <net.oauth.core-oauth.version>20100527</net.oauth.core-oauth.version>
     <net.oauth.core-oauth-provider.version>20100527</net.oauth.core-oauth-provider.version>
     <javax.servlet-servlet-api.version>2.5</javax.servlet-servlet-api.version>
-    <org.quartz-scheduler-quartz.version>2.2.1</org.quartz-scheduler-quartz.version>
+    <org.quartz-scheduler-quartz.version>2.2.2</org.quartz-scheduler-quartz.version>
     <org.jboss.resteasy-resteasy-jaxrs.version>3.5.1.Final</org.jboss.resteasy-resteasy-jaxrs.version>
     <org.jboss.resteasy-resteasy-jaxb-provider.version>3.5.1.Final</org.jboss.resteasy-resteasy-jaxb-provider.version>
     <org.jboss.resteasy-resteasy-guice.version>3.5.1.Final</org.jboss.resteasy-resteasy-guice.version>

--- a/server/src/main/java/org/candlepin/async/JobDataMap.java
+++ b/server/src/main/java/org/candlepin/async/JobDataMap.java
@@ -49,6 +49,7 @@ public class JobDataMap implements Map<String, Object> {
     /**
      * {@inheritDoc}
      */
+    @Override
     public void clear() {
         this.map.clear();
     }
@@ -56,6 +57,7 @@ public class JobDataMap implements Map<String, Object> {
     /**
      * {@inheritDoc}
      */
+    @Override
     public boolean containsKey(Object key) {
         return this.map.containsKey(key);
     }
@@ -63,6 +65,7 @@ public class JobDataMap implements Map<String, Object> {
     /**
      * {@inheritDoc}
      */
+    @Override
     public boolean containsValue(Object value) {
         return this.map.containsValue(value);
     }
@@ -70,6 +73,7 @@ public class JobDataMap implements Map<String, Object> {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Set<Map.Entry<String, Object>> entrySet() {
         return this.map.entrySet();
     }
@@ -77,6 +81,7 @@ public class JobDataMap implements Map<String, Object> {
     /**
      * {@inheritDoc}
      */
+    @Override
     public boolean equals(Object obj) {
         return this.map.equals(obj);
     }
@@ -84,6 +89,7 @@ public class JobDataMap implements Map<String, Object> {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Object get(Object key) {
         return this.map.get(key);
     }
@@ -91,6 +97,7 @@ public class JobDataMap implements Map<String, Object> {
     /**
      * {@inheritDoc}
      */
+    @Override
     public int hashCode() {
         return this.map.hashCode();
     }
@@ -98,6 +105,7 @@ public class JobDataMap implements Map<String, Object> {
     /**
      * {@inheritDoc}
      */
+    @Override
     public boolean isEmpty() {
         return this.map.isEmpty();
     }
@@ -105,6 +113,7 @@ public class JobDataMap implements Map<String, Object> {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Set<String> keySet() {
         return this.map.keySet();
     }
@@ -112,6 +121,7 @@ public class JobDataMap implements Map<String, Object> {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Object put(String key, Object value) {
         return this.map.put(key, value);
     }
@@ -119,6 +129,7 @@ public class JobDataMap implements Map<String, Object> {
     /**
      * {@inheritDoc}
      */
+    @Override
     public void putAll(Map<? extends String, ? extends Object> map) {
         this.map.putAll(map);
     }
@@ -126,6 +137,7 @@ public class JobDataMap implements Map<String, Object> {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Object remove(Object key) {
         return this.map.remove(key);
     }
@@ -133,6 +145,7 @@ public class JobDataMap implements Map<String, Object> {
     /**
      * {@inheritDoc}
      */
+    @Override
     public int size() {
         return this.map.size();
     }
@@ -140,6 +153,7 @@ public class JobDataMap implements Map<String, Object> {
     /**
      * {@inheritDoc}
      */
+    @Override
     public Collection<Object> values() {
         return this.map.values();
     }
@@ -147,6 +161,7 @@ public class JobDataMap implements Map<String, Object> {
     /**
      * {@inheritDoc}
      */
+    @Override
     public String toString() {
         StringBuilder builder = new StringBuilder(this.getClass().getName());
 

--- a/server/src/main/java/org/candlepin/async/temp/TestJob1.java
+++ b/server/src/main/java/org/candlepin/async/temp/TestJob1.java
@@ -37,7 +37,7 @@ import java.util.Collection;
 public class TestJob1 implements AsyncJob {
 
     private static Logger log = LoggerFactory.getLogger(TestJob1.class);
-    private static final String JOB_KEY = "TEST_JOB1";
+    private static final String JOB_KEY = "TestJob1";
 
     private OwnerCurator ownerCurator;
 
@@ -78,8 +78,8 @@ public class TestJob1 implements AsyncJob {
         log.info("OWNERS: {}", owners);
 
 
-        final boolean forceFailure = jdata.getJobData().getAsBoolean("force_failure");
-        final boolean sleep = jdata.getJobData().getAsBoolean("sleep");
+        final boolean forceFailure = jdata.getJobData().getAsBoolean("force_failure", false);
+        final boolean sleep = jdata.getJobData().getAsBoolean("sleep", false);
 
         if (sleep) {
             sleep();

--- a/server/src/main/java/org/candlepin/audit/MessageReceiver.java
+++ b/server/src/main/java/org/candlepin/audit/MessageReceiver.java
@@ -74,6 +74,7 @@ public abstract class MessageReceiver implements MessageHandler {
             log.warn("MessageReceiver was unable to resume message consumption. Artemis DOWN!");
             return;
         }
+
         try {
             if (this.consumer.isClosed()) {
                 log.debug("Resuming message consumption for {}.", queueName);

--- a/server/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/server/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -279,8 +279,17 @@ public class ConfigProperties {
 
     public static final String SWAGGER_ENABLED = "candlepin.swagger.enabled";
 
-    public static final String ENABLED_ASYNC_JOBS = "candlepin.jobs.enabled_jobs";
-    public static final String MAX_JOB_THREADS = "candlepin.jobs.max_threads";
+    public static final String ASYNC_JOBS_THREADS = "candlepin.async.threads";
+    public static final String ASYNC_JOBS_WHITELIST = "candlepin.async.whitelist";
+    public static final String ASYNC_JOBS_BLACKLIST = "candlepin.async.blacklist";
+
+    // Used for per-job configuration. The full syntax is "PREFIX.{job_name}.SUFFIX". For instance,
+    // to configure the schedule flag for the job TestJob1, the full configuration would be:
+    // candlepin.async.jobs.TestJob1.schedule=0 0 0/3 * * ?
+    public static final String ASYNC_JOBS_PREFIX = "candlepin.async.jobs.";
+    public static final String ASYNC_JOBS_SUFFIX_SCHEDULE = "schedule";
+    public static final String ASYNC_JOBS_SUFFIX_ENABLED = "enabled";
+
 
     public static final Map<String, String> DEFAULT_PROPERTIES = new HashMap<String, String>() {
         private static final long serialVersionUID = 1L;
@@ -421,12 +430,19 @@ public class ConfigProperties {
             this.put(MANIFEST_CLEANER_JOB_MAX_AGE_IN_MINUTES, "1440");
 
             // Async Job Defaults
-            this.put(MAX_JOB_THREADS, "10");
+            this.put(ASYNC_JOBS_THREADS, "10");
 
+            // TODO: Find a better way to load job classes
             String[] allowed = new String[] {
                 TestJob1.getJobKey()
             };
-            this.put(ENABLED_ASYNC_JOBS, StringUtils.join(allowed, ","));
+
+
+
+
+
+
+
         }
     };
 

--- a/server/src/main/java/org/candlepin/guice/CandlepinModule.java
+++ b/server/src/main/java/org/candlepin/guice/CandlepinModule.java
@@ -187,9 +187,13 @@ import com.google.inject.persist.jpa.JpaPersistModule;
 
 import org.hibernate.cfg.beanvalidation.BeanValidationEventListener;
 import org.hibernate.validator.HibernateValidator;
+
 import org.quartz.JobListener;
 import org.quartz.TriggerListener;
+import org.quartz.SchedulerFactory;
+import org.quartz.impl.StdSchedulerFactory;
 import org.quartz.spi.JobFactory;
+
 import org.xnap.commons.i18n.I18n;
 
 import io.swagger.jaxrs.config.BeanConfig;
@@ -345,6 +349,7 @@ public class CandlepinModule extends AbstractModule {
         configureInterceptors();
         configureAuth();
         configureActiveMQComponents();
+        configureAsyncJobs();
         configurePinsetter();
         configureExporter();
         configureSwagger();
@@ -403,6 +408,11 @@ public class CandlepinModule extends AbstractModule {
         bindConstant().annotatedWith(Names.named("PREFIX_APIURL_KEY")).to(ConfigProperties.PREFIX_APIURL);
     }
 
+    private void configureAsyncJobs() {
+        bind(JobMessageDispatcher.class).to(ArtemisJobMessageDispatcher.class);
+        bind(SchedulerFactory.class).to(StdSchedulerFactory.class);
+    }
+
     private void configurePinsetter() {
         bind(JobFactory.class).to(GuiceJobFactory.class);
         bind(JobListener.class).to(PinsetterJobListener.class);
@@ -456,7 +466,6 @@ public class CandlepinModule extends AbstractModule {
 
     private void configureActiveMQComponents() {
         if (config.getBoolean(ConfigProperties.ACTIVEMQ_ENABLED)) {
-            bind(JobMessageDispatcher.class).to(ArtemisJobMessageDispatcher.class);
             bind(MessageSource.class).to(ArtemisMessageSource.class);
             bind(MessageSourceReceiverFactory.class).to(ArtemisMessageSourceReceiverFactory.class);
             bind(EventSink.class).to(EventSinkImpl.class);

--- a/server/src/main/java/org/candlepin/pinsetter/core/PinsetterKernel.java
+++ b/server/src/main/java/org/candlepin/pinsetter/core/PinsetterKernel.java
@@ -306,6 +306,7 @@ public class PinsetterKernel implements ModeChangeListener {
         if (existingCronTriggers.size() > 0) {
             log.warn("Cleaning up " + existingCronTriggers.size() + " obsolete triggers.");
         }
+
         for (CronTrigger t : existingCronTriggers) {
             boolean result = scheduler.deleteJob(t.getJobKey());
             log.warn(t.getJobKey() + " deletion success?: " + result);
@@ -519,8 +520,7 @@ public class PinsetterKernel implements ModeChangeListener {
             return !scheduler.isInStandbyMode();
         }
         catch (SchedulerException e) {
-            throw new PinsetterException("There was a problem gathering" +
-                        "scheduler status ", e);
+            throw new PinsetterException("There was a problem gathering scheduler status ", e);
         }
     }
 

--- a/server/src/test/java/org/candlepin/TestingModules.java
+++ b/server/src/test/java/org/candlepin/TestingModules.java
@@ -29,6 +29,8 @@ import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 import com.fasterxml.jackson.datatype.hibernate5.Hibernate5Module;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
+import org.candlepin.async.JobMessageDispatcher;
+import org.candlepin.async.impl.ArtemisJobMessageDispatcher;
 import org.candlepin.audit.EventSink;
 import org.candlepin.audit.NoopEventSinkImpl;
 import org.candlepin.auth.Principal;
@@ -137,7 +139,9 @@ import org.jukito.TestSingleton;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.quartz.JobListener;
+import org.quartz.SchedulerFactory;
 import org.quartz.TriggerListener;
+import org.quartz.impl.StdSchedulerFactory;
 import org.quartz.spi.JobFactory;
 import org.xnap.commons.i18n.I18n;
 
@@ -350,6 +354,10 @@ public class TestingModules {
 
             // Bind model translator
             bind(ModelTranslator.class).to(StandardTranslator.class).asEagerSingleton();
+
+            // Async job stuff
+            bind(JobMessageDispatcher.class).to(ArtemisJobMessageDispatcher.class);
+            bind(SchedulerFactory.class).to(StdSchedulerFactory.class);
         }
 
         @Provides @Singleton @Named("EventFactoryObjectMapper")

--- a/server/src/test/java/org/candlepin/pinsetter/core/PinsetterKernelTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/core/PinsetterKernelTest.java
@@ -126,6 +126,7 @@ public class PinsetterKernelTest {
         verify(sched).setJobFactory(eq(jfactory));
         verify(lm, never()).addJobListener(eq(jlistener));
     }
+
     @Test
     public void ctor() throws Exception {
         pk = new PinsetterKernel(config, jfactory, jlistener, jcurator,


### PR DESCRIPTION
- Added basic support for scheduling jobs using a cron-like
  scheduling expression
- Updated the job configuration variables and expressions
- Added support for job whitelists and blacklists
- Added support for per-job configuration, currently supporting
  scheduling and disabling jobs
- Updated how the AMQP consumer filter expression is built; it
  will now use the whitelist, blacklist and job enabled flags
  to build the appropriate expression for the node
- JobManager now listens for mode change events and will pause
  and/or resume as appropriate (currently this only stops
  scheduled jobs from being executed)
- Updated the ManagerState and JobState enums to be declarative
  of their valid state transitions
- Bumped Quartz to version 2.2.2