### PR TITLE
Convert to maven style repo reference

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -172,7 +172,7 @@ subprojects {
         maven { url "http://repository.jboss.org/nexus/content/groups/public/" }
         maven { url "http://oauth.googlecode.com/svn/code/maven/" }
         // For LogDriver
-        ivy { url "http://awood.fedorapeople.org/ivy/candlepin/" }
+        maven { url "http://awood.fedorapeople.org/ivy/candlepin/" }
     }
 }
 


### PR DESCRIPTION
This fixes an issue where the ivy style structure is more strict and does not work for the JSS libraries in the repository.