### PR TITLE
[M] 1644707: Removed AHC.lockAndLoadById(s) to address quirks with refresh

### DIFF
--- a/server/src/main/java/org/candlepin/bind/BindContext.java
+++ b/server/src/main/java/org/candlepin/bind/BindContext.java
@@ -125,7 +125,8 @@ public class BindContext {
      * locks the pools and replaces the existing entities in poolQuantities.
      */
     public void lockPools() {
-        Collection<Pool> pools = poolCurator.lockAndLoadByIds(poolQuantities.keySet());
+        Collection<Pool> pools = poolCurator.lockAndLoad(poolQuantities.keySet());
+        this.poolCurator.refresh(pools);
         for (Pool pool: pools) {
             poolQuantities.get(pool.getId()).setPool(pool);
         }
@@ -133,7 +134,7 @@ public class BindContext {
 
     public Consumer getLockedConsumer() {
         if (lockedConsumer == null) {
-            lockedConsumer = consumerCurator.lockAndLoad(consumer);
+            lockedConsumer = consumerCurator.lock(consumer);
         }
 
         return lockedConsumer;

--- a/server/src/main/java/org/candlepin/controller/OwnerManager.java
+++ b/server/src/main/java/org/candlepin/controller/OwnerManager.java
@@ -112,7 +112,7 @@ public class OwnerManager {
         log.info("Cleaning up owner: {}", owner);
 
         Collection<String> consumerIds = this.ownerCurator.getConsumerIds(owner).list();
-        Collection<Consumer> consumers = this.consumerCurator.lockAndLoadByIds(consumerIds);
+        Collection<Consumer> consumers = this.consumerCurator.lockAndLoad(consumerIds);
 
         for (Consumer consumer : consumers) {
             log.info("Removing all entitlements for consumer: {}", consumer);
@@ -223,15 +223,12 @@ public class OwnerManager {
         }
 
         // Lock the owner
-        Owner locked = ownerCurator.lockAndLoad(owner);
-        if (locked == null) {
-            throw new IllegalStateException("Unable to obtain exclusive lock on owner: " + owner);
-        }
+        this.ownerCurator.lock(owner);
 
         // Fetch the upstream list and mode
-        String upstreamList = adapter.getContentAccessModeList(locked.getKey());
-        String upstreamMode = adapter.getContentAccessMode(locked.getKey());
-        String currentMode = locked.getContentAccessMode();
+        String upstreamList = adapter.getContentAccessModeList(owner.getKey());
+        String upstreamMode = adapter.getContentAccessMode(owner.getKey());
+        String currentMode = owner.getContentAccessMode();
 
         // This shouldn't happen, but in the event our upstream source is having issues, let's
         // not put ourselves in a bad state as well.
@@ -267,18 +264,18 @@ public class OwnerManager {
         }
 
         // Set new values
-        locked.setContentAccessModeList(upstreamList);
+        owner.setContentAccessModeList(upstreamList);
 
         // If the content access mode changed, we'll need to update it and refresh the access certs
         if (!StringUtils.isEmpty(currentMode) ? !currentMode.equals(upstreamMode) :
             !StringUtils.isEmpty(upstreamMode)) {
 
-            locked.setContentAccessMode(upstreamMode);
+            owner.setContentAccessMode(upstreamMode);
 
-            ownerCurator.merge(locked);
+            ownerCurator.merge(owner);
             ownerCurator.flush();
 
-            this.refreshOwnerForContentAccess(locked);
+            this.refreshOwnerForContentAccess(owner);
         }
     }
 
@@ -291,18 +288,15 @@ public class OwnerManager {
     @Transactional
     public void refreshOwnerForContentAccess(Owner owner) {
         // we need to update the owner's consumers if the content access mode has changed
-        Owner locked = ownerCurator.lockAndLoad(owner);
-        if (locked == null) {
-            throw new IllegalStateException("Unable to obtain exclusive lock for owner: " + owner);
-        }
+        this.ownerCurator.lock(owner);
 
-        String cam = locked.getContentAccessMode();
+        String cam = owner.getContentAccessMode();
         if (ContentAccessCertServiceAdapter.ENTITLEMENT_ACCESS_MODE.equals(cam)) {
-            contentAccessCertCurator.deleteForOwner(locked);
+            contentAccessCertCurator.deleteForOwner(owner);
         }
 
         // removed cached versions of content access cert data
-        ownerEnvContentAccessCurator.removeAllForOwner(locked.getId());
+        ownerEnvContentAccessCurator.removeAllForOwner(owner.getId());
         ownerCurator.flush();
     }
 

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/UndoImportsJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/UndoImportsJob.java
@@ -92,7 +92,7 @@ public class UndoImportsJob extends UniqueByEntityJob {
         JobDataMap map = context.getMergedJobDataMap();
         String ownerId = map.getString(JobStatus.TARGET_ID);
         String ownerKey = map.getString(JobStatus.OWNER_ID);
-        Owner owner = this.ownerCurator.lockAndLoadById(ownerId);
+        Owner owner = this.ownerCurator.lockAndLoad(ownerId);
         Principal principal = (Principal) map.get(PinsetterJobListener.PRINCIPAL_KEY);
 
         // TODO: Should we check the principal again here?

--- a/server/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
@@ -533,7 +533,6 @@ public class PoolRules {
         else {
             for (Branding b : pool.getBranding()) {
                 if (!existingPool.getBranding().contains(b)) {
-                    syncBranding(pool, existingPool);
                     brandingChanged = true;
                     break;
                 }
@@ -543,6 +542,7 @@ public class PoolRules {
         if (brandingChanged) {
             syncBranding(pool, existingPool);
         }
+
         return brandingChanged;
     }
 

--- a/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -16,6 +16,7 @@ package org.candlepin.controller;
 
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
+import static org.mockito.AdditionalAnswers.returnsFirstArg;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyCollection;
@@ -224,13 +225,8 @@ public class PoolManagerTest {
         when(complianceRules.getStatus(any(Consumer.class), any(Date.class))).thenReturn(
             dummyComplianceStatus);
 
-        when(consumerCuratorMock.lockAndLoad(any(Consumer.class))).thenAnswer(new Answer<Consumer>() {
-            @Override
-            public Consumer answer(InvocationOnMock invocation) throws Throwable {
-                Object[] args = invocation.getArguments();
-                return (Consumer) args[0];
-            }
-        });
+        doAnswer(returnsFirstArg()).when(this.consumerCuratorMock).lock(any(Consumer.class));
+        doAnswer(returnsFirstArg()).when(this.mockPoolCurator).lock(any(Pool.class));
     }
 
     protected ConsumerType mockConsumerType(ConsumerType ctype) {
@@ -375,7 +371,7 @@ public class PoolManagerTest {
         pool.setId("test-id");
         pools.add(pool);
 
-        when(mockPoolCurator.lockAndLoadByIds(any(Iterable.class))).thenReturn(pools);
+        when(mockPoolCurator.lockAndLoad(any(Iterable.class))).thenReturn(pools);
 
         doNothing().when(mockPoolCurator).batchDelete(eq(pools), anySetOf(String.class));
         manager.deletePools(pools);
@@ -1265,7 +1261,7 @@ public class PoolManagerTest {
         p.setConsumed(1L);
         pools.add(p);
 
-        when(mockPoolCurator.lockAndLoadByIds(anyCollection())).thenReturn(pools);
+        when(mockPoolCurator.lockAndLoad(anyCollection())).thenReturn(pools);
 
         mockPoolsList(pools);
 
@@ -1362,7 +1358,7 @@ public class PoolManagerTest {
         manager.cleanupExpiredPools();
 
         // And the pool should be deleted:
-        when(mockPoolCurator.lockAndLoadByIds(anyCollection())).thenReturn(pools);
+        when(mockPoolCurator.lockAndLoad(anyCollection())).thenReturn(pools);
     }
 
     @Test
@@ -1371,7 +1367,7 @@ public class PoolManagerTest {
         p.setSubscriptionId("subid");
         List<Pool> pools = Arrays.asList(p);
 
-        when(mockPoolCurator.lockAndLoadByIds(anyCollection())).thenReturn(pools);
+        when(mockPoolCurator.lockAndLoad(anyCollection())).thenReturn(pools);
         when(mockPoolCurator.listExpiredPools(anyInt())).thenReturn(pools);
         when(mockPoolCurator.entitlementsIn(p)).thenReturn(new ArrayList<>(p.getEntitlements()));
         Subscription sub = new Subscription();

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/UndoImportsJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/UndoImportsJobTest.java
@@ -265,7 +265,7 @@ public class UndoImportsJobTest extends DatabaseTestFixture {
     @Test
     public void handleException() throws JobExecutionException {
         // the real thing we want to handle
-        doThrow(new NullPointerException()).when(this.ownerCurator).lockAndLoadById(anyString());
+        doThrow(new NullPointerException()).when(this.ownerCurator).lockAndLoad(anyString());
 
         try {
             this.undoImportsJob.execute(this.jobContext);
@@ -281,7 +281,7 @@ public class UndoImportsJobTest extends DatabaseTestFixture {
     @Test
     public void refireOnWrappedSQLException() throws JobExecutionException {
         RuntimeException e = new RuntimeException("uh oh", new SQLException("not good"));
-        doThrow(e).when(this.ownerCurator).lockAndLoadById(anyString());
+        doThrow(e).when(this.ownerCurator).lockAndLoad(anyString());
 
         try {
             this.undoImportsJob.execute(this.jobContext);
@@ -298,7 +298,7 @@ public class UndoImportsJobTest extends DatabaseTestFixture {
     public void refireOnMultiLayerWrappedSQLException() throws JobExecutionException {
         RuntimeException e = new RuntimeException("uh oh", new SQLException("not good"));
         RuntimeException e2 = new RuntimeException("trouble!", e);
-        doThrow(e2).when(this.ownerCurator).lockAndLoadById(anyString());
+        doThrow(e2).when(this.ownerCurator).lockAndLoad(anyString());
 
         try {
             this.undoImportsJob.execute(this.jobContext);
@@ -312,7 +312,7 @@ public class UndoImportsJobTest extends DatabaseTestFixture {
     @Test
     public void noRefireOnRegularRuntimeException() throws JobExecutionException {
         RuntimeException e = new RuntimeException("uh oh", new NullPointerException());
-        doThrow(e).when(this.ownerCurator).lockAndLoadById(anyString());
+        doThrow(e).when(this.ownerCurator).lockAndLoad(anyString());
 
         try {
             this.undoImportsJob.execute(this.jobContext);
@@ -327,7 +327,7 @@ public class UndoImportsJobTest extends DatabaseTestFixture {
     public void shouldNotRefireOnGenericPersistenceException() {
         final NullPointerException cause = new NullPointerException();
         final RuntimeException e = new PersistenceException("uh oh", cause);
-        doThrow(e).when(this.ownerCurator).lockAndLoadById(anyString());
+        doThrow(e).when(this.ownerCurator).lockAndLoad(anyString());
 
         try {
             this.undoImportsJob.execute(this.jobContext);
@@ -341,7 +341,7 @@ public class UndoImportsJobTest extends DatabaseTestFixture {
     @Test
     public void shouldRefireOnLockTimeoutException() {
         final LockTimeoutException e = new LockTimeoutException("trouble!");
-        doThrow(e).when(this.ownerCurator).lockAndLoadById(anyString());
+        doThrow(e).when(this.ownerCurator).lockAndLoad(anyString());
 
         try {
             this.undoImportsJob.execute(this.jobContext);
@@ -355,7 +355,7 @@ public class UndoImportsJobTest extends DatabaseTestFixture {
     @Test
     public void shouldRefireOnOptimisticLockException() {
         final OptimisticLockException e = new OptimisticLockException("trouble!");
-        doThrow(e).when(this.ownerCurator).lockAndLoadById(anyString());
+        doThrow(e).when(this.ownerCurator).lockAndLoad(anyString());
 
         try {
             this.undoImportsJob.execute(this.jobContext);
@@ -369,7 +369,7 @@ public class UndoImportsJobTest extends DatabaseTestFixture {
     @Test
     public void shouldRefireOnPessimisticLockException() {
         final PessimisticLockException e = new PessimisticLockException("trouble!");
-        doThrow(e).when(this.ownerCurator).lockAndLoadById(anyString());
+        doThrow(e).when(this.ownerCurator).lockAndLoad(anyString());
 
         try {
             this.undoImportsJob.execute(this.jobContext);


### PR DESCRIPTION
- Entirely removed AbstractHibernateCurator.lockAndLoadById(s), as
  they were becoming increasingly resource intensive and difficult to
  maintain attempting to cover every possible edgecase that can occur
  with regards to entity state. No replacement will be added, due to
  the high risk involved with hidden/generic refresh behavior.
- AHC.lockAndLoad no longer attempts to bypass the cache or perform
  individual refreshes on the entities it returns
- Updated several places where lockAndLoad's behavior was being
  expected such that the callers now perform explicit refreshes where
  it is necessary to do so
- Added additional overloads for refresh and lock to address new
  usages
- Entitlement revocation was moved to after pool update, merging and
  flushing of changes
- Branding synchronization no longer happens twice in cases where
  the number of branding instances on a given pool is the same, but
  the contents of one or more are different