### PR TITLE
[2.4] 1704720: Synchronize java.util.Date serializations; ENT-1294

### DIFF
--- a/server/src/main/java/org/candlepin/jackson/DateSerializer.java
+++ b/server/src/main/java/org/candlepin/jackson/DateSerializer.java
@@ -15,14 +15,17 @@
 package org.candlepin.jackson;
 
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 
 import java.io.IOException;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
-import java.util.TimeZone;
 
 /**
  * DateSerializer
@@ -31,18 +34,18 @@ import java.util.TimeZone;
  * The format used is ISO 8601
  */
 public class DateSerializer extends JsonSerializer<Date> {
-    private final SimpleDateFormat dateFormat;
+    private final DateTimeFormatter dateFormat;
 
     public DateSerializer() {
-        // This SimpleDateFormat is ISO 8601 without milliseconds
-        this.dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
-        this.dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+        // This DateTimeFormatter pattern is ISO 8601 without milliseconds
+        this.dateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssZ");
     }
 
     @Override
     public void serialize(Date date, JsonGenerator jgen, SerializerProvider serializerProvider)
-        throws IOException, JsonProcessingException {
-
-        jgen.writeString(this.dateFormat.format(date));
+        throws IOException {
+        Instant instant = date.toInstant();
+        LocalDateTime localDateTime = LocalDateTime.ofInstant(instant, ZoneOffset.UTC);
+        jgen.writeString(this.dateFormat.format(ZonedDateTime.of(localDateTime, ZoneId.of("UTC"))));
     }
 }

--- a/server/src/test/java/org/candlepin/resteasy/JsonProviderTest.java
+++ b/server/src/test/java/org/candlepin/resteasy/JsonProviderTest.java
@@ -14,8 +14,10 @@
  */
 package org.candlepin.resteasy;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import org.candlepin.common.config.Configuration;
 import org.candlepin.jackson.ProductCachedSerializationModule;
@@ -26,6 +28,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationConfig;
 import com.fasterxml.jackson.databind.SerializationFeature;
 
+import org.junit.ComparisonFailure;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -33,7 +36,11 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Random;
 import java.util.TimeZone;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.ws.rs.core.MediaType;
 
@@ -68,6 +75,65 @@ public class JsonProviderTest {
         assertTrue(serializedDate.equals(expectedDate));
     }
 
+    /*
+     * This tests to see that our DateSerializer does not fail with thread-safety issues caused by
+     * SimpleDateFormat. As the https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html doc
+     * explains: "Date formats are not synchronized. It is recommended to create separate format instances
+     * for each thread. If multiple threads access a format concurrently, it must be synchronized externally."
+     *
+     * For this reason, SimpleDateFormat has been replaced with DateTimeFormatter, which is thread-safe.
+     */
+    @Test
+    public void canSerializeDatesWithLargeTimestampsConcurrently() {
+
+        JsonProvider provider = new JsonProvider(config,
+            new ProductCachedSerializationModule(productCurator));
+        ObjectMapper mapper = provider.locateMapper(Object.class, MediaType.APPLICATION_JSON_TYPE);
+
+        final AtomicBoolean processingFailure = new AtomicBoolean(false);
+        final AtomicBoolean comparisonFailure = new AtomicBoolean(false);
+        ExecutorService ex = Executors.newFixedThreadPool(1000);
+        for (int i = 0; i < 5000000; i++) {
+            ex.execute(() -> {
+                Date randomDate = new Date(getRandomTimestampWithMilliSeconds());
+
+                SimpleDateFormat iso8601WithoutMilliseconds = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
+                iso8601WithoutMilliseconds.setTimeZone(TimeZone.getTimeZone("UTC"));
+                String expectedDate = "\"" + iso8601WithoutMilliseconds.format(randomDate) + "\"";
+
+                try {
+                    String receivedDate = mapper.writeValueAsString(randomDate);
+                    try {
+                        assertEquals("The date was not serialized properly.", expectedDate, receivedDate);
+                    }
+                    catch (ComparisonFailure cf) {
+                        cf.printStackTrace();
+                        comparisonFailure.set(true);
+                    }
+                }
+                catch (JsonProcessingException e) {
+                    e.printStackTrace();
+                    processingFailure.set(true);
+                }
+            });
+        }
+
+        if (processingFailure.get()) {
+            fail("A JsonProcessingException was thrown during concurrent Date serialization.");
+        }
+
+        if (comparisonFailure.get()) {
+            fail("A date was not serialized properly during concurrent Date serialization.");
+        }
+    }
+
+    // Generate a random long whose length (13) corresponds to that of a unix timestamp with milliseconds.
+    private static long getRandomTimestampWithMilliSeconds() {
+        long x = 1000000000000L;
+        long y = 9999999999999L;
+        Random r = new Random();
+        return x + ((long) (r.nextDouble() * (y - x)));
+    }
 
     private boolean isEnabled(JsonProvider provider, SerializationFeature feature) {
         ObjectMapper mapper = provider.locateMapper(Object.class, MediaType.APPLICATION_JSON_TYPE);


### PR DESCRIPTION
- Replace SimpleDateFormat, which is not thread-safe and was shared
between threads, with DateTimeFormatter, which is thread-safe.