### PR TITLE
1461188: Creating an ActivationKey with "contentOverrides": null results in a 400 status[ENT-1130]

### DIFF
--- a/server/client/ruby/candlepin_api.rb
+++ b/server/client/ruby/candlepin_api.rb
@@ -1151,7 +1151,11 @@ class Candlepin
     end
 
     key['autoAttach'] = autobind
-    return post("/owners/#{owner_key}/activation_keys", {}, key)
+    return new_activation_key(owner_key, key)
+  end
+
+  def new_activation_key(owner_key, data)
+    return post("/owners/#{owner_key}/activation_keys", {}, data)
   end
 
   def get_activation_key(key_id)

--- a/server/spec/activation_key_spec.rb
+++ b/server/spec/activation_key_spec.rb
@@ -154,6 +154,14 @@ describe 'Activation Keys' do
     overrides.length.should == 0
   end
 
+  it 'should allow nil contentOverrides' do
+    name = random_string('key4')
+    data = {:name => name, :contentOverrides => nil}
+    activation_key = @cp.new_activation_key(@owner['key'], data)
+
+    activation_key['name'].should eq(name)
+  end
+
   it 'should verify override name is valid' do
     # name label is invalid to override
     override = {"name" => "label", "value" => "somval", "contentLabel" => "somelabel"}
@@ -334,4 +342,5 @@ describe 'Activation Keys' do
       processed.push(key['id'])
     end
   end
+
 end


### PR DESCRIPTION
- This was already fixed
- Added SPEC test to verify this behavior