### PR TITLE
[F] Updated ConsumerResource to use the new async ExportJob task (ENT-1265)

### DIFF
--- a/server/client/ruby/candlepin_api.rb
+++ b/server/client/ruby/candlepin_api.rb
@@ -1330,6 +1330,14 @@ class Candlepin
     return get(url, params)
   end
 
+  def get_async_job(job_id, result_data=false)
+    url = "/async/#{job_id}"
+    params = {}
+    params[:result_data] = true if result_data
+
+    return get(url, params)
+  end
+
   def cancel_job(job_id)
     delete "/jobs/#{job_id}"
   end

--- a/server/src/main/java/org/candlepin/async/JobConfigValidationException.java
+++ b/server/src/main/java/org/candlepin/async/JobConfigValidationException.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.async;
+
+
+
+/**
+ * The JobConfigValidationException represents a validation error with the configuration for a job.
+ * Validation errors are terminal errors, signifying the configuration is not complete or otherwise
+ * cannot be used to queue or execute the job.
+ */
+public class JobConfigValidationException extends JobException {
+
+    /**
+     * Constructs a new exception with null as its detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     */
+    public JobConfigValidationException() {
+        super(true);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     */
+    public JobConfigValidationException(String message) {
+        super(message, true);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of
+     * <tt>(cause == null ? null : cause.toString())</tt> (which typically contains the and
+     * detail message of cause). This constructor is useful for exceptions that are little more
+     * than wrappers for other throwables (for example, PrivilegedActionException).
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public JobConfigValidationException(Throwable cause) {
+        super(cause, true);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p></p>
+     * Note that the detail message associated with cause is not automatically incorporated in this
+     * exception's detail message.
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public JobConfigValidationException(String message, Throwable cause) {
+        super(message, cause, true);
+    }
+
+}

--- a/server/src/main/java/org/candlepin/auth/ConsumerPrincipal.java
+++ b/server/src/main/java/org/candlepin/auth/ConsumerPrincipal.java
@@ -15,6 +15,7 @@
 package org.candlepin.auth;
 
 import org.candlepin.auth.permissions.AttachPermission;
+import org.candlepin.auth.permissions.AsyncJobStatusPermission;
 import org.candlepin.auth.permissions.JobStatusPermission;
 import org.candlepin.auth.permissions.ConsumerEntitlementPermission;
 import org.candlepin.auth.permissions.ConsumerOrgHypervisorPermission;
@@ -54,6 +55,7 @@ public class ConsumerPrincipal extends Principal {
 
         // Allow consumers to check the status of their own jobs.
         addPermission(new JobStatusPermission(getData(), Arrays.asList(owner.getKey())));
+        addPermission(new AsyncJobStatusPermission(getData()));
     }
 
     public Consumer getConsumer() {

--- a/server/src/main/java/org/candlepin/auth/JobPrincipal.java
+++ b/server/src/main/java/org/candlepin/auth/JobPrincipal.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.auth;
+
+
+
+/**
+ * The JobPrincipal is used during the execution of a job to provide system-level access for the job
+ * operation, while inheriting the name of the principal which triggered the job.
+ */
+public class JobPrincipal extends SystemPrincipal {
+    private static final long serialVersionUID = 1L;
+
+    private final String name;
+
+    public JobPrincipal(String name) {
+        if (name == null || name.isEmpty()) {
+            throw new IllegalArgumentException("principal name is null or empty");
+        }
+
+        this.name = name;
+    }
+
+    @Override
+    public String getName() {
+        return this.name;
+    }
+}

--- a/server/src/main/java/org/candlepin/auth/UserPrincipal.java
+++ b/server/src/main/java/org/candlepin/auth/UserPrincipal.java
@@ -14,6 +14,7 @@
  */
 package org.candlepin.auth;
 
+import org.candlepin.auth.permissions.AsyncJobStatusPermission;
 import org.candlepin.auth.permissions.JobStatusPermission;
 import org.candlepin.auth.permissions.Permission;
 import org.candlepin.auth.permissions.UserUserPermission;
@@ -49,6 +50,7 @@ public class UserPrincipal extends Principal {
 
         // Allow users to check the status of their own jobs.
         addPermission(new JobStatusPermission(getData(), getOwnerKeys()));
+        addPermission(new AsyncJobStatusPermission(getData()));
     }
 
     public String getUsername() {

--- a/server/src/main/java/org/candlepin/auth/permissions/AsyncJobStatusPermission.java
+++ b/server/src/main/java/org/candlepin/auth/permissions/AsyncJobStatusPermission.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.auth.permissions;
+
+import org.candlepin.auth.Access;
+import org.candlepin.auth.PrincipalData;
+import org.candlepin.auth.SubResource;
+import org.candlepin.model.AsyncJobStatus;
+import org.candlepin.model.Owner;
+
+import org.hibernate.criterion.Criterion;
+
+
+
+/**
+ * Determines users and consumers specific access to AsyncJobStatus.
+ *
+ * Users can view all jobs in their org, but only cancel jobs they started.
+ * Consumers can view and cancel jobs they started, but only those.
+ */
+public class AsyncJobStatusPermission extends TypedPermission<AsyncJobStatus> {
+
+    private String principalName;
+    private String principalType;
+
+    public AsyncJobStatusPermission(PrincipalData principalData) {
+        this.principalName = principalData.getName();
+        this.principalType = principalData.getType();
+    }
+
+    @Override
+    public Class<AsyncJobStatus> getTargetType() {
+        return AsyncJobStatus.class;
+    }
+
+    @Override
+    public Owner getOwner() {
+        // This permission is not specific to any owner.
+        return null;
+    }
+
+    @Override
+    public Criterion getCriteriaRestrictions(Class entityClass) {
+        // This behavior is deprecated. Always return null.
+        return null;
+    }
+
+    @Override
+    public boolean canAccessTarget(AsyncJobStatus target, SubResource subResource, Access required) {
+        String principal = target.getPrincipal();
+        boolean principalMatch = principal != null && principal.equals(this.principalName);
+
+        if ("user".equalsIgnoreCase(principalType)) {
+            // a user can only cancel the job if it started it
+            Access allowed = principalMatch ? Access.ALL : Access.READ_ONLY;
+            return allowed.provides(required);
+        }
+        else if ("consumer".equalsIgnoreCase(principalType)) {
+            // if this is a consumer it must match the principle name access
+            return principalMatch && Access.ALL.provides(required);
+        }
+
+        return false;
+    }
+
+}

--- a/server/src/main/java/org/candlepin/auth/permissions/JobStatusPermission.java
+++ b/server/src/main/java/org/candlepin/auth/permissions/JobStatusPermission.java
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.auth.permissions;
 
 import org.candlepin.auth.Access;

--- a/server/src/main/java/org/candlepin/controller/ManifestManager.java
+++ b/server/src/main/java/org/candlepin/controller/ManifestManager.java
@@ -25,6 +25,9 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
+
+import org.candlepin.async.JobConfig;
+import org.candlepin.async.tasks.ExportJob;
 import org.candlepin.audit.EventFactory;
 import org.candlepin.audit.EventSink;
 import org.candlepin.common.exceptions.BadRequestException;
@@ -39,7 +42,6 @@ import org.candlepin.model.ConsumerType;
 import org.candlepin.model.ConsumerTypeCurator;
 import org.candlepin.model.EntitlementCurator;
 import org.candlepin.model.ImportRecord;
-import org.candlepin.pinsetter.tasks.ExportJob;
 import org.candlepin.pinsetter.tasks.ImportJob;
 import org.candlepin.model.Owner;
 import org.candlepin.pinsetter.tasks.ManifestCleanerJob;
@@ -116,12 +118,19 @@ public class ManifestManager {
      *                      a new export of the target consumer.
      * @return the details of the async export job.
      */
-    public JobDetail generateManifestAsync(String consumerUuid, Owner owner, String cdnLabel,
+    public JobConfig generateManifestAsync(String consumerUuid, Owner owner, String cdnLabel,
         String webUrl, String apiUrl, Map<String, String> extensionData) {
 
         log.info("Scheduling Async Export for consumer {}", consumerUuid);
         Consumer consumer = validateConsumerForExport(consumerUuid, cdnLabel);
-        return ExportJob.scheduleExport(consumer, owner, cdnLabel, webUrl, apiUrl, extensionData);
+
+        return ExportJob.createJobConfig()
+            .setConsumer(consumer)
+            .setOwner(owner)
+            .setCdnLabel(cdnLabel)
+            .setWebAppPrefix(webUrl)
+            .setApiUrl(apiUrl)
+            .setExtensionData(extensionData);
     }
 
     /**

--- a/server/src/main/java/org/candlepin/model/AsyncJobStatus.java
+++ b/server/src/main/java/org/candlepin/model/AsyncJobStatus.java
@@ -126,8 +126,8 @@ public class AsyncJobStatus extends AbstractHibernateObject implements JobExecut
 
     @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(name = "cp_async_job_metadata", joinColumns = @JoinColumn(name = "job_id"))
-    @MapKeyColumn(name = "key")
-    @Column(name = "value")
+    @MapKeyColumn(name = "\"key\"")
+    @Column(name = "\"value\"")
     private Map<String, String> metadata;
 
     @NotNull

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -14,6 +14,9 @@
  */
 package org.candlepin.resource;
 
+import org.candlepin.async.JobConfig;
+import org.candlepin.async.JobException;
+import org.candlepin.async.JobManager;
 import org.candlepin.audit.Event;
 import org.candlepin.audit.Event.Target;
 import org.candlepin.audit.Event.Type;
@@ -44,6 +47,7 @@ import org.candlepin.controller.Entitler;
 import org.candlepin.controller.ManifestManager;
 import org.candlepin.controller.PoolManager;
 import org.candlepin.dto.ModelTranslator;
+import org.candlepin.dto.api.v1.AsyncJobStatusDTO;
 import org.candlepin.dto.api.v1.CapabilityDTO;
 import org.candlepin.dto.api.v1.CertificateDTO;
 import org.candlepin.dto.api.v1.ComplianceStatusDTO;
@@ -56,6 +60,7 @@ import org.candlepin.dto.api.v1.HypervisorIdDTO;
 import org.candlepin.dto.api.v1.OwnerDTO;
 import org.candlepin.dto.api.v1.PoolQuantityDTO;
 import org.candlepin.dto.api.v1.SystemPurposeComplianceStatusDTO;
+import org.candlepin.model.AsyncJobStatus;
 import org.candlepin.model.CandlepinQuery;
 import org.candlepin.model.CdnCurator;
 import org.candlepin.model.Certificate;
@@ -226,6 +231,7 @@ public class ConsumerResource {
     private ConsumerEnricher consumerEnricher;
     private Provider<GuestMigration> migrationProvider;
     private ModelTranslator translator;
+    private JobManager jobManager;
 
     @Inject
     @SuppressWarnings({"checkstyle:parameternumber"})
@@ -253,7 +259,8 @@ public class ConsumerResource {
         ConsumerTypeValidator consumerTypeValidator,
         ConsumerEnricher consumerEnricher,
         Provider<GuestMigration> migrationProvider,
-        ModelTranslator translator) {
+        ModelTranslator translator,
+        JobManager jobManager) {
 
         this.consumerCurator = consumerCurator;
         this.consumerTypeCurator = consumerTypeCurator;
@@ -294,6 +301,7 @@ public class ConsumerResource {
         this.consumerEnricher = consumerEnricher;
         this.migrationProvider = migrationProvider;
         this.translator = translator;
+        this.jobManager = jobManager;
     }
 
     /**
@@ -2359,7 +2367,7 @@ public class ConsumerResource {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Path("{consumer_uuid}/export/async")
-    public JobDetail exportDataAsync(
+    public AsyncJobStatusDTO exportDataAsync(
         @Context HttpServletResponse response,
         @PathParam("consumer_uuid") @Verify(Consumer.class)
         @ApiParam(value = "The UUID of the target consumer", required = true) String consumerUuid,
@@ -2375,15 +2383,18 @@ public class ConsumerResource {
         @QueryParam("ext")
         @ApiParam(value = "Key/Value pairs to be passed to the extension adapter when generating a manifest",
         required = false, example = "ext=version:1.2.3&ext=extension_key:EXT1")
-        List<KeyValueParameter> extensionArgs) {
+        List<KeyValueParameter> extensionArgs) throws JobException {
 
         Consumer consumer = consumerCurator.verifyAndLookupConsumer(consumerUuid);
         ConsumerType ctype = this.consumerTypeCurator.getConsumerType(consumer);
 
         Owner owner = ownerCurator.findOwnerById(consumer.getOwnerId());
 
-        return manifestManager.generateManifestAsync(consumerUuid, owner, cdnLabel, webAppPrefix,
-            apiUrl, getExtensionParamMap(extensionArgs));
+        JobConfig config = manifestManager.generateManifestAsync(consumerUuid, owner, cdnLabel,
+            webAppPrefix, apiUrl, getExtensionParamMap(extensionArgs));
+
+        AsyncJobStatus job = this.jobManager.queueJob(config);
+        return this.translator.translate(job, AsyncJobStatusDTO.class);
     }
 
     /**

--- a/server/src/main/java/org/candlepin/resteasy/filter/StoreFactory.java
+++ b/server/src/main/java/org/candlepin/resteasy/filter/StoreFactory.java
@@ -16,6 +16,8 @@ package org.candlepin.resteasy.filter;
 
 import com.google.inject.Injector;
 import org.candlepin.common.exceptions.GoneException;
+import org.candlepin.model.AsyncJobStatus;
+import org.candlepin.model.AsyncJobStatusCurator;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerCurator;
 import org.candlepin.model.DeletedConsumerCurator;
@@ -64,6 +66,7 @@ public class StoreFactory {
         storeMap.put(ActivationKey.class, new ActivationKeyStore());
         storeMap.put(Product.class, new ProductStore());
         storeMap.put(JobStatus.class, new JobStatusStore());
+        storeMap.put(AsyncJobStatus.class, new AsyncJobStatusStore());
 
         for (EntityStore<? extends Persisted> store : storeMap.values()) {
             injector.injectMembers(store);
@@ -250,6 +253,25 @@ public class StoreFactory {
 
         @Override
         public Owner getOwner(JobStatus entity) {
+            return null;
+        }
+    }
+
+    private class AsyncJobStatusStore implements EntityStore<AsyncJobStatus> {
+        @Inject private AsyncJobStatusCurator jobCurator;
+
+        @Override
+        public AsyncJobStatus lookup(String jobId) {
+            return jobCurator.get(jobId);
+        }
+
+        @Override
+        public List<AsyncJobStatus> lookup(Collection<String> jobIds) {
+            return jobCurator.listAllByIds(jobIds).list();
+        }
+
+        @Override
+        public Owner getOwner(AsyncJobStatus entity) {
             return null;
         }
     }

--- a/server/src/test/java/org/candlepin/async/JobManagerTest.java
+++ b/server/src/test/java/org/candlepin/async/JobManagerTest.java
@@ -980,7 +980,7 @@ public class JobManagerTest {
     }
 
     @Test
-    public void testJobIsQueuedIfConstraintsPass() {
+    public void testJobIsQueuedIfConstraintsPass() throws Exception {
         Map<String, Object> ejobData1 = new HashMap<>();
         ejobData1.put("arg1", "val1");
 
@@ -997,7 +997,7 @@ public class JobManagerTest {
             .setState(JobState.QUEUED)
             .setJobData(ejobData2));
 
-        JobBuilder builder = JobBuilder.forJob(JOB_KEY)
+        JobConfig builder = JobConfig.forJob(JOB_KEY)
             .addConstraint(JobConstraints.uniqueByArgument("arg1"))
             .setJobArgument("arg1", "val3");
 
@@ -1011,7 +1011,7 @@ public class JobManagerTest {
     }
 
     @Test
-    public void testJobDoesNotQueueIfConstraintFails() {
+    public void testJobDoesNotQueueIfConstraintFails() throws Exception {
         Map<String, Object> ejobData1 = new HashMap<>();
         ejobData1.put("arg1", "val1");
 
@@ -1028,7 +1028,7 @@ public class JobManagerTest {
             .setState(JobState.QUEUED)
             .setJobData(ejobData2));
 
-        JobBuilder builder = JobBuilder.forJob(JOB_KEY)
+        JobConfig builder = JobConfig.forJob(JOB_KEY)
             .addConstraint(JobConstraints.uniqueByArgument("arg1"))
             .setJobArgument("arg1", "val2");
 

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceCreationTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceCreationTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 
+import org.candlepin.async.JobManager;
 import org.candlepin.audit.EventFactory;
 import org.candlepin.audit.EventSink;
 import org.candlepin.auth.Access;
@@ -131,6 +132,7 @@ public class ConsumerResourceCreationTest {
     @Mock protected ConsumerBindUtil consumerBindUtil;
     @Mock protected ConsumerEnricher consumerEnricher;
     @Mock protected EnvironmentCurator environmentCurator;
+    @Mock protected JobManager jobManager;
 
     protected ModelTranslator modelTranslator;
 
@@ -164,7 +166,7 @@ public class ConsumerResourceCreationTest {
             null, this.ownerCurator, this.activationKeyCurator, null, this.complianceRules,
             this.systemPurposeComplianceRules, this.deletedConsumerCurator, null, null, this.config, null,
             null, null, this.consumerBindUtil, null, null, new FactValidator(this.config, this.i18nProvider),
-            null, consumerEnricher, migrationProvider, modelTranslator);
+            null, consumerEnricher, migrationProvider, modelTranslator, jobManager);
 
         this.system = this.initConsumerType();
         this.mockConsumerType(this.system);

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
@@ -18,6 +18,7 @@ import static org.candlepin.test.TestUtil.createConsumerDTO;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
+import org.candlepin.async.JobManager;
 import org.candlepin.auth.Access;
 import org.candlepin.auth.ConsumerPrincipal;
 import org.candlepin.auth.Principal;
@@ -102,6 +103,7 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
     @Inject private CertificateSerialCurator serialCurator;
     @Inject private ConsumerEnricher consumerEnricher;
     @Inject protected ModelTranslator modelTranslator;
+    @Inject protected JobManager jobManager;
 
     private ConsumerType standardSystemType;
     private ConsumerTypeDTO standardSystemTypeDTO;
@@ -585,7 +587,8 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
             null, null, null, null, null, null, null, this.poolManager, null, null, null, null,
             null, null, null, null, null,
             new CandlepinCommonTestConfig(), null, null, null, mock(ConsumerBindUtil.class),
-            null, null, null, null, consumerEnricher, migrationProvider, this.modelTranslator);
+            null, null, null, null, consumerEnricher, migrationProvider, this.modelTranslator,
+            this.jobManager);
 
         Response rsp = consumerResource.bind(consumer.getUuid(), pool.getId().toString(), null, 1, null,
             null, false, null, null);

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 
+import org.candlepin.async.JobManager;
 import org.candlepin.audit.Event.Target;
 import org.candlepin.audit.Event.Type;
 import org.candlepin.audit.EventBuilder;
@@ -170,6 +171,7 @@ public class ConsumerResourceTest {
     @Mock private CdnCurator mockCdnCurator;
     @Mock private UserServiceAdapter userServiceAdapter;
     @Mock private DeletedConsumerCurator mockDeletedConsumerCurator;
+    @Mock private JobManager mockJobManager;
 
     private GuestMigration testMigration;
     private Provider<GuestMigration> migrationProvider;
@@ -229,7 +231,8 @@ public class ConsumerResourceTest {
             new ConsumerTypeValidator(mockConsumerTypeCurator, i18n),
             consumerEnricher,
             migrationProvider,
-            translator);
+            translator,
+            mockJobManager);
 
         mockedConsumerResource = Mockito.spy(consumerResource);
     }
@@ -390,7 +393,8 @@ public class ConsumerResourceTest {
             mockEntitlementCertServiceAdapter, null, null, null, null, null, null,
             poolManager, null, null, null, null, null, null, null, null, null,
             this.config, null, null, null, consumerBindUtil,
-            null, null, this.factValidator, null, consumerEnricher, migrationProvider, translator);
+            null, null, this.factValidator, null, consumerEnricher, migrationProvider, translator,
+            this.mockJobManager);
 
         consumerResource.regenerateEntitlementCertificates(consumer.getUuid(), "9999", false);
     }
@@ -774,7 +778,7 @@ public class ConsumerResourceTest {
     }
 
     @Test
-    public void testAsyncExport() {
+    public void testAsyncExport() throws Exception {
         List<KeyValueParameter> extParams = new ArrayList<>();
         Owner owner = this.createOwner();
         owner.setId(TestUtil.randomString());

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.*;
 
+import org.candlepin.async.JobManager;
 import org.candlepin.audit.Event;
 import org.candlepin.audit.Event.Target;
 import org.candlepin.audit.Event.Type;
@@ -125,6 +126,7 @@ public class ConsumerResourceUpdateTest {
     @Mock private ConsumerBindUtil consumerBindUtil;
     @Mock private ConsumerEnricher consumerEnricher;
     @Mock private Principal principal;
+    @Mock private JobManager jobManager;
     private ModelTranslator translator;
 
     private I18n i18n;
@@ -153,7 +155,7 @@ public class ConsumerResourceUpdateTest {
             this.deletedConsumerCurator, this.environmentCurator, null,
             config, null, null, null, this.consumerBindUtil,
             null, null, new FactValidator(config, this.i18nProvider),
-            null, consumerEnricher, migrationProvider, this.translator);
+            null, consumerEnricher, migrationProvider, this.translator, this.jobManager);
 
         when(complianceRules.getStatus(any(Consumer.class), any(Date.class), any(Boolean.class),
             any(Boolean.class))).thenReturn(new ComplianceStatus(new Date()));

--- a/server/src/test/java/org/candlepin/resource/GuestIdResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/GuestIdResourceTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.*;
 
+import org.candlepin.async.JobManager;
 import org.candlepin.audit.EventFactory;
 import org.candlepin.audit.EventSink;
 import org.candlepin.auth.Principal;
@@ -85,6 +86,7 @@ public class GuestIdResourceTest {
     @Mock private ServiceLevelValidator mockedServiceLevelValidator;
     @Mock private ConsumerEnricher consumerEnricher;
     @Mock private EnvironmentCurator environmentCurator;
+    @Mock private JobManager jobManager;
 
     private GuestIdResource guestIdResource;
 
@@ -300,8 +302,7 @@ public class GuestIdResourceTest {
         public ConsumerResourceForTesting() {
             super(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null,
                 null, null, null, null, null, null, null, null, null, null, null, null, null,
-                null,
-                null, null, null, null, consumerEnricher, null, modelTranslator);
+                null, null, null, null, null, consumerEnricher, null, modelTranslator, jobManager);
         }
 
         public void checkForMigration(Consumer host, Consumer guest) {

--- a/server/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 
+import org.candlepin.async.JobManager;
 import org.candlepin.audit.Event.Target;
 import org.candlepin.audit.Event.Type;
 import org.candlepin.audit.EventBuilder;
@@ -109,6 +110,8 @@ public class HypervisorResourceTest {
     @Mock private ConsumerEnricher consumerEnricher;
     @Mock private GuestIdCurator guestIdCurator;
     @Mock private EnvironmentCurator environmentCurator;
+    @Mock private JobManager jobManager;
+
     private GuestIdResource guestIdResource;
 
     private ConsumerResource consumerResource;
@@ -146,7 +149,7 @@ public class HypervisorResourceTest {
             this.deletedConsumerCurator, null, null, config,
             null, null, null, this.consumerBindUtil, null, null,
             new FactValidator(config, this.i18nProvider), null, consumerEnricher, migrationProvider,
-            modelTranslator);
+            modelTranslator, this.jobManager);
 
         this.guestIdResource = new GuestIdResource(this.guestIdCurator, this.consumerCurator,
             this.consumerTypeCurator, this.consumerResource, this.i18n, this.eventFactory, this.sink,


### PR DESCRIPTION
- ConsumerResource now uses the async/Artemis ExportJob task
  instead of the old Pinsetter version
- Added the AsyncJobStatusPermission to handle support for
  checking permissions on async jobs
- Updated the temp AsyncJobResource to use the DTOs and
  new permissions
- Added (temporary?) methods to the spec tests for fetching
  async jobs by ID
- Async job execution now uses the new JobPrincipal rather
  than a system principal or empty user principal
- Renamed JobBuilder to JobConfig to better match its actual usage
- JobConfig now has a .validate method which will check its
  settings and verify the minimum required fields are set
- ExportJob has been updated to use the new JobConfig and validator
- ExportJob.createJobConfig now returns a JobConfig to be filled
  in rather than taking six parameters and doing all the work
  directly
- Updated ExportTest accordingly