### PR TITLE
1664481: match syspurpose attributes case insensitively [ENT-1284]

### DIFF
--- a/server/spec/autobind_spec.rb
+++ b/server/spec/autobind_spec.rb
@@ -682,4 +682,46 @@ describe 'Autobind On Owner' do
     entitlements = @cp.list_entitlements(:uuid => consumer.uuid)
     entitlements.size.should == 1
   end
+
+  it 'pools with case-insensitively matching role or addon should be attached' do
+    eng_product = create_product(random_string('product'),
+                             random_string('product'),
+                             {:owner => owner_key})
+
+    mkt_prod_with_role_only = create_product(random_string('product'),
+                              random_string('product'),
+                              {:attributes => {:roles => "pRoViDeD_rOlE,non_provided_role"},
+                               :owner => owner_key})
+    pool_with_role_only = create_pool_and_subscription(owner_key, mkt_prod_with_role_only.id, 10, [])
+
+    mkt_prod_with_addon_only = create_product(random_string('product'),
+                              random_string('product'),
+                              {:attributes => {:addons => "pRoViDeD_aDDoN,non_provided_addon"},
+                               :owner => owner_key})
+    pool_with_addon_only = create_pool_and_subscription(owner_key, mkt_prod_with_addon_only.id, 10, [])
+
+    installed = [
+        {'productId' => eng_product.id, 'productName' => eng_product['name']}]
+
+    consumer = @cp.register(
+            random_string('systempurpose'), :system, nil, {}, nil, owner_key, [], installed, nil, [],
+            nil, [], nil, nil, nil, nil, nil, 0, nil,
+            nil, "PROVIDED_ROLE", nil, ["PROVIDED_ADDON", "ANOTHER_ADDON"])
+
+    status = @cp.get_purpose_compliance(consumer['uuid'])
+    status['status'].should == 'mismatched'
+    status['nonCompliantRole'].include?('PROVIDED_ROLE').should == true
+    status['nonCompliantAddOns'].include?('PROVIDED_ADDON').should == true
+    status['nonCompliantAddOns'].include?('ANOTHER_ADDON').should == true
+
+    @cp.consume_product(nil, {:uuid => consumer.uuid})
+    entitlements = @cp.list_entitlements(:uuid => consumer.uuid)
+    entitlements.size.should == 2
+
+    status = @cp.get_purpose_compliance(consumer.uuid)
+    status['status'].should == 'mismatched'
+    status['nonCompliantAddOns'].include?('ANOTHER_ADDON').should == true
+    status['compliantAddOns']['PROVIDED_ADDON'][0]['pool']['id'].should == pool_with_addon_only.id
+    status['compliantRole']['PROVIDED_ROLE'][0]['pool']['id'].should == pool_with_role_only.id
+  end
 end

--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -1573,11 +1573,13 @@ public class CandlepinPoolManager implements PoolManager {
                 if (!providesProduct) {
                     Set<String> consumerAddOns = consumer.getAddOns() != null ?
                         consumer.getAddOns() : new HashSet<>();
-                    String[] prodAddOns = pool.getProductAttributeValue(Product.Attributes.ADDONS) != null ?
-                        pool.getProductAttributeValue(Product.Attributes.ADDONS).split("\\s*,\\s*") :
-                        new String[]{};
-                    for (String addon : prodAddOns) {
-                        if (consumerAddOns.contains(addon)) {
+                    List<String> prodAddOns =
+                        pool.getProductAttributeValue(Product.Attributes.ADDONS) != null ?
+                        Arrays.asList(pool.getProductAttributeValue(Product.Attributes.ADDONS)
+                        .trim().split("\\s*,\\s*")) : Collections.emptyList();
+
+                    for (String consumerAddOn: consumerAddOns) {
+                        if (prodAddOns.stream().anyMatch(str -> str.equalsIgnoreCase(consumerAddOn.trim()))) {
                             matchesAddOns = true;
                             break;
                         }

--- a/server/src/main/resources/rules/rules.js
+++ b/server/src/main/resources/rules/rules.js
@@ -1,4 +1,4 @@
-// Version: 5.36
+// Version: 5.37
 
 /*
  * Default Candlepin rule set.
@@ -311,6 +311,9 @@ function createPool(pool) {
                 poolSet = [this.getProductAttribute(attribute)];
             }
         }
+        for (var i = 0 ; i < poolSet.length; i++) {
+            poolSet[i] = poolSet[i].toLowerCase();
+        }
         return poolSet;
     };
 
@@ -414,6 +417,12 @@ function createConsumer(consumer, compliance) {
             consumer_specified = [this.serviceLevel];
         }
 
+        if (attribute !== 'products') {
+            for (var i = 0 ; i < consumer_specified.length; i++) {
+                consumer_specified[i] = consumer_specified[i].toLowerCase();
+            }
+        }
+
         return consumer_specified;
     };
 
@@ -448,6 +457,9 @@ function createConsumer(consumer, compliance) {
                 });
             });
         });
+        for (var i = 0 ; i < attr_list.length; i++) {
+            attr_list[i] = attr_list[i].toLowerCase();
+        }
         return attr_list;
     };
 
@@ -2551,7 +2563,13 @@ var Autobind = {
                 var common_addons = [];
                 for (var i = 0; i < group_addons.length; i++) {
                     var group_addon = group_addons[i];
-                    if (contains(addons, group_addon)) {
+                    var is_common_addon = false;
+                    for (var j = 0; j < addons.length; j++) {
+                        if (Utils.equalsIgnoreCase(addons[j], group_addon)) {
+                            is_common_addon = true;
+                        }
+                    }
+                    if (is_common_addon) {
                         common_addons.push(group_addon);
                     }
                 }
@@ -2568,7 +2586,7 @@ var Autobind = {
                 var group_roles = this.get_roles();
                 for (var i = 0; i < group_roles.length; i++) {
                     var group_role = group_roles[i];
-                    if (group_role === role) {
+                    if (Utils.equalsIgnoreCase(group_role, role)) {
                         return role;
                     }
                 }
@@ -3053,14 +3071,15 @@ var Autobind = {
         for (var i = 0; i < attached_ents.length; i++) {
             attached_pools.push(attached_ents[i].pool);
         }
-        if (contains(get_role_pools(attached_pools), role)) {
-            return "";
-        }
-        else {
-            return role;
-        }
-    },
 
+        var attached_roles = get_role_pools(attached_pools);
+        for (var j = 0; j < attached_roles.length; j++) {
+            if (Utils.equalsIgnoreCase(attached_roles[j], role)) {
+                return "";
+            }
+        }
+        return role;
+    },
 
     get_remaining_addons: function (addons, attached_ents) {
         if (addons === null) {
@@ -3076,7 +3095,13 @@ var Autobind = {
         }
         var attached_addons = get_addons_pools(attached_pools);
         for (var i = 0; i < addons.length; i++) {
-            if (!contains(attached_addons, addons[i])) {
+            var contains_addon = false;
+            for (var j = 0; j < attached_addons.length; j++) {
+                if (Utils.equalsIgnoreCase(attached_addons[j], addons[i])) {
+                    contains_addon = true;
+                }
+            }
+            if (!contains_addon) {
                 remaining_addons.push(addons[i]);
             }
         }

--- a/server/src/test/java/org/candlepin/policy/SystemPurposeComplianceRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/SystemPurposeComplianceRulesTest.java
@@ -1,0 +1,315 @@
+/**
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.policy;
+
+import org.candlepin.audit.EventSink;
+import org.candlepin.model.Consumer;
+import org.candlepin.model.ConsumerCurator;
+import org.candlepin.model.ConsumerInstalledProduct;
+import org.candlepin.model.ConsumerType;
+import org.candlepin.model.ConsumerTypeCurator;
+import org.candlepin.model.Entitlement;
+import org.candlepin.model.Owner;
+import org.candlepin.model.Pool;
+import org.candlepin.model.Product;
+import org.candlepin.test.TestUtil;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.xnap.commons.i18n.I18n;
+import org.xnap.commons.i18n.I18nFactory;
+
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for SystemPurposeComplianceRules
+ */
+public class SystemPurposeComplianceRulesTest {
+
+    private SystemPurposeComplianceRules complianceRules;
+
+    private Owner owner;
+    @Mock private EventSink eventSink;
+    @Mock private ConsumerCurator consumerCurator;
+    @Mock private ConsumerTypeCurator consumerTypeCurator;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        Locale locale = new Locale("en_US");
+        I18n i18n = I18nFactory.getI18n(getClass(), "org.candlepin.i18n.Messages", locale,
+            I18nFactory.FALLBACK);
+        complianceRules = new SystemPurposeComplianceRules(eventSink, consumerCurator, consumerTypeCurator,
+                i18n);
+        owner = new Owner("test");
+        owner.setId(TestUtil.randomString());
+    }
+
+    private Entitlement mockEntitlement(Consumer consumer, Product product, Product ... providedProducts) {
+        // Make the end date relative to now so it won't outrun it over time.
+        Calendar cal = Calendar.getInstance();
+        cal.add(Calendar.YEAR, 50);
+
+        return mockEntitlement(
+            consumer,
+            product,
+            TestUtil.createDate(2000, 1, 1),
+            cal.getTime(),
+            providedProducts
+        );
+    }
+
+    private Entitlement mockEntitlement(Consumer consumer, Product product, Date start, Date end,
+        Product ... providedProducts) {
+
+        Set<Product> ppset = new HashSet<>(Arrays.asList(providedProducts));
+
+        Pool pool = new Pool(
+            owner,
+            product,
+            ppset,
+            1000L,
+            start,
+            end,
+            "1000",
+            "1000",
+            "1000"
+        );
+
+        pool.setId("pool_" + TestUtil.randomInt());
+        pool.setUpdated(new Date());
+        pool.setCreated(new Date());
+        Entitlement e = new Entitlement(pool, consumer, owner, 1);
+        e.setId("ent_" + TestUtil.randomInt());
+        e.setUpdated(new Date());
+        e.setCreated(new Date());
+
+        return e;
+    }
+
+    private Consumer mockConsumer(Product ... installedProducts) {
+        ConsumerType ctype = new ConsumerType(ConsumerType.ConsumerTypeEnum.SYSTEM);
+        ctype.setId("test-ctype-" + TestUtil.randomInt());
+
+        Consumer consumer = new Consumer();
+        consumer.setType(ctype);
+        consumer.setOwner(owner);
+
+        when(this.consumerTypeCurator.get(eq(ctype.getId()))).thenReturn(ctype);
+        when(this.consumerTypeCurator.getConsumerType(eq(consumer))).thenReturn(ctype);
+
+        for (Product product : installedProducts) {
+            consumer.addInstalledProduct(new ConsumerInstalledProduct(product.getId(), product.getName()));
+        }
+
+        consumer.setFact("cpu.cpu_socket(s)", "8"); // 8 socket machine
+
+        return consumer;
+    }
+
+    /*
+     * Tests that a consumer is syspurpose compliant when their specified role value matches their
+     * entitlement's role value case insensitively.
+     */
+    @Test
+    public void testConsumerRoleIsCompliantCaseInsensitively() {
+        Consumer consumer = mockConsumer();
+        consumer.setRole("mY_rOlE");
+
+        Product prod1 = new Product();
+        prod1.setAttribute(Product.Attributes.ROLES, "my_role");
+        List<Entitlement> ents = new LinkedList<>();
+        ents.add(mockEntitlement(consumer, TestUtil.createProduct("Awesome Product"), prod1));
+
+        SystemPurposeComplianceStatus status =
+            complianceRules.getStatus(consumer, ents, null, false);
+
+        assertTrue(status.isCompliant());
+        assertNull(status.getNonCompliantRole());
+        assertEquals(0, status.getReasons().size());
+    }
+
+    /*
+     * Tests that a consumer is syspurpose compliant when their specified addon value matches their
+     * entitlement's addon value case insensitively.
+     */
+    @Test
+    public void testConsumerAddonIsCompliantCaseInsensitively() {
+        Consumer consumer = mockConsumer();
+        Set<String> addons = new HashSet<>();
+        addons.add("mY_aDDoN");
+        consumer.setAddOns(addons);
+
+        Product prod1 = new Product();
+        prod1.setAttribute(Product.Attributes.ADDONS, "my_addon");
+        List<Entitlement> ents = new LinkedList<>();
+        ents.add(mockEntitlement(consumer, TestUtil.createProduct("Awesome Product"), prod1));
+
+        SystemPurposeComplianceStatus status =
+            complianceRules.getStatus(consumer, ents, null, false);
+
+        assertTrue(status.isCompliant());
+        assertEquals(0, status.getNonCompliantAddOns().size());
+        assertEquals(0, status.getReasons().size());
+    }
+
+    /*
+     * Tests that a consumer is syspurpose compliant when their specified usage value matches their
+     * entitlement's usage value case insensitively.
+     */
+    @Test
+    public void testConsumerUsageIsCompliantCaseInsensitively() {
+        Consumer consumer = mockConsumer();
+        consumer.setUsage("mY_uSaGe");
+
+        Product prod1 = new Product();
+        prod1.setAttribute(Product.Attributes.USAGE, "my_usage");
+        List<Entitlement> ents = new LinkedList<>();
+        ents.add(mockEntitlement(consumer, TestUtil.createProduct("Awesome Product"), prod1));
+
+        SystemPurposeComplianceStatus status =
+            complianceRules.getStatus(consumer, ents, null, false);
+
+        assertTrue(status.isCompliant());
+        assertNull(status.getNonCompliantUsage());
+        assertEquals(0, status.getReasons().size());
+    }
+
+    /*
+     * Tests that a consumer is syspurpose compliant when their specified SLA value matches their
+     * entitlement's SLA value case insensitively.
+     */
+    @Test
+    public void testConsumerSLAIsCompliantCaseInsensitively() {
+        Consumer consumer = mockConsumer();
+        consumer.setServiceLevel("mY_sLA");
+
+        Product prod1 = new Product();
+        prod1.setAttribute(Product.Attributes.SUPPORT_LEVEL, "my_sla");
+        List<Entitlement> ents = new LinkedList<>();
+        ents.add(mockEntitlement(consumer, TestUtil.createProduct("Awesome Product"), prod1));
+
+        SystemPurposeComplianceStatus status =
+            complianceRules.getStatus(consumer, ents, null, false);
+
+        assertTrue(status.isCompliant());
+        assertNull(status.getNonCompliantSLA());
+        assertEquals(0, status.getReasons().size());
+    }
+
+    /*
+     * Tests that a consumer is syspurpose compliant when their specified role value matches their
+     * entitlement's role value which happens to have trailing white space.
+     */
+    @Test
+    public void testConsumerRoleIsCompliantAgainstPoolRoleWithTrailingSpaces() {
+        Consumer consumer = mockConsumer();
+        consumer.setRole("mY_rOlE");
+
+        Product prod1 = new Product();
+        prod1.setAttribute(Product.Attributes.ROLES, " my_role ");
+        List<Entitlement> ents = new LinkedList<>();
+        ents.add(mockEntitlement(consumer, TestUtil.createProduct("Awesome Product"), prod1));
+
+        SystemPurposeComplianceStatus status =
+            complianceRules.getStatus(consumer, ents, null, false);
+
+        assertTrue(status.isCompliant());
+        assertNull(status.getNonCompliantRole());
+        assertEquals(0, status.getReasons().size());
+    }
+
+    /*
+     * Tests that a consumer is syspurpose compliant when their specified addon value matches their
+     * entitlement's addon value which happens to have trailing white space.
+     */
+    @Test
+    public void testConsumerAddonIsCompliantAgainstPoolAddonWithTrailingSpaces() {
+        Consumer consumer = mockConsumer();
+        Set<String> addons = new HashSet<>();
+        addons.add("mY_aDDoN");
+        consumer.setAddOns(addons);
+
+        Product prod1 = new Product();
+        prod1.setAttribute(Product.Attributes.ADDONS, " random_addon , my_addon , another_addon ");
+        List<Entitlement> ents = new LinkedList<>();
+        ents.add(mockEntitlement(consumer, TestUtil.createProduct("Awesome Product"), prod1));
+
+        SystemPurposeComplianceStatus status =
+            complianceRules.getStatus(consumer, ents, null, false);
+
+        assertTrue(status.isCompliant());
+        assertEquals(0, status.getNonCompliantAddOns().size());
+        assertEquals(0, status.getReasons().size());
+    }
+
+    /*
+     * Tests that a consumer is syspurpose compliant when their specified role value (which has trailing
+     * whitespaces) matches their entitlement's role value (which doesn't have trailing whitespaces).
+     */
+    @Test
+    public void testConsumerRoleWithTrailingWhitespaceIsCompliant() {
+        Consumer consumer = mockConsumer();
+        consumer.setRole(" mY_rOlE ");
+
+        Product prod1 = new Product();
+        prod1.setAttribute(Product.Attributes.ROLES, "my_role");
+        List<Entitlement> ents = new LinkedList<>();
+        ents.add(mockEntitlement(consumer, TestUtil.createProduct("Awesome Product"), prod1));
+
+        SystemPurposeComplianceStatus status =
+            complianceRules.getStatus(consumer, ents, null, false);
+
+        assertTrue(status.isCompliant());
+        assertNull(status.getNonCompliantRole());
+        assertEquals(0, status.getReasons().size());
+    }
+
+    /*
+     * Tests that a consumer is syspurpose compliant when their specified addon value (which has trailing
+     * whitespaces) matches their entitlement's addon value (which doesn't have trailing whitespaces).
+     */
+    @Test
+    public void testConsumerAddonWithTrailingWhitespaceIsCompliant() {
+        Consumer consumer = mockConsumer();
+        Set<String> addons = new HashSet<>();
+        addons.add(" mY_aDDoN ");
+        consumer.setAddOns(addons);
+
+        Product prod1 = new Product();
+        prod1.setAttribute(Product.Attributes.ADDONS, "random_addon,my_addon,another_addon");
+        List<Entitlement> ents = new LinkedList<>();
+        ents.add(mockEntitlement(consumer, TestUtil.createProduct("Awesome Product"), prod1));
+
+        SystemPurposeComplianceStatus status =
+            complianceRules.getStatus(consumer, ents, null, false);
+
+        assertTrue(status.isCompliant());
+        assertEquals(0, status.getNonCompliantAddOns().size());
+        assertEquals(0, status.getReasons().size());
+    }
+}


### PR DESCRIPTION
- During auto-attach and syspurpose status calculations, syspurpose
  attribute values are now compared with case insensitivity.