### PR TITLE
setting default encoding to UTF_8 during buildtime

### DIFF
--- a/buildfile
+++ b/buildfile
@@ -1,4 +1,6 @@
 # vi: set ft=ruby:
+Encoding.default_external = Encoding::UTF_8
+Encoding.default_internal = Encoding::UTF_8
 
 ### Repositories
 repositories.remote << "http://awood.fedorapeople.org/ivy/candlepin/"


### PR DESCRIPTION
Fixes build error when LANG and LC_* area are unset:

```
# server/bin/deploy -fHgt
2019-05-20 12:11:06.034  FINE: Stdout: 
2019-05-20 12:11:06.034  FINE: Stderr: 
Buildr aborted!
ArgumentError : invalid byte sequence in US-ASCII
/home/candlepin/candlepin/buildfile:76:in `<top (required)>'
/home/candlepin/.gem/ruby/gems/buildr-1.5.3/lib/buildr/core/application.rb:423:in `raw_load_buildfile'
/home/candlepin/.gem/ruby/gems/buildr-1.5.3/lib/buildr/core/application.rb:224:in `block in load_buildfile'
/home/candlepin/.gem/ruby/gems/buildr-1.5.3/lib/buildr/core/application.rb:219:in `load_buildfile'
(See full trace by running task with --trace)

```
We can work around this by always setting LANG with this command. However if yall want to fix this at the source here it is.