### PR TITLE
[F] ENT-847: Port ImportJob To The New Messaging Framework

### DIFF
--- a/server/src/main/java/org/candlepin/async/ImportConflictJobException.java
+++ b/server/src/main/java/org/candlepin/async/ImportConflictJobException.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.async;
+
+import org.candlepin.sync.ImportConflictException;
+import org.candlepin.sync.Importer;
+
+import java.util.Iterator;
+
+/**
+ * The equivalent of {@link ImportConflictException}, but for asynchronous imports.
+ * It is used by transforming an {@link org.candlepin.common.exceptions.CandlepinException} to a
+ * {@link JobExecutionException}, fit for propagating to the job management system, without keeping the
+ * redundant fields the former has (such as requestUuid & REST return code), while retaining the useful
+ * information (list of conflicts, display message) accessible through its toString method.
+ */
+public class ImportConflictJobException extends JobExecutionException {
+
+    private String message;
+
+    public ImportConflictJobException(ImportConflictException importConflictException) {
+        super(importConflictException.getLocalizedMessage(), true);
+
+        StringBuilder str = new StringBuilder(importConflictException.getLocalizedMessage());
+        str.append(" The following conflicts were found: [ ");
+        Iterator<Importer.Conflict> conflicts = importConflictException.message().getConflicts().iterator();
+        while (conflicts.hasNext()) {
+            str.append(conflicts.next());
+            if (conflicts.hasNext()) {
+                str.append(", ");
+            }
+        }
+        str.append(" ]");
+        this.message = str.toString();
+    }
+
+    @Override
+    public String toString() {
+        return message;
+    }
+}

--- a/server/src/main/java/org/candlepin/async/JobManager.java
+++ b/server/src/main/java/org/candlepin/async/JobManager.java
@@ -1086,7 +1086,6 @@ public class JobManager implements ModeChangeListener {
         // Rollback any unsent events
         eventSink.rollback();
 
-        // Only store the exception type and the message. Luckily for us, toString does exactly that.
         String result = throwable != null ? throwable.toString() : null;
 
         if (retry) {

--- a/server/src/main/java/org/candlepin/async/tasks/ExportJob.java
+++ b/server/src/main/java/org/candlepin/async/tasks/ExportJob.java
@@ -66,7 +66,8 @@ public class ExportJob implements AsyncJob {
         }
 
         /**
-         * Sets the consumer for this export job. The consumer must be
+         * Sets the consumer for this export job. The consumer is required, and also provides the
+         * context in which the job will be executed.
          *
          * @param consumer
          *  the consumer to set for this job
@@ -170,12 +171,12 @@ public class ExportJob implements AsyncJob {
                 String consumerUuid = arguments.getAsString(CONSUMER_KEY);
                 String cdnLabel = arguments.getAsString(CDN_LABEL);
 
-                if (!(consumerUuid instanceof String) || ((String) consumerUuid).isEmpty()) {
+                if (consumerUuid == null || consumerUuid.isEmpty()) {
                     String errmsg = "consumer has not been set, or the provided consumer lacks a UUID";
                     throw new JobConfigValidationException(errmsg);
                 }
 
-                if (!(cdnLabel instanceof String) || ((String) cdnLabel).isEmpty()) {
+                if (cdnLabel == null || cdnLabel.isEmpty()) {
                     String errmsg = "CDN label has not been set, or the provided label is empty";
                     throw new JobConfigValidationException(errmsg);
                 }

--- a/server/src/main/java/org/candlepin/async/tasks/ImportJob.java
+++ b/server/src/main/java/org/candlepin/async/tasks/ImportJob.java
@@ -1,0 +1,229 @@
+/**
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.async.tasks;
+
+import com.google.inject.Inject;
+import org.candlepin.async.ArgumentConversionException;
+import org.candlepin.async.AsyncJob;
+import org.candlepin.async.ImportConflictJobException;
+import org.candlepin.async.JobArguments;
+import org.candlepin.async.JobConfig;
+import org.candlepin.async.JobConfigValidationException;
+import org.candlepin.async.JobConstraints;
+import org.candlepin.async.JobExecutionContext;
+import org.candlepin.async.JobExecutionException;
+import org.candlepin.common.exceptions.NotFoundException;
+import org.candlepin.controller.ManifestManager;
+import org.candlepin.model.ImportRecord;
+import org.candlepin.model.Owner;
+import org.candlepin.model.OwnerCurator;
+import org.candlepin.sync.ConflictOverrides;
+import org.candlepin.sync.ImportConflictException;
+import org.candlepin.sync.ImporterException;
+import org.candlepin.sync.file.ManifestFileService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Runs an asynchronous manifest import. This job expects that the manifest file was already uploaded.
+ */
+public class ImportJob implements AsyncJob {
+    private static Logger log = LoggerFactory.getLogger(ImportJob.class);
+
+    public static final String JOB_KEY = "IMPORT_JOB";
+    public static final String JOB_NAME = "import_manifest";
+
+    protected static final String OWNER_KEY = "org";
+    protected static final String STORED_FILE_ID = "stored_manifest_file_id";
+    protected static final String CONFLICT_OVERRIDES = "conflict_overrides";
+    protected static final String UPLOADED_FILE_NAME = "uploaded_file_name";
+
+    /**
+     * Job configuration object for the import job
+     */
+    public static class ImportJobConfig extends JobConfig {
+        public ImportJobConfig() {
+            this.setJobKey(JOB_KEY)
+                .setJobName(JOB_NAME)
+                .addConstraint(JobConstraints.uniqueByArgument(OWNER_KEY));
+        }
+
+        /**
+         * Sets the owner for this import job. The owner is required, and also provides the org
+         * context in which the job will be executed.
+         *
+         * @param owner
+         *  the owner to set for this job
+         *
+         * @return
+         *  a reference to this job config
+         */
+        public ImportJobConfig setOwner(Owner owner) {
+            if (owner == null) {
+                throw new IllegalArgumentException("owner is null");
+            }
+
+            // The owner is both part of metadata & arguments in this job.
+            this.setJobMetadata(OWNER_KEY, owner.getKey())
+                .setJobArgument(OWNER_KEY, owner.getKey())
+                .setLogLevel(owner.getLogLevel());
+
+            return this;
+        }
+
+        /**
+         * Sets the id of the stored file on the {@link ManifestFileService}.
+         *
+         * @param storedFileId
+         *  the stored file id to set for this job
+         *
+         * @return
+         *  a reference to this job config
+         */
+        public ImportJobConfig setStoredFileId(String storedFileId) {
+            this.setJobArgument(STORED_FILE_ID, storedFileId);
+            return this;
+        }
+
+        /**
+         * Sets the file name of the uploaded file on the {@link ManifestFileService}.
+         *
+         * @param uploadedFileName
+         *  the uploaded file name to set for this job
+         *
+         * @return
+         *  a reference to this job config
+         */
+        public ImportJobConfig setUploadedFileName(String uploadedFileName) {
+            this.setJobArgument(UPLOADED_FILE_NAME, uploadedFileName);
+            return this;
+        }
+
+        /**
+         * Sets the conflict overrides the user has specified to this import job.
+         *
+         * @param conflictOverrides
+         *  the conflict overrides to set for this job
+         *
+         * @return
+         *  a reference to this job config
+         */
+        public ImportJobConfig setConflictOverrides(ConflictOverrides conflictOverrides) {
+            this.setJobArgument(CONFLICT_OVERRIDES, conflictOverrides.asStringArray());
+            return this;
+        }
+
+        @Override
+        public void validate() throws JobConfigValidationException {
+            super.validate();
+
+            try {
+                JobArguments arguments = this.getJobArguments();
+
+                String ownerKey = arguments.getAsString(OWNER_KEY);
+                String storedFileId = arguments.getAsString(STORED_FILE_ID);
+                String uploadedFileName = arguments.getAsString(UPLOADED_FILE_NAME);
+
+                if (ownerKey == null || ownerKey.isEmpty()) {
+                    String errmsg = "owner has not been set, or the provided owner lacks a key";
+                    throw new JobConfigValidationException(errmsg);
+                }
+
+                if (storedFileId == null || storedFileId.isEmpty()) {
+                    String errmsg = "stored file id has not been set, or is empty";
+                    throw new JobConfigValidationException(errmsg);
+                }
+
+                if (uploadedFileName == null || uploadedFileName.isEmpty()) {
+                    String errmsg = "uploaded file name has not been set, or is empty";
+                    throw new JobConfigValidationException(errmsg);
+                }
+            }
+            catch (ArgumentConversionException e) {
+                String errmsg = "One or more required arguments are of the wrong type";
+                throw new JobConfigValidationException(errmsg, e);
+            }
+        }
+    }
+
+    private OwnerCurator ownerCurator;
+    private ManifestManager manifestManager;
+
+    @Inject
+    public ImportJob(OwnerCurator ownerCurator, ManifestManager manifestManager) {
+        this.ownerCurator = ownerCurator;
+        this.manifestManager = manifestManager;
+    }
+
+    @Override
+    public Object execute(JobExecutionContext context) throws JobExecutionException {
+        JobArguments args = context.getJobArguments();
+
+        String ownerKey = args.getAsString(OWNER_KEY);
+        ConflictOverrides overrides = new ConflictOverrides(args.getAs(CONFLICT_OVERRIDES, String[].class));
+        String storedFileId = args.getAsString(STORED_FILE_ID);
+        String uploadedFileName = args.getAsString(UPLOADED_FILE_NAME);
+
+        JobExecutionException toThrow;
+        Throwable caught;
+        Owner targetOwner = null;
+        try {
+            targetOwner = ownerCurator.getByKey(ownerKey);
+            if (targetOwner == null) {
+                throw new NotFoundException(String.format("Owner %s was not found.", ownerKey));
+            }
+
+            ImportRecord importRecord = manifestManager.importStoredManifest(targetOwner,
+                storedFileId, overrides, uploadedFileName);
+            log.info("Async import complete.");
+            return importRecord;
+        }
+        // Here, we pass the exceptions we caught to be persisted as part of an ImportRecord failure,
+        // while we propagate JobExecutionExceptions to the job management system (marked appropriately as
+        // terminal/non-terminal, and in the case of an import conflict, extra conflict information).
+        catch (ImportConflictException e) {
+            toThrow = new ImportConflictJobException(e);
+            caught = e;
+        }
+        catch (ImporterException e) {
+            toThrow = new JobExecutionException(e.getMessage(), e, true);
+            caught = e;
+        }
+        catch (Exception e) {
+            toThrow = new JobExecutionException(e.getMessage(), e, false);
+            caught = e;
+        }
+
+        manifestManager.recordImportFailure(targetOwner, caught, uploadedFileName);
+
+        // If an exception was thrown, the importer's transaction was rolled
+        // back. We want to make sure that the file gets deleted so that it
+        // doesn't take up disk space. It may be possible that the file was
+        // already deleted, but we attempt it anyway.
+        manifestManager.deleteStoredManifest(storedFileId);
+        throw toThrow;
+    }
+
+    /**
+     * Creates a JobConfig configured to execute the import job. Callers may further manipulate
+     * the JobConfig as necessary before queuing it.
+     *
+     * @return
+     *  a JobConfig instance configured to execute the import job
+     */
+    public static ImportJobConfig createJobConfig() {
+        return new ImportJobConfig();
+    }
+}

--- a/server/src/main/java/org/candlepin/controller/ManifestManager.java
+++ b/server/src/main/java/org/candlepin/controller/ManifestManager.java
@@ -28,6 +28,7 @@ import org.apache.commons.lang.StringUtils;
 
 import org.candlepin.async.JobConfig;
 import org.candlepin.async.tasks.ExportJob;
+import org.candlepin.async.tasks.ImportJob;
 import org.candlepin.audit.EventFactory;
 import org.candlepin.audit.EventSink;
 import org.candlepin.common.exceptions.BadRequestException;
@@ -42,7 +43,6 @@ import org.candlepin.model.ConsumerType;
 import org.candlepin.model.ConsumerTypeCurator;
 import org.candlepin.model.EntitlementCurator;
 import org.candlepin.model.ImportRecord;
-import org.candlepin.pinsetter.tasks.ImportJob;
 import org.candlepin.model.Owner;
 import org.candlepin.pinsetter.tasks.ManifestCleanerJob;
 import org.candlepin.service.ExportExtensionAdapter;
@@ -170,10 +170,14 @@ public class ManifestManager {
      * @return the {@link JobDetail} that represents the asynchronous import job to start.
      * @throws ManifestFileServiceException if the archive could not be stored.
      */
-    public JobDetail importManifestAsync(Owner owner, File archive, String uploadedFileName,
+    public JobConfig importManifestAsync(Owner owner, File archive, String uploadedFileName,
         ConflictOverrides overrides) throws ManifestFileServiceException {
         ManifestFile manifestRecordId = storeImport(archive, owner);
-        return ImportJob.scheduleImport(owner, manifestRecordId.getId(), uploadedFileName, overrides);
+        return ImportJob.createJobConfig()
+            .setOwner(owner)
+            .setStoredFileId(manifestRecordId.getId())
+            .setUploadedFileName(uploadedFileName)
+            .setConflictOverrides(overrides);
     }
 
     /**

--- a/server/src/main/java/org/candlepin/guice/CandlepinModule.java
+++ b/server/src/main/java/org/candlepin/guice/CandlepinModule.java
@@ -31,6 +31,7 @@ import org.candlepin.async.JobMessageDispatcher;
 import org.candlepin.async.JobManager;
 import org.candlepin.async.impl.ArtemisJobMessageDispatcher;
 import org.candlepin.async.tasks.ExportJob;
+import org.candlepin.async.tasks.ImportJob;
 import org.candlepin.async.temp.AsyncJobResource;
 import org.candlepin.async.temp.TestJob1;
 import org.candlepin.audit.AMQPBusPublisher;
@@ -416,6 +417,7 @@ public class CandlepinModule extends AbstractModule {
 
         JobManager.registerJob(TestJob1.JOB_KEY, TestJob1.class);
         JobManager.registerJob(ExportJob.JOB_KEY, ExportJob.class);
+        JobManager.registerJob(ImportJob.JOB_KEY, ImportJob.class);
     }
 
     private void configurePinsetter() {

--- a/server/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -14,6 +14,9 @@
  */
 package org.candlepin.resource;
 
+import org.candlepin.async.JobConfig;
+import org.candlepin.async.JobException;
+import org.candlepin.async.JobManager;
 import org.candlepin.audit.Event;
 import org.candlepin.audit.Event.Target;
 import org.candlepin.audit.Event.Type;
@@ -40,6 +43,7 @@ import org.candlepin.controller.OwnerManager;
 import org.candlepin.controller.PoolManager;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.dto.api.v1.ActivationKeyDTO;
+import org.candlepin.dto.api.v1.AsyncJobStatusDTO;
 import org.candlepin.dto.api.v1.BrandingDTO;
 import org.candlepin.dto.api.v1.ConsumerDTO;
 import org.candlepin.dto.api.v1.ContentOverrideDTO;
@@ -52,14 +56,13 @@ import org.candlepin.dto.api.v1.PoolDTO;
 import org.candlepin.dto.api.v1.SystemPurposeAttributesDTO;
 import org.candlepin.dto.api.v1.UpstreamConsumerDTO;
 import org.candlepin.dto.api.v1.UeberCertificateDTO;
+import org.candlepin.model.AsyncJobStatus;
 import org.candlepin.model.Branding;
 import org.candlepin.model.CandlepinQuery;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerCurator;
 import org.candlepin.model.ConsumerType;
-import org.candlepin.model.ConsumerTypeCurator;
 import org.candlepin.model.Entitlement;
-import org.candlepin.model.EntitlementCertificateCurator;
 import org.candlepin.model.EntitlementCurator;
 import org.candlepin.model.EntitlementFilterBuilder;
 import org.candlepin.model.Environment;
@@ -78,7 +81,6 @@ import org.candlepin.model.Pool;
 import org.candlepin.model.Pool.PoolType;
 import org.candlepin.model.PoolFilterBuilder;
 import org.candlepin.model.Product;
-import org.candlepin.model.ProductCurator;
 import org.candlepin.model.Release;
 import org.candlepin.model.SourceSubscription;
 import org.candlepin.model.SystemPurposeAttributeType;
@@ -181,7 +183,6 @@ public class OwnerResource {
     private static final int FEED_LIMIT = 1000;
 
     private OwnerCurator ownerCurator;
-    private ProductCurator productCurator;
     private OwnerInfoCurator ownerInfoCurator;
     private ActivationKeyCurator activationKeyCurator;
     private OwnerServiceAdapter ownerService;
@@ -196,8 +197,6 @@ public class OwnerResource {
     private ImportRecordCurator importRecordCurator;
     private PoolManager poolManager;
     private OwnerManager ownerManager;
-    private ConsumerTypeCurator consumerTypeCurator;
-    private EntitlementCertificateCurator entitlementCertCurator;
     private EntitlementCurator entitlementCurator;
     private UeberCertificateCurator ueberCertCurator;
     private UeberCertificateGenerator ueberCertGenerator;
@@ -210,10 +209,10 @@ public class OwnerResource {
     private ConsumerTypeValidator consumerTypeValidator;
     private OwnerProductCurator ownerProductCurator;
     private ModelTranslator translator;
+    private JobManager jobManager;
 
     @Inject
     public OwnerResource(OwnerCurator ownerCurator,
-        ProductCurator productCurator,
         ActivationKeyCurator activationKeyCurator,
         ConsumerCurator consumerCurator,
         I18n i18n,
@@ -227,8 +226,6 @@ public class OwnerResource {
         ExporterMetadataCurator exportCurator,
         OwnerInfoCurator ownerInfoCurator,
         ImportRecordCurator importRecordCurator,
-        ConsumerTypeCurator consumerTypeCurator,
-        EntitlementCertificateCurator entitlementCertCurator,
         EntitlementCurator entitlementCurator,
         UeberCertificateCurator ueberCertCurator,
         UeberCertificateGenerator ueberCertGenerator,
@@ -241,10 +238,10 @@ public class OwnerResource {
         ResolverUtil resolverUtil,
         ConsumerTypeValidator consumerTypeValidator,
         OwnerProductCurator ownerProductCurator,
-        ModelTranslator translator) {
+        ModelTranslator translator,
+        JobManager jobManager) {
 
         this.ownerCurator = ownerCurator;
-        this.productCurator = productCurator;
         this.ownerInfoCurator = ownerInfoCurator;
         this.activationKeyCurator = activationKeyCurator;
         this.consumerCurator = consumerCurator;
@@ -258,8 +255,6 @@ public class OwnerResource {
         this.manifestManager = manifestManager;
         this.ownerManager = ownerManager;
         this.eventAdapter = eventAdapter;
-        this.consumerTypeCurator = consumerTypeCurator;
-        this.entitlementCertCurator = entitlementCertCurator;
         this.entitlementCurator = entitlementCurator;
         this.ueberCertCurator = ueberCertCurator;
         this.ueberCertGenerator = ueberCertGenerator;
@@ -273,6 +268,7 @@ public class OwnerResource {
         this.consumerTypeValidator = consumerTypeValidator;
         this.ownerProductCurator = ownerProductCurator;
         this.translator = translator;
+        this.jobManager = jobManager;
     }
 
     /**
@@ -2010,10 +2006,10 @@ public class OwnerResource {
         @ApiResponse(code = 404, message = "Owner not found"),
         @ApiResponse(code = 500, message = ""),
         @ApiResponse(code = 409, message = "")})
-    public JobDetail importManifestAsync(
+    public AsyncJobStatusDTO importManifestAsync(
         @PathParam("owner_key") @Verify(Owner.class) String ownerKey,
         @QueryParam("force") String[] overrideConflicts,
-        MultipartInput input) {
+        MultipartInput input) throws JobException {
 
         ConflictOverrides overrides = processConflictOverrideParams(overrideConflicts);
         UploadMetadata fileData = new UploadMetadata();
@@ -2023,8 +2019,11 @@ public class OwnerResource {
             fileData = getArchiveFromResponse(input);
             String archivePath = fileData.getData().getAbsolutePath();
             log.info("Running async import of archive {} for owner {}", archivePath, owner.getDisplayName());
-            return manifestManager.importManifestAsync(owner, fileData.getData(),
+            JobConfig config =  manifestManager.importManifestAsync(owner, fileData.getData(),
                 fileData.getUploadedFilename(), overrides);
+
+            AsyncJobStatus job = this.jobManager.queueJob(config);
+            return this.translator.translate(job, AsyncJobStatusDTO.class);
         }
         catch (IOException e) {
             manifestManager.recordImportFailure(owner, e, fileData.getUploadedFilename());

--- a/server/src/test/java/org/candlepin/async/tasks/ImportJobTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/ImportJobTest.java
@@ -1,0 +1,292 @@
+/**
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.async.tasks;
+
+import org.candlepin.async.JobArguments;
+import org.candlepin.async.JobConfig;
+import org.candlepin.async.JobConfigValidationException;
+import org.candlepin.async.JobExecutionContext;
+import org.candlepin.async.JobExecutionException;
+import org.candlepin.common.exceptions.NotFoundException;
+import org.candlepin.controller.ManifestManager;
+import org.candlepin.model.ImportRecord;
+import org.candlepin.model.Owner;
+import org.candlepin.model.OwnerCurator;
+import org.candlepin.pinsetter.tasks.BaseJobTest;
+import org.candlepin.sync.ConflictOverrides;
+import org.candlepin.sync.Importer;
+import org.candlepin.sync.ImporterException;
+import org.candlepin.test.TestUtil;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ImportJobTest extends BaseJobTest {
+
+    @Mock private ManifestManager manifestManager;
+    @Mock private JobExecutionContext ctx;
+    @Mock private OwnerCurator ownerCurator;
+    private ImportJob job;
+
+    private Owner owner;
+
+    @Before
+    public void setup() {
+        super.init();
+        owner = new Owner("my-test-owner");
+        job = new ImportJob(ownerCurator, manifestManager);
+        injector.injectMembers(job);
+    }
+
+    private Owner createTestOwner(String key, String logLevel) {
+        Owner owner = TestUtil.createOwner();
+
+        owner.setId(TestUtil.randomString());
+        owner.setKey(key);
+        owner.setLogLevel(logLevel);
+
+        return owner;
+    }
+
+    @Test
+    public void testJobConfigSetOwner() {
+        Owner owner = this.createTestOwner("owner_key", "log_level");
+
+        JobConfig config = ImportJob.createJobConfig()
+            .setOwner(owner);
+
+        Map<String, String> metadata = config.getJobMetadata();
+        JobArguments args = config.getJobArguments();
+
+        assertTrue(metadata.containsKey(ImportJob.OWNER_KEY));
+        assertEquals(owner.getKey(), metadata.get(ImportJob.OWNER_KEY));
+        assertEquals(owner.getLogLevel(), config.getLogLevel());
+        assertEquals(owner.getKey(), args.getAsString(ImportJob.OWNER_KEY));
+    }
+
+    @Test
+    public void testJobConfigSetUploadFileName() {
+        String fileName = "file_name_1";
+
+        JobConfig config = ImportJob.createJobConfig()
+            .setUploadedFileName(fileName);
+
+        JobArguments args = config.getJobArguments();
+
+        assertTrue(args.containsKey(ImportJob.UPLOADED_FILE_NAME));
+        assertEquals(fileName, args.getAsString(ImportJob.UPLOADED_FILE_NAME));
+    }
+
+    @Test
+    public void testJobConfigSetStoredFileId() {
+        String storedFileId = "stored_file_id_1";
+
+        JobConfig config = ImportJob.createJobConfig()
+            .setStoredFileId(storedFileId);
+
+        JobArguments args = config.getJobArguments();
+
+        assertTrue(args.containsKey(ImportJob.STORED_FILE_ID));
+        assertEquals(storedFileId, args.getAsString(ImportJob.STORED_FILE_ID));
+    }
+
+    @Test
+    public void testJobConfigSetConflictOverrides() {
+        ConflictOverrides conflictOverrides = new ConflictOverrides(
+            Importer.Conflict.DISTRIBUTOR_CONFLICT, Importer.Conflict.MANIFEST_SAME);
+
+        JobConfig config = ImportJob.createJobConfig()
+            .setConflictOverrides(conflictOverrides);
+
+        JobArguments args = config.getJobArguments();
+
+        assertTrue(args.containsKey(ImportJob.CONFLICT_OVERRIDES));
+        assertArrayEquals(conflictOverrides.asStringArray(),
+            args.getAs(ImportJob.CONFLICT_OVERRIDES, String[].class));
+    }
+
+    @Test
+    public void testValidate() throws JobConfigValidationException {
+        Owner owner = this.createTestOwner("owner_key", "log_level");
+
+        JobConfig config = ImportJob.createJobConfig()
+            .setOwner(owner)
+            .setStoredFileId("stored_field_id_1")
+            .setUploadedFileName("upload_file_name_1");
+
+        config.validate();
+    }
+
+    // TODO: Update this test to use the JUnit5 exception handling once this branch catches up
+    // with master
+    @Test
+    public void testValidateNoOwner() {
+        JobConfig config = ImportJob.createJobConfig()
+            .setStoredFileId("stored_field_id_1")
+            .setUploadedFileName("upload_file_name_1");
+
+        try {
+            config.validate();
+            fail("an expected exception was not thrown");
+        }
+        catch (JobConfigValidationException e) {
+            // Pass!
+        }
+    }
+
+    // TODO: Update this test to use the JUnit5 exception handling once this branch catches up
+    // with master
+    @Test
+    public void testValidateNoStoredFileId() {
+        Owner owner = this.createTestOwner("owner_key_1", "log_level_1");
+
+        JobConfig config = ImportJob.createJobConfig()
+            .setOwner(owner)
+            .setUploadedFileName("upload_file_name_1");
+
+        try {
+            config.validate();
+            fail("an expected exception was not thrown");
+        }
+        catch (JobConfigValidationException e) {
+            // Pass!
+        }
+    }
+
+    // TODO: Update this test to use the JUnit5 exception handling once this branch catches up
+    // with master
+    @Test
+    public void testValidateNoUploadedFileName() {
+        Owner owner = this.createTestOwner("owner_key_1", "log_level_1");
+
+        JobConfig config = ImportJob.createJobConfig()
+            .setOwner(owner)
+            .setStoredFileId("stored_field_id_1");
+
+        try {
+            config.validate();
+            fail("an expected exception was not thrown");
+        }
+        catch (JobConfigValidationException e) {
+            // Pass!
+        }
+    }
+
+    @Test
+    public void ensureJobSuccess() throws Exception {
+        String uploadFileName = "upload_file_name_1";
+        String storedFieldId = "stored_field_id_1";
+        ConflictOverrides conflictOverrides = new ConflictOverrides(
+            Importer.Conflict.SIGNATURE_CONFLICT, Importer.Conflict.MANIFEST_OLD);
+
+        ImportRecord importRecord = new ImportRecord(owner);
+        importRecord.setFileName(uploadFileName);
+
+        JobConfig jobConfig = ImportJob.createJobConfig()
+            .setOwner(owner)
+            .setStoredFileId(storedFieldId)
+            .setUploadedFileName(uploadFileName)
+            .setConflictOverrides(conflictOverrides);
+
+        JobExecutionContext context = mock(JobExecutionContext.class);
+        doReturn(jobConfig.getJobArguments()).when(context).getJobArguments();
+        doReturn(owner).when(ownerCurator).getByKey(eq("my-test-owner"));
+        when(manifestManager.importStoredManifest(eq(owner), eq(storedFieldId), any(ConflictOverrides.class),
+            eq(uploadFileName))).thenReturn(importRecord);
+
+        Object actualResult = this.job.execute(context);
+
+        assertEquals(importRecord, actualResult);
+    }
+
+    // TODO: Update this test to use the JUnit5 exception handling once this branch catches up
+    // with master
+    @Test
+    public void ensureJobFailure() throws Exception {
+        String archiveFilePath = "/path/to/some/file.zip";
+        ConflictOverrides co = new ConflictOverrides(Importer.Conflict.SIGNATURE_CONFLICT);
+        String uploadedFileName = "test.zip";
+        String expectedMessage = "Expected Exception Message";
+
+        JobConfig jobConfig = ImportJob.createJobConfig()
+            .setOwner(owner)
+            .setUploadedFileName(uploadedFileName)
+            .setStoredFileId(archiveFilePath)
+            .setConflictOverrides(co);
+
+        doReturn(jobConfig.getJobArguments()).when(ctx).getJobArguments();
+        doReturn(owner).when(ownerCurator).getByKey(eq("my-test-owner"));
+        when(manifestManager.importStoredManifest(eq(owner), eq(archiveFilePath),
+            any(ConflictOverrides.class), eq(uploadedFileName)))
+            .thenThrow(new ImporterException(expectedMessage));
+
+        try {
+            job.execute(ctx);
+            fail("Expected exception to be thrown");
+        }
+        catch (JobExecutionException e) {
+            // Expected this failure
+            assertEquals(expectedMessage, e.getMessage());
+            assertTrue(e.getCause() instanceof ImporterException);
+            verify(manifestManager).recordImportFailure(eq(owner), eq(e.getCause()), eq(uploadedFileName));
+        }
+    }
+
+    // TODO: Update this test to use the JUnit5 exception handling once this branch catches up
+    // with master
+    @Test
+    public void ensureJobExceptionThrownIfOwnerNotFound() {
+        String archiveFilePath = "/path/to/some/file.zip";
+        ConflictOverrides co = new ConflictOverrides(Importer.Conflict.SIGNATURE_CONFLICT);
+        String uploadedFileName = "test.zip";
+        String expectedMessage = String.format("Owner %s was not found.", owner.getKey());
+
+        JobConfig jobConfig = ImportJob.createJobConfig()
+            .setOwner(owner)
+            .setUploadedFileName(uploadedFileName)
+            .setStoredFileId(archiveFilePath)
+            .setConflictOverrides(co);
+
+        doReturn(jobConfig.getJobArguments()).when(ctx).getJobArguments();
+        doReturn(null).when(ownerCurator).getByKey(eq("my-test-owner"));
+
+        try {
+            job.execute(ctx);
+            fail("Expected exception not thrown");
+        }
+        catch (JobExecutionException e) {
+            // Expected this failure
+            assertEquals(expectedMessage, e.getMessage());
+            assertTrue(e.getCause() instanceof NotFoundException);
+            verify(manifestManager).recordImportFailure(eq(null), eq(e.getCause()), eq(uploadedFileName));
+        }
+    }
+}

--- a/server/src/test/java/org/candlepin/resource/OwnerResourceUeberCertOperationsTest.java
+++ b/server/src/test/java/org/candlepin/resource/OwnerResourceUeberCertOperationsTest.java
@@ -23,8 +23,6 @@ import org.candlepin.auth.UserPrincipal;
 import org.candlepin.auth.permissions.PermissionFactory;
 import org.candlepin.common.exceptions.NotFoundException;
 import org.candlepin.controller.CandlepinPoolManager;
-import org.candlepin.controller.ContentManager;
-import org.candlepin.controller.ProductManager;
 import org.candlepin.dto.api.v1.UeberCertificateDTO;
 import org.candlepin.model.Owner;
 import org.candlepin.model.Role;
@@ -54,8 +52,6 @@ public class OwnerResourceUeberCertOperationsTest extends DatabaseTestFixture {
     @Inject private PermissionFactory permFactory;
     @Inject private ServiceLevelValidator serviceLevelValidator;
     @Inject private ContentOverrideValidator contentOverrideValidator;
-    @Inject private ProductManager productManager;
-    @Inject private ContentManager contentManager;
 
     private Owner owner;
     private OwnerResource or;
@@ -75,11 +71,11 @@ public class OwnerResourceUeberCertOperationsTest extends DatabaseTestFixture {
         setupPrincipal(principal);
 
         or = new OwnerResource(
-            ownerCurator, productCurator, null, consumerCurator, i18n, null, null, null,
+            ownerCurator, null, consumerCurator, i18n, null, null, null,
             null, null, poolManager, null, null,
-            null, null, consumerTypeCurator, entitlementCertificateCurator, entitlementCurator,
+            null, null, entitlementCurator,
             ueberCertCurator, ueberCertGenerator, null,  null, contentOverrideValidator,
-            serviceLevelValidator, null, null, null, null, null, this.modelTranslator);
+            serviceLevelValidator, null, null, null, null, null, this.modelTranslator, this.jobManager);
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/test/DatabaseTestFixture.java
+++ b/server/src/test/java/org/candlepin/test/DatabaseTestFixture.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.*;
 
 import org.candlepin.TestingInterceptor;
 import org.candlepin.TestingModules;
+import org.candlepin.async.JobManager;
 import org.candlepin.auth.Access;
 import org.candlepin.auth.Principal;
 import org.candlepin.auth.UserPrincipal;
@@ -164,6 +165,7 @@ public class DatabaseTestFixture {
 
     @Inject protected ResourceLocatorMap locatorMap;
     @Inject protected ModelTranslator modelTranslator;
+    @Inject protected JobManager jobManager;
 
     private static Injector parentInjector;
     protected Injector injector;


### PR DESCRIPTION
* Now the ImportJob is using the new artemis messaging framework.
* Made sure that in case of an ImportJob failure due to conflicts,
  the result data returned include the list of conflicts.
* Removed some unused constructor arguments from OwnerResource.