### PR TITLE
[F] ENT-846: Port RefreshPoolsJob To The New Messaging Framework

### DIFF
--- a/server/client/ruby/candlepin_api.rb
+++ b/server/client/ruby/candlepin_api.rb
@@ -549,7 +549,10 @@ class Candlepin
     return status if immediate
 
     # otherwise poll the server to make this call synchronous
-    finished_states = ['FINISHED', 'CANCELED', 'FAILED']
+
+    #TODO: This list includes both the old and new job framework states. Once all jobs have been ported,
+    # the 'FINISHED' state should be removed.
+    finished_states = ['COMPLETED', 'ABORTED', 'FINISHED', 'CANCELED', 'FAILED']
 
     # We toss this into a new array since async_call is sometimes used with endpoints which return multiple
     # job details

--- a/server/spec/product_resource_spec.rb
+++ b/server/spec/product_resource_spec.rb
@@ -178,36 +178,36 @@ describe 'Product Resource' do
     jobs = @cp.refresh_pools_for_orgs_with_product(["p4"])
     jobs.length.should == 1
     jobs.each do |job|
-      job['id'].should include("refresh_pools")
-      wait_for_job(job['id'], 15)
+      job['name'].should include("refresh_pools")
+      wait_for_async_job(job['id'], 15)
     end
 
     jobs = @cp.refresh_pools_for_orgs_with_product(["p5d"])
     jobs.length.should == 1
     jobs.each do |job|
-      job['id'].should include("refresh_pools")
-      wait_for_job(job['id'], 15)
+      job['name'].should include("refresh_pools")
+      wait_for_async_job(job['id'], 15)
     end
 
     jobs = @cp.refresh_pools_for_orgs_with_product(["p1"])
     jobs.length.should == 3
     jobs.each do |job|
-      job['id'].should include("refresh_pools")
-      wait_for_job(job['id'], 15)
+      job['name'].should include("refresh_pools")
+      wait_for_async_job(job['id'], 15)
     end
 
     jobs = @cp.refresh_pools_for_orgs_with_product(["p3"])
     jobs.length.should == 2
     jobs.each do |job|
-      job['id'].should include("refresh_pools")
-      wait_for_job(job['id'], 15)
+      job['name'].should include("refresh_pools")
+      wait_for_async_job(job['id'], 15)
     end
 
     jobs = @cp.refresh_pools_for_orgs_with_product(["p4", "p6"])
     jobs.length.should == 2
     jobs.each do |job|
-      job['id'].should include("refresh_pools")
-      wait_for_job(job['id'], 15)
+      job['name'].should include("refresh_pools")
+      wait_for_async_job(job['id'], 15)
     end
 
     jobs = @cp.refresh_pools_for_orgs_with_product(["nope"])

--- a/server/spec/refresh_pools_spec.rb
+++ b/server/spec/refresh_pools_spec.rb
@@ -20,7 +20,7 @@ describe 'Refresh Pools' do
     owner = create_owner random_string('test_owner')
 
     status = @cp.refresh_pools(owner['key'], true)
-    status.state.should eq('CREATED')
+    status.state.should eq('CREATED').or(eq('QUEUED'))
 
     # URI returned is valid - use post to clean up
     @cp.post(status.statusPath).state.should_not be_nil

--- a/server/src/main/java/org/candlepin/async/tasks/RefreshPoolsJob.java
+++ b/server/src/main/java/org/candlepin/async/tasks/RefreshPoolsJob.java
@@ -1,0 +1,175 @@
+/**
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.async.tasks;
+
+import com.google.inject.Inject;
+import org.candlepin.async.ArgumentConversionException;
+import org.candlepin.async.AsyncJob;
+import org.candlepin.async.JobArguments;
+import org.candlepin.async.JobConfig;
+import org.candlepin.async.JobConfigValidationException;
+import org.candlepin.async.JobConstraints;
+import org.candlepin.async.JobExecutionContext;
+import org.candlepin.async.JobExecutionException;
+import org.candlepin.controller.PoolManager;
+import org.candlepin.controller.Refresher;
+import org.candlepin.model.Owner;
+import org.candlepin.model.OwnerCurator;
+import org.candlepin.service.OwnerServiceAdapter;
+import org.candlepin.service.SubscriptionServiceAdapter;
+
+/**
+ * Asynchronous job for refreshing the entitlement pools for specific {@link Owner}.
+ */
+public class RefreshPoolsJob implements AsyncJob {
+
+    public static final String JOB_KEY = "REFRESH_POOLS_JOB";
+    public static final String JOB_NAME = "refresh_pools";
+
+    protected static final String OWNER_KEY = "org";
+    protected static final String LAZY_REGEN = "lazy_regen";
+
+    protected OwnerCurator ownerCurator;
+    protected PoolManager poolManager;
+    protected SubscriptionServiceAdapter subAdapter;
+    protected OwnerServiceAdapter ownerAdapter;
+
+    /**
+     * Job configuration object for the refresh pools job
+     */
+    public static class RefreshPoolsJobConfig extends JobConfig {
+        public RefreshPoolsJobConfig() {
+            this.setJobKey(JOB_KEY)
+                .setJobName(JOB_NAME)
+                .addConstraint(JobConstraints.uniqueByArgument(OWNER_KEY));
+        }
+
+        /**
+         * Sets the owner for this refresh pools job. The owner is required, and also provides the org
+         * context in which the job will be executed.
+         *
+         * @param owner
+         *  the owner to set for this job
+         *
+         * @return
+         *  a reference to this job config
+         */
+        public RefreshPoolsJobConfig setOwner(Owner owner) {
+            if (owner == null) {
+                throw new IllegalArgumentException("owner is null");
+            }
+
+            // The owner is both part of metadata & arguments in this job.
+            this.setJobMetadata(OWNER_KEY, owner.getKey())
+                .setJobArgument(OWNER_KEY, owner.getKey())
+                .setLogLevel(owner.getLogLevel());
+
+            return this;
+        }
+
+        /**
+         * Sets whether or not to generate the certificates immediately, or mark them as dirty and allow
+         * them to be regenerated on-demand.
+         *
+         * @param lazy
+         *  whether or not to generate the certificates immediately
+         *
+         * @return
+         *  a reference to this job config
+         */
+        public RefreshPoolsJobConfig setLazyRegeneration(boolean lazy) {
+            this.setJobArgument(LAZY_REGEN, lazy);
+
+            return this;
+        }
+
+        @Override
+        public void validate() throws JobConfigValidationException {
+            super.validate();
+
+            try {
+                JobArguments arguments = this.getJobArguments();
+
+                String ownerKey = arguments.getAsString(OWNER_KEY);
+                Boolean lazyRegeneration = arguments.getAsBoolean(LAZY_REGEN);
+
+                if (ownerKey == null || ownerKey.isEmpty()) {
+                    String errmsg = "owner has not been set, or the provided owner lacks a key";
+                    throw new JobConfigValidationException(errmsg);
+                }
+
+                if (lazyRegeneration == null) {
+                    String errmsg = "lazy regeneration has not been set";
+                    throw new JobConfigValidationException(errmsg);
+                }
+            }
+            catch (ArgumentConversionException e) {
+                String errmsg = "One or more required arguments are of the wrong type";
+                throw new JobConfigValidationException(errmsg, e);
+            }
+        }
+    }
+
+    @Inject
+    public RefreshPoolsJob(OwnerCurator ownerCurator, PoolManager poolManager,
+        SubscriptionServiceAdapter subAdapter, OwnerServiceAdapter ownerAdapter) {
+
+        this.ownerCurator = ownerCurator;
+        this.poolManager = poolManager;
+        this.subAdapter = subAdapter;
+        this.ownerAdapter = ownerAdapter;
+    }
+
+   /**
+     * {@inheritDoc}
+     *
+     * Executes {@link Refresher#run()} for all products of a specific Owner as a job.
+     *
+     * @param context the job's execution context
+     */
+    public Object execute(JobExecutionContext context) throws JobExecutionException {
+        JobArguments args = context.getJobArguments();
+        String ownerKey = args.getAsString(OWNER_KEY);
+        boolean lazy = args.getAsBoolean(LAZY_REGEN);
+        Owner owner = ownerCurator.getByKey(ownerKey);
+
+        if (owner == null) {
+            throw new JobExecutionException("Nothing to do. Owner no longer exists", true);
+        }
+
+        try {
+            // Assume that we verified the request in the resource layer:
+            poolManager.getRefresher(this.subAdapter, this.ownerAdapter, lazy)
+                .add(owner)
+                .run();
+        }
+        catch (Exception e) {
+            throw new JobExecutionException(e.getMessage(), e, false);
+        }
+
+        return "Pools refreshed for owner " + owner.getDisplayName();
+    }
+
+    /**
+     * Creates a JobConfig configured to execute the refresh pools job. Callers may further manipulate
+     * the JobConfig as necessary before queuing it.
+     *
+     * @return
+     *  a JobConfig instance configured to execute the refresh pools job
+     */
+    public static RefreshPoolsJobConfig createJobConfig() {
+        return new RefreshPoolsJobConfig();
+    }
+}

--- a/server/src/main/java/org/candlepin/async/temp/AsyncJobResource.java
+++ b/server/src/main/java/org/candlepin/async/temp/AsyncJobResource.java
@@ -34,6 +34,7 @@ import org.xnap.commons.i18n.I18n;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -118,6 +119,23 @@ public class AsyncJobResource {
     @ApiOperation(notes = "Fetches the job info for a given job ID", value = "")
     public AsyncJobStatusDTO get(@PathParam("job_id") @Verify(AsyncJobStatus.class) String jobId) {
         AsyncJobStatus status = this.jobCurator.get(jobId);
+
+        return this.translator.translate(status, AsyncJobStatusDTO.class);
+    }
+
+    @ApiOperation(notes = "Retrieves a Job Status and Removes if finished",
+        value = "getStatusAndDeleteIfFinished")
+    @POST
+    @Path("/{job_id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.WILDCARD)
+    public AsyncJobStatusDTO getStatusAndDeleteIfFinished(
+        @PathParam("job_id") @Verify(AsyncJobStatus.class) String jobId) {
+        AsyncJobStatus status = this.jobCurator.get(jobId);
+
+        if (status != null && status.getState() == AsyncJobStatus.JobState.COMPLETED) {
+            this.jobCurator.delete(status);
+        }
 
         return this.translator.translate(status, AsyncJobStatusDTO.class);
     }

--- a/server/src/main/java/org/candlepin/controller/Refresher.java
+++ b/server/src/main/java/org/candlepin/controller/Refresher.java
@@ -22,8 +22,6 @@ import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.service.model.OwnerInfo;
 import org.candlepin.service.model.SubscriptionInfo;
 
-import com.google.inject.persist.UnitOfWork;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,7 +44,6 @@ public class Refresher {
     private OwnerServiceAdapter ownerAdapter;
     private OwnerManager ownerManager;
     private boolean lazy;
-    private UnitOfWork uow;
     private static Logger log = LoggerFactory.getLogger(Refresher.class);
 
     private Map<String, Owner> owners = new HashMap<>();
@@ -60,11 +57,6 @@ public class Refresher {
         this.ownerAdapter = ownerAdapter;
         this.ownerManager = ownerManager;
         this.lazy = lazy;
-    }
-
-    public Refresher setUnitOfWork(UnitOfWork uow) {
-        this.uow = uow;
-        return this;
     }
 
     public Refresher add(Owner owner) {

--- a/server/src/main/java/org/candlepin/dto/api/v1/AsyncJobStatusDTO.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/AsyncJobStatusDTO.java
@@ -428,6 +428,17 @@ public class AsyncJobStatusDTO extends TimestampedCandlepinDTO<AsyncJobStatusDTO
     }
 
     /**
+     * Retrieves the URL path of this AsyncJobStatusDTO object.
+     *
+     * @return the URL path of this AsyncJobStatusDTO object.
+     */
+    public String getStatusPath() {
+        //TODO: The `/async` resource is temporary for testing ONLY. This should change to `/jobs` once that
+        // resource has been converted to use the new job framework!
+        return this.getId() != null ? String.format("/async/%s", this.getId()) : null;
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override

--- a/server/src/main/java/org/candlepin/guice/CandlepinModule.java
+++ b/server/src/main/java/org/candlepin/guice/CandlepinModule.java
@@ -33,6 +33,7 @@ import org.candlepin.async.impl.ArtemisJobMessageDispatcher;
 import org.candlepin.async.tasks.ExportJob;
 import org.candlepin.async.tasks.ImportJob;
 import org.candlepin.async.tasks.RefreshPoolsForProductJob;
+import org.candlepin.async.tasks.RefreshPoolsJob;
 import org.candlepin.async.temp.AsyncJobResource;
 import org.candlepin.async.temp.TestJob1;
 import org.candlepin.audit.AMQPBusPublisher;
@@ -100,7 +101,6 @@ import org.candlepin.pinsetter.tasks.CertificateRevocationListTask;
 import org.candlepin.pinsetter.tasks.EntitlerJob;
 import org.candlepin.pinsetter.tasks.HypervisorUpdateJob;
 import org.candlepin.pinsetter.tasks.JobCleaner;
-import org.candlepin.pinsetter.tasks.RefreshPoolsJob;
 import org.candlepin.pinsetter.tasks.SweepBarJob;
 import org.candlepin.pinsetter.tasks.UnpauseJob;
 import org.candlepin.pki.impl.JSSPrivateKeyReader;
@@ -317,7 +317,6 @@ public class CandlepinModule extends AbstractModule {
         miscConfigurations();
 
         // Async Jobs
-        bind(RefreshPoolsJob.class);
         bind(EntitlerJob.class);
         requestStaticInjection(EntitlerJob.class);
         bind(HypervisorUpdateJob.class);
@@ -420,6 +419,7 @@ public class CandlepinModule extends AbstractModule {
         JobManager.registerJob(ExportJob.JOB_KEY, ExportJob.class);
         JobManager.registerJob(ImportJob.JOB_KEY, ImportJob.class);
         JobManager.registerJob(RefreshPoolsForProductJob.JOB_KEY, RefreshPoolsForProductJob.class);
+        JobManager.registerJob(RefreshPoolsJob.JOB_KEY, RefreshPoolsJob.class);
     }
 
     private void configurePinsetter() {

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/RefreshPoolsJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/RefreshPoolsJob.java
@@ -80,7 +80,6 @@ public class RefreshPoolsJob extends UniqueByEntityJob {
 
         // Assume that we verified the request in the resource layer:
         poolManager.getRefresher(this.subAdapter, this.ownerAdapter, lazy)
-            .setUnitOfWork(unitOfWork)
             .add(owner)
             .run();
 

--- a/server/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -17,6 +17,7 @@ package org.candlepin.resource;
 import org.candlepin.async.JobConfig;
 import org.candlepin.async.JobException;
 import org.candlepin.async.JobManager;
+import org.candlepin.async.tasks.RefreshPoolsJob;
 import org.candlepin.audit.Event;
 import org.candlepin.audit.Event.Target;
 import org.candlepin.audit.Event.Type;
@@ -94,7 +95,6 @@ import org.candlepin.model.activationkeys.ActivationKeyCurator;
 import org.candlepin.model.dto.Subscription;
 import org.candlepin.pinsetter.tasks.HealEntireOrgJob;
 import org.candlepin.pinsetter.tasks.ImportJob;
-import org.candlepin.pinsetter.tasks.RefreshPoolsJob;
 import org.candlepin.pinsetter.tasks.UndoImportsJob;
 import org.candlepin.resource.util.CalculatedAttributesUtil;
 import org.candlepin.resource.util.ConsumerTypeValidator;
@@ -1685,10 +1685,10 @@ public class OwnerResource {
         "an on-site deployment is just a no-op.", value = "Update Subscription")
     @ApiResponses({ @ApiResponse(code = 404, message = "Owner not found"),
         @ApiResponse(code = 202, message = "") })
-    public JobDetail refreshPools(
+    public AsyncJobStatusDTO refreshPools(
         @PathParam("owner_key") String ownerKey,
         @QueryParam("auto_create_owner") @DefaultValue("false") Boolean autoCreateOwner,
-        @QueryParam("lazy_regen") @DefaultValue("true") Boolean lazyRegen) {
+        @QueryParam("lazy_regen") @DefaultValue("true") Boolean lazyRegen) throws JobException {
 
         Owner owner = ownerCurator.getByKey(ownerKey);
         if (owner == null) {
@@ -1705,7 +1705,12 @@ public class OwnerResource {
             return null;
         }
 
-        return RefreshPoolsJob.forOwner(owner, lazyRegen);
+        JobConfig config = RefreshPoolsJob.createJobConfig()
+            .setOwner(owner)
+            .setLazyRegeneration(lazyRegen);
+
+        AsyncJobStatus job = this.jobManager.queueJob(config);
+        return this.translator.translate(job, AsyncJobStatusDTO.class);
     }
 
     /**

--- a/server/src/test/java/org/candlepin/async/tasks/RefreshPoolsJobTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/RefreshPoolsJobTest.java
@@ -1,0 +1,213 @@
+/**
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.async.tasks;
+
+import org.candlepin.async.JobArguments;
+import org.candlepin.async.JobConfig;
+import org.candlepin.async.JobConfigValidationException;
+import org.candlepin.async.JobExecutionContext;
+import org.candlepin.async.JobExecutionException;
+import org.candlepin.controller.PoolManager;
+import org.candlepin.controller.Refresher;
+import org.candlepin.model.Owner;
+import org.candlepin.model.OwnerCurator;
+import org.candlepin.pinsetter.tasks.BaseJobTest;
+import org.candlepin.service.OwnerServiceAdapter;
+import org.candlepin.service.SubscriptionServiceAdapter;
+import org.candlepin.test.TestUtil;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RefreshPoolsJobTest extends BaseJobTest {
+
+    private RefreshPoolsJob job;
+    @Mock protected OwnerCurator ownerCurator;
+    @Mock protected PoolManager poolManager;
+    @Mock protected SubscriptionServiceAdapter subAdapter;
+    @Mock protected OwnerServiceAdapter ownerAdapter;
+    @Mock protected Refresher refresher;
+    @Mock private JobExecutionContext ctx;
+
+    @Before
+    public void setupTest() {
+        super.init();
+
+        job = new RefreshPoolsJob(ownerCurator, poolManager, subAdapter, ownerAdapter);
+        injector.injectMembers(job);
+    }
+
+    private Owner createTestOwner(String key, String logLevel) {
+        Owner owner = TestUtil.createOwner();
+
+        owner.setId(TestUtil.randomString());
+        owner.setKey(key);
+        owner.setLogLevel(logLevel);
+
+        return owner;
+    }
+
+    @Test
+    public void testJobConfigSetOwner() {
+        Owner owner = this.createTestOwner("owner_key", "log_level");
+
+        JobConfig config = RefreshPoolsJob.createJobConfig()
+            .setOwner(owner);
+
+        Map<String, String> metadata = config.getJobMetadata();
+
+        assertTrue(metadata.containsKey(RefreshPoolsJob.OWNER_KEY));
+        assertEquals(owner.getKey(), metadata.get(RefreshPoolsJob.OWNER_KEY));
+        assertEquals(owner.getLogLevel(), config.getLogLevel());
+    }
+
+    @Test
+    public void testJobConfigSetLazyRegeneration() {
+        JobConfig config = RefreshPoolsJob.createJobConfig()
+            .setLazyRegeneration(true);
+
+        JobArguments args = config.getJobArguments();
+
+        assertTrue(args.containsKey(RefreshPoolsJob.LAZY_REGEN));
+        assertEquals(true, args.getAsBoolean(RefreshPoolsJob.LAZY_REGEN));
+    }
+
+    @Test
+    public void testValidate() throws JobConfigValidationException {
+        Owner owner = this.createTestOwner("owner_key", "log_level");
+
+        JobConfig config = RefreshPoolsJob.createJobConfig()
+            .setOwner(owner)
+            .setLazyRegeneration(false);
+
+        config.validate();
+    }
+
+
+    // TODO: Update this test to use the JUnit5 exception handling once this branch catches up
+    // with master
+    @Test
+    public void testValidateNoOwner() {
+        JobConfig config = RefreshPoolsJob.createJobConfig()
+            .setLazyRegeneration(true);
+
+        try {
+            config.validate();
+            fail("an expected exception was not thrown");
+        }
+        catch (JobConfigValidationException e) {
+            // Pass!
+        }
+    }
+
+    // TODO: Update this test to use the JUnit5 exception handling once this branch catches up
+    // with master
+    @Test
+    public void testValidateNoLazyRegeneration() {
+        Owner owner = this.createTestOwner("owner_key", "log_level");
+
+        JobConfig config = RefreshPoolsJob.createJobConfig()
+            .setOwner(owner);
+
+        try {
+            config.validate();
+            fail("an expected exception was not thrown");
+        }
+        catch (JobConfigValidationException e) {
+            // Pass!
+        }
+    }
+
+    @Test
+    public void ensureJobSuccess() throws Exception {
+        Owner owner = createTestOwner("my-test-owner", "test-log-level");
+        owner.setDisplayName("my-test-owner-displayname");
+        JobConfig jobConfig = RefreshPoolsJob.createJobConfig()
+            .setOwner(owner)
+            .setLazyRegeneration(true);
+
+        doReturn(jobConfig.getJobArguments()).when(ctx).getJobArguments();
+        doReturn(owner).when(ownerCurator).getByKey(eq("my-test-owner"));
+        doReturn(refresher).when(poolManager).getRefresher(eq(subAdapter), eq(ownerAdapter), eq(true));
+        doReturn(refresher).when(refresher).add(eq(owner));
+
+        Object actualResult = this.job.execute(ctx);
+
+        assertEquals("Pools refreshed for owner my-test-owner-displayname", actualResult);
+    }
+
+    // TODO: Update this test to use the JUnit5 exception handling once this branch catches up
+    // with master
+    @Test
+    public void ensureJobFailure() throws Exception {
+        Owner owner = createTestOwner("my-test-owner", "test-log-level");
+
+        JobConfig jobConfig = RefreshPoolsJob.createJobConfig()
+            .setOwner(owner)
+            .setLazyRegeneration(false);
+
+        doReturn(jobConfig.getJobArguments()).when(ctx).getJobArguments();
+        doReturn(owner).when(ownerCurator).getByKey(eq("my-test-owner"));
+        doReturn(refresher).when(poolManager).getRefresher(eq(subAdapter), eq(ownerAdapter), eq(false));
+        doReturn(refresher).when(refresher).add(eq(owner));
+        doThrow(new RuntimeException("something went wrong with refresh")).when(refresher).run();
+
+        try {
+            job.execute(ctx);
+            fail("Expected exception to be thrown");
+        }
+        catch (Exception e) {
+            // Expected this failure
+            assertEquals("something went wrong with refresh", e.getMessage());
+            assertTrue(e instanceof JobExecutionException);
+        }
+    }
+
+    // TODO: Update this test to use the JUnit5 exception handling once this branch catches up
+    // with master
+    @Test
+    public void ensureJobExceptionThrownIfOwnerNotFound() throws Exception {
+        Owner owner = createTestOwner("my-test-owner", "test-log-level");
+
+        JobConfig jobConfig = RefreshPoolsJob.createJobConfig()
+            .setOwner(owner)
+            .setLazyRegeneration(false);
+
+        doReturn(jobConfig.getJobArguments()).when(ctx).getJobArguments();
+        doReturn(null).when(ownerCurator).getByKey(eq("my-test-owner"));
+
+        try {
+            job.execute(ctx);
+            fail("Expected exception to be thrown");
+        }
+        catch (Exception e) {
+            // Expected this failure
+            assertEquals("Nothing to do. Owner no longer exists", e.getMessage());
+            assertTrue(e instanceof JobExecutionException);
+        }
+    }
+}

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/RefreshPoolsJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/RefreshPoolsJobTest.java
@@ -14,7 +14,6 @@
  */
 package org.candlepin.pinsetter.tasks;
 
-import com.google.inject.persist.UnitOfWork;
 import org.candlepin.controller.CandlepinPoolManager;
 import org.candlepin.controller.Refresher;
 import org.candlepin.model.Owner;
@@ -40,7 +39,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -80,7 +78,6 @@ public class RefreshPoolsJobTest extends BaseJobTest {
         when(owner.getDisplayName()).thenReturn("test owner");
         when(pm.getRefresher(eq(subAdapter), eq(ownerAdapter), eq(true))).thenReturn(refresher);
         when(refresher.add(eq(owner))).thenReturn(refresher);
-        when(refresher.setUnitOfWork(any(UnitOfWork.class))).thenReturn(refresher);
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/UndoImportsJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/UndoImportsJobTest.java
@@ -15,7 +15,6 @@
 package org.candlepin.pinsetter.tasks;
 
 import com.google.inject.Inject;
-import com.google.inject.persist.UnitOfWork;
 import org.candlepin.auth.Principal;
 import org.candlepin.auth.UserPrincipal;
 import org.candlepin.controller.CandlepinPoolManager;
@@ -123,7 +122,6 @@ public class UndoImportsJobTest extends DatabaseTestFixture {
         when(this.jobContext.getMergedJobDataMap()).thenReturn(this.jobDataMap);
         when(this.poolManager.getRefresher(eq(this.subAdapter), any(OwnerServiceAdapter.class), anyBoolean()))
             .thenReturn(this.refresher);
-        when(this.refresher.setUnitOfWork(any(UnitOfWork.class))).thenReturn(this.refresher);
         when(this.refresher.add(any(Owner.class))).thenReturn(this.refresher);
 
         this.undoImportsJob = new UndoImportsJob(

--- a/server/src/test/java/org/candlepin/resource/ProductResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/ProductResourceTest.java
@@ -15,19 +15,25 @@
 package org.candlepin.resource;
 
 import static org.junit.Assert.*;
+import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import org.candlepin.async.JobConfigValidationException;
+import org.candlepin.async.JobException;
+import org.candlepin.async.JobManager;
+import org.candlepin.async.tasks.RefreshPoolsJob;
 import org.candlepin.common.config.Configuration;
 import org.candlepin.common.config.MapConfiguration;
 import org.candlepin.common.exceptions.BadRequestException;
 import org.candlepin.config.ConfigProperties;
+import org.candlepin.dto.api.v1.AsyncJobStatusDTO;
 import org.candlepin.dto.api.v1.ContentDTO;
 import org.candlepin.dto.api.v1.OwnerDTO;
 import org.candlepin.dto.api.v1.ProductCertificateDTO;
 import org.candlepin.dto.api.v1.ProductDTO;
-import org.candlepin.model.ContentCurator;
+import org.candlepin.model.AsyncJobStatus;
 import org.candlepin.model.Pool;
 import org.candlepin.model.Product;
 import org.candlepin.model.ProductCurator;
@@ -36,14 +42,10 @@ import org.candlepin.model.ProductCertificateCurator;
 import org.candlepin.model.Owner;
 import org.candlepin.model.OwnerCurator;
 import org.candlepin.model.dto.Subscription;
-import org.candlepin.pinsetter.core.model.JobStatus;
-import org.candlepin.pinsetter.tasks.RefreshPoolsJob;
 import org.candlepin.test.DatabaseTestFixture;
 import org.candlepin.test.TestUtil;
 
 import org.junit.Test;
-import org.quartz.JobDataMap;
-import org.quartz.JobDetail;
 import org.xnap.commons.i18n.I18n;
 import org.xnap.commons.i18n.I18nFactory;
 
@@ -53,6 +55,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
@@ -63,7 +66,6 @@ import javax.inject.Inject;
  */
 public class ProductResourceTest extends DatabaseTestFixture {
     @Inject private ProductCertificateCurator productCertificateCurator;
-    @Inject private ContentCurator contentCurator;
     @Inject private ProductResource productResource;
     @Inject private OwnerCurator ownerCurator;
     @Inject private ProductCurator productCurator;
@@ -127,7 +129,8 @@ public class ProductResourceTest extends DatabaseTestFixture {
     public void testDeleteProductWithSubscriptions() {
         ProductCurator pc = mock(ProductCurator.class);
         I18n i18n = I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK);
-        ProductResource pr = new ProductResource(pc, null, null, config, i18n, this.modelTranslator);
+        ProductResource pr = new ProductResource(pc, null, null, config, i18n, this.modelTranslator,
+            this.jobManager);
         Owner o = mock(Owner.class);
         Product p = mock(Product.class);
         // when(pc.getById(eq(o), eq("10"))).thenReturn(p);
@@ -236,125 +239,101 @@ public class ProductResourceTest extends DatabaseTestFixture {
         productResource.getProductOwners(new LinkedList<>());
     }
 
-    private void verifyRefreshPoolsJobs(JobDetail[] jobs, List<Owner> owners, boolean lazyRegen) {
-        for (JobDetail job : jobs) {
-            assertTrue(RefreshPoolsJob.class.isAssignableFrom(job.getJobClass()));
-
-            JobDataMap jdmap = job.getJobDataMap();
-
-            assertTrue(jdmap.containsKey(JobStatus.OWNER_ID));
-            assertTrue(jdmap.containsKey(JobStatus.TARGET_TYPE));
-            assertTrue(jdmap.containsKey(JobStatus.TARGET_ID));
-            assertTrue(jdmap.containsKey(RefreshPoolsJob.LAZY_REGEN));
-
-            assertEquals(JobStatus.TargetType.OWNER, jdmap.get(JobStatus.TARGET_TYPE));
-            assertEquals(jdmap.get(JobStatus.OWNER_ID), jdmap.get(JobStatus.TARGET_ID));
-            assertEquals(lazyRegen, jdmap.get(RefreshPoolsJob.LAZY_REGEN));
-
-            boolean found = false;
-            for (Owner owner : owners) {
-                if (owner.getKey().equals(jdmap.get(JobStatus.OWNER_ID))) {
-                    found = true;
-                    break;
-                }
-            }
-
-            assertTrue(found);
+    private void verifyRefreshPoolsJobsWhereQueued(List<AsyncJobStatusDTO> jobs) {
+        for (AsyncJobStatusDTO job : jobs) {
+            assertEquals(RefreshPoolsJob.JOB_NAME, job.getName());
+            assertEquals(AsyncJobStatus.JobState.FAILED.toString(), job.getState());
+            assertEquals(AsyncJobStatus.JobState.CREATED.toString(), job.getPreviousState());
+            assertEquals(Integer.valueOf(0), job.getAttempts());
+            assertEquals(Integer.valueOf(1), job.getMaxAttempts());
         }
     }
 
     @Test
-    public void testRefreshPoolsByProduct() {
+    public void testRefreshPoolsByProduct() throws JobException {
         Configuration config = new MapConfiguration(this.config);
         config.setProperty(ConfigProperties.STANDALONE, "false");
 
         ProductResource productResource = new ProductResource(this.productCurator, this.ownerCurator,
-            this.productCertificateCurator, config, this.i18n, this.modelTranslator);
+            this.productCertificateCurator, config, this.i18n, this.modelTranslator, this.jobManager);
+        this.setupDBForOwnerProdTests();
 
-        List<Owner> owners = this.setupDBForOwnerProdTests();
-        Owner owner1 = owners.get(0);
-        Owner owner2 = owners.get(1);
-        Owner owner3 = owners.get(2);
+        List<AsyncJobStatusDTO> jobs;
 
-        JobDetail[] jobs;
-
-        jobs = productResource.refreshPoolsForProduct(Arrays.asList("p1"), true);
+        jobs = productResource.refreshPoolsForProduct(Arrays.asList("p1"), true)
+            .collect(Collectors.toList());
         assertNotNull(jobs);
-        assertEquals(2, jobs.length);
-        this.verifyRefreshPoolsJobs(jobs, Arrays.asList(owner1, owner2), true);
+        assertEquals(2, jobs.size());
+        this.verifyRefreshPoolsJobsWhereQueued(jobs);
 
-        jobs = productResource.refreshPoolsForProduct(Arrays.asList("p1", "p2"), false);
+        jobs = productResource.refreshPoolsForProduct(Arrays.asList("p1", "p2"), false)
+            .collect(Collectors.toList());
         assertNotNull(jobs);
-        assertEquals(3, jobs.length);
-        this.verifyRefreshPoolsJobs(jobs, Arrays.asList(owner1, owner2, owner3), false);
+        assertEquals(3, jobs.size());
+        this.verifyRefreshPoolsJobsWhereQueued(jobs);
 
-        jobs = productResource.refreshPoolsForProduct(Arrays.asList("p3"), false);
+        jobs = productResource.refreshPoolsForProduct(Arrays.asList("p3"), false)
+            .collect(Collectors.toList());
         assertNotNull(jobs);
-        assertEquals(1, jobs.length);
-        this.verifyRefreshPoolsJobs(jobs, Arrays.asList(owner3), false);
+        assertEquals(1, jobs.size());
+        this.verifyRefreshPoolsJobsWhereQueued(jobs);
 
-        jobs = productResource.refreshPoolsForProduct(Arrays.asList("nope"), false);
+        jobs = productResource.refreshPoolsForProduct(Arrays.asList("nope"), false)
+            .collect(Collectors.toList());
         assertNotNull(jobs);
-        assertEquals(0, jobs.length);
+        assertEquals(0, jobs.size());
     }
 
-    // Temporarily disabled; reenable and remove the test above when the JobDetail streaming issue
-    // is resolved.
-    // @Test
-    // public void testRefreshPoolsByProduct() {
-    //     Configuration config = new MapConfiguration(this.config);
-    //     config.setProperty(ConfigProperties.STANDALONE, "false");
-
-    //     ProductResource productResource = new ProductResource(
-    //         this.productCurator, this.ownerCurator, this.productCertificateCurator, config, this.i18n,
-    //         this.isoFactory
-    //     );
-
-    //     List<Owner> owners = this.setupDBForOwnerProdTests();
-    //     Owner owner1 = owners.get(0);
-    //     Owner owner2 = owners.get(1);
-    //     Owner owner3 = owners.get(2);
-
-    //     List<JobDetail> jobs = new LinkedList<JobDetail>();
-
-    //     Response response = productResource.refreshPoolsForProduct(Arrays.asList("p1"), true);
-    //     jobs.clear();
-    //     for (Object entity : (IterableStreamingOutput) response.getEntity()) {
-    //         jobs.add((JobDetail) entity);
-    //     }
-    //     assertNotNull(jobs);
-    //     assertEquals(2, jobs.size());
-    //     this.verifyRefreshPoolsJobs(jobs, Arrays.asList(owner1, owner2), true);
-
-    //     response = productResource.refreshPoolsForProduct(Arrays.asList("p1", "p2"), false);
-    //     jobs.clear();
-    //     for (Object entity : (IterableStreamingOutput) response.getEntity()) {
-    //         jobs.add((JobDetail) entity);
-    //     }
-    //     assertNotNull(jobs);
-    //     assertEquals(3, jobs.size());
-    //     this.verifyRefreshPoolsJobs(jobs, Arrays.asList(owner1, owner2, owner3), false);
-
-    //     response = productResource.refreshPoolsForProduct(Arrays.asList("p3"), false);
-    //     jobs.clear();
-    //     for (Object entity : (IterableStreamingOutput) response.getEntity()) {
-    //         jobs.add((JobDetail) entity);
-    //     }
-    //     assertNotNull(jobs);
-    //     assertEquals(1, jobs.size());
-    //     this.verifyRefreshPoolsJobs(jobs, Arrays.asList(owner3), false);
-
-    //     response = productResource.refreshPoolsForProduct(Arrays.asList("nope"), false);
-    //     jobs.clear();
-    //     for (Object entity : (IterableStreamingOutput) response.getEntity()) {
-    //         jobs.add((JobDetail) entity);
-    //     }
-    //     assertNotNull(jobs);
-    //     assertEquals(0, jobs.size());
-    // }
-
     @Test(expected = BadRequestException.class)
-    public void testRefreshPoolsByProductInputValidation() {
+    public void testRefreshPoolsByProductInputValidation() throws JobException {
         productResource.refreshPoolsForProduct(new LinkedList<>(), true);
+    }
+
+    @Test
+    public void testRefreshPoolsByProductJobQueueingErrorsShouldBeHandled() throws JobException {
+        Configuration config = new MapConfiguration(this.config);
+        config.setProperty(ConfigProperties.STANDALONE, "false");
+
+        // We want to simulate the first queueJob call succeeds, and the second throws a validation exception
+        JobManager jobManager = mock(JobManager.class);
+        AsyncJobStatus status1 = new AsyncJobStatus();
+        status1.setName(RefreshPoolsJob.JOB_NAME);
+        status1.setState(AsyncJobStatus.JobState.CREATED); //need to prime the previous state field
+        status1.setState(AsyncJobStatus.JobState.QUEUED);
+        when(jobManager.queueJob(anyObject()))
+            .thenReturn(status1)
+            .thenThrow(new JobConfigValidationException("a job config validation error happened!"));
+
+        ProductResource productResource = new ProductResource(this.productCurator, this.ownerCurator,
+            this.productCertificateCurator, config, this.i18n, this.modelTranslator, jobManager);
+        this.setupDBForOwnerProdTests();
+
+        List<AsyncJobStatusDTO> jobs = null;
+        try {
+            jobs = productResource.refreshPoolsForProduct(Arrays.asList("p1"), true)
+                    .collect(Collectors.toList());
+        }
+        catch (Exception e) {
+            fail("A validation exception when trying to queue a job should be handled " +
+                "by the endpoint, not thrown!");
+        }
+        assertNotNull(jobs);
+        assertEquals(2, jobs.size());
+
+        // assert first job succeeded in queueing
+        AsyncJobStatusDTO statusDTO1 = jobs.get(0);
+        assertEquals(RefreshPoolsJob.JOB_NAME, statusDTO1.getName());
+        assertEquals(AsyncJobStatus.JobState.QUEUED.toString(), statusDTO1.getState());
+        assertEquals(AsyncJobStatus.JobState.CREATED.toString(), statusDTO1.getPreviousState());
+        assertEquals(Integer.valueOf(0), statusDTO1.getAttempts());
+        assertEquals(Integer.valueOf(1), statusDTO1.getMaxAttempts());
+
+        // assert second job failed validation
+        AsyncJobStatusDTO statusDTO2 = jobs.get(1);
+        assertEquals(RefreshPoolsJob.JOB_NAME, statusDTO2.getName());
+        assertEquals(AsyncJobStatus.JobState.FAILED.toString(), statusDTO2.getState());
+        assertEquals(AsyncJobStatus.JobState.CREATED.toString(), statusDTO2.getPreviousState());
+        assertEquals(Integer.valueOf(0), statusDTO2.getAttempts());
+        assertEquals(Integer.valueOf(1), statusDTO2.getMaxAttempts());
     }
 }


### PR DESCRIPTION
* Now the RefreshPoolsJob is using the new artemis messaging
  framework.
* Updated OwnerResource.refreshPools() &
  ProductResource.refreshPoolsForProduct() to use the new job.
* Exposed the 'statusPath' field on AsyncJobStatusDTO.
* Added new 'getStatusAndDeleteIfFinished' endpoint to the temp
  async job resource.
* Updated the spec test api to expect new job states.
* Removed redundant field from Refresher.