### PR TITLE
Remove Deprecated and unused annotations.

### DIFF
--- a/server/src/main/java/org/candlepin/model/ConsumerCapability.java
+++ b/server/src/main/java/org/candlepin/model/ConsumerCapability.java
@@ -14,9 +14,7 @@
  */
 package org.candlepin.model;
 
-import org.hibernate.annotations.ForeignKey;
 import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Index;
 
 import java.io.Serializable;
 
@@ -67,9 +65,7 @@ public class ConsumerCapability implements Serializable {
     private String name;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @ForeignKey(name = "fk_consumer_capability_consumer")
     @JoinColumn(nullable = false)
-    @Index(name = "cp_consumer_capability_consumer_fk_idx")
     @NotNull
     private Consumer consumer;
 

--- a/server/src/main/java/org/candlepin/model/ConsumerContentOverride.java
+++ b/server/src/main/java/org/candlepin/model/ConsumerContentOverride.java
@@ -14,9 +14,6 @@
  */
 package org.candlepin.model;
 
-import org.hibernate.annotations.ForeignKey;
-import org.hibernate.annotations.Index;
-
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -35,9 +32,7 @@ import javax.persistence.ManyToOne;
 public class ConsumerContentOverride extends ContentOverride<ConsumerContentOverride, Consumer> {
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @ForeignKey(name = "fk_consumer_content_consumer")
     @JoinColumn(nullable = true)
-    @Index(name = "cp_cnsmr_cntnt_cnsmr_fk_idx")
     private Consumer consumer;
 
     public ConsumerContentOverride() {

--- a/server/src/main/java/org/candlepin/model/ConsumerInstalledProduct.java
+++ b/server/src/main/java/org/candlepin/model/ConsumerInstalledProduct.java
@@ -15,9 +15,7 @@
 package org.candlepin.model;
 
 import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.hibernate.annotations.ForeignKey;
 import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Index;
 
 import java.util.Date;
 
@@ -85,10 +83,8 @@ public class ConsumerInstalledProduct extends AbstractHibernateObject {
     private Date endDate;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @ForeignKey(name = "fk_consumer_installed_product")
     @JoinColumn(nullable = false)
     @XmlTransient
-    @Index(name = "cp_installedproduct_consumer_fk_idx")
     private Consumer consumer;
 
     public ConsumerInstalledProduct() {

--- a/server/src/main/java/org/candlepin/model/DistributorVersionCapability.java
+++ b/server/src/main/java/org/candlepin/model/DistributorVersionCapability.java
@@ -14,9 +14,7 @@
  */
 package org.candlepin.model;
 
-import org.hibernate.annotations.ForeignKey;
 import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Index;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -57,9 +55,7 @@ public class DistributorVersionCapability {
     private String name;
 
     @ManyToOne
-    @ForeignKey(name = "fk_dist_vrsn_cpblty")
     @JoinColumn(name = "dist_version_id", nullable = false)
-    @Index(name = "cp_capability_distver_fk_idx")
     private DistributorVersion distributorVersion;
 
     public DistributorVersionCapability() {

--- a/server/src/main/java/org/candlepin/model/EntitlementCertificate.java
+++ b/server/src/main/java/org/candlepin/model/EntitlementCertificate.java
@@ -16,9 +16,7 @@ package org.candlepin.model;
 
 import com.fasterxml.jackson.annotation.JsonFilter;
 
-import org.hibernate.annotations.ForeignKey;
 import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Index;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -54,9 +52,7 @@ public class EntitlementCertificate extends RevocableCertificate<EntitlementCert
     private String id;
 
     @ManyToOne
-    @ForeignKey(name = "fk_cert_entitlement")
     @JoinColumn(nullable = false)
-    @Index(name = "cp_cert_entitlement_fk_idx")
     @NotNull
     private Entitlement entitlement;
 

--- a/server/src/main/java/org/candlepin/model/Environment.java
+++ b/server/src/main/java/org/candlepin/model/Environment.java
@@ -14,9 +14,6 @@
  */
 package org.candlepin.model;
 
-import org.hibernate.annotations.ForeignKey;
-import org.hibernate.annotations.Index;
-
 import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;
@@ -55,9 +52,7 @@ public class Environment extends AbstractHibernateObject implements Serializable
     private static final long serialVersionUID = 4162471699021316341L;
 
     @ManyToOne
-    @ForeignKey(name = "fk_env_owner")
     @JoinColumn(nullable = false)
-    @Index(name = "cp_env_owner_fk_idx")
     @NotNull
     private Owner owner;
 

--- a/server/src/main/java/org/candlepin/model/GuestId.java
+++ b/server/src/main/java/org/candlepin/model/GuestId.java
@@ -21,9 +21,7 @@ import com.fasterxml.jackson.annotation.JsonFilter;
 
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.hibernate.annotations.Cascade;
-import org.hibernate.annotations.ForeignKey;
 import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Index;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -80,10 +78,8 @@ public class GuestId extends AbstractHibernateObject implements Owned, Named, Co
     private String guestIdLower;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @ForeignKey(name = "fk_consumer_guests")
     @JoinColumn(nullable = false)
     @XmlTransient
-    @Index(name = "cp_consumerguest_consumer_fk_idx")
     @NotNull
     private Consumer consumer;
 

--- a/server/src/main/java/org/candlepin/model/HypervisorId.java
+++ b/server/src/main/java/org/candlepin/model/HypervisorId.java
@@ -14,9 +14,7 @@
  */
 package org.candlepin.model;
 
-import org.hibernate.annotations.ForeignKey;
 import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Index;
 
 import java.io.Serializable;
 
@@ -66,7 +64,6 @@ public class HypervisorId extends AbstractHibernateObject {
     private String id;
 
     @Column(name = "hypervisor_id", nullable = false)
-    @Index(name = "idx_hypervisor_id")
     @Size(max = 255)
     @NotNull
     private String hypervisorId;
@@ -76,16 +73,13 @@ public class HypervisorId extends AbstractHibernateObject {
     private String reporterId;
 
     @OneToOne(fetch = FetchType.LAZY)
-    @ForeignKey(name = "fk_hypervisor_consumer")
     @JoinColumn(nullable = false, unique = true)
     @XmlTransient
     @NotNull
     private Consumer consumer;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @ForeignKey(name = "fk_hypervisor_owner")
     @JoinColumn(nullable = false)
-    @Index(name = "idx_hypervisor_owner_fk")
     @XmlTransient
     @NotNull
     private Owner owner;

--- a/server/src/main/java/org/candlepin/model/ImportUpstreamConsumer.java
+++ b/server/src/main/java/org/candlepin/model/ImportUpstreamConsumer.java
@@ -18,7 +18,6 @@ import org.candlepin.common.jackson.HateoasInclude;
 
 import com.fasterxml.jackson.annotation.JsonFilter;
 
-import org.hibernate.annotations.ForeignKey;
 import org.hibernate.annotations.GenericGenerator;
 
 import javax.persistence.Column;
@@ -66,7 +65,6 @@ public class ImportUpstreamConsumer extends AbstractHibernateObject {
 
     @ManyToOne
     @JoinColumn(nullable = false)
-    @ForeignKey(name = "fk_import_upstream_cnsmr_type")
     @NotNull
     private ConsumerType type;
 

--- a/server/src/main/java/org/candlepin/model/PermissionBlueprint.java
+++ b/server/src/main/java/org/candlepin/model/PermissionBlueprint.java
@@ -18,9 +18,7 @@ import org.candlepin.auth.Access;
 import org.candlepin.auth.permissions.PermissionFactory.PermissionType;
 import org.candlepin.service.model.PermissionBlueprintInfo;
 
-import org.hibernate.annotations.ForeignKey;
 import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Index;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -59,16 +57,12 @@ public class PermissionBlueprint extends AbstractHibernateObject implements Perm
     private String id;
 
     @ManyToOne
-    @ForeignKey(name = "fk_permission_owner")
     @JoinColumn(nullable = false)
-    @Index(name = "cp_permission_owner_fk_idx")
     @NotNull
     private Owner owner;
 
     @ManyToOne
-    @ForeignKey(name = "fk_permission_role")
     @JoinColumn(nullable = false)
-    @Index(name = "cp_permission_role_fk_idx")
     @NotNull
     private Role role;
 

--- a/server/src/main/java/org/candlepin/model/Role.java
+++ b/server/src/main/java/org/candlepin/model/Role.java
@@ -16,7 +16,6 @@ package org.candlepin.model;
 
 import org.candlepin.service.model.RoleInfo;
 
-import org.hibernate.annotations.ForeignKey;
 import org.hibernate.annotations.GenericGenerator;
 
 import java.util.HashSet;
@@ -53,9 +52,6 @@ public class Role extends AbstractHibernateObject implements Linkable, RoleInfo 
     private String id;
 
     @ManyToMany(targetEntity = User.class)
-    @ForeignKey(
-        name = "fk_user_id",
-        inverseName = "fk_role_id")
     @JoinTable(
         name = "cp_role_users",
         joinColumns = @JoinColumn(name = "role_id"),

--- a/server/src/main/java/org/candlepin/model/UpstreamConsumer.java
+++ b/server/src/main/java/org/candlepin/model/UpstreamConsumer.java
@@ -19,7 +19,6 @@ import org.candlepin.common.jackson.HateoasInclude;
 
 import com.fasterxml.jackson.annotation.JsonFilter;
 
-import org.hibernate.annotations.ForeignKey;
 import org.hibernate.annotations.GenericGenerator;
 
 import javax.persistence.Column;
@@ -72,7 +71,6 @@ public class UpstreamConsumer extends AbstractHibernateObject<UpstreamConsumer> 
 
     @ManyToOne
     @JoinColumn(nullable = false)
-    @ForeignKey(name = "fk_upstream_consumer_type")
     @NotNull
     private ConsumerType type;
 


### PR DESCRIPTION
Candlepin now uses liquibase to generate the database schema. Because of this the ForeignKey and Index annotations are no longer necessary on the model objects. In addition the Hibernate.annotations.ForeignKey & Index annotations have been deprecated.

Rather than converting to the new JPA style annotations this change removes them entirely as they are not providing additional value on top of the liquibase schema generation.