### PR TITLE
[F] Quartz should be bumped to version 2.2.2

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -120,7 +120,7 @@ dependencies {
 
     implementation "org.mozilla:jss:4.5.0"
     implementation "ldapjdk:ldapjdk:4.19"
-    implementation "org.quartz-scheduler:quartz:2.2.1"
+    implementation "org.quartz-scheduler:quartz:2.2.2"
 
     // These for ActiveMQ Artemis
     implementation "org.apache.activemq:artemis-server:${versions.artemis}"


### PR DESCRIPTION
- This was lost after the merging of master back into the new job
  framework branch, due to it being simultaneously bumped in the
  buildfile in one branch, and the switch from buildr to gradle
  in the other.