### PR TITLE
[F] Ported the UndoImportsJob to the Artemis job system (ENT-854)

### DIFF
--- a/common/src/main/java/org/candlepin/common/filter/LoggingFilter.java
+++ b/common/src/main/java/org/candlepin/common/filter/LoggingFilter.java
@@ -49,6 +49,9 @@ public class LoggingFilter implements Filter {
     private static final int CSID_MAX_LENGTH = 40;
     private static final Pattern CSID_REGEX = Pattern.compile("^([a-zA-Z0-9-]){1," + CSID_MAX_LENGTH + "}$");
 
+    /** The metadata key used to display the owner's key or display name */
+    public static final String OWNER_KEY = "org"; // This value must match that set in logback.xml
+
 
     private String customHeaderName;
 

--- a/server/spec/import_spec.rb
+++ b/server/spec/import_spec.rb
@@ -11,9 +11,10 @@ describe 'Import Test Group:', :serial => true do
 
     before(:all) do
       # Decide the import method to use, async or synchronous
-      @import_method = import_now
       if async
         @import_method = import_and_wait
+      else
+        @import_method = import_now
       end
 
       @cp = Candlepin.new('admin', 'admin')
@@ -127,7 +128,7 @@ describe 'Import Test Group:', :serial => true do
       custom_pool = @cp.create_pool(@import_owner['key'], prod['id'])
 
       job = @import_owner_client.undo_import(@import_owner['key'])
-      wait_for_job(job['id'], 30)
+      wait_for_async_job(job['id'], 30)
 
       pools = @import_owner_client.list_pools({:owner => @import_owner['id']})
       pools.length.should == 1 # this is our custom pool
@@ -144,7 +145,7 @@ describe 'Import Test Group:', :serial => true do
       # Delete again and make sure another owner is clear to import the
       # same manifest:
       job = @import_owner_client.undo_import(@import_owner['key'])
-      wait_for_job(job['id'], 30)
+      wait_for_async_job(job['id'], 30)
 
       # Verify our custom sub still exists
       pools = @import_owner_client.list_pools({:owner => @import_owner['id']})
@@ -169,7 +170,7 @@ describe 'Import Test Group:', :serial => true do
 
     it 'should create a DELETE record on a deleted import' do
       job = @import_owner_client.undo_import(@import_owner['key'])
-      wait_for_job(job['id'], 30)
+      wait_for_async_job(job['id'], 30)
       @import_owner_client.list_imports(@import_owner['key']).find_all do |import|
         import.status == 'DELETE'
       end.should_not be_empty
@@ -371,7 +372,7 @@ describe 'Import Test Group:', :serial => true do
       # Also added the confirmation that the exception occurs when importing to
       # another owner.
       job = @import_owner_client.undo_import(@import_owner['key'])
-      wait_for_job(job['id'], 30)
+      wait_for_async_job(job['id'], 30)
 
       @import_method.call(@import_owner['key'], @cp_export_file)
       owner2 = @cp.create_owner(random_string("owner2"))

--- a/server/src/main/java/org/candlepin/async/JobExecutionContext.java
+++ b/server/src/main/java/org/candlepin/async/JobExecutionContext.java
@@ -30,6 +30,16 @@ public interface JobExecutionContext {
      */
     JobArguments getJobArguments();
 
+    /**
+     * Fetches the name of the principal that created this job. This may be different from the
+     * principal of the context in which the job is executing.
+     *
+     * @return
+     *  the name of the principal which created the executing job
+     */
+    String getPrincipalName();
+
+
     // TODO: Add other stuff here as necessary
 
 }

--- a/server/src/main/java/org/candlepin/async/JobManager.java
+++ b/server/src/main/java/org/candlepin/async/JobManager.java
@@ -650,7 +650,7 @@ public class JobManager implements ModeChangeListener {
         // Add environment-specific metadata...
         job.setOrigin(Util.getHostname());
         Principal principal = this.principalProvider.get();
-        job.setPrincipal(principal != null ? principal.getName() : null);
+        job.setPrincipalName(principal != null ? principal.getName() : null);
 
         // Metadata and logging configuration...
         job.setMetadata(builder.getJobMetadata());
@@ -942,7 +942,7 @@ public class JobManager implements ModeChangeListener {
      *  the job status to use to configure the principal
      */
     private void setupPrincipal(AsyncJobStatus status) {
-        String name = status.getPrincipal();
+        String name = status.getPrincipalName();
         Principal principal = name != null ? new JobPrincipal(name) : new SystemPrincipal();
 
         ResteasyProviderFactory.pushContext(Principal.class, principal);

--- a/server/src/main/java/org/candlepin/async/tasks/ExportJob.java
+++ b/server/src/main/java/org/candlepin/async/tasks/ExportJob.java
@@ -23,6 +23,7 @@ import org.candlepin.async.JobConfigValidationException;
 import org.candlepin.async.JobExecutionContext;
 import org.candlepin.async.JobExecutionException;
 import org.candlepin.async.JobConstraints;
+import org.candlepin.common.filter.LoggingFilter;
 import org.candlepin.controller.ManifestManager;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.Owner;
@@ -48,7 +49,6 @@ public class ExportJob implements AsyncJob {
     public static final String JOB_KEY = "EXPORT_JOB";
     public static final String JOB_NAME = "export_manifest";
 
-    protected static final String OWNER_KEY = "org";
     protected static final String CONSUMER_KEY = "consumer_uuid";
     protected static final String CDN_LABEL = "cdn_label";
     protected static final String WEBAPP_PREFIX = "webapp_prefix";
@@ -99,7 +99,7 @@ public class ExportJob implements AsyncJob {
                 throw new IllegalArgumentException("owner is null");
             }
 
-            this.setJobMetadata(OWNER_KEY, owner.getKey())
+            this.setJobMetadata(LoggingFilter.OWNER_KEY, owner.getKey())
                 .setLogLevel(owner.getLogLevel());
 
             return this;

--- a/server/src/main/java/org/candlepin/async/tasks/HypervisorUpdateJob.java
+++ b/server/src/main/java/org/candlepin/async/tasks/HypervisorUpdateJob.java
@@ -24,6 +24,7 @@ import org.candlepin.async.JobExecutionContext;
 import org.candlepin.async.JobExecutionException;
 import org.candlepin.auth.Principal;
 import org.candlepin.common.exceptions.BadRequestException;
+import org.candlepin.common.filter.LoggingFilter;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.dto.api.v1.HypervisorConsumerDTO;
 import org.candlepin.dto.api.v1.HypervisorUpdateResultDTO;
@@ -236,6 +237,7 @@ public class HypervisorUpdateJob implements AsyncJob {
             }
 
             this.setJobArgument(OWNER_KEY, owner.getKey())
+                .setJobMetadata(LoggingFilter.OWNER_KEY, owner.getKey())
                 .setLogLevel(owner.getLogLevel());
 
             return this;

--- a/server/src/main/java/org/candlepin/async/tasks/ImportJob.java
+++ b/server/src/main/java/org/candlepin/async/tasks/ImportJob.java
@@ -24,6 +24,7 @@ import org.candlepin.async.JobConfigValidationException;
 import org.candlepin.async.JobConstraints;
 import org.candlepin.async.JobExecutionContext;
 import org.candlepin.async.JobExecutionException;
+import org.candlepin.common.filter.LoggingFilter;
 import org.candlepin.common.exceptions.NotFoundException;
 import org.candlepin.controller.ManifestManager;
 import org.candlepin.model.ImportRecord;
@@ -76,7 +77,7 @@ public class ImportJob implements AsyncJob {
             }
 
             // The owner is both part of metadata & arguments in this job.
-            this.setJobMetadata(OWNER_KEY, owner.getKey())
+            this.setJobMetadata(LoggingFilter.OWNER_KEY, owner.getKey())
                 .setJobArgument(OWNER_KEY, owner.getKey())
                 .setLogLevel(owner.getLogLevel());
 

--- a/server/src/main/java/org/candlepin/async/tasks/RefreshPoolsJob.java
+++ b/server/src/main/java/org/candlepin/async/tasks/RefreshPoolsJob.java
@@ -23,6 +23,7 @@ import org.candlepin.async.JobConfigValidationException;
 import org.candlepin.async.JobConstraints;
 import org.candlepin.async.JobExecutionContext;
 import org.candlepin.async.JobExecutionException;
+import org.candlepin.common.filter.LoggingFilter;
 import org.candlepin.controller.PoolManager;
 import org.candlepin.controller.Refresher;
 import org.candlepin.model.Owner;
@@ -72,7 +73,7 @@ public class RefreshPoolsJob implements AsyncJob {
             }
 
             // The owner is both part of metadata & arguments in this job.
-            this.setJobMetadata(OWNER_KEY, owner.getKey())
+            this.setJobMetadata(LoggingFilter.OWNER_KEY, owner.getKey())
                 .setJobArgument(OWNER_KEY, owner.getKey())
                 .setLogLevel(owner.getLogLevel());
 

--- a/server/src/main/java/org/candlepin/async/tasks/UndoImportsJob.java
+++ b/server/src/main/java/org/candlepin/async/tasks/UndoImportsJob.java
@@ -1,0 +1,227 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.async.tasks;
+
+import org.candlepin.async.ArgumentConversionException;
+import org.candlepin.async.AsyncJob;
+import org.candlepin.async.JobArguments;
+import org.candlepin.async.JobConfig;
+import org.candlepin.async.JobConfigValidationException;
+import org.candlepin.async.JobExecutionContext;
+import org.candlepin.async.JobExecutionException;
+import org.candlepin.async.JobConstraints;
+import org.candlepin.common.filter.LoggingFilter;
+import org.candlepin.controller.PoolManager;
+import org.candlepin.model.ExporterMetadata;
+import org.candlepin.model.ExporterMetadataCurator;
+import org.candlepin.model.ImportRecord;
+import org.candlepin.model.ImportRecordCurator;
+import org.candlepin.model.ImportUpstreamConsumer;
+import org.candlepin.model.Owner;
+import org.candlepin.model.OwnerCurator;
+import org.candlepin.model.Pool;
+import org.candlepin.model.UpstreamConsumer;
+import org.candlepin.service.SubscriptionServiceAdapter;
+
+import com.google.inject.persist.Transactional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.xnap.commons.i18n.I18n;
+
+import javax.inject.Inject;
+import java.util.Date;
+import java.util.List;
+
+
+
+/**
+ * Asynchronous job for removing pools created during manifest import.
+ *
+ * {@link Owner}.
+ */
+public class UndoImportsJob implements AsyncJob {
+    private static Logger log = LoggerFactory.getLogger(UndoImportsJob.class);
+
+    public static final String JOB_KEY = "UNDO_IMPORTS";
+    public static final String JOB_NAME = "undo_imports";
+
+    private static final String OWNER_KEY = "owner_key";
+
+    /**
+     * Job configuration object for the undo imports job
+     */
+    public static class UndoImportsJobConfig extends JobConfig {
+        public UndoImportsJobConfig() {
+            this.setJobKey(JOB_KEY)
+                .setJobName(JOB_NAME)
+                .addConstraint(JobConstraints.uniqueByArgument(OWNER_KEY));
+        }
+
+        /**
+         * Sets the owner for this job config.
+         *
+         * @param owner
+         *  the owner to set for this job
+         *
+         * @return
+         *  a reference to this job config
+         */
+        public UndoImportsJobConfig setOwner(Owner owner) {
+            if (owner == null) {
+                throw new IllegalArgumentException("owner is null");
+            }
+
+            this.setJobArgument(OWNER_KEY, owner.getKey())
+                .setJobMetadata(LoggingFilter.OWNER_KEY, owner.getKey())
+                .setLogLevel(owner.getLogLevel());
+
+            return this;
+        }
+
+        @Override
+        public void validate() throws JobConfigValidationException {
+            super.validate();
+
+            try {
+                JobArguments arguments = this.getJobArguments();
+
+                String ownerKey = arguments.getAsString(OWNER_KEY);
+
+                if (ownerKey == null || ownerKey.isEmpty()) {
+                    String errmsg = "owner has not been set, or the provided owner lacks a key";
+                    throw new JobConfigValidationException(errmsg);
+                }
+            }
+            catch (ArgumentConversionException e) {
+                String errmsg = "One or more required arguments are of the wrong type";
+                throw new JobConfigValidationException(errmsg, e);
+            }
+        }
+    }
+
+
+    protected I18n i18n;
+    protected OwnerCurator ownerCurator;
+    protected PoolManager poolManager;
+    protected SubscriptionServiceAdapter subAdapter;
+    protected ExporterMetadataCurator exportCurator;
+    protected ImportRecordCurator importRecordCurator;
+
+    @Inject
+    public UndoImportsJob(I18n i18n,
+        OwnerCurator ownerCurator,
+        PoolManager poolManager,
+        SubscriptionServiceAdapter subAdapter,
+        ExporterMetadataCurator exportCurator,
+        ImportRecordCurator importRecordCurator) {
+
+        this.i18n = i18n;
+        this.ownerCurator = ownerCurator;
+        this.poolManager = poolManager;
+        this.subAdapter = subAdapter;
+        this.exportCurator = exportCurator;
+        this.importRecordCurator = importRecordCurator;
+    }
+
+    @Override
+    @Transactional
+    public Object execute(JobExecutionContext context) throws JobExecutionException {
+        JobArguments args = context.getJobArguments();
+        String principalName = context.getPrincipalName();
+
+        String ownerKey = args.getAsString(OWNER_KEY);
+        Owner owner = this.ownerCurator.lockAndLoadByKey(ownerKey);
+
+        if (owner == null) {
+            // Apparently this isn't a failure...?
+            log.debug("Owner no longer exists: {}", ownerKey);
+            return String.format("Nothing to do; owner no longer exists: %s", ownerKey);
+        }
+
+        String displayName = owner.getDisplayName();
+
+        // Remove imports
+        ExporterMetadata metadata = this.exportCurator
+            .getByTypeAndOwner(ExporterMetadata.TYPE_PER_USER, owner);
+
+        if (metadata == null) {
+            log.debug("No imports exist for owner {}", displayName);
+            return String.format("Nothing to do; imports no longer exist for owner: %s", displayName);
+        }
+
+        log.info("Deleting all pools originating from manifests for owner/org: {}", displayName);
+
+        List<Pool> pools = this.poolManager.listPoolsByOwner(owner).list();
+        for (Pool pool : pools) {
+            if (this.poolManager.isManaged(pool)) {
+                this.poolManager.deletePool(pool);
+            }
+        }
+
+        // Clear out upstream ID so owner can import from other distributors:
+        UpstreamConsumer uc = owner.getUpstreamConsumer();
+        owner.setUpstreamConsumer(null);
+
+        this.exportCurator.delete(metadata);
+        this.recordManifestDeletion(owner, principalName, uc);
+
+        return String.format("Imported pools removed for owner: %s", displayName);
+    }
+
+    private void recordManifestDeletion(Owner owner, String principalName, UpstreamConsumer uc) {
+        ImportRecord record = new ImportRecord(owner);
+        record.setGeneratedBy(principalName);
+        record.setGeneratedDate(new Date());
+        String msg = this.i18n.tr("Subscriptions deleted by {0}", principalName);
+        record.recordStatus(ImportRecord.Status.DELETE, msg);
+        record.setUpstreamConsumer(this.createImportUpstreamConsumer(owner, uc));
+
+        this.importRecordCurator.create(record);
+    }
+
+    private ImportUpstreamConsumer createImportUpstreamConsumer(Owner owner, UpstreamConsumer uc) {
+        ImportUpstreamConsumer iup = null;
+
+        if (uc == null) {
+            uc = owner.getUpstreamConsumer();
+        }
+
+        if (uc != null) {
+            iup = new ImportUpstreamConsumer();
+            iup.setOwnerId(uc.getOwnerId());
+            iup.setName(uc.getName());
+            iup.setUuid(uc.getUuid());
+            iup.setType(uc.getType());
+            iup.setWebUrl(uc.getWebUrl());
+            iup.setApiUrl(uc.getApiUrl());
+        }
+
+        return iup;
+    }
+
+    /**
+     * Creates a JobConfig configured to execute the undo imports job. Callers may further
+     * manipulate the JobConfig as necessary before queuing it.
+     *
+     * @return
+     *  a JobConfig instance configured to execute the undo imports job
+     */
+    public static UndoImportsJobConfig createJobConfig() {
+        return new UndoImportsJobConfig();
+    }
+
+}

--- a/server/src/main/java/org/candlepin/auth/permissions/AsyncJobStatusPermission.java
+++ b/server/src/main/java/org/candlepin/auth/permissions/AsyncJobStatusPermission.java
@@ -59,7 +59,7 @@ public class AsyncJobStatusPermission extends TypedPermission<AsyncJobStatus> {
 
     @Override
     public boolean canAccessTarget(AsyncJobStatus target, SubResource subResource, Access required) {
-        String principal = target.getPrincipal();
+        String principal = target.getPrincipalName();
         boolean principalMatch = principal != null && principal.equals(this.principalName);
 
         if ("user".equalsIgnoreCase(principalType)) {

--- a/server/src/main/java/org/candlepin/dto/api/v1/AsyncJobStatusTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/AsyncJobStatusTranslator.java
@@ -65,7 +65,7 @@ public class AsyncJobStatusTranslator extends TimestampedEntityTranslator<AsyncJ
         destination.setGroup(source.getGroup());
         destination.setOrigin(source.getOrigin());
         destination.setExecutor(source.getExecutor());
-        destination.setPrincipal(source.getPrincipal());
+        destination.setPrincipal(source.getPrincipalName());
         destination.setStartTime(source.getStartTime());
         destination.setEndTime(source.getEndTime());
         destination.setAttempts(source.getAttempts());

--- a/server/src/main/java/org/candlepin/guice/CandlepinModule.java
+++ b/server/src/main/java/org/candlepin/guice/CandlepinModule.java
@@ -35,6 +35,7 @@ import org.candlepin.async.tasks.HypervisorUpdateJob;
 import org.candlepin.async.tasks.ImportJob;
 import org.candlepin.async.tasks.RefreshPoolsForProductJob;
 import org.candlepin.async.tasks.RefreshPoolsJob;
+import org.candlepin.async.tasks.UndoImportsJob;
 import org.candlepin.async.temp.AsyncJobResource;
 import org.candlepin.async.temp.TestJob1;
 import org.candlepin.audit.AMQPBusPublisher;
@@ -428,6 +429,7 @@ public class CandlepinModule extends AbstractModule {
         JobManager.registerJob(RefreshPoolsForProductJob.JOB_KEY, RefreshPoolsForProductJob.class);
         JobManager.registerJob(RefreshPoolsJob.JOB_KEY, RefreshPoolsJob.class);
         JobManager.registerJob(HypervisorUpdateJob.JOB_KEY, HypervisorUpdateJob.class);
+        JobManager.registerJob(UndoImportsJob.JOB_KEY, UndoImportsJob.class);
     }
 
     private void configurePinsetter() {

--- a/server/src/main/java/org/candlepin/model/AsyncJobStatus.java
+++ b/server/src/main/java/org/candlepin/model/AsyncJobStatus.java
@@ -394,7 +394,7 @@ public class AsyncJobStatus extends AbstractHibernateObject implements JobExecut
      *  The name of the principal that created this job, or null if the job is a system-level job
      *  or the principal has not been set
      */
-    public String getPrincipal() {
+    public String getPrincipalName() {
         return this.principal;
     }
 
@@ -408,7 +408,7 @@ public class AsyncJobStatus extends AbstractHibernateObject implements JobExecut
      * @return
      *  this job status instance
      */
-    public AsyncJobStatus setPrincipal(String principal) {
+    public AsyncJobStatus setPrincipalName(String principal) {
         this.principal = (principal != null && !principal.isEmpty()) ? principal : null;
         return this;
     }

--- a/server/src/main/java/org/candlepin/model/OwnerCurator.java
+++ b/server/src/main/java/org/candlepin/model/OwnerCurator.java
@@ -19,6 +19,8 @@ import com.google.inject.persist.Transactional;
 
 import org.apache.commons.lang3.StringUtils;
 import org.hibernate.Criteria;
+import org.hibernate.LockMode;
+import org.hibernate.LockOptions;
 import org.hibernate.ReplicationMode;
 import org.hibernate.Session;
 import org.hibernate.criterion.DetachedCriteria;
@@ -105,6 +107,27 @@ public class OwnerCurator extends AbstractHibernateCurator<Owner> {
         return (Owner) createSecureCriteria()
             .add(Restrictions.eq("key", key))
             .uniqueResult();
+    }
+
+    /**
+     * Fetches and locks the owner by the owner key. If a matching owner could not be found, this
+     * method returns null.
+     *
+     * @param key
+     *  the key to use to lock and load the owner
+     *
+     * @return
+     *  the locked owner, or null if a matching owner could not be found
+     */
+    public Owner lockAndLoadByKey(String key) {
+        if (key != null && !key.isEmpty()) {
+            return this.currentSession()
+                .bySimpleNaturalId(Owner.class)
+                .with(new LockOptions(LockMode.PESSIMISTIC_WRITE))
+                .load(key);
+        }
+
+        return null;
     }
 
     /**

--- a/server/src/main/java/org/candlepin/pinsetter/tasks/UndoImportsJob.java
+++ b/server/src/main/java/org/candlepin/pinsetter/tasks/UndoImportsJob.java
@@ -103,6 +103,7 @@ public class UndoImportsJob extends UniqueByEntityJob {
             return;
         }
 
+
         String displayName = owner.getDisplayName();
 
         // Remove imports

--- a/server/src/test/java/org/candlepin/async/tasks/ExportJobTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/ExportJobTest.java
@@ -21,6 +21,7 @@ import org.candlepin.async.JobArguments;
 import org.candlepin.async.JobConfig;
 import org.candlepin.async.JobConfigValidationException;
 import org.candlepin.async.JobExecutionContext;
+import org.candlepin.common.filter.LoggingFilter;
 import org.candlepin.controller.ManifestManager;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.Owner;
@@ -87,8 +88,8 @@ public class ExportJobTest extends BaseJobTest {
 
         Map<String, String> metadata = config.getJobMetadata();
 
-        assertTrue(metadata.containsKey(ExportJob.OWNER_KEY));
-        assertEquals(owner.getKey(), metadata.get(ExportJob.OWNER_KEY));
+        assertTrue(metadata.containsKey(LoggingFilter.OWNER_KEY));
+        assertEquals(owner.getKey(), metadata.get(LoggingFilter.OWNER_KEY));
         assertEquals(owner.getLogLevel(), config.getLogLevel());
     }
 

--- a/server/src/test/java/org/candlepin/async/tasks/UndoImportsJobTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/UndoImportsJobTest.java
@@ -1,0 +1,235 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.async.tasks;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.candlepin.async.JobConfig;
+import org.candlepin.async.JobExecutionContext;
+import org.candlepin.async.JobExecutionException;
+import org.candlepin.controller.CandlepinPoolManager;
+import org.candlepin.controller.Refresher;
+import org.candlepin.model.Consumer;
+import org.candlepin.model.ConsumerType;
+import org.candlepin.model.Entitlement;
+import org.candlepin.model.ExporterMetadata;
+import org.candlepin.model.ExporterMetadataCurator;
+import org.candlepin.model.ImportRecord;
+import org.candlepin.model.ImportRecordCurator;
+import org.candlepin.model.Owner;
+import org.candlepin.model.OwnerCurator;
+import org.candlepin.model.Pool;
+import org.candlepin.model.Pool.PoolType;
+import org.candlepin.model.Product;
+import org.candlepin.model.UeberCertificate;
+import org.candlepin.model.UeberCertificateGenerator;
+import org.candlepin.model.UpstreamConsumer;
+import org.candlepin.service.OwnerServiceAdapter;
+import org.candlepin.service.SubscriptionServiceAdapter;
+import org.candlepin.test.DatabaseTestFixture;
+import org.candlepin.test.TestUtil;
+
+import com.google.inject.Inject;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.xnap.commons.i18n.I18n;
+import org.xnap.commons.i18n.I18nFactory;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+
+
+
+/**
+ * UndoImportsJobTest
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class UndoImportsJobTest extends DatabaseTestFixture {
+
+    @Inject protected I18n i18n;
+    @Inject protected CandlepinPoolManager poolManagerBase;
+    @Inject protected ImportRecordCurator importRecordCurator;
+    @Inject protected ExporterMetadataCurator exportCuratorBase;
+    @Inject protected UeberCertificateGenerator ueberCertGenerator;
+
+    @Mock protected CandlepinPoolManager poolManager;
+    @Mock protected OwnerCurator ownerCurator;
+    @Mock protected SubscriptionServiceAdapter subAdapter;
+    @Mock protected Refresher refresher;
+    @Mock protected ExporterMetadataCurator exportCurator;
+
+    protected UndoImportsJob undoImportsJob;
+
+    @BeforeEach
+    public void setUp() {
+        this.i18n = I18nFactory.getI18n(this.getClass(), Locale.US, I18nFactory.FALLBACK);
+
+        // Setup common behavior
+        when(this.poolManager.getRefresher(eq(this.subAdapter), any(OwnerServiceAdapter.class), anyBoolean()))
+            .thenReturn(this.refresher);
+        when(this.refresher.add(any(Owner.class))).thenReturn(this.refresher);
+
+        this.undoImportsJob = new UndoImportsJob(
+            this.i18n, this.ownerCurator, this.poolManager, this.subAdapter,
+            this.exportCurator, this.importRecordCurator
+        );
+        injector.injectMembers(undoImportsJob);
+    }
+
+    @Test
+    public void testUndoImport() throws JobExecutionException {
+        // We need proper curators for this test
+        this.poolManager = this.poolManagerBase;
+        this.ownerCurator = super.ownerCurator;
+        this.exportCurator = this.exportCuratorBase;
+
+        this.undoImportsJob = new UndoImportsJob(
+            this.i18n, this.ownerCurator, this.poolManager, this.subAdapter,
+            this.exportCurator, this.importRecordCurator
+        );
+
+        // Create owner w/upstream consumer
+        Owner owner1 = TestUtil.createOwner();
+        Owner owner2 = TestUtil.createOwner();
+        owner1.setId(null);
+        owner2.setId(null);
+
+        ConsumerType type = this.createConsumerType();
+        UpstreamConsumer uc1 = new UpstreamConsumer("uc1", null, type, "uc1");
+        UpstreamConsumer uc2 = new UpstreamConsumer("uc2", null, type, "uc2");
+        this.ownerCurator.create(owner1);
+        this.ownerCurator.create(owner2);
+        owner1.setUpstreamConsumer(uc1);
+        owner1.setUpstreamConsumer(uc2);
+        this.ownerCurator.merge(owner1);
+        this.ownerCurator.merge(owner2);
+
+        // Create metadata
+        ExporterMetadata metadata1 = new ExporterMetadata(ExporterMetadata.TYPE_PER_USER, new Date(), owner1);
+        ExporterMetadata metadata2 = new ExporterMetadata(ExporterMetadata.TYPE_PER_USER, new Date(), owner2);
+        this.exportCurator.create(metadata1);
+        this.exportCurator.create(metadata2);
+
+        // Create pools w/upstream pool IDs
+        Pool pool1 = this.createPool("pool1", owner1, true, PoolType.NORMAL);
+        Pool pool2 = this.createPool("pool2", owner1, true, PoolType.BONUS);
+        Pool pool3 = this.createPool("pool3", owner1, false, PoolType.NORMAL);
+        Pool pool4 = this.createPool("pool4", owner1, false, PoolType.BONUS);
+        Pool pool5 = this.createPool("pool5", owner1, true, PoolType.ENTITLEMENT_DERIVED);
+        Pool pool6 = this.createPool("pool6", owner1, false, PoolType.ENTITLEMENT_DERIVED);
+        Pool pool7 = this.createPool("pool7", owner2, true, PoolType.NORMAL);
+        Pool pool8 = this.createPool("pool8", owner2, true, PoolType.BONUS);
+        Pool pool9 = this.createPool("pool9", owner2, true, PoolType.ENTITLEMENT_DERIVED);
+
+        // Create an ueber certificate for the owner.
+        UeberCertificate uebercert = ueberCertGenerator.generate(owner1.getKey(),
+            this.setupAdminPrincipal("test_admin"));
+        assertNotNull(uebercert);
+
+        // Verify initial state
+        assertEquals(
+            Arrays.asList(pool1, pool2, pool3, pool4, pool5, pool6),
+            this.poolManager.listPoolsByOwner(owner1).list()
+        );
+        assertEquals(Arrays.asList(pool7, pool8, pool9), this.poolManager.listPoolsByOwner(owner2).list());
+        assertEquals(metadata1, exportCurator.getByTypeAndOwner(ExporterMetadata.TYPE_PER_USER, owner1));
+        assertEquals(metadata2, exportCurator.getByTypeAndOwner(ExporterMetadata.TYPE_PER_USER, owner2));
+        assertEquals(0, this.importRecordCurator.findRecords(owner1).list().size());
+        assertEquals(0, this.importRecordCurator.findRecords(owner2).list().size());
+
+        JobConfig config = UndoImportsJob.createJobConfig()
+            .setOwner(owner1);
+
+        JobExecutionContext context = mock(JobExecutionContext.class);
+        when(context.getJobArguments()).thenReturn(config.getJobArguments());
+        when(context.getPrincipalName()).thenReturn("JarJarBinks");
+
+        // Execute job
+        beginTransaction(); //since we locking owner we need start transaction
+        this.undoImportsJob.execute(context);
+        commitTransaction();
+
+        // Verify deletions -- Ueber pools should not get deleted.
+        assertEquals(Arrays.asList(pool3, pool4, pool5, pool6),
+            this.poolManager.listPoolsByOwner(owner1).list());
+
+        assertEquals(Arrays.asList(pool7, pool8, pool9), this.poolManager.listPoolsByOwner(owner2).list());
+        assertNull(exportCurator.getByTypeAndOwner(ExporterMetadata.TYPE_PER_USER, owner1));
+        assertEquals(metadata2, exportCurator.getByTypeAndOwner(ExporterMetadata.TYPE_PER_USER, owner2));
+        assertNull(owner1.getUpstreamConsumer());
+
+        List<ImportRecord> records = this.importRecordCurator.findRecords(owner1).list();
+        assertEquals(1, records.size());
+        assertEquals(ImportRecord.Status.DELETE, records.get(0).getStatus());
+
+        assertEquals(0, this.importRecordCurator.findRecords(owner2).list().size());
+    }
+
+    protected Pool createPool(String name, Owner owner, boolean keepSourceSub, PoolType type) {
+        Product product = this.createProduct(name, name, owner);
+
+        Pool pool = TestUtil.createPool(owner, product);
+        if (!keepSourceSub) {
+            pool.setSourceSubscription(null);
+        }
+        else {
+            pool.setUpstreamPoolId("upstream_pool_id");
+        }
+
+        this.poolCurator.create(pool);
+
+        Consumer consumer;
+        Entitlement entitlement;
+
+        switch (type) {
+            // TODO: Others as necessary
+
+            case ENTITLEMENT_DERIVED:
+                pool.setAttribute(Pool.Attributes.DERIVED_POOL, "true");
+                consumer = this.createConsumer(owner);
+                entitlement = this.createEntitlement(owner, consumer, pool, null);
+
+                pool.setSourceEntitlement(entitlement);
+                break;
+
+            case BONUS:
+                pool.setAttribute(Pool.Attributes.DERIVED_POOL, "true");
+                break;
+
+            default:
+                // Required by checkstyle.
+        }
+
+        this.poolCurator.merge(pool);
+
+        return pool;
+    }
+}

--- a/server/src/test/java/org/candlepin/dto/api/v1/AsyncJobStatusTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/AsyncJobStatusTranslatorTest.java
@@ -56,7 +56,7 @@ public class AsyncJobStatusTranslatorTest extends
         source.setGroup("job_group");
         source.setOrigin("localhost_origin");
         source.setExecutor("localhost_exec");
-        source.setPrincipal("admin");
+        source.setPrincipalName("admin");
         source.setState(JobState.QUEUED);
         source.setState(JobState.RUNNING); // The second set should prime the previous state field
         source.setStartTime(new Date());
@@ -84,7 +84,7 @@ public class AsyncJobStatusTranslatorTest extends
             assertEquals(source.getGroup(), dto.getGroup());
             assertEquals(source.getOrigin(), dto.getOrigin());
             assertEquals(source.getExecutor(), dto.getExecutor());
-            assertEquals(source.getPrincipal(), dto.getPrincipal());
+            assertEquals(source.getPrincipalName(), dto.getPrincipal());
             assertEquals(source.getStartTime(), dto.getStartTime());
             assertEquals(source.getEndTime(), dto.getEndTime());
             assertEquals(source.getJobResult(), dto.getResult());

--- a/server/src/test/java/org/candlepin/model/OwnerCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/OwnerCuratorTest.java
@@ -207,7 +207,6 @@ public class OwnerCuratorTest extends DatabaseTestFixture {
         assertFalse(result.contains(c3.getUuid()));
     }
 
-
     private List<Owner> setupDBForLookupOwnersForProductTests() {
         Owner owner1 = this.createOwner("owner1");
         Owner owner2 = this.createOwner("owner2");
@@ -291,5 +290,45 @@ public class OwnerCuratorTest extends DatabaseTestFixture {
 
         owners = this.ownerCurator.getOwnersWithProducts(Arrays.asList("nope")).list();
         assertEquals(0, owners.size());
+    }
+
+    @Test
+    public void testLockAndLoadByKey() {
+        String ownerKey = "test_key";
+
+        Owner owner = this.createOwner(ownerKey);
+        this.ownerCurator.flush();
+        this.ownerCurator.clear();
+
+        Owner actual = this.ownerCurator.lockAndLoadByKey(ownerKey);
+
+        assertNotNull(actual);
+        assertEquals(ownerKey, actual.getKey());
+    }
+
+    @Test
+    public void testLockAndLoadByKeyDoesntLoadBadKey() {
+        String ownerKey = "test_key";
+
+        Owner owner = this.createOwner(ownerKey);
+        this.ownerCurator.flush();
+        this.ownerCurator.clear();
+
+        Owner actual = this.ownerCurator.lockAndLoadByKey(ownerKey + "-bad");
+
+        assertNull(actual);
+    }
+
+    @Test
+    public void testLockAndLoadByKeyDoesntLoadNullKey() {
+        String ownerKey = "test_key";
+
+        Owner owner = this.createOwner(ownerKey);
+        this.ownerCurator.flush();
+        this.ownerCurator.clear();
+
+        Owner actual = this.ownerCurator.lockAndLoadByKey(null);
+
+        assertNull(actual);
     }
 }


### PR DESCRIPTION
- Ported the UndoImportsJob to the Artemis job system
- Added a new owner-specific lockAndLoad variant that can
  lock and load an owner entity by key
- Added a constant to LoggingFilter to specify the key
  used in the packaged logback.xml configuration for
  referencing the org/owner key
- Updated all async tests to use the new
  LoggingFilter.OWNER_KEY constant when setting the
  owner key in the job metadata