### PR TITLE
Improved deploy script to allow usage of symlinks by tomcat

### DIFF
--- a/server/bin/deploy
+++ b/server/bin/deploy
@@ -109,19 +109,37 @@ upload_products() {
 }
 
 create_test_repos() {
-    if [ ! -d "${REPOS}" ]; then
-        $SUDO mkdir "${REPOS}"
-    fi
     if [ "$TESTREPO" = "1" ]; then
+        if [ ! -d "${REPOS}" ]; then
+            $SUDO mkdir "${REPOS}"
+        fi
+
+        # Run Python script and generate all repos and testing rpms
         $SUDO $SELF_DIR/create_test_repos.py $SELF_DIR/test_data.json
+
+        # Tomcat has to own all of that
+        $SUDO chown -R tomcat:tomcat "${REPOS}"
+
+        echo ""
+        echo "Run following commands on registered system to use created repositories:"
+        echo ""
+        echo "    subscription-manager config --rhsm.baseurl=http://<ip_of_this_server>:8080"
+        echo "    curl http://<ip_of_this_server>:8080/RPM-GPG-KEY-candlepin > /etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin"
+        echo ""
     fi
-    $SUDO chown -R tomcat:tomcat "${REPOS}"
-    echo ""
-    echo "Run following commands on registered system to use created repositories:"
-    echo ""
-    echo "    subscription-manager config --rhsm.baseurl=http://<ip_of_this_server>:8080"
-    echo "    curl http://<ip_of_this_server>:8080/RPM-GPG-KEY-candlepin > /etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin"
-    echo ""
+}
+
+configure_tomcat_root_dir() {
+    # Create configuration file for tomcat to be able to use symbolic links
+    if [ "$TESTREPO" = "1" ]; then
+        if [ ! -d "${REPOS}/META-INF" ]; then
+            $SUDO mkdir -p "${REPOS}/META-INF"
+        fi
+
+        if [ ! -f "${REPOS}/META-INF/context.xml" ]; then
+            $SUDO cp "$PROJECT_DIR/src/main/root/META-INF/context.xml" "${REPOS}/META-INF/context.xml"
+        fi
+    fi
 }
 
 create_var_lib_candlepin() {
@@ -379,6 +397,7 @@ update_keystore
 $SUDO python $PROJECT_DIR/bin/update-server-xml.py --tomcat-version $TC_VERSION $CONTAINER_CONF_DIR
 
 create_var_lib_candlepin
+configure_tomcat_root_dir
 create_var_log_candlepin
 create_var_cache_candlepin
 

--- a/server/src/main/root/META-INF/context.xml
+++ b/server/src/main/root/META-INF/context.xml
@@ -1,0 +1,2 @@
+<!-- Testing repositories have to contain symlinks, when golden ticket is used -->
+<Context override="true" allowLinking="true" />


### PR DESCRIPTION
* Tomcat doesn't allow to use symbolic links be default due to
  security reasons. It is necessary to allow it in configuration
  file META-INF/context.xml
* Improved a little bit deploy script