### PR TITLE
[F] Added synchronization between the database and messaging bus

### DIFF
--- a/server/src/main/java/org/candlepin/async/JobMessageDispatcher.java
+++ b/server/src/main/java/org/candlepin/async/JobMessageDispatcher.java
@@ -23,15 +23,34 @@ package org.candlepin.async;
 public interface JobMessageDispatcher {
 
     /**
-     * Sends a job message to the backing message bus. If the message cannot be sent, this method
-     * should throw an exception.
+     * Posts a job message to the backing message bus, which may or may not be sent immediately.
+     * If the message cannot be posted, this method should throw an exception.
      *
      * @param jobMessage
-     *  The JobMessage to send
+     *  The JobMessage to post
      *
      * @throws JobMessageDispatchException
-     *  if the message cannot be sent for any reason
+     *  if the message cannot be posted for any reason
      */
-    void sendJobMessage(JobMessage jobMessage) throws JobMessageDispatchException;
+    void postJobMessage(JobMessage jobMessage) throws JobMessageDispatchException;
+
+    /**
+     * Commits any pending messages posted to the backing message bus. If no transaction is
+     * active, or no messages have been posted, this method returns silently.
+     *
+     * @throws JobMessageDispatchException
+     *  if the messaging session cannot be committed for any reason
+     */
+    void commit() throws JobMessageDispatchException;
+
+    /**
+     * Rolls back any pending messages posted to the backing message bus that have not yet been
+     * committed. If no transaction is active or there are no messages to roll back, this method
+     * returns silently.
+     *
+     * @throws JobMessageDispatchException
+     *  if the messaging session cannot be rolled back for any reason
+     */
+    void rollback() throws JobMessageDispatchException;
 
 }

--- a/server/src/main/java/org/candlepin/model/AsyncJobStatus.java
+++ b/server/src/main/java/org/candlepin/model/AsyncJobStatus.java
@@ -18,6 +18,9 @@ import org.candlepin.async.JobArguments;
 import org.candlepin.async.JobExecutionContext;
 import org.candlepin.hibernate.AbstractJsonConverter;
 
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+
 import org.hibernate.annotations.GenericGenerator;
 
 import java.util.Collections;
@@ -112,6 +115,36 @@ public class AsyncJobStatus extends AbstractHibernateObject implements JobExecut
         public Map<String, String> metadata;
         public JobArguments arguments;
         public Object result;
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) {
+                return true;
+            }
+
+            if (!(obj instanceof SerializedJobData)) {
+                return false;
+            }
+
+            SerializedJobData that = (SerializedJobData) obj;
+
+            EqualsBuilder builder = new EqualsBuilder()
+                .append(this.metadata, that.metadata)
+                .append(this.arguments, that.arguments)
+                .append(this.result, that.result);
+
+            return builder.isEquals();
+        }
+
+        @Override
+        public int hashCode() {
+            HashCodeBuilder builder = new HashCodeBuilder(37, 7)
+                .append(this.metadata)
+                .append(this.arguments)
+                .append(this.result);
+
+            return builder.toHashCode();
+        }
     }
 
     /**
@@ -123,7 +156,6 @@ public class AsyncJobStatus extends AbstractHibernateObject implements JobExecut
             super(SerializedJobData.class);
         }
     }
-
 
 
     @Id


### PR DESCRIPTION
- Added a synchronization operation between the database and
  messaging bus to ensure job messages aren't committed until
  the active transaction which would persist the backing job
  is complete
- Added an additional check to ensure a job class is registered
  for a given job key