### PR TITLE
[2.6] 1724115: Initialize the NSS db when loading a JSS provider [ENT-1388]

### DIFF
--- a/buildfile
+++ b/buildfile
@@ -1,6 +1,7 @@
 # vi: set ft=ruby:
 
 ### Repositories
+repositories.remote << "https://barnabycourt.fedorapeople.org/repo/candlepin"
 repositories.remote << "http://awood.fedorapeople.org/ivy/candlepin/"
 repositories.remote << "http://repository.jboss.org/nexus/content/groups/public/"
 repositories.remote << "https://repo.maven.apache.org/maven2/"
@@ -158,7 +159,7 @@ BOUNCYCASTLE = group('bcpkix-jdk15on', 'bcprov-jdk15on',
                      :under => 'org.bouncycastle',
                      :version => '1.60')
 
-JSS = ['org.mozilla:jss:jar:4.5.0', 'ldapjdk:ldapjdk:jar:4.19']
+JSS = ['org.mozilla:jss:jar:4.4.6', 'ldapjdk:ldapjdk:jar:4.19']
 
 SERVLET = 'javax.servlet:servlet-api:jar:2.5'
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -80,7 +80,7 @@
     <org.hibernate.javax.persistence-hibernate-jpa-2.1-api.version>1.0.2.Final</org.hibernate.javax.persistence-hibernate-jpa-2.1-api.version>
     <javax.transaction-jta.version>1.1</javax.transaction-jta.version>
     <javax.persistence-javax.persistence-api.version>2.2</javax.persistence-javax.persistence-api.version>
-    <org.mozilla-jss.version>4.5.0</org.mozilla-jss.version>
+    <org.mozilla-jss.version>4.4.6</org.mozilla-jss.version>
     <ldapjdk-ldapjdk.version>4.19</ldapjdk-ldapjdk.version>
     <com.fasterxml.jackson.core-jackson-annotations.version>2.9.4</com.fasterxml.jackson.core-jackson-annotations.version>
     <com.fasterxml.jackson.core-jackson-core.version>2.9.4</com.fasterxml.jackson.core-jackson-core.version>


### PR DESCRIPTION
- Now, when creating a JSS provider on deployment, we also create
  a JSS CryptoManager, which initializes the NSS db.
- Downgraded JSS to 4.4.6 to be in line with the jars/libraries
  distributed in RHEL 7. This means with this fix, candlepin is
  not compatible with RHEL 8, which ships with JSS 4.5.x.
- Added https://barnabycourt.fedorapeople.org/repo/candlepin as
  a new, temporary, artifact repository for our builds, which holds
  the jss 4.4.6 dependency for now.

Co-authored-by: Alexander Scheel <ascheel@redhat.com>