### PR TITLE
[M] 1723799: Initialize the NSS db when loading a JSS provider [ENT-1388]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -176,6 +176,8 @@ subprojects {
         maven { url "http://oauth.googlecode.com/svn/code/maven/" }
         // For LogDriver
         maven { url "http://awood.fedorapeople.org/ivy/candlepin/" }
+        // Temporary repo, which stores jss 4.4.6
+        maven { url "http://barnabycourt.fedorapeople.org/repo/candlepin/" }
     }
 }
 

--- a/buildfile
+++ b/buildfile
@@ -3,6 +3,7 @@ Encoding.default_external = Encoding::UTF_8
 Encoding.default_internal = Encoding::UTF_8
 
 ### Repositories
+repositories.remote << "https://barnabycourt.fedorapeople.org/repo/candlepin"
 repositories.remote << "http://awood.fedorapeople.org/ivy/candlepin/"
 repositories.remote << "http://repository.jboss.org/nexus/content/groups/public/"
 repositories.remote << "https://repo.maven.apache.org/maven2/"
@@ -168,7 +169,7 @@ BOUNCYCASTLE = group('bcpkix-jdk15on', 'bcprov-jdk15on',
                      :under => 'org.bouncycastle',
                      :version => '1.60')
 
-JSS = ['org.mozilla:jss:jar:4.5.0', 'ldapjdk:ldapjdk:jar:4.19']
+JSS = ['org.mozilla:jss:jar:4.4.6', 'ldapjdk:ldapjdk:jar:4.19']
 
 SERVLET = 'javax.servlet:servlet-api:jar:2.5'
 

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -118,7 +118,7 @@ dependencies {
     implementation "org.ehcache:jcache:1.0.0"
     implementation "javax.cache:cache-api:1.0.0"
 
-    implementation "org.mozilla:jss:4.5.0"
+    implementation "org.mozilla:jss:4.4.6"
     implementation "ldapjdk:ldapjdk:4.19"
     implementation "org.quartz-scheduler:quartz:2.2.1"
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -1004,7 +1004,7 @@
     <dependency>
       <groupId>org.mozilla</groupId>
       <artifactId>jss</artifactId>
-      <version>4.5.0</version>
+      <version>4.4.6</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
- Now, when creating a JSS provider on deployment, we also create
  a JSS CryptoManager, which initializes the NSS db.
- Downgraded JSS to 4.4.6 to be in line with the jars/libraries
  distributed in RHEL 7. This means with this fix, candlepin is
  not compatible with RHEL 8, which ships with JSS 4.5.x.
- Added https://barnabycourt.fedorapeople.org/repo/candlepin as
  a new, temporary, artifact repository for our builds, which holds
  the jss 4.4.6 dependency for now.

Co-authored-by: Alexander Scheel <ascheel@redhat.com>