### PR TITLE
[F] Added support for multiple parameters in the UniqueByArgConstraint

### DIFF
--- a/server/src/main/java/org/candlepin/async/JobConstraints.java
+++ b/server/src/main/java/org/candlepin/async/JobConstraints.java
@@ -16,6 +16,8 @@ package org.candlepin.async;
 
 import org.candlepin.async.impl.UniqueByArgConstraint;
 
+import java.util.List;
+
 
 
 /**
@@ -29,17 +31,30 @@ public class JobConstraints {
     }
 
     /**
-     * Creates a new unique-by-argument constraint, using the specified parameter as the target of
+     * Creates a new unique-by-argument constraint, using the specified parameters as the target of
      * the constraint.
      *
-     * @param param
-     *  The parameter to use as the target of the new constraint
+     * @param params
+     *  The parameter, or parameters, to use as the target of the new constraint
      *
      * @return
      *  a new unique-by-argument constraint
      */
-    public static JobConstraint uniqueByArgument(String param) {
-        return new UniqueByArgConstraint(param);
+    public static JobConstraint uniqueByArguments(String... params) {
+        return new UniqueByArgConstraint(params);
     }
 
+    /**
+     * Creates a new unique-by-argument constraint, using the specified parameters as the target of
+     * the constraint.
+     *
+     * @param params
+     *  The parameters to use as the target of the new constraint
+     *
+     * @return
+     *  a new unique-by-argument constraint
+     */
+    public static JobConstraint uniqueByArguments(List<String> params) {
+        return new UniqueByArgConstraint(params);
+    }
 }

--- a/server/src/main/java/org/candlepin/async/tasks/ExportJob.java
+++ b/server/src/main/java/org/candlepin/async/tasks/ExportJob.java
@@ -62,7 +62,7 @@ public class ExportJob implements AsyncJob {
         public ExportJobConfig() {
             this.setJobKey(JOB_KEY)
                 .setJobName(JOB_NAME)
-                .addConstraint(JobConstraints.uniqueByArgument(CONSUMER_KEY));
+                .addConstraint(JobConstraints.uniqueByArguments(CONSUMER_KEY));
         }
 
         /**

--- a/server/src/main/java/org/candlepin/async/tasks/HypervisorHeartbeatUpdateJob.java
+++ b/server/src/main/java/org/candlepin/async/tasks/HypervisorHeartbeatUpdateJob.java
@@ -19,6 +19,7 @@ import org.candlepin.async.ArgumentConversionException;
 import org.candlepin.async.JobArguments;
 import org.candlepin.async.JobConfig;
 import org.candlepin.async.JobConfigValidationException;
+import org.candlepin.async.JobConstraints;
 import org.candlepin.async.JobExecutionContext;
 import org.candlepin.async.JobExecutionException;
 import org.candlepin.common.filter.LoggingFilter;
@@ -55,11 +56,8 @@ public class HypervisorHeartbeatUpdateJob implements AsyncJob {
     public static class HypervisorHeartbeatUpdateJobConfig extends JobConfig {
         public HypervisorHeartbeatUpdateJobConfig() {
             this.setJobKey(JOB_KEY)
-                .setJobName(JOB_NAME);
-
-            // TODO: Should this be unique by (owner_key, reporter_id) or owner_key? If it's the
-            // former, we'll need to update the UniqueByArgConstraint to support examining multiple
-            // parameters
+                .setJobName(JOB_NAME)
+                .addConstraint(JobConstraints.uniqueByArguments(OWNER_KEY, REPORTER_ID));
         }
 
         /**

--- a/server/src/main/java/org/candlepin/async/tasks/HypervisorUpdateJob.java
+++ b/server/src/main/java/org/candlepin/async/tasks/HypervisorUpdateJob.java
@@ -219,7 +219,7 @@ public class HypervisorUpdateJob implements AsyncJob {
         public HypervisorUpdateJobConfig() {
             this.setJobKey(JOB_KEY)
                 .setJobName(JOB_NAME)
-                .addConstraint(JobConstraints.uniqueByArgument(OWNER_KEY));
+                .addConstraint(JobConstraints.uniqueByArguments(OWNER_KEY));
         }
 
         /**

--- a/server/src/main/java/org/candlepin/async/tasks/ImportJob.java
+++ b/server/src/main/java/org/candlepin/async/tasks/ImportJob.java
@@ -58,7 +58,7 @@ public class ImportJob implements AsyncJob {
         public ImportJobConfig() {
             this.setJobKey(JOB_KEY)
                 .setJobName(JOB_NAME)
-                .addConstraint(JobConstraints.uniqueByArgument(OWNER_KEY));
+                .addConstraint(JobConstraints.uniqueByArguments(OWNER_KEY));
         }
 
         /**

--- a/server/src/main/java/org/candlepin/async/tasks/RefreshPoolsJob.java
+++ b/server/src/main/java/org/candlepin/async/tasks/RefreshPoolsJob.java
@@ -54,7 +54,7 @@ public class RefreshPoolsJob implements AsyncJob {
         public RefreshPoolsJobConfig() {
             this.setJobKey(JOB_KEY)
                 .setJobName(JOB_NAME)
-                .addConstraint(JobConstraints.uniqueByArgument(OWNER_KEY));
+                .addConstraint(JobConstraints.uniqueByArguments(OWNER_KEY));
         }
 
         /**

--- a/server/src/main/java/org/candlepin/async/tasks/UndoImportsJob.java
+++ b/server/src/main/java/org/candlepin/async/tasks/UndoImportsJob.java
@@ -68,7 +68,7 @@ public class UndoImportsJob implements AsyncJob {
         public UndoImportsJobConfig() {
             this.setJobKey(JOB_KEY)
                 .setJobName(JOB_NAME)
-                .addConstraint(JobConstraints.uniqueByArgument(OWNER_KEY));
+                .addConstraint(JobConstraints.uniqueByArguments(OWNER_KEY));
         }
 
         /**

--- a/server/src/test/java/org/candlepin/async/JobManagerTest.java
+++ b/server/src/test/java/org/candlepin/async/JobManagerTest.java
@@ -1036,7 +1036,7 @@ public class JobManagerTest {
             .setJobArguments(this.buildJobArguments(ejobData2)));
 
         JobConfig builder = JobConfig.forJob(JOB_KEY)
-            .addConstraint(JobConstraints.uniqueByArgument("arg1"))
+            .addConstraint(JobConstraints.uniqueByArguments("arg1"))
             .setJobArgument("arg1", "val3");
 
         doReturn(Arrays.asList(ejob1, ejob2)).when(this.jobCurator).getNonTerminalJobs();
@@ -1067,7 +1067,7 @@ public class JobManagerTest {
             .setJobArguments(this.buildJobArguments(ejobData2)));
 
         JobConfig builder = JobConfig.forJob(JOB_KEY)
-            .addConstraint(JobConstraints.uniqueByArgument("arg1"))
+            .addConstraint(JobConstraints.uniqueByArguments("arg1"))
             .setJobArgument("arg1", "val2");
 
         doReturn(Arrays.asList(ejob1, ejob2)).when(this.jobCurator).getNonTerminalJobs();

--- a/server/src/test/java/org/candlepin/async/impl/UniqueByArgConstraintTest.java
+++ b/server/src/test/java/org/candlepin/async/impl/UniqueByArgConstraintTest.java
@@ -24,6 +24,7 @@ import org.candlepin.model.AsyncJobStatus;
 
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -73,6 +74,17 @@ public class UniqueByArgConstraintTest {
     }
 
     @Test
+    public void testStandardMatchingFromCollection() {
+        AsyncJobStatus inbound = this.buildJobStatus("inbound", "test_key", this.map("param1", "val1"));
+        AsyncJobStatus existing = this.buildJobStatus("existing", "test_key", this.map("param1", "val1"));
+
+        JobConstraint constraint = new UniqueByArgConstraint(Arrays.asList("param1"));
+        boolean result = constraint.test(inbound, existing);
+
+        assertTrue(result);
+    }
+
+    @Test
     public void testMatchingOnJobsWithMultipleParams() {
         AsyncJobStatus inbound = this.buildJobStatus("inbound", "test_key", this.map(
             "paramA", "valA",
@@ -90,6 +102,121 @@ public class UniqueByArgConstraintTest {
         assertTrue(result);
     }
 
+    @Test
+    public void testMatchingOnJobsWithMultipleParamsFromCollection() {
+        AsyncJobStatus inbound = this.buildJobStatus("inbound", "test_key", this.map(
+            "paramA", "valA",
+            "param2", "val2",
+            "paramC", "valC"));
+
+        AsyncJobStatus existing = this.buildJobStatus("existing", "test_key", this.map(
+            "param1", "val1",
+            "param2", "val2",
+            "param3", "val3"));
+
+        JobConstraint constraint = new UniqueByArgConstraint(Arrays.asList("param2"));
+        boolean result = constraint.test(inbound, existing);
+
+        assertTrue(result);
+    }
+
+    @Test
+    public void testMultiMatchingOnJobsWithMultipleParams() {
+        AsyncJobStatus inbound = this.buildJobStatus("inbound", "test_key", this.map(
+            "param1", "val1",
+            "param2", "val2",
+            "param3", "val3"));
+
+        AsyncJobStatus existing = this.buildJobStatus("existing", "test_key", this.map(
+            "param1", "val1",
+            "param2", "val2",
+            "param3", "val3"));
+
+        JobConstraint constraint = new UniqueByArgConstraint("param1", "param2", "param3");
+        boolean result = constraint.test(inbound, existing);
+
+        assertTrue(result);
+    }
+
+    @Test
+    public void testMultiMatchingOnJobsWithMultipleParamsFromCollection() {
+        AsyncJobStatus inbound = this.buildJobStatus("inbound", "test_key", this.map(
+            "param1", "val1",
+            "param2", "val2",
+            "param3", "val3"));
+
+        AsyncJobStatus existing = this.buildJobStatus("existing", "test_key", this.map(
+            "param1", "val1",
+            "param2", "val2",
+            "param3", "val3"));
+
+        JobConstraint constraint = new UniqueByArgConstraint(Arrays.asList("param1", "param2", "param3"));
+        boolean result = constraint.test(inbound, existing);
+
+        assertTrue(result);
+    }
+
+    @Test
+    public void testMultiMatchingOnJobsWithMultipleParamsOutOfOrder() {
+        AsyncJobStatus inbound = this.buildJobStatus("inbound", "test_key", this.map(
+            "param1", "val1",
+            "param2", "val2",
+            "param3", "val3"));
+
+        AsyncJobStatus existing = this.buildJobStatus("existing", "test_key", this.map(
+            "param1", "val1",
+            "param2", "val2",
+            "param3", "val3"));
+
+        JobConstraint constraint = new UniqueByArgConstraint("param2", "param1", "param3");
+        boolean result = constraint.test(inbound, existing);
+
+        assertTrue(result);
+    }
+
+    @Test
+    public void testMultiMatchingOnJobsWithMultipleParamsOutOfOrderFromCollection() {
+        AsyncJobStatus inbound = this.buildJobStatus("inbound", "test_key", this.map(
+            "param1", "val1",
+            "param2", "val2",
+            "param3", "val3"));
+
+        AsyncJobStatus existing = this.buildJobStatus("existing", "test_key", this.map(
+            "param1", "val1",
+            "param2", "val2",
+            "param3", "val3"));
+
+        JobConstraint constraint = new UniqueByArgConstraint(Arrays.asList("param2", "param1", "param3"));
+        boolean result = constraint.test(inbound, existing);
+
+        assertTrue(result);
+    }
+
+    @Test
+    public void testMultiMatchingOnJobsWithMultipleParamsAndExtraParams() {
+        AsyncJobStatus inbound = this.buildJobStatus("inbound", "test_key", this.map(
+            "paramA", "valA",
+            "param1", "val1",
+            "paramB", "valB",
+            "param2", "val2",
+            "paramC", "valC",
+            "param3", "val3",
+            "paramD", "valD"));
+
+        AsyncJobStatus existing = this.buildJobStatus("existing", "test_key", this.map(
+            "paramR", "valR",
+            "param1", "val1",
+            "paramS", "valS",
+            "param2", "val2",
+            "paramT", "valT",
+            "param3", "val3",
+            "paramU", "valU"));
+
+        JobConstraint constraint = new UniqueByArgConstraint("param2", "param1", "param3");
+        boolean result = constraint.test(inbound, existing);
+
+        assertTrue(result);
+    }
 
     @Test
     public void testNoMatchOnKeyMismatch() {
@@ -103,7 +230,25 @@ public class UniqueByArgConstraintTest {
     }
 
     @Test
-    public void testNoMatchOnparamKeyMismatch() {
+    public void testNoMatchOnKeyMismatchWithMultiParam() {
+        AsyncJobStatus inbound = this.buildJobStatus("inbound", "test_key", this.map(
+            "param1", "val1",
+            "param2", "val2",
+            "param3", "val3"));
+
+        AsyncJobStatus existing = this.buildJobStatus("existing", "alt_key", this.map(
+            "param1", "val1",
+            "param2", "val2",
+            "param3", "val3"));
+
+        JobConstraint constraint = new UniqueByArgConstraint("param1", "param2", "param3");
+        boolean result = constraint.test(inbound, existing);
+
+        assertFalse(result);
+    }
+
+    @Test
+    public void testNoMatchOnParamMismatch() {
         AsyncJobStatus inbound = this.buildJobStatus("inbound", "test_key", this.map("param1", "val1"));
         AsyncJobStatus existing = this.buildJobStatus("existing", "test_key", this.map("paramX", "val1"));
 
@@ -114,11 +259,47 @@ public class UniqueByArgConstraintTest {
     }
 
     @Test
-    public void testNoMatchOnparamValueMismatch() {
+    public void testMultiParamsNoMatchOnParamMismatch() {
+        AsyncJobStatus inbound = this.buildJobStatus("inbound", "test_key", this.map(
+            "param1", "val1",
+            "param2", "val2",
+            "param3", "val3"));
+
+        AsyncJobStatus existing = this.buildJobStatus("existing", "test_key", this.map(
+            "param1", "val1",
+            "paramX", "val2",
+            "param3", "val3"));
+
+        JobConstraint constraint = new UniqueByArgConstraint("param1", "param2", "param3");
+        boolean result = constraint.test(inbound, existing);
+
+        assertFalse(result);
+    }
+
+    @Test
+    public void testNoMatchOnArgMismatch() {
         AsyncJobStatus inbound = this.buildJobStatus("inbound", "test_key", this.map("param1", "val1"));
         AsyncJobStatus existing = this.buildJobStatus("existing", "test_key", this.map("param1", "valX"));
 
         JobConstraint constraint = new UniqueByArgConstraint("param1");
+        boolean result = constraint.test(inbound, existing);
+
+        assertFalse(result);
+    }
+
+    @Test
+    public void testMultiParamsNoMatchOnArgMismatch() {
+        AsyncJobStatus inbound = this.buildJobStatus("inbound", "test_key", this.map(
+            "param1", "val1",
+            "param2", "val2",
+            "param3", "val3"));
+
+        AsyncJobStatus existing = this.buildJobStatus("existing", "test_key", this.map(
+            "param1", "val1",
+            "param2", "valX",
+            "param3", "val3"));
+
+        JobConstraint constraint = new UniqueByArgConstraint("param1", "param2", "param3");
         boolean result = constraint.test(inbound, existing);
 
         assertFalse(result);
@@ -136,6 +317,23 @@ public class UniqueByArgConstraintTest {
     }
 
     @Test
+    public void testMultiParamNoMatchWhenInboundJobLacksParam() {
+        AsyncJobStatus inbound = this.buildJobStatus("inbound", "test_key", this.map(
+            "param1", "val1",
+            "param2", "val2"));
+
+        AsyncJobStatus existing = this.buildJobStatus("existing", "test_key", this.map(
+            "param1", "val1",
+            "param2", "val2",
+            "param3", "val3"));
+
+        JobConstraint constraint = new UniqueByArgConstraint("param1", "param2", "param3");
+        boolean result = constraint.test(inbound, existing);
+
+        assertFalse(result);
+    }
+
+    @Test
     public void testNoMatchWhenExistingJobsLackParam() {
         AsyncJobStatus inbound = this.buildJobStatus("inbound", "test_key", this.map("param1", null));
         AsyncJobStatus existing = this.buildJobStatus("existing", "test_key", this.map("param2", "val2"));
@@ -146,5 +344,21 @@ public class UniqueByArgConstraintTest {
         assertFalse(result);
     }
 
+    @Test
+    public void testMultiParamNoMatchWhenExistingJobsLackParam() {
+        AsyncJobStatus inbound = this.buildJobStatus("inbound", "test_key", this.map(
+            "param1", "val1",
+            "param2", "val2",
+            "param3", "val3"));
+
+        AsyncJobStatus existing = this.buildJobStatus("existing", "test_key", this.map(
+            "param1", "val1",
+            "param3", "val3"));
+
+        JobConstraint constraint = new UniqueByArgConstraint("param1", "param2", "param3");
+        boolean result = constraint.test(inbound, existing);
+
+        assertFalse(result);
+    }
 
 }


### PR DESCRIPTION
- The UniqueByArgConstraint now accepts more than one parameter
  for restriction job scheduling based on job arguments
- Updated several jobs to use the new method name and syntax for
  adding the unique-by-arg constraint