### PR TITLE
[F] Ported the ManifestCleanerJob to the Artemis job system (ENT-859)

### DIFF
--- a/server/src/main/java/org/candlepin/async/JobManager.java
+++ b/server/src/main/java/org/candlepin/async/JobManager.java
@@ -145,14 +145,14 @@ public class JobManager implements ModeChangeListener {
 
         @Override
         public void execute(org.quartz.JobExecutionContext context) throws org.quartz.JobExecutionException {
-            String name = context.getJobDetail().getKey().getName();
+            String jobKey = context.getJobDetail().getKey().getName();
 
             try {
-                log.trace("Queuing job: {}", name);
-                this.manager.queueJob(JobConfig.forJob(name));
+                log.trace("Queuing job: {}", jobKey);
+                this.manager.queueJob(JobConfig.forJob(jobKey));
             }
             catch (JobException e) {
-                String errmsg = String.format("Unable to queue scheduled job: %s", name);
+                String errmsg = String.format("Unable to queue scheduled job: %s", jobKey);
                 throw new org.quartz.JobExecutionException(errmsg, e);
             }
         }
@@ -335,7 +335,7 @@ public class JobManager implements ModeChangeListener {
      */
     private void readJobConfiguration(Configuration config) {
         // Check if our scheduler is running in "clustered" mode
-        this.clustered = config.getBoolean("org.quartz.jobStore.isClustered", false);
+        this.clustered = config.getBoolean(ConfigProperties.QUARTZ_CLUSTERED_MODE, false);
 
         // Get the job whitelist and blacklist
         List<String> list = config.getList(ConfigProperties.ASYNC_JOBS_WHITELIST, null);
@@ -560,7 +560,7 @@ public class JobManager implements ModeChangeListener {
 
         // Check per-job config
         Configuration config = this.jobConfig.get(jobKey);
-        if (config != null && !config.getBoolean(ConfigProperties.ASYNC_JOBS_SUFFIX_ENABLED, true)) {
+        if (config != null && !config.getBoolean(ConfigProperties.ASYNC_JOBS_JOB_ENABLED, true)) {
             return false;
         }
 
@@ -610,7 +610,7 @@ public class JobManager implements ModeChangeListener {
                     continue;
                 }
 
-                String schedule = config.getString(ConfigProperties.ASYNC_JOBS_SUFFIX_SCHEDULE, null);
+                String schedule = config.getString(ConfigProperties.ASYNC_JOBS_JOB_SCHEDULE, null);
                 boolean enabled = this.isJobEnabled(key.getName());
 
                 // Check that the job is enabled and is still scheduled
@@ -648,7 +648,7 @@ public class JobManager implements ModeChangeListener {
                 String jobName = entry.getKey();
                 Configuration config = entry.getValue();
 
-                String schedule = config.getString(ConfigProperties.ASYNC_JOBS_SUFFIX_SCHEDULE, null);
+                String schedule = config.getString(ConfigProperties.ASYNC_JOBS_JOB_SCHEDULE, null);
                 boolean enabled = this.isJobEnabled(jobName);
 
                 // If the job is not enabled, already scheduled or has no schedule, skip it.

--- a/server/src/main/java/org/candlepin/async/tasks/ManifestCleanerJob.java
+++ b/server/src/main/java/org/candlepin/async/tasks/ManifestCleanerJob.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.async.tasks;
+
+import org.candlepin.async.AsyncJob;
+import org.candlepin.async.JobExecutionContext;
+import org.candlepin.async.JobExecutionException;
+import org.candlepin.common.config.Configuration;
+import org.candlepin.config.ConfigProperties;
+import org.candlepin.controller.ManifestManager;
+import org.candlepin.util.Util;
+
+import com.google.inject.Inject;
+
+import org.apache.commons.io.FileUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Date;
+
+
+
+/**
+* The manifest cleaner job is responsible for cleaning up all artifacts that may result
+* from importing/exporting manifest files. It has three key responsibilities:
+*
+* 1) It examines the scratch directory where the importer/exporter writes temp
+*    files and deletes any that are older than a configured age (default 24 hours).
+*
+* 2) Deletes expired files that live on the {@link ManifestFileService} (default 24 hours).
+*
+* 3) Deletes any rogue {@link ManifestFileRecord}s that exist without a file in the service. This case should
+*    only happen if the {@link ManifestFileService} implementation is remote, has already deleted the file,
+*    and deleting of the {@link ManifestFileRecord} fails for some reason.
+*
+*/
+public class ManifestCleanerJob implements AsyncJob {
+    private static Logger log = LoggerFactory.getLogger(ManifestCleanerJob.class);
+
+    public static final String JOB_KEY = "MANIFEST_CLEANER";
+    public static final String JOB_NAME = "manifest cleaner";
+
+    public static final String CFG_MAX_AGE_IN_MINUTES = "max_age_in_minutes";
+    public static final int DEFAULT_MAX_AGE_IN_MINUTES = 1440;
+
+    public static final String DEFAULT_SCHEDULE = "0 0 12 * * ?";
+
+
+    private Configuration config;
+    private ManifestManager manifestManager;
+
+    @Inject
+    public ManifestCleanerJob(Configuration config, ManifestManager manifestService) {
+        this.config = config;
+        this.manifestManager = manifestService;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Object execute(JobExecutionContext context) throws JobExecutionException {
+        File baseDir = new File(config.getString(ConfigProperties.SYNC_WORK_DIR));
+        int maxAgeInMinutes = config.getInt(ConfigProperties.jobConfig(JOB_KEY, CFG_MAX_AGE_IN_MINUTES),
+            DEFAULT_MAX_AGE_IN_MINUTES);
+
+        if (maxAgeInMinutes < 1) {
+            String errmsg = String.format("Invalid value for max age, must be a positive integer: %s",
+                maxAgeInMinutes);
+
+            log.error(errmsg);
+            throw new JobExecutionException(errmsg, true);
+        }
+
+        log.info("Manifest cleanup started");
+        log.info("Max Age: {} mins ({} hours)", maxAgeInMinutes, maxAgeInMinutes / 60);
+        cleanupExportWorkDirs(baseDir, maxAgeInMinutes);
+        manifestServiceCleanup(maxAgeInMinutes);
+
+        return null;
+    }
+
+    private void cleanupExportWorkDirs(File baseDir, int maxAgeInMinutes) {
+        long dirCount = 0;
+        long delCount = 0;
+        long leftCount = 0;
+
+        Date cutOff = Util.addMinutesToDt(maxAgeInMinutes * -1);
+
+        if (baseDir.listFiles() != null) {
+            dirCount =  baseDir.listFiles().length;
+            for (File f : baseDir.listFiles()) {
+                if (f.lastModified() < cutOff.getTime()) {
+                    try {
+                        log.info("Deleting old manifest directory: {}", f.getAbsolutePath());
+
+                        FileUtils.deleteDirectory(f);
+                        delCount++;
+                    }
+                    catch (IOException io) {
+                        String errorMsg = String.format("Unable to delete export directory that is old " +
+                            "enough to delete: %s", f.getAbsolutePath());
+                        log.error(errorMsg, io);
+                    }
+                }
+                else {
+                    leftCount++;
+                }
+            }
+        }
+
+        log.info("Begining directory count: {}", dirCount);
+        log.info("Directories deleted: {}", delCount);
+        log.info("Directories remaining: {}", leftCount);
+    }
+
+    private void manifestServiceCleanup(int maxAgeInMinutes) {
+        int deleted = manifestManager.cleanup(maxAgeInMinutes);
+        log.info("Deleted from file service: {}", deleted);
+    }
+}

--- a/server/src/main/java/org/candlepin/audit/ArtemisMessageSourceReceiverFactory.java
+++ b/server/src/main/java/org/candlepin/audit/ArtemisMessageSourceReceiverFactory.java
@@ -88,7 +88,7 @@ public class ArtemisMessageSourceReceiverFactory implements MessageSourceReceive
 
         // Add jobs explicitly disabled
         String prefix = Pattern.quote(ConfigProperties.ASYNC_JOBS_PREFIX);
-        String suffix = Pattern.quote(ConfigProperties.ASYNC_JOBS_SUFFIX_ENABLED);
+        String suffix = Pattern.quote(ConfigProperties.ASYNC_JOBS_JOB_ENABLED);
         Pattern regex = Pattern.compile("\\A" + prefix + "(.+)\\." + suffix + "\\z");
 
         for (String key : this.config.getKeys()) {

--- a/server/src/main/java/org/candlepin/guice/CandlepinModule.java
+++ b/server/src/main/java/org/candlepin/guice/CandlepinModule.java
@@ -34,6 +34,7 @@ import org.candlepin.async.tasks.ExportJob;
 import org.candlepin.async.tasks.HypervisorHeartbeatUpdateJob;
 import org.candlepin.async.tasks.HypervisorUpdateJob;
 import org.candlepin.async.tasks.ImportJob;
+import org.candlepin.async.tasks.ManifestCleanerJob;
 import org.candlepin.async.tasks.RefreshPoolsForProductJob;
 import org.candlepin.async.tasks.RefreshPoolsJob;
 import org.candlepin.async.tasks.RegenEnvEntitlementCertsJob;
@@ -426,13 +427,15 @@ public class CandlepinModule extends AbstractModule {
         bind(SchedulerFactory.class).to(StdSchedulerFactory.class);
 
         JobManager.registerJob(TestJob1.JOB_KEY, TestJob1.class);
+
         JobManager.registerJob(ExportJob.JOB_KEY, ExportJob.class);
+        JobManager.registerJob(HypervisorUpdateJob.JOB_KEY, HypervisorUpdateJob.class);
+        JobManager.registerJob(HypervisorHeartbeatUpdateJob.JOB_KEY, HypervisorHeartbeatUpdateJob.class);
         JobManager.registerJob(ImportJob.JOB_KEY, ImportJob.class);
+        JobManager.registerJob(ManifestCleanerJob.JOB_KEY, ManifestCleanerJob.class);
         JobManager.registerJob(RefreshPoolsForProductJob.JOB_KEY, RefreshPoolsForProductJob.class);
         JobManager.registerJob(RefreshPoolsJob.JOB_KEY, RefreshPoolsJob.class);
         JobManager.registerJob(RegenEnvEntitlementCertsJob.JOB_KEY, RegenEnvEntitlementCertsJob.class);
-        JobManager.registerJob(HypervisorUpdateJob.JOB_KEY, HypervisorUpdateJob.class);
-        JobManager.registerJob(HypervisorHeartbeatUpdateJob.JOB_KEY, HypervisorHeartbeatUpdateJob.class);
         JobManager.registerJob(UndoImportsJob.JOB_KEY, UndoImportsJob.class);
     }
 

--- a/server/src/test/java/org/candlepin/async/tasks/BaseJobTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/BaseJobTest.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.async.tasks;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.candlepin.TestingModules;
+
+
+
+/**
+ * Base class for tests of jobs that need Guice injection
+ */
+public class BaseJobTest {
+    protected Injector injector;
+
+    public void inject() {
+        injector = Guice.createInjector(
+            new TestingModules.MockJpaModule(),
+            new TestingModules.ServletEnvironmentModule(),
+            new TestingModules.StandardTest());
+    }
+}

--- a/server/src/test/java/org/candlepin/async/tasks/ExportJobTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/ExportJobTest.java
@@ -25,7 +25,6 @@ import org.candlepin.common.filter.LoggingFilter;
 import org.candlepin.controller.ManifestManager;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.Owner;
-import org.candlepin.pinsetter.tasks.BaseJobTest;
 import org.candlepin.sync.ExportResult;
 import org.candlepin.test.TestUtil;
 import org.junit.Before;
@@ -44,12 +43,11 @@ public class ExportJobTest extends BaseJobTest {
 
     @Mock
     private ManifestManager manifestManager;
-
     private ExportJob job;
 
     @Before
     public void setupTest() {
-        super.init();
+        super.inject();
 
         job = new ExportJob(manifestManager);
         injector.injectMembers(job);

--- a/server/src/test/java/org/candlepin/async/tasks/HypervisorUpdateJobTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/HypervisorUpdateJobTest.java
@@ -49,7 +49,6 @@ import org.candlepin.model.HypervisorId;
 import org.candlepin.model.Owner;
 import org.candlepin.model.OwnerCurator;
 import org.candlepin.model.VirtConsumerMap;
-import org.candlepin.pinsetter.tasks.BaseJobTest;
 import org.candlepin.resource.ConsumerResource;
 import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.service.impl.HypervisorUpdateAction;
@@ -88,7 +87,8 @@ public class HypervisorUpdateJobTest extends BaseJobTest {
 
     @BeforeEach
     public void init() {
-        super.init();
+        super.inject();
+
         i18n = I18nFactory.getI18n(
             getClass(),
             Locale.US,

--- a/server/src/test/java/org/candlepin/async/tasks/ImportJobTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/ImportJobTest.java
@@ -24,7 +24,6 @@ import org.candlepin.controller.ManifestManager;
 import org.candlepin.model.ImportRecord;
 import org.candlepin.model.Owner;
 import org.candlepin.model.OwnerCurator;
-import org.candlepin.pinsetter.tasks.BaseJobTest;
 import org.candlepin.sync.ConflictOverrides;
 import org.candlepin.sync.Importer;
 import org.candlepin.sync.ImporterException;
@@ -60,7 +59,8 @@ public class ImportJobTest extends BaseJobTest {
 
     @Before
     public void setup() {
-        super.init();
+        super.inject();
+
         owner = new Owner("my-test-owner");
         job = new ImportJob(ownerCurator, manifestManager);
         injector.injectMembers(job);

--- a/server/src/test/java/org/candlepin/async/tasks/ManifestCleanerJobTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/ManifestCleanerJobTest.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.async.tasks;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.candlepin.async.JobExecutionContext;
+import org.candlepin.async.JobExecutionException;
+import org.candlepin.config.ConfigProperties;
+import org.candlepin.controller.ManifestManager;
+import org.candlepin.test.DatabaseTestFixture;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+
+
+/**
+ * Test suite for the ManifestCleanerJob class
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class ManifestCleanerJobTest extends DatabaseTestFixture {
+
+    private Path manifestDir;
+    private ManifestManager manifestManager;
+
+    @BeforeEach
+    public void setUp() throws IOException {
+        this.manifestDir = Files.createTempDirectory("test_sync-");
+        this.manifestManager = mock(ManifestManager.class);
+
+        this.config.setProperty(ConfigProperties.SYNC_WORK_DIR, manifestDir.toString());
+    }
+
+    private ManifestCleanerJob createJobInstance() {
+        return new ManifestCleanerJob(this.config, this.manifestManager);
+    }
+
+    private File createManifest(Path dir, String name, long lastModifiedTime) throws IOException {
+        Path manifest = Files.createTempDirectory(dir, name + '-');
+        File dummyFile = Files.createTempFile(manifest, name, "dummy").toFile();
+
+        File manifestFile = manifest.toFile();
+        manifestFile.setLastModified(lastModifiedTime);
+
+        return manifestFile;
+    }
+
+    private void setMaxAgeConfig(int maxAgeInMinutes) {
+        String cfg = ConfigProperties.jobConfig(ManifestCleanerJob.JOB_KEY,
+            ManifestCleanerJob.CFG_MAX_AGE_IN_MINUTES);
+
+        this.config.setProperty(cfg, String.valueOf(maxAgeInMinutes));
+    }
+
+    private long subtractMinutes(long baseTime, int minutes) {
+        return baseTime - minutes * 60 * 1000;
+    }
+
+    private static Stream<Arguments> maxAgeProvider() {
+        return Stream.of(
+            Arguments.of(ManifestCleanerJob.DEFAULT_MAX_AGE_IN_MINUTES),
+            Arguments.of(60),
+            Arguments.of(1));
+    }
+
+    @ParameterizedTest
+    @MethodSource("maxAgeProvider")
+    public void testStandardExecution(int maxAge) throws JobExecutionException, IOException {
+        long now = System.currentTimeMillis();
+        this.setMaxAgeConfig(maxAge);
+
+        long old = this.subtractMinutes(now, maxAge << 1);
+        long cur = this.subtractMinutes(now, maxAge >> 1);
+
+        File manifest1 = this.createManifest(this.manifestDir, "manifest1", old);
+        File manifest2 = this.createManifest(this.manifestDir, "manifest2", cur);
+        File manifest3 = this.createManifest(this.manifestDir, "manifest3", old);
+
+        JobExecutionContext context = mock(JobExecutionContext.class);
+        ManifestCleanerJob job = this.createJobInstance();
+        Object result = job.execute(context);
+
+        assertNull(result); // This job doesn't return anything
+
+        assertFalse(manifest1.exists());
+        assertTrue(manifest2.exists());
+        assertFalse(manifest3.exists());
+
+        verify(this.manifestManager, times(1)).cleanup(eq(maxAge));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "0", "-50" })
+    public void testBadAgeConfig(int maxAge) {
+        this.setMaxAgeConfig(maxAge);
+
+        JobExecutionContext context = mock(JobExecutionContext.class);
+        ManifestCleanerJob job = this.createJobInstance();
+        assertThrows(JobExecutionException.class, () -> job.execute(context));
+    }
+}

--- a/server/src/test/java/org/candlepin/async/tasks/RefreshPoolsForProductJobTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/RefreshPoolsForProductJobTest.java
@@ -30,7 +30,6 @@ import org.candlepin.controller.PoolManager;
 import org.candlepin.controller.Refresher;
 import org.candlepin.model.Product;
 import org.candlepin.model.ProductCurator;
-import org.candlepin.pinsetter.tasks.BaseJobTest;
 import org.candlepin.service.OwnerServiceAdapter;
 import org.candlepin.service.SubscriptionServiceAdapter;
 
@@ -40,7 +39,7 @@ import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
-public class RefreshPoolsForProductJobTest extends BaseJobTest {
+public class RefreshPoolsForProductJobTest {
 
     private static final String VALID_ID = "valid_id";
     private static final String VALID_NAME = "valid_name";

--- a/server/src/test/java/org/candlepin/async/tasks/RefreshPoolsJobTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/RefreshPoolsJobTest.java
@@ -30,7 +30,6 @@ import org.candlepin.controller.PoolManager;
 import org.candlepin.controller.Refresher;
 import org.candlepin.model.Owner;
 import org.candlepin.model.OwnerCurator;
-import org.candlepin.pinsetter.tasks.BaseJobTest;
 import org.candlepin.service.OwnerServiceAdapter;
 import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.test.TestUtil;
@@ -56,7 +55,7 @@ public class RefreshPoolsJobTest extends BaseJobTest {
 
     @Before
     public void setupTest() {
-        super.init();
+        super.inject();
 
         job = new RefreshPoolsJob(ownerCurator, poolManager, subAdapter, ownerAdapter);
         injector.injectMembers(job);


### PR DESCRIPTION
- Ported the ManifestCleanerJob to the Artemis job system
- Refactored some job configuration constants and methods to
  standardize how per-job configuration is done
- Updated several Artemis job tests to no longer reference
  Pinsetter classes
- Fixed a few problems in the JobManager tests involving
  scheduling