### PR TITLE
[F] Port ImportRecordJob to the new job framework (ENT-865)

### DIFF
--- a/server/spec/content_versioning_spec.rb
+++ b/server/spec/content_versioning_spec.rb
@@ -279,7 +279,7 @@ describe 'Content Versioning' do
       end
 
       sleep 1
-      pp @cp.trigger_async_job("OrphanCleanupJob");
+      @cp.trigger_async_job("ORPHAN_CLEANUP");
 
       updater.join
       generator.join

--- a/server/spec/job_schedule_spec.rb
+++ b/server/spec/job_schedule_spec.rb
@@ -60,8 +60,8 @@ describe 'Scheduled Jobs' do
     end
     records = @cp.list_imports(@import_owner['key'])
     records.size.should == 11
-    job = @cp.trigger_job('ImportRecordJob')
-    wait_for_job(job['id'], 15)
+    job = @cp.trigger_async_job('IMPORT_RECORD_CLEANER')
+    wait_for_async_job(job['id'], 15)
     records = @cp.list_imports(@import_owner['key'])
     records.size.should == 10
   end

--- a/server/spec/product_versioning_spec.rb
+++ b/server/spec/product_versioning_spec.rb
@@ -459,7 +459,7 @@ describe 'Product Versioning' do
       end
 
       sleep 1
-      @cp.trigger_async_job("OrphanCleanupJob");
+      @cp.trigger_async_job("ORPHAN_CLEANUP")
 
       updater.join
       generator.join

--- a/server/src/main/java/org/candlepin/async/tasks/ImportRecordCleanerJob.java
+++ b/server/src/main/java/org/candlepin/async/tasks/ImportRecordCleanerJob.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.async.tasks;
+
+import com.google.inject.Inject;
+import org.candlepin.async.AsyncJob;
+import org.candlepin.async.JobExecutionContext;
+import org.candlepin.async.JobExecutionException;
+import org.candlepin.common.config.Configuration;
+import org.candlepin.config.ConfigProperties;
+import org.candlepin.model.ImportRecord;
+import org.candlepin.model.ImportRecordCurator;
+import org.candlepin.model.Owner;
+import org.candlepin.model.OwnerCurator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+/**
+ * Deletes all but the newest N records, defined by the num_of_records_to_keep/DEFAULT_KEEP variable,
+ * for each owner.
+ */
+public class ImportRecordCleanerJob implements AsyncJob {
+    private static Logger log = LoggerFactory.getLogger(ImportRecordCleanerJob.class);
+
+    public static final String JOB_KEY = "IMPORT_RECORD_CLEANER";
+    public static final String JOB_NAME = "Import record cleaner";
+
+    public static final String DEFAULT_SCHEDULE = "0 0 12 * * ?";
+
+    public static final String CFG_KEEP = "num_of_records_to_keep";
+    public static final int DEFAULT_KEEP = 10;
+
+    private OwnerCurator ownerCurator;
+    private ImportRecordCurator importRecordCurator;
+    private Configuration config;
+
+    @Inject
+    public ImportRecordCleanerJob(ImportRecordCurator importRecordCurator,
+        OwnerCurator ownerCurator, Configuration config) {
+        this.importRecordCurator = importRecordCurator;
+        this.ownerCurator = ownerCurator;
+        this.config = config;
+    }
+
+    @Override
+    public Object execute(JobExecutionContext context) throws JobExecutionException {
+        int toKeep = this.config.getInt(ConfigProperties.jobConfig(JOB_KEY, CFG_KEEP), DEFAULT_KEEP);
+
+        if (toKeep < 0) {
+            String errmsg = String.format(
+                "Invalid value for number of records to keep, must be 0 or a positive integer: %s",
+                toKeep);
+
+            log.error(errmsg);
+            throw new JobExecutionException(errmsg, true);
+        }
+
+        int deleted = 0;
+        for (Owner owner : this.ownerCurator.listAll().list()) {
+            List<ImportRecord> records = this.importRecordCurator.findRecords(owner).list();
+
+            if (toKeep < records.size()) {
+                // records are already sorted by date, so just shave off of the end
+                this.importRecordCurator.bulkDelete(records.subList(toKeep, records.size()));
+                deleted += records.size() - toKeep;
+            }
+        }
+
+        String outcome;
+        if (deleted > 0) {
+            outcome = String.format("Deleted %d import records.", deleted);
+            log.info(outcome);
+            return outcome;
+        }
+        outcome = "No import records were deleted.";
+        log.debug(outcome);
+        return outcome;
+    }
+}

--- a/server/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/server/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -20,13 +20,13 @@ import static org.candlepin.common.config.ConfigurationPrefixes.*;
 import org.candlepin.async.tasks.ActiveEntitlementJob;
 import org.candlepin.async.tasks.CRLUpdateJob;
 import org.candlepin.async.tasks.ExpiredPoolsCleanupJob;
+import org.candlepin.async.tasks.ImportRecordCleanerJob;
 import org.candlepin.async.tasks.ManifestCleanerJob;
 import org.candlepin.async.tasks.UnmappedGuestEntitlementCleanerJob;
 import org.candlepin.async.tasks.OrphanCleanupJob;
 import org.candlepin.common.config.Configuration;
 import org.candlepin.pinsetter.tasks.CancelJobJob;
 import org.candlepin.pinsetter.tasks.EntitlerJob;
-import org.candlepin.pinsetter.tasks.ImportRecordJob;
 import org.candlepin.pinsetter.tasks.JobCleaner;
 import org.candlepin.pinsetter.tasks.SweepBarJob;
 import org.candlepin.pinsetter.tasks.UnpauseJob;
@@ -178,7 +178,6 @@ public class ConfigProperties {
 
     public static final String[] DEFAULT_TASK_LIST = new String[] {
         CancelJobJob.class.getName(),
-        ImportRecordJob.class.getName(),
         JobCleaner.class.getName(),
         SweepBarJob.class.getName(),
         UnpauseJob.class.getName(),
@@ -460,6 +459,8 @@ public class ConfigProperties {
                 CRLUpdateJob.DEFAULT_SCHEDULE);
             this.put(jobConfig(ExpiredPoolsCleanupJob.JOB_KEY, ASYNC_JOBS_JOB_SCHEDULE),
                 ExpiredPoolsCleanupJob.DEFAULT_SCHEDULE);
+            this.put(jobConfig(ImportRecordCleanerJob.JOB_KEY, ASYNC_JOBS_JOB_SCHEDULE),
+                ImportRecordCleanerJob.DEFAULT_SCHEDULE);
             this.put(jobConfig(ManifestCleanerJob.JOB_KEY, ASYNC_JOBS_JOB_SCHEDULE),
                 ManifestCleanerJob.DEFAULT_SCHEDULE);
             this.put(jobConfig(OrphanCleanupJob.JOB_KEY, ASYNC_JOBS_JOB_SCHEDULE),

--- a/server/src/main/java/org/candlepin/guice/CandlepinModule.java
+++ b/server/src/main/java/org/candlepin/guice/CandlepinModule.java
@@ -24,6 +24,7 @@ import org.candlepin.async.tasks.ExportJob;
 import org.candlepin.async.tasks.HypervisorHeartbeatUpdateJob;
 import org.candlepin.async.tasks.HypervisorUpdateJob;
 import org.candlepin.async.tasks.ImportJob;
+import org.candlepin.async.tasks.ImportRecordCleanerJob;
 import org.candlepin.async.tasks.ManifestCleanerJob;
 import org.candlepin.async.tasks.OrphanCleanupJob;
 import org.candlepin.async.tasks.RefreshPoolsForProductJob;
@@ -437,6 +438,7 @@ public class CandlepinModule extends AbstractModule {
         JobManager.registerJob(HypervisorUpdateJob.JOB_KEY, HypervisorUpdateJob.class);
         JobManager.registerJob(HypervisorHeartbeatUpdateJob.JOB_KEY, HypervisorHeartbeatUpdateJob.class);
         JobManager.registerJob(ImportJob.JOB_KEY, ImportJob.class);
+        JobManager.registerJob(ImportRecordCleanerJob.JOB_KEY, ImportRecordCleanerJob.class);
         JobManager.registerJob(ManifestCleanerJob.JOB_KEY, ManifestCleanerJob.class);
         JobManager.registerJob(OrphanCleanupJob.JOB_KEY, OrphanCleanupJob.class);
         JobManager.registerJob(RefreshPoolsForProductJob.JOB_KEY, RefreshPoolsForProductJob.class);

--- a/server/src/test/java/org/candlepin/async/tasks/ImportRecordCleanerJobTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/ImportRecordCleanerJobTest.java
@@ -1,0 +1,204 @@
+/**
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.async.tasks;
+
+import org.candlepin.async.JobExecutionContext;
+import org.candlepin.async.JobExecutionException;
+import org.candlepin.config.ConfigProperties;
+import org.candlepin.model.ImportRecord;
+import org.candlepin.model.Owner;
+import org.candlepin.test.DatabaseTestFixture;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Test suite for the ImportRecordCleanerJob class
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class ImportRecordCleanerJobTest extends DatabaseTestFixture {
+
+    private ImportRecordCleanerJob createJobInstance() {
+        return new ImportRecordCleanerJob(this.importRecordCurator, this.ownerCurator, this.config);
+    }
+
+    @Test
+    public void noRecords() throws Exception {
+        Owner owner = new Owner("owner");
+        Owner another = new Owner("another_owner");
+        ownerCurator.create(owner);
+        ownerCurator.create(another);
+
+        // just make sure that running this on owners with no records
+        // doesn't blow up
+        JobExecutionContext context = mock(JobExecutionContext.class);
+
+        ImportRecordCleanerJob job = createJobInstance();
+        String result = (String) job.execute(context);
+        assertEquals("No import records were deleted.", result);
+    }
+
+    @Test
+    public void singleOwner() throws Exception {
+        Owner owner = new Owner("owner");
+        ownerCurator.create(owner);
+
+        for (int i = 0; i < 13; i++) {
+            ImportRecord record = new ImportRecord(owner);
+            record.recordStatus(ImportRecord.Status.SUCCESS, "great!");
+
+            this.importRecordCurator.create(record);
+        }
+
+        JobExecutionContext context = mock(JobExecutionContext.class);
+        ImportRecordCleanerJob job = createJobInstance();
+        String result = (String) job.execute(context);
+
+        List<ImportRecord> records = this.importRecordCurator.findRecords(owner).list();
+
+        assertEquals(10, records.size());
+        assertEquals("Deleted 3 import records.", result);
+    }
+
+    @Test
+    public void lessThanThreshold() throws Exception {
+        Owner owner = new Owner("owner");
+        ownerCurator.create(owner);
+
+        for (int i = 0; i < 7; i++) {
+            ImportRecord record = new ImportRecord(owner);
+            record.recordStatus(ImportRecord.Status.SUCCESS, "great!");
+
+            this.importRecordCurator.create(record);
+        }
+
+        JobExecutionContext context = mock(JobExecutionContext.class);
+        ImportRecordCleanerJob job = createJobInstance();
+        String result = (String) job.execute(context);
+
+        List<ImportRecord> records = this.importRecordCurator.findRecords(owner).list();
+
+        assertEquals(7, records.size());
+        assertEquals("No import records were deleted.", result);
+    }
+
+    @Test
+    public void multipleOwners() throws Exception {
+        Owner owner1 = new Owner("owner1");
+        Owner owner2 = new Owner("owner2");
+        ownerCurator.create(owner1);
+        ownerCurator.create(owner2);
+
+        for (int i = 0; i < 23; i++) {
+            ImportRecord record = new ImportRecord(owner1);
+            record.recordStatus(ImportRecord.Status.FAILURE, "Bad bad");
+
+            this.importRecordCurator.create(record);
+        }
+
+        for (int i = 0; i < 4; i++) {
+            ImportRecord record = new ImportRecord(owner2);
+            record.recordStatus(ImportRecord.Status.SUCCESS, "Excellent");
+
+            this.importRecordCurator.create(record);
+        }
+
+        JobExecutionContext context = mock(JobExecutionContext.class);
+        ImportRecordCleanerJob job = createJobInstance();
+        String result = (String) job.execute(context);
+
+        assertEquals(10, importRecordCurator.findRecords(owner1).list().size());
+        assertEquals(4, importRecordCurator.findRecords(owner2).list().size());
+        assertEquals("Deleted 13 import records.", result);
+    }
+
+    private void setNumOfRecordsToKeep(int numOfRecordsToKeep) {
+        String cfg = ConfigProperties.jobConfig(ImportRecordCleanerJob.JOB_KEY,
+            ImportRecordCleanerJob.CFG_KEEP);
+
+        this.config.setProperty(cfg, String.valueOf(numOfRecordsToKeep));
+    }
+
+    private static Stream<Arguments> numOfRecordsToKeepProvider() {
+        return Stream.of(
+            Arguments.of(ImportRecordCleanerJob.DEFAULT_KEEP),
+            Arguments.of(60),
+            Arguments.of(13),
+            Arguments.of(1),
+            Arguments.of(0));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { -1, -50 })
+    public void singleOwnerBadKeepConfig(int keep) throws Exception {
+        this.setNumOfRecordsToKeep(keep);
+        Owner owner = new Owner("owner");
+        ownerCurator.create(owner);
+
+        for (int i = 0; i < 3; i++) {
+            ImportRecord record = new ImportRecord(owner);
+            record.recordStatus(ImportRecord.Status.SUCCESS, "great!");
+            this.importRecordCurator.create(record);
+        }
+
+        JobExecutionContext context = mock(JobExecutionContext.class);
+        ImportRecordCleanerJob job = createJobInstance();
+        assertThrows(JobExecutionException.class, () -> job.execute(context));
+    }
+
+    @ParameterizedTest
+    @MethodSource("numOfRecordsToKeepProvider")
+    public void singleOwnerCustomConfigSettings(int keep) throws Exception {
+        this.setNumOfRecordsToKeep(keep);
+        Owner owner = new Owner("owner");
+        ownerCurator.create(owner);
+
+        int existingRecords = 13;
+        for (int i = 0; i < existingRecords; i++) {
+            ImportRecord record = new ImportRecord(owner);
+            record.recordStatus(ImportRecord.Status.SUCCESS, "great!");
+            this.importRecordCurator.create(record);
+        }
+
+        JobExecutionContext context = mock(JobExecutionContext.class);
+        ImportRecordCleanerJob job = createJobInstance();
+        String result = (String) job.execute(context);
+
+        int expectedDeletedRecords = existingRecords - keep;
+        int expectedKeptRecords = existingRecords > keep ? keep : existingRecords;
+
+        assertEquals(expectedKeptRecords, importRecordCurator.findRecords(owner).list().size());
+        if (expectedDeletedRecords > 0) {
+            assertEquals("Deleted " + expectedDeletedRecords + " import records.", result);
+        }
+        else {
+            assertEquals("No import records were deleted.", result);
+        }
+    }
+}


### PR DESCRIPTION
- Ported the ImportRecordJob to the Artemis job system
  as the ImportRecordCleanerJob