### PR TITLE
Cleanup of async job tests

### DIFF
--- a/server/src/test/java/org/candlepin/async/JobManagerTest.java
+++ b/server/src/test/java/org/candlepin/async/JobManagerTest.java
@@ -87,8 +87,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-
-
 public class JobManagerTest {
 
     private static class StateCollectingStatus extends AsyncJobStatus {
@@ -263,7 +261,7 @@ public class JobManagerTest {
         assertThat(throwable.getMessage(), StringContains.containsString("Unable to find"));
     }
 
-    public static Object[] getTerminalJobStates() {
+    private static Object[] getTerminalJobStates() {
         List<JobState> states = new ArrayList<>();
 
         for (JobState state : JobState.values()) {
@@ -292,7 +290,7 @@ public class JobManagerTest {
     }
 
     @Test
-    public void shouldFailWhenJobCouldNotBeConstructed() throws JobException {
+    public void shouldFailWhenJobCouldNotBeConstructed() {
         AsyncJobStatus status = spy(new AsyncJobStatus()
             .setJobKey(JOB_KEY));
 
@@ -420,7 +418,7 @@ public class JobManagerTest {
     }
 
     @Test
-    public void failedJobShouldEndAsFailed() throws JobInitializationException {
+    public void failedJobShouldEndAsFailed() {
         final StateCollectingStatus status = new StateCollectingStatus();
         status.setJobKey(JOB_KEY);
 
@@ -707,9 +705,7 @@ public class JobManagerTest {
     }
 
     @Test
-    public void testFailedStateUpdateResultsInStateManagementExceptionDuringRetryExecution()
-        throws JobException {
-
+    public void testFailedStateUpdateResultsInStateManagementExceptionDuringRetryExecution() {
         AsyncJobStatus status = spy(new AsyncJobStatus()
             .setJobKey(JOB_KEY)
             .setState(JobState.QUEUED)
@@ -757,7 +753,7 @@ public class JobManagerTest {
     }
 
     @Test
-    public void testJobExecutionFailsWithNoJobKey() throws JobException {
+    public void testJobExecutionFailsWithNoJobKey() {
         AsyncJobStatus status = spy(new AsyncJobStatus()
             .setState(JobState.QUEUED)
             .setMaxAttempts(3));

--- a/server/src/test/java/org/candlepin/async/JobMessageReceiverTest.java
+++ b/server/src/test/java/org/candlepin/async/JobMessageReceiverTest.java
@@ -14,9 +14,9 @@
  */
 package org.candlepin.async;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyBoolean;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -37,8 +37,6 @@ import org.apache.activemq.artemis.api.core.client.ClientMessage;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.junit.Before;
 import org.junit.Test;
-
-
 
 public class JobMessageReceiverTest {
 
@@ -65,7 +63,7 @@ public class JobMessageReceiverTest {
         doReturn(this.consumer).when(this.session).createConsumer(anyString(), anyString());
     }
 
-    public JobMessageReceiver buildJobMessageReceiver() {
+    private JobMessageReceiver buildJobMessageReceiver() {
         try {
             JobMessageReceiver receiver = new JobMessageReceiver(this.filter, this.jobManager,
                 this.sessionFactory, this.objMapper);
@@ -79,7 +77,7 @@ public class JobMessageReceiverTest {
         }
     }
 
-    public ClientMessage buildClientMessage(String jobId, String jobKey) {
+    private ClientMessage buildClientMessage(String jobId, String jobKey) {
         try {
             String body = String.format("{ \"jobId\": \"%s\", \"jobKey\": \"%s\" }", jobId, jobKey);
 

--- a/server/src/test/java/org/candlepin/async/impl/UniqueByArgConstraintTest.java
+++ b/server/src/test/java/org/candlepin/async/impl/UniqueByArgConstraintTest.java
@@ -14,23 +14,22 @@
  */
 package org.candlepin.async.impl;
 
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.candlepin.async.JobConfig;
 import org.candlepin.async.JobConstraint;
 import org.candlepin.model.AsyncJobStatus;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-
-
 
 public class UniqueByArgConstraintTest {
 
@@ -82,7 +81,7 @@ public class UniqueByArgConstraintTest {
         AsyncJobStatus inbound = this.buildJobStatus("inbound", "test_key", this.map("param1", "val1"));
         AsyncJobStatus existing = this.buildJobStatus("existing", "test_key", this.map("param1", "val1"));
 
-        JobConstraint constraint = new UniqueByArgConstraint(Arrays.asList("param1"));
+        JobConstraint constraint = new UniqueByArgConstraint(Collections.singletonList("param1"));
         Collection<AsyncJobStatus> result = constraint.test(inbound, Collections.singletonList(existing));
 
         assertNotNull(result);
@@ -122,7 +121,7 @@ public class UniqueByArgConstraintTest {
             "param2", "val2",
             "param3", "val3"));
 
-        JobConstraint constraint = new UniqueByArgConstraint(Arrays.asList("param2"));
+        JobConstraint constraint = new UniqueByArgConstraint(Collections.singletonList("param2"));
         Collection<AsyncJobStatus> result = constraint.test(inbound, Collections.singletonList(existing));
 
         assertNotNull(result);

--- a/server/src/test/java/org/candlepin/async/tasks/ActiveEntitlementJobTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/ActiveEntitlementJobTest.java
@@ -15,8 +15,11 @@
 
 package org.candlepin.async.tasks;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
 import org.candlepin.async.JobExecutionContext;
 import org.candlepin.async.JobExecutionException;
@@ -72,7 +75,7 @@ public class ActiveEntitlementJobTest extends DatabaseTestFixture {
         entitlementCurator.create(ent);
 
         consumerCurator.refresh(consumer);
-        assertFalse("valid".equals(consumer.getEntitlementStatus()));
+        assertNotEquals("valid", consumer.getEntitlementStatus());
 
         JobExecutionContext context = mock(JobExecutionContext.class);
         job.execute(context);
@@ -111,13 +114,13 @@ public class ActiveEntitlementJobTest extends DatabaseTestFixture {
         entitlementCurator.create(ent);
 
         consumerCurator.refresh(consumer);
-        assertFalse("valid".equals(consumer.getEntitlementStatus()));
+        assertNotEquals("valid", consumer.getEntitlementStatus());
 
         JobExecutionContext context = mock(JobExecutionContext.class);
         job.execute(context);
         consumerCurator.refresh(consumer);
         // still not valid.  Probably not even set, but that doesn't matter
-        assertFalse("valid".equals(consumer.getEntitlementStatus()));
+        assertNotEquals("valid", consumer.getEntitlementStatus());
 
         // Should not have changed
         assertFalse(entitlementCurator.get(ent.getId()).isUpdatedOnStart());

--- a/server/src/test/java/org/candlepin/async/tasks/BaseJobTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/BaseJobTest.java
@@ -18,8 +18,6 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.candlepin.TestingModules;
 
-
-
 /**
  * Base class for tests of jobs that need Guice injection
  */

--- a/server/src/test/java/org/candlepin/async/tasks/CRLUpdateJobTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/CRLUpdateJobTest.java
@@ -14,32 +14,26 @@
  */
 package org.candlepin.async.tasks;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 import org.candlepin.async.JobExecutionContext;
 import org.candlepin.async.JobExecutionException;
-import org.candlepin.config.CandlepinCommonTestConfig;
 import org.candlepin.common.config.Configuration;
+import org.candlepin.config.CandlepinCommonTestConfig;
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.util.CrlFileUtil;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 
 import java.io.File;
-
-
 
 /**
  * Test suite for the CRLUpdateJob class
  */
-@ExtendWith(MockitoExtension.class)
-@MockitoSettings(strictness = Strictness.LENIENT)
 public class CRLUpdateJobTest {
 
     private Configuration config;
@@ -56,7 +50,7 @@ public class CRLUpdateJobTest {
     }
 
     @Test
-    public void executeFailsOnEmptyFilePath() throws JobExecutionException {
+    public void executeFailsOnEmptyFilePath() {
         this.config.setProperty(ConfigProperties.CRL_FILE_PATH, "");
 
         JobExecutionContext context = mock(JobExecutionContext.class);
@@ -65,7 +59,7 @@ public class CRLUpdateJobTest {
     }
 
     @Test
-    public void executeFailsOnAbsentFilePath() throws JobExecutionException {
+    public void executeFailsOnAbsentFilePath() {
         this.config.clearProperty(ConfigProperties.CRL_FILE_PATH);
 
         JobExecutionContext context = mock(JobExecutionContext.class);

--- a/server/src/test/java/org/candlepin/async/tasks/EntitleByProductsJobTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/EntitleByProductsJobTest.java
@@ -31,7 +31,6 @@ import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerType;
 import org.candlepin.model.Entitlement;
 import org.candlepin.model.Owner;
-import org.candlepin.pinsetter.tasks.BaseJobTest;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -41,7 +40,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
-public class EntitleByProductsJobTest extends BaseJobTest {
+public class EntitleByProductsJobTest {
 
     private Consumer consumer;
     private Owner owner;
@@ -50,7 +49,6 @@ public class EntitleByProductsJobTest extends BaseJobTest {
 
     @BeforeEach
     public void init() {
-        super.init();
         consumerUuid = "49bd6a8f-e9f8-40cc-b8d7-86cafd687a0e";
 
         final ConsumerType ctype = new ConsumerType("system");
@@ -171,7 +169,6 @@ public class EntitleByProductsJobTest extends BaseJobTest {
         when(entitler.bindByProducts(eq(pids), eq(consumerUuid), eq(entitleDate), eq(fromPools)))
             .thenReturn(ents);
         final EntitleByProductsJob job = new EntitleByProductsJob(entitler, null);
-        injector.injectMembers(job);
 
         job.execute(ctx);
 

--- a/server/src/test/java/org/candlepin/async/tasks/EntitlerJobTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/EntitlerJobTest.java
@@ -41,7 +41,6 @@ import org.candlepin.model.Pool;
 import org.candlepin.model.PoolCurator;
 import org.candlepin.model.dto.PoolIdAndErrors;
 import org.candlepin.model.dto.PoolIdAndQuantity;
-import org.candlepin.pinsetter.tasks.BaseJobTest;
 import org.candlepin.policy.EntitlementRefusedException;
 import org.candlepin.policy.ValidationResult;
 
@@ -60,7 +59,7 @@ import java.util.Locale;
 /**
  * EntitlerJobTest
  */
-public class EntitlerJobTest extends BaseJobTest {
+public class EntitlerJobTest {
 
     private Consumer consumer;
     private Owner owner;
@@ -73,7 +72,6 @@ public class EntitlerJobTest extends BaseJobTest {
 
     @BeforeEach
     public void init() {
-        super.init();
 
         final ConsumerType ctype = new ConsumerType("system");
         ctype.setId("test-ctype");
@@ -191,9 +189,7 @@ public class EntitlerJobTest extends BaseJobTest {
     }
 
     private EntitlerJob createEntitlerJob(final PoolCurator poolCurator, final I18n i18n) {
-        final EntitlerJob job = new EntitlerJob(entitler, poolCurator, i18n);
-        injector.injectMembers(job);
-        return job;
+        return new EntitlerJob(entitler, poolCurator, i18n);
     }
 
     private void stubEntitlerErrorResult(String poolId) throws EntitlementRefusedException {

--- a/server/src/test/java/org/candlepin/async/tasks/ExpiredPoolsCleanupJobTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/ExpiredPoolsCleanupJobTest.java
@@ -14,26 +14,18 @@
  */
 package org.candlepin.async.tasks;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 import org.candlepin.async.JobExecutionContext;
 import org.candlepin.controller.PoolManager;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
-
-
 
 /**
  * Test suite for the ExpiredPoolsCleanupJob class
  */
-@ExtendWith(MockitoExtension.class)
-@MockitoSettings(strictness = Strictness.LENIENT)
 public class ExpiredPoolsCleanupJobTest {
 
     private PoolManager poolManager;

--- a/server/src/test/java/org/candlepin/async/tasks/ExportJobTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/ExportJobTest.java
@@ -14,8 +14,12 @@
  */
 package org.candlepin.async.tasks;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
 
 import org.candlepin.async.JobArguments;
 import org.candlepin.async.JobConfig;
@@ -27,30 +31,26 @@ import org.candlepin.model.Consumer;
 import org.candlepin.model.Owner;
 import org.candlepin.sync.ExportResult;
 import org.candlepin.test.TestUtil;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.HashMap;
 import java.util.Map;
 
-
-
-@RunWith(MockitoJUnitRunner.class)
-public class ExportJobTest extends BaseJobTest {
+@ExtendWith(MockitoExtension.class)
+public class ExportJobTest {
 
     @Mock
     private ManifestManager manifestManager;
     private ExportJob job;
 
-    @Before
+    @BeforeEach
     public void setupTest() {
-        super.inject();
-
         job = new ExportJob(manifestManager);
-        injector.injectMembers(job);
     }
 
     private Owner createTestOwner(String key, String logLevel) {
@@ -158,8 +158,6 @@ public class ExportJobTest extends BaseJobTest {
         config.validate();
     }
 
-    // TODO: Update this test to use the JUnit5 exception handling once this branch catches up
-    // with master
     @Test
     public void testValidateNoConsumer() {
         Owner owner = this.createTestOwner("owner_key", "log_level");
@@ -168,17 +166,9 @@ public class ExportJobTest extends BaseJobTest {
         JobConfig config = ExportJob.createJobConfig()
             .setCdnLabel("test_label");
 
-        try {
-            config.validate();
-            fail("an expected exception was not thrown");
-        }
-        catch (JobConfigValidationException e) {
-            // Pass!
-        }
+        assertThrows(JobConfigValidationException.class, config::validate);
     }
 
-    // TODO: Update this test to use the JUnit5 exception handling once this branch catches up
-    // with master
     @Test
     public void testValidateNoLabel() {
         Owner owner = this.createTestOwner("owner_key", "log_level");
@@ -187,13 +177,7 @@ public class ExportJobTest extends BaseJobTest {
         JobConfig config = ExportJob.createJobConfig()
             .setConsumer(consumer);
 
-        try {
-            config.validate();
-            fail("an expected exception was not thrown");
-        }
-        catch (JobConfigValidationException e) {
-            // Pass!
-        }
+        assertThrows(JobConfigValidationException.class, config::validate);
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/async/tasks/HealEntireOrgJobTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/HealEntireOrgJobTest.java
@@ -14,8 +14,14 @@
  */
 package org.candlepin.async.tasks;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import org.candlepin.async.JobArguments;
 import org.candlepin.async.JobConfig;
@@ -32,11 +38,7 @@ import org.candlepin.test.TestUtil;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 import org.mockito.stubbing.Answer;
 import org.xnap.commons.i18n.I18n;
 import org.xnap.commons.i18n.I18nFactory;
@@ -48,9 +50,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-@ExtendWith(MockitoExtension.class)
-@MockitoSettings(strictness = Strictness.LENIENT)
-public class HealEntireOrgJobTest extends BaseJobTest {
+public class HealEntireOrgJobTest {
 
     private OwnerCurator ownerCurator;
     private Entitler entitler;
@@ -59,7 +59,6 @@ public class HealEntireOrgJobTest extends BaseJobTest {
 
     @BeforeEach
     public void init() {
-        super.inject();
         i18n = I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.READ_PROPERTIES | I18nFactory.FALLBACK);
 
         ownerCurator = mock(OwnerCurator.class);

--- a/server/src/test/java/org/candlepin/async/tasks/HypervisorHeartbeatUpdateJobTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/HypervisorHeartbeatUpdateJobTest.java
@@ -31,7 +31,6 @@ import org.candlepin.async.JobExecutionException;
 import org.candlepin.common.filter.LoggingFilter;
 import org.candlepin.model.ConsumerCurator;
 import org.candlepin.model.Owner;
-import org.candlepin.test.DatabaseTestFixture;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -39,24 +38,19 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 
 import java.util.Date;
 import java.util.Map;
-
-
 
 /**
  * Test suite for the HypervisorHeartbeatUpdateJob class
  */
 @ExtendWith(MockitoExtension.class)
-@MockitoSettings(strictness = Strictness.LENIENT)
-public class HypervisorHeartbeatUpdateJobTest extends DatabaseTestFixture {
+public class HypervisorHeartbeatUpdateJobTest {
 
     @Mock protected ConsumerCurator mockConsumerCurator;
 
-    protected HypervisorHeartbeatUpdateJob testJob;
+    private HypervisorHeartbeatUpdateJob testJob;
 
     @BeforeEach
     public void setUp() {
@@ -76,7 +70,7 @@ public class HypervisorHeartbeatUpdateJobTest extends DatabaseTestFixture {
         String ownerKey = "test_owner";
         String logLevel = "test_log_level";
 
-        Owner owner = this.createOwner(ownerKey);
+        Owner owner = new Owner(ownerKey, "ownerName");
         owner.setLogLevel(logLevel);
 
         JobConfig config = HypervisorHeartbeatUpdateJob.createJobConfig()
@@ -136,7 +130,7 @@ public class HypervisorHeartbeatUpdateJobTest extends DatabaseTestFixture {
         String ownerKey = "test_owner";
         String reporterId = "test_reporter_id";
 
-        Owner owner = this.createOwner(ownerKey);
+        Owner owner = new Owner(ownerKey, "ownerName");
 
         JobConfig config = HypervisorHeartbeatUpdateJob.createJobConfig()
             .setOwner(owner)

--- a/server/src/test/java/org/candlepin/async/tasks/HypervisorUpdateJobTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/HypervisorUpdateJobTest.java
@@ -19,12 +19,11 @@ import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyListOf;
-import static org.mockito.Matchers.anySetOf;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.anySet;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -58,6 +57,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 import org.xnap.commons.i18n.I18n;
 import org.xnap.commons.i18n.I18nFactory;
 
@@ -68,7 +68,7 @@ import java.util.function.Function;
 /**
  * HypervisorUpdateJobTest
  */
-public class HypervisorUpdateJobTest extends BaseJobTest {
+public class HypervisorUpdateJobTest {
 
     private Owner owner;
     private Principal principal;
@@ -87,8 +87,6 @@ public class HypervisorUpdateJobTest extends BaseJobTest {
 
     @BeforeEach
     public void init() {
-        super.inject();
-
         i18n = I18nFactory.getI18n(
             getClass(),
             Locale.US,
@@ -178,14 +176,13 @@ public class HypervisorUpdateJobTest extends BaseJobTest {
 
         JobExecutionContext ctx = mock(JobExecutionContext.class);
         when(ctx.getJobArguments()).thenReturn(config.getJobArguments());
-        when(consumerCurator.getHostConsumersMap(eq(owner), anyListOf(Consumer.class)))
+        when(consumerCurator.getHostConsumersMap(eq(owner), Mockito.<Consumer>anyList()))
             .thenReturn(new VirtConsumerMap());
 
         HypervisorUpdateJob job = new HypervisorUpdateJob(ownerCurator, consumerCurator,
             translator, hypervisorUpdateAction, i18n, objectMapper);
-        injector.injectMembers(job);
         job.execute(ctx);
-        verify(consumerCurator).saveAll(anySetOf(Consumer.class), eq(false), eq(false));
+        verify(consumerCurator).saveAll(anySet(), eq(false), eq(false));
     }
 
     @Test
@@ -196,12 +193,11 @@ public class HypervisorUpdateJobTest extends BaseJobTest {
         JobConfig config = createJobConfig("createReporterId");
         JobExecutionContext ctx = mock(JobExecutionContext.class);
         when(ctx.getJobArguments()).thenReturn(config.getJobArguments());
-        when(consumerCurator.getHostConsumersMap(eq(owner), anyListOf(Consumer.class)))
+        when(consumerCurator.getHostConsumersMap(eq(owner), Mockito.<Consumer>anyList()))
             .thenReturn(new VirtConsumerMap());
 
         HypervisorUpdateJob job = new HypervisorUpdateJob(ownerCurator, consumerCurator,
             translator, hypervisorUpdateAction, i18n, objectMapper);
-        injector.injectMembers(job);
         job.execute(ctx);
         ArgumentCaptor<Set<Consumer>> argument = createConsumersCaptor();
         verify(consumerCurator).saveAll(argument.capture(), eq(false), eq(false));
@@ -220,7 +216,7 @@ public class HypervisorUpdateJobTest extends BaseJobTest {
         hypervisor.setHypervisorId(new HypervisorId(hypervisorId));
         VirtConsumerMap vcm = new VirtConsumerMap();
         vcm.add(hypervisorId, hypervisor);
-        when(consumerCurator.getHostConsumersMap(eq(owner), anyListOf(Consumer.class)))
+        when(consumerCurator.getHostConsumersMap(eq(owner), Mockito.<Consumer>anyList()))
             .thenReturn(vcm);
 
         JobConfig config = createJobConfig(null);
@@ -229,10 +225,9 @@ public class HypervisorUpdateJobTest extends BaseJobTest {
 
         HypervisorUpdateJob job = new HypervisorUpdateJob(ownerCurator, consumerCurator,
             translator, hypervisorUpdateAction, i18n, objectMapper);
-        injector.injectMembers(job);
         job.execute(ctx);
         verify(consumerResource).checkForFactsUpdate(any(Consumer.class), any(Consumer.class));
-        verify(consumerCurator, times(2)).bulkUpdate(anySetOf(Consumer.class), eq(false));
+        verify(consumerCurator, times(2)).bulkUpdate(anySet(), eq(false));
     }
 
     @Test
@@ -246,7 +241,7 @@ public class HypervisorUpdateJobTest extends BaseJobTest {
         hypervisor.setHypervisorId(new HypervisorId(hypervisorId));
         VirtConsumerMap vcm = new VirtConsumerMap();
         vcm.add(hypervisorId, hypervisor);
-        when(consumerCurator.getHostConsumersMap(eq(owner), anyListOf(Consumer.class)))
+        when(consumerCurator.getHostConsumersMap(eq(owner), Mockito.<Consumer>anyList()))
             .thenReturn(vcm);
 
         JobConfig config = createJobConfig("updateReporterId");
@@ -255,7 +250,6 @@ public class HypervisorUpdateJobTest extends BaseJobTest {
 
         HypervisorUpdateJob job = new HypervisorUpdateJob(ownerCurator, consumerCurator,
             translator, hypervisorUpdateAction, i18n, objectMapper);
-        injector.injectMembers(job);
         job.execute(ctx);
         assertEquals("updateReporterId", hypervisor.getHypervisorId().getReporterId());
     }
@@ -272,7 +266,7 @@ public class HypervisorUpdateJobTest extends BaseJobTest {
         hypervisor.setHypervisorId(new HypervisorId(hypervisorId));
         VirtConsumerMap vcm = new VirtConsumerMap();
         vcm.add(hypervisorId, hypervisor);
-        when(consumerCurator.getHostConsumersMap(eq(owner), anyListOf(Consumer.class)))
+        when(consumerCurator.getHostConsumersMap(eq(owner), Mockito.<Consumer>anyList()))
             .thenReturn(vcm);
 
         hypervisorJson =
@@ -290,7 +284,6 @@ public class HypervisorUpdateJobTest extends BaseJobTest {
 
         HypervisorUpdateJob job = new HypervisorUpdateJob(ownerCurator, consumerCurator,
             translator, hypervisorUpdateAction, i18n, objectMapper);
-        injector.injectMembers(job);
         job.execute(ctx);
 
         ArgumentCaptor<Set<Consumer>> updateCaptor = createConsumersCaptor();
@@ -314,12 +307,11 @@ public class HypervisorUpdateJobTest extends BaseJobTest {
         JobConfig config = createJobConfig(null);
         JobExecutionContext ctx = mock(JobExecutionContext.class);
         when(ctx.getJobArguments()).thenReturn(config.getJobArguments());
-        when(consumerCurator.getHostConsumersMap(eq(owner), anyListOf(Consumer.class)))
+        when(consumerCurator.getHostConsumersMap(eq(owner), Mockito.<Consumer>anyList()))
             .thenReturn(new VirtConsumerMap());
 
         HypervisorUpdateJob job = new HypervisorUpdateJob(ownerCurator, consumerCurator,
             translator, hypervisorUpdateAction, i18n, objectMapper);
-        injector.injectMembers(job);
         job.execute(ctx);
         verify(consumerResource, never()).createConsumerFromDTO(any(ConsumerDTO.class),
             any(ConsumerType.class), any(Principal.class), anyString(), anyString(), anyString(),
@@ -343,12 +335,11 @@ public class HypervisorUpdateJobTest extends BaseJobTest {
         JobExecutionContext ctx = mock(JobExecutionContext.class);
         when(ctx.getJobArguments()).thenReturn(config.getJobArguments());
 
-        when(consumerCurator.getHostConsumersMap(eq(owner), anyListOf(Consumer.class)))
+        when(consumerCurator.getHostConsumersMap(eq(owner), Mockito.<Consumer>anyList()))
             .thenReturn(new VirtConsumerMap());
 
         HypervisorUpdateJob job = new HypervisorUpdateJob(ownerCurator, consumerCurator,
             translator, hypervisorUpdateAction, i18n, objectMapper);
-        injector.injectMembers(job);
         job.execute(ctx);
     }
 
@@ -361,13 +352,11 @@ public class HypervisorUpdateJobTest extends BaseJobTest {
         JobConfig config = createJobConfig(null);
         JobExecutionContext ctx = mock(JobExecutionContext.class);
         when(ctx.getJobArguments()).thenReturn(config.getJobArguments());
-        when(consumerCurator.getHostConsumersMap(eq(owner), anySetOf(String.class)))
+        when(consumerCurator.getHostConsumersMap(eq(owner), Mockito.<Consumer>anyList()))
             .thenReturn(new VirtConsumerMap());
 
         HypervisorUpdateJob job = new HypervisorUpdateJob(ownerCurator, consumerCurator,
             translator, hypervisorUpdateAction, i18n, objectMapper);
-        injector.injectMembers(job);
-
 
         JobExecutionException e = assertThrows(JobExecutionException.class, () -> job.execute(ctx));
         assertThat(e.getMessage(),

--- a/server/src/test/java/org/candlepin/async/tasks/ImportRecordCleanerJobTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/ImportRecordCleanerJobTest.java
@@ -14,12 +14,17 @@
  */
 package org.candlepin.async.tasks;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
 import org.candlepin.async.JobExecutionContext;
 import org.candlepin.async.JobExecutionException;
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.model.ImportRecord;
 import org.candlepin.model.Owner;
 import org.candlepin.test.DatabaseTestFixture;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -32,10 +37,6 @@ import org.mockito.quality.Strictness;
 
 import java.util.List;
 import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
 
 /**
  * Test suite for the ImportRecordCleanerJob class
@@ -156,7 +157,7 @@ public class ImportRecordCleanerJobTest extends DatabaseTestFixture {
 
     @ParameterizedTest
     @ValueSource(ints = { -1, -50 })
-    public void singleOwnerBadKeepConfig(int keep) throws Exception {
+    public void singleOwnerBadKeepConfig(int keep) {
         this.setNumOfRecordsToKeep(keep);
         Owner owner = new Owner("owner");
         ownerCurator.create(owner);

--- a/server/src/test/java/org/candlepin/async/tasks/JobCleanerTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/JobCleanerTest.java
@@ -15,33 +15,27 @@
 
 package org.candlepin.async.tasks;
 
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 import org.candlepin.async.JobExecutionContext;
 import org.candlepin.model.AsyncJobStatusCurator;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Date;
 
 /**
  * JobCleanerTest
  */
-public class JobCleanerTest extends BaseJobTest {
-
-    @Before
-    public void init() {
-        inject();
-    }
+public class JobCleanerTest {
 
     @Test
     public void execute() throws Exception {
         AsyncJobStatusCurator curator = mock(AsyncJobStatusCurator.class);
         JobCleaner cleaner = new JobCleaner(curator);
         JobExecutionContext context = mock(JobExecutionContext.class);
-        injector.injectMembers(cleaner);
 
         cleaner.execute(context);
         verify(curator).cleanUpOldCompletedJobs(any(Date.class));

--- a/server/src/test/java/org/candlepin/async/tasks/ManifestCleanerJobTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/ManifestCleanerJobTest.java
@@ -14,24 +14,27 @@
  */
 package org.candlepin.async.tasks;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import org.candlepin.async.JobExecutionContext;
 import org.candlepin.async.JobExecutionException;
+import org.candlepin.common.config.Configuration;
+import org.candlepin.config.CandlepinCommonTestConfig;
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.controller.ManifestManager;
-import org.candlepin.test.DatabaseTestFixture;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 
 import java.io.File;
 import java.io.IOException;
@@ -39,23 +42,21 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.stream.Stream;
 
-
-
 /**
  * Test suite for the ManifestCleanerJob class
  */
-@ExtendWith(MockitoExtension.class)
-@MockitoSettings(strictness = Strictness.LENIENT)
-public class ManifestCleanerJobTest extends DatabaseTestFixture {
+public class ManifestCleanerJobTest {
 
     private Path manifestDir;
     private ManifestManager manifestManager;
+    private Configuration config;
 
     @BeforeEach
     public void setUp() throws IOException {
         this.manifestDir = Files.createTempDirectory("test_sync-");
         this.manifestManager = mock(ManifestManager.class);
 
+        this.config = new CandlepinCommonTestConfig();
         this.config.setProperty(ConfigProperties.SYNC_WORK_DIR, manifestDir.toString());
     }
 

--- a/server/src/test/java/org/candlepin/async/tasks/OrphanCleanupJobTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/OrphanCleanupJobTest.java
@@ -14,8 +14,10 @@
  */
 package org.candlepin.async.tasks;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
 
 import org.candlepin.async.JobExecutionContext;
 import org.candlepin.model.Content;
@@ -24,22 +26,14 @@ import org.candlepin.model.Product;
 import org.candlepin.test.DatabaseTestFixture;
 import org.candlepin.test.TestUtil;
 
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.Test;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 
 import java.util.HashSet;
 import java.util.Set;
 
-
-
 /**
  * Test suite for the OrphanCleanupJob class
  */
-@ExtendWith(MockitoExtension.class)
-@MockitoSettings(strictness = Strictness.LENIENT)
 public class OrphanCleanupJobTest extends DatabaseTestFixture {
 
     private OrphanCleanupJob createJobInstance() {

--- a/server/src/test/java/org/candlepin/async/tasks/RefreshPoolsForProductJobTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/RefreshPoolsForProductJobTest.java
@@ -16,10 +16,11 @@ package org.candlepin.async.tasks;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyBoolean;
-import static org.mockito.Matchers.eq;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 
 import org.candlepin.async.AsyncJob;
@@ -33,12 +34,9 @@ import org.candlepin.model.ProductCurator;
 import org.candlepin.service.OwnerServiceAdapter;
 import org.candlepin.service.SubscriptionServiceAdapter;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-@RunWith(MockitoJUnitRunner.class)
 public class RefreshPoolsForProductJobTest {
 
     private static final String VALID_ID = "valid_id";
@@ -49,7 +47,7 @@ public class RefreshPoolsForProductJobTest {
     private SubscriptionServiceAdapter subAdapter;
     private OwnerServiceAdapter ownerAdapter;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         productCurator = mock(ProductCurator.class);
         poolManager = mock(PoolManager.class);
@@ -112,34 +110,34 @@ public class RefreshPoolsForProductJobTest {
             actualResult);
     }
 
-    @Test(expected = JobConfigValidationException.class)
-    public void productMustBePresent() throws JobConfigValidationException {
+    @Test
+    public void productMustBePresent() {
         final JobConfig jobConfig = RefreshPoolsForProductJob.createJobConfig()
             .setLazy(false);
 
-        jobConfig.validate();
+        assertThrows(JobConfigValidationException.class, jobConfig::validate);
     }
 
-    @Test(expected = JobConfigValidationException.class)
-    public void productUuidMustBePresent() throws JobConfigValidationException {
+    @Test
+    public void productUuidMustBePresent() {
         final Product product = new Product(INVALID_ID, VALID_NAME);
 
         final JobConfig jobConfig = RefreshPoolsForProductJob.createJobConfig()
             .setProduct(product)
             .setLazy(false);
 
-        jobConfig.validate();
+        assertThrows(JobConfigValidationException.class, jobConfig::validate);
     }
 
-    @Test(expected = JobConfigValidationException.class)
-    public void lazyFlagMustBePresent() throws JobConfigValidationException {
+    @Test
+    public void lazyFlagMustBePresent() {
         final Product product = new Product(VALID_ID, VALID_NAME);
         product.setUuid(VALID_ID);
 
         final JobConfig jobConfig = RefreshPoolsForProductJob.createJobConfig()
             .setProduct(product);
 
-        jobConfig.validate();
+        assertThrows(JobConfigValidationException.class, jobConfig::validate);
     }
 
 }

--- a/server/src/test/java/org/candlepin/async/tasks/RegenEnvEntitlementCertsJobTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/RegenEnvEntitlementCertsJobTest.java
@@ -14,23 +14,6 @@
  */
 package org.candlepin.async.tasks;
 
-import org.candlepin.async.JobConfig;
-import org.candlepin.async.JobConfigValidationException;
-import org.candlepin.async.JobExecutionContext;
-import org.candlepin.controller.PoolManager;
-import org.candlepin.model.Environment;
-import org.candlepin.model.Owner;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
-
-import java.util.HashSet;
-import java.util.Set;
-
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -38,9 +21,24 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import org.candlepin.async.JobConfig;
+import org.candlepin.async.JobConfigValidationException;
+import org.candlepin.async.JobExecutionContext;
+import org.candlepin.controller.PoolManager;
+import org.candlepin.model.Environment;
+import org.candlepin.model.Owner;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashSet;
+import java.util.Set;
+
 @ExtendWith(MockitoExtension.class)
-@MockitoSettings(strictness = Strictness.LENIENT)
-public class RegenEnvEntitlementCertsJobTest extends BaseJobTest {
+public class RegenEnvEntitlementCertsJobTest {
 
     @Mock private Owner owner;
     @Mock private PoolManager poolManager;
@@ -50,7 +48,6 @@ public class RegenEnvEntitlementCertsJobTest extends BaseJobTest {
 
     @BeforeEach
     public void init() {
-        super.inject();
         environment = new Environment();
         environment.setId("env_id_1");
         content = new HashSet<>();

--- a/server/src/test/java/org/candlepin/async/tasks/UndoImportsJobTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/UndoImportsJobTest.java
@@ -65,8 +65,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 
-
-
 /**
  * UndoImportsJobTest
  */
@@ -86,7 +84,7 @@ public class UndoImportsJobTest extends DatabaseTestFixture {
     @Mock protected Refresher refresher;
     @Mock protected ExporterMetadataCurator exportCurator;
 
-    protected UndoImportsJob undoImportsJob;
+    private UndoImportsJob undoImportsJob;
 
     @BeforeEach
     public void setUp() {

--- a/server/src/test/java/org/candlepin/async/tasks/UnmappedGuestEntitlementCleanerJobTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/UnmappedGuestEntitlementCleanerJobTest.java
@@ -14,24 +14,19 @@
  */
 package org.candlepin.async.tasks;
 
-import org.candlepin.async.JobExecutionContext;
-import org.candlepin.controller.Entitler;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import org.candlepin.async.JobExecutionContext;
+import org.candlepin.controller.Entitler;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 /**
  * Test suite for the UnmappedGuestEntitlementCleanerJob class
  */
-@ExtendWith(MockitoExtension.class)
-@MockitoSettings(strictness = Strictness.LENIENT)
 public class UnmappedGuestEntitlementCleanerJobTest {
 
     private Entitler entitler;


### PR DESCRIPTION
A lot of async job tests inherit from either BaseJobTest of DatabaseTestFixture even though only a few of them really require it. Jobs that require DatabaseTestFixture are ActiveEntitlementJobTest, ImportRecordCleanerJobTest, OrphanCleanupJobTest and UndoImportsJobTest. For the rest I removed the parent. With parent removed @MockitoSettings(strictness = Strictness.LENIENT) is redundant as unused mocking is no longer present. I also removed @ExtendWith(MockitoExtension.class) where tests do not use Mockito annotations.

- Replace try-catch with assertThrows
- Replace JUnit4 annotations with JUnit5
- Replace deprecated matchers
- Remove redundant annotations
- Remove redundant parents