### PR TITLE
ENT-1408: Candlepin RHEL 8 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,16 @@
                     <name>OAuth</name>
                     <url>http://oauth.googlecode.com/svn/code/maven/</url>
                 </repository>
+                <repository>
+                    <id>awood</id>
+                    <name>awood.fedorapeople.org</name>
+                    <url>http://awood.fedorapeople.org/ivy/candlepin/</url>
+                </repository>
+                <repository>
+                    <id>barnabycourt</id>
+                    <name>barnabycourt.fedorapeople.org</name>
+                    <url>http://barnabycourt.fedorapeople.org/repo/candlepin/</url>
+                </repository>
             </repositories>
         </profile>
     </profiles>

--- a/server/bin/deploy
+++ b/server/bin/deploy
@@ -61,10 +61,10 @@ gendb() {
 deploy() {
   printf "\nDeploying Candlepin War File\n"
   VERSION="$(grep Version: $PROJECT_DIR/candlepin.spec.tmpl | cut --delim=' ' -f2)"
-    if [ -z $CLEAN ] ; then
+    if [ -z $DEPLOY_DIR ] ; then
         $SUDO rm -rf $DEPLOY
     else
-        $SUDO rm -rf $CLEAN
+        $SUDO rm -rf $DEPLOY_DIR
     fi
     echo cp $PROJECT_DIR/build/libs/candlepin-$VERSION.war $DEPLOY
     $SUDO cp $PROJECT_DIR/build/libs/candlepin-$VERSION.war $DEPLOY
@@ -303,7 +303,7 @@ if [ "$SUPERVISOR" == "1" ]; then
 fi
 
 DEPLOY="$TC_HOME/webapps/candlepin.war"
-CLEAN="$TC_HOME/webapps/candlepin/"
+DEPLOY_DIR="$TC_HOME/webapps/candlepin/"
 
 REPOS="$TC_HOME/webapps/ROOT"
 
@@ -407,6 +407,15 @@ fi
 
 # deploy the webapp
 deploy
+
+# Need to use newer APIs in context.xml for Tomcat 8+
+MAJOR_TC_VERSION=${TC_VERSION%.*}
+if (( MAJOR_TC_VERSION >= 8 )); then
+    printf "\nTomcat version is 8 or newer. Updating context.xml...\n\n"
+    $SUDO unzip -q $DEPLOY -d $DEPLOY_DIR
+    $SUDO mv $DEPLOY_DIR/META-INF/context_tomcat8.xml $DEPLOY_DIR/META-INF/context.xml
+    $SUDO chown -R tomcat:tomcat $DEPLOY_DIR
+fi
 
 eval $START
 

--- a/server/bin/gen-certs
+++ b/server/bin/gen-certs
@@ -65,6 +65,7 @@ else
     # Tomcat 8.5+ requires the cert be separate from the key when used as both a keystore and a trust store
     $SUDO keytool -keystore $KEYSTORE -noprompt -importcert -storepass:file $KEYSTORE_PASSWORD -alias candlepin_ca -file $CA_CERT
 
+    $SUDO chmod a+r $CERTS_HOME/*
     $SUDO cp $CA_REDHAT_CERT $CA_UPSTREAM_CERT
     $SUDO chmod a+r $KEYSTORE
 fi

--- a/server/candlepin.spec.tmpl
+++ b/server/candlepin.spec.tmpl
@@ -42,12 +42,9 @@ BuildRequires: /usr/bin/pathfix.py
 
 Requires: java >= 1:1.8.0
 Requires: wget
-%if 0%{?rhel} <= 7
-Requires: tomcat >= 0:7.0.0
-%else
-Requires: pki-servlet-container >= 0:7.0.0
-%endif
-Requires: jss
+## tomcatjss itself depends on jss and tomcat/pki-servlet-container/pki-servlet-engine
+## without having to worry about about the renaming of those packages.
+Requires: tomcatjss >= 7.2.1-7.1
 Requires: javapackages-tools
 
 %description
@@ -138,6 +135,12 @@ touch %{buildroot}/%{_sysconfdir}/%{name}/%{name}.conf
 %{__install} -d -m 755 %{buildroot}/%{_sharedstatedir}/tomcat/webapps/%{name}
 %{__install} -d -m 755 %{buildroot}/%{_sysconfdir}/tomcat/
 %{__unzip} %{SOURCE1} -d %{buildroot}/%{_sharedstatedir}/tomcat/webapps/%{name}
+
+## if we're running with tomcat 8+, use the appropriate context.xml file.
+%if 0%{?rhel} > 7 || 0%{?fedora} > 27
+mv %{buildroot}/%{_sharedstatedir}/tomcat/webapps/%{name}/META-INF/context_tomcat8.xml \
+%{buildroot}/%{_sharedstatedir}/tomcat/webapps/%{name}/META-INF/context.xml
+%endif
 
 %{__ln_s} /etc/candlepin/certs/keystore %{buildroot}/%{_sysconfdir}/tomcat/keystore
 

--- a/server/code/setup/cpsetup
+++ b/server/code/setup/cpsetup
@@ -47,6 +47,7 @@ if os.path.exists('/usr/sbin/tomcat') and not os.path.exists('/usr/sbin/tomcat6'
 else:
     TOMCAT = 'tomcat6'
 
+
 def run_command(command):
     (status, output) = getstatusoutput(command)
     if status > 0:
@@ -57,12 +58,14 @@ def run_command(command):
         raise Exception("Error running command")
     return output
 
+
 # run with 'sudo' if not running as root
 def run_command_with_sudo(command):
     if os.geteuid()==0:
         run_command(command)
     else:
         run_command('sudo %s' % command)
+
 
 class TomcatSetup(object):
     def __init__(self, conf_dir, keystorepwd):
@@ -72,7 +75,8 @@ class TomcatSetup(object):
         self.https_conn = """
     <Connector port="8443" protocol="HTTP/1.1" SSLEnabled="true"
                maxThreads="150" scheme="https" secure="true"
-               clientAuth="want" SSLProtocol="TLS"
+               clientAuth="want"
+               sslEnabledProtocols="TLSv1,+TLSv1.1,+TLSv1.2"
                keystoreFile="conf/keystore"
                truststoreFile="conf/keystore"
                keystorePass="%s"
@@ -89,30 +93,30 @@ class TomcatSetup(object):
                     TLS_ECDH_anon_WITH_AES_256_CBC_SHA"
                truststorePass="%s" />""" % (keystorepwd, keystorepwd)
 
-
     def _backup_config(self, conf_dir):
         run_command('cp %s/server.xml %s/server.xml.original' % (conf_dir, conf_dir))
 
     def _replace_current(self, original):
         regex = re.compile(self.existing_pattern, re.DOTALL)
-        return regex.sub(self.https_conn, original)
+        return regex.sub(self.https_conn, original, 1)
 
     def _replace_commented(self, original):
         regex = re.compile(self.comment_pattern, re.DOTALL)
-        return regex.sub(self.https_conn, original)
+        return regex.sub(self.https_conn, original, 1)
 
     def update_config(self):
         self._backup_config(self.conf_dir)
-        original = open(os.path.join(self.conf_dir, 'server.xml'), 'r').read()
+        original_file = open(os.path.join(self.conf_dir, 'server.xml'), 'r')
+        original = original_file.read()
 
         if re.search(self.comment_pattern, original, re.DOTALL):
             updated = self._replace_commented(original)
         else:
             updated = self._replace_current(original)
-
+        original_file.close()
         config = open(os.path.join(self.conf_dir, 'server.xml'), 'w')
         config.write(updated)
-        file.close
+        config.close()
 
     def fix_perms(self):
         run_command("chmod g+x /var/log/" + TOMCAT)
@@ -139,6 +143,7 @@ class TomcatSetup(object):
             except:
                 print("Waiting for tomcat to restart...")
 
+
 class CertSetup(object):
     def __init__(self):
         self.cert_home = '/etc/candlepin/certs'
@@ -158,14 +163,27 @@ class CertSetup(object):
 
         print("Creating CA private key password")
         run_command_with_sudo('su -c "echo $RANDOM > %s"' % self.ca_key_passwd)
+
         print("Creating CA private key")
-        run_command_with_sudo('openssl genrsa -out %s -passout "file:%s" 1024' % (self.ca_key, self.ca_key_passwd))
+        run_command_with_sudo('openssl genrsa -out %s -passout "file:%s" 2048'
+                              % (self.ca_key, self.ca_key_passwd))
+
         print("Creating CA public key")
         run_command_with_sudo('openssl rsa -pubout -in %s -out %s' % (self.ca_key, self.ca_pub_key))
+
         print("Creating CA certificate")
-        run_command_with_sudo('openssl req -new -x509 -days 365 -key %s -out %s -subj "/CN=%s/C=US/L=Raleigh/"' % (self.ca_key, self.ca_cert, socket.gethostname()))
-        run_command_with_sudo('openssl pkcs12 -export -in %s -inkey %s -out %s -name tomcat -CAfile %s -caname root -chain -password pass:password' % (self.ca_cert, self.ca_key, self.keystore, self.ca_cert))
-        run_command_with_sudo('chmod a+r %s' % self.keystore)
+        run_command_with_sudo('openssl req -new -x509 -days 365 -key %s -out %s '
+                              '-subj "/CN=%s/C=US/L=Raleigh/"'
+                              % (self.ca_key, self.ca_cert, socket.gethostname()))
+        run_command_with_sudo('openssl pkcs12 -export -in %s -inkey %s -out %s -name tomcat -CAfile %s '
+                              '-caname root -chain -password pass:password'
+                              % (self.ca_cert, self.ca_key, self.keystore, self.ca_cert))
+
+        # Tomcat 8.5+ requires the cert be separate from the key when used
+        # as both a keystore and a trust store
+        run_command_with_sudo('keytool -keystore %s -noprompt -importcert -storepass password '
+                              '-alias candlepin_ca -file %s' % (self.keystore, self.ca_cert))
+        run_command_with_sudo('chmod a+r %s/*' % self.cert_home)
 
 
 class PostgresqlConf(object):

--- a/server/src/main/java/org/candlepin/pki/impl/JSSLoaderException.java
+++ b/server/src/main/java/org/candlepin/pki/impl/JSSLoaderException.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.pki.impl;
+
+/**
+ * Catastrophic error when initializing a JSS CryptoManager.
+ */
+class JSSLoaderException extends RuntimeException {
+
+    JSSLoaderException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    JSSLoaderException(String message) {
+        super(message);
+    }
+}

--- a/server/src/main/java/org/candlepin/pki/impl/JSSProviderLoader.java
+++ b/server/src/main/java/org/candlepin/pki/impl/JSSProviderLoader.java
@@ -14,8 +14,8 @@
  */
 package org.candlepin.pki.impl;
 
+import org.apache.commons.lang3.StringUtils;
 import org.mozilla.jss.CertDatabaseException;
-import org.mozilla.jss.CryptoManager;
 import org.mozilla.jss.JSSProvider;
 import org.mozilla.jss.KeyDatabaseException;
 import org.mozilla.jss.crypto.AlreadyInitializedException;
@@ -23,16 +23,16 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.security.GeneralSecurityException;
 import java.security.Security;
 import java.util.Arrays;
 
 /**
- * When this class is loaded, the JSS provider will be installed into the JVM.  The
- * provider can also be added via a call to a static method if needed in a test for example.  The
- * addProvider() method can be called more than once without ill effect (-1 will be returned if the provider
- * is already installed).
- * */
+ * Provides the addProvider() method, which, when called, initializes the JSS CryptoManager (which in turn
+ * initializes the NSS DB) and loads the JSS Provider into the JVM.
+ */
 public class JSSProviderLoader {
     private static JSSProvider jssProvider = null;
     private static final String NSS_DB_LOCATION = "/etc/pki/nssdb";
@@ -42,7 +42,6 @@ public class JSSProviderLoader {
         // Satellite 6 is only supported on 64 bit architectures
         addLibraryPath("/usr/lib64/jss");
         System.loadLibrary("jss4");
-        addProvider();
     }
 
     /**
@@ -86,7 +85,7 @@ public class JSSProviderLoader {
             usrPathsField.set(null, newPaths);
         }
         catch (NoSuchFieldException | IllegalAccessException e) {
-            throw new RuntimeException("Could not add " + pathToAdd + " to library path", e);
+            throw new JSSLoaderException("Could not add " + pathToAdd + " to library path", e);
         }
     }
 
@@ -94,27 +93,96 @@ public class JSSProviderLoader {
         // static methods only
     }
 
+    /**
+     * Initializes the JSS CryptoManager (which in turn initializes the NSS DB), and loads the JSS provider
+     * into the JVM. The method should be called during context initialization. Can be called more than once
+     * without ill effect (-1 will be returned if the provider is already installed).
+     *
+     * Note: This method uses reflection to initialize the CryptoManager, due to dynamically loading the
+     * InitializationValues class, depending on which JSS version is on the classpath. This is because of
+     * breaking changes introduced between JSS 4.4.X (RHEL 7) and 4.5.0+ (RHEL 8).
+     */
     public static void addProvider() {
         log.debug("Starting call to JSSProviderLoader.addProvider()...");
-        CryptoManager.InitializationValues ivs =
-            new CryptoManager.InitializationValues(NSS_DB_LOCATION);
-        ivs.noCertDB = true;
-        ivs.installJSSProvider = false;
-        ivs.initializeJavaOnly = false;
+
+        ClassLoader loader = JSSProviderLoader.class.getClassLoader();
+
+        Object initializationValuesObject = getInitializationValuesObject(loader);
+        Class<?> ivsClass = initializationValuesObject.getClass();
 
         try {
-            CryptoManager.initialize(ivs);
+            // Set values on fields of the InitializationValues object.
+            Field noCertDB = ivsClass.getField("noCertDB");
+            Field installJSSProvider = ivsClass.getField("installJSSProvider");
+            Field initializeJavaOnly = ivsClass.getField("initializeJavaOnly");
+            noCertDB.set(initializationValuesObject, true);
+            installJSSProvider.set(initializationValuesObject, false);
+            initializeJavaOnly.set(initializationValuesObject, false);
+
+            // Initialize the CryptoManager, which will initialize the nss DB.
+            Class<?> cryptoManagerClass = loader.loadClass("org.mozilla.jss.CryptoManager");
+            Method initialize = cryptoManagerClass.getMethod("initialize", ivsClass);
+            initialize.invoke(null, initializationValuesObject);
         }
-        catch (AlreadyInitializedException e) {
-            log.warn("CryptoManager was already initialized.", e);
-        }
-        catch (KeyDatabaseException | CertDatabaseException | GeneralSecurityException e) {
-            log.error("Could not initialize CryptoManager!", e);
+        catch (ClassNotFoundException | NoSuchMethodException | NoSuchFieldException |
+            InvocationTargetException | IllegalAccessException e) {
+
+            if (e.getCause() instanceof AlreadyInitializedException) {
+                log.warn("CryptoManager was already initialized.");
+            }
+            else if (e.getCause() instanceof KeyDatabaseException ||
+                e.getCause() instanceof CertDatabaseException ||
+                e.getCause() instanceof GeneralSecurityException) {
+                throw new JSSLoaderException("Could not initialize CryptoManager!", e.getCause());
+            }
+            else {
+                throw new JSSLoaderException("Could not initialize CryptoManager!", e);
+            }
         }
 
         jssProvider = new JSSProvider();
         int addProviderReturn = Security.addProvider(jssProvider);
         log.debug("Finished call to JSSProviderLoader.addProvider(). Returned value: {}",
             addProviderReturn);
+    }
+
+    /*
+     * Load the appropriate InitializationValues class, depending on JSS version,
+     * and return an instance of it. We load:
+     * - the 4.4.Z version of the class for RHEL 7.6+
+     * - the 4.5.Z+ version of the class for RHEL 8+
+     */
+    private static Object getInitializationValuesObject(ClassLoader loader) {
+        String jssVersionStr = JSSProvider.class.getPackage().getSpecificationVersion();
+        log.info("Using JSS version {}", jssVersionStr);
+
+        float jssVersion;
+        // Get the X.Y out of the version, even if it is in the format X.Y.Z
+        if (StringUtils.countMatches(jssVersionStr, ".") == 1) {
+            jssVersion = new Float(jssVersionStr);
+        }
+        else {
+            int indexOfLastPeriod = jssVersionStr.lastIndexOf(".");
+            jssVersion = new Float(jssVersionStr.substring(0, indexOfLastPeriod));
+        }
+
+        try {
+            String ivsClassName;
+            if (Float.compare(jssVersion, 4.4f) == 0) {
+                ivsClassName = "org.mozilla.jss.CryptoManager$InitializationValues";
+            }
+            else if (Float.compare(jssVersion, 4.4f) > 0) {
+                ivsClassName = "org.mozilla.jss.InitializationValues";
+            }
+            else {
+                throw new JSSLoaderException("Candlepin does not support JSS versions less than 4.4!");
+            }
+            return loader.loadClass(ivsClassName).getConstructor(String.class).newInstance(NSS_DB_LOCATION);
+        }
+        catch (InstantiationException | ClassNotFoundException | IllegalAccessException |
+            NoSuchMethodException | InvocationTargetException e) {
+
+            throw new JSSLoaderException("Could not instantiate a JSS InitializationValues object!", e);
+        }
     }
 }

--- a/server/src/main/webapp/META-INF/context.xml
+++ b/server/src/main/webapp/META-INF/context.xml
@@ -1,3 +1,4 @@
+<!-- context.xml file compatible with Tomcat up to version 7 -->
 <!-- Candlepin needs symlink support to read its jars -->
 <Context path="/candlepin" allowLinking="true">
     <Loader className="org.apache.catalina.loader.VirtualWebappLoader"

--- a/server/src/main/webapp/META-INF/context_tomcat8.xml
+++ b/server/src/main/webapp/META-INF/context_tomcat8.xml
@@ -1,0 +1,11 @@
+<!-- context.xml file compatible from Tomcat version 8 and up -->
+<Context path="/candlepin">
+    <!-- Candlepin needs symlink support to read its jars. Also, we want to load the jss jar from the
+    filesystem, instead of having a hard dependency on a specific version. -->
+    <Resources allowLinking="true">
+        <JarResources className="org.apache.catalina.webresources.FileResourceSet"
+            base="/usr/lib/java/jss4.jar"
+            webAppMount="/WEB-INF/lib/jss4.jar">
+        </JarResources>
+    </Resources>
+</Context>


### PR DESCRIPTION
- Now the candlepin rpm depends on tomcatjss instead of
  jss and tomcat/pki-servlet-container/pki-servlet-engine
  to avoid these name changes between RHEL 7, RHEL8 and
  RHEL 8.1, since that package is comprehensively taking
  care of that itself.
- The spec file and deploy script now update the
  META-INF/context.xml file to avoid breaking API changes
  between Tomcat 7 and 8+ when altering the classpath to
  include the jss jar from the filesystem.
- Updated cpsetup script:
    * to be python3 compatible.
    * with server.xml and CA cert/key changes for Tomcat 8+
      compatibility.
- JSSProvider/CryptoManager are now loaded once, during
  context initialization, and not during classloading of
  JSSProviderLoader.java.
- Due to the fact that we no longer package the jss jar,
  but we load it from the OS, and because of compile-
  breaking changes between jss version 4.4.X and 4.5.0,
  we now use dynamic classloading and reflection to
  initialize the CryptoManager.
- Added the *.fedorapeople.org repositories to parent
  pom to be able to do a maven build without having to
  download the artifacts they hold with buildr in the
  local .m2/repository.