### PR TITLE
1569133:Entitlements Removed from Source when transfer fails [ENT-526]

### DIFF
--- a/server/src/main/java/org/candlepin/resource/EntitlementResource.java
+++ b/server/src/main/java/org/candlepin/resource/EntitlementResource.java
@@ -46,6 +46,7 @@ import org.candlepin.resteasy.parameter.KeyValueParameter;
 import org.candlepin.util.Util;
 
 import com.google.inject.Inject;
+import com.google.inject.persist.Transactional;
 
 import org.apache.commons.lang.StringUtils;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
@@ -327,6 +328,7 @@ public class EntitlementResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.WILDCARD)
     @Path("{entitlement_id}/migrate")
+    @Transactional
     public Response migrateEntitlement(
         @PathParam("entitlement_id") @Verify(Entitlement.class) String id,
         @QueryParam("to_consumer") @Verify(Consumer.class) String uuid,


### PR DESCRIPTION
`Adjust entitlement quantity` for source consumer and `bind by pool quantity` for destination consumer operations are completed in different transactions. Due to this if something goes wrong in `bind by pool quantity` then `adjust entitlement quantity` for source consumer does not rollback. One simple solution to perform operations in one transaction.  
