### PR TITLE
1561798 - Split transaction of unmapped cleaner job into multiple transactions

### DIFF
--- a/server/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/server/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -190,6 +190,7 @@ public class ConfigProperties {
 
     public static final String ENTITLER_JOB_THROTTLE =
         "pinsetter." + EntitlerJob.class.getName() + ".throttle";
+    public static final String ENTITLER_BULK_SIZE = "entitler.bulk.size";
 
     public static final String BATCH_BIND_NUMBER_OF_POOLS_LIMIT =
         "candlepin.batch.bind.number_of_pools_limit";
@@ -348,6 +349,7 @@ public class ConfigProperties {
             this.put("org.quartz.threadPool.threadPriority", "5");
             this.put(DEFAULT_TASKS, StringUtils.join(DEFAULT_TASK_LIST, ","));
             this.put(ENTITLER_JOB_THROTTLE, "7");
+            this.put(ENTITLER_BULK_SIZE, "1000");
             this.put(BATCH_BIND_NUMBER_OF_POOLS_LIMIT, "100");
 
             // AMQP (Qpid) configuration used by events

--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -1848,6 +1848,7 @@ public class CandlepinPoolManager implements PoolManager {
     }
 
     @Override
+    @Transactional
     public Set<Pool> revokeEntitlements(List<Entitlement> entsToRevoke) {
         return revokeEntitlements(entsToRevoke, null, true);
     }


### PR DESCRIPTION
- Splitted transaction of Entitler.revokeUnmappedGuestEntitlements into a series of bulks by 1000 items
- Remove mocks marked as redundant from EntitlerTest

Reviewer notes:
- Instead of splitting the transaction itself I decided to split its input.