### PR TITLE
1734521: Consumer returning duplicate guests [ENT-1535]

### DIFF
--- a/server/src/main/java/org/candlepin/model/ConsumerCurator.java
+++ b/server/src/main/java/org/candlepin/model/ConsumerCurator.java
@@ -772,6 +772,8 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
         List<Consumer> guests = new ArrayList<>();
         List<GuestId> consumerGuests = consumer.getGuestIds();
         if (consumerGuests != null) {
+            consumerGuests = consumerGuests.stream().distinct()
+                .collect(Collectors.toList());
             for (GuestId cg : consumerGuests) {
                 // Check if this is the most recent host to report the guest by asking
                 // for the consumer's current host and comparing it to ourselves.

--- a/server/src/main/java/org/candlepin/resource/util/GuestMigration.java
+++ b/server/src/main/java/org/candlepin/resource/util/GuestMigration.java
@@ -93,7 +93,7 @@ public class GuestMigration {
         log.debug("Updating {} guest IDs.", incoming.getGuestIds().size());
         List<GuestId> existingGuests = existing.getGuestIds();
         // Transform incoming GuestIdDTOs to GuestIds
-        List<GuestId> incomingGuestIds = incoming.getGuestIds().stream().filter(Objects::nonNull)
+        List<GuestId> incomingGuestIds = incoming.getGuestIds().stream().filter(Objects::nonNull).distinct()
             .map(guestIdDTO -> new GuestId(guestIdDTO.getGuestId(), existing, guestIdDTO.getAttributes()))
             .collect(Collectors.toList());
 


### PR DESCRIPTION
The API returns duplicate guest ids in the response as the cp_consumer_guests table has duplicate guest entries for a consumer. As per my investigation, this situation occurs when update consumer request contains duplicate guest ids. Currently, there is no check to remove duplicate guest ids from the request.

To fix this, I removed duplicate guests from the response for existing records and also added code to remove duplicate entries from request to avoid duplicate entries in cp_consumer_guests table. 
