### PR TITLE
[M] Moved testing HSQLDB instance to a file rather than memory

### DIFF
--- a/server/src/main/java/org/candlepin/liquibase/LiquibaseCustomTask.java
+++ b/server/src/main/java/org/candlepin/liquibase/LiquibaseCustomTask.java
@@ -18,6 +18,8 @@ import liquibase.database.Database;
 import liquibase.database.jvm.JdbcConnection;
 import liquibase.exception.DatabaseException;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -32,7 +34,7 @@ import java.util.UUID;
  * The LiquibaseCustomTask class provides some common utility functions for performing queries or
  * generating UUIDs for new objects.
  */
-public abstract class LiquibaseCustomTask {
+public abstract class LiquibaseCustomTask implements Closeable {
 
     protected Database database;
     protected JdbcConnection connection;
@@ -58,6 +60,20 @@ public abstract class LiquibaseCustomTask {
         this.logger = logger;
 
         this.preparedStatements = new HashMap<>();
+    }
+
+    @Override
+    public void close() throws IOException {
+        try {
+            for (PreparedStatement statement : this.preparedStatements.values()) {
+                statement.close();
+            }
+
+            this.preparedStatements.clear();
+        }
+        catch (SQLException e) {
+            throw new IOException(e);
+        }
     }
 
     /**

--- a/server/src/main/java/org/candlepin/liquibase/LiquibaseCustomTaskWrapper.java
+++ b/server/src/main/java/org/candlepin/liquibase/LiquibaseCustomTaskWrapper.java
@@ -21,6 +21,8 @@ import liquibase.exception.SetupException;
 import liquibase.exception.ValidationErrors;
 import liquibase.resource.ResourceAccessor;
 
+import java.lang.reflect.InvocationTargetException;
+
 
 
 /**
@@ -40,6 +42,26 @@ public abstract class LiquibaseCustomTaskWrapper<T extends LiquibaseCustomTask> 
         }
 
         this.typeClass = typeClass;
+    }
+
+    /**
+     * Instantiates the actual task instance, providing the specified database and logger to the
+     * new instance.
+     *
+     * @param database
+     *  the database instance to provide to the new task
+     *
+     * @param logger
+     *  the custom task logger instance to provide to the new task
+     *
+     * @return
+     *  the new instance of the liquibase task
+     */
+    private T instantiateTask(Database database, CustomTaskLogger logger) throws NoSuchMethodException,
+        InstantiationException, IllegalAccessException, InvocationTargetException {
+
+        return this.typeClass.getConstructor(Database.class, CustomTaskLogger.class)
+            .newInstance(database, logger);
     }
 
     @Override
@@ -64,12 +86,10 @@ public abstract class LiquibaseCustomTaskWrapper<T extends LiquibaseCustomTask> 
 
     @Override
     public void execute(Database database) throws CustomChangeException {
-        try {
-            T task = this.typeClass.getConstructor(Database.class, CustomTaskLogger.class)
-                .newInstance(database, new LiquibaseCustomTaskLogger());
+        CustomTaskLogger logger = new LiquibaseCustomTaskLogger();
 
+        try (T task = this.instantiateTask(database, logger)) {
             task.execute();
-            task.close();
         }
         catch (Exception e) {
             throw new CustomChangeException(e);

--- a/server/src/main/java/org/candlepin/liquibase/LiquibaseCustomTaskWrapper.java
+++ b/server/src/main/java/org/candlepin/liquibase/LiquibaseCustomTaskWrapper.java
@@ -69,6 +69,7 @@ public abstract class LiquibaseCustomTaskWrapper<T extends LiquibaseCustomTask> 
                 .newInstance(database, new LiquibaseCustomTaskLogger());
 
             task.execute();
+            task.close();
         }
         catch (Exception e) {
             throw new CustomChangeException(e);

--- a/server/src/main/resources/META-INF/persistence.xml
+++ b/server/src/main/resources/META-INF/persistence.xml
@@ -38,7 +38,7 @@
         <properties>
             <property name="hibernate.dialect" value="org.hibernate.dialect.HSQLDialect"/>
             <property name="hibernate.connection.driver_class" value="org.hsqldb.jdbcDriver"/>
-            <property name="hibernate.connection.url" value="jdbc:hsqldb:mem:unit-testing-jpa;sql.enforce_strict_size=true;shutdown=true;"/>
+            <property name="hibernate.connection.url" value="jdbc:hsqldb:file:/tmp/cp-unit-testing-jpa;sql.enforce_strict_size=true;shutdown=true;"/>
             <property name="hibernate.connection.username" value="sa"/>
             <property name="hibernate.connection.password" value=""/>
             <property name="hibernate.show_sql" value="false" />

--- a/server/src/main/resources/META-INF/persistence.xml
+++ b/server/src/main/resources/META-INF/persistence.xml
@@ -38,7 +38,7 @@
         <properties>
             <property name="hibernate.dialect" value="org.hibernate.dialect.HSQLDialect"/>
             <property name="hibernate.connection.driver_class" value="org.hsqldb.jdbcDriver"/>
-            <property name="hibernate.connection.url" value="jdbc:hsqldb:file:/tmp/cp-unit-testing-jpa;sql.enforce_strict_size=true;shutdown=true;"/>
+            <property name="hibernate.connection.url" value="jdbc:hsqldb:file:${hsqldb_dir}/cp-test-db;sql.enforce_strict_size=true;shutdown=true;"/>
             <property name="hibernate.connection.username" value="sa"/>
             <property name="hibernate.connection.password" value=""/>
             <property name="hibernate.show_sql" value="false" />

--- a/server/src/test/java/org/candlepin/junit/LiquibaseExtension.java
+++ b/server/src/test/java/org/candlepin/junit/LiquibaseExtension.java
@@ -38,11 +38,8 @@ import java.util.Collections;
 
 
 public class LiquibaseExtension implements BeforeAllCallback, AfterAllCallback, AfterEachCallback {
-    private static final String TRUNCATE_SQL =
-        "TRUNCATE SCHEMA %s RESTART IDENTITY AND COMMIT NO CHECK";
-
-    private static final String DROP_SQL =
-        "DROP SCHEMA IF EXISTS %s CASCADE";
+    private static final String TRUNCATE_SQL = "TRUNCATE SCHEMA %s RESTART IDENTITY AND COMMIT NO CHECK";
+    private static final String DROP_SQL = "DROP SCHEMA IF EXISTS %s CASCADE";
 
     private Liquibase liquibase;
     private ResourceAccessor accessor;
@@ -124,11 +121,8 @@ public class LiquibaseExtension implements BeforeAllCallback, AfterAllCallback, 
     }
 
     private void executeUpdate(String sql) {
-        try {
-            Statement statement = this.connection.createStatement();
+        try (Statement statement = this.connection.createStatement()) {
             statement.executeUpdate(sql);
-
-            statement.close();
         }
         catch (Exception e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
- The HSQLDB instance used for general unit tests has moved from
  the in-memory DB, to a file-system DB in the system temp
  directory (/tmp)
- LiquibaseExtension now uses IF EXISTS when executing a
  DROP SCHEMA command
- LiquibaseExtension now drops any existing known/expected
  schema immediately after connecting to the DB, before
  attempting to create any new schemas
- LiquibaseCustomTask now implements Closeable and closing
  a custom task will forcefully close any open prepared statements
  created through the preparedStatement or executeQuery methods
- LiquibaseCustomTaskWrapper now uses the new .close method
  after executing any custom task to ensure opened statements
  are explicitly closed
- LiquibaseExtension now uses a direct Statement object and
  explicitly closes it, rather than offloading this behavior
  to the LiquibaseStatement object