### PR TITLE
[2.7] 1741209: Added principal to consumer deletion records (ENT-1572)

### DIFF
--- a/server/src/main/java/org/candlepin/dto/api/v1/DeletedConsumerDTO.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/DeletedConsumerDTO.java
@@ -35,6 +35,7 @@ public class DeletedConsumerDTO extends TimestampedCandlepinDTO<DeletedConsumerD
     private String ownerId;
     private String ownerKey;
     private String ownerDisplayName;
+    private String principalName;
 
     /**
      * Initializes a new DeletedConsumerDTO instance with null values.
@@ -159,6 +160,32 @@ public class DeletedConsumerDTO extends TimestampedCandlepinDTO<DeletedConsumerD
         return ownerDisplayName;
     }
 
+    /**
+     * Sets or clears the name of the principal that caused the consumer to be deleted. If the
+     * incoming principal name is null, any existing value will be cleared.
+     *
+     * @param principalName
+     *  the name of the principal to set for this deletion event, or null to clear it
+     *
+     * @return
+     *  a reference to this DTO
+     */
+    public DeletedConsumerDTO setPrincipalName(String principalName) {
+        this.principalName = principalName;
+        return this;
+    }
+
+    /**
+     * Fetches the name of the principal that caused the consumer to be deleted, or null if the
+     * principal has not yet been set.
+     *
+     * @return
+     *  the name of the principal that caused the consumer to be deleted, or null if the principal
+     *  has not been set
+     */
+    public String getPrincipalName() {
+        return this.principalName;
+    }
 
     /**
      * {@inheritDoc}
@@ -186,7 +213,8 @@ public class DeletedConsumerDTO extends TimestampedCandlepinDTO<DeletedConsumerD
                 .append(this.getConsumerUuid(), that.getConsumerUuid())
                 .append(this.getOwnerId(), that.getOwnerId())
                 .append(this.getOwnerKey(), that.getOwnerKey())
-                .append(this.getOwnerDisplayName(), that.getOwnerDisplayName());
+                .append(this.getOwnerDisplayName(), that.getOwnerDisplayName())
+                .append(this.getPrincipalName(), that.getPrincipalName());
 
             return builder.isEquals();
         }
@@ -205,7 +233,8 @@ public class DeletedConsumerDTO extends TimestampedCandlepinDTO<DeletedConsumerD
             .append(this.getConsumerUuid())
             .append(this.getOwnerId())
             .append(this.getOwnerKey())
-            .append(this.getOwnerDisplayName());
+            .append(this.getOwnerDisplayName())
+            .append(this.getPrincipalName());
 
         return builder.toHashCode();
     }
@@ -229,7 +258,8 @@ public class DeletedConsumerDTO extends TimestampedCandlepinDTO<DeletedConsumerD
             .setConsumerUuid(source.getConsumerUuid())
             .setOwnerId(source.getOwnerId())
             .setOwnerKey(source.getOwnerKey())
-            .setOwnerDisplayName(source.getOwnerDisplayName());
+            .setOwnerDisplayName(source.getOwnerDisplayName())
+            .setPrincipalName(source.getPrincipalName());
 
         return this;
     }

--- a/server/src/main/java/org/candlepin/dto/api/v1/DeletedConsumerTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/DeletedConsumerTranslator.java
@@ -61,7 +61,8 @@ public class DeletedConsumerTranslator extends
             .setConsumerUuid(source.getConsumerUuid())
             .setOwnerId(source.getOwnerId())
             .setOwnerKey(source.getOwnerKey())
-            .setOwnerDisplayName(source.getOwnerDisplayName());
+            .setOwnerDisplayName(source.getOwnerDisplayName())
+            .setPrincipalName(source.getPrincipalName());
 
         return dest;
     }

--- a/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
+++ b/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
@@ -562,6 +562,14 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
         create(anObject, true);
     }
 
+    @Transactional
+    public E saveOrUpdate(E entity) {
+        Session session = this.currentSession();
+        session.saveOrUpdate(entity);
+
+        return entity;
+    }
+
     public void flush() {
         try {
             getEntityManager().flush();

--- a/server/src/main/java/org/candlepin/model/ConsumerCurator.java
+++ b/server/src/main/java/org/candlepin/model/ConsumerCurator.java
@@ -14,9 +14,11 @@
  */
 package org.candlepin.model;
 
+import org.candlepin.auth.Principal;
 import org.candlepin.common.config.Configuration;
 import org.candlepin.common.exceptions.BadRequestException;
 import org.candlepin.common.exceptions.NotFoundException;
+import org.candlepin.guice.PrincipalProvider;
 import org.candlepin.pinsetter.tasks.HypervisorUpdateJob.HypervisorList;
 import org.candlepin.resteasy.parameter.KeyValueParameter;
 import org.candlepin.util.FactValidator;
@@ -77,6 +79,7 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
     @Inject private FactValidator factValidator;
     @Inject private OwnerCurator ownerCurator;
     @Inject private Provider<HostCache> cachedHostsProvider;
+    @Inject private PrincipalProvider principalProvider;
 
     public ConsumerCurator() {
         super(Consumer.class);
@@ -95,25 +98,29 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
     public void delete(Consumer entity) {
         log.debug("Deleting consumer: {}", entity);
 
-        // save off the IDs before we delete
-        Owner owner = ownerCurator.findOwnerById(entity.getOwnerId());
-        DeletedConsumer dc = new DeletedConsumer(entity.getUuid(), entity.getOwnerId(),
-            owner.getKey(), owner.getDisplayName());
+        // Fetch the principal that's triggering this
+        Principal principal = this.principalProvider.get();
 
+        Owner owner = entity.getOwner();
+
+        // Check if we've already got a record for this consumer (???), creating one if necessary
+        DeletedConsumer deletedConsumer = this.deletedConsumerCurator.findByConsumerUuid(entity.getUuid());
+        if (deletedConsumer == null) {
+            deletedConsumer = new DeletedConsumer();
+        }
+
+        // Set/update the properties on our deleted consumer record
+        deletedConsumer.setConsumerUuid(entity.getUuid())
+            .setOwnerId(entity.getOwnerId())
+            .setOwnerKey(owner.getKey())
+            .setOwnerDisplayName(owner.getDisplayName())
+            .setPrincipalName(principal != null ? principal.getName() : null);
+
+        // Actually delete the consumer
         super.delete(entity);
 
-        DeletedConsumer existing = deletedConsumerCurator.findByConsumerUuid(dc.getConsumerUuid());
-        if (existing != null) {
-            // update the owner ID in case the same UUID was specified by two owners
-            existing.setOwnerId(dc.getOwnerId());
-            existing.setOwnerKey(dc.getOwnerKey());
-            existing.setOwnerDisplayName(dc.getOwnerDisplayName());
-            existing.setUpdated(new Date());
-            deletedConsumerCurator.save(existing);
-        }
-        else {
-            deletedConsumerCurator.create(dc);
-        }
+        // Save our deletion record
+        this.deletedConsumerCurator.saveOrUpdate(deletedConsumer);
     }
 
     @Transactional

--- a/server/src/main/java/org/candlepin/model/DeletedConsumer.java
+++ b/server/src/main/java/org/candlepin/model/DeletedConsumer.java
@@ -72,6 +72,9 @@ public class DeletedConsumer extends AbstractHibernateObject {
     @Size(max = 255)
     private String ownerDisplayName;
 
+    @Column(name = "principal_name")
+    private String principalName;
+
     public DeletedConsumer(String cuuid, String oid, String okey, String oname) {
         consumerUuid = cuuid;
         ownerId = oid;
@@ -88,41 +91,53 @@ public class DeletedConsumer extends AbstractHibernateObject {
         return id;
     }
 
-    /**
-     * @param id the db id.
-     */
-    public void setId(String id) {
+    public DeletedConsumer setId(String id) {
         this.id = id;
+        return this;
     }
 
-    public void setConsumerUuid(String cid) {
+    public DeletedConsumer setConsumerUuid(String cid) {
         consumerUuid = cid;
+        return this;
     }
 
     public String getConsumerUuid() {
         return consumerUuid;
     }
 
-    public void setOwnerId(String oid) {
+    public DeletedConsumer setOwnerId(String oid) {
         ownerId = oid;
+        return this;
     }
 
     public String getOwnerId() {
         return ownerId;
     }
 
-    public void setOwnerKey(String okey) {
+    public DeletedConsumer setOwnerKey(String okey) {
         ownerKey = okey;
+        return this;
     }
 
     public String getOwnerKey() {
         return ownerKey;
     }
-    public void setOwnerDisplayName(String oname) {
+
+    public DeletedConsumer setOwnerDisplayName(String oname) {
         ownerDisplayName = oname;
+        return this;
     }
 
     public String getOwnerDisplayName() {
         return ownerDisplayName;
+    }
+
+    public DeletedConsumer setPrincipalName(String principalName) {
+        this.principalName = principalName;
+        return this;
+    }
+
+    public String getPrincipalName() {
+        return this.principalName;
     }
 }

--- a/server/src/main/java/org/candlepin/model/OwnerEnvContentAccessCurator.java
+++ b/server/src/main/java/org/candlepin/model/OwnerEnvContentAccessCurator.java
@@ -95,8 +95,4 @@ public class OwnerEnvContentAccessCurator extends AbstractHibernateCurator<Owner
                 .setParameter("environmentId", environmentId)
                 .executeUpdate();
     }
-
-    public void saveOrUpdate(OwnerEnvContentAccess ownerEnvContentAccess) {
-        this.currentSession().saveOrUpdate(ownerEnvContentAccess);
-    }
 }

--- a/server/src/main/resources/db/changelog/20190813155224-add-principal-to-deleted-consumers.xml
+++ b/server/src/main/resources/db/changelog/20190813155224-add-principal-to-deleted-consumers.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="20190813155224-1" author="crog">
+        <comment>
+            Adds a column for the principal name indicating the principal
+            that caused the consumer to be deleted
+        </comment>
+
+        <addColumn tableName="cp_deleted_consumers">
+            <column name="principal_name" type="varchar(255)"/>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/server/src/main/resources/db/changelog/changelog-create.xml
+++ b/server/src/main/resources/db/changelog/changelog-create.xml
@@ -1230,4 +1230,5 @@
     <include file="db/changelog/20181116110941-virt-fact-index.xml"/>
     <include file="db/changelog/20190401093722-add-content-override-index.xml"/>
     <include file="db/changelog/20190423122527-add-syspurpose-fields-to-act-key.xml"/>
+    <include file="db/changelog/20190813155224-add-principal-to-deleted-consumers.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-testing.xml
+++ b/server/src/main/resources/db/changelog/changelog-testing.xml
@@ -2322,4 +2322,5 @@
     <include file="db/changelog/20181116110941-virt-fact-index.xml"/>
     <include file="db/changelog/20190401093722-add-content-override-index.xml"/>
     <include file="db/changelog/20190423122527-add-syspurpose-fields-to-act-key.xml"/>
+    <include file="db/changelog/20190813155224-add-principal-to-deleted-consumers.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-update.xml
+++ b/server/src/main/resources/db/changelog/changelog-update.xml
@@ -139,4 +139,5 @@
     <include file="db/changelog/20181116110941-virt-fact-index.xml"/>
     <include file="db/changelog/20190401093722-add-content-override-index.xml"/>
     <include file="db/changelog/20190423122527-add-syspurpose-fields-to-act-key.xml"/>
+    <include file="db/changelog/20190813155224-add-principal-to-deleted-consumers.xml"/>
 </databaseChangeLog>

--- a/server/src/test/java/org/candlepin/dto/api/v1/DeletedConsumerDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/DeletedConsumerDTOTest.java
@@ -36,6 +36,7 @@ public class DeletedConsumerDTOTest extends AbstractDTOTest<DeletedConsumerDTO> 
         this.values.put("OwnerId", "owner-id");
         this.values.put("OwnerKey", "owner-key");
         this.values.put("OwnerDisplayName", "owner-display-name");
+        this.values.put("PrincipalName", "test-principal-name");
         this.values.put("Created", new Date());
         this.values.put("Updated", new Date());
     }

--- a/server/src/test/java/org/candlepin/dto/api/v1/DeletedConsumerTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/DeletedConsumerTranslatorTest.java
@@ -46,6 +46,7 @@ public class DeletedConsumerTranslatorTest extends
         source.setOwnerId("deleted-consumer-owner-id");
         source.setOwnerKey("deleted-consumer-owner-key");
         source.setOwnerDisplayName("deleted-consumer-owner-display-name");
+        source.setPrincipalName("test-principal-name");
 
         return source;
     }

--- a/server/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
@@ -32,6 +32,7 @@ import org.candlepin.util.Util;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
 import org.mockito.Mockito;
 
 import java.lang.reflect.Field;
@@ -952,6 +953,25 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
         Date deletionDate2 = dc.getUpdated();
         assertEquals(-1, deletionDate1.compareTo(deletionDate2));
         assertEquals(altOwner.getId(), dc.getOwnerId());
+    }
+
+    @Test
+    public void testDeleteRetainsPrincipalName() {
+        String principalName = "test_principal_name";
+        this.setupAdminPrincipal(principalName);
+
+        Consumer consumer = new Consumer("test_consumer", "test_user", this.owner, this.ct);
+        consumer.setUuid("test_consumer_uuid");
+        consumer = this.consumerCurator.create(consumer);
+
+        this.consumerCurator.delete(consumer);
+
+        Consumer fetched = this.consumerCurator.get(consumer.getUuid());
+        assertNull(fetched);
+
+        DeletedConsumer deletionRecord = this.dcc.findByConsumerUuid(consumer.getUuid());
+        assertNotNull(deletionRecord);
+        assertEquals(principalName, deletionRecord.getPrincipalName());
     }
 
     @Test


### PR DESCRIPTION
- DeletedConsumer now has a column to store the name of the principal
  that triggered the deletion of a consumer
- ConsumerCurator.delete now sets the name of the current principal
  on the deleted consumer record it creates