### PR TITLE
[2.7] Added an additional null check during entitlement revocation

### DIFF
--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -656,13 +656,15 @@ public class CandlepinPoolManager implements PoolManager {
             long newConsumed = pool.getConsumed();
 
             // deletes ents in order of date since we retrieved and put them in the map in order.
-            for (Entitlement ent : entitlements) {
-                if (newConsumed > pool.getQuantity()) {
-                    entitlementsToRevoke.add(ent);
-                    newConsumed -= ent.getQuantity();
-                }
-                else {
-                    break;
+            if (entitlements != null) {
+                for (Entitlement ent : entitlements) {
+                    if (newConsumed > pool.getQuantity()) {
+                        entitlementsToRevoke.add(ent);
+                        newConsumed -= ent.getQuantity();
+                    }
+                    else {
+                        break;
+                    }
                 }
             }
         }


### PR DESCRIPTION
- Added an additional null check to an entitlement revocation
  operation in CandlepinPoolManager to avoid attempting to
  iterate through a null collection