### PR TITLE
[F]  Updated JobManager's scoping capabilities (ENT-1562)

### DIFF
--- a/server/src/main/java/org/candlepin/controller/OwnerManager.java
+++ b/server/src/main/java/org/candlepin/controller/OwnerManager.java
@@ -14,9 +14,6 @@
  */
 package org.candlepin.controller;
 
-import org.candlepin.model.AsyncJobStatus.JobState;
-import org.candlepin.model.AsyncJobStatusCurator;
-import org.candlepin.model.AsyncJobStatusCurator.AsyncJobStatusQueryBuilder;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerCurator;
 import org.candlepin.model.ContentAccessCertificateCurator;
@@ -82,7 +79,6 @@ public class OwnerManager {
     private OwnerEnvContentAccessCurator ownerEnvContentAccessCurator;
     private UeberCertificateCurator uberCertificateCurator;
     private OwnerServiceAdapter ownerServiceAdapter;
-    private AsyncJobStatusCurator jobCurator;
 
     @Inject
     public OwnerManager(ConsumerCurator consumerCurator,
@@ -100,8 +96,7 @@ public class OwnerManager {
         ContentAccessCertificateCurator contentAccessCertCurator,
         OwnerEnvContentAccessCurator ownerEnvContentAccessCurator,
         UeberCertificateCurator uberCertificateCurator,
-        OwnerServiceAdapter ownerServiceAdapter,
-        AsyncJobStatusCurator jobCurator) {
+        OwnerServiceAdapter ownerServiceAdapter) {
 
         this.consumerCurator = consumerCurator;
         this.activationKeyCurator = activationKeyCurator;
@@ -119,7 +114,6 @@ public class OwnerManager {
         this.ownerEnvContentAccessCurator = ownerEnvContentAccessCurator;
         this.uberCertificateCurator = uberCertificateCurator;
         this.ownerServiceAdapter = ownerServiceAdapter;
-        this.jobCurator = jobCurator;
     }
 
     @Transactional
@@ -193,17 +187,6 @@ public class OwnerManager {
 
         log.info("Deleting all content...");
         this.contentManager.removeAllContent(owner, false);
-
-        // Impl note:
-        // This may not be the correct behavior here. Perhaps it's better to clear the context
-        // owner where applicable and let the jobs continue to run?
-        log.info("Deleting jobs associated with owner: {}", owner);
-        AsyncJobStatusQueryBuilder jobQueryBuilder = new AsyncJobStatusQueryBuilder()
-            .setOwnerIds(owner.getId())
-            .setJobStates(JobState.values());
-
-        int count = this.jobCurator.deleteJobs(jobQueryBuilder);
-        log.info("{} jobs deleted", count);
 
         log.info("Deleting owner: {}", owner);
         ownerCurator.delete(owner);

--- a/server/src/main/java/org/candlepin/guice/CandlepinRequestScope.java
+++ b/server/src/main/java/org/candlepin/guice/CandlepinRequestScope.java
@@ -24,6 +24,8 @@ import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import java.util.HashMap;
 import java.util.Map;
 
+
+
 /**
  * CandlepinRequestScope
  *
@@ -34,8 +36,8 @@ import java.util.Map;
 public class CandlepinRequestScope implements Scope {
 
     public void enter() {
-        ResteasyProviderFactory.pushContext(CandlepinRequestScopeData.class,
-            new CandlepinRequestScopeData());
+        CandlepinRequestScopeData data = new CandlepinRequestScopeData();
+        ResteasyProviderFactory.pushContext(CandlepinRequestScopeData.class, data);
     }
 
     public void exit() {
@@ -59,11 +61,13 @@ public class CandlepinRequestScope implements Scope {
     }
 
     private <T> Map<Key<?>, Object> getScopedObjectMap(Key<T> key) {
-        CandlepinRequestScopeData scopeData = ResteasyProviderFactory.getContextData(
-            CandlepinRequestScopeData.class);
+        CandlepinRequestScopeData scopeData = ResteasyProviderFactory
+            .getContextData(CandlepinRequestScopeData.class);
+
         if (scopeData == null) {
             throw new OutOfScopeException("Cannot access " + key + " outside of a scoping block");
         }
+
         return scopeData.get();
     }
 

--- a/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
+++ b/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
@@ -60,6 +60,7 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 
 import javax.persistence.EntityManager;
+import javax.persistence.EntityTransaction;
 import javax.persistence.LockModeType;
 import javax.persistence.NonUniqueResultException;
 import javax.persistence.OptimisticLockException;
@@ -600,6 +601,12 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
     public EntityManager getEntityManager() {
         return entityManager.get();
     }
+
+    public EntityTransaction getTransaction() {
+        EntityManager manager = this.getEntityManager();
+        return manager != null ? manager.getTransaction() : null;
+    }
+
 
     /**
      * Fetches the natural ID loader for this entity. This loader can be used and reused to

--- a/server/src/main/java/org/candlepin/model/AsyncJobStatus.java
+++ b/server/src/main/java/org/candlepin/model/AsyncJobStatus.java
@@ -23,6 +23,8 @@ import org.apache.commons.lang.builder.HashCodeBuilder;
 
 import org.hibernate.annotations.GenericGenerator;
 
+import org.slf4j.event.Level;
+
 import java.util.Collections;
 import java.util.Date;
 import java.util.Map;
@@ -38,6 +40,7 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
+import javax.persistence.Version;
 import javax.validation.constraints.NotNull;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -159,6 +162,9 @@ public class AsyncJobStatus extends AbstractHibernateObject implements JobExecut
     @GenericGenerator(name = "system-uuid", strategy = "uuid")
     @NotNull
     private String id;
+
+    @Version
+    private int version;
 
     @Column(name = "job_key")
     private String jobKey;
@@ -535,6 +541,20 @@ public class AsyncJobStatus extends AbstractHibernateObject implements JobExecut
     public AsyncJobStatus setLogLevel(String logLevel) {
         this.logLevel = logLevel != null && !logLevel.isEmpty() ? logLevel : null;
         return this;
+    }
+
+    /**
+     * Sets the log level with which this job will be executed. If the log level is null or empty,
+     * any existing log level will be cleared.
+     *
+     * @param logLevel
+     *  the log level to set for this job, or null to clear it
+     *
+     * @return
+     *  this job status instance
+     */
+    public AsyncJobStatus setLogLevel(Level logLevel) {
+        return this.setLogLevel(logLevel != null ? logLevel.name() : null);
     }
 
     /**

--- a/server/src/main/java/org/candlepin/model/Owner.java
+++ b/server/src/main/java/org/candlepin/model/Owner.java
@@ -32,6 +32,8 @@ import org.hibernate.annotations.GenericGenerator;
 import io.swagger.annotations.ApiModelProperty;
 import org.hibernate.annotations.NaturalId;
 
+import org.slf4j.event.Level;
+
 import java.io.Serializable;
 import java.util.Date;
 import java.util.HashSet;
@@ -474,7 +476,11 @@ public class Owner extends AbstractHibernateObject<Owner>
     }
 
     public void setLogLevel(String logLevel) {
-        this.logLevel = logLevel;
+        this.logLevel = logLevel != null && !logLevel.isEmpty() ? logLevel : null;
+    }
+
+    public void setLogLevel(Level logLevel) {
+        this.setLogLevel(logLevel != null ? logLevel.name() : null);
     }
 
     @Override

--- a/server/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -1328,7 +1328,7 @@ public class OwnerResource {
     @ApiResponses({ @ApiResponse(code = 404, message = "Owner not found")})
     public void deleteLogLevel(@PathParam("owner_key") String ownerKey) {
         Owner owner = findOwnerByKey(ownerKey);
-        owner.setLogLevel(null);
+        owner.setLogLevel((String) null);
         ownerCurator.merge(owner);
     }
 

--- a/server/src/main/resources/db/changelog/20181121151738-add-async-job-tables.xml
+++ b/server/src/main/resources/db/changelog/20181121151738-add-async-job-tables.xml
@@ -17,6 +17,7 @@
 
             <column name="created" type="${timestamp.type}"/>
             <column name="updated" type="${timestamp.type}"/>
+            <column name="version" type="int"/>
 
             <column name="name" type="varchar(255)"/>
             <column name="job_key" type="varchar(255)"/>

--- a/server/src/test/java/org/candlepin/controller/OwnerManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/OwnerManagerTest.java
@@ -16,7 +16,6 @@ package org.candlepin.controller;
 
 import static org.mockito.Mockito.*;
 
-import org.candlepin.model.AsyncJobStatusCurator;
 import org.candlepin.model.ConsumerCurator;
 import org.candlepin.model.ContentAccessCertificateCurator;
 import org.candlepin.model.EnvironmentCurator;
@@ -81,8 +80,7 @@ public class OwnerManagerTest {
     private UeberCertificateCurator uberCertificateCurator;
     @Mock
     private OwnerServiceAdapter ownerServiceAdapter;
-    @Mock
-    private AsyncJobStatusCurator jobCurator;
+
 
     @Before
     public void setUp() {
@@ -90,7 +88,7 @@ public class OwnerManagerTest {
             exportCurator, importRecordCurator, permissionCurator, ownerProductCurator, productManager,
             ownerContentCurator, contentManager, ownerCurator, contentAccessCertService,
             contentAccessCertCurator, ownerEnvContentAccessCurator, uberCertificateCurator,
-            ownerServiceAdapter, jobCurator);
+            ownerServiceAdapter);
     }
 
     @Test


### PR DESCRIPTION
- Owner is no longer strongly referenced by the jobs table
- OwnerManager no longer performs any job cleanup on owner deletion
- JobManager no longer uses UnitOfWork when setting up the job
  environment
- JobManager now performs better transaction isolation and tracking
  during job initialization and execution
- JobManager will now attempt to automatically commit or rollback an
  open database transaction after job execution completes or fails
- JobManager now properly saves and restores MDC state before/after
  job execution
- Cancelled jobs no longer cause a JobInitializationException when
  its respective message is received
- AsyncJobStatus is now versioned and uses optimistic locking to
  prevent update collisions