### PR TITLE
[M] Added the @Verify annotation to ConsumerResource.consumerExists

### DIFF
--- a/server/client/ruby/candlepin_api.rb
+++ b/server/client/ruby/candlepin_api.rb
@@ -965,6 +965,11 @@ class Candlepin
     get("/consumers/#{consumer_id}")
   end
 
+  def consumer_exists(consumer_uuid=nil)
+    consumer_uuid ||= @uuid
+    head("/consumers/#{consumer_uuid}/exists")
+  end
+
   def get_consumer_release(consumer_id=nil)
     consumer_id ||= @uuid
     get("/consumers/#{consumer_id}/release")
@@ -1516,6 +1521,21 @@ class Candlepin
     end
 
     return (response.body)
+  end
+
+  def head(uri, params={})
+    # escape and build uri
+    euri = URI.escape(uri)
+    if !params.empty?
+      euri << '?'
+      euri << URI.encode_www_form(params)
+    end
+
+    # execute
+    puts ("HEAD #{euri}") if @verbose
+    response = get_client(uri, Net::HTTP::Head, :head)[euri].head
+
+    return response
   end
 
   def post(uri, params={}, data=nil)

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -443,7 +443,7 @@ public class ConsumerResource {
     @Produces(MediaType.WILDCARD)
     @Path("{consumer_uuid}/exists")
     public void consumerExists(
-        @PathParam("consumer_uuid") String uuid) {
+        @PathParam("consumer_uuid") @Verify(Consumer.class) String uuid) {
         if (!consumerCurator.doesConsumerExist(uuid)) {
             throw new NotFoundException(i18n.tr("Consumer with id {0} could not be found.", uuid));
         }


### PR DESCRIPTION
- Added the @Verify annotation to ConsumerResource.consumerExists
  to allow consumers to check for self-existence on a given
  Candlepin node without needing to fetch and serialize the entire
  Consumer object via ConsumerResource.getConsumer