### PR TITLE
[M] 1742806: When deleting pools, delete entitlements using ids; ENT-1583

### DIFF
--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -2268,7 +2268,9 @@ public class CandlepinPoolManager implements PoolManager {
             // Revoke/delete entitlements
             if (!entitlements.isEmpty()) {
                 log.info("Revoking {} entitlements...", entitlements.size());
-                this.entitlementCurator.batchDelete(entitlements);
+                this.entitlementCurator.unlinkEntitlements(entitlements);
+                this.entitlementCertificateCurator.deleteByEntitlementIds(entitlementIds);
+                this.entitlementCurator.batchDeleteByIds(entitlementIds);
                 this.entitlementCurator.flush();
                 this.entitlementCurator.batchDetach(entitlements);
                 log.info("Entitlements successfully revoked");

--- a/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -1291,7 +1291,7 @@ public class PoolManagerTest {
         this.manager.getRefresher(mockSubAdapter, mockOwnerAdapter).add(owner).run();
 
         verify(mockPoolCurator).batchDelete(eq(pools), anyCollectionOf(String.class));
-        verify(entitlementCurator).batchDelete(eq(new HashSet<Entitlement>(poolEntitlements)));
+        verify(entitlementCurator).batchDeleteByIds(eq(new HashSet<>(Arrays.asList(ent.getId()))));
     }
 
     private List<Pool> createPoolsWithSourceEntitlement(Entitlement e, Product p) {


### PR DESCRIPTION
- Now, when deleting pools, the revocation of entitlements of those
  pools will use a delete query instead of a hibernate batch detach,
  in order to avoid memory overuse.