### PR TITLE
[F] ENT-869: Use SSL when deploying Artemis remotely

### DIFF
--- a/server/bin/artemis/README.md
+++ b/server/bin/artemis/README.md
@@ -9,7 +9,8 @@ To install artemis, this script will:
 * install the broker according to recommendations from the Artemis docs
 * create a service runnable by systemctl
 * set up the appropriate SELinux policy for the service.
-* configure the broker according to candlepin reqirements.
+* configure the broker according to candlepin requirements.
+* generate certificates and configure the broker to use SSL.
 * provide a means to clean up an existing installation of the broker.
 
 

--- a/server/bin/deploy
+++ b/server/bin/deploy
@@ -159,8 +159,8 @@ create_var_cache_candlepin() {
 
 autoconf() {
   printf "\nGenerating candlepin.conf\n"
-  echo $(checkout_directory)/gradlew generateConfig $DATABASE_SERVER $LOGDRIVER $HOSTEDTEST $QPID  -Pdb_host=${DBHOSTNAME:-localhost}
-  $(checkout_directory)/gradlew generateConfig $DATABASE_SERVER $LOGDRIVER $HOSTEDTEST $QPID  -Pdb_host=${DBHOSTNAME:-localhost}
+  echo $(checkout_directory)/gradlew generateConfig $DATABASE_SERVER $LOGDRIVER $HOSTEDTEST $QPID $EXTERNAL_BROKER -Pdb_host=${DBHOSTNAME:-localhost}
+  $(checkout_directory)/gradlew generateConfig $DATABASE_SERVER $LOGDRIVER $HOSTEDTEST $QPID $EXTERNAL_BROKER  -Pdb_host=${DBHOSTNAME:-localhost}
 
   if [ "$?" -ne "0" ]; then
     err_msg "ERROR: candlepin.conf generation failed!"
@@ -402,7 +402,7 @@ create_var_log_candlepin
 create_var_cache_candlepin
 
 if [ "$AUTOCONF" == "1" ]; then
-  autoconf $ENV_BUILDR $LOGDRIVER $HOSTEDTEST $QPID $EXTERNAL_BROKER
+  autoconf
 fi
 
 # deploy the webapp

--- a/server/conf/candlepin.conf.template
+++ b/server/conf/candlepin.conf.template
@@ -33,6 +33,10 @@ candlepin.importer.fail_on_unknown=false
 <% if (candlepin.external_broker) { %>\
 candlepin.audit.hornetq.embedded=false
 candlepin.audit.hornetq.broker_url=tcp://localhost:61617
+candlepin.audit.hornetq.truststore=/var/lib/artemis/candlepin/certs/artemis-client.ts
+candlepin.audit.hornetq.truststore_password=securepassword
+candlepin.audit.hornetq.keystore=/var/lib/artemis/candlepin/certs/artemis-client.ks
+candlepin.audit.hornetq.keystore_password=securepassword
 <% } %>\
 candlepin.pretty_print=true
 

--- a/server/src/main/java/org/candlepin/async/impl/ActiveMQSessionFactory.java
+++ b/server/src/main/java/org/candlepin/async/impl/ActiveMQSessionFactory.java
@@ -148,8 +148,7 @@ public class ActiveMQSessionFactory {
             // workaround we need on the receiving side of things. If it looks like the
             // egress configuration, something is probably broken.
 
-            ServerLocator locator = ActiveMQClient.createServerLocator(
-                this.config.getProperty(ConfigProperties.ACTIVEMQ_BROKER_URL));
+            ServerLocator locator = ActiveMQClient.createServerLocator(generateServerUrl());
 
             // TODO: Maybe make this a bit more defensive and skip setting the property if it's
             // not present in the configuration rather than crashing out?
@@ -169,8 +168,7 @@ public class ActiveMQSessionFactory {
      */
     protected synchronized SessionManager getEgressSessionManager() throws Exception {
         if (this.egressSessionManager == null) {
-            ServerLocator locator = ActiveMQClient.createServerLocator(
-                this.config.getProperty(ConfigProperties.ACTIVEMQ_BROKER_URL));
+            ServerLocator locator = ActiveMQClient.createServerLocator(generateServerUrl());
 
             // TODO: Maybe make this a bit more defensive and skip setting the property if it's
             // not present in the configuration rather than crashing out?
@@ -185,6 +183,23 @@ public class ActiveMQSessionFactory {
         }
 
         return this.egressSessionManager;
+    }
+
+    private String generateServerUrl() {
+        StringBuilder serverUrlBuilder =
+            new StringBuilder(this.config.getProperty(ConfigProperties.ACTIVEMQ_BROKER_URL));
+        if (!this.config.getBoolean(ConfigProperties.ACTIVEMQ_EMBEDDED)) {
+            serverUrlBuilder.append("?sslEnabled=true")
+                .append("&trustStorePath=")
+                .append(this.config.getProperty(ConfigProperties.ACTIVEMQ_TRUSTSTORE))
+                .append("&trustStorePassword=")
+                .append(this.config.getProperty(ConfigProperties.ACTIVEMQ_TRUSTSTORE_PASSWORD))
+                .append("&keyStorePath=")
+                .append(this.config.getProperty(ConfigProperties.ACTIVEMQ_KEYSTORE))
+                .append("&keyStorePassword=")
+                .append(this.config.getProperty(ConfigProperties.ACTIVEMQ_KEYSTORE_PASSWORD));
+        }
+        return serverUrlBuilder.toString();
     }
 
     /**

--- a/server/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/server/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -71,6 +71,10 @@ public class ConfigProperties {
 
     public static final String ACTIVEMQ_EMBEDDED = "candlepin.audit.hornetq.embedded";
     public static final String ACTIVEMQ_BROKER_URL = "candlepin.audit.hornetq.broker_url";
+    public static final String ACTIVEMQ_KEYSTORE = "candlepin.audit.hornetq.keystore";
+    public static final String ACTIVEMQ_KEYSTORE_PASSWORD = "candlepin.audit.hornetq.keystore_password";
+    public static final String ACTIVEMQ_TRUSTSTORE = "candlepin.audit.hornetq.truststore";
+    public static final String ACTIVEMQ_TRUSTSTORE_PASSWORD = "candlepin.audit.hornetq.truststore_password";
     public static final String ACTIVEMQ_SERVER_CONFIG_PATH = "candlepin.audit.hornetq.config_path";
 
     /**

--- a/server/src/main/java/org/candlepin/controller/ActiveMQStatusMonitor.java
+++ b/server/src/main/java/org/candlepin/controller/ActiveMQStatusMonitor.java
@@ -72,8 +72,24 @@ public class ActiveMQStatusMonitor implements Closeable, Runnable, CloseListener
 
     // Protected for testing purposes.
     protected void initializeLocator() throws Exception {
-        String serverUrl = this.config.getProperty(ConfigProperties.ACTIVEMQ_BROKER_URL);
-        locator = ActiveMQClient.createServerLocator(serverUrl);
+        locator = ActiveMQClient.createServerLocator(generateServerUrl());
+    }
+
+    private String generateServerUrl() {
+        StringBuilder serverUrlBuilder =
+            new StringBuilder(this.config.getProperty(ConfigProperties.ACTIVEMQ_BROKER_URL));
+        if (!this.config.getBoolean(ConfigProperties.ACTIVEMQ_EMBEDDED)) {
+            serverUrlBuilder.append("?sslEnabled=true")
+                .append("&trustStorePath=")
+                .append(this.config.getProperty(ConfigProperties.ACTIVEMQ_TRUSTSTORE))
+                .append("&trustStorePassword=")
+                .append(this.config.getProperty(ConfigProperties.ACTIVEMQ_TRUSTSTORE_PASSWORD))
+                .append("&keyStorePath=")
+                .append(this.config.getProperty(ConfigProperties.ACTIVEMQ_KEYSTORE))
+                .append("&keyStorePassword=")
+                .append(this.config.getProperty(ConfigProperties.ACTIVEMQ_KEYSTORE_PASSWORD));
+        }
+        return serverUrlBuilder.toString();
     }
 
     /**

--- a/server/src/main/resources/broker.xml
+++ b/server/src/main/resources/broker.xml
@@ -24,7 +24,7 @@
 
         <acceptors>
             <acceptor name="in-vm">vm://0</acceptor>
-            <!-- <acceptor name="netty">tcp://localhost:61617</acceptor> -->
+            <!-- <acceptor name="netty">tcp://localhost:61617?sslEnabled=true;keyStorePath=${artemis.instance}/certs/artemis-server.ks;keyStorePassword=securepassword;needClientAuth=true;trustStorePath=${artemis.instance}/certs/artemis-server.ts;trustStorePassword=securepassword</acceptor> -->
         </acceptors>
 
         <security-enabled>false</security-enabled>


### PR DESCRIPTION
- Also, now candlepin.conf is populated with remote artemis
  properties when running the deploy script with -b -a