### PR TITLE
[M] 1751727: update new hypervisorid when existing hypervisorid is null; ENT-1603

### DIFF
--- a/server/spec/hypervisor_check_in_spec.rb
+++ b/server/spec/hypervisor_check_in_spec.rb
@@ -1170,6 +1170,26 @@ describe 'Hypervisor Resource', :type => :virt do
     @cp.get_consumer(test_host.uuid)['hypervisorId']['hypervisorId'].should == host_hyp_id_2
   end
 
+  it 'should allow the hypervisor id update on the consumer with no existing hypervisor id' do
+    owner = create_owner random_string('owner')
+    user = user_client(owner, random_string('user'))
+
+    host_name = "test_hypevisor_host_name"
+    host_hyp_id = "test_hypervisor_id"
+    host_system_id = "test_system_id"
+    guest_set = [{"guestId"=>"g1"},{"guestId"=>"g2"}]
+    guests = ['g1', 'g2']
+
+    test_host = user.register(host_name, :hypervisor, nil, {"virt.is_guest"=>"false"}, nil, owner['key'], [], [], nil, [])
+    @cp.update_consumer({:uuid => test_host.uuid, :guestIds => guest_set, :facts => {"dmi.system.uuid" => host_system_id, "virt.is_guest"=>"false"}})
+    expect(@cp.get_consumer(test_host.uuid)['hypervisorId']).to be_nil
+
+    async_update_hypervisor(owner, user, host_name, host_hyp_id, guests, true,nil, {"dmi.system.uuid" => host_system_id})
+    test_host = @cp.get_consumer(test_host.uuid)
+    expect(@cp.get_consumer(test_host.uuid)['hypervisorId']['hypervisorId']).to eq(host_hyp_id)
+  end
+
+
   it 'check in will fail when json does not have the proper structure' do
     owner = create_owner random_string('test_owner1')
     user = user_client(owner, random_string("user"))

--- a/server/src/main/java/org/candlepin/service/impl/HypervisorUpdateAction.java
+++ b/server/src/main/java/org/candlepin/service/impl/HypervisorUpdateAction.java
@@ -149,13 +149,8 @@ public class HypervisorUpdateAction {
                 }
             }
             else {
-                boolean hypervisorIdUpdated = false;
-                if (knownHost.getHypervisorId() != null && !hypervisorId.equalsIgnoreCase(knownHost
-                    .getHypervisorId().getHypervisorId())) {
-                    hypervisorIdUpdated = true;
-                    log.debug("Changing hypervisor id to [" + hypervisorId + "]");
-                    knownHost.getHypervisorId().setHypervisorId(hypervisorId);
-                }
+                boolean hypervisorIdUpdated = updateHypervisorId(knownHost, owner, jobReporterId,
+                    hypervisorId);
 
                 reportedOnConsumer = knownHost;
                 if (jobReporterId != null && knownHost.getHypervisorId() != null &&
@@ -201,6 +196,26 @@ public class HypervisorUpdateAction {
             }
         }
         return new Result(result, hypervisorKnownConsumersMap);
+    }
+
+    private boolean updateHypervisorId(Consumer consumer, Owner owner, String reporterId,
+        String hypervisorId) {
+
+        boolean hypervisorIdUpdated = true;
+
+        if (consumer.getHypervisorId() == null) {
+            log.debug("Existing hypervisor id is null, changing hypervisor id to [" + hypervisorId + "]");
+            consumer.setHypervisorId(new HypervisorId(consumer, owner, hypervisorId,
+                reporterId));
+        }
+        else if (!hypervisorId.equalsIgnoreCase(consumer.getHypervisorId().getHypervisorId())) {
+            log.debug("New hypervisor id is different, Changing hypervisor id to [" + hypervisorId + "]");
+            consumer.getHypervisorId().setHypervisorId(hypervisorId);
+        }
+        else {
+            hypervisorIdUpdated = false;
+        }
+        return hypervisorIdUpdated;
     }
 
     private void parseHypervisorList(HypervisorUpdateJob.HypervisorList hypervisorList, Set<String> hosts,


### PR DESCRIPTION
  - In case of hypervisor update async flow, If existing hypervisorid entry is null then create new hypervisorid entry and add it to the consumer.