### PR TITLE
[ENT-1140]1667952: candlepin refuses to start when having too many messages in ActiveMQ journal

### DIFF
--- a/server/src/main/java/org/candlepin/audit/QpidEventMessageReceiver.java
+++ b/server/src/main/java/org/candlepin/audit/QpidEventMessageReceiver.java
@@ -70,12 +70,10 @@ public class QpidEventMessageReceiver extends MessageReceiver {
         }
         catch (Exception e) {
             log.debug("Message listener {} processed message: {} [{}]: FAILED", listener, msgId, origMsgId);
-            // Log a small message instead of a full stack trace to reduce log size.
-            String reason = (e.getCause() == null) ? e.getMessage() : e.getCause().getMessage();
-            log.error("Unable to process message {}[{}]: {}", msgId, origMsgId, reason);
+            log.error("Unable to process message {}[{}]: {}", msgId, origMsgId, e);
 
             // If debugging is enabled log a more in depth message.
-            log.debug("Unable to process message. Rolling back client session.\n{}", body, e);
+            log.debug("Unable to process message. Rolling back client session.\n{}", body);
 
             // Since we are closing the Consumer whenever Qpid is in trouble (when notified)
             // we do not want to roll back as the message will get resent when the Client


### PR DESCRIPTION
- Minor logging change to print stack trace