### PR TITLE
[2.7] 1753256: ActiveMQContextListener no longer attempts to load DatabaseListener

### DIFF
--- a/server/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/server/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -298,7 +298,6 @@ public class ConfigProperties {
             this.put(ACTIVEMQ_CONNECTION_MONITOR_INTERVAL, "5000"); // milliseconds
 
             this.put(AUDIT_LISTENERS,
-                "org.candlepin.audit.DatabaseListener," +
                 "org.candlepin.audit.LoggingListener," +
                 "org.candlepin.audit.ActivationListener");
             this.put(AUDIT_FILTER_ENABLED, "false");


### PR DESCRIPTION
- Updated default configuration to no longer attempt to load the
  removed DatabaseListener class