### PR TITLE
[F] ENT-1610: Add Branding to Product model

### DIFF
--- a/server/client/ruby/candlepin_api.rb
+++ b/server/client/ruby/candlepin_api.rb
@@ -790,6 +790,7 @@ class Candlepin
     multiplier = params[:multiplier] || 1
     attributes = params[:attributes] || {}
     dependentProductIds = params[:dependentProductIds] || []
+    branding = params[:branding] || []
     relies_on = params[:relies_on] || []
 
     #if product don't have type attributes, create_product will fail on server
@@ -801,6 +802,7 @@ class Candlepin
       'multiplier' => multiplier,
       'attributes' => attributes,
       'dependentProductIds' => dependentProductIds,
+      'branding' => branding,
       'reliesOn' => relies_on
     }
 
@@ -816,6 +818,7 @@ class Candlepin
     product[:multiplier] = params[:multiplier] if params[:multiplier]
     product[:attributes] = params[:attributes] if params[:attributes]
     product[:dependentProductIds] = params[:dependentProductIds] if params[:dependentProductIds]
+    product[:branding] = params[:branding] if params[:branding]
     product[:relies_on] = params[:relies_on] if params[:relies_on]
 
     put("/owners/#{owner_key}/products/#{product_id}", {}, product)

--- a/server/src/main/java/org/candlepin/controller/ProductManager.java
+++ b/server/src/main/java/org/candlepin/controller/ProductManager.java
@@ -14,7 +14,7 @@
  */
 package org.candlepin.controller;
 
-import org.candlepin.dto.ModelTranslator;
+import org.candlepin.dto.api.v1.BrandingDTO;
 import org.candlepin.dto.api.v1.ContentDTO;
 import org.candlepin.dto.api.v1.ProductDTO;
 import org.candlepin.dto.api.v1.ProductDTO.ProductContentDTO;
@@ -24,8 +24,10 @@ import org.candlepin.model.OwnerContentCurator;
 import org.candlepin.model.OwnerProduct;
 import org.candlepin.model.OwnerProductCurator;
 import org.candlepin.model.Product;
+import org.candlepin.model.ProductBranding;
 import org.candlepin.model.ProductContent;
 import org.candlepin.model.ProductCurator;
+import org.candlepin.pinsetter.tasks.OrphanCleanupJob;
 import org.candlepin.service.model.ContentInfo;
 import org.candlepin.service.model.ProductContentInfo;
 import org.candlepin.service.model.ProductInfo;
@@ -36,6 +38,7 @@ import org.candlepin.util.Util;
 import com.google.inject.Inject;
 import com.google.inject.persist.Transactional;
 
+import org.apache.commons.lang.builder.EqualsBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,11 +47,12 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-
+import java.util.Set;
 
 
 /**
@@ -66,18 +70,16 @@ public class ProductManager {
     private OwnerContentCurator ownerContentCurator;
     private OwnerProductCurator ownerProductCurator;
     private ProductCurator productCurator;
-    private ModelTranslator modelTranslator;
 
     @Inject
     public ProductManager(EntitlementCertificateGenerator entitlementCertGenerator,
         OwnerContentCurator ownerContentCurator, OwnerProductCurator ownerProductCurator,
-        ProductCurator productCurator, ModelTranslator modelTranslator) {
+        ProductCurator productCurator) {
 
         this.entitlementCertGenerator = entitlementCertGenerator;
         this.ownerContentCurator = ownerContentCurator;
         this.ownerProductCurator = ownerProductCurator;
         this.productCurator = productCurator;
-        this.modelTranslator = modelTranslator;
     }
 
     /**
@@ -122,7 +124,7 @@ public class ProductManager {
 
         // Check if we have an alternate version we can use instead.
         List<Product> alternateVersions = this.ownerProductCurator.getProductsByVersions(
-            owner, Collections.<String, Integer>singletonMap(entity.getId(), entity.getEntityVersion()))
+            owner, Collections.singletonMap(entity.getId(), entity.getEntityVersion()))
             .list();
 
         for (Product alt : alternateVersions) {
@@ -190,7 +192,7 @@ public class ProductManager {
         }
 
         // Make sure we actually have a change to apply
-        if (!this.isChangedBy(entity, update)) {
+        if (!isChangedBy(entity, update)) {
             return entity;
         }
 
@@ -203,7 +205,7 @@ public class ProductManager {
         // their own version.
         // This is probably going to be a very expensive operation, though.
         List<Product> alternateVersions = this.ownerProductCurator.getProductsByVersions(
-            owner, Collections.<String, Integer>singletonMap(updated.getId(), updated.getEntityVersion()))
+            owner, Collections.singletonMap(updated.getId(), updated.getEntityVersion()))
             .list();
 
         log.debug("Checking {} alternate product versions", alternateVersions.size());
@@ -317,7 +319,7 @@ public class ProductManager {
         for (Product product : this.ownerProductCurator.getProductsByIds(owner, productData.keySet())) {
             ProductInfo update = productData.get(product.getId());
 
-            if (product.isLocked() && !this.isChangedBy(product, update)) {
+            if (product.isLocked() && !isChangedBy(product, update)) {
                 // This product won't be changing, so we'll just pretend it's not being imported at all
                 skippedProducts.put(product.getId(), product);
                 continue;
@@ -451,6 +453,9 @@ public class ProductManager {
      * owners, the product will not actually be deleted, but, instead, will simply by removed from
      * the given owner's visibility.
      *
+     * If the product is/ends up not being shared by any owners, then it will be removed by the
+     * {@link OrphanCleanupJob} which runs periodically.
+     *
      * @param owner
      *  The owner for which to remove the product
      *
@@ -484,8 +489,10 @@ public class ProductManager {
     }
 
     /**
-     * Removes all products from the specified owner. Products which are shared will have any
-     * references to the owner removed, while unshared products will be deleted entirely.
+     * Removes all products from the specified owner.
+     *
+     * Products will have any references to the owner removed. Unreferenced products are not removed by
+     * this method, but by the {@link OrphanCleanupJob} which runs periodically.
      *
      * @param owner
      *  The owner from which to remove all products
@@ -499,8 +506,10 @@ public class ProductManager {
     }
 
     /**
-     * Removes the specified products from the given owner. Products which are shared will have any
-     * references to the owner removed, while unshared products will be deleted entirely.
+     * Removes the specified products from the given owner.
+     *
+     * Products will have any references to the owner removed. Unreferenced products are not removed by
+     * this method, but by the {@link OrphanCleanupJob} which runs periodically.
      *
      * @param owner
      *  The owner from which to remove products
@@ -526,8 +535,10 @@ public class ProductManager {
     }
 
     /**
-     * Removes the specified products from the given owner. Products which are shared will have any
-     * references to the owner removed, while unshared products will be deleted entirely.
+     * Removes the specified products from the given owner.
+     *
+     * Products will have any references to the owner removed. Unreferenced products are not removed by
+     * this method, but by the {@link OrphanCleanupJob} which runs periodically.
      *
      * @param owner
      *  The owner from which to remove products
@@ -562,8 +573,8 @@ public class ProductManager {
      * @param update
      *  The DTO containing the modifications to apply
      *
-     * @param content
-     *  A mapping of Red Hat content ID to content entities to use for content resolution
+     * @param owner
+     *  An owner to use for resolving entity references
      *
      * @throws IllegalArgumentException
      *  if entity, update or owner is null
@@ -607,7 +618,7 @@ public class ProductManager {
      * @param update
      *  The DTO containing the modifications to apply
      *
-     * @param content
+     * @param contentMap
      *  A mapping of Red Hat content ID to content entities to use for content resolution
      *
      * @throws IllegalArgumentException
@@ -706,6 +717,25 @@ public class ProductManager {
             entity.setDependentProductIds(update.getDependentProductIds());
         }
 
+        if (update.getBranding() != null) {
+            if (update.getBranding().isEmpty()) {
+                entity.setBranding(Collections.emptySet());
+            }
+            else {
+                Set<ProductBranding> branding = new HashSet<>();
+                for (BrandingDTO brandingDTO : update.getBranding()) {
+                    if (brandingDTO != null) {
+                        branding.add(new ProductBranding(
+                            brandingDTO.getProductId(),
+                            brandingDTO.getType(),
+                            brandingDTO.getName(),
+                            entity));
+                    }
+                }
+                entity.setBranding(branding);
+            }
+        }
+
         return entity;
     }
 
@@ -713,6 +743,9 @@ public class ProductManager {
     /**
      * Determines whether or not this entity would be changed if the given DTO were applied to this
      * object.
+     *
+     * @param entity
+     *  The product entity that would be changed
      *
      * @param dto
      *  The product DTO to check for changes
@@ -757,37 +790,59 @@ public class ProductManager {
 
         Collection<ProductContentDTO> productContent = dto.getProductContent();
         if (productContent != null) {
-            Comparator comparator = new Comparator() {
-                public int compare(Object lhs, Object rhs) {
-                    ProductContent existing = (ProductContent) lhs;
-                    ProductContentDTO update = (ProductContentDTO) rhs;
+            Comparator comparator = (lhs, rhs) -> {
+                ProductContent existing = (ProductContent) lhs;
+                ProductContentDTO update = (ProductContentDTO) rhs;
 
-                    if (existing != null && update != null) {
-                        Content content = existing.getContent();
-                        ContentDTO cdto = update.getContent();
+                if (existing != null && update != null) {
+                    Content content = existing.getContent();
+                    ContentDTO cdto = update.getContent();
 
-                        if (content != null && cdto != null) {
-                            if (cdto.getUuid() != null ?
-                                cdto.getUuid().equals(content.getUuid()) :
-                                (cdto.getId() != null && cdto.getId().equals(content.getId()))) {
-                                // At this point, we've either matched the UUIDs (which means we're
-                                // referencing identical products) or the UUID isn't present on the DTO, but
-                                // the IDs match (which means we're pointing toward the same product).
+                    if (content != null && cdto != null) {
+                        if (cdto.getUuid() != null ?
+                            cdto.getUuid().equals(content.getUuid()) :
+                            (cdto.getId() != null && cdto.getId().equals(content.getId()))) {
+                            // At this point, we've either matched the UUIDs (which means we're
+                            // referencing identical products) or the UUID isn't present on the DTO, but
+                            // the IDs match (which means we're pointing toward the same product).
 
-                                return (update.isEnabled() != null &&
-                                    !update.isEnabled().equals(existing.isEnabled())) ||
-                                    ContentManager.isChangedBy(content, cdto) ? 1 : 0;
-                            }
+                            return (update.isEnabled() != null &&
+                                !update.isEnabled().equals(existing.isEnabled())) ||
+                                ContentManager.isChangedBy(content, cdto) ? 1 : 0;
                         }
                     }
-
-                    return 1;
                 }
+
+                return 1;
             };
 
             if (!Util.collectionsAreEqual((Collection) entity.getProductContent(),
                 (Collection) productContent, comparator)) {
 
+                return true;
+            }
+        }
+
+        Collection<BrandingDTO> brandingDTOs = dto.getBranding();
+        if (brandingDTOs != null) {
+            Comparator comparator = (lhs, rhs) -> {
+                ProductBranding existing = (ProductBranding) lhs;
+                BrandingDTO update = (BrandingDTO) rhs;
+
+                if (existing != null && update != null) {
+                    boolean equals = new EqualsBuilder()
+                        .append(existing.getProductId(), update.getProductId())
+                        .append(existing.getName(), update.getName())
+                        .append(existing.getType(), update.getType())
+                        .isEquals();
+                    return equals ? 0 : 1;
+                }
+
+                return 1;
+            };
+
+            if (!Util.collectionsAreEqual((Collection) entity.getBranding(), (Collection) brandingDTOs,
+                comparator)) {
                 return true;
             }
         }
@@ -798,6 +853,9 @@ public class ProductManager {
     /**
      * Determines whether or not this entity would be changed if the given update were applied to
      * this object.
+     *
+     * @param entity
+     *  The product entity that would be changed
      *
      * @param update
      *  The product info to check for changes
@@ -886,7 +944,7 @@ public class ProductManager {
      * @param update
      *  The ProductInfo containing the modifications to apply
      *
-     * @param content
+     * @param contentMap
      *  A mapping of Red Hat content ID to content entities to use for content resolution
      *
      * @throws IllegalArgumentException

--- a/server/src/main/java/org/candlepin/dto/StandardTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/StandardTranslator.java
@@ -58,6 +58,7 @@ import org.candlepin.dto.api.v1.PermissionBlueprintTranslator;
 import org.candlepin.dto.api.v1.PermissionBlueprintInfoTranslator;
 import org.candlepin.dto.api.v1.PoolQuantityDTO;
 import org.candlepin.dto.api.v1.PoolQuantityTranslator;
+import org.candlepin.dto.api.v1.ProductBrandingTranslator;
 import org.candlepin.dto.api.v1.ProductCertificateDTO;
 import org.candlepin.dto.api.v1.ProductCertificateTranslator;
 import org.candlepin.dto.api.v1.ProductDTO;
@@ -104,6 +105,7 @@ import org.candlepin.model.PermissionBlueprint;
 import org.candlepin.model.Pool;
 import org.candlepin.model.PoolQuantity;
 import org.candlepin.model.Product;
+import org.candlepin.model.ProductBranding;
 import org.candlepin.model.ProductCertificate;
 import org.candlepin.model.Role;
 import org.candlepin.model.UeberCertificate;
@@ -139,6 +141,8 @@ public class StandardTranslator extends SimpleModelTranslator {
             new ActivationKeyTranslator(), ActivationKey.class, ActivationKeyDTO.class);
         this.registerTranslator(
             new BrandingTranslator(), Branding.class, BrandingDTO.class);
+        this.registerTranslator(
+            new ProductBrandingTranslator(), ProductBranding.class, BrandingDTO.class);
         this.registerTranslator(
             new CapabilityTranslator(), ConsumerCapability.class, CapabilityDTO.class);
         this.registerTranslator(

--- a/server/src/main/java/org/candlepin/dto/api/v1/BrandingDTO.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/BrandingDTO.java
@@ -24,8 +24,7 @@ import javax.xml.bind.annotation.XmlAccessorType;
 
 
 /**
- * A DTO representation of the Branding entity used internally by
- * other DTO entities, like PoolDTO and SubscriptionDTO.
+ * A DTO representation of the Branding entity used internally by ProductDTO.
  */
 @XmlAccessorType(XmlAccessType.PROPERTY)
 public class BrandingDTO extends TimestampedCandlepinDTO<BrandingDTO> {

--- a/server/src/main/java/org/candlepin/dto/api/v1/ProductBrandingTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/ProductBrandingTranslator.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.dto.api.v1;
+
+import org.candlepin.dto.ModelTranslator;
+import org.candlepin.dto.TimestampedEntityTranslator;
+import org.candlepin.model.ProductBranding;
+
+/**
+ * The ProductBrandingTranslator provides translation from ProductBranding model objects to BrandingDTOs
+ */
+public class ProductBrandingTranslator extends TimestampedEntityTranslator<ProductBranding, BrandingDTO> {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public BrandingDTO translate(ProductBranding source) {
+        return this.translate(null, source);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public BrandingDTO translate(ModelTranslator translator, ProductBranding source) {
+        return source != null ? this.populate(translator, source, new BrandingDTO()) : null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public BrandingDTO populate(ProductBranding source, BrandingDTO destination) {
+        return this.populate(null, source, destination);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public BrandingDTO populate(ModelTranslator modelTranslator, ProductBranding source, BrandingDTO dest) {
+        dest = super.populate(modelTranslator, source, dest);
+
+        dest.setProductId(source.getProductId());
+        dest.setName(source.getName());
+        dest.setType(source.getType());
+
+        return dest;
+    }
+}

--- a/server/src/main/java/org/candlepin/dto/api/v1/ProductDTO.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/ProductDTO.java
@@ -166,6 +166,8 @@ public class ProductDTO extends TimestampedCandlepinDTO<ProductDTO> implements P
     @ApiModelProperty(hidden = true)
     protected Boolean locked;
 
+    protected Set<BrandingDTO> branding;
+
     /**
      * Initializes a new ProductDTO instance with null values.
      */
@@ -835,6 +837,86 @@ public class ProductDTO extends TimestampedCandlepinDTO<ProductDTO> implements P
         return this;
     }
 
+    /**
+     * Retrieves a view of the branding for the product represented by this DTO. If the branding items
+     * have not yet been defined, this method returns null.
+     * <p></p>
+     * Note that the collection returned by this method is a view of the collection backing this
+     * set of branding items. Elements cannot be added to the collection, but elements may be removed.
+     * Changes made to the collection will be reflected by this product DTO instance.
+     *
+     * @return
+     *  the branding items associated with this key, or null if they have not yet been defined
+     */
+    public Set<BrandingDTO> getBranding() {
+        return this.branding != null ? new SetView<>(this.branding) : null;
+    }
+
+    /**
+     * Adds the collection of branding items to this Product DTO.
+     *
+     * @param branding
+     *  A set of branding items to attach to this DTO, or null to clear the existing ones
+     *
+     * @return
+     *  A reference to this DTO
+     */
+    public ProductDTO setBranding(Set<BrandingDTO> branding) {
+        if (branding != null) {
+            if (this.branding == null) {
+                this.branding = new HashSet<>();
+            }
+            else {
+                this.branding.clear();
+            }
+
+            for (BrandingDTO dto : branding) {
+                if (isNullOrIncomplete(dto)) {
+                    throw new IllegalArgumentException(
+                        "collection contains null or incomplete branding objects");
+                }
+            }
+
+            this.branding.addAll(branding);
+        }
+        else {
+            this.branding = null;
+        }
+        return this;
+    }
+
+    /**
+     * Adds the given branding to this product DTO.
+     *
+     * @param branding
+     *  The branding to add to this product DTO.
+     *
+     * @return
+     *  true if this branding was not already contained in this product DTO.
+     */
+    @JsonIgnore
+    public boolean addBranding(BrandingDTO branding) {
+        if (isNullOrIncomplete(branding)) {
+            throw new IllegalArgumentException("branding is null or incomplete");
+        }
+
+        if (this.branding == null) {
+            this.branding = new HashSet<>();
+        }
+
+        return this.branding.add(branding);
+    }
+
+    /**
+     * Utility method to validate BrandingDTO input
+     */
+    private boolean isNullOrIncomplete(BrandingDTO branding) {
+        return branding == null ||
+            branding.getProductId() == null || branding.getProductId().isEmpty() ||
+            branding.getName() == null || branding.getName().isEmpty() ||
+            branding.getType() == null || branding.getType().isEmpty();
+    }
+
     @Override
     public String toString() {
         return String.format("ProductDTO [id = %s, name = %s]", this.id, this.name);
@@ -857,7 +939,8 @@ public class ProductDTO extends TimestampedCandlepinDTO<ProductDTO> implements P
                 .append(this.getAttributes(), that.getAttributes())
                 .append(this.getDependentProductIds(), that.getDependentProductIds())
                 .append(this.getHref(), that.getHref())
-                .append(this.isLocked(), that.isLocked());
+                .append(this.isLocked(), that.isLocked())
+                .append(this.getBranding(), that.getBranding());
 
             // As with many collections here, we need to explicitly check the elements ourselves,
             // since it seems very common for collection implementations to not properly implement
@@ -898,6 +981,7 @@ public class ProductDTO extends TimestampedCandlepinDTO<ProductDTO> implements P
             .append(this.getAttributes())
             .append(this.getDependentProductIds())
             .append(this.isLocked())
+            .append(this.getBranding())
             .append(pcHashCode);
 
         return builder.toHashCode();
@@ -910,6 +994,7 @@ public class ProductDTO extends TimestampedCandlepinDTO<ProductDTO> implements P
         copy.setAttributes(this.getAttributes());
         copy.setProductContent(this.getProductContent());
         copy.setDependentProductIds(this.getDependentProductIds());
+        copy.setBranding(this.getBranding());
 
         return copy;
     }
@@ -940,6 +1025,7 @@ public class ProductDTO extends TimestampedCandlepinDTO<ProductDTO> implements P
         this.setDependentProductIds(source.getDependentProductIds());
         this.setHref(source.getHref());
         this.setLocked(source.isLocked());
+        this.setBranding(source.getBranding());
 
         return this;
     }

--- a/server/src/main/java/org/candlepin/dto/api/v1/ProductTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/ProductTranslator.java
@@ -17,9 +17,9 @@ package org.candlepin.dto.api.v1;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.dto.ObjectTranslator;
 import org.candlepin.dto.TimestampedEntityTranslator;
-import org.candlepin.dto.api.v1.ProductDTO.ProductContentDTO;
 import org.candlepin.model.Content;
 import org.candlepin.model.Product;
+import org.candlepin.model.ProductBranding;
 import org.candlepin.model.ProductContent;
 
 import java.util.Collection;
@@ -74,7 +74,7 @@ public class ProductTranslator extends TimestampedEntityTranslator<Product, Prod
 
         if (modelTranslator != null) {
             Collection<ProductContent> productContent = source.getProductContent();
-            destination.setProductContent(Collections.<ProductContentDTO>emptyList());
+            destination.setProductContent(Collections.emptyList());
 
             if (productContent != null) {
                 ObjectTranslator<Content, ContentDTO> contentTranslator = modelTranslator
@@ -90,9 +90,22 @@ public class ProductTranslator extends TimestampedEntityTranslator<Product, Prod
                     }
                 }
             }
+
+            Collection<ProductBranding> branding = source.getBranding();
+            if (branding != null && !branding.isEmpty()) {
+                for (ProductBranding brand : branding) {
+                    if (brand != null) {
+                        destination.addBranding(modelTranslator.translate(brand, BrandingDTO.class));
+                    }
+                }
+            }
+            else {
+                destination.setBranding(Collections.emptySet());
+            }
         }
         else {
-            destination.setProductContent(Collections.<ProductContentDTO>emptyList());
+            destination.setProductContent(Collections.emptyList());
+            destination.setBranding(Collections.emptySet());
         }
 
         return destination;

--- a/server/src/main/java/org/candlepin/model/Product.java
+++ b/server/src/main/java/org/candlepin/model/Product.java
@@ -59,13 +59,13 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.StringTokenizer;
 
@@ -245,10 +245,18 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
     @Type(type = "org.hibernate.type.NumericBooleanType")
     private boolean locked;
 
+    @OneToMany(mappedBy = "product")
+    @Cascade({org.hibernate.annotations.CascadeType.ALL})
+    @BatchSize(size = 1000)
+    @Cache(usage = CacheConcurrencyStrategy.READ_ONLY)
+    @Immutable
+    private Set<ProductBranding> branding;
+
     public Product() {
         this.attributes = new HashMap<>();
         this.productContent = new LinkedList<>();
         this.dependentProductIds = new HashSet<>();
+        this.branding = new HashSet<>();
     }
 
     /**
@@ -323,6 +331,8 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
         this.setCreated(source.getCreated() != null ? (Date) source.getCreated().clone() : null);
         this.setUpdated(source.getUpdated() != null ? (Date) source.getUpdated().clone() : null);
         this.setLocked(source.isLocked());
+
+        this.setBranding(source.getBranding());
     }
 
     /**
@@ -368,6 +378,8 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
 
         this.setUpdated(source.getUpdated() != null ? (Date) source.getUpdated().clone() : null);
 
+        this.setBranding(source.getBranding());
+
         return this;
     }
 
@@ -408,6 +420,9 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
 
         copy.setCreated(this.getCreated() != null ? (Date) this.getCreated().clone() : null);
         copy.setUpdated(this.getUpdated() != null ? (Date) this.getUpdated().clone() : null);
+
+        copy.branding = new HashSet<>();
+        copy.setBranding(this.branding);
 
         return copy;
     }
@@ -640,6 +655,95 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
         }
 
         return this;
+    }
+
+    /**
+     * Retrieves a collection of branding for this product. If the brandings have not
+     * yet been defined, this method returns an empty collection.
+     *
+     * @return
+     *  the brandings of this product
+     */
+    public Collection<ProductBranding> getBranding() {
+        return new SetView<>(branding);
+    }
+
+    /**
+     * Sets the brandings of this product.
+     *
+     * @param branding
+     *  A collection of brandings to attach to this product, or null to clear the brandings
+     *
+     * @return
+     *  a reference to this product
+     */
+    public Product setBranding(Collection<ProductBranding> branding) {
+        this.branding.clear();
+
+        if (branding != null) {
+            for (ProductBranding brand : branding) {
+                this.addBranding(brand);
+            }
+        }
+
+        return this;
+    }
+
+    /**
+     * Adds the specified branding as one of the brandings of this product. If the branding
+     * is already there, it will not be added again.
+     *
+     * @param branding
+     *  The branding to add
+     *
+     * @throws IllegalArgumentException
+     *  if branding is null
+     *
+     * @return
+     *  true if the branding was added successfully; false otherwise
+     */
+    public boolean addBranding(ProductBranding branding) {
+        if (branding == null) {
+            throw new IllegalArgumentException("branding is null");
+        }
+
+        branding.setProduct(this);
+        return this.branding.add(branding);
+    }
+
+    /**
+     * Removes the branding represented by the given branding entity from this product. Any branding
+     * with the same ID as the ID of the given branding entity will be removed.
+     *
+     * @param branding
+     *  The branding entity representing the branding to remove from this product
+     *
+     * @throws IllegalArgumentException
+     *  if branding is null or has null id
+     *
+     * @return
+     *  true if the branding was removed successfully; false otherwise
+     */
+    public boolean removeBranding(ProductBranding branding) {
+        if (branding == null) {
+            throw new IllegalArgumentException("branding is null");
+        }
+
+        if (branding.getId() == null) {
+            throw new IllegalArgumentException("branding id is null");
+        }
+
+        Collection<ProductBranding> remove = new LinkedList<>();
+
+        for (ProductBranding pb : this.branding) {
+
+            if (pb != null && branding.getId().equals(pb.getId())) {
+                pb.setProduct(null);
+                remove.add(pb);
+            }
+        }
+
+        return this.branding.removeAll(remove);
     }
 
     @XmlTransient
@@ -1080,13 +1184,11 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
 
             // Compare content UUIDs
             equals = equals && Util.collectionsAreEqual(this.productContent, that.productContent,
-                    new Comparator<ProductContent>() {
-                        public int compare(ProductContent pc1, ProductContent pc2) {
-                            // We're assuming the collections are well-formed and won't contain null
-                            // objects, but we'll verify that just in case they do.
-                            return pc1 == pc2 || (pc1 != null && pc1.equals(pc2)) ? 0 : 1;
-                        }
-                    });
+                (pc1, pc2) -> Objects.equals(pc1, pc2) ? 0 : 1);
+
+            // Compare branding collections
+            equals = equals && Util.collectionsAreEqual(this.branding, that.branding,
+                (b1, b2) -> Objects.equals(b1, b2) ? 0 : 1);
         }
 
         return equals;
@@ -1120,7 +1222,7 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
         // again, doesn't implement .hashCode reliably on the proxy collections. So, we have to
         // manually step through these and add the elements to ensure the hash code is
         // generated properly.
-        int accumulator = 0;
+        int accumulator;
 
         if (!this.dependentProductIds.isEmpty()) {
             accumulator = 0;
@@ -1135,6 +1237,15 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
             accumulator = 0;
             for (ProductContent pc : this.productContent) {
                 accumulator += (pc != null ? pc.getEntityVersion() : 0);
+            }
+
+            builder.append(accumulator);
+        }
+
+        if (!this.branding.isEmpty()) {
+            accumulator = 0;
+            for (ProductBranding branding : this.branding) {
+                accumulator += (branding != null ? branding.hashCode() : 0);
             }
 
             builder.append(accumulator);

--- a/server/src/main/java/org/candlepin/model/ProductBranding.java
+++ b/server/src/main/java/org/candlepin/model/ProductBranding.java
@@ -1,0 +1,196 @@
+/**
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.model;
+
+import org.candlepin.service.model.BrandingInfo;
+
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Immutable;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+
+
+/**
+ * Brand mapping is carried on subscription data and passed to clients through entitlement
+ * certificates. It indicates that a particular engineering product ID is being rebranded
+ * by the entitlement to the given name. The type is used by clients to determine what
+ * action to take with the brand name.
+ *
+ * NOTE: Presently only type "OS" is supported client side.
+ *
+ */
+@Entity
+@Immutable
+@Table(name = ProductBranding.DB_TABLE)
+public class ProductBranding extends AbstractHibernateObject<ProductBranding> implements BrandingInfo {
+
+    /** Name of the table backing this object in the database */
+    public static final String DB_TABLE = "cp2_product_branding";
+
+    @Id
+    @GeneratedValue(generator = "system-uuid")
+    @GenericGenerator(name = "system-uuid", strategy = "uuid")
+    @Column(length = 37)
+    @NotNull
+    private String id;
+
+    @Column(name = "product_id", nullable = false)
+    @NotNull
+    @Size(max = 255)
+    private String productId;
+
+    @Column(nullable = false)
+    @NotNull
+    @Size(max = 255)
+    private String name;
+
+    @Column(nullable = false)
+    @NotNull
+    @Size(max = 32)
+    private String type;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_uuid")
+    private Product product;
+
+    public ProductBranding() {
+        // Intentionally left empty
+    }
+
+    public ProductBranding(String productId, String type, String name, Product parent) {
+        this.productId = productId;
+        this.type = type;
+        this.name = name;
+        this.product = parent;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+     * Returns the engineering product ID we are rebranding.
+     *
+     * @return The engineering product ID we are rebranding, *if* it is installed on the
+     * client. Candlepin will always send down the brand mapping for a subscription, the
+     * client is responsible for determining if it should be applied or not, and how.
+     */
+    @Override
+    public String getProductId() {
+        return productId;
+    }
+
+    public void setProductId(String productId) {
+        this.productId = productId;
+    }
+
+    /**
+     * @return The brand name to be applied.
+     */
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     *
+     * @return The type of this branding. (i.e. "OS") Clients use this value to determine
+     * what action should be taken with the branding information.
+     */
+    @Override
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    /**
+     * Returns the parent marketing product that this branding belongs to.
+     *
+     * @return A reference to the marketing product who is the parent of this branding.
+     */
+    public Product getProduct() {
+        return product;
+    }
+
+    /**
+     * Sets the parent marketing product that this branding belongs to.
+     */
+    public void setProduct(Product product) {
+        this.product = product;
+    }
+
+    @Override
+    public boolean equals(Object anObject) {
+        if (this == anObject) {
+            return true;
+        }
+
+        if (!(anObject instanceof ProductBranding)) {
+            return false;
+        }
+
+        ProductBranding that = (ProductBranding) anObject;
+
+        // We're only interested in ensuring the mapping between the two objects is the same.
+        String thisProductUuid = this.getProduct() != null ? this.getProduct().getUuid() : null;
+        String thatProductUuid = that.getProduct() != null ? that.getProduct().getUuid() : null;
+
+        return new EqualsBuilder()
+            .append(this.name, that.name)
+            .append(this.productId, that.productId)
+            .append(this.type, that.type)
+            .append(thisProductUuid, thatProductUuid)
+            .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(129, 15)
+            .append(this.name)
+            .append(this.productId)
+            .append(this.type)
+            .append(this.getProduct() != null ? this.getProduct().getUuid() : null)
+            .toHashCode();
+    }
+
+    @Override
+    public String toString() {
+        return String.format("ProductBranding [id: %s, name: %s, productId: %s, type: %s]",
+            this.getId(), this.getName(), this.getProductId(), this.getType());
+    }
+}

--- a/server/src/main/java/org/candlepin/model/ProductCurator.java
+++ b/server/src/main/java/org/candlepin/model/ProductCurator.java
@@ -330,6 +330,19 @@ public class ProductCurator extends AbstractHibernateCurator<Product> {
             }
         }
 
+        if (entity.getBranding() != null) {
+            for (ProductBranding brand : entity.getBranding()) {
+                if (brand.getProductId() == null ||
+                    brand.getName() == null ||
+                    brand.getType() == null) {
+                    throw new IllegalStateException(
+                        "Product contains a Branding with a null product id, name or type.");
+                }
+
+                brand.setProduct(entity);
+            }
+        }
+
         // TODO: Add more reference checks here.
 
         return entity;

--- a/server/src/main/resources/db/changelog/20190919132617-create-product-branding-join-table.xml
+++ b/server/src/main/resources/db/changelog/20190919132617-create-product-branding-join-table.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="20190919132617-1" author="nmoumoul">
+        <comment>Create table for product branding.</comment>
+
+        <createTable tableName="cp2_product_branding">
+            <column name="id" type="VARCHAR(32)">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="cp2_product_branding_pkey"/>
+            </column>
+            <column name="created" type="${timestamp.type}"/>
+            <column name="updated" type="${timestamp.type}"/>
+
+            <column name="product_id" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="type" type="VARCHAR(32)">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="product_uuid" type="VARCHAR(32)">
+                <constraints nullable="false" />
+            </column>
+        </createTable>
+
+        <addForeignKeyConstraint
+                baseTableName="cp2_product_branding"
+                baseColumnNames="product_uuid"
+                constraintName="cp2_product_branding_fk1"
+                deferrable="false"
+                initiallyDeferred="false"
+                onDelete="CASCADE"
+                onUpdate="NO ACTION"
+                referencedColumnNames="uuid"
+                referencedTableName="cp2_products"
+                referencesUniqueColumn="false" />
+    </changeSet>
+
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/server/src/main/resources/db/changelog/changelog-create.xml
+++ b/server/src/main/resources/db/changelog/changelog-create.xml
@@ -1233,4 +1233,5 @@
     <include file="db/changelog/20190717140948-delete-cp-events-table.xml"/>
     <include file="db/changelog/20190729122218-add-locked-column-to-cp-pool.xml"/>
     <include file="db/changelog/20190813155224-add-principal-to-deleted-consumers.xml"/>
+    <include file="db/changelog/20190919132617-create-product-branding-join-table.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-testing.xml
+++ b/server/src/main/resources/db/changelog/changelog-testing.xml
@@ -2325,4 +2325,5 @@
     <include file="db/changelog/20190717140948-delete-cp-events-table.xml"/>
     <include file="db/changelog/20190729122218-add-locked-column-to-cp-pool.xml"/>
     <include file="db/changelog/20190813155224-add-principal-to-deleted-consumers.xml"/>
+    <include file="db/changelog/20190919132617-create-product-branding-join-table.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-update.xml
+++ b/server/src/main/resources/db/changelog/changelog-update.xml
@@ -142,4 +142,5 @@
     <include file="db/changelog/20190717140948-delete-cp-events-table.xml"/>
     <include file="db/changelog/20190729122218-add-locked-column-to-cp-pool.xml"/>
     <include file="db/changelog/20190813155224-add-principal-to-deleted-consumers.xml"/>
+    <include file="db/changelog/20190919132617-create-product-branding-join-table.xml"/>
 </databaseChangeLog>

--- a/server/src/test/java/org/candlepin/controller/ContentManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/ContentManagerTest.java
@@ -47,7 +47,7 @@ public class ContentManagerTest extends DatabaseTestFixture {
 
         this.productManager = new ProductManager(
             this.mockEntCertGenerator, this.ownerContentCurator, this.ownerProductCurator,
-            this.productCurator, this.modelTranslator);
+            this.productCurator);
 
         this.contentManager = new ContentManager(
             this.contentCurator, this.mockEntCertGenerator, this.ownerContentCurator,

--- a/server/src/test/java/org/candlepin/dto/api/v1/ProductBrandingTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/ProductBrandingTranslatorTest.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.dto.api.v1;
+
+import org.candlepin.dto.AbstractTranslatorTest;
+import org.candlepin.dto.ModelTranslator;
+import org.candlepin.model.ProductBranding;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Test suite for the ProductBrandingTranslator class
+ */
+public class ProductBrandingTranslatorTest extends
+    AbstractTranslatorTest<ProductBranding, BrandingDTO, ProductBrandingTranslator> {
+
+    protected ProductBrandingTranslator translator = new ProductBrandingTranslator();
+
+    @Override
+    protected void initModelTranslator(ModelTranslator modelTranslator) {
+        modelTranslator.registerTranslator(this.translator, ProductBranding.class, BrandingDTO.class);
+    }
+
+    @Override
+    protected ProductBrandingTranslator initObjectTranslator() {
+        return this.translator;
+    }
+
+    @Override
+    protected ProductBranding initSourceObject() {
+        ProductBranding source = new ProductBranding();
+
+        source.setProductId("test-product-id");
+        source.setName("test-name");
+        source.setType("test-type");
+
+        return source;
+    }
+
+    @Override
+    protected BrandingDTO initDestinationObject() {
+        return new BrandingDTO();
+    }
+
+    @Override
+    protected void verifyOutput(ProductBranding source, BrandingDTO dest, boolean childrenGenerated) {
+        if (source != null) {
+            assertEquals(source.getProductId(), dest.getProductId());
+            assertEquals(source.getName(), dest.getName());
+            assertEquals(source.getType(), dest.getType());
+        }
+        else {
+            assertNull(dest);
+        }
+    }
+}

--- a/server/src/test/java/org/candlepin/dto/api/v1/ProductCertificateTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/ProductCertificateTranslatorTest.java
@@ -36,6 +36,8 @@ public class ProductCertificateTranslatorTest extends
 
     @Override
     protected void initModelTranslator(ModelTranslator modelTranslator) {
+        this.productTranslatorTest.initModelTranslator(modelTranslator);
+
         modelTranslator.registerTranslator(
             this.translator, ProductCertificate.class, ProductCertificateDTO.class);
         modelTranslator.registerTranslator(new ProductTranslator(), Product.class, ProductDTO.class);

--- a/server/src/test/java/org/candlepin/dto/api/v1/ProductDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/ProductDTOTest.java
@@ -14,17 +14,18 @@
  */
 package org.candlepin.dto.api.v1;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.candlepin.dto.AbstractDTOTest;
 import org.candlepin.dto.api.v1.ProductDTO.ProductContentDTO;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Map;
 
@@ -63,6 +64,15 @@ public class ProductDTOTest extends AbstractDTOTest<ProductDTO> {
             dependentProductIds.add("dependentProdId" + i);
         }
 
+        Collection<BrandingDTO> brandings = new HashSet<>();
+        for (int i = 0; i < 5; ++i) {
+            BrandingDTO branding = new BrandingDTO();
+            branding.setProductId("prod_id_" + i);
+            branding.setType("OS");
+            branding.setName("Brand Name" + i);
+            brandings.add(branding);
+        }
+
         this.values = new HashMap<>();
         this.values.put("Uuid", "test_value");
         this.values.put("Id", "test_value");
@@ -82,6 +92,7 @@ public class ProductDTOTest extends AbstractDTOTest<ProductDTO> {
         this.values.put("Attributes", attributes);
         this.values.put("DependentProductIds", dependentProductIds);
         this.values.put("Multiplier", 3L);
+        this.values.put("Branding", brandings);
         this.values.put("Href", "test-href");
         this.values.put("Created", new Date());
         this.values.put("Updated", new Date());
@@ -146,27 +157,94 @@ public class ProductDTOTest extends AbstractDTOTest<ProductDTO> {
         assertNull(value);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetAttributeWithNullAttribute() {
         ProductDTO dto = new ProductDTO();
-        dto.getAttributeValue(null);
+        assertThrows(IllegalArgumentException.class, () -> dto.getAttributeValue(null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testSetAttributeWithNullAttribute() {
         ProductDTO dto = new ProductDTO();
-        dto.setAttribute(null, "value");
+        assertThrows(IllegalArgumentException.class, () -> dto.setAttribute(null, "value"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testHasAttributeWithNullAttribute() {
         ProductDTO dto = new ProductDTO();
-        dto.hasAttribute(null);
+        assertThrows(IllegalArgumentException.class, () -> dto.hasAttribute(null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testRemoveAttributeWithNullAttribute() {
         ProductDTO dto = new ProductDTO();
-        dto.removeAttribute(null);
+        assertThrows(IllegalArgumentException.class, () -> dto.removeAttribute(null));
+    }
+
+    @Test
+    public void testAddBrandingWithAbsentBranding() {
+        ProductDTO dto = new ProductDTO();
+
+        BrandingDTO branding = new BrandingDTO();
+        branding.setProductId("test-branding-product-id-1");
+        branding.setName("test-branding-name-1");
+        branding.setType("test-branding-type-1");
+        assertTrue(dto.addBranding(branding));
+    }
+
+    @Test
+    public void testAddBrandingWithPresentBranding() {
+        ProductDTO dto = new ProductDTO();
+
+        BrandingDTO branding = new BrandingDTO();
+        branding.setProductId("test-branding-product-id-2");
+        branding.setName("test-branding-name-2");
+        branding.setType("test-branding-type-2");
+        assertTrue(dto.addBranding(branding));
+
+        BrandingDTO branding2 = new BrandingDTO();
+        branding2.setProductId("test-branding-product-id-2");
+        branding2.setName("test-branding-name-2");
+        branding2.setType("test-branding-type-2");
+        assertFalse(dto.addBranding(branding2));
+    }
+
+    @Test
+    public void testAddBrandingWithNullInput() {
+        ProductDTO dto = new ProductDTO();
+        assertThrows(IllegalArgumentException.class, () -> dto.addBranding(null));
+    }
+
+    @Test
+    public void testAddBrandingWithEmptyProductId() {
+        ProductDTO dto = new ProductDTO();
+
+        BrandingDTO branding = new BrandingDTO();
+        branding.setProductId("");
+        branding.setName("test-branding-name-3");
+        branding.setType("test-branding-type-3");
+        assertThrows(IllegalArgumentException.class, () -> dto.addBranding(branding));
+    }
+
+    @Test
+    public void testAddBrandingWithEmptyName() {
+        ProductDTO dto = new ProductDTO();
+
+        BrandingDTO branding = new BrandingDTO();
+        branding.setProductId("test-branding-product-id-4");
+        branding.setName("");
+        branding.setType("test-branding-type-4");
+        assertThrows(IllegalArgumentException.class, () -> dto.addBranding(branding));
+    }
+
+    @Test
+    public void testAddBrandingWithEmptyType() {
+        ProductDTO dto = new ProductDTO();
+
+        BrandingDTO branding = new BrandingDTO();
+        branding.setProductId("test-branding-product-id-5");
+        branding.setName("test-branding-name-5");
+        branding.setType("");
+        assertThrows(IllegalArgumentException.class, () -> dto.addBranding(branding));
     }
 }

--- a/server/src/test/java/org/candlepin/dto/api/v1/ProductTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/ProductTranslatorTest.java
@@ -14,22 +14,23 @@
  */
 package org.candlepin.dto.api.v1;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.dto.api.v1.ProductDTO.ProductContentDTO;
 import org.candlepin.model.Content;
 import org.candlepin.model.Product;
+import org.candlepin.model.ProductBranding;
 import org.candlepin.model.ProductContent;
 import org.candlepin.test.TestUtil;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Map;
-
-
+import java.util.Set;
 
 /**
  * Test suite for the ProductTranslator class
@@ -41,9 +42,13 @@ public class ProductTranslatorTest extends
     protected ProductTranslator productTranslator = new ProductTranslator();
 
     protected ContentTranslatorTest contentTranslatorTest = new ContentTranslatorTest();
+    protected ProductBrandingTranslatorTest brandingTranslatorTest = new ProductBrandingTranslatorTest();
 
     @Override
     protected void initModelTranslator(ModelTranslator modelTranslator) {
+        this.contentTranslatorTest.initModelTranslator(modelTranslator);
+        this.brandingTranslatorTest.initModelTranslator(modelTranslator);
+
         modelTranslator.registerTranslator(this.contentTranslator, Content.class, ContentDTO.class);
         modelTranslator.registerTranslator(this.productTranslator, Product.class, ProductDTO.class);
     }
@@ -81,6 +86,10 @@ public class ProductTranslatorTest extends
 
             source.addContent(content, true);
         }
+
+        Set<ProductBranding> brandingSet = new HashSet<>();
+        brandingSet.add(this.brandingTranslatorTest.initSourceObject());
+        source.setBranding(brandingSet);
 
         return source;
     }
@@ -122,9 +131,22 @@ public class ProductTranslatorTest extends
                         }
                     }
                 }
+
+                for (ProductBranding brandingSource : source.getBranding()) {
+                    for (BrandingDTO brandingDTO : dto.getBranding()) {
+
+                        assertNotNull(brandingDTO);
+                        assertNotNull(brandingDTO.getProductId());
+
+                        if (brandingDTO.getProductId().equals(brandingSource.getProductId())) {
+                            this.brandingTranslatorTest.verifyOutput(brandingSource, brandingDTO, true);
+                        }
+                    }
+                }
             }
             else {
                 assertTrue(dto.getProductContent().isEmpty());
+                assertTrue(dto.getBranding().isEmpty());
             }
         }
         else {

--- a/server/src/test/java/org/candlepin/model/ProductTest.java
+++ b/server/src/test/java/org/candlepin/model/ProductTest.java
@@ -16,8 +16,6 @@ package org.candlepin.model;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import org.candlepin.test.DatabaseTestFixture;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -27,16 +25,15 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import javax.inject.Inject;
 
 
 /**
  * ProductTest
  */
-public class ProductTest extends DatabaseTestFixture {
-    @Inject private OwnerCurator ownerCurator;
+public class ProductTest {
 
     protected static Stream<Object[]> getValuesForEqualityAndReplication() {
         Map<String, String> attributes1 = new HashMap<>();
@@ -74,15 +71,26 @@ public class ProductTest extends DatabaseTestFixture {
             new ProductContent(null, content[5], true)
         );
 
+        Set<ProductBranding> brandings1 = Stream.of(
+            new ProductBranding("eng_prod_id_1", "OS", "eng_prod_name_1", null),
+            new ProductBranding("eng_prod_id_2", "OS", "eng_prod_name_2", null),
+            new ProductBranding("eng_prod_id_3", "OS", "eng_prod_name_3", null)
+        ).collect(Collectors.toSet());
+
+        Set<ProductBranding> brandings2 = Stream.of(
+            new ProductBranding("eng_prod_id_4", "OS", "eng_prod_name_4", null),
+            new ProductBranding("eng_prod_id_5", "OS", "eng_prod_name_5", null),
+            new ProductBranding("eng_prod_id_6", "OS", "eng_prod_name_6", null)
+        ).collect(Collectors.toSet());
+
         return Stream.of(
             new Object[] { "Id", "test_value", "alt_value" },
             new Object[] { "Name", "test_value", "alt_value" },
             new Object[] { "Multiplier", 1234L, 4567L },
             new Object[] { "Attributes", attributes1, attributes2 },
             new Object[] { "ProductContent", productContent1, productContent2 },
-            new Object[] { "DependentProductIds", Arrays.asList("1", "2", "3"), Arrays.asList("4", "5") }
-            // new Object[] { "Href", "test_value", null },
-            // new Object[] { "Locked", Boolean.TRUE, false }
+            new Object[] { "DependentProductIds", Arrays.asList("1", "2", "3"), Arrays.asList("4", "5") },
+            new Object[] { "Branding", brandings1, brandings2 }
         );
     }
 

--- a/server/src/test/java/org/candlepin/test/DatabaseTestFixture.java
+++ b/server/src/test/java/org/candlepin/test/DatabaseTestFixture.java
@@ -62,6 +62,7 @@ import org.candlepin.model.PermissionBlueprint;
 import org.candlepin.model.Pool;
 import org.candlepin.model.PoolCurator;
 import org.candlepin.model.Product;
+import org.candlepin.model.ProductBranding;
 import org.candlepin.model.ProductCertificateCurator;
 import org.candlepin.model.ProductCurator;
 import org.candlepin.model.Role;
@@ -643,6 +644,14 @@ public class DatabaseTestFixture {
 
     protected Product createProduct(String id, String name, Owner... owners) {
         Product product = TestUtil.createProduct(id, name);
+        return this.createProduct(product, owners);
+    }
+
+    protected Product createProductWithBranding(String id, String name, ProductBranding branding,
+        Owner... owners) {
+
+        Product product = TestUtil.createProduct(id, name);
+        product.addBranding(branding);
         return this.createProduct(product, owners);
     }
 


### PR DESCRIPTION
- Now Product holds Branding information by means of
  the cp_product_branding table.
- ProductDTO supports BrandingDTO information in POST/GET
  product API requests.
- Updated/Created unit and spec tests
- Updated method javadocs in ProductManager.java