### PR TITLE
1702035 - [RFE] Set autoheal as part of consumer creation.

### DIFF
--- a/server/client/ruby/candlepin_api.rb
+++ b/server/client/ruby/candlepin_api.rb
@@ -80,7 +80,7 @@ class Candlepin
               content_tags=[], created_date=nil, last_checkin_date=nil,
               annotations=nil, recipient_owner_key=nil, user_agent=nil,
               entitlement_count=0, id_cert=nil, serviceLevel=nil, role=nil, usage=nil,
-              addOns=nil, reporter_id=nil)
+              addOns=nil, reporter_id=nil, autoheal=nil)
 
     consumer = {
       :type => {:label => type},
@@ -103,6 +103,7 @@ class Candlepin
     consumer[:idCert] = id_cert if id_cert
 
     consumer[:serviceLevel] = serviceLevel if serviceLevel
+    consumer[:autoheal] = autoheal if not autoheal.nil?
     consumer[:role] = role if role
     consumer[:usage] = usage if usage
     consumer[:addOns] = addOns if addOns

--- a/server/spec/consumer_resource_spec.rb
+++ b/server/spec/consumer_resource_spec.rb
@@ -399,6 +399,22 @@ describe 'Consumer Resource' do
     expect(consumer['serviceLevel']).to eq(service_level)
   end
 
+  it 'should let a consumer register and disable autoheal' do
+    owner = create_owner(random_string('owner'))
+    user_name = random_string('user')
+    client = user_client(owner, user_name)
+
+    consumer = client.register(random_string('system'), type=:system, nil, {}, user_name,
+                               owner['key'], [], [], nil, [], nil, [], nil, nil, nil, nil, nil, 0, nil, nil,
+                               nil, nil, nil, nil, false)
+
+    expect(consumer['autoheal']).to eq(false)
+
+    #reload to be sure it was persisted
+    consumer = client.get_consumer(consumer['uuid'])
+    expect(consumer['autoheal']).to eq(false)
+  end
+
   it 'should let a consumer register and set system purpose role' do
     owner = create_owner(random_string('owner'))
     user_name = random_string('user')

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -752,7 +752,12 @@ public class ConsumerResource {
 
         validateViaConsumerType(consumer, type, keys, owner, userName, principal);
 
-        consumer.setAutoheal(true); // this is the default
+        if (consumer.getAutoheal() != null) {
+            consumer.setAutoheal(consumer.getAutoheal());
+        }
+        else {
+            consumer.setAutoheal(true); // this is the default
+        }
 
         // Sanitize the inbound facts
         this.sanitizeConsumerFacts(consumer);


### PR DESCRIPTION
Allow setting the autoheal attribute of consumer during the rest call that creates the consumer.