### PR TITLE
[F] ENT-1612, ENT-1617: Branding to Product on Refresh 

### DIFF
--- a/server/spec/pool_resource_spec.rb
+++ b/server/spec/pool_resource_spec.rb
@@ -231,10 +231,14 @@ describe 'Pool Resource' do
       owner = create_owner random_string('some-owner')
       name = random_string("product-")
 
-      product = create_product(name, name, :owner => owner['key'])
+      if is_hosted?
+        product = create_upstream_product(name, { :branding => [b1, b2] })
+      else
+        product = create_product(name, name, :owner => owner['key'], :branding => [b1, b2])
+      end
 
       created = create_pool_and_subscription(owner['key'], product.id, 11,
-        [], '', '', '', nil, nil, false, :branding => [b1, b2])
+        [], '', '', '', nil, nil, false)
 
       pool = @cp.get_pool(created['id'])
       pool.quantity.should == 11

--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -29,7 +29,6 @@ import org.candlepin.config.ConfigProperties;
 import org.candlepin.model.Cdn;
 import org.candlepin.model.CdnCertificate;
 import org.candlepin.model.CdnCurator;
-import org.candlepin.model.Branding;
 import org.candlepin.model.CandlepinQuery;
 import org.candlepin.model.CertificateSerial;
 import org.candlepin.model.Consumer;
@@ -73,7 +72,6 @@ import org.candlepin.resource.dto.AutobindData;
 import org.candlepin.resteasy.JsonProvider;
 import org.candlepin.service.OwnerServiceAdapter;
 import org.candlepin.service.SubscriptionServiceAdapter;
-import org.candlepin.service.model.BrandingInfo;
 import org.candlepin.service.model.CertificateInfo;
 import org.candlepin.service.model.CertificateSerialInfo;
 import org.candlepin.service.model.CdnInfo;
@@ -594,9 +592,7 @@ public class CandlepinPoolManager implements PoolManager {
             }
 
             // dates changed. regenerate all entitlement certificates
-            if (updatedPool.getDatesChanged() || updatedPool.getProductsChanged() ||
-                updatedPool.getBrandingChanged()) {
-
+            if (updatedPool.getDatesChanged() || updatedPool.getProductsChanged()) {
                 poolsToRegenEnts.add(existingPool);
             }
 
@@ -941,21 +937,6 @@ public class CandlepinPoolManager implements PoolManager {
             }
 
             pool.setCertificate(cert);
-        }
-
-        // Add in branding
-        if (sub.getBranding() != null) {
-            Set<Branding> branding = new HashSet<>();
-
-            for (BrandingInfo brand : sub.getBranding()) {
-                // Impl note:
-                // We create a new instance here since we don't have a separate branding DTO (yet),
-                // and we need to be certain that we don't try to move or change a branding object
-                // associated with another pool.
-                branding.add(new Branding(brand.getProductId(), brand.getType(), brand.getName()));
-            }
-
-            pool.setBranding(branding);
         }
 
         if (sub.getProduct() == null || sub.getProduct().getId() == null) {

--- a/server/src/main/java/org/candlepin/controller/ProductManager.java
+++ b/server/src/main/java/org/candlepin/controller/ProductManager.java
@@ -28,6 +28,7 @@ import org.candlepin.model.ProductBranding;
 import org.candlepin.model.ProductContent;
 import org.candlepin.model.ProductCurator;
 import org.candlepin.pinsetter.tasks.OrphanCleanupJob;
+import org.candlepin.service.model.BrandingInfo;
 import org.candlepin.service.model.ContentInfo;
 import org.candlepin.service.model.ProductContentInfo;
 import org.candlepin.service.model.ProductInfo;
@@ -38,7 +39,6 @@ import org.candlepin.util.Util;
 import com.google.inject.Inject;
 import com.google.inject.persist.Transactional;
 
-import org.apache.commons.lang.builder.EqualsBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -825,22 +825,7 @@ public class ProductManager {
 
         Collection<BrandingDTO> brandingDTOs = dto.getBranding();
         if (brandingDTOs != null) {
-            Comparator comparator = (lhs, rhs) -> {
-                ProductBranding existing = (ProductBranding) lhs;
-                BrandingDTO update = (BrandingDTO) rhs;
-
-                if (existing != null && update != null) {
-                    boolean equals = new EqualsBuilder()
-                        .append(existing.getProductId(), update.getProductId())
-                        .append(existing.getName(), update.getName())
-                        .append(existing.getType(), update.getType())
-                        .isEquals();
-                    return equals ? 0 : 1;
-                }
-
-                return 1;
-            };
-
+            Comparator<BrandingInfo> comparator = BrandingInfo.getBrandingInfoComparator();
             if (!Util.collectionsAreEqual((Collection) entity.getBranding(), (Collection) brandingDTOs,
                 comparator)) {
                 return true;
@@ -867,6 +852,7 @@ public class ProductManager {
      *  true if this product would be changed by the given product info; false otherwise
      */
     public static boolean isChangedBy(Product entity, ProductInfo update) {
+
         // Check simple properties first
         if (update.getId() != null && !update.getId().equals(entity.getId())) {
             return true;
@@ -932,6 +918,14 @@ public class ProductManager {
             }
         }
 
+        if (update.getBranding() != null) {
+            Comparator<BrandingInfo> comparator = BrandingInfo.getBrandingInfoComparator();
+            if (!Util.collectionsAreEqual((Collection) entity.getBranding(),
+                (Collection) update.getBranding(), comparator)) {
+                return true;
+            }
+        }
+
         return false;
     }
 
@@ -954,6 +948,7 @@ public class ProductManager {
      *  The updated product entity
      */
     private Product applyProductChanges(Product entity, ProductInfo update, Map<String, Content> contentMap) {
+
         // TODO:
         // Eventually content should be considered a property of products (ala attributes), so we
         // don't have to do this annoying, nested projection and owner passing. Also, it would
@@ -1038,6 +1033,25 @@ public class ProductManager {
 
         if (update.getDependentProductIds() != null) {
             entity.setDependentProductIds(update.getDependentProductIds());
+        }
+
+        if (update.getBranding() != null) {
+            if (update.getBranding().isEmpty()) {
+                entity.setBranding(Collections.emptySet());
+            }
+            else {
+                Set<ProductBranding> branding = new HashSet<>();
+                for (BrandingInfo brandingInfo : update.getBranding()) {
+                    if (brandingInfo != null) {
+                        branding.add(new ProductBranding(
+                            brandingInfo.getProductId(),
+                            brandingInfo.getType(),
+                            brandingInfo.getName(),
+                            entity));
+                    }
+                }
+                entity.setBranding(branding);
+            }
         }
 
         return entity;

--- a/server/src/main/java/org/candlepin/dto/api/v1/BrandingDTO.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/BrandingDTO.java
@@ -17,6 +17,7 @@ package org.candlepin.dto.api.v1;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.candlepin.dto.TimestampedCandlepinDTO;
+import org.candlepin.service.model.BrandingInfo;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -27,7 +28,7 @@ import javax.xml.bind.annotation.XmlAccessorType;
  * A DTO representation of the Branding entity used internally by ProductDTO.
  */
 @XmlAccessorType(XmlAccessType.PROPERTY)
-public class BrandingDTO extends TimestampedCandlepinDTO<BrandingDTO> {
+public class BrandingDTO extends TimestampedCandlepinDTO<BrandingDTO> implements BrandingInfo {
 
     public static final long serialVersionUID = 1L;
 

--- a/server/src/main/java/org/candlepin/dto/api/v1/PoolTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/PoolTranslator.java
@@ -16,13 +16,14 @@ package org.candlepin.dto.api.v1;
 
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.dto.TimestampedEntityTranslator;
-import org.candlepin.model.Branding;
 import org.candlepin.model.Entitlement;
 import org.candlepin.model.Owner;
 import org.candlepin.model.Pool;
 import org.candlepin.model.Product;
+import org.candlepin.model.ProductBranding;
 import org.candlepin.model.SubscriptionsCertificate;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
 
@@ -108,16 +109,17 @@ public class PoolTranslator extends TimestampedEntityTranslator<Pool, PoolDTO> {
             dest.setSourceEntitlement(sourceEntitlement != null ?
                 modelTranslator.translate(sourceEntitlement, EntitlementDTO.class) : null);
 
-            Set<Branding> branding = source.getBranding();
+            Collection<ProductBranding> branding = source.getProduct() != null ?
+                source.getProduct().getBranding() : null;
             if (branding != null && !branding.isEmpty()) {
-                for (Branding brand : branding) {
+                for (ProductBranding brand : branding) {
                     if (brand != null) {
                         dest.addBranding(modelTranslator.translate(brand, BrandingDTO.class));
                     }
                 }
             }
             else {
-                dest.setBranding(Collections.<BrandingDTO>emptySet());
+                dest.setBranding(Collections.emptySet());
             }
 
             Set<Product> products = source.getProvidedProducts();

--- a/server/src/main/java/org/candlepin/dto/manifest/v1/ProductDTO.java
+++ b/server/src/main/java/org/candlepin/dto/manifest/v1/ProductDTO.java
@@ -128,6 +128,8 @@ public class ProductDTO extends TimestampedCandlepinDTO<ProductDTO> implements P
     protected Set<String> dependentProductIds;
     protected Boolean locked;
 
+    protected Set<BrandingDTO> branding;
+
     /**
      * Initializes a new ProductDTO instance with null values.
      */
@@ -756,6 +758,95 @@ public class ProductDTO extends TimestampedCandlepinDTO<ProductDTO> implements P
         return this;
     }
 
+    /**
+     * Retrieves a view of the branding for the product represented by this DTO. If the branding items
+     * have not yet been defined, this method returns null.
+     * <p></p>
+     * Note that the collection returned by this method is a view of the collection backing this
+     * set of branding items. Elements cannot be added to the collection, but elements may be removed.
+     * Changes made to the collection will be reflected by this product DTO instance.
+     *
+     * IMPORTANT: The current manifest API does not support having branding on products, but rather on
+     * pools, so this field should be ignored by the serializer.
+     *
+     * @return
+     *  the branding items associated with this key, or null if they have not yet been defined
+     */
+    @JsonIgnore
+    @Override
+    public Set<BrandingDTO> getBranding() {
+        return this.branding != null ? new SetView<>(this.branding) : null;
+    }
+
+    /**
+     * Adds the collection of branding items to this Product DTO.
+     *
+     * IMPORTANT: The current manifest API does not support having branding on products, but rather on
+     * pools, so this field should be ignored by the serializer.
+     *
+     * @param branding
+     *  A set of branding items to attach to this DTO, or null to clear the existing ones
+     *
+     * @return
+     *  A reference to this DTO
+     */
+    @JsonIgnore
+    public ProductDTO setBranding(Set<BrandingDTO> branding) {
+        if (branding != null) {
+            if (this.branding == null) {
+                this.branding = new HashSet<>();
+            }
+            else {
+                this.branding.clear();
+            }
+
+            for (BrandingDTO dto : branding) {
+                if (isNullOrIncomplete(dto)) {
+                    throw new IllegalArgumentException(
+                        "collection contains null or incomplete branding objects");
+                }
+            }
+
+            this.branding.addAll(branding);
+        }
+        else {
+            this.branding = null;
+        }
+        return this;
+    }
+
+    /**
+     * Adds the given branding to this product DTO.
+     *
+     * @param branding
+     *  The branding to add to this product DTO.
+     *
+     * @return
+     *  true if this branding was not already contained in this product DTO.
+     */
+    @JsonIgnore
+    public boolean addBranding(BrandingDTO branding) {
+        if (isNullOrIncomplete(branding)) {
+            throw new IllegalArgumentException("branding is null or incomplete");
+        }
+
+        if (this.branding == null) {
+            this.branding = new HashSet<>();
+        }
+
+        return this.branding.add(branding);
+    }
+
+    /**
+     * Utility method to validate BrandingDTO input
+     */
+    private boolean isNullOrIncomplete(BrandingDTO branding) {
+        return branding == null ||
+            branding.getProductId() == null || branding.getProductId().isEmpty() ||
+            branding.getName() == null || branding.getName().isEmpty() ||
+            branding.getType() == null || branding.getType().isEmpty();
+    }
+
     @Override
     public String toString() {
         return String.format("ProductDTO [id = %s, uuid = %s, name = %s]", this.getId(), this.getUuid(),
@@ -777,7 +868,8 @@ public class ProductDTO extends TimestampedCandlepinDTO<ProductDTO> implements P
                 .append(this.getId(), that.getId())
                 .append(this.getName(), that.getName())
                 .append(this.getAttributes(), that.getAttributes())
-                .append(this.getDependentProductIds(), that.getDependentProductIds());
+                .append(this.getDependentProductIds(), that.getDependentProductIds())
+                .append(this.getBranding(), that.getBranding());
 
             // As with many collections here, we need to explicitly check the elements ourselves,
             // since it seems very common for collection implementations to not properly implement
@@ -816,6 +908,7 @@ public class ProductDTO extends TimestampedCandlepinDTO<ProductDTO> implements P
             .append(this.getName())
             .append(this.getAttributes())
             .append(this.getDependentProductIds())
+            .append(this.getBranding())
             .append(pcHashCode);
 
         return builder.toHashCode();
@@ -828,6 +921,7 @@ public class ProductDTO extends TimestampedCandlepinDTO<ProductDTO> implements P
         copy.setAttributes(this.getAttributes());
         copy.setProductContent(this.getProductContent());
         copy.setDependentProductIds(this.getDependentProductIds());
+        copy.setBranding(this.getBranding());
 
         return copy;
     }
@@ -854,6 +948,7 @@ public class ProductDTO extends TimestampedCandlepinDTO<ProductDTO> implements P
         this.setAttributes(source.getAttributes());
         this.setProductContent(source.getProductContent());
         this.setDependentProductIds(source.getDependentProductIds());
+        this.setBranding(source.getBranding());
 
         return this;
     }

--- a/server/src/main/java/org/candlepin/dto/manifest/v1/SubscriptionDTO.java
+++ b/server/src/main/java/org/candlepin/dto/manifest/v1/SubscriptionDTO.java
@@ -547,7 +547,6 @@ public class SubscriptionDTO extends CandlepinDTO<SubscriptionDTO> implements Su
     /**
      * {@inheritDoc}
      */
-    @Override
     public Collection<BrandingDTO> getBranding() {
         return this.branding != null ? new ListView<>(this.branding) : null;
     }

--- a/server/src/main/java/org/candlepin/dto/shim/ProductDataTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/shim/ProductDataTranslator.java
@@ -16,15 +16,16 @@ package org.candlepin.dto.shim;
 
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.dto.ObjectTranslator;
+import org.candlepin.dto.api.v1.BrandingDTO;
 import org.candlepin.dto.api.v1.ContentDTO;
 import org.candlepin.dto.api.v1.ProductDTO;
+import org.candlepin.model.ProductBranding;
 import org.candlepin.model.dto.ContentData;
 import org.candlepin.model.dto.ProductData;
 import org.candlepin.model.dto.ProductContentData;
 
 import java.util.Collection;
-
-
+import java.util.Collections;
 
 /**
  * The ProductDataTranslator provides translation from ProductData DTO objects to the new
@@ -81,18 +82,33 @@ public class ProductDataTranslator implements ObjectTranslator<ProductData, Prod
         dest.setHref(source.getHref());
         dest.setLocked(source.isLocked());
 
-        Collection<ProductContentData> productContentData = source.getProductContent();
-        dest.setProductContent(null);
 
-        if (modelTranslator != null && productContentData != null) {
-            ObjectTranslator<ContentData, ContentDTO> contentTranslator = modelTranslator
-                .findTranslatorByClass(ContentData.class, ContentDTO.class);
+        if (modelTranslator != null) {
+            Collection<ProductContentData> productContentData = source.getProductContent();
+            dest.setProductContent(null);
+            if (productContentData != null) {
+                ObjectTranslator<ContentData, ContentDTO> contentTranslator = modelTranslator
+                    .findTranslatorByClass(ContentData.class, ContentDTO.class);
 
-            for (ProductContentData pcd : productContentData) {
-                if (pcd != null && pcd.getContent() != null) {
-                    ContentDTO dto = contentTranslator.translate(modelTranslator, pcd.getContent());
-                    dest.addContent(dto, pcd.isEnabled());
+                for (ProductContentData pcd : productContentData) {
+                    if (pcd != null && pcd.getContent() != null) {
+                        ContentDTO dto = contentTranslator.translate(modelTranslator, pcd.getContent());
+                        dest.addContent(dto, pcd.isEnabled());
+                    }
                 }
+            }
+
+            Collection<ProductBranding> productBrandings = source.getBranding();
+            dest.setBranding(null);
+            if (productBrandings != null) {
+                for (ProductBranding brand : productBrandings) {
+                    if (brand != null) {
+                        dest.addBranding(modelTranslator.translate(brand, BrandingDTO.class));
+                    }
+                }
+            }
+            else {
+                dest.setBranding(Collections.emptySet());
             }
         }
 

--- a/server/src/main/java/org/candlepin/hostedtest/HostedTestSubscriptionServiceAdapter.java
+++ b/server/src/main/java/org/candlepin/hostedtest/HostedTestSubscriptionServiceAdapter.java
@@ -14,11 +14,11 @@
  */
 package org.candlepin.hostedtest;
 
-import org.candlepin.model.Branding;
 import org.candlepin.model.Cdn;
 import org.candlepin.model.CdnCertificate;
 import org.candlepin.model.CertificateSerial;
 import org.candlepin.model.Owner;
+import org.candlepin.model.ProductBranding;
 import org.candlepin.model.ProductContent;
 import org.candlepin.model.SubscriptionsCertificate;
 import org.candlepin.model.dto.ContentData;
@@ -142,7 +142,6 @@ public class HostedTestSubscriptionServiceAdapter implements SubscriptionService
         sdata.setUpstreamConsumerId(sinfo.getUpstreamConsumerId());
         sdata.setCertificate(this.convertSubscriptionCertificate(sinfo.getCertificate()));
         sdata.setCdn(this.convertCdn(sinfo.getCdn()));
-        sdata.setBranding(this.resolveBranding(sinfo.getBranding()));
 
         // Update mappings
         this.subscriptionMap.put(sdata.getId(), sdata);
@@ -240,10 +239,6 @@ public class HostedTestSubscriptionServiceAdapter implements SubscriptionService
 
         sdata.setCdn(this.convertCdn(sinfo.getCdn()));
 
-        if (sinfo.getBranding() != null) {
-            sdata.setBranding(this.resolveBranding(sinfo.getBranding()));
-        }
-
         // Update mappings...
         this.updateSubscriptionProductMappings(sdata);
 
@@ -294,6 +289,7 @@ public class HostedTestSubscriptionServiceAdapter implements SubscriptionService
         pdata.setDependentProductIds(pinfo.getDependentProductIds());
         pdata.setCreated(new Date());
         pdata.setUpdated(new Date());
+        pdata.setBranding(this.resolveBranding(pinfo.getBranding()));
 
         // Create our mappings...
         this.productMap.put(pdata.getId(), pdata);
@@ -342,6 +338,10 @@ public class HostedTestSubscriptionServiceAdapter implements SubscriptionService
 
         if (pinfo.getDependentProductIds() != null) {
             pdata.setDependentProductIds(pinfo.getDependentProductIds());
+        }
+
+        if (pinfo.getBranding() != null) {
+            pdata.setBranding(this.resolveBranding(pinfo.getBranding()));
         }
 
         // Update product=>content mappings
@@ -789,9 +789,9 @@ public class HostedTestSubscriptionServiceAdapter implements SubscriptionService
         return null;
     }
 
-    protected Set<Branding> resolveBranding(Collection<? extends BrandingInfo> branding) {
+    protected Set<ProductBranding> resolveBranding(Collection<? extends BrandingInfo> branding) {
         if (branding != null) {
-            Map<String, Branding> brandMap = new HashMap<>();
+            Map<String, ProductBranding> brandMap = new HashMap<>();
 
             // We don't bother keeping cross-subscription references here, so the only thing
             // we are really concerned with is making sure we don't end up with two brands
@@ -804,7 +804,7 @@ public class HostedTestSubscriptionServiceAdapter implements SubscriptionService
                         throw new IllegalArgumentException("Branding lacks a product ID: " + binfo);
                     }
 
-                    Branding bdata = new Branding();
+                    ProductBranding bdata = new ProductBranding();
 
                     bdata.setProductId(binfo.getProductId());
                     bdata.setType(binfo.getType());

--- a/server/src/main/java/org/candlepin/model/Product.java
+++ b/server/src/main/java/org/candlepin/model/Product.java
@@ -68,6 +68,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.StringTokenizer;
+import java.util.stream.Collectors;
+
 
 
 /**
@@ -422,7 +424,10 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
         copy.setUpdated(this.getUpdated() != null ? (Date) this.getUpdated().clone() : null);
 
         copy.branding = new HashSet<>();
-        copy.setBranding(this.branding);
+        copy.setBranding(this.branding.stream()
+            .map(ProductBranding::clone)
+            .peek(brand -> brand.setProduct(copy))
+            .collect(Collectors.toSet()));
 
         return copy;
     }

--- a/server/src/main/java/org/candlepin/model/ProductBranding.java
+++ b/server/src/main/java/org/candlepin/model/ProductBranding.java
@@ -46,7 +46,8 @@ import javax.validation.constraints.Size;
 @Entity
 @Immutable
 @Table(name = ProductBranding.DB_TABLE)
-public class ProductBranding extends AbstractHibernateObject<ProductBranding> implements BrandingInfo {
+public class ProductBranding extends AbstractHibernateObject<ProductBranding> implements BrandingInfo,
+    Cloneable {
 
     /** Name of the table backing this object in the database */
     public static final String DB_TABLE = "cp2_product_branding";
@@ -186,6 +187,20 @@ public class ProductBranding extends AbstractHibernateObject<ProductBranding> im
             .append(this.type)
             .append(this.getProduct() != null ? this.getProduct().getUuid() : null)
             .toHashCode();
+    }
+
+    @Override
+    public ProductBranding clone() {
+        ProductBranding copy;
+
+        try {
+            copy = (ProductBranding) super.clone();
+        }
+        catch (CloneNotSupportedException e) {
+            // This should never happen.
+            throw new RuntimeException("Clone not supported", e);
+        }
+        return copy;
     }
 
     @Override

--- a/server/src/main/java/org/candlepin/model/dto/ProductData.java
+++ b/server/src/main/java/org/candlepin/model/dto/ProductData.java
@@ -18,6 +18,7 @@ import org.candlepin.jackson.CandlepinAttributeDeserializer;
 import org.candlepin.jackson.CandlepinLegacyAttributeSerializer;
 import org.candlepin.model.Content;
 import org.candlepin.model.Product;
+import org.candlepin.model.ProductBranding;
 import org.candlepin.model.ProductContent;
 import org.candlepin.service.model.ProductInfo;
 import org.candlepin.util.MapView;
@@ -37,6 +38,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
@@ -55,6 +57,7 @@ import javax.xml.bind.annotation.XmlTransient;
  *   "attributes" : [ ... ],
  *   "productContent" : [ ... ],
  *   "dependentProductIds" : [ ... ],
+ *   "branding" : [ ... ],
  *   "href" : "/products/ff808081554a3e4101554a3e9033005d",
  *   "created" : "2016-06-13T14:51:02+0000",
  *   "updated" : "2016-06-13T14:51:02+0000"
@@ -85,6 +88,8 @@ public class ProductData extends CandlepinDTO implements ProductInfo {
     protected Map<String, ProductContentData> content;
 
     protected Set<String> dependentProductIds;
+
+    protected Set<ProductBranding> branding;
 
     @ApiModelProperty(example = "/products/ff808081554a3e4101554a3e9033005d")
     protected String href;
@@ -813,6 +818,94 @@ public class ProductData extends CandlepinDTO implements ProductInfo {
     }
 
     /**
+     * Retrieves the branding of the product represented by this DTO. If the product branding has not
+     * yet been defined, this method returns null.
+     * <p></p>
+     * Note that the collection returned by this method is a view of the collection backing this
+     * product data. Elements cannot be added to the collection, but elements may be removed.
+     * Changes made to the collection will be reflected by this product data instance.
+     *
+     * @return
+     *  the branding of the product, or null if the content not yet been defined
+     */
+    public Collection<ProductBranding> getBranding() {
+        return this.branding != null ? new SetView(this.branding) : null;
+    }
+
+    /**
+     * Sets the branding of the product represented by this DTO.
+     *
+     * @param branding
+     *  A collection of brandings to attach to this DTO, or null to clear the existing brandings
+     *
+     * @return
+     *  a reference to this DTO
+     */
+    public ProductData setBranding(Collection<ProductBranding> branding) {
+        if (branding != null) {
+            if (this.branding == null) {
+                this.branding = new HashSet<>();
+            }
+            else {
+                this.branding.clear();
+            }
+
+            for (ProductBranding brand : branding) {
+                this.addBranding(brand);
+            }
+        }
+        else {
+            this.branding = null;
+        }
+
+        return this;
+    }
+
+    /**
+     * Adds the branding to this product. If the branding
+     * is already added, it will not be added again.
+     *
+     * @param branding
+     *  The branding to add
+     *
+     * @throws IllegalArgumentException
+     *  if branding is null
+     *
+     * @return
+     *  true if the branding was added successfully; false otherwise
+     */
+    public boolean addBranding(ProductBranding branding) {
+        if (branding == null) {
+            throw new IllegalArgumentException("branding is null");
+        }
+
+        if (this.branding == null) {
+            this.branding = new HashSet<>();
+        }
+
+        // This is a DTO; we don't want references to Product model entities.
+        branding.setProduct(null);
+        return this.branding.add(branding);
+    }
+
+    /**
+     * Removes the specified branding from this product. If the branding is not on this product, this method
+     * does nothing.
+     *
+     * @param branding
+     *  The branding to remove
+     *
+     * @throws IllegalArgumentException
+     *  if branding is null
+     *
+     * @return
+     *  true if the branding was removed successfully; false otherwise
+     */
+    public boolean removeBranding(ProductBranding branding) {
+        return this.branding != null ? this.branding.remove(branding) : false;
+    }
+
+    /**
      * Retrieves the link of the product represented by this DTO. If the product hyperlink has not
      * yet been defined, this method returns null.
      *
@@ -888,6 +981,7 @@ public class ProductData extends CandlepinDTO implements ProductInfo {
             .append(this.attributes, that.attributes)
             .append(this.content, that.content)
             .append(this.dependentProductIds, that.dependentProductIds)
+            .append(this.branding, that.branding)
             .append(this.href, that.href)
             .append(this.locked, that.locked);
 
@@ -906,6 +1000,7 @@ public class ProductData extends CandlepinDTO implements ProductInfo {
             .append(this.attributes)
             .append(this.content)
             .append(this.dependentProductIds)
+            .append(this.branding)
             .append(this.locked);
 
         return builder.toHashCode();
@@ -931,6 +1026,12 @@ public class ProductData extends CandlepinDTO implements ProductInfo {
         if (this.dependentProductIds != null) {
             copy.dependentProductIds = new HashSet<>();
             copy.dependentProductIds.addAll(this.dependentProductIds);
+        }
+
+        if (this.branding != null) {
+            copy.branding = new HashSet<>();
+            copy.branding.addAll(
+                this.branding.stream().map(ProductBranding::clone).collect(Collectors.toSet()));
         }
 
         return copy;
@@ -965,6 +1066,7 @@ public class ProductData extends CandlepinDTO implements ProductInfo {
         this.setAttributes(source.getAttributes());
         this.setProductContent(source.getProductContent());
         this.setDependentProductIds(source.getDependentProductIds());
+        this.setBranding(source.getBranding());
 
         return this;
     }
@@ -1014,6 +1116,7 @@ public class ProductData extends CandlepinDTO implements ProductInfo {
         }
 
         this.setDependentProductIds(source.getDependentProductIds());
+        this.setBranding(source.getBranding());
 
         return this;
     }

--- a/server/src/main/java/org/candlepin/model/dto/Subscription.java
+++ b/server/src/main/java/org/candlepin/model/dto/Subscription.java
@@ -14,7 +14,6 @@
  */
 package org.candlepin.model.dto;
 
-import org.candlepin.model.Branding;
 import org.candlepin.model.Cdn;
 import org.candlepin.model.Eventful;
 import org.candlepin.model.Named;
@@ -63,7 +62,6 @@ public class Subscription extends CandlepinDTO implements Owned, Named, Eventful
     private ProductData derivedProduct;
     private Set<ProductData> providedProducts = new HashSet<>();
     private Set<ProductData> derivedProvidedProducts = new HashSet<>();
-    private Set<Branding> branding = new HashSet<>();
     private Long quantity;
     private Date startDate;
     private Date endDate;
@@ -395,14 +393,6 @@ public class Subscription extends CandlepinDTO implements Owned, Named, Eventful
         this.cdn = cdn;
     }
 
-    public Set<Branding> getBranding() {
-        return branding;
-    }
-
-    public void setBranding(Set<Branding> branding) {
-        this.branding = branding;
-    }
-
     public boolean isStacked() {
         return !StringUtils.isBlank(this.product.getAttributeValue(Product.Attributes.STACKING_ID));
     }
@@ -450,7 +440,6 @@ public class Subscription extends CandlepinDTO implements Owned, Named, Eventful
             .append(this.derivedProduct, that.derivedProduct)
             .append(this.providedProducts, that.providedProducts)
             .append(this.derivedProvidedProducts, that.derivedProvidedProducts)
-            .append(this.branding, that.branding)
             .append(this.quantity, that.quantity)
             .append(this.startDate, that.startDate)
             .append(this.endDate, that.endDate)
@@ -477,7 +466,6 @@ public class Subscription extends CandlepinDTO implements Owned, Named, Eventful
             .append(this.derivedProduct)
             .append(this.providedProducts)
             .append(this.derivedProvidedProducts)
-            .append(this.branding)
             .append(this.quantity)
             .append(this.startDate)
             .append(this.endDate)
@@ -520,11 +508,6 @@ public class Subscription extends CandlepinDTO implements Owned, Named, Eventful
             }
         }
 
-        if (this.branding != null) {
-            copy.branding = new HashSet<>();
-            copy.branding.addAll(this.branding);
-        }
-
         return copy;
     }
 
@@ -565,7 +548,6 @@ public class Subscription extends CandlepinDTO implements Owned, Named, Eventful
         this.setDerivedProduct(source.getDerivedProduct());
         this.setDerivedProvidedProducts(source.getDerivedProvidedProducts());
         this.setCdn(source.getCdn());
-        this.setBranding(source.getBranding());
 
         return this;
     }
@@ -607,10 +589,6 @@ public class Subscription extends CandlepinDTO implements Owned, Named, Eventful
         this.setUpstreamPoolId(source.getUpstreamPoolId());
         this.setUpstreamEntitlementId(source.getUpstreamEntitlementId());
         this.setUpstreamConsumerId(source.getUpstreamConsumerId());
-
-        //Pool.getBranding should return entity Branding. The Branding
-        //entity has no futher relationships so everything should be ok.
-        this.setBranding(source.getBranding());
 
         // Attempt to calculate the quantity from the pool and its product:
         this.setQuantityFromPool(source);

--- a/server/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
@@ -17,7 +17,6 @@ package org.candlepin.policy.js.pool;
 import org.candlepin.common.config.Configuration;
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.controller.PoolManager;
-import org.candlepin.model.Branding;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.Entitlement;
 import org.candlepin.model.EntitlementCurator;
@@ -348,8 +347,6 @@ public class PoolRules {
                 }
 
                 update.setOrderChanged(checkForOrderDataChanges(masterPool, existingPool));
-
-                update.setBrandingChanged(checkForBrandingChanges(masterPool, existingPool));
             }
 
             // All done, see if we found any changes and return an update object if so:
@@ -522,39 +519,6 @@ public class PoolRules {
             existingPool.setContractNumber(pool.getContractNumber());
         }
         return orderDataChanged;
-    }
-
-    private boolean checkForBrandingChanges(Pool pool, Pool existingPool) {
-        boolean brandingChanged = false;
-
-        if (pool.getBranding().size() != existingPool.getBranding().size()) {
-            brandingChanged = true;
-        }
-        else {
-            for (Branding b : pool.getBranding()) {
-                if (!existingPool.getBranding().contains(b)) {
-                    brandingChanged = true;
-                    break;
-                }
-            }
-        }
-
-        if (brandingChanged) {
-            syncBranding(pool, existingPool);
-        }
-
-        return brandingChanged;
-    }
-
-    /*
-     * Something has changed, sync the branding.
-     */
-    private void syncBranding(Pool pool, Pool existingPool) {
-        existingPool.getBranding().clear();
-        for (Branding b : pool.getBranding()) {
-            existingPool.getBranding().add(new Branding(b.getProductId(), b.getType(),
-                b.getName()));
-        }
     }
 
     private Set<Product> getExpectedProvidedProducts(Pool pool, boolean useDerived) {

--- a/server/src/main/java/org/candlepin/policy/js/pool/PoolUpdate.java
+++ b/server/src/main/java/org/candlepin/policy/js/pool/PoolUpdate.java
@@ -71,11 +71,6 @@ public class PoolUpdate {
      */
     private Boolean derivedProductAttributesChanged = false;
 
-    /**
-     * True if the brand mapping info on the subscription changed.
-     */
-    private Boolean brandingChanged = false;
-
     public PoolUpdate(Pool p) {
         this.pool = p;
     }
@@ -86,8 +81,7 @@ public class PoolUpdate {
     public boolean changed() {
         return datesChanged || quantityChanged || productsChanged ||
             productAttributesChanged ||
-            orderChanged || derivedProductsChanged || derivedProductAttributesChanged ||
-            brandingChanged;
+            orderChanged || derivedProductsChanged || derivedProductAttributesChanged;
     }
 
     /**
@@ -122,9 +116,6 @@ public class PoolUpdate {
         }
         if (derivedProductAttributesChanged) {
             changes.add("derivedproductattributes");
-        }
-        if (brandingChanged) {
-            changes.add("branding");
         }
         buffer.append(StringUtils.join(changes, " "));
         buffer.append("]");
@@ -197,13 +188,5 @@ public class PoolUpdate {
 
     public void setProductAttributesChanged(Boolean productAttributesChanged) {
         this.productAttributesChanged = productAttributesChanged;
-    }
-
-    public Boolean getBrandingChanged() {
-        return brandingChanged;
-    }
-
-    public void setBrandingChanged(Boolean brandingChanged) {
-        this.brandingChanged = brandingChanged;
     }
 }

--- a/server/src/main/java/org/candlepin/service/model/BrandingInfo.java
+++ b/server/src/main/java/org/candlepin/service/model/BrandingInfo.java
@@ -14,7 +14,9 @@
  */
 package org.candlepin.service.model;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
 
+import java.util.Comparator;
 
 /**
  * The BrandingInfo represents a minimal set of branding information used by the service adapters.
@@ -52,4 +54,23 @@ public interface BrandingInfo {
      */
     String getProductId();
 
+    /**
+     * Utility method that returns a Comparator for objects that implement BrandingInfo.
+     *
+     * @return A comparator for BrandingInfo objects.
+     */
+    static Comparator<BrandingInfo> getBrandingInfoComparator() {
+        return (lhs, rhs) -> {
+            if (lhs != null && rhs != null) {
+                boolean equals = new EqualsBuilder()
+                    .append(lhs.getProductId(), rhs.getProductId())
+                    .append(lhs.getName(), rhs.getName())
+                    .append(lhs.getType(), rhs.getType())
+                    .isEquals();
+                return equals ? 0 : 1;
+            }
+
+            return 1;
+        };
+    }
 }

--- a/server/src/main/java/org/candlepin/service/model/ProductInfo.java
+++ b/server/src/main/java/org/candlepin/service/model/ProductInfo.java
@@ -99,6 +99,17 @@ public interface ProductInfo {
     Collection<? extends ProductContentInfo> getProductContent();
 
     /**
+     * Fetches the branding associated with this product. If the branding has not been set,
+     * this method returns null. If this product does not have any custom branding, this method
+     * returns an empty collection.
+     *
+     * @return
+     *  A collection of custom branding associated with this product, or null if the branding
+     *  has not been set
+     */
+    Collection<? extends BrandingInfo> getBranding();
+
+    /**
      * Fetches the date this product was created. If the creation date has not been set, this method
      * returns null.
      *

--- a/server/src/main/java/org/candlepin/service/model/SubscriptionInfo.java
+++ b/server/src/main/java/org/candlepin/service/model/SubscriptionInfo.java
@@ -196,17 +196,6 @@ public interface SubscriptionInfo {
     CdnInfo getCdn();
 
     /**
-     * Fetches the branding associated with this subscription. If the branding has not been set,
-     * this method returns null. If this subscription does not have any custom branding, this method
-     * returns an empty collection.
-     *
-     * @return
-     *  A collection of custom branding associated with this subscription, or null if the branding
-     *  has not been set
-     */
-    Collection<? extends BrandingInfo> getBranding();
-
-    /**
      * Fetches the certificate for this subscription. If the certificate has not been set, this
      * method returns null.
      * <p></p>

--- a/server/src/main/java/org/candlepin/sync/EntitlementImporter.java
+++ b/server/src/main/java/org/candlepin/sync/EntitlementImporter.java
@@ -103,8 +103,6 @@ public class EntitlementImporter {
 
         subscription.setQuantity(entitlement.getQuantity().longValue());
 
-        subscription.setBranding(entitlement.getPool().getBranding());
-
         // This is a bit of an odd duck. We shouldn't be checking this here, but instead at the point
         // where we actually import it for use.
         String cdnLabel = meta.getCdnLabel();
@@ -166,6 +164,9 @@ public class EntitlementImporter {
         // Product
         ProductDTO productDTO = this.findProduct(productsById, upstreamPoolDTO.getProductId());
         subscription.setProduct(productDTO);
+        if (upstreamPoolDTO.getBranding() != null) {
+            productDTO.setBranding(upstreamPoolDTO.getBranding());
+        }
 
         // Provided products
         Set<ProductDTO> providedProducts = new HashSet<>();

--- a/server/src/main/java/org/candlepin/util/X509V3ExtensionUtil.java
+++ b/server/src/main/java/org/candlepin/util/X509V3ExtensionUtil.java
@@ -17,12 +17,12 @@ package org.candlepin.util;
 import com.google.inject.name.Named;
 import org.candlepin.common.config.Configuration;
 import org.candlepin.config.ConfigProperties;
-import org.candlepin.model.Branding;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.EntitlementCurator;
 import org.candlepin.model.EnvironmentContent;
 import org.candlepin.model.Pool;
 import org.candlepin.model.Product;
+import org.candlepin.model.ProductBranding;
 import org.candlepin.model.ProductContent;
 import org.candlepin.model.dto.Content;
 import org.candlepin.model.dto.EntitlementBody;
@@ -308,7 +308,7 @@ public class X509V3ExtensionUtil extends X509Util {
         String version = engProduct.getAttributeValue(Product.Attributes.VERSION);
         toReturn.setVersion(version != null ? version : "");
 
-        Branding brand = getBranding(pool, engProduct.getId());
+        ProductBranding brand = getBranding(pool, engProduct.getId());
         toReturn.setBrandType(brand.getType());
         toReturn.setBrandName(brand.getName());
 
@@ -331,9 +331,9 @@ public class X509V3ExtensionUtil extends X509Util {
      * Return a branding object for the given engineering product ID if one exists for
      * the pool in question.
      */
-    private Branding getBranding(Pool pool, String productId) {
-        Branding resultBranding = null;
-        for (Branding b : pool.getBranding()) {
+    private ProductBranding getBranding(Pool pool, String productId) {
+        ProductBranding resultBranding = null;
+        for (ProductBranding b : pool.getProduct().getBranding()) {
             if (b.getProductId().equals(productId)) {
                 if (resultBranding == null) {
                     resultBranding = b;
@@ -348,7 +348,7 @@ public class X509V3ExtensionUtil extends X509Util {
         }
         // If none exist, use null strings
         return resultBranding != null ? resultBranding :
-            new Branding(productId, null, null);
+            new ProductBranding(productId, null, null, null);
     }
 
     /*

--- a/server/src/test/java/org/candlepin/controller/PoolManagerFunctionalTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerFunctionalTest.java
@@ -27,7 +27,6 @@ import org.candlepin.dto.manifest.v1.BrandingDTO;
 import org.candlepin.dto.manifest.v1.OwnerDTO;
 import org.candlepin.dto.manifest.v1.ProductDTO;
 import org.candlepin.dto.manifest.v1.SubscriptionDTO;
-import org.candlepin.model.Branding;
 import org.candlepin.model.CertificateSerial;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerInstalledProduct;
@@ -40,6 +39,7 @@ import org.candlepin.model.Owner;
 import org.candlepin.model.Pool;
 import org.candlepin.model.PoolFilterBuilder;
 import org.candlepin.model.Product;
+import org.candlepin.model.ProductBranding;
 import org.candlepin.model.activationkeys.ActivationKey;
 import org.candlepin.policy.EntitlementRefusedException;
 import org.candlepin.policy.js.entitlement.Enforcer;
@@ -60,6 +60,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
 import org.mockito.Mockito;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.Arrays;
 import java.util.Date;
@@ -170,15 +171,6 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
         sub3.setEndDate(TestUtil.createDate(3020, 12, 12));
         sub3.setLastModified(new Date());
 
-        sub4 = new SubscriptionDTO();
-        sub4.setId(Util.generateDbUUID());
-        sub4.setOwner(this.modelTranslator.translate(o, OwnerDTO.class));
-        sub4.setProduct(this.modelTranslator.translate(provisioning, ProductDTO.class));
-        sub4.setQuantity(5L);
-        sub4.setStartDate(new Date());
-        sub4.setEndDate(TestUtil.createDate(3020, 12, 12));
-        sub4.setLastModified(new Date());
-
         BrandingDTO brand1 = new BrandingDTO();
         brand1.setName("branding1");
         brand1.setType("type1");
@@ -189,7 +181,17 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
         brand2.setType("type2");
         brand2.setProductId("product2");
 
-        sub4.setBranding(Arrays.asList(brand1, brand2));
+        sub4 = new SubscriptionDTO();
+        sub4.setId(Util.generateDbUUID());
+        sub4.setOwner(this.modelTranslator.translate(o, OwnerDTO.class));
+        sub4.setProduct(this.modelTranslator.translate(provisioning, ProductDTO.class));
+        sub4.getProduct().addBranding(brand1);
+        sub4.getProduct().addBranding(brand2);
+
+        sub4.setQuantity(5L);
+        sub4.setStartDate(new Date());
+        sub4.setEndDate(TestUtil.createDate(3020, 12, 12));
+        sub4.setLastModified(new Date());
 
         subscriptions.add(sub1);
         subscriptions.add(sub2);
@@ -300,16 +302,16 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
                 masterPool = pool;
             }
         }
-        Set<Branding> brandingSet = poolManager.fabricateSubscriptionFromPool(masterPool).getBranding();
+        Collection<ProductBranding> brandingSet =
+            poolManager.fabricateSubscriptionFromPool(masterPool).getProduct().getBranding();
 
         assertNotNull(brandingSet);
         assertEquals(2, brandingSet.size());
-        ArrayList<Branding> list = new ArrayList<>();
-        list.addAll(brandingSet);
-        list.sort(new Comparator<Branding>() {
+        ArrayList<ProductBranding> list = new ArrayList<>(brandingSet);
+        list.sort(new Comparator<ProductBranding>() {
 
             @Override
-            public int compare(Branding o1, Branding o2) {
+            public int compare(ProductBranding o1, ProductBranding o2) {
                 return o1.getName().compareTo(o2.getName());
             }
         });

--- a/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -42,7 +42,6 @@ import org.candlepin.common.config.Configuration;
 import org.candlepin.common.paging.Page;
 import org.candlepin.common.paging.PageRequest;
 import org.candlepin.config.ConfigProperties;
-import org.candlepin.model.Branding;
 import org.candlepin.model.CandlepinQuery;
 import org.candlepin.model.CdnCurator;
 import org.candlepin.model.Consumer;
@@ -66,6 +65,7 @@ import org.candlepin.model.PoolCurator;
 import org.candlepin.model.PoolFilterBuilder;
 import org.candlepin.model.PoolQuantity;
 import org.candlepin.model.Product;
+import org.candlepin.model.ProductBranding;
 import org.candlepin.model.ProductCurator;
 import org.candlepin.model.SourceStack;
 import org.candlepin.model.SourceSubscription;
@@ -689,10 +689,10 @@ public class PoolManagerTest {
         Product product = TestUtil.createProduct();
 
         Subscription sub = TestUtil.createSubscription(owner, product);
-        Branding b1 = new Branding("8000", "OS", "Branded Awesome OS");
-        Branding b2 = new Branding("8001", "OS", "Branded Awesome OS 2");
-        sub.getBranding().add(b1);
-        sub.getBranding().add(b2);
+        ProductBranding b1 = new ProductBranding("8000", "OS", "Branded Awesome OS", null);
+        ProductBranding b2 = new ProductBranding("8001", "OS", "Branded Awesome OS 2", null);
+        product.addBranding(b1);
+        product.addBranding(b2);
 
         this.mockProducts(owner, product);
 
@@ -702,9 +702,9 @@ public class PoolManagerTest {
         assertEquals(1, pools.size());
 
         Pool resultPool = pools.get(0);
-        assertEquals(2, resultPool.getBranding().size());
-        assertTrue(resultPool.getBranding().contains(b1));
-        assertTrue(resultPool.getBranding().contains(b2));
+        assertEquals(2, resultPool.getProduct().getBranding().size());
+        assertTrue(resultPool.getProduct().getBranding().contains(b1));
+        assertTrue(resultPool.getProduct().getBranding().contains(b2));
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/dto/api/v1/PoolTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/PoolTranslatorTest.java
@@ -17,12 +17,12 @@ package org.candlepin.dto.api.v1;
 
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
-import org.candlepin.model.Branding;
 import org.candlepin.model.CertificateSerial;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.Entitlement;
 import org.candlepin.model.Pool;
 import org.candlepin.model.Product;
+import org.candlepin.model.ProductBranding;
 import org.candlepin.model.ProvidedProduct;
 import org.candlepin.model.SourceStack;
 import org.candlepin.model.SourceSubscription;
@@ -52,7 +52,7 @@ public class PoolTranslatorTest extends AbstractTranslatorTest<Pool, PoolDTO, Po
 
     private OwnerTranslatorTest ownerTranslatorTest = new OwnerTranslatorTest();
     private ProductTranslatorTest productTranslatorTest = new ProductTranslatorTest();
-    private BrandingTranslatorTest brandingTranslatorTest = new BrandingTranslatorTest();
+    private ProductBrandingTranslatorTest brandingTranslatorTest = new ProductBrandingTranslatorTest();
     private CertificateTranslatorTest certificateTranslatorTest = new CertificateTranslatorTest();
 
     @Override
@@ -80,10 +80,6 @@ public class PoolTranslatorTest extends AbstractTranslatorTest<Pool, PoolDTO, Po
         source.setOwner(this.ownerTranslatorTest.initSourceObject());
         source.setProduct(this.productTranslatorTest.initSourceObject());
         source.setDerivedProduct(this.productTranslatorTest.initSourceObject());
-
-        Set<Branding> brandingSet = new HashSet<>();
-        brandingSet.add(this.brandingTranslatorTest.initSourceObject());
-        source.setBranding(brandingSet);
 
         Entitlement entitlement = new Entitlement();
         entitlement.setId("ent-id");
@@ -221,14 +217,17 @@ public class PoolTranslatorTest extends AbstractTranslatorTest<Pool, PoolDTO, Po
                     assertNull(destSourceEntitlement);
                 }
 
-                for (Branding brandingSource : source.getBranding()) {
-                    for (BrandingDTO brandingDTO : dest.getBranding()) {
+                Product product = source.getProduct();
+                if (product != null) {
+                    for (ProductBranding brandingSource : product.getBranding()) {
+                        for (BrandingDTO brandingDTO : dest.getBranding()) {
 
-                        assertNotNull(brandingDTO);
-                        assertNotNull(brandingDTO.getProductId());
+                            assertNotNull(brandingDTO);
+                            assertNotNull(brandingDTO.getProductId());
 
-                        if (brandingDTO.getProductId().equals(brandingSource.getProductId())) {
-                            this.brandingTranslatorTest.verifyOutput(brandingSource, brandingDTO, true);
+                            if (brandingDTO.getProductId().equals(brandingSource.getProductId())) {
+                                this.brandingTranslatorTest.verifyOutput(brandingSource, brandingDTO, true);
+                            }
                         }
                     }
                 }

--- a/server/src/test/java/org/candlepin/dto/api/v1/ProductBrandingTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/ProductBrandingTranslatorTest.java
@@ -30,17 +30,17 @@ public class ProductBrandingTranslatorTest extends
     protected ProductBrandingTranslator translator = new ProductBrandingTranslator();
 
     @Override
-    protected void initModelTranslator(ModelTranslator modelTranslator) {
+    public void initModelTranslator(ModelTranslator modelTranslator) {
         modelTranslator.registerTranslator(this.translator, ProductBranding.class, BrandingDTO.class);
     }
 
     @Override
-    protected ProductBrandingTranslator initObjectTranslator() {
+    public ProductBrandingTranslator initObjectTranslator() {
         return this.translator;
     }
 
     @Override
-    protected ProductBranding initSourceObject() {
+    public ProductBranding initSourceObject() {
         ProductBranding source = new ProductBranding();
 
         source.setProductId("test-product-id");
@@ -56,7 +56,7 @@ public class ProductBrandingTranslatorTest extends
     }
 
     @Override
-    protected void verifyOutput(ProductBranding source, BrandingDTO dest, boolean childrenGenerated) {
+    public void verifyOutput(ProductBranding source, BrandingDTO dest, boolean childrenGenerated) {
         if (source != null) {
             assertEquals(source.getProductId(), dest.getProductId());
             assertEquals(source.getName(), dest.getName());

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/ProductDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/ProductDTOTest.java
@@ -14,15 +14,16 @@
  */
 package org.candlepin.dto.manifest.v1;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.candlepin.dto.AbstractDTOTest;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Map;
 
@@ -61,6 +62,15 @@ public class ProductDTOTest extends AbstractDTOTest<ProductDTO> {
             dependentProductIds.add("dependentProdId" + i);
         }
 
+        Collection<BrandingDTO> brandings = new HashSet<>();
+        for (int i = 0; i < 5; ++i) {
+            BrandingDTO branding = new BrandingDTO();
+            branding.setProductId("prod_id_" + i);
+            branding.setType("OS");
+            branding.setName("Brand Name" + i);
+            brandings.add(branding);
+        }
+
         this.values = new HashMap<>();
         this.values.put("Id", "test_value");
         this.values.put("Uuid", "test_value");
@@ -70,6 +80,7 @@ public class ProductDTOTest extends AbstractDTOTest<ProductDTO> {
         this.values.put("ProductContent", productContent);
         this.values.put("Attributes", attributes);
         this.values.put("DependentProductIds", dependentProductIds);
+        this.values.put("Branding", brandings);
         this.values.put("Created", new Date());
         this.values.put("Updated", new Date());
     }
@@ -133,27 +144,94 @@ public class ProductDTOTest extends AbstractDTOTest<ProductDTO> {
         assertNull(value);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetAttributeWithNullAttribute() {
         ProductDTO dto = new ProductDTO();
-        dto.getAttributeValue(null);
+        assertThrows(IllegalArgumentException.class, () -> dto.getAttributeValue(null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testSetAttributeWithNullAttribute() {
         ProductDTO dto = new ProductDTO();
-        dto.setAttribute(null, "value");
+        assertThrows(IllegalArgumentException.class, () -> dto.setAttribute(null, "value"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testHasAttributeWithNullAttribute() {
         ProductDTO dto = new ProductDTO();
-        dto.hasAttribute(null);
+        assertThrows(IllegalArgumentException.class, () -> dto.hasAttribute(null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testRemoveAttributeWithNullAttribute() {
         ProductDTO dto = new ProductDTO();
-        dto.removeAttribute(null);
+        assertThrows(IllegalArgumentException.class, () -> dto.removeAttribute(null));
+    }
+
+    @Test
+    public void testAddBrandingWithAbsentBranding() {
+        ProductDTO dto = new ProductDTO();
+
+        BrandingDTO branding = new BrandingDTO();
+        branding.setProductId("test-branding-product-id-1");
+        branding.setName("test-branding-name-1");
+        branding.setType("test-branding-type-1");
+        assertTrue(dto.addBranding(branding));
+    }
+
+    @Test
+    public void testAddBrandingWithPresentBranding() {
+        ProductDTO dto = new ProductDTO();
+
+        BrandingDTO branding = new BrandingDTO();
+        branding.setProductId("test-branding-product-id-2");
+        branding.setName("test-branding-name-2");
+        branding.setType("test-branding-type-2");
+        assertTrue(dto.addBranding(branding));
+
+        BrandingDTO branding2 = new BrandingDTO();
+        branding2.setProductId("test-branding-product-id-2");
+        branding2.setName("test-branding-name-2");
+        branding2.setType("test-branding-type-2");
+        assertFalse(dto.addBranding(branding2));
+    }
+
+    @Test
+    public void testAddBrandingWithNullInput() {
+        ProductDTO dto = new ProductDTO();
+        assertThrows(IllegalArgumentException.class, () -> dto.addBranding(null));
+    }
+
+    @Test
+    public void testAddBrandingWithEmptyProductId() {
+        ProductDTO dto = new ProductDTO();
+
+        BrandingDTO branding = new BrandingDTO();
+        branding.setProductId("");
+        branding.setName("test-branding-name-3");
+        branding.setType("test-branding-type-3");
+        assertThrows(IllegalArgumentException.class, () -> dto.addBranding(branding));
+    }
+
+    @Test
+    public void testAddBrandingWithEmptyName() {
+        ProductDTO dto = new ProductDTO();
+
+        BrandingDTO branding = new BrandingDTO();
+        branding.setProductId("test-branding-product-id-4");
+        branding.setName("");
+        branding.setType("test-branding-type-4");
+        assertThrows(IllegalArgumentException.class, () -> dto.addBranding(branding));
+    }
+
+    @Test
+    public void testAddBrandingWithEmptyType() {
+        ProductDTO dto = new ProductDTO();
+
+        BrandingDTO branding = new BrandingDTO();
+        branding.setProductId("test-branding-product-id-5");
+        branding.setName("test-branding-name-5");
+        branding.setType("");
+        assertThrows(IllegalArgumentException.class, () -> dto.addBranding(branding));
     }
 }

--- a/server/src/test/java/org/candlepin/dto/shim/ProductDataTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/shim/ProductDataTranslatorTest.java
@@ -15,13 +15,18 @@
 package org.candlepin.dto.shim;
 
 import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
+import org.candlepin.dto.api.v1.BrandingDTO;
 import org.candlepin.dto.api.v1.ContentDTO;
+import org.candlepin.dto.api.v1.ProductBrandingTranslator;
+import org.candlepin.dto.api.v1.ProductBrandingTranslatorTest;
 import org.candlepin.dto.api.v1.ProductDTO;
 import org.candlepin.dto.api.v1.ProductDTO.ProductContentDTO;
 import org.candlepin.model.Content;
+import org.candlepin.model.ProductBranding;
 import org.candlepin.model.dto.ContentData;
 import org.candlepin.model.dto.ProductContentData;
 import org.candlepin.model.dto.ProductData;
@@ -29,10 +34,10 @@ import org.candlepin.test.TestUtil;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Map;
-
-
+import java.util.Set;
 
 /**
  * Test suite for the UpstreamConsumerTranslator class
@@ -42,13 +47,19 @@ public class ProductDataTranslatorTest extends
 
     protected ContentDataTranslator contentTranslator = new ContentDataTranslator();
     protected ProductDataTranslator productTranslator = new ProductDataTranslator();
+    protected ProductBrandingTranslator brandingTranslator = new ProductBrandingTranslator();
 
     protected ContentDataTranslatorTest contentDataTranslatorTest = new ContentDataTranslatorTest();
+    protected ProductBrandingTranslatorTest productBrandingTranslatorTest =
+        new ProductBrandingTranslatorTest();
 
     @Override
     protected void initModelTranslator(ModelTranslator modelTranslator) {
         modelTranslator.registerTranslator(this.contentTranslator, ContentData.class, ContentDTO.class);
         modelTranslator.registerTranslator(this.productTranslator, ProductData.class, ProductDTO.class);
+        modelTranslator.registerTranslator(this.brandingTranslator, ProductBranding.class, BrandingDTO.class);
+
+        this.productBrandingTranslatorTest.initModelTranslator(modelTranslator);
     }
 
     @Override
@@ -84,6 +95,10 @@ public class ProductDataTranslatorTest extends
 
             source.addContent(content, true);
         }
+
+        Set<ProductBranding> brandingSet = new HashSet<>();
+        brandingSet.add(this.productBrandingTranslatorTest.initSourceObject());
+        source.setBranding(brandingSet);
 
         return source;
     }
@@ -125,9 +140,25 @@ public class ProductDataTranslatorTest extends
                         }
                     }
                 }
+
+                assertNotNull(dto.getBranding());
+                assertEquals(dto.getBranding().size(), source.getBranding().size());
+                for (ProductBranding brandingSource : source.getBranding()) {
+                    for (BrandingDTO brandingDTO : dto.getBranding()) {
+
+                        assertNotNull(brandingDTO);
+                        assertNotNull(brandingDTO.getProductId());
+
+                        if (brandingDTO.getProductId().equals(brandingSource.getProductId())) {
+                            this.productBrandingTranslatorTest.verifyOutput(brandingSource, brandingDTO,
+                                true);
+                        }
+                    }
+                }
             }
             else {
                 assertNull(dto.getProductContent());
+                assertNull(dto.getBranding());
             }
         }
         else {

--- a/server/src/test/java/org/candlepin/model/ProductTest.java
+++ b/server/src/test/java/org/candlepin/model/ProductTest.java
@@ -16,6 +16,8 @@ package org.candlepin.model;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import org.candlepin.util.Util;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -198,4 +200,31 @@ public class ProductTest {
         assertNotEquals(accessor.invoke(lhs), accessor.invoke(rhs));
         assertNotEquals(lhs.getEntityVersion(), rhs.getEntityVersion());
     }
+
+    @ParameterizedTest
+    @MethodSource("getValuesForEqualityAndReplication")
+    public void testClone(String valueName, Object value1, Object value2) throws Exception {
+        Method[] methods = this.getAccessorAndMutator(valueName, value1.getClass());
+        Method accessor = methods[0];
+        Method mutator = methods[1];
+
+        Product base = new Product();
+
+        mutator.invoke(base, value1);
+
+        Product clone = (Product) base.clone();
+
+        if (value1 instanceof Collection) {
+            assertTrue(Util.collectionsAreEqual(
+                (Collection) accessor.invoke(base), (Collection) accessor.invoke(clone)
+            ));
+        }
+        else {
+            assertEquals(accessor.invoke(base), accessor.invoke(clone));
+        }
+
+        assertEquals(base, clone);
+        assertEquals(base.hashCode(), clone.hashCode());
+    }
+
 }

--- a/server/src/test/java/org/candlepin/model/dto/ProductDataTest.java
+++ b/server/src/test/java/org/candlepin/model/dto/ProductDataTest.java
@@ -19,7 +19,9 @@ import static org.junit.jupiter.api.Assertions.*;
 import org.candlepin.common.jackson.DynamicPropertyFilter;
 import org.candlepin.model.Content;
 import org.candlepin.model.Product;
+import org.candlepin.model.ProductBranding;
 import org.candlepin.model.ProductContent;
+import org.candlepin.service.model.BrandingInfo;
 import org.candlepin.util.Util;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -861,6 +863,105 @@ public class ProductDataTest {
         assertTrue(Util.collectionsAreEqual(Arrays.<String>asList(), pids));
     }
 
+    @Test
+    public void testGetSetBranding() {
+        ProductData dto = new ProductData();
+        Collection<ProductBranding> input = Arrays.asList(
+            new ProductBranding("eng_id_1", "OS", "brand_name_1", null),
+            new ProductBranding("eng_id_2", "OS", "brand_name_2", null),
+            new ProductBranding("eng_id_3", "OS", "brand_name_3", null)
+        );
+
+        Collection<ProductBranding> output = dto.getBranding();
+        assertNull(output);
+
+        ProductData output2 = dto.setBranding(input);
+        assertSame(dto, output2);
+
+        output = dto.getBranding();
+        assertTrue(Util.collectionsAreEqual(input, output));
+    }
+
+    @Test
+    public void testAddBranding() {
+        ProductData dto = new ProductData();
+
+        Collection<ProductBranding> brandings = dto.getBranding();
+        assertNull(brandings);
+
+        boolean output = dto.addBranding(new ProductBranding("eng_id_1", "OS", "brand_name_1", null));
+        brandings = dto.getBranding();
+
+        assertTrue(output);
+        assertNotNull(brandings);
+        assertTrue(Util.collectionsAreEqual(Arrays.asList(
+            new ProductBranding("eng_id_1", "OS", "brand_name_1", null)), brandings));
+
+        output = dto.addBranding(new ProductBranding("eng_id_2", "OS", "brand_name_2", null));
+        brandings = dto.getBranding();
+
+        assertTrue(output);
+        assertNotNull(brandings);
+        assertTrue(Util.collectionsAreEqual(Arrays.asList(
+            new ProductBranding("eng_id_1", "OS", "brand_name_1", null),
+            new ProductBranding("eng_id_2", "OS", "brand_name_2", null)), brandings));
+
+        output = dto.addBranding(new ProductBranding("eng_id_1", "OS", "brand_name_1", null));
+        brandings = dto.getBranding();
+
+        assertFalse(output);
+        assertNotNull(brandings);
+        assertTrue(Util.collectionsAreEqual(Arrays.asList(
+            new ProductBranding("eng_id_1", "OS", "brand_name_1", null),
+            new ProductBranding("eng_id_2", "OS", "brand_name_2", null)), brandings));
+    }
+
+    @Test
+    public void testRemoveBranding() {
+        ProductData dto = new ProductData();
+
+        Collection<ProductBranding> brandings = dto.getBranding();
+        assertNull(brandings);
+
+        boolean output = dto.removeBranding(new ProductBranding("eng_id_1", "OS", "brand_name_1", null));
+        brandings = dto.getBranding();
+
+        assertFalse(output);
+        assertNull(brandings);
+
+        dto.setBranding(Arrays.asList(
+            new ProductBranding("eng_id_1", "OS", "brand_name_1", null),
+            new ProductBranding("eng_id_2", "OS", "brand_name_2", null)));
+        brandings = dto.getBranding();
+
+        assertNotNull(brandings);
+        assertTrue(Util.collectionsAreEqual(Arrays.asList(
+            new ProductBranding("eng_id_1", "OS", "brand_name_1", null),
+            new ProductBranding("eng_id_2", "OS", "brand_name_2", null)), brandings));
+
+        output = dto.removeBranding(new ProductBranding("eng_id_1", "OS", "brand_name_1", null));
+        brandings = dto.getBranding();
+
+        assertTrue(output);
+        assertNotNull(brandings);
+        assertTrue(Util.collectionsAreEqual(Arrays.asList(
+            new ProductBranding("eng_id_2", "OS", "brand_name_2", null)), brandings));
+
+        output = dto.removeBranding(new ProductBranding("eng_id_3", "OS", "brand_name_3", null));
+        brandings = dto.getBranding();
+
+        assertFalse(output);
+        assertNotNull(brandings);
+        assertTrue(Util.collectionsAreEqual(Arrays.asList(
+            new ProductBranding("eng_id_2", "OS", "brand_name_2", null)), brandings));
+
+        output = dto.removeBranding(new ProductBranding("eng_id_2", "OS", "brand_name_2", null));
+        brandings = dto.getBranding();
+
+        assertTrue(output);
+        assertNotNull(brandings);
+        assertTrue(Util.collectionsAreEqual(Arrays.asList(), brandings));
+    }
 
     @Test
     public void testGetSetHref() {
@@ -924,6 +1025,18 @@ public class ProductDataTest {
             new ProductContentData(content[5], true)
         );
 
+        Collection<BrandingInfo> branding1 = Arrays.asList(
+            new ProductBranding("eng_id_1", "OS", "brand_name_1", null),
+            new ProductBranding("eng_id_2", "OS", "brand_name_2", null),
+            new ProductBranding("eng_id_3", "OS", "brand_name_3", null)
+        );
+
+        Collection<BrandingInfo> branding2 = Arrays.asList(
+            new ProductBranding("eng_id_4", "OS", "brand_name_4", null),
+            new ProductBranding("eng_id_5", "OS", "brand_name_5", null),
+            new ProductBranding("eng_id_6", "OS", "brand_name_6", null)
+        );
+
         return Stream.of(
             new Object[] { "Uuid", "test_value", "alt_value" },
             new Object[] { "Id", "test_value", "alt_value" },
@@ -932,6 +1045,7 @@ public class ProductDataTest {
             new Object[] { "Attributes", attributes1, attributes2 },
             new Object[] { "ProductContent", productContent1, productContent2 },
             new Object[] { "DependentProductIds", Arrays.asList("1", "2", "3"), Arrays.asList("4", "5") },
+            new Object[] { "Branding", branding1, branding2},
             // new Object[] { "Href", "test_value", null },
             new Object[] { "Locked", Boolean.TRUE, false }
         );

--- a/server/src/test/java/org/candlepin/sync/EntitlementImporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/EntitlementImporterTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.*;
 import org.candlepin.audit.EventSink;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.dto.StandardTranslator;
+import org.candlepin.dto.manifest.v1.BrandingDTO;
 import org.candlepin.dto.manifest.v1.CertificateSerialDTO;
 import org.candlepin.dto.manifest.v1.ConsumerDTO;
 import org.candlepin.dto.manifest.v1.EntitlementDTO;
@@ -151,6 +152,13 @@ public class EntitlementImporterTest {
         ent.setQuantity(3);
         EntitlementDTO dtoEnt = this.translator.translate(ent, EntitlementDTO.class);
 
+        BrandingDTO brandingDTO = new BrandingDTO();
+        brandingDTO.setName("brand_name");
+        brandingDTO.setProductId("eng_id_1");
+        brandingDTO.setType("OS");
+        brandingDTO.setId("db_id");
+        dtoEnt.getPool().addBranding(brandingDTO);
+
         when(om.readValue(reader, EntitlementDTO.class)).thenReturn(dtoEnt);
 
         // Create our expected products
@@ -190,6 +198,8 @@ public class EntitlementImporterTest {
         assertEquals(cert.getSerial().getUpdated(), serial.getUpdated());
 
         assertEquals(sub.getCdn().getLabel(), meta.getCdnLabel());
+
+        assertEquals(brandingDTO, sub.getProduct().getBranding().toArray()[0]);
     }
 
     private Map<String, ProductDTO> buildProductCache(Product... products) {

--- a/server/src/test/java/org/candlepin/test/TestUtil.java
+++ b/server/src/test/java/org/candlepin/test/TestUtil.java
@@ -649,12 +649,6 @@ public class TestUtil {
         pool.setUpstreamConsumerId(sub.getUpstreamConsumerId());
         pool.setUpstreamEntitlementId(sub.getUpstreamEntitlementId());
 
-        for (Branding branding : sub.getBranding()) {
-            pool.getBranding().add(
-                new Branding(branding.getProductId(), branding.getType(), branding.getName())
-            );
-        }
-
         return pool;
     }
 

--- a/server/src/test/java/org/candlepin/util/X509V3ExtensionUtilTest.java
+++ b/server/src/test/java/org/candlepin/util/X509V3ExtensionUtilTest.java
@@ -25,13 +25,13 @@ import com.google.inject.Injector;
 import com.google.inject.name.Named;
 import org.candlepin.TestingModules;
 import org.candlepin.common.config.Configuration;
-import org.candlepin.model.Branding;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.Content;
 import org.candlepin.model.Entitlement;
 import org.candlepin.model.EntitlementCurator;
 import org.candlepin.model.Pool;
 import org.candlepin.model.Product;
+import org.candlepin.model.ProductBranding;
 import org.candlepin.model.ProductContent;
 import org.candlepin.model.Owner;
 import org.candlepin.model.dto.TinySubscription;
@@ -153,8 +153,8 @@ public class X509V3ExtensionUtilTest {
         p.setAttribute(Product.Attributes.BRANDING_TYPE, "OS");
         Set<Product> prods = new HashSet<>(Arrays.asList(p));
         Product mktProd = new Product("mkt", "MKT SKU");
+        mktProd.addBranding(new ProductBranding(engProdId, "OS", brandedName, mktProd));
         Pool pool = TestUtil.createPool(mktProd);
-        pool.getBranding().add(new Branding(engProdId, "OS", brandedName));
         Consumer consumer = new Consumer();
         Entitlement e = new Entitlement(pool, consumer, owner, 10);
 
@@ -170,17 +170,16 @@ public class X509V3ExtensionUtilTest {
     public void productWithMultipleBrandNames() {
         String engProdId = "1000";
         String brandedName = "Branded Eng Product";
-        Owner owner = new Owner("Test Corporation");
         Product p = new Product(engProdId, "Eng Product 1000");
         p.setAttribute(Product.Attributes.BRANDING_TYPE, "OS");
         Set<Product> prods = new HashSet<>(Arrays.asList(p));
         Product mktProd = new Product("mkt", "MKT SKU");
+        mktProd.addBranding(new ProductBranding(engProdId, "OS", brandedName, mktProd));
+        mktProd.addBranding(new ProductBranding(engProdId, "OS", "another brand name", mktProd));
+        mktProd.addBranding(new ProductBranding(engProdId, "OS", "number 3", mktProd));
         Pool pool = TestUtil.createPool(mktProd);
-        pool.getBranding().add(new Branding(engProdId, "OS", brandedName));
-        pool.getBranding().add(new Branding(engProdId, "OS", "another brand name"));
-        pool.getBranding().add(new Branding(engProdId, "OS", "number 3"));
         Set<String> possibleBrandNames = new HashSet<>();
-        for (Branding b : pool.getBranding()) {
+        for (ProductBranding b : mktProd.getBranding()) {
             possibleBrandNames.add(b.getName());
         }
 


### PR DESCRIPTION
Now, during refresh, fetch branding from the upstream product
and not from the upstream subscription, and persist it on the
main product instead of the pool.

- Adapter API changes:
    - Add branding ProductInfo/ProductData.
    - Remove branding from SubscriptionInfo/Subscription.
    - Add utility method on BrandingInfo that returns a
      Comparator for objects of classes that implement it.

- REST API changes:
    - /owners/{owner_key}/subscriptions legacy APIs that use the
      Subscription object now expect branding on ProductData
      instead of Subscription.

- HostedTestSubscriptionServiceAdapter/HostedTestSubscriptionResource
  now expect branding on ProductData instead of Subscription.
- Add branding on manifest ProductDTO (but ignore it on
  serialization/deserialization), in order for EntitlementImporter
  to set imported branding to the product and not the pool.
- Populate PoolDTO branding from product on GET request (ENT-1617).
- ProductManager import now also takes into account Branding.
- Add branding to entitlement certificates from the main product
  now instead of the pool.
- PoolRules/PoolUpdate no longer track branding changes, since
  those will now be reflected in product changes.
- Add/Update relevant unit/spec tests.