### PR TITLE
ENT-797: Update ehcache version from 2.10.3 to 3.8.0

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -166,9 +166,8 @@ dependencies {
     implementation "javax.activation:javax.activation-api:1.2.0"
 
     // Ehcache
-    implementation "org.hibernate:hibernate-ehcache:5.3.8.Final"
-    implementation "net.sf.ehcache:ehcache:2.10.3"
-    implementation "org.ehcache:jcache:1.0.0"
+    implementation "org.hibernate:hibernate-jcache:5.4.6.Final"
+    implementation "org.ehcache:ehcache:3.8.0"
     implementation "javax.cache:cache-api:1.0.0"
 
     compileOnly "org.mozilla:jss:4.4.6"

--- a/server/conf/candlepin.conf.template
+++ b/server/conf/candlepin.conf.template
@@ -10,6 +10,7 @@ jpa.config.hibernate.connection.url=<%= candlepin.jdbc_url %>
 jpa.config.hibernate.connection.username=<%= candlepin.cpdb_username %>
 jpa.config.hibernate.connection.password=<%= candlepin.cpdb_password %>
 jpa.config.hibernate.dialect=<%= candlepin.jdbc_dialect %>
+jpa.config.hibernate.javax.cache.uri=ehcache.xml
 
 candlepin.auth.trusted.enable=true
 candlepin.auth.oauth.enable=true

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -1099,20 +1099,8 @@
     </dependency>
     <dependency>
       <groupId>org.hibernate</groupId>
-      <artifactId>hibernate-ehcache</artifactId>
-      <version>5.3.8.Final</version>
-      <scope>compile</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>*</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>net.sf.ehcache</groupId>
-      <artifactId>ehcache</artifactId>
-      <version>2.10.3</version>
+      <artifactId>hibernate-jcache</artifactId>
+      <version>5.4.6.Final</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -1123,8 +1111,8 @@
     </dependency>
     <dependency>
       <groupId>org.ehcache</groupId>
-      <artifactId>jcache</artifactId>
-      <version>1.0.0</version>
+      <artifactId>ehcache</artifactId>
+      <version>3.8.0</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>

--- a/server/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/server/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -159,6 +159,7 @@ public class ConfigProperties {
     public static final String DB_PASSWORD = JPA_CONFIG_PREFIX + "hibernate.connection.password";
     // Cache
     public static final String CACHE_JMX_STATS = "cache.jmx.statistics";
+    public static final String CACHE_CONFIG_FILE_URI = JPA_CONFIG_PREFIX + "hibernate.javax.cache.uri";
 
     public static final String[] ENCRYPTED_PROPERTIES = new String[] {
         DB_PASSWORD,
@@ -349,6 +350,7 @@ public class ConfigProperties {
             this.put(FAIL_ON_UNKNOWN_IMPORT_PROPERTIES, "false");
 
             this.put(CACHE_JMX_STATS, "false");
+            this.put(CACHE_CONFIG_FILE_URI, "ehcache.xml");
 
             // Pinsetter
             // prevent Quartz from checking for updates

--- a/server/src/main/java/org/candlepin/guice/CandlepinContextListener.java
+++ b/server/src/main/java/org/candlepin/guice/CandlepinContextListener.java
@@ -57,20 +57,16 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xnap.commons.i18n.I18nManager;
 
-import net.sf.ehcache.CacheManager;
-import net.sf.ehcache.management.ManagementService;
-
 import io.swagger.converter.ModelConverters;
 
 import java.io.File;
-import java.lang.management.ManagementFactory;
 import java.nio.charset.Charset;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
-import javax.management.MBeanServer;
+import javax.cache.CacheManager;
 import javax.persistence.EntityManagerFactory;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletContextEvent;
@@ -180,9 +176,13 @@ public class CandlepinContextListener extends GuiceResteasyBootstrapServletConte
         }
 
         if (config.getBoolean(ConfigProperties.CACHE_JMX_STATS)) {
-            MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
-            ManagementService.registerMBeans(CacheManager.getInstance(), mBeanServer,
-                true, true, true, true);
+            CacheManager cacheManager = injector.getInstance(CacheManager.class);
+            cacheManager.getCacheNames().forEach(cacheName -> {
+                log.info("Enabling management and statistics for {} cache", cacheName);
+                cacheManager.enableManagement(cacheName, true);
+                cacheManager.enableStatistics(cacheName, true);
+            });
+
         }
 
         pinsetterListener = injector.getInstance(PinsetterContextListener.class);

--- a/server/src/main/resources/META-INF/persistence.xml
+++ b/server/src/main/resources/META-INF/persistence.xml
@@ -19,10 +19,11 @@
             <property name="hibernate.c3p0.min_size" value="5" />
             <property name="hibernate.c3p0.max_size" value="20" />
             <property name="hibernate.c3p0.timeout" value="300" />
-            <property name="hibernate.cache.region.factory_class" value="org.hibernate.cache.ehcache.EhCacheRegionFactory" />
-            <property name="net.sf.ehcache.configurationResourceName" value="ehcache.xml" />
-            <property name="hibernate.cache.use_second_level_cache" value="true" />
-            <property name="hibernate.cache.use_query_cache" value="true" />
+            <!-- caching setting -->
+            <property name="hibernate.cache.region.factory_class" value="org.hibernate.cache.jcache.JCacheRegionFactory"/>
+            <property name="hibernate.cache.use_second_level_cache" value="true"/>
+            <property name="hibernate.cache.use_query_cache" value="true"/>
+            <property name="hibernate.javax.cache.missing_cache_strategy" value="create"/>
 
             <!-- test period in seconds -->
             <property name="hibernate.c3p0.idle_test_period" value="300" />

--- a/server/src/main/resources/ehcache.xml
+++ b/server/src/main/resources/ehcache.xml
@@ -1,25 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<config
+    xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+    xmlns='http://www.ehcache.org/v3'
+    xmlns:jsr107='http://www.ehcache.org/v3/jsr107'
+    xsi:schemaLocation="
+        http://www.ehcache.org/v3 http://www.ehcache.org/schema/ehcache-core-3.8.xsd
+        http://www.ehcache.org/v3/jsr107 http://www.ehcache.org/schema/ehcache-107-ext-3.8.xsd">
 
 
-<ehcache>
-	<sizeOfPolicy maxDepth="100" maxDepthExceededBehavior="abort"/>
+    <service>
+        <jsr107:defaults default-template="default-template"/>
+    </service>
 
-<!-- There are some internal caches created by hibernate that will
-     inherit these settings
-     -->
-    <defaultCache 
-        eternal="false" 
-        maxEntriesLocalHeap="100000"
-        timeToIdleSeconds="86400" 
-        timeToLiveSeconds="86400"/>    
-    
-    <!-- We know we gonna have just one entry in this cache -->
-     <cache
-        name="query-5-seconds"
-        maxEntriesLocalHeap="1"
-        eternal="false"
-        timeToIdleSeconds="5"
-        timeToLiveSeconds="5"
-    />
+    <cache-template name="default-template">
+        <key-type copier="org.ehcache.impl.copy.IdentityCopier">java.lang.Object</key-type>
+        <value-type copier="org.ehcache.impl.copy.IdentityCopier">java.lang.Object</value-type>
+        <expiry>
+            <ttl unit="seconds">86400</ttl>
+        </expiry>
+        <heap unit="entries">100000</heap>
+        <jsr107:mbeans enable-statistics="false" enable-management="false"/>
+    </cache-template>
 
-</ehcache>
+    <cache alias="query-5-seconds" uses-template="default-template">
+        <expiry>
+            <ttl unit="seconds">5</ttl>
+        </expiry>
+        <heap unit="entries">1</heap>
+    </cache>
+
+</config>


### PR DESCRIPTION
- I did not find a clean way to configure cache in Java and use it into JPA initialization process. Hence continue using XML to configure cache properties.
- Updated net.sf.ehcache:ehcache:2.10.3 (ehcache 2) with org.ehcache:ehcache:3.8.0 (ehcache 3 latest version)
- Updated org.hibernate:hibernate-ehcache:5.3.8.Final with org.hibernate:hibernate-jcache:5.4.6.Final to support ehcache 3 and fix related to ehcache.xml file.
- Remove org.ehcache:jcache:1.0.0 as it is not required in ehcache 3.
- Updated ehcache.xml as per ehcahce 3 specifications.
- Updated persistence.xml to use ehcache 3 JCacheRegionFactory.
- Added hibernate.javax.cache.missing_cache_strategy = create to avoid warning related to missing cache definition in ehcache.xml.
- Updated JCacheManagerProvider to get CacheManager (created while JPA initialization) from CachingProvider
- In ehache 2.x, ManagementService is being used to register various mbeans like cachemanger, caches, cache configurations etc. However, this service is not available in ehcache 3.x. For now, updated CandlepinContextListener code to only register caches mbeans.
-  Move hibernate.javax.cache.uri property from persistence.xml to Candlepin.conf to reuse it in JCacheManagerProvider