### PR TITLE
1698469: [RFE] Add options for cpdb command

### DIFF
--- a/server/code/setup/cpdb
+++ b/server/code/setup/cpdb
@@ -92,7 +92,7 @@ class DbSetup(object):
         if os.path.exists(JBOSS_CLASSPATH):
             classpath = "%s:%s" % (classpath, JBOSS_CLASSPATH)
 
-        liquibase_options = "--driver=%s --classpath=%s --changeLogFile=%s --url=%s --username=$DBUSERNAME" % (
+        liquibase_options = "--driver=%s --classpath=%s --changeLogFile=%s --url=\"%s\" --username=$DBUSERNAME" % (
             self.driver_class,
             classpath,
             changelog_path,
@@ -115,7 +115,7 @@ class DbSetup(object):
 
 
 class PostgresqlSetup(DbSetup):
-    def __init__(self, host, port, username, password, db, community, verbose):
+    def __init__(self, host, port, username, password, db, community, verbose, ssl, sslfactory, sslcertpath):
         super(PostgresqlSetup, self).__init__(username, password, db, community, verbose)
         self.host = host
         self.port = port
@@ -131,6 +131,20 @@ class PostgresqlSetup(DbSetup):
             # Append / for the database name:
             self.jdbc_url = "%s/" % (self.jdbc_url)
         self.jdbc_url = "%s%s" % (self.jdbc_url, db)
+
+        # Appending SSL connection details
+        if ssl == True:
+            if sslfactory is None:
+                if sslcertpath is None:
+                    self.jdbc_url = "%s%s" % (self.jdbc_url, "?ssl=true&sslfactory=org.postgresql.ssl.NonValidatingFactory")
+                    print("Default sslfactory=org.postgresql.ssl.NonValidatingFactory is used as you have not provided factory details.")
+                elif sslcertpath is not None:
+                    self.jdbc_url = "%s%s%s" % (self.jdbc_url, "?ssl=true&sslmode=verify-full&sslrootcert=", sslcertpath)
+
+            elif sslfactory is not None:
+                if sslcertpath is None:
+                    self.jdbc_url = "%s%s%s" % (self.jdbc_url, "?ssl=true&sslfactory=", sslfactory)
+
         print("Configuring PostgreSQL with JDBC URL: %s" % self.jdbc_url)
 
         if password:
@@ -214,6 +228,18 @@ if __name__ == "__main__":
             dest="verbose", action="store_true", default=False,
             help="enables verbose logging/output")
 
+    parser.add_option("--ssl",
+            dest="ssl", action="store_true", default=False,
+            help="true if ssl connection needed (optional)")
+
+    parser.add_option("--sslfactory",
+            dest="sslfactory",
+            help="ssl validation factory for ssl connection (optional)")
+
+    parser.add_option("--sslcertpath",
+            dest="sslcertpath",
+            help="ssl cert filepath for ssl connection (optional if sslfactory is provided)")
+
     (options, args) = parser.parse_args()
 
     if (not options.create and not options.update and not options.validate):
@@ -236,8 +262,12 @@ if __name__ == "__main__":
         print("ERROR: --drop can not be used with --schema-only")
         sys.exit(1)
 
+    if options.ssl and options.sslfactory and options.sslcertpath:
+        print("ERROR: ssl, sslfactory, and sslcertpath are not supported together.")
+        sys.exit(1)
+
     dbsetup = PostgresqlSetup(options.dbhost, options.dbport, options.dbuser, options.dbpassword,
-        options.db, options.community, options.verbose)
+        options.db, options.community, options.verbose, options.ssl, options.sslfactory, options.sslcertpath)
 
     if options.create:
         if options.drop:


### PR DESCRIPTION
Bug suggested to pass ssl and sslfactory in case of external database.
- Added ssl, sslfactory, and sslcertpath options in cpdb command
- Connection with the database can be with or without SSL validations