### PR TITLE
ENT-497: Update CertificateSerial to no longer generate UUIDs on instantiation

### DIFF
--- a/server/src/main/java/org/candlepin/model/CertificateSerial.java
+++ b/server/src/main/java/org/candlepin/model/CertificateSerial.java
@@ -14,17 +14,19 @@
  */
 package org.candlepin.model;
 
-import org.candlepin.util.Util;
 import org.candlepin.service.model.CertificateSerialInfo;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import org.hibernate.annotations.GenericGenerator;
 
 import java.math.BigInteger;
 import java.util.Date;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
@@ -43,6 +45,9 @@ public class CertificateSerial extends AbstractHibernateObject<CertificateSerial
 
     @Id
     @NotNull
+    @GeneratedValue(generator = "CertificateSerialIdGenerator")
+    @GenericGenerator(name = "CertificateSerialIdGenerator",
+        strategy = "org.candlepin.model.CertificateSerialIdGenerator")
     private Long id;
 
     @NotNull
@@ -61,11 +66,10 @@ public class CertificateSerial extends AbstractHibernateObject<CertificateSerial
      * Default constructor for serialization - DO NOT REMOVE!
      */
     public CertificateSerial() {
-        this.id = Util.generateUniqueLong();
+
     }
 
     public CertificateSerial(Date expiration) {
-        this();
         this.expiration = expiration;
     }
 

--- a/server/src/main/java/org/candlepin/model/CertificateSerialIdGenerator.java
+++ b/server/src/main/java/org/candlepin/model/CertificateSerialIdGenerator.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.model;
+
+import org.candlepin.util.Util;
+
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.id.IdentifierGenerator;
+
+import java.io.Serializable;
+
+/**
+ * CertificationSerial object ID generator
+ */
+public class CertificateSerialIdGenerator implements IdentifierGenerator {
+
+    @Override
+    public Serializable generate(SharedSessionContractImplementor session, Object object) {
+
+        if (object instanceof CertificateSerial) {
+            CertificateSerial certificateSerial = (CertificateSerial) object;
+            if (certificateSerial.getId() != null) {
+                return certificateSerial.getId();
+            }
+        }
+
+        return Util.generateUniqueLong();
+
+    }
+}

--- a/server/src/main/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapter.java
+++ b/server/src/main/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapter.java
@@ -443,11 +443,12 @@ public class DefaultEntitlementCertServiceAdapter extends BaseEntitlementCertSer
 
         Map<String, CertificateSerial> serialMap = new HashMap<>();
         for (Entry<String, PoolQuantity> entry : poolQuantities.entrySet()) {
-            // No need to persist the cert serial here as the IDs are generated on object creation.
             serialMap.put(entry.getKey(), new CertificateSerial(entry.getValue().getPool().getEndDate()));
         }
 
-        log.debug("WE HAVE {} POOL QUANTITIES TO LOOP THROUGH", poolQuantities.size());
+        // Serials need to be saved to get generated ID.
+        log.debug("Persisting new certificate serials");
+        serialCurator.saveOrUpdateAll(serialMap.values(), false, false);
 
         Map<String, EntitlementCertificate> entitlementCerts = new HashMap<>();
         for (Entry<String, PoolQuantity> entry : poolQuantities.entrySet()) {
@@ -518,10 +519,6 @@ public class DefaultEntitlementCertServiceAdapter extends BaseEntitlementCertSer
 
             entitlementCerts.put(entry.getKey(), cert);
         }
-
-        // Serials need to be saved before the certs.
-        log.debug("Persisting new certificate serials");
-        serialCurator.saveOrUpdateAll(serialMap.values(), false, false);
 
         // Now that the serials have been saved, update the newly created
         // certs with their serials and add them to the entitlements.

--- a/server/src/test/java/org/candlepin/model/CertificateSerialCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/CertificateSerialCuratorTest.java
@@ -327,7 +327,7 @@ public class CertificateSerialCuratorTest extends DatabaseTestFixture {
         CertificateSerial serial = new CertificateSerial(expectedSerialNumber, new Date());
         // When manually setting the id for an entity, hibernate requires that
         // we call merge instead of save/persist.
-        certSerialCurator.save(serial);
+        certSerialCurator.merge(serial);
         assertNotNull(serial);
         assertNotNull(serial.getId());
         assertEquals(expectedSerialNumber, serial.getId());

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
@@ -88,6 +88,7 @@ import org.candlepin.test.TestUtil;
 import org.candlepin.util.ElementTransformer;
 import org.candlepin.util.FactValidator;
 import org.candlepin.util.ServiceLevelValidator;
+import org.candlepin.util.Util;
 
 import com.google.inject.util.Providers;
 
@@ -441,7 +442,9 @@ public class ConsumerResourceTest {
         when(mockComplianceRules.getStatus(any(Consumer.class), any(Date.class), anyBoolean()))
             .thenReturn(status);
         // cert expires today which will trigger regen
-        consumer.setIdCert(createIdCert());
+        IdentityCertificate idCert = createIdCert();
+        idCert.getSerial().setId(Util.generateUniqueLong());
+        consumer.setIdCert(idCert);
         BigInteger origserial = consumer.getIdCert().getSerial().getSerial();
         when(mockIdentityCertServiceAdapter.regenerateIdentityCert(consumer)).thenReturn(createIdCert());
 

--- a/server/src/test/java/org/candlepin/test/TestUtil.java
+++ b/server/src/test/java/org/candlepin/test/TestUtil.java
@@ -541,7 +541,6 @@ public class TestUtil {
     public static IdentityCertificate createIdCert(Date expiration) {
         IdentityCertificate idCert = new IdentityCertificate();
         CertificateSerial serial = new CertificateSerial(expiration);
-        serial.setId(Long.valueOf(new Random().nextInt(1000000)));
 
         // totally arbitrary
         idCert.setId(String.valueOf(new Random().nextInt(1000000)));


### PR DESCRIPTION
 - Removed unique long id generation code from CertificateSerial constructor
 - Updated all the references to pass id while creating CertificateSerial object
 - Updated Junits related to this change