### PR TITLE
ENT-496: Update Consumer to no longer generate UUIDs on instantiation

### DIFF
--- a/server/src/main/java/org/candlepin/model/Consumer.java
+++ b/server/src/main/java/org/candlepin/model/Consumer.java
@@ -56,6 +56,7 @@ import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import javax.persistence.Transient;
+import javax.persistence.PrePersist;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
@@ -282,9 +283,6 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
     }
 
     public Consumer() {
-        // This constructor is for creating a new Consumer in the DB, so we'll
-        // generate a UUID at this point.
-        this.ensureUUID();
         this.entitlements = new HashSet<>();
         this.setEntitlementCount(0L);
     }
@@ -297,6 +295,7 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
         return uuid;
     }
 
+    @PrePersist
     public void ensureUUID() {
         if (uuid == null  || uuid.length() == 0) {
             this.uuid = Util.generateUUID();
@@ -305,9 +304,11 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
 
     /**
      * @param uuid the UUID of this consumer.
+     * @return this consumer.
      */
-    public void setUuid(String uuid) {
+    public Consumer setUuid(String uuid) {
         this.uuid = uuid;
+        return this;
     }
 
     /**

--- a/server/src/main/java/org/candlepin/resource/HypervisorResource.java
+++ b/server/src/main/java/org/candlepin/resource/HypervisorResource.java
@@ -44,6 +44,7 @@ import com.google.inject.Inject;
 import com.google.inject.persist.Transactional;
 
 import org.apache.commons.lang.StringUtils;
+import org.candlepin.util.Util;
 import org.quartz.JobDetail;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -360,7 +361,7 @@ public class HypervisorResource {
      * Create a new hypervisor type consumer to represent the incoming hypervisorId
      */
     private Consumer createConsumerForHypervisorId(String incHypervisorId, Owner owner, Principal principal) {
-        Consumer consumer = new Consumer();
+        Consumer consumer = new Consumer().setUuid(Util.generateUUID());
         consumer.setName(incHypervisorId);
         consumer.setType(this.hypervisorType);
         consumer.setFact("uname.machine", "x86_64");

--- a/server/src/main/java/org/candlepin/service/impl/HypervisorUpdateAction.java
+++ b/server/src/main/java/org/candlepin/service/impl/HypervisorUpdateAction.java
@@ -38,6 +38,7 @@ import com.google.inject.Inject;
 import com.google.inject.persist.Transactional;
 
 import org.apache.commons.lang.StringUtils;
+import org.candlepin.util.Util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -299,7 +300,7 @@ public class HypervisorUpdateAction {
      */
     private Consumer createConsumerForHypervisorId(String incHypervisorId, String reporterId,
         Owner owner, Principal principal, Consumer incoming) {
-        Consumer consumer = new Consumer();
+        Consumer consumer = new Consumer().setUuid(Util.generateUUID());
         if (incoming.getName() != null) {
             consumer.setName(incoming.getName());
         }

--- a/server/src/test/java/org/candlepin/controller/ManifestManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/ManifestManagerTest.java
@@ -45,6 +45,7 @@ import org.candlepin.sync.file.ManifestFileService;
 import org.candlepin.sync.file.ManifestFileType;
 import org.candlepin.test.TestUtil;
 
+import org.candlepin.util.Util;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -102,7 +103,8 @@ public class ManifestManagerTest {
             new ConsumerType("test-consumer-type-" + TestUtil.randomInt());
         type.setId("test-ctype-" + TestUtil.randomInt());
 
-        Consumer consumer = new Consumer("TestConsumer" + TestUtil.randomInt(), "User", owner, type);
+        Consumer consumer = new Consumer("TestConsumer" + TestUtil.randomInt(), "User", owner, type)
+            .setUuid(Util.generateUUID());
 
         when(consumerTypeCurator.getConsumerType(eq(consumer))).thenReturn(type);
         when(consumerTypeCurator.get(eq(type.getId()))).thenReturn(type);

--- a/server/src/test/java/org/candlepin/model/ConsumerTest.java
+++ b/server/src/test/java/org/candlepin/model/ConsumerTest.java
@@ -67,7 +67,7 @@ public class ConsumerTest extends DatabaseTestFixture {
 
     @Test
     public void testConsumerTypeRequired() {
-        Consumer newConsumer = new Consumer();
+        Consumer newConsumer = new Consumer().setUuid(Util.generateUUID());
         newConsumer.setName("cname");
         newConsumer.setOwner(owner);
 
@@ -81,7 +81,7 @@ public class ConsumerTest extends DatabaseTestFixture {
             name += "x";
         }
 
-        Consumer newConsumer = new Consumer();
+        Consumer newConsumer = new Consumer().setUuid(Util.generateUUID());
         newConsumer.setName(name);
         newConsumer.setOwner(owner);
         newConsumer.setType(consumerType);
@@ -96,7 +96,7 @@ public class ConsumerTest extends DatabaseTestFixture {
             name += "x";
         }
 
-        Consumer newConsumer = new Consumer();
+        Consumer newConsumer = new Consumer().setUuid(Util.generateUUID());
         newConsumer.setName(name);
         newConsumer.setOwner(owner);
         newConsumer.setType(consumerType);

--- a/server/src/test/java/org/candlepin/model/OwnerTest.java
+++ b/server/src/test/java/org/candlepin/model/OwnerTest.java
@@ -22,6 +22,7 @@ import org.candlepin.test.TestUtil;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import org.candlepin.util.Util;
 import org.junit.jupiter.api.Test;
 
 import java.util.Set;
@@ -77,7 +78,7 @@ public class OwnerTest extends DatabaseTestFixture {
         Product rhel = TestUtil.createProduct("Red Hat Enterprise Linux", "Red Hat Enterprise Linux");
 
         // Consumer
-        Consumer c = new Consumer();
+        Consumer c = new Consumer().setUuid(Util.generateUUID());
         c.setOwner(owner);
         owner.addConsumer(c);
         assertEquals(1, owner.getConsumers().size());

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/EntitleByProductsJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/EntitleByProductsJobTest.java
@@ -57,8 +57,7 @@ public class EntitleByProductsJobTest extends BaseJobTest {
         ctype.setId("test-ctype");
         owner = new Owner("test-owner");
         owner.setId("test-owner-id");
-        consumer = new Consumer("Test Consumer", "test-consumer", owner, ctype);
-        consumer.setUuid(consumerUuid);
+        consumer = new Consumer("Test Consumer", "test-consumer", owner, ctype).setUuid(consumerUuid);
         e = mock(Entitler.class);
     }
 

--- a/server/src/test/java/org/candlepin/pinsetter/tasks/HypervisorUpdateJobTest.java
+++ b/server/src/test/java/org/candlepin/pinsetter/tasks/HypervisorUpdateJobTest.java
@@ -53,6 +53,7 @@ import org.candlepin.service.impl.HypervisorUpdateAction;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import org.candlepin.util.Util;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -188,7 +189,7 @@ public class HypervisorUpdateJobTest extends BaseJobTest {
     public void hypervisorUpdateExecUpdate() throws JobExecutionException {
         when(ownerCurator.getByKey(eq("joe"))).thenReturn(owner);
         when(ownerCurator.findOwnerById(eq("joe"))).thenReturn(owner);
-        Consumer hypervisor = new Consumer();
+        Consumer hypervisor = new Consumer().setUuid(Util.generateUUID());
         hypervisor.setName("hypervisor_name");
         hypervisor.setOwner(owner);
         String hypervisorId = "uuid_999";
@@ -214,7 +215,7 @@ public class HypervisorUpdateJobTest extends BaseJobTest {
     public void reporterIdOnUpdateTest() throws JobExecutionException {
         when(ownerCurator.findOwnerById(eq("joe"))).thenReturn(owner);
         when(ownerCurator.getByKey(eq("joe"))).thenReturn(owner);
-        Consumer hypervisor = new Consumer();
+        Consumer hypervisor = new Consumer().setUuid(Util.generateUUID());
         hypervisor.setName("hypervisor_name");
         hypervisor.setOwner(owner);
         String hypervisorId = "uuid_999";
@@ -240,7 +241,7 @@ public class HypervisorUpdateJobTest extends BaseJobTest {
     public void hypervisorIdIsOverridenDuringHypervisorReportTest() throws JobExecutionException {
         when(ownerCurator.getByKey(eq("joe"))).thenReturn(owner);
         when(ownerCurator.findOwnerById(eq("joe"))).thenReturn(owner);
-        Consumer hypervisor = new Consumer();
+        Consumer hypervisor = new Consumer().setUuid(Util.generateUUID());
         hypervisor.setName("hyper-name");
         hypervisor.setOwner(owner);
         hypervisor.setFact(Consumer.Facts.SYSTEM_UUID, "myUuid");
@@ -281,7 +282,7 @@ public class HypervisorUpdateJobTest extends BaseJobTest {
     public void hypervisorMatchOnUuidTurnedOffTest() throws JobExecutionException {
         when(ownerCurator.getByKey(eq("joe"))).thenReturn(owner);
         when(ownerCurator.findOwnerById(eq("joe"))).thenReturn(owner);
-        Consumer hypervisor = new Consumer();
+        Consumer hypervisor = new Consumer().setUuid(Util.generateUUID());
         hypervisor.setName("hyper-name");
         hypervisor.setOwner(owner);
         hypervisor.setFact(Consumer.Facts.SYSTEM_UUID, "myUuid");

--- a/server/src/test/java/org/candlepin/policy/js/entitlement/PreEntitlementRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/entitlement/PreEntitlementRulesTest.java
@@ -29,6 +29,7 @@ import org.candlepin.policy.ValidationResult;
 import org.candlepin.policy.js.entitlement.Enforcer.CallerType;
 import org.candlepin.test.TestUtil;
 
+import org.candlepin.util.Util;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -562,7 +563,8 @@ public class PreEntitlementRulesTest extends EntitlementRulesTestFixture {
     public void virtOnlyPoolGuestHostMatches() {
         ConsumerType ctype = this.mockConsumerType(new ConsumerType(ConsumerTypeEnum.SYSTEM));
 
-        Consumer parent = new Consumer("test parent consumer", "test user", owner, ctype);
+        Consumer parent = new Consumer("test parent consumer", "test user", owner, ctype)
+            .setUuid(Util.generateUUID());
         Pool pool = setupHostRestrictedPool(parent);
 
         String guestId = "virtguestuuid";
@@ -582,10 +584,12 @@ public class PreEntitlementRulesTest extends EntitlementRulesTestFixture {
 
         when(config.getBoolean(ConfigProperties.STANDALONE)).thenReturn(true);
         // Parent consumer of our guest:
-        Consumer parent = new Consumer("test parent consumer", "test user", owner, ctype);
+        Consumer parent = new Consumer("test parent consumer", "test user", owner, ctype)
+            .setUuid(Util.generateUUID());
 
         // Another parent we'll make a virt only pool for:
-        Consumer otherParent = new Consumer("test parent consumer", "test user", owner, ctype);
+        Consumer otherParent = new Consumer("test parent consumer", "test user", owner, ctype)
+            .setUuid(Util.generateUUID());
         Pool pool = setupHostRestrictedPool(otherParent);
 
         String guestId = "virtguestuuid";
@@ -608,7 +612,8 @@ public class PreEntitlementRulesTest extends EntitlementRulesTestFixture {
         when(config.getBoolean(ConfigProperties.STANDALONE)).thenReturn(true);
 
         // Another parent we'll make a virt only pool for:
-        Consumer otherParent = new Consumer("test parent consumer", "test user", owner, ctype);
+        Consumer otherParent = new Consumer("test parent consumer", "test user", owner, ctype)
+            .setUuid(Util.generateUUID());
         Pool pool = setupHostRestrictedPool(otherParent);
 
         String guestId = "virtguestuuid";
@@ -671,7 +676,8 @@ public class PreEntitlementRulesTest extends EntitlementRulesTestFixture {
         ConsumerType ctype = this.mockConsumerType(new ConsumerType(ConsumerTypeEnum.SYSTEM));
 
         Pool pool = setupUnmappedGuestPool();
-        Consumer newborn = new Consumer("test newborn consumer", "test user", owner, ctype);
+        Consumer newborn = new Consumer("test newborn consumer", "test user", owner, ctype)
+            .setUuid(Util.generateUUID());
         newborn.setFact("virt.is_guest", "true");
         newborn.setCreated(new Date());
         ValidationResult result = enforcer.preEntitlement(newborn, pool, 1);
@@ -684,7 +690,8 @@ public class PreEntitlementRulesTest extends EntitlementRulesTestFixture {
         ConsumerType ctype = this.mockConsumerType(new ConsumerType(ConsumerTypeEnum.SYSTEM));
 
         Pool pool = setupUnmappedGuestPool();
-        Consumer tooOld = new Consumer("test newborn consumer", "test user", owner, ctype);
+        Consumer tooOld = new Consumer("test newborn consumer", "test user", owner, ctype)
+            .setUuid(Util.generateUUID());
         tooOld.setFact("virt.is_guest", "true");
         Date twentyFiveHoursAgo = new Date(new Date().getTime() - 25L * 60L * 60L * 1000L);
         tooOld.setCreated(twentyFiveHoursAgo);
@@ -703,7 +710,8 @@ public class PreEntitlementRulesTest extends EntitlementRulesTestFixture {
         Pool pool = setupUnmappedGuestPool();
         pool.setStartDate(fourHoursFromNow);
 
-        Consumer consumer = new Consumer("test newborn consumer", "test user", owner, ctype);
+        Consumer consumer = new Consumer("test newborn consumer", "test user", owner, ctype)
+            .setUuid(Util.generateUUID());
         consumer.setFact("virt.is_guest", "true");
         consumer.setCreated(new Date());
         ValidationResult result = enforcer.preEntitlement(consumer, pool, 1, CallerType.BIND);
@@ -717,8 +725,10 @@ public class PreEntitlementRulesTest extends EntitlementRulesTestFixture {
     public void mappedGuest() {
         ConsumerType ctype = this.mockConsumerType(new ConsumerType(ConsumerTypeEnum.SYSTEM));
 
-        Consumer parent = new Consumer("test parent consumer", "test user", owner, ctype);
-        Consumer newborn = new Consumer("test newborn consumer", "test user", owner, ctype);
+        Consumer parent = new Consumer("test parent consumer", "test user", owner, ctype)
+            .setUuid(Util.generateUUID());
+        Consumer newborn = new Consumer("test newborn consumer", "test user", owner, ctype)
+            .setUuid(Util.generateUUID());
         newborn.setCreated(new java.util.Date());
         Pool pool = setupUnmappedGuestPool();
 
@@ -856,7 +866,8 @@ public class PreEntitlementRulesTest extends EntitlementRulesTestFixture {
         // Another consumer we'll make a dev pool for:
         ConsumerType ctype = this.mockConsumerType(new ConsumerType(ConsumerTypeEnum.SYSTEM));
 
-        Consumer otherConsumer = new Consumer("test consumer", "test user", owner, ctype);
+        Consumer otherConsumer = new Consumer("test consumer", "test user", owner, ctype)
+            .setUuid(Util.generateUUID());
         Pool pool = setupDevConsumerRestrictedPool(otherConsumer);
 
         ValidationResult result = enforcer.preEntitlement(consumer, pool, 1);

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
@@ -504,8 +504,7 @@ public class ConsumerResourceUpdateTest {
         entitlement.getPool().setAttribute(Product.Attributes.VIRT_ONLY, "1");
         entitlement.getPool().setAttribute(Pool.Attributes.REQUIRES_HOST, uuid);
 
-        Consumer guest1 = new Consumer();
-        guest1.setUuid("Guest 1");
+        Consumer guest1 = new Consumer().setUuid("Guest 1");
         guest1.addEntitlement(entitlement);
         ConsumerInstalledProduct installed = mock(ConsumerInstalledProduct.class);
         guest1.addInstalledProduct(installed);
@@ -544,8 +543,7 @@ public class ConsumerResourceUpdateTest {
         entitlement.getPool().setAttribute(Product.Attributes.VIRT_ONLY, "1");
         entitlement.getPool().setAttribute(Pool.Attributes.REQUIRES_HOST, uuid);
 
-        Consumer guest1 = new Consumer();
-        guest1.setUuid("Guest 1");
+        Consumer guest1 = new Consumer().setUuid("Guest 1");
         guest1.addEntitlement(entitlement);
         guest1.setAutoheal(true);
 
@@ -582,8 +580,7 @@ public class ConsumerResourceUpdateTest {
         entitlement.getPool().setAttribute(Product.Attributes.VIRT_ONLY, "1");
         entitlement.getPool().setAttribute(Pool.Attributes.REQUIRES_HOST, uuid);
 
-        Consumer guest1 = new Consumer();
-        guest1.setUuid("Guest 1");
+        Consumer guest1 = new Consumer().setUuid("Guest 1");
         guest1.addEntitlement(entitlement);
         guest1.setAutoheal(true);
 
@@ -611,8 +608,7 @@ public class ConsumerResourceUpdateTest {
         entitlement.getPool().setAttribute(Product.Attributes.VIRT_ONLY, "1");
         entitlement.getPool().setAttribute(Pool.Attributes.REQUIRES_HOST, uuid);
 
-        Consumer guest1 = new Consumer();
-        guest1.setUuid("Guest 1");
+        Consumer guest1 = new Consumer().setUuid("Guest 1");
         guest1.addEntitlement(entitlement);
 
         // Ensure that the guest was already reported by same host.
@@ -696,8 +692,7 @@ public class ConsumerResourceUpdateTest {
         Entitlement entitlement = TestUtil.createEntitlement();
         entitlement.getPool().setAttribute(Product.Attributes.VIRT_ONLY, "1");
 
-        Consumer guest1 = new Consumer();
-        guest1.setUuid("Guest 1");
+        Consumer guest1 = new Consumer().setUuid("Guest 1");
         guest1.addEntitlement(entitlement);
         guest1.setAutoheal(true);
 

--- a/server/src/test/java/org/candlepin/resource/EntitlementResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/EntitlementResourceTest.java
@@ -42,6 +42,7 @@ import org.candlepin.policy.js.entitlement.EntitlementRulesTranslator;
 import org.candlepin.service.ProductServiceAdapter;
 import org.candlepin.test.TestUtil;
 
+import org.candlepin.util.Util;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -96,7 +97,7 @@ public class EntitlementResourceTest {
         ConsumerType ctype = TestUtil.createConsumerType();
         this.mockConsumerType(ctype);
 
-        consumer = new Consumer("myconsumer", "bill", owner, ctype);
+        consumer = new Consumer("myconsumer", "bill", owner, ctype).setUuid(Util.generateUUID());
     }
 
     protected ConsumerType mockConsumerType(ConsumerType ctype) {
@@ -212,8 +213,10 @@ public class EntitlementResourceTest {
         this.mockConsumerType(ct);
 
         Entitlement e = TestUtil.createEntitlement();
-        Consumer sourceConsumer = new Consumer("source-consumer", "bill", owner, ct);
-        Consumer destConsumer = new Consumer("destination-consumer", "bill", owner, ct);
+        Consumer sourceConsumer = new Consumer("source-consumer", "bill", owner, ct)
+            .setUuid(Util.generateUUID());
+        Consumer destConsumer = new Consumer("destination-consumer", "bill", owner, ct)
+            .setUuid(Util.generateUUID());
         e.setConsumer(sourceConsumer);
         e.setQuantity(25);
 
@@ -233,7 +236,8 @@ public class EntitlementResourceTest {
         this.mockConsumerType(ct);
 
         Entitlement e = TestUtil.createEntitlement();
-        Consumer destConsumer = new Consumer("destination-consumer", "bill", owner, ct);
+        Consumer destConsumer = new Consumer("destination-consumer", "bill", owner, ct)
+            .setUuid(Util.generateUUID());
         e.setConsumer(consumer);
         e.setQuantity(25);
 
@@ -252,7 +256,8 @@ public class EntitlementResourceTest {
         this.mockConsumerType(ct);
 
         Entitlement e = TestUtil.createEntitlement();
-        Consumer sourceConsumer = new Consumer("source-consumer", "bill", owner, ct);
+        Consumer sourceConsumer = new Consumer("source-consumer", "bill", owner, ct)
+            .setUuid(Util.generateUUID());
         e.setConsumer(sourceConsumer);
         e.setQuantity(25);
 
@@ -274,8 +279,10 @@ public class EntitlementResourceTest {
         Owner owner2 = new Owner("admin2");
         owner.setId(TestUtil.randomString());
         owner2.setId(TestUtil.randomString());
-        Consumer sourceConsumer = new Consumer("source-consumer", "bill", owner, ct);
-        Consumer destConsumer = new Consumer("destination-consumer", "bill", owner2, ct);
+        Consumer sourceConsumer = new Consumer("source-consumer", "bill", owner, ct)
+            .setUuid(Util.generateUUID());
+        Consumer destConsumer = new Consumer("destination-consumer", "bill", owner2, ct)
+            .setUuid(Util.generateUUID());
         e.setConsumer(sourceConsumer);
         e.setQuantity(25);
 

--- a/server/src/test/java/org/candlepin/resource/GuestIdResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/GuestIdResourceTest.java
@@ -46,6 +46,7 @@ import org.candlepin.util.ServiceLevelValidator;
 
 import com.google.inject.util.Providers;
 
+import org.candlepin.util.Util;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -105,7 +106,7 @@ public class GuestIdResourceTest {
         ct = new ConsumerType(ConsumerTypeEnum.SYSTEM);
         ct.setId("test-system-ctype");
 
-        consumer = new Consumer("consumer", "test", owner, ct);
+        consumer = new Consumer("consumer", "test", owner, ct).setUuid(Util.generateUUID());
         guestIdResource = new GuestIdResource(guestIdCurator, consumerCurator, consumerTypeCurator,
             consumerResource, i18n, eventFactory, sink, migrationProvider, this.modelTranslator);
 

--- a/server/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
@@ -269,8 +269,7 @@ public class HypervisorResourceTest {
         Owner o = new Owner("owner-key-2", "Owner Name 2");
         o.setId("owner-id-2");
 
-        Consumer existing = new Consumer();
-        existing.setUuid("test-host");
+        Consumer existing = new Consumer().setUuid("test-host");
         existing.setName("test-host-name");
         existing.setOwner(o);
         existing.addGuestId(new GuestId("GUEST_A"));

--- a/server/src/test/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapterTest.java
+++ b/server/src/test/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapterTest.java
@@ -289,8 +289,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
         ConsumerType type = new ConsumerType(ConsumerType.ConsumerTypeEnum.SYSTEM);
         type.setId("test-id");
 
-        consumer = new Consumer("Test Consumer", "bob", owner, type);
-        consumer.setUuid("test-consumer");
+        consumer = new Consumer("Test Consumer", "bob", owner, type).setUuid("test-consumer");
 
         when(this.mockConsumerTypeCurator.getConsumerType(eq(consumer))).thenReturn(type);
         when(this.mockConsumerTypeCurator.get(eq(type.getId()))).thenReturn(type);

--- a/server/src/test/java/org/candlepin/sync/ConsumerExporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/ConsumerExporterTest.java
@@ -67,8 +67,7 @@ public class ConsumerExporterTest {
 
         StringWriter writer = new StringWriter();
 
-        Consumer consumer = new Consumer();
-        consumer.setUuid("test-uuid");
+        Consumer consumer = new Consumer().setUuid("test-uuid");
         consumer.setName("testy consumer");
         consumer.setType(ctype);
         consumer.setContentAccessMode("access_mode");

--- a/server/src/test/java/org/candlepin/test/TestUtil.java
+++ b/server/src/test/java/org/candlepin/test/TestUtil.java
@@ -99,8 +99,9 @@ public class TestUtil {
     }
 
     public static Consumer createConsumer(ConsumerType type, Owner owner) {
-        return new Consumer("TestConsumer" + randomInt(), "User", owner, type);
+        return new Consumer("TestConsumer" + randomInt(), "User", owner, type).setUuid(Util.generateUUID());
     }
+
     public static ConsumerDTO createConsumerDTO(ConsumerTypeDTO type, OwnerDTO owner) {
         return createConsumerDTO("TestConsumer" + randomInt(), "User", owner, type);
     }
@@ -154,8 +155,7 @@ public class TestUtil {
             "User",
             owner,
             createConsumerType()
-        );
-
+        ).setUuid(Util.generateUUID());
         consumer.setCreated(new Date());
         consumer.setFact("foo", "bar");
         consumer.setFact("foo1", "bar1");


### PR DESCRIPTION
 - Removed entry of ensureUUID() from constructor Consumer()
 - Added new Constructor(String uuid) to accept UUID
 - Updated the references where parameter less constructor is called