### PR TITLE
[F] Add job blocking on constraint failure

### DIFF
--- a/server/src/main/java/org/candlepin/async/JobConfig.java
+++ b/server/src/main/java/org/candlepin/async/JobConfig.java
@@ -65,7 +65,7 @@ public class JobConfig<T extends JobConfig> {
     private String group;
     private Owner owner;
     private Map<String, String> metadata;
-    private Map<String, String> arguments;
+    private Map<String, Object> arguments;
     private Set<JobConstraint> constraints;
     private int retries;
     private String logLevel;
@@ -257,7 +257,7 @@ public class JobConfig<T extends JobConfig> {
             throw new IllegalArgumentException("arg is null");
         }
 
-        this.arguments.put(arg, JobArguments.serialize(value));
+        this.arguments.put(arg, value);
         return (T) this;
     }
 
@@ -270,8 +270,8 @@ public class JobConfig<T extends JobConfig> {
      * @return
      *  a map of arguments to pass to the job at execution time
      */
-    public JobArguments getJobArguments() {
-        return new JobArguments(this.arguments != null ? this.arguments : Collections.emptyMap());
+    public Map<String, Object> getJobArguments() {
+        return this.arguments != null ? Collections.unmodifiableMap(this.arguments) : Collections.emptyMap();
     }
 
     /**

--- a/server/src/main/java/org/candlepin/async/JobDataConverter.java
+++ b/server/src/main/java/org/candlepin/async/JobDataConverter.java
@@ -14,10 +14,28 @@
  */
 package org.candlepin.async;
 
+import org.candlepin.hibernate.AbstractJsonConverter;
+import org.candlepin.model.AsyncJobStatus.SerializedJobData;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.StringWriter;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 
 
 
 public class JobDataConverter extends AbstractJsonConverter<SerializedJobData> {
+    private static Logger log = LoggerFactory.getLogger(JobDataConverter.class);
 
     private static final String METADATA_FIELD_NAME = "metadata";
     private static final String JOB_ARGUMENTS_FIELD_NAME = "job_arguments";
@@ -41,22 +59,22 @@ public class JobDataConverter extends AbstractJsonConverter<SerializedJobData> {
             return null;
         }
 
-        try (StringWriter writer = new StringWriter(),
+        try (StringWriter writer = new StringWriter();
             JsonGenerator generator = factory.createGenerator(writer)) {
 
             generator.writeStartObject();
 
             generator.writeFieldName(METADATA_FIELD_NAME);
-            this.serializeMetadata(generator, entity.getMetadata());
+            this.serializeMetadata(generator, entity.metadata);
 
             generator.writeFieldName(JOB_ARGUMENTS_FIELD_NAME);
-            this.serializeJobArguments(generator, entity.getJobArguments());
+            this.serializeJobArguments(generator, entity.arguments);
 
             generator.writeFieldName(JOB_CONSTRAINTS_FIELD_NAME);
-            this.serializeJobConstraints(generator, entity.getJobConstraints());
+            this.serializeJobConstraints(generator, entity.constraints);
 
             generator.writeFieldName(JOB_OUTPUT_FIELD_NAME);
-            this.serializeJobOutput(generator, entity.getJobOutput());
+            this.serializeJobOutput(generator, entity.result);
 
             generator.writeEndObject();
             generator.flush();
@@ -132,7 +150,9 @@ public class JobDataConverter extends AbstractJsonConverter<SerializedJobData> {
         else if (value instanceof Map) {
             generator.writeStartObject();
 
-            for (Map.Entry<Object, Object> entry : ((Map) value).entrySet()) {
+            Map test = (Map) value;
+
+            for (Map.Entry<Object, Object> entry : test.entrySet()) {
                 Object key = entry.getKey();
 
                 if (!(key instanceof String)) {
@@ -157,9 +177,6 @@ public class JobDataConverter extends AbstractJsonConverter<SerializedJobData> {
         }
     }
 
-
-
-
     /**
      * {@inheritDoc}
      */
@@ -175,28 +192,28 @@ public class JobDataConverter extends AbstractJsonConverter<SerializedJobData> {
 
         SerializedJobData jobData = new SerializedJobData();
 
-        try (JsonParser parser = this.factory.createParser(json)) {
+        try (JsonParser parser = factory.createParser(json)) {
             while (!parser.isClosed()) {
                 if (parser.nextToken() == JsonToken.FIELD_NAME) {
                     String field = parser.currentName();
 
                     if (METADATA_FIELD_NAME.equals(field)) {
-                        Map<String, String> metadata = this.parseMetadata(parser);
-                        jobData.setMetadata(metadata);
+                        Map<String, String> metadata = this.deserializeMetadata(parser);
+                        jobData.metadata = metadata;
                     }
                     else if (JOB_ARGUMENTS_FIELD_NAME.equals(field)) {
-                        Map<String, Object> arguments = this.parseJobArguments(parser);
-                        jobData.setJobArguments(arguments);
+                        Map<String, Object> arguments = this.deserializeObjectMap(parser);
+                        jobData.arguments = arguments;
                     }
                     else if (JOB_CONSTRAINTS_FIELD_NAME.equals(field)) {
-                        Map<String, Map<String, Object>> constraints = this.parseJobConstraints(parser);
-                        jobData.setJobConstraints(constraints);
+                        Map<String, Map<String, Object>> constraints = this.deserializeJobConstraints(parser);
+                        jobData.constraints = constraints;
                     }
                     else {
                         Object value = this.recursiveDeserializer(parser);
 
                         if (JOB_OUTPUT_FIELD_NAME.equals(field)) {
-                            jobData.setJobOutput(value);
+                            jobData.result = value;
                         }
                         else {
                             log.warn("Unexpected field name received in job data: {}", field);
@@ -209,17 +226,110 @@ public class JobDataConverter extends AbstractJsonConverter<SerializedJobData> {
         return jobData;
     }
 
+    private Map<String, String> deserializeMetadata(JsonParser parser) {
+        Map<String, String> metadata = new HashMap<>();
+
+        if (parser.nextToken() != JsonToken.START_OBJECT) {
+            throw new RuntimeException("Invalid metadata format");
+        }
+
+        while (parser.nextToken() != JsonToken.END_OBJECT) {
+            switch (parser.currentToken()) {
+                case FIELD_NAME: // We should be seeing this a lot.
+                    break;
+
+                case VALUE_STRING:
+                    metadata.put(parser.getCurrentName(), parser.getText());
+                    break;
+
+                default:
+                    throw new RuntimeException("Invalid metadata format");
+            }
+        }
+
+        return metadata;
+    }
+
+    private Map<String, Object> deserializeObjectMap(JsonParser parser) {
+        Map<String, Object> args = new HashMap<>();
+
+        if (parser.nextToken() != JsonToken.START_OBJECT) {
+            throw new RuntimeException("Malformed object map");
+        }
+
+        while (parser.nextToken() != JsonToken.END_OBJECT) {
+            if (parser.currentToken() != JsonToken.FIELD_NAME) {
+                throw new RuntimeException("Malformed object map");
+            }
+
+            String name = parser.getCurrentName();
+            Object obj = this.recursiveDeserializer(parser);
+
+            args.put(name, obj);
+        }
+
+        return args;
+    }
+
+    private Map<String, Map<String, Object>> deserializeJobConstraints(JsonParser parser) {
+        Map<String, Map<String, Object>> constraints = new HashMap<>();
+
+        if (parser.nextToken() != JsonToken.START_OBJECT) {
+            throw new RuntimeException("Malformed job constraints");
+        }
+
+        while (parser.nextToken() != JsonToken.END_OBJECT) {
+            if (parser.currentToken() != JsonToken.FIELD_NAME) {
+                throw new RuntimeException("Malformed job constraints");
+            }
+
+            String name = parser.getCurrentName();
+            Map<String, Object> cargs = this.deserializeObjectMap(parser);
+
+            constraints.put(name, cargs);
+        }
+
+        return constraints;
+    }
+
 
     private Object recursiveDeserializer(JsonParser parser) {
 
         while (!parser.isClosed()) {
             switch (parser.nextToken()) {
-                case START_ARRAY:
-                    // It's an array!
-                    break;
+                case START_ARRAY: // Lists
+                    List<Object> list = new LinkedList<>();
 
-                case START_OBJECT:
-                    // It's a map!
+                    for (Object obj = this.recursiveDeserializer(parser);
+                        parser.currentToken() != JsonToken.END_ARRAY;
+                        obj = this.recursiveDeserializer(parser)) {
+
+                        list.add(obj);
+                    }
+
+                    return list;
+
+                case END_ARRAY:
+                    // Return null, the START_* step will ignore the value and terminate array processing
+                    return null;
+
+                case START_OBJECT: // Maps
+                    Map<String, Object> map = new HashMap<>();
+
+                    while (!parser.isClosed()) {
+                        switch (parser.nextToken()) {
+                            case FIELD_NAME:
+                                String name = parser.getCurrentName();
+                                map.put(name, this.recursiveDeserializer(parser));
+                                break;
+
+                            case END_OBJECT:
+                                return map;
+
+                            default:
+                                throw new RuntimeException("Unexpected token: " + parser.getCurrentToken());
+                        }
+                    }
                     break;
 
                 case VALUE_TRUE:
@@ -233,41 +343,13 @@ public class JobDataConverter extends AbstractJsonConverter<SerializedJobData> {
                     return parser.getText();
 
                 case VALUE_NUMBER_FLOAT:
+                    return parser.getDoubleValue();
+
                 case VALUE_NUMBER_INT:
+                    return parser.getIntValue();
 
-
-
-
-
-
-
-END_ARRAY
-
-END_OBJECT
-
-FIELD_NAME
-
-NOT_AVAILABLE
-
-START_ARRAY
-
-START_OBJECT
-
-VALUE_EMBEDDED_OBJECT
-
-VALUE_FALSE
-
-VALUE_NULL
-
-VALUE_NUMBER_FLOAT
-
-VALUE_NUMBER_INT
-
-VALUE_STRING
-
-VALUE_TRUE
-
-
+                default:
+                    throw new RuntimeException("Unexpected token: " + parser.getCurrentToken());
             }
         }
 

--- a/server/src/main/java/org/candlepin/async/JobDataConverter.java
+++ b/server/src/main/java/org/candlepin/async/JobDataConverter.java
@@ -1,0 +1,276 @@
+/**
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.async;
+
+
+
+
+public class JobDataConverter extends AbstractJsonConverter<SerializedJobData> {
+
+    private static final String METADATA_FIELD_NAME = "metadata";
+    private static final String JOB_ARGUMENTS_FIELD_NAME = "job_arguments";
+    private static final String JOB_CONSTRAINTS_FIELD_NAME = "job_constraints";
+    private static final String JOB_OUTPUT_FIELD_NAME = "job_output";
+
+    public JobDataConverter() {
+        super(SerializedJobData.class);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected String serialize(JsonFactory factory, SerializedJobData entity) {
+        if (factory == null) {
+            throw new IllegalArgumentException("factory is null");
+        }
+
+        if (entity == null) {
+            return null;
+        }
+
+        try (StringWriter writer = new StringWriter(),
+            JsonGenerator generator = factory.createGenerator(writer)) {
+
+            generator.writeStartObject();
+
+            generator.writeFieldName(METADATA_FIELD_NAME);
+            this.serializeMetadata(generator, entity.getMetadata());
+
+            generator.writeFieldName(JOB_ARGUMENTS_FIELD_NAME);
+            this.serializeJobArguments(generator, entity.getJobArguments());
+
+            generator.writeFieldName(JOB_CONSTRAINTS_FIELD_NAME);
+            this.serializeJobConstraints(generator, entity.getJobConstraints());
+
+            generator.writeFieldName(JOB_OUTPUT_FIELD_NAME);
+            this.serializeJobOutput(generator, entity.getJobOutput());
+
+            generator.writeEndObject();
+            generator.flush();
+
+            return writer.toString();
+        }
+    }
+
+    private void serializeMetadata(JsonGenerator generator, Map<String, String> value) {
+        if (value != null) {
+            generator.writeStartObject();
+
+            for (Map.Entry<String, String> entry : value.entrySet()) {
+                generator.writeObjectField(entry.getKey(), entry.getValue());
+            }
+
+            generator.writeEndObject();
+        }
+        else {
+            generator.writeNull();
+        }
+    }
+
+    private void serializeJobArguments(JsonGenerator generator, Map<String, Object> value) {
+        if (value != null) {
+            generator.writeStartObject();
+
+            for (Map.Entry<String, Object> entry : value.entrySet()) {
+                generator.writeFieldName(entry.getKey());
+                this.recursiveSerializer(generator, entry.getValue());
+            }
+
+            generator.writeEndObject();
+        }
+        else {
+            generator.writeNull();
+        }
+    }
+
+    private void serializeJobConstraints(JsonGenerator generator, Map<String, Map<String, Object>> value) {
+        if (value != null) {
+            generator.writeStartObject();
+
+            for (Map.Entry<String, Map<String, Object>> entry : value.entrySet()) {
+                generator.writeFieldName(entry.getKey());
+                this.recursiveSerializer(generator, entry.getValue());
+            }
+
+            generator.writeEndObject();
+        }
+        else {
+            generator.writeNull();
+        }
+    }
+
+    private void serializeJobOutput(JsonGenerator generator, Object value) {
+        this.recursiveSerializer(generator, value);
+    }
+
+    private void recursiveSerializer(JsonGenerator generator, Object value) {
+        if (value == null) {
+            generator.writeNull();
+        }
+        else if (value instanceof Collection) {
+            generator.writeStartArray();
+
+            for (Object element : (Collection) value) {
+                this.recursiveSerializer(generator, element);
+            }
+
+            generator.writeEndArray();
+        }
+        else if (value instanceof Map) {
+            generator.writeStartObject();
+
+            for (Map.Entry<Object, Object> entry : ((Map) value).entrySet()) {
+                Object key = entry.getKey();
+
+                if (!(key instanceof String)) {
+                    // TODO: Fix exception type
+                    throw new RuntimeException("Unsupported key type: " + key.getClass());
+                }
+
+                generator.writeFieldName((String) key);
+                this.recursiveSerializer(generator, entry.getValue());
+            }
+
+            generator.writeEndObject();
+        }
+        else if (value instanceof String || value.getClass().isPrimitive()) {
+            // This will only write an object format in the case of complex objects, which shouldn't
+            // be the case here.
+            generator.writeObject(value);
+        }
+        else {
+            // TODO: Fix exception type
+            throw new RuntimeException("Unsupported value type: " + value.getClass());
+        }
+    }
+
+
+
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected SerializedJobData deserialize(JsonFactory factory, String json) {
+        if (factory == null) {
+            throw new IllegalArgumentException("factory is null");
+        }
+
+        if (json == null) {
+            return null;
+        }
+
+        SerializedJobData jobData = new SerializedJobData();
+
+        try (JsonParser parser = this.factory.createParser(json)) {
+            while (!parser.isClosed()) {
+                if (parser.nextToken() == JsonToken.FIELD_NAME) {
+                    String field = parser.currentName();
+
+                    if (METADATA_FIELD_NAME.equals(field)) {
+                        Map<String, String> metadata = this.parseMetadata(parser);
+                        jobData.setMetadata(metadata);
+                    }
+                    else if (JOB_ARGUMENTS_FIELD_NAME.equals(field)) {
+                        Map<String, Object> arguments = this.parseJobArguments(parser);
+                        jobData.setJobArguments(arguments);
+                    }
+                    else if (JOB_CONSTRAINTS_FIELD_NAME.equals(field)) {
+                        Map<String, Map<String, Object>> constraints = this.parseJobConstraints(parser);
+                        jobData.setJobConstraints(constraints);
+                    }
+                    else {
+                        Object value = this.recursiveDeserializer(parser);
+
+                        if (JOB_OUTPUT_FIELD_NAME.equals(field)) {
+                            jobData.setJobOutput(value);
+                        }
+                        else {
+                            log.warn("Unexpected field name received in job data: {}", field);
+                        }
+                    }
+                }
+            }
+        }
+
+        return jobData;
+    }
+
+
+    private Object recursiveDeserializer(JsonParser parser) {
+
+        while (!parser.isClosed()) {
+            switch (parser.nextToken()) {
+                case START_ARRAY:
+                    // It's an array!
+                    break;
+
+                case START_OBJECT:
+                    // It's a map!
+                    break;
+
+                case VALUE_TRUE:
+                case VALUE_FALSE:
+                    return parser.getBooleanValue();
+
+                case VALUE_NULL:
+                    return null;
+
+                case VALUE_STRING:
+                    return parser.getText();
+
+                case VALUE_NUMBER_FLOAT:
+                case VALUE_NUMBER_INT:
+
+
+
+
+
+
+
+END_ARRAY
+
+END_OBJECT
+
+FIELD_NAME
+
+NOT_AVAILABLE
+
+START_ARRAY
+
+START_OBJECT
+
+VALUE_EMBEDDED_OBJECT
+
+VALUE_FALSE
+
+VALUE_NULL
+
+VALUE_NUMBER_FLOAT
+
+VALUE_NUMBER_INT
+
+VALUE_STRING
+
+VALUE_TRUE
+
+
+            }
+        }
+
+    }
+
+}

--- a/server/src/main/java/org/candlepin/async/impl/UniqueByArgConstraint.java
+++ b/server/src/main/java/org/candlepin/async/impl/UniqueByArgConstraint.java
@@ -132,8 +132,8 @@ public class UniqueByArgConstraint implements JobConstraint {
 
             for (String param : this.params) {
                 if (iArgs.containsKey(param) && eArgs.containsKey(param)) {
-                    String iValue = iArgs.getSerializedValue(param);
-                    String eValue = eArgs.getSerializedValue(param);
+                    Object iValue = iArgs.get(param);
+                    Object eValue = eArgs.get(param);
 
                     if (!(iValue != null ? iValue.equals(eValue) : eValue == null)) {
                         matched = false;

--- a/server/src/main/java/org/candlepin/async/tasks/HypervisorUpdateJob.java
+++ b/server/src/main/java/org/candlepin/async/tasks/HypervisorUpdateJob.java
@@ -90,6 +90,7 @@ public class HypervisorUpdateJob implements AsyncJob {
         final HypervisorUpdateAction hypervisorUpdateAction,
         final I18n i18n,
         @Named("HypervisorUpdateJobObjectMapper") final ObjectMapper objectMapper) {
+
         this.ownerCurator = Objects.requireNonNull(ownerCurator);
         this.consumerCurator = Objects.requireNonNull(consumerCurator);
         this.translator = Objects.requireNonNull(translator);
@@ -278,27 +279,28 @@ public class HypervisorUpdateJob implements AsyncJob {
             super.validate();
 
             try {
-                final JobArguments arguments = this.getJobArguments();
+                Map<String, Object> arguments = this.getJobArguments();
 
-                final String ownerKey = arguments.getAsString(OWNER_KEY);
-                final Boolean create = arguments.getAsBoolean(CREATE);
-                final String data = arguments.getAsString(DATA);
+                final String ownerKey = (String) arguments.get(OWNER_KEY);
+                final Boolean create = (Boolean) arguments.get(CREATE);
+                final String data = (String) arguments.get(DATA);
 
                 if (ownerKey == null || ownerKey.isEmpty()) {
                     final String errmsg = "owner has not been set!";
                     throw new JobConfigValidationException(errmsg);
                 }
+
                 if (create == null) {
                     final String errmsg = "create flag has not been set!";
                     throw new JobConfigValidationException(errmsg);
                 }
+
                 if (data == null || data.isEmpty()) {
                     final String errmsg = "hypervisor data has not been set!";
                     throw new JobConfigValidationException(errmsg);
                 }
-
             }
-            catch (ArgumentConversionException e) {
+            catch (ClassCastException e) {
                 final String errmsg = "One or more required arguments are of the wrong type";
                 throw new JobConfigValidationException(errmsg, e);
             }

--- a/server/src/main/java/org/candlepin/hibernate/AbstractJsonConverter.java
+++ b/server/src/main/java/org/candlepin/hibernate/AbstractJsonConverter.java
@@ -16,7 +16,7 @@ package org.candlepin.hibernate;
 
 import org.candlepin.util.ObjectMapperFactory;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.core.JsonFactory;
 
 import javax.persistence.AttributeConverter;
 
@@ -27,7 +27,8 @@ import javax.persistence.AttributeConverter;
  * JSON strings using the JPA convert interface.
  *
  * To use this class, it must first be subclassed and given a default constructor which passes
- * the target attribute class to the parent class's constructor:
+ * the target attribute class to the parent class's constructor. The subclass must also implement
+ * the serialize and deserialize methods:
  *
  * <pre>
  * public class MyTypeJsonConverter extends AbstractJsonConverter<MyType> {
@@ -112,14 +113,14 @@ public abstract class AbstractJsonConverter<T> implements AttributeConverter<T, 
      * @return
      *  JSON representing the serialized entity
      */
-    protected String serialize(JsonFactory factory, T entity);
+    protected abstract String serialize(JsonFactory factory, T entity);
 
     /**
      * Deserializes the provided JSON into an entity.
      *
      *
      */
-    protected T deserialize(JsonFactory factory, String json);
+    protected abstract T deserialize(JsonFactory factory, String json);
 
     /**
      * {@inheritDoc}
@@ -127,7 +128,7 @@ public abstract class AbstractJsonConverter<T> implements AttributeConverter<T, 
     @Override
     public String convertToDatabaseColumn(T entity) {
         try {
-            return this.serialize(this.factory, entity);
+            return this.serialize(this.jsonFactory, entity);
         }
         catch (Exception e) {
             throw new TypeConversionException(e);
@@ -140,7 +141,7 @@ public abstract class AbstractJsonConverter<T> implements AttributeConverter<T, 
     @Override
     public T convertToEntityAttribute(String data) {
         try {
-            return this.deserialize(this.factory, data);
+            return this.deserialize(this.jsonFactory, data);
         }
         catch (Exception e) {
             throw new TypeConversionException(e);

--- a/server/src/main/java/org/candlepin/jackson/CandlepinAttributeDeserializer.java
+++ b/server/src/main/java/org/candlepin/jackson/CandlepinAttributeDeserializer.java
@@ -140,8 +140,6 @@ public class CandlepinAttributeDeserializer extends StdDeserializer<Map<String, 
             }
         }
         else {
-            log.debug("Processing attributes as an array of attribute objects");
-
             // Uh oh.
             throw new CandlepinJsonProcessingException(
                 "Unexpected attribute value type: " + node.asToken(),

--- a/server/src/main/java/org/candlepin/jackson/CandlepinLegacyAttributeSerializer.java
+++ b/server/src/main/java/org/candlepin/jackson/CandlepinLegacyAttributeSerializer.java
@@ -51,5 +51,6 @@ public class CandlepinLegacyAttributeSerializer extends JsonSerializer<Map<Strin
         }
 
         generator.writeEndArray();
+        generator.flush();
     }
 }

--- a/server/src/main/java/org/candlepin/model/AsyncJobStatus.java
+++ b/server/src/main/java/org/candlepin/model/AsyncJobStatus.java
@@ -15,6 +15,7 @@
 package org.candlepin.model;
 
 import org.candlepin.async.JobArguments;
+import org.candlepin.async.JobDataConverter;
 import org.candlepin.async.JobExecutionContext;
 import org.candlepin.hibernate.AbstractJsonConverter;
 
@@ -110,9 +111,10 @@ public class AsyncJobStatus extends AbstractHibernateObject implements JobExecut
      * A simple container object to collect all of the data to be stored in as a serialized field
      */
     @SuppressWarnings("checkstyle:VisibilityModifier")
-    private static class SerializedJobData {
+    public static class SerializedJobData {
         public Map<String, String> metadata;
-        public JobArguments arguments;
+        public Map<String, Map<String, Object>> constraints;
+        public Map<String, Object> arguments;
         public Object result;
 
         @Override
@@ -146,15 +148,15 @@ public class AsyncJobStatus extends AbstractHibernateObject implements JobExecut
         }
     }
 
-    /**
-     * JSON converter class for the SerializedJobData type.
-     */
-    @Converter
-    public static class JobDataJsonConverter extends AbstractJsonConverter<SerializedJobData> {
-        public JobDataJsonConverter() {
-            super(SerializedJobData.class);
-        }
-    }
+    // /**
+    //  * JSON converter class for the SerializedJobData type.
+    //  */
+    // @Converter
+    // public static class JobDataJsonConverter extends AbstractJsonConverter<SerializedJobData> {
+    //     public JobDataJsonConverter() {
+    //         super(SerializedJobData.class);
+    //     }
+    // }
 
 
     @Id
@@ -218,7 +220,7 @@ public class AsyncJobStatus extends AbstractHibernateObject implements JobExecut
     private Date endTime;
 
     @Column(name = "job_data")
-    @Convert(converter = JobDataJsonConverter.class)
+    @Convert(converter = JobDataConverter.class)
     private SerializedJobData jobData;
 
 
@@ -796,7 +798,7 @@ public class AsyncJobStatus extends AbstractHibernateObject implements JobExecut
      *  the runtime arguments for this job
      */
     public JobArguments getJobArguments() {
-        return this.jobData.arguments;
+        return new JobArguments(this.jobData.arguments);
     }
 
     /**
@@ -808,7 +810,7 @@ public class AsyncJobStatus extends AbstractHibernateObject implements JobExecut
      * @return
      *  this job status instance
      */
-    public AsyncJobStatus setJobArguments(JobArguments arguments) {
+    public AsyncJobStatus setJobArguments(Map<String, Object> arguments) {
         this.jobData.arguments = arguments;
         return this;
     }


### PR DESCRIPTION
This is going to end up bigger than desired, so this is being broken up into several components. This PR begins addressing the serialization changes (which themselves are incomplete due to other issues pulling me in another direction for the moment).

The intended design behind these changes is as follows:
- Update the serialization for jobs such that (a) only primitives, strings, maps and collections are allowed to be serialized
- Remove the nested serialization, or change the individual components into discrete database columns which are individually serialized (probably faster overall) and deserialized on demand
- Update the job constraints to follow the registration + key lookup + stateless application model similar to jobs themselves, but without the per-invocation instantiation. When a constraint is checked, it should just be a matter of passing a few arguments to it and the list of active jobs.
- Add the per-job constraint configuration to the AsyncJobStatus entity somehow. At the time of writing, this is a map consisting of the constraint name mapped to a map of constraint arguments (Map<String, Map<String, Object>>). These should follow the same serialization rules.
- Add an additional table to the database: cp_blocked_jobs, with the following columns: blocked job id, blocking job id and blocking job state at the time of entry. When a job enters the BLOCKED state due to a constraint failure, a row should be inserted into this table for every job blocking it, along with their current state. Some diligence should be made to not consider jobs in terminal states to be blocking.
- Upon termination of any job (successful or otherwise), the cp_blocked_jobs table should be queried to find jobs that are (a) blocked on the job that just terminated and (b) are not blocked by any other job (that is, has no other rows in the table, or only has other rows in which the blocking job's state has changed since its entry). The jobs found should then have their constraints rechecked to determine whether or not they are unblocked. Unblocked jobs should be queued, though order is not guaranteed.
