### PR TITLE
1772194: use BYTES_TYPE for artemis messages

### DIFF
--- a/server/src/main/java/org/candlepin/audit/EventMessageReceiver.java
+++ b/server/src/main/java/org/candlepin/audit/EventMessageReceiver.java
@@ -45,8 +45,12 @@ public class EventMessageReceiver extends MessageReceiver {
             log.debug("ActiveMQ message {} acknowledged for listener: {}", msg.getMessageID(), listener);
 
             // Process the message via our EventListener framework.
-            body = msg.getBodyBuffer().readString();
+            int bodySize = msg.getBodySize();
+            byte[] bodyBytes = new byte[bodySize];
+            msg.getBodyBuffer().readBytes(bodyBytes);
+            body = new String(bodyBytes, 0, bodySize);
             log.debug("Got event: {}", body);
+
             Event event = mapper.readValue(body, Event.class);
             listener.onEvent(event);
 

--- a/server/src/main/java/org/candlepin/audit/EventSinkImpl.java
+++ b/server/src/main/java/org/candlepin/audit/EventSinkImpl.java
@@ -41,6 +41,8 @@ import java.util.List;
 
 import javax.inject.Inject;
 
+import static org.apache.activemq.artemis.api.core.Message.BYTES_TYPE;
+
 /**
  * EventSink - Queues events to be sent after request/job completes, and handles actual
  * sending of events on successful job or API request, as well as rollback if either fails.
@@ -241,7 +243,7 @@ public class EventSinkImpl implements EventSink {
         }
 
         public void queueMessage(String eventString) throws ActiveMQException {
-            ClientMessage message = session.createMessage(true);
+            ClientMessage message = session.createMessage(BYTES_TYPE, true);
             message.getBodyBuffer().writeString(eventString);
 
             // NOTE: not actually sent until we commit the session.

--- a/server/src/test/java/org/candlepin/audit/EventSinkImplTest.java
+++ b/server/src/test/java/org/candlepin/audit/EventSinkImplTest.java
@@ -14,11 +14,10 @@
  */
 package org.candlepin.audit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
+import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.candlepin.auth.Principal;
 import org.candlepin.common.config.Configuration;
 import org.candlepin.config.CandlepinCommonTestConfig;
@@ -146,8 +145,11 @@ public class EventSinkImplTest {
         eventSinkImpl.queueEvent(mock(Event.class));
         eventSinkImpl.sendEvents();
         verify(mockClientProducer).send(argumentCaptor.capture());
-        assertEquals(content, argumentCaptor.getValue().getBodyBuffer()
-            .readString());
+        byte[] source = content.getBytes();
+        byte[] target = new byte[source.length];
+        ActiveMQBuffer bodyBuffer = argumentCaptor.getValue().getBodyBuffer();
+        bodyBuffer.getBytes(0, target);
+        assertArrayEquals(source, target);
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/audit/EventSinkImplTest.java
+++ b/server/src/test/java/org/candlepin/audit/EventSinkImplTest.java
@@ -80,7 +80,7 @@ public class EventSinkImplTest {
         when(mockPrincipalProvider.get()).thenReturn(this.principal);
         when(mockSessionFactory.createTransactedSession()).thenReturn(mockClientSession);
         when(mockClientSession.createProducer(anyString())).thenReturn(mockClientProducer);
-        when(mockClientSession.createMessage(anyBoolean())).thenReturn(mockClientMessage);
+        when(mockClientSession.createMessage(anyByte(), anyBoolean())).thenReturn(mockClientMessage);
         when(mockClientMessage.getBodyBuffer()).thenReturn(
             ActiveMQBuffers.fixedBuffer(2000));
         when(mockSessionFactory.getServerLocator()).thenReturn(mockLocator);


### PR DESCRIPTION
Previously we did not specify a type for artemis messages. This causes problems for non-native artemis clients. Specifically Katello is working on a move to use a STOMP based client to connect directly to Candlepin instead of requiring us to bounce the messages through QPID. When the default message type is used then the messages are prefixe with two Null characters and the STOMP client is unable to parse them. Moving to the BYTES_TYPE enables the STOMP client and does appear not have any effect on our serialization or deserialization.