### PR TITLE
[F] 1772194: use BYTES_TYPE for artemis messages

### DIFF
--- a/server/src/main/java/org/candlepin/audit/EventSinkImpl.java
+++ b/server/src/main/java/org/candlepin/audit/EventSinkImpl.java
@@ -249,7 +249,7 @@ public class EventSinkImpl implements EventSink {
         }
 
         public void queueMessage(String eventString) throws ActiveMQException {
-            ClientMessage message = session.createMessage(true);
+            ClientMessage message = session.createMessage(ClientMessage.BYTES_TYPE, true);
             message.getBodyBuffer().writeString(eventString);
 
             // NOTE: not actually sent until we commit the session.

--- a/server/src/test/java/org/candlepin/audit/EventSinkImplTest.java
+++ b/server/src/test/java/org/candlepin/audit/EventSinkImplTest.java
@@ -82,7 +82,7 @@ public class EventSinkImplTest {
         when(mockPrincipalProvider.get()).thenReturn(this.principal);
         when(mockSessionFactory.createSession()).thenReturn(mockClientSession);
         when(mockClientSession.createProducer(anyString())).thenReturn(mockClientProducer);
-        when(mockClientSession.createMessage(anyBoolean())).thenReturn(mockClientMessage);
+        when(mockClientSession.createMessage(anyByte(), anyBoolean())).thenReturn(mockClientMessage);
         when(mockClientMessage.getBodyBuffer()).thenReturn(ActiveMQBuffers.fixedBuffer(2000));
         when(mockSessionFactory.getServerLocator()).thenReturn(mockLocator);
         doReturn(Mode.NORMAL).when(this.mockModeManager).getCurrentMode();


### PR DESCRIPTION
Previously we did not specify a type for artemis messages. This causes problems for non-native artemis clients. Specifically Katello is working on a move to use a STOMP based client to connect directly to Candlepin instead of requiring us to bounce the messages through QPID. When the default message type is used then the messages are prefixe with two Null characters and the STOMP client is unable to parse them. Moving to the BYTES_TYPE enables the STOMP client and does appear not have any effect on our serialization or deserialization.