### PR TITLE
1766345: hypervisor checkin fails with cp_consumer_hypervisor_ukey error [ENT-1767]

### DIFF
--- a/server/spec/hypervisor_check_in_spec.rb
+++ b/server/spec/hypervisor_check_in_spec.rb
@@ -1218,4 +1218,95 @@ describe 'Hypervisor Resource', :type => :virt do
     job_detail = send_host_guest_mapping(owner, user, report.to_json())
     job_detail["state"].should == "FINISHED"
   end
+
+  it 'will allow the hardware id to change while the hypervisor id stays constant' do
+    owner = create_owner random_string('owner')
+    user = user_client(owner, random_string('user'))
+
+    host_hyp_id = "hypervisor_id"
+    host_system_id_1 = "system_id_1"
+    host_system_id_2 = "system_id_2"
+    reporter_id = "reporter"
+    guest_set = [{"guestId"=>"g1"},{"guestId"=>"g2"}]
+    guests = ['g1', 'g2']
+
+    test_host = user.register(host_hyp_id, :hypervisor, nil, {"dmi.system.uuid" => host_system_id_1, "virt.is_guest"=>"false"}, nil, owner['key'], [], [], nil, [], host_hyp_id)
+    @cp.update_consumer({:uuid => test_host.uuid, :guestIds => guest_set})
+    @cp.get_consumer(test_host.uuid)['hypervisorId']['hypervisorId'].should == host_hyp_id
+
+    async_update_hypervisor(owner, user, host_hyp_id, host_hyp_id, guests, true, reporter_id, {"dmi.system.uuid" => host_system_id_1})
+    test_host = @cp.get_consumer(test_host.uuid)
+    @cp.get_consumer(test_host.uuid)['hypervisorId']['hypervisorId'].should == host_hyp_id
+
+    async_update_hypervisor(owner, user, host_hyp_id, host_hyp_id, guests, true, reporter_id, {"dmi.system.uuid" => host_system_id_2})
+    test_host = @cp.get_consumer(test_host.uuid)
+    @cp.get_consumer(test_host.uuid)['hypervisorId']['hypervisorId'].should == host_hyp_id
+  end
+
+  it 'can reconcile when hardware ids change across known hypervisors' do
+    owner = create_owner random_string('owner')
+    user = user_client(owner, random_string('user'))
+
+    host_hyp_id_1 = random_string("09h06").downcase
+    host_hyp_id_2 = random_string("09h07").downcase
+    host_hyp_id_3 = random_string("09h10").downcase
+    host_system_id_1 = random_string("bf").downcase
+    host_system_id_2 = random_string("c0").downcase
+    host_system_id_3 = random_string("c9").downcase
+    host_system_id_4 = random_string("c6").downcase
+    reporter_id = "reporter"
+    guest_set_1 = [{"guestId"=>"g1"},{"guestId"=>"g2"}]
+    guests_1 = ['g1', 'g2']
+    guest_set_2 = [{"guestId"=>"g3"},{"guestId"=>"g4"}]
+    guests_2 = ['g3', 'g4']
+    guest_set_3 = [{"guestId"=>"g5"},{"guestId"=>"g6"}]
+    guests_3 = ['g5', 'g6']
+
+    test_host_1 = user.register(host_hyp_id_1, :hypervisor, nil, {"dmi.system.uuid" => host_system_id_1, "virt.is_guest"=>"false"}, nil, owner['key'], [], [], nil, [], host_hyp_id_1)
+    @cp.update_consumer({:uuid => test_host_1.uuid, :guestIds => guest_set_1})
+    @cp.get_consumer(test_host_1.uuid)['hypervisorId']['hypervisorId'].should == host_hyp_id_1
+
+    test_host_2 = user.register(host_hyp_id_2, :hypervisor, nil, {"dmi.system.uuid" => host_system_id_2, "virt.is_guest"=>"false"}, nil, owner['key'], [], [], nil, [], host_hyp_id_2)
+    @cp.update_consumer({:uuid => test_host_2.uuid, :guestIds => guest_set_2})
+    @cp.get_consumer(test_host_2.uuid)['hypervisorId']['hypervisorId'].should == host_hyp_id_2
+
+    test_host_3 = user.register(host_hyp_id_3, :hypervisor, nil, {"dmi.system.uuid" => host_system_id_3, "virt.is_guest"=>"false"}, nil, owner['key'], [], [], nil, [], host_hyp_id_3)
+    @cp.update_consumer({:uuid => test_host_3.uuid, :guestIds => guest_set_3})
+    @cp.get_consumer(test_host_3.uuid)['hypervisorId']['hypervisorId'].should == host_hyp_id_3
+
+    async_update_hypervisor(owner, user, host_hyp_id_1, host_hyp_id_1, guests_1, true, reporter_id, {"dmi.system.uuid" => host_system_id_2})
+    test_host_1 = @cp.get_consumer(test_host_1.uuid)
+    test_host_1['hypervisorId']['hypervisorId'].should == host_hyp_id_1
+    test_host_1['facts']['dmi.system.uuid'].should == host_system_id_2
+
+    async_update_hypervisor(owner, user, host_hyp_id_2, host_hyp_id_2, guests_2, true, reporter_id, {"dmi.system.uuid" => host_system_id_4})
+    test_host_2 = @cp.get_consumer(test_host_2.uuid)
+    test_host_2['hypervisorId']['hypervisorId'].should == host_hyp_id_2
+    test_host_2['facts']['dmi.system.uuid'].should == host_system_id_4
+
+    async_update_hypervisor(owner, user, host_hyp_id_3, host_hyp_id_3, guests_3, true, reporter_id, {"dmi.system.uuid" => host_system_id_1})
+    test_host_3 = @cp.get_consumer(test_host_3.uuid)
+    test_host_3['hypervisorId']['hypervisorId'].should == host_hyp_id_3
+    test_host_3['facts']['dmi.system.uuid'].should == host_system_id_1
+  end
+
+  it 'will update the consumer name from the hypervisor checkin' do
+    owner = create_owner random_string('owner')
+    user = user_client(owner, random_string('user'))
+
+    host_hyp_id_1 = random_string("09h06").downcase
+    host_system_id_1 = random_string("bf").downcase
+    reporter_id = "reporter"
+    new_name = random_string('new_name')
+    guest_set_1 = [{"guestId"=>"g1"},{"guestId"=>"g2"}]
+    guests_1 = ['g1', 'g2']
+
+    test_host_1 = user.register(host_hyp_id_1, :hypervisor, nil, {"dmi.system.uuid" => host_system_id_1, "virt.is_guest"=>"false"}, nil, owner['key'], [], [], nil, [], host_hyp_id_1)
+    @cp.update_consumer({:uuid => test_host_1.uuid, :guestIds => guest_set_1})
+    @cp.get_consumer(test_host_1.uuid)['hypervisorId']['hypervisorId'].should == host_hyp_id_1
+
+    async_update_hypervisor(owner, user, new_name, host_hyp_id_1, guests_1, true, reporter_id, {"dmi.system.uuid" => host_system_id_1})
+    test_host_1 = @cp.get_consumer(test_host_1.uuid)
+    test_host_1['name'].should == new_name
+  end
 end

--- a/server/src/main/java/org/candlepin/model/ConsumerCurator.java
+++ b/server/src/main/java/org/candlepin/model/ConsumerCurator.java
@@ -896,10 +896,13 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
                 consumerIds.addAll(query.list());
             }
             for (Consumer consumer: this.getConsumers(consumerIds)) {
-                HypervisorId hypervisorId =
-                    systemUuidHypervisorMap.get(consumer.getFact(Consumer.Facts.SYSTEM_UUID).toLowerCase());
-                hypervisorMap.add(hypervisorId.getHypervisorId(), consumer);
-                remainingHypervisorIds.remove(hypervisorId.getHypervisorId());
+                if (consumer.getHypervisorId() != null) {
+                    hypervisorMap.add(consumer.getHypervisorId().getHypervisorId(), consumer);
+                    remainingHypervisorIds.remove(consumer.getHypervisorId().getHypervisorId());
+                }
+                else {
+                    hypervisorMap.add(consumer.getFact(Consumer.Facts.SYSTEM_UUID).toLowerCase(), consumer);
+                }
             }
         }
         if (!remainingHypervisorIds.isEmpty()) {

--- a/server/src/main/java/org/candlepin/service/impl/HypervisorUpdateAction.java
+++ b/server/src/main/java/org/candlepin/service/impl/HypervisorUpdateAction.java
@@ -152,6 +152,12 @@ public class HypervisorUpdateAction {
                 boolean hypervisorIdUpdated = updateHypervisorId(knownHost, owner, jobReporterId,
                     hypervisorId);
 
+                boolean nameUpdated = knownHost.getName() == null ||
+                    !knownHost.getName().equals(incoming.getName());
+                if (nameUpdated) {
+                    knownHost.setName(incoming.getName());
+                }
+
                 reportedOnConsumer = knownHost;
                 if (jobReporterId != null && knownHost.getHypervisorId() != null &&
                     hypervisorId.equalsIgnoreCase(knownHost.getHypervisorId().getHypervisorId()) &&
@@ -173,7 +179,7 @@ public class HypervisorUpdateAction {
                 final boolean factsUpdated = consumerResource.checkForFactsUpdate(knownHost, incoming);
 
                 if (factsUpdated || guestMigration.isMigrationPending() || typeUpdated ||
-                    hypervisorIdUpdated) {
+                    hypervisorIdUpdated || nameUpdated) {
                     knownHost.setLastCheckin(new Date());
                     guestMigration.migrate(false);
                     result.addUpdated(this.translator.translate(knownHost, HypervisorConsumerDTO.class));


### PR DESCRIPTION
Incorrect hypervisor id/system uuid reconcilliation fix
Added ability to update the consumer name from the hypervisor checkin. It previously
 would only use the hypervisor report names on hypervisor creation