### PR TITLE
ENT-1701; Containers now use gradle instead of buildr

### DIFF
--- a/docker/candlepin-base/cp-test
+++ b/docker/candlepin-base/cp-test
@@ -130,7 +130,7 @@ cleanup() {
         trap - $signals
         trap "" ERR EXIT
 
-        # Run buildr clean in our target CP directory
+        # Run buildr or gradle clean in our target CP directory
         if [ "$CLEAN_CP" == "1" ]; then
             cd $CP_HOME
             build_clean
@@ -380,14 +380,15 @@ fi
 
 if [ ! -z "$BUILDR_TASK" ]; then
     if [ -f ../gradlew ]; then
-        echo 'Warning: buildr is deprecated in this branch.'
-    fi
-    echo "Running buildr $BUILDR_TASK..."
-    CLEAN_CP=1
+        echo 'Warning: buildr is deprecated in this branch. Cannot run a buildr task.'
+    else
+        echo "Running buildr $BUILDR_TASK..."
+        CLEAN_CP=1
 
-    cd $CP_HOME
-    tee /var/log/candlepin/buildr.log < /tmp/teepipe &
-    buildr $BUILDR_TASK > /tmp/teepipe 2>&1
+        cd $CP_HOME
+        tee /var/log/candlepin/buildr.log < /tmp/teepipe &
+        buildr $BUILDR_TASK > /tmp/teepipe 2>&1
+    fi
 fi
 
 cleanup

--- a/docker/candlepin-base/setup-devel-env.sh
+++ b/docker/candlepin-base/setup-devel-env.sh
@@ -66,28 +66,8 @@ BASHRC
 git clone https://github.com/candlepin/candlepin.git /candlepin
 cd /candlepin
 
-# Setup and install rvm, ruby and pals
-gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
-# turning off verbose mode, rvm is nuts with this
-set +v
-curl -O https://raw.githubusercontent.com/rvm/rvm/master/binscripts/rvm-installer
-curl -O https://raw.githubusercontent.com/rvm/rvm/master/binscripts/rvm-installer.asc
-gpg2 --verify rvm-installer.asc && bash rvm-installer stable
-source /etc/profile.d/rvm.sh || true
-
-rvm install 2.5.3
-rvm use --default 2.5.3
-set -v
-
-# Install all ruby deps
-gem update --system
-gem install bundler
-bundle install --without=proton
-
 # Installs all Java deps into the image, big time saver
-# We run checkstyle explicitly here so it'll pull down its deps as well
-buildr artifacts
-buildr checkstyle || true
+./gradlew --no-daemon dependencies
 
 cd /
 rm -rf /candlepin

--- a/docker/gating-test-images/README.mkd
+++ b/docker/gating-test-images/README.mkd
@@ -1,7 +1,9 @@
 # Candlepin containers for gating tests
 This folder contains docker configurations for running Candlepin & Postgresql containers with preloaded test data.
 They are used for subscription-manager gating tests to be run against. The scripts here use docker stack, and podman, so docker-compose is not required to use this. The build script is supposed to be triggered automatically via jenkins [[1]](https://github.com/candlepin/candlepin-jobs).
-Note: The building/running scripts of these images are not configurable, because they are not supposed to be used as a development environment. 
+Notes:
+ * The building/running scripts of these images are not configurable, because they are not supposed to be used as a development environment.
+ * You need to first login to the registry [[1]](https://github.com/candlepin/candlepin-jobs) with your  kerberos credentials in order to run either the build or run scripts (for pushing/pulling images).
 
 ## Building
 The `build.sh` script is used for building a Candlepin image of the latest Candlepin version currently running in stage, and a corresponding postgresql image with preloaded test data.
@@ -26,3 +28,26 @@ Note: This requires sudo to run.
 ```bash
 sudo podman pod rm -f cp_pod
 ```
+
+### Troubleshooting
+You might encounter the following error when running the `run.sh` script on RHEL8+:
+```bash
+.curl: (35) error:1425F102:SSL routines:ssl_choose_client_version:unsupported protocol
+```
+This is due to RHEL8 enforcing a crypto policy that requires a minimum of TLSv1.2 to be used, while 
+candlepin was misconfigured by cpsetup to only support TLSv1 (this has since been fixed).
+To work around it, you need to:
+* ssh into the candlepin podman container
+    ```bash
+    sudo podman exec -it candlepin /bin/bash
+    ```
+* Edit the tomcat config:
+    ```bash
+    sudo vi /etc/tomcat/server.xml
+    # You need to remove the '+' characters from 'sslEnabledProtocols="TLSv1,+TLSv1.1,+TLSv1.2"'
+    ```
+* Restart tomcat:
+    ```bash
+    sudo supervisorctl restart tomcat
+    ```
+After exiting the container candlepin should be reachable without that error.

--- a/docker/gating-test-images/cp-latest-stage/setup-env-extras.sh
+++ b/docker/gating-test-images/cp-latest-stage/setup-env-extras.sh
@@ -21,9 +21,11 @@ curl -k -u admin:admin https://subscription.rhsm.stage.redhat.com/subscription/s
 stage_version=$(python -c 'import json; fp = open("stage_status.json", "r"); obj = json.load(fp); fp.close(); print obj["version"]');
 rm stage_status.json
 
-# build & install candlepin rpm\
+# build & install candlepin rpm
 cd /candlepin
-buildr clean test=no package
+./gradlew --no-daemon clean war
 cd /candlepin/server
+
+echo "Building candlepin rpm with tito..."
 tito build --test --rpm
 yum install -y /tmp/tito/noarch/candlepin-${stage_version}-1.noarch.rpm /tmp/tito/noarch/candlepin-selinux-${stage_version}-1.noarch.rpm

--- a/docker/gating-test-images/temp-base-cp/setup-env.sh
+++ b/docker/gating-test-images/temp-base-cp/setup-env.sh
@@ -81,27 +81,4 @@ stage_version=$(python -c 'import json; fp = open("stage_status.json", "r"); obj
 git checkout candlepin-${stage_version}-1
 rm stage_status.json
 
-# Setup and install rvm, ruby and pals
-# Import and trust rvm keys
-curl -sSL https://rvm.io/mpapis.asc | gpg --batch --import -; \
-echo 409B6B1796C275462A1703113804BB82D39DC0E3:6: | gpg --batch --import-ownertrust; \
-curl -sSL https://rvm.io/pkuczynski.asc | gpg --batch --import -; \
-echo 7D2BAF1CF37B13E2069D6956105BD0E739499BDB:6: | gpg --batch --import-ownertrust
-
-# turning off verbose mode, rvm is nuts with this
-set +v
-curl -sSL https://get.rvm.io | bash -s stable
-source /etc/profile.d/rvm.sh || true
-
-rvm install 2.5.3
-rvm use --default 2.5.3
-set -v
-
-# Install all ruby deps
-gem update --system
-gem install bundler
-bundle install --without=proton
-
-# Download all artifacts (time saver)
-buildr artifacts
-buildr checkstyle || true
+./gradlew --no-daemon dependencies

--- a/docker/gating-test-images/temp-cp/cp-test
+++ b/docker/gating-test-images/temp-cp/cp-test
@@ -39,10 +39,10 @@ cleanup() {
         trap - $signals
         trap "" ERR EXIT
 
-        # Run buildr clean in our target CP directory
+        # Run gradle clean in our target CP directory
         if [ "$CLEAN_CP" == "1" ]; then
             cd $CP_HOME
-            buildr clean
+            ./gradlew clean
         fi
     fi
 }
@@ -138,7 +138,7 @@ CP_HOME="/candlepin"
 cd $CP_HOME
 
 # Make sure we update the ruby bundle:
-bundle install
+bundle install --without=proton
 mkdir -p /var/log/candlepin
 
 PROJECT_DIR="$CP_HOME/$PROJECT"

--- a/server/code/setup/cpsetup
+++ b/server/code/setup/cpsetup
@@ -76,7 +76,7 @@ class TomcatSetup(object):
     <Connector port="8443" protocol="HTTP/1.1" SSLEnabled="true"
                maxThreads="150" scheme="https" secure="true"
                clientAuth="want"
-               sslEnabledProtocols="TLSv1,+TLSv1.1,+TLSv1.2"
+               sslEnabledProtocols="TLSv1,TLSv1.1,TLSv1.2"
                keystoreFile="conf/keystore"
                truststoreFile="conf/keystore"
                keystorePass="%s"

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -33,8 +33,7 @@ to be stopped or you will have to edit the Vagrantfile and choose different port
 1. From the root directory of your Candlepin checkout run `vagrant up`
 1. Run `vagrant ssh` to connect to the system.
 1. `cd /vagrant`
-1. `buildr clean test=no package`
-1. `./server/bin/deploy`
+1. `./server/bin/deploy` (this will automatically use gradle to recompile before deploying)
 
 ## Deploy with test data
 The Candlepin Vagrant deployer will deploy candlepin without any test data in database.


### PR DESCRIPTION
- Building/Running the gating test containers will always use gradle
  from now on (those use the candlepin version used by Hosted, which
  will always have gradle from now on).
- Building the base container (used to run tests in jenkins) will
  now use gradle from now on. The scripts running within that
  container will keep using either buildr or gradle depending on
  the branch that is checked out.
- Fix bug in cpsetup that would misconfigure tomcat to only support
  TLSv1 (instead of additionally supporting TLSv1.1 and TLSv1.2).