### PR TITLE
ENT-1686: Change the way Dev Pools are created

### DIFF
--- a/server/spec/autobind_disabled_for_owner_spec.rb
+++ b/server/spec/autobind_disabled_for_owner_spec.rb
@@ -77,7 +77,6 @@ describe 'Autobind Disabled On Owner' do
     new_pool = entitlements[0].pool
     new_pool.type.should == "DEVELOPMENT"
     new_pool.productId.should == dev_product['id']
-    new_pool.providedProducts.length.should == 2
   end
 
   it 'will still register when activation key has autobind enabled' do

--- a/server/spec/consumer_resource_dev_spec.rb
+++ b/server/spec/consumer_resource_dev_spec.rb
@@ -64,7 +64,6 @@ describe 'Consumer Dev Resource' do
     new_pool = entitlements[0].pool
     new_pool.type.should eq("DEVELOPMENT")
     new_pool.productId.should eq(expected_product_id)
-    new_pool.providedProducts.length.should eq(2)
     return entitlements[0]
   end
 
@@ -78,7 +77,6 @@ describe 'Consumer Dev Resource' do
     ent_pool = ents[0].pool
     ent_pool.type.should eq("DEVELOPMENT")
     ent_pool.productId.should eq("dev_product")
-    ent_pool.providedProducts.length.should eq(2)
     ent_pool.id.should eq(pools[0].pool.id)
   end
 

--- a/server/src/main/java/org/candlepin/controller/Entitler.java
+++ b/server/src/main/java/org/candlepin/controller/Entitler.java
@@ -24,7 +24,6 @@ import org.candlepin.config.ConfigProperties;
 import org.candlepin.model.CandlepinQuery;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerCurator;
-import org.candlepin.model.ConsumerInstalledProduct;
 import org.candlepin.model.ConsumerType;
 import org.candlepin.model.ConsumerTypeCurator;
 import org.candlepin.model.Content;
@@ -349,7 +348,7 @@ public class Entitler {
      * @return the newly created developer pool (note: not yet persisted)
      */
     protected Pool assembleDevPool(Consumer consumer, Owner owner, String sku) {
-        DeveloperProducts devProducts = getDeveloperPoolProducts(consumer, owner, sku);
+        DeveloperProducts devProducts = getDeveloperPoolProducts(owner, sku);
         Product skuProduct = devProducts.getSku();
         Date startDate = consumer.getCreated();
         Date endDate = getEndDate(skuProduct, startDate);
@@ -362,27 +361,22 @@ public class Entitler {
         return pool;
     }
 
-    private DeveloperProducts getDeveloperPoolProducts(Consumer consumer, Owner owner, String sku) {
-        DeveloperProducts devProducts = getDevProductMap(consumer, owner, sku);
-        verifyDevProducts(consumer, sku, devProducts);
+    private DeveloperProducts getDeveloperPoolProducts(Owner owner, String sku) {
+        DeveloperProducts devProducts = getDevProductMap(owner, sku);
+        verifyDevProducts(sku, devProducts);
         return devProducts;
     }
 
     /**
-     * Looks up all Products matching the specified SKU and the consumer's
-     * installed products.
+     * Looks up all Products matching the specified SKU.
      *
-     * @param consumer the consumer to pull the installed product id list from.
      * @param sku the product id of the SKU.
      * @return a {@link DeveloperProducts} object that contains the Product objects
      *         from the adapter.
      */
-    private DeveloperProducts getDevProductMap(Consumer consumer, Owner owner, String sku) {
+    private DeveloperProducts getDevProductMap(Owner owner, String sku) {
         List<String> devProductIds = new ArrayList<>();
         devProductIds.add(sku);
-        for (ConsumerInstalledProduct ip : consumer.getInstalledProducts()) {
-            devProductIds.add(ip.getProductId());
-        }
 
         log.debug("Importing products for dev pool resolution...");
         ImportedEntityCompiler compiler = new ImportedEntityCompiler();
@@ -408,28 +402,19 @@ public class Entitler {
     }
 
     /**
-     * Verifies that the expected developer SKU product was found and logs any
-     * consumer installed products that were not found by the adapter.
+     * Verifies that the expected developer SKU product was found.
      *
-     * @param consumer the consumer who's installed products are to be checked.
      * @param expectedSku the product id of the developer sku that must be found
      *                    in order to build the development pool.
      * @param devProducts all products retrieved from the adapter that are validated.
      * @throws ForbiddenException thrown if the sku was not found by the adapter.
      */
-    protected void verifyDevProducts(Consumer consumer, String expectedSku, DeveloperProducts devProducts)
+    protected void verifyDevProducts(String expectedSku, DeveloperProducts devProducts)
         throws ForbiddenException {
 
         if (!devProducts.foundSku()) {
             throw new ForbiddenException(i18n.tr("SKU product not available to this " +
                 "development unit: \"{0}\"", expectedSku));
-        }
-
-        for (ConsumerInstalledProduct ip : consumer.getInstalledProducts()) {
-            if (!devProducts.containsProduct(ip.getProductId())) {
-                log.warn(i18n.tr("Installed product not available to this " +
-                    "development unit: \"{0}\"", ip.getProductId()));
-            }
         }
     }
 


### PR DESCRIPTION
 - Removed the logic of adding all installed products into the consumer.
 - Removed the entry of provided products from the dev pools test cases.