### PR TITLE
[M] 1772194: Updated event messaging to use TEXT_TYPE and simple strings

### DIFF
--- a/server/src/main/java/org/candlepin/audit/EventMessageReceiver.java
+++ b/server/src/main/java/org/candlepin/audit/EventMessageReceiver.java
@@ -15,10 +15,15 @@
 package org.candlepin.audit;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.apache.activemq.artemis.api.core.ActiveMQException;
+import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+
 
 /**
  * A MessageReceiver implementation that on failure to handle an event, will put the message
@@ -45,7 +50,16 @@ public class EventMessageReceiver extends MessageReceiver {
             log.debug("ActiveMQ message {} acknowledged for listener: {}", msg.getMessageID(), listener);
 
             // Process the message via our EventListener framework.
-            body = msg.getBodyBuffer().readString();
+            if (msg.getType() == ClientMessage.TEXT_TYPE) {
+                SimpleString sstr = msg.getBodyBuffer().readNullableSimpleString();
+                if (sstr != null) {
+                    body = sstr.toString();
+                }
+            }
+            else {
+                body = msg.getBodyBuffer().readString();
+            }
+
             log.debug("Got event: {}", body);
             Event event = mapper.readValue(body, Event.class);
             listener.onEvent(event);

--- a/server/src/test/resources/logback-test.xml
+++ b/server/src/test/resources/logback-test.xml
@@ -7,7 +7,7 @@
     </encoder>
   </appender>
   <logger name="org.candlepin.util.filters.DumpFilter" level="INFO"/>
-  <logger name="org.candlepin" level="INFO"/>
+  <logger name="org.candlepin" level="DEBUG"/>
   <logger name="org.hibernate.tool.hbm2ddl" level="WARN"/>
   <logger name="org.hibernate.id.UUIDHexGenerator" level="ERROR"/>
   <logger name="liquibase" level="ERROR"/>


### PR DESCRIPTION
- Changed the event messaging format to use an explicit TEXT type,
  and updated the method used to write the message body to avoid
  extraneous sizing values
- Added two new properties to event messages: EVENT_TYPE and
  EVENT_TARGET, representing the event type and target, respectively
- Updated the EventSinkImpl and EventMessageReceiver tests to use
  JUnit 5
- Removed a couple tests that were no longer needed from the
  EventSinkImpl test suite