### PR TITLE
[F] Updated event messaging to use TEXT_TYPE and simple strings

### DIFF
--- a/server/src/main/java/org/candlepin/audit/EventMessageReceiver.java
+++ b/server/src/main/java/org/candlepin/audit/EventMessageReceiver.java
@@ -26,6 +26,7 @@ public abstract class EventMessageReceiver extends MessageReceiver {
 
     public EventMessageReceiver(EventListener listener, ActiveMQSessionFactory sessionFactory,
         ObjectMapper mapper) {
+
         super(ArtemisMessageSource.getQueueName(listener), sessionFactory, mapper);
         this.listener = listener;
     }

--- a/server/src/main/java/org/candlepin/audit/QpidEventMessageReceiver.java
+++ b/server/src/main/java/org/candlepin/audit/QpidEventMessageReceiver.java
@@ -16,6 +16,7 @@ package org.candlepin.audit;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.activemq.artemis.api.core.ActiveMQException;
+import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
 import org.candlepin.async.impl.ActiveMQSessionFactory;
 import org.slf4j.Logger;
@@ -57,7 +58,16 @@ public class QpidEventMessageReceiver extends EventMessageReceiver {
             }
 
             // Process the message via our EventListener framework.
-            body = msg.getBodyBuffer().readString();
+            if (msg.getType() == ClientMessage.TEXT_TYPE) {
+                SimpleString sstr = msg.getBodyBuffer().readNullableSimpleString();
+                if (sstr != null) {
+                    body = sstr.toString();
+                }
+            }
+            else {
+                body = msg.getBodyBuffer().readString();
+            }
+
             log.debug("Got event: {}", body);
             Event event = mapper.readValue(body, Event.class);
             listener.onEvent(event);

--- a/server/src/main/java/org/candlepin/messaging/impl/artemis/ArtemisSession.java
+++ b/server/src/main/java/org/candlepin/messaging/impl/artemis/ArtemisSession.java
@@ -238,7 +238,7 @@ public class ArtemisSession implements CPMSession {
             config = this.createMessageConfig();
         }
 
-        ClientMessage message = this.session.createMessage(config.isDurable());
+        ClientMessage message = this.session.createMessage(ClientMessage.TEXT_TYPE, config.isDurable());
         return new ArtemisMessage(this, message);
     }
 

--- a/server/src/test/java/org/candlepin/audit/DefaultEventMessageReceiverTest.java
+++ b/server/src/test/java/org/candlepin/audit/DefaultEventMessageReceiverTest.java
@@ -14,51 +14,65 @@
  */
 package org.candlepin.audit;
 
+import static org.mockito.Mockito.*;
 
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
-import org.apache.activemq.artemis.api.core.ActiveMQBuffers;
-import org.apache.activemq.artemis.api.core.ActiveMQException;
-import org.apache.activemq.artemis.api.core.ActiveMQExceptionType;
-import org.apache.activemq.artemis.api.core.client.ClientConsumer;
-import org.apache.activemq.artemis.api.core.client.ClientMessage;
-import org.apache.activemq.artemis.api.core.client.ClientSession;
-import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.candlepin.async.impl.ActiveMQSessionFactory;
 import org.candlepin.auth.PrincipalData;
 import org.candlepin.common.config.Configuration;
 import org.candlepin.controller.ActiveMQStatusMonitor;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
+import org.apache.activemq.artemis.api.core.ActiveMQBuffers;
+import org.apache.activemq.artemis.api.core.ActiveMQException;
+import org.apache.activemq.artemis.api.core.ActiveMQExceptionType;
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.api.core.client.ClientConsumer;
+import org.apache.activemq.artemis.api.core.client.ClientMessage;
+import org.apache.activemq.artemis.api.core.client.ClientSession;
+import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.quality.Strictness;
+
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Spy;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
 
 import java.io.StringWriter;
+import java.util.stream.Stream;
 
-import static org.mockito.Mockito.*;
 
-@RunWith(MockitoJUnitRunner.class)
+
+/**
+ * Test suite for the DefaultEventMessageReceiverTest class
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class DefaultEventMessageReceiverTest {
 
-    @Mock
-    private ClientSessionFactory clientSessionFactory;
+    @Mock private ClientSessionFactory clientSessionFactory;
     @Mock private ClientSession clientSession;
     @Mock private ClientConsumer clientConsumer;
     @Mock private EventListener eventListener;
     @Mock private ClientMessage clientMessage;
     @Mock private ActiveMQStatusMonitor monitor;
     @Mock private Configuration config;
-    @Spy
-    private ObjectMapper mapper = new ObjectMapper();
+    @Spy private ObjectMapper mapper = new ObjectMapper();
     @Spy private ActiveMQBuffer activeMQBuffer = ActiveMQBuffers.fixedBuffer(1000);
 
     private ActiveMQSessionFactory sessionFactory;
     private DefaultEventMessageReceiver receiver;
 
-    @Before
+    @BeforeEach
     public void init() throws Exception {
         when(clientMessage.getBodyBuffer()).thenReturn(activeMQBuffer);
         when(clientSessionFactory.createSession()).thenReturn(clientSession);
@@ -70,6 +84,26 @@ public class DefaultEventMessageReceiverTest {
         receiver.connect();
     }
 
+    private void primeBuffer(byte type, String value) {
+        doReturn(type).when(this.clientMessage).getType();
+
+        if (type == ClientMessage.TEXT_TYPE) {
+            this.activeMQBuffer.writeNullableSimpleString(SimpleString.toSimpleString(value));
+        }
+        else {
+            // Old method, injects extra sizes into the message which are not properly translated
+            // for other protocols like STOMP.
+            this.activeMQBuffer.writeString(value);
+        }
+    }
+
+    public static Stream<Arguments> testMsgTypes() {
+        return Stream.of(
+            Arguments.of(ClientMessage.DEFAULT_TYPE),
+            Arguments.of(ClientMessage.TEXT_TYPE)
+        );
+    }
+
     @Test
     public void shouldCreateNewConsumer() throws Exception {
         verify(clientSession).createConsumer(anyString());
@@ -77,9 +111,12 @@ public class DefaultEventMessageReceiverTest {
         verify(clientSession).start();
     }
 
-    @Test
-    public void whenMapperReadThrowsExceptionThenMessageShouldBeAckedAndSessionRolledBack() throws Exception {
-        doReturn("test123").when(activeMQBuffer).readString();
+    @ParameterizedTest
+    @MethodSource("testMsgTypes")
+    public void whenMapperReadThrowsExceptionThenMessageShouldBeAckedAndSessionRolledBack(byte msgType)
+        throws Exception {
+
+        this.primeBuffer(msgType, "test123");
         doThrow(new JsonMappingException("Induced exception"))
             .when(mapper).readValue(anyString(), eq(Event.class));
         receiver.onMessage(clientMessage);
@@ -89,10 +126,10 @@ public class DefaultEventMessageReceiverTest {
         verify(clientSession, never()).commit();
     }
 
-    @Test
-    public void whenMsgAcknowledgeThrowsExceptionSessionIsRolledBack()
-        throws Exception {
-        doReturn(eventJson()).when(activeMQBuffer).readString();
+    @ParameterizedTest
+    @MethodSource("testMsgTypes")
+    public void whenMsgAcknowledgeThrowsExceptionSessionIsRolledBack(byte msgType) throws Exception {
+        this.primeBuffer(msgType, eventJson());
         doThrow(new ActiveMQException(ActiveMQExceptionType.DISCONNECTED, "Induced exception for testing"))
             .when(clientMessage).acknowledge();
         receiver.onMessage(clientMessage);
@@ -100,10 +137,10 @@ public class DefaultEventMessageReceiverTest {
         verify(clientSession, never()).commit();
     }
 
-    @Test
-    public void whenProperClientMsgPassedThenOnMessageShouldSucceed()
-        throws Exception {
-        doReturn(eventJson()).when(activeMQBuffer).readString();
+    @ParameterizedTest
+    @MethodSource("testMsgTypes")
+    public void whenProperClientMsgPassedThenOnMessageShouldSucceed(byte msgType) throws Exception {
+        this.primeBuffer(msgType, eventJson());
         receiver.onMessage(clientMessage);
         verify(eventListener).onEvent(any(Event.class));
         verify(clientMessage).acknowledge();
@@ -111,9 +148,10 @@ public class DefaultEventMessageReceiverTest {
         verify(clientSession, never()).rollback();
     }
 
-    @Test
-    public void sessionIsRolledBackWhenAnyExceptionIsThrownFromEventListener() throws Exception {
-        doReturn(eventJson()).when(activeMQBuffer).readString();
+    @ParameterizedTest
+    @MethodSource("testMsgTypes")
+    public void sessionIsRolledBackWhenAnyExceptionIsThrownFromEventListener(byte msgType) throws Exception {
+        this.primeBuffer(msgType, eventJson());
         doThrow(new RuntimeException("Forced")).when(eventListener).onEvent(any(Event.class));
         receiver.onMessage(clientMessage);
         verify(clientMessage).acknowledge();

--- a/server/src/test/java/org/candlepin/audit/QpidEventMessageReceiverTest.java
+++ b/server/src/test/java/org/candlepin/audit/QpidEventMessageReceiverTest.java
@@ -16,31 +16,45 @@ package org.candlepin.audit;
 
 import static org.mockito.Mockito.*;
 
+import org.candlepin.async.impl.ActiveMQSessionFactory;
+import org.candlepin.auth.PrincipalData;
+
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffers;
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.ActiveMQExceptionType;
+import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.api.core.client.ClientConsumer;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
-import org.candlepin.async.impl.ActiveMQSessionFactory;
-import org.candlepin.auth.PrincipalData;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.quality.Strictness;
+
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Spy;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
 
 import java.io.StringWriter;
+import java.util.stream.Stream;
+
+
 
 /**
- * QpidEventMessageReceiverTest
+ * Test suite for the QpidEventMessageReceiver class
  */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class QpidEventMessageReceiverTest {
 
     @Mock private ClientSessionFactory clientSessionFactory;
@@ -54,7 +68,7 @@ public class QpidEventMessageReceiverTest {
     private ActiveMQSessionFactory sessionFactory;
     private QpidEventMessageReceiver receiver;
 
-    @Before
+    @BeforeEach
     public void init() throws Exception {
         when(clientMessage.getBodyBuffer()).thenReturn(activeMQBuffer);
         when(clientSessionFactory.createSession()).thenReturn(clientSession);
@@ -67,17 +81,40 @@ public class QpidEventMessageReceiverTest {
         receiver.connect();
     }
 
+    private void primeBuffer(byte type, String value) {
+        doReturn(type).when(this.clientMessage).getType();
+
+        if (type == ClientMessage.TEXT_TYPE) {
+            this.activeMQBuffer.writeNullableSimpleString(SimpleString.toSimpleString(value));
+        }
+        else {
+            // Old method, injects extra sizes into the message which are not properly translated
+            // for other protocols like STOMP.
+            this.activeMQBuffer.writeString(value);
+        }
+    }
+
+    public static Stream<Arguments> testMsgTypes() {
+        return Stream.of(
+            Arguments.of(ClientMessage.DEFAULT_TYPE),
+            Arguments.of(ClientMessage.TEXT_TYPE)
+        );
+    }
+
     @Test
-    public void shouldCreateNewConsumer()
-        throws Exception {
+    public void shouldCreateNewConsumer() throws Exception {
         verify(clientSession).createConsumer(anyString());
         verify(clientConsumer).setMessageHandler(eq(receiver));
         verify(clientSession).start();
     }
 
-    @Test
-    public void whenMapperReadThrowsExceptionThenMessageShouldBeAckedAndSessionRolledBack() throws Exception {
-        doReturn("test123").when(activeMQBuffer).readString();
+    @ParameterizedTest
+    @MethodSource("testMsgTypes")
+    public void whenMapperReadThrowsExceptionThenMessageShouldBeAckedAndSessionRolledBack(byte msgType)
+        throws Exception {
+
+        this.primeBuffer(msgType, "test123");
+
         doThrow(new JsonMappingException("Induced exception"))
             .when(mapper).readValue(anyString(), eq(Event.class));
 
@@ -89,10 +126,11 @@ public class QpidEventMessageReceiverTest {
         verify(clientSession, never()).commit();
     }
 
-    @Test
-    public void whenMsgAcknowledgeThrowsExceptionSessionIsRolledBack()
-        throws Exception {
-        doReturn(eventJson()).when(activeMQBuffer).readString();
+    @ParameterizedTest
+    @MethodSource("testMsgTypes")
+    public void whenMsgAcknowledgeThrowsExceptionSessionIsRolledBack(byte msgType) throws Exception {
+        this.primeBuffer(msgType, eventJson());
+
         doThrow(new ActiveMQException(ActiveMQExceptionType.DISCONNECTED, "Induced exception for testing"))
             .when(clientMessage).acknowledge();
 
@@ -102,10 +140,10 @@ public class QpidEventMessageReceiverTest {
         verify(clientSession, never()).commit();
     }
 
-    @Test
-    public void whenProperClientMsgPassedThenOnMessageShouldSucceed()
-        throws Exception {
-        doReturn(eventJson()).when(activeMQBuffer).readString();
+    @ParameterizedTest
+    @MethodSource("testMsgTypes")
+    public void whenProperClientMsgPassedThenOnMessageShouldSucceed(byte msgType) throws Exception {
+        this.primeBuffer(msgType, eventJson());
 
         receiver.onMessage(clientMessage);
 
@@ -115,9 +153,11 @@ public class QpidEventMessageReceiverTest {
         verify(clientSession, never()).rollback();
     }
 
-    @Test
-    public void sessionIsRolledBackWhenAnyExceptionIsThrownFromEventListener() throws Exception {
-        doReturn(eventJson()).when(activeMQBuffer).readString();
+    @ParameterizedTest
+    @MethodSource("testMsgTypes")
+    public void sessionIsRolledBackWhenAnyExceptionIsThrownFromEventListener(byte msgType) throws Exception {
+        this.primeBuffer(msgType, eventJson());
+
         doThrow(new RuntimeException("Forced")).when(eventListener).onEvent(any(Event.class));
 
         receiver.onMessage(clientMessage);
@@ -127,9 +167,13 @@ public class QpidEventMessageReceiverTest {
         verify(clientSession, never()).commit();
     }
 
-    @Test
-    public void noRollbackOccursWhenQpidConnectionExceptionIsThrownFromListener() throws Exception {
-        doReturn(eventJson()).when(activeMQBuffer).readString();
+    @ParameterizedTest
+    @MethodSource("testMsgTypes")
+    public void noRollbackOccursWhenQpidConnectionExceptionIsThrownFromListener(byte msgType)
+        throws Exception {
+
+        this.primeBuffer(msgType, eventJson());
+
         doThrow(new QpidConnectionException("Forced")).when(eventListener).onEvent(any(Event.class));
 
         receiver.onMessage(clientMessage);


### PR DESCRIPTION
- Changed the event messaging format to use an explicit TEXT type,
  and updated the method used to write the message body to avoid
  extraneous sizing values
- Added two new properties to event messages: EVENT_TYPE and
  EVENT_TARGET, representing the event type and target, respectively
- Updated the EventSinkImpl and EventMessageReceiver tests to use
  JUnit 5
- Removed a couple tests that were no longer needed from the
  EventSinkImpl test suite