### PR TITLE
[M] 1548048: fix warning messages in tomcat shutdown log (ENT-519)

### DIFF
--- a/server/src/main/java/org/candlepin/audit/ActiveMQContextListener.java
+++ b/server/src/main/java/org/candlepin/audit/ActiveMQContextListener.java
@@ -26,6 +26,7 @@ import com.google.inject.Injector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.List;
 
 
@@ -39,9 +40,15 @@ public class ActiveMQContextListener {
 
     private ArtemisMessageSource messageSource;
 
-    public void contextDestroyed() {
+    public void contextDestroyed(Injector injector) {
         if (this.messageSource != null) {
             this.messageSource.shutDown();
+        }
+        try {
+            injector.getInstance(ActiveMQStatusMonitor.class).close();
+        }
+        catch (IOException e) {
+            log.info("Failed to close ActiveMQ status monitor service", e);
         }
     }
 

--- a/server/src/main/java/org/candlepin/controller/ActiveMQStatusMonitor.java
+++ b/server/src/main/java/org/candlepin/controller/ActiveMQStatusMonitor.java
@@ -141,6 +141,7 @@ public class ActiveMQStatusMonitor implements Closeable, Runnable, CloseListener
         }
     }
 
+
     protected synchronized boolean testConnection() {
         if (!connectionOk) {
             try {
@@ -174,11 +175,25 @@ public class ActiveMQStatusMonitor implements Closeable, Runnable, CloseListener
 
     @Override
     public void close() throws IOException {
+
         if (this.clientSessionFactory != null) {
             this.clientSessionFactory.close();
         }
         if (this.locator != null) {
             this.locator.close();
+        }
+
+        if (future != null) {
+            future.cancel(false);
+        }
+        executorService.shutdown();
+        try {
+            if (!executorService.awaitTermination(10, TimeUnit.SECONDS)) {
+                executorService.shutdownNow();
+            }
+        }
+        catch (InterruptedException e) {
+            e.printStackTrace();
         }
     }
 }

--- a/server/src/main/java/org/candlepin/messaging/impl/artemis/ArtemisContextListener.java
+++ b/server/src/main/java/org/candlepin/messaging/impl/artemis/ArtemisContextListener.java
@@ -21,6 +21,7 @@ import org.candlepin.messaging.CPMException;
 
 import com.google.inject.Injector;
 
+import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.apache.activemq.artemis.core.server.embedded.EmbeddedActiveMQ;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -101,6 +102,7 @@ public class ArtemisContextListener implements CPMContextListener {
             log.error("Unexpected exception occurred while stopping embedded Artemis server", e);
             throw new CPMException(e);
         }
+        ActiveMQClient.clearThreadPools();
     }
 
 }

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -467,7 +467,7 @@ public class ConsumerResource {
         @ApiResponse(code = 204, message = "If all consumer UUIDs exists and can be accessed"),
         @ApiResponse(code = 400, message = "When no UUIDs are provided") })
     @POST
-    @Consumes(MediaType.WILDCARD)
+    @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @Path("exists")
     public Response consumerExistsBulk(Set<String> consumerUuids) throws BadRequestException {

--- a/server/src/main/java/org/candlepin/resource/HypervisorResource.java
+++ b/server/src/main/java/org/candlepin/resource/HypervisorResource.java
@@ -321,6 +321,7 @@ public class HypervisorResource {
         @ApiResponse(code = 400, message = "Illegal reporter ID was provided"),
         @ApiResponse(code = 404, message = "Target owner not found.")})
     @PUT
+    @Consumes(MediaType.WILDCARD)
     @Produces(MediaType.APPLICATION_JSON)
     @Transactional
     @Path("/{owner}/heartbeat")


### PR DESCRIPTION
  - Updated consumes type value from wildcard to aplication json in ConsumerResource.consumerExistsBulk method
  - Added consumes type in HypervisorResource.hypervisorHeartbeatUpdate method
  - Added method to cleanup thread and executorService in ActiveMQStatusMonitor
  - updated CandlepinContextListener.contextDestroyed method to fix shutdown warnings
        - Stop ActiveMQ status monitoring
        - Clear ActiveMQ client thread pools
        - Stop PersistService to avoid jdbc connect/pool related warning
        - De-register drivers to avoid jdbc connection/pool related warning

This PR will fix memory leak warnings related to thread cleanup, JDBC connection and driver de-registration. Still, there are few ThreadLocalMap related warning logs available in shutdown logs.  
