### PR TITLE
1655731: Auto-Attach will not correctly match on role/addon product

### DIFF
--- a/server/src/main/resources/rules/rules.js
+++ b/server/src/main/resources/rules/rules.js
@@ -312,7 +312,7 @@ function createPool(pool, consumer) {
             }
         }
         for (var i = 0 ; i < poolSet.length; i++) {
-            poolSet[i] = poolSet[i].toLowerCase();
+            poolSet[i] = poolSet[i].toLowerCase().trim();
         }
         return poolSet;
     };
@@ -2580,7 +2580,12 @@ var Autobind = {
                     var group_addon = group_addons[i];
                     var is_common_addon = false;
                     for (var j = 0; j < addons.length; j++) {
-                        if (Utils.equalsIgnoreCase(addons[j], group_addon)) {
+
+                        if (!addons[j] || !addons[j].trim()) {
+                            is_common_addon = false;
+                        }
+
+                        if (Utils.equalsIgnoreCase(addons[j].trim(), group_addon)) {
                             is_common_addon = true;
                         }
                     }
@@ -2595,9 +2600,11 @@ var Autobind = {
              * Returns the role that the stack will cover, which the consumer requires.
              */
             get_common_role: function(role) {
-                if (role == null) {
+                if (!role || !role.trim()) {
                     return null;
                 }
+                role = role.trim();
+
                 var group_roles = this.get_roles();
                 for (var i = 0; i < group_roles.length; i++) {
                     var group_role = group_roles[i];
@@ -3089,7 +3096,7 @@ var Autobind = {
 
         var attached_roles = get_role_pools(attached_pools);
         for (var j = 0; j < attached_roles.length; j++) {
-            if (Utils.equalsIgnoreCase(attached_roles[j], role)) {
+            if (Utils.equalsIgnoreCase(attached_roles[j], role.trim())) {
                 return "";
             }
         }
@@ -3112,7 +3119,7 @@ var Autobind = {
         for (var i = 0; i < addons.length; i++) {
             var contains_addon = false;
             for (var j = 0; j < attached_addons.length; j++) {
-                if (Utils.equalsIgnoreCase(attached_addons[j], addons[i])) {
+                if (Utils.equalsIgnoreCase(attached_addons[j], addons[i].trim())) {
                     contains_addon = true;
                 }
             }

--- a/server/src/test/java/org/candlepin/policy/AutobindRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/AutobindRulesTest.java
@@ -4153,4 +4153,52 @@ public class AutobindRulesTest {
         PoolQuantity q = bestPools.get(0);
         assertEquals(new Integer(2), q.getQuantity());
     }
+
+    /*
+     * Tests that during auto-attach, Role values between what the consumer specified and pool attributes
+     * are compared irrespective of the white-spaces in roles.
+     */
+    @Test
+    public void selectBestPoolsMatchesRoleValueWithWhiteSpaces() {
+        // Consumer specified syspurpose role attribute:
+        consumer.setRole("JBoss");
+
+        // Product with multiple roles:
+        Product prod1 = createSysPurposeProduct(null, "RHEL Server,  JBoss,  Satellite", null, null, null);
+        Pool p1 = TestUtil.createPool(owner, prod1);
+        p1.setId("p1");
+        List<Pool> pools = new ArrayList<>();
+        pools.add(p1);
+
+        List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
+            new String[]{}, pools, compliance, null, new HashSet<>(), false);
+
+        assertEquals(1, bestPools.size());
+        assertTrue(bestPools.contains(new PoolQuantity(p1, 1)));
+    }
+
+    /*
+     * Tests that during auto-attach, Addon values between what the consumer specified and pool attributes
+     * are compared irrespective of the white-spaces in addons.
+     */
+    @Test
+    public void selectBestPoolsMatchesAddonsValueWithWhiteSpaces() {
+        // Consumer specified syspurpose attributes:
+        Set<String> addons = new HashSet<>();
+        addons.add("RHEL ELS");
+        consumer.setAddOns(addons);
+
+        // Product with multiple addons:
+        Product prod1 = createSysPurposeProduct(null, null, "RHEL EUS,   RHEL ELS ", null, null);
+        Pool p1 = TestUtil.createPool(owner, prod1);
+        p1.setId("p1");
+        List<Pool> pools = new ArrayList<>();
+        pools.add(p1);
+
+        List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
+            new String[]{}, pools, compliance, null, new HashSet<>(), false);
+
+        assertEquals(1, bestPools.size());
+        assertTrue(bestPools.contains(new PoolQuantity(p1, 1)));
+    }
 }


### PR DESCRIPTION
attribute when a space exists after a comma
  - Added trim() in get_common_role and retrievePoolAttributeValues function
  - Added JUnit to test the roles having white-spaces