### PR TITLE
fixed qpid_proton avilable version and add keycloak dependecy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
-source 'https://rubygems.org'
+#source 'https://rubygems.org'
+source 'https://gems.ruby-china.com/'
 
 gem 'buildr', '1.5.3'
 # Not a typo - we use both buildr and builder
@@ -15,7 +16,7 @@ gem 'httpclient'
 gem 'activesupport', '~> 4.2'
 
 group 'proton' do
-  gem 'qpid_proton', '~> 0.21.0'
+  gem 'qpid_proton', '~> 0.28.0'
 end
 
 # Remove this once we are fully using the new Ruby bindings

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GEM
-  remote: https://rubygems.org/
+  remote: https://gems.ruby-china.com/
   specs:
     activesupport (4.2.8)
       i18n (~> 0.7)
@@ -60,7 +60,7 @@ GEM
     pry-stack_explorer (0.4.9.2)
       binding_of_caller (>= 0.7)
       pry (>= 0.9.11)
-    qpid_proton (0.21.0)
+    qpid_proton (0.28.0)
     rainbow (2.2.2)
       rake
     rake (0.9.2.2)
@@ -112,9 +112,12 @@ DEPENDENCIES
   pry
   pry-byebug
   pry-stack_explorer
-  qpid_proton (~> 0.21.0)
+  qpid_proton (~> 0.28.0)
   rest-client (~> 1.6.0)
   rspec (~> 3.0)
   rubocop (= 0.36.0)
   stringex
   webrick
+
+BUNDLED WITH
+   2.0.2

--- a/buildfile
+++ b/buildfile
@@ -114,6 +114,16 @@ EHCACHE = ['org.hibernate:hibernate-ehcache:jar:5.3.8.Final',
            'javax.cache:cache-api:jar:1.0.0'
           ]
 
+KEYCLOAK = ['org.keycloak:keycloak-servlet-filter-adapter:jar:6.0.1',
+            'org.keycloak:keycloak-adapter-core:jar:6.0.1',
+            'org.keycloak:keycloak-common:jar:6.0.1',
+            'org.keycloak:keycloak-core:jar:6.0.1',
+            'org.keycloak:keycloak-adapter-spi:jar:6.0.1',
+            'org.keycloak:keycloak-servlet-adapter-spi:jar:6.0.1',            
+            'org.keycloak:keycloak-jaxrs-oauth-client:jar:6.0.1',
+            'org.keycloak:keycloak-authz-client:jar:6.0.1'
+           ]
+
 VALIDATOR = ['org.hibernate.validator:hibernate-validator:jar:6.0.7.Final',
              'org.hibernate.validator:hibernate-validator-annotation-processor:jar:6.0.7.Final',
              'javax.validation:validation-api:jar:2.0.1.Final']
@@ -123,6 +133,7 @@ HIBERNATE = [group('hibernate-core', 'hibernate-c3p0',
                    :version => '5.3.8.Final'),
              ANTLR,
              EHCACHE,
+             KEYCLOAK,
              VALIDATOR,
              'org.hibernate.common:hibernate-commons-annotations:jar:5.0.4.Final',
              'net.bytebuddy:byte-buddy:jar:1.9.4',


### PR DESCRIPTION
try qpid_proton version in Gemfile*, only version 0.28.0
can be used
lack of keycloak build dependency in buildfile will block
compiling, need be added