### PR TITLE
[M] Restored the rvm+ruby setup step during container construction (ENT-1816)

### DIFF
--- a/docker/candlepin-base/setup-devel-env.sh
+++ b/docker/candlepin-base/setup-devel-env.sh
@@ -66,6 +66,24 @@ BASHRC
 git clone https://github.com/candlepin/candlepin.git /candlepin
 cd /candlepin
 
+# Setup and install rvm, ruby and pals
+gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+# turning off verbose mode, rvm is nuts with this
+set +v
+curl -O https://raw.githubusercontent.com/rvm/rvm/master/binscripts/rvm-installer
+curl -O https://raw.githubusercontent.com/rvm/rvm/master/binscripts/rvm-installer.asc
+gpg2 --verify rvm-installer.asc && bash rvm-installer stable
+source /etc/profile.d/rvm.sh || true
+
+rvm install 2.5.3
+rvm use --default 2.5.3
+set -v
+
+# Install all ruby deps
+gem update --system
+gem install bundler
+bundle install --without=proton
+
 # Installs all Java deps into the image, big time saver
 ./gradlew --no-daemon dependencies
 

--- a/docker/test
+++ b/docker/test
@@ -14,17 +14,19 @@ OPTIONS:
   -m        use mysql
   -n NAME   Sets the project name for the docker-compose run
   -p        use postgres
+  -l        skip docker pull and use local images
 
 USAGE
 }
 
-while getopts ":bc:dmn:op" opt; do
+while getopts ":bc:dmn:opl" opt; do
   case $opt in
     c) TEST_CMD="$OPTARG";;
     m) COMPOSE_ARGS="-f $DIR/docker-compose-mysql.yml";
        chcon -Rt svirt_sandbox_file_t $DIR/mysql.cnf;;
     n) PROJ_NAME="-p $OPTARG";;
     p) COMPOSE_ARGS="-f $DIR/docker-compose-postgres.yml";;
+    l) USE_CACHE="1";;
     \?)
       echo "Invalid option: -$OPTARG" >&2
       usage
@@ -43,7 +45,11 @@ done
 cd $DIR
 docker-compose $PROJ_NAME stop
 docker-compose $PROJ_NAME rm -f
-docker-compose $COMPOSE_ARGS pull
+
+if [ "$USE_CACHE" != "1" ]; then
+  docker-compose $COMPOSE_ARGS pull
+fi
+
 docker-compose $PROJ_NAME $COMPOSE_ARGS run --rm candlepin $TEST_CMD
 RETVAL=$?
 docker-compose $PROJ_NAME down


### PR DESCRIPTION
- Docker containers will install and configure rvm and Ruby again
- The test script now provides an option to skip pulling images
  from the repo in favor of using local images