### PR TITLE
[ENT-84]:Decide whether to reorganize the Certificate DTOs so they follow the same hierarchy the model objects do.

### DIFF
--- a/server/src/main/java/org/candlepin/dto/api/v1/ProductCertificateDTO.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/ProductCertificateDTO.java
@@ -25,13 +25,10 @@ import org.candlepin.dto.TimestampedCandlepinDTO;
  * The ProductCertificateDTO is a DTO representing product certificates presented to the API.
  */
 @ApiModel(parent = TimestampedCandlepinDTO.class, description = "DTO representing a product certificate")
-public class ProductCertificateDTO extends TimestampedCandlepinDTO<ProductCertificateDTO> {
+public class ProductCertificateDTO extends AbstractCertificateDTO<ProductCertificateDTO> {
 
     private static final long serialVersionUID = 1L;
 
-    protected String id;
-    protected String key;
-    protected String cert;
     private ProductDTO product;
 
     /**
@@ -50,29 +47,6 @@ public class ProductCertificateDTO extends TimestampedCandlepinDTO<ProductCertif
      */
     public ProductCertificateDTO(ProductCertificateDTO source) {
         super(source);
-    }
-
-    /**
-     * Retrieves the id field of this ProductCertificateDTO object.
-     *
-     * @return the id field of this ProductCertificateDTO object.
-     */
-    @JsonIgnore
-    public String getId() {
-        return this.id;
-    }
-
-    /**
-     * Sets the id to set on this ProductCertificateDTO object.
-     *
-     * @param id the id to set on this ProductCertificateDTO object.
-     *
-     * @return a reference to this ProductCertificateDTO object.
-     */
-    @JsonIgnore
-    public ProductCertificateDTO setId(String id) {
-        this.id = id;
-        return this;
     }
 
     /**
@@ -99,39 +73,24 @@ public class ProductCertificateDTO extends TimestampedCandlepinDTO<ProductCertif
     }
 
     /**
-     * Returns the product of this product certificate.
+     * Get CertificateSerialDTO - Always returns null
      *
-     * @return the key of this certificate.
+     * @return null
      */
-    public String getKey() {
-        return this.key;
+    @Override
+    @JsonIgnore
+    public CertificateSerialDTO getSerial() {
+        return null;
     }
 
     /**
-     * Sets the key of this certificate.
      *
-     * @param key the key to set.
-     *
+     * @param serial the serial cert to set.
      * @return a reference to this ProductCertificateDTO object.
      */
-    public ProductCertificateDTO setKey(String key) {
-        this.key = key;
-        return this;
-    }
-
-    public String getCert() {
-        return this.cert;
-    }
-
-    /**
-     * Sets the cert of this certificate.
-     *
-     * @param cert the cert to set.
-     *
-     * @return a reference to this ProductCertificateDTO object.
-     */
-    public ProductCertificateDTO setCert(String cert) {
-        this.cert = cert;
+    @Override
+    @JsonProperty
+    public ProductCertificateDTO setSerial(CertificateSerialDTO serial) {
         return this;
     }
 
@@ -159,9 +118,6 @@ public class ProductCertificateDTO extends TimestampedCandlepinDTO<ProductCertif
             ProductCertificateDTO that = (ProductCertificateDTO) obj;
 
             EqualsBuilder builder = new EqualsBuilder()
-                .append(this.getId(), that.getId())
-                .append(this.getKey(), that.getKey())
-                .append(this.getCert(), that.getCert())
                 .append(this.getProduct() != null ? this.getProduct().getId() : null,
                 that.getProduct() != null ? that.getProduct().getId() : null);
 
@@ -178,9 +134,6 @@ public class ProductCertificateDTO extends TimestampedCandlepinDTO<ProductCertif
     public int hashCode() {
         HashCodeBuilder builder = new HashCodeBuilder(37, 7)
             .append(super.hashCode())
-            .append(this.getId())
-            .append(this.getKey())
-            .append(this.getCert())
             .append(this.getProduct() != null ? this.getProduct().getId() : null);
 
         return builder.toHashCode();
@@ -206,9 +159,6 @@ public class ProductCertificateDTO extends TimestampedCandlepinDTO<ProductCertif
     public ProductCertificateDTO populate(ProductCertificateDTO source) {
         super.populate(source);
 
-        this.setId(source.getId());
-        this.setKey(source.getKey());
-        this.setCert(source.getCert());
         this.setProduct(source.getProduct());
 
         return this;

--- a/server/src/test/java/org/candlepin/dto/AbstractDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/AbstractDTOTest.java
@@ -64,7 +64,8 @@ public abstract class AbstractDTOTest<T extends CandlepinDTO<T>> {
         for (Method method : this.dtoClass.getMethods()) {
             try {
                 Matcher matcher = ACCESSOR_NAME_REGEX.matcher(method.getName());
-                if (matcher.matches() && method.getParameterTypes().length == 0) {
+                if (matcher.matches() && method.getParameterTypes().length == 0 &&
+                    !skipMethod(method.getName())) {
                     String fieldName = matcher.group(1);
                     Method mutator = this.dtoClass.getMethod("set" + fieldName, method.getReturnType());
                     fields.put(fieldName, new Method[] { method, mutator });
@@ -86,6 +87,18 @@ public abstract class AbstractDTOTest<T extends CandlepinDTO<T>> {
         }
 
         this.copyConstructor = constructor;
+    }
+
+    /**
+     * Method to skip testing any field in any DTO class by
+     * not including their accessor method for testing.
+     * Defaults to false
+     *
+     * @param methodName getter method of field.
+     * @return boolean value
+     */
+    protected boolean skipMethod(String methodName) {
+        return false;
     }
 
     public T getDTOInstance() {

--- a/server/src/test/java/org/candlepin/dto/api/v1/ProductCertificateDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/ProductCertificateDTOTest.java
@@ -19,7 +19,8 @@ import org.candlepin.dto.AbstractDTOTest;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
-
+import java.util.ArrayList;
+import java.util.Arrays;
 
 /**
  * Test suite for the ProductCertificateDTO class
@@ -27,12 +28,14 @@ import java.util.Map;
 public class ProductCertificateDTOTest extends AbstractDTOTest<ProductCertificateDTO> {
 
     protected Map<String, Object> values;
+    protected static ArrayList<String> skipMethodList = new ArrayList<>(Arrays.asList("getSerial"));
+
 
     public ProductCertificateDTOTest() {
         super(ProductCertificateDTO.class);
+
         ProductDTO pdto = new ProductDTO();
         pdto.setId("test-prod-id");
-
         this.values = new HashMap<>();
         this.values.put("Id", "test-id");
         this.values.put("Key", "test-key");
@@ -40,6 +43,19 @@ public class ProductCertificateDTOTest extends AbstractDTOTest<ProductCertificat
         this.values.put("Product", pdto);
         this.values.put("Created", new Date());
         this.values.put("Updated", new Date());
+
+    }
+
+    /**
+     * Method to skip testing any field in any DTO class by
+     * not including their accessor method for testing.
+     *
+     * @param methodName getter method of field.
+     * @return boolean
+     */
+    @Override
+    protected boolean skipMethod(String methodName) {
+        return skipMethodList.contains(methodName) ? true : false;
     }
 
     /**


### PR DESCRIPTION
- Re-organised the ProductCertificateDTO to inherit from AbstractCertificateDTO. 
- Getter method for serial certificate dto are overridden to return null.
- Skipped testing `serial` (inherited) field for ProductCertificateDTO in AbstractDTOTest