### PR TITLE
[M] Adjusted bundler version and skip container gem system update

### DIFF
--- a/docker/candlepin-base/setup-devel-env.sh
+++ b/docker/candlepin-base/setup-devel-env.sh
@@ -80,8 +80,7 @@ rvm use --default 2.5.3
 set -v
 
 # Install all ruby deps
-gem update --system
-gem install bundler
+gem install bundler -v 1.16.1
 bundle install --without=proton
 
 # Installs all Java deps into the image, big time saver


### PR DESCRIPTION
- Skip the system update for ruby gems, as this forces bundler 2.1
  to be used as the default bundler version
- Manually specify bundler v1.16 to be installed