### PR TITLE
[F] ENT-1825: Add new tables to hold mapping

### DIFF
--- a/server/src/main/resources/db/changelog/20191218180815-create-provided-product-mappings.xml
+++ b/server/src/main/resources/db/changelog/20191218180815-create-provided-product-mappings.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="20191218180815-1" author="sdhome">
+        <comment>Create table for product and provided products mappings</comment>
+
+        <createTable tableName="cp2_product_provided_products">
+
+            <column name="product_uuid" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="provided_product_uuid" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+
+        </createTable>
+
+        <addForeignKeyConstraint
+            baseTableName="cp2_product_provided_products"
+            baseColumnNames="product_uuid"
+            constraintName="cp2_product_prov_products_fk1"
+            deferrable="false"
+            initiallyDeferred="false"
+            onDelete="CASCADE"
+            onUpdate="NO ACTION"
+            referencedColumnNames="uuid"
+            referencedTableName="cp2_products"
+            referencesUniqueColumn="false" />
+
+        <addForeignKeyConstraint
+            baseTableName="cp2_product_provided_products"
+            baseColumnNames="provided_product_uuid"
+            constraintName="cp2_product_prov_products_fk2"
+            deferrable="false"
+            initiallyDeferred="false"
+            onDelete="CASCADE"
+            onUpdate="NO ACTION"
+            referencedColumnNames="uuid"
+            referencedTableName="cp2_products"
+            referencesUniqueColumn="false" />
+
+    </changeSet>
+
+    <changeSet id="20191218180815-2" author="sdhome">
+        <comment>Create table for derived product and derived provided products mappings</comment>
+
+        <createTable tableName="cp2_product_derprov_products">
+            <column name="product_uuid" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="provided_product_uuid" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+
+        </createTable>
+
+        <addForeignKeyConstraint
+            baseTableName="cp2_product_derprov_products"
+            baseColumnNames="product_uuid"
+            constraintName="cp2_prod_derprov_products_fk1"
+            deferrable="false"
+            initiallyDeferred="false"
+            onDelete="CASCADE"
+            onUpdate="NO ACTION"
+            referencedColumnNames="uuid"
+            referencedTableName="cp2_products"
+            referencesUniqueColumn="false" />
+
+        <addForeignKeyConstraint
+            baseTableName="cp2_product_derprov_products"
+            baseColumnNames="provided_product_uuid"
+            constraintName="cp2_prod_derprov_products_fk2"
+            deferrable="false"
+            initiallyDeferred="false"
+            onDelete="CASCADE"
+            onUpdate="NO ACTION"
+            referencedColumnNames="uuid"
+            referencedTableName="cp2_products"
+            referencesUniqueColumn="false" />
+
+    </changeSet>
+
+</databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-create.xml
+++ b/server/src/main/resources/db/changelog/changelog-create.xml
@@ -1238,4 +1238,5 @@
     <include file="db/changelog/20190919132617-create-product-branding-join-table.xml"/>
     <include file="db/changelog/20190927153020-index-facts-element.xml"/>
     <include file="db/changelog/20191009160315-remove-duplicate-indexes.xml"/>
+    <include file="db/changelog/20191218180815-create-provided-product-mappings.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-testing.xml
+++ b/server/src/main/resources/db/changelog/changelog-testing.xml
@@ -2330,4 +2330,5 @@
     <include file="db/changelog/20190919132617-create-product-branding-join-table.xml"/>
     <include file="db/changelog/20190927153020-index-facts-element.xml"/>
     <include file="db/changelog/20191009160315-remove-duplicate-indexes.xml"/>
+    <include file="db/changelog/20191218180815-create-provided-product-mappings.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-update.xml
+++ b/server/src/main/resources/db/changelog/changelog-update.xml
@@ -147,4 +147,5 @@
     <include file="db/changelog/20190919132617-create-product-branding-join-table.xml"/>
     <include file="db/changelog/20190927153020-index-facts-element.xml"/>
     <include file="db/changelog/20191009160315-remove-duplicate-indexes.xml"/>
+    <include file="db/changelog/20191218180815-create-provided-product-mappings.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
between marketing product and associated provided and derived provided products.
 - Created a table cp2_product_provided_products to hold mapping of products with provided products.
 - Created a table cp2_derproduct_derprov_products to hold mapping of derived product with derived provided products.
 - Updated the changelog files.