### PR TITLE
Fake insights-client in testing repository

### DIFF
--- a/server/bin/test_data.json
+++ b/server/bin/test_data.json
@@ -75,6 +75,25 @@
         {
             "name": "awesome-dummy-deb",
             "version": "1"
+        },
+        {
+            "name": "insights-client",
+            "version": "0.1",
+            "release": "01",
+            "files": [
+                {
+                    "path": "/usr/bin/insights-client",
+                    "type": "file",
+                    "perm": "0744",
+                    "owner": "root",
+                    "group": "root",
+                    "content": "#!/bin/bash"
+                },
+                {
+                    "path": "/etc/insights-client",
+                    "type": "directory"
+                }
+            ]
         }
     ],
     "content": [
@@ -390,6 +409,16 @@
             "content_url": "/path/to/awesomeos-deb",
             "gpg_url": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
             "packages": ["awesome-dummy-deb"]
+        },
+        {
+            "name": "fake-content",
+            "id": 3902,
+            "label": "fake-content",
+            "type": "yum",
+            "vendor": "Red Hat",
+            "content_url": "/path/to/fake-content",
+            "gpg_url": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
+            "packages": ["insights-client"]
         }
     ],
     "owners": [
@@ -1016,6 +1045,21 @@
             "type": "MKT",
             "provided_products": [
                 "38070"
+            ]
+        },
+        {
+            "name": "Fake OS Bits",
+            "id": "38072",
+            "content": [
+                [3902, true]
+            ]
+        },
+        {
+            "name": "Fake OS Bits",
+            "id": "fakeos-bits",
+            "type": "MKT",
+            "provided_products": [
+                "38072"
             ]
         },
         {


### PR DESCRIPTION
* It is possible to include some files in testing RPMS
  - Files should not be platform specific
  - Files should not require any other dependency
* Added one more product, content and repo containing RPM
  with fake insights-client, because this RPM is not available
  in any repo for CentOS or Fedora
* It is useful for testing cockpit plugin, e.g. this PR: https://github.com/candlepin/subscription-manager/pull/2180