### PR TITLE
ENT-1825: Add new tables to hold mapping

### DIFF
--- a/server/src/main/resources/db/changelog/20191218180815-create-provided-product-mappings.xml
+++ b/server/src/main/resources/db/changelog/20191218180815-create-provided-product-mappings.xml
@@ -47,44 +47,4 @@
 
     </changeSet>
 
-    <changeSet id="20191218180815-2" author="sdhome">
-        <comment>Create table for derived product and derived provided products mappings</comment>
-
-        <createTable tableName="cp2_product_derprov_products">
-            <column name="product_uuid" type="VARCHAR(255)">
-                <constraints nullable="false"/>
-            </column>
-
-            <column name="provided_product_uuid" type="VARCHAR(255)">
-                <constraints nullable="false"/>
-            </column>
-
-        </createTable>
-
-        <addForeignKeyConstraint
-            baseTableName="cp2_product_derprov_products"
-            baseColumnNames="product_uuid"
-            constraintName="cp2_prod_derprov_products_fk1"
-            deferrable="false"
-            initiallyDeferred="false"
-            onDelete="CASCADE"
-            onUpdate="NO ACTION"
-            referencedColumnNames="uuid"
-            referencedTableName="cp2_products"
-            referencesUniqueColumn="false" />
-
-        <addForeignKeyConstraint
-            baseTableName="cp2_product_derprov_products"
-            baseColumnNames="provided_product_uuid"
-            constraintName="cp2_prod_derprov_products_fk2"
-            deferrable="false"
-            initiallyDeferred="false"
-            onDelete="CASCADE"
-            onUpdate="NO ACTION"
-            referencedColumnNames="uuid"
-            referencedTableName="cp2_products"
-            referencesUniqueColumn="false" />
-
-    </changeSet>
-
 </databaseChangeLog>


### PR DESCRIPTION
Removed cp2_derproduct_derprov_products table. Since we are moving to keep the single table for provided products irrespective of product being normal/derived.
