### PR TITLE
Add spec-first build changes

### DIFF
--- a/api/candlepin-api-config.json
+++ b/api/candlepin-api-config.json
@@ -1,0 +1,8 @@
+{
+  "modelPackage": "org.candlepin.dto.api.v1",
+  "apiPackage": "org.candlepin.resource",
+  "invokerPackage": "org.candlepin",
+  "groupId": "org.candlepin",
+  "artifactId": "candlepin-api",
+  "java8": true
+}

--- a/api/candlepin-api-spec.yaml
+++ b/api/candlepin-api-spec.yaml
@@ -1,0 +1,28 @@
+openapi: 3.0.2
+info:
+  title: Candlepin
+  description: Candlepin is a subscription management server written in Java. It helps with management of software subscriptions.
+  version: 3.0.0-draft
+
+servers:
+  - url: /candlepin
+
+security:
+  - basicAuth: []
+
+paths: {}
+
+components:
+  schemas:
+    ExceptionMessage:
+      description: An exception occurred
+      properties:
+        displayMessage:
+          type: string
+        requestUuid:
+          type: string
+
+  securitySchemes:
+    basicAuth:
+      type: http
+      scheme: basic

--- a/build.gradle
+++ b/build.gradle
@@ -9,10 +9,12 @@ buildscript {
     }
     dependencies {
         classpath group: 'org.yaml', name: 'snakeyaml', version: '1.19'
+        classpath "org.openapitools:openapi-generator-gradle-plugin:4.0.1"
     }
 }
 
 plugins {
+    id "io.spring.dependency-management" version "1.0.8.RELEASE"
     id "nebula.lint" version "11.5.0"
     id "checkstyle"
 }
@@ -30,6 +32,7 @@ ext.versions = [
     jaxb: "2.3.0",
     junit5: "5.4.1",
     mockito: "2.23.4",
+    jboss_jaxrs_api: "1.0.2.Final",
 ]
 
 ext.libraries = [
@@ -151,6 +154,20 @@ allprojects {
     group = "org.candlepin"
     apply plugin: "maven"
     apply plugin: "nebula.lint"
+    apply plugin: "io.spring.dependency-management"
+    dependencyManagement {
+        dependencies{
+            dependency "io.swagger:swagger-annotations:${versions.swagger}"
+            dependency "javax.validation:validation-api:2.0.1.Final"
+            dependency "org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.1_spec:${versions.jboss_jaxrs_api}"
+            dependency "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}"
+            dependencySet(group: "org.jboss.resteasy", version: "${versions.resteasy}") {
+                entry "resteasy-client"
+                entry "resteasy-multipart-provider"
+                entry "resteasy-validator-provider-11"
+            }
+        }
+    }
 
     gradleLint {
         rules = ["dependency-parentheses"]
@@ -192,6 +209,74 @@ subprojects {
         // Temporary repo, which stores jss 4.4.6
         maven { url "http://barnabycourt.fedorapeople.org/repo/candlepin/" }
     }
+}
+
+project(":api") {
+    apply plugin: "org.openapi.generator"
+
+    // This project should only contain generated code.  No point in running checkstyle
+    checkstyle.sourceSets = []
+
+    ext {
+        api_spec_path = "${projectDir}/candlepin-api-spec.yaml"
+        config_file = "${projectDir}/candlepin-api-config.json"
+    }
+
+    openApiGenerate {
+      generatorName = "jaxrs-spec"
+      inputSpec = api_spec_path
+      configFile = config_file
+      outputDir = "$buildDir/generated"
+      configOptions = [
+          interfaceOnly: true,
+          generatePom: false
+      ]
+    }
+
+    openApiValidate {
+        inputSpec = api_spec_path
+    }
+
+    task generateApiDocs(type: org.openapitools.generator.gradle.plugin.tasks.GenerateTask) {
+        generatorName = "html"
+        inputSpec = api_spec_path
+        outputDir = "$buildDir/docs"
+        generateApiDocumentation = true
+        generateModelDocumentation = true
+        generateModelTests = false
+        generateApiTests = false
+        withXml = false
+    }
+
+    task generateOpenApiJson(type: org.openapitools.generator.gradle.plugin.tasks.GenerateTask) {
+        generatorName = "openapi"
+        inputSpec = api_spec_path
+        outputDir = "$buildDir/generated"
+        generateApiDocumentation = true
+        generateModelDocumentation = true
+        generateModelTests = false
+        generateApiTests = false
+        withXml = false
+    }
+
+    processResources {
+        from "$buildDir/generated/openapi.json"
+        from api_spec_path
+        rename { String fileName ->
+            api_spec_path.endsWith(fileName) ? 'openapi.yaml' : fileName  // rename yaml to openapi.yaml
+        }
+    }
+
+    dependencies {
+        compile 'com.fasterxml.jackson.core:jackson-annotations'
+        compile 'javax.validation:validation-api'
+        compile 'org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.1_spec'
+        compile 'io.swagger:swagger-annotations'
+    }
+
+    sourceSets.main.java.srcDirs = ["${buildDir}/generated/src/gen/java"]
+    compileJava.dependsOn tasks.openApiGenerate
+    processResources.dependsOn tasks.generateOpenApiJson
 }
 
 configure(subprojects.findAll { it.name == "candlepin-common" || it.name == "candlepin" }) {

--- a/build.gradle
+++ b/build.gradle
@@ -229,7 +229,8 @@ project(":api") {
       outputDir = "$buildDir/generated"
       configOptions = [
           interfaceOnly: true,
-          generatePom: false
+          generatePom: false,
+          dateLibrary: "java8"
       ]
     }
 

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -143,6 +143,7 @@ dependencies {
     annotationProcessor libraries.hibernate_validator_ap
 
     implementation project(":candlepin-common")
+    implementation project(":api")
 
     implementation libraries.antlr
     implementation libraries.commons

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,6 +2,7 @@ rootProject.name = "candlepin-parent"
 include ":candlepin-common"
 include ":candlepin"
 include ":checks"
+include ":api"
 project(":checks").projectDir = "$rootDir/checks" as File
 project(":candlepin-common").projectDir = "$rootDir/common" as File
 project(":candlepin").projectDir = "$rootDir/server" as File


### PR DESCRIPTION
After this is in place, the process for porting a given resource or DTO to spec-first is:

1. Add the resource definition to `api/candlepin-api-spec.yaml` ([editor.swagger.io](https://editor.swagger.io/) works well for this).
2. Add any DTOs to `api/candlepin-api-spec.yaml`.
3. Change the resource to implement the generated API interface.
4. Remove all `javax.ws.rs` annotations from the resource implementation.
5. Remove all `io.swagger` annotations from the resource implementation.
6. Remove old DTOs from the codebase (refactor to use the generated ones instead).
7. Fix any broken code or tests.
8. Ensure unit tests still pass and the resource still works.
9. Ensure swagger.json is still generated and is equivalent.

Note: After building, you can view generated code in `api/build/generated/src/gen/java`.