### PR TITLE
[M] 1790468: Fixed transaction requirement in JobCleaner task

### DIFF
--- a/server/src/main/java/org/candlepin/async/JobManager.java
+++ b/server/src/main/java/org/candlepin/async/JobManager.java
@@ -1650,6 +1650,7 @@ public class JobManager implements ModeChangeListener {
      * @return
      *  the number of jobs deleted as a result of this operation
      */
+    @Transactional
     public synchronized int cleanupJobs(AsyncJobStatusCurator.AsyncJobStatusQueryBuilder queryBuilder) {
         // Prepare for the defaults...
         if (queryBuilder == null) {


### PR DESCRIPTION
- JobManager.cleanupJobs is now flagged with the @Transactional
  annotation to ensure it operates within the context of a
  transaction