### PR TITLE
[F] ENT-1911 Add method to get provided products from ProductInfo

### DIFF
--- a/server/src/main/java/org/candlepin/dto/api/v1/ProductDTO.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/ProductDTO.java
@@ -41,6 +41,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
@@ -1080,7 +1081,13 @@ public class ProductDTO extends TimestampedCandlepinDTO<ProductDTO> implements P
         copy.setProductContent(this.getProductContent());
         copy.setDependentProductIds(this.getDependentProductIds());
         copy.setBranding(this.getBranding());
-        copy.setProvidedProducts(this.getProvidedProducts());
+
+        if (this.getProvidedProducts() != null) {
+            copy.providedProducts = new HashSet<>();
+            copy.providedProducts.addAll(this.getProvidedProducts().stream()
+                .map(prodDTO -> prodDTO.clone())
+                .collect(Collectors.toSet()));
+        }
 
         return copy;
     }
@@ -1112,7 +1119,12 @@ public class ProductDTO extends TimestampedCandlepinDTO<ProductDTO> implements P
         this.setHref(source.getHref());
         this.setLocked(source.isLocked());
         this.setBranding(source.getBranding());
-        this.setProvidedProducts(source.getProvidedProducts());
+
+        if (source.getProvidedProducts() != null) {
+            this.setProvidedProducts(source.getProvidedProducts().stream()
+                .map(prod -> new ProductDTO(prod))
+                .collect(Collectors.toSet()));
+        }
 
         return this;
     }

--- a/server/src/main/java/org/candlepin/model/dto/ProductData.java
+++ b/server/src/main/java/org/candlepin/model/dto/ProductData.java
@@ -91,6 +91,8 @@ public class ProductData extends CandlepinDTO implements ProductInfo {
 
     protected Set<Branding> branding;
 
+    protected Set<ProductData> providedProducts;
+
     @ApiModelProperty(example = "/products/ff808081554a3e4101554a3e9033005d")
     protected String href;
 
@@ -956,6 +958,65 @@ public class ProductData extends CandlepinDTO implements ProductInfo {
         return this;
     }
 
+    /**
+     * Retrieves a collection of provided product for this product.
+     *
+     * @return
+     *  Returns the provided product of this product.
+     */
+    public Collection<ProductData> getProvidedProducts() {
+        return this.providedProducts != null ? new SetView(this.providedProducts) : null;
+    }
+
+    /**
+     * Method to set provided products for this product.
+     *
+     * @param providedProducts
+     *  A collection of provided products.
+     * @return
+     *  A reference to this product.
+     */
+    public ProductData setProvidedProducts(Collection<ProductData> providedProducts) {
+        if (providedProducts != null) {
+            if (this.providedProducts == null) {
+                this.providedProducts = new HashSet<>();
+            }
+            else {
+                this.providedProducts.clear();
+            }
+
+            for (ProductData pData : providedProducts) {
+                this.addProvidedProduct(pData);
+            }
+        }
+        else {
+            this.providedProducts = null;
+        }
+
+        return this;
+    }
+
+    /**
+     * Adds the provided product for this product.
+     *
+     * @param providedProduct
+     *  Provided product to be added.
+     *
+     * @return
+     *  Returns true is added successfully, otherwise false.
+     */
+    public boolean addProvidedProduct(ProductData providedProduct) {
+        if (providedProduct == null) {
+            throw new IllegalArgumentException("Provided product is null");
+        }
+
+        if (this.providedProducts == null) {
+            this.providedProducts = new HashSet<>();
+        }
+
+        return this.providedProducts.add(providedProduct);
+    }
+
     @Override
     public String toString() {
         return String.format("ProductData [id = %s, name = %s]", this.id, this.name);
@@ -982,6 +1043,7 @@ public class ProductData extends CandlepinDTO implements ProductInfo {
             .append(this.content, that.content)
             .append(this.dependentProductIds, that.dependentProductIds)
             .append(this.branding, that.branding)
+            .append(this.providedProducts, that.providedProducts)
             .append(this.href, that.href)
             .append(this.locked, that.locked);
 
@@ -1001,7 +1063,8 @@ public class ProductData extends CandlepinDTO implements ProductInfo {
             .append(this.content)
             .append(this.dependentProductIds)
             .append(this.branding)
-            .append(this.locked);
+            .append(this.locked)
+            .append(this.providedProducts);
 
         return builder.toHashCode();
     }
@@ -1032,6 +1095,13 @@ public class ProductData extends CandlepinDTO implements ProductInfo {
             copy.branding = new HashSet<>();
             copy.branding.addAll(
                 this.branding.stream().map(Branding::clone).collect(Collectors.toSet()));
+        }
+
+        if (this.providedProducts != null) {
+            copy.providedProducts = new HashSet<>();
+            copy.providedProducts.addAll(this.providedProducts.stream()
+                .map(prodData -> (ProductData) prodData.clone())
+                .collect(Collectors.toSet()));
         }
 
         return copy;
@@ -1067,6 +1137,12 @@ public class ProductData extends CandlepinDTO implements ProductInfo {
         this.setProductContent(source.getProductContent());
         this.setDependentProductIds(source.getDependentProductIds());
         this.setBranding(source.getBranding());
+
+        if (source.getProvidedProducts() != null) {
+            this.setProvidedProducts(source.getProvidedProducts().stream()
+                .map(prod -> new ProductData(prod))
+                .collect(Collectors.toSet()));
+        }
 
         return this;
     }
@@ -1117,6 +1193,12 @@ public class ProductData extends CandlepinDTO implements ProductInfo {
 
         this.setDependentProductIds(source.getDependentProductIds());
         this.setBranding(source.getBranding());
+
+        if (source.getProvidedProducts() != null) {
+            this.setProvidedProducts(source.getProvidedProducts().stream()
+                .map(prod -> new ProductData(prod))
+                .collect(Collectors.toSet()));
+        }
 
         return this;
     }

--- a/server/src/main/java/org/candlepin/service/model/ProductInfo.java
+++ b/server/src/main/java/org/candlepin/service/model/ProductInfo.java
@@ -126,4 +126,15 @@ public interface ProductInfo {
      *  the last update date for this product, or null if the last update date has not been set
      */
     Date getUpdated();
+
+    /**
+     * Fetches a collection of engineering products of this product. If the provided
+     * products have not yet been set, this method returns null. If this product does not
+     * provide any engineering products, this method returns an empty collection.
+     *
+     * @return
+     *  A collection of engineering products provided by this Product, or null if the provided
+     *  products have not been set.
+     */
+    Collection<? extends ProductInfo> getProvidedProducts();
 }

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/ProductDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/ProductDTOTest.java
@@ -15,6 +15,7 @@
 package org.candlepin.dto.manifest.v1;
 
 import org.candlepin.dto.AbstractDTOTest;
+import org.candlepin.util.Util;
 
 import org.junit.jupiter.api.Test;
 
@@ -24,6 +25,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -75,6 +77,12 @@ public class ProductDTOTest extends AbstractDTOTest<ProductDTO> {
             brandings.add(branding);
         }
 
+        Set<ProductDTO> providedProd = Util.asSet(
+            new ProductDTO().setId("pp1").setName("providedProduct1"),
+            new ProductDTO().setId("pp2").setName("providedProduct2"),
+            new ProductDTO().setId("pp3").setName("providedProduct3")
+        );
+
         this.values = new HashMap<>();
         this.values.put("Id", "test_value");
         this.values.put("Uuid", "test_value");
@@ -87,6 +95,7 @@ public class ProductDTOTest extends AbstractDTOTest<ProductDTO> {
         this.values.put("Branding", brandings);
         this.values.put("Created", new Date());
         this.values.put("Updated", new Date());
+        this.values.put("ProvidedProducts", providedProd);
     }
 
     /**

--- a/server/src/test/java/org/candlepin/model/dto/ProductDataTest.java
+++ b/server/src/test/java/org/candlepin/model/dto/ProductDataTest.java
@@ -36,6 +36,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -971,6 +972,58 @@ public class ProductDataTest {
     }
 
     @Test
+    public void testGetSetProvidedProducts() {
+        ProductData dto = new ProductData();
+        Collection<ProductData> input = Arrays.asList(
+            new ProductData("eng_id_1", "name_1"),
+            new ProductData("eng_id_2", "name_2")
+        );
+
+        Collection<ProductData> output = dto.getProvidedProducts();
+        assertNull(output);
+
+        ProductData output2 = dto.setProvidedProducts(input);
+        assertSame(dto, output2);
+
+        output = dto.getProvidedProducts();
+        assertTrue(Util.collectionsAreEqual(input, output));
+    }
+
+    @Test
+    public void testAddProvidedProducts() {
+        ProductData dto = new ProductData();
+        Collection<ProductData> providedProducts = dto.getProvidedProducts();
+
+        assertNull(providedProducts);
+
+        boolean output = dto.addProvidedProduct(new ProductData("eng_id_1", "name_1"));
+        providedProducts = dto.getProvidedProducts();
+
+        assertTrue(output);
+        assertNotNull(providedProducts);
+        assertTrue(Util.collectionsAreEqual(Arrays.asList(
+            new ProductData("eng_id_1", "name_1")), providedProducts));
+
+        output = dto.addProvidedProduct(new ProductData("eng_id_2", "name_2"));
+        providedProducts = dto.getProvidedProducts();
+
+        assertTrue(output);
+        assertNotNull(providedProducts);
+        assertTrue(Util.collectionsAreEqual(Arrays.asList(
+            new ProductData("eng_id_1", "name_1"),
+            new ProductData("eng_id_2", "name_2")), providedProducts));
+
+        output = dto.addProvidedProduct(new ProductData("eng_id_1", "name_1"));
+        providedProducts = dto.getProvidedProducts();
+
+        assertFalse(output);
+        assertNotNull(providedProducts);
+        assertTrue(Util.collectionsAreEqual(Arrays.asList(
+            new ProductData("eng_id_1", "name_1"),
+            new ProductData("eng_id_2", "name_2")), providedProducts));
+    }
+
+    @Test
     public void testGetSetHref() {
         ProductData dto = new ProductData();
         String input = "test_value";
@@ -1044,6 +1097,16 @@ public class ProductDataTest {
             new Branding(null, "eng_id_6", "brand_name_6", "OS")
         );
 
+        Set<ProductData> providedProductData1 = Util.asSet(
+            new ProductData("pd1", "providedProduct1"),
+            new ProductData("pd2", "providedProduct2")
+        );
+
+        Set<ProductData> providedProductData2 = Util.asSet(
+            new ProductData("pd3", "providedProduct3"),
+            new ProductData("pd4", "providedProduct4")
+        );
+
         return Stream.of(
             new Object[] { "Uuid", "test_value", "alt_value" },
             new Object[] { "Id", "test_value", "alt_value" },
@@ -1054,7 +1117,8 @@ public class ProductDataTest {
             new Object[] { "DependentProductIds", Arrays.asList("1", "2", "3"), Arrays.asList("4", "5") },
             new Object[] { "Branding", branding1, branding2},
             // new Object[] { "Href", "test_value", null },
-            new Object[] { "Locked", Boolean.TRUE, false }
+            new Object[] { "Locked", Boolean.TRUE, false },
+            new Object[] { "ProvidedProducts", providedProductData1, providedProductData2 }
         );
     }
 


### PR DESCRIPTION
- Added method to get provided products from ProductInfo. 
(Note: `getProvidedProducts` and `getDerivedProvidedProducts` will get removed from subscriptionInfo in later PR's)

PS : 
- This is done to isolate it from refresh code flow.
- This will help to fix rspec issues related to #2565 changes.

Merge order :
This or #2563 