### PR TITLE
Add custom openapi vendor extension to override collection type

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -232,7 +232,7 @@ project(":api") {
           generatePom: false,
           dateLibrary: "java8"
       ]
-      templateDir = 'buildSrc/src/main/resources/templates'
+      templateDir = "$rootDir/buildSrc/src/main/resources/templates"
     }
 
     openApiValidate {

--- a/build.gradle
+++ b/build.gradle
@@ -232,6 +232,7 @@ project(":api") {
           generatePom: false,
           dateLibrary: "java8"
       ]
+      templateDir = 'buildSrc/src/main/resources/templates'
     }
 
     openApiValidate {

--- a/buildSrc/src/main/resources/templates/returnTypeInterface.mustache
+++ b/buildSrc/src/main/resources/templates/returnTypeInterface.mustache
@@ -1,0 +1,1 @@
+{{#vendorExtensions.x-java-response-container-type}}{{vendorExtensions.x-java-response-container-type}}<{{returnBaseType}}>{{/vendorExtensions.x-java-response-container-type}}{{^vendorExtensions.x-java-response-container-type}}{{{returnType}}}{{/vendorExtensions.x-java-response-container-type}}


### PR DESCRIPTION
Add custom openapi vendor extension to override collection type

This makes it so that if for an operation you specify a line such as:

```yaml
x-java-response-container-type: java.util.stream.Stream
```

on an operation with a response return type of

```yaml
responses:
  200:
    description: OK
    content:
      application/json:
        schema:
          type: array
          items:
            $ref: '#/components/schemas/Link'
```

then the generated return type becomes `java.util.stream.Stream<Link>`

Specifically, this goes at the same level as `operationId`, because there is not a easy way to get the vendor extension for a response incorporated into the return type.