### PR TITLE
[F] ENT-1828 Update account refresh flow to populate new tables.

### DIFF
--- a/server/spec/derived_product_spec.rb
+++ b/server/spec/derived_product_spec.rb
@@ -310,6 +310,24 @@ describe 'Derived Products' do
   it 'regenerates entitlements when updating derived content' do
     skip("candlepin running in standalone mode") if not is_hosted?
 
+    derived_content = create_upstream_content("twentyTwo", {
+        :type => "yum",
+        :label => "teardropsOnMyGuitar",
+        :name => "swiftrocks",
+        :vendor => "fifteen",
+        :releaseVer => nil
+    })
+
+    derived_eng_product = create_upstream_product(random_string(nil, true))
+    add_content_to_product_upstream(derived_eng_product.id, derived_content.id)
+
+    derived_product = create_upstream_product(random_string('derived_prod'), {
+        :attributes => {
+            :cores => 2,
+            :sockets=>4
+        }, :providedProducts => [derived_eng_product]
+    })
+
     # Create a subscription with an upstream product with a derived product that provides content
     datacenter_product = create_upstream_product(random_string('dc_prod'), {
         :attributes => {
@@ -319,27 +337,11 @@ describe 'Derived Products' do
             'multi-entitlement' => "yes"
         }
     })
-    derived_product = create_upstream_product(random_string('derived_prod'), {
-        :attributes => {
-            :cores => 2,
-            :sockets=>4
-        }
-    })
 
-    derived_eng_product = create_upstream_product(random_string(nil, true))
-    derived_content = create_upstream_content("twentyTwo", {
-        :type => "yum",
-        :label => "teardropsOnMyGuitar",
-        :name => "swiftrocks",
-        :vendor => "fifteen",
-        :releaseVer => nil
-    })
-    add_content_to_product_upstream(derived_eng_product.id, derived_content.id)
-
-    sub = create_upstream_subscription(random_string('dc_sub'), @owner_key, datacenter_product.id, {
+    sub = create_upstream_subscription(random_string('dc_sub'), @owner_key, {
         :quantity => 10,
         :derived_product => derived_product,
-        :derived_provided_products => [derived_eng_product]
+        :product => datacenter_product
     })
 
     @cp.refresh_pools(@owner_key)

--- a/server/spec/owner_product_resource_spec.rb
+++ b/server/spec/owner_product_resource_spec.rb
@@ -7,10 +7,15 @@ describe 'Owner Product Resource' do
 
   before do
     @owner = create_owner random_string('test_owner')
-    @product = create_product random_string('product')
     @prov_product = create_product random_string('provided_product')
-    @derived_product = create_product random_string('derived_product')
+
+    @product = create_product(random_string('product'), nil,
+                              {:providedProducts => [@prov_product.id]})
+
     @derived_prov_product = create_product random_string('derived_provided_product')
+
+    @derived_product = create_product(random_string('derived_product'), nil,
+                                      {:providedProducts => [@derived_prov_product.id]})
 
     create_pool_and_subscription(@owner['key'], @product.id,
       10, [@prov_product.id], '222', '', '', nil, nil, false,
@@ -102,9 +107,11 @@ describe 'Owner Product Resource' do
 
   it 'retrieves the owners of an active product' do
     owner = create_owner(random_string('owner'), nil)
-    product = create_product(random_string("test_id"), random_string("test_name"), {:owner => owner['key']})
     provided_product = create_product(nil, nil, {:owner => owner['key']})
-    create_pool_and_subscription(owner['key'], product.id, 10, [provided_product.id])
+    product = create_product(random_string("test_id"), random_string("test_name"),
+                             {:owner => owner['key'], :providedProducts => [provided_product.id]})
+    create_pool_and_subscription(owner['key'], product.id, 10, [provided_product.id],
+      nil, nil, nil, nil, nil, false)
     user = user_client(owner, random_string('billy'))
     system = consumer_client(user, 'system6')
     system.consume_product(product.id)
@@ -125,10 +132,10 @@ describe 'Owner Product Resource' do
       random_string("test_name"),
       {:owner => owner['key']}
     )
-
     provided_product = create_product(nil, nil, {:owner => owner['key']})
 
-    create_pool_and_subscription(owner['key'], product.id, 10, [provided_product.id])
+    create_pool_and_subscription(owner['key'], product.id, 10, [provided_product.id],
+      nil, nil, nil, nil, nil, false)
 
     pool = owner_client.list_pools(:owner => owner.id)
     pool.length.should eq(1)

--- a/server/spec/product_resource_spec.rb
+++ b/server/spec/product_resource_spec.rb
@@ -55,9 +55,9 @@ describe 'Product Resource' do
   end
 
   def setupOrgProductsAndPools()
-    owner1 = create_owner(random_string("owner"))
-    owner2 = create_owner(random_string("owner"))
-    owner3 = create_owner(random_string("owner"))
+    owner1 = create_owner(random_string("owner-Px"))
+    owner2 = create_owner(random_string("owner-Py"))
+    owner3 = create_owner(random_string("owner-Pz"))
 
     prod1o1 = create_product("p1", "p1", { :owner => owner1['key'] })
     prod1o2 = create_product("p1", "p1", { :owner => owner2['key'] })
@@ -69,12 +69,12 @@ describe 'Product Resource' do
     prod3o2 = create_product("p3", "p3", { :owner => owner2['key'] })
     prod3o3 = create_product("p3", "p3", { :owner => owner3['key'] })
 
-    prod4 = create_product("p4", "p4", { :owner => owner1['key'] })
-    prod4d = create_product("p4d", "p4d", { :owner => owner1['key'] })
-    prod5 = create_product("p5", "p5", { :owner => owner2['key'] })
-    prod5d = create_product("p5d", "p5d", { :owner => owner2['key'] })
-    prod6 = create_product("p6", "p6", { :owner => owner3['key'] })
-    prod6d = create_product("p6d", "p6d", { :owner => owner3['key'] })
+    prod4 = create_product("p4", "p4", { :owner => owner1['key'], :providedProducts => [prod1o1.id] })
+    prod4d = create_product("p4d", "p4d", { :owner => owner1['key'], :providedProducts => [prod2o1.id] })
+    prod5 = create_product("p5", "p5", { :owner => owner2['key'], :providedProducts => [prod1o2.id, prod2o2.id] })
+    prod5d = create_product("p5d", "p5d", { :owner => owner2['key'], :providedProducts => [prod3o2.id] })
+    prod6 = create_product("p6", "p6", { :owner => owner3['key'], :providedProducts => [prod1o3.id] })
+    prod6d = create_product("p6d", "p6d", { :owner => owner3['key'], :providedProducts => [prod3o3.id] })
 
     @cp.create_pool(owner1['key'], "p4", {
       :derived_product_id         => "p4d",

--- a/server/spec/virt_spec.rb
+++ b/server/spec/virt_spec.rb
@@ -367,7 +367,8 @@ describe 'Standalone Virt-Limit Subscriptions', :type => :virt do
   end
 
   it 'should not bind products on host if virt_only are already available for guest' do
-    @second_product = create_product(nil, nil, {:attributes => { :virt_only => true }})
+    @second_product = create_product(nil, nil, {:attributes => { :virt_only => true },
+      :providedProducts => [@virt_limit_product.id]})
     @cp.create_pool(@owner['key'],
       @second_product.id, {:quantity => 10, :provided_products => [@virt_limit_product.id]})
     @cp.refresh_pools(@owner['key'])

--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -957,54 +957,6 @@ public class CandlepinPoolManager implements PoolManager {
             pool.setDerivedProduct(product);
         }
 
-        if (sub.getProvidedProducts() != null) {
-            Set<Product> products = new HashSet<>();
-
-            for (ProductInfo pdata : sub.getProvidedProducts()) {
-                if (pdata != null) {
-                    product = productMap.get(pdata.getId());
-
-                    if (product == null) {
-                        throw new IllegalStateException("Subscription's provided products references a " +
-                            "product which cannot be resolved: " + pdata);
-                    }
-
-                    products.add(product);
-                }
-            }
-
-            pool.setProvidedProducts(products);
-            // TODO: workaround to pass import spec tests. we will revisit and update this in import and
-            // refresh code changes
-            if (pool.getProduct() != null) {
-                pool.getProduct().setProvidedProducts(products);
-            }
-        }
-
-        if (sub.getDerivedProvidedProducts() != null) {
-            Set<Product> products = new HashSet<>();
-
-            for (ProductInfo pdata : sub.getDerivedProvidedProducts()) {
-                if (pdata != null) {
-                    product = productMap.get(pdata.getId());
-
-                    if (product == null) {
-                        throw new IllegalStateException("Subscription's derived provided products " +
-                            "references a product which cannot be resolved: " + pdata);
-                    }
-
-                    products.add(product);
-                }
-            }
-
-            pool.setDerivedProvidedProducts(products);
-            // TODO: workaround to pass import spec tests. we will revisit and update this in import and
-            // refresh code changes
-            if (pool.getDerivedProduct() != null) {
-                pool.getDerivedProduct().setProvidedProducts(products);
-            }
-        }
-
         return pool;
     }
 
@@ -1038,14 +990,6 @@ public class CandlepinPoolManager implements PoolManager {
 
         productData.add(sub.getProduct());
         productData.add(sub.getDerivedProduct());
-
-        if (sub.getProvidedProducts() != null) {
-            productData.addAll(sub.getProvidedProducts());
-        }
-
-        if (sub.getDerivedProvidedProducts() != null) {
-            productData.addAll(sub.getDerivedProvidedProducts());
-        }
 
         for (ProductInfo pdata : productData) {
             if (pdata != null) {
@@ -1308,11 +1252,9 @@ public class CandlepinPoolManager implements PoolManager {
 
         // Bulk fetch our provided and derived provided product IDs so we're not hitting the DB
         // several times for this lookup.
-        Map<String, Set<String>> providedProductIds = this.poolCurator
-            .getProvidedProductIds(allOwnerPools);
-
-        Map<String, Set<String>> derivedProvidedProductIds = this.poolCurator
-            .getDerivedProvidedProductIds(allOwnerPools);
+        List<Map<String, Set<String>>> listOfMap = getAllProvidedProductsFromPool(allOwnerPools);
+        Map<String, Set<String>> providedProductIds = listOfMap.get(0);
+        Map<String, Set<String>> derivedProvidedProductIds = listOfMap.get(1);
 
         for (Pool pool : allOwnerPools) {
             boolean providesProduct = false;
@@ -1433,6 +1375,52 @@ public class CandlepinPoolManager implements PoolManager {
     }
 
     /**
+     * This method iterate over collection of pools to create a map of provided products Ids and derived
+     * products Ids against individual poolId.
+     *
+     * @param pools
+     *  Collection of Pools.
+     *
+     * @return
+     *  it return a list of maps containing map of provided products Ids and map of derived provided products
+     *  Ids.
+     */
+    private List<Map<String, Set<String>>> getAllProvidedProductsFromPool(Collection<Pool> pools) {
+        Map<String, Set<String>> providedIdsMap = new HashMap<>();
+        Map<String, Set<String>> derivedProvidedIdsMap = new HashMap<>();
+        List<Map<String, Set<String>>> listOfMap = new ArrayList<>();
+
+        if (pools != null && !pools.isEmpty()) {
+            for (Pool pool : pools) {
+                if (pool != null && pool.getId() != null && pool.getProduct() != null) {
+                    if (pool.getProduct() != null &&
+                        pool.getProduct().getProvidedProducts() != null) {
+                        Set<String> listOfIds = pool.getProduct().getProvidedProducts().stream()
+                            .map(Product::getId)
+                            .collect(Collectors.toSet());
+
+                        providedIdsMap.put(pool.getId(), listOfIds);
+                    }
+
+                    if (pool.getDerivedProduct() != null &&
+                        pool.getDerivedProduct().getProvidedProducts() != null) {
+                        Set<String> listOfIds = pool.getDerivedProduct().getProvidedProducts().stream()
+                            .map(Product::getId)
+                            .collect(Collectors.toSet());
+
+                        derivedProvidedIdsMap.put(pool.getId(), listOfIds);
+                    }
+                }
+            }
+        }
+
+        listOfMap.add(providedIdsMap);
+        listOfMap.add(derivedProvidedIdsMap);
+
+        return listOfMap;
+    }
+
+    /**
      * Do not attempt to create subscriptions for products that
      * already have virt_only pools available to the guest
      */
@@ -1441,8 +1429,9 @@ public class CandlepinPoolManager implements PoolManager {
 
         // Bulk fetch our provided product IDs so we're not hitting the DB several times
         // for this lookup.
-        Map<String, Set<String>> providedProductIds = this.poolCurator
-            .getProvidedProductIds(allOwnerPoolsForGuest);
+        List<Map<String, Set<String>>> listOfProvidedMap =
+            getAllProvidedProductsFromPool(allOwnerPoolsForGuest);
+        Map<String, Set<String>> providedProductIds = listOfProvidedMap.get(0);
 
         for (Pool pool : allOwnerPoolsForGuest) {
             if (pool.getProduct() != null && (pool.getProduct().hasAttribute(Product.Attributes.VIRT_ONLY) ||
@@ -1523,7 +1512,8 @@ public class CandlepinPoolManager implements PoolManager {
 
         // Bulk fetch our provided product IDs so we're not hitting the DB several times
         // for this lookup.
-        Map<String, Set<String>> providedProductIds = this.poolCurator.getProvidedProductIds(allOwnerPools);
+        List<Map<String, Set<String>>> listOfProvidedMap = getAllProvidedProductsFromPool(allOwnerPools);
+        Map<String, Set<String>> providedProductIds = listOfProvidedMap.get(0);
 
         for (Pool pool : allOwnerPools) {
             boolean providesProduct = false;

--- a/server/src/main/java/org/candlepin/controller/ImportedEntityCompiler.java
+++ b/server/src/main/java/org/candlepin/controller/ImportedEntityCompiler.java
@@ -103,8 +103,6 @@ public class ImportedEntityCompiler {
                 // Add any products attached to this subscription...
                 this.addProducts(subscription.getProduct());
                 this.addProducts(subscription.getDerivedProduct());
-                this.addProducts(subscription.getProvidedProducts());
-                this.addProducts(subscription.getDerivedProvidedProducts());
             }
         }
     }
@@ -161,6 +159,10 @@ public class ImportedEntityCompiler {
 
                 // Add any content attached to this product...
                 this.addProductContent(product.getProductContent());
+
+                if (product.getProvidedProducts() != null) {
+                    addProducts(product.getProvidedProducts());
+                }
             }
         }
     }

--- a/server/src/main/java/org/candlepin/dto/manifest/v1/ProductDTO.java
+++ b/server/src/main/java/org/candlepin/dto/manifest/v1/ProductDTO.java
@@ -38,7 +38,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -1019,9 +1018,10 @@ public class ProductDTO extends TimestampedCandlepinDTO<ProductDTO> implements P
 
         if (this.getProvidedProducts() != null) {
             copy.providedProducts = new HashSet<>();
-            copy.providedProducts.addAll(this.getProvidedProducts().stream()
-                .map(prodDTO -> prodDTO.clone())
-                .collect(Collectors.toSet()));
+
+            for (ProductDTO product : this.getProvidedProducts()) {
+                copy.providedProducts.add(product.clone());
+            }
         }
 
         return copy;
@@ -1052,9 +1052,19 @@ public class ProductDTO extends TimestampedCandlepinDTO<ProductDTO> implements P
         this.setBranding(source.getBranding());
 
         if (source.getProvidedProducts() != null) {
-            this.setProvidedProducts(source.getProvidedProducts().stream()
-                .map(prod -> new ProductDTO(prod))
-                .collect(Collectors.toSet()));
+            if (this.providedProducts == null) {
+                this.providedProducts = new HashSet<>();
+            }
+            else {
+                this.providedProducts.clear();
+            }
+
+            for (ProductDTO pData : source.getProvidedProducts()) {
+                this.providedProducts.add(new ProductDTO(pData));
+            }
+        }
+        else {
+            this.setProvidedProducts(null);
         }
 
         return this;

--- a/server/src/main/java/org/candlepin/dto/manifest/v1/SubscriptionDTO.java
+++ b/server/src/main/java/org/candlepin/dto/manifest/v1/SubscriptionDTO.java
@@ -197,7 +197,6 @@ public class SubscriptionDTO extends CandlepinDTO<SubscriptionDTO> implements Su
     /**
      * {@inheritDoc}
      */
-    @Override
     public Collection<ProductDTO> getProvidedProducts() {
         return this.providedProducts != null ? new ListView<>(this.providedProducts) : null;
     }
@@ -262,7 +261,6 @@ public class SubscriptionDTO extends CandlepinDTO<SubscriptionDTO> implements Su
     /**
      * {@inheritDoc}
      */
-    @Override
     public Collection<ProductDTO> getDerivedProvidedProducts() {
         return this.derivedProvidedProducts != null ? new ListView<>(this.derivedProvidedProducts) : null;
     }

--- a/server/src/main/java/org/candlepin/hostedtest/HostedTestSubscriptionResource.java
+++ b/server/src/main/java/org/candlepin/hostedtest/HostedTestSubscriptionResource.java
@@ -35,6 +35,7 @@ import com.google.inject.persist.Transactional;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -97,13 +98,20 @@ public class HostedTestSubscriptionResource {
             throw new IllegalArgumentException("subscription is null");
         }
 
-        Map<String, ProductData> pmap = new HashMap<>();
+        Map<String, ProductData> pmap = new LinkedHashMap<>();
         Map<String, ContentData> cmap = new HashMap<>();
 
+        if (subscription.getProduct() != null && subscription.getProduct().getProvidedProducts() != null) {
+            this.addProductsToMap(subscription.getProduct().getProvidedProducts(), pmap);
+        }
+
+        if (subscription.getDerivedProduct() != null &&
+            subscription.getDerivedProduct().getProvidedProducts() != null) {
+            this.addProductsToMap(subscription.getDerivedProduct().getProvidedProducts(), pmap);
+        }
+
         this.addProductsToMap(subscription.getProduct(), pmap);
-        this.addProductsToMap(subscription.getProvidedProducts(), pmap);
         this.addProductsToMap(subscription.getDerivedProduct(), pmap);
-        this.addProductsToMap(subscription.getDerivedProvidedProducts(), pmap);
 
         for (ProductData product : pmap.values()) {
             this.addContentToMap(product.getProductContent(), cmap);

--- a/server/src/main/java/org/candlepin/hostedtest/HostedTestSubscriptionServiceAdapter.java
+++ b/server/src/main/java/org/candlepin/hostedtest/HostedTestSubscriptionServiceAdapter.java
@@ -122,12 +122,8 @@ public class HostedTestSubscriptionServiceAdapter implements SubscriptionService
 
         sdata.setId(sinfo.getId());
         sdata.setOwner(this.resolveOwner(sinfo.getOwner()));
-
         sdata.setProduct(this.resolveProduct(sinfo.getProduct()));
-        sdata.setProvidedProducts(this.resolveProducts(sinfo.getProvidedProducts()));
         sdata.setDerivedProduct(this.resolveProduct(sinfo.getDerivedProduct()));
-        sdata.setDerivedProvidedProducts(this.resolveProducts(sinfo.getDerivedProvidedProducts()));
-
         sdata.setQuantity(sinfo.getQuantity());
         sdata.setStartDate(sinfo.getStartDate());
         sdata.setEndDate(sinfo.getEndDate());
@@ -135,7 +131,6 @@ public class HostedTestSubscriptionServiceAdapter implements SubscriptionService
         sdata.setContractNumber(sinfo.getContractNumber());
         sdata.setAccountNumber(sinfo.getAccountNumber());
         sdata.setOrderNumber(sinfo.getOrderNumber());
-
         sdata.setUpstreamPoolId(sinfo.getUpstreamPoolId());
         sdata.setUpstreamEntitlementId(sinfo.getUpstreamEntitlementId());
         sdata.setUpstreamConsumerId(sinfo.getUpstreamConsumerId());
@@ -169,25 +164,10 @@ public class HostedTestSubscriptionServiceAdapter implements SubscriptionService
 
         // Do product resolution here
         ProductData product = this.resolveProduct(sinfo.getProduct());
-        Collection<ProductData> providedProducts = this.resolveProducts(sinfo.getProvidedProducts());
+        sdata.setProduct(product);
 
         ProductData dProduct = this.resolveProduct(sinfo.getDerivedProduct());
-        Collection<ProductData> dpProvidedProducts = this.resolveProducts(sinfo.getDerivedProvidedProducts());
-
-        // If they all resolved, set the products
-        if (product != null) {
-            sdata.setProduct(product);
-        }
-
-        if (providedProducts != null) {
-            sdata.setProvidedProducts(providedProducts);
-        }
-
         sdata.setDerivedProduct(dProduct);
-
-        if (dpProvidedProducts != null) {
-            sdata.setDerivedProvidedProducts(dpProvidedProducts);
-        }
 
         // Set the other "safe" properties here...
         if (sinfo.getOwner() != null) {
@@ -342,6 +322,10 @@ public class HostedTestSubscriptionServiceAdapter implements SubscriptionService
 
         if (pinfo.getBranding() != null) {
             pdata.setBranding(this.resolveBranding(pinfo.getBranding()));
+        }
+
+        if (pinfo.getProvidedProducts() != null) {
+            pdata.setProvidedProducts(this.resolveProducts(pinfo.getProvidedProducts()));
         }
 
         // Update product=>content mappings
@@ -601,24 +585,24 @@ public class HostedTestSubscriptionServiceAdapter implements SubscriptionService
 
         if (sdata.getProduct() != null && sdata.getProduct().getId() != null) {
             pids.add(sdata.getProduct().getId());
-        }
 
-        if (sdata.getProvidedProducts() != null) {
-            for (ProductData pdata : sdata.getProvidedProducts()) {
-                if (pdata != null && pdata.getId() != null) {
-                    pids.add(pdata.getId());
+            if (sdata.getProduct().getProvidedProducts() != null) {
+                for (ProductData pdata : sdata.getProduct().getProvidedProducts()) {
+                    if (pdata != null && pdata.getId() != null) {
+                        pids.add(pdata.getId());
+                    }
                 }
             }
         }
 
         if (sdata.getDerivedProduct() != null && sdata.getDerivedProduct().getId() != null) {
             pids.add(sdata.getDerivedProduct().getId());
-        }
 
-        if (sdata.getDerivedProvidedProducts() != null) {
-            for (ProductData pdata : sdata.getDerivedProvidedProducts()) {
-                if (pdata != null && pdata.getId() != null) {
-                    pids.add(pdata.getId());
+            if (sdata.getDerivedProduct().getProvidedProducts() != null) {
+                for (ProductData pdata : sdata.getDerivedProduct().getProvidedProducts()) {
+                    if (pdata != null && pdata.getId() != null) {
+                        pids.add(pdata.getId());
+                    }
                 }
             }
         }

--- a/server/src/main/java/org/candlepin/model/EntitlementCurator.java
+++ b/server/src/main/java/org/candlepin/model/EntitlementCurator.java
@@ -125,7 +125,7 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
 
             if (values != null && !values.isEmpty()) {
                 if (!joinedProvided) {
-                    criteria.createAlias("Pool.providedProducts", "Provided", JoinType.LEFT_OUTER_JOIN);
+                    criteria.createAlias("Product.providedProducts", "Provided", JoinType.LEFT_OUTER_JOIN);
                     joinedProvided = true;
                 }
 
@@ -148,7 +148,7 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
             if (values != null && !values.isEmpty()) {
                 if (!joinedProvided) {
                     // This was an inner join -- might end up being important later
-                    criteria.createAlias("Pool.providedProducts", "Provided", JoinType.LEFT_OUTER_JOIN);
+                    criteria.createAlias("Product.providedProducts", "Provided", JoinType.LEFT_OUTER_JOIN);
                     joinedProvided = true;
                 }
 
@@ -955,6 +955,8 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
      * on provided products only. Dependent entitlements are those who's
      * content are being modified by the consumption of another entitlement.
      *
+     * Note : This method does not support N-tier product hierarchy.
+     *
      * @param entitlementIds the entitlements to match on.
      * @return the set of entitlement IDs for the matched modifier entitlements.
      */
@@ -962,18 +964,21 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
         String queryStr = "SELECT DISTINCT e2.id " +
             // Required entitlement
             "FROM cp_entitlement e1 " +
-            // Required entitlement => required pool
-            "JOIN cp2_pool_provided_products ppp1 ON ppp1.pool_id = e1.pool_id " +
             // Required pool => required product
-            "JOIN cp2_products p ON p.uuid = ppp1.product_uuid " +
+            "JOIN cp_pool pl1 on pl1.id = e1.pool_id " +
+            // Pools Product => Provided product
+            "JOIN cp2_product_provided_products ppp1 ON ppp1.product_uuid = pl1.product_uuid " +
+            // Provided product => Product
+            "JOIN cp2_products p ON p.uuid = ppp1.provided_product_uuid " +
             // Required product => conditional content
             "JOIN cp2_content_modified_products cmp ON cmp.element = p.product_id " +
             // Conditional content => dependent product
             "JOIN cp2_product_content pc ON pc.content_uuid = cmp.content_uuid " +
-            // Dependent product => dependent pool
-            "JOIN cp2_pool_provided_products ppp2 ON ppp2.product_uuid = pc.product_uuid " +
+            // Provided Product => Dependent product => dependent pool
+            "JOIN cp2_product_provided_products ppp2 ON ppp2.provided_product_uuid = pc.product_uuid " +
+            "JOIN cp_pool pl2 on pl2.product_uuid = ppp2.product_uuid " +
             // Dependent pool => dependent entitlement
-            "JOIN cp_entitlement e2 ON e2.pool_id = ppp2.pool_id " +
+            "JOIN cp_entitlement e2 ON e2.pool_id = pl2.id " +
             "WHERE e1.consumer_id = e2.consumer_id " +
             "  AND e1.id != e2.id " +
             "  AND e2.dirty = false " +
@@ -999,6 +1004,8 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
      * on derived provided products only. Dependent entitlements are those who's
      * content are being modified by the consumption of another entitlement.
      *
+     * Note : This method does not support N-tier product hierarchy.
+     *
      * @param entitlementIds the entitlements to match on.
      * @return the set of entitlement IDs for the matched modifier entitlements.
      */
@@ -1006,18 +1013,19 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
         String queryStr = "SELECT DISTINCT e2.id " +
             // Required entitlement
             "FROM cp_entitlement e1 " +
-            // Required entitlement => required pool
-            "JOIN cp2_pool_derprov_products ppp1 ON ppp1.pool_id = e1.pool_id " +
-            // Required pool => required product
-            "JOIN cp2_products p ON p.uuid = ppp1.product_uuid " +
+            "JOIN cp_pool pl1 on pl1.id = e1.pool_id " +
+            // Required entitlement => required pool => derived product => provided product
+            "JOIN cp2_product_provided_products ppp1 ON ppp1.product_uuid = pl1.derived_product_uuid " +
+            "JOIN cp2_products p ON p.uuid = ppp1.provided_product_uuid " +
             // Required product => conditional content
             "JOIN cp2_content_modified_products cmp ON cmp.element = p.product_id " +
             // Conditional content => dependent product
             "JOIN cp2_product_content pc ON pc.content_uuid = cmp.content_uuid " +
             // Dependent product => dependent pool
-            "JOIN cp2_pool_provided_products ppp2 ON ppp2.product_uuid = pc.product_uuid " +
+            "JOIN cp2_product_provided_products ppp2 ON ppp2.provided_product_uuid = pc.product_uuid " +
+            "JOIN cp_pool pl2 on pl2.product_uuid = ppp2.product_uuid " +
             // Dependent pool => dependent entitlement
-            "JOIN cp_entitlement e2 ON e2.pool_id = ppp2.pool_id " +
+            "JOIN cp_entitlement e2 ON e2.pool_id = pl2.id " +
             "WHERE e1.consumer_id = e2.consumer_id " +
             "  AND e1.id != e2.id " +
             "  AND e2.dirty = false " +
@@ -1042,6 +1050,8 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
      * given consumer. Dependent entitlements are those who's content are being modified by the
      * consumption of another entitlement.
      *
+     * Note : This method does not support N-tier product hierarchy.
+     *
      * @param consumer
      *  The consumer for which to find dependent entitlement IDs
      *
@@ -1064,20 +1074,22 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
             // entitlements, rather than the lunacy that would be required with HQL, JPQL or
             // CriteriaBuilder.
             String querySql = "SELECT DISTINCT e.id " +
-                // Required pool
-                "FROM cp2_pool_provided_products ppp1 " +
                 // Required pool => required product
-                "JOIN cp2_products p ON p.uuid = ppp1.product_uuid " +
+                "FROM cp_pool pl1 " +
+                "JOIN cp2_product_provided_products ppp1 on ppp1.product_uuid = pl1.product_uuid " +
+                // Provided product => Product
+                "JOIN cp2_products p ON p.uuid = ppp1.provided_product_uuid " +
                 // Required product => conditional content
                 "JOIN cp2_content_modified_products cmp ON cmp.element = p.product_id " +
                 // Conditional content => dependent product
                 "JOIN cp2_product_content pc ON pc.content_uuid = cmp.content_uuid " +
                 // Dependent product => dependent pool
-                "JOIN cp2_pool_provided_products ppp2 ON ppp2.product_uuid = pc.product_uuid " +
+                "JOIN cp2_product_provided_products ppp2 ON ppp2.provided_product_uuid = pc.product_uuid " +
+                "JOIN cp_pool pl2 on pl2.product_uuid = ppp2.product_uuid " +
                 // Dependent pool => dependent entitlement
-                "JOIN cp_entitlement e ON e.pool_id = ppp2.pool_id " +
+                "JOIN cp_entitlement e ON e.pool_id = pl2.id " +
                 "WHERE e.consumer_id = :consumer_id " +
-                "  AND ppp1.pool_id IN (:pool_ids) ";
+                "  AND pl1.id IN (:pool_ids) ";
 
 
             int blockSize = Math.min(this.getInBlockSize(), this.getQueryParameterLimit() - 1);
@@ -1094,20 +1106,24 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
             // avoid unnecessary query overhead when we are not dealing with a distributor.
             if (ctype.isManifest()) {
                 querySql = "SELECT DISTINCT e.id " +
-                    // Required pool
-                    "FROM cp2_pool_derprov_products ppp1 " +
                     // Required pool => required product
-                    "JOIN cp2_products p ON p.uuid = ppp1.product_uuid " +
+                    "FROM cp_pool pl1 " +
+                    "JOIN cp2_product_provided_products ppp1 " +
+                    "on ppp1.product_uuid = pl1.derived_product_uuid " +
+                    // Provided product => Product
+                    "JOIN cp2_products p ON p.uuid = ppp1.provided_product_uuid " +
                     // Required product => conditional content
                     "JOIN cp2_content_modified_products cmp ON cmp.element = p.product_id " +
                     // Conditional content => dependent product
                     "JOIN cp2_product_content pc ON pc.content_uuid = cmp.content_uuid " +
                     // Dependent product => dependent pool
-                    "JOIN cp2_pool_provided_products ppp2 ON ppp2.product_uuid = pc.product_uuid " +
+                    "JOIN cp2_product_provided_products ppp2 " +
+                    "ON ppp2.provided_product_uuid = pc.product_uuid " +
+                    "JOIN cp_pool pl2 on pl2.product_uuid = ppp2.product_uuid " +
                     // Dependent pool => dependent entitlement
-                    "JOIN cp_entitlement e ON e.pool_id = ppp2.pool_id " +
+                    "JOIN cp_entitlement e ON e.pool_id = pl2.id " +
                     "WHERE e.consumer_id = :consumer_id " +
-                    "  AND ppp1.pool_id IN (:pool_ids) ";
+                    "  AND pl1.id IN (:pool_ids) ";
 
                 query = getEntityManager().createNativeQuery(querySql)
                     .setParameter("consumer_id", consumer.getId());
@@ -1121,5 +1137,4 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
 
         return entitlementIds;
     }
-
 }

--- a/server/src/main/java/org/candlepin/model/OwnerCurator.java
+++ b/server/src/main/java/org/candlepin/model/OwnerCurator.java
@@ -164,7 +164,8 @@ public class OwnerCurator extends AbstractHibernateCurator<Owner> {
     public CandlepinQuery<Owner> getOwnersByActiveProduct(Collection<String> productIds) {
         // NOTE: only used by superadmin API calls, no permissions filtering needed here.
         DetachedCriteria poolIdQuery = DetachedCriteria.forClass(Pool.class, "pool")
-            .createAlias("pool.providedProducts", "providedProducts")
+            .createAlias("pool.product", "product")
+            .createAlias("product.providedProducts", "providedProducts")
             .add(CPRestrictions.in("providedProducts.id", productIds))
             .setProjection(Property.forName("pool.id"));
 
@@ -213,8 +214,8 @@ public class OwnerCurator extends AbstractHibernateCurator<Owner> {
                 .createAlias("Owner.pools", "Pool")
                 .createAlias("Pool.product", "Prod", JoinType.LEFT_OUTER_JOIN)
                 .createAlias("Pool.derivedProduct", "DProd", JoinType.LEFT_OUTER_JOIN)
-                .createAlias("Pool.providedProducts", "PProd", JoinType.LEFT_OUTER_JOIN)
-                .createAlias("Pool.derivedProvidedProducts", "DPProd", JoinType.LEFT_OUTER_JOIN)
+                .createAlias("Prod.providedProducts", "PProd", JoinType.LEFT_OUTER_JOIN)
+                .createAlias("DProd.providedProducts", "DPProd", JoinType.LEFT_OUTER_JOIN)
                 .add(Restrictions.or(
                     CPRestrictions.in("Prod.id", productIds),
                     CPRestrictions.in("DProd.id", productIds),

--- a/server/src/main/java/org/candlepin/model/OwnerProductCurator.java
+++ b/server/src/main/java/org/candlepin/model/OwnerProductCurator.java
@@ -642,13 +642,15 @@ public class OwnerProductCurator extends AbstractHibernateCurator<OwnerProduct> 
 
             // Ensure we aren't trying to remove product references for products still used by
             // pools for this owner
-            Long poolCount = (Long) session.createCriteria(Pool.class)
-                .createAlias("providedProducts", "providedProd", JoinType.LEFT_OUTER_JOIN)
-                .createAlias("derivedProvidedProducts", "derivedProvidedProd", JoinType.LEFT_OUTER_JOIN)
+            Long poolCount = (Long) session.createCriteria(Pool.class, "Pool")
+                .createAlias("Pool.product", "Product")
+                .createAlias("Product.providedProducts", "providedProd", JoinType.LEFT_OUTER_JOIN)
+                .createAlias("Pool.derivedProduct", "DProduct", JoinType.LEFT_OUTER_JOIN)
+                .createAlias("DProduct.providedProducts", "derivedProvidedProd", JoinType.LEFT_OUTER_JOIN)
                 .add(Restrictions.eq("owner", owner))
                 .add(Restrictions.or(
-                    CPRestrictions.in("product.uuid", productUuids),
-                    CPRestrictions.in("derivedProduct.uuid", productUuids),
+                    CPRestrictions.in("Product.uuid", productUuids),
+                    CPRestrictions.in("DProduct.uuid", productUuids),
                     CPRestrictions.in("providedProd.uuid", productUuids),
                     CPRestrictions.in("derivedProvidedProd.uuid", productUuids)))
                 .setProjection(Projections.count("id"))

--- a/server/src/main/java/org/candlepin/model/PoolCurator.java
+++ b/server/src/main/java/org/candlepin/model/PoolCurator.java
@@ -474,7 +474,7 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
 
         if (values != null && !values.isEmpty()) {
             if (!joinedProvided) {
-                criteria.createAlias("Pool.providedProducts", "Provided", JoinType.LEFT_OUTER_JOIN);
+                criteria.createAlias("Pool.product.providedProducts", "Provided", JoinType.LEFT_OUTER_JOIN);
                 joinedProvided = true;
             }
 
@@ -497,7 +497,8 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
             if (values != null && !values.isEmpty()) {
                 if (!joinedProvided) {
                     // This was an inner join -- might end up being important later
-                    criteria.createAlias("Pool.providedProducts", "Provided", JoinType.LEFT_OUTER_JOIN);
+                    criteria.createAlias("Pool.product.providedProducts", "Provided",
+                        JoinType.LEFT_OUTER_JOIN);
                     joinedProvided = true;
                 }
 
@@ -1437,14 +1438,14 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
 
         query = this.currentSession().createQuery(
             "SELECT DISTINCT PP.id " +
-            "FROM Pool P INNER JOIN P.providedProducts AS PP " +
+            "FROM Pool P INNER JOIN P.product.providedProducts AS PP " +
             "WHERE NULLIF(PP.id, '') IS NOT NULL"
         );
         result.addAll(query.list());
 
         query = this.currentSession().createQuery(
             "SELECT DISTINCT DPP.id " +
-            "FROM Pool P INNER JOIN P.derivedProvidedProducts AS DPP " +
+            "FROM Pool P INNER JOIN P.derivedProduct.providedProducts AS DPP " +
             "WHERE NULLIF(DPP.id, '') IS NOT NULL"
         );
         result.addAll(query.list());
@@ -1490,7 +1491,7 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
 
         query = this.currentSession().createQuery(
             "SELECT DISTINCT PP.id " +
-            "FROM Pool P INNER JOIN P.providedProducts AS PP " +
+            "FROM Pool P INNER JOIN P.product.providedProducts AS PP " +
             "WHERE NULLIF(PP.id, '') IS NOT NULL " +
             "AND P.owner = :owner"
         );
@@ -1499,7 +1500,7 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
 
         query = this.currentSession().createQuery(
             "SELECT DISTINCT DPP.id " +
-            "FROM Pool P INNER JOIN P.derivedProvidedProducts AS DPP " +
+            "FROM Pool P INNER JOIN P.derivedProduct.providedProducts AS DPP " +
             "WHERE NULLIF(DPP.id, '') IS NOT NULL " +
             "AND P.owner = :owner"
         );
@@ -1604,7 +1605,7 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
         Collection<String> productIds) {
 
         String statement = "update Entitlement e set e.dirty=true where e.pool.id in " +
-            "(select p.id from Pool p join p.providedProducts pp where pp.id in :productIds)" +
+            "(select p.id from Pool p join p.product.providedProducts pp where pp.id in :productIds)" +
             "and e.owner = :owner";
         Query query = currentSession().createQuery(statement);
         query.setParameter("owner", owner);
@@ -1617,7 +1618,7 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
      *
      * Figures out if the pool with poolId provides a product providedProductId.
      * 'provides' means that the product is either Pool product or is linked through
-     * cp2_pool_provided_products table
+     * cp2_provided_products table
      * @param poolId
      * @param providedProductId
      * @return True if and only if providedProductId is provided product or pool product
@@ -1625,7 +1626,7 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
     public Boolean provides(Pool pool, String providedProductId) {
         TypedQuery<Long> query = getEntityManager().createQuery(
             "SELECT count(product.uuid) FROM Pool p " +
-            "LEFT JOIN p.providedProducts pproduct " +
+            "LEFT JOIN p.product.providedProducts pproduct " +
             "LEFT JOIN p.product product " +
             "WHERE p.id = :poolid and (pproduct.id = :providedProductId OR product.id = :providedProductId)",
             Long.class);
@@ -1649,7 +1650,7 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
         if (pool.getDerivedProduct() != null) {
             TypedQuery<Long> query = getEntityManager().createQuery(
                 "SELECT count(product.uuid) FROM Pool p " +
-                "LEFT JOIN p.derivedProvidedProducts pproduct " +
+                "LEFT JOIN p.derivedProduct.providedProducts pproduct " +
                 "LEFT JOIN p.derivedProduct product " + "WHERE p.id = :poolid and " +
                 "(pproduct.id = :providedProductId OR product.id = :providedProductId)",
                 Long.class);

--- a/server/src/main/java/org/candlepin/model/Product.java
+++ b/server/src/main/java/org/candlepin/model/Product.java
@@ -1286,7 +1286,7 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
         if (!this.providedProducts.isEmpty()) {
             accumulator = 0;
             for (Product product : this.providedProducts) {
-                accumulator += (product != null ? product.hashCode() : 0);
+                accumulator += (product != null ? product.getEntityVersion() : 0);
             }
 
             builder.append(accumulator);

--- a/server/src/main/java/org/candlepin/model/dto/ProductData.java
+++ b/server/src/main/java/org/candlepin/model/dto/ProductData.java
@@ -1099,9 +1099,10 @@ public class ProductData extends CandlepinDTO implements ProductInfo {
 
         if (this.providedProducts != null) {
             copy.providedProducts = new HashSet<>();
-            copy.providedProducts.addAll(this.providedProducts.stream()
-                .map(prodData -> (ProductData) prodData.clone())
-                .collect(Collectors.toSet()));
+
+            for (ProductData productData : this.getProvidedProducts()) {
+                copy.providedProducts.add((ProductData) productData.clone());
+            }
         }
 
         return copy;
@@ -1139,9 +1140,19 @@ public class ProductData extends CandlepinDTO implements ProductInfo {
         this.setBranding(source.getBranding());
 
         if (source.getProvidedProducts() != null) {
-            this.setProvidedProducts(source.getProvidedProducts().stream()
-                .map(prod -> new ProductData(prod))
-                .collect(Collectors.toSet()));
+            if (this.providedProducts == null) {
+                this.providedProducts = new HashSet<>();
+            }
+            else {
+                this.providedProducts.clear();
+            }
+
+            for (ProductData pData : source.getProvidedProducts()) {
+                this.providedProducts.add(new ProductData(pData));
+            }
+        }
+        else {
+            this.setProvidedProducts(null);
         }
 
         return this;
@@ -1195,9 +1206,19 @@ public class ProductData extends CandlepinDTO implements ProductInfo {
         this.setBranding(source.getBranding());
 
         if (source.getProvidedProducts() != null) {
-            this.setProvidedProducts(source.getProvidedProducts().stream()
-                .map(prod -> new ProductData(prod))
-                .collect(Collectors.toSet()));
+            if (this.providedProducts == null) {
+                this.providedProducts = new HashSet<>();
+            }
+            else {
+                this.providedProducts.clear();
+            }
+
+            for (Product pData : source.getProvidedProducts()) {
+                this.providedProducts.add(new ProductData(pData));
+            }
+        }
+        else {
+            this.setProvidedProducts(null);
         }
 
         return this;

--- a/server/src/main/java/org/candlepin/model/dto/Subscription.java
+++ b/server/src/main/java/org/candlepin/model/dto/Subscription.java
@@ -35,7 +35,6 @@ import org.slf4j.LoggerFactory;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.Set;
 
 import javax.xml.bind.annotation.XmlAccessType;
@@ -78,11 +77,10 @@ public class Subscription extends CandlepinDTO implements Owned, Named, Eventful
         // Intentionally left empty
     }
 
-    public Subscription(Owner ownerIn, ProductData productIn, Set<ProductData> providedProducts,
-        Long maxMembersIn, Date startDateIn, Date endDateIn, Date modified) {
+    public Subscription(Owner ownerIn, ProductData productIn, Long maxMembersIn, Date startDateIn,
+        Date endDateIn, Date modified) {
         this.owner = ownerIn;
         this.product = productIn;
-        this.providedProducts = providedProducts;
         this.quantity = maxMembersIn;
         this.startDate = startDateIn;
         this.endDate = endDateIn;
@@ -319,16 +317,9 @@ public class Subscription extends CandlepinDTO implements Owned, Named, Eventful
         return false;
     }
 
-    public Set<ProductData> getProvidedProducts() {
-        return providedProducts;
-    }
-
-    public void setProvidedProducts(Collection<ProductData> providedProducts) {
-        this.providedProducts.clear();
-
-        if (providedProducts != null) {
-            this.providedProducts.addAll(providedProducts);
-        }
+    public Collection<ProductData> getProvidedProducts() {
+        return this.product != null && this.product.getProvidedProducts() != null ?
+            this.product.getProvidedProducts() : null;
     }
 
     public void setUpstreamPoolId(String upstreamPoolId) {
@@ -371,16 +362,9 @@ public class Subscription extends CandlepinDTO implements Owned, Named, Eventful
         this.derivedProduct = subProduct;
     }
 
-    public Set<ProductData> getDerivedProvidedProducts() {
-        return derivedProvidedProducts;
-    }
-
-    public void setDerivedProvidedProducts(Collection<ProductData> subProvidedProducts) {
-        this.derivedProvidedProducts.clear();
-
-        if (subProvidedProducts != null) {
-            this.derivedProvidedProducts.addAll(subProvidedProducts);
-        }
+    public Collection<ProductData> getDerivedProvidedProducts() {
+        return this.derivedProduct != null && this.derivedProduct.getProvidedProducts() != null ?
+            this.derivedProduct.getProvidedProducts() : null;
     }
 
     public Cdn getCdn() {
@@ -538,13 +522,11 @@ public class Subscription extends CandlepinDTO implements Owned, Named, Eventful
         this.setContractNumber(source.getContractNumber());
         this.setAccountNumber(source.getAccountNumber());
         this.setOrderNumber(source.getOrderNumber());
-        this.setProvidedProducts(source.getProvidedProducts());
         this.setUpstreamPoolId(source.getUpstreamPoolId());
         this.setUpstreamEntitlementId(source.getUpstreamEntitlementId());
         this.setUpstreamConsumerId(source.getUpstreamConsumerId());
         this.setCertificate(source.getCertificate());
         this.setDerivedProduct(source.getDerivedProduct());
-        this.setDerivedProvidedProducts(source.getDerivedProvidedProducts());
         this.setCdn(source.getCdn());
 
         return this;
@@ -596,38 +578,6 @@ public class Subscription extends CandlepinDTO implements Owned, Named, Eventful
         this.setDerivedProduct(
             source.getDerivedProduct() != null ? new ProductData(source.getDerivedProduct()) : null
         );
-
-        // Will work only if source is stored in the database and linked to provided products there!
-        Collection<Product> products = source.getProduct().getProvidedProducts();
-        if (products != null) {
-            Collection<ProductData> pdata = new LinkedList<>();
-
-            for (Product product : products) {
-                pdata.add(product.toDTO());
-            }
-
-            this.setProvidedProducts(pdata);
-        }
-        else {
-            this.setProvidedProducts(null);
-        }
-
-        if (source.getDerivedProduct() != null) {
-            products = source.getDerivedProduct().getProvidedProducts();
-            if (products != null) {
-                Collection<ProductData> pdata = new LinkedList<>();
-
-                for (Product product : products) {
-                    pdata.add(product.toDTO());
-                }
-
-                this.setDerivedProvidedProducts(pdata);
-            }
-            else {
-                this.setDerivedProvidedProducts(null);
-            }
-        }
-
 
         return this;
     }

--- a/server/src/main/java/org/candlepin/policy/SystemPurposeComplianceRules.java
+++ b/server/src/main/java/org/candlepin/policy/SystemPurposeComplianceRules.java
@@ -150,12 +150,14 @@ public class SystemPurposeComplianceRules {
 
             Set<Product> entitlementProducts = new HashSet<>();
 
-            if (entitlementPool.getProvidedProducts() != null) {
-                entitlementProducts.addAll(entitlementPool.getProvidedProducts());
+            if (entitlementPool.getProduct() != null &&
+                entitlementPool.getProduct().getProvidedProducts() != null) {
+                entitlementProducts.addAll(entitlementPool.getProduct().getProvidedProducts());
             }
 
-            if (entitlementPool.getDerivedProvidedProducts() != null) {
-                entitlementProducts.addAll(entitlementPool.getDerivedProvidedProducts());
+            if (entitlementPool.getDerivedProduct() != null &&
+                entitlementPool.getDerivedProduct().getProvidedProducts() != null) {
+                entitlementProducts.addAll(entitlementPool.getDerivedProduct().getProvidedProducts());
             }
 
             entitlementProducts.add(entitlementPool.getProduct());

--- a/server/src/main/java/org/candlepin/policy/js/pool/PoolHelper.java
+++ b/server/src/main/java/org/candlepin/policy/js/pool/PoolHelper.java
@@ -34,13 +34,9 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Set;
-
-
 
 /**
  * Post Entitlement Helper, and some attribute utility methods.
@@ -101,7 +97,6 @@ public class PoolHelper {
                     pool.getContractNumber(),
                     pool.getAccountNumber(),
                     pool.getOrderNumber(),
-                    productCurator.getPoolProvidedProductsCached(pool),
                     sourceEntitlements.get(pool.getId()),
                     consumer,
                     pool);
@@ -122,7 +117,6 @@ public class PoolHelper {
                     pool.getContractNumber(),
                     pool.getAccountNumber(),
                     pool.getOrderNumber(),
-                    productCurator.getPoolDerivedProvidedProductsCached(pool),
                     sourceEntitlements.get(pool.getId()),
                     consumer,
                     pool);
@@ -159,71 +153,6 @@ public class PoolHelper {
         return poolOperationCallback;
     }
 
-    /**
-     * Copies the provided products from a source pool to a bonus pool. The
-     * logic is not completely straightforward.
-     *
-     * The source has so called 'main product' (source.getProduct()) and also
-     * derived product source.getDerivedProduct(). It also has 'main provided products'
-     * source.getProvidedProducts().
-     *
-     * During the copy, the following takes place.
-     *
-     * If the source has derived product, then the destination will receive source's
-     * derived product as main product (destination.getProduct). Also, it will receive
-     * source's derived provided products as destination main provided products.
-     * In other words:
-     *
-     * IF source.getDerivedProduct is null
-     *
-     *     source.product  >>>   destination.product
-     *     source.providedProducts >>> destionation.providedProducts
-     *
-     * IF source.getDerivedProduct is not null
-     *
-     *     source.derivedProduct >>> destination.product
-     *     source.derivedProvidedProducts >>> destination.providedProducts
-     *
-     * @param source subscription
-     * @param destination bonus pool
-     */
-    private static void copyProvidedProducts(Pool source, Pool destination,
-        OwnerProductCurator curator, ProductCurator productCurator) {
-        Set<Product> products;
-
-        // If the source pool has id filled, we assume that it is stored in the
-        // database and also assume that the provided Products or
-        // derived provided Products are linked with the Pool in the database!
-        if (source.getId() != null) {
-            if (source.getDerivedProduct() != null) {
-                products = productCurator.getPoolDerivedProvidedProductsCached(source);
-            }
-            else {
-                products = productCurator.getPoolProvidedProductsCached(source);
-            }
-        }
-        // Otherwise we just use the products attached directly on the entity
-        else {
-            if (source.getDerivedProduct() != null) {
-                products = source.getDerivedProvidedProducts();
-            }
-            else {
-                products = source.getProvidedProducts();
-            }
-        }
-
-        for (Product product : products) {
-            // If no result is returned here, the product has not been correctly imported
-            // into the organization, indicating a problem somewhere in the sync or refresh code:
-            Product destprod = curator.getProductById(destination.getOwner(), product.getId());
-            if (destprod == null) {
-                throw new RuntimeException("Product " + product.getId() +
-                    " has not been imported into org " + destination.getOwner().getKey());
-            }
-            destination.addProvidedProduct(destprod);
-        }
-    }
-
     public static Pool clonePool(Pool sourcePool, Product product, String quantity,
         Map<String, String> attributes, String subKey, OwnerProductCurator curator,
         Entitlement sourceEntitlement, Consumer sourceConsumer, ProductCurator productCurator) {
@@ -231,15 +160,13 @@ public class PoolHelper {
         Pool pool = createPool(product, sourcePool.getOwner(), quantity,
             sourcePool.getStartDate(), sourcePool.getEndDate(),
             sourcePool.getContractNumber(), sourcePool.getAccountNumber(),
-            sourcePool.getOrderNumber(), new HashSet<>(), sourceEntitlement,
+            sourcePool.getOrderNumber(), sourceEntitlement,
             sourceConsumer, sourcePool);
 
         SourceSubscription srcSub = sourcePool.getSourceSubscription();
         if (srcSub != null && srcSub.getSubscriptionId() != null) {
             pool.setSourceSubscription(new SourceSubscription(srcSub.getSubscriptionId(), subKey));
         }
-
-        copyProvidedProducts(sourcePool, pool, curator, productCurator);
 
         // Add in the new attributes
         for (Entry<String, String> entry : attributes.entrySet()) {
@@ -264,25 +191,20 @@ public class PoolHelper {
 
     private static Pool createPool(Product product, Owner owner, String quantity, Date startDate,
         Date endDate, String contractNumber, String accountNumber, String orderNumber,
-        Set<Product> providedProducts, Entitlement sourceEntitlement, Consumer sourceConsumer,
+        Entitlement sourceEntitlement, Consumer sourceConsumer,
         Pool sourcePool) {
 
         Long q = Pool.parseQuantity(quantity);
 
-        Pool pool = new Pool(
-            owner,
-            product,
-            new HashSet<>(),
-            q,
-            startDate,
-            endDate,
-            contractNumber,
-            accountNumber,
-            orderNumber
-        );
-
-        // Must be sure to copy the provided products, not try to re-use them directly:
-        pool.setProvidedProducts(providedProducts);
+        Pool pool = new Pool();
+        pool.setOwner(owner);
+        pool.setProduct(product);
+        pool.setQuantity(q);
+        pool.setStartDate(startDate);
+        pool.setEndDate(endDate);
+        pool.setContractNumber(contractNumber);
+        pool.setAccountNumber(accountNumber);
+        pool.setOrderNumber(orderNumber);
 
         if (sourcePool != null && sourceConsumer != null && sourceEntitlement != null) {
             if (sourcePool.isStacked()) {

--- a/server/src/main/java/org/candlepin/policy/js/pool/StackedSubPoolValueAccumulator.java
+++ b/server/src/main/java/org/candlepin/policy/js/pool/StackedSubPoolValueAccumulator.java
@@ -15,15 +15,10 @@
 package org.candlepin.policy.js.pool;
 
 import org.candlepin.model.Entitlement;
-import org.candlepin.model.Pool;
 import org.candlepin.model.Product;
-import org.candlepin.model.ProductCurator;
 
 import java.util.Collection;
 import java.util.Date;
-import java.util.HashSet;
-import java.util.Set;
-
 
 
 /**
@@ -38,19 +33,12 @@ public class StackedSubPoolValueAccumulator {
     private Entitlement eldestWithVirtLimit;
     private Date startDate;
     private Date endDate;
-    private Set<Product> expectedProvidedProds = new HashSet<>();
-    private ProductCurator productCurator;
 
-    public StackedSubPoolValueAccumulator(Pool stackedSubPool, Collection<Entitlement> stackedEnts,
-        ProductCurator productCurator) {
-
-        this.productCurator = productCurator;
+    public StackedSubPoolValueAccumulator(Collection<Entitlement> stackedEnts) {
         for (Entitlement nextStacked : stackedEnts) {
-            Pool nextStackedPool = nextStacked.getPool();
             updateEldest(nextStacked);
             accumulateDateRange(nextStacked);
             updateEldestWithVirtLimit(nextStacked);
-            accumulateProvidedProducts(stackedSubPool, nextStackedPool);
         }
     }
 
@@ -92,7 +80,7 @@ public class StackedSubPoolValueAccumulator {
      * Check if the entitlement is the eldest with a specified virt limit.
      *
      * @param nextStacked the entitlement to check.
-     * @param nextStackedPool
+     * @param nextStacked
      */
     private void updateEldestWithVirtLimit(Entitlement nextStacked) {
         // Keep track of the eldest with virt limit so that we can change the
@@ -104,30 +92,6 @@ public class StackedSubPoolValueAccumulator {
             if (eldestWithVirtLimit == null ||
                 createdDate.before(eldestWithVirtLimit.getCreated())) {
                 eldestWithVirtLimit = nextStacked;
-            }
-        }
-    }
-
-    /**
-     * Add the provided products from the specified entitlement to the
-     * collection of ProvidedProducts for the stack.
-     *
-     * @param stackedSubPool
-     * @param nextStackedPool
-     */
-    private void accumulateProvidedProducts(Pool stackedSubPool, Pool nextStackedPool) {
-        Product product = nextStackedPool.getDerivedProduct() != null ?
-            nextStackedPool.getDerivedProduct() :
-            nextStackedPool.getProduct();
-
-        if (nextStackedPool.getDerivedProduct() == null) {
-            for (Product provided : productCurator.getPoolProvidedProductsCached(nextStackedPool)) {
-                this.expectedProvidedProds.add(provided);
-            }
-        }
-        else {
-            for (Product provided : productCurator.getPoolDerivedProvidedProductsCached(nextStackedPool)) {
-                this.expectedProvidedProds.add(provided);
             }
         }
     }
@@ -146,10 +110,6 @@ public class StackedSubPoolValueAccumulator {
 
     public Date getEndDate() {
         return endDate;
-    }
-
-    public Set<Product> getExpectedProvidedProds() {
-        return expectedProvidedProds;
     }
 
 }

--- a/server/src/main/java/org/candlepin/resource/util/ResolverUtil.java
+++ b/server/src/main/java/org/candlepin/resource/util/ResolverUtil.java
@@ -28,7 +28,6 @@ import com.google.inject.Inject;
 
 import org.xnap.commons.i18n.I18n;
 
-import java.util.HashSet;
 
 /**
  * Convinience util for resolving owners, products, pools & subscriptions
@@ -147,13 +146,16 @@ public class ResolverUtil {
         // Ensure the specified product(s) exists for the given owner
         this.validateProductData(subscription.getProduct(), owner, false);
         this.validateProductData(subscription.getDerivedProduct(), owner, true);
-
-        for (ProductData product : subscription.getProvidedProducts()) {
-            this.validateProductData(product, owner, true);
+        if (subscription.getProvidedProducts() != null) {
+            for (ProductData product : subscription.getProvidedProducts()) {
+                this.validateProductData(product, owner, true);
+            }
         }
 
-        for (ProductData product : subscription.getDerivedProvidedProducts()) {
-            this.validateProductData(product, owner, true);
+        if (subscription.getDerivedProvidedProducts() != null) {
+            for (ProductData product : subscription.getDerivedProvidedProducts()) {
+                this.validateProductData(product, owner, true);
+            }
         }
 
         // TODO: Do we need to resolve Branding objects?
@@ -188,20 +190,6 @@ public class ResolverUtil {
             subscription.setDerivedProduct(p);
         }
 
-        HashSet<ProductData> providedProducts = new HashSet<>();
-        for (ProductData product : subscription.getProvidedProducts()) {
-            if (product != null) {
-                providedProducts.add(new ProductData(this.resolveProduct(owner, product.getId())));
-            }
-        }
-        subscription.setProvidedProducts(providedProducts);
-        HashSet<ProductData> derivedProvidedProducts = new HashSet<>();
-        for (ProductData product : subscription.getDerivedProvidedProducts()) {
-            if (product != null) {
-                derivedProvidedProducts.add(new ProductData(this.resolveProduct(owner, product.getId())));
-            }
-        }
-        subscription.setDerivedProvidedProducts(derivedProvidedProducts);
         // TODO: Do we need to resolve Branding objects?
 
         return subscription;

--- a/server/src/main/java/org/candlepin/service/model/SubscriptionInfo.java
+++ b/server/src/main/java/org/candlepin/service/model/SubscriptionInfo.java
@@ -14,7 +14,6 @@
  */
 package org.candlepin.service.model;
 
-import java.util.Collection;
 import java.util.Date;
 
 
@@ -56,17 +55,6 @@ public interface SubscriptionInfo {
     ProductInfo getProduct();
 
     /**
-     * Fetches a collection of engineering products this subscription provides. If the provided
-     * products have not yet been set, this method returns null. If this subscription does not
-     * provide any engineering products, this method returns an empty collection.
-     *
-     * @return
-     *  A collection of engineering products provided by this subscription, or null if the provided
-     *  products have not been set
-     */
-    Collection<? extends ProductInfo> getProvidedProducts();
-
-    /**
      * Fetches the derived marketing product (SKU) provided to guests of hosts consuming this
      * subscription. If the derived product has not been set, this method returns null.
      * <p></p>
@@ -78,18 +66,6 @@ public interface SubscriptionInfo {
      *  been set
      */
     ProductInfo getDerivedProduct();
-
-    /**
-     * Fetches a collection of derived engineering products provided to guests of hosts consuming
-     * this subscription. If the derived provided products have not been set, this method returns
-     * null. If this subscription does not provide any derived products, this method returns an
-     * empty collection.
-     *
-     * @return
-     *  A collection of engineering products provided by this subscription, or null if the derived
-     *  provided products have not been set
-     */
-    Collection<? extends ProductInfo> getDerivedProvidedProducts();
 
     /**
      * Fetches the quantity of this subscription. If the quantity has not yet been set, this method

--- a/server/src/main/java/org/candlepin/sync/EntitlementImporter.java
+++ b/server/src/main/java/org/candlepin/sync/EntitlementImporter.java
@@ -41,9 +41,7 @@ import org.xnap.commons.i18n.I18n;
 import java.io.IOException;
 import java.io.Reader;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 
 
 
@@ -160,37 +158,36 @@ public class EntitlementImporter {
      */
     public void associateProducts(Map<String, ProductDTO> productsById, PoolDTO upstreamPoolDTO,
         SubscriptionDTO subscription) throws SyncDataFormatException {
-
         // Product
         ProductDTO productDTO = this.findProduct(productsById, upstreamPoolDTO.getProductId());
         subscription.setProduct(productDTO);
+
         if (upstreamPoolDTO.getBranding() != null) {
             productDTO.setBranding(upstreamPoolDTO.getBranding());
         }
 
-        // Provided products
-        Set<ProductDTO> providedProducts = new HashSet<>();
         for (ProvidedProductDTO pp : upstreamPoolDTO.getProvidedProducts()) {
-            productDTO = this.findProduct(productsById, pp.getProductId());
-            providedProducts.add(productDTO);
+            ProductDTO product = this.findProduct(productsById, pp.getProductId());
+
+            if (product != null) {
+                productDTO.addProvidedProduct(product);
+            }
         }
-        subscription.setProvidedProducts(providedProducts);
-        log.debug("Subscription has {} provided products.", providedProducts.size());
 
         // Derived product
         if (upstreamPoolDTO.getDerivedProductId() != null) {
             productDTO = this.findProduct(productsById, upstreamPoolDTO.getDerivedProductId());
             subscription.setDerivedProduct(productDTO);
+
+            for (ProvidedProductDTO pp : upstreamPoolDTO.getDerivedProvidedProducts()) {
+                ProductDTO product = this.findProduct(productsById, pp.getProductId());
+
+                if (product != null) {
+                    productDTO.addProvidedProduct(product);
+                }
+            }
         }
 
-        // Derived provided products
-        Set<ProductDTO> derivedProvidedProducts = new HashSet<>();
-        for (ProvidedProductDTO pp : upstreamPoolDTO.getDerivedProvidedProducts()) {
-            productDTO = this.findProduct(productsById, pp.getProductId());
-            derivedProvidedProducts.add(productDTO);
-        }
-        subscription.setDerivedProvidedProducts(derivedProvidedProducts);
-        log.debug("Subscription has {} derived provided products.", derivedProvidedProducts.size());
     }
 
     private ProductDTO findProduct(Map<String, ProductDTO> productsById, String productId)

--- a/server/src/test/java/org/candlepin/controller/EntitlementCertificateGeneratorTest.java
+++ b/server/src/test/java/org/candlepin/controller/EntitlementCertificateGeneratorTest.java
@@ -201,9 +201,9 @@ public class EntitlementCertificateGeneratorTest {
         pprod2.addContent(c2, true);
         prod3.addContent(c3, true);
 
-        Pool pool1 = createPool(owner, prod1, Collections.singleton(pprod1), 1);
-        Pool pool2 = createPool(owner, prod2, Collections.singleton(pprod2), 1);
-        Pool pool3 = createPool(owner, prod3, Collections.singleton(pprod3), 1);
+        Pool pool1 = createPool(owner, prod1, 1);
+        Pool pool2 = createPool(owner, prod2, 1);
+        Pool pool3 = createPool(owner, prod3, 1);
 
         Consumer consumer = TestUtil.createConsumer(owner);
 
@@ -223,13 +223,13 @@ public class EntitlementCertificateGeneratorTest {
      * This method creates pool for testing without in-memory database. The provided
      * products are 'cached' in mocked product curator
      */
-    private Pool createPool(Owner owner, Product prod, Set<Product> providedProd, int q) {
-        Pool p = TestUtil.createPool(owner, prod, providedProd, q);
+    private Pool createPool(Owner owner, Product prod, int q) {
+        Pool p = TestUtil.createPool(owner, prod, q);
 
         p.setId("" + lastPoolId++);
         System.out.println("Caching providedProducts for Pool:" + p.getId());
         when(mockProductCurator.getPoolProvidedProductsCached(p.getId())).
-            thenReturn(providedProd);
+            thenReturn((Set<Product>) p.getProduct().getProvidedProducts());
         return p;
     }
 

--- a/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -691,11 +691,10 @@ public class PoolManagerTest {
         Product subProduct = TestUtil.createProduct();
         Product subProvidedProduct = TestUtil.createProduct();
 
+        subProduct.setProvidedProducts(Arrays.asList(subProvidedProduct));
+
         Subscription sub = TestUtil.createSubscription(owner, product);
         sub.setDerivedProduct(subProduct.toDTO());
-        Set<ProductData> subProvided = new HashSet<>();
-        subProvided.add(subProvidedProduct.toDTO());
-        sub.setDerivedProvidedProducts(subProvided);
 
         this.mockProducts(owner, product, subProduct, subProvidedProduct);
 
@@ -705,7 +704,31 @@ public class PoolManagerTest {
         assertEquals(1, pools.size());
 
         Pool resultPool = pools.get(0);
-        assertEquals(1, resultPool.getDerivedProvidedProducts().size());
+        assertEquals(1, resultPool.getDerivedProduct().getProvidedProducts().size());
+    }
+
+    @Test
+    public void providedProductsCopiedWhenCreatingPools() {
+        Product product = TestUtil.createProduct();
+
+        Subscription sub = TestUtil.createSubscription(owner, product);
+        Product p1 = TestUtil.createProduct();
+        Product p2 = TestUtil.createProduct();
+
+        product.addProvidedProduct(p1);
+        product.addProvidedProduct(p2);
+
+        this.mockProducts(owner, product);
+
+        PoolRules pRules = new PoolRules(manager, mockConfig, entitlementCurator,
+            mockOwnerProductCurator, mockProductCurator);
+        List<Pool> pools = pRules.createAndEnrichPools(sub);
+        assertEquals(1, pools.size());
+
+        Pool resultPool = pools.get(0);
+        assertEquals(2, resultPool.getProduct().getProvidedProducts().size());
+        assertTrue(resultPool.getProduct().getProvidedProducts().contains(p1));
+        assertTrue(resultPool.getProduct().getProvidedProducts().contains(p2));
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/model/EntitlementCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/EntitlementCuratorTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.sql.SQLIntegrityConstraintViolationException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
@@ -230,9 +231,7 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
     private Pool newPoolUsingProducts(Pool pool, Date startDate, Date endDate) {
         Pool anotherPool = new Pool();
         anotherPool.setProduct(pool.getProduct());
-        anotherPool.setProvidedProducts(pool.getProvidedProducts());
         anotherPool.setDerivedProduct(pool.getDerivedProduct());
-        anotherPool.setDerivedProvidedProducts(pool.getDerivedProvidedProducts());
         anotherPool.setStartDate(startDate);
         anotherPool.setEndDate(endDate);
         return anotherPool;
@@ -786,9 +785,11 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
     }
 
     protected Pool createPoolWithProducts(Owner owner, String sku, Collection<Product> provided) {
-        Product skuProd = this.createProduct(sku, sku, owner);
+        Product skuProd = TestUtil.createProduct(sku, sku);
+        skuProd.setProvidedProducts(provided);
+        skuProd = this.createProduct(skuProd, owner);
 
-        Pool pool = this.createPool(owner, skuProd, provided, 1000L, TestUtil.createDate(2000, 1, 1),
+        Pool pool = this.createPool(owner, skuProd, 1000L, TestUtil.createDate(2000, 1, 1),
             TestUtil.createDate(2100, 1, 1));
 
         return pool;
@@ -1163,8 +1164,12 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
         List<Product> dependentProduct = this.createDependentProducts(owner, 1, "test_dep_prod_a",
             requiredProducts);
 
+        Product derivedProduct = TestUtil.createProduct("derivedProductId", "dProductName");
+        derivedProduct.setProvidedProducts(requiredProducts);
+        this.createProduct(derivedProduct, owner);
+
         Pool requiredPool = this.createPoolWithProducts(owner, "reqPool1", providedProducts);
-        requiredPool.setDerivedProvidedProducts(requiredProducts);
+        requiredPool.setDerivedProduct(derivedProduct);
         this.poolCurator.merge(requiredPool);
 
         Pool dependentPool = this.createPoolWithProducts(owner, "depPool1", dependentProduct);
@@ -1213,9 +1218,12 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
         List<Product> providedProducts = this.createProducts(owner, 3, "test_prov_prod");
         List<Product> dependentProducts = this.createDependentProducts(owner, 1, "test_dep_prod_a",
             requiredProducts);
+        List<Product> productSet = new LinkedList<>();
 
-        Pool requiredPool = this.createPoolWithProducts(owner, "reqPool1", providedProducts);
-        requiredPool.addProvidedProduct(requiredProducts.get(0));
+        productSet.addAll(providedProducts);
+        productSet.add(requiredProducts.get(0));
+        Pool requiredPool = this.createPoolWithProducts(owner, "reqPool1", productSet);
+
         this.poolCurator.merge(requiredPool);
 
         Pool dependentPool = this.createPoolWithProducts(owner, "depPool1", dependentProducts);
@@ -1254,13 +1262,22 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
         Consumer distributor = this.createDistributor(owner);
 
         List<Product> requiredProducts = this.createProducts(owner, 3, "test_req_prod");
-        List<Product> providedProducts = this.createProducts(owner, 3, "test_prov_prod");
+
+        Product p1 = TestUtil.createProduct("p1", "p1");
+        p1.setProvidedProducts(Arrays.asList(requiredProducts.get(0)));
+
+        p1 = this.createProduct(p1, owner);
+        Product p2 = this.createProduct("p2", "p2", owner);
+        Product p3 = this.createProduct("p3", "p3", owner);
+
+        List<Product> providedProducts = new ArrayList<>();
+        providedProducts.addAll(Arrays.asList(p1, p2, p3));
         List<Product> dependentProducts = this.createDependentProducts(owner, 1, "test_dep_prod_a",
             requiredProducts);
 
         Pool requiredPool = this.createPoolWithProducts(owner, "reqPool1", providedProducts);
-        requiredPool.setDerivedProduct(providedProducts.get(0));
-        requiredPool.addDerivedProvidedProduct(requiredProducts.get(0));
+        requiredPool.setDerivedProduct(p1);
+
         this.poolCurator.merge(requiredPool);
 
         Pool dependentPool = this.createPoolWithProducts(owner, "depPool1", dependentProducts);

--- a/server/src/test/java/org/candlepin/model/OwnerCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/OwnerCuratorTest.java
@@ -78,11 +78,8 @@ public class OwnerCuratorTest extends DatabaseTestFixture {
         assertThrows(PersistenceException.class, () -> ownerCurator.create(owner1));
     }
 
-    private void associateProductToOwner(Owner o, Product p, Product provided) {
-        Set<Product> providedProducts = new HashSet<>();
-        providedProducts.add(provided);
-
-        Pool pool = TestUtil.createPool(o, p, providedProducts, 5);
+    private void associateProductToOwner(Owner o, Product p) {
+        Pool pool = TestUtil.createPool(o, p, 5);
         poolCurator.create(pool);
 
         Consumer c = createConsumer(o);
@@ -96,13 +93,18 @@ public class OwnerCuratorTest extends DatabaseTestFixture {
         Owner owner = createOwner();
         Owner owner2 = createOwner();
 
-        Product product = this.createProduct(owner);
         Product provided = this.createProduct(owner);
-        Product product2 = this.createProduct(owner2);
-        Product provided2 = this.createProduct(owner2);
+        Product product = TestUtil.createProduct("productId1", "productName1");
+        product.setProvidedProducts(Arrays.asList(provided));
+        Product finalProduct1 = this.createProduct(product, owner);
 
-        associateProductToOwner(owner, product, provided);
-        associateProductToOwner(owner2, product2, provided2);
+        Product provided2 = this.createProduct(owner2);
+        Product product2 = TestUtil.createProduct("productId1", "productName1");
+        product2.setProvidedProducts(Arrays.asList(provided));
+        Product finalProduct2 = this.createProduct(product2, owner);
+
+        associateProductToOwner(owner, finalProduct1);
+        associateProductToOwner(owner2, finalProduct2);
 
         List<String> productIds = new ArrayList<>();
         productIds.add(provided.getId());
@@ -116,10 +118,12 @@ public class OwnerCuratorTest extends DatabaseTestFixture {
     public void testGetOwnerByActiveProduct() {
         Owner owner = createOwner();
 
-        Product product = this.createProduct(owner);
         Product provided = this.createProduct(owner);
+        Product product = TestUtil.createProduct("productId1", "productName1");
+        product.setProvidedProducts(Arrays.asList(provided));
+        Product finalProduct1 = this.createProduct(product, owner);
 
-        associateProductToOwner(owner, product, provided);
+        associateProductToOwner(owner, finalProduct1);
 
         List<String> productIds = new ArrayList<>();
         productIds.add(provided.getId());
@@ -238,8 +242,8 @@ public class OwnerCuratorTest extends DatabaseTestFixture {
         pool1.setOwner(owner1);
         pool1.setProduct(prod4);
         pool1.setDerivedProduct(prod4d);
-        pool1.setProvidedProducts(new HashSet<>(Arrays.asList(prod1o1)));
-        pool1.setDerivedProvidedProducts(new HashSet<>(Arrays.asList(prod2o1)));
+        prod4.setProvidedProducts(new HashSet<>(Arrays.asList(prod1o1)));
+        prod4d.setProvidedProducts(new HashSet<>(Arrays.asList(prod2o1)));
         pool1.setStartDate(TestUtil.createDate(2000, 1, 1));
         pool1.setEndDate(TestUtil.createDate(3000, 1, 1));
         pool1.setQuantity(5L);
@@ -248,8 +252,8 @@ public class OwnerCuratorTest extends DatabaseTestFixture {
         pool2.setOwner(owner2);
         pool2.setProduct(prod5);
         pool2.setDerivedProduct(prod5d);
-        pool2.setProvidedProducts(new HashSet<>(Arrays.asList(prod1o2, prod2o2)));
-        pool2.setDerivedProvidedProducts(new HashSet<>(Arrays.asList(prod3o2)));
+        prod5.setProvidedProducts(new HashSet<>(Arrays.asList(prod1o2, prod2o2)));
+        prod5d.setProvidedProducts(new HashSet<>(Arrays.asList(prod3o2)));
         pool2.setStartDate(TestUtil.createDate(1000, 1, 1));
         pool2.setEndDate(TestUtil.createDate(2000, 1, 1));
         pool2.setQuantity(5L);
@@ -258,8 +262,8 @@ public class OwnerCuratorTest extends DatabaseTestFixture {
         pool3.setOwner(owner3);
         pool3.setProduct(prod6);
         pool3.setDerivedProduct(prod6d);
-        pool3.setProvidedProducts(new HashSet<>(Arrays.asList(prod1o3)));
-        pool3.setDerivedProvidedProducts(new HashSet<>(Arrays.asList(prod3o3)));
+        prod6.setProvidedProducts(new HashSet<>(Arrays.asList(prod1o3)));
+        prod6d.setProvidedProducts(new HashSet<>(Arrays.asList(prod3o3)));
         pool3.setStartDate(new Date());
         pool3.setEndDate(new Date());
         pool3.setQuantity(5L);

--- a/server/src/test/java/org/candlepin/model/PoolCuratorFilterTest.java
+++ b/server/src/test/java/org/candlepin/model/PoolCuratorFilterTest.java
@@ -22,6 +22,7 @@ import org.candlepin.test.TestUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
@@ -63,19 +64,17 @@ public class PoolCuratorFilterTest extends DatabaseTestFixture {
 
         Product searchProduct = TestUtil.createProduct("awesomeos-server", "Awesome OS Server Premium");
         searchProduct.setAttribute(Product.Attributes.SUPPORT_LEVEL, "CustomSupportLevel");
+
+        Product provided1 = TestUtil.createProduct("101111", "Server Bits");
+        provided1.addContent(content, true);
+        provided1 = this.createProduct(provided1, owner);
+        Product provided2 = this.createProduct("202222", "Containers In This One", owner);
+        searchProduct.setProvidedProducts(Arrays.asList(provided1, provided2));
+
         searchProduct = this.createProduct(searchProduct, owner);
 
         Pool searchPool = createPool(owner, searchProduct, 100L, TestUtil.createDate(2005, 3, 2),
             TestUtil.createDate(2050, 3, 2));
-
-        Product provided = TestUtil.createProduct("101111", "Server Bits");
-        provided.addContent(content, true);
-        provided = this.createProduct(provided, owner);
-
-        searchPool.addProvidedProduct(provided);
-
-        provided = this.createProduct("202222", "Containers In This One", owner);
-        searchPool.addProvidedProduct(provided);
 
         searchPool.setContractNumber("mycontract");
         searchPool.setOrderNumber("myorder");
@@ -84,13 +83,13 @@ public class PoolCuratorFilterTest extends DatabaseTestFixture {
         poolCurator.create(searchPool);
 
         // Create another we don't intend to see in the results:
-        Product hideProduct = this.createProduct("hidden-product", "Not-So-Awesome OS Home Edition", owner);
+        Product hProduct = TestUtil.createProduct("hidden-product", "Not-So-Awesome OS Home Edition");
+        Product provided = this.createProduct("101", "Workstation Bits", owner);
+        hProduct.setProvidedProducts(Arrays.asList(provided));
+        Product hideProduct = this.createProduct(hProduct, owner);
+
         hidePool = createPool(owner, hideProduct, 100L, TestUtil.createDate(2005, 3, 2),
             TestUtil.createDate(2050, 3, 2));
-
-        provided = this.createProduct("101", "Workstation Bits", owner);
-        hidePool.addProvidedProduct(provided);
-        poolCurator.create(hidePool);
 
         return searchPool;
     }

--- a/server/src/test/java/org/candlepin/model/PoolTest.java
+++ b/server/src/test/java/org/candlepin/model/PoolTest.java
@@ -29,18 +29,20 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
+
 
 import javax.inject.Inject;
+import javax.persistence.PersistenceException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -105,10 +107,9 @@ public class PoolTest extends DatabaseTestFixture {
             prod1 = this.createProduct(owner);
             prod2 = this.createProduct(owner);
 
-            Set<Product> providedProducts = new HashSet<>();
-            providedProducts.add(prod2);
+            prod1.setProvidedProducts(Arrays.asList(prod2));
 
-            pool = TestUtil.createPool(owner, prod1, providedProducts, 1000);
+            pool = TestUtil.createPool(owner, prod1, 1000);
             subscription = TestUtil.createSubscription(owner, prod1);
             subscription.setId(Util.generateDbUUID());
 
@@ -140,20 +141,22 @@ public class PoolTest extends DatabaseTestFixture {
     @Test
     public void testCreateWithDerivedProvidedProducts() {
         Product derivedProd = this.createProduct(owner);
+        Product derivedProvidedProduct = this.createProduct(owner);
 
-        Pool p = TestUtil.createPool(owner, prod1, new HashSet<>(), 1000);
-        p.addProvidedProduct(prod2);
-        Set<Product> derivedProducts = new HashSet<>();
-        derivedProducts.add(derivedProd);
+        Pool p = TestUtil.createPool(owner, prod1, 1000);
+        p.getProduct().setProvidedProducts(Arrays.asList(prod2));
 
-        p.setDerivedProvidedProducts(derivedProducts);
+        derivedProd.setProvidedProducts(Arrays.asList(derivedProvidedProduct));
+        p.setDerivedProduct(derivedProd);
+
         poolCurator.create(p);
 
         Pool lookedUp = this.getEntityManager().find(Pool.class, p.getId());
-        assertEquals(1, lookedUp.getProvidedProducts().size());
-        assertEquals(prod2.getId(), lookedUp.getProvidedProducts().iterator().next().getId());
-        assertEquals(1, lookedUp.getDerivedProvidedProducts().size());
-        assertEquals(derivedProd.getId(), lookedUp.getDerivedProvidedProducts().iterator().next().getId());
+        assertEquals(1, lookedUp.getProduct().getProvidedProducts().size());
+        assertEquals(prod2.getId(), lookedUp.getProduct().getProvidedProducts().iterator().next().getId());
+        assertEquals(1, lookedUp.getDerivedProduct().getProvidedProducts().size());
+        assertEquals(derivedProvidedProduct.getId(),
+            lookedUp.getDerivedProduct().getProvidedProducts().iterator().next().getId());
     }
 
     @Test
@@ -253,13 +256,14 @@ public class PoolTest extends DatabaseTestFixture {
 
     @Test
     public void testLookupPoolsProvidingProduct() {
-        Product parentProduct = this.createProduct("1", "product-1", owner);
+
         Product childProduct = this.createProduct("2", "product-2", owner);
 
-        Set<Product> providedProducts = new HashSet<>();
-        providedProducts.add(childProduct);
+        Product parentProduct = TestUtil.createProduct("1", "product-1");
+        parentProduct.setProvidedProducts(Arrays.asList(childProduct));
 
-        Pool pool = TestUtil.createPool(owner, parentProduct, providedProducts, 5);
+        parentProduct = this.createProduct(parentProduct, owner);
+        Pool pool = TestUtil.createPool(owner, parentProduct, 5);
         poolCurator.create(pool);
 
 
@@ -325,29 +329,23 @@ public class PoolTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void providedProductCleanup() {
-        Product parentProduct = this.createProduct("1", "product-1", owner);
-        Product childProduct1 = this.createProduct("child1", "child1", owner);
-        Product childProduct2 = this.createProduct("child2", "child2", owner);
-        Product childProduct3 = this.createProduct("child3", "child3", owner);
+    public void testProvidedProductImmutability() {
+        Product parentProduct = TestUtil.createProduct("1", "product-1");
         Product providedProduct = this.createProduct("provided", "Child 1", owner);
+        parentProduct.setProvidedProducts(Arrays.asList(providedProduct));
 
-        Set<Product> providedProducts = new HashSet<>();
-        providedProducts.add(providedProduct);
+        Product childProduct1 = this.createProduct("child1", "child1", owner);
 
-        Pool pool = TestUtil.createPool(owner, parentProduct, providedProducts, 5);
+        parentProduct = this.createProduct(parentProduct, owner);
+        Pool pool = TestUtil.createPool(owner, parentProduct, 5);
         poolCurator.create(pool);
         pool = poolCurator.get(pool.getId());
-        assertEquals(1, pool.getProvidedProducts().size());
+        assertEquals(1, pool.getProduct().getProvidedProducts().size());
 
-        // Clear the set and create a new one:
-        pool.getProvidedProducts().clear();
-        pool.addProvidedProduct(childProduct2);
-        pool.addProvidedProduct(childProduct3);
-        poolCurator.merge(pool);
-
-        pool = poolCurator.get(pool.getId());
-        assertEquals(2, pool.getProvidedProducts().size());
+        // provided products are immutable set.
+        pool.getProduct().addProvidedProduct(childProduct1);
+        Pool finalPool = pool;
+        Assertions.assertThrows(PersistenceException.class, () ->poolCurator.merge(finalPool));
     }
 
     // sunny test - real rules not invoked here. Can only be sure the counts are recorded.

--- a/server/src/test/java/org/candlepin/model/ProductCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ProductCuratorTest.java
@@ -80,27 +80,28 @@ public class ProductCuratorTest extends DatabaseTestFixture {
         this.owner = this.createOwner();
 
         product = TestUtil.createProduct();
-        productCurator.create(product);
-
         providedProduct = TestUtil.createProduct();
         productCurator.create(providedProduct);
-
         Set<Product> providedProducts = new HashSet<>();
         providedProducts.add(providedProduct);
 
-        derivedProduct = TestUtil.createProduct();
-        productCurator.create(derivedProduct);
+        product.setProvidedProducts(providedProducts);
+        productCurator.create(product);
 
+        derivedProduct = TestUtil.createProduct();
         derivedProvidedProduct = TestUtil.createProduct();
         productCurator.create(derivedProvidedProduct);
 
         Set<Product> derivedProvidedProducts = new HashSet<>();
         derivedProvidedProducts.add(derivedProvidedProduct);
+        derivedProduct.setProvidedProducts(derivedProvidedProducts);
+
+        productCurator.create(derivedProduct);
 
         pool = new Pool(
             owner,
             product,
-            providedProducts,
+            new HashSet<>(),
             16L,
             TestUtil.createDate(2006, 10, 21),
             TestUtil.createDate(2020, 1, 1),
@@ -110,7 +111,6 @@ public class ProductCuratorTest extends DatabaseTestFixture {
         );
 
         pool.setDerivedProduct(derivedProduct);
-        pool.setDerivedProvidedProducts(derivedProvidedProducts);
         poolCurator.create(pool);
     }
 

--- a/server/src/test/java/org/candlepin/policy/AutobindRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/AutobindRulesTest.java
@@ -3629,9 +3629,7 @@ public class AutobindRulesTest {
         product.setAttribute(Pool.Attributes.MULTI_ENTITLEMENT, "yes");
         derivedProduct.setProvidedProducts(derivedProvided);
 
-        Pool pool = TestUtil.createPool(
-            owner, product, new HashSet<>(), derivedProduct, derivedProvided, 100
-        );
+        Pool pool = TestUtil.createPool(owner, product, derivedProduct, 100);
 
         pool.setId("DEAD-BEEF-DER");
 

--- a/server/src/test/java/org/candlepin/policy/PoolRulesStackDerivedTest.java
+++ b/server/src/test/java/org/candlepin/policy/PoolRulesStackDerivedTest.java
@@ -164,25 +164,26 @@ public class PoolRulesStackDerivedTest {
         provided3 = TestUtil.createProduct();
         provided4 = TestUtil.createProduct();
 
+        prod1.addProvidedProduct(provided1);
+        prod2.addProvidedProduct(provided2);
+        prod3.addProvidedProduct(provided3);
+
         // Create three subscriptions with various start/end dates:
         sub1 = createStackedVirtSub(owner, prod1, TestUtil.createDate(2010, 1, 1),
             TestUtil.createDate(2015, 1, 1));
-        sub1.getProvidedProducts().add(provided1.toDTO());
         pool1 = copyFromSub(sub1);
 
         sub2 = createStackedVirtSub(owner, prod2, TestUtil.createDate(2011, 1, 1),
             TestUtil.createDate(2017, 1, 1));
-        sub2.getProvidedProducts().add(provided2.toDTO());
-        pool2 = copyFromSub(sub2);
 
+        pool2 = copyFromSub(sub2);
+        prod2.addProvidedProduct(provided3);
         sub3 = createStackedVirtSub(owner, prod2, TestUtil.createDate(2012, 1, 1),
             TestUtil.createDate(2020, 1, 1));
-        sub3.getProvidedProducts().add(provided3.toDTO());
         pool3 = copyFromSub(sub3);
 
         sub4 = createStackedVirtSub(owner, prod3, TestUtil.createDate(2012, 1, 1),
             TestUtil.createDate(2020, 1, 1));
-        sub4.getProvidedProducts().add(provided4.toDTO());
         pool4 = copyFromSub(sub4);
 
         // Initial entitlement from one of the pools:
@@ -226,9 +227,9 @@ public class PoolRulesStackDerivedTest {
         Pool pool = TestUtil.copyFromSub(sub);
         pool.setId("" + lastPoolId++);
         when(productCurator.getPoolProvidedProductsCached(pool))
-            .thenReturn(pool.getProvidedProducts());
+            .thenReturn((Set<Product>) pool.getProduct().getProvidedProducts());
         when(productCurator.getPoolDerivedProvidedProductsCached(pool))
-            .thenReturn(pool.getDerivedProvidedProducts());
+            .thenReturn((Set<Product>) pool.getProduct().getProvidedProducts());
         return pool;
     }
 
@@ -276,9 +277,9 @@ public class PoolRulesStackDerivedTest {
 
     @Test
     public void initialProvidedProducts() {
-        assertEquals(1, stackDerivedPool.getProvidedProducts().size());
+        assertEquals(1, stackDerivedPool.getProduct().getProvidedProducts().size());
         assertEquals(provided2.getUuid(),
-            stackDerivedPool.getProvidedProducts().iterator().next().getUuid());
+            stackDerivedPool.getProduct().getProvidedProducts().iterator().next().getUuid());
     }
 
     @Test
@@ -320,18 +321,6 @@ public class PoolRulesStackDerivedTest {
 
         assertTrue(update.getProductAttributesChanged());
         assertEquals(pool1.getProductAttributes(), stackDerivedPool.getProductAttributes());
-    }
-
-    @Test
-    public void mergedProvidedProducts() {
-        stackedEnts.add(createEntFromPool(pool1));
-        stackedEnts.add(createEntFromPool(pool3));
-        PoolUpdate update = poolRules.updatePoolFromStack(stackDerivedPool, null);
-        assertTrue(update.getProductsChanged());
-        assertEquals(3, stackDerivedPool.getProvidedProducts().size());
-        assertTrue(stackDerivedPool.getProvidedProducts().contains(provided1));
-        assertTrue(stackDerivedPool.getProvidedProducts().contains(provided2));
-        assertTrue(stackDerivedPool.getProvidedProducts().contains(provided3));
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/policy/PoolRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/PoolRulesTest.java
@@ -46,13 +46,13 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.eq;
@@ -134,18 +134,18 @@ public class PoolRulesTest {
         Product product1 = TestUtil.createProduct();
         Product product2 = TestUtil.createProduct();
         Product product3 = TestUtil.createProduct();
-        p.getProvidedProducts().add(product1);
-        p.getProvidedProducts().add(product2);
+        p.getProduct().addProvidedProduct(product1);
+        p.getProduct().addProvidedProduct(product2);
 
         // Setup a pool with a single (different) provided product:
         Pool p1 = TestUtil.clone(p);
-        p1.getProvidedProducts().clear();
-        p1.getProvidedProducts().add(product3);
+        p1.getProduct().getProvidedProducts().clear();
+        p1.getProduct().addProvidedProduct(product3);
 
         List<Pool> existingPools = new LinkedList<>();
         existingPools.add(p1);
         List<PoolUpdate> updates = this.poolRules.updatePools(p, existingPools, p.getQuantity(),
-            Collections.<String, Product>emptyMap());
+            TestUtil.stubChangedProducts(p.getProduct()));
         assertEquals(1, updates.size());
         PoolUpdate update = updates.get(0);
         assertTrue(update.getProductsChanged());
@@ -291,20 +291,20 @@ public class PoolRulesTest {
         Product product1 = TestUtil.createProduct();
         Product product2 = TestUtil.createProduct();
         Product product3 = TestUtil.createProduct();
-        p.getDerivedProvidedProducts().add(product1);
-        p.getDerivedProvidedProducts().add(product2);
+        p.getDerivedProduct().addProvidedProduct(product1);
+        p.getDerivedProduct().addProvidedProduct(product2);
 
         // Setup a pool with a single (different) provided product:
         Pool p1 = TestUtil.clone(p);
-        p1.getProvidedProducts().clear();
-        p1.getProvidedProducts().add(product3);
+        p1.getDerivedProduct().getProvidedProducts().clear();
+        p1.getDerivedProduct().addProvidedProduct(product3);
 
         List<Pool> existingPools = Arrays.asList(p1);
         List<PoolUpdate> updates = this.poolRules.updatePools(p, existingPools, p.getQuantity(),
-            Collections.<String, Product>emptyMap());
+            TestUtil.stubChangedProducts(p.getDerivedProduct()));
 
         assertEquals(1, updates.size());
-        assertEquals(2, updates.get(0).getPool().getDerivedProvidedProducts().size());
+        assertEquals(2, updates.get(0).getPool().getDerivedProduct().getProvidedProducts().size());
     }
 
     private Pool createVirtLimitPool(String productId, int quantity, int virtLimit) {
@@ -495,16 +495,16 @@ public class PoolRulesTest {
             .thenReturn(derivedProvidedProd2);
 
         p.setId("mockPoolRuleTestID");
-        p.getProvidedProducts().add(provided1);
-        p.getProvidedProducts().add(provided2);
+        p.getProduct().addProvidedProduct(provided1);
+        p.getProduct().addProvidedProduct(provided2);
         p.setDerivedProduct(derivedProd);
-        p.getDerivedProvidedProducts().add(derivedProvidedProd1);
-        p.getDerivedProvidedProducts().add(derivedProvidedProd2);
+        p.getDerivedProduct().addProvidedProduct(derivedProvidedProd1);
+        p.getDerivedProduct().addProvidedProduct(derivedProvidedProd2);
 
         when(productCurator.getPoolProvidedProductsCached(p))
-            .thenReturn(p.getProvidedProducts());
+            .thenReturn((Set<Product>) p.getProduct().getProvidedProducts());
         when(productCurator.getPoolDerivedProvidedProductsCached(p))
-            .thenReturn(p.getDerivedProvidedProducts());
+            .thenReturn((Set<Product>) p.getDerivedProduct().getProvidedProducts());
         List<Pool> pools = poolRules.createAndEnrichPools(p, new LinkedList<>());
 
         // Should be virt_only pool for unmapped guests:
@@ -512,9 +512,11 @@ public class PoolRulesTest {
 
         Pool physicalPool = pools.get(0);
         assertEquals(0, physicalPool.getAttributes().size());
-        assertProvidedProducts(p.getProvidedProducts(), physicalPool.getProvidedProducts());
-        assertProvidedProducts(p.getDerivedProvidedProducts(),
-            physicalPool.getDerivedProvidedProducts());
+        assertProvidedProducts((Set<Product>) p.getProduct().getProvidedProducts(),
+            (Set<Product>) physicalPool.getProduct().getProvidedProducts());
+
+        assertProvidedProducts((Set<Product>) p.getDerivedProduct().getProvidedProducts(),
+            (Set<Product>) physicalPool.getDerivedProduct().getProvidedProducts());
 
         Pool unmappedVirtPool = pools.get(1);
         assert ("true".equals(unmappedVirtPool.getAttributeValue(Product.Attributes.VIRT_ONLY)));
@@ -522,9 +524,9 @@ public class PoolRulesTest {
 
         // The derived provided products of the sub should be promoted to provided products
         // on the unmappedVirtPool
-        assertProvidedProducts(p.getDerivedProvidedProducts(), unmappedVirtPool.getProvidedProducts());
-        assertProvidedProducts(new HashSet<>(), unmappedVirtPool.getDerivedProvidedProducts());
-
+        assertProvidedProducts((Set<Product>) p.getDerivedProduct().getProvidedProducts(),
+            (Set<Product>) unmappedVirtPool.getProduct().getProvidedProducts());
+        assertNull(unmappedVirtPool.getDerivedProduct());
         // Test for BZ 1204311 - Refreshing pools should not change unmapped guest pools
         // Refresh is a no-op in multiorg
         // List<PoolUpdate> updates = poolRules.updatePools(s, pools);
@@ -540,7 +542,7 @@ public class PoolRulesTest {
         when(poolManagerMock.isManaged(eq(p))).thenReturn(true);
         p.setId("mockVirtLimitSubCreateDerived");
         when(productCurator.getPoolDerivedProvidedProductsCached(p))
-            .thenReturn(p.getDerivedProvidedProducts());
+            .thenReturn((Set<Product>) p.getDerivedProduct().getProvidedProducts());
         List<Pool> pools = poolRules.createAndEnrichPools(p, new LinkedList<>());
 
         // Should be virt_only pool for unmapped guests:
@@ -553,10 +555,11 @@ public class PoolRulesTest {
         Pool unmappedVirtPool = pools.get(1);
         assert ("true".equals(unmappedVirtPool.getAttributeValue(Product.Attributes.VIRT_ONLY)));
         assert ("true".equals(unmappedVirtPool.getAttributeValue(Pool.Attributes.UNMAPPED_GUESTS_ONLY)));
-        assertEquals("derivedProd", unmappedVirtPool.getProductId());
 
-        assertProvidedProductsForSub(s.getDerivedProvidedProducts(), unmappedVirtPool.getProvidedProducts());
-        assertProvidedProducts(new HashSet<>(), unmappedVirtPool.getDerivedProvidedProducts());
+        assertEquals("derivedProd", unmappedVirtPool.getProductId());
+        assertProvidedProductsForSub((Set<ProductData>) s.getDerivedProvidedProducts(),
+            (Set<Product>) unmappedVirtPool.getProduct().getProvidedProducts());
+        assertNull(unmappedVirtPool.getDerivedProduct());
         assertTrue(unmappedVirtPool.getProduct().hasAttribute(DERIVED_ATTR));
     }
 
@@ -620,15 +623,13 @@ public class PoolRulesTest {
         when(ownerProdCuratorMock.getProductById(owner, derivedProvided2.getId()))
             .thenReturn(derivedProvided2);
 
+        product.setProvidedProducts(Arrays.asList(provided1, provided2));
+        derivedProd.setProvidedProducts(Arrays.asList(derivedProvided1, derivedProvided2));
 
         Subscription s = TestUtil.createSubscription(owner, product);
         s.setQuantity(new Long(quantity));
         s.setDerivedProduct(derivedProd.toDTO());
 
-        Set<ProductData> derivedProds = new HashSet<>();
-        derivedProds.add(derivedProvided1.toDTO());
-        derivedProds.add(derivedProvided2.toDTO());
-        s.setDerivedProvidedProducts(derivedProds);
         return s;
     }
 

--- a/server/src/test/java/org/candlepin/policy/SystemPurposeComplianceRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/SystemPurposeComplianceRulesTest.java
@@ -88,13 +88,12 @@ public class SystemPurposeComplianceRulesTest {
 
     private Entitlement mockEntitlement(Consumer consumer, Product product, Date start, Date end,
         Product ... providedProducts) {
-
-        Set<Product> ppset = new HashSet<>(Arrays.asList(providedProducts));
+        product.setProvidedProducts(Arrays.asList(providedProducts));
 
         Pool pool = new Pool(
             owner,
             product,
-            ppset,
+            new HashSet<>(),
             1000L,
             start,
             end,

--- a/server/src/test/java/org/candlepin/policy/js/pool/PoolHelperTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/pool/PoolHelperTest.java
@@ -34,6 +34,7 @@ import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -222,7 +223,7 @@ public class PoolHelperTest {
         targetPool.setId("sub-prod-pool");
         targetPool.setDerivedProduct(subProduct);
 
-        targetPool.setDerivedProvidedProducts(derivedProducts);
+        targetPool.getDerivedProduct().setProvidedProducts(derivedProducts);
         when(productCurator.getPoolDerivedProvidedProductsCached(targetPool))
             .thenReturn(derivedProducts);
         targetPool.setAttribute(Product.Attributes.VIRT_LIMIT, "unlimited");
@@ -253,7 +254,7 @@ public class PoolHelperTest {
         assertEquals("SV2", hostRestrictedPool.getProduct().getAttributeValue("SA2"));
 
         // Check that the sub provided products made it to the sub pool
-        Set<Product> providedProducts = hostRestrictedPool.getProvidedProducts();
+        Collection<Product> providedProducts = hostRestrictedPool.getProduct().getProvidedProducts();
 
         assertEquals(2, providedProducts.size());
         assertTrue(providedProducts.contains(derivedProduct1));

--- a/server/src/test/java/org/candlepin/resource/ProductResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/ProductResourceTest.java
@@ -219,16 +219,18 @@ public class ProductResourceTest extends DatabaseTestFixture {
         Product poolProd4 = this.createProduct(owner3);
         Product poolProd5 = this.createProduct(owner3);
 
-        Pool pool1 = this.poolCurator.create(TestUtil.createPool(
-            owner1, poolProd1, new HashSet(Arrays.asList(prod1)), 5));
-        Pool pool2 = this.poolCurator.create(TestUtil.createPool(
-            owner2, poolProd2, new HashSet(Arrays.asList(prod2)), 5));
-        Pool pool3 = this.poolCurator.create(TestUtil.createPool(
-            owner2, poolProd3, new HashSet(Arrays.asList(prod3)), 5));
-        Pool pool4 = this.poolCurator.create(TestUtil.createPool(
-            owner3, poolProd4, new HashSet(Arrays.asList(prod4)), 5));
-        Pool pool5 = this.poolCurator.create(TestUtil.createPool(
-            owner3, poolProd5, new HashSet(Arrays.asList(prod5)), 5));
+        // Set Provided Products
+        poolProd1.setProvidedProducts(Arrays.asList(prod1));
+        poolProd2.setProvidedProducts(Arrays.asList(prod2));
+        poolProd3.setProvidedProducts(Arrays.asList(prod3));
+        poolProd4.setProvidedProducts(Arrays.asList(prod4));
+        poolProd5.setProvidedProducts(Arrays.asList(prod5));
+
+        Pool pool1 = this.poolCurator.create(TestUtil.createPool(owner1, poolProd1, 5));
+        Pool pool2 = this.poolCurator.create(TestUtil.createPool(owner2, poolProd2, 5));
+        Pool pool3 = this.poolCurator.create(TestUtil.createPool(owner2, poolProd3, 5));
+        Pool pool4 = this.poolCurator.create(TestUtil.createPool(owner3, poolProd4, 5));
+        Pool pool5 = this.poolCurator.create(TestUtil.createPool(owner3, poolProd5, 5));
 
         return Arrays.asList(owner1, owner2, owner3);
     }

--- a/server/src/test/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapterTest.java
+++ b/server/src/test/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapterTest.java
@@ -280,12 +280,12 @@ public class DefaultEntitlementCertServiceAdapterTest {
                 CONTENT_LABEL, CONTENT_TYPE, CONTENT_VENDOR, url, CONTENT_GPG_URL, ARCH_LABEL));
         }
 
-        subscription = TestUtil.createSubscription(null, product, new HashSet<>());
+        subscription = TestUtil.createSubscription(null, product);
         subscription.setId("1");
         subscription.setQuantity(1L);
 
         Subscription largeContentSubscription = TestUtil
-            .createSubscription(null, largeContentProduct, new HashSet<>());
+            .createSubscription(null, largeContentProduct);
         largeContentSubscription.setId("2");
         largeContentSubscription.setQuantity(1L);
 

--- a/server/src/test/java/org/candlepin/sync/EntitlementImporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/EntitlementImporterTest.java
@@ -145,12 +145,7 @@ public class EntitlementImporterTest {
         derivedProvidedProducts.add(new Product(derivedProvided1));
         derivedProduct.setProvidedProducts(derivedProvidedProducts);
 
-        Pool pool = TestUtil.createPool(
-            owner, parentProduct, new HashSet<>(), derivedProduct, new HashSet<>(), 3);
-
-        pool.setProvidedProducts(providedProducts);
-        pool.setDerivedProvidedProducts(derivedProvidedProducts);
-
+        Pool pool = TestUtil.createPool(owner, parentProduct, derivedProduct, 3);
 
         Entitlement ent = TestUtil.createEntitlement(owner, consumer, pool, cert);
         ent.setQuantity(3);
@@ -187,12 +182,13 @@ public class EntitlementImporterTest {
         assertEquals(ent.getQuantity().intValue(), sub.getQuantity().intValue());
 
         assertEquals(parentProduct.getId(), sub.getProduct().getId());
-        assertEquals(providedProducts.size(), sub.getProvidedProducts().size());
-        assertEquals(provided1.getId(), sub.getProvidedProducts().iterator().next().getId());
+        assertEquals(providedProducts.size(), parentProduct.getProvidedProducts().size());
+        assertEquals(provided1.getId(), parentProduct.getProvidedProducts().iterator().next().getId());
 
         assertEquals(derivedProduct.getId(), sub.getDerivedProduct().getId());
-        assertEquals(1, sub.getDerivedProvidedProducts().size());
-        assertEquals(derivedProvided1.getId(), sub.getDerivedProvidedProducts().iterator().next().getId());
+        assertEquals(1, derivedProduct.getProvidedProducts().size());
+        assertEquals(derivedProvided1.getId(),
+            derivedProduct.getProvidedProducts().iterator().next().getId());
 
         assertNotNull(sub.getCertificate());
         CertificateSerialDTO serial = sub.getCertificate().getSerial();

--- a/server/src/test/java/org/candlepin/sync/SubscriptionReconcilerTest.java
+++ b/server/src/test/java/org/candlepin/sync/SubscriptionReconcilerTest.java
@@ -52,6 +52,7 @@ import org.xnap.commons.i18n.I18nFactory;
 
 import java.util.Arrays;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
@@ -155,30 +156,27 @@ public class SubscriptionReconcilerTest {
         Product product = convertFromDTO(sub.getProduct());
         Product derivedProduct = convertFromDTO(sub.getDerivedProduct());
 
-        List<Product> providedProducts = new LinkedList<>();
         if (sub.getProvidedProducts() != null) {
             for (ProductDTO pdata : sub.getProvidedProducts()) {
                 if (pdata != null) {
-                    providedProducts.add(convertFromDTO(pdata));
+                    product.addProvidedProduct(convertFromDTO(pdata));
                 }
             }
         }
 
-        List<Product> derivedProvidedProducts = new LinkedList<>();
         if (sub.getDerivedProvidedProducts() != null) {
             for (ProductDTO pdata : sub.getDerivedProvidedProducts()) {
                 if (pdata != null) {
-                    derivedProvidedProducts.add(convertFromDTO(pdata));
+                    derivedProduct.addProvidedProduct(convertFromDTO(pdata));
                 }
             }
         }
 
-        Pool pool = new Pool(this.owner, product, providedProducts, sub.getQuantity(),
+        Pool pool = new Pool(this.owner, product, new HashSet<>(), sub.getQuantity(),
             sub.getStartDate(), sub.getEndDate(), sub.getContractNumber(), sub.getAccountNumber(),
             sub.getOrderNumber());
 
         pool.setDerivedProduct(derivedProduct);
-        pool.setDerivedProvidedProducts(derivedProvidedProducts);
 
         if (sub.getId() != null) {
             pool.setSourceSubscription(new SourceSubscription(sub.getId(), "master"));

--- a/server/src/test/java/org/candlepin/test/DatabaseTestFixture.java
+++ b/server/src/test/java/org/candlepin/test/DatabaseTestFixture.java
@@ -612,7 +612,7 @@ public class DatabaseTestFixture {
         Pool pool = new Pool(
             owner,
             product,
-            provided,
+            new HashSet<>(),
             quantity,
             startDate,
             endDate,

--- a/server/src/test/java/org/candlepin/test/TestUtil.java
+++ b/server/src/test/java/org/candlepin/test/TestUtil.java
@@ -63,7 +63,6 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -383,37 +382,13 @@ public class TestUtil {
     }
 
     public static Subscription createSubscription(Owner owner, Product product) {
-        return createSubscription(owner, product, null);
+        return createSubscription(owner, product.toDTO());
     }
 
-    public static Subscription createSubscription(Owner owner, Product product,
-        Collection<Product> providedProducts) {
-
-        Collection<ProductData> providedProductsDTOs = new LinkedList<>();
-
-        if (providedProducts != null) {
-            for (Product providedProduct : providedProducts) {
-                providedProductsDTOs.add(providedProduct.toDTO());
-            }
-        }
-
-        return createSubscription(owner, product.toDTO(), providedProductsDTOs);
-    }
-
-    public static Subscription createSubscription(Owner owner, ProductData product) {
-        return createSubscription(owner, product, null);
-    }
-
-    public static Subscription createSubscription(Owner owner, ProductData dto,
-        Collection<ProductData> providedProductsData) {
-
-        Set<ProductData> providedProductsSet = new HashSet<>();
-        providedProductsSet.addAll(providedProductsData);
-
+    public static Subscription createSubscription(Owner owner, ProductData dto) {
         Subscription sub = new Subscription(
             owner,
             dto,
-            providedProductsSet,
             1000L,
             createDate(2000, 1, 1),
             createDate(2050, 1, 1),
@@ -438,47 +413,29 @@ public class TestUtil {
     }
 
     public static Pool createPool(Owner owner, Product product, int quantity) {
-        return createPool(owner, product, null, quantity);
-    }
-
-    public static Pool createPool(Owner owner, Product product, Collection<Product> providedProducts,
-        int quantity) {
-
         String random = String.valueOf(randomInt());
 
-        Set<Product> provided = new HashSet<>();
-        if (providedProducts != null) {
-            provided.addAll(providedProducts);
-        }
-
-        Pool pool = new Pool(
-            owner,
-            product,
-            provided,
-            Long.valueOf(quantity),
-            TestUtil.createDate(2009, 11, 30),
-            TestUtil.createDate(Calendar.getInstance().get(Calendar.YEAR) + 10, 11, 30),
-            "SUB234598S" + random,
-            "ACC123" + random,
-            "ORD222" + random
-        );
-
+        Pool pool = new Pool();
+        pool.setOwner(owner);
+        pool.setProduct(product);
+        pool.setQuantity(Long.valueOf(quantity));
+        pool.setStartDate(TestUtil.createDate(2009, 11, 30));
+        pool.setEndDate(
+            TestUtil.createDate(Calendar.getInstance().get(Calendar.YEAR) + 10, 11, 30));
+        pool.setContractNumber("SUB234598S" + random);
+        pool.setAccountNumber("ACC123" + random);
+        pool.setOrderNumber("ORD222" + random);
         pool.setSourceSubscription(new SourceSubscription("SUB234598S" + random, "master" + random));
 
         return pool;
     }
 
-    public static Pool createPool(Owner owner, Product product, Collection<Product> providedProducts,
-        Product derivedProduct, Collection<Product> subProvidedProducts, int quantity) {
+    public static Pool createPool(Owner owner, Product product, Product derivedProduct, int quantity) {
+        Pool pool = createPool(owner, product, quantity);
 
-        Pool pool = createPool(owner, product, providedProducts, quantity);
-        Set<Product> subProvided = new HashSet<>();
-        if (subProvidedProducts != null) {
-            subProvided.addAll(subProvidedProducts);
+        if (derivedProduct != null) {
+            pool.setDerivedProduct(derivedProduct);
         }
-
-        pool.setDerivedProduct(derivedProduct);
-        pool.setDerivedProvidedProducts(subProvided);
 
         return pool;
     }
@@ -647,13 +604,24 @@ public class TestUtil {
             }
         }
 
-        Pool pool = new Pool(sub.getOwner(), product, providedProducts, sub.getQuantity(),
-            sub.getStartDate(), sub.getEndDate(), sub.getContractNumber(), sub.getAccountNumber(),
-            sub.getOrderNumber()
-        );
+        Pool pool = new Pool();
+        pool.setOwner(sub.getOwner());
+        pool.setQuantity(sub.getQuantity());
+        pool.setStartDate(sub.getStartDate());
+        pool.setEndDate(sub.getEndDate());
+        pool.setAccountNumber(sub.getContractNumber());
+        pool.setAccountNumber(sub.getAccountNumber());
+        pool.setOrderNumber(sub.getOrderNumber());
 
-        pool.setDerivedProduct(derivedProduct);
-        pool.setDerivedProvidedProducts(derivedProvidedProducts);
+        if (product != null) {
+            product.setProvidedProducts(providedProducts);
+            pool.setProduct(product);
+        }
+
+        if (derivedProduct != null) {
+            derivedProduct.setProvidedProducts(derivedProvidedProducts);
+            pool.setDerivedProduct(derivedProduct);
+        }
 
         if (sub.getId() != null) {
             pool.setSourceSubscription(new SourceSubscription(sub.getId(), "master"));
@@ -685,7 +653,13 @@ public class TestUtil {
             new SourceSubscription(pool.getSubscriptionId(), pool.getSubscriptionSubKey()));
 
         // Copy sub-product data if there is any:
-        p.setDerivedProduct(pool.getDerivedProduct());
+        if (pool.getDerivedProduct() != null) {
+            p.setDerivedProduct((Product) pool.getDerivedProduct().clone());
+        }
+
+        if (pool.getProduct() != null) {
+            p.setProduct((Product) pool.getProduct().clone());
+        }
 
         return p;
     }


### PR DESCRIPTION
- Removed logic for setting provided and derived provided product from CandlepinPoolManager.
- Removed logic for setting provided and derived provided product from ImportedEntityCompiler, since Subscription Info adapter now does not support Provided products.
- Modified ProductManager to support applying provided product changes to Product entity for account refresh flow.
- PoolRules class modified, not to detect provide product changes, since provided products are the part of a main product these changes are detected in Product Manger itself.
- Override annotation is removed from manifest/v1/SubscriptionDTO.java for Get/Set providedProducts methods.
- `getProvidedProducts` & `getDerivedProvidedProducts` methods are now removed from SubscriptionInfo interface.  
- Modified HostedTestSubscriptionResource & HostedTestSubscriptionServiceAdapter to support the change related to provided products being part of mkt products.
- Bunch of JPQL and hibernate criteria queries are modified to correctly reference/fetch the provided products from new table `cp2_product_provided_products`
- we do not need to accumulate provided products in case of stacked entitlement as marketing product and stack id has one to one relationship i.e. different marketing product will not have the same stacking id and all the required provided products will be available in marketing product itself from adapter. Accumulator logic from StackedSubPoolValueAccumulator is now removed.
