### PR TITLE
1787601 - Provide configuration option to disable UUID uniqueness

### DIFF
--- a/server/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/server/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -251,6 +251,7 @@ public class ConfigProperties {
 
     public static final String STANDALONE = "candlepin.standalone";
     public static final String ENV_CONTENT_FILTERING = "candlepin.environment_content_filtering";
+    public static final String USE_SYSTEM_UUID_FOR_MATCHING = "candlepin.use_system_uuid_for_matching";
 
     public static final String CONSUMER_SYSTEM_NAME_PATTERN = "candlepin.consumer_system_name_pattern";
     public static final String CONSUMER_PERSON_NAME_PATTERN = "candlepin.consumer_person_name_pattern";
@@ -420,6 +421,7 @@ public class ConfigProperties {
             this.put(STANDALONE, "true");
 
             this.put(ENV_CONTENT_FILTERING, "true");
+            this.put(USE_SYSTEM_UUID_FOR_MATCHING, "true");
 
             // what constitutes a valid consumer name
             this.put(CONSUMER_SYSTEM_NAME_PATTERN, "[\\#\\?\\'\\`\\!@{}()\\[\\]\\?&\\w-\\.]+");

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -597,13 +597,13 @@ public class ConsumerResource {
         }
 
         if (dto.getHypervisorId() == null &&
-            dto.getFact("dmi.system.uuid") != null &&
+            dto.getFact(Consumer.Facts.SYSTEM_UUID) != null &&
             !"true".equals(dto.getFact("virt.is_guest")) &&
             entity.getOwnerId() != null) {
             HypervisorId hypervisorId = new HypervisorId(
                 entity,
                 ownerCurator.findOwnerById(entity.getOwnerId()),
-                dto.getFact("dmi.system.uuid"));
+                dto.getFact(Consumer.Facts.SYSTEM_UUID));
             entity.setHypervisorId(hypervisorId);
         }
 
@@ -703,7 +703,8 @@ public class ConsumerResource {
 
         // fix for duplicate hypervisor/consumer problem
         Consumer consumer = null;
-        if (ownerKey != null && dto.getFact("dmi.system.uuid") != null &&
+        if (ownerKey != null && config.getBoolean(ConfigProperties.USE_SYSTEM_UUID_FOR_MATCHING) &&
+            dto.getFact(Consumer.Facts.SYSTEM_UUID) != null &&
             !"true".equalsIgnoreCase(dto.getFact("virt.is_guest"))) {
 
             Owner owner = ownerCurator.getByKey(ownerKey);
@@ -714,7 +715,7 @@ public class ConsumerResource {
             }
 
             if (owner != null) {
-                consumer = consumerCurator.getHypervisor(dto.getFact("dmi.system.uuid"), owner);
+                consumer = consumerCurator.getHypervisor(dto.getFact(Consumer.Facts.SYSTEM_UUID), owner);
                 if (consumer != null) {
                     consumer.setIdCert(generateIdCert(consumer, false));
                     this.updateConsumer(consumer.getUuid(), dto, principal);

--- a/server/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
@@ -1112,7 +1112,7 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
     public void testGetHypervisorConsumerMapWithFacts() {
         String hypervisorId1 = "Hypervisor";
         Consumer consumer1 = new Consumer("testConsumer", "testUser", owner, ct);
-        consumer1.setFact("dmi.system.uuid", "blah");
+        consumer1.setFact(Consumer.Facts.SYSTEM_UUID, "blah");
         HypervisorId hypervisorId = new HypervisorId(hypervisorId1);
         hypervisorId.setOwner(owner);
         consumer1.setHypervisorId(hypervisorId);
@@ -1131,7 +1131,7 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
         // first consumer set with only the fact, not the hypervisor
         String hypervisorId1 = "Hypervisor";
         Consumer consumer1 = new Consumer("testConsumer", "testUser", owner, ct);
-        consumer1.setFact("dmi.system.uuid", "blah");
+        consumer1.setFact(Consumer.Facts.SYSTEM_UUID, "blah");
         consumer1 = consumerCurator.create(consumer1);
 
         // next consumer set with the hypervisor, not the fact

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceCreationLiberalNameRules.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceCreationLiberalNameRules.java
@@ -41,6 +41,7 @@ public class ConsumerResourceCreationLiberalNameRules extends
     }
     public Configuration initConfig() {
         Configuration config = new ConfigForTesting();
+        config.setProperty(ConfigProperties.USE_SYSTEM_UUID_FOR_MATCHING, "true");
         return config;
     }
 

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceCreationTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceCreationTest.java
@@ -158,6 +158,7 @@ public class ConsumerResourceCreationTest {
         migrationProvider = Providers.of(testMigration);
 
         this.config = initConfig();
+        config.setProperty(ConfigProperties.USE_SYSTEM_UUID_FOR_MATCHING, "true");
         this.resource = new ConsumerResource(
             this.consumerCurator, this.consumerTypeCurator, null, this.subscriptionService, this.ownerService,
             null, this.idCertService, null, this.i18n, this.sink, null, null, null, this.userService, null,


### PR DESCRIPTION
constraint in Satellite 6
Changes are done from reference of:
1774640: Provide configuration option to disable UUID uniqueness constraint in Satellite 6.