### PR TITLE
Fix the checkstyle to put static imports at the top of each file.

### DIFF
--- a/common/src/main/java/org/candlepin/common/exceptions/mappers/CandlepinExceptionMapper.java
+++ b/common/src/main/java/org/candlepin/common/exceptions/mappers/CandlepinExceptionMapper.java
@@ -14,6 +14,9 @@
  */
 package org.candlepin.common.exceptions.mappers;
 
+import static org.jboss.resteasy.util.MediaTypeHelper.getBestMatch;
+import static org.jboss.resteasy.util.MediaTypeHelper.parseHeader;
+
 import org.candlepin.common.exceptions.CandlepinException;
 import org.candlepin.common.exceptions.ExceptionMessage;
 import org.candlepin.common.util.VersionUtil;
@@ -35,9 +38,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.Response.Status;
-
-import static org.jboss.resteasy.util.MediaTypeHelper.getBestMatch;
-import static org.jboss.resteasy.util.MediaTypeHelper.parseHeader;
 
 
 

--- a/common/src/test/java/org/candlepin/common/config/EncryptedConfigurationTest.java
+++ b/common/src/test/java/org/candlepin/common/config/EncryptedConfigurationTest.java
@@ -14,6 +14,11 @@
  */
 package org.candlepin.common.config;
 
+import static org.candlepin.common.config.ConfigurationPrefixes.JPA_CONFIG_PREFIX;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.hamcrest.core.IsInstanceOf;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -27,11 +32,6 @@ import java.nio.file.Path;
 import java.util.Properties;
 
 import javax.crypto.BadPaddingException;
-
-import static org.candlepin.common.config.ConfigurationPrefixes.JPA_CONFIG_PREFIX;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class EncryptedConfigurationTest {
     // generated with katello-secure-passphrase and katell-passwd

--- a/common/src/test/java/org/candlepin/common/config/MapConfigurationTest.java
+++ b/common/src/test/java/org/candlepin/common/config/MapConfigurationTest.java
@@ -14,6 +14,13 @@
  */
 package org.candlepin.common.config;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.candlepin.common.config.Configuration.TrimMode;
 
 import org.hamcrest.core.IsInstanceOf;
@@ -29,13 +36,6 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Properties;
 import java.util.Set;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * MapConfigurationTest

--- a/common/src/test/java/org/candlepin/common/config/PropertiesFileConfigurationTest.java
+++ b/common/src/test/java/org/candlepin/common/config/PropertiesFileConfigurationTest.java
@@ -14,6 +14,11 @@
  */
 package org.candlepin.common.config;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.hamcrest.core.IsInstanceOf;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -26,11 +31,6 @@ import java.io.Reader;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Properties;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 
 public class PropertiesFileConfigurationTest {

--- a/common/src/test/java/org/candlepin/common/config/PropertyConverterTest.java
+++ b/common/src/test/java/org/candlepin/common/config/PropertyConverterTest.java
@@ -14,12 +14,6 @@
  */
 package org.candlepin.common.config;
 
-import org.junit.jupiter.api.Test;
-
-import java.math.BigInteger;
-import java.util.Arrays;
-import java.util.List;
-
 import static org.candlepin.common.config.PropertyConverter.toBigInteger;
 import static org.candlepin.common.config.PropertyConverter.toBoolean;
 import static org.candlepin.common.config.PropertyConverter.toInteger;
@@ -29,6 +23,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.List;
 
 public class PropertyConverterTest {
     private Object BAD_COMPARISON = new Object();

--- a/common/src/test/java/org/candlepin/common/exceptions/mappers/ApplicationExceptionMapperTest.java
+++ b/common/src/test/java/org/candlepin/common/exceptions/mappers/ApplicationExceptionMapperTest.java
@@ -14,14 +14,14 @@
  */
 package org.candlepin.common.exceptions.mappers;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.jboss.resteasy.spi.ApplicationException;
 import org.junit.jupiter.api.Test;
 
 import java.io.EOFException;
 
 import javax.ws.rs.core.Response;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * ApplicationExceptionMapperTest

--- a/common/src/test/java/org/candlepin/common/exceptions/mappers/BadRequestExceptionMapperTest.java
+++ b/common/src/test/java/org/candlepin/common/exceptions/mappers/BadRequestExceptionMapperTest.java
@@ -14,13 +14,13 @@
  */
 package org.candlepin.common.exceptions.mappers;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.jboss.resteasy.spi.BadRequestException;
 import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * BadRequestExceptionMapperTest

--- a/common/src/test/java/org/candlepin/common/exceptions/mappers/CandlepinExceptionMapperTest.java
+++ b/common/src/test/java/org/candlepin/common/exceptions/mappers/CandlepinExceptionMapperTest.java
@@ -14,6 +14,11 @@
  */
 package org.candlepin.common.exceptions.mappers;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.common.exceptions.ExceptionMessage;
 import org.candlepin.common.guice.CommonI18nProvider;
 import org.candlepin.common.guice.TestingScope;
@@ -35,11 +40,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.Response.Status;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 
 

--- a/common/src/test/java/org/candlepin/common/exceptions/mappers/DefaultOptionsMethodExceptionMapperTest.java
+++ b/common/src/test/java/org/candlepin/common/exceptions/mappers/DefaultOptionsMethodExceptionMapperTest.java
@@ -14,14 +14,14 @@
  */
 package org.candlepin.common.exceptions.mappers;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import org.jboss.resteasy.spi.DefaultOptionsMethodException;
 import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.core.Response;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 /**
  * DefaultOptionsMethodExceptionMapperTest
  */

--- a/common/src/test/java/org/candlepin/common/exceptions/mappers/FailureExceptionMapperTest.java
+++ b/common/src/test/java/org/candlepin/common/exceptions/mappers/FailureExceptionMapperTest.java
@@ -14,14 +14,14 @@
  */
 package org.candlepin.common.exceptions.mappers;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import org.jboss.resteasy.spi.Failure;
 import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.core.Response;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * FailureExceptionMapperTest

--- a/common/src/test/java/org/candlepin/common/exceptions/mappers/InternalServerErrorExceptionMapperTest.java
+++ b/common/src/test/java/org/candlepin/common/exceptions/mappers/InternalServerErrorExceptionMapperTest.java
@@ -14,12 +14,12 @@
  */
 package org.candlepin.common.exceptions.mappers;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.jboss.resteasy.spi.InternalServerErrorException;
 import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.core.Response;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * InternalServerErrorExceptionMapperTest

--- a/common/src/test/java/org/candlepin/common/exceptions/mappers/JAXBMarshalExceptionMapperTest.java
+++ b/common/src/test/java/org/candlepin/common/exceptions/mappers/JAXBMarshalExceptionMapperTest.java
@@ -14,14 +14,14 @@
  */
 package org.candlepin.common.exceptions.mappers;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import org.jboss.resteasy.plugins.providers.jaxb.JAXBMarshalException;
 import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.core.Response;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * JAXBMarshalExceptionMapperTest

--- a/common/src/test/java/org/candlepin/common/exceptions/mappers/JAXBUnmarshalExceptionMapperTest.java
+++ b/common/src/test/java/org/candlepin/common/exceptions/mappers/JAXBUnmarshalExceptionMapperTest.java
@@ -14,14 +14,14 @@
  */
 package org.candlepin.common.exceptions.mappers;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import org.jboss.resteasy.plugins.providers.jaxb.JAXBUnmarshalException;
 import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.core.Response;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * JAXBUnmarshalExceptionMapperTest

--- a/common/src/test/java/org/candlepin/common/exceptions/mappers/NoLogWebApplicationExceptionMapperTest.java
+++ b/common/src/test/java/org/candlepin/common/exceptions/mappers/NoLogWebApplicationExceptionMapperTest.java
@@ -14,12 +14,12 @@
  */
 package org.candlepin.common.exceptions.mappers;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.jboss.resteasy.spi.NoLogWebApplicationException;
 import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.core.Response;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * NoLogWebApplicationExceptionMapperTest

--- a/common/src/test/java/org/candlepin/common/exceptions/mappers/NotAcceptableExceptionMapperTest.java
+++ b/common/src/test/java/org/candlepin/common/exceptions/mappers/NotAcceptableExceptionMapperTest.java
@@ -14,12 +14,12 @@
  */
 package org.candlepin.common.exceptions.mappers;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.NotAcceptableException;
 import javax.ws.rs.core.Response;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * NotAcceptableExceptionMapperTest

--- a/common/src/test/java/org/candlepin/common/exceptions/mappers/NotAllowedExceptionMapperTest.java
+++ b/common/src/test/java/org/candlepin/common/exceptions/mappers/NotAllowedExceptionMapperTest.java
@@ -14,12 +14,12 @@
  */
 package org.candlepin.common.exceptions.mappers;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.NotAllowedException;
 import javax.ws.rs.core.Response;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * MethodNotAllowedExceptionMapperTest

--- a/common/src/test/java/org/candlepin/common/exceptions/mappers/NotAuthorizedExceptionMapperTest.java
+++ b/common/src/test/java/org/candlepin/common/exceptions/mappers/NotAuthorizedExceptionMapperTest.java
@@ -14,12 +14,12 @@
  */
 package org.candlepin.common.exceptions.mappers;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.NotAuthorizedException;
 import javax.ws.rs.core.Response;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * UnauthorizedExceptionMapperTest

--- a/common/src/test/java/org/candlepin/common/exceptions/mappers/NotFoundExceptionMapperTest.java
+++ b/common/src/test/java/org/candlepin/common/exceptions/mappers/NotFoundExceptionMapperTest.java
@@ -14,13 +14,13 @@
  */
 package org.candlepin.common.exceptions.mappers;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * NotFoundExceptionMapperTest

--- a/common/src/test/java/org/candlepin/common/exceptions/mappers/NotSupportedExceptionMapperTest.java
+++ b/common/src/test/java/org/candlepin/common/exceptions/mappers/NotSupportedExceptionMapperTest.java
@@ -14,12 +14,12 @@
  */
 package org.candlepin.common.exceptions.mappers;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.Response;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * UnsupportedMediaTypeExceptionMapperTest

--- a/common/src/test/java/org/candlepin/common/exceptions/mappers/ReaderExceptionMapperTest.java
+++ b/common/src/test/java/org/candlepin/common/exceptions/mappers/ReaderExceptionMapperTest.java
@@ -14,16 +14,16 @@
  */
 package org.candlepin.common.exceptions.mappers;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import com.fasterxml.jackson.databind.JsonMappingException;
 
 import org.jboss.resteasy.spi.ReaderException;
 import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.core.Response;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 
 

--- a/common/src/test/java/org/candlepin/common/exceptions/mappers/RuntimeExceptionMapperTest.java
+++ b/common/src/test/java/org/candlepin/common/exceptions/mappers/RuntimeExceptionMapperTest.java
@@ -14,6 +14,11 @@
  */
 package org.candlepin.common.exceptions.mappers;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.common.exceptions.CandlepinException;
 import org.candlepin.common.exceptions.ConflictException;
 import org.candlepin.common.exceptions.ExceptionMessage;
@@ -35,11 +40,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 
 /**

--- a/common/src/test/java/org/candlepin/common/exceptions/mappers/TestExceptionMapperBase.java
+++ b/common/src/test/java/org/candlepin/common/exceptions/mappers/TestExceptionMapperBase.java
@@ -14,6 +14,11 @@
  */
 package org.candlepin.common.exceptions.mappers;
 
+import static org.candlepin.common.test.RegexMatcher.matchesRegex;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+
 import org.candlepin.common.exceptions.ExceptionMessage;
 import org.candlepin.common.guice.CommonI18nProvider;
 import org.candlepin.common.guice.TestingScope;
@@ -29,11 +34,6 @@ import org.xnap.commons.i18n.I18n;
 import javax.servlet.ServletRequest;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.Response;
-
-import static org.candlepin.common.test.RegexMatcher.matchesRegex;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.Mockito.mock;
 
 /**
  * TestExceptionMapperBase

--- a/common/src/test/java/org/candlepin/common/exceptions/mappers/WebApplicationExceptionMapperTest.java
+++ b/common/src/test/java/org/candlepin/common/exceptions/mappers/WebApplicationExceptionMapperTest.java
@@ -14,15 +14,15 @@
  */
 package org.candlepin.common.exceptions.mappers;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * WebApplicationExceptionMapper

--- a/common/src/test/java/org/candlepin/common/exceptions/mappers/WriterExceptionMapperTest.java
+++ b/common/src/test/java/org/candlepin/common/exceptions/mappers/WriterExceptionMapperTest.java
@@ -14,14 +14,14 @@
  */
 package org.candlepin.common.exceptions.mappers;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import org.jboss.resteasy.spi.WriterException;
 import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.core.Response;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * WriterExceptionMapperTest

--- a/common/src/test/java/org/candlepin/common/filter/LoggingFilterTest.java
+++ b/common/src/test/java/org/candlepin/common/filter/LoggingFilterTest.java
@@ -14,6 +14,14 @@
  */
 package org.candlepin.common.filter;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
@@ -38,14 +46,6 @@ import javax.servlet.FilterConfig;
 import javax.servlet.ServletInputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * LoggingFilterTest

--- a/common/src/test/java/org/candlepin/common/filter/TeeHttpServletRequestTest.java
+++ b/common/src/test/java/org/candlepin/common/filter/TeeHttpServletRequestTest.java
@@ -14,6 +14,10 @@
  */
 package org.candlepin.common.filter;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.common.util.Util;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -34,10 +38,6 @@ import java.util.Map;
 import javax.servlet.ServletInputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.MediaType;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.Mockito.when;
 
 
 /**

--- a/common/src/test/java/org/candlepin/common/filter/TeeHttpServletResponseTest.java
+++ b/common/src/test/java/org/candlepin/common/filter/TeeHttpServletResponseTest.java
@@ -14,6 +14,9 @@
  */
 package org.candlepin.common.filter;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.common.util.Util;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -30,9 +33,6 @@ import java.util.Map;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.core.MediaType;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.when;
 
 
 /**

--- a/common/src/test/java/org/candlepin/common/guice/HttpMethodMatcherTest.java
+++ b/common/src/test/java/org/candlepin/common/guice/HttpMethodMatcherTest.java
@@ -14,6 +14,9 @@
  */
 package org.candlepin.common.guice;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Method;
@@ -24,9 +27,6 @@ import javax.ws.rs.HEAD;
 import javax.ws.rs.OPTIONS;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
-
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * HttpMethodMatcherTest

--- a/common/src/test/java/org/candlepin/common/jackson/DynamicFilterDataTest.java
+++ b/common/src/test/java/org/candlepin/common/jackson/DynamicFilterDataTest.java
@@ -14,14 +14,14 @@
  */
 package org.candlepin.common.jackson;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
-
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 

--- a/common/src/test/java/org/candlepin/common/jackson/DynamicPropertyFilterTest.java
+++ b/common/src/test/java/org/candlepin/common/jackson/DynamicPropertyFilterTest.java
@@ -14,6 +14,14 @@
  */
 package org.candlepin.common.jackson;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.anyList;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonStreamContext;
 import com.fasterxml.jackson.databind.ser.PropertyWriter;
@@ -26,14 +34,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
-
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.anyList;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class DynamicPropertyFilterTest {

--- a/common/src/test/java/org/candlepin/common/logging/LoggingConfiguratorTest.java
+++ b/common/src/test/java/org/candlepin/common/logging/LoggingConfiguratorTest.java
@@ -14,6 +14,10 @@
  */
 package org.candlepin.common.logging;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 import org.candlepin.common.config.ConfigurationPrefixes;
 import org.candlepin.common.config.MapConfiguration;
 
@@ -26,10 +30,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * LoggingConfigTest

--- a/common/src/test/java/org/candlepin/common/resteasy/auth/AuthUtilTest.java
+++ b/common/src/test/java/org/candlepin/common/resteasy/auth/AuthUtilTest.java
@@ -14,10 +14,10 @@
  */
 package org.candlepin.common.resteasy.auth;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.jboss.resteasy.mock.MockHttpRequest;
 import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
 public class AuthUtilTest {

--- a/common/src/test/java/org/candlepin/common/resteasy/filter/DynamicJsonFilterTest.java
+++ b/common/src/test/java/org/candlepin/common/resteasy/filter/DynamicJsonFilterTest.java
@@ -14,6 +14,12 @@
  */
 package org.candlepin.common.resteasy.filter;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.common.jackson.DynamicFilterData;
 
 import org.jboss.resteasy.mock.MockHttpRequest;
@@ -29,12 +35,6 @@ import java.net.URI;
 import java.util.Arrays;
 
 import javax.ws.rs.container.ContainerRequestContext;
-
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.when;
 
 
 /**

--- a/common/src/test/java/org/candlepin/common/resteasy/filter/LinkHeaderResponseFilterTest.java
+++ b/common/src/test/java/org/candlepin/common/resteasy/filter/LinkHeaderResponseFilterTest.java
@@ -14,6 +14,14 @@
  */
 package org.candlepin.common.resteasy.filter;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.common.config.Configuration;
 import org.candlepin.common.config.MapConfiguration;
 import org.candlepin.common.paging.Page;
@@ -38,14 +46,6 @@ import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.UriBuilder;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class LinkHeaderResponseFilterTest {

--- a/common/src/test/java/org/candlepin/common/resteasy/filter/PageRequestFilterTest.java
+++ b/common/src/test/java/org/candlepin/common/resteasy/filter/PageRequestFilterTest.java
@@ -14,6 +14,12 @@
  */
 package org.candlepin.common.resteasy.filter;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.common.exceptions.BadRequestException;
 import org.candlepin.common.guice.CommonI18nProvider;
 import org.candlepin.common.paging.PageRequest;
@@ -30,12 +36,6 @@ import org.xnap.commons.i18n.I18n;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.container.ContainerRequestContext;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.when;
 
 /**
  * PageRequestFilterTest

--- a/common/src/test/java/org/candlepin/common/util/JaxRsExceptionResponseBuilderTest.java
+++ b/common/src/test/java/org/candlepin/common/util/JaxRsExceptionResponseBuilderTest.java
@@ -14,6 +14,10 @@
  */
 package org.candlepin.common.util;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.candlepin.common.exceptions.CandlepinParameterParseException;
 import org.candlepin.common.exceptions.ExceptionMessage;
 import org.candlepin.common.exceptions.mappers.TestExceptionMapperBase.MapperTestModule;
@@ -27,10 +31,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import javax.ws.rs.core.Response;
-
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 /**

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -201,7 +201,7 @@
     <module name="UnusedImports"/>
     <module name="ImportOrder">
       <!-- Static imports should go at the top of the import list -->
-      <property name="option" value="bottom"/>
+      <property name="option" value="top"/>
       <property name="ordered" value="true"/>
       <property name="groups" value="org.candlepin,com.redhat.rhn,ch,com,io,liquibase,net,org,java,javax"/>
       <property name="separated" value="true"/>

--- a/server/src/main/java/org/candlepin/cache/JCacheManagerProvider.java
+++ b/server/src/main/java/org/candlepin/cache/JCacheManagerProvider.java
@@ -14,6 +14,8 @@
  */
 package org.candlepin.cache;
 
+import static org.candlepin.config.ConfigProperties.CACHE_CONFIG_FILE_URI;
+
 import org.candlepin.common.config.Configuration;
 
 import com.google.inject.Inject;
@@ -25,8 +27,6 @@ import javax.cache.CacheException;
 import javax.cache.CacheManager;
 import javax.cache.Caching;
 import javax.cache.spi.CachingProvider;
-
-import static org.candlepin.config.ConfigProperties.CACHE_CONFIG_FILE_URI;
 
 /**
  * Provides object cache by indexed by String.

--- a/server/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/server/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -15,6 +15,8 @@
 
 package org.candlepin.config;
 
+import static org.candlepin.common.config.ConfigurationPrefixes.JPA_CONFIG_PREFIX;
+
 import org.candlepin.async.tasks.ActiveEntitlementJob;
 import org.candlepin.async.tasks.CRLUpdateJob;
 import org.candlepin.async.tasks.ExpiredPoolsCleanupJob;
@@ -27,8 +29,6 @@ import org.candlepin.common.config.Configuration;
 
 import java.util.HashMap;
 import java.util.Map;
-
-import static org.candlepin.common.config.ConfigurationPrefixes.JPA_CONFIG_PREFIX;
 
 
 

--- a/server/src/main/java/org/candlepin/guice/CandlepinContextListener.java
+++ b/server/src/main/java/org/candlepin/guice/CandlepinContextListener.java
@@ -14,6 +14,10 @@
  */
 package org.candlepin.guice;
 
+import static org.candlepin.config.ConfigProperties.ACTIVEMQ_ENABLED;
+import static org.candlepin.config.ConfigProperties.ENCRYPTED_PROPERTIES;
+import static org.candlepin.config.ConfigProperties.PASSPHRASE_SECRET_FILE;
+
 import org.candlepin.async.JobManager;
 import org.candlepin.audit.AMQPBusPublisher;
 import org.candlepin.audit.ActiveMQContextListener;
@@ -73,10 +77,6 @@ import javax.cache.CacheManager;
 import javax.persistence.EntityManagerFactory;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletContextEvent;
-
-import static org.candlepin.config.ConfigProperties.ACTIVEMQ_ENABLED;
-import static org.candlepin.config.ConfigProperties.ENCRYPTED_PROPERTIES;
-import static org.candlepin.config.ConfigProperties.PASSPHRASE_SECRET_FILE;
 
 /**
  * Customized Candlepin version of

--- a/server/src/main/java/org/candlepin/guice/CandlepinRequestScoped.java
+++ b/server/src/main/java/org/candlepin/guice/CandlepinRequestScoped.java
@@ -14,14 +14,14 @@
  */
 package org.candlepin.guice;
 
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
 import com.google.inject.ScopeAnnotation;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
-
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.ElementType.TYPE;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 
 /**

--- a/server/src/main/java/org/candlepin/util/AbstractX509CRLStreamWriter.java
+++ b/server/src/main/java/org/candlepin/util/AbstractX509CRLStreamWriter.java
@@ -14,6 +14,15 @@
  */
 package org.candlepin.util;
 
+import static org.candlepin.util.DERUtil.readFullyAndTrack;
+import static org.candlepin.util.DERUtil.readLength;
+import static org.candlepin.util.DERUtil.readTag;
+import static org.candlepin.util.DERUtil.readTagNumber;
+import static org.candlepin.util.DERUtil.writeBytes;
+import static org.candlepin.util.DERUtil.writeLength;
+import static org.candlepin.util.DERUtil.writeTag;
+import static org.candlepin.util.DERUtil.writeValue;
+
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -25,15 +34,6 @@ import java.security.PrivateKey;
 import java.security.Signature;
 import java.util.Date;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import static org.candlepin.util.DERUtil.readFullyAndTrack;
-import static org.candlepin.util.DERUtil.readLength;
-import static org.candlepin.util.DERUtil.readTag;
-import static org.candlepin.util.DERUtil.readTagNumber;
-import static org.candlepin.util.DERUtil.writeBytes;
-import static org.candlepin.util.DERUtil.writeLength;
-import static org.candlepin.util.DERUtil.writeTag;
-import static org.candlepin.util.DERUtil.writeValue;
 
 /**
  * Abstract class with DER utility methods for X509CRLStreamWriter.

--- a/server/src/main/java/org/candlepin/util/JSSX509CRLStreamWriter.java
+++ b/server/src/main/java/org/candlepin/util/JSSX509CRLStreamWriter.java
@@ -14,6 +14,19 @@
  */
 package org.candlepin.util;
 
+import static org.candlepin.util.DERUtil.GENERALIZED_TIME_TAG_NUM;
+import static org.candlepin.util.DERUtil.SEQUENCE_TAG_NUM;
+import static org.candlepin.util.DERUtil.UTC_TIME_TAG_NUM;
+import static org.candlepin.util.DERUtil.findHeaderBytesDelta;
+import static org.candlepin.util.DERUtil.readFullyAndTrack;
+import static org.candlepin.util.DERUtil.readLength;
+import static org.candlepin.util.DERUtil.readTag;
+import static org.candlepin.util.DERUtil.readTagNumber;
+import static org.candlepin.util.DERUtil.writeBytes;
+import static org.candlepin.util.DERUtil.writeLength;
+import static org.candlepin.util.DERUtil.writeTag;
+import static org.candlepin.util.DERUtil.writeValue;
+
 import org.candlepin.pki.impl.JSSPKIUtility;
 
 import com.google.common.io.ByteStreams;
@@ -72,19 +85,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import static org.candlepin.util.DERUtil.GENERALIZED_TIME_TAG_NUM;
-import static org.candlepin.util.DERUtil.SEQUENCE_TAG_NUM;
-import static org.candlepin.util.DERUtil.UTC_TIME_TAG_NUM;
-import static org.candlepin.util.DERUtil.findHeaderBytesDelta;
-import static org.candlepin.util.DERUtil.readFullyAndTrack;
-import static org.candlepin.util.DERUtil.readLength;
-import static org.candlepin.util.DERUtil.readTag;
-import static org.candlepin.util.DERUtil.readTagNumber;
-import static org.candlepin.util.DERUtil.writeBytes;
-import static org.candlepin.util.DERUtil.writeLength;
-import static org.candlepin.util.DERUtil.writeTag;
-import static org.candlepin.util.DERUtil.writeValue;
 
 /**
  * Implementation of X509CRLStreamWriter using JSS crypto provider.

--- a/server/src/main/java/org/candlepin/util/X509CRLEntryStream.java
+++ b/server/src/main/java/org/candlepin/util/X509CRLEntryStream.java
@@ -14,6 +14,16 @@
  */
 package org.candlepin.util;
 
+import static org.candlepin.util.DERUtil.GENERALIZED_TIME_TAG_NUM;
+import static org.candlepin.util.DERUtil.OBJECT_IDENTIFIER_TAG_NUM;
+import static org.candlepin.util.DERUtil.SEQUENCE_TAG_NUM;
+import static org.candlepin.util.DERUtil.UTC_TIME_TAG_NUM;
+import static org.candlepin.util.DERUtil.readFullyAndTrack;
+import static org.candlepin.util.DERUtil.readLength;
+import static org.candlepin.util.DERUtil.readTag;
+import static org.candlepin.util.DERUtil.readTagNumber;
+import static org.candlepin.util.DERUtil.writeLength;
+
 import java.io.BufferedInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
@@ -24,16 +34,6 @@ import java.io.InputStream;
 import java.security.cert.X509CRLEntry;
 import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import static org.candlepin.util.DERUtil.GENERALIZED_TIME_TAG_NUM;
-import static org.candlepin.util.DERUtil.OBJECT_IDENTIFIER_TAG_NUM;
-import static org.candlepin.util.DERUtil.SEQUENCE_TAG_NUM;
-import static org.candlepin.util.DERUtil.UTC_TIME_TAG_NUM;
-import static org.candlepin.util.DERUtil.readFullyAndTrack;
-import static org.candlepin.util.DERUtil.readLength;
-import static org.candlepin.util.DERUtil.readTag;
-import static org.candlepin.util.DERUtil.readTagNumber;
-import static org.candlepin.util.DERUtil.writeLength;
 
 /**
  * Reads an X509 CRL in a stream and returns the serial number for a revoked certificate

--- a/server/src/test/java/org/candlepin/TestingModules.java
+++ b/server/src/test/java/org/candlepin/TestingModules.java
@@ -14,6 +14,10 @@
  */
 package org.candlepin;
 
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.audit.EventSink;
 import org.candlepin.audit.NoopEventSinkImpl;
 import org.candlepin.auth.Principal;
@@ -147,10 +151,6 @@ import javax.servlet.http.HttpServletResponse;
 import javax.validation.MessageInterpolator;
 import javax.validation.Validation;
 import javax.validation.ValidatorFactory;
-
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * Guice modules for unit testing

--- a/server/src/test/java/org/candlepin/async/JobManagerTest.java
+++ b/server/src/test/java/org/candlepin/async/JobManagerTest.java
@@ -14,6 +14,40 @@
  */
 package org.candlepin.async;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.AdditionalAnswers.returnsFirstArg;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.async.JobManager.ManagerState;
 import org.candlepin.audit.EventSink;
 import org.candlepin.auth.Access;
@@ -76,40 +110,6 @@ import java.util.Random;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.hasItems;
-import static org.hamcrest.Matchers.isEmptyOrNullString;
-import static org.hamcrest.Matchers.lessThan;
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
-import static org.hamcrest.Matchers.not;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.AdditionalAnswers.returnsFirstArg;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
-import static org.mockito.Mockito.when;
 
 
 

--- a/server/src/test/java/org/candlepin/async/JobMessageReceiverTest.java
+++ b/server/src/test/java/org/candlepin/async/JobMessageReceiverTest.java
@@ -14,6 +14,17 @@
  */
 package org.candlepin.async;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
 import org.candlepin.common.config.Configuration;
 import org.candlepin.config.CandlepinCommonTestConfig;
 import org.candlepin.config.ConfigProperties;
@@ -32,17 +43,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.junit.Before;
 import org.junit.Test;
-
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 
 

--- a/server/src/test/java/org/candlepin/async/impl/ThrottledByJobKeyConstraintTest.java
+++ b/server/src/test/java/org/candlepin/async/impl/ThrottledByJobKeyConstraintTest.java
@@ -15,6 +15,9 @@
 
 package org.candlepin.async.impl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.candlepin.async.JobConstraint;
 import org.candlepin.async.tasks.EntitlerJob;
 import org.candlepin.model.AsyncJobStatus;
@@ -25,9 +28,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ThrottledByJobKeyConstraintTest {
 

--- a/server/src/test/java/org/candlepin/async/impl/UniqueByArgConstraintTest.java
+++ b/server/src/test/java/org/candlepin/async/impl/UniqueByArgConstraintTest.java
@@ -14,6 +14,11 @@
  */
 package org.candlepin.async.impl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.candlepin.async.JobConfig;
 import org.candlepin.async.JobConstraint;
 import org.candlepin.model.AsyncJobStatus;
@@ -25,11 +30,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class UniqueByArgConstraintTest {
 

--- a/server/src/test/java/org/candlepin/async/tasks/ActiveEntitlementJobTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/ActiveEntitlementJobTest.java
@@ -15,6 +15,12 @@
 
 package org.candlepin.async.tasks;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
 import org.candlepin.async.JobExecutionContext;
 import org.candlepin.async.JobExecutionException;
 import org.candlepin.model.Consumer;
@@ -31,12 +37,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import javax.inject.Inject;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
 
 /**
  * TestActiveEntitlementJob

--- a/server/src/test/java/org/candlepin/async/tasks/CRLUpdateJobTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/CRLUpdateJobTest.java
@@ -14,6 +14,11 @@
  */
 package org.candlepin.async.tasks;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
 import org.candlepin.async.JobExecutionContext;
 import org.candlepin.async.JobExecutionException;
 import org.candlepin.common.config.Configuration;
@@ -25,11 +30,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
-
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 
 /**
  * Test suite for the CRLUpdateJob class

--- a/server/src/test/java/org/candlepin/async/tasks/EntitleByProductsJobTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/EntitleByProductsJobTest.java
@@ -16,6 +16,13 @@
 package org.candlepin.async.tasks;
 
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.async.JobConfig;
 import org.candlepin.async.JobConfigValidationException;
 import org.candlepin.async.JobExecutionContext;
@@ -32,13 +39,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 public class EntitleByProductsJobTest {
 

--- a/server/src/test/java/org/candlepin/async/tasks/EntitlerJobTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/EntitlerJobTest.java
@@ -15,6 +15,17 @@
 
 package org.candlepin.async.tasks;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.anySet;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.async.JobConfig;
 import org.candlepin.async.JobConfigValidationException;
 import org.candlepin.async.JobExecutionContext;
@@ -44,17 +55,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
-
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.anyMap;
-import static org.mockito.Mockito.anySet;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * EntitlerJobTest

--- a/server/src/test/java/org/candlepin/async/tasks/ExpiredPoolsCleanupJobTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/ExpiredPoolsCleanupJobTest.java
@@ -14,14 +14,14 @@
  */
 package org.candlepin.async.tasks;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
 import org.candlepin.async.JobExecutionContext;
 import org.candlepin.controller.PoolManager;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 
 /**
  * Test suite for the ExpiredPoolsCleanupJob class

--- a/server/src/test/java/org/candlepin/async/tasks/ExportJobTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/ExportJobTest.java
@@ -14,6 +14,13 @@
  */
 package org.candlepin.async.tasks;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+
 import org.candlepin.async.JobArguments;
 import org.candlepin.async.JobConfig;
 import org.candlepin.async.JobConfigValidationException;
@@ -32,13 +39,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.HashMap;
 import java.util.Map;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
 public class ExportJobTest {

--- a/server/src/test/java/org/candlepin/async/tasks/HealEntireOrgJobTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/HealEntireOrgJobTest.java
@@ -14,6 +14,16 @@
  */
 package org.candlepin.async.tasks;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.async.JobArguments;
 import org.candlepin.async.JobConfig;
 import org.candlepin.async.JobExecutionContext;
@@ -42,16 +52,6 @@ import java.util.Locale;
 import java.util.Map;
 
 import javax.persistence.EntityManager;
-
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 
 

--- a/server/src/test/java/org/candlepin/async/tasks/HypervisorHeartbeatUpdateJobTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/HypervisorHeartbeatUpdateJobTest.java
@@ -14,6 +14,16 @@
  */
 package org.candlepin.async.tasks;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
 import org.candlepin.async.JobArguments;
 import org.candlepin.async.JobConfig;
 import org.candlepin.async.JobExecutionContext;
@@ -29,16 +39,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Date;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 /**
  * Test suite for the HypervisorHeartbeatUpdateJob class

--- a/server/src/test/java/org/candlepin/async/tasks/HypervisorUpdateJobTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/HypervisorUpdateJobTest.java
@@ -14,6 +14,21 @@
  */
 package org.candlepin.async.tasks;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.async.JobConfig;
 import org.candlepin.async.JobConfigValidationException;
 import org.candlepin.async.JobExecutionContext;
@@ -55,21 +70,6 @@ import java.util.Set;
 import java.util.function.Function;
 
 import javax.persistence.EntityManager;
-
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.ArgumentMatchers.nullable;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 
 

--- a/server/src/test/java/org/candlepin/async/tasks/ImportJobTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/ImportJobTest.java
@@ -14,6 +14,18 @@
  */
 package org.candlepin.async.tasks;
 
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.async.JobArguments;
 import org.candlepin.async.JobConfig;
 import org.candlepin.async.JobConfigValidationException;
@@ -33,18 +45,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 
 

--- a/server/src/test/java/org/candlepin/async/tasks/ImportRecordCleanerJobTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/ImportRecordCleanerJobTest.java
@@ -14,6 +14,10 @@
  */
 package org.candlepin.async.tasks;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
 import org.candlepin.async.JobExecutionContext;
 import org.candlepin.async.JobExecutionException;
 import org.candlepin.config.ConfigProperties;
@@ -33,10 +37,6 @@ import org.mockito.quality.Strictness;
 
 import java.util.List;
 import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
 
 /**
  * Test suite for the ImportRecordCleanerJob class

--- a/server/src/test/java/org/candlepin/async/tasks/JobCleanerTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/JobCleanerTest.java
@@ -14,6 +14,15 @@
  */
 package org.candlepin.async.tasks;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
 import org.candlepin.async.JobExecutionContext;
 import org.candlepin.async.JobExecutionException;
 import org.candlepin.async.JobManager;
@@ -38,15 +47,6 @@ import java.util.Date;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 
 

--- a/server/src/test/java/org/candlepin/async/tasks/ManifestCleanerJobTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/ManifestCleanerJobTest.java
@@ -14,6 +14,15 @@
  */
 package org.candlepin.async.tasks;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
 import org.candlepin.async.JobExecutionContext;
 import org.candlepin.async.JobExecutionException;
 import org.candlepin.common.config.Configuration;
@@ -32,15 +41,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 /**
  * Test suite for the ManifestCleanerJob class

--- a/server/src/test/java/org/candlepin/async/tasks/OrphanCleanupJobTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/OrphanCleanupJobTest.java
@@ -14,6 +14,11 @@
  */
 package org.candlepin.async.tasks;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+
 import org.candlepin.async.JobExecutionContext;
 import org.candlepin.model.Content;
 import org.candlepin.model.Owner;
@@ -25,11 +30,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.HashSet;
 import java.util.Set;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.mockito.Mockito.mock;
 
 /**
  * Test suite for the OrphanCleanupJob class

--- a/server/src/test/java/org/candlepin/async/tasks/RefreshPoolsForProductJobTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/RefreshPoolsForProductJobTest.java
@@ -14,6 +14,15 @@
  */
 package org.candlepin.async.tasks;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+
 import org.candlepin.async.AsyncJob;
 import org.candlepin.async.JobConfig;
 import org.candlepin.async.JobConfigValidationException;
@@ -27,15 +36,6 @@ import org.candlepin.service.SubscriptionServiceAdapter;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyBoolean;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
 
 public class RefreshPoolsForProductJobTest {
 

--- a/server/src/test/java/org/candlepin/async/tasks/RefreshPoolsJobTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/RefreshPoolsJobTest.java
@@ -14,6 +14,13 @@
  */
 package org.candlepin.async.tasks;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+
 import org.candlepin.async.JobArguments;
 import org.candlepin.async.JobConfig;
 import org.candlepin.async.JobConfigValidationException;
@@ -32,13 +39,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.eq;
 
 
 

--- a/server/src/test/java/org/candlepin/async/tasks/RegenEnvEntitlementCertsJobTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/RegenEnvEntitlementCertsJobTest.java
@@ -14,6 +14,13 @@
  */
 package org.candlepin.async.tasks;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
 import org.candlepin.async.JobConfig;
 import org.candlepin.async.JobConfigValidationException;
 import org.candlepin.async.JobExecutionContext;
@@ -29,13 +36,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.HashSet;
 import java.util.Set;
-
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 public class RegenEnvEntitlementCertsJobTest {

--- a/server/src/test/java/org/candlepin/async/tasks/RegenProductEntitlementCertsJobTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/RegenProductEntitlementCertsJobTest.java
@@ -14,6 +14,19 @@
  */
 package org.candlepin.async.tasks;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
 import org.candlepin.async.JobArguments;
 import org.candlepin.async.JobConfig;
 import org.candlepin.async.JobExecutionContext;
@@ -34,19 +47,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyBoolean;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 
 

--- a/server/src/test/java/org/candlepin/async/tasks/UndoImportsJobTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/UndoImportsJobTest.java
@@ -14,6 +14,15 @@
  */
 package org.candlepin.async.tasks;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.async.JobConfig;
 import org.candlepin.async.JobExecutionContext;
 import org.candlepin.async.JobExecutionException;
@@ -55,15 +64,6 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyBoolean;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * UndoImportsJobTest

--- a/server/src/test/java/org/candlepin/async/tasks/UnmappedGuestEntitlementCleanerJobTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/UnmappedGuestEntitlementCleanerJobTest.java
@@ -14,15 +14,15 @@
  */
 package org.candlepin.async.tasks;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.async.JobExecutionContext;
 import org.candlepin.controller.Entitler;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * Test suite for the UnmappedGuestEntitlementCleanerJob class

--- a/server/src/test/java/org/candlepin/audit/AMQPBusPublisherTest.java
+++ b/server/src/test/java/org/candlepin/audit/AMQPBusPublisherTest.java
@@ -14,6 +14,11 @@
  */
 package org.candlepin.audit;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.audit.Event.Target;
 import org.candlepin.audit.Event.Type;
 import org.candlepin.guice.PrincipalProvider;
@@ -29,11 +34,6 @@ import org.mockito.Mockito;
 import java.io.IOException;
 
 import javax.jms.JMSException;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 /**
  * AMQPBusPublisherTest
  */

--- a/server/src/test/java/org/candlepin/audit/ActivationListenerTest.java
+++ b/server/src/test/java/org/candlepin/audit/ActivationListenerTest.java
@@ -14,6 +14,11 @@
  */
 package org.candlepin.audit;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.service.impl.ImportSubscriptionServiceAdapter;
 
@@ -21,11 +26,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.junit.Before;
 import org.junit.Test;
-
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 public class ActivationListenerTest {
 

--- a/server/src/test/java/org/candlepin/audit/ArtemisMessageSourceTest.java
+++ b/server/src/test/java/org/candlepin/audit/ArtemisMessageSourceTest.java
@@ -14,6 +14,16 @@
  */
 package org.candlepin.audit;
 
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.async.impl.ActiveMQSessionFactory;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -31,16 +41,6 @@ import org.mockito.runners.MockitoJUnitRunner;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
-
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
-import static org.mockito.Mockito.when;
 
 /**
  * ArtemisMessageSourceTest

--- a/server/src/test/java/org/candlepin/audit/DefaultEventMessageReceiverTest.java
+++ b/server/src/test/java/org/candlepin/audit/DefaultEventMessageReceiverTest.java
@@ -14,6 +14,16 @@
  */
 package org.candlepin.audit;
 
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.async.impl.ActiveMQSessionFactory;
 import org.candlepin.auth.PrincipalData;
 import org.candlepin.common.config.Configuration;
@@ -45,16 +55,6 @@ import org.mockito.quality.Strictness;
 
 import java.io.StringWriter;
 import java.util.stream.Stream;
-
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
-import static org.mockito.Mockito.when;
 
 
 

--- a/server/src/test/java/org/candlepin/audit/EventAdapterTest.java
+++ b/server/src/test/java/org/candlepin/audit/EventAdapterTest.java
@@ -14,6 +14,11 @@
  */
 package org.candlepin.audit;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import org.candlepin.TestingModules;
 import org.candlepin.auth.PrincipalData;
 import org.candlepin.common.config.MapConfiguration;
@@ -33,11 +38,6 @@ import java.util.LinkedList;
 import java.util.List;
 
 import javax.inject.Inject;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 
 /**

--- a/server/src/test/java/org/candlepin/audit/EventBuilderTest.java
+++ b/server/src/test/java/org/candlepin/audit/EventBuilderTest.java
@@ -14,6 +14,10 @@
  */
 package org.candlepin.audit;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.auth.Principal;
 import org.candlepin.common.exceptions.IseException;
 import org.candlepin.guice.PrincipalProvider;
@@ -25,10 +29,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class EventBuilderTest {
 

--- a/server/src/test/java/org/candlepin/audit/EventFactoryTest.java
+++ b/server/src/test/java/org/candlepin/audit/EventFactoryTest.java
@@ -14,6 +14,11 @@
  */
 package org.candlepin.audit;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.auth.Principal;
 import org.candlepin.guice.PrincipalProvider;
 import org.candlepin.model.Consumer;
@@ -34,11 +39,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 
 /**

--- a/server/src/test/java/org/candlepin/audit/EventFilterTest.java
+++ b/server/src/test/java/org/candlepin/audit/EventFilterTest.java
@@ -14,6 +14,11 @@
  */
 package org.candlepin.audit;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.audit.Event.Target;
 import org.candlepin.audit.Event.Type;
 import org.candlepin.common.config.Configuration;
@@ -26,11 +31,6 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.Arrays;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class EventFilterTest {

--- a/server/src/test/java/org/candlepin/audit/EventSinkImplTest.java
+++ b/server/src/test/java/org/candlepin/audit/EventSinkImplTest.java
@@ -14,6 +14,21 @@
  */
 package org.candlepin.audit;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.anyByte;
+import static org.mockito.Mockito.anyObject;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.async.impl.ActiveMQSessionFactory;
 import org.candlepin.auth.Principal;
 import org.candlepin.config.CandlepinCommonTestConfig;
@@ -48,21 +63,6 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 import java.util.ArrayList;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyBoolean;
-import static org.mockito.Mockito.anyByte;
-import static org.mockito.Mockito.anyObject;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 
 

--- a/server/src/test/java/org/candlepin/audit/QpidConnectionTest.java
+++ b/server/src/test/java/org/candlepin/audit/QpidConnectionTest.java
@@ -14,6 +14,19 @@
  */
 package org.candlepin.audit;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.atMost;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.common.config.Configuration;
 import org.candlepin.common.config.MapConfiguration;
 
@@ -29,19 +42,6 @@ import javax.jms.Topic;
 import javax.jms.TopicSession;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.atMost;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class QpidConnectionTest {

--- a/server/src/test/java/org/candlepin/audit/QpidEventMessageReceiverTest.java
+++ b/server/src/test/java/org/candlepin/audit/QpidEventMessageReceiverTest.java
@@ -14,6 +14,16 @@
  */
 package org.candlepin.audit;
 
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.async.impl.ActiveMQSessionFactory;
 import org.candlepin.auth.PrincipalData;
 
@@ -43,16 +53,6 @@ import org.mockito.quality.Strictness;
 
 import java.io.StringWriter;
 import java.util.stream.Stream;
-
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
-import static org.mockito.Mockito.when;
 
 
 

--- a/server/src/test/java/org/candlepin/audit/TestingActiveMQSessionFactory.java
+++ b/server/src/test/java/org/candlepin/audit/TestingActiveMQSessionFactory.java
@@ -14,13 +14,13 @@
  */
 package org.candlepin.audit;
 
+import static org.mockito.Mockito.mock;
+
 import org.candlepin.async.impl.ActiveMQSessionFactory;
 import org.candlepin.common.config.Configuration;
 
 import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
-
-import static org.mockito.Mockito.mock;
 
 /**
  * A test class for overriding/mocking the ActiveMQ client session creation/utilization.

--- a/server/src/test/java/org/candlepin/auth/BasicAuthViaUserServiceTest.java
+++ b/server/src/test/java/org/candlepin/auth/BasicAuthViaUserServiceTest.java
@@ -14,6 +14,11 @@
  */
 package org.candlepin.auth;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.auth.permissions.OwnerPermission;
 import org.candlepin.auth.permissions.PermissionFactory;
 import org.candlepin.common.exceptions.NotAuthorizedException;
@@ -43,11 +48,6 @@ import java.util.Set;
 
 import javax.inject.Provider;
 import javax.ws.rs.core.HttpHeaders;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.when;
 
 public class BasicAuthViaUserServiceTest {
 

--- a/server/src/test/java/org/candlepin/auth/ConsumerPrincipalTest.java
+++ b/server/src/test/java/org/candlepin/auth/ConsumerPrincipalTest.java
@@ -14,6 +14,12 @@
  */
 package org.candlepin.auth;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerType;
 import org.candlepin.model.Entitlement;
@@ -25,12 +31,6 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * ConsumerPrincipalTest

--- a/server/src/test/java/org/candlepin/auth/ExternalSystemPrincipalTest.java
+++ b/server/src/test/java/org/candlepin/auth/ExternalSystemPrincipalTest.java
@@ -14,10 +14,10 @@
  */
 package org.candlepin.auth;
 
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Before;
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * ExternalSystemPrincipalTest

--- a/server/src/test/java/org/candlepin/auth/NoAuthPrincipalTest.java
+++ b/server/src/test/java/org/candlepin/auth/NoAuthPrincipalTest.java
@@ -14,10 +14,10 @@
  */
 package org.candlepin.auth;
 
-import org.junit.Test;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+
+import org.junit.Test;
 
 /**
  * NoAuthPrincipalTest

--- a/server/src/test/java/org/candlepin/auth/SSLAuthTest.java
+++ b/server/src/test/java/org/candlepin/auth/SSLAuthTest.java
@@ -14,6 +14,12 @@
  */
 package org.candlepin.auth;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerCurator;
 import org.candlepin.model.ConsumerType;
@@ -34,12 +40,6 @@ import java.security.cert.X509Certificate;
 
 import javax.inject.Provider;
 import javax.security.auth.x500.X500Principal;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class SSLAuthTest {
 

--- a/server/src/test/java/org/candlepin/auth/SSLCertTest.java
+++ b/server/src/test/java/org/candlepin/auth/SSLCertTest.java
@@ -14,6 +14,8 @@
  */
 package org.candlepin.auth;
 
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -25,8 +27,6 @@ import java.security.cert.PKIXParameters;
 import java.security.cert.TrustAnchor;
 import java.security.cert.X509Certificate;
 import java.util.Collections;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * some useful sources of certificate-related information:

--- a/server/src/test/java/org/candlepin/auth/SystemPrincipalTest.java
+++ b/server/src/test/java/org/candlepin/auth/SystemPrincipalTest.java
@@ -14,14 +14,14 @@
  */
 package org.candlepin.auth;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
 import org.candlepin.model.Entitlement;
 
 import org.junit.Before;
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
 
 /**
  * NoAuthPrincipalTest

--- a/server/src/test/java/org/candlepin/auth/TrustedUserAuthTest.java
+++ b/server/src/test/java/org/candlepin/auth/TrustedUserAuthTest.java
@@ -14,6 +14,17 @@
  */
 package org.candlepin.auth;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.auth.permissions.PermissionFactory;
 import org.candlepin.model.User;
 import org.candlepin.service.UserServiceAdapter;
@@ -34,17 +45,6 @@ import java.util.Locale;
 
 import javax.inject.Provider;
 import javax.ws.rs.core.HttpHeaders;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 public class TrustedUserAuthTest {
 

--- a/server/src/test/java/org/candlepin/auth/TrustedUserPrincipalTest.java
+++ b/server/src/test/java/org/candlepin/auth/TrustedUserPrincipalTest.java
@@ -14,16 +14,16 @@
  */
 package org.candlepin.auth;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
 import org.candlepin.model.Consumer;
 import org.candlepin.model.Pool;
 
 import org.junit.Before;
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
 
 /**
  * TrustedUserPrincipalTest

--- a/server/src/test/java/org/candlepin/auth/UserPrincipalTest.java
+++ b/server/src/test/java/org/candlepin/auth/UserPrincipalTest.java
@@ -14,6 +14,14 @@
  */
 package org.candlepin.auth;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.auth.permissions.OwnerPermission;
 import org.candlepin.auth.permissions.Permission;
 import org.candlepin.model.Owner;
@@ -23,14 +31,6 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 
 /**

--- a/server/src/test/java/org/candlepin/auth/permissions/AttachPermissionTest.java
+++ b/server/src/test/java/org/candlepin/auth/permissions/AttachPermissionTest.java
@@ -14,6 +14,9 @@
  */
 package org.candlepin.auth.permissions;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.candlepin.auth.Access;
 import org.candlepin.auth.SubResource;
 import org.candlepin.model.Owner;
@@ -21,9 +24,6 @@ import org.candlepin.model.Pool;
 
 import org.junit.Before;
 import org.junit.Test;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 public class AttachPermissionTest {
 

--- a/server/src/test/java/org/candlepin/auth/permissions/ConsumerCuratorPermissionsTest.java
+++ b/server/src/test/java/org/candlepin/auth/permissions/ConsumerCuratorPermissionsTest.java
@@ -14,6 +14,9 @@
  */
 package org.candlepin.auth.permissions;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 import org.candlepin.auth.Access;
 import org.candlepin.auth.Principal;
 import org.candlepin.auth.UserPrincipal;
@@ -34,9 +37,6 @@ import java.util.List;
 import java.util.Set;
 
 import javax.inject.Inject;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class ConsumerCuratorPermissionsTest extends DatabaseTestFixture {
     @Inject private OwnerCurator ownerCurator;

--- a/server/src/test/java/org/candlepin/auth/permissions/OwnerCuratorPermissionsTest.java
+++ b/server/src/test/java/org/candlepin/auth/permissions/OwnerCuratorPermissionsTest.java
@@ -14,6 +14,10 @@
  */
 package org.candlepin.auth.permissions;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.candlepin.auth.Access;
 import org.candlepin.auth.Principal;
 import org.candlepin.auth.UserPrincipal;
@@ -31,10 +35,6 @@ import java.util.List;
 import java.util.Set;
 
 import javax.inject.Inject;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class OwnerCuratorPermissionsTest extends DatabaseTestFixture {
     @Inject private OwnerCurator ownerCurator;

--- a/server/src/test/java/org/candlepin/auth/permissions/UsernameConsumersPermissionTest.java
+++ b/server/src/test/java/org/candlepin/auth/permissions/UsernameConsumersPermissionTest.java
@@ -14,6 +14,9 @@
  */
 package org.candlepin.auth.permissions;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.candlepin.auth.Access;
 import org.candlepin.auth.SubResource;
 import org.candlepin.model.Consumer;
@@ -24,9 +27,6 @@ import org.candlepin.test.TestUtil;
 
 import org.junit.Before;
 import org.junit.Test;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 public class UsernameConsumersPermissionTest {
 

--- a/server/src/test/java/org/candlepin/cache/StatusCacheTest.java
+++ b/server/src/test/java/org/candlepin/cache/StatusCacheTest.java
@@ -15,15 +15,15 @@
 
 package org.candlepin.cache;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import org.candlepin.dto.api.v1.StatusDTO;
 
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Date;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 /**
  * Created by mstead on 11/04/17.

--- a/server/src/test/java/org/candlepin/controller/ActiveMQStatusMonitorTest.java
+++ b/server/src/test/java/org/candlepin/controller/ActiveMQStatusMonitorTest.java
@@ -14,6 +14,10 @@
  */
 package org.candlepin.controller;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.audit.ActiveMQStatus;
 import org.candlepin.common.config.Configuration;
 import org.candlepin.config.ConfigProperties;
@@ -27,10 +31,6 @@ import org.mockito.runners.MockitoJUnitRunner;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ActiveMQStatusMonitorTest {

--- a/server/src/test/java/org/candlepin/controller/CdnManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/CdnManagerTest.java
@@ -14,6 +14,12 @@
  */
 package org.candlepin.controller;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.candlepin.model.Cdn;
 import org.candlepin.model.CdnCertificate;
 import org.candlepin.model.CdnCurator;
@@ -28,12 +34,6 @@ import com.google.inject.Inject;
 import org.junit.jupiter.api.Test;
 
 import java.util.Date;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 public class CdnManagerTest extends DatabaseTestFixture {

--- a/server/src/test/java/org/candlepin/controller/ContentManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/ContentManagerTest.java
@@ -14,20 +14,6 @@
  */
 package org.candlepin.controller;
 
-import org.candlepin.dto.api.v1.ContentDTO;
-import org.candlepin.model.Content;
-import org.candlepin.model.Owner;
-import org.candlepin.model.Product;
-import org.candlepin.test.DatabaseTestFixture;
-import org.candlepin.test.TestUtil;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
-
-import java.util.Arrays;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -42,6 +28,20 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
+
+import org.candlepin.dto.api.v1.ContentDTO;
+import org.candlepin.model.Content;
+import org.candlepin.model.Owner;
+import org.candlepin.model.Product;
+import org.candlepin.test.DatabaseTestFixture;
+import org.candlepin.test.TestUtil;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Arrays;
 
 
 /**

--- a/server/src/test/java/org/candlepin/controller/EntitlementCertificateGeneratorTest.java
+++ b/server/src/test/java/org/candlepin/controller/EntitlementCertificateGeneratorTest.java
@@ -14,6 +14,20 @@
  */
 package org.candlepin.controller;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.anyMapOf;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.audit.Event;
 import org.candlepin.audit.EventFactory;
 import org.candlepin.audit.EventSink;
@@ -57,20 +71,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyBoolean;
-import static org.mockito.Mockito.anyMapOf;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.isNull;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
-import static org.mockito.Mockito.when;
 
 
 

--- a/server/src/test/java/org/candlepin/controller/EntitlerTest.java
+++ b/server/src/test/java/org/candlepin/controller/EntitlerTest.java
@@ -14,6 +14,21 @@
  */
 package org.candlepin.controller;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyMap;
+import static org.mockito.Mockito.anySet;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.nullable;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.audit.Event;
 import org.candlepin.audit.EventFactory;
 import org.candlepin.audit.EventSink;
@@ -64,21 +79,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyMap;
-import static org.mockito.Mockito.anySet;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.nullable;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 
 // TODO: FIXME: Rewrite this test to not be so reliant upon mocks. It's making things incredibly brittle and

--- a/server/src/test/java/org/candlepin/controller/ManifestManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/ManifestManagerTest.java
@@ -15,6 +15,21 @@
 package org.candlepin.controller;
 
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.nullable;
+import static org.mockito.Mockito.anyCollection;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.async.JobArguments;
 import org.candlepin.async.JobConfig;
 import org.candlepin.async.tasks.ImportJob;
@@ -67,21 +82,6 @@ import java.util.Map;
 
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletResponse;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.nullable;
-import static org.mockito.Mockito.anyCollection;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)

--- a/server/src/test/java/org/candlepin/controller/OwnerManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/OwnerManagerTest.java
@@ -14,6 +14,9 @@
  */
 package org.candlepin.controller;
 
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.model.ConsumerCurator;
 import org.candlepin.model.ContentAccessCertificateCurator;
 import org.candlepin.model.EnvironmentCurator;
@@ -36,9 +39,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.when;
 
 
 /**

--- a/server/src/test/java/org/candlepin/controller/PoolManagerFunctionalTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerFunctionalTest.java
@@ -14,6 +14,17 @@
  */
 package org.candlepin.controller;
 
+import static org.apache.commons.collections.CollectionUtils.containsAny;
+import static org.apache.commons.collections.TransformerUtils.invokerTransformer;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.reset;
+
 import org.candlepin.audit.Event;
 import org.candlepin.audit.EventSink;
 import org.candlepin.common.paging.Page;
@@ -70,17 +81,6 @@ import java.util.Set;
 
 import javax.inject.Inject;
 import javax.persistence.EntityNotFoundException;
-
-import static org.apache.commons.collections.CollectionUtils.containsAny;
-import static org.apache.commons.collections.TransformerUtils.invokerTransformer;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.reset;
 
 
 

--- a/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -14,6 +14,37 @@
  */
 package org.candlepin.controller;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.AdditionalAnswers.returnsFirstArg;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.anyCollection;
+import static org.mockito.Mockito.anyCollectionOf;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.anyList;
+import static org.mockito.Mockito.anyListOf;
+import static org.mockito.Mockito.anyMap;
+import static org.mockito.Mockito.anyMapOf;
+import static org.mockito.Mockito.anySetOf;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.nullable;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.same;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.audit.Event;
 import org.candlepin.audit.Event.Target;
 import org.candlepin.audit.Event.Type;
@@ -120,37 +151,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Stream;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.AdditionalAnswers.returnsFirstArg;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyBoolean;
-import static org.mockito.Mockito.anyCollection;
-import static org.mockito.Mockito.anyCollectionOf;
-import static org.mockito.Mockito.anyInt;
-import static org.mockito.Mockito.anyList;
-import static org.mockito.Mockito.anyListOf;
-import static org.mockito.Mockito.anyMap;
-import static org.mockito.Mockito.anyMapOf;
-import static org.mockito.Mockito.anySetOf;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.nullable;
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.same;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * PoolManagerTest

--- a/server/src/test/java/org/candlepin/controller/ProductManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/ProductManagerTest.java
@@ -14,6 +14,21 @@
  */
 package org.candlepin.controller;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.anyCollectionOf;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
 import org.candlepin.dto.api.v1.BrandingDTO;
 import org.candlepin.dto.api.v1.ContentDTO;
 import org.candlepin.dto.api.v1.ProductDTO;
@@ -34,21 +49,6 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.anyBoolean;
-import static org.mockito.Mockito.anyCollectionOf;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
 
 
 

--- a/server/src/test/java/org/candlepin/controller/QpidStatusMonitorTest.java
+++ b/server/src/test/java/org/candlepin/controller/QpidStatusMonitorTest.java
@@ -15,6 +15,14 @@
 
 package org.candlepin.controller;
 
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.audit.QpidQmf;
 import org.candlepin.audit.QpidStatus;
 import org.candlepin.common.config.Configuration;
@@ -28,14 +36,6 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-
-import static org.junit.Assert.assertNotNull;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class QpidStatusMonitorTest {

--- a/server/src/test/java/org/candlepin/controller/RefresherTest.java
+++ b/server/src/test/java/org/candlepin/controller/RefresherTest.java
@@ -14,6 +14,14 @@
  */
 package org.candlepin.controller;
 
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.model.Owner;
 import org.candlepin.model.Pool;
 import org.candlepin.model.Product;
@@ -33,14 +41,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 
 

--- a/server/src/test/java/org/candlepin/controller/SuspendModeTransitionerTest.java
+++ b/server/src/test/java/org/candlepin/controller/SuspendModeTransitionerTest.java
@@ -14,6 +14,10 @@
  */
 package org.candlepin.controller;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.audit.ActiveMQStatus;
 import org.candlepin.audit.QpidStatus;
 import org.candlepin.common.config.Configuration;
@@ -34,10 +38,6 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.when;
 
 
 

--- a/server/src/test/java/org/candlepin/controller/mode/CandlepinModeManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/mode/CandlepinModeManagerTest.java
@@ -17,14 +17,6 @@ package org.candlepin.controller.mode;
 // import static org.hamcrest.MatcherAssert.*;
 // import static org.hamcrest.Matchers.*;
 
-import org.candlepin.controller.mode.CandlepinModeManager.Mode;
-
-import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
-
-import java.util.Iterator;
-import java.util.Set;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.eq;
@@ -32,6 +24,14 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+
+import org.candlepin.controller.mode.CandlepinModeManager.Mode;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Iterator;
+import java.util.Set;
 
 
 

--- a/server/src/test/java/org/candlepin/dto/AbstractDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/AbstractDTOTest.java
@@ -14,6 +14,14 @@
  */
 package org.candlepin.dto;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.candlepin.util.Util;
 
 import org.junit.jupiter.api.Test;
@@ -32,14 +40,6 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeTrue;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Base test suite for the CandlepinDTO subclasses

--- a/server/src/test/java/org/candlepin/dto/AbstractTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/AbstractTranslatorTest.java
@@ -14,13 +14,13 @@
  */
 package org.candlepin.dto;
 
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
 
 
 

--- a/server/src/test/java/org/candlepin/dto/SimpleModelTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/SimpleModelTranslatorTest.java
@@ -14,14 +14,14 @@
  */
 package org.candlepin.dto;
 
-import org.candlepin.model.ModelEntity;
-
-import org.junit.Test;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+
+import org.candlepin.model.ModelEntity;
+
+import org.junit.Test;
 
 
 /**

--- a/server/src/test/java/org/candlepin/dto/api/v1/ActivationKeyDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/ActivationKeyDTOTest.java
@@ -14,6 +14,9 @@
  */
 package org.candlepin.dto.api.v1;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.candlepin.dto.AbstractDTOTest;
 
 import org.junit.Test;
@@ -23,9 +26,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 
 

--- a/server/src/test/java/org/candlepin/dto/api/v1/ActivationKeyTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/ActivationKeyTranslatorTest.java
@@ -14,6 +14,11 @@
  */
 package org.candlepin.dto.api.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.ContentOverride;
@@ -29,11 +34,6 @@ import org.apache.commons.lang.builder.EqualsBuilder;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 
 

--- a/server/src/test/java/org/candlepin/dto/api/v1/AsyncJobStatusTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/AsyncJobStatusTranslatorTest.java
@@ -14,17 +14,17 @@
  */
 package org.candlepin.dto.api.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.AsyncJobStatus;
 import org.candlepin.model.AsyncJobStatus.JobState;
 
 import java.util.Date;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.spy;
 
 /**
  * Test suite for the AsyncJobStatusTranslator class

--- a/server/src/test/java/org/candlepin/dto/api/v1/BrandingTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/BrandingTranslatorTest.java
@@ -14,12 +14,12 @@
  */
 package org.candlepin.dto.api.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.Branding;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 /**
  * Test suite for the BrandingTranslator class

--- a/server/src/test/java/org/candlepin/dto/api/v1/CapabilityTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/CapabilityTranslatorTest.java
@@ -14,12 +14,12 @@
  */
 package org.candlepin.dto.api.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.ConsumerCapability;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 /**
  * Test suite for the CapabilityTranslator class

--- a/server/src/test/java/org/candlepin/dto/api/v1/CdnTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/CdnTranslatorTest.java
@@ -14,6 +14,9 @@
  */
 package org.candlepin.dto.api.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.Cdn;
@@ -21,9 +24,6 @@ import org.candlepin.model.CdnCertificate;
 import org.candlepin.model.CertificateSerial;
 
 import java.util.Date;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 /**
  * Test suite for the CdnTranslator class

--- a/server/src/test/java/org/candlepin/dto/api/v1/CertificateSerialTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/CertificateSerialTranslatorTest.java
@@ -14,14 +14,14 @@
  */
 package org.candlepin.dto.api.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.CertificateSerial;
 
 import java.util.Date;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 
 

--- a/server/src/test/java/org/candlepin/dto/api/v1/CertificateTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/CertificateTranslatorTest.java
@@ -14,14 +14,14 @@
  */
 package org.candlepin.dto.api.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.Certificate;
 import org.candlepin.model.CertificateSerial;
 import org.candlepin.model.IdentityCertificate;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 
 

--- a/server/src/test/java/org/candlepin/dto/api/v1/ComplianceReasonTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/ComplianceReasonTranslatorTest.java
@@ -14,15 +14,15 @@
  */
 package org.candlepin.dto.api.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.policy.js.compliance.ComplianceReason;
 
 import java.util.HashMap;
 import java.util.Map;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 
 

--- a/server/src/test/java/org/candlepin/dto/api/v1/ComplianceStatusTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/ComplianceStatusTranslatorTest.java
@@ -14,6 +14,11 @@
  */
 package org.candlepin.dto.api.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.Entitlement;
@@ -29,11 +34,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 
 

--- a/server/src/test/java/org/candlepin/dto/api/v1/ConsumerDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/ConsumerDTOTest.java
@@ -14,6 +14,10 @@
  */
 package org.candlepin.dto.api.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.candlepin.dto.AbstractDTOTest;
 
 import org.junit.Test;
@@ -25,10 +29,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Test suite for the ConsumerDTO class

--- a/server/src/test/java/org/candlepin/dto/api/v1/ConsumerInstalledProductTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/ConsumerInstalledProductTranslatorTest.java
@@ -14,14 +14,14 @@
  */
 package org.candlepin.dto.api.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.ConsumerInstalledProduct;
 
 import java.util.Date;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 /**
  * Test suite for the ConsumerInstalledProductTranslator class

--- a/server/src/test/java/org/candlepin/dto/api/v1/ConsumerTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/ConsumerTranslatorTest.java
@@ -14,6 +14,14 @@
  */
 package org.candlepin.dto.api.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.Consumer;
@@ -36,14 +44,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * Test suite for the ConsumerTranslator class

--- a/server/src/test/java/org/candlepin/dto/api/v1/ConsumerTypeTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/ConsumerTypeTranslatorTest.java
@@ -14,12 +14,12 @@
  */
 package org.candlepin.dto.api.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.ConsumerType;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 
 

--- a/server/src/test/java/org/candlepin/dto/api/v1/ContentDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/ContentDTOTest.java
@@ -14,6 +14,8 @@
  */
 package org.candlepin.dto.api.v1;
 
+import static org.junit.Assert.assertEquals;
+
 import org.candlepin.dto.AbstractDTOTest;
 
 import org.junit.Test;
@@ -23,8 +25,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
-
-import static org.junit.Assert.assertEquals;
 
 
 

--- a/server/src/test/java/org/candlepin/dto/api/v1/ContentOverrideTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/ContentOverrideTranslatorTest.java
@@ -14,13 +14,13 @@
  */
 package org.candlepin.dto.api.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.ConsumerContentOverride;
 import org.candlepin.model.ContentOverride;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 
 

--- a/server/src/test/java/org/candlepin/dto/api/v1/ContentTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/ContentTranslatorTest.java
@@ -14,14 +14,14 @@
  */
 package org.candlepin.dto.api.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.Content;
 
 import java.util.Arrays;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 
 

--- a/server/src/test/java/org/candlepin/dto/api/v1/DeletedConsumerTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/DeletedConsumerTranslatorTest.java
@@ -14,12 +14,12 @@
  */
 package org.candlepin.dto.api.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.DeletedConsumer;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 /**
  * Test suite for the DeletedConsumerTranslator class

--- a/server/src/test/java/org/candlepin/dto/api/v1/DistributorVersionDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/DistributorVersionDTOTest.java
@@ -14,6 +14,9 @@
  */
 package org.candlepin.dto.api.v1;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.candlepin.dto.AbstractDTOTest;
 
 import org.junit.Test;
@@ -23,9 +26,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Test suite for the DistributorVersionDTO (API) class

--- a/server/src/test/java/org/candlepin/dto/api/v1/DistributorVersionTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/DistributorVersionTranslatorTest.java
@@ -14,6 +14,11 @@
  */
 package org.candlepin.dto.api.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.DistributorVersion;
@@ -21,11 +26,6 @@ import org.candlepin.model.DistributorVersionCapability;
 
 import java.util.HashSet;
 import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Test suite for the DistributorVersionTranslator (API) class

--- a/server/src/test/java/org/candlepin/dto/api/v1/EntitlementDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/EntitlementDTOTest.java
@@ -14,6 +14,9 @@
  */
 package org.candlepin.dto.api.v1;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.candlepin.dto.AbstractDTOTest;
 
 import org.junit.Test;
@@ -23,9 +26,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 
 

--- a/server/src/test/java/org/candlepin/dto/api/v1/EntitlementTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/EntitlementTranslatorTest.java
@@ -14,6 +14,10 @@
  */
 package org.candlepin.dto.api.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.Certificate;
@@ -24,10 +28,6 @@ import org.candlepin.model.EntitlementCertificate;
 
 import java.util.Date;
 import java.util.HashSet;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 
 /**
  * Test suite for the EntitlementTranslator class.

--- a/server/src/test/java/org/candlepin/dto/api/v1/EnvironmentTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/EnvironmentTranslatorTest.java
@@ -14,6 +14,10 @@
  */
 package org.candlepin.dto.api.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.dto.api.v1.EnvironmentDTO.EnvironmentContentDTO;
@@ -24,10 +28,6 @@ import org.candlepin.test.TestUtil;
 
 import java.util.HashSet;
 import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 
 /**
  * Test suite for the ProductTranslator class

--- a/server/src/test/java/org/candlepin/dto/api/v1/GuestIdTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/GuestIdTranslatorTest.java
@@ -14,15 +14,15 @@
  */
 package org.candlepin.dto.api.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.GuestId;
 
 import java.util.HashMap;
 import java.util.Map;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 
 

--- a/server/src/test/java/org/candlepin/dto/api/v1/HypervisorConsumerTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/HypervisorConsumerTranslatorTest.java
@@ -14,17 +14,17 @@
  */
 package org.candlepin.dto.api.v1;
 
-import org.candlepin.dto.AbstractTranslatorTest;
-import org.candlepin.dto.ModelTranslator;
-import org.candlepin.model.Consumer;
-import org.candlepin.model.Owner;
-import org.candlepin.model.OwnerCurator;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
+import org.candlepin.dto.AbstractTranslatorTest;
+import org.candlepin.dto.ModelTranslator;
+import org.candlepin.model.Consumer;
+import org.candlepin.model.Owner;
+import org.candlepin.model.OwnerCurator;
 
 
 /**

--- a/server/src/test/java/org/candlepin/dto/api/v1/HypervisorIdTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/HypervisorIdTranslatorTest.java
@@ -14,12 +14,12 @@
  */
 package org.candlepin.dto.api.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.HypervisorId;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 /**
  * Test suite for the HypervisorIdTranslator class

--- a/server/src/test/java/org/candlepin/dto/api/v1/HypervisorUpdateResultDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/HypervisorUpdateResultDTOTest.java
@@ -14,6 +14,9 @@
  */
 package org.candlepin.dto.api.v1;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.candlepin.dto.AbstractDTOTest;
 
 import org.junit.Test;
@@ -22,9 +25,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 
 /**

--- a/server/src/test/java/org/candlepin/dto/api/v1/ImportRecordTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/ImportRecordTranslatorTest.java
@@ -14,15 +14,15 @@
  */
 package org.candlepin.dto.api.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.ImportRecord;
 import org.candlepin.model.ImportUpstreamConsumer;
 
 import java.util.Date;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 
 

--- a/server/src/test/java/org/candlepin/dto/api/v1/ImportUpstreamConsumerTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/ImportUpstreamConsumerTranslatorTest.java
@@ -14,12 +14,12 @@
  */
 package org.candlepin.dto.api.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.ImportUpstreamConsumer;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 
 

--- a/server/src/test/java/org/candlepin/dto/api/v1/OwnerInfoTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/OwnerInfoTranslatorTest.java
@@ -14,15 +14,15 @@
  */
 package org.candlepin.dto.api.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.Owner;
 import org.candlepin.service.model.OwnerInfo;
 
 import java.util.Date;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 
 

--- a/server/src/test/java/org/candlepin/dto/api/v1/OwnerTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/OwnerTranslatorTest.java
@@ -14,14 +14,14 @@
  */
 package org.candlepin.dto.api.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.Owner;
 
 import java.util.Date;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 
 

--- a/server/src/test/java/org/candlepin/dto/api/v1/PermissionBlueprintInfoTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/PermissionBlueprintInfoTranslatorTest.java
@@ -14,6 +14,9 @@
  */
 package org.candlepin.dto.api.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import org.candlepin.auth.Access;
 import org.candlepin.auth.permissions.PermissionFactory.PermissionType;
 import org.candlepin.dto.AbstractTranslatorTest;
@@ -21,9 +24,6 @@ import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.Owner;
 import org.candlepin.model.PermissionBlueprint;
 import org.candlepin.service.model.PermissionBlueprintInfo;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 
 

--- a/server/src/test/java/org/candlepin/dto/api/v1/PermissionBlueprintTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/PermissionBlueprintTranslatorTest.java
@@ -14,14 +14,14 @@
  */
 package org.candlepin.dto.api.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import org.candlepin.auth.Access;
 import org.candlepin.auth.permissions.PermissionFactory.PermissionType;
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.PermissionBlueprint;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 
 

--- a/server/src/test/java/org/candlepin/dto/api/v1/PoolDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/PoolDTOTest.java
@@ -14,6 +14,9 @@
  */
 package org.candlepin.dto.api.v1;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.candlepin.dto.AbstractDTOTest;
 import org.candlepin.model.Pool;
 
@@ -24,9 +27,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Test suite for the PoolDTO class

--- a/server/src/test/java/org/candlepin/dto/api/v1/PoolQuantityTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/PoolQuantityTranslatorTest.java
@@ -14,12 +14,12 @@
  */
 package org.candlepin.dto.api.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.PoolQuantity;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 
 /**

--- a/server/src/test/java/org/candlepin/dto/api/v1/PoolTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/PoolTranslatorTest.java
@@ -15,6 +15,11 @@
 package org.candlepin.dto.api.v1;
 
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.Branding;
@@ -33,11 +38,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Test suite for the PoolTranslator class.

--- a/server/src/test/java/org/candlepin/dto/api/v1/ProductCertificateTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/ProductCertificateTranslatorTest.java
@@ -14,14 +14,14 @@
  */
 package org.candlepin.dto.api.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.Content;
 import org.candlepin.model.Product;
 import org.candlepin.model.ProductCertificate;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 
 /**

--- a/server/src/test/java/org/candlepin/dto/api/v1/ProductDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/ProductDTOTest.java
@@ -14,6 +14,12 @@
  */
 package org.candlepin.dto.api.v1;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.candlepin.dto.AbstractDTOTest;
 import org.candlepin.dto.api.v1.ProductDTO.ProductContentDTO;
 
@@ -26,12 +32,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Map;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 

--- a/server/src/test/java/org/candlepin/dto/api/v1/ProductTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/ProductTranslatorTest.java
@@ -14,6 +14,11 @@
  */
 package org.candlepin.dto.api.v1;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.dto.api.v1.ProductDTO.ProductContentDTO;
@@ -29,11 +34,6 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Set;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test suite for the ProductTranslator class

--- a/server/src/test/java/org/candlepin/dto/api/v1/RoleDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/RoleDTOTest.java
@@ -14,6 +14,12 @@
  */
 package org.candlepin.dto.api.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import org.candlepin.dto.AbstractDTOTest;
 
 import org.junit.Test;
@@ -23,12 +29,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 
 

--- a/server/src/test/java/org/candlepin/dto/api/v1/RoleInfoTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/RoleInfoTranslatorTest.java
@@ -14,6 +14,11 @@
  */
 package org.candlepin.dto.api.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.PermissionBlueprint;
@@ -28,11 +33,6 @@ import org.apache.commons.lang.builder.EqualsBuilder;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 
 

--- a/server/src/test/java/org/candlepin/dto/api/v1/RoleTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/RoleTranslatorTest.java
@@ -14,6 +14,11 @@
  */
 package org.candlepin.dto.api.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.PermissionBlueprint;
@@ -23,11 +28,6 @@ import org.candlepin.model.User;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 
 

--- a/server/src/test/java/org/candlepin/dto/api/v1/StatusDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/StatusDTOTest.java
@@ -14,6 +14,10 @@
  */
 package org.candlepin.dto.api.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.candlepin.dto.AbstractDTOTest;
 
 import org.junit.Test;
@@ -23,10 +27,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 
 

--- a/server/src/test/java/org/candlepin/dto/api/v1/SystemPurposeComplianceStatusTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/SystemPurposeComplianceStatusTranslatorTest.java
@@ -14,6 +14,12 @@
  */
 package org.candlepin.dto.api.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
 import org.candlepin.TestingModules;
 import org.candlepin.common.config.Configuration;
 import org.candlepin.dto.AbstractTranslatorTest;
@@ -31,12 +37,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.Map;
 import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
 
 /**
  * Test suite for the ComplianceStatusTranslator class

--- a/server/src/test/java/org/candlepin/dto/api/v1/UeberCertificateTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/UeberCertificateTranslatorTest.java
@@ -14,12 +14,12 @@
  */
 package org.candlepin.dto.api.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.UeberCertificate;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 
 

--- a/server/src/test/java/org/candlepin/dto/api/v1/UpstreamConsumerTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/UpstreamConsumerTranslatorTest.java
@@ -14,14 +14,14 @@
  */
 package org.candlepin.dto.api.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.Certificate;
 import org.candlepin.model.IdentityCertificate;
 import org.candlepin.model.UpstreamConsumer;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 
 

--- a/server/src/test/java/org/candlepin/dto/api/v1/UserDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/UserDTOTest.java
@@ -14,6 +14,10 @@
  */
 package org.candlepin.dto.api.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
 import org.candlepin.dto.AbstractDTOTest;
 import org.candlepin.util.Util;
 
@@ -22,10 +26,6 @@ import org.junit.Test;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 
 
 

--- a/server/src/test/java/org/candlepin/dto/api/v1/UserInfoTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/UserInfoTranslatorTest.java
@@ -14,13 +14,13 @@
  */
 package org.candlepin.dto.api.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.User;
 import org.candlepin.service.model.UserInfo;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 
 

--- a/server/src/test/java/org/candlepin/dto/api/v1/UserTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/UserTranslatorTest.java
@@ -14,13 +14,13 @@
  */
 package org.candlepin.dto.api.v1;
 
-import org.candlepin.dto.AbstractTranslatorTest;
-import org.candlepin.dto.ModelTranslator;
-import org.candlepin.model.User;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+
+import org.candlepin.dto.AbstractTranslatorTest;
+import org.candlepin.dto.ModelTranslator;
+import org.candlepin.model.User;
 
 
 

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/BrandingTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/BrandingTranslatorTest.java
@@ -14,12 +14,12 @@
  */
 package org.candlepin.dto.manifest.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.Branding;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 /**
  * Test suite for the BrandingTranslator (manifest import/export) class

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/CdnTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/CdnTranslatorTest.java
@@ -14,6 +14,9 @@
  */
 package org.candlepin.dto.manifest.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.Cdn;
@@ -21,9 +24,6 @@ import org.candlepin.model.CdnCertificate;
 import org.candlepin.model.CertificateSerial;
 
 import java.util.Date;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 /**
  * Test suite for the CdnTranslator (manifest import/export) class

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/CertificateSerialTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/CertificateSerialTranslatorTest.java
@@ -14,14 +14,14 @@
  */
 package org.candlepin.dto.manifest.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.CertificateSerial;
 
 import java.util.Date;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 
 /**

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/CertificateTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/CertificateTranslatorTest.java
@@ -14,6 +14,9 @@
  */
 package org.candlepin.dto.manifest.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.Certificate;
@@ -21,9 +24,6 @@ import org.candlepin.model.CertificateSerial;
 import org.candlepin.model.IdentityCertificate;
 
 import java.util.Date;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 
 /**

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/ConsumerTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/ConsumerTranslatorTest.java
@@ -14,6 +14,12 @@
  */
 package org.candlepin.dto.manifest.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.Consumer;
@@ -21,12 +27,6 @@ import org.candlepin.model.ConsumerType;
 import org.candlepin.model.ConsumerTypeCurator;
 import org.candlepin.model.Owner;
 import org.candlepin.model.OwnerCurator;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 
 

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/ConsumerTypeTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/ConsumerTypeTranslatorTest.java
@@ -14,12 +14,12 @@
  */
 package org.candlepin.dto.manifest.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.ConsumerType;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 
 

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/ContentDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/ContentDTOTest.java
@@ -14,6 +14,8 @@
  */
 package org.candlepin.dto.manifest.v1;
 
+import static org.junit.Assert.assertEquals;
+
 import org.candlepin.dto.AbstractDTOTest;
 
 import org.junit.Test;
@@ -23,8 +25,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
-
-import static org.junit.Assert.assertEquals;
 
 
 

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/ContentTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/ContentTranslatorTest.java
@@ -14,14 +14,14 @@
  */
 package org.candlepin.dto.manifest.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.Content;
 
 import java.util.Arrays;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 
 

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/DistributorVersionDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/DistributorVersionDTOTest.java
@@ -14,6 +14,9 @@
  */
 package org.candlepin.dto.manifest.v1;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.candlepin.dto.AbstractDTOTest;
 
 import org.junit.Test;
@@ -23,9 +26,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Test suite for the DistributorVersionDTO (manifest import/export) class

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/DistributorVersionTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/DistributorVersionTranslatorTest.java
@@ -14,6 +14,11 @@
  */
 package org.candlepin.dto.manifest.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.DistributorVersion;
@@ -21,11 +26,6 @@ import org.candlepin.model.DistributorVersionCapability;
 
 import java.util.HashSet;
 import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Test suite for the DistributorVersionTranslator (manifest import/export) class

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/EntitlementDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/EntitlementDTOTest.java
@@ -14,6 +14,9 @@
  */
 package org.candlepin.dto.manifest.v1;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.candlepin.dto.AbstractDTOTest;
 
 import org.junit.Test;
@@ -23,9 +26,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 
 

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/EntitlementTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/EntitlementTranslatorTest.java
@@ -14,6 +14,10 @@
  */
 package org.candlepin.dto.manifest.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.Certificate;
@@ -24,10 +28,6 @@ import org.candlepin.model.EntitlementCertificate;
 
 import java.util.Date;
 import java.util.HashSet;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 
 
 

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/OwnerTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/OwnerTranslatorTest.java
@@ -14,14 +14,14 @@
  */
 package org.candlepin.dto.manifest.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.Owner;
 
 import java.util.Date;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 
 

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/PoolDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/PoolDTOTest.java
@@ -14,6 +14,9 @@
  */
 package org.candlepin.dto.manifest.v1;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.candlepin.dto.AbstractDTOTest;
 import org.candlepin.model.Pool;
 
@@ -24,9 +27,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Test suite for the PoolDTO (manifest import/export) class

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/PoolTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/PoolTranslatorTest.java
@@ -15,6 +15,11 @@
 package org.candlepin.dto.manifest.v1;
 
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.Branding;
@@ -33,11 +38,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Test suite for the PoolTranslator (manifest import/export) class.

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/ProductDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/ProductDTOTest.java
@@ -14,6 +14,12 @@
  */
 package org.candlepin.dto.manifest.v1;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.candlepin.dto.AbstractDTOTest;
 
 import org.junit.jupiter.api.Test;
@@ -24,12 +30,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Map;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/ProductTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/ProductTranslatorTest.java
@@ -14,6 +14,11 @@
  */
 package org.candlepin.dto.manifest.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.Content;
@@ -26,11 +31,6 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.stream.IntStream;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Test suite for the ProductTranslator (manifest import/export) class

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/UpstreamConsumerTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/UpstreamConsumerTranslatorTest.java
@@ -14,14 +14,14 @@
  */
 package org.candlepin.dto.manifest.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.Certificate;
 import org.candlepin.model.IdentityCertificate;
 import org.candlepin.model.UpstreamConsumer;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 
 

--- a/server/src/test/java/org/candlepin/dto/rules/v1/ActivationKeyTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/rules/v1/ActivationKeyTranslatorTest.java
@@ -14,6 +14,11 @@
  */
 package org.candlepin.dto.rules.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.Pool;
@@ -24,11 +29,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Test suite for the ActivationKeyTranslator class for Rules

--- a/server/src/test/java/org/candlepin/dto/rules/v1/ComplianceReasonTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/rules/v1/ComplianceReasonTranslatorTest.java
@@ -14,15 +14,15 @@
  */
 package org.candlepin.dto.rules.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.policy.js.compliance.ComplianceReason;
 
 import java.util.HashMap;
 import java.util.Map;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 
 

--- a/server/src/test/java/org/candlepin/dto/rules/v1/ComplianceStatusTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/rules/v1/ComplianceStatusTranslatorTest.java
@@ -14,6 +14,11 @@
  */
 package org.candlepin.dto.rules.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.Entitlement;
@@ -28,11 +33,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 
 

--- a/server/src/test/java/org/candlepin/dto/rules/v1/ConsumerDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/rules/v1/ConsumerDTOTest.java
@@ -14,6 +14,10 @@
  */
 package org.candlepin.dto.rules.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.candlepin.dto.AbstractDTOTest;
 
 import org.junit.Test;
@@ -23,10 +27,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Test suite for the ConsumerDTO class

--- a/server/src/test/java/org/candlepin/dto/rules/v1/ConsumerTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/rules/v1/ConsumerTranslatorTest.java
@@ -14,6 +14,14 @@
  */
 package org.candlepin.dto.rules.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.Consumer;
@@ -28,14 +36,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * Test suite for the ConsumerTranslator (Rules framework) class

--- a/server/src/test/java/org/candlepin/dto/rules/v1/ConsumerTypeTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/rules/v1/ConsumerTypeTranslatorTest.java
@@ -14,12 +14,12 @@
  */
 package org.candlepin.dto.rules.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.ConsumerType;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 
 

--- a/server/src/test/java/org/candlepin/dto/rules/v1/EntitlementTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/rules/v1/EntitlementTranslatorTest.java
@@ -14,12 +14,12 @@
  */
 package org.candlepin.dto.rules.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.Entitlement;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 
 

--- a/server/src/test/java/org/candlepin/dto/rules/v1/GuestIdTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/rules/v1/GuestIdTranslatorTest.java
@@ -14,15 +14,15 @@
  */
 package org.candlepin.dto.rules.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.GuestId;
 
 import java.util.HashMap;
 import java.util.Map;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 
 

--- a/server/src/test/java/org/candlepin/dto/rules/v1/OwnerTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/rules/v1/OwnerTranslatorTest.java
@@ -14,12 +14,12 @@
  */
 package org.candlepin.dto.rules.v1;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.Owner;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 
 

--- a/server/src/test/java/org/candlepin/dto/rules/v1/PoolDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/rules/v1/PoolDTOTest.java
@@ -14,6 +14,9 @@
  */
 package org.candlepin.dto.rules.v1;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.candlepin.dto.AbstractDTOTest;
 
 import org.junit.Test;
@@ -23,9 +26,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Test suite for the PoolDTO (Rules) class

--- a/server/src/test/java/org/candlepin/dto/rules/v1/PoolTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/rules/v1/PoolTranslatorTest.java
@@ -15,6 +15,11 @@
 package org.candlepin.dto.rules.v1;
 
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.Pool;
@@ -26,11 +31,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Test suite for the PoolTranslator (Rules) class.

--- a/server/src/test/java/org/candlepin/dto/shim/ContentDTOTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/shim/ContentDTOTranslatorTest.java
@@ -14,15 +14,15 @@
  */
 package org.candlepin.dto.shim;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.dto.manifest.v1.ContentDTO;
 import org.candlepin.model.dto.ContentData;
 
 import java.util.Arrays;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 
 

--- a/server/src/test/java/org/candlepin/dto/shim/ContentDataTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/shim/ContentDataTranslatorTest.java
@@ -14,15 +14,15 @@
  */
 package org.candlepin.dto.shim;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.dto.api.v1.ContentDTO;
 import org.candlepin.model.dto.ContentData;
 
 import java.util.Arrays;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 
 

--- a/server/src/test/java/org/candlepin/dto/shim/ProductDTOTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/shim/ProductDTOTranslatorTest.java
@@ -14,6 +14,11 @@
  */
 package org.candlepin.dto.shim;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.dto.manifest.v1.ContentDTO;
@@ -27,11 +32,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 
 

--- a/server/src/test/java/org/candlepin/dto/shim/ProductDataTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/shim/ProductDataTranslatorTest.java
@@ -14,6 +14,10 @@
  */
 package org.candlepin.dto.shim;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.dto.api.v1.BrandingDTO;
@@ -35,10 +39,6 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Test suite for the UpstreamConsumerTranslator class

--- a/server/src/test/java/org/candlepin/guice/CandlepinContextListenerTest.java
+++ b/server/src/test/java/org/candlepin/guice/CandlepinContextListenerTest.java
@@ -14,6 +14,19 @@
  */
 package org.candlepin.guice;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.atMost;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.TestingModules;
 import org.candlepin.audit.AMQPBusPublisher;
 import org.candlepin.audit.ActiveMQContextListener;
@@ -50,19 +63,6 @@ import java.util.concurrent.ScheduledExecutorService;
 
 import javax.servlet.ServletContext;
 import javax.servlet.ServletContextEvent;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.atMost;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.isNull;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
-import static org.mockito.Mockito.when;
 
 
 

--- a/server/src/test/java/org/candlepin/guice/CustomizableModulesTest.java
+++ b/server/src/test/java/org/candlepin/guice/CustomizableModulesTest.java
@@ -14,6 +14,9 @@
  */
 package org.candlepin.guice;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import org.candlepin.common.config.Configuration;
 import org.candlepin.common.config.PropertiesFileConfiguration;
 
@@ -23,9 +26,6 @@ import org.junit.Test;
 
 import java.net.URISyntaxException;
 import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class CustomizableModulesTest {
 

--- a/server/src/test/java/org/candlepin/hibernate/EmptyStringInterceptorTest.java
+++ b/server/src/test/java/org/candlepin/hibernate/EmptyStringInterceptorTest.java
@@ -14,6 +14,8 @@
  */
 package org.candlepin.hibernate;
 
+import static org.junit.Assert.assertEquals;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -27,8 +29,6 @@ import javax.persistence.EntityManagerFactory;
 import javax.persistence.Id;
 import javax.persistence.Persistence;
 import javax.persistence.Table;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * EmptyStringInterceptorTest

--- a/server/src/test/java/org/candlepin/hibernate/EmptyStringUserTypeTest.java
+++ b/server/src/test/java/org/candlepin/hibernate/EmptyStringUserTypeTest.java
@@ -14,6 +14,10 @@
  */
 package org.candlepin.hibernate;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.hibernate.annotations.Type;
 import org.junit.After;
 import org.junit.Before;
@@ -28,10 +32,6 @@ import javax.persistence.EntityManagerFactory;
 import javax.persistence.Id;
 import javax.persistence.Persistence;
 import javax.persistence.Table;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 /**
  * EmptyStringUserTypeTest

--- a/server/src/test/java/org/candlepin/hibernate/ResultDataUserTypeTest.java
+++ b/server/src/test/java/org/candlepin/hibernate/ResultDataUserTypeTest.java
@@ -14,6 +14,11 @@
  */
 package org.candlepin.hibernate;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
 import org.hibernate.annotations.Type;
 import org.junit.After;
 import org.junit.Before;
@@ -37,11 +42,6 @@ import javax.persistence.Table;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
-
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
 
 /**
  * Test for ResultDataUserType

--- a/server/src/test/java/org/candlepin/jackson/StringTrimmingConverterTest.java
+++ b/server/src/test/java/org/candlepin/jackson/StringTrimmingConverterTest.java
@@ -14,10 +14,10 @@
  */
 package org.candlepin.jackson;
 
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Before;
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
 
 public class StringTrimmingConverterTest {
     private StringTrimmingConverter converter;

--- a/server/src/test/java/org/candlepin/katello/KatelloUserServiceAdapterTest.java
+++ b/server/src/test/java/org/candlepin/katello/KatelloUserServiceAdapterTest.java
@@ -14,13 +14,13 @@
  */
 package org.candlepin.katello;
 
+import static org.mockito.Mockito.mock;
+
 import org.candlepin.model.Role;
 import org.candlepin.model.User;
 
 import org.junit.Before;
 import org.junit.Test;
-
-import static org.mockito.Mockito.mock;
 
 /**
  * KatelloUserServiceAdapterTest

--- a/server/src/test/java/org/candlepin/logging/LoggerAndMDCFilterTest.java
+++ b/server/src/test/java/org/candlepin/logging/LoggerAndMDCFilterTest.java
@@ -14,6 +14,10 @@
  */
 package org.candlepin.logging;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
@@ -23,10 +27,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.MDC;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 /**
  * LoggerAndMDCFilterTest

--- a/server/src/test/java/org/candlepin/model/AbstractHibernateCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/AbstractHibernateCuratorTest.java
@@ -14,6 +14,14 @@
  */
 package org.candlepin.model;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.candlepin.config.DatabaseConfigFactory;
 import org.candlepin.test.DatabaseTestFixture;
 
@@ -33,14 +41,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * AbstractHibernateCuratorTest

--- a/server/src/test/java/org/candlepin/model/ActivationKeyContentOverrideCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ActivationKeyContentOverrideCuratorTest.java
@@ -14,6 +14,11 @@
  */
 package org.candlepin.model;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.candlepin.model.ConsumerType.ConsumerTypeEnum;
 import org.candlepin.model.activationkeys.ActivationKey;
 import org.candlepin.model.activationkeys.ActivationKeyContentOverride;
@@ -27,11 +32,6 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import javax.inject.Inject;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * ActivationKeyContentOverrideCuratorTest

--- a/server/src/test/java/org/candlepin/model/ActivationKeyTest.java
+++ b/server/src/test/java/org/candlepin/model/ActivationKeyTest.java
@@ -14,6 +14,11 @@
  */
 package org.candlepin.model;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.candlepin.model.activationkeys.ActivationKey;
 import org.candlepin.model.activationkeys.ActivationKeyCurator;
 import org.candlepin.test.DatabaseTestFixture;
@@ -25,11 +30,6 @@ import org.junit.jupiter.api.Test;
 import java.util.Date;
 
 import javax.inject.Inject;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * ActivationKeyTest

--- a/server/src/test/java/org/candlepin/model/AsyncJobStatusCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/AsyncJobStatusCuratorTest.java
@@ -14,6 +14,12 @@
  */
 package org.candlepin.model;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.candlepin.model.AsyncJobStatus.JobState;
 import org.candlepin.model.AsyncJobStatusCurator.AsyncJobStatusQueryBuilder;
 import org.candlepin.test.DatabaseTestFixture;
@@ -33,12 +39,6 @@ import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {

--- a/server/src/test/java/org/candlepin/model/CPRestrictionsTest.java
+++ b/server/src/test/java/org/candlepin/model/CPRestrictionsTest.java
@@ -14,6 +14,8 @@
  */
 package org.candlepin.model;
 
+import static org.junit.Assert.assertEquals;
+
 import org.candlepin.TestingModules;
 import org.candlepin.common.config.Configuration;
 import org.candlepin.config.DatabaseConfigFactory;
@@ -31,8 +33,6 @@ import java.util.LinkedList;
 import java.util.List;
 
 import javax.inject.Inject;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * CPRestrictionsTest

--- a/server/src/test/java/org/candlepin/model/CertificateSerialCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/CertificateSerialCuratorTest.java
@@ -14,6 +14,12 @@
  */
 package org.candlepin.model;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.candlepin.test.DatabaseTestFixture;
 import org.candlepin.util.Util;
 
@@ -29,12 +35,6 @@ import java.util.Map;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 

--- a/server/src/test/java/org/candlepin/model/CertificateTest.java
+++ b/server/src/test/java/org/candlepin/model/CertificateTest.java
@@ -15,6 +15,9 @@
 
 package org.candlepin.model;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import org.candlepin.test.DatabaseTestFixture;
 
 import org.junit.jupiter.api.Test;
@@ -23,9 +26,6 @@ import java.util.Date;
 import java.util.List;
 
 import javax.inject.Inject;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class CertificateTest extends DatabaseTestFixture {
     @Inject private SubscriptionsCertificateCurator certificateCurator;

--- a/server/src/test/java/org/candlepin/model/ColumnarResultIteratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ColumnarResultIteratorTest.java
@@ -14,6 +14,10 @@
  */
 package org.candlepin.model;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.candlepin.test.DatabaseTestFixture;
 
 import org.hibernate.Query;
@@ -25,10 +29,6 @@ import org.junit.jupiter.api.Test;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.NoSuchElementException;
-
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 

--- a/server/src/test/java/org/candlepin/model/ConsumerContentOverrideCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ConsumerContentOverrideCuratorTest.java
@@ -14,6 +14,11 @@
  */
 package org.candlepin.model;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import org.candlepin.model.ConsumerType.ConsumerTypeEnum;
 import org.candlepin.test.DatabaseTestFixture;
 
@@ -23,11 +28,6 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import javax.inject.Inject;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 /**
  * ConsumerContentOverrideCuratorTest

--- a/server/src/test/java/org/candlepin/model/ConsumerCuratorSearchTest.java
+++ b/server/src/test/java/org/candlepin/model/ConsumerCuratorSearchTest.java
@@ -14,6 +14,9 @@
  */
 package org.candlepin.model;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.candlepin.common.config.Configuration;
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.model.ConsumerType.ConsumerTypeEnum;
@@ -34,9 +37,6 @@ import java.util.List;
 import java.util.Map;
 
 import javax.inject.Inject;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 

--- a/server/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
@@ -14,6 +14,18 @@
  */
 package org.candlepin.model;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.common.config.Configuration;
 import org.candlepin.common.exceptions.NotFoundException;
 import org.candlepin.config.ConfigProperties;
@@ -46,18 +58,6 @@ import java.util.Set;
 
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertIterableEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 
 /**

--- a/server/src/test/java/org/candlepin/model/ConsumerInstalledProductTest.java
+++ b/server/src/test/java/org/candlepin/model/ConsumerInstalledProductTest.java
@@ -14,11 +14,11 @@
  */
 package org.candlepin.model;
 
-import org.junit.Before;
-import org.junit.Test;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * ConsumerInstalledProductTest

--- a/server/src/test/java/org/candlepin/model/ConsumerTest.java
+++ b/server/src/test/java/org/candlepin/model/ConsumerTest.java
@@ -14,6 +14,14 @@
  */
 package org.candlepin.model;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
 import org.candlepin.auth.ConsumerPrincipal;
 import org.candlepin.auth.Principal;
 import org.candlepin.dto.api.v1.ConsumerDTO;
@@ -31,14 +39,6 @@ import java.util.Map;
 
 import javax.inject.Inject;
 import javax.validation.ConstraintViolationException;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
 
 
 

--- a/server/src/test/java/org/candlepin/model/ConsumerTypeCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ConsumerTypeCuratorTest.java
@@ -14,17 +14,17 @@
  */
 package org.candlepin.model;
 
-import org.candlepin.model.ConsumerType.ConsumerTypeEnum;
-import org.candlepin.test.DatabaseTestFixture;
-
-import org.junit.jupiter.api.Test;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.candlepin.model.ConsumerType.ConsumerTypeEnum;
+import org.candlepin.test.DatabaseTestFixture;
+
+import org.junit.jupiter.api.Test;
 
 
 

--- a/server/src/test/java/org/candlepin/model/ConsumerTypeTest.java
+++ b/server/src/test/java/org/candlepin/model/ConsumerTypeTest.java
@@ -14,15 +14,15 @@
  */
 package org.candlepin.model;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.candlepin.test.DatabaseTestFixture;
 
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ConsumerTypeTest extends DatabaseTestFixture {
 

--- a/server/src/test/java/org/candlepin/model/ContentTest.java
+++ b/server/src/test/java/org/candlepin/model/ContentTest.java
@@ -14,6 +14,11 @@
  */
 package org.candlepin.model;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.candlepin.test.DatabaseTestFixture;
 import org.candlepin.test.TestUtil;
 
@@ -28,11 +33,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * ContentTest

--- a/server/src/test/java/org/candlepin/model/CuratorPaginationTest.java
+++ b/server/src/test/java/org/candlepin/model/CuratorPaginationTest.java
@@ -14,6 +14,9 @@
  */
 package org.candlepin.model;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
 import org.candlepin.common.paging.Page;
 import org.candlepin.common.paging.PageRequest;
 import org.candlepin.test.DatabaseTestFixture;
@@ -28,9 +31,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.inject.Inject;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * This class is used to test the pagination capabilities of the AbstractHibernateCurator.

--- a/server/src/test/java/org/candlepin/model/DeletedConsumerCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/DeletedConsumerCuratorTest.java
@@ -14,6 +14,10 @@
  */
 package org.candlepin.model;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.test.DatabaseTestFixture;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -23,10 +27,6 @@ import java.util.Date;
 import java.util.List;
 
 import javax.inject.Inject;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * DeletedConsumerCuratorTest

--- a/server/src/test/java/org/candlepin/model/DeletedConsumerTest.java
+++ b/server/src/test/java/org/candlepin/model/DeletedConsumerTest.java
@@ -14,9 +14,9 @@
  */
 package org.candlepin.model;
 
-import org.junit.Test;
-
 import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
 
 /**
  * DeletedConsumerTest

--- a/server/src/test/java/org/candlepin/model/EntitlementCertificateCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/EntitlementCertificateCuratorTest.java
@@ -14,6 +14,11 @@
  */
 package org.candlepin.model;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.candlepin.test.DatabaseTestFixture;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -23,11 +28,6 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 

--- a/server/src/test/java/org/candlepin/model/EntitlementCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/EntitlementCuratorTest.java
@@ -14,6 +14,14 @@
  */
 package org.candlepin.model;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.candlepin.common.paging.Page;
 import org.candlepin.common.paging.PageRequest;
 import org.candlepin.test.DatabaseTestFixture;
@@ -34,14 +42,6 @@ import java.util.List;
 import java.util.Set;
 
 import javax.inject.Inject;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 

--- a/server/src/test/java/org/candlepin/model/EnvironmentContentCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/EnvironmentContentCuratorTest.java
@@ -14,6 +14,10 @@
  */
 package org.candlepin.model;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.candlepin.test.DatabaseTestFixture;
 import org.candlepin.test.TestUtil;
 
@@ -21,10 +25,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import javax.persistence.PersistenceException;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 
 

--- a/server/src/test/java/org/candlepin/model/EnvironmentCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/EnvironmentCuratorTest.java
@@ -14,6 +14,10 @@
  */
 package org.candlepin.model;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 import org.candlepin.test.DatabaseTestFixture;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -25,10 +29,6 @@ import java.util.List;
 import java.util.Set;
 
 import javax.inject.Inject;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 
 

--- a/server/src/test/java/org/candlepin/model/ExporterMetadataCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ExporterMetadataCuratorTest.java
@@ -14,6 +14,10 @@
  */
 package org.candlepin.model;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 import org.candlepin.test.DatabaseTestFixture;
 
 import org.junit.jupiter.api.Test;
@@ -21,10 +25,6 @@ import org.junit.jupiter.api.Test;
 import java.util.Date;
 
 import javax.inject.Inject;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * ExporterMetadataCuratorTest

--- a/server/src/test/java/org/candlepin/model/GuestIdCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/GuestIdCuratorTest.java
@@ -14,6 +14,10 @@
  */
 package org.candlepin.model;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.candlepin.model.ConsumerType.ConsumerTypeEnum;
 import org.candlepin.test.DatabaseTestFixture;
 
@@ -23,10 +27,6 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import javax.inject.Inject;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * GuestIdCuratorTest

--- a/server/src/test/java/org/candlepin/model/HibernateValidationAnnotationTest.java
+++ b/server/src/test/java/org/candlepin/model/HibernateValidationAnnotationTest.java
@@ -14,6 +14,8 @@
  */
 package org.candlepin.model;
 
+import static org.junit.Assert.assertTrue;
+
 import org.candlepin.model.activationkeys.ActivationKey;
 
 import com.google.inject.matcher.Matcher;
@@ -28,8 +30,6 @@ import java.util.Map;
 
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
-
-import static org.junit.Assert.assertTrue;
 
 /**
  * HibernateAnnotationTest

--- a/server/src/test/java/org/candlepin/model/KeyPairCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/KeyPairCuratorTest.java
@@ -14,6 +14,9 @@
  */
 package org.candlepin.model;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
 import org.candlepin.test.DatabaseTestFixture;
 
 import org.junit.jupiter.api.Test;
@@ -21,9 +24,6 @@ import org.junit.jupiter.api.Test;
 import java.security.KeyPair;
 
 import javax.inject.Inject;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * KeyPairCuratorTest

--- a/server/src/test/java/org/candlepin/model/ManifestFileRecordCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ManifestFileRecordCuratorTest.java
@@ -14,6 +14,10 @@
  */
 package org.candlepin.model;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.candlepin.sync.file.ManifestFileType;
 import org.candlepin.test.DatabaseTestFixture;
 
@@ -27,10 +31,6 @@ import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Calendar;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ManifestFileRecordCuratorTest extends DatabaseTestFixture {
 

--- a/server/src/test/java/org/candlepin/model/OwnerAccessControlTest.java
+++ b/server/src/test/java/org/candlepin/model/OwnerAccessControlTest.java
@@ -14,6 +14,9 @@
  */
 package org.candlepin.model;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.candlepin.auth.Access;
 import org.candlepin.auth.ConsumerPrincipal;
 import org.candlepin.common.exceptions.ForbiddenException;
@@ -25,9 +28,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import javax.inject.Inject;
-
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * OwnerAccessTest

--- a/server/src/test/java/org/candlepin/model/OwnerContentCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/OwnerContentCuratorTest.java
@@ -14,6 +14,13 @@
  */
 package org.candlepin.model;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.candlepin.test.DatabaseTestFixture;
 import org.candlepin.test.TestUtil;
 
@@ -26,13 +33,6 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 

--- a/server/src/test/java/org/candlepin/model/OwnerCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/OwnerCuratorTest.java
@@ -14,6 +14,13 @@
  */
 package org.candlepin.model;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.candlepin.model.ConsumerType.ConsumerTypeEnum;
 import org.candlepin.test.DatabaseTestFixture;
 import org.candlepin.test.TestUtil;
@@ -29,13 +36,6 @@ import java.util.Set;
 
 import javax.persistence.PersistenceException;
 import javax.persistence.RollbackException;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 

--- a/server/src/test/java/org/candlepin/model/OwnerInfoCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/OwnerInfoCuratorTest.java
@@ -14,6 +14,8 @@
  */
 package org.candlepin.model;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.candlepin.auth.Principal;
 import org.candlepin.auth.UserPrincipal;
 import org.candlepin.auth.permissions.Permission;
@@ -30,8 +32,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
 

--- a/server/src/test/java/org/candlepin/model/OwnerProductCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/OwnerProductCuratorTest.java
@@ -14,6 +14,14 @@
  */
 package org.candlepin.model;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.candlepin.model.activationkeys.ActivationKey;
 import org.candlepin.test.DatabaseTestFixture;
 import org.candlepin.test.TestUtil;
@@ -28,14 +36,6 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 

--- a/server/src/test/java/org/candlepin/model/OwnerTest.java
+++ b/server/src/test/java/org/candlepin/model/OwnerTest.java
@@ -14,6 +14,11 @@
  */
 package org.candlepin.model;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.candlepin.test.DatabaseTestFixture;
 import org.candlepin.test.TestUtil;
 import org.candlepin.util.Util;
@@ -24,11 +29,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
 import java.util.Set;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 

--- a/server/src/test/java/org/candlepin/model/PoolCuratorEntitlementRulesTest.java
+++ b/server/src/test/java/org/candlepin/model/PoolCuratorEntitlementRulesTest.java
@@ -14,6 +14,10 @@
  */
 package org.candlepin.model;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.candlepin.controller.CandlepinPoolManager;
 import org.candlepin.policy.EntitlementRefusedException;
 import org.candlepin.policy.js.entitlement.Enforcer;
@@ -33,10 +37,6 @@ import java.util.List;
 import java.util.Map;
 
 import javax.inject.Inject;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * PoolCuratorEntitlementRulesTest

--- a/server/src/test/java/org/candlepin/model/PoolCuratorFilterTest.java
+++ b/server/src/test/java/org/candlepin/model/PoolCuratorFilterTest.java
@@ -14,6 +14,9 @@
  */
 package org.candlepin.model;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.candlepin.common.paging.Page;
 import org.candlepin.common.paging.PageRequest;
 import org.candlepin.test.DatabaseTestFixture;
@@ -24,9 +27,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 

--- a/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
@@ -14,6 +14,17 @@
  */
 package org.candlepin.model;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.candlepin.auth.NoAuthPrincipal;
 import org.candlepin.common.paging.Page;
 import org.candlepin.common.paging.PageRequest;
@@ -49,17 +60,6 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import javax.inject.Inject;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.hasItems;
-import static org.hamcrest.Matchers.not;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 

--- a/server/src/test/java/org/candlepin/model/PoolTest.java
+++ b/server/src/test/java/org/candlepin/model/PoolTest.java
@@ -14,6 +14,12 @@
  */
 package org.candlepin.model;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import org.candlepin.common.jackson.DynamicPropertyFilter;
 import org.candlepin.common.jackson.HateoasBeanPropertyFilter;
 import org.candlepin.controller.CandlepinPoolManager;
@@ -41,12 +47,6 @@ import java.util.Map;
 import java.util.Set;
 
 import javax.inject.Inject;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 
 

--- a/server/src/test/java/org/candlepin/model/ProductCertificateCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ProductCertificateCuratorTest.java
@@ -14,13 +14,13 @@
  */
 package org.candlepin.model;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 import org.candlepin.test.DatabaseTestFixture;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * ProductCertificateCuratorTest

--- a/server/src/test/java/org/candlepin/model/ProductCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ProductCuratorTest.java
@@ -14,6 +14,15 @@
  */
 package org.candlepin.model;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.candlepin.common.config.Configuration;
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.test.DatabaseTestFixture;
@@ -42,15 +51,6 @@ import java.util.Set;
 import javax.inject.Inject;
 import javax.persistence.PersistenceException;
 import javax.validation.ConstraintViolationException;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItem;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ProductCuratorTest extends DatabaseTestFixture {
     private static Logger log = LoggerFactory.getLogger(ProductCuratorTest.class);

--- a/server/src/test/java/org/candlepin/model/ProductTest.java
+++ b/server/src/test/java/org/candlepin/model/ProductTest.java
@@ -14,6 +14,11 @@
  */
 package org.candlepin.model;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.candlepin.util.Util;
 
 import org.junit.jupiter.api.Test;
@@ -28,11 +33,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 /**

--- a/server/src/test/java/org/candlepin/model/ReleaseTest.java
+++ b/server/src/test/java/org/candlepin/model/ReleaseTest.java
@@ -14,10 +14,10 @@
  */
 package org.candlepin.model;
 
-import org.junit.Test;
-
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
 
 /**
  * ReleaseTest

--- a/server/src/test/java/org/candlepin/model/RoleTest.java
+++ b/server/src/test/java/org/candlepin/model/RoleTest.java
@@ -14,6 +14,9 @@
  */
 package org.candlepin.model;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import org.candlepin.auth.Access;
 import org.candlepin.auth.permissions.PermissionFactory.PermissionType;
 import org.candlepin.test.DatabaseTestFixture;
@@ -26,9 +29,6 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import javax.inject.Inject;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class RoleTest extends DatabaseTestFixture {
     @Inject private UserCurator userCurator;

--- a/server/src/test/java/org/candlepin/model/RowResultIteratorTest.java
+++ b/server/src/test/java/org/candlepin/model/RowResultIteratorTest.java
@@ -14,6 +14,10 @@
  */
 package org.candlepin.model;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.candlepin.test.DatabaseTestFixture;
 
 import org.hibernate.Query;
@@ -25,10 +29,6 @@ import org.junit.jupiter.api.Test;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.NoSuchElementException;
-
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 

--- a/server/src/test/java/org/candlepin/model/RulesCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/RulesCuratorTest.java
@@ -14,14 +14,14 @@
  */
 package org.candlepin.model;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
 import org.candlepin.test.DatabaseTestFixture;
 
 import org.junit.jupiter.api.Test;
 
 import javax.inject.Inject;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * RulesCuratorTest

--- a/server/src/test/java/org/candlepin/model/UeberCertificateCuratorTests.java
+++ b/server/src/test/java/org/candlepin/model/UeberCertificateCuratorTests.java
@@ -14,6 +14,11 @@
  */
 package org.candlepin.model;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import org.candlepin.test.DatabaseTestFixture;
 
 import org.hibernate.exception.ConstraintViolationException;
@@ -22,11 +27,6 @@ import org.junit.jupiter.api.Test;
 
 import javax.inject.Inject;
 import javax.persistence.PersistenceException;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * UeberCertificateCuratorTests

--- a/server/src/test/java/org/candlepin/model/UpstreamConsumerTest.java
+++ b/server/src/test/java/org/candlepin/model/UpstreamConsumerTest.java
@@ -14,11 +14,11 @@
  */
 package org.candlepin.model;
 
-import org.junit.Before;
-import org.junit.Test;
-
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
+
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * UpstreamConsumerTest

--- a/server/src/test/java/org/candlepin/model/UserTest.java
+++ b/server/src/test/java/org/candlepin/model/UserTest.java
@@ -14,11 +14,11 @@
  */
 package org.candlepin.model;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.candlepin.test.DatabaseTestFixture;
 
 import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
 

--- a/server/src/test/java/org/candlepin/model/dto/CandlepinDTOTest.java
+++ b/server/src/test/java/org/candlepin/model/dto/CandlepinDTOTest.java
@@ -14,6 +14,13 @@
  */
 package org.candlepin.model.dto;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
 import org.candlepin.model.AbstractHibernateObject;
 import org.candlepin.test.TestUtil;
 import org.candlepin.util.Util;
@@ -27,13 +34,6 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.stream.Stream;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Test suite for the CandlepinDTO class

--- a/server/src/test/java/org/candlepin/model/dto/ContentDataTest.java
+++ b/server/src/test/java/org/candlepin/model/dto/ContentDataTest.java
@@ -14,6 +14,15 @@
  */
 package org.candlepin.model.dto;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.candlepin.model.Content;
 import org.candlepin.util.Util;
 
@@ -26,15 +35,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test suite for the ContentData class

--- a/server/src/test/java/org/candlepin/model/dto/ProductContentDataTest.java
+++ b/server/src/test/java/org/candlepin/model/dto/ProductContentDataTest.java
@@ -14,6 +14,13 @@
  */
 package org.candlepin.model.dto;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
 import org.candlepin.model.Content;
 import org.candlepin.model.ProductContent;
 import org.candlepin.util.Util;
@@ -25,13 +32,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.stream.Stream;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Test suite for the ProductContentData class

--- a/server/src/test/java/org/candlepin/model/dto/ProductDataTest.java
+++ b/server/src/test/java/org/candlepin/model/dto/ProductDataTest.java
@@ -14,6 +14,15 @@
  */
 package org.candlepin.model.dto;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.candlepin.common.jackson.DynamicPropertyFilter;
 import org.candlepin.model.Branding;
 import org.candlepin.model.Content;
@@ -37,15 +46,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test suite for the ProductData class

--- a/server/src/test/java/org/candlepin/pki/ProviderBasedPrivateKeyReaderTest.java
+++ b/server/src/test/java/org/candlepin/pki/ProviderBasedPrivateKeyReaderTest.java
@@ -14,6 +14,8 @@
  */
 package org.candlepin.pki;
 
+import static org.junit.Assert.assertEquals;
+
 import org.candlepin.pki.impl.JSSPrivateKeyReader;
 import org.candlepin.pki.impl.ProviderBasedPrivateKeyReader;
 
@@ -41,8 +43,6 @@ import java.lang.reflect.Constructor;
 import java.security.PrivateKey;
 import java.security.Provider;
 import java.util.Arrays;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * Test ProviderBasedPrivateKeyReader

--- a/server/src/test/java/org/candlepin/pki/SubjectKeyIdentifierWriterTest.java
+++ b/server/src/test/java/org/candlepin/pki/SubjectKeyIdentifierWriterTest.java
@@ -15,11 +15,11 @@
 
 package org.candlepin.pki;
 
+import static org.junit.Assert.assertArrayEquals;
+
 import org.candlepin.pki.impl.DefaultSubjectKeyIdentifierWriter;
 
 import org.junit.Test;
-
-import static org.junit.Assert.assertArrayEquals;
 
 public class SubjectKeyIdentifierWriterTest {
 

--- a/server/src/test/java/org/candlepin/pki/impl/DefaultSubjectKeyIdentifierWriterTest.java
+++ b/server/src/test/java/org/candlepin/pki/impl/DefaultSubjectKeyIdentifierWriterTest.java
@@ -14,14 +14,14 @@
  */
 package org.candlepin.pki.impl;
 
+import static org.junit.Assert.assertArrayEquals;
+
 import org.bouncycastle.cert.jcajce.JcaX509ExtensionUtils;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
-
-import static org.junit.Assert.assertArrayEquals;
 
 
 public class DefaultSubjectKeyIdentifierWriterTest {

--- a/server/src/test/java/org/candlepin/pki/impl/JSSPKIUtilityTest.java
+++ b/server/src/test/java/org/candlepin/pki/impl/JSSPKIUtilityTest.java
@@ -14,6 +14,11 @@
  */
 package org.candlepin.pki.impl;
 
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.candlepin.common.config.Configuration;
 import org.candlepin.config.CandlepinCommonTestConfig;
 import org.candlepin.config.ConfigProperties;
@@ -85,11 +90,6 @@ import java.util.List;
 import java.util.Set;
 
 import javax.inject.Inject;
-
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 
 /** Unit tests for JSSPKIUtility */

--- a/server/src/test/java/org/candlepin/policy/AutobindRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/AutobindRulesTest.java
@@ -14,6 +14,14 @@
  */
 package org.candlepin.policy;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.common.config.Configuration;
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.dto.ModelTranslator;
@@ -69,14 +77,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.when;
 
 /**
  * AutobindRulesTest

--- a/server/src/test/java/org/candlepin/policy/CriteriaRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/CriteriaRulesTest.java
@@ -14,6 +14,8 @@
  */
 package org.candlepin.policy;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerType;
 import org.candlepin.model.GuestId;
@@ -33,8 +35,6 @@ import org.mockito.quality.Strictness;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
 

--- a/server/src/test/java/org/candlepin/policy/EnforcerTest.java
+++ b/server/src/test/java/org/candlepin/policy/EnforcerTest.java
@@ -14,6 +14,13 @@
  */
 package org.candlepin.policy;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.audit.EventFactory;
 import org.candlepin.audit.EventSink;
 import org.candlepin.common.config.Configuration;
@@ -67,13 +74,6 @@ import java.util.Map;
 import java.util.Set;
 
 import javax.inject.Inject;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class EnforcerTest extends DatabaseTestFixture {
     @Inject private I18n i18n;

--- a/server/src/test/java/org/candlepin/policy/ExportRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/ExportRulesTest.java
@@ -14,6 +14,12 @@
  */
 package org.candlepin.policy;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerType;
 import org.candlepin.model.ConsumerTypeCurator;
@@ -36,12 +42,6 @@ import java.io.InputStream;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 
 

--- a/server/src/test/java/org/candlepin/policy/PoolRulesInstanceTest.java
+++ b/server/src/test/java/org/candlepin/policy/PoolRulesInstanceTest.java
@@ -14,6 +14,12 @@
  */
 package org.candlepin.policy;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.common.config.Configuration;
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.controller.PoolManager;
@@ -42,12 +48,6 @@ import java.io.InputStream;
 import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.when;
 
 
 

--- a/server/src/test/java/org/candlepin/policy/PoolRulesStackDerivedTest.java
+++ b/server/src/test/java/org/candlepin/policy/PoolRulesStackDerivedTest.java
@@ -14,6 +14,17 @@
  */
 package org.candlepin.policy;
 
+import static org.hamcrest.Matchers.hasItems;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.AdditionalAnswers.returnsFirstArg;
+import static org.mockito.Mockito.anyListOf;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.auth.UserPrincipal;
 import org.candlepin.bind.PoolOperationCallback;
 import org.candlepin.common.config.Configuration;
@@ -56,17 +67,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import static org.hamcrest.Matchers.hasItems;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.AdditionalAnswers.returnsFirstArg;
-import static org.mockito.Mockito.anyListOf;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 
 

--- a/server/src/test/java/org/candlepin/policy/PoolRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/PoolRulesTest.java
@@ -14,6 +14,14 @@
  */
 package org.candlepin.policy;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.auth.UserPrincipal;
 import org.candlepin.common.config.Configuration;
 import org.candlepin.config.ConfigProperties;
@@ -50,14 +58,6 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 
 

--- a/server/src/test/java/org/candlepin/policy/RulesVersionMatchingTest.java
+++ b/server/src/test/java/org/candlepin/policy/RulesVersionMatchingTest.java
@@ -14,6 +14,8 @@
  */
 package org.candlepin.policy;
 
+import static org.junit.Assert.assertEquals;
+
 import org.candlepin.model.Rules;
 import org.candlepin.policy.js.RuleParseException;
 
@@ -24,8 +26,6 @@ import org.junit.runners.Parameterized.Parameters;
 
 import java.util.Arrays;
 import java.util.Collection;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * RulesVersionmatchingTest

--- a/server/src/test/java/org/candlepin/policy/SystemPurposeComplianceRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/SystemPurposeComplianceRulesTest.java
@@ -14,6 +14,12 @@
  */
 package org.candlepin.policy;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.audit.EventSink;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerCurator;
@@ -41,12 +47,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.when;
 
 /**
  * Tests for SystemPurposeComplianceRules

--- a/server/src/test/java/org/candlepin/policy/ValidationResultTest.java
+++ b/server/src/test/java/org/candlepin/policy/ValidationResultTest.java
@@ -14,15 +14,15 @@
  */
 package org.candlepin.policy;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * ValidationResultTest

--- a/server/src/test/java/org/candlepin/policy/ValidationWarningTest.java
+++ b/server/src/test/java/org/candlepin/policy/ValidationWarningTest.java
@@ -14,9 +14,9 @@
  */
 package org.candlepin.policy;
 
-import org.junit.Test;
-
 import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
 
 
 /**

--- a/server/src/test/java/org/candlepin/policy/activationkey/ActivationKeyRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/activationkey/ActivationKeyRulesTest.java
@@ -14,6 +14,9 @@
  */
 package org.candlepin.policy.activationkey;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.candlepin.model.Owner;
 import org.candlepin.model.Pool;
 import org.candlepin.model.Product;
@@ -28,9 +31,6 @@ import org.xnap.commons.i18n.I18n;
 import org.xnap.commons.i18n.I18nFactory;
 
 import java.util.Locale;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * ActivationKeyRulesTest

--- a/server/src/test/java/org/candlepin/policy/js/JsRunnerProviderTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/JsRunnerProviderTest.java
@@ -14,6 +14,11 @@
  */
 package org.candlepin.policy.js;
 
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.model.Rules;
 import org.candlepin.model.Rules.RulesSourceEnum;
 import org.candlepin.model.RulesCurator;
@@ -29,11 +34,6 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.Date;
-
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
 /**
  * JsRunnerProviderTest
  */

--- a/server/src/test/java/org/candlepin/policy/js/RulesObjectMapperTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/RulesObjectMapperTest.java
@@ -14,6 +14,8 @@
  */
 package org.candlepin.policy.js;
 
+import static org.junit.Assert.assertFalse;
+
 import org.candlepin.jackson.ProductCachedSerializationModule;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.Entitlement;
@@ -38,8 +40,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import static org.junit.Assert.assertFalse;
 
 
 

--- a/server/src/test/java/org/candlepin/policy/js/compliance/ComplianceRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/compliance/ComplianceRulesTest.java
@@ -14,6 +14,18 @@
  */
 package org.candlepin.policy.js.compliance;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.audit.EventSink;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.dto.StandardTranslator;
@@ -64,18 +76,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 
 

--- a/server/src/test/java/org/candlepin/policy/js/compliance/StatusReasonMessageGeneratorTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/compliance/StatusReasonMessageGeneratorTest.java
@@ -14,6 +14,8 @@
  */
 package org.candlepin.policy.js.compliance;
 
+import static org.junit.Assert.assertEquals;
+
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerInstalledProduct;
 import org.candlepin.model.ConsumerType;
@@ -34,8 +36,6 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * StatusReasonMessageGeneratorTest

--- a/server/src/test/java/org/candlepin/policy/js/compliance/hash/ComplianceStatusHasherTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/compliance/hash/ComplianceStatusHasherTest.java
@@ -15,6 +15,11 @@
 
 package org.candlepin.policy.js.compliance.hash;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerInstalledProduct;
 import org.candlepin.model.ConsumerType;
@@ -35,11 +40,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
 
 public class ComplianceStatusHasherTest {
 

--- a/server/src/test/java/org/candlepin/policy/js/entitlement/EntitlementRulesTestFixture.java
+++ b/server/src/test/java/org/candlepin/policy/js/entitlement/EntitlementRulesTestFixture.java
@@ -14,6 +14,12 @@
  */
 package org.candlepin.policy.js.entitlement;
 
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.audit.EventFactory;
 import org.candlepin.audit.EventSink;
 import org.candlepin.common.config.Configuration;
@@ -62,12 +68,6 @@ import org.xnap.commons.i18n.I18nFactory;
 
 import java.io.InputStream;
 import java.util.Locale;
-
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyBoolean;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.when;
 
 public class EntitlementRulesTestFixture {
     protected Enforcer enforcer;

--- a/server/src/test/java/org/candlepin/policy/js/entitlement/HostedVirtLimitEntitlementRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/entitlement/HostedVirtLimitEntitlementRulesTest.java
@@ -14,6 +14,18 @@
  */
 package org.candlepin.policy.js.entitlement;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.bind.PoolOperationCallback;
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.controller.PoolManager;
@@ -36,18 +48,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyInt;
-import static org.mockito.Mockito.anyLong;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * HostedVirtLimitEntitlementRulesTest: Complex tests around the hosted virt limit

--- a/server/src/test/java/org/candlepin/policy/js/entitlement/ManifestEntitlementRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/entitlement/ManifestEntitlementRulesTest.java
@@ -15,6 +15,12 @@
 package org.candlepin.policy.js.entitlement;
 
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.controller.PoolManager;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerCapability;
@@ -36,12 +42,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * ManifestEntitlementRulesTest

--- a/server/src/test/java/org/candlepin/policy/js/entitlement/PostEntitlementRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/entitlement/PostEntitlementRulesTest.java
@@ -14,6 +14,14 @@
  */
 package org.candlepin.policy.js.entitlement;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.bind.PoolOperationCallback;
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.model.ConsumerType;
@@ -28,14 +36,6 @@ import org.junit.Test;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyInt;
-import static org.mockito.Mockito.anyLong;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * PostEntitlementRulesTest: Tests for post-entitlement rules, as well as the post-unbind

--- a/server/src/test/java/org/candlepin/policy/js/entitlement/PreEntitlementRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/entitlement/PreEntitlementRulesTest.java
@@ -14,6 +14,11 @@
  */
 package org.candlepin.policy.js.entitlement;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerType;
@@ -35,11 +40,6 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.when;
 
 /**
  * PreEntitlementRulesTest

--- a/server/src/test/java/org/candlepin/policy/js/pool/PoolHelperTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/pool/PoolHelperTest.java
@@ -14,6 +14,16 @@
  */
 package org.candlepin.policy.js.pool;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.AdditionalAnswers.returnsFirstArg;
+import static org.mockito.Mockito.anyListOf;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.bind.PoolOperationCallback;
 import org.candlepin.common.config.Configuration;
 import org.candlepin.config.ConfigProperties;
@@ -39,16 +49,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.AdditionalAnswers.returnsFirstArg;
-import static org.mockito.Mockito.anyListOf;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * PoolHelperTest

--- a/server/src/test/java/org/candlepin/policy/js/quantity/QuantityRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/quantity/QuantityRulesTest.java
@@ -14,6 +14,11 @@
  */
 package org.candlepin.policy.js.quantity;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.dto.StandardTranslator;
 import org.candlepin.dto.rules.v1.SuggestedQuantityDTO;
@@ -54,11 +59,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.when;
 
 /**
  * QuantityRulesTest

--- a/server/src/test/java/org/candlepin/resource/ActivationKeyContentOverrideResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/ActivationKeyContentOverrideResourceTest.java
@@ -14,6 +14,11 @@
  */
 package org.candlepin.resource;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.auth.Access;
 import org.candlepin.auth.Principal;
 import org.candlepin.auth.SubResource;
@@ -43,11 +48,6 @@ import java.util.stream.Collectors;
 
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.UriInfo;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.when;
 
 
 

--- a/server/src/test/java/org/candlepin/resource/ActivationKeyResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/ActivationKeyResourceTest.java
@@ -14,6 +14,14 @@
  */
 package org.candlepin.resource;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.common.exceptions.BadRequestException;
 import org.candlepin.controller.PoolManager;
 import org.candlepin.dto.api.v1.ActivationKeyDTO;
@@ -43,14 +51,6 @@ import java.util.HashSet;
 import java.util.Set;
 
 import javax.inject.Inject;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * ActivationKeyResourceTest

--- a/server/src/test/java/org/candlepin/resource/AdminResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/AdminResourceTest.java
@@ -14,6 +14,12 @@
  */
 package org.candlepin.resource;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.common.config.Configuration;
 import org.candlepin.model.User;
 import org.candlepin.model.UserCurator;
@@ -24,12 +30,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import javax.inject.Inject;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * AdminResourceTest

--- a/server/src/test/java/org/candlepin/resource/CertificateSerialResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/CertificateSerialResourceTest.java
@@ -14,6 +14,13 @@
  */
 package org.candlepin.resource;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.TestingModules;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.dto.api.v1.CertificateSerialDTO;
@@ -28,13 +35,6 @@ import com.google.inject.Injector;
 
 import org.junit.Before;
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 
 

--- a/server/src/test/java/org/candlepin/resource/ConsumerContentOverrideResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerContentOverrideResourceTest.java
@@ -14,6 +14,11 @@
  */
 package org.candlepin.resource;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.auth.Access;
 import org.candlepin.auth.Principal;
 import org.candlepin.auth.SubResource;
@@ -43,11 +48,6 @@ import java.util.stream.Collectors;
 
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.UriInfo;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.when;
 
 
 

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceCreationTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceCreationTest.java
@@ -14,6 +14,13 @@
  */
 package org.candlepin.resource;
 
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.async.JobManager;
 import org.candlepin.audit.EventFactory;
 import org.candlepin.audit.EventSink;
@@ -92,13 +99,6 @@ import java.util.List;
 import java.util.Locale;
 
 import javax.inject.Provider;
-
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyBoolean;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 
 

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceDisableStatusTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceDisableStatusTest.java
@@ -14,6 +14,9 @@
  */
 package org.candlepin.resource;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import org.candlepin.dto.api.v1.ComplianceStatusDTO;
 import org.candlepin.dto.api.v1.SystemPurposeComplianceStatusDTO;
 import org.candlepin.model.Consumer;
@@ -34,9 +37,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import javax.inject.Inject;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 /**
  * ConsumerResourceEntitlementRulesTest

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceEntitlementRulesTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceEntitlementRulesTest.java
@@ -14,6 +14,8 @@
  */
 package org.candlepin.resource;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.candlepin.async.JobException;
 import org.candlepin.common.exceptions.ForbiddenException;
 import org.candlepin.model.Consumer;
@@ -38,8 +40,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import javax.inject.Inject;
-
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * ConsumerResourceEntitlementRulesTest

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
@@ -14,6 +14,16 @@
  */
 package org.candlepin.resource;
 
+import static org.candlepin.test.TestUtil.createConsumerDTO;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
 import org.candlepin.async.JobException;
 import org.candlepin.async.JobManager;
 import org.candlepin.auth.Access;
@@ -82,16 +92,6 @@ import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.core.Response;
-
-import static org.candlepin.test.TestUtil.createConsumerDTO;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
 
 
 

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
@@ -14,6 +14,23 @@
  */
 package org.candlepin.resource;
 
+import static org.candlepin.test.TestUtil.createIdCert;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.nullable;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.async.JobManager;
 import org.candlepin.audit.Event.Target;
 import org.candlepin.audit.Event.Type;
@@ -120,23 +137,6 @@ import java.util.Set;
 import javax.inject.Provider;
 import javax.persistence.OptimisticLockException;
 import javax.ws.rs.core.Response;
-
-import static org.candlepin.test.TestUtil.createIdCert;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyBoolean;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.nullable;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 
 

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
@@ -14,6 +14,23 @@
  */
 package org.candlepin.resource;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.atMost;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.nullable;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.async.JobManager;
 import org.candlepin.audit.Event;
 import org.candlepin.audit.Event.Target;
@@ -93,23 +110,6 @@ import java.util.Locale;
 import java.util.Set;
 
 import javax.inject.Provider;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyBoolean;
-import static org.mockito.Mockito.atMost;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.nullable;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 
 

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceVirtEntitlementTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceVirtEntitlementTest.java
@@ -14,6 +14,9 @@
  */
 package org.candlepin.resource;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.candlepin.async.JobException;
 import org.candlepin.common.config.Configuration;
 import org.candlepin.config.CandlepinCommonTestConfig;
@@ -46,9 +49,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.inject.Inject;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 

--- a/server/src/test/java/org/candlepin/resource/ConsumerTypeResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerTypeResourceTest.java
@@ -14,6 +14,11 @@
  */
 package org.candlepin.resource;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.candlepin.common.exceptions.BadRequestException;
 import org.candlepin.common.exceptions.NotFoundException;
 import org.candlepin.dto.api.v1.ConsumerTypeDTO;
@@ -24,11 +29,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import javax.inject.Inject;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 
 

--- a/server/src/test/java/org/candlepin/resource/ContentResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/ContentResourceTest.java
@@ -14,6 +14,16 @@
  */
 package org.candlepin.resource;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.common.exceptions.BadRequestException;
 import org.candlepin.common.exceptions.NotFoundException;
 import org.candlepin.controller.PoolManager;
@@ -38,16 +48,6 @@ import org.xnap.commons.i18n.I18nFactory;
 
 import java.util.Arrays;
 import java.util.Locale;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyLong;
-import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 
 

--- a/server/src/test/java/org/candlepin/resource/CrlResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/CrlResourceTest.java
@@ -14,6 +14,16 @@
  */
 package org.candlepin.resource;
 
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyCollection;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.nullable;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.common.config.Configuration;
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.model.CandlepinQuery;
@@ -33,16 +43,6 @@ import java.io.File;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
-
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyCollection;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.nullable;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
 
 
 

--- a/server/src/test/java/org/candlepin/resource/EntitlementFinderUtilTest.java
+++ b/server/src/test/java/org/candlepin/resource/EntitlementFinderUtilTest.java
@@ -14,12 +14,12 @@
  */
 package org.candlepin.resource;
 
+import static org.junit.Assert.assertEquals;
+
 import org.candlepin.model.EntitlementFilterBuilder;
 import org.candlepin.resource.util.EntitlementFinderUtil;
 
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
 
 
 public class EntitlementFinderUtilTest {

--- a/server/src/test/java/org/candlepin/resource/EntitlementResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/EntitlementResourceTest.java
@@ -14,6 +14,16 @@
  */
 package org.candlepin.resource;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.isA;
+import static org.mockito.Mockito.nullable;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.async.JobManager;
 import org.candlepin.common.exceptions.BadRequestException;
 import org.candlepin.common.exceptions.NotFoundException;
@@ -56,16 +66,6 @@ import org.xnap.commons.i18n.I18nFactory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyBoolean;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.isA;
-import static org.mockito.Mockito.nullable;
-import static org.mockito.Mockito.when;
 
 
 

--- a/server/src/test/java/org/candlepin/resource/GuestIdResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/GuestIdResourceTest.java
@@ -14,6 +14,18 @@
  */
 package org.candlepin.resource;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.nullable;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.async.JobManager;
 import org.candlepin.audit.EventFactory;
 import org.candlepin.audit.EventSink;
@@ -59,18 +71,6 @@ import java.util.List;
 import java.util.Locale;
 
 import javax.inject.Provider;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.nullable;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 
 

--- a/server/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
@@ -14,6 +14,16 @@
  */
 package org.candlepin.resource;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.async.JobManager;
 import org.candlepin.audit.Event.Target;
 import org.candlepin.audit.Event.Type;
@@ -82,16 +92,6 @@ import java.util.Map;
 import java.util.Set;
 
 import javax.inject.Provider;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyBoolean;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class HypervisorResourceTest {

--- a/server/src/test/java/org/candlepin/resource/JobResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/JobResourceTest.java
@@ -14,6 +14,22 @@
  */
 package org.candlepin.resource;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
 import org.candlepin.async.JobConfig;
 import org.candlepin.async.JobException;
 import org.candlepin.async.JobManager;
@@ -63,22 +79,6 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.clearInvocations;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 
 

--- a/server/src/test/java/org/candlepin/resource/OwnerContentResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/OwnerContentResourceTest.java
@@ -14,6 +14,13 @@
  */
 package org.candlepin.resource;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.candlepin.common.exceptions.ForbiddenException;
 import org.candlepin.common.exceptions.NotFoundException;
 import org.candlepin.controller.ContentManager;
@@ -36,13 +43,6 @@ import java.util.Arrays;
 import java.util.Collection;
 
 import javax.inject.Inject;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 

--- a/server/src/test/java/org/candlepin/resource/OwnerProductResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/OwnerProductResourceTest.java
@@ -14,6 +14,15 @@
  */
 package org.candlepin.resource;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.async.JobManager;
 import org.candlepin.common.exceptions.BadRequestException;
 import org.candlepin.common.exceptions.ForbiddenException;
@@ -42,15 +51,6 @@ import java.util.Locale;
 import java.util.Set;
 
 import javax.inject.Inject;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 
 

--- a/server/src/test/java/org/candlepin/resource/OwnerResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/OwnerResourceTest.java
@@ -14,6 +14,21 @@
  */
 package org.candlepin.resource;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.async.JobConfig;
 import org.candlepin.async.JobException;
 import org.candlepin.async.JobManager;
@@ -113,21 +128,6 @@ import javax.inject.Inject;
 import javax.persistence.PersistenceException;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.MultivaluedMap;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 
 /**

--- a/server/src/test/java/org/candlepin/resource/OwnerResourceUeberCertOperationsTest.java
+++ b/server/src/test/java/org/candlepin/resource/OwnerResourceUeberCertOperationsTest.java
@@ -14,6 +14,12 @@
  */
 package org.candlepin.resource;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
 import org.candlepin.async.JobManager;
 import org.candlepin.auth.Principal;
 import org.candlepin.auth.UserPrincipal;
@@ -36,12 +42,6 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 
 import javax.inject.Inject;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
 
 /**
  * OwnerResourceUeberCertOperationsTest

--- a/server/src/test/java/org/candlepin/resource/PersonConsumerResourceCreationLiberalNameRules.java
+++ b/server/src/test/java/org/candlepin/resource/PersonConsumerResourceCreationLiberalNameRules.java
@@ -14,6 +14,8 @@
  */
 package org.candlepin.resource;
 
+import static org.mockito.Mockito.when;
+
 import org.candlepin.auth.Access;
 import org.candlepin.auth.permissions.PermissionFactory.PermissionType;
 import org.candlepin.common.exceptions.BadRequestException;
@@ -24,8 +26,6 @@ import org.candlepin.model.Role;
 import org.candlepin.model.User;
 
 import org.junit.Test;
-
-import static org.mockito.Mockito.when;
 
 
 

--- a/server/src/test/java/org/candlepin/resource/PersonConsumerResourceCreationTest.java
+++ b/server/src/test/java/org/candlepin/resource/PersonConsumerResourceCreationTest.java
@@ -14,6 +14,8 @@
  */
 package org.candlepin.resource;
 
+import static org.mockito.Mockito.when;
+
 import org.candlepin.auth.Access;
 import org.candlepin.auth.permissions.PermissionFactory.PermissionType;
 import org.candlepin.common.exceptions.BadRequestException;
@@ -24,8 +26,6 @@ import org.candlepin.model.Role;
 import org.candlepin.model.User;
 
 import org.junit.Test;
-
-import static org.mockito.Mockito.when;
 
 
 

--- a/server/src/test/java/org/candlepin/resource/PoolResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/PoolResourceTest.java
@@ -14,6 +14,14 @@
  */
 package org.candlepin.resource;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.argThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
 import org.candlepin.auth.Access;
 import org.candlepin.auth.ConsumerPrincipal;
 import org.candlepin.auth.Principal;
@@ -41,14 +49,6 @@ import java.util.Date;
 import java.util.List;
 
 import javax.inject.Inject;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.argThat;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 
 

--- a/server/src/test/java/org/candlepin/resource/ProductResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/ProductResourceTest.java
@@ -14,6 +14,18 @@
  */
 package org.candlepin.resource;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyObject;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.async.JobConfig;
 import org.candlepin.async.JobConfigValidationException;
 import org.candlepin.async.JobException;
@@ -56,18 +68,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyObject;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 
 

--- a/server/src/test/java/org/candlepin/resource/RootResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/RootResourceTest.java
@@ -14,6 +14,8 @@
  */
 package org.candlepin.resource;
 
+import static org.junit.Assert.assertEquals;
+
 import org.candlepin.common.util.SuppressSwaggerCheck;
 import org.candlepin.config.CandlepinCommonTestConfig;
 import org.candlepin.dto.api.v1.Link;
@@ -24,8 +26,6 @@ import org.junit.Test;
 import java.lang.reflect.Method;
 
 import javax.ws.rs.Path;
-
-import static org.junit.Assert.assertEquals;
 
 
 /**

--- a/server/src/test/java/org/candlepin/resource/RulesResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/RulesResourceTest.java
@@ -14,6 +14,8 @@
  */
 package org.candlepin.resource;
 
+import static org.junit.Assert.assertEquals;
+
 import org.candlepin.model.Rules;
 import org.candlepin.model.RulesCurator;
 import org.candlepin.test.DatabaseTestFixture;
@@ -23,8 +25,6 @@ import org.apache.commons.codec.binary.Base64;
 import org.junit.jupiter.api.Test;
 
 import javax.inject.Inject;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * RulesResourceTest

--- a/server/src/test/java/org/candlepin/resource/StatusResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/StatusResourceTest.java
@@ -14,6 +14,16 @@
  */
 package org.candlepin.resource;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.auth.KeycloakConfiguration;
 import org.candlepin.cache.CandlepinCache;
 import org.candlepin.cache.StatusCache;
@@ -49,16 +59,6 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.PrintStream;
 import java.util.ArrayList;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 
 

--- a/server/src/test/java/org/candlepin/resource/SubscriptionResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/SubscriptionResourceTest.java
@@ -14,6 +14,12 @@
  */
 package org.candlepin.resource;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.common.exceptions.BadRequestException;
 import org.candlepin.common.exceptions.NotFoundException;
 import org.candlepin.controller.PoolManager;
@@ -36,12 +42,6 @@ import java.util.Locale;
 
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.core.Response;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 
 

--- a/server/src/test/java/org/candlepin/resource/UserResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/UserResourceTest.java
@@ -14,6 +14,13 @@
  */
 package org.candlepin.resource;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.candlepin.auth.Access;
 import org.candlepin.auth.Principal;
 import org.candlepin.auth.UserPrincipal;
@@ -42,13 +49,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.inject.Inject;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 

--- a/server/src/test/java/org/candlepin/resource/util/CalculatedAttributesUtilTest.java
+++ b/server/src/test/java/org/candlepin/resource/util/CalculatedAttributesUtilTest.java
@@ -14,6 +14,11 @@
  */
 package org.candlepin.resource.util;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.dto.rules.v1.SuggestedQuantityDTO;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.Owner;
@@ -40,11 +45,6 @@ import java.util.Locale;
 import java.util.Map;
 
 import javax.inject.Inject;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.when;
 
 /**
  * CalculatedAttributesUtilTest

--- a/server/src/test/java/org/candlepin/resource/util/ConsumerBindUtilTest.java
+++ b/server/src/test/java/org/candlepin/resource/util/ConsumerBindUtilTest.java
@@ -14,6 +14,11 @@
  */
 package org.candlepin.resource.util;
 
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.common.exceptions.BadRequestException;
 import org.candlepin.common.exceptions.ForbiddenException;
 import org.candlepin.controller.Entitler;
@@ -46,11 +51,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
-
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 
 /**

--- a/server/src/test/java/org/candlepin/resource/util/InstalledProductStatusCalculatorTest.java
+++ b/server/src/test/java/org/candlepin/resource/util/InstalledProductStatusCalculatorTest.java
@@ -14,6 +14,15 @@
  */
 package org.candlepin.resource.util;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyCollection;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.audit.EventSink;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.dto.StandardTranslator;
@@ -74,15 +83,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyCollection;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 
 

--- a/server/src/test/java/org/candlepin/resource/util/ResourceDateParserTest.java
+++ b/server/src/test/java/org/candlepin/resource/util/ResourceDateParserTest.java
@@ -14,6 +14,9 @@
  */
 package org.candlepin.resource.util;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import org.candlepin.common.exceptions.BadRequestException;
 
 import org.junit.Test;
@@ -21,9 +24,6 @@ import org.junit.Test;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.TimeZone;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 /**
  * ResourceDateParserTest

--- a/server/src/test/java/org/candlepin/resteasy/JsonProviderTest.java
+++ b/server/src/test/java/org/candlepin/resteasy/JsonProviderTest.java
@@ -14,6 +14,11 @@
  */
 package org.candlepin.resteasy;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import org.candlepin.common.config.Configuration;
 import org.candlepin.jackson.ProductCachedSerializationModule;
 import org.candlepin.model.ProductCurator;
@@ -38,11 +43,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.ws.rs.core.MediaType;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 
 

--- a/server/src/test/java/org/candlepin/resteasy/filter/AuthenticationFilterTest.java
+++ b/server/src/test/java/org/candlepin/resteasy/filter/AuthenticationFilterTest.java
@@ -14,6 +14,17 @@
  */
 package org.candlepin.resteasy.filter;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.auth.CandlepinKeycloakRequestAuthenticator;
 import org.candlepin.auth.KeycloakConfiguration;
 import org.candlepin.auth.KeycloakOIDCFacade;
@@ -63,17 +74,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Path;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ResourceInfo;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * AuthInterceptorTest

--- a/server/src/test/java/org/candlepin/resteasy/filter/AuthorizationFeatureTest.java
+++ b/server/src/test/java/org/candlepin/resteasy/filter/AuthorizationFeatureTest.java
@@ -14,6 +14,12 @@
  */
 package org.candlepin.resteasy.filter;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.auth.Verify;
 import org.candlepin.common.auth.SecurityHole;
 import org.candlepin.model.Consumer;
@@ -35,9 +41,6 @@ import java.lang.reflect.Method;
 import javax.ws.rs.Path;
 import javax.ws.rs.container.ResourceInfo;
 import javax.ws.rs.core.FeatureContext;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AuthorizationFeatureTest {

--- a/server/src/test/java/org/candlepin/resteasy/filter/CandlepinQueryInterceptorTest.java
+++ b/server/src/test/java/org/candlepin/resteasy/filter/CandlepinQueryInterceptorTest.java
@@ -14,6 +14,20 @@
  */
 package org.candlepin.resteasy.filter;
 
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.common.paging.PageRequest;
 import org.candlepin.model.Owner;
 import org.candlepin.resteasy.JsonProvider;
@@ -43,20 +57,6 @@ import java.util.stream.Stream;
 import javax.persistence.EntityManager;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.StreamingOutput;
-
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 public class CandlepinQueryInterceptorTest extends DatabaseTestFixture {
 

--- a/server/src/test/java/org/candlepin/resteasy/filter/ConsumerCheckInFilterTest.java
+++ b/server/src/test/java/org/candlepin/resteasy/filter/ConsumerCheckInFilterTest.java
@@ -14,6 +14,10 @@
  */
 package org.candlepin.resteasy.filter;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.auth.ConsumerPrincipal;
 import org.candlepin.auth.Principal;
 import org.candlepin.auth.UpdateConsumerCheckIn;
@@ -41,10 +45,6 @@ import javax.inject.Inject;
 import javax.ws.rs.Path;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ResourceInfo;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.mockito.Mockito.when;
 
 
 

--- a/server/src/test/java/org/candlepin/resteasy/filter/VerifyAuthorizationFilterTest.java
+++ b/server/src/test/java/org/candlepin/resteasy/filter/VerifyAuthorizationFilterTest.java
@@ -14,6 +14,10 @@
  */
 package org.candlepin.resteasy.filter;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.auth.Principal;
 import org.candlepin.auth.SSLAuth;
 import org.candlepin.auth.Verify;
@@ -63,10 +67,6 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ResourceInfo;
 import javax.ws.rs.core.UriInfo;
-
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)

--- a/server/src/test/java/org/candlepin/resteasy/parameter/KeyValueParameterTest.java
+++ b/server/src/test/java/org/candlepin/resteasy/parameter/KeyValueParameterTest.java
@@ -14,11 +14,11 @@
  */
 package org.candlepin.resteasy.parameter;
 
+import static org.junit.Assert.assertEquals;
+
 import org.candlepin.common.exceptions.CandlepinParameterParseException;
 
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * KeyValueParameterTest

--- a/server/src/test/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapterTest.java
+++ b/server/src/test/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapterTest.java
@@ -14,6 +14,24 @@
  */
 package org.candlepin.service.impl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.argThat;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.nullable;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.TestingModules;
 import org.candlepin.common.config.Configuration;
 import org.candlepin.model.CertificateSerial;
@@ -97,24 +115,6 @@ import java.util.StringTokenizer;
 import java.util.zip.InflaterOutputStream;
 
 import javax.inject.Inject;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyBoolean;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.argThat;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.nullable;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
-import static org.mockito.Mockito.when;
 
 /**
  * DefaultEntitlementCertServiceAdapter

--- a/server/src/test/java/org/candlepin/service/impl/DefaultIdentityCertServiceAdapterTest.java
+++ b/server/src/test/java/org/candlepin/service/impl/DefaultIdentityCertServiceAdapterTest.java
@@ -14,6 +14,16 @@
  */
 package org.candlepin.service.impl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.nullable;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.model.CertificateSerial;
 import org.candlepin.model.CertificateSerialCurator;
 import org.candlepin.model.Consumer;
@@ -43,16 +53,6 @@ import java.security.PublicKey;
 import java.security.cert.X509Certificate;
 import java.util.Date;
 import java.util.Set;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.nullable;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * DefaultIdentityCertServiceAdapterTest

--- a/server/src/test/java/org/candlepin/service/impl/DefaultProductServiceAdapterTest.java
+++ b/server/src/test/java/org/candlepin/service/impl/DefaultProductServiceAdapterTest.java
@@ -14,6 +14,23 @@
  */
 package org.candlepin.service.impl;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.AdditionalAnswers.returnsFirstArg;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.anyCollection;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.nullable;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.common.config.Configuration;
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.model.CandlepinQuery;
@@ -38,23 +55,6 @@ import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.util.ArrayList;
 import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.mockito.AdditionalAnswers.returnsFirstArg;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyBoolean;
-import static org.mockito.Mockito.anyCollection;
-import static org.mockito.Mockito.anyInt;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.nullable;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 
 // TODO: FIXME: Rewrite this test to not be so reliant upon mocks. It's making things incredibly brittle and

--- a/server/src/test/java/org/candlepin/service/impl/DefaultUserServiceAdapterTest.java
+++ b/server/src/test/java/org/candlepin/service/impl/DefaultUserServiceAdapterTest.java
@@ -14,6 +14,14 @@
  */
 package org.candlepin.service.impl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.auth.Access;
 import org.candlepin.model.Owner;
 import org.candlepin.model.PermissionBlueprintCurator;
@@ -36,14 +44,6 @@ import java.util.List;
 import java.util.Set;
 
 import javax.inject.Inject;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * DefaultUserServiceAdapterTest

--- a/server/src/test/java/org/candlepin/service/impl/ProductCertCreationTest.java
+++ b/server/src/test/java/org/candlepin/service/impl/ProductCertCreationTest.java
@@ -14,6 +14,10 @@
  */
 package org.candlepin.service.impl;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.candlepin.model.Owner;
 import org.candlepin.model.Product;
 import org.candlepin.pki.CertificateReader;
@@ -28,10 +32,6 @@ import com.google.inject.Module;
 import org.junit.jupiter.api.Test;
 
 import javax.inject.Inject;
-
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 

--- a/server/src/test/java/org/candlepin/servlet/filter/CandlepinPersistFilterTest.java
+++ b/server/src/test/java/org/candlepin/servlet/filter/CandlepinPersistFilterTest.java
@@ -14,6 +14,13 @@
  */
 package org.candlepin.servlet.filter;
 
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
 import com.google.inject.persist.UnitOfWork;
 
 import org.junit.Before;
@@ -26,13 +33,6 @@ import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
-
-import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 
 /**
  * CandlepinPersistFilterTest

--- a/server/src/test/java/org/candlepin/servlet/filter/CandlepinScopeFilterTest.java
+++ b/server/src/test/java/org/candlepin/servlet/filter/CandlepinScopeFilterTest.java
@@ -14,6 +14,12 @@
  */
 package org.candlepin.servlet.filter;
 
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
 import org.candlepin.guice.CandlepinRequestScope;
 
 import org.junit.Before;
@@ -24,12 +30,6 @@ import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
-import static org.junit.Assert.fail;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 
 /**
  * CandlepinScopeFilterTest

--- a/server/src/test/java/org/candlepin/sync/ConsumerExporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/ConsumerExporterTest.java
@@ -14,6 +14,10 @@
  */
 package org.candlepin.sync;
 
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.common.config.MapConfiguration;
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.dto.ModelTranslator;
@@ -35,10 +39,6 @@ import org.mockito.runners.MockitoJUnitRunner;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.HashMap;
-
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.when;
 
 /**
  * ConsumerExporterTest

--- a/server/src/test/java/org/candlepin/sync/ConsumerImporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/ConsumerImporterTest.java
@@ -14,6 +14,14 @@
  */
 package org.candlepin.sync;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.common.config.MapConfiguration;
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.dto.manifest.v1.ConsumerDTO;
@@ -41,14 +49,6 @@ import java.io.StringReader;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * ConsumerImporterTest

--- a/server/src/test/java/org/candlepin/sync/ConsumerTypeExporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/ConsumerTypeExporterTest.java
@@ -14,6 +14,8 @@
  */
 package org.candlepin.sync;
 
+import static org.junit.Assert.assertTrue;
+
 import org.candlepin.common.config.MapConfiguration;
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.dto.ModelTranslator;
@@ -34,8 +36,6 @@ import org.mockito.runners.MockitoJUnitRunner;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.HashMap;
-
-import static org.junit.Assert.assertTrue;
 
 /**
  * ConsumerTypeExporterTest

--- a/server/src/test/java/org/candlepin/sync/ConsumerTypeImporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/ConsumerTypeImporterTest.java
@@ -14,6 +14,12 @@
  */
 package org.candlepin.sync;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.common.config.Configuration;
 import org.candlepin.common.config.MapConfiguration;
 import org.candlepin.config.ConfigProperties;
@@ -28,12 +34,6 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.util.HashMap;
 import java.util.HashSet;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * ConsumerTypeImporterTest

--- a/server/src/test/java/org/candlepin/sync/EntitlementImporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/EntitlementImporterTest.java
@@ -14,6 +14,12 @@
  */
 package org.candlepin.sync;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.audit.EventSink;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.dto.StandardTranslator;
@@ -58,12 +64,6 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * EntitlementImporterTest

--- a/server/src/test/java/org/candlepin/sync/ExporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/ExporterTest.java
@@ -14,6 +14,16 @@
  */
 package org.candlepin.sync;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.auth.Principal;
 import org.candlepin.common.config.MapConfiguration;
 import org.candlepin.common.util.VersionUtil;
@@ -83,16 +93,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 
 // TODO: FIXME: Rewrite this test to not be so reliant upon mocks. It's making things incredibly brittle and

--- a/server/src/test/java/org/candlepin/sync/ImporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/ImporterTest.java
@@ -14,6 +14,21 @@
  */
 package org.candlepin.sync;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.audit.EventSink;
 import org.candlepin.common.config.MapConfiguration;
 import org.candlepin.config.CandlepinCommonTestConfig;
@@ -91,21 +106,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * ImporterTest

--- a/server/src/test/java/org/candlepin/sync/ImporterUtilsTest.java
+++ b/server/src/test/java/org/candlepin/sync/ImporterUtilsTest.java
@@ -14,6 +14,9 @@
  */
 package org.candlepin.sync;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import org.candlepin.dto.manifest.v1.CertificateDTO;
 import org.candlepin.dto.manifest.v1.CertificateSerialDTO;
 import org.candlepin.model.CdnCertificate;
@@ -26,9 +29,6 @@ import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.Date;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ImporterUtilsTest {

--- a/server/src/test/java/org/candlepin/sync/MetaExporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/MetaExporterTest.java
@@ -14,6 +14,8 @@
  */
 package org.candlepin.sync;
 
+import static org.junit.Assert.assertTrue;
+
 import org.candlepin.common.config.MapConfiguration;
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.test.TestUtil;
@@ -26,8 +28,6 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.util.Date;
 import java.util.HashMap;
-
-import static org.junit.Assert.assertTrue;
 
 /**
  * MetaExporterTest

--- a/server/src/test/java/org/candlepin/sync/ProductExporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/ProductExporterTest.java
@@ -14,6 +14,8 @@
  */
 package org.candlepin.sync;
 
+import static org.junit.Assert.assertTrue;
+
 import org.candlepin.common.config.MapConfiguration;
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.dto.StandardTranslator;
@@ -31,8 +33,6 @@ import org.junit.Test;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.HashMap;
-
-import static org.junit.Assert.assertTrue;
 
 /**
  * ProductExporterTest

--- a/server/src/test/java/org/candlepin/sync/ProductImporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/ProductImporterTest.java
@@ -14,6 +14,8 @@
  */
 package org.candlepin.sync;
 
+import static org.junit.Assert.assertEquals;
+
 import org.candlepin.common.config.MapConfiguration;
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.dto.manifest.v1.ContentDTO;
@@ -36,8 +38,6 @@ import java.io.Writer;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
 
 
 /**

--- a/server/src/test/java/org/candlepin/sync/RulesExporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/RulesExporterTest.java
@@ -14,6 +14,10 @@
  */
 package org.candlepin.sync;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.model.Rules;
 import org.candlepin.model.RulesCurator;
 
@@ -21,10 +25,6 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.io.StringWriter;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * RulesExporterTest

--- a/server/src/test/java/org/candlepin/sync/RulesImporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/RulesImporterTest.java
@@ -14,6 +14,11 @@
  */
 package org.candlepin.sync;
 
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.audit.EventSink;
 import org.candlepin.model.Rules;
 import org.candlepin.model.RulesCurator;
@@ -32,11 +37,6 @@ import java.io.IOException;
 import java.io.StringReader;
 
 import javax.inject.Inject;
-
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * RulesImporterTest

--- a/server/src/test/java/org/candlepin/sync/SubscriptionReconcilerTest.java
+++ b/server/src/test/java/org/candlepin/sync/SubscriptionReconcilerTest.java
@@ -14,6 +14,10 @@
  */
 package org.candlepin.sync;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.audit.EventSink;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.dto.StandardTranslator;
@@ -55,10 +59,6 @@ import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 
 

--- a/server/src/test/java/org/candlepin/test/DatabaseTestFixture.java
+++ b/server/src/test/java/org/candlepin/test/DatabaseTestFixture.java
@@ -14,6 +14,9 @@
  */
 package org.candlepin.test;
 
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.TestingInterceptor;
 import org.candlepin.TestingModules;
 import org.candlepin.auth.Access;
@@ -110,9 +113,6 @@ import javax.persistence.EntityManagerFactory;
 import javax.persistence.EntityTransaction;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.when;
 
 
 

--- a/server/src/test/java/org/candlepin/test/TestDateUtil.java
+++ b/server/src/test/java/org/candlepin/test/TestDateUtil.java
@@ -14,13 +14,13 @@
  */
 package org.candlepin.test;
 
+import static org.junit.Assert.assertEquals;
+
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Calendar;
 import java.util.Date;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * Utilitiy methods used in tests

--- a/server/src/test/java/org/candlepin/test/TestUtil.java
+++ b/server/src/test/java/org/candlepin/test/TestUtil.java
@@ -14,6 +14,11 @@
  */
 package org.candlepin.test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+
 import org.candlepin.auth.Access;
 import org.candlepin.auth.UserPrincipal;
 import org.candlepin.auth.permissions.OwnerPermission;
@@ -76,11 +81,6 @@ import java.util.Set;
 
 import javax.persistence.EntityManager;
 import javax.persistence.EntityTransaction;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doReturn;
 
 
 

--- a/server/src/test/java/org/candlepin/util/ArchTest.java
+++ b/server/src/test/java/org/candlepin/util/ArchTest.java
@@ -14,13 +14,13 @@
  */
 package org.candlepin.util;
 
-import org.junit.Test;
-
-import java.util.Set;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.util.Set;
 
 /**
  * ArchTest

--- a/server/src/test/java/org/candlepin/util/AttributeValidatorTest.java
+++ b/server/src/test/java/org/candlepin/util/AttributeValidatorTest.java
@@ -14,6 +14,9 @@
  */
 package org.candlepin.util;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.candlepin.common.config.Configuration;
 import org.candlepin.config.CandlepinCommonTestConfig;
 import org.candlepin.config.ConfigProperties;
@@ -29,9 +32,6 @@ import org.xnap.commons.i18n.I18nFactory;
 import java.util.Locale;
 
 import javax.inject.Provider;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 
 

--- a/server/src/test/java/org/candlepin/util/CollectionViewTest.java
+++ b/server/src/test/java/org/candlepin/util/CollectionViewTest.java
@@ -14,6 +14,10 @@
  */
 package org.candlepin.util;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -22,10 +26,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedList;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 
 

--- a/server/src/test/java/org/candlepin/util/ContentOverrideValidatorTest.java
+++ b/server/src/test/java/org/candlepin/util/ContentOverrideValidatorTest.java
@@ -14,6 +14,11 @@
  */
 package org.candlepin.util;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.when;
+
 import org.candlepin.common.config.Configuration;
 import org.candlepin.common.exceptions.BadRequestException;
 import org.candlepin.config.ConfigProperties;
@@ -35,11 +40,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.anyBoolean;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.when;
 
 /**
  * ContentOverrideValidatorTest

--- a/server/src/test/java/org/candlepin/util/CrlFileUtilTest.java
+++ b/server/src/test/java/org/candlepin/util/CrlFileUtilTest.java
@@ -14,6 +14,10 @@
  */
 package org.candlepin.util;
 
+import static org.candlepin.test.MatchesPattern.matchesPattern;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+
 import org.candlepin.TestingModules;
 import org.candlepin.common.config.Configuration;
 import org.candlepin.model.CertificateSerialCurator;
@@ -48,10 +52,6 @@ import java.util.HashSet;
 import java.util.Set;
 
 import javax.inject.Inject;
-
-import static org.candlepin.test.MatchesPattern.matchesPattern;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 
 /**
  * CrlFileUtilTest

--- a/server/src/test/java/org/candlepin/util/DateRangeTest.java
+++ b/server/src/test/java/org/candlepin/util/DateRangeTest.java
@@ -14,15 +14,15 @@
  */
 package org.candlepin.util;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.candlepin.test.TestDateUtil;
 
 import org.junit.Test;
 
 import java.util.Date;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 
 

--- a/server/src/test/java/org/candlepin/util/DateSourceImplTest.java
+++ b/server/src/test/java/org/candlepin/util/DateSourceImplTest.java
@@ -14,11 +14,11 @@
  */
 package org.candlepin.util;
 
+import static org.junit.Assert.assertTrue;
+
 import org.junit.Test;
 
 import java.util.Date;
-
-import static org.junit.Assert.assertTrue;
 
 /**
  * Test Class for the DateSourceImpl class

--- a/server/src/test/java/org/candlepin/util/FactValidatorTest.java
+++ b/server/src/test/java/org/candlepin/util/FactValidatorTest.java
@@ -14,6 +14,9 @@
  */
 package org.candlepin.util;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.candlepin.common.config.Configuration;
 import org.candlepin.config.CandlepinCommonTestConfig;
 import org.candlepin.config.ConfigProperties;
@@ -29,9 +32,6 @@ import org.xnap.commons.i18n.I18nFactory;
 import java.util.Locale;
 
 import javax.inject.Provider;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 
 

--- a/server/src/test/java/org/candlepin/util/ListViewTest.java
+++ b/server/src/test/java/org/candlepin/util/ListViewTest.java
@@ -14,6 +14,13 @@
  */
 package org.candlepin.util;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -25,13 +32,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test suite for the ListView class

--- a/server/src/test/java/org/candlepin/util/MapViewTest.java
+++ b/server/src/test/java/org/candlepin/util/MapViewTest.java
@@ -14,17 +14,17 @@
  */
 package org.candlepin.util;
 
-import org.junit.Before;
-import org.junit.Test;
-
-import java.util.HashMap;
-import java.util.Map;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
 
 
 

--- a/server/src/test/java/org/candlepin/util/PropertyUtilTest.java
+++ b/server/src/test/java/org/candlepin/util/PropertyUtilTest.java
@@ -14,13 +14,13 @@
  */
 package org.candlepin.util;
 
-import org.junit.Test;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
+import org.junit.Test;
 
 /**
  * PropertyUtilTest

--- a/server/src/test/java/org/candlepin/util/PropertyValidatorTest.java
+++ b/server/src/test/java/org/candlepin/util/PropertyValidatorTest.java
@@ -14,6 +14,9 @@
  */
 package org.candlepin.util;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.candlepin.util.PropertyValidator.Validator;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -29,9 +32,6 @@ import java.util.Locale;
 import java.util.Map;
 
 import javax.inject.Provider;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 
 

--- a/server/src/test/java/org/candlepin/util/RpmVersionComparatorTest.java
+++ b/server/src/test/java/org/candlepin/util/RpmVersionComparatorTest.java
@@ -14,13 +14,13 @@
  */
 package org.candlepin.util;
 
+import static org.junit.Assert.assertEquals;
+
 import org.candlepin.common.util.RpmVersionComparator;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * RpmVersionComparatorTest

--- a/server/src/test/java/org/candlepin/util/SetViewTest.java
+++ b/server/src/test/java/org/candlepin/util/SetViewTest.java
@@ -14,16 +14,16 @@
  */
 package org.candlepin.util;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.HashSet;
 import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
 
 
 /**

--- a/server/src/test/java/org/candlepin/util/TransactionalTest.java
+++ b/server/src/test/java/org/candlepin/util/TransactionalTest.java
@@ -14,15 +14,6 @@
  */
 package org.candlepin.util;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
-
-import javax.persistence.EntityManager;
-import javax.persistence.EntityTransaction;
-import javax.transaction.Status;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.any;
@@ -34,6 +25,15 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityTransaction;
+import javax.transaction.Status;
 
 
 

--- a/server/src/test/java/org/candlepin/util/UtilTest.java
+++ b/server/src/test/java/org/candlepin/util/UtilTest.java
@@ -14,6 +14,18 @@
  */
 package org.candlepin.util;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
@@ -39,18 +51,6 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
 
 
 /**

--- a/server/src/test/java/org/candlepin/util/VersionUtilTest.java
+++ b/server/src/test/java/org/candlepin/util/VersionUtilTest.java
@@ -14,6 +14,9 @@
  */
 package org.candlepin.util;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.candlepin.common.util.VersionUtil;
 import org.candlepin.model.Rules;
 
@@ -23,9 +26,6 @@ import org.junit.Test;
 import java.io.File;
 import java.io.PrintStream;
 import java.util.Map;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 /**
  * VersionUtilTest

--- a/server/src/test/java/org/candlepin/util/X509CRLEntryStreamTest.java
+++ b/server/src/test/java/org/candlepin/util/X509CRLEntryStreamTest.java
@@ -14,6 +14,10 @@
  */
 package org.candlepin.util;
 
+import static org.candlepin.test.MatchesPattern.matchesPattern;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import org.apache.commons.codec.binary.Base64InputStream;
 import org.apache.commons.io.FileUtils;
 import org.bouncycastle.asn1.x500.X500Name;
@@ -57,10 +61,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import static org.candlepin.test.MatchesPattern.matchesPattern;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Test implementations of X509CRLEntryStream

--- a/server/src/test/java/org/candlepin/util/X509CRLStreamWriterTest.java
+++ b/server/src/test/java/org/candlepin/util/X509CRLStreamWriterTest.java
@@ -14,6 +14,13 @@
  */
 package org.candlepin.util;
 
+import static org.candlepin.test.MatchesPattern.matchesPattern;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
 import org.apache.commons.io.FileUtils;
 import org.bouncycastle.asn1.ASN1Integer;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
@@ -68,13 +75,6 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
-
-import static org.candlepin.test.MatchesPattern.matchesPattern;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Test implementations of X509CRLStreamWriter

--- a/server/src/test/java/org/candlepin/util/X509V3ExtensionUtilTest.java
+++ b/server/src/test/java/org/candlepin/util/X509V3ExtensionUtilTest.java
@@ -14,6 +14,11 @@
  */
 package org.candlepin.util;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
 import org.candlepin.TestingModules;
 import org.candlepin.common.config.Configuration;
 import org.candlepin.model.Branding;
@@ -45,11 +50,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
 
 
 


### PR DESCRIPTION
This reverts a mistake in the previous checkstyle update & brings the
settings in alignment with the comments in our checkstyle definition.