### PR TITLE
Remove checkstyle from the root project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,6 @@ buildscript {
 plugins {
     id "io.spring.dependency-management" version "1.0.8.RELEASE"
     id "nebula.lint" version "11.5.0"
-    id "checkstyle"
 }
 
 version = "2.0"
@@ -213,9 +212,6 @@ subprojects {
 
 project(":api") {
     apply plugin: "org.openapi.generator"
-
-    // This project should only contain generated code.  No point in running checkstyle
-    checkstyle.sourceSets = []
 
     ext {
         api_spec_path = "${projectDir}/candlepin-api-spec.yaml"


### PR DESCRIPTION
Having checkstyle defined at the root even though we have no source that is
using it & no toolversion specified was causing errors when running dependency
analysis. Removing it fixes the dependencies tasks and removes the need for
masking in projects where we don't want it.