### PR TITLE
[M] ENT-2049: Use new hibernate session per job

### DIFF
--- a/server/src/main/java/org/candlepin/async/tasks/UndoImportsJob.java
+++ b/server/src/main/java/org/candlepin/async/tasks/UndoImportsJob.java
@@ -173,6 +173,8 @@ public class UndoImportsJob implements AsyncJob {
         // Clear out upstream ID so owner can import from other distributors:
         UpstreamConsumer uc = owner.getUpstreamConsumer();
         owner.setUpstreamConsumer(null);
+        owner = this.ownerCurator.merge(owner);
+        this.ownerCurator.flush();
 
         this.exportCurator.delete(metadata);
         this.recordManifestDeletion(owner, principalName, uc);

--- a/server/src/test/java/org/candlepin/async/JobMessageReceiverTest.java
+++ b/server/src/test/java/org/candlepin/async/JobMessageReceiverTest.java
@@ -40,6 +40,7 @@ import org.candlepin.model.AsyncJobStatus;
 import org.candlepin.model.AsyncJobStatus.JobState;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.persist.UnitOfWork;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -55,6 +56,7 @@ public class JobMessageReceiverTest {
     private Configuration config;
     private CPMSessionFactory cpmSessionFactory;
     private ObjectMapper mapper;
+    private UnitOfWork unitOfWork;
 
     // Collected state issued on a per-test basis
     private CPMSession session;
@@ -66,6 +68,7 @@ public class JobMessageReceiverTest {
         this.config = new CandlepinCommonTestConfig();
         this.jobManager = mock(JobManager.class);
         this.mapper = new ObjectMapper();
+        this.unitOfWork = mock(UnitOfWork.class);
 
         // Set the number of threads/consumers to 1 so we don't have to worry about
         // clobbering any collected state during consumer creation
@@ -140,7 +143,7 @@ public class JobMessageReceiverTest {
     private JobMessageReceiver buildJobMessageReceiver() {
         try {
             JobMessageReceiver receiver = new JobMessageReceiver(this.config, this.cpmSessionFactory,
-                this.mapper);
+                this.mapper, this.unitOfWork);
 
             receiver.initialize(this.jobManager);
 
@@ -164,6 +167,9 @@ public class JobMessageReceiverTest {
         verify(message, times(1)).acknowledge();
         verify(this.session, times(1)).commit();
         verify(this.session, never()).rollback();
+
+        verify(this.unitOfWork, times(1)).begin();
+        verify(this.unitOfWork, times(1)).end();
     }
 
     @Test
@@ -181,6 +187,9 @@ public class JobMessageReceiverTest {
         verify(message, times(1)).acknowledge();
         verify(this.session, times(1)).commit();
         verify(this.session, never()).rollback();
+
+        verify(this.unitOfWork, times(1)).begin();
+        verify(this.unitOfWork, times(1)).end();
     }
 
     @Test
@@ -201,6 +210,9 @@ public class JobMessageReceiverTest {
         verify(message, times(1)).acknowledge();
         verify(this.session, times(1)).commit();
         verify(this.session, never()).rollback();
+
+        verify(this.unitOfWork, times(1)).begin();
+        verify(this.unitOfWork, times(1)).end();
     }
 
     @Test
@@ -221,6 +233,9 @@ public class JobMessageReceiverTest {
         verify(message, times(1)).acknowledge();
         verify(this.session, never()).commit();
         verify(this.session, times(1)).rollback();
+
+        verify(this.unitOfWork, times(1)).begin();
+        verify(this.unitOfWork, times(1)).end();
     }
 
     @Test
@@ -238,6 +253,9 @@ public class JobMessageReceiverTest {
         verify(message, times(1)).acknowledge();
         verify(this.session, never()).commit();
         verify(this.session, times(1)).rollback();
+
+        verify(this.unitOfWork, times(1)).begin();
+        verify(this.unitOfWork, times(1)).end();
     }
 
     @Test
@@ -255,6 +273,9 @@ public class JobMessageReceiverTest {
         verify(message, times(1)).acknowledge();
         verify(this.session, times(1)).commit();
         verify(this.session, never()).rollback();
+
+        verify(this.unitOfWork, times(1)).begin();
+        verify(this.unitOfWork, times(1)).end();
     }
 
     @Test
@@ -271,6 +292,9 @@ public class JobMessageReceiverTest {
         verify(message, times(1)).acknowledge();
         verify(this.session, never()).commit();
         verify(this.session, times(1)).rollback();
+
+        verify(this.unitOfWork, times(1)).begin();
+        verify(this.unitOfWork, times(1)).end();
     }
 
     @Test
@@ -289,6 +313,9 @@ public class JobMessageReceiverTest {
         verify(message, times(1)).acknowledge();
         verify(this.session, never()).commit();
         verify(this.session, times(1)).rollback();
+
+        verify(this.unitOfWork, times(0)).begin();
+        verify(this.unitOfWork, times(1)).end();
     }
 
 }


### PR DESCRIPTION
- Use UnitOfWork to open/close a sessions when starting/stopping a
  job. Currently hibernate sessions are staying open when artemis
  jobs are running, which causes a lot of issues, one of them being
  manifested as stale data when the same artemis thread happens to
  execute the same job sequentially, resulting in intermittent
  spec test failures in import_spec.rb