### PR TITLE
[M] Updated repository URLs to use https instead of http

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -200,13 +200,13 @@ subprojects {
         mavenLocal()
         mavenCentral()
 
-        maven { url "http://repo.jenkins-ci.org/public/" }
-        maven { url "http://repository.jboss.org/nexus/content/groups/public/" }
-        maven { url "http://oauth.googlecode.com/svn/code/maven/" }
+        maven { url "https://repo.jenkins-ci.org/public/" }
+        maven { url "https://repository.jboss.org/nexus/content/groups/public/" }
+        maven { url "https://oauth.googlecode.com/svn/code/maven/" }
         // For LogDriver
-        maven { url "http://awood.fedorapeople.org/ivy/candlepin/" }
+        maven { url "https://awood.fedorapeople.org/ivy/candlepin/" }
         // Temporary repo, which stores jss 4.4.6
-        maven { url "http://barnabycourt.fedorapeople.org/repo/candlepin/" }
+        maven { url "https://barnabycourt.fedorapeople.org/repo/candlepin/" }
     }
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -48,22 +48,22 @@
                 <repository>
                     <id>jboss</id>
                     <name>JBoss</name>
-                    <url>http://repository.jboss.org/nexus/content/groups/public/</url>
+                    <url>https://repository.jboss.org/nexus/content/groups/public/</url>
                 </repository>
                 <repository>
                     <id>oauth</id>
                     <name>OAuth</name>
-                    <url>http://oauth.googlecode.com/svn/code/maven/</url>
+                    <url>https://oauth.googlecode.com/svn/code/maven/</url>
                 </repository>
                 <repository>
                     <id>awood</id>
                     <name>awood.fedorapeople.org</name>
-                    <url>http://awood.fedorapeople.org/ivy/candlepin/</url>
+                    <url>https://awood.fedorapeople.org/ivy/candlepin/</url>
                 </repository>
                 <repository>
                     <id>barnabycourt</id>
                     <name>barnabycourt.fedorapeople.org</name>
-                    <url>http://barnabycourt.fedorapeople.org/repo/candlepin/</url>
+                    <url>https://barnabycourt.fedorapeople.org/repo/candlepin/</url>
                 </repository>
             </repositories>
         </profile>


### PR DESCRIPTION
See #2606 for details. This PR includes changes to build.gradle as well as the pom.xml changes.