### PR TITLE
ENT-2068: 1798699: Found (local) serial# [9160844745519149032L];

### DIFF
--- a/server/spec/cert_revocation_spec.rb
+++ b/server/spec/cert_revocation_spec.rb
@@ -84,7 +84,7 @@ describe 'Certificate Revocation List', :serial => true do
     new_time = File.mtime("/var/lib/candlepin/candlepin-crl.crl")
     new_time.should_not == old_time
     crl = OpenSSL::X509::CRL.new File.read "/var/lib/candlepin/candlepin-crl.crl"
-    expect(crl.revoked.map { |i| i.serial.to_s }).to include(serial)
+    expect(crl.revoked.map { |i| i.serial }).to include(serial)
   end
 
   it 'should regenerate the on-disk crl' do
@@ -135,7 +135,7 @@ describe 'Certificate Revocation List', :serial => true do
   it 'should put revoked id cert on CRL' do
     id_cert = OpenSSL::X509::Certificate.new(@system.identity_certificate)
     @system.unregister
-    expect(revoked_serials).to include(id_cert.serial.to_s)
+    expect(revoked_serials).to include(id_cert.serial.to_i)
   end
 
   it 'should put revoked content access cert on CRL' do
@@ -171,7 +171,7 @@ end
   end
 
   def revoked_serials
-    return @cp.get_crl.revoked.map {|entry| entry.serial.to_s}
+    return @cp.get_crl.revoked.map {|entry| entry.serial.to_i }
   end
 
 end

--- a/server/spec/client_v1_size_spec.rb
+++ b/server/spec/client_v1_size_spec.rb
@@ -120,6 +120,6 @@ describe 'Entitlement Certificate V1 Size' do
   end
 
   def revoked_serials
-    return @cp.get_crl.revoked.map {|entry| entry.serial.to_s }
+    return @cp.get_crl.revoked.map {|entry| entry.serial.to_i }
   end
 end

--- a/server/src/main/java/org/candlepin/dto/api/v1/CertificateSerialDTO.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/CertificateSerialDTO.java
@@ -21,6 +21,7 @@ import io.swagger.annotations.ApiModel;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 
+import java.math.BigInteger;
 import java.util.Date;
 
 
@@ -32,8 +33,8 @@ import java.util.Date;
 public class CertificateSerialDTO extends TimestampedCandlepinDTO<CertificateSerialDTO> {
     public static final long serialVersionUID = 1L;
 
-    protected String id;
-    protected String serial;
+    protected Long id;
+    protected BigInteger serial;
     protected Date expiration;
     protected Boolean collected;
     protected Boolean revoked;
@@ -57,20 +58,20 @@ public class CertificateSerialDTO extends TimestampedCandlepinDTO<CertificateSer
         super(source);
     }
 
-    public String getId() {
+    public Long getId() {
         return this.id;
     }
 
-    public CertificateSerialDTO setId(String id) {
+    public CertificateSerialDTO setId(Long id) {
         this.id = id;
         return this;
     }
 
-    public String getSerial() {
+    public BigInteger getSerial() {
         return this.serial;
     }
 
-    public CertificateSerialDTO setSerial(String serial) {
+    public CertificateSerialDTO setSerial(BigInteger serial) {
         this.serial = serial;
         return this;
     }

--- a/server/src/main/java/org/candlepin/dto/api/v1/CertificateSerialTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/CertificateSerialTranslator.java
@@ -59,8 +59,8 @@ public class CertificateSerialTranslator extends
 
         dest = super.populate(translator, source, dest);
 
-        dest.setId(source.getId() == null ? null : source.getId().toString());
-        dest.setSerial(source.getSerial() == null ? null : source.getSerial().toString());
+        dest.setId(source.getId());
+        dest.setSerial(source.getSerial());
         dest.setExpiration(source.getExpiration());
         dest.setCollected(source.isCollected());
         dest.setRevoked(source.isRevoked());

--- a/server/src/main/java/org/candlepin/resource/CdnResource.java
+++ b/server/src/main/java/org/candlepin/resource/CdnResource.java
@@ -172,7 +172,7 @@ public class CdnResource {
                     CertificateSerial certSerial = new CertificateSerial();
                     certSerial.setExpiration(certSerialDTO.getExpiration());
                     if (certSerialDTO.getSerial() != null) {
-                        certSerial.setSerial(Long.valueOf(certSerialDTO.getSerial()));
+                        certSerial.setSerial(certSerialDTO.getSerial().longValue());
                     }
 
                     if (certSerialDTO.isCollected() != null) {

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -150,6 +150,7 @@ import org.xnap.commons.i18n.I18n;
 
 import java.io.File;
 import java.io.IOException;
+import java.math.BigInteger;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -1947,14 +1948,15 @@ public class ConsumerResource {
 
         List<CertificateSerialDTO> allCerts = new LinkedList<>();
         for (Long id : entCertService.listEntitlementSerialIds(consumer)) {
-            allCerts.add(new CertificateSerialDTO().setSerial(id.toString()));
+            allCerts.add(new CertificateSerialDTO().setSerial(BigInteger.valueOf(id)));
         }
 
         // add content access cert if needed
         try {
             ContentAccessCertificate cac = contentAccessCertService.getCertificate(consumer);
             if (cac != null) {
-                allCerts.add(new CertificateSerialDTO().setSerial(cac.getSerial().getId().toString()));
+                allCerts.add(new CertificateSerialDTO().setSerial(
+                    BigInteger.valueOf(cac.getSerial().getId())));
             }
         }
         catch (IOException ioe) {

--- a/server/src/test/java/org/candlepin/dto/api/v1/CertificateDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/CertificateDTOTest.java
@@ -34,8 +34,8 @@ public class CertificateDTOTest extends AbstractDTOTest<CertificateDTO> {
         super(CertificateDTO.class);
 
         CertificateSerialDTO serial = new CertificateSerialDTO();
-        serial.setId("123");
-        serial.setSerial(BigInteger.TEN.toString());
+        serial.setId(123L);
+        serial.setSerial(BigInteger.TEN);
         serial.setExpiration(new Date());
         serial.setCollected(true);
         serial.setRevoked(true);

--- a/server/src/test/java/org/candlepin/dto/api/v1/CertificateSerialDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/CertificateSerialDTOTest.java
@@ -34,8 +34,8 @@ public class CertificateSerialDTOTest extends AbstractDTOTest<CertificateSerialD
         super(CertificateSerialDTO.class);
 
         this.values = new HashMap<>();
-        this.values.put("Id", "12345");
-        this.values.put("Serial", BigInteger.TEN.toString());
+        this.values.put("Id", 12345L);
+        this.values.put("Serial", BigInteger.TEN);
         this.values.put("Date", new Date());
         this.values.put("Collected", true);
         this.values.put("Revoked", true);

--- a/server/src/test/java/org/candlepin/dto/api/v1/CertificateSerialTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/CertificateSerialTranslatorTest.java
@@ -71,8 +71,8 @@ public class CertificateSerialTranslatorTest extends
             // This DTO does not have any nested objects, so we don't need to worry about the
             // childrenGenerated flag
 
-            assertEquals(source.getId() == null ? null : source.getId().toString(), dest.getId());
-            assertEquals(source.getSerial() == null ? null : source.getSerial().toString(), dest.getSerial());
+            assertEquals(source.getId(), dest.getId());
+            assertEquals(source.getSerial(), dest.getSerial());
             assertEquals(source.getExpiration(), dest.getExpiration());
             assertEquals(source.isCollected(), dest.isCollected());
             assertEquals(source.isRevoked(), dest.isRevoked());

--- a/server/src/test/java/org/candlepin/dto/api/v1/UeberCertificateDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/UeberCertificateDTOTest.java
@@ -34,8 +34,8 @@ public class UeberCertificateDTOTest extends AbstractDTOTest<UeberCertificateDTO
         super(UeberCertificateDTO.class);
 
         CertificateSerialDTO serial = new CertificateSerialDTO();
-        serial.setId("123");
-        serial.setSerial(BigInteger.TEN.toString());
+        serial.setId(123L);
+        serial.setSerial(BigInteger.TEN);
         serial.setExpiration(new Date());
         serial.setCollected(true);
         serial.setRevoked(true);

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
@@ -198,8 +198,8 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
             .getEntitlementCertificates(consumer.getUuid(), null);
         assertEquals(4, certificates.size());
 
-        String serial1 = certificates.get(0).getSerial().getId();
-        String serial2 = certificates.get(3).getSerial().getId();
+        Long serial1 = certificates.get(0).getSerial().getId();
+        Long serial2 = certificates.get(3).getSerial().getId();
 
         String serialsToFilter = serial1.toString() + "," + serial2.toString();
 
@@ -372,7 +372,7 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
             .getEntitlementCertificates(consumer.getUuid(), null);
         assertEquals(1, serials.size());
 
-        consumerResource.unbindBySerial(consumer.getUuid(), Long.valueOf(serials.get(0).getSerial().getId()));
+        consumerResource.unbindBySerial(consumer.getUuid(), serials.get(0).getSerial().getId());
         assertEquals(0, consumerResource.listEntitlements(
             consumer.getUuid(), null, true, "", new ArrayList<>(), null).size());
     }
@@ -669,9 +669,8 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
 
         CertificateDTO original = serials.get(0);
         CertificateSerialDTO serialDTO  = original.getSerial();
-        CertificateSerial serial = new CertificateSerial(Long.valueOf(serialDTO.getId()),
-            serialDTO.getExpiration());
-        serial.setSerial(Long.valueOf(serialDTO.getSerial()));
+        CertificateSerial serial = new CertificateSerial(serialDTO.getId(), serialDTO.getExpiration());
+        serial.setSerial(serialDTO.getSerial().longValue());
         serial.setCollected(serialDTO.isCollected());
         serial.setRevoked(serialDTO.isRevoked());
 

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
@@ -410,7 +410,7 @@ public class ConsumerResourceTest {
     private void verifyCertificateSerialNumbers(
         List<CertificateSerialDTO> serials) {
         assertEquals(3, serials.size());
-        assertTrue(Long.valueOf(serials.get(0).getSerial()) > 0);
+        assertTrue(serials.get(0).getSerial().equals(BigInteger.ONE));
     }
 
     private List<EntitlementCertificate> createEntitlementCertificates() {


### PR DESCRIPTION
Expected (UEP) serial# [u'9160844745519149032']
- Revert "1476028: ENT-528: Changed serial number datatype to String"
- This reverts commit 6be9ea3d1ad620ae1c7313d8d65bce5d13fe9d34.
- CertificateSerialDto.java is not reverted from this commit. This is removed as a part of a discussion in #2523. Hence kept this change to use CertificateSerialDTO.