### PR TITLE
[M] ENT-2107: Make jobs run in parallel

### DIFF
--- a/server/src/main/java/org/candlepin/async/JobManager.java
+++ b/server/src/main/java/org/candlepin/async/JobManager.java
@@ -982,8 +982,7 @@ public class JobManager implements ModeChangeListener {
      *  an AsyncJobStatus instance representing the queued job's status, or the status of the
      *  existing job if it already exists
      */
-    public synchronized AsyncJobStatus queueJob(JobConfig config) throws JobException {
-
+    public AsyncJobStatus queueJob(JobConfig config) throws JobException {
         ManagerState state = this.getManagerState();
         if (state != ManagerState.RUNNING) {
             // Check if we're paused. If so, and if the "queue while paused" config is not set,
@@ -1177,10 +1176,9 @@ public class JobManager implements ModeChangeListener {
      * @return
      *  a JobStatus instance representing the job's status
      */
-    public synchronized AsyncJobStatus executeJob(JobMessage message) throws JobException {
-
+    public AsyncJobStatus executeJob(JobMessage message) throws JobException {
         ManagerState state = this.getManagerState();
-        if (this.getManagerState() != ManagerState.RUNNING) {
+        if (state != ManagerState.RUNNING) {
             String msg = String.format("Jobs cannot be executed while the manager is in the %s state", state);
             throw new IllegalStateException(msg);
         }
@@ -1602,7 +1600,7 @@ public class JobManager implements ModeChangeListener {
      *  could be found
      */
     @Transactional
-    public synchronized AsyncJobStatus cancelJob(String jobId) {
+    public AsyncJobStatus cancelJob(String jobId) {
         if (jobId == null || jobId.isEmpty()) {
             throw new IllegalArgumentException("jobId is null or empty");
         }
@@ -1651,7 +1649,7 @@ public class JobManager implements ModeChangeListener {
      *  the number of jobs deleted as a result of this operation
      */
     @Transactional
-    public synchronized int cleanupJobs(AsyncJobStatusCurator.AsyncJobStatusQueryBuilder queryBuilder) {
+    public int cleanupJobs(AsyncJobStatusCurator.AsyncJobStatusQueryBuilder queryBuilder) {
         // Prepare for the defaults...
         if (queryBuilder == null) {
             queryBuilder = new AsyncJobStatusCurator.AsyncJobStatusQueryBuilder();

--- a/server/src/main/java/org/candlepin/messaging/impl/artemis/ArtemisProducer.java
+++ b/server/src/main/java/org/candlepin/messaging/impl/artemis/ArtemisProducer.java
@@ -90,7 +90,7 @@ public class ArtemisProducer implements CPMProducer {
     /**
      * {@inheritDoc}
      */
-    public void send(String address, CPMMessage message) throws CPMException {
+    public synchronized void send(String address, CPMMessage message) throws CPMException {
         if (address == null || address.isEmpty()) {
             throw new IllegalArgumentException("address is null or empty");
         }

--- a/server/src/main/java/org/candlepin/messaging/impl/artemis/ArtemisSession.java
+++ b/server/src/main/java/org/candlepin/messaging/impl/artemis/ArtemisSession.java
@@ -59,7 +59,7 @@ public class ArtemisSession implements CPMSession {
      * {@inheritDoc}
      */
     @Override
-    public void start() throws CPMException {
+    public synchronized void start() throws CPMException {
         try {
             this.session.start();
         }
@@ -72,7 +72,7 @@ public class ArtemisSession implements CPMSession {
      * {@inheritDoc}
      */
     @Override
-    public void stop() throws CPMException {
+    public synchronized void stop() throws CPMException {
         try {
             this.session.stop();
         }
@@ -85,7 +85,7 @@ public class ArtemisSession implements CPMSession {
      * {@inheritDoc}
      */
     @Override
-    public void close() throws CPMException {
+    public synchronized void close() throws CPMException {
         try {
             this.session.close();
         }
@@ -106,7 +106,7 @@ public class ArtemisSession implements CPMSession {
      * {@inheritDoc}
      */
     @Override
-    public void commit() throws CPMException {
+    public synchronized void commit() throws CPMException {
         try {
             this.session.commit();
         }
@@ -119,7 +119,7 @@ public class ArtemisSession implements CPMSession {
      * {@inheritDoc}
      */
     @Override
-    public void rollback() throws CPMException {
+    public synchronized void rollback() throws CPMException {
         try {
             this.session.rollback();
         }


### PR DESCRIPTION
- Currently, jobs cannot run in parallel because we synchronize on
  the JobManager singleton object on the execute method.
  Once an artemis thread starts running a job, no other job can run
  in parallel because the other artemis threads are waiting for the
  lock. Not only that, but we also can't queue jobs at the same
  time that a job is running, because the queue method is also
  synchronized. This fix removes synchronization from these two
  methods (and a couple more that don't need it).
- Added synchronization on ArtemisProducer & ArtemisSession to avoid
  an artemis client warning when we try to queue jobs (AMQ212051:
  Invalid concurrent session usage. Sessions are not supposed to be
  used by more than one thread concurrently). This appeared once
  the queueJob method stopped being synchronized.