### PR TITLE
Add arch content filter setting

### DIFF
--- a/server/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/server/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -203,6 +203,8 @@ public class ConfigProperties {
 
     public static final String STANDALONE = "candlepin.standalone";
     public static final String ENV_CONTENT_FILTERING = "candlepin.environment_content_filtering";
+    public static final String ARCH_CONTENT_FILTERING = "candlepin.arch_content_filtering";
+    public static final String ARCH_CONTENT_FILTERING_FOR_DEBIAN = "candlepin.arch_content_filtering_for_debian";
     public static final String USE_SYSTEM_UUID_FOR_MATCHING = "candlepin.use_system_uuid_for_matching";
 
     public static final String CONSUMER_SYSTEM_NAME_PATTERN = "candlepin.consumer_system_name_pattern";
@@ -442,6 +444,8 @@ public class ConfigProperties {
             this.put(STANDALONE, "true");
 
             this.put(ENV_CONTENT_FILTERING, "true");
+            this.put(ARCH_CONTENT_FILTERING, "true");
+            this.put(ARCH_CONTENT_FILTERING_FOR_DEBIAN, "false");
             this.put(USE_SYSTEM_UUID_FOR_MATCHING, "true");
 
             // what constitutes a valid consumer name

--- a/server/src/main/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapter.java
+++ b/server/src/main/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapter.java
@@ -339,7 +339,13 @@ public class DefaultEntitlementCertServiceAdapter extends BaseEntitlementCertSer
             consumer, pool);
 
         int contentCounter = 0;
-        boolean enableEnvironmentFiltering = config.getBoolean(ConfigProperties.ENV_CONTENT_FILTERING);
+        boolean enableEnvContentFiltering = config.getBoolean(ConfigProperties.ENV_CONTENT_FILTERING);
+        boolean enableArchContentFiltering = config.getBoolean(ConfigProperties.ARCH_CONTENT_FILTERING);
+
+        String distribution_name = consumer.getFact("distribution.name");
+        if (("Ubuntu".equalsIgnoreCase(distribution_name)) || ("Debian GNU/Linux".equalsIgnoreCase(distribution_name))) {
+          enableArchContentFiltering = config.getBoolean(ConfigProperties.ARCH_CONTENT_FILTERING_FOR_DEBIAN);
+        }
 
         Product skuProd = pool.getProduct();
 
@@ -348,10 +354,12 @@ public class DefaultEntitlementCertServiceAdapter extends BaseEntitlementCertSer
             result.addAll(extensionUtil.productExtensions(prod));
 
             Set<ProductContent> filteredContent = extensionUtil.filterProductContent(
-                prod, consumer, promotedContent, enableEnvironmentFiltering, entitledProductIds);
+                prod, consumer, promotedContent, enableEnvContentFiltering, entitledProductIds);
 
-            filteredContent = extensionUtil.filterContentByContentArch(filteredContent,
-                consumer, prod);
+            if (enableArchContentFiltering) {
+              filteredContent = extensionUtil.filterContentByContentArch(filteredContent,
+                  consumer, prod);
+            }
 
             // Keep track of the number of content sets that are being added.
             contentCounter += filteredContent.size();


### PR DESCRIPTION
On Debian / Ubuntu hosts it is common to use multi-architecture (amd64 + i386 e.g.). 
In case of candlepin on Katello with Debian support, it is necessary, to set the architecture of repositories if multiple architectures are used but a specific repository provides only package for one arch. Otherwise, the following issue occurs: https://askubuntu.com/questions/741410/skipping-acquire-of-configured-file-main-binary-i386-packages-as-repository-x?answertab=active

As the architecture of a host is always juse one but multiple content repository archs are supported, we don't need to filter the arch on the server side but on the client side. 

With this PR together with https://github.com/candlepin/subscription-manager/pull/2213 and one outstanding Katello PR, it is possible to set the architecture of a repository. The architecture is later on written in the apt sources list. 

