### PR TITLE
Update mead build chain for api sub-project

### DIFF
--- a/server/mead.chain
+++ b/server/mead.chain
@@ -8,7 +8,12 @@ scmurl=${mead_scm}?common#${git_ref}
 buildrequires=org.candlepin-candlepin-parent
 packages=gettext java-1.8.0-openjdk-devel
 
+[org.candlepin-api]
+scmurl=${mead_scm}?api#${git_ref}
+buildrequires=org.candlepin-candlepin-parent
+packages=java-1.8.0-openjdk-devel
+
 [org.candlepin-candlepin]
 scmurl=${mead_scm}?server#${git_ref}
-buildrequires=org.candlepin-candlepin-common
+buildrequires=org.candlepin-candlepin-common org.candlepin-api
 packages=java-1.8.0-openjdk-devel


### PR DESCRIPTION
To test, you can use:

```
tito release --dry-run --no-build --no-cleanup mead
```
(answer yes to any questions, `--dry-run` prevents pushes); then:

```
brew maven-chain --skip-tag --scratch  candlepin-1-maven-candidate $changeme/candlepin/mead.chain
```
where `$changeme` is the path mentioned in tito output (like: `/tmp/tito/release-candlepinwkd3skn0` from `WARNING: leaving /tmp/tito/release-candlepinwkd3skn0 (--no-cleanup)`)