### PR TITLE
[2.9] ENT-2065 Migrate to new docker registry

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -1,1 +1,1 @@
-REGISTRY=docker-registry.engineering.redhat.com/candlepin
+REGISTRY=docker-registry.upshift.redhat.com/chainsaw

--- a/docker/gating-test-images/README.mkd
+++ b/docker/gating-test-images/README.mkd
@@ -1,11 +1,13 @@
 # Candlepin containers for gating tests
 This folder contains docker configurations for running Candlepin & Postgresql containers with preloaded test data.
 They are used for subscription-manager gating tests to be run against. The scripts here use docker stack, and podman, so docker-compose is not required to use this. The build script is supposed to be triggered automatically via jenkins [[1]](https://github.com/candlepin/candlepin-jobs).
-Note: The building/running scripts of these images are not configurable, because they are not supposed to be used as a development environment. 
+Notes:
+ * The building/running scripts of these images are not configurable, because they are not supposed to be used as a development environment.
+ * You need to first login to the internal docker registry in order to run either the build or run scripts (for pushing/pulling images).
 
 ## Building
 The `build.sh` script is used for building a Candlepin image of the latest Candlepin version currently running in stage, and a corresponding postgresql image with preloaded test data.
-The images (`cp_latest_stage` & `cp_postgres`) are then pushed to the internal registry [[2]](https://registry-console.engineering.redhat.com/registry#/images/candlepin).
+The images (`cp_latest_stage` & `cp_postgres`) are then pushed to the internal registry.
 It uses `docker` to build images & `docker stack` to run intermediate images.
 Note: This script needs to run with SELinux off!
 ```bash

--- a/docker/gating-test-images/build.sh
+++ b/docker/gating-test-images/build.sh
@@ -76,7 +76,7 @@ docker build --tag=cp_latest_stage cp-latest-stage/
 evalrc $? "cp_latest_stage image build was not successful."
 
 echo "============ Pushing images to registry... ============ "
-REGISTRY=docker-registry.engineering.redhat.com/candlepin
+REGISTRY=docker-registry.upshift.redhat.com/chainsaw
 
 # Find out the candlepin version used in stage
 curl -k -u admin:admin https://subscription.rhsm.stage.redhat.com/subscription/status > stage_status.json

--- a/docker/gating-test-images/run.sh
+++ b/docker/gating-test-images/run.sh
@@ -6,7 +6,7 @@
 # The postgresql container has a sql dump with the required test data and imports them
 # on startup.
 
-REGISTRY=docker-registry.engineering.redhat.com/candlepin
+REGISTRY=docker-registry.upshift.redhat.com/chainsaw
 
 retry() {
     local -r -i max_attempts="$1"; shift


### PR DESCRIPTION
The old one has been decommissioned

Note: this is a cherry-pick of the fix from master