### PR TITLE
[2.6] ENT-2065 Migrate to new docker registry

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -1,1 +1,1 @@
-REGISTRY=docker-registry.engineering.redhat.com/candlepin
+REGISTRY=docker-registry.upshift.redhat.com/chainsaw


### PR DESCRIPTION
The old one has been decommissioned

Note: this is a cherry-pick from master to fix jenkins builds