### PR TITLE
[POC] N-Tier Refresh Refactor (Do not merge)

### DIFF
--- a/server/src/main/java/org/candlepin/controller/ActualRefresher.java
+++ b/server/src/main/java/org/candlepin/controller/ActualRefresher.java
@@ -1,0 +1,355 @@
+/*
+ *  Copyright (c) 2009 - ${YEAR} Red Hat, Inc.
+ *
+ *  This software is licensed to you under the GNU General Public License,
+ *  version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ *  implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ *  FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ *  along with this software; if not, see
+ *  http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ *  Red Hat trademarks are not licensed under GPLv2. No permission is
+ *  granted to use or replicate Red Hat trademarks that are incorporated
+ *  in this software or its documentation.
+ */
+package org.candlepin.controller;
+
+import org.candlepin.service.model.ContentInfo;
+import org.candlepin.service.model.ProductContentInfo;
+import org.candlepin.service.model.ProductInfo;
+import org.candlepin.service.model.SubscriptionInfo;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+
+/**
+ * The ActualRefresher class does actual refresh operations, as opposed to calling into other
+ * classes to do the refresh work. It does that, too, but the Refresher name is already in use
+ * and this is PoC code so I'm not going to change the world to call this something a little
+ * nicer... yet.
+ *
+ * This is looking like it'll almost entirely replace the ImportedEntityCompiler, and its
+ * primary output from the execute operation is going to be a beefier version of ImportResult
+ * that allows for looking up things directly rather than just spitting out maps.
+ */
+public class ActualRefresher {
+
+    private static Logger log = LoggerFactory.getLogger(ImportedEntityCompiler.class);
+
+    private Map<String, SubscriptionInfo> importSubscriptions;
+    private Map<String, ProductInfo> importProducts;
+    private Map<String, ContentInfo> importContent;
+
+    /**
+     * Creates a new ImportedEntityCompiler
+     */
+
+    public ImportedEntityCompiler() {
+        this.importSubscriptions = new HashMap<>();
+        this.importProducts = new HashMap<>();
+        this.importContent = new HashMap<>();
+    }
+
+    /**
+     * Adds the specified subscriptions to this refresher. If a given subscription has already
+     * been added, but differs from the existing version, a warning will be generated and the
+     * previous entry will be replaced. Products and content attached to the subscriptions will be
+     * mapped by this compiler. Null subscriptions will be silently ignored.
+     *
+     * @param subscriptions
+     *  The subscriptions to add to this compiler
+     *
+     * @throws IllegalArgumentException
+     *  if any provided subscription does not contain a valid subscription ID
+     */
+    public void addSubscriptions(SubscriptionInfo... subscriptions) {
+        this.addSubscriptions(Arrays.asList(subscriptions));
+    }
+
+    /**
+     * Adds the specified subscriptions to this refresher. If a given subscription has already
+     * been added, but differs from the existing version, a warning will be generated and the
+     * previous entry will be replaced. Products and content attached to the subscriptions will be
+     * mapped by this compiler. Null subscriptions will be silently ignored.
+     *
+     * @param subscriptions
+     *  The subscriptions to add to this compiler
+     *
+     * @throws IllegalArgumentException
+     *  if any provided subscription does not contain a valid subscription ID
+     */
+    public void addSubscriptions(Collection<? extends SubscriptionInfo> subscriptions) {
+        if (subscriptions != null) {
+            for (SubscriptionInfo subscription : subscriptions) {
+                if (subscription == null) {
+                    continue;
+                }
+
+                if (subscription.getId() == null || subscription.getId().isEmpty()) {
+                    String msg = String.format(
+                        "subscription does not contain a mappable Red Hat ID: %s", subscription);
+
+                    log.error(msg);
+                    throw new IllegalArgumentException(msg);
+                }
+
+                SubscriptionInfo existing = this.importSubscriptions.get(subscription.getId());
+                if (existing != null && !existing.equals(subscription)) {
+                    log.warn("Multiple versions of the same subscription received during refresh; " +
+                        "discarding previous: {} => {}, {}", subscription.getId(), existing, subscription);
+                }
+
+                this.importSubscriptions.put(subscription.getId(), subscription);
+
+                // Add any products attached to this subscription...
+                this.addProducts(subscription.getProduct());
+                this.addProducts(subscription.getDerivedProduct());
+            }
+        }
+    }
+
+    /**
+     * Adds the specified products to this refresher. If a given product has already
+     * been added, but differs from the existing version, a warning will be generated and the
+     * previous entry will be replaced. Content attached to the products will be mapped by this
+     * compiler. Null products will be silently ignored.
+     *
+     * @param products
+     *  The products to add to this compiler
+     *
+     * @throws IllegalArgumentException
+     *  if any provided product does not contain a valid product ID
+     */
+    public void addProducts(ProductInfo... products) {
+        this.addProducts(Arrays.asList(products));
+    }
+
+    /**
+     * Adds the specified products to this refresher. If a given product has already
+     * been added, but differs from the existing version, a warning will be generated and the
+     * previous entry will be replaced. Content attached to the products will be mapped by this
+     * compiler. Null products will be silently ignored.
+     *
+     * @param products
+     *  The products to add to this compiler
+     *
+     * @throws IllegalArgumentException
+     *  if any provided product does not contain a valid product ID
+     */
+    public void addProducts(Collection<? extends ProductInfo> products) {
+        if (products != null) {
+            for (ProductInfo product : products) {
+                if (product == null) {
+                    continue;
+                }
+
+                if (product.getId() == null || product.getId().isEmpty()) {
+                    String msg = String.format("product does not contain a mappable Red Hat ID: %s", product);
+
+                    log.error(msg);
+                    throw new IllegalArgumentException(msg);
+                }
+
+                ProductInfo existing = this.importProducts.get(product.getId());
+                if (existing != null && !existing.equals(product)) {
+                    log.warn("Multiple versions of the same product received during refresh; " +
+                        "discarding previous: {} => {}, {}", product.getId(), existing, product);
+                }
+
+                this.importProducts.put(product.getId(), product);
+
+                // Add any content attached to this product...
+                this.addProductContent(product.getProductContent());
+            }
+        }
+    }
+
+    /**
+     * Adds the specified content to this refresher. If a given content has already
+     * been added, but differs from the existing version, a warning will be generated and the
+     * previous entry will be replaced. Null content will be silently ignored.
+     *
+     * @param contents
+     *  The content to add to this compiler
+     *
+     * @throws IllegalArgumentException
+     *  if any provided content does not contain a valid content ID
+     */
+    public void addProductContent(ProductContentInfo... contents) {
+        this.addProductContent(Arrays.asList(contents));
+    }
+
+    /**
+     * Adds the specified content to this refresher. If a given content has already
+     * been added, but differs from the existing version, a warning will be generated and the
+     * previous entry will be replaced. Null content will be silently ignored.
+     *
+     * @param contents
+     *  The content to add to this compiler
+     *
+     * @throws IllegalArgumentException
+     *  if any provided content does not contain a valid content ID
+     */
+    public void addProductContent(Collection<? extends ProductContentInfo> contents) {
+        if (contents != null) {
+            for (ProductContentInfo container : contents) {
+                if (container == null) {
+                    continue;
+                }
+
+                ContentInfo content = container.getContent();
+
+                // Do some simple mapping validation
+                if (content == null) {
+                    String msg = "collection contains an incomplete product-content mapping";
+
+                    log.error(msg);
+                    throw new IllegalArgumentException(msg);
+                }
+
+                if (content.getId() == null || content.getId().isEmpty()) {
+                    String msg = String.format("content does not contain a mappable Red Hat ID: %s", content);
+
+                    log.error(msg);
+                    throw new IllegalArgumentException(msg);
+                }
+
+                ContentInfo existing = this.importContent.get(content.getId());
+                if (existing != null && !existing.equals(content)) {
+                    log.warn("Multiple versions of the same content received during refresh; " +
+                        "discarding previous: {} => {}, {}", content.getId(), existing, content);
+                }
+
+                this.importContent.put(content.getId(), content);
+            }
+        }
+    }
+
+    /**
+     * Adds the specified content to this refresher. If a given content has already
+     * been added, but differs from the existing version, a warning will be generated and the
+     * previous entry will be replaced. Null content will be silently ignored.
+     *
+     * @param contents
+     *  The content to add to this compiler
+     *
+     * @throws IllegalArgumentException
+     *  if any provided content does not contain a valid content ID
+     */
+    public void addContent(ContentInfo... contents) {
+        this.addContent(Arrays.asList(contents));
+    }
+
+    /**
+     * Adds the specified content to this refresher. If a given content has already
+     * been added, but differs from the existing version, a warning will be generated and the
+     * previous entry will be replaced. Null content will be silently ignored.
+     *
+     * @param contents
+     *  The content to add to this compiler
+     *
+     * @throws IllegalArgumentException
+     *  if any provided content does not contain a valid content ID
+     */
+    public void addContent(Collection<? extends ContentInfo> contents) {
+        if (contents != null) {
+            for (ContentInfo content : contents) {
+                if (content == null) {
+                    continue;
+                }
+
+                if (content.getId() == null || content.getId().isEmpty()) {
+                    String msg = String.format("content does not contain a mappable Red Hat ID: %s", content);
+
+                    log.error(msg);
+                    throw new IllegalArgumentException(msg);
+                }
+
+                ContentInfo existing = this.importContent.get(content.getId());
+                if (existing != null && !existing.equals(content)) {
+                    log.warn("Multiple versions of the same content received during refresh; " +
+                        "discarding previous: {} => {}, {}", content.getId(), existing, content);
+                }
+
+                this.importContent.put(content.getId(), content);
+            }
+        }
+    }
+
+    /**
+     * Fetches the compiled set of subscriptions to import, mapped by subscription ID. If no subscriptions
+     * have been added, this method returns an empty map.
+     *
+     * @return
+     *  A compiled mapping of the subscriptions to import
+     */
+    public Map<String, ? extends SubscriptionInfo> getSubscriptions() {
+        return this.importSubscriptions;
+    }
+
+    /**
+     * Fetches the compiled set of products to import, mapped by product ID. If no products have been added,
+     * this method returns an empty map.
+     *
+     * @return
+     *  A compiled mapping of the products to import
+     */
+    public Map<String, ? extends ProductInfo> getProducts() {
+        return this.importProducts;
+    }
+
+    /**
+     * Fetches the compiled set of content to import, mapped by content ID. If no content has been added,
+     * this method returns an empty map.
+     *
+     * @return
+     *  A compiled mapping of the content to import
+     */
+    public Map<String, ? extends ContentInfo> getContent() {
+        return this.importContent;
+    }
+
+    /**
+     * Performs the import operation on the currently compiled objects
+     */
+    public void execute() {
+
+        // Step 01: Determine which entities are to be created, updated, or skipped
+        // Step 02: From the entities being updated, find all existing entities *not* being imported
+        //          that will be implicitly updated
+        // Step 03: Initialize a list of "finished" entities
+        // Step 04: Invoke the recursive block with the combined list of entities to be created or
+        //          updated as the current list.
+
+        // Recursive block:
+        // Step R1: For each entity in the current list, check if the entity has already been
+        //          processed. If so, continue to the next entity in the list
+        // Step R2: Create a list of all children entities of the current entity.
+        // Step R3: If child list is not empty, invoke the recursive block with the child list as
+        //          the current list
+        // Step R4: Apply the received changes to the entity, using only the finished entities for
+        //          resolution of child entity referencing
+        // Step R5: Store the updated entity in the finished entity collection
+        // Step R6: If current entity list has more entities, continue to next entity in the list;
+        //          otherwise, break out of the current invocation of the recursive block
+
+        // Step 05: Persist pending entity changes
+        // Step 06: Update entity references not already corrected in the traversal above. This
+        //          should include updating owners, pools, activation keys, and other such objects
+        //          which reference products or content, but are not part of the tree.
+
+        // Step 07: Return the collections of the finalized imported entities
+
+
+    }
+
+
+
+
+}

--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -263,10 +263,11 @@ public class CandlepinPoolManager implements PoolManager {
         // ImportResult<Product> importResult = this.productManager
         //     .importProducts(owner, productMap, importedContent);
 
-        RefreshResult refreshResult = refresher.execute();
+        RefreshResult refreshResult = refresher.execute(owner);
 
         Map<String, Product> importedProducts = refreshResult.getImportedProducts();
         Map<String, Product> updatedProducts = refreshResult.getUpdatedProducts();
+        Map<String, ? extends SubscriptionInfo> subscriptionMap = refresher.getSubscriptions();
 
         log.debug("Refreshing {} pool(s)...", subscriptionMap.size());
         for (Iterator<? extends SubscriptionInfo> si = subscriptionMap.values().iterator(); si.hasNext();) {

--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -301,6 +301,29 @@ public class CandlepinPoolManager implements PoolManager {
             System.currentTimeMillis() - now.getTime());
     }
 
+    private void doImportPoC(ImportedEntityCompiler compiler) {
+
+
+
+
+
+
+
+
+
+    }
+
+
+
+
+
+
+
+
+
+
+
+
     private Owner resolveOwner(Owner owner) {
         if (owner == null || (owner.getKey() == null && owner.getId() == null)) {
             throw new IllegalArgumentException(

--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -224,44 +224,49 @@ public class CandlepinPoolManager implements PoolManager {
         owner = this.resolveOwner(owner);
         log.info("Refreshing pools for owner: {}", owner);
 
-        ImportedEntityCompiler compiler = new ImportedEntityCompiler();
+        // ImportedEntityCompiler compiler = new ImportedEntityCompiler();
+
+        ActualRefresher refresher = new ActualRefresher(this.ownerProductCurator, this.ownerContentCurator);
 
         log.debug("Fetching subscriptions from adapter...");
-        compiler.addSubscriptions(subAdapter.getSubscriptions(owner.getKey()));
+        // compiler.addSubscriptions(subAdapter.getSubscriptions(owner.getKey()));
+        refresher.addSubscriptions(subAdapter.getSubscriptions(owner.getKey()));
 
-        Map<String, ? extends SubscriptionInfo> subscriptionMap = compiler.getSubscriptions();
-        Map<String, ? extends ProductInfo> productMap = compiler.getProducts();
-        Map<String, ? extends ContentInfo> contentMap = compiler.getContent();
+        // Map<String, ? extends SubscriptionInfo> subscriptionMap = compiler.getSubscriptions();
+        // Map<String, ? extends ProductInfo> productMap = compiler.getProducts();
+        // Map<String, ? extends ContentInfo> contentMap = compiler.getContent();
 
-        // If trace output is enabled, dump some JSON representing the subscriptions we received so
-        // we can simulate this in a testing environment.
-        if (log.isTraceEnabled() || "TRACE".equalsIgnoreCase(owner.getLogLevel())) {
-            try {
-                ObjectMapper mapper = this.jsonProvider
-                    .locateMapper(Object.class, MediaType.APPLICATION_JSON_TYPE);
+        // // If trace output is enabled, dump some JSON representing the subscriptions we received so
+        // // we can simulate this in a testing environment.
+        // if (log.isTraceEnabled() || "TRACE".equalsIgnoreCase(owner.getLogLevel())) {
+        //     try {
+        //         ObjectMapper mapper = this.jsonProvider
+        //             .locateMapper(Object.class, MediaType.APPLICATION_JSON_TYPE);
 
-                log.trace("Received {} subscriptions from upstream:", subscriptionMap.size());
-                log.trace(mapper.writeValueAsString(subscriptionMap.values()));
-                log.trace("Finished outputting upstream subscriptions");
-            }
-            catch (Exception e) {
-                log.trace("Exception occurred while outputting upstream subscriptions", e);
-            }
-        }
+        //         log.trace("Received {} subscriptions from upstream:", subscriptionMap.size());
+        //         log.trace(mapper.writeValueAsString(subscriptionMap.values()));
+        //         log.trace("Finished outputting upstream subscriptions");
+        //     }
+        //     catch (Exception e) {
+        //         log.trace("Exception occurred while outputting upstream subscriptions", e);
+        //     }
+        // }
 
-        // Persist content changes
-        log.debug("Importing {} content...", contentMap.size());
+        // // Persist content changes
+        // log.debug("Importing {} content...", contentMap.size());
 
-        Map<String, Content> importedContent = this.contentManager
-            .importContent(owner, contentMap, productMap.keySet())
-            .getImportedEntities();
+        // Map<String, Content> importedContent = this.contentManager
+        //     .importContent(owner, contentMap, productMap.keySet())
+        //     .getImportedEntities();
 
-        log.debug("Importing {} product(s)...", productMap.size());
-        ImportResult<Product> importResult = this.productManager
-            .importProducts(owner, productMap, importedContent);
+        // log.debug("Importing {} product(s)...", productMap.size());
+        // ImportResult<Product> importResult = this.productManager
+        //     .importProducts(owner, productMap, importedContent);
 
-        Map<String, Product> importedProducts = importResult.getImportedEntities();
-        Map<String, Product> updatedProducts = importResult.getUpdatedEntities();
+        RefreshResult refreshResult = refresher.execute();
+
+        Map<String, Product> importedProducts = refreshResult.getImportedProducts();
+        Map<String, Product> updatedProducts = refreshResult.getUpdatedProducts();
 
         log.debug("Refreshing {} pool(s)...", subscriptionMap.size());
         for (Iterator<? extends SubscriptionInfo> si = subscriptionMap.values().iterator(); si.hasNext();) {
@@ -300,29 +305,6 @@ public class CandlepinPoolManager implements PoolManager {
         log.info("Refresh pools for owner: {} completed in: {}ms", owner.getKey(),
             System.currentTimeMillis() - now.getTime());
     }
-
-    private void doImportPoC(ImportedEntityCompiler compiler) {
-
-
-
-
-
-
-
-
-
-    }
-
-
-
-
-
-
-
-
-
-
-
 
     private Owner resolveOwner(Owner owner) {
         if (owner == null || (owner.getKey() == null && owner.getId() == null)) {

--- a/server/src/main/java/org/candlepin/controller/ContentManager.java
+++ b/server/src/main/java/org/candlepin/controller/ContentManager.java
@@ -807,54 +807,56 @@ public class ContentManager {
      * @return
      *  true if this content would be changed by the given DTO; false otherwise
      */
-    public static boolean isChangedBy(Content entity, ContentInfo dto) {
-        if (dto.getId() != null && !dto.getId().equals(entity.getId())) {
+    public static boolean isChangedBy(ContentInfo entity, ContentInfo update) {
+        if (update.getId() != null && !update.getId().equals(entity.getId())) {
             return true;
         }
 
-        if (dto.getType() != null && !dto.getType().equals(entity.getType())) {
+        if (update.getType() != null && !update.getType().equals(entity.getType())) {
             return true;
         }
 
-        if (dto.getLabel() != null && !dto.getLabel().equals(entity.getLabel())) {
+        if (update.getLabel() != null && !update.getLabel().equals(entity.getLabel())) {
             return true;
         }
 
-        if (dto.getName() != null && !dto.getName().equals(entity.getName())) {
+        if (update.getName() != null && !update.getName().equals(entity.getName())) {
             return true;
         }
 
-        if (dto.getVendor() != null && !dto.getVendor().equals(entity.getVendor())) {
+        if (update.getVendor() != null && !update.getVendor().equals(entity.getVendor())) {
             return true;
         }
 
-        if (dto.getContentUrl() != null && !dto.getContentUrl().equals(entity.getContentUrl())) {
+        if (update.getContentUrl() != null && !update.getContentUrl().equals(entity.getContentUrl())) {
             return true;
         }
 
-        if (dto.getRequiredTags() != null && !dto.getRequiredTags().equals(entity.getRequiredTags())) {
+        if (update.getRequiredTags() != null && !update.getRequiredTags().equals(entity.getRequiredTags())) {
             return true;
         }
 
-        if (dto.getReleaseVersion() != null && !dto.getReleaseVersion().equals(entity.getReleaseVersion())) {
-            return true;
-        }
-
-        if (dto.getGpgUrl() != null && !dto.getGpgUrl().equals(entity.getGpgUrl())) {
-            return true;
-        }
-
-        if (dto.getMetadataExpiration() != null &&
-            !dto.getMetadataExpiration().equals(entity.getMetadataExpiration())) {
+        if (update.getReleaseVersion() != null &&
+            !update.getReleaseVersion().equals(entity.getReleaseVersion())) {
 
             return true;
         }
 
-        if (dto.getArches() != null && !dto.getArches().equals(entity.getArches())) {
+        if (update.getGpgUrl() != null && !update.getGpgUrl().equals(entity.getGpgUrl())) {
             return true;
         }
 
-        Collection<String> requiredProductIds = dto.getRequiredProductIds();
+        if (update.getMetadataExpiration() != null &&
+            !update.getMetadataExpiration().equals(entity.getMetadataExpiration())) {
+
+            return true;
+        }
+
+        if (update.getArches() != null && !update.getArches().equals(entity.getArches())) {
+            return true;
+        }
+
+        Collection<String> requiredProductIds = update.getRequiredProductIds();
         if (requiredProductIds != null &&
             !Util.collectionsAreEqual(entity.getRequiredProductIds(), requiredProductIds)) {
 

--- a/server/src/main/java/org/candlepin/controller/ProductManager.java
+++ b/server/src/main/java/org/candlepin/controller/ProductManager.java
@@ -903,7 +903,7 @@ public class ProductManager {
      * @return
      *  true if this product would be changed by the given product info; false otherwise
      */
-    public static boolean isChangedBy(Product entity, ProductInfo update) {
+    public static boolean isChangedBy(ProductInfo entity, ProductInfo update) {
 
         // Check simple properties first
         if (update.getId() != null && !update.getId().equals(entity.getId())) {
@@ -940,7 +940,7 @@ public class ProductManager {
         if (productContent != null) {
             Comparator comparator = new Comparator() {
                 public int compare(Object lhs, Object rhs) {
-                    ProductContent existing = (ProductContent) lhs;
+                    ProductContentInfo existing = (ProductContentInfo) lhs;
                     ProductContentInfo update = (ProductContentInfo) rhs;
 
                     if (existing != null && update != null) {

--- a/server/src/main/java/org/candlepin/controller/ProductManager.java
+++ b/server/src/main/java/org/candlepin/controller/ProductManager.java
@@ -944,7 +944,7 @@ public class ProductManager {
                     ProductContentInfo update = (ProductContentInfo) rhs;
 
                     if (existing != null && update != null) {
-                        Content content = existing.getContent();
+                        ContentInfo content = existing.getContent();
                         ContentInfo cdto = update.getContent();
 
                         if (content != null && cdto != null) {

--- a/server/src/main/java/org/candlepin/controller/RefreshResult.java
+++ b/server/src/main/java/org/candlepin/controller/RefreshResult.java
@@ -14,7 +14,14 @@
  */
 package org.candlepin.controller;
 
+import org.candlepin.model.Content;
+import org.candlepin.model.Pool;
+import org.candlepin.model.Product;
 
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 
 public class RefreshResult {
@@ -100,7 +107,7 @@ public class RefreshResult {
             throw new IllegalArgumentException("content is null");
         }
 
-        return (this.createdContents.put(content.getId(), content) != content);
+        return (this.createdContent.put(content.getId(), content) != content);
     }
 
     public boolean addUpdatedContent(Content content) {
@@ -108,7 +115,7 @@ public class RefreshResult {
             throw new IllegalArgumentException("content is null");
         }
 
-        return (this.updatedContents.put(content.getId(), content) != content);
+        return (this.updatedContent.put(content.getId(), content) != content);
     }
 
     public boolean addSkippedContent(String contentId) {
@@ -116,7 +123,7 @@ public class RefreshResult {
             throw new IllegalArgumentException("contentId is null or empty");
         }
 
-        return this.skippedContents.add(contentId);
+        return this.skippedContent.add(contentId);
     }
 
 

--- a/server/src/main/java/org/candlepin/controller/RefreshResult.java
+++ b/server/src/main/java/org/candlepin/controller/RefreshResult.java
@@ -121,7 +121,36 @@ public class RefreshResult {
 
 
 
+    public Map<String, Product> getUpdatedProducts() {
+        // This should be encapsulated, probably
+        return this.updatedProducts;
+    }
 
+    public Map<String, Product> getImportedProducts() {
+        // Make this more efficient/safe/more gooder
+        Map<String, Product> imported = new HashMap<>();
+
+        imported.putAll(this.createdProducts);
+        imported.putAll(this.updatedProducts);
+
+        return imported;
+    }
+
+
+    public Map<String, Content> getUpdatedContent() {
+        // This should be encapsulated, probably
+        return this.updatedContent;
+    }
+
+    public Map<String, Content> getImportedContent() {
+        // Make this more efficient/safe/more gooder
+        Map<String, Content> imported = new HashMap<>();
+
+        imported.putAll(this.createdContent);
+        imported.putAll(this.updatedContent);
+
+        return imported;
+    }
 
 
 

--- a/server/src/main/java/org/candlepin/controller/RefreshResult.java
+++ b/server/src/main/java/org/candlepin/controller/RefreshResult.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) 2009 - ${YEAR} Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.controller;
+
+
+
+
+public class RefreshResult {
+
+    private Map<String, Pool> createdPools;
+    private Map<String, Pool> updatedPools;
+    private Set<String> skippedPools;
+
+    private Map<String, Product> createdProducts;
+    private Map<String, Product> updatedProducts;
+    private Set<String> skippedProducts;
+
+    private Map<String, Content> createdContent;
+    private Map<String, Content> updatedContent;
+    private Set<String> skippedContent;
+
+
+
+    public RefreshResult() {
+        this.createdPools = new HashMap<>();
+        this.updatedPools = new HashMap<>();
+        this.skippedPools = new HashSet<>();
+
+        this.createdProducts = new HashMap<>();
+        this.updatedProducts = new HashMap<>();
+        this.skippedProducts = new HashSet<>();
+
+        this.createdContent = new HashMap<>();
+        this.updatedContent = new HashMap<>();
+        this.skippedContent = new HashSet<>();
+    }
+
+    public boolean addCreatedPool(Pool pool) {
+        if (pool == null) {
+            throw new IllegalArgumentException("pool is null");
+        }
+
+        return (this.createdPools.put(pool.getId(), pool) != pool);
+    }
+
+    public boolean addUpdatedPool(Pool pool) {
+        if (pool == null) {
+            throw new IllegalArgumentException("pool is null");
+        }
+
+        return (this.updatedPools.put(pool.getId(), pool) != pool);
+    }
+
+    public boolean addSkippedPool(String poolId) {
+        if (poolId == null || poolId.isEmpty()) {
+            throw new IllegalArgumentException("poolId is null or empty");
+        }
+
+        return this.skippedPools.add(poolId);
+    }
+
+    public boolean addCreatedProduct(Product product) {
+        if (product == null) {
+            throw new IllegalArgumentException("product is null");
+        }
+
+        return (this.createdProducts.put(product.getId(), product) != product);
+    }
+
+    public boolean addUpdatedProduct(Product product) {
+        if (product == null) {
+            throw new IllegalArgumentException("product is null");
+        }
+
+        return (this.updatedProducts.put(product.getId(), product) != product);
+    }
+
+    public boolean addSkippedProduct(String productId) {
+        if (productId == null || productId.isEmpty()) {
+            throw new IllegalArgumentException("productId is null or empty");
+        }
+
+        return this.skippedProducts.add(productId);
+    }
+
+    public boolean addCreatedContent(Content content) {
+        if (content == null) {
+            throw new IllegalArgumentException("content is null");
+        }
+
+        return (this.createdContents.put(content.getId(), content) != content);
+    }
+
+    public boolean addUpdatedContent(Content content) {
+        if (content == null) {
+            throw new IllegalArgumentException("content is null");
+        }
+
+        return (this.updatedContents.put(content.getId(), content) != content);
+    }
+
+    public boolean addSkippedContent(String contentId) {
+        if (contentId == null || contentId.isEmpty()) {
+            throw new IllegalArgumentException("contentId is null or empty");
+        }
+
+        return this.skippedContents.add(contentId);
+    }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+}

--- a/server/src/main/java/org/candlepin/model/Content.java
+++ b/server/src/main/java/org/candlepin/model/Content.java
@@ -550,6 +550,14 @@ public class Content extends AbstractHibernateObject implements SharedEntity, Cl
      *  a version hash for this entity
      */
     public int getEntityVersion() {
+        return this.getEntityVersion(false);
+    }
+
+    public int getEntityVersion(boolean useCache) {
+        if (useCache && this.entityVersion != null) {
+            return this.entityVersion;
+        }
+
         // This must always be a subset of equals
         HashCodeBuilder builder = new HashCodeBuilder(37, 7)
             .append(this.id)

--- a/server/src/main/java/org/candlepin/model/OwnerContentCurator.java
+++ b/server/src/main/java/org/candlepin/model/OwnerContentCurator.java
@@ -29,10 +29,15 @@ import org.slf4j.LoggerFactory;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.inject.Singleton;
+import javax.persistence.TypedQuery;
+
+
 
 /**
  * The OwnerContentCurator provides functionality for managing the mapping between owners and
@@ -355,7 +360,7 @@ public class OwnerContentCurator extends AbstractHibernateCurator<OwnerContent> 
                 jpql = "SELECT c FROM Content c WHERE p.contentId IN (:cids)";
             }
 
-            TypedQuery<Content> query = this.getEntityManager().createTypedQuery(jpql, Content.class);
+            TypedQuery<Content> query = this.getEntityManager().createQuery(jpql, Content.class);
 
             if (owner != null) {
                 query.setParameter("owner_id", owner.getId());

--- a/server/src/main/java/org/candlepin/model/OwnerContentCurator.java
+++ b/server/src/main/java/org/candlepin/model/OwnerContentCurator.java
@@ -327,9 +327,9 @@ public class OwnerContentCurator extends AbstractHibernateCurator<OwnerContent> 
     }
 
     /**
-     * Retrieves a set containing all known versions of the content specified by IDs, for all orgs
+     * Retrieves a map containing all known versions of the content specified by IDs, for all orgs
      * <em>except</em> the org specified. If no content is found for the specified IDs in other
-     * orgs, this method returns an empty set.
+     * orgs, this method returns an empty map.
      *
      * @param owner
      *  The owner to exclude from the content lookup. If this value is null, no owner-filtering
@@ -339,10 +339,10 @@ public class OwnerContentCurator extends AbstractHibernateCurator<OwnerContent> 
      *  A collection of content IDs for which to fetch all known versions
      *
      * @return
-     *  A set containing all known versions of the given content
+     *  A map containing all known versions of the given content, mapped by Red Hat ID
      */
-    public Set<Content> getVersionedContentById(Owner owner, Collection<String> contentIds) {
-        Set<Content> result = new HashSet<>();
+    public Map<String, Set<Content>> getVersionedContentById(Owner owner, Collection<String> contentIds) {
+        Map<String, Set<Content>> result = new HashMap<>();
 
         if (contentIds != null && !contentIds.isEmpty()) {
             String jpql;
@@ -365,7 +365,16 @@ public class OwnerContentCurator extends AbstractHibernateCurator<OwnerContent> 
                 List<Content> fetched = query.setParameter("cids", block)
                     .getResultList();
 
-                result.addAll(fetched);
+                for (Content entity : fetched) {
+                    Set<Content> idSet = result.get(entity.getId());
+
+                    if (idSet == null) {
+                        idSet = new HashSet<>();
+                        result.put(entity.getId(), idSet);
+                    }
+
+                    idSet.add(entity);
+                }
             }
         }
 

--- a/server/src/main/java/org/candlepin/model/OwnerProductCurator.java
+++ b/server/src/main/java/org/candlepin/model/OwnerProductCurator.java
@@ -38,6 +38,7 @@ import java.util.Map;
 import java.util.Set;
 
 import javax.inject.Singleton;
+import javax.persistence.TypedQuery;
 
 
 
@@ -440,6 +441,52 @@ public class OwnerProductCurator extends AbstractHibernateCurator<OwnerProduct> 
         }
 
         return this.cpQueryFactory.<Product>buildQuery();
+    }
+
+    /**
+     * Retrieves a set containing all known versions of the products specified by IDs, for all orgs
+     * <em>except</em> the org specified. If no products are found for the specified IDs in other
+     * orgs, this method returns an empty set.
+     *
+     * @param owner
+     *  The owner to exclude from the product lookup. If this value is null, no owner-filtering
+     *  will be performed.
+     *
+     * @param productIds
+     *  A collection of productIds for which to fetch all known versions
+     *
+     * @return
+     *  A set containing all known versions of the given products
+     */
+    public Set<Product> getVersionedProductsById(Owner owner, Collection<String> productIds) {
+        Set<Product> result = new HashSet<>();
+
+        if (productIds != null && !productIds.isEmpty()) {
+            String jpql;
+
+            if (owner != null) {
+                jpql = "SELECT p FROM OwnerProducts op JOIN op.product p " +
+                    "WHERE op.owner.id != :owner_id AND p.productId IN (:pids)";
+            }
+            else {
+                jpql = "SELECT p FROM Products p WHERE p.productId IN (:pids)";
+            }
+
+            TypedQuery<Product> query = this.getEntityManager().createTypedQuery(jpql, Product.class);
+
+            if (owner != null) {
+                query.setParameter("owner_id", owner.getId());
+            }
+
+            for (Collection<String> block : this.partition(productIds)) {
+                List<Product> fetched = query.setParameter("pids", block)
+                    .getResultList();
+
+                result.addAll(fetched);
+            }
+        }
+
+        return result;
     }
 
     /**

--- a/server/src/main/java/org/candlepin/model/OwnerProductCurator.java
+++ b/server/src/main/java/org/candlepin/model/OwnerProductCurator.java
@@ -444,9 +444,9 @@ public class OwnerProductCurator extends AbstractHibernateCurator<OwnerProduct> 
     }
 
     /**
-     * Retrieves a set containing all known versions of the products specified by IDs, for all orgs
+     * Retrieves a map containing all known versions of the products specified by IDs, for all orgs
      * <em>except</em> the org specified. If no products are found for the specified IDs in other
-     * orgs, this method returns an empty set.
+     * orgs, this method returns an empty map.
      *
      * @param owner
      *  The owner to exclude from the product lookup. If this value is null, no owner-filtering
@@ -456,10 +456,10 @@ public class OwnerProductCurator extends AbstractHibernateCurator<OwnerProduct> 
      *  A collection of productIds for which to fetch all known versions
      *
      * @return
-     *  A set containing all known versions of the given products
+     *  A map containing all known versions of the given products, mapped by Red Hat ID
      */
-    public Set<Product> getVersionedProductsById(Owner owner, Collection<String> productIds) {
-        Set<Product> result = new HashSet<>();
+    public Map<String, Set<Product>> getVersionedProductsById(Owner owner, Collection<String> productIds) {
+        Map<String, Set<Product>> result = new HashMap<>();
 
         if (productIds != null && !productIds.isEmpty()) {
             String jpql;
@@ -482,7 +482,16 @@ public class OwnerProductCurator extends AbstractHibernateCurator<OwnerProduct> 
                 List<Product> fetched = query.setParameter("pids", block)
                     .getResultList();
 
-                result.addAll(fetched);
+                for (Product entity : fetched) {
+                    Set<Product> idSet = result.get(entity.getId());
+
+                    if (idSet == null) {
+                        idSet = new HashSet<>();
+                        result.put(entity.getId(), idSet);
+                    }
+
+                    idSet.add(entity);
+                }
             }
         }
 

--- a/server/src/main/java/org/candlepin/model/OwnerProductCurator.java
+++ b/server/src/main/java/org/candlepin/model/OwnerProductCurator.java
@@ -472,7 +472,7 @@ public class OwnerProductCurator extends AbstractHibernateCurator<OwnerProduct> 
                 jpql = "SELECT p FROM Products p WHERE p.productId IN (:pids)";
             }
 
-            TypedQuery<Product> query = this.getEntityManager().createTypedQuery(jpql, Product.class);
+            TypedQuery<Product> query = this.getEntityManager().createQuery(jpql, Product.class);
 
             if (owner != null) {
                 query.setParameter("owner_id", owner.getId());

--- a/server/src/main/java/org/candlepin/model/Product.java
+++ b/server/src/main/java/org/candlepin/model/Product.java
@@ -1319,7 +1319,6 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
      * @return A reference to this product.
      */
     public Product setProvidedProducts(Collection<Product> providedProducts) {
-
         if (providedProducts != null) {
             this.providedProducts = new HashSet<>(providedProducts);
         }

--- a/server/src/main/java/org/candlepin/model/Product.java
+++ b/server/src/main/java/org/candlepin/model/Product.java
@@ -1242,6 +1242,19 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
      *  a version hash for this entity
      */
     public int getEntityVersion() {
+        return this.getEntityVersion(false);
+    }
+
+    /**
+     * Fetches the entity version, using the last-calcualted cache if available
+     */
+    public int getEntityVersion(boolean useCache) {
+        if (useCache && this.entityVersion != null) {
+            // It would be super nice if we just cleared entityVersion on any setter, and then
+            // always returned it if it were available.
+            return this.entityVersion;
+        }
+
         // This must always be a subset of equals
         HashCodeBuilder builder = new HashCodeBuilder(37, 7)
             .append(this.id)

--- a/server/src/main/java/org/candlepin/service/model/BrandingInfo.java
+++ b/server/src/main/java/org/candlepin/service/model/BrandingInfo.java
@@ -24,7 +24,7 @@ import java.util.Comparator;
  * Data which is not set or does not change should be represented by null values. To explicitly
  * clear a value, an empty string or non-null "empty" value should be used instead.
  */
-public interface BrandingInfo {
+public interface BrandingInfo extends ServiceModelInfo {
 
     /**
      * Fetches the name of this branding instance. If the name has not been set, this method

--- a/server/src/main/java/org/candlepin/service/model/CdnInfo.java
+++ b/server/src/main/java/org/candlepin/service/model/CdnInfo.java
@@ -22,7 +22,7 @@ package org.candlepin.service.model;
  * Data which is not set or does not change should be represented by null values. To explicitly
  * clear a value, an empty string or non-null "empty" value should be used instead.
  */
-public interface CdnInfo {
+public interface CdnInfo extends ServiceModelInfo {
 
     /**
      * Fetches the name of this CDN. If the name has not been set, this method returns null.

--- a/server/src/main/java/org/candlepin/service/model/CertificateInfo.java
+++ b/server/src/main/java/org/candlepin/service/model/CertificateInfo.java
@@ -23,7 +23,7 @@ package org.candlepin.service.model;
  * Data which is not set or does not change should be represented by null values. To explicitly
  * clear a value, an empty string or non-null "empty" value should be used instead.
  */
-public interface CertificateInfo {
+public interface CertificateInfo extends ServiceModelInfo {
 
     /**
      * Fetches the serial of this certificate. If the serial has not been set, this method returns

--- a/server/src/main/java/org/candlepin/service/model/CertificateSerialInfo.java
+++ b/server/src/main/java/org/candlepin/service/model/CertificateSerialInfo.java
@@ -32,7 +32,7 @@ import java.util.Date;
  *  building functionality around it is not advised.
  */
 @Deprecated
-public interface CertificateSerialInfo {
+public interface CertificateSerialInfo extends ServiceModelInfo {
 
     /**
      * Fetches the serial of the linking certificate. If the serial has not been set, this method

--- a/server/src/main/java/org/candlepin/service/model/ConsumerInfo.java
+++ b/server/src/main/java/org/candlepin/service/model/ConsumerInfo.java
@@ -24,7 +24,7 @@ import java.util.Map;
  * Data which is not set or does not change should be represented by null values. To explicitly
  * clear a value, an empty string or non-null "empty" value should be used instead.
  */
-public interface ConsumerInfo {
+public interface ConsumerInfo extends ServiceModelInfo {
 
     // /**
     //  * Fetches the ID of this consumer. If the ID has not yet been generated or set, this method

--- a/server/src/main/java/org/candlepin/service/model/ContentInfo.java
+++ b/server/src/main/java/org/candlepin/service/model/ContentInfo.java
@@ -26,7 +26,7 @@ import java.util.Date;
  * Data which is not set or does not change should be represented by null values. To explicitly
  * clear a value, an empty string or non-null "empty" value should be used instead.
  */
-public interface ContentInfo {
+public interface ContentInfo extends ServiceModelInfo {
 
     /**
      * Fetches the Red Hat ID of this content. If the ID has not yet been set, this method returns

--- a/server/src/main/java/org/candlepin/service/model/OwnerInfo.java
+++ b/server/src/main/java/org/candlepin/service/model/OwnerInfo.java
@@ -25,7 +25,7 @@ import java.util.Date;
  * Data which is not set or does not change should be represented by null values. To explicitly
  * clear a value, an empty string or non-null "empty" value should be used instead.
  */
-public interface OwnerInfo {
+public interface OwnerInfo extends ServiceModelInfo {
 
     /**
      * Fetches the key of this owner. If the key has not been set, this method returns null.

--- a/server/src/main/java/org/candlepin/service/model/PermissionBlueprintInfo.java
+++ b/server/src/main/java/org/candlepin/service/model/PermissionBlueprintInfo.java
@@ -23,7 +23,7 @@ package org.candlepin.service.model;
  * Data which is not set or does not change should be represented by null values. To explicitly
  * clear a value, an empty string or non-null "empty" value should be used instead.
  */
-public interface PermissionBlueprintInfo {
+public interface PermissionBlueprintInfo extends ServiceModelInfo {
 
     // /**
     //  * Fetches the ID of this role. If the ID has not yet been set, this method returns null.

--- a/server/src/main/java/org/candlepin/service/model/ProductContentInfo.java
+++ b/server/src/main/java/org/candlepin/service/model/ProductContentInfo.java
@@ -23,7 +23,7 @@ package org.candlepin.service.model;
  * Data which is not set or does not change should be represented by null values. To explicitly
  * clear a value, an empty string or non-null "empty" value should be used instead.
  */
-public interface ProductContentInfo {
+public interface ProductContentInfo extends ServiceModelInfo {
 
     /**
      * Fetches the content associated with the parent product. If the content has not been set,

--- a/server/src/main/java/org/candlepin/service/model/ProductInfo.java
+++ b/server/src/main/java/org/candlepin/service/model/ProductInfo.java
@@ -27,7 +27,7 @@ import java.util.Map;
  * Data which is not set or does not change should be represented by null values. To explicitly
  * clear a value, an empty string or non-null "empty" value should be used instead.
  */
-public interface ProductInfo {
+public interface ProductInfo extends ServiceModelInfo {
 
     /**
      * Fetches the Red Hat ID of this product. If the ID has not yet been set, this method returns

--- a/server/src/main/java/org/candlepin/service/model/RoleInfo.java
+++ b/server/src/main/java/org/candlepin/service/model/RoleInfo.java
@@ -25,7 +25,7 @@ import java.util.Date;
  * Data which is not set or does not change should be represented by null values. To explicitly
  * clear a value, an empty string or non-null "empty" value should be used instead.
  */
-public interface RoleInfo {
+public interface RoleInfo extends ServiceModelInfo {
 
     // /**
     //  * Fetches the ID of this role. If the ID has not yet been set, this method returns null.

--- a/server/src/main/java/org/candlepin/service/model/ServiceModelInfo.java
+++ b/server/src/main/java/org/candlepin/service/model/ServiceModelInfo.java
@@ -18,7 +18,7 @@ package org.candlepin.service.model;
 /**
  * Parent interface for all service model interfaces.
  */
-public interface ServiceModelInfo extends ServiceModelInfo {
+public interface ServiceModelInfo {
 
     // Intentionally left empty... for now.
 

--- a/server/src/main/java/org/candlepin/service/model/ServiceModelInfo.java
+++ b/server/src/main/java/org/candlepin/service/model/ServiceModelInfo.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2009 - 2018 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.model;
+
+
+/**
+ * Parent interface for all service model interfaces.
+ */
+public interface ServiceModelInfo extends ServiceModelInfo {
+
+    // Intentionally left empty... for now.
+
+}

--- a/server/src/main/java/org/candlepin/service/model/SubscriptionInfo.java
+++ b/server/src/main/java/org/candlepin/service/model/SubscriptionInfo.java
@@ -26,7 +26,7 @@ import java.util.Date;
  * Data which is not set or does not change should be represented by null values. To explicitly
  * clear a value, an empty string or non-null "empty" value should be used instead.
  */
-public interface SubscriptionInfo {
+public interface SubscriptionInfo extends ServiceModelInfo {
 
     /**
      * Fetches the ID of this subscription. If the ID has not yet been set, this method returns

--- a/server/src/main/java/org/candlepin/service/model/UserInfo.java
+++ b/server/src/main/java/org/candlepin/service/model/UserInfo.java
@@ -26,7 +26,7 @@ import java.util.Date;
  * Data which is not set or does not change should be represented by null values. To explicitly
  * clear a value, an empty string or non-null "empty" value should be used instead.
  */
-public interface UserInfo {
+public interface UserInfo extends ServiceModelInfo {
 
     // /**
     //  * Fetches the ID of this user. If the ID has not yet been set, this method returns null.


### PR DESCRIPTION
This PR is a current sampling of the PoC work for the n-tier refresh refactor currently underway. Feedback or questions on the code changes are welcome, and where this PR lands made here will affect the final design document. However, at no point should this PR be merged as-is. 

Unfortunately (or expectedly, I suppose), I've gone down a number of rabbit holes in searching for best/efficient ways of performing certain actions which has delayed things, but it's approaching the point where it's compilable and runnable.

Some interesting changes of note:
- To avoid a multitude of DB hits with the tree-like nature of the model, it now fetches *all* products and content for the org being refreshed, and builds the trees based on that. This should also avoid the scenario where we could end up with multiple products with the same RHID within a given org due to how the processing is performed.
- Versioning and convergence/divergence is slightly different this time around. Again, in the interest in avoiding several unnecessary DB hits, all known versions of entities are fetched, mapped and then compared against once 
- Currently we're only storing a boolean value indicating whether or not a change has taken place. However, in the future, we could easily expand this check to identify *what* has changed in some kind of change map. If pools are also rolled into the "ActualRefresher" class, these changes could completely eliminate some of the duplicate or unnecessary work we do to pools and entitlements during refresh.

Things I've learned throughout this work:
- The shape of our data is much smaller in the general case than I had imagined. For products, we're looking at an average of around 50 products/org, with a standard deviation of around 15. On content it's ~1000/~250 if I'm remembering correctly.
