### PR TITLE
Revert "Bump rake from 0.9.2.2 to 13.0.1"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,7 +40,7 @@ GEM
     qpid_proton (0.21.0)
     rainbow (2.2.2)
       rake
-    rake (13.0.1)
+    rake (0.9.2.2)
     rest-client (1.6.9)
       mime-types (~> 1.16)
     rspec (3.6.0)


### PR DESCRIPTION
Reverts candlepin/candlepin#2629

This breaks our vagrant setups, as our current base images do not have (easy) access to ruby 2.2+ without adding rvm or changing the image. Reverting this change until we can get around to updating the vagrant config to be compatible with this change.