### PR TITLE
[M] Removed the constraint on the CDN label in ExportJob (ENT-2218)

### DIFF
--- a/server/src/main/java/org/candlepin/async/tasks/ExportJob.java
+++ b/server/src/main/java/org/candlepin/async/tasks/ExportJob.java
@@ -153,11 +153,6 @@ public class ExportJob implements AsyncJob {
                     String errmsg = "consumer has not been set, or the provided consumer lacks a UUID";
                     throw new JobConfigValidationException(errmsg);
                 }
-
-                if (cdnLabel == null || cdnLabel.isEmpty()) {
-                    String errmsg = "CDN label has not been set, or the provided label is empty";
-                    throw new JobConfigValidationException(errmsg);
-                }
             }
             catch (ArgumentConversionException e) {
                 String errmsg = "One or more required arguments are of the wrong type";

--- a/server/src/test/java/org/candlepin/async/tasks/ExportJobTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/ExportJobTest.java
@@ -156,23 +156,23 @@ public class ExportJobTest {
     }
 
     @Test
+    public void testValidateCDNLabelNotRequired() throws JobConfigValidationException {
+        Owner owner = this.createTestOwner("owner_key", "log_level");
+        Consumer consumer = TestUtil.createDistributor(owner);
+
+        JobConfig config = ExportJob.createJobConfig()
+            .setConsumer(consumer);
+
+        config.validate();
+    }
+
+    @Test
     public void testValidateNoConsumer() {
         Owner owner = this.createTestOwner("owner_key", "log_level");
         Consumer consumer = TestUtil.createDistributor(owner);
 
         JobConfig config = ExportJob.createJobConfig()
             .setCdnLabel("test_label");
-
-        assertThrows(JobConfigValidationException.class, config::validate);
-    }
-
-    @Test
-    public void testValidateNoLabel() {
-        Owner owner = this.createTestOwner("owner_key", "log_level");
-        Consumer consumer = TestUtil.createDistributor(owner);
-
-        JobConfig config = ExportJob.createJobConfig()
-            .setConsumer(consumer);
 
         assertThrows(JobConfigValidationException.class, config::validate);
     }


### PR DESCRIPTION
- ExportJob no longer requires a non-null and non-empty CDN label
  to perform an export