### PR TITLE
[F] ENT-2177: Use concrete method to locate ResourceLocator

### DIFF
--- a/server/src/main/java/org/candlepin/guice/CandlepinContextListener.java
+++ b/server/src/main/java/org/candlepin/guice/CandlepinContextListener.java
@@ -32,7 +32,7 @@ import org.candlepin.controller.SuspendModeTransitioner;
 import org.candlepin.logging.LoggerContextListener;
 import org.candlepin.messaging.CPMContextListener;
 import org.candlepin.pki.impl.JSSProviderLoader;
-import org.candlepin.resteasy.AnnotationLocator;
+import org.candlepin.resteasy.MethodLocator;
 import org.candlepin.resteasy.ResourceLocatorMap;
 import org.candlepin.swagger.CandlepinSwaggerModelConverter;
 import org.candlepin.util.Util;
@@ -160,13 +160,11 @@ public class CandlepinContextListener extends GuiceResteasyBootstrapServletConte
         // Must call super.contextInitialized() before accessing injector
         insertValidationEventListeners(injector);
 
-        AnnotationLocator annotationLocator = injector.getInstance(AnnotationLocator.class);
-        annotationLocator.init();
+        MethodLocator methodLocator = injector.getInstance(MethodLocator.class);
+        methodLocator.init();
 
         ResourceLocatorMap map = injector.getInstance(ResourceLocatorMap.class);
         map.init();
-
-
 
         // make sure our session factory is initialized before we attempt to start something
         // that relies upon it

--- a/server/src/main/java/org/candlepin/guice/CandlepinModule.java
+++ b/server/src/main/java/org/candlepin/guice/CandlepinModule.java
@@ -147,6 +147,7 @@ import org.candlepin.resource.util.ResolverUtil;
 import org.candlepin.resteasy.AnnotationLocator;
 import org.candlepin.resteasy.DateFormatter;
 import org.candlepin.resteasy.JsonProvider;
+import org.candlepin.resteasy.MethodLocator;
 import org.candlepin.resteasy.ResourceLocatorMap;
 import org.candlepin.resteasy.filter.AuthenticationFilter;
 import org.candlepin.resteasy.filter.AuthorizationFeature;
@@ -281,6 +282,7 @@ public class CandlepinModule extends AbstractModule {
         bind(JAXBMarshalExceptionMapper.class);
         bind(JAXBUnmarshalExceptionMapper.class);
         bind(AnnotationLocator.class).asEagerSingleton();
+        bind(MethodLocator.class).asEagerSingleton();
 
         bind(Principal.class).toProvider(PrincipalProvider.class);
         bind(JsRunnerProvider.class).asEagerSingleton();

--- a/server/src/main/java/org/candlepin/resteasy/MethodLocator.java
+++ b/server/src/main/java/org/candlepin/resteasy/MethodLocator.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.resteasy;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Binding;
+import com.google.inject.Injector;
+
+import org.jboss.resteasy.spi.metadata.ResourceBuilder;
+import org.jboss.resteasy.spi.metadata.ResourceClass;
+import org.jboss.resteasy.spi.metadata.ResourceLocator;
+import org.jboss.resteasy.spi.metadata.ResourceMethod;
+import org.jboss.resteasy.util.GetRestful;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.inject.Inject;
+
+/**
+ * Holds a mapping of interface methods to concrete methods.
+ * This map is populated during servlet initialization and then locked.
+ */
+public class MethodLocator {
+    private static final Logger log = LoggerFactory.getLogger(MethodLocator.class);
+
+    private Map<Method, Method> internalMap;
+    private boolean hasBeenInitialized = false;
+
+    private Injector injector;
+
+    @Inject
+    public MethodLocator(Injector injector) {
+        // Maintain the insertion order for nice output in debug statement
+        internalMap = new LinkedHashMap<>();
+        this.injector = injector;
+    }
+
+    @SuppressWarnings("rawtypes")
+    public synchronized MethodLocator init() {
+        if (hasBeenInitialized) {
+            throw new IllegalStateException("This map has already been initialized.");
+        }
+
+        List<Binding<?>> rootResourceBindings = new ArrayList<>();
+        for (Binding<?> binding : injector.getBindings().values()) {
+            Type type = binding.getKey().getTypeLiteral().getType();
+            if (type instanceof Class) {
+                Class<?> beanClass = (Class) type;
+                if (GetRestful.isRootResource(beanClass)) {
+                    rootResourceBindings.add(binding);
+                }
+            }
+        }
+
+        for (Binding<?> binding : rootResourceBindings) {
+            Class<?> clazz = (Class) binding.getKey().getTypeLiteral().getType();
+            if (Proxy.isProxyClass(clazz)) {
+                for (Class<?> intf : clazz.getInterfaces()) {
+                    ResourceClass resourceClass = ResourceBuilder.rootResourceFromAnnotations(intf);
+                    registerConcreteMethods(resourceClass, clazz);
+                }
+            }
+            else {
+                ResourceClass resourceClass = ResourceBuilder.rootResourceFromAnnotations(clazz);
+                registerConcreteMethods(resourceClass, clazz);
+            }
+        }
+
+        lock();
+        return this;
+    }
+
+    /**
+     *
+     * @param method
+     * @return concrete method if available
+     */
+    public Method getConcreteMethod(Method method) {
+        return this.internalMap.get(method);
+    }
+
+    private void registerConcreteMethods(ResourceClass resourceClass, Class<?> concreteClass) {
+        for (ResourceMethod resourceMethod : resourceClass.getResourceMethods()) {
+            registerConcreteMethod(resourceMethod.getMethod(), concreteClass);
+        }
+
+        for (ResourceLocator resourceMethod : resourceClass.getResourceLocators()) {
+            registerConcreteMethod(resourceMethod.getMethod(), concreteClass);
+        }
+    }
+
+    private void registerConcreteMethod(Method method, Class<?> concreteClass) {
+        try {
+            for (Class<?> iface : concreteClass.getInterfaces()) {
+                Method ifaceMethod = iface.getMethod(method.getName(), method.getParameterTypes());
+                internalMap.put(ifaceMethod, method);
+            }
+        }
+        catch (NoSuchMethodException e) {
+            log.error("Can't find concrete method for method {}!", method);
+        }
+    }
+
+    private void lock() {
+        hasBeenInitialized = true;
+        internalMap = ImmutableMap.copyOf(internalMap);
+    }
+
+}

--- a/server/src/main/java/org/candlepin/resteasy/ResourceLocatorMap.java
+++ b/server/src/main/java/org/candlepin/resteasy/ResourceLocatorMap.java
@@ -62,14 +62,16 @@ public class ResourceLocatorMap implements Map<Method, ResourceLocator> {
     private static final Logger log = LoggerFactory.getLogger(ResourceLocatorMap.class);
 
     private Map<Method, ResourceLocator> internalMap;
+    private MethodLocator methodLocator;
     private boolean hasBeenInitialized = false;
 
     private Injector injector;
 
     @Inject
-    public ResourceLocatorMap(Injector injector) {
+    public ResourceLocatorMap(Injector injector, MethodLocator methodLocator) {
         // Maintain the insertion order for nice output in debug statement
         internalMap = new LinkedHashMap<>();
+        this.methodLocator = methodLocator;
         this.injector = injector;
     }
 
@@ -95,6 +97,10 @@ public class ResourceLocatorMap implements Map<Method, ResourceLocator> {
 
     @Override
     public ResourceLocator get(Object key) {
+        Method concreteMethod = methodLocator.getConcreteMethod((Method) key);
+        if (concreteMethod != null) {
+            return internalMap.get(concreteMethod);
+        }
         return internalMap.get(key);
     }
 
@@ -140,10 +146,10 @@ public class ResourceLocatorMap implements Map<Method, ResourceLocator> {
         }
 
         List<Binding<?>> rootResourceBindings = new ArrayList<>();
-        for (final Binding<?> binding : injector.getBindings().values()) {
-            final Type type = binding.getKey().getTypeLiteral().getType();
+        for (Binding<?> binding : injector.getBindings().values()) {
+            Type type = binding.getKey().getTypeLiteral().getType();
             if (type instanceof Class) {
-                final Class<?> beanClass = (Class) type;
+                Class<?> beanClass = (Class) type;
                 if (GetRestful.isRootResource(beanClass)) {
                     rootResourceBindings.add(binding);
                 }

--- a/server/src/test/java/org/candlepin/resteasy/filter/AuthenticationFilterTest.java
+++ b/server/src/test/java/org/candlepin/resteasy/filter/AuthenticationFilterTest.java
@@ -29,6 +29,7 @@ import org.candlepin.model.ConsumerCurator;
 import org.candlepin.model.DeletedConsumerCurator;
 import org.candlepin.model.User;
 import org.candlepin.resteasy.AnnotationLocator;
+import org.candlepin.resteasy.MethodLocator;
 import org.candlepin.service.UserServiceAdapter;
 import org.candlepin.test.DatabaseTestFixture;
 
@@ -141,8 +142,9 @@ public class AuthenticationFilterTest extends DatabaseTestFixture {
         when(bearerTokenRequestAuthenticator.getToken()).
             thenReturn(TokenVerifier.create(TESTTOKEN, AccessToken.class).getToken());
 
-        AnnotationLocator annotationLocator = new AnnotationLocator(injector);
-        annotationLocator.init();
+        MethodLocator methodLocator = new MethodLocator(injector);
+        methodLocator.init();
+        AnnotationLocator annotationLocator = new AnnotationLocator(methodLocator);
         interceptor = new AuthenticationFilter(config, consumerCurator, deletedConsumerCurator, injector,
             annotationLocator);
         interceptor.setHttpServletRequest(mockHttpServletRequest);

--- a/server/src/test/java/org/candlepin/resteasy/filter/AuthorizationFeatureTest.java
+++ b/server/src/test/java/org/candlepin/resteasy/filter/AuthorizationFeatureTest.java
@@ -18,6 +18,7 @@ import org.candlepin.auth.Verify;
 import org.candlepin.common.auth.SecurityHole;
 import org.candlepin.model.Consumer;
 import org.candlepin.resteasy.AnnotationLocator;
+import org.candlepin.resteasy.MethodLocator;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
@@ -101,8 +102,9 @@ public class AuthorizationFeatureTest {
     @Before
     public void setUp() throws Exception {
         injector = Guice.createInjector(getGuiceOverrideModule());
-        AnnotationLocator annotationLocator = new AnnotationLocator(injector);
-        annotationLocator.init();
+        MethodLocator methodLocator = new MethodLocator(injector);
+        methodLocator.init();
+        AnnotationLocator annotationLocator = new AnnotationLocator(methodLocator);
         this.authorizationFeature = new AuthorizationFeature(
             verifyFilter, superAdminFilter, securityHoleFilter, annotationLocator);
 

--- a/server/src/test/java/org/candlepin/resteasy/filter/ConsumerCheckInFilterTest.java
+++ b/server/src/test/java/org/candlepin/resteasy/filter/ConsumerCheckInFilterTest.java
@@ -20,6 +20,7 @@ import org.candlepin.auth.UpdateConsumerCheckIn;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.Owner;
 import org.candlepin.resteasy.AnnotationLocator;
+import org.candlepin.resteasy.MethodLocator;
 import org.candlepin.test.DatabaseTestFixture;
 
 import com.google.inject.AbstractModule;
@@ -84,8 +85,9 @@ public class ConsumerCheckInFilterTest extends DatabaseTestFixture {
         ResteasyProviderFactory.pushContext(ResourceInfo.class, mockInfo);
         ResteasyProviderFactory.pushContext(Principal.class, this.principal);
 
-        AnnotationLocator annotationLocator = new AnnotationLocator(injector);
-        annotationLocator.init();
+        MethodLocator methodLocator = new MethodLocator(injector);
+        methodLocator.init();
+        AnnotationLocator annotationLocator = new AnnotationLocator(methodLocator);
         interceptor = new ConsumerCheckInFilter(consumerCurator, annotationLocator);
     }
 

--- a/server/src/test/java/org/candlepin/test/DatabaseTestFixture.java
+++ b/server/src/test/java/org/candlepin/test/DatabaseTestFixture.java
@@ -71,6 +71,7 @@ import org.candlepin.model.activationkeys.ActivationKey;
 import org.candlepin.model.activationkeys.ActivationKeyContentOverrideCurator;
 import org.candlepin.model.activationkeys.ActivationKeyCurator;
 import org.candlepin.resteasy.AnnotationLocator;
+import org.candlepin.resteasy.MethodLocator;
 import org.candlepin.resteasy.ResourceLocatorMap;
 import org.candlepin.util.DateSource;
 import org.candlepin.util.Util;
@@ -153,12 +154,12 @@ public class DatabaseTestFixture {
     @Inject protected PoolCurator poolCurator;
     @Inject protected RoleCurator roleCurator;
     @Inject protected UserCurator userCurator;
-
     @Inject protected PermissionFactory permissionFactory;
-
-    @Inject protected ResourceLocatorMap locatorMap;
-    @Inject protected AnnotationLocator annotationLocator;
     @Inject protected ModelTranslator modelTranslator;
+
+    protected ResourceLocatorMap locatorMap;
+    protected MethodLocator methodLocator;
+    protected AnnotationLocator annotationLocator;
 
     private static Injector parentInjector;
     protected Injector injector;
@@ -208,11 +209,13 @@ public class DatabaseTestFixture {
         this.injector = parentInjector.createChildInjector(
             Modules.override(testingModule).with(getGuiceOverrideModule()));
 
-        locatorMap = this.injector.getInstance(ResourceLocatorMap.class);
+        methodLocator = new MethodLocator(injector);
+        methodLocator.init();
+
+        locatorMap = new ResourceLocatorMap(injector, methodLocator);
         locatorMap.init();
 
-        annotationLocator = this.injector.getInstance(AnnotationLocator.class);
-        annotationLocator.init();
+        annotationLocator = new AnnotationLocator(methodLocator);
 
         securityInterceptor = this.injector.getInstance(TestingInterceptor.class);
 


### PR DESCRIPTION
  - Added new class MethodLocator to hold interface method and concrete method mapping
  - Updated ResourceLocatorMap class to use MethodLocator
  - Update AnnotationLocator class to use MethodLocator instead of internal