### PR TITLE
[M] Remove non-ASCII character that breaks tito rpm build

### DIFF
--- a/server/candlepin.spec.tmpl
+++ b/server/candlepin.spec.tmpl
@@ -234,7 +234,7 @@ fi
 - 1692411: Added additional product ids into consumer installed products
   Current rule code is only to consider consumer installed products to
   calculate the pool's average priority. Hence added any additional products
-  into consumer’s installed products to correctly calculate pool average
+  into consumer's installed products to correctly calculate pool average
   priority. (abhiskum@redhat.com)
 - 1813982: EUS Content not available in content access mode
   (wpoteat@redhat.com)


### PR DESCRIPTION
- This fixes the following error thrown by the Cheetah template
  engine used by tito, when building the rpm:

  File "/usr/lib64/python2.7/site-packages/Cheetah/Compiler.py", line 1711, in `__init__`
    source = unicode(source)
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 8104: ordinal not in range(128)