### PR TITLE
[M] Added support for JAAS in the embedded ActiveMQ broker (ENT-2154)

### DIFF
--- a/server/src/main/java/org/candlepin/async/impl/ActiveMQSessionFactory.java
+++ b/server/src/main/java/org/candlepin/async/impl/ActiveMQSessionFactory.java
@@ -187,7 +187,12 @@ public class ActiveMQSessionFactory {
     private String generateServerUrl() {
         StringBuilder serverUrlBuilder =
             new StringBuilder(this.config.getProperty(ConfigProperties.ACTIVEMQ_BROKER_URL));
-        if (!this.config.getBoolean(ConfigProperties.ACTIVEMQ_EMBEDDED)) {
+
+        // TODO: Change this to use ACTIVEMQ_EMBEDDED_BROKER once configuration upgrades are in
+        // place
+        boolean embedded = this.config.getBoolean(ConfigProperties.ACTIVEMQ_EMBEDDED);
+
+        if (!embedded) {
             serverUrlBuilder.append("?sslEnabled=true")
                 .append("&trustStorePath=")
                 .append(this.config.getProperty(ConfigProperties.ACTIVEMQ_TRUSTSTORE))
@@ -198,6 +203,7 @@ public class ActiveMQSessionFactory {
                 .append("&keyStorePassword=")
                 .append(this.config.getProperty(ConfigProperties.ACTIVEMQ_KEYSTORE_PASSWORD));
         }
+
         return serverUrlBuilder.toString();
     }
 

--- a/server/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/server/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -62,7 +62,8 @@ public class ConfigProperties {
 
     /*
      * XXX The actual property key refers to HornetQ which was ActiveMQ's ancestor.  We have to keep the
-     * key unchanged for compatibility reasons.
+     * key unchanged for compatibility reasons. These are deprecated, however, and should be replaced by
+     * newer configuration values as features are added.
      */
     public static final String ACTIVEMQ_ENABLED = "candlepin.audit.hornetq.enable";
 
@@ -150,8 +151,14 @@ public class ConfigProperties {
     // TODO:
     // Clean up all the messaging configuration. We have all sorts of prefixes and definitions for
     // common broker options, and stuff which is unique to specific brokers. We should be defining
-    // them as "candlepin.<broker type>.<setting>" instead of the various sections we have now.
+    // them as "candlepin.messaging.<broker type>.<setting>" instead of the various sections we
+    // have now.
+    public static final String ACTIVEMQ_EMBEDDED_BROKER = "candlepin.messaging.activemq.embedded.enabled";
 
+    public static final String ACTIVEMQ_JAAS_INVM_LOGIN_NAME =
+        "candlepin.messaging.activemq.embedded.jaas_invm_login_name";
+    public static final String ACTIVEMQ_JAAS_CERTIFICATE_LOGIN_NAME =
+        "candlepin.messaging.activemq.embedded.jaas_certificate_login_name";
 
     // AMQP stuff
     public static final String AMQP_INTEGRATION_ENABLED = "candlepin.amqp.enable";
@@ -362,9 +369,19 @@ public class ConfigProperties {
             this.put(CPM_PROVIDER, "artemis");
 
             this.put(ACTIVEMQ_ENABLED, "true");
+
             this.put(ACTIVEMQ_EMBEDDED, "true");
+
+            // TODO: Delete the above configuration and only use EMBEDDED_BROKER going forward.
+            // This is currently blocked by complexity in supporting moving configuration paths,
+            // and should coincide with an update to the Configuration object
+            this.put(ACTIVEMQ_EMBEDDED_BROKER, "true");
+            this.put(ACTIVEMQ_JAAS_INVM_LOGIN_NAME, "InVMLogin");
+            this.put(ACTIVEMQ_JAAS_CERTIFICATE_LOGIN_NAME, "CertificateLogin");
+
             // By default, connect to embedded artemis (InVM)
             this.put(ACTIVEMQ_BROKER_URL, "vm://0");
+
             // By default use the broker.xml file that is packaged in the war.
             this.put(ACTIVEMQ_SERVER_CONFIG_PATH, "");
             this.put(ACTIVEMQ_LARGE_MSG_SIZE, Integer.toString(100 * 1024));

--- a/server/src/main/java/org/candlepin/controller/ActiveMQStatusMonitor.java
+++ b/server/src/main/java/org/candlepin/controller/ActiveMQStatusMonitor.java
@@ -80,7 +80,12 @@ public class ActiveMQStatusMonitor implements Closeable, Runnable, CloseListener
     private String generateServerUrl() {
         StringBuilder serverUrlBuilder =
             new StringBuilder(this.config.getProperty(ConfigProperties.ACTIVEMQ_BROKER_URL));
-        if (!this.config.getBoolean(ConfigProperties.ACTIVEMQ_EMBEDDED)) {
+
+        // TODO: Change this to use ACTIVEMQ_EMBEDDED_BROKER once configuration upgrades are in
+        // place
+        boolean embedded = this.config.getBoolean(ConfigProperties.ACTIVEMQ_EMBEDDED);
+
+        if (!embedded) {
             serverUrlBuilder.append("?sslEnabled=true")
                 .append("&trustStorePath=")
                 .append(this.config.getProperty(ConfigProperties.ACTIVEMQ_TRUSTSTORE))
@@ -91,6 +96,7 @@ public class ActiveMQStatusMonitor implements Closeable, Runnable, CloseListener
                 .append("&keyStorePassword=")
                 .append(this.config.getProperty(ConfigProperties.ACTIVEMQ_KEYSTORE_PASSWORD));
         }
+
         return serverUrlBuilder.toString();
     }
 

--- a/server/src/main/java/org/candlepin/messaging/impl/artemis/ArtemisContextListener.java
+++ b/server/src/main/java/org/candlepin/messaging/impl/artemis/ArtemisContextListener.java
@@ -23,6 +23,7 @@ import com.google.inject.Injector;
 
 import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.apache.activemq.artemis.core.server.embedded.EmbeddedActiveMQ;
+import org.apache.activemq.artemis.spi.core.security.ActiveMQJAASSecurityManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,7 +50,9 @@ public class ArtemisContextListener implements CPMContextListener {
     public void initialize(Injector injector) throws CPMException {
         this.config = injector.getInstance(Configuration.class);
 
-        // Create the server if we're configured to do so
+        // Create the server if we're configured to do so.
+        // TODO: Change this to use ACTIVEMQ_EMBEDDED_BROKER once configuration upgrades are in
+        // place
         boolean embedded = this.config.getBoolean(ConfigProperties.ACTIVEMQ_EMBEDDED);
 
         if (embedded) {
@@ -68,6 +71,17 @@ public class ArtemisContextListener implements CPMContextListener {
                     this.activeMQServer.setConfigResourcePath(
                         new File(artemisConfigFilePath).toURI().toString());
                 }
+
+                String invmLoginEntryName = this.config
+                    .getString(ConfigProperties.ACTIVEMQ_JAAS_INVM_LOGIN_NAME);
+
+                String certLoginEntryName = this.config
+                    .getString(ConfigProperties.ACTIVEMQ_JAAS_CERTIFICATE_LOGIN_NAME);
+
+                ActiveMQJAASSecurityManager securityManager =
+                    new ActiveMQJAASSecurityManager(invmLoginEntryName, certLoginEntryName);
+
+                this.activeMQServer.setSecurityManager(securityManager);
             }
 
             try {

--- a/server/src/main/resources/broker.xml
+++ b/server/src/main/resources/broker.xml
@@ -19,15 +19,87 @@
                xsi:schemaLocation="urn:activemq /schema/artemis-configuration.xsd">
 
     <core xmlns="urn:activemq:core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:schemaLocation="urn:activemq:core ">
+        xsi:schemaLocation="urn:activemq:core ">
 
+        <!--
+            By default, Candlepin only enables the in-vm connection with no security manager, but
+            supports adding additional acceptors which can then be secured using JAAS modules.
+
+            Below is a commented-out example acceptor that accepts clients using the STOMP protocol,
+            over an SSL connection. In addition to the acceptor, the remaining JAAS configuration
+            needs to be added, such as the login.config file loaded with the Java runtime.
+
+            When configuring the login.config, Candlepin uses two sections for certificate-based
+            and non-certificate logins attempts. By default, these are named "CertificateLogin" and
+            "InVMLogin" respectively, but can be modified in candlepin.conf if necessary [1].
+
+            As Candlepin's in-vm connection does not provide any credentials, it is imperative that
+            the guest login module is present in the non-certificate login section when using the
+            embedded broker. Omitting or misconfiguring this module will prevent Candlepin from
+            communicating with its own broker, leading to an inability to operate normally and being
+            permanently stuck in suspend mode, or not starting at all.
+
+            An example of a login.config configured for Candlepin's embedded broker to allow both
+            external SSL connections and Candlepin's own in-vm connection is given below [2].
+
+            Beyond this, the security settings will need to be configured to allow the various users
+            to actually use the broker. Again, when using the embedded broker, Candlepin's in-vm
+            connection should be configured to perform any action to prevent operation failure. The
+            security settings section below has a commented-out block for the in-vm role to perform
+            any operation on any address/queue.
+
+            [1] candlepin.conf properties renaming:
+                - "candlepin.messaging.activemq.embedded.jaas_properties_login_name"
+                - "candlepin.messaging.activemq.embedded.jaas_certificate_login_name"
+
+            [2] Example login.config for an embedded broker with external clients:
+                CertificateLogin {
+                    org.apache.activemq.artemis.spi.core.security.jaas.TextFileCertificateLoginModule required
+                        debug=true
+                        org.apache.activemq.jaas.textfiledn.user="cert-users.properties"
+                        org.apache.activemq.jaas.textfiledn.role="cert-roles.properties";
+                };
+
+                InVMLogin {
+                    org.apache.activemq.artemis.spi.core.security.jaas.GuestLoginModule required
+                        debug=true
+                        credentialsInvalidate=true
+                        org.apache.activemq.jaas.guest.user="invm-user"
+                        org.apache.activemq.jaas.guest.role="invm-role";
+                };
+        -->
 
         <acceptors>
             <acceptor name="in-vm">vm://0</acceptor>
-            <!-- <acceptor name="netty">tcp://localhost:61617?sslEnabled=true;keyStorePath=${artemis.instance}/certs/artemis-server.ks;keyStorePassword=securepassword;needClientAuth=true;trustStorePath=${artemis.instance}/certs/artemis-server.ts;trustStorePassword=securepassword</acceptor> -->
+
+            <!-- <acceptor name="netty">
+                tcp://localhost:61613?protocols=STOMP;needClientAuth=true;sslEnabled=true;keyStorePath=${artemis.instance}/certs/server-side-keystore.jks;keyStorePassword=changeme;trustStorePath=${artemis.instance}/certs/server-side-truststore.jks;trustStorePassword=changeme
+            </acceptor> -->
         </acceptors>
 
+        <!-- set this to true if using external clients -->
         <security-enabled>false</security-enabled>
+
+        <security-settings>
+            <!--
+                Enable this when using the embedded broker with the security manager enabled.
+                Remember sure to update the role name to match the role given to the "guest"
+                in-vm user, following the login details provided above.
+
+            <security-setting match="#">
+                <permission type="createAddress" roles="invm-role"/>
+                <permission type="deleteAddress" roles="invm-role"/>
+                <permission type="createDurableQueue" roles="invm-role"/>
+                <permission type="deleteDurableQueue" roles="invm-role"/>
+                <permission type="createNonDurableQueue" roles="invm-role"/>
+                <permission type="deleteNonDurableQueue" roles="invm-role"/>
+                <permission type="send" roles="invm-role"/>
+                <permission type="consume" roles="invm-role"/>
+                <permission type="browse" roles="invm-role"/>
+                <permission type="manage" roles="invm-role"/>
+            </security-setting>
+            -->
+        </security-settings>
 
         <!-- Silence warnings on server startup -->
         <cluster-user></cluster-user>


### PR DESCRIPTION
- Added support for the using the ActiveMQJAASSecurityManager when
  creating the embedded ActiveMQ broker
- Added new configurations for modifying which entries are used
  in a JAAS config file
- Updated the broker.xml with details about using external
  connections to the embedded Artemis instance