### PR TITLE
[2.9] Fix oauth spec test

### DIFF
--- a/server/spec/oauth_spec.rb
+++ b/server/spec/oauth_spec.rb
@@ -30,9 +30,9 @@ describe 'OAuth' do
   def make_request(oauth_consumer, oauth_secret, uri, headers = {})
     consumer = OAuth::Consumer.new(oauth_consumer, oauth_secret, @oauth_params)
 
-    request = Net::HTTP::Get.new("#{@site}#{uri}")
-    consumer.sign!(request)
     url = URI.parse("#{@site}#{uri}")
+    request = Net::HTTP::Get.new(url)
+    consumer.sign!(request)
 
     headers.each_pair do |k, v|
       request[k] = v


### PR DESCRIPTION
  oauth spec tests are failing with the newly created vagrant box (destroy and up).
  As per my investigation, either we need to pass only #{uri} or URL object
  instead of #{site}#{uri} in Net::HTTP::Get.new.

Note: This is a cherry-pick from master