### PR TITLE
Bug 1751848 Stopped checking & consider pools irrespective of Consumer Entitlement SLA for auto attach. (ENT-2278)

### DIFF
--- a/server/spec/consumer_resource_spec.rb
+++ b/server/spec/consumer_resource_spec.rb
@@ -1021,7 +1021,8 @@ describe 'Consumer Resource' do
     pool.subscriptionId.should == pool2.subscriptionId
   end
 
-  it "should allow a consumer dry run an autoattach based on SLA and filter on their existing entitlement SLAs" do
+  it "should allow a consumer dry run an autoattach based on SLA and do not filter pool on their existing
+    entitlement SLAs" do
     product1 = create_product(random_string('product'),
       random_string('product'),
       {:attributes => {:support_level => 'VIP'},
@@ -1059,13 +1060,17 @@ describe 'Consumer Resource' do
     consumer_client.consume_pool(pool2.id, {:quantity => 1})
 
     # dry run against the set service level:
-    # should return only one pool because we no longer filter on consumer's sla,
-    # but we do filter on the consumer's existing entitlements' SLA's, and in this case
+    # NOTE : we do NOT filter on the consumer's existing entitlements' SLA's, and in this case
     # the consumer has an existing entitlement whose SLA is 'Ultra-VIP',
-    # so only 'Ultra-VIP' pools are eligible during autoattach (and the 'VIP' pool is not).
+    # so 'Ultra-VIP' & 'VIP' both pools are considered and eligible during auto attach.
     returned_pools = @cp.autobind_dryrun(consumer['uuid'])
-    returned_pools.length.should == 1
+    returned_pools.length.should == 2
     returned_pool_id = returned_pools.first.pool.id
+    returned_pool = @cp.get_pool(returned_pool_id)
+    returned_pool.subscriptionId.should == pool1.subscriptionId
+    expect(get_attribute_value(returned_pool['productAttributes'], 'support_level')).to eq('VIP')
+
+    returned_pool_id = returned_pools[1].pool.id
     returned_pool = @cp.get_pool(returned_pool_id)
     returned_pool.subscriptionId.should == pool3.subscriptionId
     expect(get_attribute_value(returned_pool['productAttributes'], 'support_level')).to eq('Ultra-VIP')

--- a/server/src/main/resources/rules/rules.js
+++ b/server/src/main/resources/rules/rules.js
@@ -1,4 +1,4 @@
-// Version: 5.39
+// Version: 5.40
 
 /*
  * Default Candlepin rule set.
@@ -603,46 +603,6 @@ function get_pool_priority(pool, consumer) {
     }
     log.debug("Final overall score for pool {}: {}", pool.id, priority);
     return priority;
-}
-
-/*
- * Returns true if the following are all true:
- * - the pool's SLA is non-null, non-empty and not in the exempt list.
- * - at least one of these is non-null and non-empty: SLA override, consumer's SLA, owner's default SLA.
- * - the pool's SLA matches either the SLA override, the consumer's SLA, or the owner's default SLA
- *   (Order of priority is: SLA override > consumer's SLA > owner's default SLA.)
- *
- * False otherwise.
- */
-function should_pool_be_prioritized_for_sla(context, pool) {
-    var poolSLA = pool.getProductAttribute('support_level');
-
-    log.debug("context.serviceLevelOverride: " + context.serviceLevelOverride);
-    var consumerSLA = context.serviceLevelOverride;
-    if (!consumerSLA || consumerSLA == "") {
-        consumerSLA = context.consumer.serviceLevel;
-            if (!consumerSLA || consumerSLA == "") {
-                consumerSLA = context.owner.defaultServiceLevel;
-            }
-    }
-
-    if (!is_pool_sla_null_or_exempt(context, poolSLA) &&
-        consumerSLA && consumerSLA !== "" &&
-        Utils.equalsIgnoreCase(consumerSLA, poolSLA)) {
-        return true;
-    }
-    return false;
-}
-
-/*
- * Returns true if the pool's SLA is null or empty, or is included in the exempt list; false otherwise.
- */
-function is_pool_sla_null_or_exempt(context, poolSLA) {
-    if (!poolSLA || poolSLA === "") {
-        return true;
-    }
-
-    return isLevelExempt(poolSLA, context.exemptList);
 }
 
 /* Utility functions */
@@ -1478,17 +1438,6 @@ function comparePools(pool1, pool2) {
         return true;
     }
 
-}
-
-function isLevelExempt (level, exemptList) {
-    for (var j = 0; j < exemptList.length; j++) {
-        var exemptLevel = exemptList[j];
-
-        if (Utils.equalsIgnoreCase(exemptLevel, level)) {
-            return true;
-        }
-    }
-    return false;
 }
 
 /**
@@ -2725,81 +2674,6 @@ var Autobind = {
         return true;
     },
 
-    /*
-     * The pool is valid if any of these is true:
-     *  - The pool's SLA is null or in the exempt list.
-     *  - The pool's SLA is non-null, non-exempt, and the consumer does not have any existing entitlements.
-     *  - The pool's SLA is non-null, non-exempt, and the consumer has existing entitlements,
-     *    but none of their products has an SLA or a product has an SLA and it is exempt.
-     *  - The pool's SLA is non-null, non-exempt, and the consumer has existing entitlements,
-     *    and at least one of them has a product with a non-null SLA that matches the pool SLA.
-     *
-     * The pool is invalid if this is true:
-     *  - The pool's SLA is non-null, non-exempt, and the consumer has existing entitlements,
-     *    and one or more of those have products with non-null SLAs,
-     *    but those SLAs do not match with the pool's SLA.
-     */
-    is_pool_sla_valid: function(context, pool) {
-        var poolSLA = pool.getProductAttribute('support_level');
-
-        if (is_pool_sla_null_or_exempt(context, poolSLA)) {
-            return true;
-        }
-
-        var consumer_entitlement_slas = this.get_slas_of_existing_consumer_entitlements_from_compliance_status(context);
-        if (consumer_entitlement_slas.length <= 0) {
-            return true;
-        }
-
-        var is_valid = false;
-        for (i = 0 ; i < consumer_entitlement_slas.length ; i++) {
-            if (Utils.equalsIgnoreCase(poolSLA, consumer_entitlement_slas[i])) {
-                is_valid = true;
-                break;
-            }
-        }
-
-        if (!is_valid) {
-            log.debug("Skipping pool " + pool.id +
-            " since SLA is non-null, non-exempt, and does not match any of the consumer's entitlements' SLAs.");
-        }
-        return is_valid;
-    },
-
-    /*
-     * Traverses the ComplianceStatus object's product maps to find and return a list of
-     * the consumer's entitlements' SLAs. Null SLAs are not returned.
-     */
-    get_slas_of_existing_consumer_entitlements_from_compliance_status: function(context) {
-        var listOfProductMaps = [];
-        listOfProductMaps.push(context.compliance.compliantProducts);
-        listOfProductMaps.push(context.compliance.partiallyCompliantProducts);
-        listOfProductMaps.push(context.compliance.partialStacks);
-
-        var sla_list = [];
-        listOfProductMaps.forEach(function(productMap) {
-            Object.keys(productMap).forEach(function(productId) {
-                var setOfEntitlements = productMap[productId];
-                setOfEntitlements.forEach(function(entitlement) {
-                    var sla = entitlement.pool.getProductAttribute('support_level');
-                    var exempt = entitlement.pool.getProductAttribute('support_level_exempt');
-                    var exists = false;
-                    for (i = 0 ; i < sla_list.length ; i++) {
-                        if (Utils.equalsIgnoreCase(sla_list[i], sla)) {
-                            exists = true;
-                            break;
-                        }
-                    }
-
-                    if (!exists && sla  && !exempt) {
-                        sla_list.push(sla);
-                    }
-                });
-            });
-        });
-        return sla_list;
-    },
-
     is_pool_not_empty: function(pool) {
         if (pool.currently_available > 0) {
             return true;
@@ -2827,7 +2701,6 @@ var Autobind = {
              */
             if (this.is_pool_arch_valid(context, pool, consumerArch) &&
                     this.is_pool_virt_valid(pool, isGuest) &&
-                    this.is_pool_sla_valid(context, pool) &&
                     pool_not_empty) {
                 valid_pools.push(pool);
             }

--- a/server/src/test/java/org/candlepin/policy/AutobindRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/AutobindRulesTest.java
@@ -550,15 +550,24 @@ public class AutobindRulesTest {
     }
 
     @Test
-    public void selectBestPoolsDoesNotFilterPoolsBySLAWhenConsumerHasNonNullMatchingEntitlementSLAs() {
+    @SuppressWarnings("checkstyle:LineLength")
+    public void selectBestPoolsDoesNotFilterPoolsByConsumerEntitlementInsteadPrioritizePoolsMatchingConsumerSLA() {
         // Create Premium SLA prod
-        String slaPremiumProdId = "premium-sla-product";
-        Product slaPremiumProduct = TestUtil.createProduct(slaPremiumProdId, "Product with SLA Permium");
+        Product slaPremiumProduct = TestUtil.createProduct(productId, "Product with SLA Permium");
         slaPremiumProduct.setAttribute(Product.Attributes.SUPPORT_LEVEL, "Premium");
 
         Pool slaPremiumPool = TestUtil.createPool(owner, slaPremiumProduct);
         slaPremiumPool.setId("pool-with-premium-sla");
         slaPremiumPool.getProduct().setAttribute(Product.Attributes.SUPPORT_LEVEL, "Premium");
+
+        // Create Standard SLA Product
+        String slaStandardProdId = "standard-sla-product";
+        Product slaStandardProduct = TestUtil.createProduct(slaStandardProdId, "Product with SLA Standard");
+        slaStandardProduct.setAttribute(Product.Attributes.SUPPORT_LEVEL, "Standard");
+
+        Pool slaStandardPool = TestUtil.createPool(owner, slaStandardProduct);
+        slaStandardPool.setId("pool-with-standard-sla");
+        slaStandardPool.getProduct().setAttribute(Product.Attributes.SUPPORT_LEVEL, "Standard");
 
         // Create a product with no SLA.
         Product noSLAProduct = TestUtil.createProduct(productId, "A test product");
@@ -568,249 +577,30 @@ public class AutobindRulesTest {
         List<Pool> pools = new LinkedList<>();
         pools.add(noSLAPool);
         pools.add(slaPremiumPool);
+        // ^ A Standard SLA pool is not in the list of candidate pools.
 
-        // The consumer has set their SLA to Premium, and also has an existing entitlement with Premium SLA
-        // which means the pool with Premium SLA should not be filtered.
+        // The consumer has set their SLA to Premium.
         consumer.setServiceLevel("Premium");
-        Entitlement entitlementWithPremiumSLA = new Entitlement();
-        entitlementWithPremiumSLA.setPool(slaPremiumPool);
-        compliance.addCompliantProduct("2432", entitlementWithPremiumSLA);
+
+        // Here Consumer entitlement SLA will have no effect on auto attach.
+        // All pools (noSLAPool & slaPremiumPool) are considered, & prioritized based on SLA.
+        Entitlement entitlementWithStandardSLA = new Entitlement();
+        entitlementWithStandardSLA.setPool(slaStandardPool);
+        compliance.addPartiallyCompliantProduct("b4b4b4", entitlementWithStandardSLA);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{ productId, slaPremiumProdId },
-            pools, compliance, null, new HashSet<>(), false);
+            new String[]{ productId, slaStandardProdId}, pools, compliance, null,
+            new HashSet<>(), false);
 
-        assertEquals(2, bestPools.size());
-        // The Premium SLA pool should NOT have gotten filtered because the customer had
-        // existing entitlements that included one with a Premium SLA.
+        // Pool will get prioritized by SLA matching Consumer SLA preference.
+        assertEquals(1, bestPools.size());
+
+        // The Premium SLA pool will get more priority as it matches consumer SLA preference.
         assertTrue(bestPools.contains(new PoolQuantity(slaPremiumPool, 1)));
-        // Also, check pool with no sla is not filtered (as always)
-        assertTrue(bestPools.contains(new PoolQuantity(noSLAPool, 1)));
+
+        // Pool with no SLA will get filtered out (De-Prioritized).
+        assertFalse(bestPools.contains(new PoolQuantity(noSLAPool, 1)));
     }
-
-    @Test
-    @SuppressWarnings("checkstyle:LineLength")
-    public void selectBestPoolsFiltersPoolsBySLAWhenConsumerHasNonNullNonMatchingEntitlementSLAsAndConsumerSLAIsUsed() {
-        // Create Premium SLA prod
-        String slaPremiumProdId = "premium-sla-product";
-        Product slaPremiumProduct = TestUtil.createProduct(slaPremiumProdId, "Product with SLA Permium");
-        slaPremiumProduct.setAttribute(Product.Attributes.SUPPORT_LEVEL, "Premium");
-
-        Pool slaPremiumPool = TestUtil.createPool(owner, slaPremiumProduct);
-        slaPremiumPool.setId("pool-with-premium-sla");
-        slaPremiumPool.getProduct().setAttribute(Product.Attributes.SUPPORT_LEVEL, "Premium");
-
-        // Create Standard SLA Product
-        String slaStandardProdId = "standard-sla-product";
-        Product slaStandardProduct = TestUtil.createProduct(slaStandardProdId, "Product with SLA Standard");
-        slaStandardProduct.setAttribute(Product.Attributes.SUPPORT_LEVEL, "Standard");
-
-        Pool slaStandardPool = TestUtil.createPool(owner, slaStandardProduct);
-        slaStandardPool.setId("pool-with-standard-sla");
-        slaStandardPool.getProduct().setAttribute(Product.Attributes.SUPPORT_LEVEL, "Standard");
-
-        // Create a product with no SLA.
-        Product noSLAProduct = TestUtil.createProduct(productId, "A test product");
-        Pool noSLAPool = TestUtil.createPool(owner, noSLAProduct);
-        noSLAPool.setId("pool-1");
-
-        List<Pool> pools = new LinkedList<>();
-        pools.add(noSLAPool);
-        pools.add(slaPremiumPool);
-        // ^ A Standard SLA pool is not in the list of candidate pools.
-
-        // The consumer has set their SLA to Premium, and also has an existing entitlement with Standard SLA
-        // which means the pool with Premium SLA SHOULD get filtered.
-        consumer.setServiceLevel("Premium");
-        Entitlement entitlementWithStandardSLA = new Entitlement();
-        entitlementWithStandardSLA.setPool(slaStandardPool);
-        compliance.addPartiallyCompliantProduct("b4b4b4", entitlementWithStandardSLA);
-
-        List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{ productId, slaStandardProdId},
-            pools, compliance, null, new HashSet<>(), false);
-
-        assertEquals(1, bestPools.size());
-        // The Premium SLA pool should get filtered because the customer had existing entitlements that
-        // did not include one with a Premium SLA.
-        assertFalse(bestPools.contains(new PoolQuantity(slaPremiumPool, 1)));
-        // Also, check pool with no sla is not filtered (as always)
-        assertTrue(bestPools.contains(new PoolQuantity(noSLAPool, 1)));
-    }
-
-    @Test
-    @SuppressWarnings("checkstyle:LineLength")
-    public void selectBestPoolsFiltersPoolsBySLAWhenConsumerWithSLAHasNonNullNonMatchingEntitlementSLAsAndOverrideSLAIsUsed() {
-        // Create Premium SLA prod
-        String slaPremiumProdId = "premium-sla-product";
-        Product slaPremiumProduct = TestUtil.createProduct(slaPremiumProdId, "Product with SLA Permium");
-        slaPremiumProduct.setAttribute(Product.Attributes.SUPPORT_LEVEL, "Premium");
-
-        Pool slaPremiumPool = TestUtil.createPool(owner, slaPremiumProduct);
-        slaPremiumPool.setId("pool-with-premium-sla");
-        slaPremiumPool.getProduct().setAttribute(Product.Attributes.SUPPORT_LEVEL, "Premium");
-
-        // Create Standard SLA Product
-        String slaStandardProdId = "standard-sla-product";
-        Product slaStandardProduct = TestUtil.createProduct(slaStandardProdId, "Product with SLA Standard");
-        slaStandardProduct.setAttribute(Product.Attributes.SUPPORT_LEVEL, "Standard");
-
-        Pool slaStandardPool = TestUtil.createPool(owner, slaStandardProduct);
-        slaStandardPool.setId("pool-with-standard-sla");
-        slaStandardPool.getProduct().setAttribute(Product.Attributes.SUPPORT_LEVEL, "Standard");
-
-        // Create Sub-Standard SLA Product
-        String slaSubStandardProdId = "sub-standard-sla-product";
-        Product slaSubStandardProduct = TestUtil.createProduct(slaSubStandardProdId, "Product with SLA Sub-Standard");
-        slaSubStandardProduct.setAttribute(Product.Attributes.SUPPORT_LEVEL, "Sub-Standard");
-
-        Pool slaSubStandardPool = TestUtil.createPool(owner, slaSubStandardProduct);
-        slaSubStandardPool.setId("pool-with-sub-standard-sla");
-        slaSubStandardPool.getProduct().setAttribute(Product.Attributes.SUPPORT_LEVEL, "Sub-Standard");
-
-        // Create a product with no SLA.
-        Product noSLAProduct = TestUtil.createProduct(productId, "A test product");
-        Pool noSLAPool = TestUtil.createPool(owner, noSLAProduct);
-        noSLAPool.setId("pool-1");
-
-        List<Pool> pools = new LinkedList<>();
-        pools.add(noSLAPool);
-        pools.add(slaPremiumPool);
-        pools.add(slaSubStandardPool);
-        // ^ A Standard SLA pool is not in the list of candidate pools.
-
-        // The consumer has set their SLA to Premium, but will be ignored because we specify an override SLA,
-        // and also the consumer has an existing entitlement with Standard SLA
-        // which means the candidate pools with Premium SLA and Sub-Standard SLA SHOULD BOTH get filtered.
-        consumer.setServiceLevel("Premium");
-        Entitlement entitlementWithStandardSLA = new Entitlement();
-        entitlementWithStandardSLA.setPool(slaStandardPool);
-        compliance.addPartiallyCompliantProduct("b4b4b4", entitlementWithStandardSLA);
-
-        String overrideSLA = "Sub-Standard";
-
-        List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{ productId, slaStandardProdId},
-            pools, compliance, overrideSLA, new HashSet<>(), false);
-
-        assertEquals(1, bestPools.size());
-        // Both The Premium SLA and Sub-Standard SLA pools should get filtered
-        // because the customer had existing entitlements that
-        // did not include one with a Premium or Sub-Standard SLA.
-        assertFalse(bestPools.contains(new PoolQuantity(slaPremiumPool, 1)));
-        assertFalse(bestPools.contains(new PoolQuantity(slaSubStandardPool, 1)));
-        // Also, check pool with no sla is not filtered (as always)
-        assertTrue(bestPools.contains(new PoolQuantity(noSLAPool, 1)));
-    }
-
-    @Test
-    @SuppressWarnings("checkstyle:LineLength")
-    public void selectBestPoolsFiltersPoolsBySLAWhenConsumerWithSLAHasNonNullNonMatchingEntitlementSLAsAndOwnerDefaultSLAIsUsed() {
-        // Create Premium SLA prod
-        String slaPremiumProdId = "premium-sla-product";
-        Product slaPremiumProduct = TestUtil.createProduct(slaPremiumProdId, "Product with SLA Permium");
-        slaPremiumProduct.setAttribute(Product.Attributes.SUPPORT_LEVEL, "Premium");
-
-        Pool slaPremiumPool = TestUtil.createPool(owner, slaPremiumProduct);
-        slaPremiumPool.setId("pool-with-premium-sla");
-        slaPremiumPool.getProduct().setAttribute(Product.Attributes.SUPPORT_LEVEL, "Premium");
-
-        // Create Standard SLA Product
-        String slaStandardProdId = "standard-sla-product";
-        Product slaStandardProduct = TestUtil.createProduct(slaStandardProdId, "Product with SLA Standard");
-        slaStandardProduct.setAttribute(Product.Attributes.SUPPORT_LEVEL, "Standard");
-
-        Pool slaStandardPool = TestUtil.createPool(owner, slaStandardProduct);
-        slaStandardPool.setId("pool-with-standard-sla");
-        slaStandardPool.getProduct().setAttribute(Product.Attributes.SUPPORT_LEVEL, "Standard");
-
-        // Create a product with no SLA.
-        Product noSLAProduct = TestUtil.createProduct(productId, "A test product");
-        Pool noSLAPool = TestUtil.createPool(owner, noSLAProduct);
-        noSLAPool.setId("pool-1");
-
-        List<Pool> pools = new LinkedList<>();
-        pools.add(noSLAPool);
-        pools.add(slaPremiumPool);
-        // ^ A Standard SLA pool is not in the list of candidate pools.
-
-        // The consumer has set their SLA to nothing, so it will be ignored in favor of the
-        // owner default SLA which is set to Premium,
-        // but the consumer also has an existing entitlement with Standard SLA
-        // which means the candidate pool with Premium SLA SHOULD get filtered.
-        consumer.setServiceLevel("");
-        owner.setDefaultServiceLevel("Premium");
-        Entitlement entitlementWithStandardSLA = new Entitlement();
-        entitlementWithStandardSLA.setPool(slaStandardPool);
-        compliance.addPartiallyCompliantProduct("b4b4b4", entitlementWithStandardSLA);
-
-        List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{ productId, slaStandardProdId},
-            pools, compliance, null, new HashSet<>(), false);
-
-        assertEquals(1, bestPools.size());
-        // The Premium SLA pool should get filtered because the customer had existing entitlements that
-        // did not include one with a Premium SLA.
-        assertFalse(bestPools.contains(new PoolQuantity(slaPremiumPool, 1)));
-        // Also, check pool with no sla is not filtered (as always)
-        assertTrue(bestPools.contains(new PoolQuantity(noSLAPool, 1)));
-    }
-
-    @Test
-    public void selectBestPoolsDoesNotFilterPoolsBySLAWhenConsumerHasOnlyNullEntitlementSLAs() {
-        // Create Premium SLA prod
-        String slaPremiumProdId = "premium-sla-product";
-        Product slaPremiumProduct = TestUtil.createProduct(slaPremiumProdId, "Product with SLA Permium");
-        slaPremiumProduct.setAttribute(Product.Attributes.SUPPORT_LEVEL, "Premium");
-
-        Pool slaPremiumPool = TestUtil.createPool(owner, slaPremiumProduct);
-        slaPremiumPool.setId("pool-with-premium-sla");
-        slaPremiumPool.getProduct().setAttribute(Product.Attributes.SUPPORT_LEVEL, "Premium");
-
-        // Create Standard SLA Product
-        String slaStandardProdId = "standard-sla-product";
-        Product slaStandardProduct = TestUtil.createProduct(slaStandardProdId, "Product with SLA Standard");
-        slaStandardProduct.setAttribute(Product.Attributes.SUPPORT_LEVEL, "Standard");
-
-        Pool slaStandardPool = TestUtil.createPool(owner, slaStandardProduct);
-        slaStandardPool.setId("pool-with-standard-sla");
-        slaStandardPool.getProduct().setAttribute(Product.Attributes.SUPPORT_LEVEL, "Standard");
-
-        // Create a product with no SLA.
-        Product noSLAProduct = TestUtil.createProduct(productId, "A test product");
-        Pool noSLAPool = TestUtil.createPool(owner, noSLAProduct);
-        noSLAPool.setId("pool-with-NO-sla-1");
-
-        // Create another product with no SLA.
-        String noSLAProdId2 = "no-sla-product2";
-        Product noSLAProduct2 = TestUtil.createProduct(noSLAProdId2, "A test product 2");
-        Pool noSLAPool2 = TestUtil.createPool(owner, noSLAProduct2);
-        noSLAPool2.setId("pool-with-NO-sla-2");
-
-        List<Pool> pools = new LinkedList<>();
-        pools.add(noSLAPool);
-        pools.add(slaPremiumPool);
-        pools.add(slaStandardPool);
-
-        // The consumer has set their SLA to Premium, and also has an existing entitlement with no SLA
-        // which means no pools should get filtered.
-        consumer.setServiceLevel("Premium");
-        Entitlement entitlementWithNoSLA = new Entitlement();
-        entitlementWithNoSLA.setPool(noSLAPool2);
-        compliance.addPartiallyCompliantProduct("b4b4b4", entitlementWithNoSLA);
-
-        List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{ productId, slaStandardProdId, slaPremiumProdId },
-            pools, compliance, null, new HashSet<>(), false);
-
-        assertEquals(3, bestPools.size());
-        // Check that no pools were filtered, since the customer has an existing entitlement with a null SLA.
-        assertTrue(bestPools.contains(new PoolQuantity(slaPremiumPool, 1)));
-        assertTrue(bestPools.contains(new PoolQuantity(slaStandardPool, 1)));
-        // Also, check pool with no sla is not filtered (as always)
-        assertTrue(bestPools.contains(new PoolQuantity(noSLAPool, 1)));
-    }
-
 
     /*
      * This is a case that happens when:


### PR DESCRIPTION
Fixes - 
- Removed Pool validation on Consumer Existing SLA from rules.js
- SLA is only going to be used to prioritize/de-prioritize pools.

PS: Will raise a PR against `candlepin-2.6-HOTIFX` when this is reviewed. 