### PR TITLE
ENT-2316: Introduce Swatch Profile Timestamp

### DIFF
--- a/server/src/main/java/org/candlepin/model/CloudProfileFacts.java
+++ b/server/src/main/java/org/candlepin/model/CloudProfileFacts.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package org.candlepin.model;
+
+/**
+ * The subscription profile time stamp should also get updated
+ * on the specific Facts updates.
+ * This Enum helps to configure more facts if required in the future.
+ */
+public enum CloudProfileFacts {
+
+    CPU_CORES_PERSOCKET("cpu.core(s)_per_socket"),
+    CPU_SOCKETS("cpu.cpu_socket(s)"),
+    DMI_BIOS_VENDOR("dmi.bios.vendor"),
+    DMI_BIOS_VERSION("dmi.bios.version"),
+    DMI_CHASSIS_ASSET_TAG("dmi.chassis.asset_tag"),
+    DMI_SYSTEM_MANUFACTURER("dmi.system.manufacturer"),
+    DMI_SYSTEM_UUID("dmi.system.uuid"),
+    MEMORY_MEMTOTAL("memory.memtotal"),
+    OCM_UNITS("ocm.units"),
+    UNAME_MACHINE("uname.machine"),
+    VIRT_IS_GUEST("virt.is_guest");
+
+    private final String fact;
+
+    CloudProfileFacts(String fact) {
+        this.fact = fact;
+    }
+
+    public String getFact() {
+        return this.fact;
+    }
+
+    @Override
+    public String toString() {
+        return fact;
+    }
+
+    public static boolean containsFact(String incomingFact) {
+        for (CloudProfileFacts fact : CloudProfileFacts.values()) {
+            if (fact.getFact().equals(incomingFact)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/server/src/main/java/org/candlepin/model/ConsumerCurator.java
+++ b/server/src/main/java/org/candlepin/model/ConsumerCurator.java
@@ -541,7 +541,14 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
         existingConsumer.setFacts(updatedConsumer.getFacts());
         existingConsumer.setName(updatedConsumer.getName());
         existingConsumer.setOwner(updatedConsumer.getOwner());
-        existingConsumer.setTypeId(updatedConsumer.getTypeId());
+
+        // Set TypeId only if the existing consumer and update consumer typeId is not equal.
+        // This check has been added for updating Swatch timestamp
+        if (updatedConsumer.getTypeId() != null &&
+            !Util.equals(existingConsumer.getTypeId(), updatedConsumer.getTypeId())) {
+            existingConsumer.setTypeId(updatedConsumer.getTypeId());
+        }
+
         existingConsumer.setUuid(updatedConsumer.getUuid());
 
         if (flush) {

--- a/server/src/main/java/org/candlepin/model/GuestId.java
+++ b/server/src/main/java/org/candlepin/model/GuestId.java
@@ -145,6 +145,7 @@ public class GuestId extends AbstractHibernateObject implements Owned, Named, Co
 
     public void setConsumer(Consumer consumer) {
         this.consumer = consumer;
+        this.consumer.updateRHCloudProfileModified();
     }
 
     public void setAttributes(Map<String, String> attributes) {

--- a/server/src/main/resources/db/changelog/20200430172317-add-column-rh-cloud-profile-modified.xml
+++ b/server/src/main/resources/db/changelog/20200430172317-add-column-rh-cloud-profile-modified.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <!-- Include definitions for cert.type, timestamp.type, etc. -->
+    <include file="db/changelog/datatypes.xml"/>
+
+    <changeSet id="20200430172317-1" author="sdhome">
+        <comment>Adding column rh_cloud_profile_modified for Swatch Profile Timestamp feature.
+        </comment>
+
+        <addColumn tableName="cp_consumer">
+            <column name="rh_cloud_profile_modified" type="${timestamp.type}"/>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-create.xml
+++ b/server/src/main/resources/db/changelog/changelog-create.xml
@@ -1238,4 +1238,5 @@
     <include file="db/changelog/20190919132617-create-product-branding-join-table.xml"/>
     <include file="db/changelog/20190927153020-index-facts-element.xml"/>
     <include file="db/changelog/20191009160315-remove-duplicate-indexes.xml"/>
+    <include file="db/changelog/20200430172317-add-column-rh-cloud-profile-modified.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-testing.xml
+++ b/server/src/main/resources/db/changelog/changelog-testing.xml
@@ -2330,4 +2330,5 @@
     <include file="db/changelog/20190919132617-create-product-branding-join-table.xml"/>
     <include file="db/changelog/20190927153020-index-facts-element.xml"/>
     <include file="db/changelog/20191009160315-remove-duplicate-indexes.xml"/>
+    <include file="db/changelog/20200430172317-add-column-rh-cloud-profile-modified.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-update.xml
+++ b/server/src/main/resources/db/changelog/changelog-update.xml
@@ -147,4 +147,5 @@
     <include file="db/changelog/20190919132617-create-product-branding-join-table.xml"/>
     <include file="db/changelog/20190927153020-index-facts-element.xml"/>
     <include file="db/changelog/20191009160315-remove-duplicate-indexes.xml"/>
+    <include file="db/changelog/20200430172317-add-column-rh-cloud-profile-modified.xml"/>
 </databaseChangeLog>

--- a/server/src/test/java/org/candlepin/TestingModules.java
+++ b/server/src/test/java/org/candlepin/TestingModules.java
@@ -106,6 +106,7 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.databind.AnnotationIntrospector;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.introspect.AnnotationIntrospectorPair;
 import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
@@ -393,6 +394,13 @@ public class TestingModules {
             ObjectMapper mapper = new ObjectMapper();
             mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
             mapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+            return mapper;
+        }
+
+        @Provides @Singleton @Named("HypervisorUpdateJobObjectMapper")
+        private ObjectMapper configureHypervisorUpdateJobObjectMapper() {
+            ObjectMapper mapper = new ObjectMapper();
+            mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
             return mapper;
         }
     }

--- a/server/src/test/java/org/candlepin/model/ConsumerTest.java
+++ b/server/src/test/java/org/candlepin/model/ConsumerTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Date;
+import java.util.HashMap;
 import java.util.Map;
 
 import javax.inject.Inject;
@@ -518,5 +519,78 @@ public class ConsumerTest extends DatabaseTestFixture {
 
         consumer = consumerCurator.get(cid);
         assertTrue(consumer.getUsage().isEmpty());
+    }
+
+    @Test
+    public void testCloudProfileFactDidNotChange() {
+        Consumer consumer = new Consumer();
+        consumer.setFact("dmi.bios.vendor", "vendorA");
+        consumer.setFact("lscpu.model", "78");
+
+        Map<String, String> newFacts = new HashMap<>();
+        newFacts.put("dmi.bios.vendor", "vendorA");
+        newFacts.put("lscpu.model", "100");
+
+        // this should return false because the only cloud fact  the consumer has did not change
+        assertFalse(consumer.checkForCloudProfileFacts(newFacts));
+    }
+
+    @Test
+    public void testCloudProfileFactDidNotChangeWhenPassingSingleFact() {
+        Consumer consumer = new Consumer();
+        consumer.setFact("dmi.bios.vendor", "vendorA");
+        consumer.setFact("lscpu.model", "78");
+
+        Map<String, String> newFacts = new HashMap<>();
+        newFacts.put("dmi.bios.vendor", "vendorA");
+
+        assertFalse(consumer.checkForCloudProfileFacts(newFacts));
+    }
+
+    @Test
+    public void testCloudProfileFactOnEmptyExistingFacts() {
+        Consumer consumer = new Consumer();
+
+        Map<String, String> newFacts = new HashMap<>();
+        newFacts.put("dmi.bios.vendor", "vendorA");
+
+        assertTrue(consumer.checkForCloudProfileFacts(newFacts));
+    }
+
+    @Test
+    public void testCloudProfileFactOnEmptyIncomingFacts() {
+        Consumer consumer = new Consumer();
+        consumer.setFact("dmi.bios.vendor", "vendorA");
+
+        Map<String, String> newFacts = null;
+
+        assertFalse(consumer.checkForCloudProfileFacts(newFacts));
+    }
+
+    @Test
+    public void testCloudProfileFactOnNullValueOfIncomingFacts() {
+        Consumer consumer = new Consumer();
+        consumer.setFact("dmi.bios.vendor", "vendorA");
+
+        Map<String, String> newFacts = new HashMap<>();
+        newFacts.put("dmi.bios.vendor", null);
+
+        assertTrue(consumer.checkForCloudProfileFacts(newFacts));
+
+        newFacts = new HashMap<>();
+        newFacts.put("null", "vendorA");
+
+        assertFalse(consumer.checkForCloudProfileFacts(newFacts));
+    }
+
+    @Test
+    public void testCloudProfileFactExistingIncomingFacts() {
+        Consumer consumer = new Consumer();
+        consumer.setFact("dmi.bios.vendor", "vendorA");
+
+        Map<String, String> newFacts = new HashMap<>();
+        newFacts.put("dmi.bios.vendor", "vendorA");
+
+        assertFalse(consumer.checkForCloudProfileFacts(newFacts));
     }
 }

--- a/server/src/test/java/org/candlepin/resource/HypervisorCloudProfileTest.java
+++ b/server/src/test/java/org/candlepin/resource/HypervisorCloudProfileTest.java
@@ -1,0 +1,247 @@
+/**
+ * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package org.candlepin.resource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.candlepin.auth.UserPrincipal;
+import org.candlepin.auth.permissions.Permission;
+import org.candlepin.auth.permissions.PermissionFactory;
+import org.candlepin.dto.StandardTranslator;
+import org.candlepin.dto.api.v1.GuestIdDTO;
+import org.candlepin.dto.api.v1.HypervisorConsumerDTO;
+import org.candlepin.dto.api.v1.HypervisorUpdateResultDTO;
+import org.candlepin.model.Consumer;
+import org.candlepin.model.ConsumerCurator;
+import org.candlepin.model.ConsumerType;
+import org.candlepin.model.ConsumerTypeCurator;
+import org.candlepin.model.EnvironmentCurator;
+import org.candlepin.model.GuestId;
+import org.candlepin.model.HypervisorId;
+import org.candlepin.model.Owner;
+import org.candlepin.model.OwnerCurator;
+import org.candlepin.model.Role;
+import org.candlepin.model.User;
+import org.candlepin.test.DatabaseTestFixture;
+import org.candlepin.test.TestUtil;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import javax.inject.Inject;
+
+/**
+ * Test suite for the HypervisorResource and
+ * GuestIdResource update methods. This validates the
+ * Subscription profile time-stamp updates
+ */
+public class HypervisorCloudProfileTest extends DatabaseTestFixture {
+
+    private static final String USER_NAME = "testing user";
+
+    @Inject private ConsumerCurator consumerCurator;
+    @Inject private ConsumerTypeCurator consumerTypeCurator;
+    @Inject private GuestIdResource guestIdResource;
+    @Inject private OwnerCurator ownerCurator;
+    @Inject private EnvironmentCurator environmentCurator;
+    @Inject private PermissionFactory permFactory;
+    @Inject private HypervisorResource hypervisorResource;
+
+    private ConsumerType hypervisorType;
+
+    private UserPrincipal principal;
+    private Consumer consumer;
+    private Owner owner;
+    private Role ownerAdminRole;
+    private User someuser;
+
+    @BeforeEach
+    public void setUp() {
+
+        this.modelTranslator = new StandardTranslator(this.consumerTypeCurator, this.environmentCurator,
+            this.ownerCurator);
+
+        owner = ownerCurator.create(new Owner("test-owner"));
+
+        someuser = userCurator.create(new User(USER_NAME, "dontcare"));
+        ownerAdminRole = createAdminRole(owner);
+        ownerAdminRole.addUser(someuser);
+        roleCurator.create(ownerAdminRole);
+
+        Collection<Permission> perms = permFactory.createPermissions(someuser,
+            ownerAdminRole.getPermissions());
+
+        principal = new UserPrincipal(USER_NAME, perms, false);
+        setupPrincipal(principal);
+
+        hypervisorType = consumerTypeCurator.getByLabel(ConsumerType.ConsumerTypeEnum.HYPERVISOR.getLabel());
+
+        consumer = TestUtil.createConsumer(hypervisorType, owner);
+        consumer = consumerCurator.create(consumer);
+    }
+
+    @Test
+    public void testCloudProfileUpdatedOnGuestIdsForHostConsumerUpdates() {
+        Map<String, List<GuestIdDTO>> hostGuestMap = new HashMap<>();
+        String hypervisorId = "test-host";
+        hostGuestMap.put(hypervisorId, new ArrayList(Collections
+            .singletonList(TestUtil.createGuestIdDTO("GUEST_B"))));
+
+        HypervisorUpdateResultDTO result = hypervisorResource.hypervisorUpdate(
+            hostGuestMap, principal, owner.getKey(), true);
+
+        List<HypervisorConsumerDTO> created = new ArrayList<>(result.getCreated());
+
+        assertEquals(1, created.size());
+        assertNotNull(consumerCurator.findByUuid(created.get(0).getUuid()).getRHCloudProfileModified());
+
+        hostGuestMap.put(hypervisorId, new ArrayList(Collections
+            .singletonList(TestUtil.createGuestIdDTO("GUEST_C"))));
+
+        result = hypervisorResource.hypervisorUpdate(
+            hostGuestMap, principal, owner.getKey(), true);
+
+        List<HypervisorConsumerDTO> updated = new ArrayList<>(result.getUpdated());
+
+        assertEquals(1, updated.size());
+        assertNotNull(consumerCurator.findByUuid(updated.get(0).getUuid()).getRHCloudProfileModified());
+    }
+
+    @Test
+    public void testCloudProfileUpdatedOnConsumerTypeUpdates() {
+        ConsumerType system = new ConsumerType(ConsumerType.ConsumerTypeEnum.SYSTEM);
+        consumerTypeCurator.create(system);
+
+        String hypervisorid = "test-host";
+        Consumer testConsumer = new Consumer(hypervisorid, someuser.getUsername(), owner, system);
+        HypervisorId hypervisorId = new HypervisorId(hypervisorid);
+        hypervisorId.setOwner(owner);
+        testConsumer.setHypervisorId(hypervisorId);
+        testConsumer = consumerCurator.create(testConsumer);
+
+        Map<String, List<GuestIdDTO>> hostGuestMap = new HashMap<>();
+        hostGuestMap.put(testConsumer.getName(), new ArrayList<>());
+
+        HypervisorUpdateResultDTO result = hypervisorResource.hypervisorUpdate(
+            hostGuestMap, principal, owner.getKey(), true);
+
+        List<HypervisorConsumerDTO> updated = new ArrayList<>(result.getUpdated());
+
+        assertEquals(1, updated.size());
+        assertNotNull(consumerCurator.findByUuid(updated.get(0).getUuid()).getRHCloudProfileModified());
+    }
+
+    @Test
+    public void testCloudProfileUpdatedOnGuestUpdate() {
+        Consumer testConsumer = new Consumer("test_consumer", someuser.getUsername(), owner, hypervisorType);
+        testConsumer = consumerCurator.create(testConsumer);
+
+        GuestIdDTO guest = TestUtil.createGuestIdDTO("some_guest");
+        GuestId guestEnt = new GuestId();
+        guestEnt.setId("some_id");
+
+        Date beforeUpdateTimestamp = consumerCurator.findByUuid(testConsumer.getUuid())
+            .getRHCloudProfileModified();
+
+        guestIdResource.updateGuest(testConsumer.getUuid(), guest.getGuestId(), guest);
+        Date afterUpdateTimestamp = consumerCurator.findByUuid(testConsumer.getUuid())
+            .getRHCloudProfileModified();
+
+        assertNotNull(afterUpdateTimestamp);
+        assertNotEquals(beforeUpdateTimestamp, afterUpdateTimestamp);
+    }
+
+    @Test
+    public void testCloudProfileUpdatedOnMultipleGuestUpdate() {
+        List<GuestIdDTO> guestIds = new LinkedList<>();
+        guestIds.add(TestUtil.createGuestIdDTO("1"));
+
+        Date beforeUpdateTimestamp = consumerCurator.findByUuid(consumer.getUuid())
+            .getRHCloudProfileModified();
+
+        guestIdResource.updateGuests(consumer.getUuid(), guestIds);
+        Date afterUpdateTimestamp = consumerCurator.findByUuid(consumer.getUuid())
+            .getRHCloudProfileModified();
+
+        assertNotNull(afterUpdateTimestamp);
+        assertNotEquals(beforeUpdateTimestamp, afterUpdateTimestamp);
+    }
+
+    @Test
+    public void testCloudProfileNotUpdatedOnSameGuestUpdate() {
+        List<GuestIdDTO> guestIds = new LinkedList<>();
+        guestIds.add(TestUtil.createGuestIdDTO("1"));
+
+        Date beforeUpdateTimestamp = consumerCurator.findByUuid(consumer.getUuid())
+            .getRHCloudProfileModified();
+
+        guestIdResource.updateGuests(consumer.getUuid(), guestIds);
+        Date afterUpdateTimestamp = consumerCurator.findByUuid(consumer.getUuid())
+            .getRHCloudProfileModified();
+
+        assertNotEquals(beforeUpdateTimestamp, afterUpdateTimestamp);
+
+        //Updating the same Guests
+        beforeUpdateTimestamp = consumerCurator.findByUuid(consumer.getUuid())
+            .getRHCloudProfileModified();
+
+        guestIdResource.updateGuests(consumer.getUuid(), guestIds);
+        afterUpdateTimestamp = consumerCurator.findByUuid(consumer.getUuid())
+            .getRHCloudProfileModified();
+
+        assertEquals(beforeUpdateTimestamp, afterUpdateTimestamp);
+    }
+
+    @Test
+    public void testCloudProfileNotUpdatedWithNoUpdatesForHypervisor() {
+        Map<String, List<GuestIdDTO>> hostGuestMap = new HashMap<>();
+        String hypervisorId = "test-host";
+        hostGuestMap.put(hypervisorId, new ArrayList(Collections
+            .singletonList(TestUtil.createGuestIdDTO("GUEST_B"))));
+
+        HypervisorUpdateResultDTO result = hypervisorResource.hypervisorUpdate(
+            hostGuestMap, principal, owner.getKey(), true);
+
+        List<HypervisorConsumerDTO> created = new ArrayList<>(result.getCreated());
+        Date profileCreated = consumerCurator.findByUuid(created.get(0).getUuid())
+            .getRHCloudProfileModified();
+
+        assertEquals(1, created.size());
+        assertNotNull(profileCreated);
+
+        result = hypervisorResource.hypervisorUpdate(
+            hostGuestMap, principal, owner.getKey(), true);
+
+        List<HypervisorConsumerDTO> unChanged = new ArrayList<>(result.getUnchanged());
+        Date profileModified = consumerCurator.findByUuid(unChanged.get(0).getUuid())
+            .getRHCloudProfileModified();
+        assertEquals(1, unChanged.size());
+
+        assertEquals(profileCreated, profileModified);
+    }
+
+}


### PR DESCRIPTION
 - Added `rh_cloud_profile_modified` column in consumer
 - Updated the ConsumerResource, HypervisorResource and HypervisorUpdateAction
   to add modified timestamp on certain conditions
 - Added Enum for specific facts
 - Test suites added for the respective changes