### PR TITLE
[F] Removed unnecessary code and added missing refresh tests (ENT-2207)

### DIFF
--- a/server/src/main/java/org/candlepin/controller/ProductManager.java
+++ b/server/src/main/java/org/candlepin/controller/ProductManager.java
@@ -269,6 +269,10 @@ public class ProductManager {
      * The product info provided in the given map should be mapped by the product's Red Hat ID. If
      * the mappings are incorrect or inconsistent, the result of this method is undefined.
      *
+     * @deprecated
+     *  This method has been replaced by the RefreshWorker and its various components. New code
+     *  should avoid using this method if at all possible, instead opting to use the RefreshWorker.
+     *
      * @param owner
      *  The owner for which to import the given product
      *
@@ -284,6 +288,7 @@ public class ProductManager {
      */
     @Transactional
     @Traceable
+    @Deprecated
     public ImportResult<Product> importProducts(@TraceableParam("owner") Owner owner,
         Map<String, ? extends ProductInfo> productData, Map<String, Content> importedContent) {
 
@@ -335,6 +340,10 @@ public class ProductManager {
      * The product info provided in the given map should be mapped by the product's Red Hat ID. If
      * the mappings are incorrect or inconsistent, the result of this method is undefined.
      *
+     * @deprecated
+     *  This method has been replaced by the RefreshWorker and its various components. New code
+     *  should avoid using this method if at all possible, instead opting to use the RefreshWorker.
+     *
      * @param owner
      *  The owner for which to import the given product
      *
@@ -349,6 +358,7 @@ public class ProductManager {
      *  A mapping of Red Hat content ID to content entities representing the imported content
      */
     @Traceable
+    @Deprecated
     public ImportResult<Product> processProductImport(@TraceableParam("owner") Owner owner,
         Map<String, ? extends ProductInfo> productData, Map<String, Content> importedContent) {
 
@@ -1123,16 +1133,8 @@ public class ProductManager {
             if (!Util.collectionsAreEqual((Collection<ProductInfo>) entity.getProvidedProducts(),
                 (Collection<ProductInfo>) update.getProvidedProducts(), productComparator)) {
 
-                log.debug("Product's derived products are changed: {}", entity.getId());
-
                 return true;
             }
-            else {
-                log.debug("Product's derived products are unchanged: {}", entity.getId());
-            }
-        }
-        else {
-            log.debug("Updated product does not have any provided product changes: {}", update.getId());
         }
 
         return false;

--- a/server/src/main/java/org/candlepin/controller/refresher/RefreshResult.java
+++ b/server/src/main/java/org/candlepin/controller/refresher/RefreshResult.java
@@ -32,6 +32,24 @@ import java.util.Map;
  */
 public class RefreshResult {
 
+    // TODO: Flesh out the collection types here a bit more, in accordance with the table below
+    //
+    // Existing     Imported    Merged entity       Result
+    // not-null     not-null    not-null            updated entity
+    // not-null     not-null    null                unchanged entity (imported but unchanged)
+    // not-null     null        not-null            children updated
+    // not-null     null        null                unchanged entity (not imported, no changes to children)
+    // null         not-null    not-null            created entity
+    // null         not-null    null                ERROR STATE - creation failed
+    // null         null        null                ERROR STATE - uninitialized node
+    //
+    // Following this, we have 3 states to report, and 2 pseudo-states:
+    // - resultant states: created (5), updated (1, 3), unchanged (2, 4)
+    // - pseudo-states: imported (1, 2, 5) and skipped (3, 4)
+    //
+    // At the time of writing, we can kind of discern the pseudo-states by getting the collections
+    // back out of the refresh worker, so maybe this is a non-issue.
+
     private Map<String, Pool> createdPools;
     private Map<String, Pool> updatedPools;
     private Map<String, Pool> skippedPools;

--- a/server/src/main/java/org/candlepin/controller/refresher/RefreshWorker.java
+++ b/server/src/main/java/org/candlepin/controller/refresher/RefreshWorker.java
@@ -37,6 +37,7 @@ import org.candlepin.service.model.ProductInfo;
 import org.candlepin.service.model.SubscriptionInfo;
 
 import com.google.inject.Inject;
+import com.google.inject.persist.Transactional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -105,7 +106,9 @@ public class RefreshWorker {
      *  if any provided subscription does not contain a valid subscription ID
      */
     public void addSubscriptions(SubscriptionInfo... subscriptions) {
-        this.addSubscriptions(Arrays.asList(subscriptions));
+        if (subscriptions != null) {
+            this.addSubscriptions(Arrays.asList(subscriptions));
+        }
     }
 
     /**
@@ -162,7 +165,9 @@ public class RefreshWorker {
      *  if any provided product does not contain a valid product ID
      */
     public void addProducts(ProductInfo... products) {
-        this.addProducts(Arrays.asList(products));
+        if (products != null) {
+            this.addProducts(Arrays.asList(products));
+        }
     }
 
     /**
@@ -223,7 +228,9 @@ public class RefreshWorker {
      *  if any provided content does not contain a valid content ID
      */
     public void addProductContent(ProductContentInfo... contents) {
-        this.addProductContent(Arrays.asList(contents));
+        if (contents != null) {
+            this.addProductContent(Arrays.asList(contents));
+        }
     }
 
     /**
@@ -284,7 +291,9 @@ public class RefreshWorker {
      *  if any provided content does not contain a valid content ID
      */
     public void addContent(ContentInfo... contents) {
-        this.addContent(Arrays.asList(contents));
+        if (contents != null) {
+            this.addContent(Arrays.asList(contents));
+        }
     }
 
     /**
@@ -362,6 +371,7 @@ public class RefreshWorker {
      * @return
      *  the result of this refresh operation
      */
+    @Transactional
     public RefreshResult execute(Owner owner) {
         NodeMapper nodeMapper = new NodeMapper();
 

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -2177,8 +2177,8 @@ public class ConsumerResource {
             else {
                 message = (i18n.tr("Organization \"{0}\" has auto-attach disabled.", owner.getKey()));
             }
-            throw new BadRequestException(message);
 
+            throw new BadRequestException(message);
         }
 
         List<PoolQuantity> dryRunPools = new ArrayList<>();
@@ -2195,13 +2195,16 @@ public class ConsumerResource {
             throw bre;
         }
         catch (RuntimeException re) {
+            log.debug("Unexpected exception occurred while performing dry-run:", re);
             return Collections.<PoolQuantityDTO>emptyList();
         }
+
         if (dryRunPools != null) {
             List<PoolQuantityDTO> dryRunPoolDtos = new ArrayList<>();
             for (PoolQuantity pq : dryRunPools) {
                 dryRunPoolDtos.add(this.translator.translate(pq, PoolQuantityDTO.class));
             }
+
             return dryRunPoolDtos;
         }
         else {

--- a/server/src/test/java/org/candlepin/controller/EntitlerTest.java
+++ b/server/src/test/java/org/candlepin/controller/EntitlerTest.java
@@ -21,20 +21,25 @@ import org.candlepin.common.config.Configuration;
 import org.candlepin.common.exceptions.BadRequestException;
 import org.candlepin.common.exceptions.ForbiddenException;
 import org.candlepin.config.ConfigProperties;
+import org.candlepin.controller.refresher.RefreshResult;
+import org.candlepin.controller.refresher.RefreshWorker;
 import org.candlepin.model.CandlepinQuery;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerCurator;
 import org.candlepin.model.ConsumerInstalledProduct;
 import org.candlepin.model.ConsumerTypeCurator;
 import org.candlepin.model.Content;
+import org.candlepin.model.ContentCurator;
 import org.candlepin.model.Entitlement;
 import org.candlepin.model.EntitlementCurator;
 import org.candlepin.model.Owner;
+import org.candlepin.model.OwnerContentCurator;
 import org.candlepin.model.OwnerCurator;
+import org.candlepin.model.OwnerProductCurator;
 import org.candlepin.model.Pool;
 import org.candlepin.model.PoolCurator;
 import org.candlepin.model.Product;
-import org.candlepin.model.dto.ContentData;
+import org.candlepin.model.ProductCurator;
 import org.candlepin.model.dto.ProductData;
 import org.candlepin.policy.EntitlementRefusedException;
 import org.candlepin.policy.ValidationError;
@@ -55,6 +60,7 @@ import org.xnap.commons.i18n.I18nFactory;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -65,20 +71,13 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import javax.inject.Provider;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyMap;
-import static org.mockito.Mockito.anySet;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.nullable;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 
 // TODO: FIXME: Rewrite this test to not be so reliant upon mocks. It's making things incredibly brittle and
@@ -109,6 +108,14 @@ public class EntitlerTest {
     @Mock private ContentManager contentManager;
     @Mock private ConsumerTypeCurator consumerTypeCurator;
 
+    @Mock private ContentCurator mockContentCurator;
+    @Mock private OwnerContentCurator mockOwnerContentCurator;
+    @Mock private ProductCurator mockProductCurator;
+    @Mock private OwnerProductCurator mockOwnerProductCurator;
+
+    private RefreshWorker refreshWorker;
+    private Provider<RefreshWorker> refreshWorkerProvider;
+
     private ValidationResult fakeOutResult(String msg) {
         ValidationResult result = new ValidationResult();
         ValidationError err = new ValidationError(msg);
@@ -125,74 +132,35 @@ public class EntitlerTest {
         );
         translator = new EntitlementRulesTranslator(i18n);
 
+        this.refreshWorker = spy(new RefreshWorker(this.mockProductCurator, this.mockOwnerProductCurator,
+            this.mockContentCurator, this.mockOwnerContentCurator));
+
+        this.refreshWorkerProvider = () -> refreshWorker;
+
         entitler = new Entitler(pm, cc, i18n, ef, sink, translator, entitlementCurator, config,
             ownerCurator, poolCurator, productManager, productAdapter,
-            contentManager, consumerTypeCurator);
+            contentManager, consumerTypeCurator, this.refreshWorkerProvider);
     }
 
-    private void mockProductImport(Map<String, Product> products) {
-        when(productManager.importProducts(any(Owner.class), anyMap(), anyMap()))
-            .thenAnswer(invocation -> {
-                Object[] args = invocation.getArguments();
-                Map<String, ProductData> productData = (Map<String, ProductData>) args[1];
-                ImportResult<Product> importResult = new ImportResult<>();
-                Map<String, Product> output = importResult.getCreatedEntities();
+    private void mockRefresh(Owner owner, Collection<Product> products, Collection<Content> contents) {
+        doAnswer(iom -> {
+            RefreshResult output = new RefreshResult();
 
-                if (productData != null) {
-                    for (String pid : productData.keySet()) {
-                        Product product = products.get(pid);
-
-                        if (product != null) {
-                            output.put(product.getId(), product);
-                        }
-                    }
+            if (products != null) {
+                for (Product product : products) {
+                    output.addCreatedProduct(product);
                 }
+            }
 
-                return importResult;
-            });
-    }
-
-    private void mockProductImport(Product... products) {
-        this.mockContentImport(Collections.emptyMap());
-        Map<String, Product> productMap = new HashMap<>();
-
-        for (Product product : products) {
-            productMap.put(product.getId(), product);
-        }
-
-        this.mockProductImport(productMap);
-    }
-
-    private void mockContentImport(Map<String, Content> contents) {
-        when(contentManager.importContent(any(), anyMap(), anySet()))
-            .thenAnswer(invocation -> {
-                Object[] args = invocation.getArguments();
-                Map<String, ContentData> contentData = (Map<String, ContentData>) args[1];
-                ImportResult<Content> importResult = new ImportResult<>();
-                Map<String, Content> output = importResult.getCreatedEntities();
-
-                if (contentData != null) {
-                    for (String pid : contentData.keySet()) {
-                        Content content = contents.get(pid);
-
-                        if (content != null) {
-                            output.put(content.getId(), content);
-                        }
-                    }
+            if (contents != null) {
+                for (Content content : contents) {
+                    output.addCreatedContent(content);
                 }
+            }
 
-                return importResult;
-            });
-    }
-
-    private void mockContentImport(Content... contents) {
-        Map<String, Content> contentMap = new HashMap<>();
-
-        for (Content content : contents) {
-            contentMap.put(content.getId(), content);
-        }
-
-        this.mockContentImport(contentMap);
+            return output;
+        })
+        .when(this.refreshWorker).execute(eq(owner));
     }
 
     @Test
@@ -512,8 +480,7 @@ public class EntitlerTest {
         when(poolCurator.hasActiveEntitlementPools(eq(owner.getId()), nullable(Date.class))).thenReturn(true);
         doReturn(devProdDTOs).when(productAdapter).getProductsByIds(eq(owner.getKey()), anyList());
 
-        this.mockProductImport(p);
-        this.mockContentImport(Collections.emptyMap());
+        this.mockRefresh(owner, Arrays.asList(p), null);
 
         when(pm.createPool(any(Pool.class))).thenReturn(devPool);
         when(devPool.getId()).thenReturn("test_pool_id");
@@ -571,8 +538,7 @@ public class EntitlerTest {
         when(poolCurator.hasActiveEntitlementPools(eq(owner.getId()), nullable(Date.class))).thenReturn(true);
         doReturn(devProdDTOs).when(productAdapter).getProductsByIds(eq(owner.getKey()), anyList());
 
-        mockProductImport(p, ip);
-        mockContentImport();
+        this.mockRefresh(owner, Arrays.asList(p, ip), null);
 
         AutobindData ad = new AutobindData(devSystem, owner);
         try {
@@ -603,8 +569,7 @@ public class EntitlerTest {
         when(poolCurator.hasActiveEntitlementPools(eq(owner.getId()), nullable(Date.class))).thenReturn(true);
         doReturn(devProdDTOs).when(productAdapter).getProductsByIds(eq(owner.getKey()), anyList());
 
-        this.mockProductImport(p, ip1, ip2);
-        this.mockContentImport(Collections.emptyMap());
+        this.mockRefresh(owner, Arrays.asList(p, ip1, ip2), null);
 
         Pool expectedPool = entitler.assembleDevPool(devSystem, owner, p.getId());
         when(pm.createPool(any(Pool.class))).thenReturn(expectedPool);
@@ -630,8 +595,7 @@ public class EntitlerTest {
         devSystem.addInstalledProduct(new ConsumerInstalledProduct(p3));
         doReturn(devProdDTOs).when(productAdapter).getProductsByIds(eq(owner.getKey()), anyList());
 
-        this.mockProductImport(p1, p2, p3);
-        this.mockContentImport(Collections.emptyMap());
+        this.mockRefresh(owner, Arrays.asList(p1, p2, p3), null);
 
         Pool created = entitler.assembleDevPool(devSystem, owner, devSystem.getFact("dev_sku"));
         Calendar cal = Calendar.getInstance();

--- a/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -429,8 +429,6 @@ public class PoolManagerTest {
         when(mockOwnerCurator.getByKey(owner.getKey())).thenReturn(owner);
         this.mockProducts(owner, product);
         this.mockRefresh(owner, Arrays.asList(product), Collections.emptyList());
-        // this.mockProductImport(owner, product);
-        // this.mockContentImport(owner, new Content[] {});
 
         CandlepinQuery<Pool> cqmock = mock(CandlepinQuery.class);
         when(cqmock.list()).thenReturn(pools);
@@ -472,8 +470,6 @@ public class PoolManagerTest {
         when(mockOwnerCurator.getByKey(owner.getKey())).thenReturn(owner);
         this.mockProducts(owner, product);
         this.mockRefresh(owner, Arrays.asList(product), Collections.emptyList());
-        // this.mockProductImport(owner, product);
-        // this.mockContentImport(owner, new Content[] {});
 
         CandlepinQuery<Pool> cqmock = mock(CandlepinQuery.class);
         when(cqmock.list()).thenReturn(pools);
@@ -578,76 +574,6 @@ public class PoolManagerTest {
             }})
         .when(this.refreshWorker).execute(eq(owner));
     }
-
-    // private void mockProductImport(Owner owner, final Map<String, Product> products) {
-    //     when(mockProductManager.importProducts(eq(owner), any(Map.class), any(Map.class)))
-    //         .thenAnswer(new Answer<ImportResult<Product>>() {
-    //             @Override
-    //             public ImportResult<Product> answer(InvocationOnMock invocation) throws Throwable {
-    //                 Object[] args = invocation.getArguments();
-    //                 Map<String, ProductData> productData = (Map<String, ProductData>) args[1];
-    //                 ImportResult<Product> importResult = new ImportResult<>();
-    //                 Map<String, Product> output = importResult.getCreatedEntities();
-
-    //                 if (productData != null) {
-    //                     for (String pid : productData.keySet()) {
-    //                         Product product = products.get(pid);
-
-    //                         if (product != null) {
-    //                             output.put(product.getId(), product);
-    //                         }
-    //                     }
-    //                 }
-
-    //                 return importResult;
-    //             }
-    //         });
-    // }
-
-    // private void mockProductImport(Owner owner, Product... products) {
-    //     Map<String, Product> productMap = new HashMap<>();
-
-    //     for (Product product : products) {
-    //         productMap.put(product.getId(), product);
-    //     }
-
-    //     this.mockProductImport(owner, productMap);
-    // }
-
-    // private void mockContentImport(Owner owner, final Map<String, Content> contents) {
-    //     when(mockContentManager.importContent(eq(owner), any(Map.class), any(Set.class)))
-    //         .thenAnswer(new Answer<ImportResult<Content>>() {
-    //             @Override
-    //             public ImportResult<Content> answer(InvocationOnMock invocation) throws Throwable {
-    //                 Object[] args = invocation.getArguments();
-    //                 Map<String, ContentData> contentData = (Map<String, ContentData>) args[1];
-    //                 ImportResult<Content> importResult = new ImportResult<>();
-    //                 Map<String, Content> output = importResult.getCreatedEntities();
-
-    //                 if (contentData != null) {
-    //                     for (String pid : contentData.keySet()) {
-    //                         Content content = contents.get(pid);
-
-    //                         if (content != null) {
-    //                             output.put(content.getId(), content);
-    //                         }
-    //                     }
-    //                 }
-
-    //                 return importResult;
-    //             }
-    //         });
-    // }
-
-    // private void mockContentImport(Owner owner, Content... contents) {
-    //     Map<String, Content> contentMap = new HashMap<>();
-
-    //     for (Content content : contents) {
-    //         contentMap.put(content.getId(), content);
-    //     }
-
-    //     this.mockContentImport(owner, contentMap);
-    // }
 
     @Test
     public void productAttributesCopiedOntoPoolWhenCreatingNewPool() {
@@ -810,8 +736,6 @@ public class PoolManagerTest {
         when(mockPoolCurator.getPoolsBySubscriptionIds(anyList())).thenReturn(cqmock);
 
         this.mockRefresh(owner, Arrays.asList(product), Collections.emptyList());
-        // this.mockProductImport(owner, product);
-        // this.mockContentImport(owner, new Content[] {});
 
         Owner owner = getOwner();
         when(mockOwnerCurator.getByKey(owner.getKey())).thenReturn(owner);
@@ -841,8 +765,6 @@ public class PoolManagerTest {
         when(mockOwnerCurator.getByKey(owner.getKey())).thenReturn(owner);
 
         this.mockRefresh(owner, Arrays.asList(product), Collections.emptyList());
-        // this.mockProductImport(owner, product);
-        // this.mockContentImport(owner, new Content[] {});
 
         CandlepinQuery<Pool> cqmock = mock(CandlepinQuery.class);
         when(cqmock.list()).thenReturn(pools);
@@ -879,8 +801,6 @@ public class PoolManagerTest {
         when(mockOwnerCurator.getByKey(owner.getKey())).thenReturn(owner);
 
         this.mockRefresh(owner, Arrays.asList(product), Collections.emptyList());
-        // this.mockProductImport(owner, product);
-        // this.mockContentImport(owner, new Content[] {});
 
         CandlepinQuery<Pool> cqmock = mock(CandlepinQuery.class);
         when(cqmock.list()).thenReturn(pools);
@@ -909,8 +829,6 @@ public class PoolManagerTest {
         mockPoolsList(pools);
 
         this.mockRefresh(owner, Arrays.asList(product), Collections.emptyList());
-        // this.mockProductImport(owner, product);
-        // this.mockContentImport(owner, new Content[] {});
 
         CandlepinQuery<Pool> cqmock = mock(CandlepinQuery.class);
         when(cqmock.list()).thenReturn(pools);
@@ -944,8 +862,6 @@ public class PoolManagerTest {
         when(mockPoolCurator.listByOwnerAndType(eq(owner), any(PoolType.class))).thenReturn(cqmock);
 
         this.mockRefresh(owner, Arrays.asList(product), Collections.emptyList());
-        // this.mockProductImport(owner, product);
-        // this.mockContentImport(owner, new Content[] {});
 
         Owner owner = getOwner();
         when(mockOwnerCurator.getByKey(owner.getKey())).thenReturn(owner);
@@ -973,8 +889,6 @@ public class PoolManagerTest {
         when(mockOwnerCurator.getByKey(owner.getKey())).thenReturn(owner);
 
         this.mockRefresh(owner, Arrays.asList(product), Collections.emptyList());
-        // this.mockProductImport(owner, product);
-        // this.mockContentImport(owner, new Content[] {});
 
         CandlepinQuery<Pool> cqmock = mock(CandlepinQuery.class);
         when(cqmock.list()).thenReturn(pools);
@@ -1013,8 +927,6 @@ public class PoolManagerTest {
         when(mockOwnerCurator.getByKey(owner.getKey())).thenReturn(owner);
         this.mockProducts(owner, product);
         this.mockRefresh(owner, Arrays.asList(product), Collections.emptyList());
-        // this.mockProductImport(owner, product);
-        // this.mockContentImport(owner, new Content[] {});
 
         CandlepinQuery<Pool> cqmock = mock(CandlepinQuery.class);
         when(cqmock.list()).thenReturn(pools);
@@ -1070,8 +982,6 @@ public class PoolManagerTest {
         when(mockOwnerCurator.getByKey(owner.getKey())).thenReturn(owner);
         this.mockProducts(owner, product);
         this.mockRefresh(owner, Arrays.asList(product), Collections.emptyList());
-        // this.mockProductImport(owner, product);
-        // this.mockContentImport(owner, new Content[] {});
 
         CandlepinQuery<Pool> cqmock = mock(CandlepinQuery.class);
         when(cqmock.list()).thenReturn(pools);
@@ -1361,8 +1271,6 @@ public class PoolManagerTest {
         when(mockOwnerCurator.getByKey(owner.getKey())).thenReturn(owner);
         this.mockProducts(owner, product);
         this.mockRefresh(owner, Arrays.asList(product), Collections.emptyList());
-        // this.mockProductImport(owner, product);
-        // this.mockContentImport(owner, new Content[] {});
 
         CandlepinQuery<Pool> cqmock = mock(CandlepinQuery.class);
         when(cqmock.list()).thenReturn(pools);
@@ -1571,8 +1479,6 @@ public class PoolManagerTest {
         when(mockOwnerCurator.getByKey(owner.getKey())).thenReturn(owner);
         this.mockProducts(owner, product);
         this.mockRefresh(owner, Arrays.asList(product), Collections.emptyList());
-        // this.mockProductImport(owner, product);
-        // this.mockContentImport(owner, new Content[] {});
 
         CandlepinQuery<Pool> cqmock = mock(CandlepinQuery.class);
         when(cqmock.list()).thenReturn(pools);

--- a/server/src/test/java/org/candlepin/controller/refresher/RefreshWorkerVersioningTest.java
+++ b/server/src/test/java/org/candlepin/controller/refresher/RefreshWorkerVersioningTest.java
@@ -1,0 +1,256 @@
+/**
+ * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.controller.refresher.visitors;
+
+import org.candlepin.controller.refresher.RefreshResult;
+import org.candlepin.controller.refresher.RefreshWorker;
+import org.candlepin.model.Content;
+import org.candlepin.model.Owner;
+import org.candlepin.model.Product;
+import org.candlepin.service.model.ContentInfo;
+import org.candlepin.service.model.ProductInfo;
+import org.candlepin.test.DatabaseTestFixture;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+
+
+/**
+ * Test suite for the RefreshWorker class focusing specifically on entity versioning,
+ * and the required converging and diverging functionality
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class RefreshWorkerVersioningTest extends DatabaseTestFixture {
+
+    @BeforeEach
+    public void init() throws Exception {
+        super.init();
+    }
+
+    private RefreshWorker buildRefreshWorker() {
+        return new RefreshWorker(this.productCurator, this.ownerProductCurator,
+            this.contentCurator, this.ownerContentCurator);
+    }
+
+    private ProductInfo mockProductInfo(String id, String name) {
+        ProductInfo entity = mock(ProductInfo.class);
+        doReturn(id).when(entity).getId();
+        doReturn(null).when(entity).getMultiplier();
+        doReturn(name).when(entity).getName();
+
+        return entity;
+    }
+
+    private ContentInfo mockContentInfo(String id, String name) {
+        ContentInfo entity = mock(ContentInfo.class);
+        doReturn(id).when(entity).getId();
+        doReturn(null).when(entity).getMetadataExpiration();
+        doReturn(name).when(entity).getName();
+
+        return entity;
+    }
+
+    @Test
+    public void testProductCreationMergesWithExistingVersion() {
+        Owner owner1 = this.createOwner("owner-1");
+        Owner owner2 = this.createOwner("owner-2");
+
+        String id = "pid-1";
+        String name = "product_name";
+
+        Product product = this.createProduct(id, name, owner1);
+
+        RefreshWorker worker = this.buildRefreshWorker();
+        worker.addProducts(product);
+
+        RefreshResult result = worker.execute(owner2);
+
+        assertNotNull(result);
+        assertEquals(1, result.getCreatedProducts().size());
+        assertEquals(0, result.getUpdatedProducts().size());
+        assertEquals(0, result.getSkippedProducts().size());
+
+        Product created = result.getProduct(id);
+
+        assertNotNull(created);
+        assertEquals(product, created);
+        assertEquals(product.getUuid(), created.getUuid());
+        assertTrue(this.ownerProductCurator.isProductMappedToOwner(created, owner1));
+        assertTrue(this.ownerProductCurator.isProductMappedToOwner(created, owner2));
+    }
+
+    @Test
+    public void testProductUpdateMergesWithExistingVersion() {
+        Owner owner1 = this.createOwner("owner-1");
+        Owner owner2 = this.createOwner("owner-2");
+
+        String id = "pid-1";
+        String name = "product_name";
+
+        Product product = this.createProduct(id, name, owner1);
+        Product existing = this.createProduct(id, "old_name", owner2);
+        ProductInfo imported = this.mockProductInfo(id, name);
+
+        RefreshWorker worker = this.buildRefreshWorker();
+        worker.addProducts(imported);
+
+        RefreshResult result = worker.execute(owner2);
+
+        assertNotNull(result);
+        assertEquals(0, result.getCreatedProducts().size());
+        assertEquals(1, result.getUpdatedProducts().size());
+        assertEquals(0, result.getSkippedProducts().size());
+
+        Product updated = result.getProduct(id);
+
+        assertNotNull(updated);
+        assertEquals(product, updated);
+        assertEquals(product.getUuid(), updated.getUuid());
+        assertTrue(this.ownerProductCurator.isProductMappedToOwner(updated, owner1));
+        assertTrue(this.ownerProductCurator.isProductMappedToOwner(updated, owner2));
+    }
+
+    @Test
+    public void testProductUpdateDivergesFromExistingVersion() {
+        Owner owner1 = this.createOwner("owner-1");
+        Owner owner2 = this.createOwner("owner-2");
+
+        String id = "pid-1";
+
+        Product product = this.createProduct(id, "old_name", owner1, owner2);
+        ProductInfo imported = this.mockProductInfo(id, "new_name");
+
+        RefreshWorker worker = this.buildRefreshWorker();
+        worker.addProducts(imported);
+
+        RefreshResult result = worker.execute(owner2);
+
+        assertNotNull(result);
+        assertEquals(0, result.getCreatedProducts().size());
+        assertEquals(1, result.getUpdatedProducts().size());
+        assertEquals(0, result.getSkippedProducts().size());
+
+        Product updated = result.getProduct(id);
+
+        assertNotNull(updated);
+        assertNotEquals(product, updated);
+        assertNotEquals(product.getUuid(), updated.getUuid());
+        assertTrue(this.ownerProductCurator.isProductMappedToOwner(product, owner1));
+        assertFalse(this.ownerProductCurator.isProductMappedToOwner(product, owner2));
+        assertFalse(this.ownerProductCurator.isProductMappedToOwner(updated, owner1));
+        assertTrue(this.ownerProductCurator.isProductMappedToOwner(updated, owner2));
+    }
+
+
+    @Test
+    public void testContentCreationMergesWithExistingVersion() {
+        Owner owner1 = this.createOwner("owner-1");
+        Owner owner2 = this.createOwner("owner-2");
+
+        String id = "pid-1";
+        String name = "content_name";
+
+        Content content = this.createContent(id, name, owner1);
+
+        RefreshWorker worker = this.buildRefreshWorker();
+        worker.addContent(content);
+
+        RefreshResult result = worker.execute(owner2);
+
+        assertNotNull(result);
+        assertEquals(1, result.getCreatedContent().size());
+        assertEquals(0, result.getUpdatedContent().size());
+        assertEquals(0, result.getSkippedContent().size());
+
+        Content created = result.getContent(id);
+
+        assertNotNull(created);
+        assertEquals(content, created);
+        assertEquals(content.getUuid(), created.getUuid());
+        assertTrue(this.ownerContentCurator.isContentMappedToOwner(created, owner1));
+        assertTrue(this.ownerContentCurator.isContentMappedToOwner(created, owner2));
+    }
+
+    @Test
+    public void testContentUpdateMergesWithExistingVersion() {
+        Owner owner1 = this.createOwner("owner-1");
+        Owner owner2 = this.createOwner("owner-2");
+
+        String id = "pid-1";
+        String name = "content_name";
+
+        Content content = this.createContent(id, name, owner1);
+        Content existing = this.createContent(id, "old_name", owner2);
+        ContentInfo imported = this.mockContentInfo(id, name);
+
+        RefreshWorker worker = this.buildRefreshWorker();
+        worker.addContent(imported);
+
+        RefreshResult result = worker.execute(owner2);
+
+        assertNotNull(result);
+        assertEquals(0, result.getCreatedContent().size());
+        assertEquals(1, result.getUpdatedContent().size());
+        assertEquals(0, result.getSkippedContent().size());
+
+        Content updated = result.getContent(id);
+
+        assertNotNull(updated);
+        assertEquals(content, updated);
+        assertEquals(content.getUuid(), updated.getUuid());
+        assertTrue(this.ownerContentCurator.isContentMappedToOwner(updated, owner1));
+        assertTrue(this.ownerContentCurator.isContentMappedToOwner(updated, owner2));
+    }
+
+    @Test
+    public void testContentUpdateDivergesFromExistingVersion() {
+        Owner owner1 = this.createOwner("owner-1");
+        Owner owner2 = this.createOwner("owner-2");
+
+        String id = "pid-1";
+
+        Content content = this.createContent(id, "old_name", owner1, owner2);
+        ContentInfo imported = this.mockContentInfo(id, "new_name");
+
+        RefreshWorker worker = this.buildRefreshWorker();
+        worker.addContent(imported);
+
+        RefreshResult result = worker.execute(owner2);
+
+        assertNotNull(result);
+        assertEquals(0, result.getCreatedContent().size());
+        assertEquals(1, result.getUpdatedContent().size());
+        assertEquals(0, result.getSkippedContent().size());
+
+        Content updated = result.getContent(id);
+
+        assertNotNull(updated);
+        assertNotEquals(content, updated);
+        assertNotEquals(content.getUuid(), updated.getUuid());
+        assertTrue(this.ownerContentCurator.isContentMappedToOwner(content, owner1));
+        assertFalse(this.ownerContentCurator.isContentMappedToOwner(content, owner2));
+        assertFalse(this.ownerContentCurator.isContentMappedToOwner(updated, owner1));
+        assertTrue(this.ownerContentCurator.isContentMappedToOwner(updated, owner2));
+    }
+}


### PR DESCRIPTION
- Added versioning tests for the full RefreshWorker execute
  code path
- Removed ContentManager.importContent, as it is entirely
  obsoleted by the RefreshWorker framework
- Deprecated the ProductManager and ContentManager classes
  as a whole