### PR TITLE
[M] Added handling of HTTP errors to the cpc utility

### DIFF
--- a/server/client/ruby/cpc
+++ b/server/client/ruby/cpc
@@ -127,9 +127,14 @@ else
         arg
       end
     end
-    val = cli.send(method_name, *args)
 
-    pp val
+    begin
+      pp cli.send(method_name, *args)
+    rescue RestClient::Exception => e
+      errmsg = JSON.parse(e.http_body)['displayMessage']
+      puts "Error: #{e.message} -- #{errmsg}"
+    end
+
   else
     puts "#{method_name} is not a valid command!"
   end


### PR DESCRIPTION
- The cpc utility now catches HTTP errors originating from the
  targeted request and will print the error code, friendly name,
  and server response rather than dumping a stack trace