### PR TITLE
[M] 1815172: Upon registration, first resolve owner; ENT-2246

### DIFF
--- a/server/src/main/java/org/candlepin/resource/HypervisorResource.java
+++ b/server/src/main/java/org/candlepin/resource/HypervisorResource.java
@@ -396,7 +396,7 @@ public class HypervisorResource {
             this.hypervisorType,
             principal,
             null,
-            owner.getKey(),
+            owner,
             null,
             false);
     }

--- a/server/src/test/java/org/candlepin/async/tasks/HypervisorUpdateJobTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/HypervisorUpdateJobTest.java
@@ -374,7 +374,7 @@ public class HypervisorUpdateJobTest {
             translator, hypervisorUpdateAction, i18n, objectMapper);
         job.execute(ctx);
         verify(consumerResource, never()).createConsumerFromDTO(any(ConsumerDTO.class),
-            any(ConsumerType.class), any(Principal.class), anyString(), anyString(), anyString(),
+            any(ConsumerType.class), any(Principal.class), anyString(), any(Owner.class), anyString(),
             eq(false));
     }
 


### PR DESCRIPTION
- This resolves a scenario where after a virt-who check-in that resulted in a
  new consumer creation, that same consumer (using username/password)
  would try to register without specifying an owner key, and fail with a
  duplicate hypervisor key error because we would attempt to create another
  consumer.
- Now, during registration, first resolve the owner (even if no key was
  specified), and then check if we have an existing hypervisor record for
  this user, instead of blindly creating a new consumer record.