### PR TITLE
1836988: Fix for datetime parsing error with bad TZ offset (ENT-2379)

### DIFF
--- a/common/src/main/java/org/candlepin/common/util/JaxRsExceptionResponseBuilder.java
+++ b/common/src/main/java/org/candlepin/common/util/JaxRsExceptionResponseBuilder.java
@@ -54,7 +54,7 @@ public class JaxRsExceptionResponseBuilder {
      * Regex to extract the errored values from the JAX-RS Exception.
      */
     private static final Pattern ILLEGAL_VAL_REGEX = Pattern
-        .compile(":?value\\sis\\s'([\\w\\s]+)(:?'\\sfor)");
+        .compile(":?value\\sis\\s'([\\w\\s-:+]+)(:?'\\sfor)");
 
     /**
      * Service for i18n.

--- a/common/src/test/java/org/candlepin/common/util/JaxRsExceptionResponseBuilderTest.java
+++ b/common/src/test/java/org/candlepin/common/util/JaxRsExceptionResponseBuilderTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import javax.ws.rs.NotFoundException;
 import javax.ws.rs.core.Response;
 
 
@@ -89,5 +90,19 @@ public class JaxRsExceptionResponseBuilderTest {
     public void badMessageNotHandleable() {
         String foo = "javax.ws.rs.SomeThing(\"paramName\") value is strVal for";
         assertFalse(exceptionBuilder.canHandle(new RuntimeException(foo)));
+    }
+
+    @Test
+    public void canHandleIncorrectDateTimeFormats() {
+        NotFoundException ex = new NotFoundException("Unable to extract parameter from http request: " +
+            "javax.ws.rs.QueryParam(\"param\") value is '2019-01-16T01:02:03-0400' for public",
+            new RuntimeException("Invalid Date"));
+
+        assertTrue(exceptionBuilder.canHandle(ex));
+
+        Response resp = exceptionBuilder.getResponse(ex);
+        ExceptionMessage e =  (ExceptionMessage) resp.getEntity();
+
+        assertTrue(e.getDisplayMessage().contains("is not a valid value for"));
     }
 }


### PR DESCRIPTION
Fixes 
- Resteasy 4.2.2 now throws `javax.ws.rs.NotFoundException` which needed to be mapped to BAD_REQUEST via candlepin NotFoundExceptionMapper.