### PR TITLE
[2.9] 1840823: Fixed parameter overflow in bulk entitlement deletion (ENT-2437)

### DIFF
--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -2255,7 +2255,6 @@ public class CandlepinPoolManager implements PoolManager {
             Set<Entitlement> entitlements = new HashSet<>();
 
             if (!entitlementIds.isEmpty()) {
-                log.debug("IN BLOCK SIZE: {}", this.entitlementCurator.getInBlockSize());
                 Iterable<List<String>> blocks =
                     Iterables.partition(entitlementIds, this.entitlementCurator.getInBlockSize());
 
@@ -2340,6 +2339,7 @@ public class CandlepinPoolManager implements PoolManager {
                 this.poolCurator.updateAll(poolsToSave, false, false);
                 this.consumerCurator.updateAll(consumerStackedEnts.keySet(), false, false);
                 this.consumerCurator.flush();
+
                 log.info("Entitlement counts successfully updated for {} pools and {} consumers",
                     poolsToSave.size(), consumerStackedEnts.size());
 

--- a/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
+++ b/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
@@ -1212,7 +1212,13 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
      *
      * @return
      *  the number of rows deleted as a result of this query
+     *
+     * @deprecated
+     *  This method does not check the parameter limit when building queries, and will fail when
+     *  provided criteria that exceeds it. As such, this method should be avoided in favor of
+     *  a query written specifically for the desired task.
      */
+    @Deprecated
     protected int bulkSQLDelete(String table, Map<String, Object> criteria) {
         StringBuilder builder = new StringBuilder("DELETE FROM ").append(table);
 

--- a/server/src/test/java/org/candlepin/model/EntitlementCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/EntitlementCuratorTest.java
@@ -1284,4 +1284,41 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
         assertTrue(poolIds.contains(distributorDependentEnt.getId()));
     }
 
+    @Test
+    public void testBatchDeleteEntitlementsWithLargeDataSet() {
+        // We're only expecting 10 or so total deletions, but the parameters we provide should not
+        // exceed the limit in a single query. At the time of writing, a signed, two-byte value
+        // seems to be used for parameter definitions, so we'll use 32k as our in-test minimum, but
+        // use the larger of that and actual value of getParameterLimit as our base parameter limit
+
+        int defaultLimit = 32000;
+        int configLimit = this.entitlementCurator.getQueryParameterLimit();
+        int testLimit = Math.max(defaultLimit, configLimit) * 2;
+
+        int entitlementCount = 10;
+
+        Owner owner = this.createOwner();
+        Consumer consumer = this.createConsumer(owner);
+        Product product = this.createProduct(owner);
+        Pool pool = this.createPool(owner, product);
+
+        List<String> entIds = new LinkedList<>();
+
+        // Pad the entIds collection with a ton of extra IDs so we can exceed the known parameter
+        // limits
+        for (int i = 0; i < testLimit; ++i) {
+            entIds.add("test_id-" + i);
+        }
+
+        // Add our actual IDs to the end so we verify the query isn't just being truncated
+        for (int i = 0; i < entitlementCount; ++i) {
+            Entitlement entitlement = this.createEntitlement(owner, consumer, pool);
+            entIds.add(entitlement.getId());
+        }
+
+        int deleted = this.entitlementCurator.batchDeleteByIds(entIds);
+
+        assertEquals(entitlementCount, deleted);
+    }
+
 }


### PR DESCRIPTION
- Fixed an issue during entitlement deletion that could cause a
  query to be generated that attempts to use more parameters than
  the backend database supports
- Flagged the bulkSQLDelete method as deprecated, as it lacks
  protection for the database parameter limit