### PR TITLE
[M] 1840850: Fixed parameter overflow in bulk entitlement deletion (ENT-2437)

### DIFF
--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -2229,7 +2229,6 @@ public class CandlepinPoolManager implements PoolManager {
             Set<Entitlement> entitlements = new HashSet<>();
 
             if (!entitlementIds.isEmpty()) {
-                log.debug("IN BLOCK SIZE: {}", this.entitlementCurator.getInBlockSize());
                 Iterable<List<String>> blocks =
                     Iterables.partition(entitlementIds, this.entitlementCurator.getInBlockSize());
 
@@ -2314,6 +2313,7 @@ public class CandlepinPoolManager implements PoolManager {
                 this.poolCurator.updateAll(poolsToSave, false, false);
                 this.consumerCurator.updateAll(consumerStackedEnts.keySet(), false, false);
                 this.consumerCurator.flush();
+
                 log.info("Entitlement counts successfully updated for {} pools and {} consumers",
                     poolsToSave.size(), consumerStackedEnts.size());
 

--- a/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
+++ b/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
@@ -1282,7 +1282,13 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
      *
      * @return
      *  the number of rows deleted as a result of this query
+     *
+     * @deprecated
+     *  This method does not check the parameter limit when building queries, and will fail when
+     *  provided criteria that exceeds it. As such, this method should be avoided in favor of
+     *  a query written specifically for the desired task.
      */
+    @Deprecated
     protected int bulkSQLDelete(String table, Map<String, Object> criteria) {
         StringBuilder builder = new StringBuilder("DELETE FROM ").append(table);
 


### PR DESCRIPTION
- Fixed an issue during entitlement deletion that could cause a
  query to be generated that attempts to use more parameters than
  the backend database supports
- Flagged the bulkSQLDelete method as deprecated, as it lacks
  protection for the database parameter limit