### PR TITLE
[2.9] 1842933: Delete removed Artemis queues on broker.xml reload; ENT-2465

### DIFF
--- a/server/src/main/resources/broker.xml
+++ b/server/src/main/resources/broker.xml
@@ -63,6 +63,7 @@
 
         <address-settings>
             <address-setting match="event.default">
+                <config-delete-queues>FORCE</config-delete-queues>
                 <auto-create-queues>true</auto-create-queues>
                 <max-size-bytes>10485760</max-size-bytes>
 


### PR DESCRIPTION
- Currently, when we remove an artemis queue from broker.xml and
  redeploy/restart candlepin, the queue is not actually removed
  from the artemis broker by default. This has caused a problem
  for all Satellite customers that upgraded to 6.6+ from earlier
  versions, since that is the version that the DatabaseListener
  queue and DatabaseListener.java listener were removed, because
  the queue is still there, receiving messages, but the listener
  is not there to consume them. So the queue gets filled up,
  causing all it's messages to get paged to the journal.
  Once the journal gets large enough, and on Candlepin startup,
  artemis tries to read all these messages from the journal into
  memory, causing extremely high CPU/memory usage, hanging
  indefinitely, and bringing the machine on it's knees.
- This change adds a configuration option to the broker.xml
  that will force the removal of any queues from Artemis if
  they've been deleted from broker.xml.