### PR TITLE
[M] JobManager.queueJob is now always executed in a transactional context (ENT-2571)

### DIFF
--- a/server/src/main/java/org/candlepin/async/JobManager.java
+++ b/server/src/main/java/org/candlepin/async/JobManager.java
@@ -82,6 +82,10 @@ import javax.transaction.Status;
 import javax.transaction.Synchronization;
 
 
+// FIXME: The transaction management here is getting out of hand. The annotations should probably
+// be removed entirely and replaced with explicit transaction management, and the protected methods
+// using them should be reverted to their propery visibility (private).
+
 
 /**
  * The JobManager manages the queueing, execution and general bookkeeping on jobs
@@ -1016,6 +1020,7 @@ public class JobManager implements ModeChangeListener {
      *  an AsyncJobStatus instance representing the queued job's status, or the status of the
      *  existing job if it already exists
      */
+    @Transactional
     public AsyncJobStatus queueJob(JobConfig config) throws JobException {
         ManagerState state = this.getManagerState();
         if (state != ManagerState.RUNNING) {
@@ -1611,7 +1616,7 @@ public class JobManager implements ModeChangeListener {
             log.warn("Job \"{}\" failed in {}ms; retrying...",
                 status.getName(), this.getJobRuntime(status), throwable);
 
-            this.postJobStatusMessage(status);
+            status = this.postJobStatusMessage(status);
         }
         else {
             status = this.updateJobStatus(status, JobState.FAILED, result);


### PR DESCRIPTION
- JobManager.queueJob has been given the @Transactional annotation
  to ensure it is performed within the context of a transaction. This
  should help avoid a race condition that can occur when queueing jobs
  from outside a transaction which allowed messages to be dispatched
  before the database could be updated completely