### PR TITLE
[M] Restored omitted return statement in the hypervisor update job (ENT-2577)

### DIFF
--- a/server/src/main/java/org/candlepin/async/tasks/HypervisorUpdateJob.java
+++ b/server/src/main/java/org/candlepin/async/tasks/HypervisorUpdateJob.java
@@ -122,6 +122,8 @@ public class HypervisorUpdateJob implements AsyncJob {
 
                 log.warn(result);
                 context.setJobResult(result);
+
+                return;
             }
 
             final HypervisorList hypervisors = parsedHypervisors(arguments);


### PR DESCRIPTION
- Restored a return statement which was erroneously removed during
  the transition to the updated JobExecutionContext