### PR TITLE
ENT-2515: Fix jenkins docker build

### DIFF
--- a/docker/gating-test-images/cp-latest-stage/setup-env-extras.sh
+++ b/docker/gating-test-images/cp-latest-stage/setup-env-extras.sh
@@ -5,16 +5,26 @@
 set -e
 
 PACKAGES=(
-    tito
     java
     java-devel
     ant
     selinux-policy-doc
     selinux-policy-devel
     maven
+    python-bugzilla
+    python2-cheetah
+    rpm-build
 )
 
 yum install -y ${PACKAGES[@]}
+
+# Due to issues with latest version of tito (v0.6.14) https://github.com/rpm-software-management/tito/issues/380
+# older version of tito v0.6.12 is used.
+# python-bugzilla, python2-cheetah & rpm-build dependencies are installed manually for tito v0.6.12
+# Installing tito v0.6.12
+git clone -b tito-0.6.12-1 https://github.com/rpm-software-management/tito.git ./tito
+cd ./tito
+./setup.py install
 
 # find stage candlepin version
 curl -k -u admin:admin https://subscription.rhsm.stage.redhat.com/subscription/status > stage_status.json

--- a/docker/gating-test-images/temp-base-cp/setup-env.sh
+++ b/docker/gating-test-images/temp-base-cp/setup-env.sh
@@ -41,7 +41,7 @@ PACKAGES=(
 yum install -y ${PACKAGES[@]}
 
 # Install postgres 9.5.X and the corresponding client tools (we need pg_dump)
-yum install -y https://download.postgresql.org/pub/repos/yum/9.5/redhat/rhel-7-x86_64/pgdg-centos95-9.5-3.noarch.rpm
+yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm
 yum install -y yum install postgresql95 postgresql95-server
 
 # pg_isready is used to check if the postgres server is up

--- a/docker/gating-test-images/temp-cp/docker-compose.yml
+++ b/docker/gating-test-images/temp-cp/docker-compose.yml
@@ -23,4 +23,4 @@ services:
         condition: none
     # mount the location of the data dump
     volumes:
-      - ./sql:/db-data
+      - ../sql:/db-data


### PR DESCRIPTION
Changes/fixes -
- Updated PostgreSQL download URL
- Mount point fix for ```invalid mount config for type “bind”: bind source path does not exist``` during docker stack deploy. 
- Due to issues with latest version of tito v0.6.14, falling back to older version of tito v0.6.12 as a workaround. The issue has been reported - https://github.com/rpm-software-management/tito/issues/380
