### PR TITLE
[M] 1855847: Added blocking jobs to job result for ABORTED jobs (ENT-2606)

### DIFF
--- a/server/src/main/java/org/candlepin/async/JobManager.java
+++ b/server/src/main/java/org/candlepin/async/JobManager.java
@@ -1077,7 +1077,10 @@ public class JobManager implements ModeChangeListener {
                 String jobIds = blockingJobIds.stream()
                     .collect(Collectors.joining(", "));
 
-                this.updateJobStatus(status, JobState.ABORTED);
+                StringBuilder errmsg = new StringBuilder("Job blocked by the following existing jobs: ")
+                    .append(jobIds);
+
+                this.updateJobStatus(status, JobState.ABORTED, errmsg.toString());
 
                 log.info("Unable to queue job: {}; blocked by the following existing jobs: {}",
                     status.getName(), jobIds);

--- a/server/src/test/java/org/candlepin/async/JobManagerTest.java
+++ b/server/src/test/java/org/candlepin/async/JobManagerTest.java
@@ -15,14 +15,7 @@
 package org.candlepin.async;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.hasItems;
-import static org.hamcrest.Matchers.isEmptyOrNullString;
-import static org.hamcrest.Matchers.lessThan;
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
-import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -1262,6 +1255,10 @@ public class JobManagerTest {
 
         assertNotNull(result);
         assertEquals(JobState.ABORTED, result.getState());
+
+        // The job result should contain details about the jobs that blocked it
+        assertNotNull(result.getJobResult());
+        assertThat(result.getJobResult(), containsString("Job blocked by the following existing jobs:"));
     }
 
     @Test


### PR DESCRIPTION
- When a job is put into the ABORTED state due to being blocked
  by existing, active jobs, the job result will be updated with
  an error message containing the blocking jobs