### PR TITLE
[M] 1855412: Add a result limit on the GET /jobs endpoint

### DIFF
--- a/server/src/main/java/org/candlepin/resource/JobResource.java
+++ b/server/src/main/java/org/candlepin/resource/JobResource.java
@@ -84,6 +84,7 @@ public class JobResource {
     private static Logger log = LoggerFactory.getLogger(JobResource.class);
 
     private static final String NULL_OWNER_KEY = "null";
+    private static final int MAX_JOB_RESULTS = 10000;
 
     private Configuration config;
     private I18n i18n;
@@ -232,6 +233,14 @@ public class JobResource {
 
             // Store the page for the LinkHeaderResponseFilter
             ResteasyContext.pushContext(Page.class, page);
+        }
+        // If no paging was specified, force a limit on amount of results
+        else {
+            if (this.jobCurator.getJobCount(queryBuilder) > MAX_JOB_RESULTS) {
+                String errmsg = this.i18n.tr("This endpoint does not support returning more than {0} " +
+                    "results at a time, please use paging.", MAX_JOB_RESULTS);
+                throw new BadRequestException(errmsg);
+            }
         }
 
         try {

--- a/server/src/test/java/org/candlepin/resource/JobResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/JobResourceTest.java
@@ -14,12 +14,7 @@
  */
 package org.candlepin.resource;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doReturn;
@@ -873,6 +868,24 @@ public class JobResourceTest extends DatabaseTestFixture {
 
         JobResource resource = this.buildJobResource();
         assertThrows(BadRequestException.class, () ->
+            resource.listJobStatuses(null, null, null, null, null, null, null, null, null));
+    }
+
+    @Test
+    public void testListJobStatusesFailsWhenResultMaxLimitExceeded() {
+        doReturn(10001L).when(this.jobCurator).getJobCount(any(AsyncJobStatusQueryBuilder.class));
+
+        JobResource resource = this.buildJobResource();
+        assertThrows(BadRequestException.class, () ->
+            resource.listJobStatuses(null, null, null, null, null, null, null, null, null));
+    }
+
+    @Test
+    public void testListJobStatusesDoesNotFailWhenResultMaxLimitNotExceeded() {
+        doReturn(10000L).when(this.jobCurator).getJobCount(any(AsyncJobStatusQueryBuilder.class));
+
+        JobResource resource = this.buildJobResource();
+        assertDoesNotThrow(() ->
             resource.listJobStatuses(null, null, null, null, null, null, null, null, null));
     }
 


### PR DESCRIPTION
- An HTTP 400 will be returned now when the GET /jobs request does
  not specify paging arguments and it is about to return more than
  10000 results, with an error message asking clients to use paging
  instead.