### PR TITLE
[M] Update swagger annotations for accurate API docs

### DIFF
--- a/server/src/main/java/org/candlepin/resource/ActivationKeyResource.java
+++ b/server/src/main/java/org/candlepin/resource/ActivationKeyResource.java
@@ -307,7 +307,7 @@ public class ActivationKeyResource {
     }
 
     @ApiOperation(notes = "Retrieves a list of Activation Keys", value = "findActivationKey",
-        response = ActivationKey.class, responseContainer = "list")
+        response = ActivationKeyDTO.class, responseContainer = "list")
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public CandlepinQuery<ActivationKeyDTO> findActivationKey() {

--- a/server/src/main/java/org/candlepin/resource/CertificateSerialResource.java
+++ b/server/src/main/java/org/candlepin/resource/CertificateSerialResource.java
@@ -52,7 +52,7 @@ public class CertificateSerialResource {
     }
 
     @ApiOperation(notes = "Retrieves a list of Certificate Serials", value = "getCertificateSerials",
-        response = CertificateSerial.class, responseContainer = "list")
+        response = CertificateSerialDTO.class, responseContainer = "list")
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public CandlepinQuery<CertificateSerialDTO> getCertificateSerials() {

--- a/server/src/main/java/org/candlepin/resource/ContentOverrideResource.java
+++ b/server/src/main/java/org/candlepin/resource/ContentOverrideResource.java
@@ -29,6 +29,8 @@ import org.candlepin.util.ContentOverrideValidator;
 
 import com.google.inject.persist.Transactional;
 
+import io.swagger.annotations.ApiOperation;
+
 import org.apache.commons.lang.StringUtils;
 import org.xnap.commons.i18n.I18n;
 
@@ -96,6 +98,8 @@ public abstract class ContentOverrideResource<T extends ContentOverride<T, Paren
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(notes = "Adds or Updates a list of Content Overrides", value = "addContentOverrides",
+        response = ContentOverrideDTO.class, responseContainer = "List")
     @Transactional
     @SecurityHole
     public CandlepinQuery<ContentOverrideDTO> addContentOverrides(
@@ -160,6 +164,8 @@ public abstract class ContentOverrideResource<T extends ContentOverride<T, Paren
     @DELETE
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(notes = "Deletes a list of Content Overrides", value = "deleteContentOverrides",
+        response = ContentOverrideDTO.class, responseContainer = "List")
     @Transactional
     @SecurityHole
     public CandlepinQuery<ContentOverrideDTO> deleteContentOverrides(
@@ -208,6 +214,8 @@ public abstract class ContentOverrideResource<T extends ContentOverride<T, Paren
      */
     @GET
     @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(notes = "Retrieves list of Content Overrides", value = "getContentOverrideList",
+        response = ContentOverrideDTO.class, responseContainer = "List")
     @SecurityHole
     public CandlepinQuery<ContentOverrideDTO> getContentOverrideList(
         @Context UriInfo info,

--- a/server/src/main/java/org/candlepin/resource/DistributorVersionResource.java
+++ b/server/src/main/java/org/candlepin/resource/DistributorVersionResource.java
@@ -116,7 +116,8 @@ public class DistributorVersionResource {
 
     }
 
-    @ApiOperation(notes = "Retrieves list of Distributor Versions", value = "getVersions")
+    @ApiOperation(notes = "Retrieves list of Distributor Versions", value = "getVersions",
+        response = DistributorVersionDTO.class, responseContainer = "List")
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public Stream<DistributorVersionDTO> getVersions(
@@ -152,7 +153,8 @@ public class DistributorVersionResource {
         }
     }
 
-    @ApiOperation(notes = "Creates a Distributor Version", value = "create")
+    @ApiOperation(notes = "Creates a Distributor Version", value = "create",
+        response = DistributorVersionDTO.class)
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
@@ -170,7 +172,8 @@ public class DistributorVersionResource {
         return this.translator.translate(curator.create(toCreate), DistributorVersionDTO.class);
     }
 
-    @ApiOperation(notes = "Updates a Distributor Version", value = "update")
+    @ApiOperation(notes = "Updates a Distributor Version", value = "update",
+        response = DistributorVersionDTO.class)
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)

--- a/server/src/main/java/org/candlepin/resource/EnvironmentResource.java
+++ b/server/src/main/java/org/candlepin/resource/EnvironmentResource.java
@@ -165,7 +165,7 @@ public class EnvironmentResource {
     }
 
     @ApiOperation(notes = "Lists the Environments.  Only available to super admins.",
-        value = "getEnvironments", response = Environment.class, responseContainer = "list")
+        value = "getEnvironments", response = EnvironmentDTO.class, responseContainer = "list")
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Wrapped(element = "environments")

--- a/server/src/main/java/org/candlepin/resource/GuestIdResource.java
+++ b/server/src/main/java/org/candlepin/resource/GuestIdResource.java
@@ -102,7 +102,8 @@ public class GuestIdResource {
         this.translator = translator;
     }
 
-    @ApiOperation(notes = "Retrieves the List of a Consumer's Guests", value = "getGuestIds")
+    @ApiOperation(notes = "Retrieves the List of a Consumer's Guests", value = "getGuestIds",
+        response = GuestIdDTO.class, responseContainer = "list")
     @ApiResponses({ @ApiResponse(code = 400, message = ""), @ApiResponse(code = 404, message = "") })
     @GET
     @Produces(MediaType.APPLICATION_JSON)

--- a/server/src/main/java/org/candlepin/resource/JobResource.java
+++ b/server/src/main/java/org/candlepin/resource/JobResource.java
@@ -114,7 +114,7 @@ public class JobResource {
     // Scheduler status
     @ApiOperation(
         value = "fetches the status of the job scheduler for this Candlepin node",
-        response = AsyncJobStatusDTO.class, responseContainer = "set")
+        response = SchedulerStatusDTO.class)
     @ApiResponses({
         @ApiResponse(code = 400, message = ""),
         @ApiResponse(code = 404, message = "")
@@ -136,7 +136,7 @@ public class JobResource {
 
     @ApiOperation(
         value = "enables or disables the job scheduler for this Candlepin node",
-        response = AsyncJobStatusDTO.class, responseContainer = "set")
+        response = SchedulerStatusDTO.class)
     @ApiResponses({
         @ApiResponse(code = 400, message = ""),
         @ApiResponse(code = 404, message = "")

--- a/server/src/main/java/org/candlepin/resource/OwnerContentResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerContentResource.java
@@ -158,7 +158,7 @@ public class OwnerContentResource {
         return content;
     }
 
-    @ApiOperation(notes = "Retrieves list of Content", value = "list", response = Content.class,
+    @ApiOperation(notes = "Retrieves list of Content", value = "list", response = ContentDTO.class,
         responseContainer = "list")
     @GET
     @Produces(MediaType.APPLICATION_JSON)

--- a/server/src/main/java/org/candlepin/resource/OwnerProductResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerProductResource.java
@@ -193,7 +193,7 @@ public class OwnerProductResource {
     }
 
     @ApiOperation(notes = "Retrieves a list of Products", value = "List Products for an Owner",
-        response = Product.class, responseContainer = "list")
+        response = ProductDTO.class, responseContainer = "list")
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public CandlepinQuery<ProductDTO> listProducts(

--- a/server/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -842,7 +842,7 @@ public class OwnerResource {
     @GET
     @Path("/{owner_key}")
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(notes = "Retrieves a single Owner", value = "Get Owner")
+    @ApiOperation(notes = "Retrieves a single Owner", value = "Get Owner", response = OwnerDTO.class)
     @ApiResponses({ @ApiResponse(code = 404, message = "An owner not found") })
     public OwnerDTO getOwner(@PathParam("owner_key") @Verify(Owner.class) String ownerKey) {
         Owner owner = findOwnerByKey(ownerKey);
@@ -878,7 +878,7 @@ public class OwnerResource {
     @POST
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
-    @ApiOperation(notes = "Creates an Owner", value = "Create Owner")
+    @ApiOperation(notes = "Creates an Owner", value = "Create Owner", response = OwnerDTO.class)
     @ApiResponses({ @ApiResponse(code = 400, message = "Invalid owner specified in body") })
     public OwnerDTO createOwner(@ApiParam(name = "owner", required = true) OwnerDTO dto) {
         // Verify that we have an owner key (as required)
@@ -978,7 +978,7 @@ public class OwnerResource {
     @Path("{owner_key}")
     @Transactional
     @ApiOperation(notes = "To un-set the defaultServiceLevel for an owner, submit an empty string.",
-        value = "Update Owner")
+        value = "Update Owner", response = OwnerDTO.class)
     @ApiResponses({ @ApiResponse(code = 404, message = "Owner not found") })
     public OwnerDTO updateOwner(@PathParam("owner_key") @Verify(Owner.class) String key,
         @ApiParam(name = "owner", required = true) OwnerDTO dto) {
@@ -1231,7 +1231,8 @@ public class OwnerResource {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Path("{owner_key}/activation_keys")
-    @ApiOperation(notes = "Retrieves a list of Activation Keys for an Owner", value = "Owner Activation Keys")
+    @ApiOperation(notes = "Retrieves a list of Activation Keys for an Owner", value = "Owner Activation Keys",
+        response = ActivationKeyDTO.class, responseContainer = "List")
     @ApiResponses({ @ApiResponse(code = 404, message = "Owner not found") })
     public CandlepinQuery<ActivationKeyDTO> ownerActivationKeys(
         @PathParam("owner_key") @Verify(Owner.class) String ownerKey,
@@ -1334,7 +1335,8 @@ public class OwnerResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Path("{owner_key}/environments")
     @Wrapped(element = "environments")
-    @ApiOperation(notes = "Retrieves a list of Environments for an Owner", value = "List environments")
+    @ApiOperation(notes = "Retrieves a list of Environments for an Owner", value = "List environments",
+        response = EnvironmentDTO.class, responseContainer = "List")
     @ApiResponses({ @ApiResponse(code = 404, message = "Owner not found")})
     public CandlepinQuery<EnvironmentDTO> listEnvironments(@PathParam("owner_key")
         @Verify(Owner.class) String ownerKey,
@@ -1407,7 +1409,7 @@ public class OwnerResource {
     @Path("{owner_key}/consumers")
     @SuppressWarnings("checkstyle:indentation")
     @ApiOperation(notes = "Retrieve a list of Consumers for the Owner", value = "List Consumers",
-        response = Consumer.class, responseContainer = "list")
+        response = ConsumerDTO.class, responseContainer = "list")
     @ApiResponses({
         @ApiResponse(code = 404, message = "Owner not found"),
         @ApiResponse(code = 400, message = "Invalid request")
@@ -2237,7 +2239,7 @@ public class OwnerResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/{owner_key}/hypervisors")
     @ApiOperation(notes = "Retrieves a list of Hypervisors for an Owner", value = "Get Hypervisors",
-        response = Consumer.class, responseContainer = "list")
+        response = ConsumerDTO.class, responseContainer = "list")
     @ApiResponses({ @ApiResponse(code = 404, message = "Owner not found") })
     public CandlepinQuery<ConsumerDTO> getHypervisors(
         @PathParam("owner_key") @Verify(Owner.class) String ownerKey,

--- a/server/src/main/java/org/candlepin/resource/ProductResource.java
+++ b/server/src/main/java/org/candlepin/resource/ProductResource.java
@@ -260,7 +260,7 @@ public class ProductResource {
     }
 
     @ApiOperation(notes = "Retrieves a list of Owners by Product", value = "getProductOwners",
-        response = Owner.class, responseContainer = "list")
+        response = OwnerDTO.class, responseContainer = "list")
     @ApiResponses({ @ApiResponse(code = 400, message = "") })
     @GET
     @Path("/owners")
@@ -277,7 +277,8 @@ public class ProductResource {
             this.ownerCurator.getOwnersWithProducts(productUuids), OwnerDTO.class);
     }
 
-    @ApiOperation(notes = "Refreshes Pools by Product", value = "refreshPoolsForProduct")
+    @ApiOperation(notes = "Refreshes Pools by Product", value = "refreshPoolsForProduct",
+        response = AsyncJobStatusDTO.class, responseContainer = "List")
     @PUT
     @Path("/subscriptions")
     @Produces(MediaType.APPLICATION_JSON)

--- a/server/src/main/java/org/candlepin/resource/RoleResource.java
+++ b/server/src/main/java/org/candlepin/resource/RoleResource.java
@@ -273,7 +273,8 @@ public class RoleResource {
         return this.modelTranslator.translate(role, RoleDTO.class);
     }
 
-    @ApiOperation(notes = "Retrieves a list of Roles", value = "getRoles")
+    @ApiOperation(notes = "Retrieves a list of Roles", value = "getRoles",
+        response = RoleDTO.class, responseContainer = "List")
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Wrapped(element = "roles")

--- a/server/src/main/java/org/candlepin/resource/UserResource.java
+++ b/server/src/main/java/org/candlepin/resource/UserResource.java
@@ -114,7 +114,8 @@ public class UserResource {
         return user;
     }
 
-    @ApiOperation(notes = "Retrieves a list of Users", value = "list")
+    @ApiOperation(notes = "Retrieves a list of Users", value = "list",
+        response = UserDTO.class, responseContainer = "List")
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public Stream<UserDTO> list() {
@@ -138,7 +139,8 @@ public class UserResource {
      * getUserRoles will only return roles for one user. If you want a
      * full view of a role, use /roles/ instead.
      */
-    @ApiOperation(notes = "Retrieves a list of Roles by User", value = "getUserRoles")
+    @ApiOperation(notes = "Retrieves a list of Roles by User", value = "getUserRoles",
+        response = RoleDTO.class, responseContainer = "List")
     @ApiResponses({ @ApiResponse(code = 400, message = ""), @ApiResponse(code = 404, message = "") })
     @GET
     @Path("/{username}/roles")
@@ -221,7 +223,8 @@ public class UserResource {
         "client uses this API call to list the owners a user can register to, when " +
         "we introduced 'my systems' administrator, we have to change its meaning to " +
         "listing the owners that can be registered to by default to maintain " +
-        "compatability with released clients.", value = "listUsersOwners")
+        "compatability with released clients.", value = "listUsersOwners",
+        response = OwnerDTO.class, responseContainer = "List")
     // TODO: should probably accept access level and sub-resource query params someday
     @GET
     @Path("/{username}/owners")


### PR DESCRIPTION
- Mark endpoints that return CandlepinQuery<> or Stream<> as
  returning a 'List', for accurate swagger UI representation.
- Update endpoint annotations with DTO instead of model entity
  as their response types.