### PR TITLE
[M] Add constraint for unique activation key names

### DIFF
--- a/server/src/main/resources/db/changelog/20200715155048-add-ak-name-owner-constraint.xml
+++ b/server/src/main/resources/db/changelog/20200715155048-add-ak-name-owner-constraint.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="20200715155048-1" author="nmoumoul" dbms="mysql,mariadb">
+        <comment>Adding constraint to mysql that already existed in postgres to avoid activation keys with duplicate
+            names for the same owner.
+        </comment>
+        <addUniqueConstraint columnNames="name, owner_id" constraintName="cp_ak_name_owner_id_key" deferrable="false" disabled="false" initiallyDeferred="false" tableName="cp_activation_key"/>
+    </changeSet>
+
+</databaseChangeLog>
+<!-- vim: set expandtab sts=4 sw=4 ai: -->

--- a/server/src/main/resources/db/changelog/changelog-create.xml
+++ b/server/src/main/resources/db/changelog/changelog-create.xml
@@ -1241,4 +1241,5 @@
     <include file="db/changelog/20200430172317-add-column-rh-cloud-profile-modified.xml"/>
     <include file="db/changelog/20200525150632-switch-job-data-to-longtext.xml"/>
     <include file="db/changelog/20200604045445-async-job-data-restructure.xml"/>
+    <include file="db/changelog/20200715155048-add-ak-name-owner-constraint.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-testing.xml
+++ b/server/src/main/resources/db/changelog/changelog-testing.xml
@@ -2333,4 +2333,5 @@
     <include file="db/changelog/20200430172317-add-column-rh-cloud-profile-modified.xml"/>
     <include file="db/changelog/20200525150632-switch-job-data-to-longtext.xml"/>
     <include file="db/changelog/20200604045445-async-job-data-restructure.xml"/>
+    <include file="db/changelog/20200715155048-add-ak-name-owner-constraint.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-update.xml
+++ b/server/src/main/resources/db/changelog/changelog-update.xml
@@ -150,4 +150,5 @@
     <include file="db/changelog/20200430172317-add-column-rh-cloud-profile-modified.xml"/>
     <include file="db/changelog/20200525150632-switch-job-data-to-longtext.xml"/>
     <include file="db/changelog/20200604045445-async-job-data-restructure.xml"/>
+    <include file="db/changelog/20200715155048-add-ak-name-owner-constraint.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
- Creating activation keys with the same name for the same owner
  was already disallowed for postrgresql. This fix adds the same
  constraint for mysql/mariadb.