### PR TITLE
[M] 1859693: JobManager now loads Quartz config from candlepin.conf (ENT-2652)

### DIFF
--- a/server/src/main/java/org/candlepin/async/JobManager.java
+++ b/server/src/main/java/org/candlepin/async/JobManager.java
@@ -54,6 +54,7 @@ import org.quartz.Trigger;
 import org.quartz.TriggerBuilder;
 import org.quartz.TriggerKey;
 import org.quartz.TriggerListener;
+import org.quartz.impl.StdSchedulerFactory;
 import org.quartz.impl.matchers.GroupMatcher;
 import org.quartz.spi.JobFactory;
 import org.quartz.spi.TriggerFiredBundle;
@@ -69,6 +70,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Properties;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -447,6 +449,12 @@ public class JobManager implements ModeChangeListener {
 
             if (this.state == ManagerState.CREATED) {
                 if (this.isSchedulerEnabled()) {
+                    // Initialize the scheduler factory with the Quartz-specific configuration, if possible
+                    if (this.schedulerFactory instanceof StdSchedulerFactory) {
+                        Properties quartzConfig = this.configuration.subset("org.quartz").toProperties();
+                        ((StdSchedulerFactory) this.schedulerFactory).initialize(quartzConfig);
+                    }
+
                     if (this.scheduler == null || this.scheduler.isShutdown()) {
                         this.scheduler = this.schedulerFactory.getScheduler();
                     }

--- a/server/src/test/java/org/candlepin/async/JobManagerTest.java
+++ b/server/src/test/java/org/candlepin/async/JobManagerTest.java
@@ -88,6 +88,7 @@ import org.quartz.ListenerManager;
 import org.quartz.Scheduler;
 import org.quartz.SchedulerFactory;
 import org.quartz.Trigger;
+import org.quartz.impl.StdSchedulerFactory;
 import org.slf4j.MDC;
 import org.slf4j.event.Level;
 
@@ -100,6 +101,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Random;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -1552,5 +1554,26 @@ public class JobManagerTest {
         // If mockito ever gets a way to verify the inverse of "zero interactions", do that here
         // instead of specifically looking for the start op.
         verify(this.scheduler, atLeastOnce()).start();
+    }
+
+    @Test
+    public void testSchedulerReceivesConfig() throws Exception {
+        StdSchedulerFactory schedulerFactory = mock(StdSchedulerFactory.class);
+        this.schedulerFactory = schedulerFactory;
+
+        doReturn(this.scheduler).when(this.schedulerFactory).getScheduler();
+
+        this.config.setProperty("org.quartz.testcfg1", "val1");
+        this.config.setProperty("org.quartz.testcfg2", "val2");
+
+        Properties expected = this.config.subset("org.quartz").toProperties();
+
+        JobManager manager = this.createJobManager();
+
+        assertTrue(manager.isSchedulerEnabled());
+
+        manager.initialize();
+
+        verify(schedulerFactory, times(1)).initialize(eq(expected));
     }
 }


### PR DESCRIPTION
- The JobManager will now properly parse Quartz configuration from
  candlepin.conf and reinitialize the Quartz scheduler factory
  with the settings