### PR TITLE
Bug 1858320: Expired Pools Cleanup Job - EcmaError: TypeError: Cannot read property "length" from null (ENT-2647)

### DIFF
--- a/server/src/main/resources/rules/rules.js
+++ b/server/src/main/resources/rules/rules.js
@@ -1,4 +1,4 @@
-// Version: 5.40
+// Version: 5.41
 
 /*
  * Default Candlepin rule set.
@@ -216,11 +216,14 @@ function createPool(pool, consumer) {
         if (this.productId == productId) {
             return true;
         }
-        for (var k = 0; k < this.providedProducts.length; k++) {
-            var provided = this.providedProducts[k];
+        if (this.providedProducts !== undefined && this.providedProducts !== null
+            && this.providedProducts.length > 0) {
+            for (var k = 0; k < this.providedProducts.length; k++) {
+                var provided = this.providedProducts[k];
 
-            if (provided.productId == productId) {
-                return true;
+                if (provided.productId == productId) {
+                    return true;
+                }
             }
         }
         return false;


### PR DESCRIPTION
ExpiredPoolsCleanupJob runs into race condition when multiple instances of this job is executed in parallel, resulting in concurrent modification & locking exceptions since jobs compete to delete pools in parallel. This should resolve once we have job scheduling synchronization in place.
Changes 
- Added a null check in rules.js to guard against TypeError exceptions. 