### PR TITLE
Fix for params in Link header URLs when paging

### DIFF
--- a/common/src/main/java/org/candlepin/common/resteasy/filter/LinkHeaderResponseFilter.java
+++ b/common/src/main/java/org/candlepin/common/resteasy/filter/LinkHeaderResponseFilter.java
@@ -178,7 +178,9 @@ public class LinkHeaderResponseFilter implements ContainerResponseFilter {
             String requestUri = reqContext.getUriInfo().getRequestUri().toString();
 
             int resourceStartOffset = requestUri.lastIndexOf(contextPath);
-            int queryParamsStartOffset = requestUri.lastIndexOf("?");
+            int queryParamsStartOffset = requestUri.lastIndexOf("?") > 0 ?
+                requestUri.lastIndexOf("?") :  requestUri.length();
+
             if (resourceStartOffset >= 0) {
                 // Strip off the context and the query parameters
                 url.append(requestUri, resourceStartOffset + contextPath.length(), queryParamsStartOffset);


### PR DESCRIPTION
- Getting queryParamsStartOffset = -1 if the URI does not
have query parameters. Altered this condition to set the offset
as request-URI length.