### PR TITLE
[M] 1854221: Graceful shutdown of Artemis job threads; ENT-2586

### DIFF
--- a/server/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/server/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -315,6 +315,9 @@ public class ConfigProperties {
         UnmappedGuestEntitlementCleanerJob.JOB_KEY
     };
 
+    // How long (in seconds) to wait for job threads to finish during a graceful Tomcat shutdown
+    public static final String ASYNC_JOBS_THREAD_SHUTDOWN_TIMEOUT = "candlepin.async.thread.shutdown.timeout";
+
     /**
      * Fetches a string representing the prefix for all per-job configuration for the specified job.
      * The job key or class name may be used, but the usage must be consistent.
@@ -500,6 +503,7 @@ public class ConfigProperties {
             this.put(ASYNC_JOBS_THREADS, "10");
             this.put(ASYNC_JOBS_QUEUE_WHILE_SUSPENDED, "true");
             this.put(ASYNC_JOBS_SCHEDULER_ENABLED, "true");
+            this.put(ASYNC_JOBS_THREAD_SHUTDOWN_TIMEOUT, "600"); // 10 minutes
 
             this.put(jobConfig(ActiveEntitlementJob.JOB_KEY, ASYNC_JOBS_JOB_SCHEDULE),
                 ActiveEntitlementJob.DEFAULT_SCHEDULE);

--- a/server/src/main/java/org/candlepin/guice/CandlepinContextListener.java
+++ b/server/src/main/java/org/candlepin/guice/CandlepinContextListener.java
@@ -14,9 +14,7 @@
  */
 package org.candlepin.guice;
 
-import static org.candlepin.config.ConfigProperties.ACTIVEMQ_ENABLED;
-import static org.candlepin.config.ConfigProperties.ENCRYPTED_PROPERTIES;
-import static org.candlepin.config.ConfigProperties.PASSPHRASE_SECRET_FILE;
+import static org.candlepin.config.ConfigProperties.*;
 
 import org.candlepin.async.JobManager;
 import org.candlepin.audit.AMQPBusPublisher;
@@ -259,6 +257,9 @@ public class CandlepinContextListener extends GuiceResteasyBootstrapServletConte
     }
 
     private void destroySubsystems() throws Exception {
+        // Perform graceful shutdown operations before the job system's final destruction
+        this.cpmContextListener.shutdown();
+
         // Tear down the job system
         this.jobManager.shutdown();
 

--- a/server/src/main/java/org/candlepin/messaging/CPMContextListener.java
+++ b/server/src/main/java/org/candlepin/messaging/CPMContextListener.java
@@ -40,6 +40,19 @@ public interface CPMContextListener {
     /**
      * Called when the Candlepin context is destroyed, indicating the messaging implementation
      * should shut down any backing services or functionality associated with it.
+     *
+     * Used to perform any required graceful shutdown operations of the messaging implementation,
+     * before the messaging infrastructure itself is destroyed.
+     *
+     * NOTE: Must be called before {@link #destroy()}
+     */
+    void shutdown() throws CPMException;
+
+    /**
+     * Called when the Candlepin context is destroyed, indicating the messaging implementation
+     * should shut down any backing services or functionality associated with it.
+     *
+     * Used to perform the final destruction of the messaging infrastructure.
      */
     void destroy() throws CPMException;
 

--- a/server/src/main/java/org/candlepin/messaging/impl/noop/NoopContextListener.java
+++ b/server/src/main/java/org/candlepin/messaging/impl/noop/NoopContextListener.java
@@ -42,6 +42,14 @@ public class NoopContextListener implements CPMContextListener {
      * {@inheritDoc}
      */
     @Override
+    public void shutdown() throws CPMException {
+        // Intentionally left empty
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public void destroy() throws CPMException {
         // Intentionally left empty
     }


### PR DESCRIPTION
Now, when tomcat is shut down gracefully:
- First wait for Artemis client threads to finish before
  closing the sessions, to make sure that commits happen
  instead of potentially finishing a job and the broker
  not getting a commit back.
- Don't use ActiveMQClient.clearThreadPools() to quiesce
  the threads, because it:
   * Waits only 10 seconds for jobs to finish before force
   shutting them down.
   * Uses ExecutorService.shutdownNow() which will interrupt
   threads, causing an InterruptedException and not wait for
   the jobs to finish.
- Use ExecutorService.shutdown() which will gracefully wait
  for the threads to finish their work.
- Introduce new config "candlepin.async.thread.shutdown.timeout"
  to specify how long (in seconds) to wait for job threads to
  finish before forcefully shutting them down.