### PR TITLE
[M] Remove redundant Artemis connection properties; ENT-2325

### DIFF
--- a/server/bin/artemis/configure-artemis.py
+++ b/server/bin/artemis/configure-artemis.py
@@ -27,7 +27,7 @@ logging.basicConfig(level=logging.INFO, format="%(message)s")
 logger = logging.getLogger('configure-artemis')
 
 BASE_DIR = os.path.dirname(os.path.realpath(__file__))
-DEFAULT_VERSION = "2.4.0"
+DEFAULT_VERSION = "2.12.0"
 
 # Installation paths for Artemis as suggested by the docs.
 # For this reason, we are not allowing these to be changed by
@@ -36,11 +36,11 @@ INSTALL_DIR = "/opt"
 BROKER_ROOT = "/var/lib/artemis"
 BROKER_NAME = "candlepin"
 
-SELINUX_BASE_DIR = os.path.join(BASE_DIR, "selinux");
+SELINUX_BASE_DIR = os.path.join(BASE_DIR, "selinux")
 SELINUX_POLICY_TEMPLATE = os.path.join(SELINUX_BASE_DIR, "artemis.te")
 SELINUX_BUILD_DIR = os.path.join(SELINUX_BASE_DIR, "build")
 
-SERVICE_TEMPLATE_PATH = os.path.join(BASE_DIR, "service", "artemis.service");
+SERVICE_TEMPLATE_PATH = os.path.join(BASE_DIR, "service", "artemis.service")
 SERVICE_FILE_TARGET_PATH = "/usr/lib/systemd/system/artemis.service"
 
 
@@ -174,9 +174,10 @@ def setup_selinux():
 def generate_certs(broker_path):
     logger.debug("Creating the certs/ directory.")
     certs_dir = os.path.join(broker_path, "certs/")
-    if not os.path.exists(certs_dir):
-        logger.debug("%s does not exist. Creating it now." % certs_dir)
-        os.mkdir(certs_dir)
+    if os.path.exists(certs_dir):
+        shutil.rmtree(certs_dir)
+        logger.debug("%s already exists. Recreating it now." % certs_dir)
+    os.mkdir(certs_dir)
 
     logger.debug("Setting file permissions on certs directory for artemis user.")
     call("sudo chown -R artemis:artemis %s" % certs_dir, "Failed to set permissions on certs directory.")
@@ -228,7 +229,7 @@ def modify_broker_xml(broker_xml_path):
         acceptor_nodes[0].setProp("name", "netty")
 
         certs_dir = os.path.join(BROKER_ROOT, BROKER_NAME, "certs")
-        connector_string = ("tcp://localhost:61617?sslEnabled=true;"
+        connector_string = ("tcp://localhost:61613?sslEnabled=true;"
                             "keyStorePath={0}/artemis-server.ks;"
                             "keyStorePassword=securepassword;"
                             "needClientAuth=true;"

--- a/server/conf/candlepin.conf.template
+++ b/server/conf/candlepin.conf.template
@@ -33,11 +33,7 @@ candlepin.importer.fail_on_unknown=false
 
 <% if (candlepin.external_broker) { %>\
 candlepin.audit.hornetq.embedded=false
-candlepin.audit.hornetq.broker_url=tcp://localhost:61617
-candlepin.audit.hornetq.truststore=/var/lib/artemis/candlepin/certs/artemis-client.ts
-candlepin.audit.hornetq.truststore_password=securepassword
-candlepin.audit.hornetq.keystore=/var/lib/artemis/candlepin/certs/artemis-client.ks
-candlepin.audit.hornetq.keystore_password=securepassword
+candlepin.audit.hornetq.broker_url=tcp://localhost:61613?sslEnabled=true&trustStorePath=/var/lib/artemis/candlepin/certs/artemis-client.ts&trustStorePassword=securepassword&keyStorePath=/var/lib/artemis/candlepin/certs/artemis-client.ks&keyStorePassword=securepassword
 <% } %>\
 candlepin.pretty_print=true
 

--- a/server/src/main/java/org/candlepin/async/impl/ActiveMQSessionFactory.java
+++ b/server/src/main/java/org/candlepin/async/impl/ActiveMQSessionFactory.java
@@ -147,7 +147,8 @@ public class ActiveMQSessionFactory {
             // workaround we need on the receiving side of things. If it looks like the
             // egress configuration, something is probably broken.
 
-            ServerLocator locator = ActiveMQClient.createServerLocator(generateServerUrl());
+            String brokerUrl = this.config.getProperty(ConfigProperties.ACTIVEMQ_BROKER_URL);
+            ServerLocator locator = ActiveMQClient.createServerLocator(brokerUrl);
 
             // TODO: Maybe make this a bit more defensive and skip setting the property if it's
             // not present in the configuration rather than crashing out?
@@ -167,7 +168,8 @@ public class ActiveMQSessionFactory {
      */
     protected synchronized SessionManager getEgressSessionManager() throws Exception {
         if (this.egressSessionManager == null) {
-            ServerLocator locator = ActiveMQClient.createServerLocator(generateServerUrl());
+            String brokerUrl = this.config.getProperty(ConfigProperties.ACTIVEMQ_BROKER_URL);
+            ServerLocator locator = ActiveMQClient.createServerLocator(brokerUrl);
 
             // TODO: Maybe make this a bit more defensive and skip setting the property if it's
             // not present in the configuration rather than crashing out?
@@ -182,29 +184,6 @@ public class ActiveMQSessionFactory {
         }
 
         return this.egressSessionManager;
-    }
-
-    private String generateServerUrl() {
-        StringBuilder serverUrlBuilder =
-            new StringBuilder(this.config.getProperty(ConfigProperties.ACTIVEMQ_BROKER_URL));
-
-        // TODO: Change this to use ACTIVEMQ_EMBEDDED_BROKER once configuration upgrades are in
-        // place
-        boolean embedded = this.config.getBoolean(ConfigProperties.ACTIVEMQ_EMBEDDED);
-
-        if (!embedded) {
-            serverUrlBuilder.append("?sslEnabled=true")
-                .append("&trustStorePath=")
-                .append(this.config.getProperty(ConfigProperties.ACTIVEMQ_TRUSTSTORE))
-                .append("&trustStorePassword=")
-                .append(this.config.getProperty(ConfigProperties.ACTIVEMQ_TRUSTSTORE_PASSWORD))
-                .append("&keyStorePath=")
-                .append(this.config.getProperty(ConfigProperties.ACTIVEMQ_KEYSTORE))
-                .append("&keyStorePassword=")
-                .append(this.config.getProperty(ConfigProperties.ACTIVEMQ_KEYSTORE_PASSWORD));
-        }
-
-        return serverUrlBuilder.toString();
     }
 
     /**

--- a/server/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/server/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -69,10 +69,6 @@ public class ConfigProperties {
 
     public static final String ACTIVEMQ_EMBEDDED = "candlepin.audit.hornetq.embedded";
     public static final String ACTIVEMQ_BROKER_URL = "candlepin.audit.hornetq.broker_url";
-    public static final String ACTIVEMQ_KEYSTORE = "candlepin.audit.hornetq.keystore";
-    public static final String ACTIVEMQ_KEYSTORE_PASSWORD = "candlepin.audit.hornetq.keystore_password";
-    public static final String ACTIVEMQ_TRUSTSTORE = "candlepin.audit.hornetq.truststore";
-    public static final String ACTIVEMQ_TRUSTSTORE_PASSWORD = "candlepin.audit.hornetq.truststore_password";
     public static final String ACTIVEMQ_SERVER_CONFIG_PATH = "candlepin.audit.hornetq.config_path";
 
     /**

--- a/server/src/main/java/org/candlepin/controller/ActiveMQStatusMonitor.java
+++ b/server/src/main/java/org/candlepin/controller/ActiveMQStatusMonitor.java
@@ -74,31 +74,10 @@ public class ActiveMQStatusMonitor implements Closeable, Runnable, CloseListener
 
     // Protected for testing purposes.
     protected void initializeLocator() throws Exception {
-        locator = ActiveMQClient.createServerLocator(generateServerUrl());
+        String brokerUrl = this.config.getProperty(ConfigProperties.ACTIVEMQ_BROKER_URL);
+        locator = ActiveMQClient.createServerLocator(brokerUrl);
     }
 
-    private String generateServerUrl() {
-        StringBuilder serverUrlBuilder =
-            new StringBuilder(this.config.getProperty(ConfigProperties.ACTIVEMQ_BROKER_URL));
-
-        // TODO: Change this to use ACTIVEMQ_EMBEDDED_BROKER once configuration upgrades are in
-        // place
-        boolean embedded = this.config.getBoolean(ConfigProperties.ACTIVEMQ_EMBEDDED);
-
-        if (!embedded) {
-            serverUrlBuilder.append("?sslEnabled=true")
-                .append("&trustStorePath=")
-                .append(this.config.getProperty(ConfigProperties.ACTIVEMQ_TRUSTSTORE))
-                .append("&trustStorePassword=")
-                .append(this.config.getProperty(ConfigProperties.ACTIVEMQ_TRUSTSTORE_PASSWORD))
-                .append("&keyStorePath=")
-                .append(this.config.getProperty(ConfigProperties.ACTIVEMQ_KEYSTORE))
-                .append("&keyStorePassword=")
-                .append(this.config.getProperty(ConfigProperties.ACTIVEMQ_KEYSTORE_PASSWORD));
-        }
-
-        return serverUrlBuilder.toString();
-    }
 
     /**
      * Checks the status of the connection to the broker and starts the monitor


### PR DESCRIPTION
- Don't build Artemis client connection URLs using individual
  properties for keystore/truststore and their passwords. Instead
  use only candlepin.audit.hornetq.broker_url to specify the full
  URL with query parameters.
- Drop the following properties:
    * candlepin.audit.hornetq.keystore
    * candlepin.audit.hornetq.keystore_password
    * candlepin.audit.hornetq.truststore
    * candlepin.audit.hornetq.truststore_password
- Alter our dev external artemis setup script (deploy -ba)
  to download and setup Artemis 2.12.0 instead of 2.4.0, and also
  to use port 61613 instead of 61617, since that is what Katello
  has chosen to use. Also make sure that it doesn't error out
  when run consecutive times.