### PR TITLE
[M] 1861739: Close sessions when external Artemis goes down; ENT-2704

### DIFF
--- a/server/src/main/java/org/candlepin/async/JobMessageReceiver.java
+++ b/server/src/main/java/org/candlepin/async/JobMessageReceiver.java
@@ -214,12 +214,11 @@ public class JobMessageReceiver {
     }
 
     /**
-     * Stops all known sessions, potentially leaving them open to be restarted without needing to
-     * create new sessions.
+     * Close all known sessions.
      */
-    private void stopSessions() throws CPMException {
+    private void closeSessions() throws CPMException {
         for (CPMSession session : this.sessions) {
-            session.stop();
+            session.close();
         }
     }
 
@@ -319,7 +318,7 @@ public class JobMessageReceiver {
     public synchronized void suspend() throws JobException {
         try {
             if (!this.suspended) {
-                this.stopSessions();
+                this.closeSessions();
 
                 log.debug("Job message processing suspended");
                 this.suspended = true;


### PR DESCRIPTION
- Problem: When an externally deployed Artemis broker goes down,
  trying to stop the job-related Artemis client sessions
  results in one of the following errors
  * AMQ219019: Session is closed
  * AMQ219016: Connection failure detected. Unblocking a blocking call that will never get a response
  * AMQ219014: Timed out after waiting 30,000 ms for response when sending packet 68
  with the JobManager in a bad state, and the sessions
  never recreated when the broker goes up again.

- Solution: close the sessions instead of stopping them.