### PR TITLE
ENT-2703: Jenkins isn't running unit tests of common package

### DIFF
--- a/docker/candlepin-base/cp-test
+++ b/docker/candlepin-base/cp-test
@@ -45,7 +45,7 @@ build_lint() {
 build_unittest() {
     UTCMD=$1
     if [ -f ../gradlew ]; then
-        ../gradlew test
+        cd $CP_HOME; ./gradlew test; cd $PROJECT_DIR
     else
         buildr $UTCMD
     fi


### PR DESCRIPTION
 - The project directory path is set to the server package.
   This leads to execute the test only from the server package.
   Hence added the path of commons package to execute
   the test of commons.