### PR TITLE
[M] 1866525: Updated SCA certificate content prefixes and paths (ENT-2717)

### DIFF
--- a/server/spec/unpack.rb
+++ b/server/spec/unpack.rb
@@ -29,8 +29,12 @@ module Unpack
   end
 
   def are_content_urls_present(value, urls)
-    parent = prepare_from_blob(value)
-    return content_in_tree(parent, urls)
+    if !value.nil? && !value.empty?
+      parent = prepare_from_blob(value)
+      return content_in_tree(parent, urls)
+    end
+
+    return false
   end
 
   def prepare_from_blob(byte_data)

--- a/server/src/main/java/org/candlepin/util/X509Util.java
+++ b/server/src/main/java/org/candlepin/util/X509Util.java
@@ -156,8 +156,6 @@ public abstract class X509Util {
         return prefix + contentPath;
     }
 
-
-
     /*
      * remove content sets that do not match the consumers arch
      */
@@ -178,8 +176,8 @@ public abstract class X509Util {
         }
 
         if (consumerArches.isEmpty()) {
-            log.debug("consumer: " + consumer.getId() + " has no " +
-                ARCH_FACT + " / " + SUPPORTED_ARCH_FACT + " attribute.");
+            log.debug("consumer: {} has no {} / {} attribute",
+                consumer.getId(), ARCH_FACT, SUPPORTED_ARCH_FACT);
             log.debug("Not filtering by arch");
             return pcSet;
         }

--- a/server/src/test/java/org/candlepin/controller/ContentAccessManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/ContentAccessManagerTest.java
@@ -19,27 +19,66 @@ import static org.mockito.AdditionalAnswers.returnsFirstArg;
 import static org.mockito.Mockito.*;
 
 import org.candlepin.audit.EventSink;
+import org.candlepin.common.config.Configuration;
+import org.candlepin.config.CandlepinCommonTestConfig;
+import org.candlepin.config.ConfigProperties;
 import org.candlepin.controller.ContentAccessManager.ContentAccessMode;
+import org.candlepin.model.CandlepinQuery;
+import org.candlepin.model.CertificateSerial;
 import org.candlepin.model.CertificateSerialCurator;
+import org.candlepin.model.Consumer;
+import org.candlepin.model.ConsumerCapability;
 import org.candlepin.model.ConsumerCurator;
+import org.candlepin.model.ConsumerType;
 import org.candlepin.model.ConsumerTypeCurator;
+import org.candlepin.model.Content;
 import org.candlepin.model.ContentAccessCertificateCurator;
+import org.candlepin.model.Entitlement;
+import org.candlepin.model.EntitlementCurator;
+import org.candlepin.model.Environment;
+import org.candlepin.model.EnvironmentContent;
 import org.candlepin.model.EnvironmentCurator;
 import org.candlepin.model.KeyPairCurator;
 import org.candlepin.model.Owner;
 import org.candlepin.model.OwnerContentCurator;
 import org.candlepin.model.OwnerCurator;
+import org.candlepin.model.OwnerEnvContentAccess;
 import org.candlepin.model.OwnerEnvContentAccessCurator;
+import org.candlepin.model.Pool;
+import org.candlepin.model.Product;
+import org.candlepin.pki.CertificateReader;
 import org.candlepin.pki.PKIUtility;
+import org.candlepin.pki.PrivateKeyReader;
+import org.candlepin.pki.SubjectKeyIdentifierWriter;
+import org.candlepin.pki.impl.DefaultSubjectKeyIdentifierWriter;
+import org.candlepin.pki.impl.JSSPKIUtility;
+import org.candlepin.pki.impl.JSSPrivateKeyReader;
+import org.candlepin.test.TestUtil;
+import org.candlepin.util.Util;
 import org.candlepin.util.X509V3ExtensionUtil;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.bouncycastle.openssl.PEMKeyPair;
+import org.bouncycastle.openssl.PEMParser;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.security.KeyPair;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 
 
@@ -49,6 +88,11 @@ import org.mockito.quality.Strictness;
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class ContentAccessManagerTest {
+
+    private static KeyPair testingKeyPair;
+
+    private Configuration config;
+
     @Mock private EventSink mockEventSink;
     @Mock private KeyPairCurator mockKeyPairCurator;
     @Mock private CertificateSerialCurator mockCertSerialCurator;
@@ -59,24 +103,165 @@ public class ContentAccessManagerTest {
     @Mock private OwnerCurator mockOwnerCurator;
     @Mock private OwnerEnvContentAccessCurator mockOwnerEnvContentAccessCurator;
     @Mock private EnvironmentCurator mockEnvironmentCurator;
-    @Mock private PKIUtility mockPKIUtility;
-    @Mock private X509V3ExtensionUtil mockX509V3ExtensionUtil;
+    @Mock private EntitlementCurator mockEntitlementCurator;
+    private PKIUtility pkiUtility;
+    private ObjectMapper objMapper;
+    private X509V3ExtensionUtil x509V3ExtensionUtil;
 
     private final String entitlementMode = ContentAccessMode.ENTITLEMENT.toDatabaseValue();
     private final String orgEnvironmentMode = ContentAccessMode.ORG_ENVIRONMENT.toDatabaseValue();
 
+
+    @BeforeAll
+    public static void loadTestKeyPair() throws Exception {
+        ClassLoader classloader = ContentAccessManagerTest.class.getClassLoader();
+        InputStream keyStream = classloader.getResourceAsStream("test.key");
+        assertNotNull(keyStream);
+
+        testingKeyPair = null;
+        try (PEMParser reader = new PEMParser(new InputStreamReader(keyStream))) {
+            testingKeyPair = new JcaPEMKeyConverter().getKeyPair((PEMKeyPair) reader.readObject());
+        }
+        assertNotNull(testingKeyPair);
+    }
+
+    @BeforeEach
+    public void setup() throws Exception {
+        this.config = new CandlepinCommonTestConfig();
+
+        PrivateKeyReader keyReader = new JSSPrivateKeyReader();
+        CertificateReader certReader = new CertificateReader(this.config, keyReader);
+        SubjectKeyIdentifierWriter keyIdWriter = new DefaultSubjectKeyIdentifierWriter();
+        this.pkiUtility = spy(new JSSPKIUtility(certReader, keyIdWriter, this.config));
+
+        this.objMapper = new ObjectMapper();
+        this.x509V3ExtensionUtil = spy(new X509V3ExtensionUtil(this.config, this.mockEntitlementCurator,
+            this.objMapper));
+
+        // FIXME: This mess of mocks is why we should not be using mocks in this way. We should be
+        // using a test database framework and our actual curators and objects.
+
+        doAnswer(returnsFirstArg()).when(this.mockOwnerCurator).merge(any(Owner.class));
+        doAnswer(returnsFirstArg()).when(this.mockConsumerCurator).merge(any(Consumer.class));
+        doAnswer(returnsFirstArg()).when(this.mockOwnerEnvContentAccessCurator)
+            .saveOrUpdate(any(OwnerEnvContentAccess.class));
+        doReturn(this.testingKeyPair).when(this.mockKeyPairCurator).getConsumerKeyPair(any(Consumer.class));
+
+        doAnswer(iom -> {
+            CertificateSerial serial = (CertificateSerial) iom.getArgument(0);
+
+            if (serial != null) {
+                serial.setId(Util.generateUniqueLong());
+            }
+
+            return serial;
+        }).when(this.mockCertSerialCurator).create(any(CertificateSerial.class));
+    }
+
+
     private ContentAccessManager createManager() {
         return new ContentAccessManager(
-            this.mockPKIUtility, this.mockX509V3ExtensionUtil, this.mockContentAccessCertCurator,
+            this.config, this.pkiUtility, this.x509V3ExtensionUtil, this.mockContentAccessCertCurator,
             this.mockKeyPairCurator, this.mockCertSerialCurator, this.mockOwnerContentCurator,
             this.mockOwnerCurator, this.mockOwnerEnvContentAccessCurator, this.mockConsumerCurator,
             this.mockConsumerTypeCurator, this.mockEnvironmentCurator, this.mockContentAccessCertCurator,
             this.mockEventSink);
     }
 
-    @BeforeEach
-    public void setup() {
-        doAnswer(returnsFirstArg()).when(this.mockOwnerCurator).merge(any(Owner.class));
+    private Owner mockOwner() {
+        Owner owner = new Owner();
+        owner.setId("test_owner");
+        owner.setKey("test_owner");
+        owner.setContentAccessModeList(entitlementMode + "," + orgEnvironmentMode);
+        owner.setContentAccessMode(orgEnvironmentMode);
+
+        doReturn(owner).when(this.mockOwnerCurator).findOwnerById(eq(owner.getId()));
+
+        return owner;
+    }
+
+    private Consumer mockConsumer(Owner owner) {
+        ConsumerType type = new ConsumerType(ConsumerType.ConsumerTypeEnum.SYSTEM);
+        type.setId("test-id");
+
+        Consumer consumer = new Consumer("Test Consumer", "bob", owner, type);
+        consumer.setUuid("test-consumer-uuid");
+        consumer.setId("test-consumer-id");
+
+        consumer.setFact("system.certificate_version", X509V3ExtensionUtil.CERT_VERSION);
+        consumer.setCapabilities(Util.asSet(new ConsumerCapability(consumer, "cert_v3")));
+
+        doReturn(type).when(this.mockConsumerTypeCurator).getConsumerType(eq(consumer));
+
+        return consumer;
+    }
+
+    private Content mockContent(Owner owner) {
+        Content content = new Content();
+        content.setUuid("test_content-uuid");
+        content.setId("1234");
+        content.setName("test_content");
+        content.setLabel("test_content-label");
+        content.setType("yum");
+        content.setVendor("vendor");
+        content.setContentUrl("/content/dist/rhel/$releasever/$basearch/os");
+        content.setGpgUrl("gpgUrl");
+        content.setArches("x86_64");
+        content.setMetadataExpiration(3200L);
+        content.setRequiredTags("TAG1,TAG2");
+
+        List<Content> contentList = Arrays.asList(content);
+
+        CandlepinQuery cqmock = mock(CandlepinQuery.class);
+        doReturn(contentList).when(cqmock).list();
+        doAnswer(iom -> contentList.iterator()).when(cqmock).iterator();
+
+        doReturn(cqmock).when(this.mockOwnerContentCurator).getContentByOwner(eq(owner));
+
+        return content;
+    }
+
+    private Product mockProduct(Content content) {
+        Product product = new Product("test_product_id", "test_product", null);
+        product.setAttribute(Product.Attributes.VERSION, "version");
+        product.setAttribute(Product.Attributes.VARIANT, "variant");
+        product.setAttribute(Product.Attributes.TYPE, "SVC");
+        product.setAttribute(Product.Attributes.ARCHITECTURE, "x86_64");
+        product.addContent(content, false);
+
+        return product;
+    }
+
+    private Pool mockPool(Product product) {
+        Pool pool = new Pool();
+        pool.setQuantity(1L);
+        pool.setProduct(product);
+        pool.setStartDate(TestUtil.createDate(2000, 1, 1));
+        pool.setEndDate(TestUtil.createDate(2050, 1, 1));
+
+        return pool;
+    }
+
+    private Entitlement mockEntitlement(Owner owner, Consumer consumer, Pool pool) {
+        Entitlement entitlement = new Entitlement();
+        entitlement.setQuantity(10);
+        entitlement.setOwner(owner);
+        entitlement.setConsumer(consumer);
+        entitlement.setPool(pool);
+
+        return entitlement;
+    }
+
+    private Environment mockEnvironment(Owner owner, Consumer consumer, Content content) {
+        Environment environment = new Environment("test_environment", "test_environment", owner);
+        environment.setEnvironmentContent(Util.asSet(new EnvironmentContent(environment, content, true)));
+
+        consumer.setEnvironment(environment);
+
+        doReturn(environment).when(this.mockEnvironmentCurator).get(eq(environment.getId()));
+        doReturn(environment).when(this.mockEnvironmentCurator).getConsumerEnvironment(eq(consumer));
+
+        return environment;
     }
 
     @Test
@@ -318,5 +503,158 @@ public class ContentAccessManagerTest {
 
         assertEquals(owner.getContentAccessModeList(), contentAccessModeList);
         assertEquals(owner.getContentAccessMode(), contentAccessMode);
+    }
+
+    private void verifyContainerContentPath(String expected) throws Exception {
+        ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
+
+        verify(this.x509V3ExtensionUtil, times(1)).getByteExtensions(nullable(Product.class),
+            captor.capture(), nullable(String.class), nullable(Map.class));
+
+        List<org.candlepin.model.dto.Product> products = captor.getValue();
+
+        assertNotNull(products);
+        assertEquals(1, products.size());
+
+        org.candlepin.model.dto.Product product = products.get(0);
+        assertNotNull(product);
+
+        List<org.candlepin.model.dto.Content> contents = product.getContent();
+        assertNotNull(contents);
+        assertEquals(1, contents.size());
+
+        org.candlepin.model.dto.Content content = contents.get(0);
+        assertNotNull(content);
+
+        assertEquals(expected, content.getPath());
+    }
+
+    @Test
+    public void testContentPrefixShouldBeOmittedInHosted() throws Exception {
+        this.config.setProperty(ConfigProperties.STANDALONE, "false");
+
+        Owner owner = this.mockOwner();
+        Consumer consumer = this.mockConsumer(owner);
+        Content content = this.mockContent(owner);
+        Product product = this.mockProduct(content);
+        Pool pool = this.mockPool(product);
+        Entitlement entitlement = this.mockEntitlement(owner, consumer, pool);
+
+        String expectedPrefix = "";
+
+        ContentAccessManager manager = this.createManager();
+        manager.getCertificate(consumer);
+
+        verify(this.x509V3ExtensionUtil, times(1)).mapProduct(any(Product.class), any(Product.class),
+            eq(expectedPrefix), any(Map.class), any(Consumer.class), any(Pool.class), any(Set.class));
+    }
+
+    @Test
+    public void testContainerContentPathShouldUseOwnerKeyInHosted() throws Exception {
+        this.config.setProperty(ConfigProperties.STANDALONE, "false");
+
+        Owner owner = this.mockOwner();
+        Consumer consumer = this.mockConsumer(owner);
+        Content content = this.mockContent(owner);
+        Product product = this.mockProduct(content);
+        Pool pool = this.mockPool(product);
+        Entitlement entitlement = this.mockEntitlement(owner, consumer, pool);
+
+        String expectedPath = "/sca/" + owner.getKey();
+
+        ContentAccessManager manager = this.createManager();
+        manager.getCertificate(consumer);
+
+        this.verifyContainerContentPath(expectedPath);
+    }
+
+    @Test
+    public void testContentPrefixesShouldBeUsedInStandalone() throws Exception {
+        this.config.setProperty(ConfigProperties.STANDALONE, "true");
+
+        Owner owner = this.mockOwner();
+        Consumer consumer = this.mockConsumer(owner);
+        Content content = this.mockContent(owner);
+        Product product = this.mockProduct(content);
+        Pool pool = this.mockPool(product);
+        Entitlement entitlement = this.mockEntitlement(owner, consumer, pool);
+
+        String expectedPrefix = "/" + owner.getKey();
+
+        ContentAccessManager manager = this.createManager();
+        manager.getCertificate(consumer);
+
+        verify(this.x509V3ExtensionUtil, times(1)).mapProduct(any(Product.class), any(Product.class),
+            eq(expectedPrefix), any(Map.class), any(Consumer.class), any(Pool.class), any(Set.class));
+    }
+
+    @Test
+    public void testContainerContentPathShouldBeContentPrefixInStandalone() throws Exception {
+        this.config.setProperty(ConfigProperties.STANDALONE, "true");
+
+        Owner owner = this.mockOwner();
+        Consumer consumer = this.mockConsumer(owner);
+        Content content = this.mockContent(owner);
+        Product product = this.mockProduct(content);
+        Pool pool = this.mockPool(product);
+        Entitlement entitlement = this.mockEntitlement(owner, consumer, pool);
+
+        String expectedPath = "/" + owner.getKey();
+
+        ContentAccessManager manager = this.createManager();
+        manager.getCertificate(consumer);
+
+        verify(this.x509V3ExtensionUtil, times(1)).mapProduct(any(Product.class), any(Product.class),
+            eq(expectedPath), any(Map.class), any(Consumer.class), any(Pool.class), any(Set.class));
+
+        this.verifyContainerContentPath(expectedPath);
+    }
+
+    @Test
+    public void testContentPrefixIncludesEnvironmentWhenPresent() throws Exception {
+        this.config.setProperty(ConfigProperties.STANDALONE, "true");
+
+        Owner owner = this.mockOwner();
+        Consumer consumer = this.mockConsumer(owner);
+        Content content = this.mockContent(owner);
+        Product product = this.mockProduct(content);
+        Pool pool = this.mockPool(product);
+        Entitlement entitlement = this.mockEntitlement(owner, consumer, pool);
+        Environment environment = this.mockEnvironment(owner, consumer, content);
+
+        String expectedPrefix = "/" + owner.getKey() + "/" + environment.getName();
+
+        ContentAccessManager manager = this.createManager();
+        manager.getCertificate(consumer);
+
+        verify(this.x509V3ExtensionUtil, times(1)).mapProduct(any(Product.class), any(Product.class),
+            eq(expectedPrefix), any(Map.class), any(Consumer.class), any(Pool.class), any(Set.class));
+
+        this.verifyContainerContentPath(expectedPrefix);
+    }
+
+    @Test
+    public void testContentPrefixEncoding() throws Exception {
+        this.config.setProperty(ConfigProperties.STANDALONE, "true");
+
+        Owner owner = this.mockOwner();
+        Consumer consumer = this.mockConsumer(owner);
+        Content content = this.mockContent(owner);
+        Product product = this.mockProduct(content);
+        Pool pool = this.mockPool(product);
+        Entitlement entitlement = this.mockEntitlement(owner, consumer, pool);
+        Environment environment = this.mockEnvironment(owner, consumer, content);
+
+        owner.setKey("org! #$%&'()*+,/123:;=?@[]\"-.<>\\^_`{|}~£円");
+        environment.setName("test environment #1");
+
+        String expectedPrefix = "/org%21+%23%24%25%26%27%28%29*%2B%2C%2F123%3A%3B%3D%3F%40%5B%5D%22" +
+            "-.%3C%3E%5C%5E_%60%7B%7C%7D%7E%C2%A3%E5%86%86/test+environment+%231";
+
+        ContentAccessManager manager = this.createManager();
+        manager.getCertificate(consumer);
+
+        verify(this.x509V3ExtensionUtil, times(1)).mapProduct(any(Product.class), any(Product.class),
+            eq(expectedPrefix), any(Map.class), any(Consumer.class), any(Pool.class), any(Set.class));
     }
 }


### PR DESCRIPTION
- Certificates generated for Simple Content Access (SCA) will
  use a placeholder value for the ENTITLEMENT_DATA certificate
  extension when generated from a Candlepin instance not running
  in standalone mode
- Content prefixes are no longer generated while Candlepin is not
  running in standalone mode