### PR TITLE
[2.6] 1869582 - Satellite does not have "Layered" SLA option for system purpose

### DIFF
--- a/server/spec/autobind_spec.rb
+++ b/server/spec/autobind_spec.rb
@@ -682,4 +682,56 @@ describe 'Autobind On Owner' do
     entitlements = @cp.list_entitlements(:uuid => consumer.uuid)
     entitlements.size.should == 1
   end
+
+  it 'should be matched with consumer on auto attach when SLA of current entitlement is layered exempt' do
+    product1 = create_product(random_string('product'),
+                              random_string('product'),
+                              {:attributes => {:support_level => 'Standard'},
+                               :owner => owner_key})
+    product2 = create_product(random_string('product'),
+                              random_string('product'),
+                              {:attributes => {:support_level => 'Layered',
+                                               :support_level_exempt => 'true'},
+                               :owner => owner_key})
+
+    @cp.create_pool(owner_key, product1.id)
+    @cp.create_pool(owner_key, product2.id)
+
+    installed = [
+        {'productId' => product1.id, 'productName' => product1['name']},
+        {'productId' => product2.id, 'productName' => product2['name']}]
+
+    consumer = @cp.register(
+        random_string('system'), :system, nil, {}, nil, owner_key, [], installed, nil, [],
+        nil, [], nil, nil, nil, nil, nil, 0, nil, 'Standard')
+
+    @cp.consume_product(product2['id'], {:uuid => consumer.uuid})
+
+    status = @cp.get_purpose_compliance(consumer['uuid'])
+    expect(status['status']).to eq('mismatched')
+
+    entitlements = @cp.list_entitlements(:uuid => consumer.uuid)
+
+    # Trying to bind the without SLA exempt.
+    # Then system purpose status should be match.
+
+    entitlements.each do |ent|
+      @cp.unbind_entitlement(ent.id, {:uuid => consumer.uuid})
+    end
+
+    product3 = create_product(random_string('product'),
+                              random_string('product'),
+                              {:attributes => {:support_level => 'Standard',
+                                               :support_level_exempt => 'false'},
+                               :owner => owner_key})
+
+    @cp.create_pool(owner_key, product3.id)
+
+    @cp.consume_product(product3['id'], {:uuid => consumer.uuid})
+
+    status = @cp.get_purpose_compliance(consumer['uuid'])
+    expect(status['status']).to eq('matched')
+
+  end
+
 end

--- a/server/src/main/java/org/candlepin/policy/SystemPurposeComplianceRules.java
+++ b/server/src/main/java/org/candlepin/policy/SystemPurposeComplianceRules.java
@@ -198,7 +198,11 @@ public class SystemPurposeComplianceRules {
                 if (StringUtils.isNotEmpty(preferredSla) &&
                     product.hasAttribute(Product.Attributes.SUPPORT_LEVEL)) {
                     String sla = product.getAttributeValue(Product.Attributes.SUPPORT_LEVEL);
-                    if (sla.equalsIgnoreCase(preferredSla)) {
+                    //TODO: This is a short term fix for bug 1858167. Added a condition to ignore
+                    // Syspurpose status for entitlement which has SLA exempt as true
+                    boolean slaExempt = Boolean.parseBoolean(product
+                        .getAttributeValue(Product.Attributes.SUPPORT_LEVEL_EXEMPT));
+                    if (!slaExempt && sla.equalsIgnoreCase(preferredSla)) {
                         status.addCompliantSLA(sla, entitlement);
                     }
                 }

--- a/server/src/main/resources/rules/rules.js
+++ b/server/src/main/resources/rules/rules.js
@@ -1,4 +1,4 @@
-// Version: 5.36.1
+// Version: 5.36.2
 
 /*
  * Default Candlepin rule set.
@@ -506,20 +506,25 @@ function get_pool_priority(pool, consumer) {
         var null_rule_score = 0;
         var mismatch_rule_score = 0;
 
-        log.debug("Evaluating attribute {} with weight {}", attr, attrs[attr]);
-        if (unsatisfiedSet.length === 0 && poolSet.length === 0) {
-            null_rule_score = 0.1;
-            log.debug("NULL rule score for attribute {} and pool {}, which is: {}", [attr, pool.id, null_rule_score]);
+        if(Utils.equalsIgnoreCase(attr, 'support_level') && Utils.equalsIgnoreCase(poolSet[0], 'Layered')) {
+            log.debug("Ignoring the pool prioritization when SLA is Layered", attr, poolSet[0]);
         }
+        else {
+            log.debug("Evaluating attribute {} with weight {}", attr, attrs[attr]);
+            if (unsatisfiedSet.length === 0 && poolSet.length === 0) {
+                null_rule_score = 0.1;
+                log.debug("NULL rule score for attribute {} and pool {}, which is: {}", [attr, pool.id, null_rule_score]);
+            }
 
-        if (unsatisfiedSet.length > 0) {
-            match_rule_score = Utils.intersection(unsatisfiedSet, poolSet).length / unsatisfiedSet.length;
-            log.debug("MATCH rule score for attribute {} and pool {}, which is: {}", [attr, pool.id, match_rule_score]);
-        }
+            if (unsatisfiedSet.length > 0) {
+                match_rule_score = Utils.intersection(unsatisfiedSet, poolSet).length / unsatisfiedSet.length;
+                log.debug("MATCH rule score for attribute {} and pool {}, which is: {}", [attr, pool.id, match_rule_score]);
+            }
 
-        if (specifiedSet.length > 0 && poolSet.length > 0) {
-            mismatch_rule_score = (Utils.difference(specifiedSet, poolSet).length / specifiedSet.length) * -0.05;
-            log.debug("MISMATCH rule score for attribute {} and pool {}, which is: {}", [attr, pool.id, mismatch_rule_score]);
+            if (specifiedSet.length > 0 && poolSet.length > 0) {
+                mismatch_rule_score = (Utils.difference(specifiedSet, poolSet).length / specifiedSet.length) * -0.05;
+                log.debug("MISMATCH rule score for attribute {} and pool {}, which is: {}", [attr, pool.id, mismatch_rule_score]);
+            }
         }
 
         attrScore = (null_rule_score + match_rule_score + mismatch_rule_score) * attrs[attr];


### PR DESCRIPTION
- Added a condition in compliance rules do not match the system
   purpose status
 - Added rspec to test this scenario
 - Updated rules.js to ignore calculating priority of subscriptions
   to attach during auto-attach