### PR TITLE
[M] 1591315: Registration with activation keys no longer fails in SCA mode (ENT-2747)

### DIFF
--- a/server/client/ruby/candlepin_api.rb
+++ b/server/client/ruby/candlepin_api.rb
@@ -347,7 +347,7 @@ class Candlepin
   end
 
   def update_owner(owner_key, owner)
-    put("/owners/#{owner_key}",{},  owner)
+    put("/owners/#{owner_key}", {}, owner)
   end
 
   def set_owner_log_level(owner_key, log_level=nil)


### PR DESCRIPTION
- Clients registering with activation keys to organizations using
  simple content access (SCA) mode will no longer fail if a key
  cannot be fully entitled