### PR TITLE
[M] Standardized string keys used for modifying the logging context

### DIFF
--- a/common/src/main/java/org/candlepin/common/exceptions/ExceptionMessage.java
+++ b/common/src/main/java/org/candlepin/common/exceptions/ExceptionMessage.java
@@ -14,6 +14,8 @@
  */
 package org.candlepin.common.exceptions;
 
+import org.candlepin.common.logging.LoggingUtil;
+
 import org.slf4j.MDC;
 
 import java.io.Serializable;
@@ -61,17 +63,15 @@ public class ExceptionMessage implements Serializable {
     }
 
     /**
-     * Pulls the request UUID from the log4j MDC if possible, and sets them
-     * for return to the client.
+     * Pulls the request UUID from the log4j MDC if possible, and sets them for return to the client.
      *
      * Doesn't include the requestType, as I believe we can assume it's an HTTP request
      * and not a job, if this exception is being used.
      */
     private void setRequestUuid() {
-        if (MDC.get("requestUuid") != null) {
-            this.requestUuid = (String) MDC.get("requestUuid");
+        if (MDC.get(LoggingUtil.MDC_REQUEST_UUID_KEY) != null) {
+            this.requestUuid = (String) MDC.get(LoggingUtil.MDC_REQUEST_UUID_KEY);
         }
-
     }
 
     public String toString() {

--- a/common/src/main/java/org/candlepin/common/filter/LoggingFilter.java
+++ b/common/src/main/java/org/candlepin/common/filter/LoggingFilter.java
@@ -14,6 +14,8 @@
  */
 package org.candlepin.common.filter;
 
+import org.candlepin.common.logging.LoggingUtil;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -45,12 +47,8 @@ public class LoggingFilter implements Filter {
 
     private static Logger log = LoggerFactory.getLogger(LoggingFilter.class);
 
-    public static final String CSID_KEY = "csid";
     private static final int CSID_MAX_LENGTH = 40;
     private static final Pattern CSID_REGEX = Pattern.compile("^([a-zA-Z0-9-]){1,}$");
-
-    /** The metadata key used to display the owner's key or display name */
-    public static final String OWNER_KEY = "org"; // This value must match that set in logback.xml
 
     private String customHeaderName;
 
@@ -78,9 +76,9 @@ public class LoggingFilter implements Filter {
         try {
             // Generate a UUID for this request and store in the thread local MDC.
             // Will be logged with every request if the ConversionPattern uses it.
-            MDC.put("requestType", "req");
+            MDC.put(LoggingUtil.MDC_REQUEST_TYPE_KEY, "req");
             String requestUUID = UUID.randomUUID().toString();
-            MDC.put("requestUuid", requestUUID);
+            MDC.put(LoggingUtil.MDC_REQUEST_UUID_KEY, requestUUID);
 
             String correlationId = null;
 
@@ -100,7 +98,7 @@ public class LoggingFilter implements Filter {
                             correlationId, CSID_MAX_LENGTH, CSID_MAX_LENGTH);
                         correlationId = correlationId.substring(0, CSID_MAX_LENGTH);
                     }
-                    MDC.put(CSID_KEY, correlationId);
+                    MDC.put(LoggingUtil.MDC_CSID_KEY, correlationId);
                 }
                 else {
                     log.warn("Correlation Id must consist of alphanumeric characters or hypens");

--- a/common/src/main/java/org/candlepin/common/logging/LoggingUtil.java
+++ b/common/src/main/java/org/candlepin/common/logging/LoggingUtil.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.common.logging;
+
+
+
+/**
+ * The LoggingUtil class provides variables and utility functionality for the logging subsystems
+ * used within Candlepin
+ */
+public class LoggingUtil {
+
+    /** The MDC key for specifying the request type in log messages */
+    public static final String MDC_REQUEST_TYPE_KEY = "requestType";
+
+    /** The MDC key for specifying the request UUID in log messages */
+    public static final String MDC_REQUEST_UUID_KEY = "requestUuid";
+
+    /** The MDC key for specifying the context owner for the request or job in log messages */
+    public static final String MDC_OWNER_KEY = "org";
+
+    /** The MDC key for specifying the job key in log messages */
+    public static final String MDC_JOB_KEY_KEY = "jobKey";
+
+    /** The MDC key for specifying the correlation ID, or correlated service ID */
+    public static final String MDC_CSID_KEY = "csid";
+
+    /**
+     * The MDC key for specifying the log level to use for logging. While this key is set, the
+     * value associated with the key will be used for logging, overriding whatever is configured
+     * in logback.xml and/or candlepin.conf.
+     *
+     * Valid values associated with this key are: ALL, TRACE, DEBUG, INFO, WARN, ERROR, OFF
+     */
+    public static final String MDC_LOG_LEVEL_KEY = "logLevel";
+
+
+    private LoggingUtil() {
+        // Intentionally left empty; instantiation disabled for utility classes
+    }
+
+}

--- a/server/src/main/java/org/candlepin/resteasy/filter/VerifyAuthorizationFilter.java
+++ b/server/src/main/java/org/candlepin/resteasy/filter/VerifyAuthorizationFilter.java
@@ -20,6 +20,7 @@ import org.candlepin.auth.SubResource;
 import org.candlepin.auth.Verify;
 import org.candlepin.common.exceptions.IseException;
 import org.candlepin.common.exceptions.NotFoundException;
+import org.candlepin.common.logging.LoggingUtil;
 import org.candlepin.model.Owner;
 import org.candlepin.model.Persisted;
 import org.candlepin.resteasy.AnnotationLocator;
@@ -233,10 +234,10 @@ public class VerifyAuthorizationFilter extends AbstractAuthorizationFilter {
         }
 
         if (hasAccess && owner != null) {
-            MDC.put("org", owner.getKey());
+            MDC.put(LoggingUtil.MDC_OWNER_KEY, owner.getKey());
 
             if (owner.getLogLevel() != null) {
-                MDC.put("orgLogLevel", owner.getLogLevel());
+                MDC.put(LoggingUtil.MDC_LOG_LEVEL_KEY, owner.getLogLevel());
             }
         }
 

--- a/server/src/test/java/org/candlepin/async/JobManagerTest.java
+++ b/server/src/test/java/org/candlepin/async/JobManagerTest.java
@@ -49,7 +49,7 @@ import org.candlepin.auth.UserPrincipal;
 import org.candlepin.auth.permissions.OwnerPermission;
 import org.candlepin.auth.permissions.Permission;
 import org.candlepin.common.config.Configuration;
-import org.candlepin.common.filter.LoggingFilter;
+import org.candlepin.common.logging.LoggingUtil;
 import org.candlepin.config.CandlepinCommonTestConfig;
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.controller.mode.CandlepinModeManager;
@@ -459,10 +459,10 @@ public class JobManagerTest {
         assertEquals(expectedLogLevel, mdcCapture.get("logLevel"));
 
         if (owner != null) {
-            assertEquals(owner.getKey(), mdcCapture.get(LoggingFilter.OWNER_KEY));
+            assertEquals(owner.getKey(), mdcCapture.get(LoggingUtil.MDC_OWNER_KEY));
         }
         else {
-            assertNull(mdcCapture.get(LoggingFilter.OWNER_KEY));
+            assertNull(mdcCapture.get(LoggingUtil.MDC_OWNER_KEY));
         }
     }
 


### PR DESCRIPTION
- Added the LoggingUtil class in the common package to hold
  constants for the various MDC keys used throughout Candlepin
- All instances of MDC.set and MDC.get now use the constants
  defined in the LoggingUtil class rather than hard-coded
  strings or locally-defined constants