### PR TITLE
ENT-2817 : Fix candlepin docker image Jenkins build

### DIFF
--- a/docker/gating-test-images/build.sh
+++ b/docker/gating-test-images/build.sh
@@ -58,8 +58,14 @@ docker stack deploy -c temp-cp/docker-compose.yml load_and_dump_stack
 evalrc $? "load_and_dump_stack stack deploy was not successful."
 
 echo "============ Waiting for data to be dumped... ============ "
-retry 30 "dump.sql" test -f /tmp/cp-docker/dump.sql
-evalrc $? "dump.sql did not get dumped in time. Exiting..."
+retry 35 "dump.sql" test -f /tmp/cp-docker/dump.sql
+
+if [ "$?" -ne "0" ]; then
+  docker stack rm load_and_dump_stack
+  docker swarm leave --force
+  echo "dump.sql did not get dumped in time. Exiting..."
+  exit $1
+fi
 
 echo "============ Removing temporary stack ============ "
 docker stack rm load_and_dump_stack

--- a/docker/gating-test-images/cp-latest-stage/setup-env-extras.sh
+++ b/docker/gating-test-images/cp-latest-stage/setup-env-extras.sh
@@ -5,26 +5,16 @@
 set -e
 
 PACKAGES=(
+    tito
     java
     java-devel
     ant
     selinux-policy-doc
     selinux-policy-devel
     maven
-    python-bugzilla
-    python2-cheetah
-    rpm-build
 )
 
 yum install -y ${PACKAGES[@]}
-
-# Due to issues with latest version of tito (v0.6.14) https://github.com/rpm-software-management/tito/issues/380
-# older version of tito v0.6.12 is used.
-# python-bugzilla, python2-cheetah & rpm-build dependencies are installed manually for tito v0.6.12
-# Installing tito v0.6.12
-git clone -b tito-0.6.12-1 https://github.com/rpm-software-management/tito.git ./tito
-cd ./tito
-./setup.py install
 
 # find stage candlepin version
 curl -k -u admin:admin https://subscription.rhsm.stage.redhat.com/subscription/status > stage_status.json


### PR DESCRIPTION
Docker build occasionally fails while dumping the database. 
Changes 
- Increased timeout for dumping database, proper cleanup of docker swam & stack in case of failure.
- Upgraded Tito to newer version (0.6.15) which is available with the fixes needed by Candlepin, therefore no need to manually install older version.