### PR TITLE
[F] Use RESTEasy's MultipartInput for multipart/form-data

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -443,6 +443,7 @@ project(":api") {
         compile 'javax.validation:validation-api'
         compile 'javax.ws.rs:javax.ws.rs-api'
         compile 'io.swagger:swagger-annotations'
+        compile 'org.jboss.resteasy:resteasy-multipart-provider'
     }
 
     sourceSets.main.java.srcDirs = ["${buildDir}/generated/src/gen/java"]

--- a/buildSrc/src/main/resources/templates/api.mustache
+++ b/buildSrc/src/main/resources/templates/api.mustache
@@ -1,0 +1,30 @@
+package {{package}};
+
+{{#imports}}import {{import}};
+{{/imports}}
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.Response;
+
+{{#useSwaggerAnnotations}}
+import io.swagger.annotations.*;
+{{/useSwaggerAnnotations}}
+
+import java.io.InputStream;
+import java.util.Map;
+import java.util.List;
+{{#useBeanValidation}}import javax.validation.constraints.*;
+import javax.validation.Valid;{{/useBeanValidation}}
+
+@Path("/{{{baseName}}}"){{#useSwaggerAnnotations}}
+@Api(description = "the {{{baseName}}} API"){{/useSwaggerAnnotations}}{{#hasConsumes}}
+@Consumes({ {{#consumes}}"{{{mediaType}}}"{{#hasMore}}, {{/hasMore}}{{/consumes}} }){{/hasConsumes}}{{#hasProduces}}
+@Produces({ {{#produces}}"{{{mediaType}}}"{{#hasMore}}, {{/hasMore}}{{/produces}} }){{/hasProduces}}
+{{>generatedAnnotation}}public {{#interfaceOnly}}interface{{/interfaceOnly}}{{^interfaceOnly}}class{{/interfaceOnly}} {{classname}} {
+{{#operations}}
+{{#operation}}
+
+{{#interfaceOnly}}{{>apiInterface}}{{/interfaceOnly}}{{^interfaceOnly}}{{>apiMethod}}{{/interfaceOnly}}
+{{/operation}}
+}
+{{/operations}}

--- a/buildSrc/src/main/resources/templates/api.mustache
+++ b/buildSrc/src/main/resources/templates/api.mustache
@@ -10,7 +10,7 @@ import javax.ws.rs.core.Response;
 import io.swagger.annotations.*;
 {{/useSwaggerAnnotations}}
 
-import java.io.InputStream;
+import org.jboss.resteasy.plugins.providers.multipart.MultipartInput;
 import java.util.Map;
 import java.util.List;
 {{#useBeanValidation}}import javax.validation.constraints.*;

--- a/buildSrc/src/main/resources/templates/formParams.mustache
+++ b/buildSrc/src/main/resources/templates/formParams.mustache
@@ -1,0 +1,1 @@
+{{#isFormParam}}{{^isFile}}@FormParam(value = "{{baseName}}")  {{{dataType}}} {{paramName}}{{/isFile}}{{#isFile}} @FormParam(value = "{{baseName}}") InputStream {{paramName}}InputStream{{/isFile}}{{/isFormParam}}

--- a/buildSrc/src/main/resources/templates/formParams.mustache
+++ b/buildSrc/src/main/resources/templates/formParams.mustache
@@ -1,1 +1,1 @@
-{{#isFormParam}}{{^isFile}}@FormParam(value = "{{baseName}}")  {{{dataType}}} {{paramName}}{{/isFile}}{{#isFile}} @FormParam(value = "{{baseName}}") InputStream {{paramName}}InputStream{{/isFile}}{{/isFormParam}}
+{{#isFormParam}}{{^isFile}}@FormParam(value = "{{baseName}}")  {{{dataType}}} {{paramName}}{{/isFile}}{{#isFile}} MultipartInput {{paramName}}{{/isFile}}{{/isFormParam}}


### PR DESCRIPTION
- Add the default api/formParams mustache templates that ship
  with openapi-generator for the JavaJaxRS/spec/ generator type.

- The openapi-generator type we use (pure JAX-RS spec) has no
  knowledge of our JAX-RS implementation (RESTEasy) and by
  default generates '@FormParam InputStream' as the input type
  when declaring to consume 'multipart/form-data' for file
  uploads.

  This change alters the default templates used for code
  generation to use RESTEasy's 'MultipartInput' utility class
  instead of '@FormParam InputStream' for file uploads.