### PR TITLE
[M] 1877340: Remove stale Quartz data on upgrade; ENT-2859

### DIFF
--- a/server/src/main/resources/db/changelog/20200910161135-purge-stale-quartz-data.xml
+++ b/server/src/main/resources/db/changelog/20200910161135-purge-stale-quartz-data.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="20200910161135-1" author="nmoumoul" dbms="postgresql">
+        <comment>
+            This task that removes stale Pinsetter job data from Quartz tables so that the new Artemis-based job
+            framework has a clean slate during startup and avoid errors caused by said stale data.
+        </comment>
+
+        <sql>
+            TRUNCATE TABLE qrtz_blob_triggers CASCADE;
+            TRUNCATE TABLE qrtz_cron_triggers CASCADE;
+            TRUNCATE TABLE qrtz_simple_triggers CASCADE;
+            TRUNCATE TABLE qrtz_simprop_triggers CASCADE;
+            TRUNCATE TABLE qrtz_triggers CASCADE;
+            TRUNCATE TABLE qrtz_job_details CASCADE;
+            TRUNCATE TABLE qrtz_calendars CASCADE;
+            TRUNCATE TABLE qrtz_fired_triggers CASCADE;
+            TRUNCATE TABLE qrtz_locks CASCADE;
+            TRUNCATE TABLE qrtz_paused_trigger_grps CASCADE;
+            TRUNCATE TABLE qrtz_scheduler_state CASCADE;
+        </sql>
+    </changeSet>
+</databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-create.xml
+++ b/server/src/main/resources/db/changelog/changelog-create.xml
@@ -1243,4 +1243,5 @@
     <include file="db/changelog/20200604045445-async-job-data-restructure.xml"/>
     <include file="db/changelog/20200715155048-add-ak-name-owner-constraint.xml"/>
     <include file="db/changelog/20200717020619-add-job-arguments-constraints.xml"/>
+    <include file="db/changelog/20200910161135-purge-stale-quartz-data.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-testing.xml
+++ b/server/src/main/resources/db/changelog/changelog-testing.xml
@@ -2335,4 +2335,5 @@
     <include file="db/changelog/20200604045445-async-job-data-restructure.xml"/>
     <include file="db/changelog/20200715155048-add-ak-name-owner-constraint.xml"/>
     <include file="db/changelog/20200717020619-add-job-arguments-constraints.xml"/>
+    <include file="db/changelog/20200910161135-purge-stale-quartz-data.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-update.xml
+++ b/server/src/main/resources/db/changelog/changelog-update.xml
@@ -152,4 +152,5 @@
     <include file="db/changelog/20200604045445-async-job-data-restructure.xml"/>
     <include file="db/changelog/20200715155048-add-ak-name-owner-constraint.xml"/>
     <include file="db/changelog/20200717020619-add-job-arguments-constraints.xml"/>
+    <include file="db/changelog/20200910161135-purge-stale-quartz-data.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
- Add liquibase task to truncate all Quartz tables in order
  to avoid stale data from the old Pinsetter job framework
  causing startup errors when the new Artemis-based job
  framework is initialized after an upgrade to Candlepin 3