### PR TITLE
ENT-2794: @ApiResponse annotation with message

### DIFF
--- a/buildSrc/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/buildSrc/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2759,7 +2759,7 @@ public class DefaultCodegen implements CodegenConfig {
     public CodegenResponse fromResponse(String responseCode, ApiResponse response) {
         CodegenResponse r = CodegenModelFactory.newInstance(CodegenModelType.RESPONSE);
         if ("default".equals(responseCode)) {
-            r.code = "0";
+            r.code = "500";
         } else {
             r.code = responseCode;
         }


### PR DESCRIPTION
 'An unexpected exception has occurred' and status code 200
 is added to API endpoints.
 - Overridden status code to 500 as default response code.
   Initially, it is set as 0 but fails with regular expression
   in openapi schema json. It needs 3 occurrences of a number.
   Also, it cannot be set a "default" string because the ApiResponse
   class has an int type code. Hence keeping the default status code to 500.