### PR TITLE
[M] 1879494: Allow consumer registration with SCA mode; ENT-3062

### DIFF
--- a/server/client/ruby/candlepin_api.rb
+++ b/server/client/ruby/candlepin_api.rb
@@ -80,7 +80,7 @@ class Candlepin
               content_tags=[], created_date=nil, last_checkin_date=nil,
               annotations=nil, recipient_owner_key=nil, user_agent=nil,
               entitlement_count=0, id_cert=nil, serviceLevel=nil, role=nil, usage=nil,
-              addOns=nil, reporter_id=nil, autoheal=nil)
+              addOns=nil, reporter_id=nil, autoheal=nil, content_access_mode=nil)
 
     consumer = {
       :type => {:label => type},
@@ -107,6 +107,7 @@ class Candlepin
     consumer[:role] = role if role
     consumer[:usage] = usage if usage
     consumer[:addOns] = addOns if addOns
+    consumer[:contentAccessMode] = content_access_mode if content_access_mode
 
     params = {}
 

--- a/server/spec/content_access_spec.rb
+++ b/server/spec/content_access_spec.rb
@@ -346,6 +346,11 @@ describe 'Content Access' do
     expect {
       @consumer.update_consumer({'contentAccessMode' => "invalid"})
     }.to raise_exception(RestClient::BadRequest)
+
+    # We should also be able to set the correct content access mode when registering (instead of updating)
+    consumer2 = @user.register(random_string('consumer'), :candlepin, nil, {}, nil, nil, [], [], nil, [],
+        nil, [], nil, nil, nil, nil, nil, 0, nil, nil, nil, nil, [], nil, nil, "org_environment")
+    expect(consumer2["contentAccessMode"]).to eq("org_environment")
   end
 
   it "will not set the content access mode for a regular consumer" do

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -901,7 +901,7 @@ public class ConsumerResource {
                 throw new BadRequestException(
                     i18n.tr("The consumer cannot be assigned a content access mode."));
             }
-            if (owner.isAllowedContentAccessMode(consumer.getContentAccessMode())) {
+            if (!owner.isAllowedContentAccessMode(consumer.getContentAccessMode())) {
                 throw new BadRequestException(
                     i18n.tr("The consumer cannot use the supplied content access mode."));
             }


### PR DESCRIPTION
- Add back negation operator that was accidentally removed
  which resulted in failure to register manifest consumer
  when the provided content access mode was in fact allowed by
  the owner.