### PR TITLE
[M] 1854221: Validate early if executing job in RUNNING state

### DIFF
--- a/server/src/main/java/org/candlepin/async/JobManager.java
+++ b/server/src/main/java/org/candlepin/async/JobManager.java
@@ -1539,6 +1539,21 @@ public class JobManager implements ModeChangeListener {
             log.error(errmsg);
             throw new JobInitializationException(errmsg, true);
         }
+        else if (jobState == JobState.RUNNING) {
+            if (Util.getHostname().equals(status.getExecutor())) {
+                // This goes against valid state transitions, but this node was the previous executor,
+                // so we should be fine to go on executing it again here.
+                status.setState(JobState.QUEUED);
+            }
+            else {
+                String errmsg = String.format(
+                    "Job \"%s\" (%s) is already running on host \"%s\"; ignoring execution request",
+                    status.getId(), status.getJobKey(), status.getExecutor());
+
+                log.error(errmsg);
+                throw new IllegalStateException(errmsg);
+            }
+        }
         else if (jobState != JobState.QUEUED) {
             // Warn if we're about to execute a job that's not queued for execution (this is likely
             // just state recovery and is probably okay).

--- a/server/src/test/java/org/candlepin/async/JobManagerTest.java
+++ b/server/src/test/java/org/candlepin/async/JobManagerTest.java
@@ -16,14 +16,7 @@ package org.candlepin.async;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
@@ -892,6 +885,48 @@ public class JobManagerTest {
 
         assertThrows(JobStateManagementException.class,
             () -> manager.executeJob(new JobMessage(JOB_ID, TestJob.JOB_KEY)));
+    }
+
+    @Test
+    public void testTryingToExecuteJobInRunningStateThrowsIllegalStateException() {
+        AsyncJobStatus status = spy(new AsyncJobStatus()
+            .setJobKey(TestJob.JOB_KEY)
+            .setState(JobState.RUNNING)
+            .setMaxAttempts(3))
+            .setExecutor("random.hostname.com");  // this job was running on another node previously
+
+        // TODO: Stop doing this when we stop relying on Hibernate to generate the ID for us
+        doReturn(JOB_ID).when(status).getId();
+        this.injectMockedJobStatus(status);
+
+        JobManager manager = this.createJobManager();
+        manager.initialize();
+        manager.start();
+
+        assertThrows(IllegalStateException.class,
+            () -> manager.executeJob(new JobMessage(JOB_ID, TestJob.JOB_KEY)));
+    }
+
+    @Test
+    public void testTryingToExecuteJobInRunningStateOnTheSameExecutorShouldContinueExecutingTheJob() {
+        AsyncJobStatus status = spy(new AsyncJobStatus()
+            .setJobKey(TestJob.JOB_KEY)
+            .setState(JobState.RUNNING)
+            .setMaxAttempts(3))
+            .setExecutor(Util.getHostname()); // this job was running on the current node previously
+
+        AsyncJob job = jdata -> { /* do nothing */ };
+
+        // TODO: Stop doing this when we stop relying on Hibernate to generate the ID for us
+        doReturn(JOB_ID).when(status).getId();
+        doReturn(job).when(this.injector).getInstance(TestJob.class);
+        this.injectMockedJobStatus(status);
+
+        JobManager manager = this.createJobManager();
+        manager.initialize();
+        manager.start();
+
+        assertDoesNotThrow(() -> manager.executeJob(new JobMessage(JOB_ID, TestJob.JOB_KEY)));
     }
 
     @Test


### PR DESCRIPTION
- In a clustered environment, if somehow a job that is
  already in the RUNNING state would get picked up for
  execution, we would update the executor field for that record
  (before eventually failing), causing the original node that
  previously executed it to never recover that job.
- This change makes it so that we error out early when trying to
  execute a job that is in the RUNNING state, and don't end up
  updating it's record.
- In the special case that the job is in the RUNNING state, but
  was previously executed on the current node, we don't fail at
  all, but move the job to QUEUED, so that it will be executed
  as normal.