### PR TITLE
[2.9] 1881181: Fixed an NPE during refresh when adding new derived products

### DIFF
--- a/server/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
@@ -621,8 +621,8 @@ public class PoolRules {
 
         boolean productsChanged = false;
         if (pool.getDerivedProduct() != null) {
-            productsChanged = !pool.getDerivedProduct().getId()
-                .equals(existingPool.getDerivedProduct().getId());
+            productsChanged = existingPool.getDerivedProduct() == null ||
+                !pool.getDerivedProduct().getId().equals(existingPool.getDerivedProduct().getId());
 
             productsChanged |=
                 (changedProducts != null && changedProducts.containsKey(pool.getDerivedProduct().getId()));


### PR DESCRIPTION
- Fixed a null pointer exception (NPE) that can occur during refresh
  if an existing pool which does not define a derived product is
  updated to have a derived product