### PR TITLE
ENT-1675: Upgrade candlepin to use Java 11

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -33,6 +33,12 @@
       <artifactId>swagger-annotations</artifactId>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+      <version>1.3.2</version>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>
@@ -97,7 +103,7 @@
       <dependency>
         <groupId>com.google.inject.extensions</groupId>
         <artifactId>guice-throwingproviders</artifactId>
-        <version>4.1.0</version>
+        <version>4.2.3</version>
       </dependency>
       <dependency>
         <groupId>org.hamcrest</groupId>
@@ -187,7 +193,7 @@
       <dependency>
         <groupId>com.google.inject</groupId>
         <artifactId>guice</artifactId>
-        <version>4.1.0</version>
+        <version>4.2.3</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
@@ -197,7 +203,7 @@
       <dependency>
         <groupId>com.google.inject.extensions</groupId>
         <artifactId>guice-assistedinject</artifactId>
-        <version>4.1.0</version>
+        <version>4.2.3</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
@@ -232,7 +238,7 @@
       <dependency>
         <groupId>com.google.inject.extensions</groupId>
         <artifactId>guice-persist</artifactId>
-        <version>4.1.0</version>
+        <version>4.2.3</version>
       </dependency>
       <dependency>
         <groupId>org.hibernate</groupId>
@@ -352,7 +358,7 @@
       <dependency>
         <groupId>com.google.inject.extensions</groupId>
         <artifactId>guice-servlet</artifactId>
-        <version>4.1.0</version>
+        <version>4.2.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
@@ -427,7 +433,7 @@
       <dependency>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-guice</artifactId>
-        <version>4.4.2.Final</version>
+        <version>4.5.8.Final</version>
       </dependency>
       <dependency>
         <groupId>net.oauth.core</groupId>
@@ -502,7 +508,12 @@
       <dependency>
         <groupId>com.google.inject.extensions</groupId>
         <artifactId>guice-multibindings</artifactId>
-        <version>4.1.0</version>
+        <version>4.2.3</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.annotation</groupId>
+        <artifactId>javax.annotation-api</artifactId>
+        <version>1.3.2</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ plugins {
 
 ext.versions = [
     jackson   : "2.10.1",
-    guice     : "4.1.0",
+    guice     : "4.2.3",
     checkstyle: "8.29",
     junit5    : "5.4.2"
 ]
@@ -86,6 +86,7 @@ ext.libraries = [
         "javax.transaction:jta",
         "javax.persistence:javax.persistence-api",
         "javax.xml.bind:jaxb-api",
+        "javax.annotation:javax.annotation-api", 
     ],
     commons: [
         "commons-codec:commons-codec",
@@ -161,6 +162,7 @@ allprojects {
             dependency group: 'javax.validation', name: 'validation-api', version: '2.0.1.Final'
             dependency group: 'javax.ws.rs', name: 'javax.ws.rs-api', version: '2.1'
             dependency group: 'javax.servlet', name: 'servlet-api', version: '2.5'
+            dependency group: 'javax.annotation', name: 'javax.annotation-api', version: '1.3.2'
             dependency group: 'org.ehcache', name: 'ehcache', version: '3.8.0'
             dependency group: 'javax.cache', name: 'cache-api', version: '1.0.0'
             dependency group: 'org.mozilla', name: 'jss', version: '4.4.6'
@@ -304,12 +306,13 @@ allprojects {
 subprojects {
     apply plugin: "java"
 
-    sourceCompatibility = 1.8
-    targetCompatibility = 1.8
+    sourceCompatibility = 11
+    targetCompatibility = 11
 
     tasks.withType(JavaCompile) {
         options.encoding = "UTF-8"
         // options.compilerArgs << "-Xlint:deprecation"
+        // options.compilerArgs.addAll(['--release', '8'])
     }
 
     repositories {
@@ -436,6 +439,7 @@ project(":api") {
         compile 'javax.validation:validation-api'
         compile 'javax.ws.rs:javax.ws.rs-api'
         compile 'io.swagger:swagger-annotations'
+        compile 'javax.annotation:javax.annotation-api'
     }
 
     sourceSets.main.java.srcDirs = ["${buildDir}/generated/src/gen/java"]

--- a/checks/pom.xml
+++ b/checks/pom.xml
@@ -72,7 +72,7 @@
       <dependency>
         <groupId>com.google.inject.extensions</groupId>
         <artifactId>guice-throwingproviders</artifactId>
-        <version>4.1.0</version>
+        <version>4.2.3</version>
       </dependency>
       <dependency>
         <groupId>org.hamcrest</groupId>
@@ -162,7 +162,7 @@
       <dependency>
         <groupId>com.google.inject</groupId>
         <artifactId>guice</artifactId>
-        <version>4.1.0</version>
+        <version>4.2.3</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
@@ -172,7 +172,7 @@
       <dependency>
         <groupId>com.google.inject.extensions</groupId>
         <artifactId>guice-assistedinject</artifactId>
-        <version>4.1.0</version>
+        <version>4.2.3</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
@@ -207,7 +207,7 @@
       <dependency>
         <groupId>com.google.inject.extensions</groupId>
         <artifactId>guice-persist</artifactId>
-        <version>4.1.0</version>
+        <version>4.2.3</version>
       </dependency>
       <dependency>
         <groupId>org.hibernate</groupId>
@@ -327,7 +327,7 @@
       <dependency>
         <groupId>com.google.inject.extensions</groupId>
         <artifactId>guice-servlet</artifactId>
-        <version>4.1.0</version>
+        <version>4.2.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
@@ -402,7 +402,7 @@
       <dependency>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-guice</artifactId>
-        <version>4.4.2.Final</version>
+        <version>4.5.8.Final</version>
       </dependency>
       <dependency>
         <groupId>net.oauth.core</groupId>
@@ -477,7 +477,12 @@
       <dependency>
         <groupId>com.google.inject.extensions</groupId>
         <artifactId>guice-multibindings</artifactId>
-        <version>4.1.0</version>
+        <version>4.2.3</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.annotation</groupId>
+        <artifactId>javax.annotation-api</artifactId>
+        <version>1.3.2</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -351,7 +351,7 @@
       <dependency>
         <groupId>com.google.inject.extensions</groupId>
         <artifactId>guice-throwingproviders</artifactId>
-        <version>4.1.0</version>
+        <version>4.2.3</version>
       </dependency>
       <dependency>
         <groupId>org.hamcrest</groupId>
@@ -441,7 +441,7 @@
       <dependency>
         <groupId>com.google.inject</groupId>
         <artifactId>guice</artifactId>
-        <version>4.1.0</version>
+        <version>4.2.3</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
@@ -451,7 +451,7 @@
       <dependency>
         <groupId>com.google.inject.extensions</groupId>
         <artifactId>guice-assistedinject</artifactId>
-        <version>4.1.0</version>
+        <version>4.2.3</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
@@ -486,7 +486,7 @@
       <dependency>
         <groupId>com.google.inject.extensions</groupId>
         <artifactId>guice-persist</artifactId>
-        <version>4.1.0</version>
+        <version>4.2.3</version>
       </dependency>
       <dependency>
         <groupId>org.hibernate</groupId>
@@ -606,7 +606,7 @@
       <dependency>
         <groupId>com.google.inject.extensions</groupId>
         <artifactId>guice-servlet</artifactId>
-        <version>4.1.0</version>
+        <version>4.2.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
@@ -681,7 +681,7 @@
       <dependency>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-guice</artifactId>
-        <version>4.4.2.Final</version>
+        <version>4.5.8.Final</version>
       </dependency>
       <dependency>
         <groupId>net.oauth.core</groupId>
@@ -756,7 +756,12 @@
       <dependency>
         <groupId>com.google.inject.extensions</groupId>
         <artifactId>guice-multibindings</artifactId>
-        <version>4.1.0</version>
+        <version>4.2.3</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.annotation</groupId>
+        <artifactId>javax.annotation-api</artifactId>
+        <version>1.3.2</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/common/src/test/java/org/candlepin/common/guice/HttpMethodMatcherTest.java
+++ b/common/src/test/java/org/candlepin/common/guice/HttpMethodMatcherTest.java
@@ -72,7 +72,7 @@ public class HttpMethodMatcherTest {
     @Test
     public void testMatches() {
         HttpMethodMatcher matcher = new HttpMethodMatcher();
-        Method[] methods = TestResource.class.getMethods();
+        Method[] methods = TestResource.class.getDeclaredMethods();
 
         for (int i = 0; i < methods.length; i++) {
             if (methods[i].getAnnotations().length != 0) {

--- a/docker/candlepin-base/cp-test
+++ b/docker/candlepin-base/cp-test
@@ -157,6 +157,16 @@ cleanup() {
     fi
 }
 
+# This function converts candlepin version to a int value with (Zero) padding
+# which helps in comparing versions.
+# Examples -
+# 2.5.6  -> 2005006000
+# 3.2.0  -> 3002000000
+# 2.9.6  -> 2009006000
+get_simplified_version() {
+	echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }';
+}
+
 usage() {
     cat <<HELP
 usage: cp-test [options]
@@ -224,30 +234,8 @@ done
 
 shift $(($OPTIND - 1))
 
-
-# Auto-detect JAVA_VERSION if necessary and set JAVA_HOME and update executable links
-# Note that alternatives doesn't update the JDK binaries properly, and doesn't order
-# versions predictably, so we'll just explicitly make the links ourself.
-if [ -z "$JAVA_VERSION" ]; then
-    JAVA_VERSION=$(java -version 2>&1 | head -1 | sed -r 's/^(java|openjdk) version \"([0-9]+\.[0-9]+\.[0-9]+).*\"/\2/')
-fi
-
-export JAVA_VERSION
-export JAVA_HOME=/usr/lib/jvm/java-$JAVA_VERSION
-
-if [ -d "$JAVA_HOME" ]; then
-    ln -sf -t /usr/bin $JAVA_HOME/bin/*
-    echo "Using Java version: $JAVA_VERSION ($JAVA_HOME)"
-else
-    echo "Java home not found for version $JAVA_VERSION: $JAVA_HOME"
-    exit 1
-fi
-
 # Set our project to test
 PROJECT=${PROJECT:-server}
-
-# WARNING: control+c while this is running will take out supervisor as well.
-/usr/bin/supervisord -c /etc/supervisord.conf
 
 # Pass volume with docker run mounted at this location if you'd like to
 # run against your source checkout.
@@ -276,6 +264,41 @@ else
         git checkout "$CHECKOUT"
     fi
 fi
+
+# Check if we need to use Java 11, otherwie auto detect Java version.
+# Candlepin support Java 11 from 3.2.0 & onwards.
+
+CANDLEPIN_BASE_VERSION=$(git describe --abbrev=0 | awk -F"-" '{print $2}')
+JAVA_11_SUPPORTED_VERSION=3.2.0
+
+echo "Base version of candlepin: " $CANDLEPIN_BASE_VERSION
+if [ $(get_simplified_version $CANDLEPIN_BASE_VERSION) -ge $(get_simplified_version $JAVA_11_SUPPORTED_VERSION) ] ; then
+    JAVA_VERSION=11
+    echo "Overriding tomcat.conf to use Java 11"
+    update-alternatives --set java /usr/lib/jvm/java-$JAVA_VERSION-openjdk-$JAVA_VERSION*/bin/java
+    sed -i 's/JAVA_HOME=.*/JAVA_HOME="\/usr\/lib\/jvm\/jre-11"/' /etc/tomcat/tomcat.conf
+fi
+
+# Auto-detect JAVA_VERSION if necessary and set JAVA_HOME and update executable links
+# Note that alternatives doesn't update the JDK binaries properly, and doesn't order
+# versions predictably, so we'll just explicitly make the links ourself.
+if [ -z "$JAVA_VERSION" ]; then
+    JAVA_VERSION=$(java -version 2>&1 | head -1 | sed -r 's/^(java|openjdk) version \"([0-9]+\.[0-9]+\.[0-9]+).*\"/\2/')
+fi
+
+export JAVA_VERSION
+export JAVA_HOME=/usr/lib/jvm/java-$JAVA_VERSION
+
+if [ -d "$JAVA_HOME" ]; then
+    ln -sf -t /usr/bin $JAVA_HOME/bin/*
+    echo "Using Java version: $JAVA_VERSION ($JAVA_HOME)"
+else
+    echo "Java home not found for version $JAVA_VERSION: $JAVA_HOME"
+    exit 1
+fi
+
+# WARNING: control+c while this is running will take out supervisor as well.
+/usr/bin/supervisord -c /etc/supervisord.conf
 
 # Make sure we update the ruby bundle:
 if [ ! -f ./gradlew ]; then

--- a/docker/candlepin-base/setup-devel-env.sh
+++ b/docker/candlepin-base/setup-devel-env.sh
@@ -18,6 +18,7 @@ PACKAGES=(
     gettext
     git
     hostname
+    java-11-openjdk-devel
     java-$JAVA_VERSION-openjdk-devel
     jss
     libxml2-python

--- a/pom.xml
+++ b/pom.xml
@@ -125,10 +125,11 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.3</version>
+                    <version>3.8.0</version>
                     <configuration>
-                        <source>1.8</source>
-                        <target>1.8</target>
+                        <source>11</source>
+                        <target>11</target>
+                        <release>11</release>
                         <debug>true</debug>
                         <debuglevel>lines,vars,source</debuglevel>
                     </configuration>

--- a/server/candlepin.spec.tmpl
+++ b/server/candlepin.spec.tmpl
@@ -40,7 +40,7 @@ BuildRequires: selinux-policy-doc
 BuildRequires: /usr/bin/pathfix.py
 %endif
 
-Requires: java >= 1:1.8.0
+Requires: java >= 11
 Requires: wget
 ## tomcatjss itself depends on jss and tomcat/pki-servlet-container/pki-servlet-engine
 ## without having to worry about about the renaming of those packages.

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -492,7 +492,7 @@
       <dependency>
         <groupId>com.google.inject.extensions</groupId>
         <artifactId>guice-throwingproviders</artifactId>
-        <version>4.1.0</version>
+        <version>4.2.3</version>
       </dependency>
       <dependency>
         <groupId>org.hamcrest</groupId>
@@ -582,7 +582,7 @@
       <dependency>
         <groupId>com.google.inject</groupId>
         <artifactId>guice</artifactId>
-        <version>4.1.0</version>
+        <version>4.2.3</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
@@ -592,7 +592,7 @@
       <dependency>
         <groupId>com.google.inject.extensions</groupId>
         <artifactId>guice-assistedinject</artifactId>
-        <version>4.1.0</version>
+        <version>4.2.3</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
@@ -627,7 +627,7 @@
       <dependency>
         <groupId>com.google.inject.extensions</groupId>
         <artifactId>guice-persist</artifactId>
-        <version>4.1.0</version>
+        <version>4.2.3</version>
       </dependency>
       <dependency>
         <groupId>org.hibernate</groupId>
@@ -747,7 +747,7 @@
       <dependency>
         <groupId>com.google.inject.extensions</groupId>
         <artifactId>guice-servlet</artifactId>
-        <version>4.1.0</version>
+        <version>4.2.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
@@ -822,7 +822,7 @@
       <dependency>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-guice</artifactId>
-        <version>4.4.2.Final</version>
+        <version>4.5.8.Final</version>
       </dependency>
       <dependency>
         <groupId>net.oauth.core</groupId>
@@ -897,7 +897,12 @@
       <dependency>
         <groupId>com.google.inject.extensions</groupId>
         <artifactId>guice-multibindings</artifactId>
-        <version>4.1.0</version>
+        <version>4.2.3</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.annotation</groupId>
+        <artifactId>javax.annotation-api</artifactId>
+        <version>1.3.2</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Changes 
- Dependencies upgraded to support Java 11

How to test/verify this PR locally ?
1. For Local Gradle build 
- Install Java-11
```java-11-openjdk-devel```
- Make it a default
```update-alternatives --config java```
 - Run gradle build
  
2. For Vagrant (Dependent on https://github.com/candlepin/ansible-role-candlepin/pull/14)
Update [requirement.yml](https://github.com/candlepin/candlepin/blob/master/vagrant/requirements.yml) file to checkout the above PR's branch.