### PR TITLE
[M] 1894035: Fixed encoding of environment name in SCA certificates (ENT-3211)

### DIFF
--- a/server/src/main/java/org/candlepin/controller/ContentAccessManager.java
+++ b/server/src/main/java/org/candlepin/controller/ContentAccessManager.java
@@ -468,7 +468,12 @@ public class ContentAccessManager {
             prefix.append('/').append(URLEncoder.encode(owner.getKey(), charset));
 
             if (environment != null) {
-                prefix.append('/').append(URLEncoder.encode(environment.getName(), charset));
+                for (String chunk : environment.getName().split("/")) {
+                    if (!chunk.isEmpty()) {
+                        prefix.append("/");
+                        prefix.append(URLEncoder.encode(chunk, charset));
+                    }
+                }
             }
         }
 

--- a/server/src/main/resources/db/changelog/20201103112757-purge-current-sca-certs.xml
+++ b/server/src/main/resources/db/changelog/20201103112757-purge-current-sca-certs.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="20201103112757-1" author="crog">
+        <comment>
+            Removes any existing SCA certs to address a problem with cert generation in some organizations
+        </comment>
+
+        <sql>
+            UPDATE cp_cert_serial cs SET revoked = true
+                WHERE EXISTS (SELECT cac.serial_id FROM cp_cont_access_cert cac WHERE cac.serial_id = cs.id);
+        </sql>
+
+        <update tableName="cp_consumer">
+            <column name="cont_acc_cert_id"/> <!-- this sets the column value to null -->
+        </update>
+
+        <delete tableName="cp_cont_access_cert" />
+
+        <delete tableName="cp_owner_env_content_access" />
+    </changeSet>
+</databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-create.xml
+++ b/server/src/main/resources/db/changelog/changelog-create.xml
@@ -1244,4 +1244,5 @@
     <include file="db/changelog/20200715155048-add-ak-name-owner-constraint.xml"/>
     <include file="db/changelog/20200717020619-add-job-arguments-constraints.xml"/>
     <include file="db/changelog/20200910161135-purge-stale-quartz-data.xml"/>
+    <include file="db/changelog/20201103112757-purge-current-sca-certs.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-testing.xml
+++ b/server/src/main/resources/db/changelog/changelog-testing.xml
@@ -2336,4 +2336,5 @@
     <include file="db/changelog/20200715155048-add-ak-name-owner-constraint.xml"/>
     <include file="db/changelog/20200717020619-add-job-arguments-constraints.xml"/>
     <include file="db/changelog/20200910161135-purge-stale-quartz-data.xml"/>
+    <include file="db/changelog/20201103112757-purge-current-sca-certs.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-update.xml
+++ b/server/src/main/resources/db/changelog/changelog-update.xml
@@ -153,4 +153,5 @@
     <include file="db/changelog/20200715155048-add-ak-name-owner-constraint.xml"/>
     <include file="db/changelog/20200717020619-add-job-arguments-constraints.xml"/>
     <include file="db/changelog/20200910161135-purge-stale-quartz-data.xml"/>
+    <include file="db/changelog/20201103112757-purge-current-sca-certs.xml"/>
 </databaseChangeLog>

--- a/server/src/test/java/org/candlepin/controller/ContentAccessManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/ContentAccessManagerTest.java
@@ -643,10 +643,10 @@ public class ContentAccessManagerTest {
         Environment environment = this.mockEnvironment(owner, consumer, content);
 
         owner.setKey("org! #$%&'()*+,/123:;=?@[]\"-.<>\\^_`{|}~£円");
-        environment.setName("test environment #1");
+        environment.setName("foo/test environment #1/bar");
 
         String expectedPrefix = "/org%21+%23%24%25%26%27%28%29*%2B%2C%2F123%3A%3B%3D%3F%40%5B%5D%22" +
-            "-.%3C%3E%5C%5E_%60%7B%7C%7D%7E%C2%A3%E5%86%86/test+environment+%231";
+            "-.%3C%3E%5C%5E_%60%7B%7C%7D%7E%C2%A3%E5%86%86/foo/test+environment+%231/bar";
 
         ContentAccessManager manager = this.createManager();
         manager.getCertificate(consumer);


### PR DESCRIPTION
- Content paths in certificates for simple content access (SCA)
  no longer encode the forward slash of any containing environment
  name