### PR TITLE
Set Java 11 specific mead target

### DIFF
--- a/rel-eng/releasers.conf
+++ b/rel-eng/releasers.conf
@@ -36,5 +36,5 @@ autobuild_tags = candlepin-nightly-rhel6 candlepin-nightly-rhel7
 releaser = tito.release.DistGitMeadReleaser
 branches = candlepin-mead-rhel-6
 mead_scm = git://git.app.eng.bos.redhat.com/candlepin.git
-target = candlepin-1-maven-candidate
+target = candlepin-1-jdk11-maven-candidate
 mead_push_url = git+ssh://MEAD_SCM_USERNAME@code.engineering.redhat.com/candlepin.git

--- a/server/mead.chain
+++ b/server/mead.chain
@@ -1,19 +1,16 @@
 [org.candlepin-candlepin-parent]
 scmurl=${mead_scm}#${git_ref}
 maven_options=-N ${maven_options}
-packages=java-11-openjdk-devel
 
 [org.candlepin-candlepin-common]
 scmurl=${mead_scm}?common#${git_ref}
 buildrequires=org.candlepin-candlepin-parent
-packages=gettext java-11-openjdk-devel
+packages=gettext
 
 [org.candlepin-api]
 scmurl=${mead_scm}?api#${git_ref}
 buildrequires=org.candlepin-candlepin-parent
-packages=java-11-openjdk-devel
 
 [org.candlepin-candlepin]
 scmurl=${mead_scm}?server#${git_ref}
 buildrequires=org.candlepin-candlepin-common org.candlepin-api
-packages=java-11-openjdk-devel


### PR DESCRIPTION
- A new brew/mead target was added for explicitly
  building with Java 11. We will target it from now on.
- Remove jdk 11 from the required packages, since it
  is redundant now.