### PR TITLE
1884410: Fix for misleading exception message in auto-attach (ENT-3128)

### DIFF
--- a/server/spec/autobind_disabled_for_owner_spec.rb
+++ b/server/spec/autobind_disabled_for_owner_spec.rb
@@ -24,11 +24,41 @@ describe 'Autobind Disabled On Owner' do
       @consumer_cp.consume_product()
     rescue RestClient::BadRequest => e
       exception_thrown = true
-      ex_message = "Ignoring request to auto-attach. It is disabled for org \"#{@owner['key']}\" because of the content access mode setting."
+      ex_message = "Ignoring request to auto-attach. It is disabled for org \"#{@owner['key']}\"."
       data = JSON.parse(e.response)
       data['displayMessage'].should == ex_message
     end
     exception_thrown.should be true
+  end
+
+  it 'autobind should fail when owner is in SCA mode' do
+    skip("candlepin running in standalone mode") if not is_hosted?
+
+    exception_thrown = false
+    owner = create_owner(random_string("test_owner"), nil, {
+      'contentAccessModeList' => 'org_environment,entitlement',
+      'contentAccessMode' => "org_environment"
+    })
+    owner = @cp.get_owner(owner['key'])
+
+    expect(owner).to_not be_nil
+
+    cp_user = user_client(owner, random_string("testing-user"))
+    consumer = cp_user.register("foofy_test", :system, nil,
+      {'cpu.cpu_socket(s)' => '8'}, nil, owner['key'], [], [])
+    consumer_cp = Candlepin.new(nil, nil, consumer.idCert.cert, consumer.idCert['key'])
+
+    begin
+      consumer_cp.consume_product()
+    rescue RestClient::BadRequest => e
+      exception_thrown = true
+      ex_message = "Ignoring request to auto-attach. " +
+        "It is disabled for org \"#{owner['key']}\" because of the content access mode setting."
+      data = JSON.parse(e.response)
+      expect(data['displayMessage']).to eq(ex_message)
+    end
+
+    expect(exception_thrown).to eq(true)
   end
 
   it 'autobind fails when hypervisor autobind disabled on owner' do

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -2136,9 +2136,16 @@ public class ConsumerResource {
                 entitlements = entitler.bindByProducts(autobindData);
             }
             catch (AutobindDisabledForOwnerException e) {
-                throw new BadRequestException(i18n.tr("Ignoring request to auto-attach. " +
-                    "It is disabled for org \"{0}\" because of the content access mode setting."
-                    , owner.getKey()));
+                if (owner.isContentAccessEnabled()) {
+                    throw new BadRequestException(i18n.tr("Ignoring request to auto-attach. " +
+                        "It is disabled for org \"{0}\" because of the content access mode setting."
+                        , owner.getKey()));
+                }
+                else {
+                    throw new BadRequestException(i18n.tr("Ignoring request to auto-attach. " +
+                        "It is disabled for org \"{0}\"."
+                        , owner.getKey()));
+                }
             }
             catch (AutobindHypervisorDisabledException e) {
                 throw new BadRequestException(i18n.tr("Ignoring request to auto-attach. " +


### PR DESCRIPTION
Changes/Fix 
- There was ambiguity in handling exception for conditions, where auto-attach is disabled for org & when org in SCA mode. This was leading to misleading exception messages.
- Added functional tests.